### PR TITLE
README: Need args for connect_ec2

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,11 @@ def test_add_servers():
     assert instance1.image_id == 'ami-1234abcd'
 ```
 
+*Note: You must pass the two arguments to the `connect_ec2` method,
+otherwise the call will fail with a `NoAuthHandlerFound` error. However, the
+argument values don't matter, as long as they are present.*
+
+
 ## Usage
 
 All of the services can be used as a decorator, context manager, or in a raw form.


### PR DESCRIPTION
Add some text to the readme to specify that the boto.connect_ec2 function needs to have arguments passed to it, or it will fail.
