### PR TITLE
Created tags are not available when retrieving instances

### DIFF
--- a/tests/test_ec2/test_tags.py
+++ b/tests/test_ec2/test_tags.py
@@ -1,5 +1,6 @@
 import boto
 import sure  # flake8: noqa
+import itertools
 
 from moto import mock_ec2
 
@@ -19,3 +20,17 @@ def test_instance_launch_and_terminate():
 
     instance.remove_tag("a key")
     conn.get_all_tags().should.have.length_of(0)
+
+@mock_ec2
+def test_instance_launch_and_retrieve_all_instances():
+    conn = boto.connect_ec2('the_key', 'the_secret')
+    reservation = conn.run_instances('ami-1234abcd')
+    instance = reservation.instances[0]
+
+    instance.add_tag("a key", "some value")
+    chain = itertools.chain.from_iterable
+    existing_instances = list(chain([reservation.instances for reservation in conn.get_all_instances()]))
+    existing_instances.should.have.length_of(1)
+    existing_instance = existing_instances[0]
+    existing_instance.tags["a key"].should.equal("some value")
+


### PR DESCRIPTION
Hi,
1st of all thanks a lot for this project, it's being super-useful to me.

Now, I'm having some trouble with the "tags" part. I am trying to create a tag into an existing instance, and then retrieve the instance and have that tag available... but either my "boto" usage flow is wrong (which is likely and in which case I'd like to apologize beforehand) or the mock is not returning the instances with the tags I've just created.

Would you mind taking a look at my test-case?

Many thanks in advance.
