### PR TITLE
Use backport of ordereddict for Python 2.6 or earlier.

### DIFF
--- a/moto/dynamodb/models.py
+++ b/moto/dynamodb/models.py
@@ -1,4 +1,9 @@
-from collections import defaultdict, OrderedDict
+from collections import defaultdict
+try:
+    from collections import OrderedDict
+except ImportError:
+    # Use backport for python 2.6 or earlier
+    from ordereddict import OrderedDict
 import datetime
 import json
 


### PR DESCRIPTION
The 'ImportError' occurs if using Python 2.6 or earlier.

```
.tox/py26/lib/python2.6/site-packages/moto/dynamodb/models.py:1: in <module>
>   from collections import defaultdict, OrderedDict
E   ImportError: cannot import name OrderedDict
```

This patch needs the following backport package for the old version of python.

```
$ sudo pip install ordereddict
```
