### PR TITLE
Fix the 'www.' strip changing the lstrip method by the replace

### DIFF
--- a/moto/s3/utils.py
+++ b/moto/s3/utils.py
@@ -8,8 +8,8 @@ bucket_name_regex = re.compile("(.+).s3.amazonaws.com")
 def bucket_name_from_url(url):
     domain = urlparse.urlparse(url).netloc
 
-    # If 'www' prefixed, strip it.
-    domain = domain.replace("www.", "")
+    if domain.startswith('www.'):
+        domain = domain[4:]
 
     if 'amazonaws.com' in domain:
         bucket_result = bucket_name_regex.search(domain)

--- a/tests/test_s3/test_s3_utils.py
+++ b/tests/test_s3/test_s3_utils.py
@@ -7,7 +7,7 @@ def test_base_url():
 
 
 def test_localhost_bucket():
-    expect(bucket_name_from_url('https://foobar.localhost:5000/abc')).should.equal("foobar")
+    expect(bucket_name_from_url('https://wfoobar.localhost:5000/abc')).should.equal("wfoobar")
 
 
 def test_localhost_without_bucket():


### PR DESCRIPTION
If the domain name is something containing a 'w' as 'wgs-dev.amazon.com', lstrip with 'www.' removes the 'w' giving 'gs-dev.amazon.com'. The domain is then corrupted.
I propose to simply replace 'www.' by ''. 
It is also possible to check that the domain starts with 'www.' and then uses domain[4:]
