### PR TITLE
updated to fix split issue with paths with slashes

### DIFF
--- a/moto/s3/responses.py
+++ b/moto/s3/responses.py
@@ -130,7 +130,7 @@ def _key_response(request, full_url, headers):
     if method == 'PUT':
         if 'x-amz-copy-source' in request.headers:
             # Copy key
-            src_bucket, src_key = request.headers.get("x-amz-copy-source").split("/",2)
+            src_bucket, src_key = request.headers.get("x-amz-copy-source").split("/",1)
             s3_backend.copy_key(src_bucket, src_key, bucket_name, key_name)
             template = Template(S3_OBJECT_COPY_RESPONSE)
             return template.render(key=src_key)


### PR DESCRIPTION
the whitespace changes were only my editor being dumb, the specific change is on line 133.

This fixes a bug in a path that uses / to seperate the location:

for instance:

bucketASDF/keypart1/keypart2/keypart3

the unrestricted split would create 4 variables and attempt to assign them to 2 output variables, resulting in a ValueError Exception.

This change simply limits the split to the bucket and the full key name.
