### PR TITLE
Enables the usage of special characters in keys when using s3bucket_path

### DIFF
--- a/moto/s3bucket_path/urls.py
+++ b/moto/s3bucket_path/urls.py
@@ -16,5 +16,5 @@ url_paths = {
     '{0}/$': bucket_response3,
     '{0}/(?P<bucket_name>[a-zA-Z0-9\-_.]+)$': ro.bucket_response,
     '{0}/(?P<bucket_name>[a-zA-Z0-9\-_.]+)/$': bucket_response2,
-    '{0}/(?P<bucket_name>[a-zA-Z0-9\-_./]+)/(?P<key_name>[a-zA-Z0-9\-_.?]+)': ro.key_response
+    '{0}/(?P<bucket_name>[a-zA-Z0-9\-_./]+)/(?P<key_name>.+)': ro.key_response
 }

--- a/tests/test_s3bucket_path/test_s3bucket_path.py
+++ b/tests/test_s3bucket_path/test_s3bucket_path.py
@@ -231,12 +231,12 @@ def test_key_with_special_characters():
     conn = create_connection()
     bucket = conn.create_bucket('test_bucket_name')
 
-    key = Key(bucket, 'test_list_keys_2/x?y')
+    key = Key(bucket, 'test_list_keys_2/*x+?^@~!y')
     key.set_contents_from_string('value1')
 
     key_list = bucket.list('test_list_keys_2/', '/')
     keys = [x for x in key_list]
-    keys[0].name.should.equal("test_list_keys_2/x?y")
+    keys[0].name.should.equal("test_list_keys_2/*x+?^@~!y")
 
 
 @mock_s3bucket_path


### PR DESCRIPTION
According to Amazon S3 documentation:

"The name for a key is a sequence of Unicode characters whose UTF-8 encoding is at most 1024 bytes long."
Source: http://docs.aws.amazon.com/AmazonS3/latest/dev/UsingMetadata.html

While bucket names are restricted to certain characters, key names are not. This change makes s3bucket_path use a '.+' regex to match keys rather than the '[a-zA-Z0-9\-_.]+' regex used to match buckets. In addition, I added a few more special characters to test_s3bucket_path.py's 'test_key_with_special_characters' test to ensure this change works.

This fixes issue #78.
