### PR TITLE
don't add None to source_group list

### DIFF
--- a/moto/ec2/models.py
+++ b/moto/ec2/models.py
@@ -351,7 +351,9 @@ class SecurityGroupBackend(object):
         group = self.get_security_group_from_name(group_name)
         source_groups = []
         for source_group_name in source_group_names:
-            source_groups.append(self.get_security_group_from_name(source_group_name))
+            source_group = self.get_security_group_from_name(source_group_name)
+            if source_group:
+                source_groups.append(source_group)
 
         security_rule = SecurityRule(ip_protocol, from_port, to_port, ip_ranges, source_groups)
         group.ingress_rules.append(security_rule)
@@ -360,7 +362,9 @@ class SecurityGroupBackend(object):
         group = self.get_security_group_from_name(group_name)
         source_groups = []
         for source_group_name in source_group_names:
-            source_groups.append(self.get_security_group_from_name(source_group_name))
+            source_group = self.get_security_group_from_name(source_group_name)
+            if source_group:
+                source_groups.append(source_group)
 
         security_rule = SecurityRule(ip_protocol, from_port, to_port, ip_ranges, source_groups)
         if security_rule in group.ingress_rules:


### PR DESCRIPTION
When one security group has another as the source group, there is an exception.  It dues to a bug in parsing, but adding a check here fixes the problem.
