### PR TITLE
Fixed typo in REQUEST_POST_INSTANCES_TEMPLATE

### DIFF
--- a/moto/ec2/responses/spot_instances.py
+++ b/moto/ec2/responses/spot_instances.py
@@ -87,7 +87,7 @@ REQUEST_SPOT_INSTANCES_TEMPLATE = """<RequestSpotInstancesResponse xmlns="http:/
   <spotInstanceRequestSet>
     {% for request in requests %}
     <item>
-      <spotInstanceRequestId>{{ request.price }}</spotInstanceRequestId>
+      <spotInstanceRequestId>{{ request.id }}</spotInstanceRequestId>
       <spotPrice>{{ request.price }}</spotPrice>
       <type>{{ request.type }}</type>
       <state>{{ request.state }}</state>


### PR DESCRIPTION
Hey, we stumbled across this at work when mocking EC2 spot instances and it's an easy fix. spotInstanceRequestId should contain the instance's id, not the price.
