### PR TITLE
Order results for query with key range_key and enfore limit on query and scan calls

### DIFF
--- a/moto/dynamodb/responses.py
+++ b/moto/dynamodb/responses.py
@@ -242,6 +242,11 @@ class DynamoHandler(BaseResponse):
             er = 'com.amazonaws.dynamodb.v20111205#ResourceNotFoundException'
             return self.error(er)
 
+        items.sort(lambda item: item.range_key)
+        limit = self.body.get("Limit", None)
+        if limit:
+            items = items[0:limit]
+            
         result = {
             "Count": len(items),
             "Items": [item.attrs for item in items],
@@ -272,6 +277,10 @@ class DynamoHandler(BaseResponse):
         if items is None:
             er = 'com.amazonaws.dynamodb.v20111205#ResourceNotFoundException'
             return self.error(er)
+
+        limit = self.body.get("Limit", None)
+        if limit:
+            items = items[:limit]
 
         result = {
             "Count": len(items),


### PR DESCRIPTION
Currently when doing a `query` the order and limit are not being observed as should be per the [docs](http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/QueryAndScan.html)

> Query results are always sorted by the range key. If the data type of the range key is Number, the results are returned in numeric order; otherwise, the results are returned in order of ASCII character code values. By default, the sort order is ascending. To reverse the order use the ScanIndexForward parameter set to false.

Also when passing a limit parameter, `scan` will return that number of items.
