### PR TITLE
Query order/limit enforced. Scan limit enforced

### DIFF
--- a/moto/dynamodb2/models.py
+++ b/moto/dynamodb2/models.py
@@ -42,6 +42,18 @@ class DynamoType(object):
             self.value == other.value
         )
 
+    def __lt__(self, other):
+        return self.value < other.value
+
+    def __le__(self, other):
+        return self.value <= other.value
+
+    def __gt__(self, other):
+        return self.value > other.value
+
+    def __ge__(self, other):
+        return self.value >= other.value
+
     def __repr__(self):
         return "DynamoType: {0}".format(self.to_json())
 
@@ -196,6 +208,8 @@ class Table(object):
         else:
             # If we're not filtering on range key, return all values
             results = possible_results
+
+        results.sort(key=lambda item: item.range_key)
         return results, last_page
 
     def all_items(self):

--- a/moto/dynamodb2/responses.py
+++ b/moto/dynamodb2/responses.py
@@ -238,12 +238,11 @@ class DynamoHandler(BaseResponse):
         if items is None:
             er = 'com.amazonaws.dynamodb.v20111205#ResourceNotFoundException'
             return self.error(er) 
-        
-        items.sort(key=lambda item: item.range_key)
+
         limit = self.body.get("Limit")
         if limit:
             items = items[:limit]
-        
+
         result = {
             "Count": len(items),
             "Items": [item.attrs for item in items],


### PR DESCRIPTION
Currently when doing a `query` the order and `limit` are not being observed as should be per the docs

> Query results are always sorted by the range key. If the data type of the range key is Number, the results are returned in numeric order; otherwise, the results are returned in order of ASCII character code values. By default, the sort order is ascending. To reverse the order use the ScanIndexForward parameter set to false.

Also when passing a `limit` parameter, `scan` will return that number of items.
