### PR TITLE
support x-amz-copy-source in multipart uploads

### DIFF
--- a/moto/s3/models.py
+++ b/moto/s3/models.py
@@ -182,6 +182,14 @@ class S3Backend(BaseBackend):
         multipart = bucket.multiparts[multipart_id]
         return multipart.set_part(part_id, value)
 
+    def copy_part(self, dest_bucket_name, multipart_id, part_id,
+                  src_bucket_name, src_key_name):
+        src_key_name = clean_key_name(src_key_name)
+        src_bucket = self.buckets[src_bucket_name]
+        dest_bucket = self.buckets[dest_bucket_name]
+        multipart = dest_bucket.multiparts[multipart_id]
+        return multipart.set_part(part_id, src_bucket.keys[src_key_name].value)
+
     def prefix_query(self, bucket, prefix, delimiter):
         key_results = set()
         folder_results = set()


### PR DESCRIPTION
In the current code the x-amz-copy-source header is not supported when uploading a part of a multipart upload. This commit adds that support. Also in the current code the multipart PUT operation incorrectly returned a CopyPartResult document in the response. This response is only valid when doing a PUT with x-amz-copy-source.
