### PR TITLE
Fix bug with POST uploads returning 400 client error

### DIFF
--- a/moto/s3/responses.py
+++ b/moto/s3/responses.py
@@ -100,7 +100,10 @@ class ResponseObject(object):
                     form[k] = v
 
             key = form['key']
-            f = form['file']
+            if 'file' in form:
+                f = form['file']
+            else:
+                f = request.files['file'].stream.read()
 
             new_key = self.backend.set_key(bucket_name, key, f)
 


### PR DESCRIPTION
This fixes a bug I was seeing where moto wouldn't accept a POST upload from my client software. For whatever reason the file came in `request.files` rather than `request.form`. 

In case you're curious, here's the request that needed this change:

```
POST / HTTP/1.1
Host: xxxxx.s3.amazonaws.com
Content-Type: multipart/form-data; boundary=Boundary+832DF3B4960B5C10
Accept: */*
Expect: 100-continue
User-Agent: Xxxxx/1.0 (Mac OS X Version 10.9.2 (Build 13C64))
Accept-Language: en-GB;q=1, en;q=0.9, fr;q=0.8, de;q=0.7, zh-Hans;q=0.6, zh-Hant;q=0.5
Accept-Encoding: gzip, deflate
X-Forwarded-For: 127.0.0.1
X-Forwarded-Host: xxxxx.s3.amazonaws.com
X-Forwarded-Server: s3.amazonaws.com
Connection: Keep-Alive
Content-Length: 1022

--Boundary+832DF3B4960B5C10
Content-Disposition: form-data; name="AWSAccessKeyId"

xxxxxxxxxxxxxxxxxxxx
--Boundary+832DF3B4960B5C10
Content-Disposition: form-data; name="key"

116b8311bee6ee747c7b7e7f527e8c2f.raw
--Boundary+832DF3B4960B5C10
Content-Disposition: form-data; name="policy"

<snip>
--Boundary+832DF3B4960B5C10
Content-Disposition: form-data; name="signature"

<snip>
--Boundary+832DF3B4960B5C10
Content-Disposition: form-data; name="file"; filename="116b8311bee6ee747c7b7e7f527e8c2f.raw"
Content-Type: application/octet-stream

<snip>
--Boundary+832DF3B4960B5C10--
```
