### PR TITLE
include LICENSE, README, AUTHORS in pypi

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include README.md LICENSE AUTHORS.md


### PR DESCRIPTION
I've proposed moto for inclusion in Fedora and EPEL (https://bugzilla.redhat.com/show_bug.cgi?id=1084202), and they usually like the license to be included in the upstream tarball itself, so that we're guaranteed to be including the correct license for the source.
