### PR TITLE
Route 53 GET request honors the Name parameter.

### DIFF
--- a/moto/route53/responses.py
+++ b/moto/route53/responses.py
@@ -66,8 +66,11 @@ def rrset_response(request, full_url, headers):
         template = Template(LIST_RRSET_REPONSE)
         rrset_list = []
         for key, value in the_zone.rrsets.items():
-            if 'type' not in querystring or querystring["type"][0] == value["Type"]:
-                rrset_list.append(dicttoxml.dicttoxml({"ResourceRecordSet": value}, root=False))
+            if 'type' in querystring and querystring["type"][0] != value["Type"]:
+                continue
+            if 'name' in querystring and querystring["name"][0] != value["Name"]:
+                continue
+            rrset_list.append(dicttoxml.dicttoxml({"ResourceRecordSet": value}, root=False))
 
         return 200, headers, template.render(rrsets=rrset_list)
 

--- a/tests/test_route53/test_route53.py
+++ b/tests/test_route53/test_route53.py
@@ -72,3 +72,24 @@ def test_rrset():
 
     rrsets = conn.get_all_rrsets(zoneid)
     rrsets.should.have.length_of(0)
+
+    changes = ResourceRecordSets(conn, zoneid)
+    change = changes.add_change("CREATE", "foo.bar.testdns.aws.com", "A")
+    change.add_value("1.2.3.4")
+    change = changes.add_change("CREATE", "bar.foo.testdns.aws.com", "A")
+    change.add_value("5.6.7.8")
+    changes.commit()
+
+    rrsets = conn.get_all_rrsets(zoneid, type="A")
+    rrsets.should.have.length_of(2)
+
+    rrsets = conn.get_all_rrsets(zoneid, name="foo.bar.testdns.aws.com", type="A")
+    rrsets.should.have.length_of(1)
+    rrsets[0].resource_records[0].should.equal('1.2.3.4')
+
+    rrsets = conn.get_all_rrsets(zoneid, name="bar.foo.testdns.aws.com", type="A")
+    rrsets.should.have.length_of(1)
+    rrsets[0].resource_records[0].should.equal('5.6.7.8')
+
+    rrsets = conn.get_all_rrsets(zoneid, name="foo.foo.testdns.aws.com", type="A")
+    rrsets.should.have.length_of(0)


### PR DESCRIPTION
Now record sets can be retrieved by name via `get_all_rrsets`.
