### PR TITLE
Fix retrieval of autoscaling group instances.

### DIFF
--- a/moto/autoscaling/responses.py
+++ b/moto/autoscaling/responses.py
@@ -258,7 +258,17 @@ DESCRIBE_AUTOSCALING_GROUPS_TEMPLATE = """<DescribeAutoScalingGroupsResponse xml
         <CreatedTime>2013-05-06T17:47:15.107Z</CreatedTime>
         <EnabledMetrics/>
         <LaunchConfigurationName>{{ group.launch_config_name }}</LaunchConfigurationName>
-        <Instances/>
+        <Instances>
+          {% for instance in group.instances %}
+          <member>
+            <HealthStatus>HEALTHY</HealthStatus>
+            <AvailabilityZone>us-east-1e</AvailabilityZone>
+            <InstanceId>{{ instance.id }}</InstanceId>
+            <LaunchConfigurationName>{{ instance.autoscaling_group.launch_config_name }}</LaunchConfigurationName>
+            <LifecycleState>InService</LifecycleState>
+          </member>
+          {% endfor %}
+        </Instances>
         <DesiredCapacity>{{ group.desired_capacity }}</DesiredCapacity>
         <AvailabilityZones>
           {% for availability_zone in group.availability_zones %}

--- a/tests/test_autoscaling/test_autoscaling.py
+++ b/tests/test_autoscaling/test_autoscaling.py
@@ -40,6 +40,7 @@ def test_create_autoscaling_group():
     group.desired_capacity.should.equal(2)
     group.max_size.should.equal(2)
     group.min_size.should.equal(2)
+    group.instances.should.have.length_of(2)
     group.vpc_zone_identifier.should.equal('subnet-1234abcd')
     group.launch_config_name.should.equal('tester')
     group.default_cooldown.should.equal(60)


### PR DESCRIPTION
The current implementation of `describe_autoscaling_groups` always incorrectly returns groups with zero instances.
