### PR TITLE
Turn on threading for Werkzeug's run_simple()

### DIFF
--- a/moto/server.py
+++ b/moto/server.py
@@ -102,7 +102,7 @@ def main(argv=sys.argv[1:]):
     main_app = DomainDispatcherApplication(create_backend_app, service=args.service)
     main_app.debug = True
 
-    run_simple(args.host, args.port, main_app)
+    run_simple(args.host, args.port, main_app, threaded=True)
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
This is now default behavior. Without this, moto is unable to deal
with simultaneous requests.
