### PR TITLE
Creating a queue with existing name is now a no-op

### DIFF
--- a/moto/sqs/models.py
+++ b/moto/sqs/models.py
@@ -158,8 +158,10 @@ class SQSBackend(BaseBackend):
         super(SQSBackend, self).__init__()
 
     def create_queue(self, name, visibility_timeout):
-        queue = Queue(name, visibility_timeout)
-        self.queues[name] = queue
+        queue = self.queues.get(name)
+        if queue is None:
+            queue = Queue(name, visibility_timeout)
+            self.queues[name] = queue
         return queue
 
     def list_queues(self, queue_name_prefix):


### PR DESCRIPTION
This is more in line with Amazon's CreateQueue API
(http://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_CreateQueue.html).

Previously, calling create_queue with a name that already existed
would cause moto to overwrite the existing queue with a new empty one.
