### PR TITLE
Support filtering instances by tag

### DIFF
--- a/moto/ec2/utils.py
+++ b/moto/ec2/utils.py
@@ -190,11 +190,17 @@ def passes_filter_dict(instance, filter_dict):
     for filter_name, filter_values in filter_dict.items():
         if filter_name in filter_dict_attribute_mapping:
             instance_attr = filter_dict_attribute_mapping[filter_name]
+            instance_value = getattr(instance, instance_attr)
+            if instance_value not in filter_values:
+                return False
+        elif filter_name.startswith('tag:'):
+            tags = dict((tag['key'], tag['value']) for tag in instance.get_tags())
+            tag_name = filter_name.replace('tag:', '', 1)
+            tag_value = tags.get(tag_name)
+            if tag_value not in filter_values:
+                return False
         else:
             raise NotImplementedError("Filter dicts have not been implemented in Moto for '%s' yet. Feel free to open an issue at https://github.com/spulec/moto/issues", filter_name)
-        instance_value = getattr(instance, instance_attr)
-        if instance_value not in filter_values:
-            return False
     return True
 
 

--- a/tests/test_ec2/test_instances.py
+++ b/tests/test_ec2/test_instances.py
@@ -131,6 +131,47 @@ def test_get_instances_filtering_by_instance_id():
     reservations.should.have.length_of(0)
 
 @mock_ec2
+def test_get_instances_filtering_by_tag():
+    conn = boto.connect_ec2()
+    reservation = conn.run_instances('ami-1234abcd', min_count=3)
+    instance1, instance2, instance3 = reservation.instances
+    instance1.add_tag('tag1', 'value1')
+    instance1.add_tag('tag2', 'value2')
+    instance2.add_tag('tag1', 'value1')
+    instance2.add_tag('tag2', 'wrong value')
+    instance3.add_tag('tag2', 'value2')
+
+    reservations = conn.get_all_instances(filters={'tag:tag0' : 'value0'})
+    # get_all_instances should return no instances
+    reservations.should.have.length_of(0)
+
+    reservations = conn.get_all_instances(filters={'tag:tag1' : 'value1'})
+    # get_all_instances should return both instances with this tag value
+    reservations.should.have.length_of(1)
+    reservations[0].instances.should.have.length_of(2)
+    reservations[0].instances[0].id.should.equal(instance1.id)
+    reservations[0].instances[1].id.should.equal(instance2.id)
+
+    reservations = conn.get_all_instances(filters={'tag:tag1' : 'value1', 'tag:tag2' : 'value2'})
+    # get_all_instances should return the instance with both tag values
+    reservations.should.have.length_of(1)
+    reservations[0].instances.should.have.length_of(1)
+    reservations[0].instances[0].id.should.equal(instance1.id)
+
+    reservations = conn.get_all_instances(filters={'tag:tag1' : 'value1', 'tag:tag2' : 'value2'})
+    # get_all_instances should return the instance with both tag values
+    reservations.should.have.length_of(1)
+    reservations[0].instances.should.have.length_of(1)
+    reservations[0].instances[0].id.should.equal(instance1.id)
+
+    reservations = conn.get_all_instances(filters={'tag:tag2' : ['value2', 'bogus']})
+    # get_all_instances should return both instances with one of the acceptable tag values
+    reservations.should.have.length_of(1)
+    reservations[0].instances.should.have.length_of(2)
+    reservations[0].instances[0].id.should.equal(instance1.id)
+    reservations[0].instances[1].id.should.equal(instance3.id)
+
+@mock_ec2
 def test_instance_start_and_stop():
     conn = boto.connect_ec2('the_key', 'the_secret')
     reservation = conn.run_instances('ami-1234abcd', min_count=2)


### PR DESCRIPTION
Adds the ability to do (for EC2)

`conn.get_all_instances(filters={'tag:MyTag' : 'MyValue'})`
