### PR TITLE
Fix for S3 metadata on moto_server

### DIFF
--- a/moto/s3/responses.py
+++ b/moto/s3/responses.py
@@ -229,7 +229,7 @@ class ResponseObject(object):
         meta_regex = re.compile('^x-amz-meta-([a-zA-Z0-9\-_]+)$', flags=re.IGNORECASE)
         if replace is True:
             key.clear_metadata()
-        for header in request.headers:
+        for header, value in request.headers.items():
             if isinstance(header, six.string_types):
                 result = meta_regex.match(header)
                 if result:


### PR DESCRIPTION
When running moto via `moto_server` the `request.headers` object is a
list of dicts, not the special object that HTTPretty provides. This
commit fixes setting metadata on S3 when using `moto_server` and doesn't
break using HTTPretty I believe.
