### PR TITLE
Security Groups: Fix for filtering support.

### DIFF
--- a/moto/ec2/models.py
+++ b/moto/ec2/models.py
@@ -749,42 +749,42 @@ class SecurityGroup(object):
     def physical_resource_id(self):
         return self.id
 
-    def matches_filters(self, filters):
+
+    def matches_filter(self, key, filter_value):
         result = True
 
         def to_attr(filter_name):
             attr = None
 
-            if attr == 'group-name':
+            if filter_name == 'group-name':
                 attr = 'name'
-            elif attr == 'group-id':
+            elif filter_name == 'group-id':
                 attr = 'id'
+            elif filter_name == 'vpc-id':
+                attr = 'vpc_id'
             else:
                 attr = filter_name.replace('-', '_')
 
             return attr
 
-        for key, value in filters.items():
-            ret = False
+        if key.startswith('ip-permission'):
+            match = re.search(r"ip-permission.(*)", key)
+            ingress_attr = to_attr(match.groups()[0])
 
-            if key.startswith('ip-permission'):
-                match = re.search(r"ip-permission.(*)", key)
-                ingress_attr = to_attr(match.groups()[0])
-
-                for ingress in self.ingress_rules:
-                    if getattr(ingress, ingress_attr) in filters[key]:
-                        ret = True
-                        break
-            else:
-                attr_name = to_attr(key)
-                ret = getattr(self, attr_name) in filters[key]
-
-            if not ret:
-                break
+            for ingress in self.ingress_rules:
+                if getattr(ingress, ingress_attr) in filters[key]:
+                    return True
         else:
-            result = False
+            attr_name = to_attr(key)
+            return getattr(self, attr_name) in filter_value
 
-        return result
+        return False
+
+    def matches_filters(self, filters):
+        for key, value in filters.items():
+            if not self.matches_filter(key, value):
+                return False
+        return True
 
 
 class SecurityGroupBackend(object):

--- a/tests/test_ec2/test_security_groups.py
+++ b/tests/test_ec2/test_security_groups.py
@@ -200,17 +200,24 @@ def test_authorize_group_in_vpc():
 @mock_ec2
 def test_get_all_security_groups():
     conn = boto.connect_ec2()
-    conn.create_security_group(name='test1', description='test1', vpc_id='vpc-mjm05d27')
-    conn.create_security_group(name='test2', description='test2')
+    sg1 = conn.create_security_group(name='test1', description='test1', vpc_id='vpc-mjm05d27')
+    sg2 = conn.create_security_group(name='test2', description='test2')
 
     resp = conn.get_all_security_groups(groupnames=['test1'])
     resp.should.have.length_of(1)
+    resp[0].id.should.equal(sg1.id)
+
+    resp = conn.get_all_security_groups(filters={'vpc-id': ['vpc-mjm05d27']})
+    resp.should.have.length_of(1)
+    resp[0].id.should.equal(sg1.id)
 
     resp = conn.get_all_security_groups(filters={'vpc_id': ['vpc-mjm05d27']})
     resp.should.have.length_of(1)
+    resp[0].id.should.equal(sg1.id)
 
     resp = conn.get_all_security_groups(filters={'description': ['test1']})
     resp.should.have.length_of(1)
+    resp[0].id.should.equal(sg1.id)
 
     resp = conn.get_all_security_groups()
     resp.should.have.length_of(2)


### PR DESCRIPTION
This fixes #195.

There were two nested problems:
- The "to_attr" conversion checked "attr" (always None) instead of the passed "filter_name" param
- The foreach/else loop had a break on "if not ret" instead of "if ret" (proper) -- the "break" action is what causes the "else" clause to be skipped. So "if not ret: break" meant that a True match would not break, thus entering the else clause, and the True match would result in a False verdict.

The tests passed because they only checked for the number of results, and in each case the number of groups which did not match was the same as the number of groups which did match. I've added an explicit id check to the result to make sure the right group is returned.

My fix involved a minor refactor which no longer uses a foreach/else loop -- between my having to look up the semantics to make sure I wasn't crazy, and the logic having a bug in the first place, I think it's a bit more complex than we need here.

Bonus: I also added a couple of lines for the "vpc-id" filter while I was in there.
