### PR TITLE
allow get_filter_value to return state of ami and test

### DIFF
--- a/moto/ec2/models.py
+++ b/moto/ec2/models.py
@@ -606,6 +606,10 @@ class Ami(TaggedEC2Instance):
             return self.id
         elif filter_name == 'state':
             return self.state
+        elif filter_name.startswith('tag:'):
+            tag_name = filter_name.replace('tag:', '', 1)
+            tags = dict((tag['key'], tag['value']) for tag in self.get_tags())
+            return tags.get(tag_name)
         else:
             ec2_backend.raise_not_implemented_error("The filter '{0}' for DescribeImages".format(filter_name))
 


### PR DESCRIPTION
Moto didn't support filtering AMIs by their 'state' value.  This PR enhances moto to allow state filtering on AMIs.
- updated Ami.get_filter_value to return the state value of the AMI
- updated test_ec2.test_amis.test_ami_filters to test for AMIs in the state of 'available'

This was done per: http://docs.aws.amazon.com/AWSEC2/latest/APIReference/ApiReference-query-DescribeImages.html
