### PR TITLE
raise NotImplementedError on unknown metadata path

### DIFF
--- a/moto/core/responses.py
+++ b/moto/core/responses.py
@@ -158,4 +158,6 @@ def metadata_response(request, full_url, headers):
         result = 'default-role'
     elif path == 'iam/security-credentials/default-role':
         result = json.dumps(credentials)
+    else:
+        raise NotImplementedError("The {0} metadata path has not been implemented".format(path))
     return 200, headers, result

--- a/tests/test_core/test_instance_metadata.py
+++ b/tests/test_core/test_instance_metadata.py
@@ -1,4 +1,6 @@
 from __future__ import unicode_literals
+import sure  # noqa
+from nose.tools import assert_raises
 import requests
 
 from moto import mock_ec2
@@ -35,3 +37,9 @@ def test_meta_data_default_role():
     json_response.should.contain('SecretAccessKey')
     json_response.should.contain('Token')
     json_response.should.contain('Expiration')
+
+
+@mock_ec2
+def test_meta_data_unknown_path():
+    with assert_raises(NotImplementedError):
+        requests.get("http://169.254.169.254/latest/meta-data/badpath")


### PR DESCRIPTION
Metadata is only partially implemented so raise an error if we try to access something that isn't ready.
