### PR TITLE
Report route53 changes immediately as INSYNC.

### DIFF
--- a/moto/route53/responses.py
+++ b/moto/route53/responses.py
@@ -86,7 +86,7 @@ LIST_RRSET_REPONSE = """<ListResourceRecordSetsResponse xmlns="https://route53.a
 
 CHANGE_RRSET_RESPONSE = """<ChangeResourceRecordSetsResponse xmlns="https://route53.amazonaws.com/doc/2012-12-12/">
    <ChangeInfo>
-      <Status>PENDING</Status>
+      <Status>INSYNC</Status>
       <SubmittedAt>2010-09-10T01:36:41.958Z</SubmittedAt>
    </ChangeInfo>
 </ChangeResourceRecordSetsResponse>"""


### PR DESCRIPTION
This avoids leaving changes in a perennial PENDING limbo.
