### PR TITLE
Use travis new build workers.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: python
+sudo: false
 python:
   - 2.6
   - 2.7


### PR DESCRIPTION
They boot up faster but disallow sudo which we don't use.
