### PR TITLE
Feature instance launch time

### DIFF
--- a/moto/ec2/models.py
+++ b/moto/ec2/models.py
@@ -299,6 +299,7 @@ class Instance(BotoInstance, TaggedEC2Resource):
         self.subnet_id = kwargs.get("subnet_id")
         self.key_name = kwargs.get("key_name")
         self.source_dest_check = "true"
+        self.launch_time = datetime.now().strftime('%y-%m-%dT%H:%M:%S%z')
 
         self.block_device_mapping = BlockDeviceMapping()
         self.block_device_mapping['/dev/sda1'] = BlockDeviceType(volume_id=random_volume_id())

--- a/moto/ec2/models.py
+++ b/moto/ec2/models.py
@@ -299,7 +299,7 @@ class Instance(BotoInstance, TaggedEC2Resource):
         self.subnet_id = kwargs.get("subnet_id")
         self.key_name = kwargs.get("key_name")
         self.source_dest_check = "true"
-        self.launch_time = datetime.now().strftime('%y-%m-%dT%H:%M:%S%z')
+        self.launch_time = datetime.now().isoformat()
 
         self.block_device_mapping = BlockDeviceMapping()
         self.block_device_mapping['/dev/sda1'] = BlockDeviceType(volume_id=random_volume_id())

--- a/moto/ec2/models.py
+++ b/moto/ec2/models.py
@@ -299,11 +299,8 @@ class Instance(BotoInstance, TaggedEC2Resource):
         self.subnet_id = kwargs.get("subnet_id")
         self.key_name = kwargs.get("key_name")
         self.source_dest_check = "true"
-<<<<<<< HEAD
         self.launch_time = datetime.now().isoformat()
-=======
         self.private_ip_address = kwargs.get('private_ip_address')
->>>>>>> c22ea3014b8d2068696ef246e90bd9ec8ec90b91
 
         self.block_device_mapping = BlockDeviceMapping()
         self.block_device_mapping['/dev/sda1'] = BlockDeviceType(volume_id=random_volume_id())

--- a/moto/ec2/responses/instances.py
+++ b/moto/ec2/responses/instances.py
@@ -204,7 +204,7 @@ EC2_RUN_INSTANCES = """<RunInstancesResponse xmlns="http://ec2.amazonaws.com/doc
           <keyName>{{ instance.key_name }}</keyName>
           <amiLaunchIndex>0</amiLaunchIndex>
           <instanceType>{{ instance.instance_type }}</instanceType>
-          <launchTime>2007-08-07T11:51:50.000Z</launchTime>
+          <launchTime>{{ instance.launch_time }}</launchTime>
           <placement>
             <availabilityZone>us-east-1b</availabilityZone>
             <groupName/>

--- a/moto/ec2/responses/instances.py
+++ b/moto/ec2/responses/instances.py
@@ -325,7 +325,7 @@ EC2_DESCRIBE_INSTANCES = """<DescribeInstancesResponse xmlns='http://ec2.amazona
                     <amiLaunchIndex>0</amiLaunchIndex>
                     <productCodes/>
                     <instanceType>{{ instance.instance_type }}</instanceType>
-                    <launchTime>YYYY-MM-DDTHH:MM:SS+0000</launchTime>
+                    <launchTime>{{ instance.launch_time }}</launchTime>
                     <placement>
                       <availabilityZone>us-west-2a</availabilityZone>
                       <groupName/>

--- a/tests/test_ec2/test_instances.py
+++ b/tests/test_ec2/test_instances.py
@@ -4,6 +4,7 @@ import tests.backport_assert_raises
 from nose.tools import assert_raises
 
 import base64
+import datetime
 
 import boto
 from boto.ec2.instance import Reservation, InstanceAttribute
@@ -50,6 +51,7 @@ def test_instance_launch_and_terminate():
     instances.should.have.length_of(1)
     instances[0].id.should.equal(instance.id)
     instances[0].state.should.equal('running')
+    datetime.datetime.strptime(instances[0].launch_time, '%Y-%m-%dT%H:%M:%S.%f')
 
     root_device_name = instances[0].root_device_name
     instances[0].block_device_mapping[root_device_name].status.should.equal('attached')
@@ -604,13 +606,13 @@ def test_describe_instance_status_with_non_running_instances():
 @mock_ec2
 def test_get_instance_by_security_group():
     conn = boto.connect_ec2('the_key', 'the_secret')
-    
+
     conn.run_instances('ami-1234abcd')
     instance = conn.get_only_instances()[0]
 
     security_group = conn.create_security_group('test', 'test')
     conn.modify_instance_attribute(instance.id, "groupSet", [security_group.id])
-    
+
     security_group_instances = security_group.instances()
 
     assert len(security_group_instances) == 1


### PR DESCRIPTION
I have some code that looks at instance launch times, and looks for either the oldest or newest instance. This allows me to call `run_instances` with a sleep in between and ensure everything works correctly.