### PR TITLE
Folder results should include the delimiter.

### DIFF
--- a/moto/s3/models.py
+++ b/moto/s3/models.py
@@ -333,7 +333,7 @@ class S3Backend(BaseBackend):
             for key_name, key in bucket.keys.items():
                 if delimiter and delimiter in key_name:
                     # If delimiter, we need to split out folder_results
-                    folder_results.add(key_name.split(delimiter)[0])
+                    folder_results.add(key_name.split(delimiter)[0] + delimiter)
                 else:
                     key_results.add(key)
 

--- a/tests/test_s3/test_s3.py
+++ b/tests/test_s3/test_s3.py
@@ -496,7 +496,7 @@ def test_bucket_key_listing_order():
     # Test delimiter with no prefix
     delimiter = '/'
     keys = [x.name for x in bucket.list(prefix=None, delimiter=delimiter)]
-    keys.should.equal(['toplevel'])
+    keys.should.equal(['toplevel/'])
 
     delimiter = None
     keys = [x.name for x in bucket.list(prefix + 'x', delimiter)]

--- a/tests/test_s3bucket_path/test_s3bucket_path.py
+++ b/tests/test_s3bucket_path/test_s3bucket_path.py
@@ -272,7 +272,7 @@ def test_bucket_key_listing_order():
     # Test delimiter with no prefix
     delimiter = '/'
     keys = [x.name for x in bucket.list(prefix=None, delimiter=delimiter)]
-    keys.should.equal(['toplevel'])
+    keys.should.equal(['toplevel/'])
 
     delimiter = None
     keys = [x.name for x in bucket.list(prefix + 'x', delimiter)]


### PR DESCRIPTION
This matches actual AWS results, the behavior in the [`if prefix` branch](https://github.com/jbalogh/moto/blob/c7bf6ffc91b378a14c653d6cbf7594f379e38504/moto/s3/models.py#L329), and the [docs](http://docs.aws.amazon.com/AmazonS3/latest/dev/ListingKeysHierarchy.html) which say:

> Amazon S3 groups these keys and return a single CommonPrefixes element with prefix value photos/ that is a substring from the beginning of these keys to the first occurrence of the specified delimiter.