### PR TITLE
Make RDS interface work with us-east-1 region

### DIFF
--- a/moto/rds/urls.py
+++ b/moto/rds/urls.py
@@ -2,7 +2,7 @@ from __future__ import unicode_literals
 from .responses import RDSResponse
 
 url_bases = [
-    "https?://rds.(.+).amazonaws.com",
+    "https?://rds(\..+)?.amazonaws.com",
 ]
 
 url_paths = {


### PR DESCRIPTION
At the moment moto does not work with us-east-1 because boto endpoint does not specify that region: https://github.com/boto/boto/blob/e271ff09364ea18d9d8b6f4d63d6b0ac6cbc9b75/boto/endpoints.json#L285

This pull request fixes that issue by changing the RDS regex pattern to have the region as an optional value.