### PR TITLE
Add StorageType and Iops elements to DBInstance XML response

### DIFF
--- a/moto/rds/models.py
+++ b/moto/rds/models.py
@@ -199,6 +199,12 @@ class Database(object):
               <PubliclyAccessible>{{ database.publicly_accessible }}</PubliclyAccessible>
               <AutoMinorVersionUpgrade>{{ database.auto_minor_version_upgrade }}</AutoMinorVersionUpgrade>
               <AllocatedStorage>{{ database.allocated_storage }}</AllocatedStorage>
+              {% if database.iops %}
+              <Iops>{{ database.iops }}</Iops>
+              <StorageType>io1</StorageType>
+              {% else %}
+              <StorageType>{{ database.storage_type }}</StorageType>
+              {% endif %}
               <DBInstanceClass>{{ database.db_instance_class }}</DBInstanceClass>
               <MasterUsername>{{ database.master_username }}</MasterUsername>
               <Endpoint>

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -26,19 +26,6 @@ class requires_boto_gte(object):
         return skip_test
 
 
-class requires_boto_lte(object):
-    """Decorator for requiring boto version lesser than or equal to 'version'"""
-    def __init__(self, version):
-        self.version = version
-
-    def __call__(self, test):
-        boto_version = version_tuple(boto.__version__)
-        required = version_tuple(self.version)
-        if boto_version <= required:
-            return test
-        return skip_test
-
-
 class disable_on_py3(object):
     def __call__(self, test):
         if not six.PY3:

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -26,6 +26,19 @@ class requires_boto_gte(object):
         return skip_test
 
 
+class requires_boto_lte(object):
+    """Decorator for requiring boto version lesser than or equal to 'version'"""
+    def __init__(self, version):
+        self.version = version
+
+    def __call__(self, test):
+        boto_version = version_tuple(boto.__version__)
+        required = version_tuple(self.version)
+        if boto_version <= required:
+            return test
+        return skip_test
+
+
 class disable_on_py3(object):
     def __call__(self, test):
         if not six.PY3:

--- a/tests/test_rds/test_rds.py
+++ b/tests/test_rds/test_rds.py
@@ -6,7 +6,7 @@ from boto.exception import BotoServerError
 import sure  # noqa
 
 from moto import mock_ec2, mock_rds
-from tests.helpers import disable_on_py3, requires_boto_lte
+from tests.helpers import disable_on_py3
 
 
 @disable_on_py3()
@@ -259,7 +259,6 @@ def test_connecting_to_us_east_1():
     database.security_groups[0].name.should.equal('my_sg')
 
 
-@requires_boto_lte('2.36.0')
 @disable_on_py3()
 @mock_rds
 def test_create_database_with_iops():
@@ -269,4 +268,5 @@ def test_create_database_with_iops():
 
     database.status.should.equal('available')
     database.iops.should.equal(6000)
+    # boto>2.36.0 may change the following property name to `storage_type`
     database.StorageType.should.equal('io1')


### PR DESCRIPTION
API Version 2014-10-31: http://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_DBInstance.html

Unfortunately boto does not support accessing StorageType through `storage_type` yet: https://github.com/boto/boto/issues/2923