### PR TITLE
Support for client supplied part order in multipart uploads

### DIFF
--- a/moto/core/exceptions.py
+++ b/moto/core/exceptions.py
@@ -1,0 +1,28 @@
+from werkzeug.exceptions import HTTPException
+from jinja2 import DictLoader, Environment
+
+
+ERROR_RESPONSE = u"""<?xml version="1.0" encoding="UTF-8"?>
+  <Response>
+    <Errors>
+      <Error>
+        <Code>{{code}}</Code>
+        <Message>{{message}}</Message>
+        {% block extra %}{% endblock %}
+      </Error>
+    </Errors>
+  <RequestID>7a62c49f-347e-4fc4-9331-6e8eEXAMPLE</RequestID>
+</Response>
+"""
+
+
+class RESTError(HTTPException):
+    templates = {
+        'error': ERROR_RESPONSE
+    }
+
+    def __init__(self, code, message, template='error', **kwargs):
+        super(RESTError, self).__init__()
+        env = Environment(loader=DictLoader(self.templates))
+        self.description = env.get_template(template).render(
+            code=code, message=message, **kwargs)

--- a/moto/ec2/exceptions.py
+++ b/moto/ec2/exceptions.py
@@ -1,13 +1,9 @@
 from __future__ import unicode_literals
-from werkzeug.exceptions import BadRequest
-from jinja2 import Template
+from moto.core.exceptions import RESTError
 
 
-class EC2ClientError(BadRequest):
-    def __init__(self, code, message):
-        super(EC2ClientError, self).__init__()
-        self.description = ERROR_RESPONSE_TEMPLATE.render(
-            code=code, message=message)
+class EC2ClientError(RESTError):
+    code = 400
 
 
 class DependencyViolationError(EC2ClientError):
@@ -306,17 +302,3 @@ class InvalidCIDRSubnetError(EC2ClientError):
             "InvalidParameterValue",
             "invalid CIDR subnet specification: {0}"
             .format(cidr))
-
-
-ERROR_RESPONSE = u"""<?xml version="1.0" encoding="UTF-8"?>
-  <Response>
-    <Errors>
-      <Error>
-        <Code>{{code}}</Code>
-        <Message>{{message}}</Message>
-      </Error>
-    </Errors>
-  <RequestID>7a62c49f-347e-4fc4-9331-6e8eEXAMPLE</RequestID>
-</Response>
-"""
-ERROR_RESPONSE_TEMPLATE = Template(ERROR_RESPONSE)

--- a/moto/s3/exceptions.py
+++ b/moto/s3/exceptions.py
@@ -38,3 +38,36 @@ class MissingBucket(BucketError):
             "NoSuchBucket",
             "The specified bucket does not exist",
             *args, **kwargs)
+
+
+class InvalidPartOrder(S3ClientError):
+    code = 400
+
+    def __init__(self, *args, **kwargs):
+        super(InvalidPartOrder, self).__init__(
+            "InvalidPartOrder",
+            ("The list of parts was not in ascending order. The parts "
+             "list must be specified in order by part number."),
+            *args, **kwargs)
+
+
+class InvalidPart(S3ClientError):
+    code = 400
+
+    def __init__(self, *args, **kwargs):
+        super(InvalidPart, self).__init__(
+            "InvalidPart",
+            ("One or more of the specified parts could not be found. "
+             "The part might not have been uploaded, or the specified "
+             "entity tag might not have matched the part's entity tag."),
+            *args, **kwargs)
+
+
+class EntityTooSmall(S3ClientError):
+    code = 400
+
+    def __init__(self, *args, **kwargs):
+        super(EntityTooSmall, self).__init__(
+            "EntityTooSmall",
+            "Your proposed upload is smaller than the minimum allowed object size.",
+            *args, **kwargs)

--- a/moto/s3/exceptions.py
+++ b/moto/s3/exceptions.py
@@ -1,9 +1,40 @@
 from __future__ import unicode_literals
+from moto.core.exceptions import RESTError
 
 
-class BucketAlreadyExists(Exception):
+ERROR_WITH_BUCKET_NAME = """{% extends 'error' %}
+{% block extra %}<BucketName>{{ bucket }}</BucketName>{% endblock %}
+"""
+
+
+class S3ClientError(RESTError):
     pass
 
 
-class MissingBucket(Exception):
-    pass
+class BucketError(S3ClientError):
+    def __init__(self, *args, **kwargs):
+        kwargs.setdefault('template', 'bucket_error')
+        self.templates['bucket_error'] = ERROR_WITH_BUCKET_NAME
+        super(BucketError, self).__init__(*args, **kwargs)
+
+
+class BucketAlreadyExists(BucketError):
+    code = 409
+
+    def __init__(self, *args, **kwargs):
+        super(BucketAlreadyExists, self).__init__(
+            "BucketAlreadyExists",
+            ("The requested bucket name is not available. The bucket "
+             "namespace is shared by all users of the system. Please "
+             "select a different name and try again"),
+            *args, **kwargs)
+
+
+class MissingBucket(BucketError):
+    code = 404
+
+    def __init__(self, *args, **kwargs):
+        super(MissingBucket, self).__init__(
+            "NoSuchBucket",
+            "The specified bucket does not exist",
+            *args, **kwargs)

--- a/moto/s3/models.py
+++ b/moto/s3/models.py
@@ -191,7 +191,7 @@ class S3Backend(BaseBackend):
 
     def create_bucket(self, bucket_name, region_name):
         if bucket_name in self.buckets:
-            raise BucketAlreadyExists()
+            raise BucketAlreadyExists(bucket=bucket_name)
         new_bucket = FakeBucket(name=bucket_name, region_name=region_name)
         self.buckets[bucket_name] = new_bucket
         return new_bucket
@@ -203,7 +203,7 @@ class S3Backend(BaseBackend):
         try:
             return self.buckets[bucket_name]
         except KeyError:
-            raise MissingBucket()
+            raise MissingBucket(bucket=bucket_name)
 
     def delete_bucket(self, bucket_name):
         bucket = self.get_bucket(bucket_name)

--- a/tests/test_s3/test_s3.py
+++ b/tests/test_s3/test_s3.py
@@ -176,9 +176,9 @@ def test_multipart_invalid_order():
     # last part, can be less than 5 MB
     part2 = b'1'
     etag2 = multipart.upload_part_from_file(BytesIO(part2), 2).etag
-    xml = "<Part><PartNumber>{}</PartNumber><ETag>{}</ETag></Part>"
+    xml = "<Part><PartNumber>{0}</PartNumber><ETag>{1}</ETag></Part>"
     xml = xml.format(2, etag2) + xml.format(1, etag1)
-    xml = "<CompleteMultipartUpload>{}</CompleteMultipartUpload>".format(xml)
+    xml = "<CompleteMultipartUpload>{0}</CompleteMultipartUpload>".format(xml)
     bucket.complete_multipart_upload.when.called_with(
         multipart.key_name, multipart.id, xml).should.throw(S3ResponseError)
 


### PR DESCRIPTION
The multipart code ignores the request body when completing a multipart upload and just assume the client wants all the parts it uploaded (and in that order). This PR adds support for using and validating the request body which contains the list of parts that should be included (possibly a subset of total uploaded parts).

I have also done some refactoring in the REST error code generation, inspired by the work done in the ec2 backend.

Last, I have a commit, not pushed yet, that patches the S3 backend during the multipart tests so that the minimum part size is smaller (e.g. 256 bytes instead of 5 MB). This speeds the tests up significantly. Do you think it's a good idea? If so, I'll push it here.