### PR TITLE
Escaping tags individually for building the describe_tags template

### DIFF
--- a/moto/ec2/responses/tags.py
+++ b/moto/ec2/responses/tags.py
@@ -1,7 +1,10 @@
 from __future__ import unicode_literals
+from jinja2 import Template
+
 from moto.core.responses import BaseResponse
 from moto.ec2.models import validate_resource_ids
 from moto.ec2.utils import sequence_from_querystring, tags_from_query_string, filters_from_querystring
+from xml.sax.saxutils import escape
 
 
 class TagResponse(BaseResponse):
@@ -24,7 +27,9 @@ class TagResponse(BaseResponse):
     def describe_tags(self):
         filters = filters_from_querystring(querystring_dict=self.querystring)
         tags = self.ec2_backend.describe_tags(filters=filters)
-        template = self.response_template(DESCRIBE_RESPONSE)
+        for tag in tags:
+            tag['value'] = escape(tag['value'])
+        template = Template(DESCRIBE_RESPONSE)
         return template.render(tags=tags)
 
 


### PR DESCRIPTION
Calling "get_all_tags" of an ec2 connection fails, because the template doesn't get escaped. Iterating through the results to escape them individually. Issue happens when using tags including special characters.