### PR TITLE
allow running mock_s3 and mock_s3bucket_path one after the other

### DIFF
--- a/moto/core/models.py
+++ b/moto/core/models.py
@@ -61,6 +61,7 @@ class MockAWS(object):
 
         if self.__class__.nested_count == 0:
             HTTPretty.disable()
+            HTTPretty.reset()
 
     def decorate_callable(self, func):
         def wrapper(*args, **kwargs):

--- a/tests/test_s3bucket_path/test_s3bucket_path_combo.py
+++ b/tests/test_s3bucket_path/test_s3bucket_path_combo.py
@@ -1,0 +1,25 @@
+from __future__ import unicode_literals
+
+import boto
+from boto.s3.connection import OrdinaryCallingFormat
+
+from moto import mock_s3bucket_path, mock_s3
+
+
+def create_connection(key=None, secret=None):
+    return boto.connect_s3(key, secret, calling_format=OrdinaryCallingFormat())
+
+
+def test_bucketpath_combo_serial():
+    @mock_s3bucket_path
+    def make_bucket_path():
+        conn = create_connection()
+        conn.create_bucket('mybucketpath')
+
+    @mock_s3
+    def make_bucket():
+        conn = boto.connect_s3('the_key', 'the_secret')
+        conn.create_bucket('mybucket')
+
+    make_bucket()
+    make_bucket_path()


### PR DESCRIPTION
Trying to get the full test suite running for me, and I've ran into some issues. One, fixed for me with this PR, is that the s3bucket_path tests all fail when run together with the s3 tests. The reason is that the URL patterns between them conflict in some cases (such as listing all buckets). If someone is using moto to test code that needs to handle both calling formats then they might have to do call reset on the backend manually. Instead I thought we could just call it when disabling the backend. I added a test case so you can see the problem.

Also, is there any reason there are no `__init__.py` files in the test suite? If I want to run a specific test I have to `touch` the needed files for `nose` to find the module.