### PR TITLE
Fix handling of bucket versioning for moto_server

### DIFF
--- a/moto/s3/responses.py
+++ b/moto/s3/responses.py
@@ -137,8 +137,14 @@ class ResponseObject(_TemplateEnvironmentMixin):
         )
 
     def _bucket_response_put(self, request, region_name, bucket_name, querystring, headers):
+        if hasattr(request, 'body'):
+            # Boto
+            body = request.body
+        else:
+            # Flask server
+            body = request.data
         if 'versioning' in querystring:
-            ver = re.search('<Status>([A-Za-z]+)</Status>', request.body.decode('utf-8'))
+            ver = re.search('<Status>([A-Za-z]+)</Status>', body.decode('utf-8'))
             if ver:
                 self.backend.set_bucket_versioning(bucket_name, ver.group(1))
                 template = self.response_template(S3_BUCKET_VERSIONING)

--- a/tests/test_s3/test_server.py
+++ b/tests/test_s3/test_server.py
@@ -39,6 +39,16 @@ def test_s3_server_bucket_create():
     res.data.should.equal(b"test value")
 
 
+def test_s3_server_bucket_versioning():
+    backend = server.create_backend_app("s3")
+    test_client = backend.test_client()
+
+    # Just enough XML to enable versioning
+    body = '<Status>Enabled</Status>'
+    res = test_client.put('/?versioning', 'http://foobaz.localhost:5000', data=body)
+    res.status_code.should.equal(200)
+
+
 def test_s3_server_post_to_bucket():
     backend = server.create_backend_app("s3")
     test_client = backend.test_client()


### PR DESCRIPTION
The code that handles parsing the the PUT body assumes that the data is stored on `request.body`. However, moto_server uses Flask and data from a PUT request is on `request.data`. 