### PR TITLE
Support tag-key, tag-value and instance_type filters (second try)

### DIFF
--- a/moto/ec2/utils.py
+++ b/moto/ec2/utils.py
@@ -310,7 +310,9 @@ def get_object_value(obj, attr):
 
 
 def is_tag_filter(filter_name):
-    return filter_name.startswith('tag:')
+    return (filter_name.startswith('tag:') or 
+            filter_name.startswith('tag-value') or
+            filter_name.startswith('tag-key'))
 
 
 def get_obj_tag(obj, filter_name):
@@ -318,10 +320,24 @@ def get_obj_tag(obj, filter_name):
     tags = dict((tag['key'], tag['value']) for tag in obj.get_tags())
     return tags.get(tag_name)
 
+def get_obj_tag_names(obj):
+    tags = set((tag['key'] for tag in obj.get_tags()))
+    return tags
+
+def get_obj_tag_values(obj):
+    tags = set((tag['value'] for tag in obj.get_tags()))
+    return tags
 
 def tag_filter_matches(obj, filter_name, filter_values):
-    tag_value = get_obj_tag(obj, filter_name)
-    return tag_value in filter_values
+    if filter_name == 'tag-key':
+        tag_names = get_obj_tag_names(obj)
+        return len(set(filter_values).intersection(tag_names)) > 0
+    elif filter_name == 'tag-value':
+        tag_values = get_obj_tag_values(obj)
+        return len(set(filter_values).intersection(tag_values)) > 0
+    else:
+        tag_value = get_obj_tag(obj, filter_name)
+        return tag_value in filter_values
 
 
 filter_dict_attribute_mapping = {
@@ -331,7 +347,7 @@ filter_dict_attribute_mapping = {
     'source-dest-check': 'source_dest_check',
     'vpc-id': 'vpc_id',
     'group-id': 'security_groups',
-    'instance.group-id': 'security_groups'
+    'instance.group-id': 'security_groups',
 }
 
 

--- a/moto/ec2/utils.py
+++ b/moto/ec2/utils.py
@@ -348,6 +348,7 @@ filter_dict_attribute_mapping = {
     'vpc-id': 'vpc_id',
     'group-id': 'security_groups',
     'instance.group-id': 'security_groups',
+    'instance-type': 'instance_type'
 }
 
 

--- a/tests/test_ec2/test_instances.py
+++ b/tests/test_ec2/test_instances.py
@@ -155,8 +155,8 @@ def test_get_instances_filtering_by_instance_type():
     reservations.should.have.length_of(2)
     reservations[0].instances.should.have.length_of(1)
     reservations[1].instances.should.have.length_of(1)
-    reservations[0].instances[0].id.should.equal(instance1.id)
-    reservations[1].instances[0].id.should.equal(instance2.id)
+    instance_ids = [ reservations[0].instances[0].id, reservations[1].instances[0].id ]
+    set(instance_ids).should.equal(set([instance1.id, instance2.id]))
 
     reservations = conn.get_all_instances(filters={'instance-type': 't1.micro'})
     # get_all_instances should return one
@@ -169,9 +169,12 @@ def test_get_instances_filtering_by_instance_type():
     reservations[0].instances.should.have.length_of(1)
     reservations[1].instances.should.have.length_of(1)
     reservations[2].instances.should.have.length_of(1)
-    reservations[0].instances[0].id.should.equal(instance1.id)
-    reservations[1].instances[0].id.should.equal(instance3.id)
-    reservations[2].instances[0].id.should.equal(instance2.id)
+    instance_ids = [
+        reservations[0].instances[0].id,
+        reservations[1].instances[0].id,
+        reservations[2].instances[0].id,
+        ]
+    set(instance_ids).should.equal(set([instance1.id, instance2.id, instance3.id]))
 
     reservations = conn.get_all_instances(filters={'instance-type': 'bogus'})
     #bogus instance-type should return none

--- a/tests/test_ec2/test_instances.py
+++ b/tests/test_ec2/test_instances.py
@@ -155,7 +155,8 @@ def test_get_instances_filtering_by_instance_type():
     reservations.should.have.length_of(2)
     reservations[0].instances.should.have.length_of(1)
     reservations[1].instances.should.have.length_of(1)
-    instance_ids = [ reservations[0].instances[0].id, reservations[1].instances[0].id ]
+    instance_ids = [ reservations[0].instances[0].id, 
+                     reservations[1].instances[0].id ]
     set(instance_ids).should.equal(set([instance1.id, instance2.id]))
 
     reservations = conn.get_all_instances(filters={'instance-type': 't1.micro'})

--- a/tests/test_ec2/test_instances.py
+++ b/tests/test_ec2/test_instances.py
@@ -241,6 +241,42 @@ def test_get_instances_filtering_by_tag():
     reservations[0].instances[1].id.should.equal(instance3.id)
 
 @mock_ec2
+def test_get_instances_filtering_by_tag_name():
+    conn = boto.connect_ec2()
+    reservation = conn.run_instances('ami-1234abcd', min_count=3)
+    instance1, instance2, instance3 = reservation.instances
+    instance1.add_tag('tag1')
+    instance1.add_tag('tag2')
+    instance2.add_tag('tag1')
+    instance2.add_tag('tag2X')
+    instance3.add_tag('tag3')
+
+    reservations = conn.get_all_instances(filters={'tag-key' : 'tagX'})
+    # get_all_instances should return no instances
+    reservations.should.have.length_of(0)
+
+    reservations = conn.get_all_instances(filters={'tag-key' : 'tag1'})
+    # get_all_instances should return both instances with this tag value
+    reservations.should.have.length_of(1)
+    reservations[0].instances.should.have.length_of(2)
+    reservations[0].instances[0].id.should.equal(instance1.id)
+    reservations[0].instances[1].id.should.equal(instance2.id)
+
+    reservations = conn.get_all_instances(filters={'tag-key' : 'tag1', 'tag-key' : 'tag2'})
+    # get_all_instances should return the instance with both tag values
+    reservations.should.have.length_of(1)
+    reservations[0].instances.should.have.length_of(1)
+    reservations[0].instances[0].id.should.equal(instance1.id)
+
+    reservations = conn.get_all_instances(filters={'tag-key' : ['tag1', 'tag3']})
+    # get_all_instances should return both instances with one of the acceptable tag values
+    reservations.should.have.length_of(1)
+    reservations[0].instances.should.have.length_of(3)
+    reservations[0].instances[0].id.should.equal(instance1.id)
+    reservations[0].instances[1].id.should.equal(instance2.id)
+    reservations[0].instances[2].id.should.equal(instance3.id)
+
+@mock_ec2
 def test_instance_start_and_stop():
     conn = boto.connect_ec2('the_key', 'the_secret')
     reservation = conn.run_instances('ami-1234abcd', min_count=2)


### PR DESCRIPTION
I added support for the instance filters listed above, including tests.

This time I've verified that travis-ci passes.  Sorry, I've never contributed to a project using travis-ci before. I needed to rewrite the failed test.  Thanks!