### PR TITLE
Change SecurityGroupBackend.{authorize,revoke}_security_group_ingress() methods to receive group name or id, never both

### DIFF
--- a/moto/ec2/responses/security_groups.py
+++ b/moto/ec2/responses/security_groups.py
@@ -4,14 +4,10 @@ from moto.ec2.utils import filters_from_querystring
 
 
 def process_rules_from_querystring(querystring):
-
-    name = None
-    group_id = None
-
     try:
-        name = querystring.get('GroupName')[0]
+        group_name_or_id = querystring.get('GroupName')[0]
     except:
-        group_id = querystring.get('GroupId')[0]
+        group_name_or_id = querystring.get('GroupId')[0]
 
     ip_protocol = querystring.get('IpPermissions.1.IpProtocol')[0]
     from_port = querystring.get('IpPermissions.1.FromPort')[0]
@@ -30,7 +26,7 @@ def process_rules_from_querystring(querystring):
         elif 'IpPermissions.1.Groups' in key:
             source_groups.append(value[0])
 
-    return (name, group_id, ip_protocol, from_port, to_port, ip_ranges, source_groups, source_group_ids)
+    return (group_name_or_id, ip_protocol, from_port, to_port, ip_ranges, source_groups, source_group_ids)
 
 
 class SecurityGroups(BaseResponse):

--- a/tests/test_cloudformation/test_cloudformation_stack_integration.py
+++ b/tests/test_cloudformation/test_cloudformation_stack_integration.py
@@ -1128,3 +1128,69 @@ def test_security_group_ingress_separate_from_security_group_by_id():
     security_group1.rules[0].ip_protocol.should.equal('tcp')
     security_group1.rules[0].from_port.should.equal('80')
     security_group1.rules[0].to_port.should.equal('8080')
+
+
+@mock_cloudformation
+@mock_ec2
+def test_security_group_ingress_separate_from_security_group_by_id_using_vpc():
+    vpc_conn = boto.vpc.connect_to_region("us-west-1")
+    vpc = vpc_conn.create_vpc("10.0.0.0/16")
+
+    template = {
+        "AWSTemplateFormatVersion": "2010-09-09",
+        "Resources": {
+            "test-security-group1": {
+                "Type": "AWS::EC2::SecurityGroup",
+                "Properties": {
+                    "GroupDescription": "test security group",
+                    "VpcId": vpc.id,
+                    "Tags": [
+                        {
+                            "Key": "sg-name",
+                            "Value": "sg1"
+                        }
+                    ]
+                },
+            },
+            "test-security-group2": {
+                "Type": "AWS::EC2::SecurityGroup",
+                "Properties": {
+                    "GroupDescription": "test security group",
+                    "VpcId": vpc.id,
+                    "Tags": [
+                        {
+                            "Key": "sg-name",
+                            "Value": "sg2"
+                        }
+                    ]
+                },
+            },
+            "test-sg-ingress": {
+                "Type": "AWS::EC2::SecurityGroupIngress",
+                "Properties": {
+                    "GroupId": {"Ref": "test-security-group1"},
+                    "VpcId": vpc.id,
+                    "IpProtocol": "tcp",
+                    "FromPort": "80",
+                    "ToPort": "8080",
+                    "SourceSecurityGroupId": {"Ref": "test-security-group2"},
+                }
+            }
+        }
+    }
+
+    template_json = json.dumps(template)
+    cf_conn = boto.cloudformation.connect_to_region("us-west-1")
+    cf_conn.create_stack(
+        "test_stack",
+        template_body=template_json,
+    )
+    security_group1 = vpc_conn.get_all_security_groups(filters={"tag:sg-name": "sg1"})[0]
+    security_group2 = vpc_conn.get_all_security_groups(filters={"tag:sg-name": "sg2"})[0]
+
+    security_group1.rules.should.have.length_of(1)
+    security_group1.rules[0].grants.should.have.length_of(1)
+    security_group1.rules[0].grants[0].group_id.should.equal(security_group2.id)
+    security_group1.rules[0].ip_protocol.should.equal('tcp')
+    security_group1.rules[0].from_port.should.equal('80')
+    security_group1.rules[0].to_port.should.equal('8080')


### PR DESCRIPTION
this fixes a problem with cloudformation and security groups. The test in this PR was failing with this traceback:
```
======================================================================
ERROR: tests.test_cloudformation.test_cloudformation_stack_integration.test_security_group_ingress_separate_from_security_group_by_id_using_vpc
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/hugo/.virtualenvs/moto/lib/python2.7/site-packages/nose/case.py", line 197, in runTest
    self.test(*self.arg)
  File "/Users/hugo/yipit-stuff/moto/moto/core/models.py", line 69, in wrapper
    result = func(*args, **kwargs)
  File "/Users/hugo/yipit-stuff/moto/moto/core/models.py", line 69, in wrapper
    result = func(*args, **kwargs)
  File "/Users/hugo/yipit-stuff/moto/tests/test_cloudformation/test_cloudformation_stack_integration.py", line 1186, in test_security_group_ingress_separate_from_security_group_by_id_using_vpc
    template_body=template_json,
  File "/Users/hugo/.virtualenvs/moto/lib/python2.7/site-packages/boto/cloudformation/connection.py", line 394, in create_stack
    body = self._do_request('CreateStack', params, '/', 'POST')
  File "/Users/hugo/.virtualenvs/moto/lib/python2.7/site-packages/boto/cloudformation/connection.py", line 287, in _do_request
    response = self.make_request(call, params, path, method)
  File "/Users/hugo/.virtualenvs/moto/lib/python2.7/site-packages/boto/connection.py", line 1115, in make_request
    return self._mexe(http_request)
  File "/Users/hugo/.virtualenvs/moto/lib/python2.7/site-packages/boto/connection.py", line 943, in _mexe
    response = connection.getresponse()
  File "/usr/local/Cellar/python/2.7.6/Frameworks/Python.framework/Versions/2.7/lib/python2.7/httplib.py", line 1043, in getresponse
    response = self.response_class(*args, **kwds)
  File "/Users/hugo/.virtualenvs/moto/lib/python2.7/site-packages/boto/connection.py", line 390, in __init__
    http_client.HTTPResponse.__init__(self, *args, **kwargs)
  File "/usr/local/Cellar/python/2.7.6/Frameworks/Python.framework/Versions/2.7/lib/python2.7/httplib.py", line 346, in __init__
    self.fp = sock.makefile('rb', 0)
  File "/Users/hugo/.virtualenvs/moto/lib/python2.7/site-packages/httpretty-0.8.0-py2.7.egg/httpretty/core.py", line 312, in makefile
    self._entry.fill_filekind(self.fd)
  File "/Users/hugo/.virtualenvs/moto/lib/python2.7/site-packages/httpretty-0.8.0-py2.7.egg/httpretty/core.py", line 562, in fill_filekind
    status, headers, self.body = self.callable_body(self.request, self.info.full_url(), headers)
  File "/Users/hugo/yipit-stuff/moto/moto/core/responses.py", line 124, in dispatch
    return self.call_action()
  File "/Users/hugo/yipit-stuff/moto/moto/core/responses.py", line 140, in call_action
    response = method()
  File "/Users/hugo/yipit-stuff/moto/moto/cloudformation/responses.py", line 46, in create_stack
    notification_arns=stack_notification_arns
  File "/Users/hugo/yipit-stuff/moto/moto/cloudformation/models.py", line 58, in create_stack
    notification_arns=notification_arns,
  File "/Users/hugo/yipit-stuff/moto/moto/cloudformation/models.py", line 26, in __init__
    self.resource_map.create()
  File "/Users/hugo/yipit-stuff/moto/moto/cloudformation/parsing.py", line 316, in create
    self[resource]
  File "/Users/hugo/yipit-stuff/moto/moto/cloudformation/parsing.py", line 261, in __getitem__
    new_resource = parse_resource(resource_logical_id, resource_json, self, self._region_name)
  File "/Users/hugo/yipit-stuff/moto/moto/cloudformation/parsing.py", line 186, in parse_resource
    resource = resource_class.create_from_cloudformation_json(resource_name, resource_json, region_name)
  File "/Users/hugo/yipit-stuff/moto/moto/ec2/models.py", line 1350, in create_from_cloudformation_json
    source_group_names=source_security_group_names,
  File "/Users/hugo/yipit-stuff/moto/moto/ec2/models.py", line 1261, in authorize_security_group_ingress
    group.ingress_rules.append(security_rule)
AttributeError: 'NoneType' object has no attribute 'ingress_rules'
```