### PR TITLE
Fix reduced_min_part_size so that tests run

### DIFF
--- a/tests/test_s3/test_s3.py
+++ b/tests/test_s3/test_s3.py
@@ -3,6 +3,7 @@
 from __future__ import unicode_literals
 from six.moves.urllib.request import urlopen
 from six.moves.urllib.error import HTTPError
+from functools import wraps
 from io import BytesIO
 
 import boto
@@ -29,6 +30,7 @@ def reduced_min_part_size(f):
     import moto.s3.models as s3model
     orig_size = s3model.UPLOAD_PART_MIN_SIZE
 
+    @wraps(f)
     def wrapped(*args, **kwargs):
         try:
             s3model.UPLOAD_PART_MIN_SIZE = REDUCED_PART_SIZE


### PR DESCRIPTION
While writing a test for #324 I noticed that the tests using the new `reduced_min_part_size` decorator were not being run.

This fixes it and shows that `test_s3.test_multipart_etag` fails too:

```
======================================================================
FAIL: test_s3.test_multipart_etag
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/jean/ws/python/moto-env/lib/python2.7/site-packages/nose/case.py", line 197, in runTest
    self.test(*self.arg)
  File "/Users/jean/ws/src/moto/moto/core/models.py", line 69, in wrapper
    result = func(*args, **kwargs)
  File "/Users/jean/ws/src/moto/tests/test_s3/test_s3.py", line 37, in wrapped
    return f(*args, **kwargs)
  File "/Users/jean/ws/src/moto/tests/test_s3/test_s3.py", line 209, in test_multipart_etag
    '"140f92a6df9f9e415f74a1463bcee9bb-2"')
  File "/Users/jean/ws/python/moto-env/lib/python2.7/site-packages/sure/__init__.py", line 375, in wrapper
    value = func(self, *args, **kw)
  File "/Users/jean/ws/python/moto-env/lib/python2.7/site-packages/sure/__init__.py", line 615, in equal
    raise error
AssertionError: given
X = '"66d1a1a2ed08fd05c137f316af4ff255-2"'
    and
Y = u'"140f92a6df9f9e415f74a1463bcee9bb-2"'
X is '"66d1a1a2ed08fd05c137f316af4ff255-2"' whereas Y is u'"140f92a6df9f9e415f74a1463bcee9bb-2"'
```