### PR TITLE
allow starting without reseting

### DIFF
--- a/moto/core/models.py
+++ b/moto/core/models.py
@@ -29,10 +29,11 @@ class MockAWS(object):
     def __exit__(self, *args):
         self.stop()
 
-    def start(self):
+    def start(self, reset=True):
         self.__class__.nested_count += 1
-        for backend in self.backends.values():
-            backend.reset()
+        if reset:
+            for backend in self.backends.values():
+                backend.reset()
 
         if not HTTPretty.is_enabled():
             HTTPretty.enable()


### PR DESCRIPTION
The ultimate motivation for this is working around HTTPretty bugs that cause it to interfere with other network calls when moto is enabled, specifically [this](https://github.com/gabrielfalcao/HTTPretty/issues/182), [this](https://github.com/gabrielfalcao/HTTPretty/issues/65), etc. Relatedly https://github.com/spulec/moto/issues/303.

I'm using moto in some Big Fat Integration Tests™, and HTTPretty was causing other http calls in my tests to fail. Obviously the right thing to do is fix HTTPretty, but in the meantime I figured I would just `mock.patch` out my calls to functions that do S3 interaction so that they turn moto on and off before and after running respectively.

Unfortunately this doesn't work, since the backends get reset every time a `MockAWS` is `start`ed. For now I'm monkeypatching around this, but it would be nice to be able to do it explicitly.

I basically need the following to work:


```python

s3 = mock_s3()

s3.start()

conn = boto.connect_s3()
conn.create_bucket("test_bucket")

s3.stop()

# . . . other network calls that I need HTTPretty not to interfere with

s3.start(reset=False)

# . . . boto calls that use test_bucket

s3.stop()
```

I'm not attached to this interface, it was just the quickest way to get what I wanted. If you want me to change things / refactor I'm happy to do so.