### PR TITLE
Adding support for comments on hosted zones.

### DIFF
--- a/moto/route53/models.py
+++ b/moto/route53/models.py
@@ -106,9 +106,10 @@ class RecordSet(object):
 
 class FakeZone(object):
 
-    def __init__(self, name, id_):
+    def __init__(self, name, id_, comment=None):
         self.name = name
         self.id = id_
+        self.comment = comment
         self.rrsets = []
 
     def add_rrset(self, record_set):
@@ -170,9 +171,9 @@ class Route53Backend(BaseBackend):
         self.zones = {}
         self.health_checks = {}
 
-    def create_hosted_zone(self, name):
+    def create_hosted_zone(self, name, comment=None):
         new_id = get_random_hex()
-        new_zone = FakeZone(name, new_id)
+        new_zone = FakeZone(name, new_id, comment=comment)
         self.zones[new_id] = new_zone
         return new_zone
 

--- a/moto/route53/responses.py
+++ b/moto/route53/responses.py
@@ -9,7 +9,8 @@ def list_or_create_hostzone_response(request, full_url, headers):
 
     if request.method == "POST":
         elements = xmltodict.parse(request.body)
-        new_zone = route53_backend.create_hosted_zone(elements["CreateHostedZoneRequest"]["Name"])
+        comment = elements["CreateHostedZoneRequest"]["HostedZoneConfig"]["Comment"]
+        new_zone = route53_backend.create_hosted_zone(elements["CreateHostedZoneRequest"]["Name"], comment=comment)
         template = Template(CREATE_HOSTED_ZONE_RESPONSE)
         return 201, headers, template.render(zone=new_zone)
 
@@ -125,6 +126,9 @@ GET_HOSTED_ZONE_RESPONSE = """<GetHostedZoneResponse xmlns="https://route53.amaz
       <Id>/hostedzone/{{ zone.id }}</Id>
       <Name>{{ zone.name }}</Name>
       <ResourceRecordSetCount>{{ zone.rrsets|count }}</ResourceRecordSetCount>
+      <Config>
+        <Comment>{{ zone.comment }}</Comment>
+      </Config>
    </HostedZone>
    <DelegationSet>
          <NameServer>moto.test.com</NameServer>
@@ -150,6 +154,9 @@ LIST_HOSTED_ZONES_RESPONSE = """<ListHostedZonesResponse xmlns="https://route53.
       <HostedZone>
          <Id>{{ zone.id }}</Id>
          <Name>{{ zone.name }}</Name>
+         <Config>
+           <Comment>{{ zone.comment }}</Comment>
+         </Config>
          <ResourceRecordSetCount>{{ zone.rrsets|count  }}</ResourceRecordSetCount>
       </HostedZone>
       {% endfor %}

--- a/tests/test_route53/test_route53.py
+++ b/tests/test_route53/test_route53.py
@@ -166,3 +166,19 @@ def test_use_health_check_in_resource_record_set():
 
     record_sets = conn.get_all_rrsets(zone_id)
     record_sets[0].health_check.should.equal(check_id)
+
+@mock_route53
+def test_hosted_zone_comment_preserved():
+    conn = boto.connect_route53('the_key', 'the_secret')
+
+    firstzone = conn.create_hosted_zone("testdns.aws.com.", comment="test comment")
+    zone_id = firstzone["CreateHostedZoneResponse"]["HostedZone"]["Id"].split("/")[-1]
+
+    hosted_zone = conn.get_hosted_zone(zone_id)
+    hosted_zone["GetHostedZoneResponse"]["HostedZone"]["Config"]["Comment"].should.equal("test comment")
+
+    hosted_zones = conn.get_all_hosted_zones()
+    hosted_zones["ListHostedZonesResponse"]["HostedZones"][0]["Config"]["Comment"].should.equal("test comment")
+
+    zone = conn.get_zone("testdns.aws.com.")
+    zone.config["Comment"].should.equal("test comment")


### PR DESCRIPTION
Paired with @kpdonn

Route53 Hosted Zones can be created with a comment in boto. This is currently the only way to differentiate two hosted zones via boto when retrieving a list. Wanted to get support in this for moto.