### PR TITLE
Bad XML from S3_BUCKET_VERSIONING and S3_BUCKET_GET_VERSIONING

### DIFF
--- a/moto/s3/responses.py
+++ b/moto/s3/responses.py
@@ -551,15 +551,13 @@ S3_BUCKET_LIFECYCLE_CONFIGURATION = """<?xml version="1.0" encoding="UTF-8"?>
 </LifecycleConfiguration>
 """
 
-S3_BUCKET_VERSIONING = """
-<?xml version="1.0" encoding="UTF-8"?>
+S3_BUCKET_VERSIONING = """<?xml version="1.0" encoding="UTF-8"?>
 <VersioningConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
     <Status>{{ bucket_versioning_status }}</Status>
 </VersioningConfiguration>
 """
 
-S3_BUCKET_GET_VERSIONING = """
-<?xml version="1.0" encoding="UTF-8"?>
+S3_BUCKET_GET_VERSIONING = """<?xml version="1.0" encoding="UTF-8"?>
 {% if status is none %}
     <VersioningConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"/>
 {% else %}


### PR DESCRIPTION
The '<?xml version="1.0" encoding="UTF-8"?>' bit must be on the first line, but the templates used for versioning were generating strings that started with a newline