### PR TITLE
IAM: get_role should thrown when role is unexisting

### DIFF
--- a/moto/iam/models.py
+++ b/moto/iam/models.py
@@ -249,6 +249,7 @@ class IAMBackend(BaseBackend):
         for role in self.get_roles():
             if role.name == role_name:
                 return role
+        raise BotoServerError(404, 'Not Found')
 
     def get_roles(self):
         return self.roles.values()

--- a/tests/test_iam/test_iam.py
+++ b/tests/test_iam/test_iam.py
@@ -6,6 +6,7 @@ from nose.tools import assert_raises, assert_equals, assert_not_equals
 from boto.exception import BotoServerError
 import base64
 from moto import mock_iam
+from nose.tools import raises
 
 
 @mock_iam()
@@ -39,6 +40,12 @@ def test_upload_server_cert():
     cert.server_certificate_name.should.equal("certname")
     cert.arn.should.equal("arn:aws:iam::123456789012:server-certificate/certname")
 
+@mock_iam()
+@raises(BotoServerError)
+def test_get_role__should_throw__when_role_does_not_exist():
+    conn = boto.connect_iam()
+
+    conn.get_role('unexisting_role')
 
 @mock_iam()
 def test_create_role_and_instance_profile():


### PR DESCRIPTION
This better mimics the behaviour of Boto

