### PR TITLE
IAM: unnecessary check for role

### DIFF
--- a/moto/iam/models.py
+++ b/moto/iam/models.py
@@ -256,26 +256,17 @@ class IAMBackend(BaseBackend):
 
     def put_role_policy(self, role_name, policy_name, policy_json):
         role = self.get_role(role_name)
-        if role:
-            role.put_policy(policy_name, policy_json)
-        else:
-            raise BotoServerError(404, 'Not Found')
+        role.put_policy(policy_name, policy_json)
 
     def get_role_policy(self, role_name, policy_name):
         role = self.get_role(role_name)
-        if role:
-            for p, d in role.policies.items():
-                if p == policy_name:
-                    return p, d
-        else:
-            raise BotoServerError(404, 'Not Found')
+        for p, d in role.policies.items():
+            if p == policy_name:
+                return p, d
 
     def list_role_policies(self, role_name):
         role = self.get_role(role_name)
-        if role:
-            return role.policies.keys()
-        else:
-            raise BotoServerError(404, 'Not Found')
+        return role.policies.keys()
 
     def create_instance_profile(self, name, path, role_ids):
         instance_profile_id = random_resource_id()


### PR DESCRIPTION
The `if role` check is not necessary anymore, per #366.