### PR TITLE
Improves range request support.

### DIFF
--- a/moto/s3/responses.py
+++ b/moto/s3/responses.py
@@ -252,7 +252,7 @@ class ResponseObject(_TemplateEnvironmentMixin):
         toint = lambda i: int(i) if i else None
         begin, end = map(toint, rspec.split('-'))
         if begin is not None:  # byte range
-            end = last if end is None else end
+            end = last if end is None else min(end, last)
         elif end is not None:  # suffix byte range
             begin = length - end
             end = last

--- a/moto/s3/responses.py
+++ b/moto/s3/responses.py
@@ -258,7 +258,7 @@ class ResponseObject(_TemplateEnvironmentMixin):
             end = last
         else:
             return 400, headers, ""
-        if begin < 0 or end > length or begin > min(end, last):
+        if begin < 0 or end > last or begin > min(end, last):
             return 416, headers, ""
         headers['content-range'] = "bytes {0}-{1}/{2}".format(
             begin, end, length)

--- a/moto/s3/responses.py
+++ b/moto/s3/responses.py
@@ -254,7 +254,7 @@ class ResponseObject(_TemplateEnvironmentMixin):
         if begin is not None:  # byte range
             end = last if end is None else min(end, last)
         elif end is not None:  # suffix byte range
-            begin = length - end
+            begin = length - min(end, length)
             end = last
         else:
             return 400, headers, ""

--- a/tests/test_s3/test_s3.py
+++ b/tests/test_s3/test_s3.py
@@ -794,6 +794,7 @@ def test_ranged_get():
     key.get_contents_as_string(headers={'Range': 'bytes=0-'}).should.equal(rep * 10)
     key.get_contents_as_string(headers={'Range': 'bytes=0-99'}).should.equal(rep * 10)
     key.get_contents_as_string(headers={'Range': 'bytes=0-100'}).should.equal(rep * 10)
+    key.get_contents_as_string(headers={'Range': 'bytes=0-700'}).should.equal(rep * 10)
     key.get_contents_as_string(headers={'Range': 'bytes=0-0'}).should.equal(b'0')
     key.get_contents_as_string(headers={'Range': 'bytes=99-99'}).should.equal(b'9')
     key.get_contents_as_string(headers={'Range': 'bytes=50-54'}).should.equal(rep[:5])

--- a/tests/test_s3/test_s3.py
+++ b/tests/test_s3/test_s3.py
@@ -791,13 +791,35 @@ def test_ranged_get():
     key.key = 'bigkey'
     rep = b"0123456789"
     key.set_contents_from_string(rep * 10)
+
+    # Implicitly bounded range requests.
     key.get_contents_as_string(headers={'Range': 'bytes=0-'}).should.equal(rep * 10)
+    key.get_contents_as_string(headers={'Range': 'bytes=50-'}).should.equal(rep * 5)
+    key.get_contents_as_string(headers={'Range': 'bytes=99-'}).should.equal(rep[-1])
+
+    # Explicitly bounded range requests starting from the first byte.
+    key.get_contents_as_string(headers={'Range': 'bytes=0-0'}).should.equal(b'0')
+    key.get_contents_as_string(headers={'Range': 'bytes=0-49'}).should.equal(rep * 5)
     key.get_contents_as_string(headers={'Range': 'bytes=0-99'}).should.equal(rep * 10)
     key.get_contents_as_string(headers={'Range': 'bytes=0-100'}).should.equal(rep * 10)
     key.get_contents_as_string(headers={'Range': 'bytes=0-700'}).should.equal(rep * 10)
-    key.get_contents_as_string(headers={'Range': 'bytes=0-0'}).should.equal(b'0')
-    key.get_contents_as_string(headers={'Range': 'bytes=99-99'}).should.equal(b'9')
+
+    # Explicitly bounded range requests starting from the / a middle byte.
     key.get_contents_as_string(headers={'Range': 'bytes=50-54'}).should.equal(rep[:5])
-    key.get_contents_as_string(headers={'Range': 'bytes=50-'}).should.equal(rep * 5)
+    key.get_contents_as_string(headers={'Range': 'bytes=50-99'}).should.equal(rep * 5)
+    key.get_contents_as_string(headers={'Range': 'bytes=50-100'}).should.equal(rep * 5)
+    key.get_contents_as_string(headers={'Range': 'bytes=50-700'}).should.equal(rep * 5)
+
+    # Explicitly bounded range requests starting from the last byte.
+    key.get_contents_as_string(headers={'Range': 'bytes=99-99'}).should.equal(b'9')
+    key.get_contents_as_string(headers={'Range': 'bytes=99-100'}).should.equal(b'9')
+    key.get_contents_as_string(headers={'Range': 'bytes=99-700'}).should.equal(b'9')
+
+    # Suffix range requests.
+    key.get_contents_as_string(headers={'Range': 'bytes=-1'}).should.equal(rep[-1])
     key.get_contents_as_string(headers={'Range': 'bytes=-60'}).should.equal(rep * 6)
+    key.get_contents_as_string(headers={'Range': 'bytes=-100'}).should.equal(rep * 10)
+    key.get_contents_as_string(headers={'Range': 'bytes=-101'}).should.equal(rep * 10)
+    key.get_contents_as_string(headers={'Range': 'bytes=-700'}).should.equal(rep * 10)
+
     key.size.should.equal(100)

--- a/tests/test_s3/test_s3.py
+++ b/tests/test_s3/test_s3.py
@@ -793,6 +793,7 @@ def test_ranged_get():
     key.set_contents_from_string(rep * 10)
     key.get_contents_as_string(headers={'Range': 'bytes=0-'}).should.equal(rep * 10)
     key.get_contents_as_string(headers={'Range': 'bytes=0-99'}).should.equal(rep * 10)
+    key.get_contents_as_string(headers={'Range': 'bytes=0-100'}).should.equal(rep * 10)
     key.get_contents_as_string(headers={'Range': 'bytes=0-0'}).should.equal(b'0')
     key.get_contents_as_string(headers={'Range': 'bytes=99-99'}).should.equal(b'9')
     key.get_contents_as_string(headers={'Range': 'bytes=50-54'}).should.equal(rep[:5])

--- a/tests/test_s3/test_s3.py
+++ b/tests/test_s3/test_s3.py
@@ -795,7 +795,7 @@ def test_ranged_get():
     # Implicitly bounded range requests.
     key.get_contents_as_string(headers={'Range': 'bytes=0-'}).should.equal(rep * 10)
     key.get_contents_as_string(headers={'Range': 'bytes=50-'}).should.equal(rep * 5)
-    key.get_contents_as_string(headers={'Range': 'bytes=99-'}).should.equal(rep[-1])
+    key.get_contents_as_string(headers={'Range': 'bytes=99-'}).should.equal(b'9')
 
     # Explicitly bounded range requests starting from the first byte.
     key.get_contents_as_string(headers={'Range': 'bytes=0-0'}).should.equal(b'0')
@@ -816,7 +816,7 @@ def test_ranged_get():
     key.get_contents_as_string(headers={'Range': 'bytes=99-700'}).should.equal(b'9')
 
     # Suffix range requests.
-    key.get_contents_as_string(headers={'Range': 'bytes=-1'}).should.equal(rep[-1])
+    key.get_contents_as_string(headers={'Range': 'bytes=-1'}).should.equal(b'9')
     key.get_contents_as_string(headers={'Range': 'bytes=-60'}).should.equal(rep * 6)
     key.get_contents_as_string(headers={'Range': 'bytes=-100'}).should.equal(rep * 10)
     key.get_contents_as_string(headers={'Range': 'bytes=-101'}).should.equal(rep * 10)


### PR DESCRIPTION
Just a couple small modifications to range request handling.

The current implementation of range request handling raises errors on byte-range-spec range requests with explicit last-byte-pos that are greater than or equal to the length of the underlying data. The expected behavior of such a request is that it will be interpreted as a request for all remaining bytes after and including the first-byte-pos, similar to a byte-range-spec range request where no last-byte-pos was specified.

Likewise, suffix-byte-range-spec range requests with last-byte-pos that are greater than the length of the underlying data raise errors. The expected behavior of such a request is that it will be interpreted as a request for the entire length of the data.

These behaviors are also observable using AWS S3. You can find this described in RFC 7233 section 2.1, and the older RFC 2616 section 14.3.1 that is referenced in the AWS S3 specs.

This also adds a couple tests for different range requests, checks for some off-by-one errors and groups the individual tests by what they're looking for.

Thanks!  o7