### PR TITLE
Adds the ConditionalCheckFailedException to put_item

### DIFF
--- a/moto/dynamodb2/models.py
+++ b/moto/dynamodb2/models.py
@@ -220,7 +220,7 @@ class Table(object):
             else:
                 current_attr = current
 
-            for key, val in expected.iteritems():
+            for key, val in expected.items():
                 if 'Exists' in val and val['Exists'] == False:
                     if key in current_attr:
                         raise ValueError("The conditional request failed")

--- a/moto/dynamodb2/responses.py
+++ b/moto/dynamodb2/responses.py
@@ -134,7 +134,17 @@ class DynamoHandler(BaseResponse):
     def put_item(self):
         name = self.body['TableName']
         item = self.body['Item']
-        result = dynamodb_backend2.put_item(name, item)
+        overwrite = 'Expected' not in self.body
+        if not overwrite:
+            expected = self.body['Expected']
+        else:
+            expected = None
+
+        try:
+            result = dynamodb_backend2.put_item(name, item, expected, overwrite)
+        except Exception:
+            er = 'com.amazonaws.dynamodb.v20111205#ConditionalCheckFailedException'
+            return self.error(er)
 
         if result:
             item_dict = result.to_json()


### PR DESCRIPTION
If the Item‘s original data is inconsistent with what's in DynamoDB,
the request should fail (unless overwrite is set to True).

http://boto.readthedocs.org/en/latest/ref/dynamodb2.html#boto.dynamodb2.table.Table.put_item