### PR TITLE
Make EMR multi region

### DIFF
--- a/moto/emr/__init__.py
+++ b/moto/emr/__init__.py
@@ -1,3 +1,12 @@
 from __future__ import unicode_literals
-from .models import emr_backend
-mock_emr = emr_backend.decorator
+from .models import emr_backends
+from ..core.models import MockAWS
+
+emr_backend = emr_backends['us-east-1']
+
+
+def mock_emr(func=None):
+    if func:
+        return MockAWS(emr_backends)(func)
+    else:
+        return MockAWS(emr_backends)


### PR DESCRIPTION
@spulec 

This pr makes EMR mock support multi region.
https://github.com/spulec/moto/issues/347

Note:
Since this issue https://github.com/boto/boto/pull/3186 can't be resolved, moto's EMR multi region can only support ```us-east-1``` and ```eu-west-1```. These two regions are only regions which have compatible endpoints (```elasticmapreduce.eu-west-1.amazonaws.com``` and ```elasticmapreduce.us-east-1.amazonaws.com```) with moto's ```emr/urls.py```. However, we can use other regions with moto when boto3 is used instead of boto. 