### PR TITLE
Fixed regex

### DIFF
--- a/moto/s3/urls.py
+++ b/moto/s3/urls.py
@@ -2,7 +2,7 @@ from __future__ import unicode_literals
 from .responses import S3ResponseInstance
 
 url_bases = [
-    "https?://(?P<bucket_name>[a-zA-Z0-9\-_.]*)\.?s3(.*).amazonaws.com"
+    "https?://(?P<bucket_name>[a-zA-Z0-9\-_.]+)\.s3(.*).amazonaws.com"
 ]
 
 url_paths = {


### PR DESCRIPTION
The regex in url_bases in moto.s3.urls was too broad. Bucket names cannot be zero characters, and the dot separating the bucket name from the rest of the domain name is not optional. This overly-broad regex caused URLs that should have gone to the moto.s3bucket_path backend go to the moto.s3 backend instead.
