### PR TITLE
Use extras_require to build a wheel usable on Python 2.6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,11 +13,10 @@ install_requires = [
     "werkzeug",
 ]
 
-import sys
-
-if sys.version_info < (2, 7):
-    # No buildint OrderedDict before 2.7
-    install_requires.append('ordereddict')
+extras_require = {
+    # No builtin OrderedDict before 2.7
+    ':python_version=="2.6"': ['ordereddict'],
+}
 
 setup(
     name='moto',
@@ -34,6 +33,7 @@ setup(
     },
     packages=find_packages(exclude=("tests", "tests.*")),
     install_requires=install_requires,
+    extras_require=extras_require,
     license="Apache",
     test_suite="tests",
     classifiers=[


### PR DESCRIPTION
By using PEP 426 markers with `extras_require` in `setup.py`, wheel can parse the marker and install ordereddict only on Python 2.6.

ref: https://wheel.readthedocs.org/en/latest/#defining-conditional-dependencies

Fixes #340.