### PR TITLE
Return messages once they are gathered

### DIFF
--- a/moto/sqs/models.py
+++ b/moto/sqs/models.py
@@ -281,7 +281,7 @@ class SQSBackend(BaseBackend):
                 if len(result) >= count:
                     break
 
-            if time.time() > polling_end:
+            if result or time.time() > polling_end:
                 break
 
         return result

--- a/tests/test_sqs/test_server.py
+++ b/tests/test_sqs/test_server.py
@@ -53,10 +53,14 @@ def test_messages_polling():
             time.sleep(.5)
 
     def get_messages():
-        msg_res = test_client.get(
-            '/123/testqueue?Action=ReceiveMessage&MaxNumberOfMessages=1&WaitTimeSeconds=5'
-        )
-        [messages.append(m) for m in re.findall("<Body>(.*?)</Body>", msg_res.data.decode('utf-8'))]
+        count = 0
+        while count < 5:
+            msg_res = test_client.get(
+                '/123/testqueue?Action=ReceiveMessage&MaxNumberOfMessages=1&WaitTimeSeconds=5'
+            )
+            new_msgs = re.findall("<Body>(.*?)</Body>", msg_res.data.decode('utf-8'))
+            count += len(new_msgs)
+            messages.append(new_msgs)
 
     get_messages_thread = threading.Thread(target=get_messages)
     insert_messages_thread = threading.Thread(target=insert_messages)
@@ -67,4 +71,5 @@ def test_messages_polling():
     get_messages_thread.join()
     insert_messages_thread.join()
 
+    # got each message in a separate call to ReceiveMessage, despite the long WaitTimeSeconds
     assert len(messages) == 5


### PR DESCRIPTION
If one or more messages are available, stop waiting and return them.

This avoids waiting the full `wait_seconds_timeout` when there are messages in the queue

More importantly, it avoids returning more than `count` messages.  Boto's `Queue.read` passes `count=1`, an then returns the message if `len(rs) == 1`, otherwise None.  So if `len(rs) > 1`, it returns `None` and discards the multiple messages returned.