### PR TITLE
DynamoDB2 is overwriting the table instead of returning an error

### DIFF
--- a/moto/dynamodb2/models.py
+++ b/moto/dynamodb2/models.py
@@ -336,6 +336,8 @@ class DynamoDBBackend(BaseBackend):
         self.tables = OrderedDict()
 
     def create_table(self, name, **params):
+        if name in self.tables:
+            return None
         table = Table(name, **params)
         self.tables[name] = table
         return table

--- a/moto/dynamodb2/responses.py
+++ b/moto/dynamodb2/responses.py
@@ -100,12 +100,17 @@ class DynamoHandler(BaseResponse):
         attr = body["AttributeDefinitions"]
         # getting the indexes
         global_indexes = body.get("GlobalSecondaryIndexes", [])
+
         table = dynamodb_backend2.create_table(table_name,
                    schema=key_schema,
                    throughput=throughput,
                    attr=attr,
                    global_indexes=global_indexes)
-        return dynamo_json_dump(table.describe)
+        if table is not None:
+            return dynamo_json_dump(table.describe)
+        else:
+            er = 'com.amazonaws.dynamodb.v20111205#ResourceInUseException'
+            return self.error(er)
 
     def delete_table(self):
         name = self.body['TableName']


### PR DESCRIPTION
This fix returns 400 and ResourceInUseException, in case  you try to create the table but the table already exists. According to AWS DynamoDB documentation.