### PR TITLE
Data pipeline improvements: Add support to ListPipelines & change CloudFormation to support Data Pipelines

### DIFF
--- a/moto/cloudformation/parsing.py
+++ b/moto/cloudformation/parsing.py
@@ -4,6 +4,7 @@ import functools
 import logging
 
 from moto.autoscaling import models as autoscaling_models
+from moto.datapipeline import models as datapipeline_models
 from moto.ec2 import models as ec2_models
 from moto.elb import models as elb_models
 from moto.iam import models as iam_models
@@ -36,6 +37,7 @@ MODEL_MAP = {
     "AWS::EC2::VPCGatewayAttachment": ec2_models.VPCGatewayAttachment,
     "AWS::EC2::VPCPeeringConnection": ec2_models.VPCPeeringConnection,
     "AWS::ElasticLoadBalancing::LoadBalancer": elb_models.FakeLoadBalancer,
+    "AWS::DataPipeline::Pipeline": datapipeline_models.Pipeline,
     "AWS::IAM::InstanceProfile": iam_models.InstanceProfile,
     "AWS::IAM::Role": iam_models.Role,
     "AWS::RDS::DBInstance": rds_models.Database,

--- a/moto/datapipeline/models.py
+++ b/moto/datapipeline/models.py
@@ -90,6 +90,9 @@ class DataPipelineBackend(BaseBackend):
         self.pipelines[pipeline.pipeline_id] = pipeline
         return pipeline
 
+    def list_pipelines(self):
+        return self.pipelines.values()
+
     def describe_pipelines(self, pipeline_ids):
         pipelines = [pipeline for pipeline in self.pipelines.values() if pipeline.pipeline_id in pipeline_ids]
         return pipelines

--- a/moto/datapipeline/responses.py
+++ b/moto/datapipeline/responses.py
@@ -28,6 +28,16 @@ class DataPipelineResponse(BaseResponse):
             "pipelineId": pipeline.pipeline_id,
         })
 
+    def list_pipelines(self):
+        pipelines = self.datapipeline_backend.list_pipelines()
+        return json.dumps({
+            "HasMoreResults": False,
+            "Marker": None,
+            "PipelineIdList": [
+                {"Id": pipeline.pipeline_id, "Name": pipeline.name} for pipeline in pipelines
+            ]
+        })
+
     def describe_pipelines(self):
         pipeline_ids = self.parameters["pipelineIds"]
         pipelines = self.datapipeline_backend.describe_pipelines(pipeline_ids)

--- a/moto/datapipeline/utils.py
+++ b/moto/datapipeline/utils.py
@@ -1,5 +1,23 @@
+import collections
+import six
 from moto.core.utils import get_random_hex
 
 
 def get_random_pipeline_id():
     return "df-{0}".format(get_random_hex(length=19))
+
+
+def remove_capitalization_of_dict_keys(obj):
+    if isinstance(obj, collections.Mapping):
+        result = obj.__class__()
+        for key, value in obj.items():
+            normalized_key = key[:1].lower() + key[1:]
+            result[normalized_key] = remove_capitalization_of_dict_keys(value)
+        return result
+    elif isinstance(obj, collections.Iterable) and not isinstance(obj, six.string_types):
+        result = obj.__class__()
+        for item in obj:
+            result += (remove_capitalization_of_dict_keys(item),)
+        return result
+    else:
+        return obj

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,3 +6,4 @@ coverage
 freezegun
 flask
 boto3
+six

--- a/tests/test_datapipeline/test_datapipeline.py
+++ b/tests/test_datapipeline/test_datapipeline.py
@@ -130,3 +130,27 @@ def test_activate_pipeline():
     fields = pipeline_description['Fields']
 
     get_value_from_fields('@pipelineState', fields).should.equal("SCHEDULED")
+
+
+@mock_datapipeline
+def test_listing_pipelines():
+    conn = boto.datapipeline.connect_to_region("us-west-2")
+    res1 = conn.create_pipeline("mypipeline1", "some-unique-id1")
+    res2 = conn.create_pipeline("mypipeline2", "some-unique-id2")
+    pipeline_id1 = res1["pipelineId"]
+    pipeline_id2 = res2["pipelineId"]
+
+    response = conn.list_pipelines()
+
+    response["HasMoreResults"].should.be(False)
+    response["Marker"].should.be.none
+    response["PipelineIdList"].should.equal([
+        {
+            "Id": res1["pipelineId"],
+            "Name": "mypipeline1",
+        },
+        {
+            "Id": res2["pipelineId"],
+            "Name": "mypipeline2"
+        }
+    ])

--- a/tests/test_datapipeline/test_datapipeline.py
+++ b/tests/test_datapipeline/test_datapipeline.py
@@ -4,6 +4,7 @@ import boto.datapipeline
 import sure  # noqa
 
 from moto import mock_datapipeline
+from moto.datapipeline.utils import remove_capitalization_of_dict_keys
 
 
 def get_value_from_fields(key, fields):
@@ -144,13 +145,33 @@ def test_listing_pipelines():
 
     response["HasMoreResults"].should.be(False)
     response["Marker"].should.be.none
-    response["PipelineIdList"].should.equal([
+    response["PipelineIdList"].should.have.length_of(2)
+    response["PipelineIdList"].should.contain({
+        "Id": res1["pipelineId"],
+        "Name": "mypipeline1",
+    })
+    response["PipelineIdList"].should.contain({
+        "Id": res2["pipelineId"],
+        "Name": "mypipeline2"
+    })
+
+
+# testing a helper function
+def test_remove_capitalization_of_dict_keys():
+    result = remove_capitalization_of_dict_keys(
         {
-            "Id": res1["pipelineId"],
-            "Name": "mypipeline1",
-        },
-        {
-            "Id": res2["pipelineId"],
-            "Name": "mypipeline2"
+            "Id": "IdValue",
+            "Fields": [{
+                "Key": "KeyValue",
+                "StringValue": "StringValueValue"
+            }]
         }
-    ])
+    )
+
+    result.should.equal({
+        "id": "IdValue",
+        "fields": [{
+            "key": "KeyValue",
+            "stringValue": "StringValueValue"
+        }],
+    })


### PR DESCRIPTION
Can you please take a look at this PR, @spulec?

I am not happy with the implementation of `remove_capitalization_of_dict_keys`, but I don't know how to make it simpler (the package `six` is only used by that function). It is necessary because AWS accepts capitalized and non-capitalized property names for data pipelines.

The value of variable `cloudformation_unique_id` was arbitrarily chosen. Do you think that a different value should be used?
