### PR TITLE
Added fixture system for images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ moto.egg-info/*
 dist/*
 .tox
 .coverage
+htmlcov/
 *.pyc
 *~
 .noseids

--- a/moto/ec2/__init__.py
+++ b/moto/ec2/__init__.py
@@ -5,8 +5,8 @@ from ..core.models import MockAWS
 ec2_backend = ec2_backends['us-east-1']
 
 
-def mock_ec2(func=None):
+def mock_ec2(func=None, fixtures={}):
     if func:
-        return MockAWS(ec2_backends)(func)
+        return MockAWS(ec2_backends, fixtures)(func)
     else:
-        return MockAWS(ec2_backends)
+        return MockAWS(ec2_backends, fixtures)

--- a/tests/test_core/test_decorator_calls.py
+++ b/tests/test_core/test_decorator_calls.py
@@ -61,6 +61,16 @@ def test_decorater_wrapped_gets_set():
     """
     test_decorater_wrapped_gets_set.__wrapped__.__name__.should.equal('test_decorater_wrapped_gets_set')
 
+FIXTURES = {'us-east-1': {'images': [{'ami_id': 'foo_id', 'name': 'foo_name'}]}}
+
+
+@mock_ec2(fixtures=FIXTURES)
+def test_inject_image_fixtures():
+    conn = boto.connect_ec2('the_key', 'the_secret')
+    images = conn.get_all_images()
+    assert len(images) == 1
+    assert images[0].id == 'foo_id'
+
 
 @mock_ec2
 class Tester(object):


### PR DESCRIPTION
Added the ability to have images set after mock starting.
Fixtures are set by a dictionary example:

```
{
  'us-east-1': {
    'images': [
      {'ami_id': 'foo_id', 'name': 'foo_name'},
      {'ami_id': 'bar_id', 'name': 'fbar_name'}
    ]
  }
}
```
