### PR TITLE
[wip] Added more Python version to CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,13 +3,11 @@ sudo: false
 python:
   - 2.6
   - 2.7
+  - 3.3
+  - 3.4
 env:
     matrix:
       - BOTO_VERSION=2.36.0
-matrix:
-    include:
-      - python: "3.3"
-        env: BOTO_VERSION=2.36.0
 install:
   - travis_retry pip install boto==$BOTO_VERSION
   - travis_retry pip install boto3

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,7 @@ setup(
         "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.3",
+        "Programming Language :: Python :: 3.4",
         "License :: OSI Approved :: Apache Software License",
         "Topic :: Software Development :: Testing",
     ],


### PR DESCRIPTION
I made the following tasks:
- Added Python 3.3 and 3.4 to Travis
- Added Python 3.4 to `setup.py`
- Mock out AWS' response for tests without moto enabled (it failed in some Python 3 version)
- Sort `tests/test_core/test_decorator_calls.py`
