### PR TITLE
Fixes #430: MD5 hashing should be done to the real body, not an escaped one

### DIFF
--- a/moto/sqs/models.py
+++ b/moto/sqs/models.py
@@ -34,7 +34,7 @@ class Message(object):
     @property
     def md5(self):
         body_md5 = hashlib.md5()
-        body_md5.update(self.body.encode('utf-8'))
+        body_md5.update(self._body.encode('utf-8'))
         return body_md5.hexdigest()
 
     @property


### PR DESCRIPTION
Resolves compatibility issues with Amazon PHP SDK for SQS.