### PR TITLE
Change CloudFormationResponse.get_template() to return `GetTemplateResponse/GetTemplateResult/TemplateBody`

### DIFF
--- a/moto/cloudformation/responses.py
+++ b/moto/cloudformation/responses.py
@@ -86,9 +86,19 @@ class CloudFormationResponse(BaseResponse):
 
     def get_template(self):
         name_or_stack_id = self.querystring.get('StackName')[0]
-
         stack = self.cloudformation_backend.get_stack(name_or_stack_id)
-        return stack.template
+
+        response = {
+            "GetTemplateResponse": {
+            "GetTemplateResult": {
+                "TemplateBody": stack.template,
+                "ResponseMetadata": {
+                    "RequestId": "2d06e36c-ac1d-11e0-a958-f9382b6eb86bEXAMPLE"
+                }
+            }
+          }
+        }
+        return json.dumps(response)
 
     def update_stack(self):
         stack_name = self._get_param('StackName')

--- a/tests/test_cloudformation/test_cloudformation_stack_crud.py
+++ b/tests/test_cloudformation/test_cloudformation_stack_crud.py
@@ -40,7 +40,17 @@ def test_create_stack():
 
     stack = conn.describe_stacks()[0]
     stack.stack_name.should.equal('test_stack')
-    stack.get_template().should.equal(dummy_template)
+    stack.get_template().should.equal({
+        'GetTemplateResponse': {
+            'GetTemplateResult': {
+                'TemplateBody': dummy_template_json,
+                'ResponseMetadata': {
+                    'RequestId': '2d06e36c-ac1d-11e0-a958-f9382b6eb86bEXAMPLE'
+                }
+            }
+        }
+
+    })
 
 
 @mock_cloudformation
@@ -83,7 +93,18 @@ def test_create_stack_from_s3_url():
 
     stack = conn.describe_stacks()[0]
     stack.stack_name.should.equal('new-stack')
-    stack.get_template().should.equal(dummy_template)
+    stack.get_template().should.equal(
+        {
+        'GetTemplateResponse': {
+            'GetTemplateResult': {
+                'TemplateBody': dummy_template_json,
+                'ResponseMetadata': {
+                    'RequestId': '2d06e36c-ac1d-11e0-a958-f9382b6eb86bEXAMPLE'
+                }
+            }
+        }
+
+    })
 
 
 @mock_cloudformation
@@ -138,7 +159,17 @@ def test_get_template_by_name():
     )
 
     template = conn.get_template("test_stack")
-    template.should.equal(dummy_template)
+    template.should.equal({
+        'GetTemplateResponse': {
+            'GetTemplateResult': {
+                'TemplateBody': dummy_template_json,
+                'ResponseMetadata': {
+                    'RequestId': '2d06e36c-ac1d-11e0-a958-f9382b6eb86bEXAMPLE'
+                }
+            }
+        }
+
+    })
 
 
 @mock_cloudformation
@@ -243,4 +274,13 @@ def test_stack_tags():
 #     conn.update_stack("test_stack", dummy_template_json2)
 
 #     stack = conn.describe_stacks()[0]
-#     stack.get_template().should.equal(dummy_template2)
+#     stack.get_template().should.equal({
+#         'GetTemplateResponse': {
+#             'GetTemplateResult': {
+#                 'TemplateBody': dummy_template_json2,
+#                 'ResponseMetadata': {
+#                     'RequestId': '2d06e36c-ac1d-11e0-a958-f9382b6eb86bEXAMPLE'
+#                 }
+#             }
+#         }
+#     })


### PR DESCRIPTION
This pull request fixes #432.

I noticed that some methods use a constant as XML template and other methods use an inline dict (and then call `json.dumps()` on it). This should probably be all constants, right? I followed what existed, but I think it can be improved.
Also, this works perfectly with boto2, [which has JSON as content type hardcoded for `GetTemplate`](https://github.com/boto/boto/blob/dc33c30ee24623c3cc6418bcdaa5c1254ae45b21/boto/cloudformation/connection.py#L692-L715), but it will not work with any client that relies on XML.

Can you please review, @spulec?