### PR TITLE
Set snapshots to be in a completed state after being created and added

### DIFF
--- a/moto/ec2/responses/elastic_block_store.py
+++ b/moto/ec2/responses/elastic_block_store.py
@@ -198,9 +198,9 @@ DESCRIBE_SNAPSHOTS_RESPONSE = """<DescribeSnapshotsResponse xmlns="http://ec2.am
           <item>
              <snapshotId>{{ snapshot.id }}</snapshotId>
              <volumeId>{{ snapshot.volume.id }}</volumeId>
-             <status>pending</status>
+             <status>completed</status>
              <startTime>{{ snapshot.start_time}}</startTime>
-             <progress>30%</progress>
+             <progress>100%</progress>
              <ownerId>111122223333</ownerId>
              <volumeSize>{{ snapshot.volume.size }}</volumeSize>
              <description>{{ snapshot.description }}</description>

--- a/tests/test_ec2/test_elastic_block_store.py
+++ b/tests/test_ec2/test_elastic_block_store.py
@@ -93,7 +93,9 @@ def test_create_snapshot():
     conn = boto.connect_ec2('the_key', 'the_secret')
     volume = conn.create_volume(80, "us-east-1a")
 
-    volume.create_snapshot('a test snapshot')
+    snapshot = volume.create_snapshot('a test snapshot')
+    snapshot.update()
+    snapshot.status.should.equal('completed')
 
     snapshots = conn.get_all_snapshots()
     snapshots.should.have.length_of(1)


### PR DESCRIPTION
This would mirror the functionality of volumes when snapshot.update() is called.