### PR TITLE
Use correct kwarg for master_user_password when creating rds2 database

### DIFF
--- a/moto/rds2/models.py
+++ b/moto/rds2/models.py
@@ -135,7 +135,7 @@ class Database(object):
             "engine": properties.get("Engine"),
             "engine_version": properties.get("EngineVersion"),
             "iops": properties.get("Iops"),
-            "master_password": properties.get('MasterUserPassword'),
+            "master_user_password": properties.get('MasterUserPassword'),
             "master_username": properties.get('MasterUsername'),
             "multi_az": properties.get("MultiAZ"),
             "port": properties.get('Port', 3306),

--- a/moto/rds2/responses.py
+++ b/moto/rds2/responses.py
@@ -27,7 +27,7 @@ class RDS2Response(BaseResponse):
             "engine": self._get_param("Engine"),
             "engine_version": self._get_param("EngineVersion"),
             "iops": self._get_int_param("Iops"),
-            "master_password": self._get_param('MasterUserPassword'),
+            "master_user_password": self._get_param('MasterUserPassword'),
             "master_username": self._get_param('MasterUsername'),
             "multi_az": self._get_bool_param("MultiAZ"),
             # OptionGroupName


### PR DESCRIPTION
This uses the correct [kwarg to set the `master_user_password`](https://github.com/spulec/moto/blob/master/moto/rds2/models.py#L40) in the rds2 backend.