### PR TITLE
Fix for #458 - Allow unicode in SQS messages

### DIFF
--- a/moto/core/responses.py
+++ b/moto/core/responses.py
@@ -115,7 +115,10 @@ class BaseResponse(_TemplateEnvironmentMixin):
         if not querystring:
             querystring.update(parse_qs(urlparse(full_url).query, keep_blank_values=True))
         if not querystring:
-            querystring.update(parse_qs(self.body, keep_blank_values=True))
+            body = self.body
+            if isinstance(body, six.binary_type):
+                body = body.decode('utf-8')
+            querystring.update(parse_qs(body, keep_blank_values=True))
         if not querystring:
             querystring.update(headers)
 
@@ -156,12 +159,12 @@ class BaseResponse(_TemplateEnvironmentMixin):
             except HTTPException as http_error:
                 response = http_error.description, dict(status=http_error.code)
             if isinstance(response, six.string_types):
-                return 200, headers, response
+                return 200, headers, response.encode("utf-8")
             else:
                 body, new_headers = response
                 status = new_headers.get('status', 200)
                 headers.update(new_headers)
-                return status, headers, body
+                return status, headers, body.encode("utf-8")
         raise NotImplementedError("The {0} action has not been implemented".format(action))
 
     def _get_param(self, param_name):

--- a/tests/test_sqs/test_sqs.py
+++ b/tests/test_sqs/test_sqs.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 import boto
 import boto3
@@ -116,6 +117,24 @@ def test_send_message_with_xml_characters():
     queue.set_message_class(RawMessage)
 
     body_one = '< & >'
+
+    queue.write(queue.new_message(body_one))
+
+    messages = conn.receive_message(queue, number_messages=1)
+
+    messages[0].get_body().should.equal(body_one)
+
+
+@mock_sqs
+def test_send_message_with_unicode_characters():
+    import logging
+    logging.getLogger('boto').setLevel(logging.DEBUG)
+
+    conn = boto.connect_sqs('the_key', 'the_secret')
+    queue = conn.create_queue("test-queue", visibility_timeout=60)
+    queue.set_message_class(RawMessage)
+
+    body_one = 'Héllo!😀'
 
     queue.write(queue.new_message(body_one))
 


### PR DESCRIPTION
The fix is in `core/responses.py`, which may impact non-sqs calls as well. If you would rather, I can isolate it to sqs. If you are OK with leaving it there, I wonder if there are places that could benefit from tests that would include unicode or other non-ascii content in responses. I would be happy to add those, if needed.
