### PR TITLE
Support associate acl

### DIFF
--- a/moto/ec2/models.py
+++ b/moto/ec2/models.py
@@ -2610,10 +2610,12 @@ class NetworkAcl(TaggedEC2Resource):
         self.vpc_id = vpc_id
         self.network_acl_entries = []
         self.associations = {}
-        self.default = default
+        self.default = 'true' if default is True else 'false'
 
     def get_filter_value(self, filter_name):
-        if filter_name == "vpc-id":
+        if filter_name == "default":
+            return self.default
+        elif filter_name == "vpc-id":
             return self.vpc_id
         elif filter_name == "association.network-acl-id":
             return self.id

--- a/moto/ec2/models.py
+++ b/moto/ec2/models.py
@@ -2597,6 +2597,7 @@ class NetworkAclAssociation(object):
                  subnet_id, network_acl_id):
         self.ec2_backend = ec2_backend
         self.id = new_association_id
+        self.new_association_id = new_association_id
         self.subnet_id = subnet_id
         self.network_acl_id = network_acl_id
         super(NetworkAclAssociation, self).__init__()

--- a/moto/ec2/responses/network_acls.py
+++ b/moto/ec2/responses/network_acls.py
@@ -96,7 +96,7 @@ DESCRIBE_NETWORK_ACL_RESPONSE = """
    <item>
      <networkAclId>{{ network_acl.id }}</networkAclId>
      <vpcId>{{ network_acl.vpc_id }}</vpcId>
-     <default>true</default>
+     <default>{{ network_acl.default }}</default>
      <entrySet>
        {% for entry in network_acl.network_acl_entries %}
          <item>


### PR DESCRIPTION
Support boto calls:
 - associate_network_acl
 - disassociate_network_acl

In order to support associate_network_acl, it needs a new_association_id field on NetworkAclAssociation. It is referenced in the ReplaceNetworkAclAssociationResponse.

In order to support disassociate_network_acl, it needs to filter get_all_network_acl by default field and vpc_id. It uses the output to get the default association object. For some unknown reason, boto wants default property to be a string instead of a boolean. Also added the conditional for 'filter' in the get_filter_value function.