### PR TITLE
Add support for default VPCs and subnets.

### DIFF
--- a/moto/ec2/responses/subnets.py
+++ b/moto/ec2/responses/subnets.py
@@ -73,6 +73,7 @@ DESCRIBE_SUBNETS_RESPONSE = """
         <cidrBlock>{{ subnet.cidr_block }}</cidrBlock>
         <availableIpAddressCount>251</availableIpAddressCount>
         <availabilityZone>{{ subnet.availability_zone }}</availabilityZone>
+        <defaultForAz>{{ subnet.defaultForAz }}</defaultForAz>
         <tagSet>
           {% for tag in subnet.get_tags() %}
             <item>

--- a/moto/ec2/responses/vpcs.py
+++ b/moto/ec2/responses/vpcs.py
@@ -57,6 +57,7 @@ DESCRIBE_VPCS_RESPONSE = """
         <cidrBlock>{{ vpc.cidr_block }}</cidrBlock>
         <dhcpOptionsId>dopt-7a8b9c2d</dhcpOptionsId>
         <instanceTenancy>default</instanceTenancy>
+        <isDefault>{{ vpc.is_default }}</isDefault>
         <tagSet>
           {% for tag in vpc.get_tags() %}
             <item>

--- a/tests/test_ec2/test_subnets.py
+++ b/tests/test_ec2/test_subnets.py
@@ -115,6 +115,11 @@ def test_get_subnets_filtering():
     subnets_by_az.should.have.length_of(1)
     set([subnet.id for subnet in subnets_by_az]).should.equal(set([subnetB1.id]))
 
+    # Filter by defaultForAz
+    subnets_by_az = conn.get_all_subnets(filters={'defaultForAz': "true"})
+    subnets_by_az.should.have.length_of(1)
+    set([subnet.id for subnet in subnets_by_az]).should.equal(set([subnetA.id]))
+
     # Unsupported filter
     conn.get_all_subnets.when.called_with(filters={'not-implemented-filter': 'foobar'}).should.throw(NotImplementedError)
 


### PR DESCRIPTION
The first VPC created will be elected as default.
All subnets of the default VPC are considered default for their availability zone.