### PR TITLE
Quick boto3 fix for autoscaling

### DIFF
--- a/moto/autoscaling/responses.py
+++ b/moto/autoscaling/responses.py
@@ -10,6 +10,10 @@ class AutoScalingResponse(BaseResponse):
     def autoscaling_backend(self):
         return autoscaling_backends[self.region]
 
+    @property
+    def boto3_request(self):
+        return 'Boto3' in self.headers.get('User-Agent', [])
+
     def create_launch_configuration(self):
         instance_monitoring_string = self._get_param('InstanceMonitoring.Enabled')
         if instance_monitoring_string == 'true':
@@ -68,6 +72,11 @@ class AutoScalingResponse(BaseResponse):
     def describe_auto_scaling_groups(self):
         names = self._get_multi_param("AutoScalingGroupNames.member")
         groups = self.autoscaling_backend.describe_autoscaling_groups(names)
+        if self.boto3_request:
+            for group in groups:
+                if group.health_check_period is None:
+                    group.health_check_period = 300
+                self.autoscaling_backend.autoscaling_groups[group.name] = group
         template = self.response_template(DESCRIBE_AUTOSCALING_GROUPS_TEMPLATE)
         return template.render(groups=groups)
 

--- a/tests/test_autoscaling/test_autoscaling_boto3.py
+++ b/tests/test_autoscaling/test_autoscaling_boto3.py
@@ -7,7 +7,7 @@ from moto import mock_autoscaling
 
 @mock_autoscaling
 def test_create_autoscaling_group():
-        client = boto3.client('autoscaling')
+        client = boto3.client('autoscaling', region_name='us-east-1')
         _ = client.create_launch_configuration(
             LaunchConfigurationName='test_launch_configuration'
         )
@@ -23,7 +23,7 @@ def test_create_autoscaling_group():
 
 @mock_autoscaling
 def test_describe_autoscaling_groups():
-        client = boto3.client('autoscaling')
+        client = boto3.client('autoscaling', region_name='us-east-1')
         _ = client.create_launch_configuration(
             LaunchConfigurationName='test_launch_configuration'
         )

--- a/tests/test_autoscaling/test_autoscaling_boto3.py
+++ b/tests/test_autoscaling/test_autoscaling_boto3.py
@@ -1,0 +1,41 @@
+from __future__ import unicode_literals
+import boto3
+import sure  # noqa
+
+from moto import mock_autoscaling
+
+
+@mock_autoscaling
+def test_create_autoscaling_group():
+        client = boto3.client('autoscaling')
+        _ = client.create_launch_configuration(
+            LaunchConfigurationName='test_launch_configuration'
+        )
+        response = client.create_auto_scaling_group(
+            AutoScalingGroupName='test_asg',
+            LaunchConfigurationName='test_launch_configuration',
+            MinSize=0,
+            MaxSize=20,
+            DesiredCapacity=5
+        )
+        response['ResponseMetadata']['HTTPStatusCode'].should.equal(200)
+
+
+@mock_autoscaling
+def test_describe_autoscaling_groups():
+        client = boto3.client('autoscaling')
+        _ = client.create_launch_configuration(
+            LaunchConfigurationName='test_launch_configuration'
+        )
+        _ = client.create_auto_scaling_group(
+            AutoScalingGroupName='test_asg',
+            LaunchConfigurationName='test_launch_configuration',
+            MinSize=0,
+            MaxSize=20,
+            DesiredCapacity=5
+        )
+        response = client.describe_auto_scaling_groups(
+            AutoScalingGroupNames=["test_asg"]
+        )
+        response['ResponseMetadata']['HTTPStatusCode'].should.equal(200)
+        response['AutoScalingGroups'][0]['AutoScalingGroupName'].should.equal('test_asg')

--- a/tests/test_autoscaling/test_launch_configurations_boto3.py
+++ b/tests/test_autoscaling/test_launch_configurations_boto3.py
@@ -1,0 +1,23 @@
+from __future__ import unicode_literals
+import boto3
+
+import sure  # noqa
+
+from moto import mock_autoscaling
+
+
+@mock_autoscaling
+def test_create_launch_configuration():
+    client = boto3.client('autoscaling')
+    response = client.create_launch_configuration(
+        LaunchConfigurationName='tester',
+        ImageId='ami-abcd1234',
+        InstanceType='t1.micro',
+        KeyName='the_keys',
+        SecurityGroups=["default", "default2"],
+        UserData="This is some user_data",
+        InstanceMonitoring={'Enabled': True},
+        IamInstanceProfile='arn:aws:iam::123456789012:instance-profile/testing',
+        SpotPrice='0.1'
+    )
+    response['ResponseMetadata']['HTTPStatusCode'].should.equal(200)

--- a/tests/test_autoscaling/test_launch_configurations_boto3.py
+++ b/tests/test_autoscaling/test_launch_configurations_boto3.py
@@ -8,7 +8,7 @@ from moto import mock_autoscaling
 
 @mock_autoscaling
 def test_create_launch_configuration():
-    client = boto3.client('autoscaling')
+    client = boto3.client('autoscaling', region_name='us-east-1')
     response = client.create_launch_configuration(
         LaunchConfigurationName='tester',
         ImageId='ami-abcd1234',


### PR DESCRIPTION
When I try to run the following:

```
import moto
import boto3

@moto.mock_autoscaling
def test_describe_autoscaling_groups():
    client = boto3.client('autoscaling')
    _ = client.create_launch_configuration(
        LaunchConfigurationName='test_launch_configuration'
    )
    _ = client.create_auto_scaling_group(
        AutoScalingGroupName='test_asg',
        LaunchConfigurationName='test_launch_configuration',
        MinSize=0,
        MaxSize=20,
        DesiredCapacity=5
    )
    response = client.describe_auto_scaling_groups(
        AutoScalingGroupNames=["test_asg"]
    )
    print response['ResponseMetadata']

test_describe_autoscaling_groups()
```

I get this error:

```
Traceback (most recent call last):
  File "asg_test.py", line 22, in <module>
    test_describe_autoscaling_groups()
  File "/Users/bencook/anaconda/lib/python2.7/site-packages/moto/core/models.py", line 71, in wrapper
    result = func(*args, **kwargs)
  File "asg_test.py", line 18, in test_describe_autoscaling_groups
    AutoScalingGroupNames=["test_asg"]
  File "/Users/bencook/anaconda/lib/python2.7/site-packages/botocore/client.py", line 310, in _api_call
    return self._make_api_call(operation_name, kwargs)
  File "/Users/bencook/anaconda/lib/python2.7/site-packages/botocore/client.py", line 385, in _make_api_call
    operation_model, request_dict)
  File "/Users/bencook/anaconda/lib/python2.7/site-packages/botocore/endpoint.py", line 111, in make_request
    return self._send_request(request_dict, operation_model)
  File "/Users/bencook/anaconda/lib/python2.7/site-packages/botocore/endpoint.py", line 138, in _send_request
    request, operation_model, attempts)
  File "/Users/bencook/anaconda/lib/python2.7/site-packages/botocore/endpoint.py", line 198, in _get_response
    operation_model.output_shape)
  File "/Users/bencook/anaconda/lib/python2.7/site-packages/botocore/parsers.py", line 208, in parse
    parsed = self._do_parse(response, shape)
  File "/Users/bencook/anaconda/lib/python2.7/site-packages/botocore/parsers.py", line 418, in _do_parse
    parsed = self._parse_shape(shape, start)
  File "/Users/bencook/anaconda/lib/python2.7/site-packages/botocore/parsers.py", line 226, in _parse_shape
    return handler(shape, node)
  File "/Users/bencook/anaconda/lib/python2.7/site-packages/botocore/parsers.py", line 295, in _handle_structure
    member_shape, member_node)
  File "/Users/bencook/anaconda/lib/python2.7/site-packages/botocore/parsers.py", line 226, in _parse_shape
    return handler(shape, node)
  File "/Users/bencook/anaconda/lib/python2.7/site-packages/botocore/parsers.py", line 279, in _handle_list
    return super(BaseXMLResponseParser, self)._handle_list(shape, node)
  File "/Users/bencook/anaconda/lib/python2.7/site-packages/botocore/parsers.py", line 234, in _handle_list
    parsed.append(self._parse_shape(member_shape, item))
  File "/Users/bencook/anaconda/lib/python2.7/site-packages/botocore/parsers.py", line 226, in _parse_shape
    return handler(shape, node)
  File "/Users/bencook/anaconda/lib/python2.7/site-packages/botocore/parsers.py", line 295, in _handle_structure
    member_shape, member_node)
  File "/Users/bencook/anaconda/lib/python2.7/site-packages/botocore/parsers.py", line 226, in _parse_shape
    return handler(shape, node)
  File "/Users/bencook/anaconda/lib/python2.7/site-packages/botocore/parsers.py", line 149, in _get_text_content
    return func(self, shape, text)
  File "/Users/bencook/anaconda/lib/python2.7/site-packages/botocore/parsers.py", line 375, in _handle_integer
    return int(text)
ValueError: invalid literal for int() with base 10: 'None'
```

After a bunch of digging, it turns out the problem is with an XML tag getting rendered as "None" instead of a default integer value:

```
<HealthCheckGracePeriod>None</HealthCheckGracePeriod>
```

Originally I added an if/else check in the template, but that broke [this test](https://github.com/spulec/moto/blob/5d421dc343046bda58220b047133d5b418248ee8/tests/test_autoscaling/test_autoscaling.py#L106). Instead, I'm checking for `'Boto3'` in the response header. If I find it, I replace the `heaalth_check_period` in all of the `FakeAutoScalingGroup` instances.