### PR TITLE
fix response for get_queue_by_name on non existing queue

### DIFF
--- a/moto/sqs/responses.py
+++ b/moto/sqs/responses.py
@@ -52,7 +52,8 @@ class SQSResponse(BaseResponse):
             template = self.response_template(GET_QUEUE_URL_RESPONSE)
             return template.render(queue=queue)
         else:
-            return "", dict(status=404)
+            template = self.response_template(ERROR_QUEUE_DOESNT_EXIST)
+            return template.render(), dict(status=404)
 
     def list_queues(self):
         queue_name_prefix = self.querystring.get("QueueNamePrefix", [None])[0]
@@ -431,3 +432,14 @@ ERROR_TOO_LONG_RESPONSE = """<ErrorResponse xmlns="http://queue.amazonaws.com/do
     </Error>
     <RequestId>6fde8d1e-52cd-4581-8cd9-c512f4c64223</RequestId>
 </ErrorResponse>"""
+
+ERROR_QUEUE_DOESNT_EXIST = """<?xml version="1.0"?>
+    <Response>
+        <Errors>
+            <Error>
+                <Code>AWS.SimpleQueueService.NonExistentQueue</Code>
+                <Message>The specified queue does not exist for this wsdl version.</Message>
+            </Error>
+        </Errors>
+        <RequestID>1d479d93-8058-404d-8563-af22d3236976</RequestID>
+    </Response>"""

--- a/tests/test_sqs/test_sqs.py
+++ b/tests/test_sqs/test_sqs.py
@@ -47,7 +47,7 @@ def test_get_queue():
     queue.get_timeout().should.equal(60)
 
     nonexisting_queue = conn.get_queue("nonexisting_queue")
-    nonexisting_queue.should.be.none
+    nonexisting_queue.should.throw(ClientError)
 
 
 @mock_sqs

--- a/tests/test_sqs/test_sqs.py
+++ b/tests/test_sqs/test_sqs.py
@@ -2,7 +2,11 @@ from __future__ import unicode_literals
 import boto
 import boto3
 from boto.exception import SQSError
+from botocore.exceptions import ClientError
 from boto.sqs.message import RawMessage, Message
+
+import tests.backport_assert_raises
+from nose.tools import assert_raises
 
 import requests
 import sure  # noqa
@@ -46,8 +50,8 @@ def test_get_queue():
     queue.name.should.equal("test-queue")
     queue.get_timeout().should.equal(60)
 
-    nonexisting_queue = conn.get_queue("nonexisting_queue")
-    nonexisting_queue.should.throw(ClientError)
+    with assert_raises(ClientError):
+        conn.get_queue("nonexisting_queue")
 
 
 @mock_sqs


### PR DESCRIPTION
Fix problem where get_queue_by_name with non existing queue did not raise an AWS.SimpleQueueService.NonExistentQueue error but returned 404 only.
