### PR TITLE
Reverse before limit

### DIFF
--- a/moto/dynamodb2/responses.py
+++ b/moto/dynamodb2/responses.py
@@ -320,13 +320,13 @@ class DynamoHandler(BaseResponse):
             er = 'com.amazonaws.dynamodb.v20111205#ResourceNotFoundException'
             return self.error(er)
 
-        limit = self.body.get("Limit")
-        if limit:
-            items = items[:limit]
-
         reversed = self.body.get("ScanIndexForward")
         if reversed is False:
             items.reverse()
+
+        limit = self.body.get("Limit")
+        if limit:
+            items = items[:limit]
 
         result = {
             "Count": len(items),

--- a/tests/test_dynamodb2/test_dynamodb_table_with_range_key.py
+++ b/tests/test_dynamodb2/test_dynamodb_table_with_range_key.py
@@ -590,7 +590,7 @@ def test_reverse_query():
                             limit=4,
                             reverse=True)
 
-    expected = map(Decimal, [5, 4, 3, 2])
+    expected = [Decimal(5), Decimal(4), Decimal(3), Decimal(2)]
     [r['created_at'] for r in results].should.equal(expected)
 
 

--- a/tests/test_dynamodb2/test_dynamodb_table_with_range_key.py
+++ b/tests/test_dynamodb2/test_dynamodb_table_with_range_key.py
@@ -571,6 +571,30 @@ def test_query_with_global_indexes():
 
 
 @mock_dynamodb2
+def test_reverse_query():
+    conn = boto.dynamodb2.layer1.DynamoDBConnection()
+
+    table = Table.create('messages', schema=[
+        HashKey('subject'),
+        RangeKey('created_at', data_type='N')
+    ])
+
+    for i in range(10):
+        table.put_item({
+            'subject': "Hi",
+            'created_at': i
+        })
+
+    results = table.query_2(subject__eq="Hi",
+                            created_at__lt=6,
+                            limit=4,
+                            reverse=True)
+
+    expected = map(Decimal, [5, 4, 3, 2])
+    [r['created_at'] for r in results].should.equal(expected)
+
+
+@mock_dynamodb2
 def test_lookup():
     from decimal import Decimal
     table = Table.create('messages', schema=[


### PR DESCRIPTION
This is (I think) a bug where if you reverse your query (ScanIndexForward) and limit your results, you will get the wrong set of items do to limiting them before reversing them.

I say "I think" because I'm assuming this is not the expected behavior of DynamoDB2, but I guess I could be wrong.

The test I added would fail before:
```
======================================================================
FAIL: test_dynamodb_table_with_range_key.test_reverse_query
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/site-packages/nose/case.py", line 197, in runTest
    self.test(*self.arg)
  File "/Users/joshink/Development/moto/moto/core/models.py", line 71, in wrapper
    result = func(*args, **kwargs)
  File "/Users/joshink/Development/moto/tests/test_dynamodb2/test_dynamodb_table_with_range_key.py", line 594, in test_reverse_query
    [r['created_at'] for r in results].should.equal(expected)
  File "/usr/local/lib/python2.7/site-packages/sure/__init__.py", line 384, in wrapper
    value = func(self, *args, **kw)
  File "/usr/local/lib/python2.7/site-packages/sure/__init__.py", line 660, in equal
    raise error
AssertionError: given
X = [Decimal('3'), Decimal('2'), Decimal('1'), Decimal('0')]
    and
Y = [Decimal('5'), Decimal('4'), Decimal('3'), Decimal('2')]
X[0] != Y[0]
```
Hopefully this helps!