### PR TITLE
Bug fix secondary indexes ignored

### DIFF
--- a/moto/dynamodb2/models.py
+++ b/moto/dynamodb2/models.py
@@ -184,6 +184,7 @@ class Table(object):
                 'ItemCount': len(self),
                 'CreationDateTime': unix_time(self.created_at),
                 'GlobalSecondaryIndexes': [index for index in self.global_indexes],
+                'LocalSecondaryIndexes': [index for index in self.indexes]
             }
         }
         return results

--- a/moto/dynamodb2/responses.py
+++ b/moto/dynamodb2/responses.py
@@ -100,12 +100,14 @@ class DynamoHandler(BaseResponse):
         attr = body["AttributeDefinitions"]
         # getting the indexes
         global_indexes = body.get("GlobalSecondaryIndexes", [])
+        local_secondary_indexes = body.get("LocalSecondaryIndexes", [])
 
         table = dynamodb_backend2.create_table(table_name,
                    schema=key_schema,
                    throughput=throughput,
                    attr=attr,
-                   global_indexes=global_indexes)
+                   global_indexes=global_indexes,
+                   indexes=local_secondary_indexes)
         if table is not None:
             return dynamo_json_dump(table.describe)
         else:

--- a/tests/test_dynamodb2/test_dynamodb_table_with_range_key.py
+++ b/tests/test_dynamodb2/test_dynamodb_table_with_range_key.py
@@ -11,8 +11,9 @@ from moto import mock_dynamodb2
 from boto.exception import JSONResponseError
 from tests.helpers import requires_boto_gte
 try:
-    from boto.dynamodb2.fields import GlobalAllIndex, HashKey, RangeKey
+    from boto.dynamodb2.fields import GlobalAllIndex, HashKey, RangeKey, AllIndex
     from boto.dynamodb2.table import Item, Table
+    from boto.dynamodb2.types import STRING
     from boto.dynamodb2.exceptions import ValidationException
     from boto.dynamodb2.exceptions import ConditionalCheckFailedException
 except ImportError:
@@ -27,6 +28,30 @@ def create_table():
         'read': 10,
         'write': 10,
     })
+    return table
+
+
+def create_table_with_local_indexes():
+    table = Table.create(
+        'messages',
+        schema=[
+            HashKey('forum_name'),
+            RangeKey('subject'),
+        ],
+        throughput={
+            'read': 10,
+            'write': 10,
+        },
+        indexes=[
+            AllIndex(
+                'recipient_timestamp_index',
+                parts=[
+                    HashKey('forum_name', data_type=STRING),
+                    RangeKey('timestamp'),
+                ]
+            )
+        ]
+    )
     return table
 
 
@@ -57,6 +82,48 @@ def test_create_table():
                 {'KeyType': 'RANGE', 'AttributeName': 'subject'}
             ],
             'ItemCount': 0, 'CreationDateTime': 1326499200.0,
+            'GlobalSecondaryIndexes': [],
+        }
+    }
+    table.describe().should.equal(expected)
+
+
+@requires_boto_gte("2.9")
+@mock_dynamodb2
+@freeze_time("2012-01-14")
+def test_create_table():
+    table = create_table_with_local_indexes()
+    expected = {
+        'Table': {
+            'AttributeDefinitions': [
+                {'AttributeName': 'forum_name', 'AttributeType': 'S'},
+                {'AttributeName': 'subject', 'AttributeType': 'S'},
+                {'AttributeName': 'timestamp', 'AttributeType': 'S'}
+            ],
+            'ProvisionedThroughput': {
+                'NumberOfDecreasesToday': 0,
+                'WriteCapacityUnits': 10,
+                'ReadCapacityUnits': 10,
+            },
+            'TableSizeBytes': 0,
+            'TableName': 'messages',
+            'TableStatus': 'ACTIVE',
+            'KeySchema': [
+                {'KeyType': 'HASH', 'AttributeName': 'forum_name'},
+                {'KeyType': 'RANGE', 'AttributeName': 'subject'}
+            ],
+            'LocalSecondaryIndexes': [
+                {
+                    'IndexName': 'recipient_timestamp_index',
+                    'KeySchema': [
+                        {'AttributeName': 'forum_name', 'KeyType': 'HASH'},
+                        {'AttributeName': 'timestamp', 'KeyType': 'RANGE'}
+                    ],
+                    'Projection': {'ProjectionType': 'ALL'}
+                }
+            ],
+            'ItemCount': 0,
+            'CreationDateTime': 1326499200.0,
             'GlobalSecondaryIndexes': [],
         }
     }

--- a/tests/test_dynamodb2/test_dynamodb_table_without_range_key.py
+++ b/tests/test_dynamodb2/test_dynamodb_table_without_range_key.py
@@ -48,6 +48,7 @@ def test_create_table():
             ],
             'ItemCount': 0, 'CreationDateTime': 1326499200.0,
             'GlobalSecondaryIndexes': [],
+            'LocalSecondaryIndexes': []
         }
     }
     conn = boto.dynamodb2.connect_to_region(


### PR DESCRIPTION
Basic support for secondary indexes (`AllIndex`). Will need to ass support for QueryFiltering to get full support.

Currently when creating a table like this one:

```
Table.create(settings.NOTIFICATIONS_TABLE_NAME, schema=[
            HashKey('user_id', data_type=NUMBER),
            RangeKey('uniq', data_type=NUMBER),
        ], throughput={
            'read': 5,
            'write': 5,
        }, indexes=[
            AllIndex('timestamp_index', parts=[
                HashKey('user_id', data_type=NUMBER),
                RangeKey('timestamp'),
            ])
        ])
```

When querying this table like so:

```
notification_table.query_2(
    recipient_id__eq=user_id,
    timestamp__gt=timestamp_cutoff,  # this isn't supported yet, I will be working on that next
    index='recipient_timestamp_index',
    reverse=True
)
```

You will get an error in your test since currently the key `LocalSecondaryIndexes` isn't added to the table. This result in call to `query2()` failing due to there being no available indexes.