### PR TITLE
Add value and UPDATE fixes

### DIFF
--- a/moto/dynamodb2/models.py
+++ b/moto/dynamodb2/models.py
@@ -1,6 +1,7 @@
 from __future__ import unicode_literals
 from collections import defaultdict
 import datetime
+import decimal
 import json
 
 from moto.compat import OrderedDict
@@ -142,6 +143,16 @@ class Item(object):
                         del self.attrs[attribute_name]
                 else:
                     self.attrs[attribute_name] = DynamoType({"S": new_value})
+            elif action == 'ADD':
+                if set(update_action['Value'].keys()) == set(['N']):
+                    existing = self.attrs.get(attribute_name, DynamoType({"N": '0'}))
+                    self.attrs[attribute_name] = DynamoType({"N": str(
+                            decimal.Decimal(existing.value) +
+                            decimal.Decimal(new_value)
+                    )})
+                else:
+                    # TODO: implement other data types
+                    raise NotImplementedError('ADD not supported for %s' % ', '.join(update_action['Value'].keys()))
 
 
 class Table(object):

--- a/moto/dynamodb2/responses.py
+++ b/moto/dynamodb2/responses.py
@@ -400,8 +400,12 @@ class DynamoHandler(BaseResponse):
         key = self.body['Key']
         update_expression = self.body.get('UpdateExpression')
         attribute_updates = self.body.get('AttributeUpdates')
+        existing_item = dynamodb_backend2.get_item(name, key)
         item = dynamodb_backend2.update_item(name, key, update_expression, attribute_updates)
 
         item_dict = item.to_json()
         item_dict['ConsumedCapacityUnits'] = 0.5
+        if not existing_item:
+            item_dict['Attributes'] = {}
+
         return dynamo_json_dump(item_dict)

--- a/tests/test_dynamodb2/test_dynamodb_table_with_range_key.py
+++ b/tests/test_dynamodb2/test_dynamodb_table_with_range_key.py
@@ -889,6 +889,60 @@ def test_update_item_does_not_exist_is_created():
 
 
 @mock_dynamodb2
+def test_update_item_add_value():
+    table = _create_table_with_range_key()
+
+    table.put_item(Item={
+        'forum_name': 'the-key',
+        'subject': '123',
+        'numeric_field': Decimal('-1'),
+    })
+
+    item_key = {'forum_name': 'the-key', 'subject': '123'}
+    table.update_item(
+        Key=item_key,
+        AttributeUpdates={
+            'numeric_field': {
+                'Action': u'ADD',
+                'Value': Decimal('2'),
+            },
+        },
+    )
+
+    returned_item = dict((k, str(v) if isinstance(v, Decimal) else v)
+                         for k, v in table.get_item(Key=item_key)['Item'].items())
+    dict(returned_item).should.equal({
+        'numeric_field': '1',
+        'forum_name': 'the-key',
+        'subject': '123',
+    })
+
+
+@mock_dynamodb2
+def test_update_item_add_value_does_not_exist_is_created():
+    table = _create_table_with_range_key()
+
+    item_key = {'forum_name': 'the-key', 'subject': '123'}
+    table.update_item(
+        Key=item_key,
+        AttributeUpdates={
+            'numeric_field': {
+                'Action': u'ADD',
+                'Value': Decimal('2'),
+            },
+        },
+    )
+
+    returned_item = dict((k, str(v) if isinstance(v, Decimal) else v)
+                         for k, v in table.get_item(Key=item_key)['Item'].items())
+    dict(returned_item).should.equal({
+        'numeric_field': '2',
+        'forum_name': 'the-key',
+        'subject': '123',
+    })
+
+
+@mock_dynamodb2
 def test_boto3_query_gsi_range_comparison():
     table = _create_table_with_range_key()
 

--- a/tests/test_dynamodb2/test_dynamodb_table_with_range_key.py
+++ b/tests/test_dynamodb2/test_dynamodb_table_with_range_key.py
@@ -859,7 +859,7 @@ def test_update_item_does_not_exist_is_created():
     table = _create_table_with_range_key()
 
     item_key = {'forum_name': 'the-key', 'subject': '123'}
-    table.update_item(
+    result = table.update_item(
         Key=item_key,
         AttributeUpdates={
             'username': {
@@ -875,7 +875,10 @@ def test_update_item_does_not_exist_is_created():
                 'Value': {'key': 'value'},
             }
         },
+        ReturnValues='ALL_OLD',
     )
+
+    assert not result.get('Attributes')
 
     returned_item = dict((k, str(v) if isinstance(v, Decimal) else v)
                          for k, v in table.get_item(Key=item_key)['Item'].items())

--- a/tests/test_dynamodb2/test_dynamodb_table_with_range_key.py
+++ b/tests/test_dynamodb2/test_dynamodb_table_with_range_key.py
@@ -853,6 +853,41 @@ def test_update_item_range_key_set():
     })
 
 
+
+@mock_dynamodb2
+def test_update_item_does_not_exist_is_created():
+    table = _create_table_with_range_key()
+
+    item_key = {'forum_name': 'the-key', 'subject': '123'}
+    table.update_item(
+        Key=item_key,
+        AttributeUpdates={
+            'username': {
+                'Action': u'PUT',
+                'Value': 'johndoe2'
+            },
+            'created': {
+                'Action': u'PUT',
+                'Value': Decimal('4'),
+            },
+            'mapfield': {
+                'Action': u'PUT',
+                'Value': {'key': 'value'},
+            }
+        },
+    )
+
+    returned_item = dict((k, str(v) if isinstance(v, Decimal) else v)
+                         for k, v in table.get_item(Key=item_key)['Item'].items())
+    dict(returned_item).should.equal({
+        'username': "johndoe2",
+        'forum_name': 'the-key',
+        'subject': '123',
+        'created': '4',
+        'mapfield': {'key': 'value'},
+    })
+
+
 @mock_dynamodb2
 def test_boto3_query_gsi_range_comparison():
     table = _create_table_with_range_key()

--- a/tests/test_dynamodb2/test_dynamodb_table_without_range_key.py
+++ b/tests/test_dynamodb2/test_dynamodb_table_without_range_key.py
@@ -430,7 +430,7 @@ def test_update_item_remove():
     }
     table.put_item(data=data)
     key_map = {
-        "S": "steve"
+        'username': {"S": "steve"}
     }
 
     # Then remove the SentBy field
@@ -455,7 +455,7 @@ def test_update_item_set():
     }
     table.put_item(data=data)
     key_map = {
-        "S": "steve"
+        'username': {"S": "steve"}
     }
 
     conn.update_item("messages", key_map, update_expression="SET foo=:bar, blah=:baz REMOVE :SentBy")


### PR DESCRIPTION
* Supporrt ADD Value for numeric types
* Create item when it doesn't exist on update (to match real DynamoDB behavior)
* When hash/range key overlap, range key may end up null