### PR TITLE
Creating a S3 key with unicode and slash fails

### DIFF
--- a/moto/s3/urls.py
+++ b/moto/s3/urls.py
@@ -1,5 +1,6 @@
 from __future__ import unicode_literals
 
+from moto.compat import OrderedDict
 from .responses import S3ResponseInstance
 
 url_bases = [
@@ -7,13 +8,13 @@ url_bases = [
     "https?://(?P<bucket_name>[a-zA-Z0-9\-_.]*)\.?s3(.*).amazonaws.com"
 ]
 
-url_paths = {
+url_paths = OrderedDict([
     # subdomain bucket
-    '{0}/$': S3ResponseInstance.bucket_response,
+    ('{0}/$', S3ResponseInstance.bucket_response),
 
     # subdomain key of path-based bucket
-    '{0}/(?P<key_or_bucket_name>[^/]+)/?$': S3ResponseInstance.ambiguous_response,
+    ('{0}/(?P<key_or_bucket_name>.+)', S3ResponseInstance.ambiguous_response),
 
     # path-based bucket + key
-    '{0}/(?P<bucket_name_path>[a-zA-Z0-9\-_./]+)/(?P<key_name>.+)': S3ResponseInstance.key_response,
-}
+    ('{0}/(?P<bucket_name_path>[a-zA-Z0-9\-_./]+)/(?P<key_name>.+)', S3ResponseInstance.key_response),
+])

--- a/tests/test_s3/test_s3.py
+++ b/tests/test_s3/test_s3.py
@@ -835,6 +835,18 @@ def test_unicode_value():
 
 
 @mock_s3
+def test_unicode_key_with_slash():
+    conn = boto.connect_s3('the_key', 'the_secret')
+    bucket = conn.create_bucket("foobar")
+    key = Key(bucket)
+    key.key = "/the-key-unîcode/test"
+    key.set_contents_from_string("value")
+
+    key = bucket.get_key("/the-key-unîcode/test")
+    key.get_contents_as_string().should.equal(b'value')
+
+
+@mock_s3
 def test_setting_content_encoding():
     conn = boto.connect_s3()
     bucket = conn.create_bucket('mybucket')


### PR DESCRIPTION
I added some test case to reproduce this issue, setting a key with unicode char and slash.

Not sure reverting the commit is the good solution.

Here is the traceback:

```
======================================================================
ERROR: test_s3.test_unicode_key_with_slash
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/venv/moto/lib/python2.7/site-packages/nose/case.py", line 197, in runTest
    self.test(*self.arg)
  File "/work/moto/moto/core/models.py", line 71, in wrapper
    result = func(*args, **kwargs)
  File "/work/moto/tests/test_s3/test_s3.py", line 843, in test_unicode_key_with_slash
    key.set_contents_from_string("value")
  File "/venv/moto/lib/python2.7/site-packages/boto/s3/key.py", line 1426, in set_contents_from_string
    encrypt_key=encrypt_key)
  File "/venv/moto/lib/python2.7/site-packages/boto/s3/key.py", line 1293, in set_contents_from_file
    chunked_transfer=chunked_transfer, size=size)
  File "/venv/moto/lib/python2.7/site-packages/boto/s3/key.py", line 750, in send_file
    chunked_transfer=chunked_transfer, size=size)
  File "/venv/moto/lib/python2.7/site-packages/boto/s3/key.py", line 951, in _send_file_internal
    query_args=query_args
  File "/venv/moto/lib/python2.7/site-packages/boto/s3/connection.py", line 665, in make_request
    retry_handler=retry_handler
  File "/venv/moto/lib/python2.7/site-packages/boto/connection.py", line 1071, in make_request
    retry_handler=retry_handler)
  File "/venv/moto/lib/python2.7/site-packages/boto/connection.py", line 1030, in _mexe
    raise ex
error: [Errno 22] Invalid argument
```