### PR TITLE
Ensuring boto3 can correctly identify instance security groups

### DIFF
--- a/moto/ec2/responses/instances.py
+++ b/moto/ec2/responses/instances.py
@@ -314,8 +314,12 @@ EC2_DESCRIBE_INSTANCES = """<DescribeInstancesResponse xmlns='http://ec2.amazona
             <groupSet>
               {% for group in reservation.dynamic_group_list %}
               <item>
+		{% if group.id %}
                 <groupId>{{ group.id }}</groupId>
                 <groupName>{{ group.name }}</groupName>
+                {% else %}
+                <groupId>{{ group }}</groupId>
+                {% endif %}
               </item>
               {% endfor %}
             </groupSet>
@@ -361,8 +365,12 @@ EC2_DESCRIBE_INSTANCES = """<DescribeInstancesResponse xmlns='http://ec2.amazona
                     <groupSet>
                       {% for group in instance.dynamic_group_list %}
                       <item>
-                        <groupId>{{ group.id }}</groupId>
-                        <groupName>{{ group.name }}</groupName>
+		        {% if group.id %}
+		        <groupId>{{ group.id }}</groupId>
+		        <groupName>{{ group.name }}</groupName>
+		        {% else %}
+		        <groupId>{{ group }}</groupId>
+		        {% endif %}
                       </item>
                       {% endfor %}
                     </groupSet>
@@ -418,8 +426,12 @@ EC2_DESCRIBE_INSTANCES = """<DescribeInstancesResponse xmlns='http://ec2.amazona
                           <groupSet>
                             {% for group in nic.group_set %}
                             <item>
-                              <groupId>{{ group.id }}</groupId>
-                              <groupName>{{ group.name }}</groupName>
+			      {% if group.id %}
+			      <groupId>{{ group.id }}</groupId>
+			      <groupName>{{ group.name }}</groupName>
+			      {% else %}
+			      <groupId>{{ group }}</groupId>
+			      {% endif %}
                             </item>
                             {% endfor %}
                           </groupSet>


### PR DESCRIPTION
This is another subtle boto3 issue, it seems that it no longer expects that a dict will be passed ```{'id': '', 'name': ''}```. Instead it only requires (and passes) the security groupId. My guess was that the name was no longer needed. I believe the changes I made will be backward compatible with boto. 

There are probably a few other places this is an issue. I will try to update them as I find them. 