### PR TITLE
Add method describe_clusters and fix create_cluster,  list_clusters, list_task_definitions,  list_services for service ecs

### DIFF
--- a/moto/ecs/models.py
+++ b/moto/ecs/models.py
@@ -117,6 +117,20 @@ class EC2ContainerServiceBackend(BaseBackend):
         """
         return [cluster.arn for cluster in self.clusters.values()]
 
+    def describe_clusters(self, list_clusters_name=None):
+        list_clusters = []
+        if list_clusters_name is None:
+            if 'default' in self.clusters:
+                list_clusters.append(self.clusters['default'].response_object)
+        else:
+            for cluster in list_clusters_name:
+                cluster_name = cluster.split('/')[-1]
+                if cluster_name in self.clusters:
+                    list_clusters.append(self.clusters[cluster_name].response_object)
+                else:
+                    raise Exception("{0} is not a cluster".format(cluster_name))
+        return list_clusters
+
     def delete_cluster(self, cluster_str):
         cluster_name = cluster_str.split('/')[-1]
         if cluster_name in self.clusters:

--- a/moto/ecs/responses.py
+++ b/moto/ecs/responses.py
@@ -33,8 +33,9 @@ class EC2ContainerServiceResponse(BaseResponse):
     def list_clusters(self):
         cluster_arns = self.ecs_backend.list_clusters()
         return json.dumps({
-            'clusterArns': cluster_arns,
-            'nextToken': str(uuid.uuid1())
+            'clusterArns': cluster_arns
+            #,
+            #'nextToken': str(uuid.uuid1())
         })
 
     def describe_clusters(self):
@@ -64,8 +65,9 @@ class EC2ContainerServiceResponse(BaseResponse):
     def list_task_definitions(self):
         task_definition_arns = self.ecs_backend.list_task_definitions()
         return json.dumps({
-            'taskDefinitionArns': task_definition_arns,
-            'nextToken': str(uuid.uuid1())
+            'taskDefinitionArns': task_definition_arns
+            #,
+            #'nextToken': str(uuid.uuid1())
         })
 
     def deregister_task_definition(self):
@@ -89,8 +91,9 @@ class EC2ContainerServiceResponse(BaseResponse):
         cluster_str = self._get_param('cluster')
         service_arns = self.ecs_backend.list_services(cluster_str)
         return json.dumps({
-            'serviceArns': service_arns,
-            'nextToken': str(uuid.uuid1())
+            'serviceArns': service_arns
+            # ,
+            # 'nextToken': str(uuid.uuid1())
         })
 
     def update_service(self):

--- a/moto/ecs/responses.py
+++ b/moto/ecs/responses.py
@@ -23,6 +23,8 @@ class EC2ContainerServiceResponse(BaseResponse):
 
     def create_cluster(self):
         cluster_name = self._get_param('clusterName')
+        if cluster_name is None:
+            cluster_name = 'default'
         cluster = self.ecs_backend.create_cluster(cluster_name)
         return json.dumps({
             'cluster': cluster.response_object

--- a/moto/ecs/responses.py
+++ b/moto/ecs/responses.py
@@ -35,6 +35,14 @@ class EC2ContainerServiceResponse(BaseResponse):
             'nextToken': str(uuid.uuid1())
         })
 
+    def describe_clusters(self):
+        list_clusters_name = self._get_param('clusters')
+        clusters = self.ecs_backend.describe_clusters(list_clusters_name)
+        return json.dumps({
+            'clusters': clusters,
+            'failures': []
+        })
+
     def delete_cluster(self):
         cluster_str = self._get_param('cluster')
         cluster = self.ecs_backend.delete_cluster(cluster_str)


### PR DESCRIPTION
Add method describe_clusters and I fix create_cluster when it doesn't have name. 

It should create a cluster with name default and not with name None. See documentation http://docs.aws.amazon.com/cli/latest/reference/ecs/create-cluster.html

Remove nexToken from methods:
* list_clusters
* list_task_definitions
* list_services

Because the library doesn't support pagination and it  doesn't send nextToken or put it to None if it doesn't exceed maxResults. See documentation http://docs.aws.amazon.com/cli/latest/reference/ecs/list-clusters.html