### PR TITLE
Support placement when starting new instances

### DIFF
--- a/moto/ec2/models.py
+++ b/moto/ec2/models.py
@@ -312,6 +312,7 @@ class Instance(BotoInstance, TaggedEC2Resource):
         self.user_data = user_data
         self.security_groups = security_groups
         self.instance_type = kwargs.get("instance_type", "m1.small")
+        placement = kwargs.get("placement", None)
         self.vpc_id = None
         self.subnet_id = kwargs.get("subnet_id")
         in_ec2_classic = not bool(self.subnet_id)
@@ -343,6 +344,8 @@ class Instance(BotoInstance, TaggedEC2Resource):
             subnet = ec2_backend.get_subnet(self.subnet_id)
             self.vpc_id = subnet.vpc_id
             self._placement.zone = subnet.availability_zone
+        elif placement:
+            self._placement.zone = placement
         else:
             self._placement.zone = ec2_backend.region_name + 'a'
 

--- a/moto/ec2/responses/instances.py
+++ b/moto/ec2/responses/instances.py
@@ -26,6 +26,7 @@ class InstanceResponse(BaseResponse):
         security_group_ids = self._get_multi_param('SecurityGroupId')
         nics = dict_from_querystring("NetworkInterface", self.querystring)
         instance_type = self.querystring.get("InstanceType", ["m1.small"])[0]
+        placement = self.querystring.get("Placement.AvailabilityZone", [None])[0]
         subnet_id = self.querystring.get("SubnetId", [None])[0]
         private_ip = self.querystring.get("PrivateIpAddress", [None])[0]
         associate_public_ip = self.querystring.get("AssociatePublicIpAddress", [None])[0]
@@ -33,7 +34,7 @@ class InstanceResponse(BaseResponse):
 
         new_reservation = self.ec2_backend.add_instances(
             image_id, min_count, user_data, security_group_names,
-            instance_type=instance_type, subnet_id=subnet_id,
+            instance_type=instance_type, placement=placement, subnet_id=subnet_id,
             key_name=key_name, security_group_ids=security_group_ids,
             nics=nics, private_ip=private_ip, associate_public_ip=associate_public_ip)
 

--- a/tests/test_ec2/test_instances.py
+++ b/tests/test_ec2/test_instances.py
@@ -538,6 +538,24 @@ def test_run_instance_with_instance_type():
 
 
 @mock_ec2
+def test_run_instance_with_default_placement():
+    conn = boto.connect_ec2('the_key', 'the_secret')
+    reservation = conn.run_instances('ami-1234abcd')
+    instance = reservation.instances[0]
+
+    instance.placement.should.equal("us-east-1a")
+
+
+@mock_ec2
+def test_run_instance_with_placement():
+    conn = boto.connect_ec2('the_key', 'the_secret')
+    reservation = conn.run_instances('ami-1234abcd', placement="us-east-1b")
+    instance = reservation.instances[0]
+
+    instance.placement.should.equal("us-east-1b")
+
+
+@mock_ec2
 def test_run_instance_with_subnet():
     conn = boto.connect_vpc('the_key', 'the_secret')
     vpc = conn.create_vpc("10.0.0.0/16")


### PR DESCRIPTION
Thanks for this module, finding it very useful!

Boto/AWS lets you specify the availability zone when starting [new instances](http://boto.cloudhackers.com/en/latest/ref/ec2.html#boto.ec2.connection.EC2Connection.run_instances)