### PR TITLE
Include tests module and test files in sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,3 @@
 include README.md LICENSE AUTHORS.md
+include requirements.txt requirements-dev.txt tox.ini
+recursive-include tests * 


### PR DESCRIPTION
Allows downstream users and operating system packagers and porters to test released package within their own QA, build or other environments