### PR TITLE
Fix route53

### DIFF
--- a/moto/cloudwatch/responses.py
+++ b/moto/cloudwatch/responses.py
@@ -95,52 +95,54 @@ PUT_METRIC_ALARM_TEMPLATE = """<PutMetricAlarmResponse xmlns="http://monitoring.
 </PutMetricAlarmResponse>"""
 
 DESCRIBE_ALARMS_TEMPLATE = """<DescribeAlarmsResponse xmlns="http://monitoring.amazonaws.com/doc/2010-08-01/">
-    <MetricAlarms>
-        {% for alarm in alarms %}
-        <member>
-            <ActionsEnabled>{{ alarm.actions_enabled }}</ActionsEnabled>
-            <AlarmActions>
-                {% for action in alarm.alarm_actions %}
-                <member>{{ action }}</member>
-                {% endfor %}
-            </AlarmActions>
-            <AlarmArn>{{ alarm.arn }}</AlarmArn>
-            <AlarmConfigurationUpdatedTimestamp>{{ alarm.configuration_updated_timestamp }}</AlarmConfigurationUpdatedTimestamp>
-            <AlarmDescription>{{ alarm.description }}</AlarmDescription>
-            <AlarmName>{{ alarm.name }}</AlarmName>
-            <ComparisonOperator>{{ alarm.comparison_operator }}</ComparisonOperator>
-            <Dimensions>
-                {% for dimension in alarm.dimensions %}
-                <member>
-                    <Name>{{ dimension.name }}</Name>
-                    <Value>{{ dimension.value }}</Value>
-                </member>
-                {% endfor %}
-            </Dimensions>
-            <EvaluationPeriods>{{ alarm.evaluation_periods }}</EvaluationPeriods>
-            <InsufficientDataActions>
-                {% for action in alarm.insufficient_data_actions %}
-                <member>{{ action }}</member>
-                {% endfor %}
-            </InsufficientDataActions>
-            <MetricName>{{ alarm.metric_name }}</MetricName>
-            <Namespace>{{ alarm.namespace }}</Namespace>
-            <OKActions>
-                {% for action in alarm.ok_actions %}
-                <member>{{ action }}</member>
-                {% endfor %}
-            </OKActions>
-            <Period>{{ alarm.period }}</Period>
-            <StateReason>{{ alarm.state_reason }}</StateReason>
-            <StateReasonData>{{ alarm.state_reason_data }}</StateReasonData>
-            <StateUpdatedTimestamp>{{ alarm.state_updated_timestamp }}</StateUpdatedTimestamp>
-            <StateValue>{{ alarm.state_value }}</StateValue>
-            <Statistic>{{ alarm.statistic }}</Statistic>
-            <Threshold>{{ alarm.threshold }}</Threshold>
-            <Unit>{{ alarm.unit }}</Unit>
-        </member>
-        {% endfor %}
-    </MetricAlarms>
+    <DescribeAlarmsResult>
+        <MetricAlarms>
+            {% for alarm in alarms %}
+            <member>
+                <ActionsEnabled>{{ alarm.actions_enabled }}</ActionsEnabled>
+                <AlarmActions>
+                    {% for action in alarm.alarm_actions %}
+                    <member>{{ action }}</member>
+                    {% endfor %}
+                </AlarmActions>
+                <AlarmArn>{{ alarm.arn }}</AlarmArn>
+                <AlarmConfigurationUpdatedTimestamp>{{ alarm.configuration_updated_timestamp }}</AlarmConfigurationUpdatedTimestamp>
+                <AlarmDescription>{{ alarm.description }}</AlarmDescription>
+                <AlarmName>{{ alarm.name }}</AlarmName>
+                <ComparisonOperator>{{ alarm.comparison_operator }}</ComparisonOperator>
+                <Dimensions>
+                    {% for dimension in alarm.dimensions %}
+                    <member>
+                        <Name>{{ dimension.name }}</Name>
+                        <Value>{{ dimension.value }}</Value>
+                    </member>
+                    {% endfor %}
+                </Dimensions>
+                <EvaluationPeriods>{{ alarm.evaluation_periods }}</EvaluationPeriods>
+                <InsufficientDataActions>
+                    {% for action in alarm.insufficient_data_actions %}
+                    <member>{{ action }}</member>
+                    {% endfor %}
+                </InsufficientDataActions>
+                <MetricName>{{ alarm.metric_name }}</MetricName>
+                <Namespace>{{ alarm.namespace }}</Namespace>
+                <OKActions>
+                    {% for action in alarm.ok_actions %}
+                    <member>{{ action }}</member>
+                    {% endfor %}
+                </OKActions>
+                <Period>{{ alarm.period }}</Period>
+                <StateReason>{{ alarm.state_reason }}</StateReason>
+                <StateReasonData>{{ alarm.state_reason_data }}</StateReasonData>
+                <StateUpdatedTimestamp>{{ alarm.state_updated_timestamp }}</StateUpdatedTimestamp>
+                <StateValue>{{ alarm.state_value }}</StateValue>
+                <Statistic>{{ alarm.statistic }}</Statistic>
+                <Threshold>{{ alarm.threshold }}</Threshold>
+                <Unit>{{ alarm.unit }}</Unit>
+            </member>
+            {% endfor %}
+        </MetricAlarms>
+    </DescribeAlarmsResult>
 </DescribeAlarmsResponse>"""
 
 DELETE_METRIC_ALARMS_TEMPLATE = """<DeleteMetricAlarmResponse xmlns="http://monitoring.amazonaws.com/doc/2010-08-01/">

--- a/moto/route53/models.py
+++ b/moto/route53/models.py
@@ -114,6 +114,7 @@ class FakeZone(object):
         self.name = name
         self.id = id_
         self.comment = comment
+        self.private_zone = False
         self.rrsets = []
 
     def add_rrset(self, record_set):

--- a/moto/route53/models.py
+++ b/moto/route53/models.py
@@ -113,7 +113,8 @@ class FakeZone(object):
     def __init__(self, name, id_, comment=None):
         self.name = name
         self.id = id_
-        self.comment = comment
+        if comment is not None:
+            self.comment = comment
         self.private_zone = False
         self.rrsets = []
 

--- a/moto/route53/responses.py
+++ b/moto/route53/responses.py
@@ -113,7 +113,7 @@ def health_check_response(request, full_url, headers):
         health_checks = route53_backend.get_health_checks()
         return 200, headers, template.render(health_checks=health_checks)
 
-def not_implemented_methods(request, full_url, headers):
+def not_implemented_response(request, full_url, headers):
     action = ''
     if 'tags' in full_url:
         action = 'tags'

--- a/moto/route53/responses.py
+++ b/moto/route53/responses.py
@@ -9,7 +9,10 @@ def list_or_create_hostzone_response(request, full_url, headers):
 
     if request.method == "POST":
         elements = xmltodict.parse(request.body)
-        comment = elements["CreateHostedZoneRequest"]["HostedZoneConfig"]["Comment"]
+        if "HostedZoneConfig" in elements["CreateHostedZoneRequest"]:
+            comment = elements["CreateHostedZoneRequest"]["HostedZoneConfig"]["Comment"]
+        else:
+            comment = None
         new_zone = route53_backend.create_hosted_zone(elements["CreateHostedZoneRequest"]["Name"], comment=comment)
         template = Template(CREATE_HOSTED_ZONE_RESPONSE)
         return 201, headers, template.render(zone=new_zone)
@@ -138,7 +141,9 @@ GET_HOSTED_ZONE_RESPONSE = """<GetHostedZoneResponse xmlns="https://route53.amaz
       <Name>{{ zone.name }}</Name>
       <ResourceRecordSetCount>{{ zone.rrsets|count }}</ResourceRecordSetCount>
       <Config>
-        <Comment>{{ zone.comment }}</Comment>
+        {% if zone.comment %}
+            <Comment>{{ zone.comment }}</Comment>
+        {% endif %}
         <PrivateZone>{{ zone.private_zone }}</PrivateZone>
       </Config>
    </HostedZone>
@@ -155,7 +160,9 @@ CREATE_HOSTED_ZONE_RESPONSE = """<CreateHostedZoneResponse xmlns="https://route5
       <Name>{{ zone.name }}</Name>
       <ResourceRecordSetCount>0</ResourceRecordSetCount>
       <Config>
-        <Comment>{{ zone.comment }}</Comment>
+        {% if zone.comment %}
+            <Comment>{{ zone.comment }}</Comment>
+        {% endif %}
         <PrivateZone>{{ zone.private_zone }}</PrivateZone>
       </Config>
    </HostedZone>
@@ -173,7 +180,9 @@ LIST_HOSTED_ZONES_RESPONSE = """<ListHostedZonesResponse xmlns="https://route53.
          <Id>{{ zone.id }}</Id>
          <Name>{{ zone.name }}</Name>
          <Config>
-           <Comment>{{ zone.comment }}</Comment>
+            {% if zone.comment %}
+                <Comment>{{ zone.comment }}</Comment>
+            {% endif %}
            <PrivateZone>{{ zone.private_zone }}</PrivateZone>
          </Config>
          <ResourceRecordSetCount>{{ zone.rrsets|count  }}</ResourceRecordSetCount>

--- a/moto/route53/responses.py
+++ b/moto/route53/responses.py
@@ -113,6 +113,14 @@ def health_check_response(request, full_url, headers):
         health_checks = route53_backend.get_health_checks()
         return 200, headers, template.render(health_checks=health_checks)
 
+def not_implemented_methods(request, full_url, headers):
+    action = ''
+    if 'tags' in full_url:
+        action = 'tags'
+    elif 'trafficpolicyinstances' in full_url:
+        action = 'policies'
+    raise NotImplementedError("The action for {0} has not been implemented for route 53".format(action))
+
 
 LIST_RRSET_REPONSE = """<ListResourceRecordSetsResponse xmlns="https://route53.amazonaws.com/doc/2012-12-12/">
    <ResourceRecordSets>

--- a/moto/route53/responses.py
+++ b/moto/route53/responses.py
@@ -174,6 +174,7 @@ LIST_HOSTED_ZONES_RESPONSE = """<ListHostedZonesResponse xmlns="https://route53.
       </HostedZone>
       {% endfor %}
    </HostedZones>
+   <IsTruncated>false</IsTruncated>
 </ListHostedZonesResponse>"""
 
 CREATE_HEALTH_CHECK_RESPONSE = """<?xml version="1.0" encoding="UTF-8"?>

--- a/moto/route53/responses.py
+++ b/moto/route53/responses.py
@@ -139,6 +139,7 @@ GET_HOSTED_ZONE_RESPONSE = """<GetHostedZoneResponse xmlns="https://route53.amaz
       <ResourceRecordSetCount>{{ zone.rrsets|count }}</ResourceRecordSetCount>
       <Config>
         <Comment>{{ zone.comment }}</Comment>
+        <PrivateZone>{{ zone.private_zone }}</PrivateZone>
       </Config>
    </HostedZone>
    <DelegationSet>
@@ -153,6 +154,10 @@ CREATE_HOSTED_ZONE_RESPONSE = """<CreateHostedZoneResponse xmlns="https://route5
       <Id>/hostedzone/{{ zone.id }}</Id>
       <Name>{{ zone.name }}</Name>
       <ResourceRecordSetCount>0</ResourceRecordSetCount>
+      <Config>
+        <Comment>{{ zone.comment }}</Comment>
+        <PrivateZone>{{ zone.private_zone }}</PrivateZone>
+      </Config>
    </HostedZone>
    <DelegationSet>
       <NameServers>
@@ -169,6 +174,7 @@ LIST_HOSTED_ZONES_RESPONSE = """<ListHostedZonesResponse xmlns="https://route53.
          <Name>{{ zone.name }}</Name>
          <Config>
            <Comment>{{ zone.comment }}</Comment>
+           <PrivateZone>{{ zone.private_zone }}</PrivateZone>
          </Config>
          <ResourceRecordSetCount>{{ zone.rrsets|count  }}</ResourceRecordSetCount>
       </HostedZone>

--- a/moto/route53/urls.py
+++ b/moto/route53/urls.py
@@ -10,4 +10,5 @@ url_paths = {
     '{0}hostedzone/[^/]+$': responses.get_or_delete_hostzone_response,
     '{0}hostedzone/[^/]+/rrset$': responses.rrset_response,
     '{0}healthcheck': responses.health_check_response,
+    '{0}tags|trafficpolicyinstances/*': responses.not_implemented,
 }

--- a/moto/route53/urls.py
+++ b/moto/route53/urls.py
@@ -10,5 +10,5 @@ url_paths = {
     '{0}hostedzone/[^/]+$': responses.get_or_delete_hostzone_response,
     '{0}hostedzone/[^/]+/rrset$': responses.rrset_response,
     '{0}healthcheck': responses.health_check_response,
-    '{0}tags|trafficpolicyinstances/*': responses.not_implemented,
+    '{0}tags|trafficpolicyinstances/*': responses.not_implemented_response,
 }


### PR DESCRIPTION
* Add IsTruncated to False in template list_hosted_zones_response in route53. Because it always has it.

* add private zone in templates. Because it should have. It is always to False because it doesn't support for private zones.

* Comment's params is optional in create_hosted_zones. It is fix to support and templates adapted to it.

* add responses for methods don't have implemented in route53
