### PR TITLE
boto3 SQS set attributes fix.

### DIFF
--- a/moto/sqs/responses.py
+++ b/moto/sqs/responses.py
@@ -90,9 +90,14 @@ class SQSResponse(BaseResponse):
 
     def set_queue_attributes(self):
         queue_name = self._get_queue_name()
-        key = camelcase_to_underscores(self.querystring.get('Attribute.Name')[0])
-        value = self.querystring.get('Attribute.Value')[0]
-        self.sqs_backend.set_queue_attribute(queue_name, key, value)
+        if "Attribute.Name" in self.querystring:
+            key = camelcase_to_underscores(self.querystring.get("Attribute.Name")[0])
+            value = self.querystring.get("Attribute.Value")[0]
+            self.sqs_backend.set_queue_attribute(queue_name, key, value)
+        for a in self._get_list_prefix("Attribute"):
+            key = camelcase_to_underscores(a["name"])
+            value = a["value"]
+            self.sqs_backend.set_queue_attribute(queue_name, key, value)
         return SET_QUEUE_ATTRIBUTE_RESPONSE
 
     def delete_queue(self):

--- a/tests/test_sqs/test_sqs.py
+++ b/tests/test_sqs/test_sqs.py
@@ -491,3 +491,14 @@ def test_boto3_message_send():
 
     messages = queue.receive_messages()
     messages.should.have.length_of(1)
+
+
+@mock_sqs
+def test_boto3_set_queue_attributes():
+    sqs = boto3.resource('sqs', region_name='us-east-1')
+    queue = sqs.create_queue(QueueName="blah")
+
+    queue.attributes['VisibilityTimeout'].should.equal("30")
+
+    queue.set_attributes(Attributes={"VisibilityTimeout": "45"})
+    queue.attributes['VisibilityTimeout'].should.equal("45")


### PR DESCRIPTION
In boto3, the SQS `set_queue_attributes` items are now presented as a list of values of the form `Attribute.1.Name`, `Attribute.1.Value`, `Attribute.2.Name`, and so on.

This patch ensures these are properly handled.