### PR TITLE
remove NextMarker in response list_functions (Lambda)

### DIFF
--- a/moto/awslambda/responses.py
+++ b/moto/awslambda/responses.py
@@ -32,7 +32,7 @@ class LambdaResponse(BaseResponse):
         lambda_backend = self.get_lambda_backend(full_url)
         return 200, headers, json.dumps({
             "Functions": [fn.get_configuration() for fn in lambda_backend.list_functions()],
-            "NextMarker": str(uuid.uuid4()),
+            # "NextMarker": str(uuid.uuid4()),
         })
 
     def _create_function(self, request, full_url, headers):


### PR DESCRIPTION
I remove NextMarker in response for list_functions (Lambda), because It doesn't have a correctly support to call with markers and it shouldn't send if it doesn't have more functions to response. Reference to documentation: http://docs.aws.amazon.com/cli/latest/reference/lambda/list-functions.html 

Best.