### PR TITLE
Pin boto3 and botocore (fix the builds!)

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,6 +5,8 @@ sure>=1.2.24
 coverage
 freezegun
 flask
-boto3>=1.2.3
-botocore>=1.3.26
+# botocore 1.3.29 breaks s3 in tests (lambda and s3 tests)
+# so we need to pin a boto3 and botocore revision pair that we know works
+boto3==1.2.4
+botocore==1.3.28
 six


### PR DESCRIPTION
botocore 1.3.29 (new as of yesterday) breaks a few of the s3 and
lambda tests; something about a StringIO being closed prematurely.

¯\\\_(ツ)\_/¯

boto3 doesn't pin the botocore version; as a result the new version of
botocore gets pulled in transitively, breaking today's builds.

Signed-off-by: Scott Greene <scott.greene@getbraintree.com>