### PR TITLE
Fix a typo in DESCRIBE_ROUTE_TABLES_RESPONSE

### DIFF
--- a/moto/ec2/responses/route_tables.py
+++ b/moto/ec2/responses/route_tables.py
@@ -179,7 +179,6 @@ DESCRIBE_ROUTE_TABLES_RESPONSE = """
               </item>
             {% endfor %}
           </associationSet>
-         <tagSet/>
          <tagSet>
           {% for tag in route_table.get_tags() %}
            <item>


### PR DESCRIPTION
There are two 'tagSet' nodes in the DESCRIBE_ROUTE_TABLES_RESPONSE, so responses to 'DescribeRouteTables' requests are buggy.