### PR TITLE
Allow cloudformation to delete Route 53 RecordSets

### DIFF
--- a/moto/route53/models.py
+++ b/moto/route53/models.py
@@ -70,6 +70,8 @@ class RecordSet(object):
         self.weight = kwargs.get('Weight')
         self.region = kwargs.get('Region')
         self.health_check = kwargs.get('HealthCheckId')
+        self.hosted_zone_name = kwargs.get('HostedZoneName')
+        self.hosted_zone_id = kwargs.get('HostedZoneId')
 
     @classmethod
     def create_from_cloudformation_json(cls, resource_name, cloudformation_json, region_name):
@@ -106,6 +108,11 @@ class RecordSet(object):
                 {% endif %}
             </ResourceRecordSet>""")
         return template.render(record_set=self)
+
+    def delete(self, *args, **kwargs):
+        ''' Not exposed as part of the Route 53 API - used for CloudFormation. args are ignored '''
+        hosted_zone = route53_backend.get_hosted_zone_by_name(self.hosted_zone_name)
+        hosted_zone.delete_rrset_by_name(self.name)
 
 
 class FakeZone(object):


### PR DESCRIPTION
While there isn't an API method exposed for directly deleting a Route 53 RecordSet [it's performed via `POST` that acts more like a `PATCH` than anything else](http://docs.aws.amazon.com/Route53/latest/APIReference/API_ChangeResourceRecordSets.html), CloudFormation can have templates which contain RecordSets which refer to zones that don't exist inside the template. Ergo, we need a way to effect a delete upon these RecordSets when we don't have a direct reference to the zone.

This exposes a delete method that isn't hooked up to any response (and rightfully so), it just enables the ~polymorphic deletion behavior that we've written into the CloudFormation implementation.

Signed-off-by: Scott Greene <scott.greene@getbraintree.com>