### PR TITLE
Support HostedZoneId in RecordSet templates

### DIFF
--- a/moto/route53/models.py
+++ b/moto/route53/models.py
@@ -77,8 +77,11 @@ class RecordSet(object):
     def create_from_cloudformation_json(cls, resource_name, cloudformation_json, region_name):
         properties = cloudformation_json['Properties']
 
-        zone_name = properties["HostedZoneName"]
-        hosted_zone = route53_backend.get_hosted_zone_by_name(zone_name)
+        zone_name = properties.get("HostedZoneName")
+        if zone_name:
+            hosted_zone = route53_backend.get_hosted_zone_by_name(zone_name)
+        else:
+            hosted_zone = route53_backend.get_hosted_zone(properties["HostedZoneId"])
         record_set = hosted_zone.add_rrset(properties)
         return record_set
 
@@ -112,6 +115,8 @@ class RecordSet(object):
     def delete(self, *args, **kwargs):
         ''' Not exposed as part of the Route 53 API - used for CloudFormation. args are ignored '''
         hosted_zone = route53_backend.get_hosted_zone_by_name(self.hosted_zone_name)
+        if not hosted_zone:
+            hosted_zone = route53_backend.get_hosted_zone(self.hosted_zone_id)
         hosted_zone.delete_rrset_by_name(self.name)
 
 


### PR DESCRIPTION
Before this commit, using `HostedZoneId` would result in you not being able to find the hosted zone.