### PR TITLE
Add roles to the list instance profiles response

### DIFF
--- a/moto/iam/responses.py
+++ b/moto/iam/responses.py
@@ -391,7 +391,18 @@ LIST_INSTANCE_PROFILES_TEMPLATE = """<ListInstanceProfilesResponse xmlns="https:
       {% for instance in instance_profiles %}
       <member>
         <Id>{{ instance.id }}</Id>
-        <Roles/>
+        <Roles>
+          {% for role in instance.roles %}
+          <member>
+            <Path>{{ role.path }}</Path>
+            <Arn>arn:aws:iam::123456789012:role/application_abc/component_xyz/S3Access</Arn>
+            <RoleName>{{ role.name }}</RoleName>
+            <AssumeRolePolicyDocument>{{ role.assume_role_policy_document }}</AssumeRolePolicyDocument>
+            <CreateDate>2012-05-09T15:45:35Z</CreateDate>
+            <RoleId>{{ role.id }}</RoleId>
+          </member>
+          {% endfor %}
+        </Roles>
         <InstanceProfileName>{{ instance.name }}</InstanceProfileName>
         <Path>{{ instance.path }}</Path>
         <Arn>arn:aws:iam::123456789012:instance-profile/application_abc/component_xyz/Database</Arn>

--- a/tests/test_iam/test_iam.py
+++ b/tests/test_iam/test_iam.py
@@ -66,7 +66,21 @@ def test_create_role_and_instance_profile():
     role_from_profile['role_name'].should.equal("my-role")
 
     conn.list_roles().roles[0].role_name.should.equal('my-role')
-    conn.list_instance_profiles().instance_profiles[0].instance_profile_name.should.equal("my-profile")
+
+
+@mock_iam()
+def test_list_instance_profiles():
+    conn = boto.connect_iam()
+    conn.create_instance_profile("my-profile", path="my-path")
+    conn.create_role("my-role", path="my-path")
+
+    conn.add_role_to_instance_profile("my-profile", "my-role")
+
+    profiles = conn.list_instance_profiles().instance_profiles
+
+    len(profiles).should.equal(1)
+    profiles[0].instance_profile_name.should.equal("my-profile")
+    profiles[0].roles.role_name.should.equal("my-role")
 
 
 @mock_iam()


### PR DESCRIPTION
Hi Steve, instance profiles can have a role associated with them. This PR adds the role to the list instance profile response