### PR TITLE
Propagate stack-level tags to resources

### DIFF
--- a/moto/cloudformation/models.py
+++ b/moto/cloudformation/models.py
@@ -26,7 +26,7 @@ class FakeStack(object):
         self.output_map = self._create_output_map()
 
     def _create_resource_map(self):
-        resource_map = ResourceMap(self.stack_id, self.name, self.parameters, self.region_name, self.template_dict)
+        resource_map = ResourceMap(self.stack_id, self.name, self.parameters, self.tags, self.region_name, self.template_dict)
         resource_map.create()
         return resource_map
 

--- a/moto/ec2/models.py
+++ b/moto/ec2/models.py
@@ -774,9 +774,9 @@ class TagBackend(object):
             raise InvalidParameterValueErrorTagNull()
         for resource_id in resource_ids:
             if resource_id in self.tags:
-                if len(self.tags[resource_id]) + len(tags) > 10:
+                if len(self.tags[resource_id]) + len([tag for tag in tags if not tag.startswith("aws:")]) > 10:
                     raise TagLimitExceeded()
-            elif len(tags) > 10:
+            elif len([tag for tag in tags if not tag.startswith("aws:")]) > 10:
                 raise TagLimitExceeded()
         for resource_id in resource_ids:
             for tag in tags:

--- a/tests/test_cloudformation/test_cloudformation_stack_integration.py
+++ b/tests/test_cloudformation/test_cloudformation_stack_integration.py
@@ -363,6 +363,12 @@ def test_stack_security_groups():
                 "Type": "AWS::EC2::SecurityGroup",
                 "Properties": {
                     "GroupDescription": "My security group",
+                    "Tags": [
+                        {
+                            "Key": "bar",
+                            "Value": "baz"
+                        }
+                    ],
                     "SecurityGroupIngress": [{
                         "IpProtocol": "tcp",
                         "FromPort": "22",
@@ -384,6 +390,7 @@ def test_stack_security_groups():
     conn.create_stack(
         "security_group_stack",
         template_body=security_group_template_json,
+        tags={"foo":"bar"}
     )
 
     ec2_conn = boto.ec2.connect_to_region("us-west-1")
@@ -395,6 +402,8 @@ def test_stack_security_groups():
 
     ec2_instance.groups[0].id.should.equal(instance_group.id)
     instance_group.description.should.equal("My security group")
+    instance_group.tags.should.have.key('foo').which.should.equal('bar')
+    instance_group.tags.should.have.key('bar').which.should.equal('baz')
     rule1, rule2 = instance_group.rules
     int(rule1.to_port).should.equal(22)
     int(rule1.from_port).should.equal(22)


### PR DESCRIPTION
According to
http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-resource-tags.html

"All stack-level tags, including automatically created tags, are
propagated to resources that AWS CloudFormation supports. Currently,
tags are not propagated to Amazon EBS volumes that are created from
block device mappings."

I didn't take care of the EBS volume case from block device mappings, but generally fixed that stack level tags are propagated to any taggable ec2 resource.