### PR TITLE
Moto requires boto >= 2.36.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 install_requires = [
     "Jinja2",
-    "boto>=2.33.0",
+    "boto>=2.36.0",
     "flask",
     "httpretty==0.8.10",
     "requests",

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 install_requires = [
     "Jinja2",
-    "boto>=2.26.0",
+    "boto>=2.33.0",
     "flask",
     "httpretty==0.8.10",
     "requests",


### PR DESCRIPTION
Moto imports a class in boto that did not exist before boto 2.33.0

Partial traceback showing ImportError with versions of boto < 2.33.0:
  File "/src/python/moto/moto/__init__.py", line 8, in <module>
    from .autoscaling import mock_autoscaling  # flake8: noqa
  File "/src/python/moto/moto/autoscaling/__init__.py", line 2, in <module>
    from .models import autoscaling_backends
  File "/src/python/moto/moto/autoscaling/models.py", line 5, in <module>
    from moto.elb import elb_backends
  File "/src/python/moto/moto/elb/__init__.py", line 2, in <module>
    from .models import elb_backends
  File "/src/python/moto/moto/elb/models.py", line 4, in <module>
    from boto.ec2.elb.attributes import (
ImportError: cannot import name ConnectionSettingAttribute

And boto.awslambda didn't exist until 2.36.0