### PR TITLE
Add ip-address and private-ip-address to the list of filters for instance filtering

### DIFF
--- a/moto/ec2/utils.py
+++ b/moto/ec2/utils.py
@@ -360,7 +360,9 @@ filter_dict_attribute_mapping = {
     'vpc-id': 'vpc_id',
     'group-id': 'security_groups',
     'instance.group-id': 'security_groups',
-    'instance-type': 'instance_type'
+    'instance-type': 'instance_type',
+    'private-ip-address' : 'private_ip',
+    'ip-address' : 'public_ip'
 }
 
 


### PR DESCRIPTION
Please let me know if I'm missing anything. 

These filters are described in
http://boto3.readthedocs.org/en/latest/reference/services/ec2.html#EC2.Client.describe_instances

and map to the instance methods of public_ip() and private_ip() respectively.