### PR TITLE
Update dependency of httpretty from 0.8.10 to latest 0.8.14

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ install_requires = [
     "Jinja2",
     "boto>=2.26.0",
     "flask",
-    "httpretty==0.8.10",
+    "httpretty==0.8.14",
     "requests",
     "xmltodict",
     "six",


### PR DESCRIPTION
httpretty 0.8.10 has a defect in setup.py where there is an attempt to read a UTF-8 character `ã` from `httpretty/__init__.py` using ascii encoding. The defect is fixed in this commit:

(https://github.com/gabrielfalcao/HTTPretty/commit/f899d1bda8234658c2cec5aab027cb5b7c42203c)
[setup.py:48]

```
Traceback of the defect that occurs when installing moto 0.4.20 with pip:

Collecting httpretty==0.8.10 (from moto==0.4.20->-r docker/requirements.txt (line 10))
  Downloading httpretty-0.8.10.tar.gz (41kB)
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-build-hekq9nhs/httpretty/setup.py", line 86, in <module>
        version=read_version(),
      File "/tmp/pip-build-hekq9nhs/httpretty/setup.py", line 46, in read_version
        finder.visit(ast.parse(local_file('httpretty', '__init__.py')))
      File "/tmp/pip-build-hekq9nhs/httpretty/setup.py", line 78, in <lambda>
        open(os.path.join(os.path.dirname(__file__), *f)).read()
      File "/home/ubuntu/pigeon/venv/lib/python3.4/encodings/ascii.py", line 26, in decode
        return codecs.ascii_decode(input, self.errors)[0]
    UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 133: ordinal not in range(128)
```