### PR TITLE
Fixed DynamoDB 'IN' comparison function

### DIFF
--- a/moto/dynamodb/comparisons.py
+++ b/moto/dynamodb/comparisons.py
@@ -12,7 +12,7 @@ COMPARISON_FUNCS = {
     'CONTAINS': lambda item_value, test_value: test_value in item_value,
     'NOT_CONTAINS': lambda item_value, test_value: test_value not in item_value,
     'BEGINS_WITH': lambda item_value, test_value: item_value.startswith(test_value),
-    'IN': lambda item_value, test_value: item_value in test_value,
+    'IN': lambda item_value, *test_values: item_value in test_values,
     'BETWEEN': lambda item_value, lower_test_value, upper_test_value: lower_test_value <= item_value <= upper_test_value,
 }
 

--- a/moto/dynamodb2/comparisons.py
+++ b/moto/dynamodb2/comparisons.py
@@ -32,7 +32,7 @@ COMPARISON_FUNCS = {
     'CONTAINS': lambda item_value, test_value: test_value in item_value,
     'NOT_CONTAINS': lambda item_value, test_value: test_value not in item_value,
     'BEGINS_WITH': lambda item_value, test_value: item_value.startswith(test_value),
-    'IN': lambda item_value, test_value: item_value in test_value,
+    'IN': lambda item_value, *test_values: item_value in test_values,
     'BETWEEN': lambda item_value, lower_test_value, upper_test_value: lower_test_value <= item_value <= upper_test_value,
 }
 


### PR DESCRIPTION
Previously experiencing this error when using the "IN" comparison function:

```
File "[path]/moto/dynamodb2/models.py", line 65, in compare
    return comparison_func(self.value, *range_values)
TypeError: <lambda>() takes exactly 2 arguments (3 given)
```

Modified the lambdas to take an argument list.