### PR TITLE
Some more CloudFormation functionality

### DIFF
--- a/moto/autoscaling/models.py
+++ b/moto/autoscaling/models.py
@@ -82,8 +82,8 @@ class FakeLaunchConfiguration(object):
         return config
 
     @classmethod
-    def update_from_cloudformation_json(cls, resource_name, cloudformation_json, region_name):
-        cls.delete_from_cloudformation_json(resource_name, cloudformation_json, region_name)
+    def update_from_cloudformation_json(cls, original_resource, new_resource_name, cloudformation_json, region_name):
+        cls.delete_from_cloudformation_json(original_resource.name, cloudformation_json, region_name)
         return cls.create_from_cloudformation_json(resource_name, cloudformation_json, region_name)
 
     @classmethod
@@ -186,9 +186,9 @@ class FakeAutoScalingGroup(object):
         return group
 
     @classmethod
-    def update_from_cloudformation_json(cls, resource_name, cloudformation_json, region_name):
-        cls.delete_from_cloudformation_json(resource_name, cloudformation_json, region_name)
-        return cls.create_from_cloudformation_json(resource_name, cloudformation_json, region_name)
+    def update_from_cloudformation_json(cls, original_resource, new_resource_name, cloudformation_json, region_name):
+        cls.delete_from_cloudformation_json(original_resource.name, cloudformation_json, region_name)
+        return cls.create_from_cloudformation_json(new_resource_name, cloudformation_json, region_name)
 
     @classmethod
     def delete_from_cloudformation_json(cls, resource_name, cloudformation_json, region_name):

--- a/moto/autoscaling/models.py
+++ b/moto/autoscaling/models.py
@@ -3,6 +3,7 @@ from boto.ec2.blockdevicemapping import BlockDeviceType, BlockDeviceMapping
 from moto.core import BaseBackend
 from moto.ec2 import ec2_backends
 from moto.elb import elb_backends
+from moto.elb.exceptions import LoadBalancerNotFoundError
 
 # http://docs.aws.amazon.com/AutoScaling/latest/DeveloperGuide/AS_Concepts.html#Cooldown
 DEFAULT_COOLDOWN = 300
@@ -79,6 +80,16 @@ class FakeLaunchConfiguration(object):
             block_device_mappings=properties.get("BlockDeviceMapping.member")
         )
         return config
+
+    @classmethod
+    def update_from_cloudformation_json(cls, resource_name, cloudformation_json, region_name):
+        backend = autoscaling_backends[region_name]
+        try:
+            backend.delete_launch_configuration(resource_name)
+        except KeyError:
+            pass
+
+        return cls.create_from_cloudformation_json(resource_name, cloudformation_json, region_name)
 
     def delete(self, region_name):
         backend = autoscaling_backends[region_name]
@@ -171,9 +182,26 @@ class FakeAutoScalingGroup(object):
         )
         return group
 
+    @classmethod
+    def update_from_cloudformation_json(cls, resource_name, cloudformation_json, region_name):
+        backend = autoscaling_backends[region_name]
+        try:
+            backend.delete_autoscaling_group(resource_name)
+        except KeyError:
+            pass
+        except LoadBalancerNotFoundError:
+            # sometimes the ELB gets modified before the ASG, so just skip over desired capacity
+            backend.autoscaling_groups.pop(resource_name, None)
+
+        return cls.create_from_cloudformation_json(resource_name, cloudformation_json, region_name)
+
     def delete(self, region_name):
         backend = autoscaling_backends[region_name]
-        backend.delete_autoscaling_group(self.name)
+        try:
+            backend.delete_autoscaling_group(self.name)
+        except LoadBalancerNotFoundError:
+            # sometimes the ELB gets deleted before the ASG, so just skip over desired capacity
+            backend.autoscaling_groups.pop(self.name, None)
 
     @property
     def physical_resource_id(self):

--- a/moto/autoscaling/models.py
+++ b/moto/autoscaling/models.py
@@ -83,13 +83,16 @@ class FakeLaunchConfiguration(object):
 
     @classmethod
     def update_from_cloudformation_json(cls, resource_name, cloudformation_json, region_name):
+        cls.delete_from_cloudformation_json(resource_name, cloudformation_json, region_name)
+        return cls.create_from_cloudformation_json(resource_name, cloudformation_json, region_name)
+
+    @classmethod
+    def delete_from_cloudformation_json(cls, resource_name, cloudformation_json, region_name):
         backend = autoscaling_backends[region_name]
         try:
             backend.delete_launch_configuration(resource_name)
         except KeyError:
             pass
-
-        return cls.create_from_cloudformation_json(resource_name, cloudformation_json, region_name)
 
     def delete(self, region_name):
         backend = autoscaling_backends[region_name]
@@ -184,6 +187,11 @@ class FakeAutoScalingGroup(object):
 
     @classmethod
     def update_from_cloudformation_json(cls, resource_name, cloudformation_json, region_name):
+        cls.delete_from_cloudformation_json(resource_name, cloudformation_json, region_name)
+        return cls.create_from_cloudformation_json(resource_name, cloudformation_json, region_name)
+
+    @classmethod
+    def delete_from_cloudformation_json(cls, resource_name, cloudformation_json, region_name):
         backend = autoscaling_backends[region_name]
         try:
             backend.delete_autoscaling_group(resource_name)
@@ -192,8 +200,6 @@ class FakeAutoScalingGroup(object):
         except LoadBalancerNotFoundError:
             # sometimes the ELB gets modified before the ASG, so just skip over desired capacity
             backend.autoscaling_groups.pop(resource_name, None)
-
-        return cls.create_from_cloudformation_json(resource_name, cloudformation_json, region_name)
 
     def delete(self, region_name):
         backend = autoscaling_backends[region_name]

--- a/moto/cloudformation/exceptions.py
+++ b/moto/cloudformation/exceptions.py
@@ -14,7 +14,7 @@ class ValidationError(BadRequest):
         super(ValidationError, self).__init__()
         self.description = template.render(
             code="ValidationError",
-            messgae="Stack:{0} does not exist".format(name_or_id),
+            message="Stack:{0} does not exist".format(name_or_id),
         )
 
 
@@ -24,7 +24,7 @@ class MissingParameterError(BadRequest):
         super(MissingParameterError, self).__init__()
         self.description = template.render(
             code="Missing Parameter",
-            messgae="Missing parameter {0}".format(parameter_name),
+            message="Missing parameter {0}".format(parameter_name),
         )
 
 

--- a/moto/cloudformation/models.py
+++ b/moto/cloudformation/models.py
@@ -51,10 +51,11 @@ class FakeStack(object):
         self.template = template
         self.resource_map.update(json.loads(template))
         self.output_map = self._create_output_map()
+        self.status = "UPDATE_COMPLETE"
 
     def delete(self):
         self.resource_map.delete()
-        self.status = 'DELETE_COMPLETE'
+        self.status = "DELETE_COMPLETE"
 
 
 class CloudFormationBackend(BaseBackend):

--- a/moto/cloudformation/parsing.py
+++ b/moto/cloudformation/parsing.py
@@ -207,11 +207,17 @@ def parse_and_create_resource(logical_id, resource_json, resources_map, region_n
 
 
 def parse_and_update_resource(logical_id, resource_json, resources_map, region_name):
-    resource_class, resource_json, resource_name = parse_resource(logical_id, resource_json, resources_map)
-    resource = resource_class.update_from_cloudformation_json(resource_name, resource_json, region_name)
-    resource.type = resource_json['Type']
-    resource.logical_resource_id = logical_id
-    return resource
+    resource_class, new_resource_json, new_resource_name = parse_resource(logical_id, resource_json, resources_map)
+    original_resource = resources_map[logical_id]
+    new_resource = resource_class.update_from_cloudformation_json(
+        original_resource=original_resource,
+        new_resource_name=new_resource_name,
+        cloudformation_json=new_resource_json,
+        region_name=region_name
+    )
+    new_resource.type = resource_json['Type']
+    new_resource.logical_resource_id = logical_id
+    return new_resource
 
 
 def parse_and_delete_resource(logical_id, resource_json, resources_map, region_name):

--- a/moto/cloudformation/parsing.py
+++ b/moto/cloudformation/parsing.py
@@ -209,13 +209,14 @@ def parse_and_create_resource(logical_id, resource_json, resources_map, region_n
 def parse_and_update_resource(logical_id, resource_json, resources_map, region_name):
     resource_class, resource_json, resource_name = parse_resource(logical_id, resource_json, resources_map)
     resource = resource_class.update_from_cloudformation_json(resource_name, resource_json, region_name)
+    resource.type = resource_json['Type']
+    resource.logical_resource_id = logical_id
     return resource
 
 
 def parse_and_delete_resource(logical_id, resource_json, resources_map, region_name):
     resource_class, resource_json, resource_name = parse_resource(logical_id, resource_json, resources_map)
     resource_class.delete_from_cloudformation_json(resource_name, resource_json, region_name)
-    return None
 
 
 def parse_condition(condition, resources_map, condition_map):
@@ -368,17 +369,40 @@ class ResourceMap(collections.Mapping):
             parse_and_delete_resource(resource_name, resource_json, self, self._region_name)
             self._parsed_resources.pop(resource_name)
 
-        for resource_name in new_template:
-            if resource_name in old_template and new_template[resource_name] != old_template[resource_name]:
+        resources_to_update = set(name for name in new_template if name in old_template and new_template[name] != old_template[name])
+        tries = 1
+        while resources_to_update and tries < 5:
+            for resource_name in resources_to_update.copy():
                 resource_json = new_template[resource_name]
-
-                changed_resource = parse_and_update_resource(resource_name, resource_json, self, self._region_name)
-                self._parsed_resources[resource_name] = changed_resource
+                try:
+                    changed_resource = parse_and_update_resource(resource_name, resource_json, self, self._region_name)
+                except Exception as e:
+                    # skip over dependency violations, and try again in a second pass
+                    last_exception = e
+                else:
+                    self._parsed_resources[resource_name] = changed_resource
+                    resources_to_update.remove(resource_name)
+            tries += 1
+        if tries == 5:
+            raise last_exception
 
     def delete(self):
-        for resource in self.resources:
-            parsed_resource = self._parsed_resources.pop(resource)
-            parsed_resource.delete(self._region_name)
+        remaining_resources = set(self.resources)
+        tries = 1
+        while remaining_resources and tries < 5:
+            for resource in remaining_resources.copy():
+                parsed_resource = self._parsed_resources.get(resource)
+                if parsed_resource:
+                    try:
+                        parsed_resource.delete(self._region_name)
+                    except Exception as e:
+                        # skip over dependency violations, and try again in a second pass
+                        last_exception = e 
+                    else:
+                        remaining_resources.remove(resource)
+            tries += 1
+        if tries == 5:
+            raise last_exception
 
 
 class OutputMap(collections.Mapping):

--- a/moto/cloudformation/parsing.py
+++ b/moto/cloudformation/parsing.py
@@ -114,7 +114,7 @@ def clean_json(resource_json, resources_map):
             return result
 
         if 'Fn::GetAtt' in resource_json:
-            resource = resources_map[resource_json['Fn::GetAtt'][0]]
+            resource = resources_map.get(resource_json['Fn::GetAtt'][0])
             if resource is None:
                 return resource_json
             try:
@@ -288,6 +288,8 @@ class ResourceMap(collections.Mapping):
             return self._parsed_resources[resource_logical_id]
         else:
             resource_json = self._resource_json_map.get(resource_logical_id)
+            if not resource_json:
+                raise KeyError(resource_logical_id)
             new_resource = parse_and_create_resource(resource_logical_id, resource_json, self, self._region_name)
             self._parsed_resources[resource_logical_id] = new_resource
             return new_resource

--- a/moto/cloudformation/responses.py
+++ b/moto/cloudformation/responses.py
@@ -79,8 +79,8 @@ class CloudFormationResponse(BaseResponse):
                 resource = stack_resource
                 break
         else:
-            raise ValidationError(logical_resource_id)   
-        
+            raise ValidationError(logical_resource_id)
+
         template = self.response_template(DESCRIBE_STACK_RESOURCE_RESPONSE_TEMPLATE)
         return template.render(stack=stack, resource=resource)
 
@@ -106,7 +106,7 @@ class CloudFormationResponse(BaseResponse):
     def get_template(self):
         name_or_stack_id = self.querystring.get('StackName')[0]
         stack = self.cloudformation_backend.get_stack(name_or_stack_id)
-        
+
         if self.request_json:
             return json.dumps({
                 "GetTemplateResponse": {
@@ -124,7 +124,10 @@ class CloudFormationResponse(BaseResponse):
 
     def update_stack(self):
         stack_name = self._get_param('StackName')
-        stack_body = self._get_param('TemplateBody')
+        if self._get_param('UsePreviousTemplate') == "true":
+            stack_body = self.cloudformation_backend.get_stack(stack_name).template
+        else:
+            stack_body = self._get_param('TemplateBody')
 
         stack = self.cloudformation_backend.update_stack(
             name=stack_name,

--- a/moto/cloudformation/responses.py
+++ b/moto/cloudformation/responses.py
@@ -130,14 +130,18 @@ class CloudFormationResponse(BaseResponse):
             name=stack_name,
             template=stack_body,
         )
-        stack_body = {
-            'UpdateStackResponse': {
-                'UpdateStackResult': {
-                    'StackId': stack.name,
+        if self.request_json:
+            stack_body = {
+                'UpdateStackResponse': {
+                    'UpdateStackResult': {
+                        'StackId': stack.name,
+                    }
                 }
             }
-        }
-        return json.dumps(stack_body)
+            return json.dumps(stack_body)
+        else:
+            template = self.response_template(UPDATE_STACK_RESPONSE_TEMPLATE)
+            return template.render(stack=stack)
 
     def delete_stack(self):
         name_or_stack_id = self.querystring.get('StackName')[0]
@@ -294,6 +298,16 @@ GET_TEMPLATE_RESPONSE_TEMPLATE = """<GetTemplateResponse>
   </ResponseMetadata>
 </GetTemplateResponse>"""
 
+
+UPDATE_STACK_RESPONSE_TEMPLATE = """<UpdateStackResponse xmlns="http://cloudformation.amazonaws.com/doc/2010-05-15/">
+  <UpdateStackResult>
+    <StackId>{{ stack.stack_id }}</StackId>
+  </UpdateStackResult>
+  <ResponseMetadata>
+    <RequestId>b9b4b068-3a41-11e5-94eb-example</RequestId>
+  </ResponseMetadata>
+</UpdateStackResponse>
+"""
 
 DELETE_STACK_RESPONSE_TEMPLATE = """<DeleteStackResponse>
   <ResponseMetadata>

--- a/moto/ec2/models.py
+++ b/moto/ec2/models.py
@@ -1136,17 +1136,19 @@ class SecurityGroup(TaggedEC2Resource):
         return security_group
 
     @classmethod
-    def update_from_cloudformation_json(cls, resource_name, cloudformation_json, region_name):
-        cls.delete_from_cloudformation_json(resource_name, cloudformation_json, region_name)
-        return cls.create_from_cloudformation_json(resource_name, cloudformation_json, region_name)
+    def update_from_cloudformation_json(cls, original_resource, new_resource_name, cloudformation_json, region_name):
+        cls._delete_security_group_given_vpc_id(original_resource.name, original_resource.vpc_id, region_name)
+        return cls.create_from_cloudformation_json(new_resource_name, cloudformation_json, region_name)
 
     @classmethod
     def delete_from_cloudformation_json(cls, resource_name, cloudformation_json, region_name):
         properties = cloudformation_json['Properties']
-
-        ec2_backend = ec2_backends[region_name]
         vpc_id = properties.get('VpcId')
+        cls._delete_security_group_given_vpc_id(resource_name, vpc_id, region_name)
 
+    @classmethod
+    def _delete_security_group_given_vpc_id(cls, resource_name, vpc_id, region_name):
+        ec2_backend = ec2_backends[region_name]
         security_group = ec2_backend.get_security_group_from_name(resource_name, vpc_id)
         if security_group:
             security_group.delete(region_name)

--- a/moto/ec2/models.py
+++ b/moto/ec2/models.py
@@ -1137,15 +1137,19 @@ class SecurityGroup(TaggedEC2Resource):
 
     @classmethod
     def update_from_cloudformation_json(cls, resource_name, cloudformation_json, region_name):
+        cls.delete_from_cloudformation_json(resource_name, cloudformation_json, region_name)
+        return cls.create_from_cloudformation_json(resource_name, cloudformation_json, region_name)
+
+    @classmethod
+    def delete_from_cloudformation_json(cls, resource_name, cloudformation_json, region_name):
         properties = cloudformation_json['Properties']
 
         ec2_backend = ec2_backends[region_name]
         vpc_id = properties.get('VpcId')
 
         security_group = ec2_backend.get_security_group_from_name(resource_name, vpc_id)
-        security_group.delete(region_name)
-
-        return cls.create_from_cloudformation_json(resource_name, cloudformation_json, region_name)
+        if security_group:
+            security_group.delete(region_name)
 
     def delete(self, region_name):
         ''' Not exposed as part of the ELB API - used for CloudFormation. '''

--- a/moto/ec2/models.py
+++ b/moto/ec2/models.py
@@ -1135,6 +1135,23 @@ class SecurityGroup(TaggedEC2Resource):
 
         return security_group
 
+    @classmethod
+    def update_from_cloudformation_json(cls, resource_name, cloudformation_json, region_name):
+        properties = cloudformation_json['Properties']
+
+        ec2_backend = ec2_backends[region_name]
+        vpc_id = properties.get('VpcId')
+
+        security_group = ec2_backend.get_security_group_from_name(resource_name, vpc_id)
+        security_group.delete(region_name)
+
+        return cls.create_from_cloudformation_json(resource_name, cloudformation_json, region_name)
+
+    def delete(self, region_name):
+        ''' Not exposed as part of the ELB API - used for CloudFormation. '''
+        backend = ec2_backends[region_name]
+        self.ec2_backend.delete_security_group(group_id=self.id)
+
     @property
     def physical_resource_id(self):
         return self.id

--- a/moto/elb/models.py
+++ b/moto/elb/models.py
@@ -61,6 +61,7 @@ class FakeLoadBalancer(object):
         self.policies.app_cookie_stickiness_policies = []
         self.policies.lb_cookie_stickiness_policies = []
         self.tags = {}
+        self.dns_name = "tests.us-east-1.elb.amazonaws.com"
 
         for port in ports:
             listener = FakeListener(
@@ -117,7 +118,7 @@ class FakeLoadBalancer(object):
         elif attribute_name == 'CanonicalHostedZoneNameID':
             raise NotImplementedError('"Fn::GetAtt" : [ "{0}" , "CanonicalHostedZoneNameID" ]"')
         elif attribute_name == 'DNSName':
-            raise NotImplementedError('"Fn::GetAtt" : [ "{0}" , "DNSName" ]"')
+            return self.dns_name
         elif attribute_name == 'SourceSecurityGroup.GroupName':
             raise NotImplementedError('"Fn::GetAtt" : [ "{0}" , "SourceSecurityGroup.GroupName" ]"')
         elif attribute_name == 'SourceSecurityGroup.OwnerAlias':

--- a/moto/elb/models.py
+++ b/moto/elb/models.py
@@ -94,6 +94,18 @@ class FakeLoadBalancer(object):
         instance_ids = properties.get('Instances', [])
         for instance_id in instance_ids:
             elb_backend.register_instances(new_elb.name, [instance_id])
+
+        health_check = properties.get('HealthCheck')
+        if health_check:
+            elb_backend.configure_health_check(
+                load_balancer_name=new_elb.name,
+                timeout=health_check['Timeout'],
+                healthy_threshold=health_check['HealthyThreshold'],
+                unhealthy_threshold=health_check['UnhealthyThreshold'],
+                interval=health_check['Interval'],
+                target=health_check['Target'],
+            )
+
         return new_elb
 
     @classmethod
@@ -105,7 +117,6 @@ class FakeLoadBalancer(object):
             pass
 
         return cls.create_from_cloudformation_json(resource_name, cloudformation_json, region_name)
-
 
     @property
     def physical_resource_id(self):

--- a/moto/elb/models.py
+++ b/moto/elb/models.py
@@ -109,9 +109,9 @@ class FakeLoadBalancer(object):
         return new_elb
 
     @classmethod
-    def update_from_cloudformation_json(cls, resource_name, cloudformation_json, region_name):
-        cls.delete_from_cloudformation_json(resource_name, cloudformation_json, region_name)
-        return cls.create_from_cloudformation_json(resource_name, cloudformation_json, region_name)
+    def update_from_cloudformation_json(cls, original_resource, new_resource_name, cloudformation_json, region_name):
+        cls.delete_from_cloudformation_json(original_resource.name, cloudformation_json, region_name)
+        return cls.create_from_cloudformation_json(new_resource_name, cloudformation_json, region_name)
 
     @classmethod
     def delete_from_cloudformation_json(cls, resource_name, cloudformation_json, region_name):

--- a/moto/elb/models.py
+++ b/moto/elb/models.py
@@ -110,13 +110,16 @@ class FakeLoadBalancer(object):
 
     @classmethod
     def update_from_cloudformation_json(cls, resource_name, cloudformation_json, region_name):
+        cls.delete_from_cloudformation_json(resource_name, cloudformation_json, region_name)
+        return cls.create_from_cloudformation_json(resource_name, cloudformation_json, region_name)
+
+    @classmethod
+    def delete_from_cloudformation_json(cls, resource_name, cloudformation_json, region_name):
         elb_backend = elb_backends[region_name]
         try:
             elb_backend.delete_load_balancer(resource_name)
         except KeyError:
             pass
-
-        return cls.create_from_cloudformation_json(resource_name, cloudformation_json, region_name)
 
     @property
     def physical_resource_id(self):

--- a/moto/elb/responses.py
+++ b/moto/elb/responses.py
@@ -28,14 +28,14 @@ class ELBResponse(BaseResponse):
         ports = self._get_list_prefix("Listeners.member")
         scheme = self._get_param('Scheme')
 
-        self.elb_backend.create_load_balancer(
+        load_balancer = self.elb_backend.create_load_balancer(
             name=load_balancer_name,
             zones=availability_zones,
             ports=ports,
             scheme=scheme
         )
         template = self.response_template(CREATE_LOAD_BALANCER_TEMPLATE)
-        return template.render()
+        return template.render(load_balancer=load_balancer)
 
     def create_load_balancer_listeners(self):
         load_balancer_name = self._get_param('LoadBalancerName')
@@ -330,7 +330,7 @@ DESCRIBE_TAGS_TEMPLATE = """<DescribeTagsResponse xmlns="http://elasticloadbalan
 
 CREATE_LOAD_BALANCER_TEMPLATE = """<CreateLoadBalancerResponse xmlns="http://elasticloadbalancing.amazonaws.com/doc/2012-06-01/">
   <CreateLoadBalancerResult>
-    <DNSName>tests.us-east-1.elb.amazonaws.com</DNSName>
+    <DNSName>{{ load_balancer.dns_name }}</DNSName>
   </CreateLoadBalancerResult>
   <ResponseMetadata>
     <RequestId>1549581b-12b7-11e3-895e-1334aEXAMPLE</RequestId>
@@ -434,7 +434,7 @@ DESCRIBE_LOAD_BALANCERS_TEMPLATE = """<DescribeLoadBalancersResponse xmlns="http
           <CanonicalHostedZoneName>tests.us-east-1.elb.amazonaws.com</CanonicalHostedZoneName>
           <CanonicalHostedZoneNameID>Z3ZONEID</CanonicalHostedZoneNameID>
           <Scheme>{{ load_balancer.scheme }}</Scheme>
-          <DNSName>tests.us-east-1.elb.amazonaws.com</DNSName>
+          <DNSName>{{ load_balancer.dns_name }}</DNSName>
           <BackendServerDescriptions>
           {% for backend in load_balancer.backends %}
             <member>

--- a/moto/route53/models.py
+++ b/moto/route53/models.py
@@ -86,9 +86,9 @@ class RecordSet(object):
         return record_set
 
     @classmethod
-    def update_from_cloudformation_json(cls, resource_name, cloudformation_json, region_name):
-        cls.delete_from_cloudformation_json(resource_name, cloudformation_json, region_name)
-        return cls.create_from_cloudformation_json(resource_name, cloudformation_json, region_name)
+    def update_from_cloudformation_json(cls, original_resource, new_resource_name, cloudformation_json, region_name):
+        cls.delete_from_cloudformation_json(original_resource.name, cloudformation_json, region_name)
+        return cls.create_from_cloudformation_json(new_resource_name, cloudformation_json, region_name)
 
     @classmethod
     def delete_from_cloudformation_json(cls, resource_name, cloudformation_json, region_name):

--- a/moto/route53/models.py
+++ b/moto/route53/models.py
@@ -87,6 +87,11 @@ class RecordSet(object):
 
     @classmethod
     def update_from_cloudformation_json(cls, resource_name, cloudformation_json, region_name):
+        cls.delete_from_cloudformation_json(resource_name, cloudformation_json, region_name)
+        return cls.create_from_cloudformation_json(resource_name, cloudformation_json, region_name)
+
+    @classmethod
+    def delete_from_cloudformation_json(cls, resource_name, cloudformation_json, region_name):
         # this will break if you changed the zone the record is in, unfortunately
         properties = cloudformation_json['Properties']
 
@@ -100,8 +105,6 @@ class RecordSet(object):
             hosted_zone.delete_rrset_by_name(resource_name)
         except KeyError:
             pass
-
-        return cls.create_from_cloudformation_json(resource_name, cloudformation_json, region_name)
 
     def to_xml(self):
         template = Template("""<ResourceRecordSet>

--- a/moto/sqs/models.py
+++ b/moto/sqs/models.py
@@ -137,7 +137,7 @@ class Queue(object):
         )
 
     @classmethod
-    def update_from_cloudformation_json(cls, resource_name, cloudformation_json, region_name):
+    def update_from_cloudformation_json(cls, original_resource, new_resource_name, cloudformation_json, region_name):
         properties = cloudformation_json['Properties']
         queue_name = properties['QueueName']
 

--- a/tests/test_cloudformation/test_cloudformation_stack_crud.py
+++ b/tests/test_cloudformation/test_cloudformation_stack_crud.py
@@ -286,3 +286,24 @@ def test_update_stack():
         }
     })
 
+@mock_cloudformation
+def test_update_stack():
+    conn = boto.connect_cloudformation()
+    conn.create_stack(
+        "test_stack",
+        template_body=dummy_template_json,
+    )
+    conn.update_stack("test_stack", use_previous_template=True)
+
+    stack = conn.describe_stacks()[0]
+    stack.stack_status.should.equal("UPDATE_COMPLETE")
+    stack.get_template().should.equal({
+        'GetTemplateResponse': {
+            'GetTemplateResult': {
+                'TemplateBody': dummy_template_json,
+                'ResponseMetadata': {
+                    'RequestId': '2d06e36c-ac1d-11e0-a958-f9382b6eb86bEXAMPLE'
+                }
+            }
+        }
+    })

--- a/tests/test_cloudformation/test_cloudformation_stack_crud.py
+++ b/tests/test_cloudformation/test_cloudformation_stack_crud.py
@@ -263,24 +263,26 @@ def test_stack_tags():
     dict(stack.tags).should.equal({"foo": "bar", "baz": "bleh"})
 
 
-# @mock_cloudformation
-# def test_update_stack():
-#     conn = boto.connect_cloudformation()
-#     conn.create_stack(
-#         "test_stack",
-#         template_body=dummy_template_json,
-#     )
+@mock_cloudformation
+def test_update_stack():
+    conn = boto.connect_cloudformation()
+    conn.create_stack(
+        "test_stack",
+        template_body=dummy_template_json,
+    )
 
-#     conn.update_stack("test_stack", dummy_template_json2)
+    conn.update_stack("test_stack", dummy_template_json2)
 
-#     stack = conn.describe_stacks()[0]
-#     stack.get_template().should.equal({
-#         'GetTemplateResponse': {
-#             'GetTemplateResult': {
-#                 'TemplateBody': dummy_template_json2,
-#                 'ResponseMetadata': {
-#                     'RequestId': '2d06e36c-ac1d-11e0-a958-f9382b6eb86bEXAMPLE'
-#                 }
-#             }
-#         }
-#     })
+    stack = conn.describe_stacks()[0]
+    stack.stack_status.should.equal("UPDATE_COMPLETE")
+    stack.get_template().should.equal({
+        'GetTemplateResponse': {
+            'GetTemplateResult': {
+                'TemplateBody': dummy_template_json2,
+                'ResponseMetadata': {
+                    'RequestId': '2d06e36c-ac1d-11e0-a958-f9382b6eb86bEXAMPLE'
+                }
+            }
+        }
+    })
+

--- a/tests/test_cloudformation/test_cloudformation_stack_integration.py
+++ b/tests/test_cloudformation/test_cloudformation_stack_integration.py
@@ -351,6 +351,50 @@ def test_stack_elb_integration_with_health_check():
     health_check.unhealthy_threshold.should.equal(2)
 
 
+@mock_elb()
+@mock_cloudformation()
+def test_stack_elb_integration_with_update():
+    elb_template = {
+        "AWSTemplateFormatVersion": "2010-09-09",
+        "Resources": {
+            "MyELB": {
+                "Type": "AWS::ElasticLoadBalancing::LoadBalancer",
+                "Properties": {
+                    "LoadBalancerName": "test-elb",
+                    "AvailabilityZones": ['us-west-1a'],
+                    "Listeners": [
+                        {
+                            "InstancePort": "80",
+                            "LoadBalancerPort": "80",
+                            "Protocol": "HTTP",
+                        }
+                    ],
+                }
+            },
+        },
+    }
+    elb_template_json = json.dumps(elb_template)
+
+    conn = boto.cloudformation.connect_to_region("us-west-1")
+    conn.create_stack(
+        "elb_stack",
+        template_body=elb_template_json,
+    )
+
+    elb_conn = boto.ec2.elb.connect_to_region("us-west-1")
+    load_balancer = elb_conn.get_all_load_balancers()[0]
+    load_balancer.availability_zones[0].should.equal('us-west-1a')
+
+    elb_template['Resources']['MyELB']['Properties']['AvailabilityZones'] = ['us-west-1b']
+    elb_template_json = json.dumps(elb_template)
+    conn.update_stack(
+        "elb_stack",
+        template_body=elb_template_json,
+    )
+    load_balancer = elb_conn.get_all_load_balancers()[0]
+    load_balancer.availability_zones[0].should.equal('us-west-1b')
+
+
 @mock_ec2()
 @mock_redshift()
 @mock_cloudformation()
@@ -542,6 +586,55 @@ def test_autoscaling_group_with_elb():
 
     elb_resource = [resource for resource in resources if resource.resource_type == 'AWS::ElasticLoadBalancing::LoadBalancer'][0]
     elb_resource.physical_resource_id.should.contain("my-elb")
+
+
+@mock_autoscaling()
+@mock_cloudformation()
+def test_autoscaling_group_update():
+    asg_template = {
+        "AWSTemplateFormatVersion": "2010-09-09",
+        "Resources": {
+            "my-as-group": {
+                "Type": "AWS::AutoScaling::AutoScalingGroup",
+                "Properties": {
+                    "AvailabilityZones": ['us-west-1'],
+                    "LaunchConfigurationName": {"Ref": "my-launch-config"},
+                    "MinSize": "2",
+                    "MaxSize": "2",
+                },
+            },
+
+            "my-launch-config": {
+                "Type": "AWS::AutoScaling::LaunchConfiguration",
+                "Properties": {
+                    "ImageId": "ami-1234abcd",
+                    "UserData": "some user data",
+                }
+            },
+        },
+    }
+    asg_template_json = json.dumps(asg_template)
+
+    conn = boto.cloudformation.connect_to_region("us-west-1")
+    conn.create_stack(
+        "asg_stack",
+        template_body=asg_template_json,
+    )
+
+    autoscale_conn = boto.ec2.autoscale.connect_to_region("us-west-1")
+    asg = autoscale_conn.get_all_groups()[0]
+    asg.min_size.should.equal(2)
+    asg.max_size.should.equal(2)
+
+    asg_template['Resources']['my-as-group']['Properties']['MaxSize'] = 3
+    asg_template_json = json.dumps(asg_template)
+    conn.update_stack(
+        "asg_stack",
+        template_body=asg_template_json,
+    )
+    asg = autoscale_conn.get_all_groups()[0]
+    asg.min_size.should.equal(2)
+    asg.max_size.should.equal(3)
 
 
 @mock_ec2()
@@ -1119,6 +1212,46 @@ def test_route53_associate_health_check():
 
 
 @mock_cloudformation()
+@mock_route53()
+def test_route53_with_update():
+    route53_conn = boto.connect_route53()
+
+    template_json = json.dumps(route53_health_check.template)
+    cf_conn = boto.cloudformation.connect_to_region("us-west-1")
+    cf_conn.create_stack(
+        "test_stack",
+        template_body=template_json,
+    )
+
+    zones = route53_conn.get_all_hosted_zones()['ListHostedZonesResponse']['HostedZones']
+    list(zones).should.have.length_of(1)
+    zone_id = zones[0]['Id']
+
+    rrsets = route53_conn.get_all_rrsets(zone_id)
+    rrsets.should.have.length_of(1)
+
+    record_set = rrsets[0]
+    record_set.resource_records.should.equal(["my.example.com"])
+
+    route53_health_check.template['Resources']['myDNSRecord']['Properties']['ResourceRecords'] = ["my_other.example.com"]
+    template_json = json.dumps(route53_health_check.template)
+    cf_conn.update_stack(
+        "test_stack",
+        template_body=template_json,
+    )
+
+    zones = route53_conn.get_all_hosted_zones()['ListHostedZonesResponse']['HostedZones']
+    list(zones).should.have.length_of(1)
+    zone_id = zones[0]['Id']
+
+    rrsets = route53_conn.get_all_rrsets(zone_id)
+    rrsets.should.have.length_of(1)
+
+    record_set = rrsets[0]
+    record_set.resource_records.should.equal(["my_other.example.com"])
+
+
+@mock_cloudformation()
 @mock_sns()
 def test_sns_topic():
     dummy_template = {
@@ -1426,6 +1559,51 @@ def test_security_group_ingress_separate_from_security_group_by_id_using_vpc():
     security_group1.rules[0].ip_protocol.should.equal('tcp')
     security_group1.rules[0].from_port.should.equal('80')
     security_group1.rules[0].to_port.should.equal('8080')
+
+
+@mock_cloudformation
+@mock_ec2
+def test_security_group_with_update():
+    vpc_conn = boto.vpc.connect_to_region("us-west-1")
+    vpc1 = vpc_conn.create_vpc("10.0.0.0/16")
+
+    template = {
+        "AWSTemplateFormatVersion": "2010-09-09",
+        "Resources": {
+            "test-security-group": {
+                "Type": "AWS::EC2::SecurityGroup",
+                "Properties": {
+                    "GroupDescription": "test security group",
+                    "VpcId": vpc1.id,
+                    "Tags": [
+                        {
+                            "Key": "sg-name",
+                            "Value": "sg"
+                        }
+                    ]
+                },
+            },
+        }
+    }
+
+    template_json = json.dumps(template)
+    cf_conn = boto.cloudformation.connect_to_region("us-west-1")
+    cf_conn.create_stack(
+        "test_stack",
+        template_body=template_json,
+    )
+    security_group = vpc_conn.get_all_security_groups(filters={"tag:sg-name": "sg"})[0]
+    security_group.vpc_id.should.equal(vpc1.id)
+
+    vpc2 = vpc_conn.create_vpc("10.1.0.0/16")
+    template['Resources']['test-security-group']['Properties']['VpcId'] = vpc2.id
+    template_json = json.dumps(template)
+    cf_conn.update_stack(
+        "test_stack",
+        template_body=template_json,
+    )
+    security_group = vpc_conn.get_all_security_groups(filters={"tag:sg-name": "sg"})[0]
+    security_group.vpc_id.should.equal(vpc2.id)
 
 
 @mock_cloudformation

--- a/tests/test_cloudformation/test_cloudformation_stack_integration.py
+++ b/tests/test_cloudformation/test_cloudformation_stack_integration.py
@@ -262,10 +262,17 @@ def test_stack_elb_integration_with_attached_ec2_instances():
         "Resources": {
             "MyELB": {
                 "Type": "AWS::ElasticLoadBalancing::LoadBalancer",
-                "Instances": [{"Ref": "Ec2Instance1"}],
                 "Properties": {
+                    "Instances": [{"Ref": "Ec2Instance1"}],
                     "LoadBalancerName": "test-elb",
-                    "AvailabilityZones": ['us-east1'],
+                    "AvailabilityZones": ['us-east-1'],
+                    "Listeners": [
+                        {
+                            "InstancePort": "80",
+                            "LoadBalancerPort": "80",
+                            "Protocol": "HTTP",
+                        }
+                    ],
                 }
             },
             "Ec2Instance1": {
@@ -293,7 +300,7 @@ def test_stack_elb_integration_with_attached_ec2_instances():
     ec2_instance = reservation.instances[0]
 
     load_balancer.instances[0].id.should.equal(ec2_instance.id)
-    list(load_balancer.availability_zones).should.equal(['us-east1'])
+    list(load_balancer.availability_zones).should.equal(['us-east-1'])
 
 
 @mock_ec2()
@@ -442,7 +449,7 @@ def test_autoscaling_group_with_elb():
                     "Listeners": [{
                         "LoadBalancerPort": "80",
                         "InstancePort": "80",
-                        "Protocol": "HTTP"
+                        "Protocol": "HTTP",
                     }],
                     "LoadBalancerName": "my-elb",
                     "HealthCheck": {


### PR DESCRIPTION
* Implements updating for:
    * ASGs
    * Launch Configurations
    * ELBs
    * Route53 records
* Adds support for:
    * ELB health checks
    * `GetAtt` (for `DNSName` in ELBs only, since it was the only thing I needed when working on my own code.)
    * `UsePreviousTemplate` in `Stack.update`
* Fixes:
    * Sets stack status to `UPDATE_COMPLETE` after updating the stack