### PR TITLE
Add datetime to cloudwatch's alarms

### DIFF
--- a/moto/cloudwatch/models.py
+++ b/moto/cloudwatch/models.py
@@ -1,5 +1,6 @@
 from moto.core import BaseBackend
 import boto.ec2.cloudwatch
+import datetime
 
 
 class Dimension(object):
@@ -24,6 +25,8 @@ class FakeAlarm(object):
         self.ok_actions = ok_actions
         self.insufficient_data_actions = insufficient_data_actions
         self.unit = unit
+        self.state_updated_timestamp = datetime.datetime.now()
+        self.configuration_updated_timestamp = datetime.datetime.now()
 
 
 class MetricDatum(object):


### PR DESCRIPTION
it appears in template's response but it didn't have it in model.
Boto3 needs a non-empty date.

Best.