### PR TITLE
Added availability-zone filtering to instance collections

### DIFF
--- a/moto/ec2/utils.py
+++ b/moto/ec2/utils.py
@@ -362,7 +362,8 @@ filter_dict_attribute_mapping = {
     'instance.group-id': 'security_groups',
     'instance-type': 'instance_type',
     'private-ip-address' : 'private_ip',
-    'ip-address' : 'public_ip'
+    'ip-address' : 'public_ip',
+    'availability-zone' :'placement'
 }
 
 


### PR DESCRIPTION
Code Changes:
* Adds the ability to filter by availability zones as described in: http://boto3.readthedocs.org/en/latest/reference/services/ec2.html#EC2.ServiceResource.instances
* maps to placement function which describes the availability zone

Please let me know if anything else can be done.
Thanks!