### PR TITLE
Throw exception if an update is attempted on a stack in ROLLBACK_COMP…

### DIFF
--- a/moto/cloudformation/exceptions.py
+++ b/moto/cloudformation/exceptions.py
@@ -9,12 +9,15 @@ class UnformattedGetAttTemplateException(Exception):
 
 
 class ValidationError(BadRequest):
-    def __init__(self, name_or_id):
+    def __init__(self, name_or_id, message=None):
+        if message is None:
+            messgae="Stack:{0} does not exist".format(name_or_id),
+
         template = Template(ERROR_RESPONSE)
         super(ValidationError, self).__init__()
         self.description = template.render(
             code="ValidationError",
-            messgae="Stack:{0} does not exist".format(name_or_id),
+            message=message,
         )
 
 

--- a/moto/cloudformation/responses.py
+++ b/moto/cloudformation/responses.py
@@ -126,6 +126,10 @@ class CloudFormationResponse(BaseResponse):
         stack_name = self._get_param('StackName')
         stack_body = self._get_param('TemplateBody')
 
+        stack = self.cloudformation_backend.get_stack(stack_name)
+        if stack.status == 'ROLLBACK_COMPLETE':
+            raise ValidationError(stack.stack_id, message="Stack:{} is in ROLLBACK_COMPLETE state and can not be updated.".format(stack.stack_id))
+
         stack = self.cloudformation_backend.update_stack(
             name=stack_name,
             template=stack_body,


### PR DESCRIPTION
…LETE

If a stack has a status of ROLLBACK_COMPLETE and you attempt to update
it, the AWS API throws a validation error. This updates moto to have the
same behvaior. We also uncommented a test which tests updating a stack
which passed without any additional modification -- it is unclear why
this test was commented.

Signed-off-by: Jack Lund <jack.lund@getbraintree.com>