### PR TITLE
Fix for cloudformation update_stack response ResponseParserError #575

### DIFF
--- a/moto/cloudformation/models.py
+++ b/moto/cloudformation/models.py
@@ -51,6 +51,7 @@ class FakeStack(object):
         self.template = template
         self.resource_map.update(json.loads(template))
         self.output_map = self._create_output_map()
+        self.status = 'UPDATE_COMPLETE'
 
     def delete(self):
         self.resource_map.delete()

--- a/moto/cloudformation/responses.py
+++ b/moto/cloudformation/responses.py
@@ -130,14 +130,18 @@ class CloudFormationResponse(BaseResponse):
             name=stack_name,
             template=stack_body,
         )
-        stack_body = {
-            'UpdateStackResponse': {
-                'UpdateStackResult': {
-                    'StackId': stack.name,
+
+        if self.request_json:
+            return json.dumps({
+                'UpdateStackResponse': {
+                    'UpdateStackResult': {
+                        'StackId': stack.name,
+                    }
                 }
-            }
-        }
-        return json.dumps(stack_body)
+            })
+        else:
+            template = self.response_template(UPDATE_STACK_RESPONSE_TEMPLATE)
+            return template.render(stack=stack)
 
     def delete_stack(self):
         name_or_stack_id = self.querystring.get('StackName')[0]
@@ -164,6 +168,15 @@ CREATE_STACK_RESPONSE_TEMPLATE = """<CreateStackResponse>
 </CreateStackResponse>
 """
 
+UPDATE_STACK_RESPONSE_TEMPLATE = """<UpdateStackResponse>
+  <UpdateStackResult>
+    <StackId>{{ stack.stack_id }}</StackId>
+  </UpdateStackResult>
+  <ResponseMetadata>
+    <RequestId>b9b5b068-3a41-11e5-94eb-example</RequestId>
+    </ResponseMetadata>
+</UpdateStackResponse>
+"""
 
 DESCRIBE_STACKS_TEMPLATE = """<DescribeStacksResponse>
   <DescribeStacksResult>

--- a/tests/test_cloudformation/test_cloudformation_stack_crud.py
+++ b/tests/test_cloudformation/test_cloudformation_stack_crud.py
@@ -9,7 +9,7 @@ import boto.cloudformation
 from boto.exception import BotoServerError
 import sure  # noqa
 # Ensure 'assert_raises' context manager support for Python 2.6
-import tests.backport_assert_raises  # noqa
+# import tests.backport_assert_raises  # noqa
 from nose.tools import assert_raises
 
 from moto import mock_cloudformation, mock_s3
@@ -263,24 +263,24 @@ def test_stack_tags():
     dict(stack.tags).should.equal({"foo": "bar", "baz": "bleh"})
 
 
-# @mock_cloudformation
-# def test_update_stack():
-#     conn = boto.connect_cloudformation()
-#     conn.create_stack(
-#         "test_stack",
-#         template_body=dummy_template_json,
-#     )
+@mock_cloudformation
+def test_update_stack():
+    conn = boto.connect_cloudformation()
+    conn.create_stack(
+        "test_stack",
+        template_body=dummy_template_json,
+    )
 
-#     conn.update_stack("test_stack", dummy_template_json2)
+    conn.update_stack("test_stack", dummy_template_json2)
 
-#     stack = conn.describe_stacks()[0]
-#     stack.get_template().should.equal({
-#         'GetTemplateResponse': {
-#             'GetTemplateResult': {
-#                 'TemplateBody': dummy_template_json2,
-#                 'ResponseMetadata': {
-#                     'RequestId': '2d06e36c-ac1d-11e0-a958-f9382b6eb86bEXAMPLE'
-#                 }
-#             }
-#         }
-#     })
+    stack = conn.describe_stacks()[0]
+    stack.get_template().should.equal({
+        'GetTemplateResponse': {
+            'GetTemplateResult': {
+                'TemplateBody': dummy_template_json2,
+                'ResponseMetadata': {
+                    'RequestId': '2d06e36c-ac1d-11e0-a958-f9382b6eb86bEXAMPLE'
+                }
+            }
+        }
+    })

--- a/tests/test_cloudformation/test_cloudformation_stack_crud.py
+++ b/tests/test_cloudformation/test_cloudformation_stack_crud.py
@@ -9,7 +9,7 @@ import boto.cloudformation
 from boto.exception import BotoServerError
 import sure  # noqa
 # Ensure 'assert_raises' context manager support for Python 2.6
-# import tests.backport_assert_raises  # noqa
+import tests.backport_assert_raises  # noqa
 from nose.tools import assert_raises
 
 from moto import mock_cloudformation, mock_s3

--- a/tests/test_cloudformation/test_cloudformation_stack_crud_boto3.py
+++ b/tests/test_cloudformation/test_cloudformation_stack_crud_boto3.py
@@ -10,7 +10,7 @@ from moto import mock_cloudformation, mock_s3
 import json
 import sure  # noqa
 # Ensure 'assert_raises' context manager support for Python 2.6
-# import tests.backport_assert_raises  # noqa
+import tests.backport_assert_raises  # noqa
 from nose.tools import assert_raises
 
 dummy_template = {


### PR DESCRIPTION
This is a fix for [#575](https://github.com/spulec/moto/issues/575).

The following changes were made:

* In models.py, added a one-liner that updated the stack status appropriately when the stack is updated.
* In responses.py, modified the update_stack function to fix the ResponseParserError.
* Added some tests for these fixes