### PR TITLE
Improved the ELBBackend

### DIFF
--- a/moto/elb/models.py
+++ b/moto/elb/models.py
@@ -62,7 +62,7 @@ class FakeLoadBalancer(object):
         self.policies.app_cookie_stickiness_policies = []
         self.policies.lb_cookie_stickiness_policies = []
         self.subnets = subnets or []
-        self.vpc_id = vpc_id
+        self.vpc_id = vpc_id or 'vpc-56e10e3d'
         self.tags = {}
 
         for port in ports:

--- a/moto/elb/models.py
+++ b/moto/elb/models.py
@@ -10,6 +10,7 @@ from boto.ec2.elb.attributes import (
 )
 from boto.ec2.elb.policies import Policies
 from moto.core import BaseBackend
+from moto.ec2.models import ec2_backends
 from .exceptions import LoadBalancerNotFoundError, TooManyTagsError, BadHealthCheckDefinition
 
 
@@ -47,7 +48,7 @@ class FakeBackend(object):
 
 
 class FakeLoadBalancer(object):
-    def __init__(self, name, zones, ports, scheme='internet-facing',):
+    def __init__(self, name, zones, ports, scheme='internet-facing', vpc_id=None, subnets=None):
         self.name = name
         self.health_check = None
         self.instance_ids = []
@@ -60,6 +61,8 @@ class FakeLoadBalancer(object):
         self.policies.other_policies = []
         self.policies.app_cookie_stickiness_policies = []
         self.policies.lb_cookie_stickiness_policies = []
+        self.subnets = subnets or []
+        self.vpc_id = vpc_id
         self.tags = {}
 
         for port in ports:
@@ -149,11 +152,22 @@ class FakeLoadBalancer(object):
 
 class ELBBackend(BaseBackend):
 
-    def __init__(self):
+    def __init__(self, region_name=None):
+        self.region_name = region_name
         self.load_balancers = {}
 
-    def create_load_balancer(self, name, zones, ports, scheme='internet-facing'):
-        new_load_balancer = FakeLoadBalancer(name=name, zones=zones, ports=ports, scheme=scheme)
+    def reset(self):
+        region_name = self.region_name
+        self.__dict__ = {}
+        self.__init__(region_name)
+
+    def create_load_balancer(self, name, zones, ports, scheme='internet-facing', subnets=None):
+        vpc_id = None
+        ec2_backend = ec2_backends[self.region_name]
+        if subnets:
+            subnet = ec2_backend.get_subnet(subnets[0])
+            vpc_id = subnet.vpc_id
+        new_load_balancer = FakeLoadBalancer(name=name, zones=zones, ports=ports, scheme=scheme, subnets=subnets, vpc_id=vpc_id)
         self.load_balancers[name] = new_load_balancer
         return new_load_balancer
 
@@ -286,4 +300,4 @@ class ELBBackend(BaseBackend):
 
 elb_backends = {}
 for region in boto.ec2.elb.regions():
-    elb_backends[region.name] = ELBBackend()
+    elb_backends[region.name] = ELBBackend(region.name)

--- a/moto/elb/responses.py
+++ b/moto/elb/responses.py
@@ -459,9 +459,7 @@ DESCRIBE_LOAD_BALANCERS_TEMPLATE = """<DescribeLoadBalancersResponse xmlns="http
           </BackendServerDescriptions>
           <Subnets>
           {% for subnet in load_balancer.subnets %}
-              <member>
-              {{ subnet }}
-              </member>
+              <member>{{ subnet }}</member>
           {% endfor %}
           </Subnets>
         </member>

--- a/moto/elb/responses.py
+++ b/moto/elb/responses.py
@@ -27,12 +27,14 @@ class ELBResponse(BaseResponse):
         availability_zones = self._get_multi_param("AvailabilityZones.member")
         ports = self._get_list_prefix("Listeners.member")
         scheme = self._get_param('Scheme')
+        subnets = self._get_multi_param("Subnets.member")
 
         self.elb_backend.create_load_balancer(
             name=load_balancer_name,
             zones=availability_zones,
             ports=ports,
-            scheme=scheme
+            scheme=scheme,
+            subnets=subnets
         )
         template = self.response_template(CREATE_LOAD_BALANCER_TEMPLATE)
         return template.render()
@@ -369,7 +371,11 @@ DESCRIBE_LOAD_BALANCERS_TEMPLATE = """<DescribeLoadBalancersResponse xmlns="http
               <UnhealthyThreshold>{{ load_balancer.health_check.unhealthy_threshold }}</UnhealthyThreshold>
             {% endif %}
           </HealthCheck>
-          <VPCId>vpc-56e10e3d</VPCId>
+          {% if load_balancer.vpc_id %}
+          <VPCId>{{ load_balancer.vpc_id }}</VPCId>
+          {% else %}
+          <VPCId />
+          {% endif %}
           <ListenerDescriptions>
             {% for listener in load_balancer.listeners %}
               <member>
@@ -452,6 +458,11 @@ DESCRIBE_LOAD_BALANCERS_TEMPLATE = """<DescribeLoadBalancersResponse xmlns="http
           {% endfor %}
           </BackendServerDescriptions>
           <Subnets>
+          {% for subnet in load_balancer.subnets %}
+              <member>
+              {{ subnet }}
+              </member>
+          {% endfor %}
           </Subnets>
         </member>
       {% endfor %}

--- a/tests/test_elb/test_elb.py
+++ b/tests/test_elb/test_elb.py
@@ -721,6 +721,24 @@ def test_add_remove_tags():
     lb_tags['other-lb'].should.have.key('other').which.should.equal('something')
 
 
+@mock_elb
+def test_create_with_tags():
+    client = boto3.client('elb', region_name='us-east-1')
+
+    client.create_load_balancer(
+        LoadBalancerName='my-lb',
+        Listeners=[{'Protocol':'tcp', 'LoadBalancerPort':80, 'InstancePort':8080}],
+        AvailabilityZones=['us-east-1a', 'us-east-1b'],
+        Tags=[{
+           'Key': 'k',
+           'Value': 'v'
+        }]
+    )
+
+    tags = dict((d['Key'], d['Value']) for d in client.describe_tags(LoadBalancerNames=['my-lb'])['TagDescriptions'][0]['Tags'])
+    tags.should.have.key('k').which.should.equal('v')
+
+
 @mock_ec2
 @mock_elb
 def test_subnets():

--- a/tests/test_elb/test_elb.py
+++ b/tests/test_elb/test_elb.py
@@ -742,5 +742,6 @@ def test_subnets():
 
     lb = client.describe_load_balancers()['LoadBalancerDescriptions'][0]
     lb.should.have.key('Subnets').which.should.have.length_of(1)
+    lb['Subnets'][0].should.equal(subnet.id)
 
     lb.should.have.key('VPCId').which.should.equal(vpc.id)

--- a/tests/test_elb/test_elb.py
+++ b/tests/test_elb/test_elb.py
@@ -614,11 +614,11 @@ def test_add_remove_tags():
     client.add_tags(LoadBalancerNames=['my-lb'],
                     Tags=[{
                        'Key': 'a',
-                       'Value': 'a'
+                       'Value': 'b'
                     }])
 
     tags = dict([(d['Key'], d['Value']) for d in client.describe_tags(LoadBalancerNames=['my-lb'])['TagDescriptions'][0]['Tags']])
-    tags.should.have('a').should.equal('a')
+    tags.should.have.key('a').which.should.equal('b')
 
     client.add_tags(LoadBalancerNames=['my-lb'],
                     Tags=[{


### PR DESCRIPTION
This change implements subnet and tag handling for the CreateLoadBalancer call.

* when subnets are given, the corresponding VPC is assigned to the ELB
* tags can also be set on creation

Before, subnets and tags passed on creation where silently ignored.