### PR TITLE
Add trailing slash to route53 rrset url path

### DIFF
--- a/moto/route53/urls.py
+++ b/moto/route53/urls.py
@@ -8,7 +8,7 @@ url_bases = [
 url_paths = {
     '{0}hostedzone$': responses.list_or_create_hostzone_response,
     '{0}hostedzone/[^/]+$': responses.get_or_delete_hostzone_response,
-    '{0}hostedzone/[^/]+/rrset$': responses.rrset_response,
+    '{0}hostedzone/[^/]+/rrset/?$': responses.rrset_response,
     '{0}healthcheck': responses.health_check_response,
     '{0}tags|trafficpolicyinstances/*': responses.not_implemented_response,
 }


### PR DESCRIPTION
Fixes #529. The [API docs](http://docs.aws.amazon.com/Route53/latest/APIReference/API_ChangeResourceRecordSets.html) make no mention of a trailing slash but adding one seems to make it work.