### PR TITLE
Added ec2 describe-instances filter: 'architecture'

### DIFF
--- a/moto/ec2/utils.py
+++ b/moto/ec2/utils.py
@@ -361,15 +361,15 @@ filter_dict_attribute_mapping = {
     'group-id': 'security_groups',
     'instance.group-id': 'security_groups',
     'instance-type': 'instance_type',
-    'private-ip-address' : 'private_ip',
-    'ip-address' : 'public_ip',
-    'availability-zone' :'placement'
+    'private-ip-address': 'private_ip',
+    'ip-address': 'public_ip',
+    'availability-zone': 'placement',
+    'architecture': 'architecture'
 }
 
 
 def passes_filter_dict(instance, filter_dict):
     for filter_name, filter_values in filter_dict.items():
-
         if filter_name in filter_dict_attribute_mapping:
             instance_attr = filter_dict_attribute_mapping[filter_name]
             instance_value = get_object_value(instance, instance_attr)
@@ -381,7 +381,7 @@ def passes_filter_dict(instance, filter_dict):
                 return False
         else:
             raise NotImplementedError(
-                "Filter dicts have not been implemented in Moto for '%s' yet. Feel free to open an issue at https://github.com/spulec/moto/issues",
+                "Filter dicts have not been implemented in Moto for '%s' yet. Feel free to open an issue at https://github.com/spulec/moto/issues" %
                 filter_name)
     return True
 

--- a/tests/test_ec2/test_instances.py
+++ b/tests/test_ec2/test_instances.py
@@ -279,6 +279,17 @@ def test_get_instances_filtering_by_vpc_id():
 
 
 @mock_ec2
+def test_get_instances_filtering_by_architecture():
+    conn = boto.connect_ec2()
+    reservation = conn.run_instances('ami-1234abcd', min_count=1)
+    instance = reservation.instances
+
+    reservations = conn.get_all_instances(filters={'architecture': 'x86_64'})
+    # get_all_instances should return the instance
+    reservations[0].instances.should.have.length_of(1)
+
+
+@mock_ec2
 def test_get_instances_filtering_by_tag():
     conn = boto.connect_ec2()
     reservation = conn.run_instances('ami-1234abcd', min_count=3)
@@ -519,7 +530,6 @@ def test_run_instance_with_security_group_name():
 def test_run_instance_with_security_group_id():
     conn = boto.connect_ec2('the_key', 'the_secret')
     group = conn.create_security_group('group1', "some description")
-
     reservation = conn.run_instances('ami-1234abcd',
                                      security_group_ids=[group.id])
     instance = reservation.instances[0]


### PR DESCRIPTION
This is a fix for issue [#581](https://github.com/spulec/moto/issues/581).

* Modified moto/ec2/utils.py to add 'architecture' to the filter dict, as well as change the exception message to format correctly.
* Added a test for filtering by architecture in tests/test_ec2/test_instances.py

There are still plenty more filters that need to be added, but this was the one that our team needed. If we need more in the future, I will add them.