### PR TITLE
Fix security groups

### DIFF
--- a/moto/ec2/exceptions.py
+++ b/moto/ec2/exceptions.py
@@ -136,7 +136,7 @@ class InvalidPermissionNotFoundError(EC2ClientError):
     def __init__(self):
         super(InvalidPermissionNotFoundError, self).__init__(
             "InvalidPermission.NotFound",
-            "Could not find a matching ingress rule")
+            "The specified rule does not exist in this security group")
 
 
 class InvalidRouteTableIdError(EC2ClientError):

--- a/moto/ec2/models.py
+++ b/moto/ec2/models.py
@@ -1102,6 +1102,7 @@ class SecurityGroup(TaggedEC2Resource):
         self.enis = {}
         self.vpc_id = vpc_id
         self.owner_id = "123456789012"
+        self.egress_rules.append(SecurityRule(-1, -1, -1, ['0.0.0.0/0'], []))
 
     @classmethod
     def create_from_cloudformation_json(cls, resource_name, cloudformation_json, region_name):

--- a/moto/ec2/models.py
+++ b/moto/ec2/models.py
@@ -1098,11 +1098,10 @@ class SecurityGroup(TaggedEC2Resource):
         self.name = name
         self.description = description
         self.ingress_rules = []
-        self.egress_rules = []
+        self.egress_rules = [SecurityRule(-1, -1, -1, ['0.0.0.0/0'], [])]
         self.enis = {}
         self.vpc_id = vpc_id
         self.owner_id = "123456789012"
-        self.egress_rules.append(SecurityRule(-1, -1, -1, ['0.0.0.0/0'], []))
 
     @classmethod
     def create_from_cloudformation_json(cls, resource_name, cloudformation_json, region_name):

--- a/moto/ec2/models.py
+++ b/moto/ec2/models.py
@@ -1324,7 +1324,6 @@ class SecurityGroupBackend(object):
         if security_rule in group.ingress_rules:
             group.ingress_rules.remove(security_rule)
             return security_rule
-
         raise InvalidPermissionNotFoundError()
 
     def authorize_security_group_egress(self,
@@ -1333,22 +1332,33 @@ class SecurityGroupBackend(object):
                                         from_port,
                                         to_port,
                                         ip_ranges,
-                                        src_group_id=None,
-                                        cidr_ip=None,
+                                        source_group_names=None,
+                                        source_group_ids=None,
                                         vpc_id=None):
 
         group = self.get_security_group_by_name_or_id(group_name_or_id, vpc_id)
-
+        if ip_ranges and not isinstance(ip_ranges, list):
+            ip_ranges = [ip_ranges]
         if ip_ranges:
             for cidr in ip_ranges:
                 if not is_valid_cidr(cidr):
                     raise InvalidCIDRSubnetError(cidr=cidr)
 
-        # for VPCs
+        source_group_names = source_group_names if source_group_names else []
+        source_group_ids = source_group_ids if source_group_ids else []
+
         source_groups = []
-        source_group = self.get_security_group_from_id(src_group_id)
-        if source_group:
-            source_groups.append(source_group)
+        for source_group_name in source_group_names:
+            source_group = self.get_security_group_from_name(source_group_name, vpc_id)
+            if source_group:
+                source_groups.append(source_group)
+
+        # for VPCs
+        for source_group_id in source_group_ids:
+            source_group = self.get_security_group_from_id(source_group_id)
+            if source_group:
+                source_groups.append(source_group)
+
         security_rule = SecurityRule(ip_protocol, from_port, to_port, ip_ranges, source_groups)
         group.egress_rules.append(security_rule)
 
@@ -1367,6 +1377,11 @@ class SecurityGroupBackend(object):
         source_groups = []
         for source_group_name in source_group_names:
             source_group = self.get_security_group_from_name(source_group_name, vpc_id)
+            if source_group:
+                source_groups.append(source_group)
+
+        for source_group_id in source_group_ids:
+            source_group = self.get_security_group_from_id(source_group_id)
             if source_group:
                 source_groups.append(source_group)
 

--- a/tests/test_ec2/test_security_groups.py
+++ b/tests/test_ec2/test_security_groups.py
@@ -157,8 +157,8 @@ def test_authorize_ip_range_and_revoke():
     success = conn.authorize_security_group_egress(egress_security_group.id, "tcp", from_port="22", to_port="2222", cidr_ip="123.123.123.123/32")
     assert success.should.be.true
     egress_security_group = conn.get_all_security_groups(groupnames='testegress')[0]
-    int(egress_security_group.rules_egress[0].to_port).should.equal(2222)
-    egress_security_group.rules_egress[0].grants[0].cidr_ip.should.equal("123.123.123.123/32")
+    int(egress_security_group.rules_egress[1].to_port).should.equal(2222)
+    egress_security_group.rules_egress[1].grants[0].cidr_ip.should.equal("123.123.123.123/32")
 
     # Wrong Cidr should throw error
     egress_security_group.revoke.when.called_with(ip_protocol="tcp", from_port="22", to_port="2222", cidr_ip="123.123.123.122/32").should.throw(EC2ResponseError)
@@ -167,7 +167,7 @@ def test_authorize_ip_range_and_revoke():
     conn.revoke_security_group_egress(egress_security_group.id, "tcp", from_port="22", to_port="2222", cidr_ip="123.123.123.123/32")
 
     egress_security_group = conn.get_all_security_groups()[0]
-    egress_security_group.rules_egress.should.have.length_of(0)
+    egress_security_group.rules_egress.should.have.length_of(1)
 
 
 @mock_ec2

--- a/tests/test_ec2/test_security_groups.py
+++ b/tests/test_ec2/test_security_groups.py
@@ -212,7 +212,7 @@ def test_authorize_other_group_egress_and_revoke():
     sg02 = ec2.create_security_group(GroupName='sg02', Description='Test security group sg02', VpcId=vpc.id)
 
     ip_permission = {
-        'IpProtocol': u'tcp',
+        'IpProtocol': 'tcp',
         'FromPort': 27017,
         'ToPort': 27017,
         'UserIdGroupPairs': [{'GroupId': sg02.id, 'GroupName': 'sg02', 'UserId': sg02.owner_id}],


### PR DESCRIPTION
The boto documentation is pretty vague about egress rules management, but according to boto3 documentation, it looks pretty clear that the same logic should apply for both ingress and egress rules, because the API expects the same payloads. See:

http://boto3.readthedocs.org/en/latest/reference/services/ec2.html#EC2.SecurityGroup.authorize_egress
http://boto3.readthedocs.org/en/latest/reference/services/ec2.html?#EC2.SecurityGroup.revoke_egress

and:

http://boto3.readthedocs.org/en/latest/reference/services/ec2.html?#EC2.SecurityGroup.authorize_ingress
http://boto3.readthedocs.org/en/latest/reference/services/ec2.html?#EC2.SecurityGroup.authorize_ingress

These modifications make it possible to authorize or revoke an outbound rule for another security group.

It also add the default outbound rule for a security group.