### PR TITLE
Disallow creation of ELBs with duplicate names.

### DIFF
--- a/moto/elb/exceptions.py
+++ b/moto/elb/exceptions.py
@@ -35,3 +35,11 @@ class BadHealthCheckDefinition(ELBClientError):
             "ValidationError",
             "HealthCheck Target must begin with one of HTTP, TCP, HTTPS, SSL")
 
+
+class DuplicateLoadBalancerName(ELBClientError):
+    def __init__(self, name):
+        super(DuplicateLoadBalancerName, self).__init__(
+            "DuplicateLoadBalancerName",
+            "The specified load balancer name already exists for this account: {0}"
+            .format(name))
+

--- a/moto/elb/responses.py
+++ b/moto/elb/responses.py
@@ -438,7 +438,7 @@ DESCRIBE_LOAD_BALANCERS_TEMPLATE = """<DescribeLoadBalancersResponse xmlns="http
               <member>{{ zone }}</member>
             {% endfor %}
           </AvailabilityZones>
-          <CanonicalHostedZoneName>tests.us-east-1.elb.amazonaws.com</CanonicalHostedZoneName>
+          <CanonicalHostedZoneName>{{ load_balancer.dns_name }}</CanonicalHostedZoneName>
           <CanonicalHostedZoneNameID>Z3ZONEID</CanonicalHostedZoneNameID>
           <Scheme>{{ load_balancer.scheme }}</Scheme>
           <DNSName>{{ load_balancer.dns_name }}</DNSName>

--- a/tests/test_elb/test_elb.py
+++ b/tests/test_elb/test_elb.py
@@ -763,3 +763,12 @@ def test_subnets():
     lb['Subnets'][0].should.equal(subnet.id)
 
     lb.should.have.key('VPCId').which.should.equal(vpc.id)
+
+
+@mock_elb
+def test_create_load_balancer_duplicate():
+    conn = boto.connect_elb()
+    ports = [(80, 8080, 'http'), (443, 8443, 'tcp')]
+    conn.create_load_balancer('my-lb', [], ports)
+    conn.create_load_balancer.when.called_with('my-lb', [], ports).should.throw(BotoServerError)
+


### PR DESCRIPTION
As the AWS API does: http://docs.aws.amazon.com/ElasticLoadBalancing/latest/APIReference/API_CreateLoadBalancer.html

This commit also makes sure that the ELB dns_name is always unique.