### PR TITLE
Respect VisibilityTimeout when calling receive_message

### DIFF
--- a/moto/sqs/models.py
+++ b/moto/sqs/models.py
@@ -265,7 +265,7 @@ class SQSBackend(BaseBackend):
 
         return message
 
-    def receive_messages(self, queue_name, count, wait_seconds_timeout):
+    def receive_messages(self, queue_name, count, wait_seconds_timeout, visibility_timeout):
         """
         Attempt to retrieve visible messages from a queue.
 
@@ -276,6 +276,7 @@ class SQSBackend(BaseBackend):
 
         :param string queue_name: The name of the queue to read from.
         :param int count: The maximum amount of messages to retrieve.
+        :param int visibility_timeout: The number of seconds the message should remain invisible to other queue readers.
         """
         queue = self.get_queue(queue_name)
         result = []
@@ -288,7 +289,7 @@ class SQSBackend(BaseBackend):
                 if not message.visible:
                     continue
                 message.mark_received(
-                    visibility_timeout=queue.visibility_timeout
+                    visibility_timeout=visibility_timeout
                 )
                 result.append(message)
                 if len(result) >= count:

--- a/tests/test_sqs/test_sqs.py
+++ b/tests/test_sqs/test_sqs.py
@@ -204,6 +204,23 @@ def test_message_becomes_inflight_when_received():
 
 
 @mock_sqs
+def test_receive_message_with_explicit_visibility_timeout():
+    conn = boto.connect_sqs('the_key', 'the_secret')
+    queue = conn.create_queue("test-queue", visibility_timeout=60)
+    queue.set_message_class(RawMessage)
+
+    body_one = 'this is another test message'
+    queue.write(queue.new_message(body_one))
+
+    queue.count().should.equal(1)
+    messages = conn.receive_message(queue, number_messages=1, visibility_timeout=0)
+
+    assert len(messages) == 1
+
+    # Message should remain visible
+    queue.count().should.equal(1)
+
+@mock_sqs
 def test_change_message_visibility():
     conn = boto.connect_sqs('the_key', 'the_secret')
     queue = conn.create_queue("test-queue", visibility_timeout=2)


### PR DESCRIPTION
Previously, receive_message would always use the queue's default
visibility timeout instead of the value passed as a query parameter when
calling the receive_message method on an SQS connection.