### PR TITLE
Fix retrieving inexistent queue errors when using boto3

### DIFF
--- a/moto/sqs/responses.py
+++ b/moto/sqs/responses.py
@@ -50,6 +50,12 @@ class SQSResponse(BaseResponse):
 
         return visibility_timeout
 
+    def call_action(self):
+        status_code, headers, body = super(SQSResponse, self).call_action()
+        if status_code == 404:
+            return 404, headers, ERROR_INEXISTENT_QUEUE
+        return status_code, headers, body
+
     def create_queue(self):
         queue_name = self.querystring.get("QueueName")[0]
         queue = self.sqs_backend.create_queue(queue_name, visibility_timeout=self.attribute.get('VisibilityTimeout'),
@@ -438,3 +444,13 @@ ERROR_TOO_LONG_RESPONSE = """<ErrorResponse xmlns="http://queue.amazonaws.com/do
 </ErrorResponse>"""
 
 ERROR_MAX_VISIBILITY_TIMEOUT_RESPONSE = "Invalid request, maximum visibility timeout is {0}".format(MAXIMUM_VISIBILTY_TIMEOUT)
+
+ERROR_INEXISTENT_QUEUE = """<ErrorResponse xmlns="http://queue.amazonaws.com/doc/2012-11-05/">
+    <Error>
+        <Type>Sender</Type>
+        <Code>AWS.SimpleQueueService.NonExistentQueue</Code>
+        <Message>The specified queue does not exist for this wsdl version.</Message>
+        <Detail/>
+    </Error>
+    <RequestId>b8bc806b-fa6b-53b5-8be8-cfa2f9836bc3</RequestId>
+</ErrorResponse>"""

--- a/tests/test_sqs/test_sqs.py
+++ b/tests/test_sqs/test_sqs.py
@@ -1,6 +1,7 @@
 from __future__ import unicode_literals
 import boto
 import boto3
+import botocore.exceptions
 from boto.exception import SQSError
 from boto.sqs.message import RawMessage, Message
 
@@ -498,6 +499,26 @@ def test_delete_message_after_visibility_timeout():
 """
 boto3
 """
+
+
+@mock_sqs
+def test_boto3_get_queue():
+    sqs = boto3.resource('sqs', region_name='us-east-1')
+    new_queue = sqs.create_queue(QueueName='test-queue')
+    new_queue.should_not.be.none
+    new_queue.should.have.property('url').should.contain('test-queue')
+
+    queue = sqs.get_queue_by_name(QueueName='test-queue')
+    queue.attributes.get('QueueArn').should_not.be.none
+    queue.attributes.get('QueueArn').split(':')[-1].should.equal('test-queue')
+    queue.attributes.get('VisibilityTimeout').should_not.be.none
+    queue.attributes.get('VisibilityTimeout').should.equal('30')
+
+
+@mock_sqs
+def test_boto3_get_inexistent_queue():
+    sqs = boto3.resource('sqs', region_name='us-east-1')
+    sqs.get_queue_by_name.when.called_with(QueueName='nonexisting-queue').should.throw(botocore.exceptions.ClientError)
 
 
 @mock_sqs


### PR DESCRIPTION
When trying to retrieve an inexistent queue with boto3, instead of returning None (or a boto3 exception) we get an XML parsing exception. I'm adding these tests so we can reproduce the problem, although you should probably hold on merging until the problem is fixed.

I admit I only had a very quick look at the code, but I couldn't find the cause, stack trace shows mostly botocore calls. If you have a rough idea of what's happening I'm happy to look into it.