### PR TITLE
Save the sns messages in the PlatformEndpoint

### DIFF
--- a/moto/sns/models.py
+++ b/moto/sns/models.py
@@ -119,6 +119,7 @@ class PlatformEndpoint(object):
         self.token = token
         self.attributes = attributes
         self.id = uuid.uuid4()
+        self.messages = OrderedDict()
 
     @property
     def arn(self):
@@ -130,8 +131,9 @@ class PlatformEndpoint(object):
         )
 
     def publish(self, message):
-        message_id = six.text_type(uuid.uuid4())
         # This is where we would actually send a message
+        message_id = six.text_type(uuid.uuid4())
+        self.messages[message_id] = message
         return message_id
 
 


### PR DESCRIPTION
This makes it easier to test the correct sns messages are sent.

For example in my test cases I can now do:

```python
    from moto.sns.models import sns_backends
    messages = sns_backends['eu-west-1'].platform_endpoints.values()[0].messages
    
    # check number of messages
    assert len(messages) == 1
    assert 'Hello' in messages.values()[0]
```

