### PR TITLE
Strip extra whitespace and newlines from SQS response templates.

### DIFF
--- a/moto/core/responses.py
+++ b/moto/core/responses.py
@@ -81,7 +81,8 @@ class _TemplateEnvironmentMixin(object):
         template_id = id(source)
         if not self.contains_template(template_id):
             self.loader.update({template_id: source})
-            self.environment = Environment(loader=self.loader, autoescape=self.should_autoescape)
+            self.environment = Environment(loader=self.loader, autoescape=self.should_autoescape, trim_blocks=True,
+                                           lstrip_blocks=True)
         return self.environment.get_template(template_id)
 
 

--- a/moto/sqs/responses.py
+++ b/moto/sqs/responses.py
@@ -245,9 +245,7 @@ CREATE_QUEUE_RESPONSE = """<CreateQueueResponse>
         <VisibilityTimeout>{{ queue.visibility_timeout }}</VisibilityTimeout>
     </CreateQueueResult>
     <ResponseMetadata>
-        <RequestId>
-            7a62c49f-347e-4fc4-9331-6e8e7a96aa73
-        </RequestId>
+        <RequestId>7a62c49f-347e-4fc4-9331-6e8e7a96aa73</RequestId>
     </ResponseMetadata>
 </CreateQueueResponse>"""
 
@@ -267,17 +265,13 @@ LIST_QUEUES_RESPONSE = """<ListQueuesResponse>
         {% endfor %}
     </ListQueuesResult>
     <ResponseMetadata>
-        <RequestId>
-            725275ae-0b9b-4762-b238-436d7c65a1ac
-        </RequestId>
+        <RequestId>725275ae-0b9b-4762-b238-436d7c65a1ac</RequestId>
     </ResponseMetadata>
 </ListQueuesResponse>"""
 
 DELETE_QUEUE_RESPONSE = """<DeleteQueueResponse>
     <ResponseMetadata>
-        <RequestId>
-            6fde8d1e-52cd-4581-8cd9-c512f4c64223
-        </RequestId>
+        <RequestId>6fde8d1e-52cd-4581-8cd9-c512f4c64223</RequestId>
     </ResponseMetadata>
 </DeleteQueueResponse>"""
 
@@ -297,28 +291,24 @@ GET_QUEUE_ATTRIBUTES_RESPONSE = """<GetQueueAttributesResponse>
 
 SET_QUEUE_ATTRIBUTE_RESPONSE = """<SetQueueAttributesResponse>
     <ResponseMetadata>
-        <RequestId>
-            e5cca473-4fc0-4198-a451-8abb94d02c75
-        </RequestId>
+        <RequestId>e5cca473-4fc0-4198-a451-8abb94d02c75</RequestId>
     </ResponseMetadata>
 </SetQueueAttributesResponse>"""
 
 SEND_MESSAGE_RESPONSE = """<SendMessageResponse>
     <SendMessageResult>
         <MD5OfMessageBody>
-            {{ message.md5 }}
+            {{- message.md5 -}}
         </MD5OfMessageBody>
         {% if message.message_attributes.items()|count > 0 %}
           <MD5OfMessageAttributes>324758f82d026ac6ec5b31a3b192d1e3</MD5OfMessageAttributes>
         {% endif %}
         <MessageId>
-            {{ message.id }}
+            {{- message.id -}}
         </MessageId>
     </SendMessageResult>
     <ResponseMetadata>
-        <RequestId>
-            27daac76-34dd-47df-bd01-1f6e873584a0
-        </RequestId>
+        <RequestId>27daac76-34dd-47df-bd01-1f6e873584a0</RequestId>
     </ResponseMetadata>
 </SendMessageResponse>"""
 
@@ -366,9 +356,7 @@ RECEIVE_MESSAGE_RESPONSE = """<ReceiveMessageResponse>
     {% endfor %}
   </ReceiveMessageResult>
   <ResponseMetadata>
-    <RequestId>
-      b6633655-283d-45b4-aee4-4e84e0ae6afa
-    </RequestId>
+    <RequestId>b6633655-283d-45b4-aee4-4e84e0ae6afa</RequestId>
   </ResponseMetadata>
 </ReceiveMessageResponse>"""
 
@@ -392,9 +380,7 @@ SEND_MESSAGE_BATCH_RESPONSE = """<SendMessageBatchResponse>
 
 DELETE_MESSAGE_RESPONSE = """<DeleteMessageResponse>
     <ResponseMetadata>
-        <RequestId>
-            b5293cb5-d306-4a17-9048-b263635abe42
-        </RequestId>
+        <RequestId>b5293cb5-d306-4a17-9048-b263635abe42</RequestId>
     </ResponseMetadata>
 </DeleteMessageResponse>"""
 
@@ -413,17 +399,13 @@ DELETE_MESSAGE_BATCH_RESPONSE = """<DeleteMessageBatchResponse>
 
 CHANGE_MESSAGE_VISIBILITY_RESPONSE = """<ChangeMessageVisibilityResponse>
     <ResponseMetadata>
-        <RequestId>
-            6a7a282a-d013-4a59-aba9-335b0fa48bed
-        </RequestId>
+        <RequestId>6a7a282a-d013-4a59-aba9-335b0fa48bed</RequestId>
     </ResponseMetadata>
 </ChangeMessageVisibilityResponse>"""
 
 PURGE_QUEUE_RESPONSE = """<PurgeQueueResponse>
     <ResponseMetadata>
-        <RequestId>
-            6fde8d1e-52cd-4581-8cd9-c512f4c64223
-        </RequestId>
+        <RequestId>6fde8d1e-52cd-4581-8cd9-c512f4c64223</RequestId>
     </ResponseMetadata>
 </PurgeQueueResponse>"""
 

--- a/tests/test_sqs/test_sqs.py
+++ b/tests/test_sqs/test_sqs.py
@@ -487,7 +487,11 @@ boto3
 def test_boto3_message_send():
     sqs = boto3.resource('sqs', region_name='us-east-1')
     queue = sqs.create_queue(QueueName="blah")
-    queue.send_message(MessageBody="derp")
+    msg = queue.send_message(MessageBody="derp")
+
+    msg.get('MD5OfMessageBody').should.equal('58fd9edd83341c29f1aebba81c31e257')
+    msg.get('ResponseMetadata', {}).get('RequestId').should.equal('27daac76-34dd-47df-bd01-1f6e873584a0')
+    msg.get('MessageId').should_not.contain(' \n')
 
     messages = queue.receive_messages()
     messages.should.have.length_of(1)


### PR DESCRIPTION
Whitespace and newlines in the template strings are significant, and it seems boto is usually not expecting it. This leads to things like `'RequestId': '\n 27daac76-34dd-47df-bd01-1f6e873584a0\n '`.

The solution is to remove newlines/whitespace completely when not using variables (i.e. RequestId blocks), or use `{{-` and `-}}` when using variables in a new line, so that Jinja2 ignores them.

I tried a generic solution in `core/responses.py`, both using `replace()` and regexes, but none of them satisfied all tests, so perhaps the best solution is to fix all template strings instead.

Fixes #623 