### PR TITLE
Support Filters in describe_security_groups() for boto3

### DIFF
--- a/moto/ec2/models.py
+++ b/moto/ec2/models.py
@@ -1226,6 +1226,8 @@ class SecurityGroup(TaggedEC2Resource):
                     return True
         elif is_tag_filter(key):
             tag_value = self.get_filter_value(key)
+            if isinstance(filter_value, list):
+                return any(v in tag_value for v in filter_value)
             return tag_value in filter_value
         else:
             attr_name = to_attr(key)

--- a/tests/test_ec2/test_security_groups.py
+++ b/tests/test_ec2/test_security_groups.py
@@ -335,7 +335,7 @@ Boto3
 
 @mock_ec2
 def test_security_group_tagging_boto3():
-    conn = boto3.client('ec2')
+    conn = boto3.client('ec2', region_name='us-east-1')
     sg = conn.create_security_group(GroupName="test-sg", Description="Test SG")
     conn.create_tags(Resources=[sg['GroupId']], Tags=[{'Key': 'Test', 'Value': 'Tag'}])
     describe = conn.describe_security_groups(Filters=[{'Name': 'tag-value', 'Values': ['Tag']}])

--- a/tests/test_ec2/test_security_groups.py
+++ b/tests/test_ec2/test_security_groups.py
@@ -326,3 +326,19 @@ def test_authorize_all_protocols_with_no_port_specification():
     sg = conn.get_all_security_groups('test')[0]
     sg.rules[0].from_port.should.equal(None)
     sg.rules[0].to_port.should.equal(None)
+
+  
+'''
+Boto3
+'''
+
+
+@mock_ec2
+def test_security_group_tagging_boto3():
+    conn = boto3.client('ec2')
+    sg = conn.create_security_group(GroupName="test-sg", Description="Test SG")
+    conn.create_tags(Resources=[sg['GroupId']], Tags=[{'Key': 'Test', 'Value': 'Tag'}])
+    describe = conn.describe_security_groups(Filters=[{'Name': 'tag-value', 'Values': ['Tag']}])
+    tag = describe["SecurityGroups"][0]['Tags'][0]
+    tag['Value'].should.equal("Tag")
+    tag['Key'].should.equal("Test")


### PR DESCRIPTION
Filters in boto3 are passed in a list, which means any comparisons will currently fail.  Update to model and tests to resolve this issue.