### PR TITLE
Pin boto3 and botocore (again)

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,8 +5,21 @@ sure>=1.2.24
 coverage
 freezegun
 flask
-# botocore 1.3.29 breaks s3 in tests (lambda and s3 tests)
+# botocore 1.4.29 breaks the following tests:
+# test_nat_gateway.test_delete_nat_gateway
+# test `list -> create -> list -> get -> delete -> list` integration
+# test_lambda.test_get_function
+# test_lambda.test_delete_function
+# test_lambda.test_create_function_from_zipfile
+# test_lambda.test_create_function_from_aws_bucket
+# test_apigateway.test_integrations
+# test_apigateway.test_integration_response
+# test_apigateway.test_deployment
+# test_apigateway.test_create_resource
+# test_apigateway.test_create_method_response
+# test_apigateway.test_create_method
+# test_apigateway.test_child_resource
 # so we need to pin a boto3 and botocore revision pair that we know works
-boto3
-botocore
+boto3==1.3.1
+botocore==1.4.28
 six


### PR DESCRIPTION
Builds started failing 7 days ago. Turns out it was because of the bump from 1.4.28 to 1.4.29. It may not be worth playing whac-a-mole - I'll file an issue in either the boto3 or botocore repo in the meantime.

Affected PRs:

* #644 
* #645 
* #653 