### PR TITLE
Remove HTTPHeaders from ResponseMetadata in some tests

### DIFF
--- a/tests/test_apigateway/test_apigateway.py
+++ b/tests/test_apigateway/test_apigateway.py
@@ -76,6 +76,7 @@ def test_create_resource():
         restApiId=api_id,
         resourceId=root_id,
     )
+    root_resource['ResponseMetadata'].pop('HTTPHeaders') # this is hard to match against, so remove it
     root_resource.should.equal({
         'path': '/',
         'id': root_id,
@@ -133,6 +134,7 @@ def test_child_resource():
         restApiId=api_id,
         resourceId=tags_id,
     )
+    child_resource['ResponseMetadata'].pop('HTTPHeaders') # this is hard to match against, so remove it
     child_resource.should.equal({
         'path': '/users/tags',
         'pathPart': 'tags',
@@ -168,6 +170,7 @@ def test_create_method():
         httpMethod='GET'
     )
 
+    response['ResponseMetadata'].pop('HTTPHeaders') # this is hard to match against, so remove it
     response.should.equal({
         'httpMethod': 'GET',
         'authorizationType': 'none',
@@ -206,6 +209,7 @@ def test_create_method_response():
         httpMethod='GET',
         statusCode='200',
     )
+    response['ResponseMetadata'].pop('HTTPHeaders') # this is hard to match against, so remove it
     response.should.equal({
         'ResponseMetadata': {'HTTPStatusCode': 200},
         'statusCode': '200'
@@ -217,6 +221,7 @@ def test_create_method_response():
         httpMethod='GET',
         statusCode='200',
     )
+    response['ResponseMetadata'].pop('HTTPHeaders') # this is hard to match against, so remove it
     response.should.equal({
         'ResponseMetadata': {'HTTPStatusCode': 200},
         'statusCode': '200'
@@ -228,6 +233,7 @@ def test_create_method_response():
         httpMethod='GET',
         statusCode='200',
     )
+    response['ResponseMetadata'].pop('HTTPHeaders') # this is hard to match against, so remove it
     response.should.equal({'ResponseMetadata': {'HTTPStatusCode': 200}})
 
 
@@ -264,6 +270,7 @@ def test_integrations():
         type='HTTP',
         uri='http://httpbin.org/robots.txt',
     )
+    response['ResponseMetadata'].pop('HTTPHeaders') # this is hard to match against, so remove it
     response.should.equal({
         'ResponseMetadata': {'HTTPStatusCode': 200},
         'httpMethod': 'GET',
@@ -284,6 +291,7 @@ def test_integrations():
         resourceId=root_id,
         httpMethod='GET'
     )
+    response['ResponseMetadata'].pop('HTTPHeaders') # this is hard to match against, so remove it
     response.should.equal({
         'ResponseMetadata': {'HTTPStatusCode': 200},
         'httpMethod': 'GET',
@@ -303,6 +311,7 @@ def test_integrations():
         restApiId=api_id,
         resourceId=root_id,
     )
+    response['ResponseMetadata'].pop('HTTPHeaders') # this is hard to match against, so remove it
     response['resourceMethods']['GET']['methodIntegration'].should.equal({
         'httpMethod': 'GET',
         'integrationResponses': {
@@ -371,6 +380,7 @@ def test_integration_response():
         statusCode='200',
         selectionPattern='foobar',
     )
+    response['ResponseMetadata'].pop('HTTPHeaders') # this is hard to match against, so remove it
     response.should.equal({
         'statusCode': '200',
         'selectionPattern': 'foobar',
@@ -386,6 +396,7 @@ def test_integration_response():
         httpMethod='GET',
         statusCode='200',
     )
+    response['ResponseMetadata'].pop('HTTPHeaders') # this is hard to match against, so remove it
     response.should.equal({
         'statusCode': '200',
         'selectionPattern': 'foobar',
@@ -400,6 +411,7 @@ def test_integration_response():
         resourceId=root_id,
         httpMethod='GET',
     )
+    response['ResponseMetadata'].pop('HTTPHeaders') # this is hard to match against, so remove it
     response['methodIntegration']['integrationResponses'].should.equal({
         '200': {
             'responseTemplates': {
@@ -444,6 +456,7 @@ def test_deployment():
         restApiId=api_id,
         deploymentId=deployment_id,
     )
+    response['ResponseMetadata'].pop('HTTPHeaders') # this is hard to match against, so remove it
     response.should.equal({
         'id': deployment_id,
         'ResponseMetadata': {'HTTPStatusCode': 200}

--- a/tests/test_awslambda/test_lambda.py
+++ b/tests/test_awslambda/test_lambda.py
@@ -86,6 +86,7 @@ def test_create_function_from_aws_bucket():
             "SubnetIds": ["subnet-123abc"],
         },
     )
+    result['ResponseMetadata'].pop('HTTPHeaders') # this is hard to match against, so remove it
     result.should.equal({
         'FunctionName': 'testFunction',
         'FunctionArn': 'arn:aws:lambda:123456789012:function:testFunction',
@@ -128,6 +129,7 @@ def test_create_function_from_zipfile():
         MemorySize=128,
         Publish=True,
     )
+    result['ResponseMetadata'].pop('HTTPHeaders') # this is hard to match against, so remove it
     result.should.equal({
         'FunctionName': 'testFunction',
         'FunctionArn': 'arn:aws:lambda:123456789012:function:testFunction',
@@ -177,6 +179,7 @@ def test_get_function():
     )
 
     result = conn.get_function(FunctionName='testFunction')
+    result['ResponseMetadata'].pop('HTTPHeaders') # this is hard to match against, so remove it
 
     result.should.equal({
         "Code": {
@@ -232,6 +235,7 @@ def test_delete_function():
     )
 
     success_result = conn.delete_function(FunctionName='testFunction')
+    success_result['ResponseMetadata'].pop('HTTPHeaders') # this is hard to match against, so remove it
     success_result.should.equal({'ResponseMetadata': {'HTTPStatusCode': 204}})
 
     conn.delete_function.when.called_with(FunctionName='testFunctionThatDoesntExist').should.throw(botocore.client.ClientError)
@@ -295,7 +299,9 @@ def test_list_create_list_get_delete_list():
     }
     conn.list_functions()['Functions'].should.equal([expected_function_result['Configuration']])
 
-    conn.get_function(FunctionName='testFunction').should.equal(expected_function_result)
+    func = conn.get_function(FunctionName='testFunction')
+    func['ResponseMetadata'].pop('HTTPHeaders') # this is hard to match against, so remove it
+    func.should.equal(expected_function_result)
     conn.delete_function(FunctionName='testFunction')
 
     conn.list_functions()['Functions'].should.have.length_of(0)

--- a/tests/test_ec2/test_nat_gateway.py
+++ b/tests/test_ec2/test_nat_gateway.py
@@ -56,6 +56,7 @@ def test_delete_nat_gateway():
     nat_gateway_id = nat_gateway['NatGateway']['NatGatewayId']
     response = conn.delete_nat_gateway(NatGatewayId=nat_gateway_id)
 
+    response['ResponseMetadata'].pop('HTTPHeaders') # this is hard to match against, so remove it
     response.should.equal({
         'NatGatewayId': nat_gateway_id,
         'ResponseMetadata': {


### PR DESCRIPTION
botocore 1.4.29 started adding this. I'd match against it, but it contains a date object and it's just not worth rewriting the assertions for a key-by-key approach.

If this is acceptable it will eliminate the need for #654 