### PR TITLE
Update format of S3 client errors

### DIFF
--- a/moto/core/exceptions.py
+++ b/moto/core/exceptions.py
@@ -3,6 +3,15 @@ from jinja2 import DictLoader, Environment
 from six import text_type
 
 
+SINGLE_ERROR_RESPONSE = u"""<?xml version="1.0" encoding="UTF-8"?>
+<Error>
+    <Code>{{error_type}}</Code>
+    <Message>{{message}}</Message>
+    {% block extra %}{% endblock %}
+    <RequestID>7a62c49f-347e-4fc4-9331-6e8eEXAMPLE</RequestID>
+</Error>
+"""
+
 ERROR_RESPONSE = u"""<?xml version="1.0" encoding="UTF-8"?>
   <Response>
     <Errors>
@@ -24,6 +33,7 @@ ERROR_JSON_RESPONSE = u"""{
 
 class RESTError(HTTPException):
     templates = {
+        'single_error': SINGLE_ERROR_RESPONSE,
         'error': ERROR_RESPONSE,
         'error_json': ERROR_JSON_RESPONSE,
     }

--- a/moto/s3/exceptions.py
+++ b/moto/s3/exceptions.py
@@ -2,17 +2,20 @@ from __future__ import unicode_literals
 from moto.core.exceptions import RESTError
 
 
-ERROR_WITH_BUCKET_NAME = """{% extends 'error' %}
+ERROR_WITH_BUCKET_NAME = """{% extends 'single_error' %}
 {% block extra %}<BucketName>{{ bucket }}</BucketName>{% endblock %}
 """
 
-ERROR_WITH_KEY_NAME = """{% extends 'error' %}
+ERROR_WITH_KEY_NAME = """{% extends 'single_error' %}
 {% block extra %}<KeyName>{{ key_name }}</KeyName>{% endblock %}
 """
 
 
 class S3ClientError(RESTError):
-    pass
+    def __init__(self, *args, **kwargs):
+        kwargs.setdefault('template', 'single_error')
+        self.templates['bucket_error'] = ERROR_WITH_BUCKET_NAME
+        super(S3ClientError, self).__init__(*args, **kwargs)
 
 
 class BucketError(S3ClientError):

--- a/tests/test_s3/test_s3.py
+++ b/tests/test_s3/test_s3.py
@@ -1014,6 +1014,21 @@ def test_boto3_head_object():
 
 
 @mock_s3
+def test_boto3_get_object():
+    s3 = boto3.resource('s3', region_name='us-east-1')
+    s3.create_bucket(Bucket="blah")
+
+    s3.Object('blah', 'hello.txt').put(Body="some text")
+
+    s3.Object('blah', 'hello.txt').meta.client.head_object(Bucket='blah', Key='hello.txt')
+
+    with assert_raises(ClientError) as e:
+        s3.Object('blah', 'hello2.txt').get()
+
+    e.exception.response['Error']['Code'].should.equal('NoSuchKey')
+
+
+@mock_s3
 def test_boto3_head_object_with_versioning():
     s3 = boto3.resource('s3', region_name='us-east-1')
     bucket = s3.create_bucket(Bucket='blah')


### PR DESCRIPTION
To match
http://docs.aws.amazon.com/AmazonS3/latest/API/ErrorResponses.html#RESTErrorResponses
which documents that it should be at the top level rather than nested
under `Errors`.