### PR TITLE
Fix broken SQS QueueArn attribute

### DIFF
--- a/moto/sqs/models.py
+++ b/moto/sqs/models.py
@@ -122,7 +122,7 @@ class Queue(object):
         self.last_modified_timestamp = now
         self.maximum_message_size = 64 << 10
         self.message_retention_period = 86400 * 4  # four days
-        self.queue_arn = 'arn:aws:sqs:sqs.us-east-1:123456789012:%s' % self.name
+        self.queue_arn = 'arn:aws:sqs:us-east-1:123456789012:%s' % self.name
         self.receive_message_wait_time_seconds = 0
 
     @classmethod

--- a/tests/test_sqs/test_sqs.py
+++ b/tests/test_sqs/test_sqs.py
@@ -394,7 +394,7 @@ def test_queue_attributes():
     attributes = queue.get_attributes()
 
     attributes['QueueArn'].should.look_like(
-        'arn:aws:sqs:sqs.us-east-1:123456789012:%s' % queue_name)
+        'arn:aws:sqs:us-east-1:123456789012:%s' % queue_name)
 
     attributes['VisibilityTimeout'].should.look_like(str(visibility_timeout))
 


### PR DESCRIPTION
Hello,

I think the QueueArn attribute of SQS queues is broken. If you split the ARN by `:` the third element shall be the region coded as `us-east-1`, but it is hardcoded to be `sqs.us-east-1`. The unit test hardcodes the same mistake and is not able to detect a problem.

For this reason code like the following fails:
```python
sns = boto3.client('sns')
sns_arn = sns.create_topic(Name='test-topic')['TopicArn']

sqs = boto3.client('sqs')
sqs_url = sqs.create_queue(QueueName='test-queue')['QueueUrl']

sns.subscribe(
    TopicArn=sns_arn,
    Protocol='sqs',
    Endpoint=sqs.get_queue_attributes(
        QueueUrl=sqs_url,
        AttributeNames=['QueueArn']
    )['Attributes']['QueueArn']
)
```

As the unit tests of subscribe use hardcored endpoints they are also not able to detect a problem.