### PR TITLE
Add volume attachment status

### DIFF
--- a/tests/test_ec2/test_elastic_block_store.py
+++ b/tests/test_ec2/test_elastic_block_store.py
@@ -93,6 +93,9 @@ def test_volume_filters():
     volumes_by_attach_instance_id = conn.get_all_volumes(filters={'attachment.instance-id': instance.id})
     set([vol.id for vol in volumes_by_attach_instance_id]).should.equal(set([block_mapping.volume_id]))
 
+    volumes_by_attach_status = conn.get_all_volumes(filters={'attachment.status': 'attached'})
+    set([vol.id for vol in volumes_by_attach_status]).should.equal(set([block_mapping.volume_id]))
+
     volumes_by_create_time = conn.get_all_volumes(filters={'create-time': volume4.create_time})
     set([vol.create_time for vol in volumes_by_create_time]).should.equal(set([volume4.create_time]))
 
@@ -142,6 +145,7 @@ def test_volume_attach_and_detach():
 
     volume.update()
     volume.volume_state().should.equal('in-use')
+    volume.attachment_state().should.equal('attached')
 
     volume.attach_data.instance_id.should.equal(instance.id)
 


### PR DESCRIPTION
Adds volume attachment status for filtering. 

Current possible statuses are `attached` or `detached`, the intermediate states (`attaching` and `detaching`) are not implemented yet, because I couldn't figure out a good implementation.  The `detached` status is tricky to test, since you have to keep the `VolumeAttachment` from `detach_volume`. 

