### PR TITLE
Add support for requestTemplates parameter in apigateway integrations mock

### DIFF
--- a/moto/apigateway/models.py
+++ b/moto/apigateway/models.py
@@ -27,11 +27,12 @@ class IntegrationResponse(dict):
 
 
 class Integration(dict):
-    def __init__(self, integration_type, uri, http_method):
+    def __init__(self, integration_type, uri, http_method, request_templates=None):
         super(Integration, self).__init__()
         self['type'] = integration_type
         self['uri'] = uri
         self['httpMethod'] = http_method
+        self['requestTemplates'] = request_templates
         self["integrationResponses"] = {
             "200": IntegrationResponse(200)
         }
@@ -136,8 +137,8 @@ class Resource(object):
     def get_method(self, method_type):
         return self.resource_methods[method_type]
 
-    def add_integration(self, method_type, integration_type, uri):
-        integration = Integration(integration_type, uri, method_type)
+    def add_integration(self, method_type, integration_type, uri, request_templates=None):
+        integration = Integration(integration_type, uri, method_type, request_templates=request_templates)
         self.resource_methods[method_type]['methodIntegration'] = integration
         return integration
 
@@ -290,9 +291,11 @@ class APIGatewayBackend(BaseBackend):
         method_response = method.delete_response(response_code)
         return method_response
 
-    def create_integration(self, function_id, resource_id, method_type, integration_type, uri):
+    def create_integration(self, function_id, resource_id, method_type, integration_type, uri,
+            request_templates=None):
         resource = self.get_resource(function_id, resource_id)
-        integration = resource.add_integration(method_type, integration_type, uri)
+        integration = resource.add_integration(method_type, integration_type, uri,
+            request_templates=request_templates)
         return integration
 
     def get_integration(self, function_id, resource_id, method_type):

--- a/moto/apigateway/responses.py
+++ b/moto/apigateway/responses.py
@@ -107,7 +107,8 @@ class APIGatewayResponse(BaseResponse):
         elif self.method == 'PUT':
             integration_type = self._get_param('type')
             uri = self._get_param('uri')
-            integration_response = self.backend.create_integration(function_id, resource_id, method_type, integration_type, uri)
+            request_templates = self._get_param('requestTemplates')
+            integration_response = self.backend.create_integration(function_id, resource_id, method_type, integration_type, uri, request_templates=request_templates)
         elif self.method == 'DELETE':
             integration_response = self.backend.delete_integration(function_id, resource_id, method_type)
         return 200, headers, json.dumps(integration_response)

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,8 @@ install_requires = [
     "xmltodict",
     "six",
     "werkzeug",
+    "sure",
+    "freezegun"
 ]
 
 extras_require = {

--- a/tests/test_apigateway/test_apigateway.py
+++ b/tests/test_apigateway/test_apigateway.py
@@ -338,6 +338,38 @@ def test_integrations():
     )
     response['resourceMethods']['GET'].shouldnt.contain("methodIntegration")
 
+    # Create a new integration with a requestTemplates config
+
+    client.put_method(
+        restApiId=api_id,
+        resourceId=root_id,
+        httpMethod='POST',
+        authorizationType='none',
+    )
+
+    templates = {
+        # example based on http://docs.aws.amazon.com/apigateway/latest/developerguide/api-as-kinesis-proxy-export-swagger-with-extensions.html
+        'application/json': "{\n    \"StreamName\": \"$input.params('stream-name')\",\n    \"Records\": []\n}"
+    }
+    test_uri = 'http://example.com/foobar.txt'
+    response = client.put_integration(
+        restApiId=api_id,
+        resourceId=root_id,
+        httpMethod='POST',
+        type='HTTP',
+        uri=test_uri,
+        requestTemplates=templates
+    )
+    response['ResponseMetadata'].should.equal({'HTTPStatusCode': 200})
+
+    response = client.get_integration(
+        restApiId=api_id,
+        resourceId=root_id,
+        httpMethod='POST'
+    )
+    response['uri'].should.equal(test_uri)
+    response['requestTemplates'].should.equal(templates)
+
 
 @mock_apigateway
 def test_integration_response():


### PR DESCRIPTION
This PR adds support for the requestTemplates=... parameter for the put_integration method in apigateway mock. See http://boto3.readthedocs.io/en/latest/reference/services/apigateway.html#APIGateway.Client.put_integration

This is a non-breaking change. New test cases have been added to ensure we keep backward compatibility.

@spulec Thanks for maintaining this awesome project! :)