### PR TITLE
additional filters to get_all_vpcs

### DIFF
--- a/moto/ec2/models.py
+++ b/moto/ec2/models.py
@@ -1791,6 +1791,10 @@ class VPC(TaggedEC2Resource):
             return self.id
         elif filter_name == 'cidr':
             return self.cidr_block
+        elif filter_name == 'isDefault':
+            return self.is_default
+        elif filter_name == 'state':
+            return self.state
         elif filter_name == 'dhcp-options-id':
             if not self.dhcp_options:
                 return None

--- a/tests/test_ec2/test_vpcs.py
+++ b/tests/test_ec2/test_vpcs.py
@@ -50,6 +50,35 @@ def test_vpc_defaults():
     conn.get_all_route_tables().should.have.length_of(0)
     conn.get_all_security_groups(filters={'vpc-id': [vpc.id]}).should.have.length_of(0)
 
+@mock_ec2
+def test_vpc_isdefault_filter():
+    conn = boto.connect_vpc('the_key', 'the_secret')
+    vpc = conn.create_vpc("10.0.0.0/16")
+    conn.get_all_vpcs(filters={'isDefault': 'true'}).should.have.length_of(1)
+    vpc.delete()
+    conn.get_all_vpcs(filters={'isDefault': 'true'}).should.have.length_of(0)
+
+
+@mock_ec2
+def test_multiple_vpcs_default_filter():
+    conn = boto.connect_vpc('the_key', 'the_secret')
+    conn.create_vpc("10.8.0.0/16")
+    conn.create_vpc("10.0.0.0/16")
+    conn.create_vpc("192.168.0.0/16")
+    conn.get_all_vpcs().should.have.length_of(3)
+    vpc = conn.get_all_vpcs(filters={'isDefault': 'true'})
+    vpc.should.have.length_of(1)
+    vpc[0].cidr_block.should.equal('10.8.0.0/16')
+
+
+@mock_ec2
+def test_vpc_state_available_filter():
+    conn = boto.connect_vpc('the_key', 'the_secret')
+    vpc = conn.create_vpc("10.0.0.0/16")
+    conn.create_vpc("10.1.0.0/16")
+    conn.get_all_vpcs(filters={'state': 'available'}).should.have.length_of(2)
+    vpc.delete()
+    conn.get_all_vpcs(filters={'state': 'available'}).should.have.length_of(1)
 
 @mock_ec2
 def test_vpc_tagging():


### PR DESCRIPTION
Additional filters on get_vpcs (isDefault and state)

First VPC created by moto is the default VPC. Was required by user to remove default VPCs prior to rebuilding.

state is difficult to filter in moto as state is only pending on initial create; subsequent describe results is available. However this may show up when creating a VPC when running live (loop until a vpc is available for instance). Unit tests for this are lame as not sure how to test for pending state.
