### PR TITLE
Causes get_server_certificate to fail correctly

### DIFF
--- a/moto/iam/models.py
+++ b/moto/iam/models.py
@@ -318,6 +318,10 @@ class IAMBackend(BaseBackend):
             if name == cert.cert_name:
                 return cert
 
+        raise IAMNotFoundException(
+            "The Server Certificate with name {0} cannot be "
+            "found.".format(name))
+
     def create_group(self, group_name, path='/'):
         if group_name in self.groups:
             raise IAMConflictException("Group {0} already exists".format(group_name))

--- a/tests/test_iam/test_iam.py
+++ b/tests/test_iam/test_iam.py
@@ -22,6 +22,14 @@ def test_get_all_server_certs():
 
 
 @mock_iam()
+def test_get_server_cert_doesnt_exist():
+    conn = boto.connect_iam()
+
+    with assert_raises(BotoServerError):
+        conn.get_server_certificate("NonExistant")
+
+
+@mock_iam()
 def test_get_server_cert():
     conn = boto.connect_iam()
 


### PR DESCRIPTION
When no certificate with the name exists, the API should return a 404
(NoSuchEntity).