### PR TITLE
Use region from ctor to set queue_arn.

### DIFF
--- a/moto/sqs/models.py
+++ b/moto/sqs/models.py
@@ -122,7 +122,7 @@ class Queue(object):
         self.last_modified_timestamp = now
         self.maximum_message_size = 64 << 10
         self.message_retention_period = 86400 * 4  # four days
-        self.queue_arn = 'arn:aws:sqs:us-east-1:123456789012:%s' % self.name
+        self.queue_arn = 'arn:aws:sqs:{0}:123456789012:{1}'.format(self.region, self.name)
         self.receive_message_wait_time_seconds = 0
 
     @classmethod

--- a/tests/test_sqs/test_sqs.py
+++ b/tests/test_sqs/test_sqs.py
@@ -511,6 +511,7 @@ def test_boto3_get_queue():
     queue = sqs.get_queue_by_name(QueueName='test-queue')
     queue.attributes.get('QueueArn').should_not.be.none
     queue.attributes.get('QueueArn').split(':')[-1].should.equal('test-queue')
+    queue.attributes.get('QueueArn').split(':')[3].should.equal('us-east-1')
     queue.attributes.get('VisibilityTimeout').should_not.be.none
     queue.attributes.get('VisibilityTimeout').should.equal('30')
 


### PR DESCRIPTION
Without this, any region passed to boto3.resource is ignored and unit
tests depending on it break.