### PR TITLE
Initial support for apigateway stages

### DIFF
--- a/moto/apigateway/responses.py
+++ b/moto/apigateway/responses.py
@@ -95,6 +95,19 @@ class APIGatewayResponse(BaseResponse):
             method_response = self.backend.delete_method_response(function_id, resource_id, method_type, response_code)
         return 200, headers, json.dumps(method_response)
 
+    def stages(self, request, full_url, headers):
+        self.setup_class(request, full_url, headers)
+        url_path_parts = self.path.split("/")
+        function_id = url_path_parts[2]
+        stage_name = url_path_parts[4]
+
+        if self.method == 'GET':
+            stage_response = self.backend.get_stage(function_id, stage_name)
+        elif self.method == 'PATCH':
+            path_operations = self._get_param('patchOperations')
+            stage_response = self.backend.update_stage(function_id, stage_name, path_operations)
+        return 200, headers, json.dumps(stage_response)
+
     def integrations(self, request, full_url, headers):
         self.setup_class(request, full_url, headers)
         url_path_parts = self.path.split("/")

--- a/moto/apigateway/urls.py
+++ b/moto/apigateway/urls.py
@@ -9,11 +9,12 @@ url_paths = {
     '{0}/restapis$': APIGatewayResponse().restapis,
     '{0}/restapis/(?P<function_id>[^/]+)/?$': APIGatewayResponse().restapis_individual,
     '{0}/restapis/(?P<function_id>[^/]+)/resources$': APIGatewayResponse().resources,
+    '{0}/restapis/(?P<function_id>[^/]+)/stages/(?P<stage_name>[^/]+)/?$': APIGatewayResponse().stages,
     '{0}/restapis/(?P<function_id>[^/]+)/deployments$': APIGatewayResponse().deployments,
     '{0}/restapis/(?P<function_id>[^/]+)/deployments/(?P<deployment_id>[^/]+)/?$': APIGatewayResponse().individual_deployment,
     '{0}/restapis/(?P<function_id>[^/]+)/resources/(?P<resource_id>[^/]+)/?$': APIGatewayResponse().resource_individual,
     '{0}/restapis/(?P<function_id>[^/]+)/resources/(?P<resource_id>[^/]+)/methods/(?P<method_name>[^/]+)/?$': APIGatewayResponse().resource_methods,
-    '{0}/restapis/(?P<function_id>[^/]+)/resources/(?P<resource_id>[^/]+)/methods/(?P<method_name>[^/]+)/responses/200$': APIGatewayResponse().resource_method_responses,
+    '{0}/restapis/(?P<function_id>[^/]+)/resources/(?P<resource_id>[^/]+)/methods/(?P<method_name>[^/]+)/responses/(?P<status_code>\d+)$': APIGatewayResponse().resource_method_responses,
     '{0}/restapis/(?P<function_id>[^/]+)/resources/(?P<resource_id>[^/]+)/methods/(?P<method_name>[^/]+)/integration/?$': APIGatewayResponse().integrations,
     '{0}/restapis/(?P<function_id>[^/]+)/resources/(?P<resource_id>[^/]+)/methods/(?P<method_name>[^/]+)/integration/responses/(?P<status_code>\d+)/?$': APIGatewayResponse().integration_responses,
 }

--- a/moto/server.py
+++ b/moto/server.py
@@ -16,7 +16,7 @@ from werkzeug.serving import run_simple
 from moto.backends import BACKENDS
 from moto.core.utils import convert_flask_to_httpretty_response
 
-HTTP_METHODS = ["GET", "POST", "PUT", "DELETE", "HEAD"]
+HTTP_METHODS = ["GET", "POST", "PUT", "DELETE", "HEAD", "PATCH"]
 
 
 class DomainDispatcherApplication(object):

--- a/tests/test_apigateway/test_apigateway.py
+++ b/tests/test_apigateway/test_apigateway.py
@@ -472,6 +472,7 @@ def test_integration_response():
 @mock_apigateway
 def test_deployment():
     client = boto3.client('apigateway', region_name='us-west-2')
+    stage_name = 'staging'
     response = client.create_rest_api(
         name='my_api',
         description='this is my api',
@@ -480,7 +481,7 @@ def test_deployment():
 
     response = client.create_deployment(
         restApiId=api_id,
-        stageName='staging',
+        stageName=stage_name,
     )
     deployment_id = response['id']
 
@@ -510,6 +511,35 @@ def test_deployment():
         restApiId=api_id,
     )
     len(response['items']).should.equal(0)
+
+    # test deployment stages
+
+    stage = client.get_stage(
+        restApiId=api_id,
+        stageName=stage_name
+    )
+    stage['stageName'].should.equal(stage_name)
+    stage['deploymentId'].should.equal(deployment_id)
+
+    stage = client.update_stage(
+        restApiId=api_id,
+        stageName=stage_name,
+        patchOperations=[
+            {
+                'op': 'replace',
+                'path': 'description',
+                'value': '_new_description_'
+            },
+        ]
+    )
+
+    stage = client.get_stage(
+        restApiId=api_id,
+        stageName=stage_name
+    )
+    stage['stageName'].should.equal(stage_name)
+    stage['deploymentId'].should.equal(deployment_id)
+    stage['description'].should.equal('_new_description_')
 
 
 @httpretty.activate


### PR DESCRIPTION
This PR adds initial support for deployment stages for the apigateway service.

When a new deployment is created, a new stage is automatically created for the `stageName` that has been specified for this deployment. Using the `update_stage` operation (which is an HTTP `PATCH` method), the stage information can be modified. Currently this works only for very simple examples, and the `"/*/*/<fieldName>"` path syntax is not supported yet. Will be added as part of a future PR.

Additional tests have been added to cover the new functionality.