### PR TITLE
Make testing a bit safer binding to 127.0.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,20 +206,31 @@ To run a service:
 
 ```console
 $ moto_server ec2
- * Running on http://0.0.0.0:5000/
+ * Running on http://127.0.0.1:5000/
 ```
 
 You can also pass the port as the second argument:
 
 ```console
 $ moto_server ec2 -p3000
- * Running on http://0.0.0.0:3000/
+ * Running on http://127.0.0.1:3000/
 ```
 
+If you want to be able to use the server externally you can pass an IP
+address to bind to as a hostname or allow any of your external
+interfaces with 0.0.0.0:
+
+```console
+$ moto_server ec2 -H 0.0.0.0
+ * Running on http://0.0.0.0:5000/
+```
+
+Please be aware this might allow other network users to access your
+server.
 
 Then go to [localhost](http://localhost:5000/?Action=DescribeInstances) to see a list of running instances (it will be empty since you haven't added any yet).
 
-If you want to use boto with this (using the simpler decorators above instead is strongly encouraged), the easiest way is to create a boto config file (`~/.boto`) with the following values:
+If you want to use boto with this (using the simpler decorators above instead is strongly encouraged), the easiest way is to create a boto config file (`~/.boto`) with the following valuesp:
 
 ```
 [Boto]

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -107,6 +107,6 @@ Moto comes with a stand-alone server allowing you to mock out an AWS HTTP endpoi
 .. sourcecode:: bash
 
     $ moto_server ec2 -p3000
-     * Running on http://0.0.0.0:3000/
+     * Running on http://127.0.0.1:3000/
 
 This method isn't encouraged if you're using ``boto``, best is to use decorator method.

--- a/moto/server.py
+++ b/moto/server.py
@@ -131,7 +131,7 @@ def main(argv=sys.argv[1:]):
     parser.add_argument(
         '-H', '--host', type=str,
         help='Which host to bind',
-        default='0.0.0.0')
+        default='127.0.0.1')
     parser.add_argument(
         '-p', '--port', type=int,
         help='Port number to use for connection',

--- a/tests/test_core/test_server.py
+++ b/tests/test_core/test_server.py
@@ -18,7 +18,7 @@ def test_wrong_arguments():
 def test_right_arguments(run_simple):
     main(["s3"])
     func_call = run_simple.call_args[0]
-    func_call[0].should.equal("0.0.0.0")
+    func_call[0].should.equal("127.0.0.1")
     func_call[1].should.equal(5000)
 
 
@@ -26,7 +26,7 @@ def test_right_arguments(run_simple):
 def test_port_argument(run_simple):
     main(["s3", "--port", "8080"])
     func_call = run_simple.call_args[0]
-    func_call[0].should.equal("0.0.0.0")
+    func_call[0].should.equal("127.0.0.1")
     func_call[1].should.equal(8080)
 
 


### PR DESCRIPTION
Please accept this patch which changes to bind by default to 127.0.0.1 so that mistakes during testing are less likely to cause problems.  I've updated also the documentation and this passes tests on travis.  

Thanks for moto in any case.  Very nice.  