### PR TITLE
Fix unicode S3 key listing in Python 2

### DIFF
--- a/moto/s3/utils.py
+++ b/moto/s3/utils.py
@@ -46,6 +46,9 @@ def metadata_from_headers(headers):
 
 
 def clean_key_name(key_name):
+    if six.PY2:
+        return unquote(key_name.encode('utf-8')).decode('utf-8')
+
     return unquote(key_name)
 
 

--- a/tests/test_s3/test_s3.py
+++ b/tests/test_s3/test_s3.py
@@ -846,9 +846,10 @@ def test_unicode_key():
     key = Key(bucket)
     key.key = u'こんにちは.jpg'
     key.set_contents_from_string('Hello world!')
-    list(bucket.list())
-    key = bucket.get_key(key.key)
-    assert key.get_contents_as_string().decode("utf-8") == 'Hello world!'
+    assert [listed_key.key for listed_key in bucket.list()] == [key.key]
+    fetched_key = bucket.get_key(key.key)
+    assert fetched_key.key == key.key
+    assert fetched_key.get_contents_as_string().decode("utf-8") == 'Hello world!'
 
 
 @mock_s3


### PR DESCRIPTION
Unicode keys returned by `bucket.list()` have malformed name in Python 2.

Using separating key name unquoting logic for Python 2 fixes the problem (Call `unquote` with `str`, then decode to `unicode` again). Updated the test case for unicode key to reproduce the error (without the fix).
