### PR TITLE
ALWAYS use utcnow(), never now()

### DIFF
--- a/moto/cloudwatch/models.py
+++ b/moto/cloudwatch/models.py
@@ -27,8 +27,8 @@ class FakeAlarm(object):
         self.ok_actions = ok_actions
         self.insufficient_data_actions = insufficient_data_actions
         self.unit = unit
-        self.state_updated_timestamp = datetime.datetime.now()
-        self.configuration_updated_timestamp = datetime.datetime.now()
+        self.state_updated_timestamp = datetime.datetime.utcnow()
+        self.configuration_updated_timestamp = datetime.datetime.utcnow()
 
 
 class MetricDatum(object):

--- a/moto/core/responses.py
+++ b/moto/core/responses.py
@@ -269,7 +269,7 @@ def metadata_response(request, full_url, headers):
     http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/AESDG-chapter-instancedata.html
     """
     parsed_url = urlparse(full_url)
-    tomorrow = datetime.datetime.now() + datetime.timedelta(days=1)
+    tomorrow = datetime.datetime.utcnow() + datetime.timedelta(days=1)
     credentials = dict(
         AccessKeyId="test-key",
         SecretAccessKey="test-secret-key",

--- a/moto/dynamodb/models.py
+++ b/moto/dynamodb/models.py
@@ -100,7 +100,7 @@ class Table(object):
         self.range_key_type = range_key_type
         self.read_capacity = read_capacity
         self.write_capacity = write_capacity
-        self.created_at = datetime.datetime.now()
+        self.created_at = datetime.datetime.utcnow()
         self.items = defaultdict(dict)
 
     @property

--- a/moto/dynamodb2/models.py
+++ b/moto/dynamodb2/models.py
@@ -189,7 +189,7 @@ class Table(object):
         self.throughput["NumberOfDecreasesToday"] = 0
         self.indexes = indexes
         self.global_indexes = global_indexes if global_indexes else []
-        self.created_at = datetime.datetime.now()
+        self.created_at = datetime.datetime.utcnow()
         self.items = defaultdict(dict)
 
     def describe(self, base_key='TableDescription'):

--- a/moto/rds/models.py
+++ b/moto/rds/models.py
@@ -50,7 +50,7 @@ class Database(object):
         self.availability_zone = kwargs.get("availability_zone")
         self.multi_az = kwargs.get("multi_az")
         self.db_subnet_group_name = kwargs.get("db_subnet_group_name")
-        self.instance_create_time = str(datetime.datetime.now())
+        self.instance_create_time = str(datetime.datetime.utcnow())
         if self.db_subnet_group_name:
             self.db_subnet_group = rds_backends[self.region].describe_subnet_groups(self.db_subnet_group_name)[0]
         else:

--- a/moto/sns/models.py
+++ b/moto/sns/models.py
@@ -87,7 +87,7 @@ class Subscription(object):
             "TopicArn": self.topic.arn,
             "Subject": "my subject",
             "Message": message,
-            "Timestamp": iso_8601_datetime_with_milliseconds(datetime.datetime.now()),
+            "Timestamp": iso_8601_datetime_with_milliseconds(datetime.datetime.utcnow()),
             "SignatureVersion": "1",
             "Signature": "EXAMPLElDMXvB8r9R83tGoNn0ecwd5UjllzsvSvbItzfaMpN2nk5HVSw7XnOn/49IkxDKz8YrlH2qJXj2iZB0Zo2O71c4qQk1fMUDi3LGpij7RCW7AW9vYYsSqIKRnFS94ilu7NFhUzLiieYr4BKHpdTmdD6c0esKEYBpabxDSc=",
             "SigningCertURL": "https://sns.us-east-1.amazonaws.com/SimpleNotificationService-f3ecfb7224c7233fe7bb5f59f96de52f.pem",

--- a/moto/sts/models.py
+++ b/moto/sts/models.py
@@ -6,7 +6,7 @@ from moto.core.utils import iso_8601_datetime_with_milliseconds
 
 class Token(object):
     def __init__(self, duration, name=None, policy=None):
-        now = datetime.datetime.now()
+        now = datetime.datetime.utcnow()
         self.expiration = now + datetime.timedelta(seconds=duration)
         self.name = name
         self.policy = None
@@ -21,7 +21,7 @@ class AssumedRole(object):
         self.session_name = role_session_name
         self.arn = role_arn
         self.policy = policy
-        now = datetime.datetime.now()
+        now = datetime.datetime.utcnow()
         self.expiration = now + datetime.timedelta(seconds=duration)
         self.external_id = external_id
 

--- a/tests/test_swf/responses/test_workflow_executions.py
+++ b/tests/test_swf/responses/test_workflow_executions.py
@@ -125,7 +125,7 @@ def test_list_open_workflow_executions():
                                       reason='a more complete reason',
                                       run_id=run_id)
 
-    yesterday = datetime.now() - timedelta(days=1)
+    yesterday = datetime.utcnow() - timedelta(days=1)
     oldest_date = unix_time(yesterday)
     response = conn.list_open_workflow_executions('test-domain',
                                                   oldest_date,
@@ -159,7 +159,7 @@ def test_list_closed_workflow_executions():
                                       reason='a more complete reason',
                                       run_id=run_id)
 
-    yesterday = datetime.now() - timedelta(days=1)
+    yesterday = datetime.utcnow() - timedelta(days=1)
     oldest_date = unix_time(yesterday)
     response = conn.list_closed_workflow_executions(
         'test-domain',


### PR DESCRIPTION
Moto only returns the right CreationDateTime for DynamoDB tables if the current timezone is UTC. This PR fixes that behavior.