### PR TITLE
Invalid resource types would return all resources if no other filters were included

### DIFF
--- a/moto/ec2/models.py
+++ b/moto/ec2/models.py
@@ -846,8 +846,7 @@ class TagBackend(object):
                             resource_id_filters.append(re.compile(simple_aws_filter_to_re(value)))
                     if tag_filter == 'resource-type':
                         for value in filters[tag_filter]:
-                            if value in self.VALID_TAG_RESOURCE_FILTER_TYPES:
-                                resource_type_filters.append(value)
+                            resource_type_filters.append(value)
                     if tag_filter == 'value':
                         for value in filters[tag_filter]:
                             value_filters.append(re.compile(simple_aws_filter_to_re(value)))

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ extras_require = {
 
 setup(
     name='moto',
-    version='0.4.27',
+    version='0.4.26',
     description='A library that allows your python tests to easily'
                 ' mock out the boto library',
     author='Steve Pulec',

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ extras_require = {
 
 setup(
     name='moto',
-    version='0.4.26',
+    version='0.4.27',
     description='A library that allows your python tests to easily'
                 ' mock out the boto library',
     author='Steve Pulec',


### PR DESCRIPTION
If the resource-type in describe_tags was invalid it would skip adding that filter. 

This behavior differed from that of AWS behavior which would instead return 0 results.