### PR TITLE
Update S3 object GET response headers with response_dict from key

### DIFF
--- a/moto/s3/responses.py
+++ b/moto/s3/responses.py
@@ -400,6 +400,7 @@ class ResponseObject(_TemplateEnvironmentMixin):
             return 200, headers, template.render(obj=key)
 
         headers.update(key.metadata)
+        headers.update(key.response_dict)
         return 200, headers, key.value
 
     def _key_response_put(self, request, body, bucket_name, query, key_name, headers):

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ deps =
     -r{toxinidir}/requirements-dev.txt
 commands =
     {envpython} setup.py test
-    nosetests
+    nosetests {posargs}
 
 [flake8]
 ignore = E128,E501


### PR DESCRIPTION
When using `boto3`, GET S3 object responses do not include ETag in the response headers. The updating response headers with `key.response_dict` appears to fix the issue without breaking the existing `boto` behavior.

This resolves #703, without breaking `boto`.

The `boto3` version of relevant tests have been added. 

