### PR TITLE
Parse JSON request body from boto3

### DIFF
--- a/moto/core/responses.py
+++ b/moto/core/responses.py
@@ -92,18 +92,18 @@ def flatten_json_request_body(dict_body):
         if isinstance(value, dict):
             r = flatten_json_request_body(value)
             for k, v in r.items():
-                flat[key + '.' + k] = [v]
+                flat[key + '.' + k] = v
         elif isinstance(value, list):
             for i, v in enumerate(value, 1):
                 memberstr = '.member.' + str(i)
                 if isinstance(v, dict):
                     r = flatten_json_request_body(v)
                     for k, vv in r.items():
-                        flat[key + memberstr + '.' + k] = [vv]
+                        flat[key + memberstr + '.' + k] = vv
                 else:
-                    flat[key + memberstr] = [v]
+                    flat[key + memberstr] = v
         else:
-            flat[key] = [value]
+            flat[key] = value
     return flat
 
 
@@ -141,7 +141,9 @@ class BaseResponse(_TemplateEnvironmentMixin):
                     decoded = json.loads(self.body.decode('utf-8'))
                 else:
                     decoded = json.loads(self.body)
-                querystring.update(flatten_json_request_body(decoded))
+                flat = flatten_json_request_body(decoded)
+                for key, value in flat.items():
+                    querystring[key] = [value]
             else:
                 querystring.update(parse_qs(self.body, keep_blank_values=True))
         if not querystring:

--- a/moto/core/responses.py
+++ b/moto/core/responses.py
@@ -86,24 +86,32 @@ class _TemplateEnvironmentMixin(object):
         return self.environment.get_template(template_id)
 
 
+def to_str(v):
+    if isinstance(v, bool):
+        return 'true' if v else 'false'
+    elif v is None:
+        return 'null'
+    return str(v)
+
+
 def flatten_json_request_body(dict_body):
     flat = {}
     for key, value in dict_body.items():
         if isinstance(value, dict):
             r = flatten_json_request_body(value)
             for k, v in r.items():
-                flat[key + '.' + k] = v
+                flat[key + '.' + k] = to_str(v)
         elif isinstance(value, list):
             for i, v in enumerate(value, 1):
                 memberstr = '.member.' + str(i)
                 if isinstance(v, dict):
                     r = flatten_json_request_body(v)
                     for k, vv in r.items():
-                        flat[key + memberstr + '.' + k] = vv
+                        flat[key + memberstr + '.' + k] = to_str(vv)
                 else:
-                    flat[key + memberstr] = v
+                    flat[key + memberstr] = to_str(v)
         else:
-            flat[key] = value
+            flat[key] = to_str(value)
     return flat
 
 

--- a/moto/core/responses.py
+++ b/moto/core/responses.py
@@ -86,6 +86,27 @@ class _TemplateEnvironmentMixin(object):
         return self.environment.get_template(template_id)
 
 
+def flatten_json_request_body(dict_body):
+    flat = {}
+    for key, value in dict_body.items():
+        if isinstance(value, dict):
+            r = flatten_json_request_body(value)
+            for k, v in r.items():
+                flat[key + '.' + k] = [v]
+        elif isinstance(value, list):
+            for i, v in enumerate(value, 1):
+                memberstr = '.member.' + str(i)
+                if isinstance(v, dict):
+                    r = flatten_json_request_body(v)
+                    for k, vv in r.items():
+                        flat[key + memberstr + '.' + k] = [vv]
+                else:
+                    flat[key + memberstr] = [v]
+        else:
+            flat[key] = [value]
+    return flat
+
+
 class BaseResponse(_TemplateEnvironmentMixin):
 
     default_region = 'us-east-1'
@@ -115,7 +136,14 @@ class BaseResponse(_TemplateEnvironmentMixin):
         if not querystring:
             querystring.update(parse_qs(urlparse(full_url).query, keep_blank_values=True))
         if not querystring:
-            querystring.update(parse_qs(self.body, keep_blank_values=True))
+            if 'json' in request.headers.get('content-type', []):
+                if isinstance(self.body, six.binary_type):
+                    decoded = json.loads(self.body.decode('utf-8'))
+                else:
+                    decoded = json.loads(self.body)
+                querystring.update(flatten_json_request_body(decoded))
+            else:
+                querystring.update(parse_qs(self.body, keep_blank_values=True))
         if not querystring:
             querystring.update(headers)
 

--- a/moto/emr/models.py
+++ b/moto/emr/models.py
@@ -35,6 +35,7 @@ class Cluster(object):
         self.log_uri = log_uri
         self.master_public_dns_name = ""
         self.normalized_instance_hours = 0
+        self.release_label = 'emr-2.4.2'
         self.requested_ami_version = "2.4.2"
         self.running_ami_version = "2.4.2"
         self.service_role = "my-service-role"

--- a/tests/test_core/test_responses.py
+++ b/tests/test_core/test_responses.py
@@ -8,16 +8,16 @@ from moto.core.responses import flatten_json_request_body
 def test_flatten_json_request_body():
     jd = {'A': {'B': 1,
                 'C': [2, 3],
-                'D': [{'E': 4, 'F': 5},
-                      {'E': 6, 'F': 7}],
+                'D': [{'E': True, 'F': False},
+                      {'E': None, 'F': 7}],
                 'G': [{'H': [{'I': 'good', 'J': 'bad'}]}]}}
     flat = flatten_json_request_body(jd)
-    flat['A.B'].should.equal(1)
-    flat['A.C.member.1'].should.equal(2)
-    flat['A.C.member.2'].should.equal(3)
-    flat['A.D.member.1.E'].should.equal(4)
-    flat['A.D.member.1.F'].should.equal(5)
-    flat['A.D.member.2.E'].should.equal(6)
-    flat['A.D.member.2.F'].should.equal(7)
+    flat['A.B'].should.equal('1')
+    flat['A.C.member.1'].should.equal('2')
+    flat['A.C.member.2'].should.equal('3')
+    flat['A.D.member.1.E'].should.equal('true')
+    flat['A.D.member.1.F'].should.equal('false')
+    flat['A.D.member.2.E'].should.equal('null')
+    flat['A.D.member.2.F'].should.equal('7')
     flat['A.G.member.1.H.member.1.I'].should.equal('good')
     flat['A.G.member.1.H.member.1.J'].should.equal('bad')

--- a/tests/test_core/test_responses.py
+++ b/tests/test_core/test_responses.py
@@ -1,0 +1,23 @@
+from __future__ import unicode_literals
+
+import sure  # noqa
+
+from moto.core.responses import flatten_json_request_body
+
+
+def test_flatten_json_request_body():
+    jd = {'A': {'B': 1,
+                'C': [2, 3],
+                'D': [{'E': 4, 'F': 5},
+                      {'E': 6, 'F': 7}],
+                'G': [{'H': [{'I': 'good', 'J': 'bad'}]}]}}
+    flat = flatten_json_request_body(jd)
+    flat['A.B'].should.equal(1)
+    flat['A.C.member.1'].should.equal(2)
+    flat['A.C.member.2'].should.equal(3)
+    flat['A.D.member.1.E'].should.equal(4)
+    flat['A.D.member.1.F'].should.equal(5)
+    flat['A.D.member.2.E'].should.equal(6)
+    flat['A.D.member.2.F'].should.equal(7)
+    flat['A.G.member.1.H.member.1.I'].should.equal('good')
+    flat['A.G.member.1.H.member.1.J'].should.equal('bad')

--- a/tests/test_emr/test_emr_boto3.py
+++ b/tests/test_emr/test_emr_boto3.py
@@ -44,3 +44,55 @@ def test_list_clusters():
     cluster = clusters[0]
     cluster['NormalizedInstanceHours'].should.equal(0)
     cluster['Status']['State'].should.equal("RUNNING")
+
+
+@mock_emr
+def test_describe_cluster():
+    client = boto3.client('emr', region_name='us-east-1')
+    resp = client.run_job_flow(
+        Name='cluster',
+        LogUri='s3://mybucket/log',
+        Instances={
+            'MasterInstanceType': 'c3.xlarge',
+            'SlaveInstanceType': 'c3.xlarge',
+            'InstanceCount': 3,
+            'Placement': {'AvailabilityZone': 'us-east-1a'},
+            'KeepJobFlowAliveWhenNoSteps': True,
+        },
+        VisibleToAllUsers=True,
+    )
+    cluster_id = resp['JobFlowId']
+
+    resp = client.describe_cluster(ClusterId=cluster_id)
+
+    cluster = resp['Cluster']
+    cluster['Id'].should.equal(cluster_id)
+    cluster['Name'].should.equal('cluster')
+    cluster['LogUri'].should.equal('s3://mybucket/log')
+    cluster['NormalizedInstanceHours'].should.equal(0)
+    cluster['Status']['State'].should.equal('RUNNING')
+
+
+@mock_emr
+def test_terminate_job_flows():
+    client = boto3.client('emr', region_name='us-east-1')
+    resp = client.run_job_flow(
+        Name='cluster',
+        LogUri='s3://mybucket/log',
+        Instances={
+            'MasterInstanceType': 'c3.xlarge',
+            'SlaveInstanceType': 'c3.xlarge',
+            'InstanceCount': 3,
+            'Placement': {'AvailabilityZone': 'us-east-1a'},
+            'KeepJobFlowAliveWhenNoSteps': True,
+        },
+        VisibleToAllUsers=True,
+    )
+    cluster_id = resp['JobFlowId']
+
+    client.terminate_job_flows(JobFlowIds=[cluster_id])
+
+    resp = client.describe_job_flows(JobFlowIds=[cluster_id])
+    resp['JobFlows'].should.have.length_of(1)
+    jobflow = resp['JobFlows'][0]
+    jobflow['ExecutionStatusDetail']['State'].should.equal('TERMINATED')


### PR DESCRIPTION
This revision adds code to handle cases when request body is JSON
(typically from boto3). A couple EMR endpoints are updated with boto3
responses and corresponding test cases are added to demonstrate that
it works.

This resolves #707.