### PR TITLE
Fix Route53 tagging code

### DIFF
--- a/moto/route53/models.py
+++ b/moto/route53/models.py
@@ -238,18 +238,19 @@ class Route53Backend(BaseBackend):
 
     def change_tags_for_resource(self, resource_id, tags):
         if 'Tag' in tags:
-            for key, tag in tags.items():
-                for t in tag:
-                    self.resource_tags[resource_id][t['Key']] = t['Value']
-
+            if isinstance(tags['Tag'], list):
+                for tag in tags['Tag']:
+                    self.resource_tags[resource_id][tag['Key']] = tag['Value']
+            else:
+                key, value = (tags['Tag']['Key'], tags['Tag']['Value'])
+                self.resource_tags[resource_id][key] = value
         else:
-            for _, keys in tags.items():
-                if isinstance(keys, list):
-                    for key in keys:
+            if 'Key' in tags:
+                if isinstance(tags['Key'], list):
+                    for key in tags['Key']:
                         del(self.resource_tags[resource_id][key])
                 else:
-                        del(self.resource_tags[resource_id][keys])
-
+                    del(self.resource_tags[resource_id][tags['Key']])
 
     def list_tags_for_resource(self, resource_id):
         if resource_id in self.resource_tags:

--- a/tests/test_route53/test_route53.py
+++ b/tests/test_route53/test_route53.py
@@ -354,6 +354,8 @@ def test_list_or_change_tags_for_resource_request():
     response['ResourceTagSet']['Tags'].should.contain(tag1)
     response['ResourceTagSet']['Tags'].should.contain(tag2)
 
+    len(response['ResourceTagSet']['Tags']).should.equal(2)
+
     # Try to remove the tags
     conn.change_tags_for_resource(
         ResourceType='healthcheck',


### PR DESCRIPTION
Hey Steve, 

I suppose I should have tried using the built library locally. Although the Unittests were passing, the underlying implementation was not producing the correct results. I've refactored the models file to correct the issue.

Tags for a resourceID were all being placed under `self.resource_tags[UUID]['Value']`. Keys are now correctly added under the UUID with the proper key name and the delete logic works. 

I also tested this build code against the project I'm working on. Looks solid to me!