### PR TITLE
setup.py - use extras_require for flask

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,16 +200,24 @@ In general, Moto doesn't rely on anything specific to Boto. It only mocks AWS en
 
 ## Stand-alone Server Mode
 
-Moto also comes with a stand-alone server mode. This allows you to utilize the backend structure of Moto even if you don't use Python.
+Moto also has a stand-alone server mode. This allows you to utilize
+the backend structure of Moto even if you don't use Python.
 
-To run a service:
+It uses flask, which isn't a default dependency. You can install the
+server 'extra' package with:
+
+```python
+pip install moto[server]
+```
+
+You can then start it running a service:
 
 ```console
 $ moto_server ec2
  * Running on http://127.0.0.1:5000/
 ```
 
-You can also pass the port as the second argument:
+You can also pass the port:
 
 ```console
 $ moto_server ec2 -p3000

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,6 @@ from setuptools import setup, find_packages
 install_requires = [
     "Jinja2",
     "boto>=2.36.0",
-    "flask",
     "httpretty==0.8.10",
     "requests",
     "xmltodict",
@@ -18,6 +17,8 @@ install_requires = [
 extras_require = {
     # No builtin OrderedDict before 2.7
     ':python_version=="2.6"': ['ordereddict'],
+
+    'server': ['flask'],
 }
 
 setup(


### PR DESCRIPTION
Adding `moto` to the requirements file for my Django project pulls in `flask`, even though I don't need the server component. By making the `server` 'extra' then there is no hard requirement on flask.