### PR TITLE
Remove sure and freezegun from setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,8 +11,6 @@ install_requires = [
     "xmltodict",
     "six",
     "werkzeug",
-    "sure",
-    "freezegun"
 ]
 
 extras_require = {


### PR DESCRIPTION
They still exist in requirements-dev.txt. Opening for testing.

This addresses #717.