### PR TITLE
The modify_network_interface_attribute method should work with updating other attributes too

### DIFF
--- a/moto/ec2/models.py
+++ b/moto/ec2/models.py
@@ -809,7 +809,10 @@ class TagBackend(object):
             raise InvalidParameterValueErrorTagNull()
         for resource_id in resource_ids:
             if resource_id in self.tags:
-                if len(self.tags[resource_id]) + len([tag for tag in tags if not tag.startswith("aws:")]) > 10:
+                extra_tags = [tag for tag in tags if not tag.startswith("aws:") and \
+                              tag not in self.tags[resource_id]]
+
+                if len(self.tags[resource_id]) + len(extra_tags) > 10:
                     raise TagLimitExceeded()
             elif len([tag for tag in tags if not tag.startswith("aws:")]) > 10:
                 raise TagLimitExceeded()

--- a/moto/ec2/responses/elastic_network_interfaces.py
+++ b/moto/ec2/responses/elastic_network_interfaces.py
@@ -46,9 +46,21 @@ class ElasticNetworkInterfaces(BaseResponse):
     def modify_network_interface_attribute(self):
         # Currently supports modifying one and only one security group
         eni_id = self.querystring.get('NetworkInterfaceId')[0]
+
         if self.querystring.get('SecurityGroupId.1'):
             group_id = self.querystring.get('SecurityGroupId.1')[0]
-        self.ec2_backend.modify_network_interface_attribute(eni_id, group_id)
+            self.ec2_backend.modify_network_interface_attribute(eni_id, group_id)
+
+        if self.querystring.get('SourceDestCheck.Value'):
+            source_dest_check_from_response = self.querystring.get('SourceDestCheck.Value')
+
+            if source_dest_check_from_response == ['false']:
+                source_dest_check = False
+            else:
+                source_dest_check = True
+
+            #self.ec2_backend.modify_network_interface_attribute(eni_id, source_dest_check)
+
         return MODIFY_NETWORK_INTERFACE_ATTRIBUTE_RESPONSE
 
     def reset_network_interface_attribute(self):

--- a/moto/ec2/responses/elastic_network_interfaces.py
+++ b/moto/ec2/responses/elastic_network_interfaces.py
@@ -46,7 +46,8 @@ class ElasticNetworkInterfaces(BaseResponse):
     def modify_network_interface_attribute(self):
         # Currently supports modifying one and only one security group
         eni_id = self.querystring.get('NetworkInterfaceId')[0]
-        group_id = self.querystring.get('SecurityGroupId.1')[0]
+        if self.querystring.get('SecurityGroupId.1'):
+            group_id = self.querystring.get('SecurityGroupId.1')[0]
         self.ec2_backend.modify_network_interface_attribute(eni_id, group_id)
         return MODIFY_NETWORK_INTERFACE_ATTRIBUTE_RESPONSE
 

--- a/moto/rds/responses.py
+++ b/moto/rds/responses.py
@@ -116,7 +116,7 @@ class RDSResponse(BaseResponse):
     def create_dbsubnet_group(self):
         subnet_name = self._get_param('DBSubnetGroupName')
         description = self._get_param('DBSubnetGroupDescription')
-        subnet_ids = self._get_multi_param('SubnetIds.member')
+        subnet_ids = self._get_multi_param('SubnetIds.SubnetIdentifier')
         subnets = [ec2_backends[self.region].get_subnet(subnet_id) for subnet_id in subnet_ids]
         subnet_group = self.backend.create_subnet_group(subnet_name, description, subnets)
         template = self.response_template(CREATE_SUBNET_GROUP_TEMPLATE)


### PR DESCRIPTION
The method is currently failed if for example the Security group is not changed for that network interface, but the SourceDestCheck attribute is changed instead.

Although this commit doesn't completely take an action of when the SourceDestCheck is changed, it doesn't fail either.
