### PR TITLE
lambderize the moto lambda

### DIFF
--- a/moto/awslambda/models.py
+++ b/moto/awslambda/models.py
@@ -1,13 +1,18 @@
 from __future__ import unicode_literals
 
+import StringIO
 import base64
 import datetime
 import hashlib
 import io
 import json
-import StringIO
 import sys
 import zipfile
+
+try:
+    from StringIO import StringIO
+except:
+    from io import StringIO
 
 import boto.awslambda
 from moto.core import BaseBackend
@@ -104,18 +109,18 @@ class LambdaFunction(object):
     def _invoke_lambda(self, code, event={}, context={}):
         # TO DO: context not yet implemented
         try:
-            codeOut = StringIO.StringIO()
-            codeErr = StringIO.StringIO()
-            mycode = "\n".join([self.code, 'print lambda_handler(%s, %s)'  % (event, context)])
+            codeOut = StringIO()
+            codeErr = StringIO()
+            mycode = "\n".join([self.code, 'print lambda_handler(%s, %s)' % (event, context)])
             #print "moto_lambda_debug: ", mycode
             sys.stdout = codeOut
             sys.stderr = codeErr
-            exec(mycode, {'event': event, 'context': context})
+            exec mycode
             exec_err = codeErr.getvalue()
             exec_out = codeOut.getvalue()
             result = "\n".join([exec_out, exec_err])
         except Exception as ex:
-            result = 'Exception %s, %s' % (ex, ex.message)
+            result = '%s\n\n\nException %s, %s' % (mycode, ex, ex.message)
         finally:
             codeErr.close()
             codeOut.close()

--- a/moto/awslambda/models.py
+++ b/moto/awslambda/models.py
@@ -107,11 +107,12 @@ class LambdaFunction(object):
 
     def _invoke_lambda(self, code, event={}, context={}):
         # TO DO: context not yet implemented
+        mycode = "\n".join([self.code, 'print lambda_handler(%s, %s)' % (event, context)])
+        #print "moto_lambda_debug: ", mycode
+
         try:
             codeOut = StringIO()
             codeErr = StringIO()
-            mycode = "\n".join([self.code, 'print lambda_handler(%s, %s)' % (event, context)])
-            #print "moto_lambda_debug: ", mycode
             sys.stdout = codeOut
             sys.stderr = codeErr
             exec(mycode)

--- a/moto/awslambda/models.py
+++ b/moto/awslambda/models.py
@@ -129,9 +129,9 @@ class LambdaFunction(object):
             mycode = "\n".join(['import json',
                                 self.convert(self.code),
                                 self.convert('print(lambda_handler(%s, %s))' % (self.is_json(self.convert(event)), context))])
-            print("moto_lambda_debug: ", mycode)
+            #print("moto_lambda_debug: ", mycode)
         except Exception as ex:
-            print('fuck ', ex)
+            print("Exception %s", ex)
 
         try:
             codeOut = StringIO()

--- a/moto/awslambda/models.py
+++ b/moto/awslambda/models.py
@@ -1,6 +1,5 @@
 from __future__ import unicode_literals
 
-import StringIO
 import base64
 import datetime
 import hashlib

--- a/moto/awslambda/models.py
+++ b/moto/awslambda/models.py
@@ -115,7 +115,7 @@ class LambdaFunction(object):
             #print "moto_lambda_debug: ", mycode
             sys.stdout = codeOut
             sys.stderr = codeErr
-            exec mycode
+            exec(mycode)
             exec_err = codeErr.getvalue()
             exec_out = codeOut.getvalue()
             result = "\n".join([exec_out, exec_err])

--- a/moto/awslambda/models.py
+++ b/moto/awslambda/models.py
@@ -107,8 +107,8 @@ class LambdaFunction(object):
 
     def _invoke_lambda(self, code, event={}, context={}):
         # TO DO: context not yet implemented
-        mycode = "\n".join([self.code, 'print lambda_handler(%s, %s)' % (event, context)])
-        #print "moto_lambda_debug: ", mycode
+        mycode = "\n".join([self.code, 'print(lambda_handler(%s, %s))' % (event, context)])
+        print("moto_lambda_debug: ", mycode)
 
         try:
             codeOut = StringIO()

--- a/moto/awslambda/models.py
+++ b/moto/awslambda/models.py
@@ -3,7 +3,11 @@ from __future__ import unicode_literals
 import base64
 import datetime
 import hashlib
+import io
 import json
+import StringIO
+import sys
+import zipfile
 
 import boto.awslambda
 from moto.core import BaseBackend
@@ -34,9 +38,13 @@ class LambdaFunction(object):
         self.version = '$LATEST'
         self.last_modified = datetime.datetime.utcnow().strftime('%Y-%m-%d %H:%M:%S')
         if 'ZipFile' in self.code:
-            code = base64.b64decode(self.code['ZipFile'])
-            self.code_size = len(code)
-            self.code_sha_256 = hashlib.sha256(code).hexdigest()
+            to_unzip_code = base64.b64decode(self.code['ZipFile'])
+            zbuffer = io.BytesIO()
+            zbuffer.write(to_unzip_code)
+            zip_file = zipfile.ZipFile(zbuffer, 'r', zipfile.ZIP_DEFLATED)
+            self.code = zip_file.read("".join(zip_file.namelist()))
+            self.code_size = len(to_unzip_code)
+            self.code_sha_256 = hashlib.sha256(to_unzip_code).hexdigest()
         else:
             # validate s3 bucket
             try:
@@ -93,15 +101,47 @@ class LambdaFunction(object):
             "Configuration": self.get_configuration(),
         }
 
+    def _invoke_lambda(self, code, event={}, context={}):
+        # TO DO: context not yet implemented
+        try:
+            codeOut = StringIO.StringIO()
+            codeErr = StringIO.StringIO()
+            mycode = "\n".join([self.code, 'print lambda_handler(%s, %s)'  % (event, context)])
+            #print "moto_lambda_debug: ", mycode
+            sys.stdout = codeOut
+            sys.stderr = codeErr
+            exec(mycode, {'event': event, 'context': context})
+            exec_err = codeErr.getvalue()
+            exec_out = codeOut.getvalue()
+            result = "\n".join([exec_out, exec_err])
+        except Exception as ex:
+            result = 'Exception %s, %s' % (ex, ex.message)
+        finally:
+            codeErr.close()
+            codeOut.close()
+            sys.stdout = sys.__stdout__
+            sys.stderr = sys.__stderr__
+        return result
+
+    def is_json(self, test_str):
+        try:
+            response = json.loads(test_str)
+        except:
+            response = test_str
+        return response
+
     def invoke(self, request, headers):
         payload = dict()
 
         # Get the invocation type:
+        invoke_type = request.headers.get("x-amz-invocation-type")
+        response = self._invoke_lambda(code=self.code, event=self.is_json(request.body))
         if request.headers.get("x-amz-invocation-type") == "RequestResponse":
-            encoded = base64.b64encode("Some log file output...".encode('utf-8'))
+            encoded = base64.b64encode(response.encode('utf-8'))
+            payload['result'] = encoded
             headers["x-amz-log-result"] = encoded.decode('utf-8')
-
-            payload["result"] = "Good"
+        elif request.headers.get("x-amz-invocation-type") == "Event":
+            payload['result'] = 'good'  # nothing should be sent back possibly headers etc.
 
         return json.dumps(payload, indent=4)
 
@@ -154,3 +194,7 @@ class LambdaBackend(BaseBackend):
 lambda_backends = {}
 for region in boto.awslambda.regions():
     lambda_backends[region.name] = LambdaBackend()
+
+# Handle us forgotten regions, unless Lambda truly only runs out of US and EU?????
+for region in ['ap-southeast-2']:
+    lambda_backends[region] = LambdaBackend()

--- a/moto/awslambda/responses.py
+++ b/moto/awslambda/responses.py
@@ -43,7 +43,7 @@ class LambdaResponse(BaseResponse):
         if lambda_backend.has_function(function_name):
             fn = lambda_backend.get_function(function_name)
             payload = fn.invoke(request, headers)
-            return 200, headers, payload
+            return 202, headers, payload
         else:
             return 404, headers, "{}"
 

--- a/tests/test_awslambda/test_lambda.py
+++ b/tests/test_awslambda/test_lambda.py
@@ -5,6 +5,7 @@ import botocore.client
 import boto3
 import hashlib
 import io
+import json
 import zipfile
 import sure  # noqa
 
@@ -67,7 +68,7 @@ def test_invoke_function():
         Publish=True,
     )
 
-    success_result = conn.invoke(FunctionName='testFunction', InvocationType='Event', Payload="Mostly Harmless")
+    success_result = conn.invoke(FunctionName='testFunction', InvocationType='Event', Payload='Mostly Harmless')
     success_result["StatusCode"].should.equal(202)
 
     conn.invoke.when.called_with(
@@ -76,10 +77,9 @@ def test_invoke_function():
         Payload='{}'
     ).should.throw(botocore.client.ClientError)
 
-    success_result = conn.invoke(FunctionName='testFunction', InvocationType='RequestResponse', Payload='{"msg": "So long and thanks for all the fish"}')
+    success_result = conn.invoke(FunctionName='testFunction', InvocationType='RequestResponse',
+                                 Payload=json.dumps({'msg': 'So long and thanks for all the fish'}))
     success_result["StatusCode"].should.equal(202)
-
-    import base64
     base64.b64decode(success_result["LogResult"]).decode('utf-8').should.equal("({u'msg': u'So long and thanks for all the fish'}, {})\n\n")
 
 @mock_ec2

--- a/tests/test_cloudformation/test_cloudformation_stack_integration.py
+++ b/tests/test_cloudformation/test_cloudformation_stack_integration.py
@@ -1,6 +1,7 @@
 from __future__ import unicode_literals
 import json
 
+import base64
 import boto
 import boto.cloudformation
 import boto.datapipeline
@@ -1724,10 +1725,29 @@ def test_datapipeline():
     stack_resources.should.have.length_of(1)
     stack_resources[0].physical_resource_id.should.equal(data_pipelines['pipelineIdList'][0]['id'])
 
+def _process_lamda(pfunc):
+    import io
+    import zipfile
+    zip_output = io.BytesIO()
+    zip_file = zipfile.ZipFile(zip_output, 'w', zipfile.ZIP_DEFLATED)
+    zip_file.writestr('lambda_function.zip', pfunc)
+    zip_file.close()
+    zip_output.seek(0)
+    return zip_output.read()
+
+
+def get_test_zip_file1():
+    pfunc = b"""
+def lambda_handler(event, context):
+    return (event, context)
+"""
+    return _process_lamda(pfunc)
+
 
 @mock_cloudformation
 @mock_lambda
 def test_lambda_function():
+    # switch this to python as backend lambda only supports python execution.
     conn = boto3.client('lambda', 'us-east-1')
     template = {
         "AWSTemplateFormatVersion": "2010-09-09",
@@ -1736,22 +1756,15 @@ def test_lambda_function():
                 "Type": "AWS::Lambda::Function",
                 "Properties": {
                     "Code": {
-                        "ZipFile": {"Fn::Join": [
-                            "\n",
-                            """
-                            exports.handler = function(event, context) {
-                                context.succeed();
-                            }
-                            """.splitlines()
-                        ]}
+                        "ZipFile": base64.b64encode(get_test_zip_file1())
                     },
-                    "Handler": "index.handler",
+                    "Handler": "lambda_function.handler",
                     "Description": "Test function",
                     "MemorySize": 128,
                     "Role": "test-role",
-                    "Runtime": "nodejs",
+                    "Runtime": "python2.7"
                 }
-            },
+            }
         }
     }
 
@@ -1765,10 +1778,10 @@ def test_lambda_function():
     result = conn.list_functions()
     result['Functions'].should.have.length_of(1)
     result['Functions'][0]['Description'].should.equal('Test function')
-    result['Functions'][0]['Handler'].should.equal('index.handler')
+    result['Functions'][0]['Handler'].should.equal('lambda_function.handler')
     result['Functions'][0]['MemorySize'].should.equal(128)
     result['Functions'][0]['Role'].should.equal('test-role')
-    result['Functions'][0]['Runtime'].should.equal('nodejs')
+    result['Functions'][0]['Runtime'].should.equal('python2.7')
 
 
 @mock_cloudformation

--- a/tests/test_cloudformation/test_cloudformation_stack_integration.py
+++ b/tests/test_cloudformation/test_cloudformation_stack_integration.py
@@ -1737,7 +1737,7 @@ def _process_lamda(pfunc):
 
 
 def get_test_zip_file1():
-    pfunc = b"""
+    pfunc = """
 def lambda_handler(event, context):
     return (event, context)
 """
@@ -1756,7 +1756,7 @@ def test_lambda_function():
                 "Type": "AWS::Lambda::Function",
                 "Properties": {
                     "Code": {
-                        "ZipFile": base64.b64encode(get_test_zip_file1())
+                        "ZipFile": base64.b64encode(get_test_zip_file1()).decode('utf-8')
                     },
                     "Handler": "lambda_function.handler",
                     "Description": "Test function",


### PR DESCRIPTION
This patch allows someone to run some rudimentary python lambda functions for unit testing. For example one can have a lambda function working within moto which can get a list of EC2 instances and return them to an existing moto'd lambda function (as per test).

Some minor tweaks were required on cloud-formation unit test as it was developed for node and well this just uses the python exec function to invoke the retrieved zip function and runs it.

Hopefully this will work for python 3, but I haven't caught up with it yet ;)

Also a few issues found. regions is retrieved from boto and for some reason only US and EU are in the latest boto release so have an append in for AUS, may require others or maybe use boto3 regions collection or something?

Also noticed 202 is returned on invoke rather than 200 - possibly when using boto?

