### PR TITLE
Return the right dhcp_options id in the vpc response

### DIFF
--- a/moto/ec2/responses/vpcs.py
+++ b/moto/ec2/responses/vpcs.py
@@ -50,7 +50,7 @@ CREATE_VPC_RESPONSE = """
       <vpcId>{{ vpc.id }}</vpcId>
       <state>pending</state>
       <cidrBlock>{{ vpc.cidr_block }}</cidrBlock>
-      <dhcpOptionsId>dopt-1a2b3c4d2</dhcpOptionsId>
+      <dhcpOptionsId>{% if vpc.dhcp_options %}{{ vpc.dhcp_options.id }}{% else %}dopt-7a8b9c2d{% endif %}</dhcpOptionsId>
       <instanceTenancy>default</instanceTenancy>
       <tagSet>
         {% for tag in vpc.get_tags() %}
@@ -74,7 +74,7 @@ DESCRIBE_VPCS_RESPONSE = """
         <vpcId>{{ vpc.id }}</vpcId>
         <state>{{ vpc.state }}</state>
         <cidrBlock>{{ vpc.cidr_block }}</cidrBlock>
-        <dhcpOptionsId>dopt-7a8b9c2d</dhcpOptionsId>
+        <dhcpOptionsId>{% if vpc.dhcp_options %}{{ vpc.dhcp_options.id }}{% else %}dopt-7a8b9c2d{% endif %}</dhcpOptionsId>
         <instanceTenancy>default</instanceTenancy>
         <isDefault>{{ vpc.is_default }}</isDefault>
         <tagSet>

--- a/moto/ec2/responses/vpcs.py
+++ b/moto/ec2/responses/vpcs.py
@@ -50,7 +50,7 @@ CREATE_VPC_RESPONSE = """
       <vpcId>{{ vpc.id }}</vpcId>
       <state>pending</state>
       <cidrBlock>{{ vpc.cidr_block }}</cidrBlock>
-      <dhcpOptionsId>{% if vpc.dhcp_options %}{{ vpc.dhcp_options.id }}{% else %}dopt-7a8b9c2d{% endif %}</dhcpOptionsId>
+      <dhcpOptionsId>{% if vpc.dhcp_options %}{{ vpc.dhcp_options.id }}{% else %}dopt-1a2b3c4d2{% endif %}</dhcpOptionsId>
       <instanceTenancy>default</instanceTenancy>
       <tagSet>
         {% for tag in vpc.get_tags() %}

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ extras_require = {
 
 setup(
     name='moto',
-    version='0.4.28',
+    version='0.4.27',
     description='A library that allows your python tests to easily'
                 ' mock out the boto library',
     author='Steve Pulec',

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ extras_require = {
 
 setup(
     name='moto',
-    version='0.4.27',
+    version='0.4.28',
     description='A library that allows your python tests to easily'
                 ' mock out the boto library',
     author='Steve Pulec',

--- a/tests/test_ec2/test_vpcs.py
+++ b/tests/test_ec2/test_vpcs.py
@@ -321,3 +321,14 @@ def test_vpc_modify_enable_dns_hostnames():
     response = vpc.describe_attribute(Attribute='enableDnsHostnames')
     attr = response.get('EnableDnsHostnames')
     attr.get('Value').should.be.ok
+
+@mock_ec2
+def test_vpc_associate_dhcp_options():
+    conn = boto.connect_vpc()
+    dhcp_options = conn.create_dhcp_options(SAMPLE_DOMAIN_NAME, SAMPLE_NAME_SERVERS)
+    vpc = conn.create_vpc("10.0.0.0/16")
+
+    conn.associate_dhcp_options(dhcp_options.id, vpc.id)
+
+    vpc.update()
+    dhcp_options.id.should.equal(vpc.dhcp_options_id)


### PR DESCRIPTION
After associate a vpc with a dhcp_options moto wasn't updating the id of the dhcp_options in the vpc describe response.