### PR TITLE
Some fixes for Route53 mocks

### DIFF
--- a/moto/route53/responses.py
+++ b/moto/route53/responses.py
@@ -21,8 +21,14 @@ def list_or_create_hostzone_response(request, full_url, headers):
         else:
             comment = None
             private_zone = False
+
+        # Ensure that zone name ends in a period.
+        name = elements["CreateHostedZoneRequest"]["Name"]
+        if name[-1] != ".":
+            name += "."
+
         new_zone = route53_backend.create_hosted_zone(
-            elements["CreateHostedZoneRequest"]["Name"],
+            name,
             comment=comment,
             private_zone=private_zone,
         )
@@ -247,7 +253,7 @@ LIST_HOSTED_ZONES_RESPONSE = """<ListHostedZonesResponse xmlns="https://route53.
    <HostedZones>
       {% for zone in zones %}
       <HostedZone>
-         <Id>{{ zone.id }}</Id>
+         <Id>/hostedzone/{{ zone.id }}</Id>
          <Name>{{ zone.name }}</Name>
          <Config>
             {% if zone.comment %}

--- a/tests/test_route53/test_route53.py
+++ b/tests/test_route53/test_route53.py
@@ -25,7 +25,7 @@ def test_hosted_zone():
 
     id1 = firstzone["CreateHostedZoneResponse"]["HostedZone"]["Id"].split("/")[-1]
     zone = conn.get_hosted_zone(id1)
-    zone["GetHostedZoneResponse"]["HostedZone"]["Name"].should.equal("testdns.aws.com")
+    zone["GetHostedZoneResponse"]["HostedZone"]["Name"].should.equal("testdns.aws.com.")
 
     conn.delete_hosted_zone(id1)
     zones = conn.get_all_hosted_zones()


### PR DESCRIPTION
Two fixes for mocking Route53 API calls:
1. When calling `created_hosted_name`, a period will be appended to the zone name if it did not already end in a period.
2. The zone IDs in the response from the `list_hosted_zones` are prefixed with `/hostedzone/`, similar to the responses from other Route53 methods.
