### PR TITLE
Remove botocore version pinning

### DIFF
--- a/moto/core/responses.py
+++ b/moto/core/responses.py
@@ -576,9 +576,14 @@ def xml_to_json_response(service_spec, operation, xml, result_node=None):
                 if v is None:
                     od[k] = {}
                 else:
-                    key = from_str(v['entry']['key'], spec[k]['key'])
-                    val = from_str(v['entry']['value'], spec[k]['value'])
-                    od[k] = {key: val}
+                    items = ([v['entry']] if not isinstance(v['entry'], list) else
+                             v['entry'])
+                    for item in items:
+                        key = from_str(item['key'], spec[k]['key'])
+                        val = from_str(item['value'], spec[k]['value'])
+                        if k not in od:
+                            od[k] = {}
+                        od[k][key] = val
             else:
                 if v is None:
                     od[k] = None

--- a/moto/emr/models.py
+++ b/moto/emr/models.py
@@ -24,12 +24,19 @@ class FakeBootstrapAction(object):
 
 
 class FakeInstanceGroup(object):
-    def __init__(self, instance_count, instance_role, instance_type, market, name,
-                 id=None, bid_price=None):
+    def __init__(self, instance_count, instance_role, instance_type,
+                 market='ON_DEMAND', name=None, id=None, bid_price=None):
         self.id = id or random_instance_group_id()
 
         self.bid_price = bid_price
         self.market = market
+        if name is None:
+            if instance_role == 'MASTER':
+                name = 'master'
+            elif instance_role == 'CORE':
+                name = 'slave'
+            else:
+                name = 'Task instance group'
         self.name = name
         self.num_instances = instance_count
         self.role = instance_role

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,21 +5,6 @@ sure==1.2.24
 coverage
 freezegun
 flask
-# botocore 1.4.29 breaks the following tests:
-# test_nat_gateway.test_delete_nat_gateway
-# test `list -> create -> list -> get -> delete -> list` integration
-# test_lambda.test_get_function
-# test_lambda.test_delete_function
-# test_lambda.test_create_function_from_zipfile
-# test_lambda.test_create_function_from_aws_bucket
-# test_apigateway.test_integrations
-# test_apigateway.test_integration_response
-# test_apigateway.test_deployment
-# test_apigateway.test_create_resource
-# test_apigateway.test_create_method_response
-# test_apigateway.test_create_method
-# test_apigateway.test_child_resource
-# so we need to pin a boto3 and botocore revision pair that we know works
-boto3==1.3.1
-botocore==1.4.28
+boto3>=1.3.1
+botocore>=1.4.28
 six

--- a/tests/test_apigateway/test_apigateway.py
+++ b/tests/test_apigateway/test_apigateway.py
@@ -79,6 +79,7 @@ def test_create_resource():
         resourceId=root_id,
     )
     root_resource['ResponseMetadata'].pop('HTTPHeaders', None) # this is hard to match against, so remove it
+    root_resource['ResponseMetadata'].pop('RetryAttempts', None)
     root_resource.should.equal({
         'path': '/',
         'id': root_id,
@@ -137,6 +138,7 @@ def test_child_resource():
         resourceId=tags_id,
     )
     child_resource['ResponseMetadata'].pop('HTTPHeaders', None) # this is hard to match against, so remove it
+    child_resource['ResponseMetadata'].pop('RetryAttempts', None)
     child_resource.should.equal({
         'path': '/users/tags',
         'pathPart': 'tags',
@@ -173,6 +175,7 @@ def test_create_method():
     )
 
     response['ResponseMetadata'].pop('HTTPHeaders', None) # this is hard to match against, so remove it
+    response['ResponseMetadata'].pop('RetryAttempts', None)
     response.should.equal({
         'httpMethod': 'GET',
         'authorizationType': 'none',
@@ -212,6 +215,7 @@ def test_create_method_response():
         statusCode='200',
     )
     response['ResponseMetadata'].pop('HTTPHeaders', None) # this is hard to match against, so remove it
+    response['ResponseMetadata'].pop('RetryAttempts', None)
     response.should.equal({
         'ResponseMetadata': {'HTTPStatusCode': 200},
         'statusCode': '200'
@@ -224,6 +228,7 @@ def test_create_method_response():
         statusCode='200',
     )
     response['ResponseMetadata'].pop('HTTPHeaders', None) # this is hard to match against, so remove it
+    response['ResponseMetadata'].pop('RetryAttempts', None)
     response.should.equal({
         'ResponseMetadata': {'HTTPStatusCode': 200},
         'statusCode': '200'
@@ -236,6 +241,7 @@ def test_create_method_response():
         statusCode='200',
     )
     response['ResponseMetadata'].pop('HTTPHeaders', None) # this is hard to match against, so remove it
+    response['ResponseMetadata'].pop('RetryAttempts', None)
     response.should.equal({'ResponseMetadata': {'HTTPStatusCode': 200}})
 
 
@@ -273,6 +279,7 @@ def test_integrations():
         uri='http://httpbin.org/robots.txt',
     )
     response['ResponseMetadata'].pop('HTTPHeaders', None) # this is hard to match against, so remove it
+    response['ResponseMetadata'].pop('RetryAttempts', None)
     response.should.equal({
         'ResponseMetadata': {'HTTPStatusCode': 200},
         'httpMethod': 'GET',
@@ -294,6 +301,7 @@ def test_integrations():
         httpMethod='GET'
     )
     response['ResponseMetadata'].pop('HTTPHeaders', None) # this is hard to match against, so remove it
+    response['ResponseMetadata'].pop('RetryAttempts', None)
     response.should.equal({
         'ResponseMetadata': {'HTTPStatusCode': 200},
         'httpMethod': 'GET',
@@ -314,6 +322,7 @@ def test_integrations():
         resourceId=root_id,
     )
     response['ResponseMetadata'].pop('HTTPHeaders', None) # this is hard to match against, so remove it
+    response['ResponseMetadata'].pop('RetryAttempts', None)
     response['resourceMethods']['GET']['methodIntegration'].should.equal({
         'httpMethod': 'GET',
         'integrationResponses': {
@@ -363,6 +372,7 @@ def test_integrations():
         requestTemplates=templates
     )
     response['ResponseMetadata'].pop('HTTPHeaders', None) # this is hard to match against, so remove it
+    response['ResponseMetadata'].pop('RetryAttempts', None)
     response['ResponseMetadata'].should.equal({'HTTPStatusCode': 200})
 
     response = client.get_integration(
@@ -416,6 +426,7 @@ def test_integration_response():
         selectionPattern='foobar',
     )
     response['ResponseMetadata'].pop('HTTPHeaders', None) # this is hard to match against, so remove it
+    response['ResponseMetadata'].pop('RetryAttempts', None)
     response.should.equal({
         'statusCode': '200',
         'selectionPattern': 'foobar',
@@ -432,6 +443,7 @@ def test_integration_response():
         statusCode='200',
     )
     response['ResponseMetadata'].pop('HTTPHeaders', None) # this is hard to match against, so remove it
+    response['ResponseMetadata'].pop('RetryAttempts', None)
     response.should.equal({
         'statusCode': '200',
         'selectionPattern': 'foobar',
@@ -447,6 +459,7 @@ def test_integration_response():
         httpMethod='GET',
     )
     response['ResponseMetadata'].pop('HTTPHeaders', None) # this is hard to match against, so remove it
+    response['ResponseMetadata'].pop('RetryAttempts', None)
     response['methodIntegration']['integrationResponses'].should.equal({
         '200': {
             'responseTemplates': {
@@ -495,6 +508,7 @@ def test_update_stage_configuration():
     )
     response.pop('createdDate',None) # createdDate is hard to match against, remove it
     response['ResponseMetadata'].pop('HTTPHeaders', None) # this is hard to match against, so remove it
+    response['ResponseMetadata'].pop('RetryAttempts', None)
     response.should.equal({
         'id': deployment_id,
         'ResponseMetadata': {'HTTPStatusCode': 200},
@@ -658,6 +672,7 @@ def test_create_stage():
     )
     response.pop('createdDate',None) # createdDate is hard to match against, remove it
     response['ResponseMetadata'].pop('HTTPHeaders', None) # this is hard to match against, so remove it
+    response['ResponseMetadata'].pop('RetryAttempts', None)
     response.should.equal({
         'id': deployment_id,
         'ResponseMetadata': {'HTTPStatusCode': 200},
@@ -677,6 +692,7 @@ def test_create_stage():
     )
 
     response['ResponseMetadata'].pop('HTTPHeaders', None) # this is hard to match against, so remove it
+    response['ResponseMetadata'].pop('RetryAttempts', None)
 
     response['items'][0].pop('createdDate')
     response['items'][1].pop('createdDate')
@@ -688,6 +704,7 @@ def test_create_stage():
     response = client.create_stage(restApiId=api_id,stageName=new_stage_name,deploymentId=deployment_id2)
 
     response['ResponseMetadata'].pop('HTTPHeaders', None) # this is hard to match against, so remove it
+    response['ResponseMetadata'].pop('RetryAttempts', None)
 
     response.should.equal({
         'stageName':new_stage_name,
@@ -712,6 +729,7 @@ def test_create_stage():
     })
 
     response['ResponseMetadata'].pop('HTTPHeaders', None) # this is hard to match against, so remove it
+    response['ResponseMetadata'].pop('RetryAttempts', None)
 
     response.should.equal({
         'stageName':new_stage_name_with_vars,
@@ -737,6 +755,7 @@ def test_create_stage():
     }, cacheClusterEnabled=True,description="hello moto")
 
     response['ResponseMetadata'].pop('HTTPHeaders', None) # this is hard to match against, so remove it
+    response['ResponseMetadata'].pop('RetryAttempts', None)
 
     response.should.equal({
         'stageName':new_stage_name,
@@ -762,6 +781,7 @@ def test_create_stage():
     }, cacheClusterEnabled=True,cacheClusterSize="1.6",description="hello moto")
 
     response['ResponseMetadata'].pop('HTTPHeaders', None) # this is hard to match against, so remove it
+    response['ResponseMetadata'].pop('RetryAttempts', None)
 
     response.should.equal({
         'stageName':new_stage_name,
@@ -807,6 +827,7 @@ def test_deployment():
     )
     response.pop('createdDate',None) # createdDate is hard to match against, remove it
     response['ResponseMetadata'].pop('HTTPHeaders', None) # this is hard to match against, so remove it
+    response['ResponseMetadata'].pop('RetryAttempts', None)
     response.should.equal({
         'id': deployment_id,
         'ResponseMetadata': {'HTTPStatusCode': 200},

--- a/tests/test_ec2/test_nat_gateway.py
+++ b/tests/test_ec2/test_nat_gateway.py
@@ -57,6 +57,7 @@ def test_delete_nat_gateway():
     response = conn.delete_nat_gateway(NatGatewayId=nat_gateway_id)
 
     response['ResponseMetadata'].pop('HTTPHeaders', None) # this is hard to match against, so remove it
+    response['ResponseMetadata'].pop('RetryAttempts', None)
     response.should.equal({
         'NatGatewayId': nat_gateway_id,
         'ResponseMetadata': {

--- a/tests/test_emr/test_emr.py
+++ b/tests/test_emr/test_emr.py
@@ -43,6 +43,8 @@ def test_describe_cluster():
             'Configurations.member.1.Classification': 'yarn-site',
             'Configurations.member.1.Properties.entry.1.key': 'someproperty',
             'Configurations.member.1.Properties.entry.1.value': 'somevalue',
+            'Configurations.member.1.Properties.entry.2.key': 'someotherproperty',
+            'Configurations.member.1.Properties.entry.2.value': 'someothervalue',
             'Instances.EmrManagedMasterSecurityGroup': 'master-security-group',
             'Instances.Ec2SubnetId': 'subnet-8be41cec',
         },

--- a/tests/test_emr/test_emr_boto3.py
+++ b/tests/test_emr/test_emr_boto3.py
@@ -60,7 +60,8 @@ def test_describe_cluster():
     args['Applications'] = [{'Name': 'Spark', 'Version': '2.4.2'}]
     args['Configurations'] = [
         {'Classification': 'yarn-site',
-         'Properties': {'someproperty': 'somevalue'}}]
+         'Properties': {'someproperty': 'somevalue',
+                        'someotherproperty': 'someothervalue'}}]
     args['Instances']['AdditionalMasterSecurityGroups'] = ['additional-master']
     args['Instances']['AdditionalSlaveSecurityGroups'] = ['additional-slave']
     args['Instances']['Ec2KeyName'] = 'mykey'

--- a/tests/test_emr/test_emr_boto3.py
+++ b/tests/test_emr/test_emr_boto3.py
@@ -194,8 +194,8 @@ def test_describe_job_flow():
     jf['LogUri'].should.equal(args['LogUri'])
     jf['Name'].should.equal(args['Name'])
     jf['ServiceRole'].should.equal(args['ServiceRole'])
-    jf.shouldnt.have.key('Steps')
-    jf.shouldnt.have.key('SupportedProducts')
+    jf['Steps'].should.equal([])
+    jf['SupportedProducts'].should.equal([])
     jf['VisibleToAllUsers'].should.equal(True)
 
 
@@ -254,7 +254,7 @@ def test_run_job_flow():
     resp['LogUri'].should.equal(args['LogUri'])
     resp['VisibleToAllUsers'].should.equal(args['VisibleToAllUsers'])
     resp['Instances']['NormalizedInstanceHours'].should.equal(0)
-    resp.shouldnt.have.key('Steps')
+    resp['Steps'].should.equal([])
 
 
 @mock_emr
@@ -379,10 +379,11 @@ def test_bootstrap_actions():
         {'Name': 'bs1',
          'ScriptBootstrapAction': {
              'Args': ['arg1', 'arg2'],
-             'Path': 'path/to/script'}},
+             'Path': 's3://path/to/script'}},
         {'Name': 'bs2',
          'ScriptBootstrapAction': {
-             'Path': 'path/to/anotherscript'}}
+             'Args': [],
+             'Path': 's3://path/to/anotherscript'}}
     ]
 
     client = boto3.client('emr', region_name='us-east-1')
@@ -583,4 +584,4 @@ def test_tags():
 
     client.remove_tags(ResourceId=cluster_id, TagKeys=[t['Key'] for t in input_tags])
     resp = client.describe_cluster(ClusterId=cluster_id)['Cluster']
-    resp.shouldnt.have.key('Tags')
+    resp['Tags'].should.equal([])


### PR DESCRIPTION
The boto3 and botocore packages in the install requirement (for development) are pinned to older versions, due to a recently added field `RetryAttempts` in JSON response making existing tests to fail. That field doesn't appear important for mocking purposes, and can therefore safely be ignored for testing. This revision modifies tests to ignore it, so that more recent version of boto3 and botocore can be used while testing.

This revision also includes a minor update to JSON response generation routine to align its behavior more closely to the unmocked behavior.
