### PR TITLE
made the Security Group backend throw the same error as AWS if the nb of sec groups limit is hit

### DIFF
--- a/moto/ec2/exceptions.py
+++ b/moto/ec2/exceptions.py
@@ -318,3 +318,11 @@ class InvalidCIDRSubnetError(EC2ClientError):
             "InvalidParameterValue",
             "invalid CIDR subnet specification: {0}"
             .format(cidr))
+
+
+class RulesPerSecurityGroupLimitExceededError(EC2ClientError):
+    def __init__(self):
+        super(RulesPerSecurityGroupLimitExceededError, self).__init__(
+            "RulesPerSecurityGroupLimitExceeded",
+            'The maximum number of rules per security group '
+            'has been reached.')

--- a/moto/ec2/models.py
+++ b/moto/ec2/models.py
@@ -1363,7 +1363,8 @@ class SecurityGroupBackend(object):
 
         max_nb_rules = 50 if group.vpc_id else 100
         future_group_nb_rules = sum(
-            len(rule.ip_ranges) for rule in group.ingress_rules)
+            len(rule.ip_ranges) + len(rule.source_groups)
+            for rule in group.ingress_rules)
         if ip_ranges:
             future_group_nb_rules += len(ip_ranges)
         if source_group_ids:
@@ -1440,7 +1441,8 @@ class SecurityGroupBackend(object):
 
         max_nb_rules = 50 if group.vpc_id else 100
         future_group_nb_rules = sum(
-            len(rule.ip_ranges) for rule in group.egress_rules)
+            len(rule.ip_ranges) + len(rule.source_groups)
+            for rule in group.egress_rules)
         if ip_ranges:
             future_group_nb_rules += len(ip_ranges)
         if source_group_ids:


### PR DESCRIPTION
I have used the default limits from:
- [https://docs.aws.amazon.com/general/latest/gr/aws_service_limits.html#limits_ec2](EC2-classic sec group limits)
- [https://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/VPC_Appendix_Limits.html#vpc-limits-security-groups](EC-VPC sec group limits)
