### PR TITLE
Fix failure of scan() after has_item()

### DIFF
--- a/moto/dynamodb/responses.py
+++ b/moto/dynamodb/responses.py
@@ -278,7 +278,7 @@ class DynamoHandler(BaseResponse):
 
         result = {
             "Count": len(items),
-            "Items": [item.attrs for item in items],
+            "Items": [item.attrs for item in items if item],
             "ConsumedCapacityUnits": 1,
             "ScannedCount": scanned_count
         }

--- a/tests/test_dynamodb/test_dynamodb_table_with_range_key.py
+++ b/tests/test_dynamodb/test_dynamodb_table_with_range_key.py
@@ -420,6 +420,17 @@ def test_scan_with_undeclared_table():
 
 
 @mock_dynamodb
+def test_scan_after_has_item():
+    conn = boto.connect_dynamodb()
+    table = create_table(conn)
+    list(table.scan()).should.equal([])
+
+    table.has_item(hash_key='the-key', range_key='123')
+
+    list(table.scan()).should.equal([])
+
+
+@mock_dynamodb
 def test_write_batch():
     conn = boto.connect_dynamodb()
     table = create_table(conn)

--- a/tests/test_dynamodb/test_dynamodb_table_without_range_key.py
+++ b/tests/test_dynamodb/test_dynamodb_table_without_range_key.py
@@ -336,6 +336,17 @@ def test_scan_with_undeclared_table():
 
 
 @mock_dynamodb
+def test_scan_after_has_item():
+    conn = boto.connect_dynamodb()
+    table = create_table(conn)
+    list(table.scan()).should.equal([])
+
+    table.has_item('the-key')
+
+    list(table.scan()).should.equal([])
+
+
+@mock_dynamodb
 def test_write_batch():
     conn = boto.connect_dynamodb()
     table = create_table(conn)


### PR DESCRIPTION
Fixes #731 

It wasn't causing problems with range key (perhaps `has_item` follows a different path there) but I suppose good to test it in any case?
