### PR TITLE
bump tag limit from 10 to 50 to align with actual AWS limit

### DIFF
--- a/moto/ec2/models.py
+++ b/moto/ec2/models.py
@@ -815,9 +815,9 @@ class TagBackend(object):
             raise InvalidParameterValueErrorTagNull()
         for resource_id in resource_ids:
             if resource_id in self.tags:
-                if len(self.tags[resource_id]) + len([tag for tag in tags if not tag.startswith("aws:")]) > 10:
+                if len(self.tags[resource_id]) + len([tag for tag in tags if not tag.startswith("aws:")]) > 50:
                     raise TagLimitExceeded()
-            elif len([tag for tag in tags if not tag.startswith("aws:")]) > 10:
+            elif len([tag for tag in tags if not tag.startswith("aws:")]) > 50:
                 raise TagLimitExceeded()
         for resource_id in resource_ids:
             for tag in tags:

--- a/tests/test_ec2/test_tags.py
+++ b/tests/test_ec2/test_tags.py
@@ -113,17 +113,9 @@ def test_tag_limit_exceeded():
     conn = boto.connect_ec2('the_key', 'the_secret')
     reservation = conn.run_instances('ami-1234abcd')
     instance = reservation.instances[0]
-    tag_dict = {'01': '',
-                '02': '',
-                '03': '',
-                '04': '',
-                '05': '',
-                '06': '',
-                '07': '',
-                '08': '',
-                '09': '',
-                '10': '',
-                '11': ''}
+    tag_dict = {}
+    for i in range(51):
+        tag_dict['{:02}'.format(i)] = ''
 
     with assert_raises(EC2ResponseError) as cm:
         conn.create_tags(instance.id, tag_dict)

--- a/tests/test_ec2/test_tags.py
+++ b/tests/test_ec2/test_tags.py
@@ -115,7 +115,7 @@ def test_tag_limit_exceeded():
     instance = reservation.instances[0]
     tag_dict = {}
     for i in range(51):
-        tag_dict['{:02}'.format(i)] = ''
+        tag_dict['{:02d}'.format(i+1)] = ''
 
     with assert_raises(EC2ResponseError) as cm:
         conn.create_tags(instance.id, tag_dict)

--- a/tests/test_ec2/test_tags.py
+++ b/tests/test_ec2/test_tags.py
@@ -115,7 +115,7 @@ def test_tag_limit_exceeded():
     instance = reservation.instances[0]
     tag_dict = {}
     for i in range(51):
-        tag_dict['{:02d}'.format(i+1)] = ''
+        tag_dict['{0:02d}'.format(i+1)] = ''
 
     with assert_raises(EC2ResponseError) as cm:
         conn.create_tags(instance.id, tag_dict)


### PR DESCRIPTION
See #754 