### PR TITLE
Attempt to parse simple ConditionExpressions in DynamoDB put_item().

### DIFF
--- a/moto/dynamodb2/responses.py
+++ b/moto/dynamodb2/responses.py
@@ -1,6 +1,7 @@
 from __future__ import unicode_literals
 import json
 import six
+import re
 
 from moto.core.responses import BaseResponse
 from moto.core.utils import camelcase_to_underscores
@@ -149,6 +150,26 @@ class DynamoHandler(BaseResponse):
             expected = self.body['Expected']
         else:
             expected = None
+
+        # Attempt to parse simple ConditionExpressions into an Expected expression
+        if not expected:
+            condition_expression = self.body.get('ConditionExpression')
+            if condition_expression and 'OR' not in condition_expression:
+                cond_items = [c.strip() for c in condition_expression.split('AND')]
+
+                if cond_items:
+                    expected = {}
+                    overwrite = False
+                    exists_re = re.compile('^attribute_exists\((.*)\)$')
+                    not_exists_re = re.compile('^attribute_not_exists\((.*)\)$')
+
+                for cond in cond_items:
+                    exists_m = exists_re.match(cond)
+                    not_exists_m = not_exists_re.match(cond)
+                    if exists_m:
+                        expected[exists_m.group(1)] = {'Exists': True}
+                    elif not_exists_m:
+                        expected[not_exists_m.group(1)] = {'Exists': False}
 
         try:
             result = dynamodb_backend2.put_item(name, item, expected, overwrite)

--- a/tests/test_dynamodb2/test_dynamodb_table_with_range_key.py
+++ b/tests/test_dynamodb2/test_dynamodb_table_with_range_key.py
@@ -1072,6 +1072,15 @@ def test_boto3_put_item_with_conditions():
         ConditionExpression='attribute_not_exists(forum_name) AND attribute_not_exists(subject)'
     ).should.throw(botocore.exceptions.ClientError)
 
+    table.put_item.when.called_with(
+        Item={
+            'forum_name': 'bogus-key',
+            'subject': 'bogus',
+            'test': '123'
+        },
+        ConditionExpression='attribute_exists(forum_name) AND attribute_exists(subject)'
+    ).should.throw(botocore.exceptions.ClientError)
+
 
 def _create_table_with_range_key():
     dynamodb = boto3.resource('dynamodb', region_name='us-east-1')


### PR DESCRIPTION
Internally these get converted into simpler Expected={} parameters, so
for now only `attribute_exists` and `attribute_not_exists` are supported;
OR is also not suported since `expected` does not support it.