### PR TITLE
Fix SNS application endpoint to match AWS return format

### DIFF
--- a/moto/sns/models.py
+++ b/moto/sns/models.py
@@ -120,6 +120,15 @@ class PlatformEndpoint(object):
         self.attributes = attributes
         self.id = uuid.uuid4()
         self.messages = OrderedDict()
+        self.__fixup_attributes()
+
+    def __fixup_attributes(self):
+        # When AWS returns the attributes dict, it always contains these two elements, so we need to
+        # automatically ensure they exist as well.
+        if not 'Token' in self.attributes:
+            self.attributes['Token'] = self.token
+        if not 'Enabled' in self.attributes:
+            self.attributes['Enabled'] = True
 
     @property
     def arn(self):

--- a/tests/test_sns/test_application.py
+++ b/tests/test_sns/test_application.py
@@ -181,6 +181,7 @@ def test_get_endpoint_attributes():
 
     attributes = conn.get_endpoint_attributes(endpoint_arn)['GetEndpointAttributesResponse']['GetEndpointAttributesResult']['Attributes']
     attributes.should.equal({
+        "Token": "some_unique_id",
         "Enabled": 'False',
         "CustomUserData": "some data",
     })
@@ -217,6 +218,7 @@ def test_set_endpoint_attributes():
     )
     attributes = conn.get_endpoint_attributes(endpoint_arn)['GetEndpointAttributesResponse']['GetEndpointAttributesResult']['Attributes']
     attributes.should.equal({
+        "Token": "some_unique_id",
         "Enabled": 'False',
         "CustomUserData": "other data",
     })

--- a/tests/test_sns/test_application_boto3.py
+++ b/tests/test_sns/test_application_boto3.py
@@ -188,6 +188,7 @@ def test_get_endpoint_attributes():
 
     attributes = conn.get_endpoint_attributes(EndpointArn=endpoint_arn)['Attributes']
     attributes.should.equal({
+        "Token": "some_unique_id",
         "Enabled": 'false',
         "CustomUserData": "some data",
     })
@@ -225,6 +226,7 @@ def test_set_endpoint_attributes():
     )
     attributes = conn.get_endpoint_attributes(EndpointArn=endpoint_arn)['Attributes']
     attributes.should.equal({
+        "Token": "some_unique_id",
         "Enabled": 'false',
         "CustomUserData": "other data",
     })


### PR DESCRIPTION
SNS endpoints currently only hold exactly the `attributes` dict that is passed into the constructor. While this naively seems correct, it turns out it doesn't match the behavior of AWS typically, which automatically sets 2 attributes - `Token` and `Enabled`. My change simply auto-sets those attributes if they weren't explicitly included, and modifies the tests accordingly. 