### PR TITLE
Fixed time formatting in ec2/models.py

### DIFF
--- a/moto/ec2/models.py
+++ b/moto/ec2/models.py
@@ -917,7 +917,7 @@ class Ami(TaggedEC2Resource):
         self.architecture = None
         self.kernel_id = None
         self.platform = None
-        self.creation_date = datetime.utcnow().isoformat()
+        self.creation_date = utc_date_and_time()
 
         if instance:
             self.instance = instance

--- a/tests/test_opsworks/test_layers.py
+++ b/tests/test_opsworks/test_layers.py
@@ -3,6 +3,10 @@ import boto3
 import sure  # noqa
 import re
 
+from datetime import datetime
+
+from freezegun import freeze_time
+
 from moto import mock_opsworks
 
 
@@ -45,6 +49,7 @@ def test_create_layer_response():
     )
 
 
+@freeze_time(datetime.now())
 @mock_opsworks
 def test_describe_layers():
     client = boto3.client('opsworks', region_name='us-east-1')


### PR DESCRIPTION
The format returned by Amazon's API follows what was created in the `utc_date_and_time()` function already in this file, not `datetime.utcnow().isoformat()`. Made running tests on comparisons by creation date difficult since the test format would return different than the real API. Haven't checked if this problem occurs anywhere else.