### PR TITLE
Fix s3bucketpath handling for IP based requests

### DIFF
--- a/moto/s3/responses.py
+++ b/moto/s3/responses.py
@@ -46,23 +46,28 @@ class ResponseObject(_TemplateEnvironmentMixin):
 
     def subdomain_based_buckets(self, request):
         host = request.headers.get('host', request.headers.get('Host'))
-        if host.startswith("localhost"):
+
+        if not host or host.startswith("localhost"):
             # For localhost, default to path-based buckets
             return False
 
-        try:
-            socket.inet_pton(socket.AF_INET, host)
-            # For IPv4, default to path-based buckets
-            return False
-        except socket.error:
-            pass
+        match = re.match(r'^([^\[\]:]+)(:\d+)?$', host)
+        if match:
+            try:
+                socket.inet_pton(socket.AF_INET, match.groups()[0])
+                 # For IPv4, default to path-based buckets
+                return False
+            except socket.error:
+                pass
 
-        try:
-            socket.inet_pton(socket.AF_INET6, host)
-            # For IPv6, default to path-based buckets
-            return False
-        except socket.error:
-            pass
+        match = re.match(r'^\[(.+)\])(:\d+)?$', host)
+        if match:
+            try:
+                socket.inet_pton(socket.AF_INET6, match.groups()[0])
+                # For IPv6, default to path-based buckets
+                return False
+            except socket.error:
+                pass
 
         path_based = (host == 's3.amazonaws.com' or re.match(r"s3[\.\-]([^.]*)\.amazonaws\.com", host))
         return not path_based

--- a/moto/s3/responses.py
+++ b/moto/s3/responses.py
@@ -4,6 +4,8 @@ import re
 
 import six
 from six.moves.urllib.parse import parse_qs, urlparse
+
+import socket
 import xmltodict
 
 from moto.core.responses import _TemplateEnvironmentMixin
@@ -47,6 +49,20 @@ class ResponseObject(_TemplateEnvironmentMixin):
         if host.startswith("localhost"):
             # For localhost, default to path-based buckets
             return False
+
+        try:
+            socket.inet_pton(socket.AF_INET, host)
+            # For IPv4, default to path-based buckets
+            return False
+        except socket.error:
+            pass
+
+        try:
+            socket.inet_pton(socket.AF_INET6, host)
+            # For IPv6, default to path-based buckets
+            return False
+        except socket.error:
+            pass
 
         path_based = (host == 's3.amazonaws.com' or re.match(r"s3[\.\-]([^.]*)\.amazonaws\.com", host))
         return not path_based

--- a/moto/s3/responses.py
+++ b/moto/s3/responses.py
@@ -60,7 +60,7 @@ class ResponseObject(_TemplateEnvironmentMixin):
             except socket.error:
                 pass
 
-        match = re.match(r'^\[(.+)\])(:\d+)?$', host)
+        match = re.match(r'^\[(.+)\](:\d+)?$', host)
         if match:
             try:
                 socket.inet_pton(socket.AF_INET6, match.groups()[0])


### PR DESCRIPTION
I've made some additions to the 'Host' field checking to determine whether it is subdomain based or url path based.
With this change it works with plain IP-Addresses.

This partially fixes issue #532 