### PR TITLE
Add support for login profile deletion

### DIFF
--- a/moto/iam/models.py
+++ b/moto/iam/models.py
@@ -604,6 +604,12 @@ class IAMBackend(BaseBackend):
             raise IAMConflictException("User {0} already has password".format(user_name))
         user.password = password
 
+    def delete_login_profile(self, user_name):
+        user = self.get_user(user_name)
+        if not user.password:
+            raise IAMNotFoundException("Login profile for {0} not found".format(user_name))
+        user.password = None
+
     def add_user_to_group(self, group_name, user_name):
         user = self.get_user(user_name)
         group = self.get_group(group_name)

--- a/moto/iam/responses.py
+++ b/moto/iam/responses.py
@@ -736,12 +736,12 @@ LIST_USERS_TEMPLATE = """<{{ action }}UsersResponse>
 
 CREATE_LOGIN_PROFILE_TEMPLATE = """
 <CreateLoginProfileResponse>
-   <CreateUserResult>
+   <CreateLoginProfileResult>
       <LoginProfile>
          <UserName>{{ user_name }}</UserName>
          <CreateDate>2011-09-19T23:00:56Z</CreateDate>
       </LoginProfile>
-   </CreateUserResult>
+   </CreateLoginProfileResult>
    <ResponseMetadata>
       <RequestId>7a62c49f-347e-4fc4-9331-6e8eEXAMPLE</RequestId>
    </ResponseMetadata>

--- a/moto/iam/responses.py
+++ b/moto/iam/responses.py
@@ -289,6 +289,12 @@ class IamResponse(BaseResponse):
         template = self.response_template(GENERIC_EMPTY_TEMPLATE)
         return template.render(name='DeleteUser')
 
+    def delete_login_profile(self):
+        user_name = self._get_param('UserName')
+        iam_backend.delete_login_profile(user_name)
+        template = self.response_template(GENERIC_EMPTY_TEMPLATE)
+        return template.render(name='DeleteLoginProfile')
+
     def generate_credential_report(self):
         if iam_backend.report_generated():
             template = self.response_template(CREDENTIAL_REPORT_GENERATED)

--- a/tests/test_iam/test_iam.py
+++ b/tests/test_iam/test_iam.py
@@ -187,6 +187,7 @@ def test_get_user():
     conn.create_user('my-user')
     conn.get_user('my-user')
 
+
 @mock_iam()
 def test_list_users():
     path_prefix = '/'
@@ -209,6 +210,16 @@ def test_create_login_profile():
     conn.create_login_profile('my-user', 'my-pass')
     with assert_raises(BotoServerError):
         conn.create_login_profile('my-user', 'my-pass')
+
+
+@mock_iam()
+def test_delete_login_profile():
+    conn = boto.connect_iam()
+    conn.create_user('my-user')
+    with assert_raises(BotoServerError):
+        conn.delete_login_profile('my-user')
+    conn.create_login_profile('my-user', 'my-pass')
+    conn.delete_login_profile('my-user')
 
 
 @mock_iam()

--- a/tests/test_iam/test_iam.py
+++ b/tests/test_iam/test_iam.py
@@ -5,6 +5,7 @@ import boto
 import boto3
 import sure  # noqa
 from boto.exception import BotoServerError
+from botocore.exceptions import ClientError
 from moto import mock_iam
 from moto.iam.models import aws_managed_policies
 from nose.tools import assert_raises, assert_equals, assert_not_equals
@@ -324,3 +325,17 @@ def test_managed_policy():
                              {'RoleName': role_name},
                              list_marker='AttachedPolicies')
     resp['list_attached_role_policies_response']['list_attached_role_policies_result']['attached_policies'].should.have.length_of(2)
+
+
+@mock_iam
+def test_boto3_create_login_profile():
+    conn = boto3.client('iam')
+
+    with assert_raises(ClientError):
+        conn.create_login_profile(UserName='my-user', Password='Password')
+
+    conn.create_user(UserName='my-user')
+    conn.create_login_profile(UserName='my-user', Password='Password')
+
+    with assert_raises(ClientError):
+        conn.create_login_profile(UserName='my-user', Password='Password')


### PR DESCRIPTION
Support the creation of login profiles using boto3 and deletion of login profiles.

A KeyError was raised when attempting to create a login profile using boto3:
- Fixed typo in XML result.
- Add test to cover boto3.

delete_login_profile:
- Resets user password to None.
- If user password is already none (login profile does not exist) raise exception.