### PR TITLE
Add more availability zones and implement default VPC

### DIFF
--- a/moto/__init__.py
+++ b/moto/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import unicode_literals
 import logging
-logging.getLogger('boto').setLevel(logging.CRITICAL)
+#logging.getLogger('boto').setLevel(logging.CRITICAL)
 
 __title__ = 'moto'
 __version__ = '0.4.30'

--- a/moto/ec2/urls.py
+++ b/moto/ec2/urls.py
@@ -3,7 +3,7 @@ from .responses import EC2Response
 
 
 url_bases = [
-    "https?://ec2.(.+).amazonaws.com",
+    "https?://ec2.(.+).amazonaws.com(|.cn)",
 ]
 
 url_paths = {

--- a/moto/elb/models.py
+++ b/moto/elb/models.py
@@ -19,6 +19,7 @@ from .exceptions import (
 )
 
 
+
 class FakeHealthCheck(object):
     def __init__(self, timeout, healthy_threshold, unhealthy_threshold,
                  interval, target):
@@ -337,5 +338,5 @@ class ELBBackend(BaseBackend):
 
 
 elb_backends = {}
-for region in boto.ec2.elb.regions():
-    elb_backends[region.name] = ELBBackend(region.name)
+for region in ec2_backends.keys():
+    elb_backends[region] = ELBBackend(region)

--- a/tests/test_cloudformation/test_cloudformation_stack_integration.py
+++ b/tests/test_cloudformation/test_cloudformation_stack_integration.py
@@ -661,13 +661,14 @@ def test_vpc_single_instance_in_subnet():
     )
 
     vpc_conn = boto.vpc.connect_to_region("us-west-1")
-    vpc = vpc_conn.get_all_vpcs()[0]
+
+    vpc = vpc_conn.get_all_vpcs(filters={'cidrBlock': '10.0.0.0/16'})[0]
     vpc.cidr_block.should.equal("10.0.0.0/16")
 
     # Add this once we implement the endpoint
     # vpc_conn.get_all_internet_gateways().should.have.length_of(1)
 
-    subnet = vpc_conn.get_all_subnets()[0]
+    subnet = vpc_conn.get_all_subnets(filters={'vpcId': vpc.id})[0]
     subnet.vpc_id.should.equal(vpc.id)
 
     ec2_conn = boto.ec2.connect_to_region("us-west-1")
@@ -1355,7 +1356,7 @@ def test_vpc_gateway_attachment_creation_should_attach_itself_to_vpc():
     )
 
     vpc_conn = boto.vpc.connect_to_region("us-west-1")
-    vpc = vpc_conn.get_all_vpcs()[0]
+    vpc = vpc_conn.get_all_vpcs(filters={'cidrBlock': '10.0.0.0/16'})[0]
     igws = vpc_conn.get_all_internet_gateways(
         filters={'attachment.vpc-id': vpc.id}
     )

--- a/tests/test_ec2/test_availability_zones_and_regions.py
+++ b/tests/test_ec2/test_availability_zones_and_regions.py
@@ -1,5 +1,7 @@
 from __future__ import unicode_literals
 import boto
+import boto.ec2
+import boto3
 import sure  # noqa
 
 from moto import mock_ec2
@@ -9,16 +11,39 @@ from moto import mock_ec2
 def test_describe_regions():
     conn = boto.connect_ec2('the_key', 'the_secret')
     regions = conn.get_all_regions()
-    regions.should.have.length_of(8)
-    regions[0].name.should.equal('eu-west-1')
-    regions[0].endpoint.should.equal('ec2.eu-west-1.amazonaws.com')
+    regions.should.have.length_of(14)
+    for region in regions:
+        region.endpoint.should.contain(region.name)
 
 
 @mock_ec2
 def test_availability_zones():
-    # Just testing us-east-1 for now
     conn = boto.connect_ec2('the_key', 'the_secret')
-    zones = conn.get_all_zones()
-    zones.should.have.length_of(5)
-    zones[0].name.should.equal('us-east-1a')
-    zones[0].region_name.should.equal('us-east-1')
+    regions = conn.get_all_regions()
+    for region in regions:
+        conn = boto.ec2.connect_to_region(region.name)
+        if conn is None:
+            continue
+        for zone in conn.get_all_zones():
+            zone.name.should.contain(region.name)
+
+
+@mock_ec2
+def test_boto3_describe_regions():
+    ec2 = boto3.client('ec2', 'us-east-1')
+    resp = ec2.describe_regions()
+    resp['Regions'].should.have.length_of(14)
+    for rec in resp['Regions']:
+        rec['Endpoint'].should.contain(rec['RegionName'])
+
+
+@mock_ec2
+def test_boto3_availability_zones():
+    ec2 = boto3.client('ec2', 'us-east-1')
+    resp = ec2.describe_regions()
+    regions = [r['RegionName'] for r in resp['Regions']]
+    for region in regions:
+        conn = boto3.client('ec2', region)
+        resp = conn.describe_availability_zones()
+        for rec in resp['AvailabilityZones']:
+            rec['ZoneName'].should.contain(region)

--- a/tests/test_ec2/test_key_pairs.py
+++ b/tests/test_ec2/test_key_pairs.py
@@ -52,15 +52,12 @@ def test_key_pairs_create_two():
     kp = conn.create_key_pair('bar')
     assert kp.material.startswith('---- BEGIN RSA PRIVATE KEY ----')
     kps = conn.get_all_key_pairs()
-    assert len(kps) == 2
-    # on Python 3, these are reversed for some reason
-    if six.PY3:
-        return
-    assert kps[0].name == 'foo'
-    assert kps[1].name == 'bar'
+    kps.should.have.length_of(2)
+    [i.name for i in kps].should.contain('foo')
+    [i.name for i in kps].should.contain('bar')
     kps = conn.get_all_key_pairs('foo')
-    assert len(kps) == 1
-    assert kps[0].name == 'foo'
+    kps.should.have.length_of(1)
+    kps[0].name.should.equal('foo')
 
 
 @mock_ec2

--- a/tests/test_ec2/test_network_acls.py
+++ b/tests/test_ec2/test_network_acls.py
@@ -7,41 +7,37 @@ from moto import mock_ec2
 
 @mock_ec2
 def test_default_network_acl_created_with_vpc():
-
     conn = boto.connect_vpc('the_key', 'the secret')
     vpc = conn.create_vpc("10.0.0.0/16")
-
-    all_network_acls = conn.get_all_network_acls()
-    all_network_acls.should.have.length_of(1)
-
-@mock_ec2
-def test_network_acls():
-
-    conn = boto.connect_vpc('the_key', 'the secret')
-    vpc = conn.create_vpc("10.0.0.0/16")
-
-    network_acl = conn.create_network_acl(vpc.id)
-
     all_network_acls = conn.get_all_network_acls()
     all_network_acls.should.have.length_of(2)
 
-@mock_ec2
-def test_new_subnet_associates_with_default_network_acl():
 
+@mock_ec2
+def test_network_acls():
     conn = boto.connect_vpc('the_key', 'the secret')
     vpc = conn.create_vpc("10.0.0.0/16")
+    network_acl = conn.create_network_acl(vpc.id)
+    all_network_acls = conn.get_all_network_acls()
+    all_network_acls.should.have.length_of(3)
+
+
+@mock_ec2
+def test_new_subnet_associates_with_default_network_acl():
+    conn = boto.connect_vpc('the_key', 'the secret')
+    vpc = conn.get_all_vpcs()[0]
 
     subnet = conn.create_subnet(vpc.id, "10.0.0.0/18")
     all_network_acls = conn.get_all_network_acls()
     all_network_acls.should.have.length_of(1)
 
     acl = all_network_acls[0]
-    acl.associations.should.have.length_of(1)
-    acl.associations[0].subnet_id.should.equal(subnet.id)
+    acl.associations.should.have.length_of(4)
+    [a.subnet_id for a in acl.associations].should.contain(subnet.id)
+
 
 @mock_ec2
 def test_network_acl_entries():
-
     conn = boto.connect_vpc('the_key', 'the secret')
     vpc = conn.create_vpc("10.0.0.0/16")
 
@@ -55,7 +51,7 @@ def test_network_acl_entries():
     )
 
     all_network_acls = conn.get_all_network_acls()
-    all_network_acls.should.have.length_of(2)
+    all_network_acls.should.have.length_of(3)
 
     test_network_acl = next(na for na in all_network_acls
                             if na.id == network_acl.id)
@@ -68,7 +64,6 @@ def test_network_acl_entries():
 
 @mock_ec2
 def test_associate_new_network_acl_with_subnet():
-
     conn = boto.connect_vpc('the_key', 'the secret')
     vpc = conn.create_vpc("10.0.0.0/16")
     subnet = conn.create_subnet(vpc.id, "10.0.0.0/18")
@@ -77,7 +72,7 @@ def test_associate_new_network_acl_with_subnet():
     conn.associate_network_acl(network_acl.id, subnet.id)
 
     all_network_acls = conn.get_all_network_acls()
-    all_network_acls.should.have.length_of(2)
+    all_network_acls.should.have.length_of(3)
 
     test_network_acl = next(na for na in all_network_acls
                             if na.id == network_acl.id)
@@ -88,28 +83,26 @@ def test_associate_new_network_acl_with_subnet():
 
 @mock_ec2
 def test_delete_network_acl():
-
     conn = boto.connect_vpc('the_key', 'the secret')
     vpc = conn.create_vpc("10.0.0.0/16")
     subnet = conn.create_subnet(vpc.id, "10.0.0.0/18")
     network_acl = conn.create_network_acl(vpc.id)
 
     all_network_acls = conn.get_all_network_acls()
-    all_network_acls.should.have.length_of(2)
+    all_network_acls.should.have.length_of(3)
 
     any(acl.id == network_acl.id for acl in all_network_acls).should.be.ok
 
     conn.delete_network_acl(network_acl.id)
 
     updated_network_acls = conn.get_all_network_acls()
-    updated_network_acls.should.have.length_of(1)
+    updated_network_acls.should.have.length_of(2)
 
     any(acl.id == network_acl.id for acl in updated_network_acls).shouldnt.be.ok
 
 
 @mock_ec2
 def test_network_acl_tagging():
-
     conn = boto.connect_vpc('the_key', 'the secret')
     vpc = conn.create_vpc("10.0.0.0/16")
     network_acl = conn.create_network_acl(vpc.id)
@@ -125,4 +118,3 @@ def test_network_acl_tagging():
                             if na.id == network_acl.id)
     test_network_acl.tags.should.have.length_of(1)
     test_network_acl.tags["a key"].should.equal("some value")
-

--- a/tests/test_ec2/test_security_groups.py
+++ b/tests/test_ec2/test_security_groups.py
@@ -37,7 +37,7 @@ def test_create_and_describe_security_group():
     cm.exception.request_id.should_not.be.none
 
     all_groups = conn.get_all_security_groups()
-    all_groups.should.have.length_of(2)  # The default group gets created automatically
+    all_groups.should.have.length_of(3)  # The default group gets created automatically
     group_names = [group.name for group in all_groups]
     set(group_names).should.equal(set(["default", "test security group"]))
 
@@ -57,7 +57,7 @@ def test_create_security_group_without_description_raises_error():
 def test_default_security_group():
     conn = boto.ec2.connect_to_region('us-east-1')
     groups = conn.get_all_security_groups()
-    groups.should.have.length_of(1)
+    groups.should.have.length_of(2)
     groups[0].name.should.equal("default")
 
 
@@ -98,7 +98,7 @@ def test_create_two_security_groups_with_same_name_in_different_vpc():
 
     all_groups = conn.get_all_security_groups()
 
-    all_groups.should.have.length_of(3)
+    all_groups.should.have.length_of(4)
     group_names = [group.name for group in all_groups]
     # The default group is created automatically
     set(group_names).should.equal(set(["default", "test security group"]))
@@ -110,7 +110,7 @@ def test_deleting_security_groups():
     security_group1 = conn.create_security_group('test1', 'test1')
     conn.create_security_group('test2', 'test2')
 
-    conn.get_all_security_groups().should.have.length_of(3)  # We need to include the default security group
+    conn.get_all_security_groups().should.have.length_of(4)
 
     # Deleting a group that doesn't exist should throw an error
     with assert_raises(EC2ResponseError) as cm:
@@ -127,11 +127,11 @@ def test_deleting_security_groups():
     ex.exception.message.should.equal('An error occurred (DryRunOperation) when calling the DeleteSecurityGroup operation: Request would have succeeded, but DryRun flag is set')
 
     conn.delete_security_group('test2')
-    conn.get_all_security_groups().should.have.length_of(2)
+    conn.get_all_security_groups().should.have.length_of(3)
 
     # Delete by group id
     conn.delete_security_group(group_id=security_group1.id)
-    conn.get_all_security_groups().should.have.length_of(1)
+    conn.get_all_security_groups().should.have.length_of(2)
 
 
 @mock_ec2
@@ -267,6 +267,7 @@ def test_authorize_other_group_egress_and_revoke():
     sg01.revoke_egress(IpPermissions=[ip_permission])
     sg01.ip_permissions_egress.should.have.length_of(1)
 
+
 @mock_ec2
 def test_authorize_group_in_vpc():
     conn = boto.connect_ec2('the_key', 'the_secret')
@@ -316,7 +317,7 @@ def test_get_all_security_groups():
     resp[0].id.should.equal(sg1.id)
 
     resp = conn.get_all_security_groups()
-    resp.should.have.length_of(3)  # We need to include the default group here
+    resp.should.have.length_of(4)
 
 
 @mock_ec2
@@ -376,7 +377,7 @@ def test_authorize_all_protocols_with_no_port_specification():
     sg.rules[0].from_port.should.equal(None)
     sg.rules[0].to_port.should.equal(None)
 
-  
+
 '''
 Boto3
 '''

--- a/tests/test_ec2/test_vpcs.py
+++ b/tests/test_ec2/test_vpcs.py
@@ -21,12 +21,12 @@ def test_vpcs():
     vpc.cidr_block.should.equal('10.0.0.0/16')
 
     all_vpcs = conn.get_all_vpcs()
-    all_vpcs.should.have.length_of(1)
+    all_vpcs.should.have.length_of(2)
 
     vpc.delete()
 
     all_vpcs = conn.get_all_vpcs()
-    all_vpcs.should.have.length_of(0)
+    all_vpcs.should.have.length_of(1)
 
     with assert_raises(EC2ResponseError) as cm:
         conn.delete_vpc("vpc-1234abcd")
@@ -40,14 +40,14 @@ def test_vpc_defaults():
     conn = boto.connect_vpc('the_key', 'the_secret')
     vpc = conn.create_vpc("10.0.0.0/16")
 
-    conn.get_all_vpcs().should.have.length_of(1)
-    conn.get_all_route_tables().should.have.length_of(1)
+    conn.get_all_vpcs().should.have.length_of(2)
+    conn.get_all_route_tables().should.have.length_of(2)
     conn.get_all_security_groups(filters={'vpc-id': [vpc.id]}).should.have.length_of(1)
 
     vpc.delete()
 
-    conn.get_all_vpcs().should.have.length_of(0)
-    conn.get_all_route_tables().should.have.length_of(0)
+    conn.get_all_vpcs().should.have.length_of(1)
+    conn.get_all_route_tables().should.have.length_of(1)
     conn.get_all_security_groups(filters={'vpc-id': [vpc.id]}).should.have.length_of(0)
 
 @mock_ec2
@@ -56,7 +56,7 @@ def test_vpc_isdefault_filter():
     vpc = conn.create_vpc("10.0.0.0/16")
     conn.get_all_vpcs(filters={'isDefault': 'true'}).should.have.length_of(1)
     vpc.delete()
-    conn.get_all_vpcs(filters={'isDefault': 'true'}).should.have.length_of(0)
+    conn.get_all_vpcs(filters={'isDefault': 'true'}).should.have.length_of(1)
 
 
 @mock_ec2
@@ -65,10 +65,10 @@ def test_multiple_vpcs_default_filter():
     conn.create_vpc("10.8.0.0/16")
     conn.create_vpc("10.0.0.0/16")
     conn.create_vpc("192.168.0.0/16")
-    conn.get_all_vpcs().should.have.length_of(3)
+    conn.get_all_vpcs().should.have.length_of(4)
     vpc = conn.get_all_vpcs(filters={'isDefault': 'true'})
     vpc.should.have.length_of(1)
-    vpc[0].cidr_block.should.equal('10.8.0.0/16')
+    vpc[0].cidr_block.should.equal('172.31.0.0/16')
 
 
 @mock_ec2
@@ -76,9 +76,9 @@ def test_vpc_state_available_filter():
     conn = boto.connect_vpc('the_key', 'the_secret')
     vpc = conn.create_vpc("10.0.0.0/16")
     conn.create_vpc("10.1.0.0/16")
-    conn.get_all_vpcs(filters={'state': 'available'}).should.have.length_of(2)
+    conn.get_all_vpcs(filters={'state': 'available'}).should.have.length_of(3)
     vpc.delete()
-    conn.get_all_vpcs(filters={'state': 'available'}).should.have.length_of(1)
+    conn.get_all_vpcs(filters={'state': 'available'}).should.have.length_of(2)
 
 @mock_ec2
 def test_vpc_tagging():
@@ -86,13 +86,12 @@ def test_vpc_tagging():
     vpc = conn.create_vpc("10.0.0.0/16")
 
     vpc.add_tag("a key", "some value")
-
     tag = conn.get_all_tags()[0]
     tag.name.should.equal("a key")
     tag.value.should.equal("some value")
 
     # Refresh the vpc
-    vpc = conn.get_all_vpcs()[0]
+    vpc = conn.get_all_vpcs(vpc_ids=[vpc.id])[0]
     vpc.tags.should.have.length_of(1)
     vpc.tags["a key"].should.equal("some value")
 
@@ -245,7 +244,8 @@ def test_default_vpc():
     ec2 = boto3.resource('ec2', region_name='us-west-1')
 
     # Create the default VPC
-    default_vpc = ec2.create_vpc(CidrBlock='172.31.0.0/16')
+    default_vpc = list(ec2.vpcs.all())[0]
+    default_vpc.cidr_block.should.equal('172.31.0.0/16')
     default_vpc.reload()
     default_vpc.is_default.should.be.ok
 


### PR DESCRIPTION
This PR includes the following revisions on `mock_ec2`:

- Add more regions
- Add three availability zones for each region, and create default VPC (and its default subnet). This is more inline with the current EC2 behavior. (With the prior code base default VPC/subnet needed to be created manually)
- Bug fix: Add `availability-zone` as an appropriate filter name.
- Bug fix: Add more filter name variety (e.g., 'vpc-id' and 'vpcId')
- Bug fix: Use `subnet_ids` parameter if provided through query string. Currently `subnet_ids` filter results appropriately only when they are provided as filter, and it is not compatible with boto/botocore interface.
- Appropriate fixes for affected tests

The overall the assumptions on default VPC/availability zones/subnets change quite a bit, so please review the change and code carefully when evaluating whether to merge into the upstream.

