### PR TITLE
Make Cloudformation/parsing#load_parameters handle lists

### DIFF
--- a/moto/cloudformation/parsing.py
+++ b/moto/cloudformation/parsing.py
@@ -329,6 +329,8 @@ class ResourceMap(collections.Mapping):
         # Set any input parameters that were passed
         for key, value in self.input_parameters.items():
             if key in self.resolved_parameters:
+                if parameter_slots[key].get('Type', 'String') == 'CommaDelimitedList':
+                    value = value.split(',')
                 self.resolved_parameters[key] = value
 
         # Check if there are any non-default params that were not passed input params


### PR DESCRIPTION
We were using this and noticed that list parameters weren't getting properly turned into lists by moto. This short addition will check the `Type` of a resolved parameter and if it's a `CommaDelimitedList` will split it on commans (',').