### PR TITLE
Fix JSON dump error in ecs.update_service with task_definition

### DIFF
--- a/moto/ecs/models.py
+++ b/moto/ecs/models.py
@@ -352,8 +352,8 @@ class EC2ContainerServiceBackend(BaseBackend):
         cluster_service_pair = '{0}:{1}'.format(cluster_name, service_name)
         if cluster_service_pair in self.services:
             if task_definition_str is not None:
-                task_definition = self.fetch_task_definition(task_definition_str)
-                self.services[cluster_service_pair].task_definition = task_definition
+                self.fetch_task_definition(task_definition_str)
+                self.services[cluster_service_pair].task_definition = task_definition_str
             if desired_count is not None:
                 self.services[cluster_service_pair].desired_count = desired_count
             return self.services[cluster_service_pair]

--- a/tests/test_ecs/test_ecs_boto3.py
+++ b/tests/test_ecs/test_ecs_boto3.py
@@ -285,6 +285,7 @@ def test_update_service():
     response = client.update_service(
         cluster='test_ecs_cluster',
         service='test_ecs_service',
+        taskDefinition='test_ecs_task',
         desiredCount=0
     )
     response['service']['desiredCount'].should.equal(0)


### PR DESCRIPTION
ECS `update_service` is trying to store the full task_definition object rather than the name/arn.
Crash happens when response is JSON serialized.

```python
Traceback (most recent call last):
  File "/home/pior/.virtualenvs/moto/lib/python3.5/site-packages/botocore/endpoint.py", line 204, in _get_response
    proxies=self.proxies, timeout=self.timeout)
  File "/home/pior/.virtualenvs/moto/lib/python3.5/site-packages/botocore/vendored/requests/sessions.py", line 573, in send
    r = adapter.send(request, **kwargs)
  File "/home/pior/.virtualenvs/moto/lib/python3.5/site-packages/botocore/vendored/requests/adapters.py", line 370, in send
    timeout=timeout
  File "/home/pior/.virtualenvs/moto/lib/python3.5/site-packages/botocore/vendored/requests/packages/urllib3/connectionpool.py", line 544, in urlopen
    body=body, headers=headers)
  File "/home/pior/.virtualenvs/moto/lib/python3.5/site-packages/botocore/vendored/requests/packages/urllib3/connectionpool.py", line 374, in _make_request
    httplib_response = conn.getresponse()
  File "/usr/lib/python3.5/http/client.py", line 1194, in getresponse
    response = self.response_class(self.sock, method=self._method)
  File "/usr/lib/python3.5/http/client.py", line 235, in __init__
    self.fp = sock.makefile("rb")
  File "/home/pior/.virtualenvs/moto/lib/python3.5/site-packages/httpretty/core.py", line 332, in makefile
    self._entry.fill_filekind(self.fd)
  File "/home/pior/.virtualenvs/moto/lib/python3.5/site-packages/httpretty/core.py", line 591, in fill_filekind
    status, headers, self.body = self.callable_body(self.request, self.info.full_url(), headers)
  File "/home/pior/dev/py/moto/moto/core/responses.py", line 107, in dispatch
    return cls()._dispatch(*args, **kwargs)
  File "/home/pior/dev/py/moto/moto/core/responses.py", line 167, in _dispatch
    return self.call_action()
  File "/home/pior/dev/py/moto/moto/core/responses.py", line 183, in call_action
    response = method()
  File "/home/pior/dev/py/moto/moto/ecs/responses.py", line 162, in update_service
    'service': service.response_object
  File "/usr/lib/python3.5/json/__init__.py", line 230, in dumps
    return _default_encoder.encode(obj)
  File "/usr/lib/python3.5/json/encoder.py", line 198, in encode
    chunks = self.iterencode(o, _one_shot=True)
  File "/usr/lib/python3.5/json/encoder.py", line 256, in iterencode
    return _iterencode(o, 0)
  File "/usr/lib/python3.5/json/encoder.py", line 179, in default
    raise TypeError(repr(o) + " is not JSON serializable")
TypeError: <moto.ecs.models.TaskDefinition object at 0x7fa4ea6f3e80> is not JSON serializable
```