### PR TITLE
rename duplicate rds/models db_instance_identifier to physical_resource_id

### DIFF
--- a/moto/rds/models.py
+++ b/moto/rds/models.py
@@ -130,7 +130,7 @@ class Database(object):
         source_db_identifier = properties.get("SourceDBInstanceIdentifier")
         if source_db_identifier:
             # Replica
-            db_kwargs["source_db_identifier"] = source_db_identifier.db_instance_identifier
+            db_kwargs["source_db_identifier"] = source_db_identifier
             database = rds_backend.create_database_replica(db_kwargs)
         else:
             database = rds_backend.create_database(db_kwargs)

--- a/moto/rds/models.py
+++ b/moto/rds/models.py
@@ -37,7 +37,6 @@ class Database(object):
         self.source_db_identifier = kwargs.get("source_db_identifier")
         self.db_instance_class = kwargs.get('db_instance_class')
         self.port = kwargs.get('port')
-        self.physical_resource_id = kwargs.get('db_instance_identifier')
         self.db_name = kwargs.get("db_name")
         self.publicly_accessible = kwargs.get("publicly_accessible")
         if self.publicly_accessible is None:
@@ -64,6 +63,10 @@ class Database(object):
         # OptionGroupName
         # DBParameterGroupName
         # VpcSecurityGroupIds.member.N
+
+    @property
+    def physical_resource_id(self):
+        return self.db_instance_identifier
 
     @property
     def address(self):

--- a/moto/rds/models.py
+++ b/moto/rds/models.py
@@ -37,7 +37,7 @@ class Database(object):
         self.source_db_identifier = kwargs.get("source_db_identifier")
         self.db_instance_class = kwargs.get('db_instance_class')
         self.port = kwargs.get('port')
-        self.db_instance_identifier = kwargs.get('db_instance_identifier')
+        self.physical_resource_id = kwargs.get('db_instance_identifier')
         self.db_name = kwargs.get("db_name")
         self.publicly_accessible = kwargs.get("publicly_accessible")
         if self.publicly_accessible is None:


### PR DESCRIPTION
This is needed for [clean_json](https://github.com/spulec/moto/blob/master/moto/cloudformation/parsing.py#L98) to correctly handle 'Ref's for DBInstanceIdentifiers.

You'll notice that in the changed file an assignment happens to `self.db_instance_identifier` twice, the same value each time. I suspect that this may have been a copy paste error that forgot to rename the second occurrence to physical_resource_id.