### PR TITLE
Fix the CloudFormation ValidationError message

### DIFF
--- a/moto/cloudformation/exceptions.py
+++ b/moto/cloudformation/exceptions.py
@@ -11,7 +11,7 @@ class UnformattedGetAttTemplateException(Exception):
 class ValidationError(BadRequest):
     def __init__(self, name_or_id, message=None):
         if message is None:
-            message="Stack:{0} does not exist".format(name_or_id),
+            message="Stack with id {0} does not exist".format(name_or_id)
 
         template = Template(ERROR_RESPONSE)
         super(ValidationError, self).__init__()


### PR DESCRIPTION
It should be a string, not a tuple, and it has a different form.
I'm not sure if it used to be different, but in the most recent
boto3/botocore, the message is "Stack with id {id} does not exist"

```python
>>> cf = boto3.client('cloudformation', region_name='us-west-2')
>>> try:
...     cf.describe_stacks(StackName='adfgfhghg')
... except botocore.exceptions.ClientError as e:
...     print e.response['Error']['Message']
...
Stack with id adfgfhghg does not exist
```

I am on boto3 1.4.2 and botocore 1.4.82 as of this commit message.