### PR TITLE
Various RDS, RDS/Cloudformation, RDS/KMS fixes and additions

### DIFF
--- a/moto/cloudformation/parsing.py
+++ b/moto/cloudformation/parsing.py
@@ -12,6 +12,7 @@ from moto.elb import models as elb_models
 from moto.iam import models as iam_models
 from moto.kms import models as kms_models
 from moto.rds import models as rds_models
+from moto.rds2 import models as rds2_models
 from moto.redshift import models as redshift_models
 from moto.route53 import models as route53_models
 from moto.s3 import models as s3_models
@@ -51,6 +52,7 @@ MODEL_MAP = {
     "AWS::RDS::DBInstance": rds_models.Database,
     "AWS::RDS::DBSecurityGroup": rds_models.SecurityGroup,
     "AWS::RDS::DBSubnetGroup": rds_models.SubnetGroup,
+    "AWS::RDS::DBParameterGroup": rds2_models.DBParameterGroup,
     "AWS::Redshift::Cluster": redshift_models.Cluster,
     "AWS::Redshift::ClusterParameterGroup": redshift_models.ParameterGroup,
     "AWS::Redshift::ClusterSubnetGroup": redshift_models.SubnetGroup,
@@ -304,7 +306,8 @@ class ResourceMap(collections.Mapping):
             if not resource_json:
                 raise KeyError(resource_logical_id)
             new_resource = parse_and_create_resource(resource_logical_id, resource_json, self, self._region_name)
-            self._parsed_resources[resource_logical_id] = new_resource
+            if new_resource is not None:
+                self._parsed_resources[resource_logical_id] = new_resource
             return new_resource
 
     def __iter__(self):

--- a/moto/rds/models.py
+++ b/moto/rds/models.py
@@ -10,6 +10,7 @@ from moto.cloudformation.exceptions import UnformattedGetAttTemplateException
 from moto.core import BaseBackend
 from moto.core.utils import get_random_hex
 from moto.ec2.models import ec2_backends
+from moto.rds2.models import rds2_backends
 from .exceptions import DBInstanceNotFoundError, DBSecurityGroupNotFoundError, DBSubnetGroupNotFoundError
 
 
@@ -26,6 +27,11 @@ class Database(object):
         if self.engine_version is None:
             self.engine_version = "5.6.21"
         self.iops = kwargs.get("iops")
+        self.storage_encrypted = kwargs.get("storage_encrypted", False)
+        if self.storage_encrypted:
+            self.kms_key_id = kwargs.get("kms_key_id", "default_kms_key_id")
+        else:
+            self.kms_key_id = kwargs.get("kms_key_id")
         self.storage_type = kwargs.get("storage_type")
         self.master_username = kwargs.get('master_username')
         self.master_password = kwargs.get('master_password')
@@ -119,6 +125,7 @@ class Database(object):
             "engine": properties.get("Engine"),
             "engine_version": properties.get("EngineVersion"),
             "iops": properties.get("Iops"),
+            "kms_key_id": properties.get("KmsKeyId"),
             "master_password": properties.get('MasterUserPassword'),
             "master_username": properties.get('MasterUsername'),
             "multi_az": properties.get("MultiAZ"),
@@ -126,7 +133,9 @@ class Database(object):
             "publicly_accessible": properties.get("PubliclyAccessible"),
             "region": region_name,
             "security_groups": security_groups,
+            "storage_encrypted": properties.get("StorageEncrypted"),
             "storage_type": properties.get("StorageType"),
+            "tags": properties.get("Tags"),
         }
 
         rds_backend = rds_backends[region_name]
@@ -204,6 +213,10 @@ class Database(object):
               <PubliclyAccessible>{{ database.publicly_accessible }}</PubliclyAccessible>
               <AutoMinorVersionUpgrade>{{ database.auto_minor_version_upgrade }}</AutoMinorVersionUpgrade>
               <AllocatedStorage>{{ database.allocated_storage }}</AllocatedStorage>
+              <StorageEncrypted>{{ database.storage_encrypted }}</StorageEncrypted>
+              {% if database.kms_key_id %}
+              <KmsKeyId>{{ database.kms_key_id }}</KmsKeyId>
+              {% endif %}
               {% if database.iops %}
               <Iops>{{ database.iops }}</Iops>
               <StorageType>io1</StorageType>
@@ -219,6 +232,10 @@ class Database(object):
               </Endpoint>
             </DBInstance>""")
         return template.render(database=self)
+
+    def delete(self, region_name):
+        backend = rds_backends[region_name]
+        backend.delete_database(self.db_instance_identifier)
 
 
 class SecurityGroup(object):
@@ -267,24 +284,32 @@ class SecurityGroup(object):
         properties = cloudformation_json['Properties']
         group_name = resource_name.lower() + get_random_hex(12)
         description = properties['GroupDescription']
-        security_group_ingress = properties['DBSecurityGroupIngress']
+        security_group_ingress_rules = properties.get('DBSecurityGroupIngress', [])
+        tags = properties.get('Tags')
 
         ec2_backend = ec2_backends[region_name]
         rds_backend = rds_backends[region_name]
         security_group = rds_backend.create_security_group(
             group_name,
             description,
+            tags,
         )
-        for ingress_type, ingress_value in security_group_ingress.items():
-            if ingress_type == "CIDRIP":
-                security_group.authorize_cidr(ingress_value)
-            elif ingress_type == "EC2SecurityGroupName":
-                subnet = ec2_backend.get_security_group_from_name(ingress_value)
-                security_group.authorize_security_group(subnet)
-            elif ingress_type == "EC2SecurityGroupId":
-                subnet = ec2_backend.get_security_group_from_id(ingress_value)
-                security_group.authorize_security_group(subnet)
+
+        for security_group_ingress in security_group_ingress_rules:
+            for ingress_type, ingress_value in security_group_ingress.items():
+                if ingress_type == "CIDRIP":
+                    security_group.authorize_cidr(ingress_value)
+                elif ingress_type == "EC2SecurityGroupName":
+                    subnet = ec2_backend.get_security_group_from_name(ingress_value)
+                    security_group.authorize_security_group(subnet)
+                elif ingress_type == "EC2SecurityGroupId":
+                    subnet = ec2_backend.get_security_group_from_id(ingress_value)
+                    security_group.authorize_security_group(subnet)
         return security_group
+
+    def delete(self, region_name):
+        backend = rds_backends[region_name]
+        backend.delete_security_group(self.group_name)
 
 
 class SubnetGroup(object):
@@ -324,6 +349,7 @@ class SubnetGroup(object):
         subnet_name = resource_name.lower() + get_random_hex(12)
         description = properties['DBSubnetGroupDescription']
         subnet_ids = properties['SubnetIds']
+        tags = properties.get('Tags')
 
         ec2_backend = ec2_backends[region_name]
         subnets = [ec2_backend.get_subnet(subnet_id) for subnet_id in subnet_ids]
@@ -332,102 +358,31 @@ class SubnetGroup(object):
             subnet_name,
             description,
             subnets,
+            tags,
         )
         return subnet_group
+
+    def delete(self, region_name):
+        backend = rds_backends[region_name]
+        backend.delete_subnet_group(self.subnet_name)
 
 
 class RDSBackend(BaseBackend):
 
-    def __init__(self):
-        self.databases = {}
-        self.security_groups = {}
-        self.subnet_groups = {}
+    def __init__(self, region):
+        self.region = region
 
-    def create_database(self, db_kwargs):
-        database_id = db_kwargs['db_instance_identifier']
-        database = Database(**db_kwargs)
-        self.databases[database_id] = database
-        return database
+    def __getattr__(self, attr):
+        return self.rds2_backend().__getattribute__(attr)
 
-    def create_database_replica(self, db_kwargs):
-        database_id = db_kwargs['db_instance_identifier']
-        source_database_id = db_kwargs['source_db_identifier']
-        primary = self.describe_databases(source_database_id)[0]
-        replica = copy.deepcopy(primary)
-        replica.update(db_kwargs)
-        replica.set_as_replica()
-        self.databases[database_id] = replica
-        primary.add_replica(replica)
-        return replica
+    def reset(self):
+        # preserve region
+        region = self.region
+        self.rds2_backend().reset()
+        self.__dict__ = {}
+        self.__init__(region)
 
-    def describe_databases(self, db_instance_identifier=None):
-        if db_instance_identifier:
-            if db_instance_identifier in self.databases:
-                return [self.databases[db_instance_identifier]]
-            else:
-                raise DBInstanceNotFoundError(db_instance_identifier)
-        return self.databases.values()
+    def rds2_backend(self):
+        return rds2_backends[self.region]
 
-    def modify_database(self, db_instance_identifier, db_kwargs):
-        database = self.describe_databases(db_instance_identifier)[0]
-        database.update(db_kwargs)
-        return database
-
-    def delete_database(self, db_instance_identifier):
-        if db_instance_identifier in self.databases:
-            database = self.databases.pop(db_instance_identifier)
-            if database.is_replica:
-                primary = self.describe_databases(database.source_db_identifier)[0]
-                primary.remove_replica(database)
-            database.status = 'deleting'
-            return database
-        else:
-            raise DBInstanceNotFoundError(db_instance_identifier)
-
-    def create_security_group(self, group_name, description):
-        security_group = SecurityGroup(group_name, description)
-        self.security_groups[group_name] = security_group
-        return security_group
-
-    def describe_security_groups(self, security_group_name):
-        if security_group_name:
-            if security_group_name in self.security_groups:
-                return [self.security_groups[security_group_name]]
-            else:
-                raise DBSecurityGroupNotFoundError(security_group_name)
-        return self.security_groups.values()
-
-    def delete_security_group(self, security_group_name):
-        if security_group_name in self.security_groups:
-            return self.security_groups.pop(security_group_name)
-        else:
-            raise DBSecurityGroupNotFoundError(security_group_name)
-
-    def authorize_security_group(self, security_group_name, cidr_ip):
-        security_group = self.describe_security_groups(security_group_name)[0]
-        security_group.authorize_cidr(cidr_ip)
-        return security_group
-
-    def create_subnet_group(self, subnet_name, description, subnets):
-        subnet_group = SubnetGroup(subnet_name, description, subnets)
-        self.subnet_groups[subnet_name] = subnet_group
-        return subnet_group
-
-    def describe_subnet_groups(self, subnet_group_name):
-        if subnet_group_name:
-            if subnet_group_name in self.subnet_groups:
-                return [self.subnet_groups[subnet_group_name]]
-            else:
-                raise DBSubnetGroupNotFoundError(subnet_group_name)
-        return self.subnet_groups.values()
-
-    def delete_subnet_group(self, subnet_name):
-        if subnet_name in self.subnet_groups:
-            return self.subnet_groups.pop(subnet_name)
-        else:
-            raise DBSubnetGroupNotFoundError(subnet_name)
-
-
-rds_backends = {}
-for region in boto.rds.regions():
-    rds_backends[region.name] = RDSBackend()
+rds_backends = dict((region.name, RDSBackend(region.name)) for region in boto.rds.regions())

--- a/moto/rds2/exceptions.py
+++ b/moto/rds2/exceptions.py
@@ -1,20 +1,22 @@
 from __future__ import unicode_literals
 
-import json
+from jinja2 import Template
 from werkzeug.exceptions import BadRequest
 
 
 class RDSClientError(BadRequest):
     def __init__(self, code, message):
         super(RDSClientError, self).__init__()
-        self.description = json.dumps({
-            "Error": {
-                "Code": code,
-                "Message": message,
-                'Type': 'Sender',
-            },
-            'RequestId': '6876f774-7273-11e4-85dc-39e55ca848d1',
-        })
+        template = Template("""
+        <RDSClientError>
+            <Error>
+              <Code>{{ code }}</Code>
+              <Message>{{ message }}</Message>
+              <Type>Sender</Type>
+            </Error>
+            <RequestId>6876f774-7273-11e4-85dc-39e55ca848d1</RequestId>
+        </RDSClientError>""")
+        self.description = template.render(code=code, message=message)
 
 
 class DBInstanceNotFoundError(RDSClientError):
@@ -37,3 +39,8 @@ class DBSubnetGroupNotFoundError(RDSClientError):
             'DBSubnetGroupNotFound',
             "Subnet Group {0} not found.".format(subnet_group_name))
 
+class DBParameterGroupNotFoundError(RDSClientError):
+    def __init__(self, db_parameter_group_name):
+        super(DBParameterGroupNotFoundError, self).__init__(
+            'DBParameterGroupNotFound',
+            'DB Parameter Group {0} not found.'.format(db_parameter_group_name))

--- a/moto/rds2/responses.py
+++ b/moto/rds2/responses.py
@@ -1,8 +1,10 @@
 from __future__ import unicode_literals
+from collections import defaultdict
 
 from moto.core.responses import BaseResponse
 from moto.ec2.models import ec2_backends
 from .models import rds2_backends
+from .exceptions import DBParameterGroupNotFoundError
 import json
 import re
 
@@ -22,11 +24,12 @@ class RDS2Response(BaseResponse):
             "db_instance_class": self._get_param('DBInstanceClass'),
             "db_instance_identifier": self._get_param('DBInstanceIdentifier'),
             "db_name": self._get_param("DBName"),
-            # DBParameterGroupName
+            "db_parameter_group_name": self._get_param("DBParameterGroupName"),
             "db_subnet_group_name": self._get_param("DBSubnetGroupName"),
             "engine": self._get_param("Engine"),
             "engine_version": self._get_param("EngineVersion"),
             "iops": self._get_int_param("Iops"),
+            "kms_key_id": self._get_param("KmsKeyId"),
             "master_user_password": self._get_param('MasterUserPassword'),
             "master_username": self._get_param('MasterUsername'),
             "multi_az": self._get_bool_param("MultiAZ"),
@@ -36,12 +39,13 @@ class RDS2Response(BaseResponse):
             # PreferredMaintenanceWindow
             "publicly_accessible": self._get_param("PubliclyAccessible"),
             "region": self.region,
-            "security_groups": self._get_multi_param('DBSecurityGroups.member'),
+            "security_groups": self._get_multi_param('DBSecurityGroups.DBSecurityGroupName'),
+            "storage_encrypted": self._get_param("StorageEncrypted"),
             "storage_type": self._get_param("StorageType"),
             # VpcSecurityGroupIds.member.N
-            "tags": list()
+            "tags": list(),
         }
-        args['tags'] = self.unpack_complex_list_params('Tags.member', ('Key', 'Value'))
+        args['tags'] = self.unpack_complex_list_params('Tags.Tag', ('Key', 'Value'))
         return args
 
     def _get_db_replica_kwargs(self):
@@ -65,6 +69,14 @@ class RDS2Response(BaseResponse):
             'description': self._get_param('OptionGroupDescription'),
             'engine_name': self._get_param('EngineName'),
             'name': self._get_param('OptionGroupName')
+        }
+
+    def _get_db_parameter_group_kwargs(self):
+        return {
+            'description': self._get_param('Description'),
+            'family': self._get_param('DBParameterGroupFamily'),
+            'name': self._get_param('DBParameterGroupName'),
+            'tags': self.unpack_complex_list_params('Tags.Tag', ('Key', 'Value')),
         }
 
     def unpack_complex_list_params(self, label, names):
@@ -150,7 +162,7 @@ class RDS2Response(BaseResponse):
 
     def add_tags_to_resource(self):
         arn = self._get_param('ResourceName')
-        tags = self.unpack_complex_list_params('Tags.member', ('Key', 'Value'))
+        tags = self.unpack_complex_list_params('Tags.Tag', ('Key', 'Value'))
         tags = self.backend.add_tags_to_resource(arn, tags)
         template = self.response_template(ADD_TAGS_TO_RESOURCE_TEMPLATE)
         return template.render(tags=tags)
@@ -168,7 +180,8 @@ class RDS2Response(BaseResponse):
     def create_db_security_group(self):
         group_name = self._get_param('DBSecurityGroupName')
         description = self._get_param('DBSecurityGroupDescription')
-        security_group = self.backend.create_security_group(group_name, description)
+        tags = self.unpack_complex_list_params('Tags.Tag', ('Key', 'Value'))
+        security_group = self.backend.create_security_group(group_name, description, tags)
         template = self.response_template(CREATE_SECURITY_GROUP_TEMPLATE)
         return template.render(security_group=security_group)
 
@@ -206,9 +219,10 @@ class RDS2Response(BaseResponse):
     def create_db_subnet_group(self):
         subnet_name = self._get_param('DBSubnetGroupName')
         description = self._get_param('DBSubnetGroupDescription')
-        subnet_ids = self._get_multi_param('SubnetIds.member')
+        subnet_ids = self._get_multi_param('SubnetIds.SubnetIdentifier')
+        tags = self.unpack_complex_list_params('Tags.Tag', ('Key', 'Value'))
         subnets = [ec2_backends[self.region].get_subnet(subnet_id) for subnet_id in subnet_ids]
-        subnet_group = self.backend.create_subnet_group(subnet_name, description, subnets)
+        subnet_group = self.backend.create_subnet_group(subnet_name, description, subnets, tags)
         template = self.response_template(CREATE_SUBNET_GROUP_TEMPLATE)
         return template.render(subnet_group=subnet_group)
 
@@ -283,225 +297,326 @@ class RDS2Response(BaseResponse):
         template = self.response_template(MODIFY_OPTION_GROUP_TEMPLATE)
         return template.render(option_group=option_group)
 
+    def create_dbparameter_group(self):
+        return self.create_db_parameter_group()
 
-CREATE_DATABASE_TEMPLATE = """{
-  "CreateDBInstanceResponse": {
-    "CreateDBInstanceResult": {
-      "DBInstance": {{ database.to_json() }}
-    },
-    "ResponseMetadata": { "RequestId": "523e3218-afc7-11c3-90f5-f90431260ab4" }
-  }
-}"""
+    def create_db_parameter_group(self):
+        kwargs = self._get_db_parameter_group_kwargs()
+        db_parameter_group = self.backend.create_db_parameter_group(kwargs)
+        template = self.response_template(CREATE_DB_PARAMETER_GROUP_TEMPLATE)
+        return template.render(db_parameter_group=db_parameter_group)
 
-CREATE_DATABASE_REPLICA_TEMPLATE = """{"CreateDBInstanceReadReplicaResponse": {
-  "ResponseMetadata": {
-    "RequestId": "5e60c46d-a844-11e4-bb68-17f36418e58f"
-  },
-  "CreateDBInstanceReadReplicaResult": {
-    "DBInstance": {{ database.to_json() }}
-  }
-}}"""
+    def describe_dbparameter_groups(self):
+        return self.describe_db_parameter_groups()
 
-DESCRIBE_DATABASES_TEMPLATE = """{
-  "DescribeDBInstancesResponse": {
-    "DescribeDBInstancesResult": {
-      "DBInstances": [
-        {%- for database in databases -%}
-          {%- if loop.index != 1 -%},{%- endif -%}
-          {{ database.to_json() }}
+    def describe_db_parameter_groups(self):
+        kwargs = self._get_db_parameter_group_kwargs()
+        kwargs['max_records'] = self._get_param('MaxRecords')
+        kwargs['marker'] = self._get_param('Marker')
+        db_parameter_groups = self.backend.describe_db_parameter_groups(kwargs)
+        template = self.response_template(DESCRIBE_DB_PARAMETER_GROUPS_TEMPLATE)
+        return template.render(db_parameter_groups=db_parameter_groups)
+
+    def modify_dbparameter_group(self):
+        return self.modify_db_parameter_group()
+
+    def modify_db_parameter_group(self):
+        db_parameter_group_name = self._get_param('DBParameterGroupName')
+        db_parameter_group_parameters = self._get_db_parameter_group_paramters()
+        db_parameter_group = self.backend.modify_db_parameter_group(db_parameter_group_name,
+                                                                    db_parameter_group_parameters)
+        template = self.response_template(MODIFY_DB_PARAMETER_GROUP_TEMPLATE)
+        return template.render(db_parameter_group=db_parameter_group)
+
+    def _get_db_parameter_group_paramters(self):
+        parameter_group_parameters = defaultdict(dict)
+        for param_name, value in self.querystring.items():
+            if not param_name.startswith('Parameters.Parameter'):
+                continue
+
+            split_param_name = param_name.split('.')
+            param_id = split_param_name[2]
+            param_setting = split_param_name[3]
+
+            parameter_group_parameters[param_id][param_setting] = value[0]
+
+        return parameter_group_parameters.values()
+
+    def describe_dbparameters(self):
+        return self.describe_db_parameters()
+
+    def describe_db_parameters(self):
+        db_parameter_group_name = self._get_param('DBParameterGroupName')
+        db_parameter_groups = self.backend.describe_db_parameter_groups({'name': db_parameter_group_name})
+        if not db_parameter_groups:
+            raise DBParameterGroupNotFoundError(db_parameter_group_name)
+
+        template = self.response_template(DESCRIBE_DB_PARAMETERS_TEMPLATE)
+        return template.render(db_parameter_group=db_parameter_groups[0])
+
+    def delete_dbparameter_group(self):
+        return self.delete_db_parameter_group()
+
+    def delete_db_parameter_group(self):
+        kwargs = self._get_db_parameter_group_kwargs()
+        db_parameter_group = self.backend.delete_db_parameter_group(kwargs['name'])
+        template = self.response_template(DELETE_DB_PARAMETER_GROUP_TEMPLATE)
+        return template.render(db_parameter_group=db_parameter_group)
+
+
+CREATE_DATABASE_TEMPLATE = """<CreateDBInstanceResponse xmlns="http://rds.amazonaws.com/doc/2014-09-01/">
+  <CreateDBInstanceResult>
+  {{ database.to_xml() }}
+  </CreateDBInstanceResult>
+  <ResponseMetadata>
+    <RequestId>523e3218-afc7-11c3-90f5-f90431260ab4</RequestId>
+  </ResponseMetadata>
+</CreateDBInstanceResponse>"""
+
+CREATE_DATABASE_REPLICA_TEMPLATE = """<CreateDBInstanceReadReplicaResponse xmlns="http://rds.amazonaws.com/doc/2014-09-01/">
+  <CreateDBInstanceReadReplicaResult>
+  {{ database.to_xml() }}
+  </CreateDBInstanceReadReplicaResult>
+  <ResponseMetadata>
+    <RequestId>5e60c46d-a844-11e4-bb68-17f36418e58f</RequestId>
+  </ResponseMetadata>
+</CreateDBInstanceReadReplicaResponse>"""
+
+DESCRIBE_DATABASES_TEMPLATE = """<DescribeDBInstancesResponse xmlns="http://rds.amazonaws.com/doc/2014-09-01/">
+  <DescribeDBInstancesResult>
+    <DBInstances>
+    {%- for database in databases -%}
+      {{ database.to_xml() }}
+    {%- endfor -%}
+    </DBInstances>
+  </DescribeDBInstancesResult>
+  <ResponseMetadata>
+    <RequestId>523e3218-afc7-11c3-90f5-f90431260ab4</RequestId>
+  </ResponseMetadata>
+</DescribeDBInstancesResponse>"""
+
+MODIFY_DATABASE_TEMPLATE = """<ModifyDBInstanceResponse xmlns="http://rds.amazonaws.com/doc/2014-09-01/">
+  <ModifyDBInstanceResult>
+  {{ database.to_xml() }}
+  </ModifyDBInstanceResult>
+  <ResponseMetadata>
+    <RequestId>bb58476c-a1a8-11e4-99cf-55e92d4bbada</RequestId>
+  </ResponseMetadata>
+</ModifyDBInstanceResponse>"""
+
+REBOOT_DATABASE_TEMPLATE = """<RebootDBInstanceResponse xmlns="http://rds.amazonaws.com/doc/2014-09-01/">
+  <RebootDBInstanceResult>
+  {{ database.to_xml() }}
+  </RebootDBInstanceResult>
+  <ResponseMetadata>
+    <RequestId>d55711cb-a1ab-11e4-99cf-55e92d4bbada</RequestId>
+  </ResponseMetadata>
+</RebootDBInstanceResponse>"""
+
+
+DELETE_DATABASE_TEMPLATE = """<DeleteDBInstanceResponse xmlns="http://rds.amazonaws.com/doc/2014-09-01/">
+  <DeleteDBInstanceResult>
+    {{ database.to_xml() }}
+  </DeleteDBInstanceResult>
+  <ResponseMetadata>
+    <RequestId>7369556f-b70d-11c3-faca-6ba18376ea1b</RequestId>
+  </ResponseMetadata>
+</DeleteDBInstanceResponse>"""
+
+CREATE_SECURITY_GROUP_TEMPLATE = """<CreateDBSecurityGroupResponse xmlns="http://rds.amazonaws.com/doc/2014-09-01/">
+  <CreateDBSecurityGroupResult>
+  {{ security_group.to_xml() }}
+  </CreateDBSecurityGroupResult>
+  <ResponseMetadata>
+    <RequestId>462165d0-a77a-11e4-a5fa-75b30c556f97</RequestId>
+  </ResponseMetadata>
+</CreateDBSecurityGroupResponse>"""
+
+DESCRIBE_SECURITY_GROUPS_TEMPLATE = """<DescribeDBSecurityGroupsResponse xmlns="http://rds.amazonaws.com/doc/2014-09-01/">
+  <DescribeDBSecurityGroupsResult>
+    <DBSecurityGroups>
+    {% for security_group in security_groups %}
+      {{ security_group.to_xml() }}
+    {% endfor %}
+   </DBSecurityGroups>
+  </DescribeDBSecurityGroupsResult>
+  <ResponseMetadata>
+    <RequestId>5df2014e-a779-11e4-bdb0-594def064d0c</RequestId>
+  </ResponseMetadata>
+</DescribeDBSecurityGroupsResponse>"""
+
+DELETE_SECURITY_GROUP_TEMPLATE = """<DeleteDBSecurityGroupResponse xmlns="http://rds.amazonaws.com/doc/2014-09-01/">
+  <ResponseMetadata>
+    <RequestId>97e846bd-a77d-11e4-ac58-91351c0f3426</RequestId>
+  </ResponseMetadata>
+</DeleteDBSecurityGroupResponse>"""
+
+AUTHORIZE_SECURITY_GROUP_TEMPLATE = """<AuthorizeDBSecurityGroupIngressResponse xmlns="http://rds.amazonaws.com/doc/2014-09-01/">
+  <AuthorizeDBSecurityGroupIngressResult>
+  {{ security_group.to_xml() }}
+  </AuthorizeDBSecurityGroupIngressResult>
+  <ResponseMetadata>
+    <RequestId>75d32fd5-a77e-11e4-8892-b10432f7a87d</RequestId>
+  </ResponseMetadata>
+</AuthorizeDBSecurityGroupIngressResponse>"""
+
+CREATE_SUBNET_GROUP_TEMPLATE = """<CreateDBSubnetGroupResponse xmlns="http://rds.amazonaws.com/doc/2014-09-01/">
+  <CreateDBSubnetGroupResult>
+  {{ subnet_group.to_xml() }}
+  </CreateDBSubnetGroupResult>
+  <ResponseMetadata>
+    <RequestId>3a401b3f-bb9e-11d3-f4c6-37db295f7674</RequestId>
+  </ResponseMetadata>
+</CreateDBSubnetGroupResponse>"""
+
+DESCRIBE_SUBNET_GROUPS_TEMPLATE = """<DescribeDBSubnetGroupsResponse xmlns="http://rds.amazonaws.com/doc/2014-09-01/">
+  <DescribeDBSubnetGroupsResult>
+    <DBSubnetGroups>
+    {% for subnet_group in subnet_groups %}
+      {{ subnet_group.to_xml() }}
+    {% endfor %}
+    </DBSubnetGroups>
+  </DescribeDBSubnetGroupsResult>
+  <ResponseMetadata>
+    <RequestId>b783db3b-b98c-11d3-fbc7-5c0aad74da7c</RequestId>
+  </ResponseMetadata>
+</DescribeDBSubnetGroupsResponse>"""
+
+DELETE_SUBNET_GROUP_TEMPLATE = """<DeleteDBSubnetGroupResponse xmlns="http://rds.amazonaws.com/doc/2014-09-01/">
+  <ResponseMetadata>
+    <RequestId>13785dd5-a7fc-11e4-bb9c-7f371d0859b0</RequestId>
+  </ResponseMetadata>
+</DeleteDBSubnetGroupResponse>"""
+
+CREATE_OPTION_GROUP_TEMPLATE = """<CreateOptionGroupResponse xmlns="http://rds.amazonaws.com/doc/2014-09-01/">
+  <CreateOptionGroupResult>
+  {{ option_group.to_xml() }}
+  </CreateOptionGroupResult>
+  <ResponseMetadata>
+    <RequestId>1e38dad4-9f50-11e4-87ea-a31c60ed2e36</RequestId>
+  </ResponseMetadata>
+</CreateOptionGroupResponse>"""
+
+DELETE_OPTION_GROUP_TEMPLATE = """<DeleteOptionGroupResponse xmlns="http://rds.amazonaws.com/doc/2014-09-01/">
+  <ResponseMetadata>
+    <RequestId>e2590367-9fa2-11e4-99cf-55e92d41c60e</RequestId>
+  </ResponseMetadata>
+</DeleteOptionGroupResponse>"""
+
+DESCRIBE_OPTION_GROUP_TEMPLATE = """<DescribeOptionGroupsResponse xmlns="http://rds.amazonaws.com/doc/2014-09-01/">
+  <DescribeOptionGroupsResult>
+    <OptionGroupsList>
+    {%- for option_group in option_groups -%}
+      {{ option_group.to_xml() }}
+    {%- endfor -%}
+    </OptionGroupsList>
+  </DescribeOptionGroupsResult>
+  <ResponseMetadata>
+    <RequestId>4caf445d-9fbc-11e4-87ea-a31c60ed2e36</RequestId>
+  </ResponseMetadata>
+</DescribeOptionGroupsResponse>"""
+
+DESCRIBE_OPTION_GROUP_OPTIONS_TEMPLATE = """<DescribeOptionGroupOptionsResponse xmlns="http://rds.amazonaws.com/doc/2014-09-01/">
+  <DescribeOptionGroupOptionsResult>
+    <OptionGroupOptions>
+    {%- for option_group_option in option_group_options -%}
+      {{ option_group_option.to_xml() }}
+    {%- endfor -%}
+    </OptionGroupOptions>
+  </DescribeOptionGroupOptionsResult>
+  <ResponseMetadata>
+    <RequestId>457f7bb8-9fbf-11e4-9084-5754f80d5144</RequestId>
+  </ResponseMetadata>
+</DescribeOptionGroupOptionsResponse>"""
+
+MODIFY_OPTION_GROUP_TEMPLATE = """<ModifyOptionGroupResponse xmlns="http://rds.amazonaws.com/doc/2014-09-01/">
+  <ModifyOptionGroupResult>
+    {{ option_group.to_xml() }}
+  </ModifyOptionGroupResult>
+  <ResponseMetadata>
+    <RequestId>ce9284a5-a0de-11e4-b984-a11a53e1f328</RequestId>
+  </ResponseMetadata>
+</ModifyOptionGroupResponse>"""
+
+CREATE_DB_PARAMETER_GROUP_TEMPLATE = """<CreateDBParameterGroupResponse xmlns="http://rds.amazonaws.com/doc/2014-09-01/">
+  <CreateDBParameterGroupResult>
+    {{ db_parameter_group.to_xml() }}
+  </CreateDBParameterGroupResult>
+  <ResponseMetadata>
+    <RequestId>7805c127-af22-11c3-96ac-6999cc5f7e72</RequestId>
+  </ResponseMetadata>
+</CreateDBParameterGroupResponse>"""
+
+DESCRIBE_DB_PARAMETER_GROUPS_TEMPLATE = """<DescribeDBParameterGroupsResponse xmlns="http://rds.amazonaws.com/doc/2014-09-01/">
+  <DescribeDBParameterGroupsResult>
+    <DBParameterGroups>
+    {%- for db_parameter_group in db_parameter_groups -%}
+      {{ db_parameter_group.to_xml() }}
+    {%- endfor -%}
+    </DBParameterGroups>
+  </DescribeDBParameterGroupsResult>
+  <ResponseMetadata>
+    <RequestId>b75d527a-b98c-11d3-f272-7cd6cce12cc5</RequestId>
+  </ResponseMetadata>
+</DescribeDBParameterGroupsResponse>"""
+
+MODIFY_DB_PARAMETER_GROUP_TEMPLATE = """<ModifyDBParameterGroupResponse xmlns="http://rds.amazonaws.com/doc/2014-09-01/">
+  <ModifyDBParameterGroupResult>
+    <DBParameterGroupName>{{ db_parameter_group.name }}</DBParameterGroupName>
+  </ModifyDBParameterGroupResult>
+  <ResponseMetadata>
+    <RequestId>12d7435e-bba0-11d3-fe11-33d33a9bb7e3</RequestId>
+  </ResponseMetadata>
+</ModifyDBParameterGroupResponse>"""
+
+DELETE_DB_PARAMETER_GROUP_TEMPLATE = """<DeleteDBParameterGroupResponse xmlns="http://rds.amazonaws.com/doc/2014-09-01/">
+  <ResponseMetadata>
+    <RequestId>cad6c267-ba25-11d3-fe11-33d33a9bb7e3</RequestId>
+  </ResponseMetadata>
+</DeleteDBParameterGroupResponse>"""
+
+DESCRIBE_DB_PARAMETERS_TEMPLATE = """<DescribeDBParametersResponse xmlns="http://rds.amazonaws.com/doc/2014-09-01/">
+  <DescribeDBParametersResult>
+    <Parameters>
+      {%- for db_parameter_name, db_parameter in db_parameter_group.parameters.items() -%}
+      <Parameter>
+        {%- for parameter_name, parameter_value in db_parameter.items() -%}
+        <{{ parameter_name }}>{{ parameter_value }}</{{ parameter_name }}>
         {%- endfor -%}
-      ]
-    },
-    "ResponseMetadata": { "RequestId": "523e3218-afc7-11c3-90f5-f90431260ab4" }
-  }
-}"""
+      </Parameter>
+      {%- endfor -%}
+    </Parameters>
+  </DescribeDBParametersResult>
+  <ResponseMetadata>
+    <RequestId>8c40488f-b9ff-11d3-a15e-7ac49293f4fa</RequestId>
+  </ResponseMetadata>
+</DescribeDBParametersResponse>
+"""
 
-MODIFY_DATABASE_TEMPLATE = """{"ModifyDBInstanceResponse": {
-    "ModifyDBInstanceResult": {
-      "DBInstance": {{ database.to_json() }},
-      "ResponseMetadata": {
-        "RequestId": "bb58476c-a1a8-11e4-99cf-55e92d4bbada"
-      }
-    }
-  }
-}"""
+LIST_TAGS_FOR_RESOURCE_TEMPLATE = """<ListTagsForResourceResponse xmlns="http://rds.amazonaws.com/doc/2014-10-31/">
+  <ListTagsForResourceResult>
+    <TagList>
+    {%- for tag in tags -%}
+      <Tag>
+        <Key>{{ tag['Key'] }}</Key>
+        <Value>{{ tag['Value'] }}</Value>
+      </Tag>
+    {%- endfor -%}
+    </TagList>
+  </ListTagsForResourceResult>
+  <ResponseMetadata>
+    <RequestId>8c21ba39-a598-11e4-b688-194eaf8658fa</RequestId>
+  </ResponseMetadata>
+</ListTagsForResourceResponse>"""
 
-REBOOT_DATABASE_TEMPLATE = """{"RebootDBInstanceResponse": {
-    "RebootDBInstanceResult": {
-      "DBInstance": {{ database.to_json() }},
-      "ResponseMetadata": {
-        "RequestId": "d55711cb-a1ab-11e4-99cf-55e92d4bbada"
-      }
-    }
-  }
-}"""
+ADD_TAGS_TO_RESOURCE_TEMPLATE = """<AddTagsToResourceResponse xmlns="http://rds.amazonaws.com/doc/2014-10-31/">
+  <ResponseMetadata>
+    <RequestId>b194d9ca-a664-11e4-b688-194eaf8658fa</RequestId>
+  </ResponseMetadata>
+</AddTagsToResourceResponse>"""
 
-
-DELETE_DATABASE_TEMPLATE = """{ "DeleteDBInstanceResponse": {
-    "DeleteDBInstanceResult": {
-      "DBInstance": {{ database.to_json() }}
-    },
-    "ResponseMetadata": {
-      "RequestId": "523e3218-afc7-11c3-90f5-f90431260ab4"
-    }
-  }
-}"""
-
-CREATE_SECURITY_GROUP_TEMPLATE = """{"CreateDBSecurityGroupResponse": {
-    "CreateDBSecurityGroupResult": {
-        "DBSecurityGroup":
-            {{ security_group.to_json() }},
-        "ResponseMetadata": {
-            "RequestId": "462165d0-a77a-11e4-a5fa-75b30c556f97"
-        }}
-    }
-}"""
-
-DESCRIBE_SECURITY_GROUPS_TEMPLATE = """{
-    "DescribeDBSecurityGroupsResponse": {
-        "ResponseMetadata": {
-            "RequestId": "5df2014e-a779-11e4-bdb0-594def064d0c"
-        },
-        "DescribeDBSecurityGroupsResult": {
-            "Marker": "null",
-            "DBSecurityGroups": [
-            {% for security_group in security_groups %}
-                {%- if loop.index != 1 -%},{%- endif -%}
-                {{ security_group.to_json() }}
-            {% endfor %}
-            ]
-        }
-    }
-}"""
-
-DELETE_SECURITY_GROUP_TEMPLATE = """{"DeleteDBSecurityGroupResponse": {
-  "ResponseMetadata": {
-    "RequestId": "97e846bd-a77d-11e4-ac58-91351c0f3426"
-  }
-}}"""
-
-AUTHORIZE_SECURITY_GROUP_TEMPLATE = """{
-    "AuthorizeDBSecurityGroupIngressResponse": {
-        "AuthorizeDBSecurityGroupIngressResult": {
-            "DBSecurityGroup": {{ security_group.to_json() }}
-        },
-        "ResponseMetadata": {
-            "RequestId": "75d32fd5-a77e-11e4-8892-b10432f7a87d"
-        }
-    }
-}"""
-
-CREATE_SUBNET_GROUP_TEMPLATE = """{
-  "CreateDBSubnetGroupResponse": {
-    "CreateDBSubnetGroupResult":
-        { {{ subnet_group.to_json() }} },
-    "ResponseMetadata": { "RequestId": "3a401b3f-bb9e-11d3-f4c6-37db295f7674" }
-  }
-}"""
-
-DESCRIBE_SUBNET_GROUPS_TEMPLATE = """{
-  "DescribeDBSubnetGroupsResponse": {
-    "DescribeDBSubnetGroupsResult": {
-      "DBSubnetGroups": [
-              {% for subnet_group in subnet_groups %}
-                  { {{ subnet_group.to_json() }} }{%- if not loop.last -%},{%- endif -%}
-              {% endfor %}
-          ],
-          "Marker": null
-    },
-    "ResponseMetadata": { "RequestId": "b783db3b-b98c-11d3-fbc7-5c0aad74da7c" }
-  }
-}"""
-
-
-DELETE_SUBNET_GROUP_TEMPLATE = """{"DeleteDBSubnetGroupResponse": {"ResponseMetadata": {"RequestId": "13785dd5-a7fc-11e4-bb9c-7f371d0859b0"}}}"""
-
-CREATE_OPTION_GROUP_TEMPLATE = """{
-    "CreateOptionGroupResponse": {
-        "CreateOptionGroupResult": {
-            "OptionGroup": {{ option_group.to_json() }}
-        },
-        "ResponseMetadata": {
-            "RequestId": "1e38dad4-9f50-11e4-87ea-a31c60ed2e36"
-        }
-    }
-}"""
-
-DELETE_OPTION_GROUP_TEMPLATE = \
-    """{"DeleteOptionGroupResponse": {"ResponseMetadata": {"RequestId": "e2590367-9fa2-11e4-99cf-55e92d41c60e"}}}"""
-
-DESCRIBE_OPTION_GROUP_TEMPLATE = \
-    """{"DescribeOptionGroupsResponse": {
-          "DescribeOptionGroupsResult": {
-            "Marker": null,
-            "OptionGroupsList": [
-            {%- for option_group in option_groups -%}
-                {%- if loop.index != 1 -%},{%- endif -%}
-                {{ option_group.to_json() }}
-            {%- endfor -%}
-            ]},
-            "ResponseMetadata": {"RequestId": "4caf445d-9fbc-11e4-87ea-a31c60ed2e36"}
-        }}"""
-
-DESCRIBE_OPTION_GROUP_OPTIONS_TEMPLATE = \
-    """{"DescribeOptionGroupOptionsResponse": {
-          "DescribeOptionGroupOptionsResult": {
-            "Marker": null,
-            "OptionGroupOptions": [
-                {%- for option_group_option in option_group_options -%}
-                {%- if loop.index != 1 -%},{%- endif -%}
-                {{ option_group_option.to_json() }}
-                {%- endfor -%}
-            ]},
-          "ResponseMetadata": {"RequestId": "457f7bb8-9fbf-11e4-9084-5754f80d5144"}
-        }}"""
-
-MODIFY_OPTION_GROUP_TEMPLATE = \
-    """{"ModifyOptionGroupResponse": {
-          "ResponseMetadata": {
-              "RequestId": "ce9284a5-a0de-11e4-b984-a11a53e1f328"
-          },
-          "ModifyOptionGroupResult":
-            {{ option_group.to_json() }}
-        }
-      }"""
-
-LIST_TAGS_FOR_RESOURCE_TEMPLATE = \
-    """{"ListTagsForResourceResponse":
-      {"ListTagsForResourceResult":
-        {"TagList": [
-          {%- for tag in tags -%}
-            {%- if loop.index != 1 -%},{%- endif -%}
-            {
-              "Key": "{{ tag['Key'] }}",
-              "Value": "{{ tag['Value'] }}"
-            }
-          {%- endfor -%}
-        ]},
-        "ResponseMetadata": {
-          "RequestId": "8c21ba39-a598-11e4-b688-194eaf8658fa"
-        }
-      }
-    }"""
-
-ADD_TAGS_TO_RESOURCE_TEMPLATE = \
-   """{"ListTagsForResourceResponse":  {
-         "ListTagsForResourceResult": {
-           "TagList": [
-           {%- for tag in tags -%}
-               {%- if loop.index != 1 -%},{%- endif -%}
-               {
-                  "Key": "{{ tag['Key'] }}",
-                  "Value": "{{ tag['Value'] }}"
-               }
-           {%- endfor -%}
-           ]},
-           "ResponseMetadata": {
-             "RequestId": "b194d9ca-a664-11e4-b688-194eaf8658fa"
-           }
-         }
-   }"""
-
-REMOVE_TAGS_FROM_RESOURCE_TEMPLATE = \
-   """{"RemoveTagsFromResourceResponse": {"ResponseMetadata": {"RequestId": "c6499a01-a664-11e4-8069-fb454b71a80e"}}}
-   """
+REMOVE_TAGS_FROM_RESOURCE_TEMPLATE = """<RemoveTagsFromResourceResponse xmlns="http://rds.amazonaws.com/doc/2014-10-31/">
+  <ResponseMetadata>
+    <RequestId>b194d9ca-a664-11e4-b688-194eaf8658fa</RequestId>
+  </ResponseMetadata>
+</RemoveTagsFromResourceResponse>"""

--- a/tests/test_cloudformation/fixtures/rds_mysql_with_db_parameter_group.py
+++ b/tests/test_cloudformation/fixtures/rds_mysql_with_db_parameter_group.py
@@ -82,6 +82,17 @@ template = {
   },
 
   "Resources" : {
+    "DBParameterGroup": {
+      "Type": "AWS::RDS::DBParameterGroup",
+      "Properties" : {
+        "Description": "DB Parameter Goup",
+        "Family" : "MySQL5.1",
+        "Parameters": {
+            "BACKLOG_QUEUE_LIMIT": "2048"
+        }
+      }
+    },
+
     "DBEC2SecurityGroup": {
       "Type": "AWS::EC2::SecurityGroup",
       "Condition" : "Is-EC2-VPC",

--- a/tests/test_cloudformation/test_cloudformation_stack_integration.py
+++ b/tests/test_cloudformation/test_cloudformation_stack_integration.py
@@ -27,6 +27,7 @@ from moto import (
     mock_kms,
     mock_lambda,
     mock_rds,
+    mock_rds2,
     mock_redshift,
     mock_route53,
     mock_sns,
@@ -36,6 +37,7 @@ from moto import (
 from .fixtures import (
     ec2_classic_eip,
     fn_join,
+    rds_mysql_with_db_parameter_group,
     rds_mysql_with_read_replica,
     redshift,
     route53_ec2_instance_with_public_ip,
@@ -691,6 +693,44 @@ def test_vpc_single_instance_in_subnet():
 
     eip_resource = [resource for resource in resources if resource.resource_type == 'AWS::EC2::EIP'][0]
     eip_resource.physical_resource_id.should.equal(eip.allocation_id)
+
+@mock_cloudformation()
+@mock_ec2()
+@mock_rds2()
+def test_rds_db_parameter_groups():
+    ec2_conn = boto.ec2.connect_to_region("us-west-1")
+    ec2_conn.create_security_group('application', 'Our Application Group')
+
+    template_json = json.dumps(rds_mysql_with_db_parameter_group.template)
+    conn = boto.cloudformation.connect_to_region("us-west-1")
+    conn.create_stack(
+        "test_stack",
+        template_body=template_json,
+        parameters=[
+            ("DBInstanceIdentifier", "master_db"),
+            ("DBName", "my_db"),
+            ("DBUser", "my_user"),
+            ("DBPassword", "my_password"),
+            ("DBAllocatedStorage", "20"),
+            ("DBInstanceClass", "db.m1.medium"),
+            ("EC2SecurityGroup", "application"),
+            ("MultiAZ", "true"),
+        ],
+    )
+
+    rds_conn = boto3.client('rds', region_name="us-west-1")
+
+    db_parameter_groups = rds_conn.describe_db_parameter_groups()
+    len(db_parameter_groups['DBParameterGroups']).should.equal(1)
+    db_parameter_group_name = db_parameter_groups['DBParameterGroups'][0]['DBParameterGroupName']
+
+    found_cloudformation_set_parameter = False
+    for db_parameter in rds_conn.describe_db_parameters(DBParameterGroupName=db_parameter_group_name)['Parameters']:
+        if db_parameter['ParameterName'] == 'BACKLOG_QUEUE_LIMIT' and db_parameter['ParameterValue'] == '2048':
+            found_cloudformation_set_parameter = True
+
+    found_cloudformation_set_parameter.should.equal(True)
+
 
 
 @mock_cloudformation()

--- a/tests/test_rds2/test_rds2.py
+++ b/tests/test_rds2/test_rds2.py
@@ -2,479 +2,648 @@ from __future__ import unicode_literals
 
 import boto.rds2
 import boto.vpc
-from boto.exception import BotoServerError
+from botocore.exceptions import ClientError, ParamValidationError
+import boto3
 import sure  # noqa
-from moto import mock_ec2, mock_rds2
+from moto import mock_ec2, mock_kms, mock_rds2
 from tests.helpers import disable_on_py3
 
 
 @disable_on_py3()
 @mock_rds2
 def test_create_database():
-    conn = boto.rds2.connect_to_region("us-west-2")
-    database = conn.create_db_instance(db_instance_identifier='db-master-1',
-                                       allocated_storage=10,
-                                       engine='postgres',
-                                       db_instance_class='db.m1.small',
-                                       master_username='root',
-                                       master_user_password='hunter2',
-                                       db_security_groups=["my_sg"])
-    database['CreateDBInstanceResponse']['CreateDBInstanceResult']['DBInstance']['DBInstanceStatus'].should.equal('available')
-    database['CreateDBInstanceResponse']['CreateDBInstanceResult']['DBInstance']['DBInstanceIdentifier'].should.equal("db-master-1")
-    database['CreateDBInstanceResponse']['CreateDBInstanceResult']['DBInstance']['AllocatedStorage'].should.equal('10')
-    database['CreateDBInstanceResponse']['CreateDBInstanceResult']['DBInstance']['DBInstanceClass'].should.equal("db.m1.small")
-    database['CreateDBInstanceResponse']['CreateDBInstanceResult']['DBInstance']['MasterUsername'].should.equal("root")
-    database['CreateDBInstanceResponse']['CreateDBInstanceResult']['DBInstance']['DBSecurityGroups'][0]['DBSecurityGroup']['DBSecurityGroupName'].should.equal('my_sg')
+    conn = boto3.client('rds', region_name='us-west-2')
+    database = conn.create_db_instance(DBInstanceIdentifier='db-master-1',
+                                       AllocatedStorage=10,
+                                       Engine='postgres',
+                                       DBInstanceClass='db.m1.small',
+                                       MasterUsername='root',
+                                       MasterUserPassword='hunter2',
+                                       Port=1234,
+                                       DBSecurityGroups=["my_sg"])
+    database['DBInstance']['DBInstanceStatus'].should.equal('available')
+    database['DBInstance']['DBInstanceIdentifier'].should.equal("db-master-1")
+    database['DBInstance']['AllocatedStorage'].should.equal(10)
+    database['DBInstance']['DBInstanceClass'].should.equal("db.m1.small")
+    database['DBInstance']['MasterUsername'].should.equal("root")
+    database['DBInstance']['DBSecurityGroups'][0]['DBSecurityGroupName'].should.equal('my_sg')
 
 
 @disable_on_py3()
 @mock_rds2
 def test_get_databases():
-    conn = boto.rds2.connect_to_region("us-west-2")
+    conn = boto3.client('rds', region_name='us-west-2')
 
     instances = conn.describe_db_instances()
-    list(instances['DescribeDBInstancesResponse']['DescribeDBInstancesResult']['DBInstances']).should.have.length_of(0)
+    list(instances['DBInstances']).should.have.length_of(0)
 
-    conn.create_db_instance(db_instance_identifier='db-master-1',
-                            allocated_storage=10,
-                            engine='postgres',
-                            db_instance_class='db.m1.small',
-                            master_username='root',
-                            master_user_password='hunter2',
-                            db_security_groups=["my_sg"])
-    conn.create_db_instance(db_instance_identifier='db-master-2',
-                            allocated_storage=10,
-                            engine='postgres',
-                            db_instance_class='db.m1.small',
-                            master_username='root',
-                            master_user_password='hunter2',
-                            db_security_groups=["my_sg"])
+    conn.create_db_instance(DBInstanceIdentifier='db-master-1',
+                            AllocatedStorage=10,
+                            DBInstanceClass='postgres',
+                            Engine='db.m1.small',
+                            MasterUsername='root',
+                            MasterUserPassword='hunter2',
+                            Port=1234,
+                            DBSecurityGroups=['my_sg'])
+    conn.create_db_instance(DBInstanceIdentifier='db-master-2',
+                            AllocatedStorage=10,
+                            DBInstanceClass='postgres',
+                            Engine='db.m1.small',
+                            MasterUsername='root',
+                            MasterUserPassword='hunter2',
+                            Port=1234,
+                            DBSecurityGroups=['my_sg'])
     instances = conn.describe_db_instances()
-    list(instances['DescribeDBInstancesResponse']['DescribeDBInstancesResult']['DBInstances']).should.have.length_of(2)
+    list(instances['DBInstances']).should.have.length_of(2)
 
-    instances = conn.describe_db_instances("db-master-1")
-    list(instances['DescribeDBInstancesResponse']['DescribeDBInstancesResult']['DBInstances']).should.have.length_of(1)
-    instances['DescribeDBInstancesResponse']['DescribeDBInstancesResult']['DBInstances'][0]['DBInstanceIdentifier'].should.equal("db-master-1")
+    instances = conn.describe_db_instances(DBInstanceIdentifier="db-master-1")
+    list(instances['DBInstances']).should.have.length_of(1)
+    instances['DBInstances'][0]['DBInstanceIdentifier'].should.equal("db-master-1")
 
 
 @disable_on_py3()
 @mock_rds2
 def test_describe_non_existant_database():
-    conn = boto.rds2.connect_to_region("us-west-2")
-    conn.describe_db_instances.when.called_with("not-a-db").should.throw(BotoServerError)
+    conn = boto3.client('rds', region_name='us-west-2')
+    conn.describe_db_instances.when.called_with(DBInstanceIdentifier="not-a-db").should.throw(ClientError)
 
 
 @disable_on_py3()
 @mock_rds2
 def test_modify_db_instance():
-    conn = boto.rds2.connect_to_region("us-west-2")
-    database = conn.create_db_instance(db_instance_identifier='db-master-1',
-                                       allocated_storage=10,
-                                       engine='postgres',
-                                       db_instance_class='db.m1.small',
-                                       master_username='root',
-                                       master_user_password='hunter2',
-                                       db_security_groups=["my_sg"])
-    instances = conn.describe_db_instances('db-master-1')
-    instances['DescribeDBInstancesResponse']['DescribeDBInstancesResult']['DBInstances'][0]['AllocatedStorage'].should.equal('10')
-    conn.modify_db_instance(db_instance_identifier='db-master-1', allocated_storage=20, apply_immediately=True)
-    instances = conn.describe_db_instances('db-master-1')
-    instances['DescribeDBInstancesResponse']['DescribeDBInstancesResult']['DBInstances'][0]['AllocatedStorage'].should.equal('20')
+    conn = boto3.client('rds', region_name='us-west-2')
+    database = conn.create_db_instance(DBInstanceIdentifier='db-master-1',
+                                       AllocatedStorage=10,
+                                       DBInstanceClass='postgres',
+                                       Engine='db.m1.small',
+                                       MasterUsername='root',
+                                       MasterUserPassword='hunter2',
+                                       Port=1234,
+                                       DBSecurityGroups=['my_sg'])
+    instances = conn.describe_db_instances(DBInstanceIdentifier='db-master-1')
+    instances['DBInstances'][0]['AllocatedStorage'].should.equal(10)
+    conn.modify_db_instance(DBInstanceIdentifier='db-master-1',
+                            AllocatedStorage=20,
+                            ApplyImmediately=True)
+    instances = conn.describe_db_instances(DBInstanceIdentifier='db-master-1')
+    instances['DBInstances'][0]['AllocatedStorage'].should.equal(20)
 
 
 @disable_on_py3()
 @mock_rds2
 def test_modify_non_existant_database():
-    conn = boto.rds2.connect_to_region("us-west-2")
-    conn.modify_db_instance.when.called_with(db_instance_identifier='not-a-db',
-                                             allocated_storage=20,
-                                             apply_immediately=True).should.throw(BotoServerError)
+    conn = boto3.client('rds', region_name='us-west-2')
+    conn.modify_db_instance.when.called_with(DBInstanceIdentifier='not-a-db',
+                                             AllocatedStorage=20,
+                                             ApplyImmediately=True).should.throw(ClientError)
 
 @disable_on_py3()
 @mock_rds2
 def test_reboot_db_instance():
-    conn = boto.rds2.connect_to_region("us-west-2")
-    conn.create_db_instance(db_instance_identifier='db-master-1',
-                            allocated_storage=10,
-                            engine='postgres',
-                            db_instance_class='db.m1.small',
-                            master_username='root',
-                            master_user_password='hunter2',
-                            db_security_groups=["my_sg"])
-    database = conn.reboot_db_instance('db-master-1')
-    database['RebootDBInstanceResponse']['RebootDBInstanceResult']['DBInstance']['DBInstanceIdentifier'].should.equal("db-master-1")
+    conn = boto3.client('rds', region_name='us-west-2')
+    conn.create_db_instance(DBInstanceIdentifier='db-master-1',
+                            AllocatedStorage=10,
+                            DBInstanceClass='postgres',
+                            Engine='db.m1.small',
+                            MasterUsername='root',
+                            MasterUserPassword='hunter2',
+                            Port=1234,
+                            DBSecurityGroups=['my_sg'])
+    database = conn.reboot_db_instance(DBInstanceIdentifier='db-master-1')
+    database['DBInstance']['DBInstanceIdentifier'].should.equal("db-master-1")
 
 
 @disable_on_py3()
 @mock_rds2
 def test_reboot_non_existant_database():
-    conn = boto.rds2.connect_to_region("us-west-2")
-    conn.reboot_db_instance.when.called_with("not-a-db").should.throw(BotoServerError)
+    conn = boto3.client('rds', region_name='us-west-2')
+    conn.reboot_db_instance.when.called_with(DBInstanceIdentifier="not-a-db").should.throw(ClientError)
 
 
 @disable_on_py3()
 @mock_rds2
 def test_delete_database():
-    conn = boto.rds2.connect_to_region("us-west-2")
+    conn = boto3.client('rds', region_name='us-west-2')
     instances = conn.describe_db_instances()
-    list(instances['DescribeDBInstancesResponse']['DescribeDBInstancesResult']['DBInstances']).should.have.length_of(0)
-    conn.create_db_instance(db_instance_identifier='db-master-1',
-                            allocated_storage=10,
-                            engine='postgres',
-                            db_instance_class='db.m1.small',
-                            master_username='root',
-                            master_user_password='hunter2',
-                            db_security_groups=["my_sg"])
+    list(instances['DBInstances']).should.have.length_of(0)
+    conn.create_db_instance(DBInstanceIdentifier='db-master-1',
+                            AllocatedStorage=10,
+                            DBInstanceClass='postgres',
+                            Engine='db.m1.small',
+                            MasterUsername='root',
+                            MasterUserPassword='hunter2',
+                            Port=1234,
+                            DBSecurityGroups=['my_sg'])
     instances = conn.describe_db_instances()
-    list(instances['DescribeDBInstancesResponse']['DescribeDBInstancesResult']['DBInstances']).should.have.length_of(1)
+    list(instances['DBInstances']).should.have.length_of(1)
 
-    conn.delete_db_instance("db-master-1")
+    conn.delete_db_instance(DBInstanceIdentifier="db-master-1")
     instances = conn.describe_db_instances()
-    list(instances['DescribeDBInstancesResponse']['DescribeDBInstancesResult']['DBInstances']).should.have.length_of(0)
+    list(instances['DBInstances']).should.have.length_of(0)
 
 
 @disable_on_py3()
 @mock_rds2
 def test_delete_non_existant_database():
-    conn = boto.rds2.connect_to_region("us-west-2")
-    conn.delete_db_instance.when.called_with("not-a-db").should.throw(BotoServerError)
+    conn = boto3.client('rds2', region_name="us-west-2")
+    conn.delete_db_instance.when.called_with(DBInstanceIdentifier="not-a-db").should.throw(ClientError)
 
 
 @disable_on_py3()
 @mock_rds2
 def test_create_option_group():
-    conn = boto.rds2.connect_to_region("us-west-2")
-    option_group = conn.create_option_group('test', 'mysql', '5.6', 'test option group')
-    option_group['CreateOptionGroupResponse']['CreateOptionGroupResult']['OptionGroup']['OptionGroupName'].should.equal('test')
-    option_group['CreateOptionGroupResponse']['CreateOptionGroupResult']['OptionGroup']['EngineName'].should.equal('mysql')
-    option_group['CreateOptionGroupResponse']['CreateOptionGroupResult']['OptionGroup']['OptionGroupDescription'].should.equal('test option group')
-    option_group['CreateOptionGroupResponse']['CreateOptionGroupResult']['OptionGroup']['MajorEngineVersion'].should.equal('5.6')
+    conn = boto3.client('rds', region_name='us-west-2')
+    option_group = conn.create_option_group(OptionGroupName='test',
+                                            EngineName='mysql',
+                                            MajorEngineVersion='5.6',
+                                            OptionGroupDescription='test option group')
+    option_group['OptionGroup']['OptionGroupName'].should.equal('test')
+    option_group['OptionGroup']['EngineName'].should.equal('mysql')
+    option_group['OptionGroup']['OptionGroupDescription'].should.equal('test option group')
+    option_group['OptionGroup']['MajorEngineVersion'].should.equal('5.6')
 
 
 @disable_on_py3()
 @mock_rds2
 def test_create_option_group_bad_engine_name():
-    conn = boto.rds2.connect_to_region("us-west-2")
-    conn.create_option_group.when.called_with('test', 'invalid_engine', '5.6', 'test invalid engine').should.throw(BotoServerError)
+    conn = boto3.client('rds', region_name='us-west-2')
+    conn.create_option_group.when.called_with(OptionGroupName='test',
+                                              EngineName='invalid_engine',
+                                              MajorEngineVersion='5.6',
+                                              OptionGroupDescription='test invalid engine').should.throw(ClientError)
 
 
 @disable_on_py3()
 @mock_rds2
 def test_create_option_group_bad_engine_major_version():
-    conn = boto.rds2.connect_to_region("us-west-2")
-    conn.create_option_group.when.called_with('test', 'mysql', '6.6.6', 'test invalid engine version').should.throw(BotoServerError)
+    conn = boto3.client('rds', region_name='us-west-2')
+    conn.create_option_group.when.called_with(OptionGroupName='test',
+                                              EngineName='mysql',
+                                              MajorEngineVersion='6.6.6',
+                                              OptionGroupDescription='test invalid engine version').should.throw(ClientError)
 
 
 @disable_on_py3()
 @mock_rds2
 def test_create_option_group_empty_description():
-    conn = boto.rds2.connect_to_region("us-west-2")
-    conn.create_option_group.when.called_with('test', 'mysql', '5.6', '').should.throw(BotoServerError)
+    conn = boto3.client('rds', region_name='us-west-2')
+    conn.create_option_group.when.called_with(OptionGroupName='test',
+                                              EngineName='mysql',
+                                              MajorEngineVersion='5.6',
+                                              OptionGroupDescription='').should.throw(ClientError)
 
 
 @disable_on_py3()
 @mock_rds2
 def test_create_option_group_duplicate():
-    conn = boto.rds2.connect_to_region("us-west-2")
-    conn.create_option_group('test', 'mysql', '5.6', 'test option group')
-    conn.create_option_group.when.called_with('test', 'mysql', '5.6', 'foo').should.throw(BotoServerError)
+    conn = boto3.client('rds', region_name='us-west-2')
+    conn.create_option_group(OptionGroupName='test',
+                             EngineName='mysql',
+                             MajorEngineVersion='5.6',
+                             OptionGroupDescription='test option group')
+    conn.create_option_group.when.called_with(OptionGroupName='test',
+                                              EngineName='mysql',
+                                              MajorEngineVersion='5.6',
+                                              OptionGroupDescription='test option group').should.throw(ClientError)
 
 
 @disable_on_py3()
 @mock_rds2
 def test_describe_option_group():
-    conn = boto.rds2.connect_to_region("us-west-2")
-    conn.create_option_group('test', 'mysql', '5.6', 'test option group')
-    option_groups = conn.describe_option_groups('test')
-    option_groups['DescribeOptionGroupsResponse']['DescribeOptionGroupsResult']['OptionGroupsList'][0]['OptionGroupName'].should.equal('test')
+    conn = boto3.client('rds', region_name='us-west-2')
+    conn.create_option_group(OptionGroupName='test',
+                             EngineName='mysql',
+                             MajorEngineVersion='5.6',
+                             OptionGroupDescription='test option group')
+    option_groups = conn.describe_option_groups(OptionGroupName='test')
+    option_groups['OptionGroupsList'][0]['OptionGroupName'].should.equal('test')
 
 
 @disable_on_py3()
 @mock_rds2
 def test_describe_non_existant_option_group():
-    conn = boto.rds2.connect_to_region("us-west-2")
-    conn.describe_option_groups.when.called_with("not-a-option-group").should.throw(BotoServerError)
+    conn = boto3.client('rds', region_name='us-west-2')
+    conn.describe_option_groups.when.called_with(OptionGroupName="not-a-option-group").should.throw(ClientError)
 
 
 @disable_on_py3()
 @mock_rds2
 def test_delete_option_group():
-    conn = boto.rds2.connect_to_region("us-west-2")
-    conn.create_option_group('test', 'mysql', '5.6', 'test option group')
-    option_groups = conn.describe_option_groups('test')
-    option_groups['DescribeOptionGroupsResponse']['DescribeOptionGroupsResult']['OptionGroupsList'][0]['OptionGroupName'].should.equal('test')
-    conn.delete_option_group('test')
-    conn.describe_option_groups.when.called_with('test').should.throw(BotoServerError)
+    conn = boto3.client('rds', region_name='us-west-2')
+    conn.create_option_group(OptionGroupName='test',
+                             EngineName='mysql',
+                             MajorEngineVersion='5.6',
+                             OptionGroupDescription='test option group')
+    option_groups = conn.describe_option_groups(OptionGroupName='test')
+    option_groups['OptionGroupsList'][0]['OptionGroupName'].should.equal('test')
+    conn.delete_option_group(OptionGroupName='test')
+    conn.describe_option_groups.when.called_with(OptionGroupName='test').should.throw(ClientError)
 
 
 @disable_on_py3()
 @mock_rds2
 def test_delete_non_existant_option_group():
-    conn = boto.rds2.connect_to_region("us-west-2")
-    conn.delete_option_group.when.called_with('non-existant').should.throw(BotoServerError)
+    conn = boto3.client('rds', region_name='us-west-2')
+    conn.delete_option_group.when.called_with(OptionGroupName='non-existant').should.throw(ClientError)
 
 
 @disable_on_py3()
 @mock_rds2
 def test_describe_option_group_options():
-    conn = boto.rds2.connect_to_region("us-west-2")
-    option_group_options = conn.describe_option_group_options('sqlserver-ee')
-    len(option_group_options['DescribeOptionGroupOptionsResponse']['DescribeOptionGroupOptionsResult']['OptionGroupOptions']).should.equal(4)
-    option_group_options = conn.describe_option_group_options('sqlserver-ee', '11.00')
-    len(option_group_options['DescribeOptionGroupOptionsResponse']['DescribeOptionGroupOptionsResult']['OptionGroupOptions']).should.equal(2)
-    option_group_options = conn.describe_option_group_options('mysql', '5.6')
-    len(option_group_options['DescribeOptionGroupOptionsResponse']['DescribeOptionGroupOptionsResult']['OptionGroupOptions']).should.equal(1)
-    conn.describe_option_group_options.when.called_with('non-existent').should.throw(BotoServerError)
-    conn.describe_option_group_options.when.called_with('mysql', 'non-existent').should.throw(BotoServerError)
+    conn = boto3.client('rds', region_name='us-west-2')
+    option_group_options = conn.describe_option_group_options(EngineName='sqlserver-ee')
+    len(option_group_options['OptionGroupOptions']).should.equal(4)
+    option_group_options = conn.describe_option_group_options(EngineName='sqlserver-ee', MajorEngineVersion='11.00')
+    len(option_group_options['OptionGroupOptions']).should.equal(2)
+    option_group_options = conn.describe_option_group_options(EngineName='mysql', MajorEngineVersion='5.6')
+    len(option_group_options['OptionGroupOptions']).should.equal(1)
+    conn.describe_option_group_options.when.called_with(EngineName='non-existent').should.throw(ClientError)
+    conn.describe_option_group_options.when.called_with(EngineName='mysql', MajorEngineVersion='non-existent').should.throw(ClientError)
 
 
 @disable_on_py3()
 @mock_rds2
 def test_modify_option_group():
-    conn = boto.rds2.connect_to_region("us-west-2")
-    conn.create_option_group('test', 'mysql', '5.6', 'test option group')
+    conn = boto3.client('rds', region_name='us-west-2')
+    conn.create_option_group(OptionGroupName='test', EngineName='mysql', MajorEngineVersion='5.6', OptionGroupDescription='test option group')
     # TODO: create option and validate before deleting.
     # if Someone can tell me how the hell to use this function
     # to add options to an option_group, I can finish coding this.
-    result = conn.modify_option_group('test', [], ['MEMCACHED'], True)
-    result['ModifyOptionGroupResponse']['ModifyOptionGroupResult']['EngineName'].should.equal('mysql')
-    result['ModifyOptionGroupResponse']['ModifyOptionGroupResult']['Options'].should.equal([])
-    result['ModifyOptionGroupResponse']['ModifyOptionGroupResult']['OptionGroupName'].should.equal('test')
+    result = conn.modify_option_group(OptionGroupName='test', OptionsToInclude=[], OptionsToRemove=['MEMCACHED'], ApplyImmediately=True)
+    result['OptionGroup']['EngineName'].should.equal('mysql')
+    result['OptionGroup']['Options'].should.equal([])
+    result['OptionGroup']['OptionGroupName'].should.equal('test')
 
 
 @disable_on_py3()
 @mock_rds2
 def test_modify_option_group_no_options():
-    conn = boto.rds2.connect_to_region("us-west-2")
-    conn.create_option_group('test', 'mysql', '5.6', 'test option group')
-    conn.modify_option_group.when.called_with('test').should.throw(BotoServerError)
+    conn = boto3.client('rds', region_name='us-west-2')
+    conn.create_option_group(OptionGroupName='test', EngineName='mysql', MajorEngineVersion='5.6', OptionGroupDescription='test option group')
+    conn.modify_option_group.when.called_with(OptionGroupName='test').should.throw(ClientError)
 
 
 @disable_on_py3()
 @mock_rds2
 def test_modify_non_existant_option_group():
-    conn = boto.rds2.connect_to_region("us-west-2")
-    conn.modify_option_group.when.called_with('non-existant', [('OptionName', 'Port', 'DBSecurityGroupMemberships', 'VpcSecurityGroupMemberships', 'OptionSettings')]).should.throw(BotoServerError)
+    conn = boto3.client('rds', region_name='us-west-2')
+    conn.modify_option_group.when.called_with(OptionGroupName='non-existant', OptionsToInclude=[('OptionName', 'Port', 'DBSecurityGroupMemberships', 'VpcSecurityGroupMemberships', 'OptionSettings')]).should.throw(ParamValidationError)
 
 
 @disable_on_py3()
 @mock_rds2
 def test_delete_non_existant_database():
-    conn = boto.rds2.connect_to_region("us-west-2")
-    conn.delete_db_instance.when.called_with("not-a-db").should.throw(BotoServerError)
+    conn = boto3.client('rds', region_name='us-west-2')
+    conn.delete_db_instance.when.called_with(DBInstanceIdentifier="not-a-db").should.throw(ClientError)
 
 
 @disable_on_py3()
 @mock_rds2
 def test_list_tags_invalid_arn():
-    conn = boto.rds2.connect_to_region("us-west-2")
-    conn.list_tags_for_resource.when.called_with('arn:aws:rds:bad-arn').should.throw(BotoServerError)
+    conn = boto3.client('rds', region_name='us-west-2')
+    conn.list_tags_for_resource.when.called_with(ResourceName='arn:aws:rds:bad-arn').should.throw(ClientError)
 
 
 @disable_on_py3()
 @mock_rds2
 def test_list_tags_db():
-    conn = boto.rds2.connect_to_region("us-west-2")
-    result = conn.list_tags_for_resource('arn:aws:rds:us-west-2:1234567890:db:foo')
-    result['ListTagsForResourceResponse']['ListTagsForResourceResult']['TagList'].should.equal([])
-    conn.create_db_instance(db_instance_identifier='db-with-tags',
-                            allocated_storage=10,
-                            engine='postgres',
-                            db_instance_class='db.m1.small',
-                            master_username='root',
-                            master_user_password='hunter2',
-                            db_security_groups=["my_sg"],
-                            tags=[('foo', 'bar'), ('foo1', 'bar1')])
-    result = conn.list_tags_for_resource('arn:aws:rds:us-west-2:1234567890:db:db-with-tags')
-    result['ListTagsForResourceResponse']['ListTagsForResourceResult']['TagList'].should.equal([{'Value': 'bar',
-                                                                                                 'Key': 'foo'},
-                                                                                                {'Value': 'bar1',
-                                                                                                 'Key': 'foo1'}])
+    conn = boto3.client('rds', region_name='us-west-2')
+    result = conn.list_tags_for_resource(ResourceName='arn:aws:rds:us-west-2:1234567890:db:foo')
+    result['TagList'].should.equal([])
+    conn.create_db_instance(DBInstanceIdentifier='db-with-tags',
+                            AllocatedStorage=10,
+                            DBInstanceClass='postgres',
+                            Engine='db.m1.small',
+                            MasterUsername='root',
+                            MasterUserPassword='hunter2',
+                            Port=1234,
+                            DBSecurityGroups=['my_sg'],
+                            Tags=[
+                                {
+                                    'Key': 'foo',
+                                    'Value': 'bar',
+                                },
+                                {
+                                    'Key': 'foo1',
+                                    'Value': 'bar1',
+                                },
+                            ])
+    result = conn.list_tags_for_resource(ResourceName='arn:aws:rds:us-west-2:1234567890:db:db-with-tags')
+    result['TagList'].should.equal([{'Value': 'bar',
+                                     'Key': 'foo'},
+                                     {'Value': 'bar1',
+                                      'Key': 'foo1'}])
 
 
 @disable_on_py3()
 @mock_rds2
 def test_add_tags_db():
-    conn = boto.rds2.connect_to_region("us-west-2")
-    conn.create_db_instance(db_instance_identifier='db-without-tags',
-                            allocated_storage=10,
-                            engine='postgres',
-                            db_instance_class='db.m1.small',
-                            master_username='root',
-                            master_user_password='hunter2',
-                            db_security_groups=["my_sg"],
-                            tags=[('foo', 'bar'), ('foo1', 'bar1')])
-    result = conn.list_tags_for_resource('arn:aws:rds:us-west-2:1234567890:db:db-without-tags')
-    list(result['ListTagsForResourceResponse']['ListTagsForResourceResult']['TagList']).should.have.length_of(2)
-    conn.add_tags_to_resource('arn:aws:rds:us-west-2:1234567890:db:db-without-tags',
-                              [('foo', 'fish'), ('foo2', 'bar2')])
-    result = conn.list_tags_for_resource('arn:aws:rds:us-west-2:1234567890:db:db-without-tags')
-    list(result['ListTagsForResourceResponse']['ListTagsForResourceResult']['TagList']).should.have.length_of(3)
+    conn = boto3.client('rds', region_name='us-west-2')
+    conn.create_db_instance(DBInstanceIdentifier='db-without-tags',
+                            AllocatedStorage=10,
+                            DBInstanceClass='postgres',
+                            Engine='db.m1.small',
+                            MasterUsername='root',
+                            MasterUserPassword='hunter2',
+                            Port=1234,
+                            DBSecurityGroups=['my_sg'],
+                            Tags=[
+                                {
+                                    'Key': 'foo',
+                                    'Value': 'bar',
+                                },
+                                {
+                                    'Key': 'foo1',
+                                    'Value': 'bar1',
+                                },
+                            ])
+    result = conn.list_tags_for_resource(ResourceName='arn:aws:rds:us-west-2:1234567890:db:db-without-tags')
+    list(result['TagList']).should.have.length_of(2)
+    conn.add_tags_to_resource(ResourceName='arn:aws:rds:us-west-2:1234567890:db:db-without-tags',
+                              Tags=[
+                                  {
+                                      'Key': 'foo',
+                                      'Value': 'fish',
+                                  },
+                                  {
+                                      'Key': 'foo2',
+                                      'Value': 'bar2',
+                                  },
+                              ])
+    result = conn.list_tags_for_resource(ResourceName='arn:aws:rds:us-west-2:1234567890:db:db-without-tags')
+    list(result['TagList']).should.have.length_of(3)
 
 
 @disable_on_py3()
 @mock_rds2
 def test_remove_tags_db():
-    conn = boto.rds2.connect_to_region("us-west-2")
-    conn.create_db_instance(db_instance_identifier='db-with-tags',
-                            allocated_storage=10,
-                            engine='postgres',
-                            db_instance_class='db.m1.small',
-                            master_username='root',
-                            master_user_password='hunter2',
-                            db_security_groups=["my_sg"],
-                            tags=[('foo', 'bar'), ('foo1', 'bar1')])
-    result = conn.list_tags_for_resource('arn:aws:rds:us-west-2:1234567890:db:db-with-tags')
-    len(result['ListTagsForResourceResponse']['ListTagsForResourceResult']['TagList']).should.equal(2)
-    conn.remove_tags_from_resource('arn:aws:rds:us-west-2:1234567890:db:db-with-tags', ['foo'])
-    result = conn.list_tags_for_resource('arn:aws:rds:us-west-2:1234567890:db:db-with-tags')
-    len(result['ListTagsForResourceResponse']['ListTagsForResourceResult']['TagList']).should.equal(1)
+    conn = boto3.client('rds', region_name='us-west-2')
+    conn.create_db_instance(DBInstanceIdentifier='db-with-tags',
+                            AllocatedStorage=10,
+                            DBInstanceClass='postgres',
+                            Engine='db.m1.small',
+                            MasterUsername='root',
+                            MasterUserPassword='hunter2',
+                            Port=1234,
+                            DBSecurityGroups=['my_sg'],
+                            Tags=[
+                                {
+                                    'Key': 'foo',
+                                    'Value': 'bar',
+                                },
+                                {
+                                    'Key': 'foo1',
+                                    'Value': 'bar1',
+                                },
+                            ])
+    result = conn.list_tags_for_resource(ResourceName='arn:aws:rds:us-west-2:1234567890:db:db-with-tags')
+    list(result['TagList']).should.have.length_of(2)
+    conn.remove_tags_from_resource(ResourceName='arn:aws:rds:us-west-2:1234567890:db:db-with-tags', TagKeys=['foo'])
+    result = conn.list_tags_for_resource(ResourceName='arn:aws:rds:us-west-2:1234567890:db:db-with-tags')
+    len(result['TagList']).should.equal(1)
 
 
 @disable_on_py3()
 @mock_rds2
 def test_add_tags_option_group():
-    conn = boto.rds2.connect_to_region("us-west-2")
-    conn.create_option_group('test', 'mysql', '5.6', 'test option group')
-    result = conn.list_tags_for_resource('arn:aws:rds:us-west-2:1234567890:og:test')
-    list(result['ListTagsForResourceResponse']['ListTagsForResourceResult']['TagList']).should.have.length_of(0)
-    conn.add_tags_to_resource('arn:aws:rds:us-west-2:1234567890:og:test',
-                                       [('foo', 'fish'), ('foo2', 'bar2')])
-    result = conn.list_tags_for_resource('arn:aws:rds:us-west-2:1234567890:og:test')
-    list(result['ListTagsForResourceResponse']['ListTagsForResourceResult']['TagList']).should.have.length_of(2)
+    conn = boto3.client('rds', region_name='us-west-2')
+    conn.create_option_group(OptionGroupName='test',
+                             EngineName='mysql',
+                             MajorEngineVersion='5.6',
+                             OptionGroupDescription='test option group')
+    result = conn.list_tags_for_resource(ResourceName='arn:aws:rds:us-west-2:1234567890:og:test')
+    list(result['TagList']).should.have.length_of(0)
+    conn.add_tags_to_resource(ResourceName='arn:aws:rds:us-west-2:1234567890:og:test',
+                              Tags=[
+                                  {
+                                      'Key': 'foo',
+                                      'Value': 'fish',
+                                  },
+                                  {
+                                      'Key': 'foo2',
+                                      'Value': 'bar2',
+                                  }])
+    result = conn.list_tags_for_resource(ResourceName='arn:aws:rds:us-west-2:1234567890:og:test')
+    list(result['TagList']).should.have.length_of(2)
 
 
 @disable_on_py3()
 @mock_rds2
 def test_remove_tags_option_group():
-    conn = boto.rds2.connect_to_region("us-west-2")
-    conn.create_option_group('test', 'mysql', '5.6', 'test option group')
-    conn.add_tags_to_resource('arn:aws:rds:us-west-2:1234567890:og:test',
-                                       [('foo', 'fish'), ('foo2', 'bar2')])
-    result = conn.list_tags_for_resource('arn:aws:rds:us-west-2:1234567890:og:test')
-    list(result['ListTagsForResourceResponse']['ListTagsForResourceResult']['TagList']).should.have.length_of(2)
-    conn.remove_tags_from_resource('arn:aws:rds:us-west-2:1234567890:og:test',
-                                 ['foo'])
-    result = conn.list_tags_for_resource('arn:aws:rds:us-west-2:1234567890:og:test')
-    list(result['ListTagsForResourceResponse']['ListTagsForResourceResult']['TagList']).should.have.length_of(1)
+    conn = boto3.client('rds', region_name='us-west-2')
+    conn.create_option_group(OptionGroupName='test',
+                             EngineName='mysql',
+                             MajorEngineVersion='5.6',
+                             OptionGroupDescription='test option group')
+    result = conn.list_tags_for_resource(ResourceName='arn:aws:rds:us-west-2:1234567890:og:test')
+    conn.add_tags_to_resource(ResourceName='arn:aws:rds:us-west-2:1234567890:og:test',
+                              Tags=[
+                                  {
+                                      'Key': 'foo',
+                                      'Value': 'fish',
+                                  },
+                                  {
+                                      'Key': 'foo2',
+                                      'Value': 'bar2',
+                                  }])
+    result = conn.list_tags_for_resource(ResourceName='arn:aws:rds:us-west-2:1234567890:og:test')
+    list(result['TagList']).should.have.length_of(2)
+    conn.remove_tags_from_resource(ResourceName='arn:aws:rds:us-west-2:1234567890:og:test',
+                                   TagKeys=['foo'])
+    result = conn.list_tags_for_resource(ResourceName='arn:aws:rds:us-west-2:1234567890:og:test')
+    list(result['TagList']).should.have.length_of(1)
 
 
 @disable_on_py3()
 @mock_rds2
 def test_create_database_security_group():
-    conn = boto.rds2.connect_to_region("us-west-2")
+    conn = boto3.client('rds', region_name='us-west-2')
 
-    result = conn.create_db_security_group('db_sg', 'DB Security Group')
-    result['CreateDBSecurityGroupResponse']['CreateDBSecurityGroupResult']['DBSecurityGroup']['DBSecurityGroupName'].should.equal("db_sg")
-    result['CreateDBSecurityGroupResponse']['CreateDBSecurityGroupResult']['DBSecurityGroup']['DBSecurityGroupDescription'].should.equal("DB Security Group")
-    result['CreateDBSecurityGroupResponse']['CreateDBSecurityGroupResult']['DBSecurityGroup']['IPRanges'].should.equal([])
+    result = conn.create_db_security_group(DBSecurityGroupName='db_sg', DBSecurityGroupDescription='DB Security Group')
+    result['DBSecurityGroup']['DBSecurityGroupName'].should.equal("db_sg")
+    result['DBSecurityGroup']['DBSecurityGroupDescription'].should.equal("DB Security Group")
+    result['DBSecurityGroup']['IPRanges'].should.equal([])
 
 
 @disable_on_py3()
 @mock_rds2
 def test_get_security_groups():
-    conn = boto.rds2.connect_to_region("us-west-2")
+    conn = boto3.client('rds', region_name='us-west-2')
 
     result = conn.describe_db_security_groups()
-    result['DescribeDBSecurityGroupsResponse']['DescribeDBSecurityGroupsResult']['DBSecurityGroups'].should.have.length_of(0)
+    result['DBSecurityGroups'].should.have.length_of(0)
 
-    conn.create_db_security_group('db_sg1', 'DB Security Group')
-    conn.create_db_security_group('db_sg2', 'DB Security Group')
+    conn.create_db_security_group(DBSecurityGroupName='db_sg1', DBSecurityGroupDescription='DB Security Group')
+    conn.create_db_security_group(DBSecurityGroupName='db_sg2', DBSecurityGroupDescription='DB Security Group')
 
     result = conn.describe_db_security_groups()
-    result['DescribeDBSecurityGroupsResponse']['DescribeDBSecurityGroupsResult']['DBSecurityGroups'].should.have.length_of(2)
+    result['DBSecurityGroups'].should.have.length_of(2)
 
-    result = conn.describe_db_security_groups("db_sg1")
-    result['DescribeDBSecurityGroupsResponse']['DescribeDBSecurityGroupsResult']['DBSecurityGroups'].should.have.length_of(1)
-    result['DescribeDBSecurityGroupsResponse']['DescribeDBSecurityGroupsResult']['DBSecurityGroups'][0]['DBSecurityGroupName'].should.equal("db_sg1")
+    result = conn.describe_db_security_groups(DBSecurityGroupName="db_sg1")
+    result['DBSecurityGroups'].should.have.length_of(1)
+    result['DBSecurityGroups'][0]['DBSecurityGroupName'].should.equal("db_sg1")
 
 
 @disable_on_py3()
 @mock_rds2
 def test_get_non_existant_security_group():
-    conn = boto.rds2.connect_to_region("us-west-2")
-    conn.describe_db_security_groups.when.called_with("not-a-sg").should.throw(BotoServerError)
+    conn = boto3.client('rds', region_name='us-west-2')
+    conn.describe_db_security_groups.when.called_with(DBSecurityGroupName="not-a-sg").should.throw(ClientError)
 
 
 @disable_on_py3()
 @mock_rds2
 def test_delete_database_security_group():
-    conn = boto.rds2.connect_to_region("us-west-2")
-    conn.create_db_security_group('db_sg', 'DB Security Group')
+    conn = boto3.client('rds', region_name='us-west-2')
+    conn.create_db_security_group(DBSecurityGroupName='db_sg', DBSecurityGroupDescription='DB Security Group')
 
     result = conn.describe_db_security_groups()
-    result['DescribeDBSecurityGroupsResponse']['DescribeDBSecurityGroupsResult']['DBSecurityGroups'].should.have.length_of(1)
+    result['DBSecurityGroups'].should.have.length_of(1)
 
-    conn.delete_db_security_group("db_sg")
+    conn.delete_db_security_group(DBSecurityGroupName="db_sg")
     result = conn.describe_db_security_groups()
-    result['DescribeDBSecurityGroupsResponse']['DescribeDBSecurityGroupsResult']['DBSecurityGroups'].should.have.length_of(0)
+    result['DBSecurityGroups'].should.have.length_of(0)
 
 
 @disable_on_py3()
 @mock_rds2
 def test_delete_non_existant_security_group():
-    conn = boto.rds2.connect_to_region("us-west-2")
-    conn.delete_db_security_group.when.called_with("not-a-db").should.throw(BotoServerError)
+    conn = boto3.client('rds', region_name='us-west-2')
+    conn.delete_db_security_group.when.called_with(DBSecurityGroupName="not-a-db").should.throw(ClientError)
 
 
 @disable_on_py3()
 @mock_rds2
 def test_security_group_authorize():
-    conn = boto.rds2.connect_to_region("us-west-2")
-    security_group = conn.create_db_security_group('db_sg', 'DB Security Group')
-    security_group['CreateDBSecurityGroupResponse']['CreateDBSecurityGroupResult']['DBSecurityGroup']['IPRanges'].should.equal([])
+    conn = boto3.client('rds', region_name='us-west-2')
+    security_group = conn.create_db_security_group(DBSecurityGroupName='db_sg',
+                                                   DBSecurityGroupDescription='DB Security Group')
+    security_group['DBSecurityGroup']['IPRanges'].should.equal([])
 
 
-    conn.authorize_db_security_group_ingress(db_security_group_name='db_sg',
-                                             cidrip='10.3.2.45/32')
+    conn.authorize_db_security_group_ingress(DBSecurityGroupName='db_sg',
+                                             CIDRIP='10.3.2.45/32')
 
-    result = conn.describe_db_security_groups("db_sg")
-    result['DescribeDBSecurityGroupsResponse']['DescribeDBSecurityGroupsResult']['DBSecurityGroups'][0]['IPRanges'].should.have.length_of(1)
-    result['DescribeDBSecurityGroupsResponse']['DescribeDBSecurityGroupsResult']['DBSecurityGroups'][0]['IPRanges'].should.equal(['10.3.2.45/32'])
+    result = conn.describe_db_security_groups(DBSecurityGroupName="db_sg")
+    result['DBSecurityGroups'][0]['IPRanges'].should.have.length_of(1)
+    result['DBSecurityGroups'][0]['IPRanges'].should.equal([{'Status': 'authorized', 'CIDRIP': '10.3.2.45/32'}])
 
-    conn.authorize_db_security_group_ingress(db_security_group_name='db_sg',
-                                             cidrip='10.3.2.46/32')
-    result = conn.describe_db_security_groups("db_sg")
-    result['DescribeDBSecurityGroupsResponse']['DescribeDBSecurityGroupsResult']['DBSecurityGroups'][0]['IPRanges'].should.have.length_of(2)
-    result['DescribeDBSecurityGroupsResponse']['DescribeDBSecurityGroupsResult']['DBSecurityGroups'][0]['IPRanges'].should.equal(['10.3.2.45/32', '10.3.2.46/32'])
+    conn.authorize_db_security_group_ingress(DBSecurityGroupName='db_sg',
+                                             CIDRIP='10.3.2.46/32')
+    result = conn.describe_db_security_groups(DBSecurityGroupName="db_sg")
+    result['DBSecurityGroups'][0]['IPRanges'].should.have.length_of(2)
+    result['DBSecurityGroups'][0]['IPRanges'].should.equal([
+        {'Status': 'authorized', 'CIDRIP': '10.3.2.45/32'},
+        {'Status': 'authorized', 'CIDRIP': '10.3.2.46/32'},
+    ])
 
 
 @disable_on_py3()
 @mock_rds2
 def test_add_security_group_to_database():
-    conn = boto.rds2.connect_to_region("us-west-2")
+    conn = boto3.client('rds', region_name='us-west-2')
 
-    conn.create_db_instance(db_instance_identifier='db-master-1',
-                            allocated_storage=10,
-                            engine='postgres',
-                            db_instance_class='db.m1.small',
-                            master_username='root',
-                            master_user_password='hunter2')
+    conn.create_db_instance(DBInstanceIdentifier='db-master-1',
+                            AllocatedStorage=10,
+                            DBInstanceClass='postgres',
+                            Engine='db.m1.small',
+                            MasterUsername='root',
+                            MasterUserPassword='hunter2',
+                            Port=1234)
+
     result = conn.describe_db_instances()
-    result['DescribeDBInstancesResponse']['DescribeDBInstancesResult']['DBInstances'][0]['DBSecurityGroups'].should.equal([])
-    conn.create_db_security_group('db_sg', 'DB Security Group')
-    conn.modify_db_instance(db_instance_identifier='db-master-1',
-                            db_security_groups=['db_sg'])
+    result['DBInstances'][0]['DBSecurityGroups'].should.equal([])
+    conn.create_db_security_group(DBSecurityGroupName='db_sg',
+                                  DBSecurityGroupDescription='DB Security Group')
+    conn.modify_db_instance(DBInstanceIdentifier='db-master-1',
+                                  DBSecurityGroups=['db_sg'])
     result = conn.describe_db_instances()
-    result['DescribeDBInstancesResponse']['DescribeDBInstancesResult']['DBInstances'][0]['DBSecurityGroups'][0]['DBSecurityGroup']['DBSecurityGroupName'].should.equal('db_sg')
+    result['DBInstances'][0]['DBSecurityGroups'][0]['DBSecurityGroupName'].should.equal('db_sg')
+
+
+@disable_on_py3()
+@mock_rds2
+def test_list_tags_security_group():
+    conn = boto3.client('rds', region_name='us-west-2')
+    result = conn.describe_db_subnet_groups()
+    result['DBSubnetGroups'].should.have.length_of(0)
+
+    security_group = conn.create_db_security_group(DBSecurityGroupName="db_sg",
+                                                   DBSecurityGroupDescription='DB Security Group',
+                                                   Tags=[{'Value': 'bar',
+                                                          'Key': 'foo'},
+                                                         {'Value': 'bar1',
+                                                          'Key': 'foo1'}])['DBSecurityGroup']['DBSecurityGroupName']
+    resource = 'arn:aws:rds:us-west-2:1234567890:secgrp:{0}'.format(security_group)
+    result = conn.list_tags_for_resource(ResourceName=resource)
+    result['TagList'].should.equal([{'Value': 'bar',
+                                     'Key': 'foo'},
+                                     {'Value': 'bar1',
+                                      'Key': 'foo1'}])
+
+
+@disable_on_py3()
+@mock_rds2
+def test_add_tags_security_group():
+    conn = boto3.client('rds', region_name='us-west-2')
+    result = conn.describe_db_subnet_groups()
+    result['DBSubnetGroups'].should.have.length_of(0)
+
+    security_group = conn.create_db_security_group(DBSecurityGroupName="db_sg",
+                                                   DBSecurityGroupDescription='DB Security Group')['DBSecurityGroup']['DBSecurityGroupName']
+
+    resource = 'arn:aws:rds:us-west-2:1234567890:secgrp:{0}'.format(security_group)
+    conn.add_tags_to_resource(ResourceName=resource,
+                              Tags=[{'Value': 'bar',
+                                     'Key': 'foo'},
+                                    {'Value': 'bar1',
+                                     'Key': 'foo1'}])
+
+    result = conn.list_tags_for_resource(ResourceName=resource)
+    result['TagList'].should.equal([{'Value': 'bar',
+                                     'Key': 'foo'},
+                                     {'Value': 'bar1',
+                                      'Key': 'foo1'}])
+
+@disable_on_py3()
+@mock_rds2
+def test_remove_tags_security_group():
+    conn = boto3.client('rds', region_name='us-west-2')
+    result = conn.describe_db_subnet_groups()
+    result['DBSubnetGroups'].should.have.length_of(0)
+
+    security_group = conn.create_db_security_group(DBSecurityGroupName="db_sg",
+                                                   DBSecurityGroupDescription='DB Security Group',
+                                                   Tags=[{'Value': 'bar',
+                                                          'Key': 'foo'},
+                                                         {'Value': 'bar1',
+                                                          'Key': 'foo1'}])['DBSecurityGroup']['DBSecurityGroupName']
+
+    resource = 'arn:aws:rds:us-west-2:1234567890:secgrp:{0}'.format(security_group)
+    conn.remove_tags_from_resource(ResourceName=resource, TagKeys=['foo'])
+
+    result = conn.list_tags_for_resource(ResourceName=resource)
+    result['TagList'].should.equal([{'Value': 'bar1', 'Key': 'foo1'}])
 
 
 @disable_on_py3()
 @mock_ec2
 @mock_rds2
 def test_create_database_subnet_group():
-    vpc_conn = boto.vpc.connect_to_region("us-west-2")
-    vpc = vpc_conn.create_vpc("10.0.0.0/16")
-    subnet1 = vpc_conn.create_subnet(vpc.id, "10.1.0.0/24")
-    subnet2 = vpc_conn.create_subnet(vpc.id, "10.2.0.0/24")
+    vpc_conn = boto3.client('ec2', 'us-west-2')
+    vpc = vpc_conn.create_vpc(CidrBlock='10.0.0.0/16')['Vpc']
+    subnet1 = vpc_conn.create_subnet(VpcId=vpc['VpcId'], CidrBlock='10.1.0.0/24')['Subnet']
+    subnet2 = vpc_conn.create_subnet(VpcId=vpc['VpcId'], CidrBlock='10.1.0.0/26')['Subnet']
 
-    subnet_ids = [subnet1.id, subnet2.id]
-    conn = boto.rds2.connect_to_region("us-west-2")
-    result = conn.create_db_subnet_group("db_subnet", "my db subnet", subnet_ids)
-    result['CreateDBSubnetGroupResponse']['CreateDBSubnetGroupResult']['DBSubnetGroup']['DBSubnetGroupName'].should.equal("db_subnet")
-    result['CreateDBSubnetGroupResponse']['CreateDBSubnetGroupResult']['DBSubnetGroup']['DBSubnetGroupDescription'].should.equal("my db subnet")
-    subnets = result['CreateDBSubnetGroupResponse']['CreateDBSubnetGroupResult']['DBSubnetGroup']['Subnets']
-    subnet_group_ids = [subnets['Subnet'][0]['SubnetIdentifier'], subnets['Subnet'][1]['SubnetIdentifier']]
+    subnet_ids = [subnet1['SubnetId'], subnet2['SubnetId']]
+    conn = boto3.client('rds', region_name='us-west-2')
+    result = conn.create_db_subnet_group(DBSubnetGroupName='db_subnet',
+                                         DBSubnetGroupDescription='my db subnet',
+                                         SubnetIds=subnet_ids)
+    result['DBSubnetGroup']['DBSubnetGroupName'].should.equal("db_subnet")
+    result['DBSubnetGroup']['DBSubnetGroupDescription'].should.equal("my db subnet")
+    subnets = result['DBSubnetGroup']['Subnets']
+    subnet_group_ids = [subnets[0]['SubnetIdentifier'], subnets[1]['SubnetIdentifier']]
     list(subnet_group_ids).should.equal(subnet_ids)
 
 
@@ -482,96 +651,370 @@ def test_create_database_subnet_group():
 @mock_ec2
 @mock_rds2
 def test_create_database_in_subnet_group():
-    vpc_conn = boto.vpc.connect_to_region("us-west-2")
-    vpc = vpc_conn.create_vpc("10.0.0.0/16")
-    subnet = vpc_conn.create_subnet(vpc.id, "10.1.0.0/24")
+    vpc_conn = boto3.client('ec2', 'us-west-2')
+    vpc = vpc_conn.create_vpc(CidrBlock='10.0.0.0/16')['Vpc']
+    subnet = vpc_conn.create_subnet(VpcId=vpc['VpcId'], CidrBlock='10.1.0.0/24')['Subnet']
 
-    conn = boto.rds2.connect_to_region("us-west-2")
-    conn.create_db_subnet_group("db_subnet1", "my db subnet", [subnet.id])
-    conn.create_db_instance(db_instance_identifier='db-master-1',
-                            allocated_storage=10,
-                            engine='postgres',
-                            db_instance_class='db.m1.small',
-                            master_username='root',
-                            master_user_password='hunter2',
-                            db_subnet_group_name='db_subnet1')
-    result = conn.describe_db_instances("db-master-1")
-    result['DescribeDBInstancesResponse']['DescribeDBInstancesResult']['DBInstances'][0]['DBSubnetGroup']['DBSubnetGroupName'].should.equal("db_subnet1")
+    conn = boto3.client('rds', region_name='us-west-2')
+    conn.create_db_subnet_group(DBSubnetGroupName='db_subnet1',
+                                DBSubnetGroupDescription='my db subnet',
+                                SubnetIds=[subnet['SubnetId']])
+    conn.create_db_instance(DBInstanceIdentifier='db-master-1',
+                            AllocatedStorage=10,
+                            Engine='postgres',
+                            DBInstanceClass='db.m1.small',
+                            MasterUsername='root',
+                            MasterUserPassword='hunter2',
+                            Port=1234,
+                            DBSubnetGroupName='db_subnet1')
+    result = conn.describe_db_instances(DBInstanceIdentifier='db-master-1')
+    result['DBInstances'][0]['DBSubnetGroup']['DBSubnetGroupName'].should.equal('db_subnet1')
 
 
 @disable_on_py3()
 @mock_ec2
 @mock_rds2
 def test_describe_database_subnet_group():
-   vpc_conn = boto.vpc.connect_to_region("us-west-2")
-   vpc = vpc_conn.create_vpc("10.0.0.0/16")
-   subnet = vpc_conn.create_subnet(vpc.id, "10.1.0.0/24")
+    vpc_conn = boto3.client('ec2', 'us-west-2')
+    vpc = vpc_conn.create_vpc(CidrBlock='10.0.0.0/16')['Vpc']
+    subnet = vpc_conn.create_subnet(VpcId=vpc['VpcId'], CidrBlock='10.1.0.0/24')['Subnet']
 
-   conn = boto.rds2.connect_to_region("us-west-2")
-   conn.create_db_subnet_group("db_subnet1", "my db subnet", [subnet.id])
-   conn.create_db_subnet_group("db_subnet2", "my db subnet", [subnet.id])
+    conn = boto3.client('rds', region_name='us-west-2')
+    conn.create_db_subnet_group(DBSubnetGroupName="db_subnet1",
+                                DBSubnetGroupDescription='my db subnet',
+                                SubnetIds=[subnet['SubnetId']])
+    conn.create_db_subnet_group(DBSubnetGroupName='db_subnet2',
+                                DBSubnetGroupDescription='my db subnet',
+                                SubnetIds=[subnet['SubnetId']])
 
-   resp = conn.describe_db_subnet_groups()
-   groups_resp = resp['DescribeDBSubnetGroupsResponse']
+    resp = conn.describe_db_subnet_groups()
+    resp['DBSubnetGroups'].should.have.length_of(2)
 
-   subnet_groups = groups_resp['DescribeDBSubnetGroupsResult']['DBSubnetGroups']
-   subnet_groups.should.have.length_of(2)
+    subnets = resp['DBSubnetGroups'][0]['Subnets']
+    subnets.should.have.length_of(1)
 
-   subnets = groups_resp['DescribeDBSubnetGroupsResult']['DBSubnetGroups'][0]['DBSubnetGroup']['Subnets']
-   subnets.should.have.length_of(1)
+    list(conn.describe_db_subnet_groups(DBSubnetGroupName="db_subnet1")['DBSubnetGroups']).should.have.length_of(1)
 
-   list(resp).should.have.length_of(1)
-   list(groups_resp).should.have.length_of(2)
-   list(conn.describe_db_subnet_groups("db_subnet1")).should.have.length_of(1)
-
-   conn.describe_db_subnet_groups.when.called_with("not-a-subnet").should.throw(BotoServerError)
+    conn.describe_db_subnet_groups.when.called_with(DBSubnetGroupName="not-a-subnet").should.throw(ClientError)
 
 
 @disable_on_py3()
 @mock_ec2
 @mock_rds2
 def test_delete_database_subnet_group():
-    vpc_conn = boto.vpc.connect_to_region("us-west-2")
-    vpc = vpc_conn.create_vpc("10.0.0.0/16")
-    subnet = vpc_conn.create_subnet(vpc.id, "10.1.0.0/24")
+    vpc_conn = boto3.client('ec2', 'us-west-2')
+    vpc = vpc_conn.create_vpc(CidrBlock='10.0.0.0/16')['Vpc']
+    subnet = vpc_conn.create_subnet(VpcId=vpc['VpcId'], CidrBlock='10.1.0.0/24')['Subnet']
 
-    conn = boto.rds2.connect_to_region("us-west-2")
+    conn = boto3.client('rds', region_name='us-west-2')
     result = conn.describe_db_subnet_groups()
-    result['DescribeDBSubnetGroupsResponse']['DescribeDBSubnetGroupsResult']['DBSubnetGroups'].should.have.length_of(0)
+    result['DBSubnetGroups'].should.have.length_of(0)
 
-    conn.create_db_subnet_group("db_subnet1", "my db subnet", [subnet.id])
+    conn.create_db_subnet_group(DBSubnetGroupName="db_subnet1",
+                                DBSubnetGroupDescription='my db subnet',
+                                SubnetIds=[subnet['SubnetId']])
     result = conn.describe_db_subnet_groups()
-    result['DescribeDBSubnetGroupsResponse']['DescribeDBSubnetGroupsResult']['DBSubnetGroups'].should.have.length_of(1)
+    result['DBSubnetGroups'].should.have.length_of(1)
 
-    conn.delete_db_subnet_group("db_subnet1")
+    conn.delete_db_subnet_group(DBSubnetGroupName="db_subnet1")
     result = conn.describe_db_subnet_groups()
-    result['DescribeDBSubnetGroupsResponse']['DescribeDBSubnetGroupsResult']['DBSubnetGroups'].should.have.length_of(0)
+    result['DBSubnetGroups'].should.have.length_of(0)
 
-    conn.delete_db_subnet_group.when.called_with("db_subnet1").should.throw(BotoServerError)
+    conn.delete_db_subnet_group.when.called_with(DBSubnetGroupName="db_subnet1").should.throw(ClientError)
+
+
+@disable_on_py3()
+@mock_ec2
+@mock_rds2
+def test_list_tags_database_subnet_group():
+    vpc_conn = boto3.client('ec2', 'us-west-2')
+    vpc = vpc_conn.create_vpc(CidrBlock='10.0.0.0/16')['Vpc']
+    subnet = vpc_conn.create_subnet(VpcId=vpc['VpcId'], CidrBlock='10.1.0.0/24')['Subnet']
+
+    conn = boto3.client('rds', region_name='us-west-2')
+    result = conn.describe_db_subnet_groups()
+    result['DBSubnetGroups'].should.have.length_of(0)
+
+    subnet = conn.create_db_subnet_group(DBSubnetGroupName="db_subnet1",
+                                         DBSubnetGroupDescription='my db subnet',
+                                         SubnetIds=[subnet['SubnetId']],
+                                         Tags=[{'Value': 'bar',
+                                                'Key': 'foo'},
+                                               {'Value': 'bar1',
+                                                'Key': 'foo1'}])['DBSubnetGroup']['DBSubnetGroupName']
+    result = conn.list_tags_for_resource(ResourceName='arn:aws:rds:us-west-2:1234567890:subgrp:{0}'.format(subnet))
+    result['TagList'].should.equal([{'Value': 'bar',
+                                     'Key': 'foo'},
+                                     {'Value': 'bar1',
+                                      'Key': 'foo1'}])
+
+@disable_on_py3()
+@mock_ec2
+@mock_rds2
+def test_add_tags_database_subnet_group():
+    vpc_conn = boto3.client('ec2', 'us-west-2')
+    vpc = vpc_conn.create_vpc(CidrBlock='10.0.0.0/16')['Vpc']
+    subnet = vpc_conn.create_subnet(VpcId=vpc['VpcId'], CidrBlock='10.1.0.0/24')['Subnet']
+
+    conn = boto3.client('rds', region_name='us-west-2')
+    result = conn.describe_db_subnet_groups()
+    result['DBSubnetGroups'].should.have.length_of(0)
+
+    subnet = conn.create_db_subnet_group(DBSubnetGroupName="db_subnet1",
+                                         DBSubnetGroupDescription='my db subnet',
+                                         SubnetIds=[subnet['SubnetId']],
+                                         Tags=[])['DBSubnetGroup']['DBSubnetGroupName']
+    resource = 'arn:aws:rds:us-west-2:1234567890:subgrp:{0}'.format(subnet)
+
+    conn.add_tags_to_resource(ResourceName=resource,
+                              Tags=[{'Value': 'bar',
+                                     'Key': 'foo'},
+                                    {'Value': 'bar1',
+                                     'Key': 'foo1'}])
+
+    result = conn.list_tags_for_resource(ResourceName=resource)
+    result['TagList'].should.equal([{'Value': 'bar',
+                                     'Key': 'foo'},
+                                     {'Value': 'bar1',
+                                      'Key': 'foo1'}])
+
+@disable_on_py3()
+@mock_ec2
+@mock_rds2
+def test_remove_tags_database_subnet_group():
+    vpc_conn = boto3.client('ec2', 'us-west-2')
+    vpc = vpc_conn.create_vpc(CidrBlock='10.0.0.0/16')['Vpc']
+    subnet = vpc_conn.create_subnet(VpcId=vpc['VpcId'], CidrBlock='10.1.0.0/24')['Subnet']
+
+    conn = boto3.client('rds', region_name='us-west-2')
+    result = conn.describe_db_subnet_groups()
+    result['DBSubnetGroups'].should.have.length_of(0)
+
+    subnet = conn.create_db_subnet_group(DBSubnetGroupName="db_subnet1",
+                                         DBSubnetGroupDescription='my db subnet',
+                                         SubnetIds=[subnet['SubnetId']],
+                                         Tags=[{'Value': 'bar',
+                                                'Key': 'foo'},
+                                               {'Value': 'bar1',
+                                                'Key': 'foo1'}])['DBSubnetGroup']['DBSubnetGroupName']
+    resource = 'arn:aws:rds:us-west-2:1234567890:subgrp:{0}'.format(subnet)
+
+    conn.remove_tags_from_resource(ResourceName=resource, TagKeys=['foo'])
+
+    result = conn.list_tags_for_resource(ResourceName=resource)
+    result['TagList'].should.equal([{'Value': 'bar1', 'Key': 'foo1'}])
 
 
 @disable_on_py3()
 @mock_rds2
 def test_create_database_replica():
-    conn = boto.rds2.connect_to_region("us-west-2")
+    conn = boto3.client('rds', region_name='us-west-2')
 
-    conn.create_db_instance(db_instance_identifier='db-master-1',
-                            allocated_storage=10,
-                            engine='postgres',
-                            db_instance_class='db.m1.small',
-                            master_username='root',
-                            master_user_password='hunter2',
-                            db_security_groups=["my_sg"])
+    database = conn.create_db_instance(DBInstanceIdentifier='db-master-1',
+                                       AllocatedStorage=10,
+                                       Engine='postgres',
+                                       DBInstanceClass='db.m1.small',
+                                       MasterUsername='root',
+                                       MasterUserPassword='hunter2',
+                                       Port=1234,
+                                       DBSecurityGroups=["my_sg"])
 
-    replica = conn.create_db_instance_read_replica("db-replica-1", "db-master-1", "db.m1.small")
-    replica['CreateDBInstanceReadReplicaResponse']['CreateDBInstanceReadReplicaResult']['DBInstance']['ReadReplicaSourceDBInstanceIdentifier'].should.equal('db-master-1')
-    replica['CreateDBInstanceReadReplicaResponse']['CreateDBInstanceReadReplicaResult']['DBInstance']['DBInstanceClass'].should.equal('db.m1.small')
-    replica['CreateDBInstanceReadReplicaResponse']['CreateDBInstanceReadReplicaResult']['DBInstance']['DBInstanceIdentifier'].should.equal('db-replica-1')
+    replica = conn.create_db_instance_read_replica(DBInstanceIdentifier="db-replica-1",
+                                                   SourceDBInstanceIdentifier="db-master-1",
+                                                   DBInstanceClass="db.m1.small")
+    replica['DBInstance']['ReadReplicaSourceDBInstanceIdentifier'].should.equal('db-master-1')
+    replica['DBInstance']['DBInstanceClass'].should.equal('db.m1.small')
+    replica['DBInstance']['DBInstanceIdentifier'].should.equal('db-replica-1')
 
-    master = conn.describe_db_instances("db-master-1")
-    master['DescribeDBInstancesResponse']['DescribeDBInstancesResult']['DBInstances'][0]['ReadReplicaDBInstanceIdentifiers'].should.equal(['db-replica-1'])
+    master = conn.describe_db_instances(DBInstanceIdentifier="db-master-1")
+    master['DBInstances'][0]['ReadReplicaDBInstanceIdentifiers'].should.equal(['db-replica-1'])
 
-    conn.delete_db_instance("db-replica-1")
+    conn.delete_db_instance(DBInstanceIdentifier="db-replica-1", SkipFinalSnapshot=True)
 
-    master = conn.describe_db_instances("db-master-1")
-    master['DescribeDBInstancesResponse']['DescribeDBInstancesResult']['DBInstances'][0]['ReadReplicaDBInstanceIdentifiers'].should.equal([])
+    master = conn.describe_db_instances(DBInstanceIdentifier="db-master-1")
+    master['DBInstances'][0]['ReadReplicaDBInstanceIdentifiers'].should.equal([])
+
+@disable_on_py3()
+@mock_rds2
+@mock_kms
+def test_create_database_with_encrypted_storage():
+    kms_conn = boto3.client('kms', region_name='us-west-2')
+    key = kms_conn.create_key(Policy='my RDS encryption policy',
+                              Description='RDS encryption key',
+                              KeyUsage='ENCRYPT_DECRYPT')
+
+    conn = boto3.client('rds', region_name='us-west-2')
+    database = conn.create_db_instance(DBInstanceIdentifier='db-master-1',
+                                       AllocatedStorage=10,
+                                       Engine='postgres',
+                                       DBInstanceClass='db.m1.small',
+                                       MasterUsername='root',
+                                       MasterUserPassword='hunter2',
+                                       Port=1234,
+                                       DBSecurityGroups=["my_sg"],
+                                       StorageEncrypted=True,
+                                       KmsKeyId=key['KeyMetadata']['KeyId'])
+
+    database['DBInstance']['StorageEncrypted'].should.equal(True)
+    database['DBInstance']['KmsKeyId'].should.equal(key['KeyMetadata']['KeyId'])
+
+@disable_on_py3()
+@mock_rds2
+def test_create_db_parameter_group():
+    conn = boto3.client('rds', region_name='us-west-2')
+    db_parameter_group = conn.create_db_parameter_group(DBParameterGroupName='test',
+                                                     DBParameterGroupFamily='mysql5.6',
+                                                     Description='test parameter group')
+
+    db_parameter_group['DBParameterGroup']['DBParameterGroupName'].should.equal('test')
+    db_parameter_group['DBParameterGroup']['DBParameterGroupFamily'].should.equal('mysql5.6')
+    db_parameter_group['DBParameterGroup']['Description'].should.equal('test parameter group')
+
+@disable_on_py3()
+@mock_rds2
+def test_create_db_instance_with_parameter_group():
+    conn = boto3.client('rds', region_name='us-west-2')
+    db_parameter_group = conn.create_db_parameter_group(DBParameterGroupName='test',
+                                                        DBParameterGroupFamily='mysql5.6',
+                                                        Description='test parameter group')
+
+    database = conn.create_db_instance(DBInstanceIdentifier='db-master-1',
+                                       AllocatedStorage=10,
+                                       Engine='mysql',
+                                       DBInstanceClass='db.m1.small',
+                                       DBParameterGroupName='test',
+                                       MasterUsername='root',
+                                       MasterUserPassword='hunter2',
+                                       Port=1234)
+
+    len(database['DBInstance']['DBParameterGroups']).should.equal(1)
+    database['DBInstance']['DBParameterGroups'][0]['DBParameterGroupName'].should.equal('test')
+    database['DBInstance']['DBParameterGroups'][0]['ParameterApplyStatus'].should.equal('in-sync')
+
+@disable_on_py3()
+@mock_rds2
+def test_modify_db_instance_with_parameter_group():
+    conn = boto3.client('rds', region_name='us-west-2')
+    database = conn.create_db_instance(DBInstanceIdentifier='db-master-1',
+                                       AllocatedStorage=10,
+                                       Engine='mysql',
+                                       DBInstanceClass='db.m1.small',
+                                       MasterUsername='root',
+                                       MasterUserPassword='hunter2',
+                                       Port=1234)
+
+    len(database['DBInstance']['DBParameterGroups']).should.equal(1)
+    database['DBInstance']['DBParameterGroups'][0]['DBParameterGroupName'].should.equal('default.mysql5.6')
+    database['DBInstance']['DBParameterGroups'][0]['ParameterApplyStatus'].should.equal('in-sync')
+
+    db_parameter_group = conn.create_db_parameter_group(DBParameterGroupName='test',
+                                                        DBParameterGroupFamily='mysql5.6',
+                                                        Description='test parameter group')
+    conn.modify_db_instance(DBInstanceIdentifier='db-master-1',
+                            DBParameterGroupName='test',
+                            ApplyImmediately=True)
+
+    database = conn.describe_db_instances(DBInstanceIdentifier='db-master-1')['DBInstances'][0]
+    len(database['DBParameterGroups']).should.equal(1)
+    database['DBParameterGroups'][0]['DBParameterGroupName'].should.equal('test')
+    database['DBParameterGroups'][0]['ParameterApplyStatus'].should.equal('in-sync')
+
+
+@disable_on_py3()
+@mock_rds2
+def test_create_db_parameter_group_empty_description():
+    conn = boto3.client('rds', region_name='us-west-2')
+    conn.create_db_parameter_group.when.called_with(DBParameterGroupName='test',
+                                                    DBParameterGroupFamily='mysql5.6',
+                                                    Description='').should.throw(ClientError)
+
+
+@disable_on_py3()
+@mock_rds2
+def test_create_db_parameter_group_duplicate():
+    conn = boto3.client('rds', region_name='us-west-2')
+    conn.create_db_parameter_group(DBParameterGroupName='test',
+                                   DBParameterGroupFamily='mysql5.6',
+                                   Description='test parameter group')
+    conn.create_db_parameter_group.when.called_with(DBParameterGroupName='test',
+                                                    DBParameterGroupFamily='mysql5.6',
+                                                    Description='test parameter group').should.throw(ClientError)
+
+
+@disable_on_py3()
+@mock_rds2
+def test_describe_db_parameter_group():
+    conn = boto3.client('rds', region_name='us-west-2')
+    conn.create_db_parameter_group(DBParameterGroupName='test',
+                                   DBParameterGroupFamily='mysql5.6',
+                                   Description='test parameter group')
+    db_parameter_groups = conn.describe_db_parameter_groups(DBParameterGroupName='test')
+    db_parameter_groups['DBParameterGroups'][0]['DBParameterGroupName'].should.equal('test')
+
+
+@disable_on_py3()
+@mock_rds2
+def test_describe_non_existant_db_parameter_group():
+    conn = boto3.client('rds', region_name='us-west-2')
+    db_parameter_groups = conn.describe_db_parameter_groups(DBParameterGroupName='test')
+    len(db_parameter_groups['DBParameterGroups']).should.equal(0)
+
+
+@disable_on_py3()
+@mock_rds2
+def test_delete_db_parameter_group():
+    conn = boto3.client('rds', region_name='us-west-2')
+    conn.create_db_parameter_group(DBParameterGroupName='test',
+                             DBParameterGroupFamily='mysql5.6',
+                             Description='test parameter group')
+    db_parameter_groups = conn.describe_db_parameter_groups(DBParameterGroupName='test')
+    db_parameter_groups['DBParameterGroups'][0]['DBParameterGroupName'].should.equal('test')
+    conn.delete_db_parameter_group(DBParameterGroupName='test')
+    db_parameter_groups = conn.describe_db_parameter_groups(DBParameterGroupName='test')
+    len(db_parameter_groups['DBParameterGroups']).should.equal(0)
+
+@disable_on_py3()
+@mock_rds2
+def test_modify_db_parameter_group():
+    conn = boto3.client('rds', region_name='us-west-2')
+    conn.create_db_parameter_group(DBParameterGroupName='test',
+                                   DBParameterGroupFamily='mysql5.6',
+                                   Description='test parameter group')
+
+    modify_result = conn.modify_db_parameter_group(DBParameterGroupName='test',
+                                                   Parameters=[{
+                                                       'ParameterName': 'foo',
+                                                       'ParameterValue': 'foo_val',
+                                                       'Description': 'test param',
+                                                       'ApplyMethod': 'immediate'
+                                                   }]
+                                                  )
+
+    modify_result['DBParameterGroupName'].should.equal('test')
+
+    db_parameters = conn.describe_db_parameters(DBParameterGroupName='test')
+    db_parameters['Parameters'][0]['ParameterName'].should.equal('foo')
+    db_parameters['Parameters'][0]['ParameterValue'].should.equal('foo_val')
+    db_parameters['Parameters'][0]['Description'].should.equal('test param')
+    db_parameters['Parameters'][0]['ApplyMethod'].should.equal('immediate')
+
+
+@disable_on_py3()
+@mock_rds2
+def test_delete_non_existant_db_parameter_group():
+    conn = boto3.client('rds', region_name='us-west-2')
+    conn.delete_db_parameter_group.when.called_with(DBParameterGroupName='non-existant').should.throw(ClientError)
+
+@disable_on_py3()
+@mock_rds2
+def test_create_parameter_group_with_tags():
+    conn = boto3.client('rds', region_name='us-west-2')
+    conn.create_db_parameter_group(DBParameterGroupName='test',
+                                   DBParameterGroupFamily='mysql5.6',
+                                   Description='test parameter group',
+                                   Tags=[{
+                                      'Key': 'foo',
+                                      'Value': 'bar',
+                                   }])
+    result = conn.list_tags_for_resource(ResourceName='arn:aws:rds:us-west-2:1234567890:pg:test')
+    result['TagList'].should.equal([{'Value': 'bar', 'Key': 'foo'}])


### PR DESCRIPTION
We need to mock out deploying RDS instances with full disk encryption
and detailed tagging. We also need to be able do deploy these instances
with Cloudformation, and then access them with both boto and boto3.
The following changes were made to support this use case:

* Join RDS and RDS2 backends - this makes RDS resources created via
  either of the two boto RDS APIs visible to both, more closely
  mirroring how AWS works
* Fix RDS responses that were returning JSON but should be returning XML
* Add mocking of RDS Cloudformation calls
* Add mocking of RDS full disk encryption with KMS
* Add mocking of RDS DBParameterGroups
* Fix mocking of RDS DBSecurityGroupIngress rules
* Make mocking of RDS OptionGroupOptions more accurate
* Fix mocking of RDS cross-region DB replication
* Add tag support to RDS:
  * DBs
  * DBSubnetGroups
  * DBSecurityGroups

@ritsok and @2rs2ts helped with this work!