### PR TITLE
Use a sane aws sender_id in SQS.

### DIFF
--- a/moto/sqs/models.py
+++ b/moto/sqs/models.py
@@ -16,7 +16,7 @@ from .exceptions import (
 )
 
 DEFAULT_ACCOUNT_ID = 123456789012
-
+DEFAULT_SENDER_ID = "AIDAIT2UOQQY3AUEKVGXU"
 
 class Message(object):
     def __init__(self, message_id, body):
@@ -24,7 +24,7 @@ class Message(object):
         self._body = body
         self.message_attributes = {}
         self.receipt_handle = None
-        self.sender_id = DEFAULT_ACCOUNT_ID
+        self.sender_id = DEFAULT_SENDER_ID
         self.sent_timestamp = None
         self.approximate_first_receive_timestamp = None
         self.approximate_receive_count = 0


### PR DESCRIPTION
SQS SenderId does actually have a format to use from a bit of trial and error (there's still more services to go for testing).   I've inserted the "autoscale" type of format.  Ideally in future, decorator could take arguments to set some of the variables.

Format is as follows for services I use so-far:
SQS SenderID:
AIDAIT2UOQQY3AUEKVGXU  (autoscale)
AROAIL6GAI2XEC672SWG2:awslambda_39_20161007224708400   (lambda)
AROAIL6GAI2XEC672SWG2:i-12345678901234567 (send from an ec2 instance)


Sample regex:
    
   ```
aws_re1 = "(?P<awsid>[A-Za-z0-9]{21})(:((?P<instance>i-[a-fA-F0-9]{17})|(?P<lambda>awslambda_[0-9]{2}_(?P<year>(?:19|20)\d\d)"
        
   aws_re2 = "(?P<month>0[1-9]|1[012])(?P<day>0[1-9]|[12][0-9]|3[01])(?P<hour>[0-2][0-9])(?P<mins>[0-5][0-9])(?P<seconds>[0-5][0-9])(?P<nano>[0-9][0-9][0-9]))))?"
        
   aws_rg = regex_compile(aws_re1 + aws_re2, IGNORECASE | DOTALL)
        
   search = aws_rg.search(sender_id)
       
   awsid = search.group('awsid')
       
   sender_instance_id = search.group('instance')
```
