### PR TITLE
Add service ARNs support to the `DescribeServices` ECS API

### DIFF
--- a/moto/ecs/models.py
+++ b/moto/ecs/models.py
@@ -361,14 +361,15 @@ class EC2ContainerServiceBackend(BaseBackend):
                 service_arns.append(self.services[key].arn)
         return sorted(service_arns)
 
-    def describe_services(self, cluster_str, service_names):
+    def describe_services(self, cluster_str, service_names_or_arns):
         cluster_name = cluster_str.split('/')[-1]
-        services = []
-        for service_name in service_names:
-            cluster_service_pair = '{0}:{1}'.format(cluster_name, service_name)
-            if cluster_service_pair in self.services:
-                services.append(self.services[cluster_service_pair])
-        return services
+        result = []
+        for existing_service_name, existing_service_obj in sorted(self.services.items()):
+            for requested_name_or_arn in service_names_or_arns:
+                cluster_service_pair = '{0}:{1}'.format(cluster_name, requested_name_or_arn)
+                if cluster_service_pair == existing_service_name or existing_service_obj.arn == requested_name_or_arn:
+                    result.append(existing_service_obj)
+        return result
 
     def update_service(self, cluster_str, service_name, task_definition_str, desired_count):
         cluster_name = cluster_str.split('/')[-1]

--- a/tests/test_ecs/test_ecs_boto3.py
+++ b/tests/test_ecs/test_ecs_boto3.py
@@ -355,7 +355,7 @@ def test_describe_services():
     )
     response = client.describe_services(
         cluster='test_ecs_cluster',
-        services=['test_ecs_service1', 'test_ecs_service2']
+        services=['test_ecs_service1', 'arn:aws:ecs:us-east-1:012345678910:service/test_ecs_service2']
     )
     len(response['services']).should.equal(2)
     response['services'][0]['serviceArn'].should.equal('arn:aws:ecs:us-east-1:012345678910:service/test_ecs_service1')


### PR DESCRIPTION
Before this PR, moto only worked with service names, but AWS also supports service ARNs.