### PR TITLE
Adding PolicyType to scaling policy and implementing filtering in describe_policies

### DIFF
--- a/moto/autoscaling/models.py
+++ b/moto/autoscaling/models.py
@@ -16,9 +16,10 @@ class InstanceState(object):
 
 
 class FakeScalingPolicy(object):
-    def __init__(self, name, adjustment_type, as_name, scaling_adjustment,
+    def __init__(self, name, policy_type, adjustment_type, as_name, scaling_adjustment,
                  cooldown, autoscaling_backend):
         self.name = name
+        self.policy_type = policy_type
         self.adjustment_type = adjustment_type
         self.as_name = as_name
         self.scaling_adjustment = scaling_adjustment
@@ -407,9 +408,9 @@ class AutoScalingBackend(BaseBackend):
             desired_capacity = int(desired_capacity)
         self.set_desired_capacity(group_name, desired_capacity)
 
-    def create_autoscaling_policy(self, name, adjustment_type, as_name,
+    def create_autoscaling_policy(self, name, policy_type, adjustment_type, as_name,
                                   scaling_adjustment, cooldown):
-        policy = FakeScalingPolicy(name, adjustment_type, as_name,
+        policy = FakeScalingPolicy(name, policy_type, adjustment_type, as_name,
                                    scaling_adjustment, cooldown, self)
 
         self.policies[name] = policy

--- a/moto/autoscaling/models.py
+++ b/moto/autoscaling/models.py
@@ -416,8 +416,11 @@ class AutoScalingBackend(BaseBackend):
         self.policies[name] = policy
         return policy
 
-    def describe_policies(self):
-        return list(self.policies.values())
+    def describe_policies(self, autoscaling_group_name=None, policy_names=None, policy_types=None):
+        return [policy for policy in self.policies.values()
+                if (not autoscaling_group_name or policy.as_name == autoscaling_group_name) and
+                    (not policy_names or policy.name in policy_names) and
+                    (not policy_types or policy.policy_type in policy_types)]
 
     def delete_policy(self, group_name):
         self.policies.pop(group_name, None)

--- a/moto/autoscaling/responses.py
+++ b/moto/autoscaling/responses.py
@@ -130,7 +130,10 @@ class AutoScalingResponse(BaseResponse):
         return template.render(policy=policy)
 
     def describe_policies(self):
-        policies = self.autoscaling_backend.describe_policies()
+        policies = self.autoscaling_backend.describe_policies(
+            autoscaling_group_name=self._get_param('AutoScalingGroupName'),
+            policy_names=self._get_multi_param('PolicyNames.member'),
+            policy_types=self._get_multi_param('PolicyTypes.member'))
         template = self.response_template(DESCRIBE_SCALING_POLICIES_TEMPLATE)
         return template.render(policies=policies)
 

--- a/moto/autoscaling/responses.py
+++ b/moto/autoscaling/responses.py
@@ -120,6 +120,7 @@ class AutoScalingResponse(BaseResponse):
     def put_scaling_policy(self):
         policy = self.autoscaling_backend.create_autoscaling_policy(
             name=self._get_param('PolicyName'),
+            policy_type=self._get_param('PolicyType'),
             adjustment_type=self._get_param('AdjustmentType'),
             as_name=self._get_param('AutoScalingGroupName'),
             scaling_adjustment=self._get_int_param('ScalingAdjustment'),
@@ -373,6 +374,7 @@ DESCRIBE_SCALING_POLICIES_TEMPLATE = """<DescribePoliciesResponse xmlns="http://
         <AdjustmentType>{{ policy.adjustment_type }}</AdjustmentType>
         <ScalingAdjustment>{{ policy.scaling_adjustment }}</ScalingAdjustment>
         <PolicyName>{{ policy.name }}</PolicyName>
+        <PolicyType>{{ policy.policy_type }}</PolicyType>
         <AutoScalingGroupName>{{ policy.as_name }}</AutoScalingGroupName>
         <Cooldown>{{ policy.cooldown }}</Cooldown>
         <Alarms/>


### PR DESCRIPTION
Changes summary:
- Adding the `PolicyType` property to the autoscaling policy, which is currently missing from the mocking code
- Implementing filtering for the `describe_policies` function in autoscaling
