### PR TITLE
IAM: raise error if requiested instance profile does not exist

### DIFF
--- a/moto/iam/models.py
+++ b/moto/iam/models.py
@@ -501,6 +501,8 @@ class IAMBackend(BaseBackend):
             if profile.name == profile_name:
                 return profile
 
+        raise IAMNotFoundException("Instance profile {0} not found".format(profile_name))
+
     def get_instance_profiles(self):
         return self.instance_profiles.values()
 

--- a/tests/test_iam/test_iam.py
+++ b/tests/test_iam/test_iam.py
@@ -63,6 +63,14 @@ def test_get_role__should_throw__when_role_does_not_exist():
 
 
 @mock_iam()
+@raises(BotoServerError)
+def test_get_instance_profile__should_throw__when_instance_profile_does_not_exist():
+    conn = boto.connect_iam()
+
+    conn.get_instance_profile('unexisting_instance_profile')
+
+
+@mock_iam()
 def test_create_role_and_instance_profile():
     conn = boto.connect_iam()
     conn.create_instance_profile("my-profile", path="my-path")


### PR DESCRIPTION
Borrowed the same approach missing roles takes

Signed-off-by: Andrew Harris <andrew.harris@getbraintree.com>