### PR TITLE
Fix Route53 response and tests

### DIFF
--- a/moto/route53/responses.py
+++ b/moto/route53/responses.py
@@ -21,8 +21,15 @@ def list_or_create_hostzone_response(request, full_url, headers):
         else:
             comment = None
             private_zone = False
+
+
+        name = elements["CreateHostedZoneRequest"]["Name"]
+
+        if name[-1] != ".":
+            name += "."
+
         new_zone = route53_backend.create_hosted_zone(
-            elements["CreateHostedZoneRequest"]["Name"],
+            name,
             comment=comment,
             private_zone=private_zone,
         )
@@ -247,7 +254,7 @@ LIST_HOSTED_ZONES_RESPONSE = """<ListHostedZonesResponse xmlns="https://route53.
    <HostedZones>
       {% for zone in zones %}
       <HostedZone>
-         <Id>{{ zone.id }}</Id>
+         <Id>/hostedzone/{{ zone.id }}</Id>
          <Name>{{ zone.name }}</Name>
          <Config>
             {% if zone.comment %}

--- a/tests/test_cloudformation/test_cloudformation_stack_integration.py
+++ b/tests/test_cloudformation/test_cloudformation_stack_integration.py
@@ -1304,6 +1304,8 @@ def test_route53_with_update():
     zones = route53_conn.get_all_hosted_zones()['ListHostedZonesResponse']['HostedZones']
     list(zones).should.have.length_of(1)
     zone_id = zones[0]['Id']
+    zone_id = zone_id.split('/')
+    zone_id = zone_id[2]
 
     rrsets = route53_conn.get_all_rrsets(zone_id)
     rrsets.should.have.length_of(1)

--- a/tests/test_cloudformation/test_cloudformation_stack_integration.py
+++ b/tests/test_cloudformation/test_cloudformation_stack_integration.py
@@ -1171,7 +1171,7 @@ def test_route53_roundrobin():
     list(zones).should.have.length_of(1)
     zone_id = zones[0]['Id']
     zone_id = zone_id.split('/')
-    zone_id = zone_id[1]
+    zone_id = zone_id[2]
 
     rrsets = route53_conn.get_all_rrsets(zone_id)
     rrsets.hosted_zone_id.should.equal(zone_id)
@@ -1218,7 +1218,7 @@ def test_route53_ec2_instance_with_public_ip():
     list(zones).should.have.length_of(1)
     zone_id = zones[0]['Id']
     zone_id = zone_id.split('/')
-    zone_id = zone_id[1]
+    zone_id = zone_id[2]
 
 
     rrsets = route53_conn.get_all_rrsets(zone_id)
@@ -1261,7 +1261,7 @@ def test_route53_associate_health_check():
     list(zones).should.have.length_of(1)
     zone_id = zones[0]['Id']
     zone_id = zone_id.split('/')
-    zone_id = zone_id[1]
+    zone_id = zone_id[2]
 
     rrsets = route53_conn.get_all_rrsets(zone_id)
     rrsets.should.have.length_of(1)
@@ -1286,7 +1286,7 @@ def test_route53_with_update():
     list(zones).should.have.length_of(1)
     zone_id = zones[0]['Id']
     zone_id = zone_id.split('/')
-    zone_id = zone_id[1]
+    zone_id = zone_id[2]
 
     rrsets = route53_conn.get_all_rrsets(zone_id)
     rrsets.should.have.length_of(1)

--- a/tests/test_cloudformation/test_cloudformation_stack_integration.py
+++ b/tests/test_cloudformation/test_cloudformation_stack_integration.py
@@ -1170,6 +1170,8 @@ def test_route53_roundrobin():
     zones = route53_conn.get_all_hosted_zones()['ListHostedZonesResponse']['HostedZones']
     list(zones).should.have.length_of(1)
     zone_id = zones[0]['Id']
+    zone_id = zone_id.split('/')
+    zone_id = zone_id[1]
 
     rrsets = route53_conn.get_all_rrsets(zone_id)
     rrsets.hosted_zone_id.should.equal(zone_id)
@@ -1215,6 +1217,9 @@ def test_route53_ec2_instance_with_public_ip():
     zones = route53_conn.get_all_hosted_zones()['ListHostedZonesResponse']['HostedZones']
     list(zones).should.have.length_of(1)
     zone_id = zones[0]['Id']
+    zone_id = zone_id.split('/')
+    zone_id = zone_id[1]
+
 
     rrsets = route53_conn.get_all_rrsets(zone_id)
     rrsets.should.have.length_of(1)
@@ -1255,6 +1260,8 @@ def test_route53_associate_health_check():
     zones = route53_conn.get_all_hosted_zones()['ListHostedZonesResponse']['HostedZones']
     list(zones).should.have.length_of(1)
     zone_id = zones[0]['Id']
+    zone_id = zone_id.split('/')
+    zone_id = zone_id[1]
 
     rrsets = route53_conn.get_all_rrsets(zone_id)
     rrsets.should.have.length_of(1)
@@ -1278,6 +1285,8 @@ def test_route53_with_update():
     zones = route53_conn.get_all_hosted_zones()['ListHostedZonesResponse']['HostedZones']
     list(zones).should.have.length_of(1)
     zone_id = zones[0]['Id']
+    zone_id = zone_id.split('/')
+    zone_id = zone_id[1]
 
     rrsets = route53_conn.get_all_rrsets(zone_id)
     rrsets.should.have.length_of(1)

--- a/tests/test_route53/test_route53.py
+++ b/tests/test_route53/test_route53.py
@@ -25,7 +25,7 @@ def test_hosted_zone():
 
     id1 = firstzone["CreateHostedZoneResponse"]["HostedZone"]["Id"].split("/")[-1]
     zone = conn.get_hosted_zone(id1)
-    zone["GetHostedZoneResponse"]["HostedZone"]["Name"].should.equal("testdns.aws.com")
+    zone["GetHostedZoneResponse"]["HostedZone"]["Name"].should.equal("testdns.aws.com.")
 
     conn.delete_hosted_zone(id1)
     zones = conn.get_all_hosted_zones()


### PR DESCRIPTION
This commit is to make sure #725 and #799 pass.  This commit should not pass tests as the tests need to be changed.  If tests change before commit then it should pass.

get_all_zones() does not return just the zone ID, it returns '/hostedzone/zoneid'