### PR TITLE
Reload the server on a file change

### DIFF
--- a/moto/server.py
+++ b/moto/server.py
@@ -137,6 +137,12 @@ def main(argv=sys.argv[1:]):
         '-p', '--port', type=int,
         help='Port number to use for connection',
         default=5000)
+    parser.add_argument(
+        '-r', '--reload',
+        action='store_true',
+        help='Reload server on a signal',
+        default=False
+    )
 
     args = parser.parse_args(argv)
 
@@ -144,7 +150,7 @@ def main(argv=sys.argv[1:]):
     main_app = DomainDispatcherApplication(create_backend_app, service=args.service)
     main_app.debug = True
 
-    run_simple(args.host, args.port, main_app, threaded=True)
+    run_simple(args.host, args.port, main_app, threaded=True, use_reloader=args.reload)
 
 if __name__ == '__main__':
     main()

--- a/moto/server.py
+++ b/moto/server.py
@@ -140,7 +140,7 @@ def main(argv=sys.argv[1:]):
     parser.add_argument(
         '-r', '--reload',
         action='store_true',
-        help='Reload server on a signal',
+        help='Reload server on a file change',
         default=False
     )
 
@@ -151,6 +151,7 @@ def main(argv=sys.argv[1:]):
     main_app.debug = True
 
     run_simple(args.host, args.port, main_app, threaded=True, use_reloader=args.reload)
+
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
Using the default Werkzeug reloader. I prefer a reload using SIGHUP, but that's kinda difficult with Werkzeug. This works by "touching" one of the moto module files. This can be used for resetting a Moto server without actually killing it (useful for Docker for example)