### PR TITLE
make get_all_security_groups filter AND match group ids, not OR them

### DIFF
--- a/moto/ec2/models.py
+++ b/moto/ec2/models.py
@@ -1309,10 +1309,12 @@ class SecurityGroupBackend(object):
 
         if group_ids or groupnames or filters:
             for group in all_groups:
-                if ((group_ids and group.id in group_ids) or
-                        (groupnames and group.name in groupnames) or
-                        (filters and group.matches_filters(filters))):
-                    groups.append(group)
+                if ((group_ids and not group.id in group_ids) or
+                        (groupnames and not group.name in groupnames)):
+                    continue
+                if filters and not group.matches_filters(filters):
+                    continue
+                groups.append(group)
         else:
             groups = all_groups
 

--- a/tests/test_ec2/test_security_groups.py
+++ b/tests/test_ec2/test_security_groups.py
@@ -610,3 +610,16 @@ def test_authorize_and_revoke_in_bulk():
     sg01.ip_permissions_egress.should.have.length_of(1)
     for ip_permission in expected_ip_permissions:
         sg01.ip_permissions_egress.shouldnt.contain(ip_permission)
+
+@mock_ec2
+def test_get_all_security_groups_filter_with_same_vpc_id():
+    conn = boto.connect_ec2('the_key', 'the_secret')
+    vpc_id = 'vpc-5300000c'
+    security_group = conn.create_security_group('test1', 'test1', vpc_id=vpc_id)
+    security_group2 = conn.create_security_group('test2', 'test2', vpc_id=vpc_id)
+
+    security_group.vpc_id.should.equal(vpc_id)
+    security_group2.vpc_id.should.equal(vpc_id)
+
+    security_groups = conn.get_all_security_groups(group_ids=[security_group.id], filters={'vpc-id': [vpc_id]})
+    security_groups.should.have.length_of(1)


### PR DESCRIPTION
Currently, if you call `get_all_security_groups()` with values for `group_ids` and `filters`, security groups will be returned if they match the `group_ids` OR the `filters`. This patch changes it so that they will be returned if they match the `group_ids` AND the `filters`.  A test case is also included so you can confirm the old behavior fails the unit test.