### PR TITLE
install server version of moto for Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ADD . /moto/
 ENV PYTHONUNBUFFERED 1
 
 WORKDIR /moto/
-RUN python setup.py install
+RUN pip install ".[server]"
 
 CMD ["moto_server"]
 


### PR DESCRIPTION
Use the server install of moto for Dockerfile.

This allows the ~~flake~~ flask prerequisite of the server to be installed.
