### PR TITLE
Cloudformation ResourceMaps incorrectly share namespaces for Conditions and Resources

### DIFF
--- a/moto/cloudformation/parsing.py
+++ b/moto/cloudformation/parsing.py
@@ -143,7 +143,7 @@ def clean_json(resource_json, resources_map):
 
         if 'Fn::If' in resource_json:
             condition_name, true_value, false_value = resource_json['Fn::If']
-            if resources_map[condition_name]:
+            if resources_map.lazy_condition_map[condition_name]:
                 return clean_json(true_value, resources_map)
             else:
                 return clean_json(false_value, resources_map)
@@ -206,7 +206,7 @@ def parse_resource(logical_id, resource_json, resources_map):
 
 def parse_and_create_resource(logical_id, resource_json, resources_map, region_name):
     condition = resource_json.get('Condition')
-    if condition and not resources_map[condition]:
+    if condition and not resources_map.lazy_condition_map[condition]:
         # If this has a False condition, don't create the resource
         return None
 
@@ -352,13 +352,13 @@ class ResourceMap(collections.Mapping):
 
     def load_conditions(self):
         conditions = self._template.get('Conditions', {})
-        lazy_condition_map = LazyDict()
+        self.lazy_condition_map = LazyDict()
         for condition_name, condition in conditions.items():
-            lazy_condition_map[condition_name] = functools.partial(parse_condition,
-                condition, self._parsed_resources, lazy_condition_map)
+            self.lazy_condition_map[condition_name] = functools.partial(parse_condition,
+                condition, self._parsed_resources, self.lazy_condition_map)
 
-        for condition_name in lazy_condition_map:
-            self._parsed_resources[condition_name] = lazy_condition_map[condition_name]
+        for condition_name in self.lazy_condition_map:
+            _ = self.lazy_condition_map[condition_name]
 
     def create(self):
         self.load_mapping()


### PR DESCRIPTION
This patch is a little non-obvious so I've included a write-up.

Included is a test which has a Condition and a Resource with the same name. When run the function `create_stack` throws an exception:

      File "/home/dave/Projects/moto/moto/cloudformation/parsing.py", line 252, in parse_condition
        if 'Condition' in value:
    TypeError: argument of type 'bool' is not iterable

This code is a little weird:

    condition_values = []
    for value in list(condition.values())[0]:
        # Check if we are referencing another Condition
        if 'Condition' in value:
            condition_values.append(condition_map[value['Condition']])
        else:
            condition_values.append(clean_json(value, resources_map))

    if condition_operator == "Fn::Equals":
        return condition_values[0] == condition_values[1]

the error is occuring because `type(value) == bool`, where usually it would only be `dict` or `str`. I say this is weird because looking at the code I suspect it's only meant to be `dict`. The dict is checked for a `Condition` key, which if present uses the condition map instead of the resource map. Since `__contains__` is present on `str` as well as `dict` this code doesn't fail on strings, it just bypasses the True case of the conditional (unless the string contains "Condition" in it, which should be rare but not impossible).

I don't fix this in this PR, however changing the condtional to

    if isinstance(value, dict) and 'Condition' in value:

would likely fix it.

However this has all revealed a deeper, more fundamental bug in the surrounding code, due to there sometimes being a `bool` for `value`. This is occuring because the condition map uses bools but the resources map uses strings, and the two are being combined in the last line of the following snippet:

    def load_conditions(self):
        conditions = self._template.get('Conditions', {})
        lazy_condition_map = LazyDict()
        for condition_name, condition in conditions.items():
            lazy_condition_map[condition_name] = functools.partial(parse_condition,
                condition, self._parsed_resources, lazy_condition_map)

        for condition_name in lazy_condition_map:
            self._parsed_resources[condition_name] = lazy_condition_map[condition_name]

So even if we were to fix the above problem by checking for `__contains__` or `isinstance of dict`, we still end up comparing `True == 'true'` in some cases.

This is why this patch replaces the last line of the above snippet with:

    _ = lazy_condition_map[condition_name]

to stop overwriting the resources map. It then saves the `lazy_condition_map` by pinning it as an attribute to the resources map, and elsewhere in the two places where the resources map was previously being checked for conditions it is changed to check the newly pinned conditions map instead.

This results in a pretty limited code change, which corrects the behavior. However I feel like it does complicate things a little bit, as someone using a `ResourceMap` has to be aware of the `lazy_condition_map` attribute.

Feel free to ask questions if this explanation wasn't clear, I'm happy to discuss this PR.

Also special thanks to @privatesmith for diagnosing the problem.
