### PR TITLE
Route53: allow hosted zone id as well when creating record sets

### DIFF
--- a/moto/route53/models.py
+++ b/moto/route53/models.py
@@ -213,8 +213,11 @@ class RecordSetGroup(object):
     def create_from_cloudformation_json(cls, resource_name, cloudformation_json, region_name):
         properties = cloudformation_json['Properties']
 
-        zone_name = properties["HostedZoneName"]
-        hosted_zone = route53_backend.get_hosted_zone_by_name(zone_name)
+        zone_name = properties.get("HostedZoneName")
+        if zone_name:
+            hosted_zone = route53_backend.get_hosted_zone_by_name(zone_name)
+        else:
+            hosted_zone = route53_backend.get_hosted_zone(properties["HostedZoneId"])
         record_sets = properties["RecordSets"]
         for record_set in record_sets:
             hosted_zone.add_rrset(record_set)


### PR DESCRIPTION
Currently a `KeyError: u'HostedZoneName'` is thrown when supplying a `HostedZoneId` to a RecordSetGroup in a CloudFormation template and only a `HostedZoneName` will work. Both of these options are supposed to work, as per [here](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-recordsetgroup.html#cfn-route53-recordsetgroup-hostedzoneid).

This PR updates `RecordSetGroup.create_from_cloudformation_json()` to perform an identical check to the one in `RecordSet`. This behavior could be abstracted into a function if desired but all occurrences in `moto/route53/models.py` appear to be handled now.
