### PR TITLE
Correct IAM list_server_certs template that was based off incorrect docs

### DIFF
--- a/moto/iam/responses.py
+++ b/moto/iam/responses.py
@@ -578,18 +578,16 @@ LIST_SERVER_CERTIFICATES_TEMPLATE = """<ListServerCertificatesResponse>
     <ServerCertificateMetadataList>
       {% for certificate in server_certificates %}
       <member>
-        <ServerCertificateMetadata>
-          <ServerCertificateName>{{ certificate.cert_name }}</ServerCertificateName>
-          {% if certificate.path %}
-          <Path>{{ certificate.path }}</Path>
-          <Arn>arn:aws:iam::123456789012:server-certificate/{{ certificate.path }}/{{ certificate.cert_name }}</Arn>
-          {% else %}
-          <Arn>arn:aws:iam::123456789012:server-certificate/{{ certificate.cert_name }}</Arn>
-          {% endif %}
-          <UploadDate>2010-05-08T01:02:03.004Z</UploadDate>
-          <ServerCertificateId>ASCACKCEVSQ6C2EXAMPLE</ServerCertificateId>
-          <Expiration>2012-05-08T01:02:03.004Z</Expiration>
-        </ServerCertificateMetadata>
+        <ServerCertificateName>{{ certificate.cert_name }}</ServerCertificateName>
+        {% if certificate.path %}
+        <Path>{{ certificate.path }}</Path>
+        <Arn>arn:aws:iam::123456789012:server-certificate/{{ certificate.path }}/{{ certificate.cert_name }}</Arn>
+        {% else %}
+        <Arn>arn:aws:iam::123456789012:server-certificate/{{ certificate.cert_name }}</Arn>
+        {% endif %}
+        <UploadDate>2010-05-08T01:02:03.004Z</UploadDate>
+        <ServerCertificateId>ASCACKCEVSQ6C2EXAMPLE</ServerCertificateId>
+        <Expiration>2012-05-08T01:02:03.004Z</Expiration>
       </member>
       {% endfor %}
     </ServerCertificateMetadataList>


### PR DESCRIPTION
This removes the `<ServerCertificateMetadata>` tag from within the <member> elements of the server certificate list.

This occurred because the documentation for this method here https://docs.aws.amazon.com/IAM/latest/APIReference/API_ListServerCertificates.html

say the return type is this  `ServerCertificateMetadataList.member.N`

but the sample response incorrectly include a `<ServerCertificateMetadata>`. I've sent feedback to the AWS docs telling them to fix their stuff but this also needs to be fixed. I haven't checked other templates with <member> tags in them, as they may be prone to this same problem.