### PR TITLE
Elastic IP PhysicalResourceId should always be its public IP

### DIFF
--- a/moto/ec2/models.py
+++ b/moto/ec2/models.py
@@ -2833,7 +2833,7 @@ class ElasticAddress(object):
 
     @property
     def physical_resource_id(self):
-        return self.allocation_id if self.allocation_id else self.public_ip
+        return self.public_ip
 
     def get_cfn_attribute(self, attribute_name):
         from moto.cloudformation.exceptions import UnformattedGetAttTemplateException

--- a/tests/test_cloudformation/test_cloudformation_stack_integration.py
+++ b/tests/test_cloudformation/test_cloudformation_stack_integration.py
@@ -693,7 +693,7 @@ def test_vpc_single_instance_in_subnet():
     subnet_resource.physical_resource_id.should.equal(subnet.id)
 
     eip_resource = [resource for resource in resources if resource.resource_type == 'AWS::EC2::EIP'][0]
-    eip_resource.physical_resource_id.should.equal(eip.allocation_id)
+    eip_resource.physical_resource_id.should.equal(eip.public_ip)
 
 @mock_cloudformation()
 @mock_ec2()
@@ -990,7 +990,7 @@ def test_vpc_eip():
     stack = conn.describe_stacks()[0]
     resources = stack.describe_resources()
     cfn_eip = [resource for resource in resources if resource.resource_type == 'AWS::EC2::EIP'][0]
-    cfn_eip.physical_resource_id.should.equal(eip.allocation_id)
+    cfn_eip.physical_resource_id.should.equal(eip.public_ip)
 
 
 @mock_ec2()


### PR DESCRIPTION
According to the [CloudFormation `Ref` docs][docs], the `Ref` return value (and physical ID of the resource) for an Elastic IP is its public IP address.

[docs]: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-ref.html