### PR TITLE
make cloudformation update stack use parameters provided

### DIFF
--- a/moto/cloudformation/models.py
+++ b/moto/cloudformation/models.py
@@ -78,10 +78,10 @@ class FakeStack(object):
     def stack_outputs(self):
         return self.output_map.values()
 
-    def update(self, template, role_arn=None):
+    def update(self, template, role_arn=None, parameters=None):
         self._add_stack_event("UPDATE_IN_PROGRESS", resource_status_reason="User Initiated")
         self.template = template
-        self.resource_map.update(json.loads(template))
+        self.resource_map.update(json.loads(template), parameters)
         self.output_map = self._create_output_map()
         self._add_stack_event("UPDATE_COMPLETE")
         self.status = "UPDATE_COMPLETE"
@@ -157,9 +157,9 @@ class CloudFormationBackend(BaseBackend):
                 if stack.name == name_or_stack_id:
                     return stack
 
-    def update_stack(self, name, template, role_arn=None):
+    def update_stack(self, name, template, role_arn=None, parameters=None):
         stack = self.get_stack(name)
-        stack.update(template, role_arn)
+        stack.update(template, role_arn, parameters=parameters)
         return stack
 
     def list_stack_resources(self, stack_name_or_id):

--- a/moto/cloudformation/parsing.py
+++ b/moto/cloudformation/parsing.py
@@ -374,7 +374,9 @@ class ResourceMap(collections.Mapping):
                 self.tags['aws:cloudformation:logical-id'] = resource
                 ec2_models.ec2_backends[self._region_name].create_tags([self[resource].physical_resource_id], self.tags)
 
-    def update(self, template):
+    def update(self, template, parameters=None):
+        if parameters:
+            self.input_parameters = parameters
         self.load_mapping()
         self.load_parameters()
         self.load_conditions()

--- a/moto/cloudformation/responses.py
+++ b/moto/cloudformation/responses.py
@@ -138,6 +138,11 @@ class CloudFormationResponse(BaseResponse):
             stack_body = self.cloudformation_backend.get_stack(stack_name).template
         else:
             stack_body = self._get_param('TemplateBody')
+        parameters = dict([
+            (parameter['parameter_key'], parameter['parameter_value'])
+            for parameter
+            in self._get_list_prefix("Parameters.member")
+        ])
 
         stack = self.cloudformation_backend.get_stack(stack_name)
         if stack.status == 'ROLLBACK_COMPLETE':
@@ -147,6 +152,7 @@ class CloudFormationResponse(BaseResponse):
             name=stack_name,
             template=stack_body,
             role_arn=role_arn,
+            parameters=parameters
         )
         if self.request_json:
             stack_body = {

--- a/tests/test_cloudformation/test_cloudformation_stack_crud.py
+++ b/tests/test_cloudformation/test_cloudformation_stack_crud.py
@@ -340,6 +340,42 @@ def test_update_stack():
 
 
 @mock_cloudformation
+def test_update_stack_with_parameters():
+    dummy_template = {
+        "AWSTemplateFormatVersion": "2010-09-09",
+        "Description": "Stack",
+        "Resources": {
+            "VPC": {
+                "Properties": {
+                    "CidrBlock": {"Ref": "Bar"}
+            },
+            "Type": "AWS::EC2::VPC"
+            }
+        },
+        "Parameters": {
+            "Bar": {
+                "Type": "String"
+            }
+        }
+    }
+    dummy_template_json = json.dumps(dummy_template)
+    conn = boto.connect_cloudformation()
+    conn.create_stack(
+        "test_stack",
+        template_body=dummy_template_json,
+        parameters=[("Bar", "192.168.0.0/16")]
+    )
+    conn.update_stack(
+        "test_stack",
+        template_body=dummy_template_json,
+        parameters=[("Bar", "192.168.0.1/16")]
+    )
+
+    stack = conn.describe_stacks()[0]
+    assert stack.parameters[0].value == "192.168.0.1/16"
+
+
+@mock_cloudformation
 def test_update_stack_when_rolled_back():
     conn = boto.connect_cloudformation()
     stack_id = conn.create_stack("test_stack", template_body=dummy_template_json)


### PR DESCRIPTION
Currently when updating a stack, if parameters are provided they are ignored. This patch reads the parameters from the Response in the same way that `create_stack` does, passes it on through to the underlying `ResourceMap.update()` method and updates the `input_parameters` attribute. I'm not sure if there might be a preferred way to do this, but this seems like a reasonably small change.

As always, I'm happy to discuss or incorporate feedback to make this PR more conforming.