### PR TITLE
Cast desired capacity for cloudformation asg to int

### DIFF
--- a/moto/autoscaling/models.py
+++ b/moto/autoscaling/models.py
@@ -324,6 +324,7 @@ class AutoScalingBackend(BaseBackend):
 
         max_size = make_int(max_size)
         min_size = make_int(min_size)
+        desired_capacity = make_int(desired_capacity)
         default_cooldown = make_int(default_cooldown)
         if health_check_period is None:
             health_check_period = 300

--- a/tests/test_cloudformation/test_cloudformation_stack_integration.py
+++ b/tests/test_cloudformation/test_cloudformation_stack_integration.py
@@ -535,6 +535,7 @@ def test_autoscaling_group_with_elb():
                     "LaunchConfigurationName": {"Ref": "my-launch-config"},
                     "MinSize": "2",
                     "MaxSize": "2",
+                    "DesiredCapacity": "2",
                     "LoadBalancerNames": [{"Ref": "my-elb"}]
                 },
             },
@@ -614,6 +615,7 @@ def test_autoscaling_group_update():
                     "LaunchConfigurationName": {"Ref": "my-launch-config"},
                     "MinSize": "2",
                     "MaxSize": "2",
+                    "DesiredCapacity": "2"
                 },
             },
 
@@ -638,6 +640,7 @@ def test_autoscaling_group_update():
     asg = autoscale_conn.get_all_groups()[0]
     asg.min_size.should.equal(2)
     asg.max_size.should.equal(2)
+    asg.desired_capacity.should.equal(2)
 
     asg_template['Resources']['my-as-group']['Properties']['MaxSize'] = 3
     asg_template_json = json.dumps(asg_template)
@@ -648,6 +651,7 @@ def test_autoscaling_group_update():
     asg = autoscale_conn.get_all_groups()[0]
     asg.min_size.should.equal(2)
     asg.max_size.should.equal(3)
+    asg.desired_capacity.should.equal(2)
 
 
 @mock_ec2()


### PR DESCRIPTION
Cloudformation passes MaxSize, MinSize and DesiredCapacity as strings, but
we want to store them as ints.  Also includes tests of this fix, to help
avoid regression.