### PR TITLE
Fix lambda stdout/stderr mocking

### DIFF
--- a/moto/awslambda/models.py
+++ b/moto/awslambda/models.py
@@ -135,6 +135,8 @@ class LambdaFunction(object):
             print("Exception %s", ex)
 
         try:
+            original_stdout = sys.stdout
+            original_stderr = sys.stderr
             codeOut = StringIO()
             codeErr = StringIO()
             sys.stdout = codeOut
@@ -150,8 +152,8 @@ class LambdaFunction(object):
         finally:
             codeErr.close()
             codeOut.close()
-            sys.stdout = sys.__stdout__
-            sys.stderr = sys.__stderr__
+            sys.stdout = original_stdout
+            sys.stderr = original_stderr
         return self.convert(result)
 
     def invoke(self, request, headers):


### PR DESCRIPTION
Originally, the code was setting sys.stdout and sys.stderr back to the
original, official forms, but this breaks idioms like mocking stdout to
capture printing output for tests. So instead, we will reset sys.stdout
and sys.stderr to what they were before running the lambda function, so
that in case someone is mocking stdout or stderr, their tests won't
break.

I realize that technically someone could write code that overwrites these variables, but I think it is unlikely. Let me know if this is a dealbreaker.