### PR TITLE
Add event IDs to CF Stack events

### DIFF
--- a/moto/cloudformation/models.py
+++ b/moto/cloudformation/models.py
@@ -1,6 +1,7 @@
 from __future__ import unicode_literals
 from datetime import datetime
 import json
+import uuid
 
 import boto.cloudformation
 from moto.core import BaseBackend
@@ -105,6 +106,7 @@ class FakeEvent(object):
         self.resource_status_reason = resource_status_reason
         self.resource_properties = resource_properties
         self.timestamp = datetime.utcnow()
+        self.event_id = uuid.uuid4()
 
 
 class CloudFormationBackend(BaseBackend):

--- a/tests/test_cloudformation/test_cloudformation_stack_crud.py
+++ b/tests/test_cloudformation/test_cloudformation_stack_crud.py
@@ -376,6 +376,7 @@ def test_describe_stack_events_shows_create_update_and_delete():
         for event in events:
             event.stack_id.should.equal(stack_id)
             event.stack_name.should.equal("test_stack")
+            event.event_id.should.match(r"[0-9a-f]{8}-([0-9a-f]{4}-){3}[0-9a-f]{12}")
 
             if event.resource_type == "AWS::CloudFormation::Stack":
                 event.logical_resource_id.should.equal("test_stack")

--- a/tests/test_cloudformation/test_cloudformation_stack_crud_boto3.py
+++ b/tests/test_cloudformation/test_cloudformation_stack_crud_boto3.py
@@ -353,6 +353,7 @@ def test_stack_events():
         for event in events:
             event.stack_id.should.equal(stack.stack_id)
             event.stack_name.should.equal("test_stack")
+            event.event_id.should.match(r"[0-9a-f]{8}-([0-9a-f]{4}-){3}[0-9a-f]{12}")
 
             if event.resource_type == "AWS::CloudFormation::Stack":
                 event.logical_resource_id.should.equal("test_stack")


### PR DESCRIPTION
So that events can be uniquely identified.

I tried to match the format documented here: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-listing-event-history.html