### PR TITLE
Return CF Stack events in reverse chronological order

### DIFF
--- a/moto/cloudformation/responses.py
+++ b/moto/cloudformation/responses.py
@@ -286,7 +286,7 @@ DESCRIBE_STACK_RESOURCES_RESPONSE = """<DescribeStackResourcesResponse>
 DESCRIBE_STACK_EVENTS_RESPONSE = """<DescribeStackEventsResponse xmlns="http://cloudformation.amazonaws.com/doc/2010-05-15/">
   <DescribeStackEventsResult>
     <StackEvents>
-      {% for event in stack.events %}
+      {% for event in stack.events[::-1] %}
       <member>
         <Timestamp>{{ event.timestamp.strftime('%Y-%m-%dT%H:%M:%S.%fZ') }}</Timestamp>
         <ResourceStatus>{{ event.resource_status }}</ResourceStatus>

--- a/tests/test_cloudformation/test_cloudformation_stack_crud.py
+++ b/tests/test_cloudformation/test_cloudformation_stack_crud.py
@@ -368,10 +368,15 @@ def test_describe_stack_events_shows_create_update_and_delete():
     events[-1].resource_type.should.equal("AWS::CloudFormation::Stack")
 
     # testing ordering of stack events without assuming resource events will not exist
+    # the AWS API returns events in reverse chronological order
     stack_events_to_look_for = iter([
-        ("CREATE_IN_PROGRESS", "User Initiated"), ("CREATE_COMPLETE", None),
-        ("UPDATE_IN_PROGRESS", "User Initiated"), ("UPDATE_COMPLETE", None),
-        ("DELETE_IN_PROGRESS", "User Initiated"), ("DELETE_COMPLETE", None)])
+        ("DELETE_COMPLETE", None),
+        ("DELETE_IN_PROGRESS", "User Initiated"),
+        ("UPDATE_COMPLETE", None),
+        ("UPDATE_IN_PROGRESS", "User Initiated"),
+        ("CREATE_COMPLETE", None),
+        ("CREATE_IN_PROGRESS", "User Initiated"),
+    ])
     try:
         for event in events:
             event.stack_id.should.equal(stack_id)

--- a/tests/test_cloudformation/test_cloudformation_stack_crud_boto3.py
+++ b/tests/test_cloudformation/test_cloudformation_stack_crud_boto3.py
@@ -345,10 +345,15 @@ def test_stack_events():
     events[-1].resource_type.should.equal("AWS::CloudFormation::Stack")
 
     # testing ordering of stack events without assuming resource events will not exist
+    # the AWS API returns events in reverse chronological order
     stack_events_to_look_for = iter([
-        ("CREATE_IN_PROGRESS", "User Initiated"), ("CREATE_COMPLETE", None),
-        ("UPDATE_IN_PROGRESS", "User Initiated"), ("UPDATE_COMPLETE", None),
-        ("DELETE_IN_PROGRESS", "User Initiated"), ("DELETE_COMPLETE", None)])
+        ("DELETE_COMPLETE", None),
+        ("DELETE_IN_PROGRESS", "User Initiated"),
+        ("UPDATE_COMPLETE", None),
+        ("UPDATE_IN_PROGRESS", "User Initiated"),
+        ("CREATE_COMPLETE", None),
+        ("CREATE_IN_PROGRESS", "User Initiated"),
+    ])
     try:
         for event in events:
             event.stack_id.should.equal(stack.stack_id)


### PR DESCRIPTION
This is how the AWS API works: http://boto3.readthedocs.io/en/latest/reference/services/cloudformation.html#CloudFormation.Client.describe_stack_events

I wasn't sure whether it would be better to make the internal representation be in reverse chronological order instead of just changing the response. I could go either way. Let me know if you want me to change it!