### PR TITLE
fix etag metadata field name in key response dict (etag --> ETag)

### DIFF
--- a/moto/s3/models.py
+++ b/moto/s3/models.py
@@ -90,7 +90,7 @@ class FakeKey(object):
     @property
     def response_dict(self):
         r = {
-            'etag': self.etag,
+            'Etag': self.etag,
             'last-modified': self.last_modified_RFC1123,
         }
         if self._storage_class != 'STANDARD':


### PR DESCRIPTION
An Exception is raised when writing keys to the moto server using the Java AWS SDK:

```
com.amazonaws.AmazonClientException: Unable to complete transfer: null
	at com.amazonaws.services.s3.transfer.internal.AbstractTransfer.unwrapExecutionException(AbstractTransfer.java:277)
	at com.amazonaws.services.s3.transfer.internal.AbstractTransfer.rethrowExecutionException(AbstractTransfer.java:261)
	at com.amazonaws.services.s3.transfer.internal.AbstractTransfer.waitForCompletion(AbstractTransfer.java:103)
Caused by: java.lang.NullPointerException: null
	at com.amazonaws.util.BinaryUtils.fromHex(BinaryUtils.java:61)
	at com.amazonaws.services.s3.AmazonS3Client.putObject(AmazonS3Client.java:1441)
	at com.amazonaws.services.s3.transfer.internal.UploadCallable.uploadInOneChunk(UploadCallable.java:135)
	at com.amazonaws.services.s3.transfer.internal.UploadCallable.call(UploadCallable.java:127)
	at com.amazonaws.services.s3.transfer.internal.UploadMonitor.call(UploadMonitor.java:129)
	at com.amazonaws.services.s3.transfer.internal.UploadMonitor.call(UploadMonitor.java:50)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)
```

The key is actually written correctly and I can access it using the python `boto` client. I've identified the issue as a mis-labeled field in the HTTP response for key PUT requests. The problem (and solution) are basically identical to that described in [this Stack Overflow post](http://stackoverflow.com/questions/10512210/amazon-s3-client-connect-through-proxy-putobject-getting-nullpointerexception). One of the returned metadata fields is named `etag` in moto, while the correct field name expected by the Java AWS SDK client is `ETag`.

This PR fixes the field name in the HTTP response dict.