### PR TITLE
Fixed terraform deploy against moto fails

### DIFF
--- a/moto/ec2/models.py
+++ b/moto/ec2/models.py
@@ -369,6 +369,7 @@ class Instance(TaggedEC2Resource, BotoInstance):
         self.key_name = kwargs.get("key_name")
         self.source_dest_check = "true"
         self.launch_time = utc_date_and_time()
+        self.disable_api_termination = kwargs.get("disable_api_termination", False)
         associate_public_ip = kwargs.get("associate_public_ip", False)
         if in_ec2_classic:
             # If we are in EC2-Classic, autoassign a public IP

--- a/moto/ec2/responses/instances.py
+++ b/moto/ec2/responses/instances.py
@@ -297,7 +297,7 @@ EC2_RUN_INSTANCES = """<RunInstancesResponse xmlns="http://ec2.amazonaws.com/doc
                   <attachmentId>{{ nic.attachment_id }}</attachmentId>
                   <deviceIndex>{{ nic.device_index }}</deviceIndex>
                   <status>attached</status>
-                  <attachTime>2015-01-01T00:00:00+0000</attachTime>
+                  <attachTime>2015-01-01T00:00:00Z</attachTime>
                   <deleteOnTermination>true</deleteOnTermination>
                 </attachment>
                 {% if nic.public_ip %}
@@ -462,7 +462,7 @@ EC2_DESCRIBE_INSTANCES = """<DescribeInstancesResponse xmlns="http://ec2.amazona
                             <attachmentId>{{ nic.attachment_id }}</attachmentId>
                             <deviceIndex>{{ nic.device_index }}</deviceIndex>
                             <status>attached</status>
-                            <attachTime>2015-01-01T00:00:00+0000</attachTime>
+                            <attachTime>2015-01-01T00:00:00Z</attachTime>
                             <deleteOnTermination>true</deleteOnTermination>
                           </attachment>
                           {% if nic.public_ip %}


### PR DESCRIPTION
Before this fix, I tried to run a "terraform apply" (Terraform by HashiCorp) against a moto server (running at localhost:48411). It failed with some parsing errors. After this change, it no longer fails. Here's how to reproduce.

`terraform apply -var 'env=local' -var 'instance_name=chellman-deleteme' -var 'owner=chellman' -var 'ec2_endpoint=http://localhost:48411' -state=terraform.tfstate -input=false default_instance`

My template is fairly simple (slightly altered to remove sensitive info):

> variable "region" {
>     default = "us-west-2"
> }
> 
> variable "env" {
>     type = "string"
> }
> 
> variable "instance_name" {
>     type = "string"
> }
> 
> variable "ec2_endpoint" {
>     type = "string"
> }
> 
> variable "image" {
>     default = "ami-f173cc91"
> }
> 
> variable "instance_type" {
>     default = "t2.micro"
> }
> 
> variable "owner" {
>     type = "string"
> }
> 
> variable "key_name" {
>     type = "string"
>     default = ""
> }
> 
> provider "aws" {
>     region = "${var.region}"
>     endpoints {
>         ec2 = "${var.ec2_endpoint}"
>     }
> }
> 
> resource "aws_instance" "instance" {
>     ami = "${var.image}"
>     instance_type = "${var.instance_type}"
>     key_name = "${var.key_name}"
> }

It would fail with 

> * aws_instance.instance: Error launching source instance: SerializationError: failed decoding EC2 Query response
> caused by: parsing time "2015-01-01T00:00:00+0000" as "2006-01-02T15:04:05Z": cannot parse "+0000" as "Z"
> 2017/03/10 19:29:56 [TRACE] Preserving existing state lineage "c3a4d26b-6bcd-40c6-a74b-05e2b20fb91e"
> 2017/03/10 19:29:56 [TRACE] Preserving existing state lineage "c3a4d26b-6bcd-40c6-a74b-05e2b20fb91e"
> 2017/03/10 19:29:56 [DEBUG] plugin: waiting for all plugin processes to complete...
> caused by: parsing time "2015-01-01T00:00:00+0000" as "2006-01-02T15:04:05Z": cannot parse "+0000" as "Z"
