### PR TITLE
Be flexible with Route53 Hosted Zone IDs with /hostedzone/ prefix

### DIFF
--- a/moto/route53/models.py
+++ b/moto/route53/models.py
@@ -277,7 +277,7 @@ class Route53Backend(BaseBackend):
         return self.zones.values()
 
     def get_hosted_zone(self, id_):
-        return self.zones.get(id_.lstrip("/hostedzone/"))
+        return self.zones.get(id_.replace("/hostedzone/", ""))
 
     def get_hosted_zone_by_name(self, name):
         for zone in self.get_all_hosted_zones():
@@ -285,7 +285,7 @@ class Route53Backend(BaseBackend):
                 return zone
 
     def delete_hosted_zone(self, id_):
-        return self.zones.pop(id_.lstrip("/hostedzone/"), None)
+        return self.zones.pop(id_.replace("/hostedzone/", ""), None)
 
     def create_health_check(self, health_check_args):
         health_check_id = str(uuid.uuid4())

--- a/moto/route53/models.py
+++ b/moto/route53/models.py
@@ -277,7 +277,7 @@ class Route53Backend(BaseBackend):
         return self.zones.values()
 
     def get_hosted_zone(self, id_):
-        return self.zones.get(id_)
+        return self.zones.get(id_.lstrip("/hostedzone/"))
 
     def get_hosted_zone_by_name(self, name):
         for zone in self.get_all_hosted_zones():
@@ -285,10 +285,7 @@ class Route53Backend(BaseBackend):
                 return zone
 
     def delete_hosted_zone(self, id_):
-        zone = self.zones.get(id_)
-        if zone:
-            del self.zones[id_]
-            return zone
+        return self.zones.pop(id_.lstrip("/hostedzone/"), None)
 
     def create_health_check(self, health_check_args):
         health_check_id = str(uuid.uuid4())


### PR DESCRIPTION
We will continue to store just the unique ID, but since the AWS API
returns `/hostedzone/<id>`, we should accept attempts to pass that back.
For example, both just the ID as well as `/hostedzone/<id>` work for
specifying the `HostedZoneId` of a `ResourceRecordSet` in CloudFormation. So
we should support that too.

Signed-off-by: Scott Greene <scott.greene@getbraintree.com>