### PR TITLE
Catch KeyError instead of ValueError

### DIFF
--- a/moto/server.py
+++ b/moto/server.py
@@ -59,7 +59,7 @@ class DomainDispatcherApplication(object):
             try:
                 _, _, region, service, _ = environ['HTTP_AUTHORIZATION'].split(",")[0].split()[
                     1].split("/")
-            except ValueError:
+            except KeyError:
                 region = 'us-east-1'
                 service = 's3'
             if service == 'dynamodb':


### PR DESCRIPTION
Not catching the correct error here I believe. This allows us to run moto_server locally without passing in a `HTTP_AUTHORIZATION` environment variable.