### PR TITLE
Fix SQS message polling to abort after wait_seconds_timeout

### DIFF
--- a/moto/sqs/models.py
+++ b/moto/sqs/models.py
@@ -289,6 +289,10 @@ class SQSBackend(BaseBackend):
 
         # queue.messages only contains visible messages
         while True:
+
+            if result or (wait_seconds_timeout and unix_time() > polling_end):
+                break
+
             if len(queue.messages) == 0:
                 import time
                 time.sleep(0.001)
@@ -303,9 +307,6 @@ class SQSBackend(BaseBackend):
                 result.append(message)
                 if len(result) >= count:
                     break
-
-            if result or unix_time() > polling_end:
-                break
 
         return result
 


### PR DESCRIPTION
This PR fixes SQS message polling to abort after `wait_seconds_timeout`. In the current implementation, we loop until a new message becomes available in the queue, and never actually abort the loop based on the timeout value.

Steps to reproduce the issue:
1) create queue
2) send message to the queue
3) run `sqs receive-message` against the queue -> returns the message immediately
4) run `sqs receive-message --wait-time-seconds 1` against the queue (immediately after previous command)
   - expected behavior: call returns after 1 second and returns empty result
   - actual behavior: call waits roughly 30 seconds (until `visibility_timeout` expires and the message gets re-added to the queue) and returns the message 