### PR TITLE
Fix domain handling for local domain names in S3 API

### DIFF
--- a/moto/s3/responses.py
+++ b/moto/s3/responses.py
@@ -53,8 +53,8 @@ class ResponseObject(_TemplateEnvironmentMixin):
         if not host:
             host = urlparse(request.url).netloc
 
-        if not host or host.startswith("localhost"):
-            # For localhost, default to path-based buckets
+        if not host or host.startswith("localhost") or re.match(r"^[^.]+$", host):
+            # For localhost or local domain names, default to path-based buckets
             return False
 
         match = re.match(r'^([^\[\]:]+)(:\d+)?$', host)


### PR DESCRIPTION
This PR fixes domain handling for local domain names in the moto S3 API.

We have a use case where the S3 API is accessed from a cross-container Docker environment: Container *A* hosts the moto S3 API, container *B* contains the `aws` CLI. We try to contact the API on container *A* from container *B* with the following command:
```
aws --endpoint-url="http://container_A:4572" s3api create-bucket --bucket my-bucket
```
In the current implementation, moto only considers `localhost` as a special host name (https://github.com/spulec/moto/blob/master/moto/s3/responses.py#L56) and hence falls back to subdomain based bucket addressing (instead of path based bucket addressing).

This PR fixes this issue and considers all hostnames that do *not* contain a dot (`.`) as local hostnames, and treats them the same way as "localhost". This allows us to make cross-container API calls in a Docker environment.