### PR TITLE
Container instance resources

### DIFF
--- a/moto/ecs/models.py
+++ b/moto/ecs/models.py
@@ -595,6 +595,24 @@ class EC2ContainerServiceBackend(BaseBackend):
 
         return container_instance_objects, failures
 
+    def update_container_instances_state(self, cluster_str, list_container_instance_ids, status):
+        cluster_name = cluster_str.split('/')[-1]
+        if cluster_name not in self.clusters:
+            raise Exception("{0} is not a cluster".format(cluster_name))
+        if status.upper() not in ['ACTIVE', 'DRAINING']:
+            raise Exception("InvalidParameterException: An error occurred (InvalidParameterException) when calling the UpdateContainerInstancesState operation: Container instances status should be one of [ACTIVE,DRAINING]")
+        failures = []
+        container_instance_objects = []
+        for container_instance_id in list_container_instance_ids:
+            container_instance = self.container_instances[cluster_name].get(container_instance_id, None)
+            if container_instance is not None:
+                container_instance.status = status
+                container_instance_objects.append(container_instance)
+            else:
+                failures.append(ContainerInstanceFailure('MISSING', container_instance_id))
+
+        return container_instance_objects, failures
+
     def deregister_container_instance(self, cluster_str, container_instance_str):
         pass
 

--- a/moto/ecs/models.py
+++ b/moto/ecs/models.py
@@ -130,7 +130,6 @@ class TaskDefinition(BaseObject):
                 original_resource.volumes != volumes):
                 # currently TaskRoleArn isn't stored at TaskDefinition
                 # instances
-
             ecs_backend = ecs_backends[region_name]
             ecs_backend.deregister_task_definition(original_resource.arn)
             return ecs_backend.register_task_definition(
@@ -240,12 +239,57 @@ class ContainerInstance(BaseObject):
     def __init__(self, ec2_instance_id):
         self.ec2_instance_id = ec2_instance_id
         self.status = 'ACTIVE'
-        self.registeredResources = []
+        self.registeredResources = [
+            {'doubleValue': 0.0,
+             'integerValue': 4096,
+             'longValue': 0,
+             'name': 'CPU',
+             'type': 'INTEGER'},
+            {'doubleValue': 0.0,
+             'integerValue': 7482,
+             'longValue': 0,
+             'name': 'MEMORY',
+             'type': 'INTEGER'},
+            {'doubleValue': 0.0,
+             'integerValue': 0,
+             'longValue': 0,
+             'name': 'PORTS',
+             'stringSetValue': ['22', '2376', '2375', '51678', '51679'],
+             'type': 'STRINGSET'},
+            {'doubleValue': 0.0,
+             'integerValue': 0,
+             'longValue': 0,
+             'name': 'PORTS_UDP',
+             'stringSetValue': [],
+             'type': 'STRINGSET'}]
         self.agentConnected = True
         self.containerInstanceArn = "arn:aws:ecs:us-east-1:012345678910:container-instance/{0}".format(
             str(uuid.uuid1()))
         self.pendingTaskCount = 0
-        self.remainingResources = []
+        self.remainingResources = [
+            {'doubleValue': 0.0,
+             'integerValue': 4096,
+             'longValue': 0,
+             'name': 'CPU',
+             'type': 'INTEGER'},
+            {'doubleValue': 0.0,
+             'integerValue': 7482,
+             'longValue': 0,
+             'name': 'MEMORY',
+             'type': 'INTEGER'},
+            {'doubleValue': 0.0,
+             'integerValue': 0,
+             'longValue': 0,
+             'name': 'PORTS',
+             'stringSetValue': ['22', '2376', '2375', '51678', '51679'],
+             'type': 'STRINGSET'},
+            {'doubleValue': 0.0,
+             'integerValue': 0,
+             'longValue': 0,
+             'name': 'PORTS_UDP',
+             'stringSetValue': [],
+             'type': 'STRINGSET'}
+        ]
         self.runningTaskCount = 0
         self.versionInfo = {
             'agentVersion': "1.0.0",
@@ -600,7 +644,8 @@ class EC2ContainerServiceBackend(BaseBackend):
             raise Exception("{0} is not a cluster".format(cluster_name))
         status = status.upper()
         if status not in ['ACTIVE', 'DRAINING']:
-            raise Exception("An error occurred (InvalidParameterException) when calling the UpdateContainerInstancesState operation: Container instances status should be one of [ACTIVE,DRAINING]")
+            raise Exception(
+                "An error occurred (InvalidParameterException) when calling the UpdateContainerInstancesState operation: Container instances status should be one of [ACTIVE,DRAINING]")
         failures = []
         container_instance_objects = []
         for container_instance_id in list_container_instance_ids:

--- a/moto/ecs/models.py
+++ b/moto/ecs/models.py
@@ -736,6 +736,24 @@ class EC2ContainerServiceBackend(BaseBackend):
 
         return container_instance_objects, failures
 
+    def update_container_instances_state(self, cluster_str, list_container_instance_ids, status):
+        cluster_name = cluster_str.split('/')[-1]
+        if cluster_name not in self.clusters:
+            raise Exception("{0} is not a cluster".format(cluster_name))
+        if status.upper() not in ['ACTIVE', 'DRAINING']:
+            raise Exception("InvalidParameterException: An error occurred (InvalidParameterException) when calling the UpdateContainerInstancesState operation: Container instances status should be one of [ACTIVE,DRAINING]")
+        failures = []
+        container_instance_objects = []
+        for container_instance_id in list_container_instance_ids:
+            container_instance = self.container_instances[cluster_name].get(container_instance_id, None)
+            if container_instance is not None:
+                container_instance.status = status
+                container_instance_objects.append(container_instance)
+            else:
+                failures.append(ContainerInstanceFailure('MISSING', container_instance_id))
+
+        return container_instance_objects, failures
+
     def deregister_container_instance(self, cluster_str, container_instance_str):
         pass
 

--- a/moto/ecs/models.py
+++ b/moto/ecs/models.py
@@ -1,6 +1,6 @@
 from __future__ import unicode_literals
 import uuid
-from random import randint, random
+from random import random
 
 from moto.core import BaseBackend, BaseModel
 from moto.ec2 import ec2_backends
@@ -137,6 +137,41 @@ class TaskDefinition(BaseObject):
         else:
             # no-op when nothing changed between old and new resources
             return original_resource
+
+
+class ContainerDefinition(BaseObject):
+    def __init__(self, name, image, cpu=0, memory=0, memoryReservation=0, links=[], portMappings=[], essential=True, entryPoint=[], command=[], environment=[], mountPoints=[], volumesFrom=[], hostname='', user='', workingDirectory='', disableNetworking=False, privileged=False, readonlyRootFilesystem=False, dnsServers=[], dnsSearchDomains=[], extraHosts=[], dockerSecurityOptions=[], dockerLabels={}, uLimits=[], logConfiguration={}):
+        self.name = name
+        self.image = image
+        self.cpu = cpu
+        self.memory = memory
+        self.memory_reservation = memoryReservation
+        self.links = links
+        self.portMappings = portMappings
+        self.essential = essential
+        self.entryPoint = entryPoint
+        self.command = command
+        self.environment = environment
+        self.mountPoints = mountPoints
+        self.volumesFrom = volumesFrom
+        self.hostname = hostname
+        self.user = user
+        self.working_directory = workingDirectory
+        self.disable_networking = disableNetworking
+        self.priviliged = privileged
+        self.readonly_root_filesystem = readonlyRootFilesystem
+        self.dns_servers = dnsServers
+        self.dns_search_domains = dnsSearchDomains
+        self.extra_hosts = extraHosts
+        self.docker_security_options = dockerSecurityOptions
+        self.docker_labels = dockerLabels
+        self.u_limits = uLimits
+        self.log_configuration = logConfiguration
+
+    @property
+    def response_object(self):
+        response_object = self.gen_response_object()
+        return response_object
 
 
 class Task(BaseObject):
@@ -427,15 +462,58 @@ class EC2ContainerServiceBackend(BaseBackend):
             raise Exception("No instances found in cluster {}".format(cluster_name))
         active_container_instances = [x for x in container_instances if
                                       self.container_instances[cluster_name][x].status == 'ACTIVE']
-        for _ in range(count or 1):
-            container_instance_arn = self.container_instances[cluster_name][
-                active_container_instances[randint(0, len(active_container_instances) - 1)]
-            ].containerInstanceArn
-            task = Task(cluster, task_definition, container_instance_arn,
-                        overrides or {}, started_by or '')
-            tasks.append(task)
-            self.tasks[cluster_name][task.task_arn] = task
+        resource_requirements = {"CPU": 0, "MEMORY": 0, "PORTS": [], "PORTS_UDP": []}
+        for container_definition in task_definition.container_definitions:
+            resource_requirements["CPU"] += container_definition.get('cpu')
+            resource_requirements["MEMORY"] += container_definition.get("memory")
+            for port_mapping in container_definition.get("port_mappings", []):
+                resource_requirements["PORTS"].append(port_mapping.get('host_port'))
+        # TODO: return event about unable to place task if not able to place enough tasks to meet count
+        placed_count = 0
+        for container_instance in active_container_instances:
+            container_instance = self.container_instances[cluster_name][container_instance]
+            container_instance_arn = container_instance.containerInstanceArn
+            try_to_place = True
+            while try_to_place:
+                if self._is_placable(container_instance, resource_requirements):
+                    task = Task(cluster, task_definition, container_instance_arn, overrides or {}, started_by or '')
+                    tasks.append(task)
+                    self.tasks[cluster_name][task.task_arn] = task
+                    placed_count += 1
+                    if placed_count == count:
+                        return tasks
+                else:
+                    try_to_place = False
         return tasks
+
+    @staticmethod
+    def _is_placable(container_instance, task_resource_requirements):
+        """
+
+        :param container_instance: The container instance trying to be placed onto
+        :param task_resource_requirements: The calculated resource requirements of the task in the form of a dict
+        :return: A boolean stating whether the given container instance has enough resources to have the task placed on
+        it as well as a description, if it cannot be placed this will describe why.
+        """
+        remaining_cpu = 0
+        remaining_memory = 0
+        reserved_ports = []
+        for resource in container_instance.remainingResources:
+            if resource.get("name") == "CPU":
+                remaining_cpu = resource.get("integerValue")
+            elif resource.get("name") == "MEMORY":
+                remaining_memory = resource.get("integerValue")
+            elif resource.get("name") == "PORTS":
+                reserved_ports = resource.get("stringSetValue")
+        if task_resource_requirements.get("CPU") > remaining_cpu:
+            return False, "Not enough CPU credits"
+        if task_resource_requirements.get("MEMORY") > remaining_memory:
+            return False, "Not enough memory"
+        ports_needed = task_resource_requirements.get("PORTS")
+        for port in ports_needed:
+            if port in reserved_ports:
+                return False, "Port clash"
+        return True, "Can be placed"
 
     def start_task(self, cluster_str, task_definition_str, container_instances, overrides, started_by):
         cluster_name = cluster_str.split('/')[-1]

--- a/moto/ecs/models.py
+++ b/moto/ecs/models.py
@@ -181,7 +181,8 @@ class ContainerDefinition(BaseObject):
 
 class Task(BaseObject):
 
-    def __init__(self, cluster, task_definition, container_instance_arn, resource_requirements, overrides={}, started_by=''):
+    def __init__(self, cluster, task_definition, container_instance_arn,
+                 resource_requirements, overrides={}, started_by=''):
         self.cluster_arn = cluster.arn
         self.task_arn = 'arn:aws:ecs:us-east-1:012345678910:task/{0}'.format(
             str(uuid.uuid1()))
@@ -194,7 +195,6 @@ class Task(BaseObject):
         self.started_by = started_by
         self.stopped_reason = ''
         self.resource_requirements = resource_requirements
-        
 
     @property
     def response_object(self):
@@ -338,7 +338,6 @@ class ContainerInstance(BaseObject):
             'agentHash': '4023248',
             'dockerVersion': 'DockerVersion: 1.5.0'
         }
-            
 
         @property
         def response_object(self):
@@ -480,7 +479,8 @@ class EC2ContainerServiceBackend(BaseBackend):
             while try_to_place:
                 can_be_placed, message = self._can_be_placed(container_instance, resource_requirements)
                 if can_be_placed:
-                    task = Task(cluster, task_definition, container_instance_arn, resource_requirements, overrides or {}, started_by or '')
+                    task = Task(cluster, task_definition, container_instance_arn,
+                                resource_requirements, overrides or {}, started_by or '')
                     self.update_container_instance_resources(container_instance, resource_requirements)
                     tasks.append(task)
                     self.tasks[cluster_name][task.task_arn] = task
@@ -501,7 +501,6 @@ class EC2ContainerServiceBackend(BaseBackend):
                 resource_requirements["PORTS"].append(port_mapping.get('hostPort'))
         return resource_requirements
 
-
     @staticmethod
     def _can_be_placed(container_instance, task_resource_requirements):
         """
@@ -511,7 +510,7 @@ class EC2ContainerServiceBackend(BaseBackend):
         :return: A boolean stating whether the given container instance has enough resources to have the task placed on
         it as well as a description, if it cannot be placed this will describe why.
         """
-        # TODO: Implement default and other placement strategies as well as constraints: 
+        # TODO: Implement default and other placement strategies as well as constraints:
         # docs.aws.amazon.com/AmazonECS/latest/developerguide/task-placement.html
         remaining_cpu = 0
         remaining_memory = 0
@@ -553,10 +552,9 @@ class EC2ContainerServiceBackend(BaseBackend):
             container_instance = self.container_instances[cluster_name][
                 container_instance_id
             ]
-            task = Task(cluster, task_definition, container_instance.containerInstanceArn, 
+            task = Task(cluster, task_definition, container_instance.containerInstanceArn,
                         resource_requirements, overrides or {}, started_by or '')
             tasks.append(task)
-            
             self.update_container_instance_resources(container_instance, resource_requirements)
             self.tasks[cluster_name][task.task_arn] = task
         return tasks
@@ -613,7 +611,8 @@ class EC2ContainerServiceBackend(BaseBackend):
             if task.endswith(task_id):
                 container_instance_arn = tasks[task].container_instance_arn
                 container_instance = self.container_instances[cluster_name][container_instance_arn.split('/')[-1]]
-                self.update_container_instance_resources(container_instance, tasks[task].resource_requirements, removing=True)
+                self.update_container_instance_resources(container_instance, tasks[task].resource_requirements,
+                                                         removing=True)
                 tasks[task].last_status = 'STOPPED'
                 tasks[task].desired_status = 'STOPPED'
                 tasks[task].stopped_reason = reason
@@ -741,7 +740,6 @@ class EC2ContainerServiceBackend(BaseBackend):
 
         return container_instance_objects, failures
 
-        
     def update_container_instance_resources(self, container_instance, task_resources, removing=False):
         resource_multiplier = 1
         if removing:

--- a/moto/ecs/models.py
+++ b/moto/ecs/models.py
@@ -722,25 +722,6 @@ class EC2ContainerServiceBackend(BaseBackend):
             raise Exception("{0} is not a cluster".format(cluster_name))
         status = status.upper()
         if status not in ['ACTIVE', 'DRAINING']:
-            raise Exception(
-                "An error occurred (InvalidParameterException) when calling the UpdateContainerInstancesState operation: Container instances status should be one of [ACTIVE,DRAINING]")
-        failures = []
-        container_instance_objects = []
-        for container_instance_id in list_container_instance_ids:
-            container_instance = self.container_instances[cluster_name].get(container_instance_id, None)
-            if container_instance is not None:
-                container_instance.status = status
-                container_instance_objects.append(container_instance)
-            else:
-                failures.append(ContainerInstanceFailure('MISSING', container_instance_id))
-
-        return container_instance_objects, failures
-
-    def update_container_instances_state(self, cluster_str, list_container_instance_ids, status):
-        cluster_name = cluster_str.split('/')[-1]
-        if cluster_name not in self.clusters:
-            raise Exception("{0} is not a cluster".format(cluster_name))
-        if status.upper() not in ['ACTIVE', 'DRAINING']:
             raise Exception("An error occurred (InvalidParameterException) when calling the UpdateContainerInstancesState operation: Container instances status should be one of [ACTIVE,DRAINING]")
         failures = []
         container_instance_objects = []

--- a/moto/ecs/models.py
+++ b/moto/ecs/models.py
@@ -722,7 +722,8 @@ class EC2ContainerServiceBackend(BaseBackend):
             raise Exception("{0} is not a cluster".format(cluster_name))
         status = status.upper()
         if status not in ['ACTIVE', 'DRAINING']:
-            raise Exception("An error occurred (InvalidParameterException) when calling the UpdateContainerInstancesState operation: Container instances status should be one of [ACTIVE,DRAINING]")
+            raise Exception(
+                "An error occurred (InvalidParameterException) when calling the UpdateContainerInstancesState operation: Container instances status should be one of [ACTIVE,DRAINING]")
         failures = []
         container_instance_objects = []
         for container_instance_id in list_container_instance_ids:

--- a/moto/ecs/models.py
+++ b/moto/ecs/models.py
@@ -140,7 +140,12 @@ class TaskDefinition(BaseObject):
 
 
 class ContainerDefinition(BaseObject):
-    def __init__(self, name, image, cpu=0, memory=0, memoryReservation=0, links=[], portMappings=[], essential=True, entryPoint=[], command=[], environment=[], mountPoints=[], volumesFrom=[], hostname='', user='', workingDirectory='', disableNetworking=False, privileged=False, readonlyRootFilesystem=False, dnsServers=[], dnsSearchDomains=[], extraHosts=[], dockerSecurityOptions=[], dockerLabels={}, uLimits=[], logConfiguration={}):
+    def __init__(self, name, image, cpu=0, memory=0, memoryReservation=0, links=[],
+                 portMappings=[], essential=True, entryPoint=[], command=[], environment=[],
+                 mountPoints=[], volumesFrom=[], hostname='', user='', workingDirectory='',
+                 disableNetworking=False, privileged=False, readonlyRootFilesystem=False,
+                 dnsServers=[], dnsSearchDomains=[], extraHosts=[], dockerSecurityOptions=[],
+                 dockerLabels={}, uLimits=[], logConfiguration={}):
         self.name = name
         self.image = image
         self.cpu = cpu
@@ -703,45 +708,8 @@ class EC2ContainerServiceBackend(BaseBackend):
             raise Exception("{0} is not a cluster".format(cluster_name))
         status = status.upper()
         if status not in ['ACTIVE', 'DRAINING']:
-            raise Exception("An error occurred (InvalidParameterException) when calling the UpdateContainerInstancesState operation: Container instances status should be one of [ACTIVE,DRAINING]")
-        failures = []
-        container_instance_objects = []
-        for container_instance_id in list_container_instance_ids:
-            container_instance = self.container_instances[cluster_name].get(container_instance_id, None)
-            if container_instance is not None:
-                container_instance.status = status
-                container_instance_objects.append(container_instance)
-            else:
-                failures.append(ContainerInstanceFailure('MISSING', container_instance_id))
-
-        return container_instance_objects, failures
-
-    def update_container_instances_state(self, cluster_str, list_container_instance_ids, status):
-        cluster_name = cluster_str.split('/')[-1]
-        if cluster_name not in self.clusters:
-            raise Exception("{0} is not a cluster".format(cluster_name))
-        status = status.upper()
-        if status not in ['ACTIVE', 'DRAINING']:
-            raise Exception(
-                "An error occurred (InvalidParameterException) when calling the UpdateContainerInstancesState operation: Container instances status should be one of [ACTIVE,DRAINING]")
-        failures = []
-        container_instance_objects = []
-        for container_instance_id in list_container_instance_ids:
-            container_instance = self.container_instances[cluster_name].get(container_instance_id, None)
-            if container_instance is not None:
-                container_instance.status = status
-                container_instance_objects.append(container_instance)
-            else:
-                failures.append(ContainerInstanceFailure('MISSING', container_instance_id))
-
-        return container_instance_objects, failures
-
-    def update_container_instances_state(self, cluster_str, list_container_instance_ids, status):
-        cluster_name = cluster_str.split('/')[-1]
-        if cluster_name not in self.clusters:
-            raise Exception("{0} is not a cluster".format(cluster_name))
-        if status.upper() not in ['ACTIVE', 'DRAINING']:
-            raise Exception("An error occurred (InvalidParameterException) when calling the UpdateContainerInstancesState operation: Container instances status should be one of [ACTIVE,DRAINING]")
+            raise Exception("An error occurred (InvalidParameterException) when calling the UpdateContainerInstancesState operation: \
+                            Container instances status should be one of [ACTIVE,DRAINING]")
         failures = []
         container_instance_objects = []
         for container_instance_id in list_container_instance_ids:

--- a/moto/ecs/models.py
+++ b/moto/ecs/models.py
@@ -741,7 +741,7 @@ class EC2ContainerServiceBackend(BaseBackend):
         if cluster_name not in self.clusters:
             raise Exception("{0} is not a cluster".format(cluster_name))
         if status.upper() not in ['ACTIVE', 'DRAINING']:
-            raise Exception("InvalidParameterException: An error occurred (InvalidParameterException) when calling the UpdateContainerInstancesState operation: Container instances status should be one of [ACTIVE,DRAINING]")
+            raise Exception("An error occurred (InvalidParameterException) when calling the UpdateContainerInstancesState operation: Container instances status should be one of [ACTIVE,DRAINING]")
         failures = []
         container_instance_objects = []
         for container_instance_id in list_container_instance_ids:

--- a/moto/ecs/models.py
+++ b/moto/ecs/models.py
@@ -193,11 +193,7 @@ class Task(BaseObject):
         self.containers = []
         self.started_by = started_by
         self.stopped_reason = ''
-        self.resource_requirements = {
-            'CPU': 0,
-            'MEMORY': 0,
-            'PORTS': []
-        }
+        self.resource_requirements = resource_requirements
         
 
     @property
@@ -554,12 +550,14 @@ class EC2ContainerServiceBackend(BaseBackend):
                                   for x in container_instances]
         resource_requirements = self._calculate_task_resource_requirements(task_definition)
         for container_instance_id in container_instance_ids:
-            container_instance_arn = self.container_instances[cluster_name][
+            container_instance = self.container_instances[cluster_name][
                 container_instance_id
-            ].containerInstanceArn
-            task = Task(cluster, task_definition, container_instance_arn, resource_requirements,
-                        overrides or {}, started_by or '')
+            ]
+            task = Task(cluster, task_definition, container_instance.containerInstanceArn, 
+                        resource_requirements, overrides or {}, started_by or '')
             tasks.append(task)
+            
+            self.update_container_instance_resources(container_instance, resource_requirements)
             self.tasks[cluster_name][task.task_arn] = task
         return tasks
 

--- a/moto/ecs/models.py
+++ b/moto/ecs/models.py
@@ -139,46 +139,6 @@ class TaskDefinition(BaseObject):
             return original_resource
 
 
-class ContainerDefinition(BaseObject):
-    def __init__(self, name, image, cpu=0, memory=0, memoryReservation=0, links=[],
-                 portMappings=[], essential=True, entryPoint=[], command=[], environment=[],
-                 mountPoints=[], volumesFrom=[], hostname='', user='', workingDirectory='',
-                 disableNetworking=False, privileged=False, readonlyRootFilesystem=False,
-                 dnsServers=[], dnsSearchDomains=[], extraHosts=[], dockerSecurityOptions=[],
-                 dockerLabels={}, uLimits=[], logConfiguration={}):
-        self.name = name
-        self.image = image
-        self.cpu = cpu
-        self.memory = memory
-        self.memory_reservation = memoryReservation
-        self.links = links
-        self.portMappings = portMappings
-        self.essential = essential
-        self.entryPoint = entryPoint
-        self.command = command
-        self.environment = environment
-        self.mountPoints = mountPoints
-        self.volumesFrom = volumesFrom
-        self.hostname = hostname
-        self.user = user
-        self.working_directory = workingDirectory
-        self.disable_networking = disableNetworking
-        self.priviliged = privileged
-        self.readonly_root_filesystem = readonlyRootFilesystem
-        self.dns_servers = dnsServers
-        self.dns_search_domains = dnsSearchDomains
-        self.extra_hosts = extraHosts
-        self.docker_security_options = dockerSecurityOptions
-        self.docker_labels = dockerLabels
-        self.u_limits = uLimits
-        self.log_configuration = logConfiguration
-
-    @property
-    def response_object(self):
-        response_object = self.gen_response_object()
-        return response_object
-
-
 class Task(BaseObject):
 
     def __init__(self, cluster, task_definition, container_instance_arn,

--- a/moto/ecs/models.py
+++ b/moto/ecs/models.py
@@ -533,7 +533,7 @@ class EC2ContainerServiceBackend(BaseBackend):
             return False, "Not enough memory"
         ports_needed = task_resource_requirements.get("PORTS")
         for port in ports_needed:
-            if port in reserved_ports:
+            if str(port) in reserved_ports:
                 return False, "Port clash"
         return True, "Can be placed"
 
@@ -755,9 +755,9 @@ class EC2ContainerServiceBackend(BaseBackend):
             elif resource.get("name") == "PORTS":
                 for port in task_resources.get("PORTS"):
                     if removing:
-                        resource["stringSetValue"].remove(port)
+                        resource["stringSetValue"].remove(str(port))
                     else:
-                        resource["stringSetValue"].append(port)
+                        resource["stringSetValue"].append(str(port))
 
     def deregister_container_instance(self, cluster_str, container_instance_str):
         pass

--- a/moto/ecs/models.py
+++ b/moto/ecs/models.py
@@ -600,7 +600,7 @@ class EC2ContainerServiceBackend(BaseBackend):
         if cluster_name not in self.clusters:
             raise Exception("{0} is not a cluster".format(cluster_name))
         if status.upper() not in ['ACTIVE', 'DRAINING']:
-            raise Exception("InvalidParameterException: An error occurred (InvalidParameterException) when calling the UpdateContainerInstancesState operation: Container instances status should be one of [ACTIVE,DRAINING]")
+            raise Exception("An error occurred (InvalidParameterException) when calling the UpdateContainerInstancesState operation: Container instances status should be one of [ACTIVE,DRAINING]")
         failures = []
         container_instance_objects = []
         for container_instance_id in list_container_instance_ids:

--- a/moto/ecs/models.py
+++ b/moto/ecs/models.py
@@ -712,6 +712,7 @@ class EC2ContainerServiceBackend(BaseBackend):
         failures = []
         container_instance_objects = []
         for container_instance_id in list_container_instance_ids:
+            container_instance_id = container_instance_id.split('/')[-1]
             container_instance = self.container_instances[
                 cluster_name].get(container_instance_id, None)
             if container_instance is not None:

--- a/moto/ecs/models.py
+++ b/moto/ecs/models.py
@@ -380,8 +380,7 @@ class EC2ContainerServiceBackend(BaseBackend):
         container_instances = list(
             self.container_instances.get(cluster_name, {}).keys())
         if not container_instances:
-            raise Exception(
-                "No instances found in cluster {}".format(cluster_name))
+            raise Exception("No instances found in cluster {}".format(cluster_name))
         active_container_instances = [x for x in container_instances if
                                       self.container_instances[cluster_name][x].status == 'ACTIVE']
         for _ in range(count or 1):
@@ -599,7 +598,8 @@ class EC2ContainerServiceBackend(BaseBackend):
         cluster_name = cluster_str.split('/')[-1]
         if cluster_name not in self.clusters:
             raise Exception("{0} is not a cluster".format(cluster_name))
-        if status.upper() not in ['ACTIVE', 'DRAINING']:
+        status = status.upper()
+        if status not in ['ACTIVE', 'DRAINING']:
             raise Exception("An error occurred (InvalidParameterException) when calling the UpdateContainerInstancesState operation: Container instances status should be one of [ACTIVE,DRAINING]")
         failures = []
         container_instance_objects = []

--- a/moto/ecs/responses.py
+++ b/moto/ecs/responses.py
@@ -240,13 +240,3 @@ class EC2ContainerServiceResponse(BaseResponse):
             'failures': [ci.response_object for ci in failures],
             'containerInstances': [ci.response_object for ci in container_instances]
         })
-
-    def update_container_instances_state(self):
-        cluster_str = self._get_param('cluster')
-        list_container_instance_arns = self._get_param('containerInstances')
-        status_str = self._get_param('status')
-        container_instances, failures = self.ecs_backend.update_container_instances_state(cluster_str, list_container_instance_arns, status_str)
-        return json.dumps({
-            'failures': [ci.response_object for ci in failures],
-            'containerInstances': [ci.response_object for ci in container_instances]
-        })

--- a/moto/ecs/responses.py
+++ b/moto/ecs/responses.py
@@ -230,13 +230,3 @@ class EC2ContainerServiceResponse(BaseResponse):
             'failures': [ci.response_object for ci in failures],
             'containerInstances': [ci.response_object for ci in container_instances]
         })
-
-    def update_container_instances_state(self):
-        cluster_str = self._get_param('cluster')
-        list_container_instance_arns = self._get_param('containerInstances')
-        status_str = self._get_param('status')
-        container_instances, failures = self.ecs_backend.update_container_instances_state(cluster_str, list_container_instance_arns, status_str)
-        return json.dumps({
-            'failures': [ci.response_object for ci in failures],
-            'containerInstances': [ci.response_object for ci in container_instances]
-        })

--- a/moto/ecs/responses.py
+++ b/moto/ecs/responses.py
@@ -240,3 +240,13 @@ class EC2ContainerServiceResponse(BaseResponse):
             'failures': [ci.response_object for ci in failures],
             'containerInstances': [ci.response_object for ci in container_instances]
         })
+
+    def update_container_instances_state(self):
+        cluster_str = self._get_param('cluster')
+        list_container_instance_arns = self._get_param('containerInstances')
+        status_str = self._get_param('status')
+        container_instances, failures = self.ecs_backend.update_container_instances_state(cluster_str, list_container_instance_arns, status_str)
+        return json.dumps({
+            'failures': [ci.response_object for ci in failures],
+            'containerInstances': [ci.response_object for ci in container_instances]
+        })

--- a/moto/ecs/responses.py
+++ b/moto/ecs/responses.py
@@ -34,12 +34,7 @@ class EC2ContainerServiceResponse(BaseResponse):
         cluster_arns = self.ecs_backend.list_clusters()
         return json.dumps({
             'clusterArns': cluster_arns
-<<<<<<< HEAD
             #  'nextToken': str(uuid.uuid1())
-=======
-            # ,
-            # 'nextToken': str(uuid.uuid1())
->>>>>>> PEP8 cleanup
         })
 
     def describe_clusters(self):
@@ -71,7 +66,6 @@ class EC2ContainerServiceResponse(BaseResponse):
         task_definition_arns = self.ecs_backend.list_task_definitions()
         return json.dumps({
             'taskDefinitionArns': task_definition_arns
-<<<<<<< HEAD
             #  'nextToken': str(uuid.uuid1())
         })
 
@@ -81,10 +75,6 @@ class EC2ContainerServiceResponse(BaseResponse):
         return json.dumps({
             'taskDefinition': data.response_object,
             'failures': []
-=======
-            # ,
-            # 'nextToken': str(uuid.uuid1())
->>>>>>> PEP8 cleanup
         })
 
     def deregister_task_definition(self):

--- a/moto/ecs/responses.py
+++ b/moto/ecs/responses.py
@@ -225,7 +225,9 @@ class EC2ContainerServiceResponse(BaseResponse):
         cluster_str = self._get_param('cluster')
         list_container_instance_arns = self._get_param('containerInstances')
         status_str = self._get_param('status')
-        container_instances, failures = self.ecs_backend.update_container_instances_state(cluster_str, list_container_instance_arns, status_str)
+        container_instances, failures = self.ecs_backend.update_container_instances_state(cluster_str,
+                                                                                          list_container_instance_arns,
+                                                                                          status_str)
         return json.dumps({
             'failures': [ci.response_object for ci in failures],
             'containerInstances': [ci.response_object for ci in container_instances]

--- a/moto/ecs/responses.py
+++ b/moto/ecs/responses.py
@@ -230,3 +230,13 @@ class EC2ContainerServiceResponse(BaseResponse):
             'failures': [ci.response_object for ci in failures],
             'containerInstances': [ci.response_object for ci in container_instances]
         })
+
+    def update_container_instances_state(self):
+        cluster_str = self._get_param('cluster')
+        list_container_instance_arns = self._get_param('containerInstances')
+        status_str = self._get_param('status')
+        container_instances, failures = self.ecs_backend.update_container_instances_state(cluster_str, list_container_instance_arns, status_str)
+        return json.dumps({
+            'failures': [ci.response_object for ci in failures],
+            'containerInstances': [ci.response_object for ci in container_instances]
+        })

--- a/moto/ecs/responses.py
+++ b/moto/ecs/responses.py
@@ -34,7 +34,12 @@ class EC2ContainerServiceResponse(BaseResponse):
         cluster_arns = self.ecs_backend.list_clusters()
         return json.dumps({
             'clusterArns': cluster_arns
+<<<<<<< HEAD
             #  'nextToken': str(uuid.uuid1())
+=======
+            # ,
+            # 'nextToken': str(uuid.uuid1())
+>>>>>>> PEP8 cleanup
         })
 
     def describe_clusters(self):
@@ -66,6 +71,7 @@ class EC2ContainerServiceResponse(BaseResponse):
         task_definition_arns = self.ecs_backend.list_task_definitions()
         return json.dumps({
             'taskDefinitionArns': task_definition_arns
+<<<<<<< HEAD
             #  'nextToken': str(uuid.uuid1())
         })
 
@@ -75,6 +81,10 @@ class EC2ContainerServiceResponse(BaseResponse):
         return json.dumps({
             'taskDefinition': data.response_object,
             'failures': []
+=======
+            # ,
+            # 'nextToken': str(uuid.uuid1())
+>>>>>>> PEP8 cleanup
         })
 
     def deregister_task_definition(self):
@@ -216,16 +226,6 @@ class EC2ContainerServiceResponse(BaseResponse):
         list_container_instance_arns = self._get_param('containerInstances')
         container_instances, failures = self.ecs_backend.describe_container_instances(
             cluster_str, list_container_instance_arns)
-        return json.dumps({
-            'failures': [ci.response_object for ci in failures],
-            'containerInstances': [ci.response_object for ci in container_instances]
-        })
-
-    def update_container_instances_state(self):
-        cluster_str = self._get_param('cluster')
-        list_container_instance_arns = self._get_param('containerInstances')
-        status_str = self._get_param('status')
-        container_instances, failures = self.ecs_backend.update_container_instances_state(cluster_str, list_container_instance_arns, status_str)
         return json.dumps({
             'failures': [ci.response_object for ci in failures],
             'containerInstances': [ci.response_object for ci in container_instances]

--- a/tests/test_ecs/test_ecs_boto3.py
+++ b/tests/test_ecs/test_ecs_boto3.py
@@ -622,6 +622,7 @@ def test_describe_container_instances():
     for arn in test_instance_arns:
         response_arns.should.contain(arn)
 
+
 @mock_ec2
 @mock_ecs
 def test_update_container_instances_state():
@@ -653,26 +654,33 @@ def test_update_container_instances_state():
         test_instance_arns.append(response['containerInstance']['containerInstanceArn'])
 
     test_instance_ids = list(map((lambda x: x.split('/')[1]), test_instance_arns))
-    response = ecs_client.update_container_instances_state(cluster=test_cluster_name, containerInstances=test_instance_ids, status='DRAINING')
+    response = ecs_client.update_container_instances_state(cluster=test_cluster_name,
+                                                           containerInstances=test_instance_ids,
+                                                           status='DRAINING')
     len(response['failures']).should.equal(0)
     len(response['containerInstances']).should.equal(instance_to_create)
     response_statuses = [ci['status'] for ci in response['containerInstances']]
     for status in response_statuses:
         status.should.equal('DRAINING')
-    response = ecs_client.update_container_instances_state(cluster=test_cluster_name, containerInstances=test_instance_ids, status='DRAINING')
+    response = ecs_client.update_container_instances_state(cluster=test_cluster_name,
+                                                           containerInstances=test_instance_ids,
+                                                           status='DRAINING')
     len(response['failures']).should.equal(0)
     len(response['containerInstances']).should.equal(instance_to_create)
     response_statuses = [ci['status'] for ci in response['containerInstances']]
     for status in response_statuses:
         status.should.equal('DRAINING')
-    response = ecs_client.update_container_instances_state(cluster=test_cluster_name, containerInstances=test_instance_ids, status='ACTIVE')
+    response = ecs_client.update_container_instances_state(cluster=test_cluster_name,
+                                                           containerInstances=test_instance_ids,
+                                                           status='ACTIVE')
     len(response['failures']).should.equal(0)
     len(response['containerInstances']).should.equal(instance_to_create)
     response_statuses = [ci['status'] for ci in response['containerInstances']]
     for status in response_statuses:
         status.should.equal('ACTIVE')
-    ecs_client.update_container_instances_state.when.called_with(cluster=test_cluster_name, containerInstances=test_instance_ids, status='test_status').should.throw(Exception)
-
+    ecs_client.update_container_instances_state.when.called_with(cluster=test_cluster_name,
+                                                                 containerInstances=test_instance_ids,
+                                                                 status='test_status').should.throw(Exception)
 
 
 @mock_ec2
@@ -838,7 +846,7 @@ def test_list_tasks():
         ec2_utils.generate_instance_identity_document(test_instance)
     )
 
-    response = client.register_container_instance(
+    _ = client.register_container_instance(
         cluster=test_cluster_name,
         instanceIdentityDocument=instance_id_document
     )

--- a/tests/test_ecs/test_ecs_boto3.py
+++ b/tests/test_ecs/test_ecs_boto3.py
@@ -1149,6 +1149,132 @@ def test_create_task_definition_through_cloudformation():
     len(resp['taskDefinitionArns']).should.equal(1)
 
 
+@mock_ec2
+@mock_ecs
+def test_task_definitions_unable_to_be_placed():
+    client = boto3.client('ecs', region_name='us-east-1')
+    ec2 = boto3.resource('ec2', region_name='us-east-1')
+
+    test_cluster_name = 'test_ecs_cluster'
+
+    _ = client.create_cluster(
+        clusterName=test_cluster_name
+    )
+
+    test_instance = ec2.create_instances(
+        ImageId="ami-1234abcd",
+        MinCount=1,
+        MaxCount=1,
+    )[0]
+
+    instance_id_document = json.dumps(
+        ec2_utils.generate_instance_identity_document(test_instance)
+    )
+
+    response = client.register_container_instance(
+        cluster=test_cluster_name,
+        instanceIdentityDocument=instance_id_document
+    )
+
+    _ = client.register_task_definition(
+        family='test_ecs_task',
+        containerDefinitions=[
+            {
+                'name': 'hello_world',
+                'image': 'docker/hello-world:latest',
+                'cpu': 5000,
+                'memory': 40000,
+                'essential': True,
+                'environment': [{
+                    'name': 'AWS_ACCESS_KEY_ID',
+                    'value': 'SOME_ACCESS_KEY'
+                }],
+                'logConfiguration': {'logDriver': 'json-file'}
+            }
+        ]
+    )
+    response = client.run_task(
+        cluster='test_ecs_cluster',
+        overrides={},
+        taskDefinition='test_ecs_task',
+        count=2,
+        startedBy='moto'
+    )
+    len(response['tasks']).should.equal(0)
+
+@mock_ec2
+@mock_ecs
+def test_task_definitions_with_port_clash():
+    client = boto3.client('ecs', region_name='us-east-1')
+    ec2 = boto3.resource('ec2', region_name='us-east-1')
+
+    test_cluster_name = 'test_ecs_cluster'
+
+    _ = client.create_cluster(
+        clusterName=test_cluster_name
+    )
+
+    test_instance = ec2.create_instances(
+        ImageId="ami-1234abcd",
+        MinCount=1,
+        MaxCount=1,
+    )[0]
+
+    instance_id_document = json.dumps(
+        ec2_utils.generate_instance_identity_document(test_instance)
+    )
+
+    response = client.register_container_instance(
+        cluster=test_cluster_name,
+        instanceIdentityDocument=instance_id_document
+    )
+
+    _ = client.register_task_definition(
+        family='test_ecs_task',
+        containerDefinitions=[
+            {
+                'name': 'hello_world',
+                'image': 'docker/hello-world:latest',
+                'cpu': 256,
+                'memory': 512,
+                'essential': True,
+                'environment': [{
+                    'name': 'AWS_ACCESS_KEY_ID',
+                    'value': 'SOME_ACCESS_KEY'
+                }],
+                'logConfiguration': {'logDriver': 'json-file'},
+                'portMappings': [
+                    {
+                        'hostPort': 80,
+                        'containerPort': 8080
+                    }
+                ]
+            }
+        ]
+    )
+    response = client.run_task(
+        cluster='test_ecs_cluster',
+        overrides={},
+        taskDefinition='test_ecs_task',
+        count=2,
+        startedBy='moto'
+    )
+    len(response['tasks']).should.equal(1)
+    response['tasks'][0]['taskArn'].should.contain(
+        'arn:aws:ecs:us-east-1:012345678910:task/')
+    response['tasks'][0]['clusterArn'].should.equal(
+        'arn:aws:ecs:us-east-1:012345678910:cluster/test_ecs_cluster')
+    response['tasks'][0]['taskDefinitionArn'].should.equal(
+        'arn:aws:ecs:us-east-1:012345678910:task-definition/test_ecs_task:1')
+    response['tasks'][0]['containerInstanceArn'].should.contain(
+        'arn:aws:ecs:us-east-1:012345678910:container-instance/')
+    response['tasks'][0]['overrides'].should.equal({})
+    response['tasks'][0]['lastStatus'].should.equal("RUNNING")
+    response['tasks'][0]['desiredStatus'].should.equal("RUNNING")
+    response['tasks'][0]['startedBy'].should.equal("moto")
+    response['tasks'][0]['stoppedReason'].should.equal("")
+    
+
 @mock_ecs
 @mock_cloudformation
 def test_update_task_definition_family_through_cloudformation_should_trigger_a_replacement():

--- a/tests/test_ecs/test_ecs_boto3.py
+++ b/tests/test_ecs/test_ecs_boto3.py
@@ -531,8 +531,8 @@ def test_register_container_instance():
         'arn:aws:ecs:us-east-1:012345678910:container-instance')
     arn_part[1].should.equal(str(UUID(arn_part[1])))
     response['containerInstance']['status'].should.equal('ACTIVE')
-    len(response['containerInstance']['registeredResources']).should.equal(0)
-    len(response['containerInstance']['remainingResources']).should.equal(0)
+    len(response['containerInstance']['registeredResources']).should.equal(4)
+    len(response['containerInstance']['remainingResources']).should.equal(4)
     response['containerInstance']['agentConnected'].should.equal(True)
     response['containerInstance']['versionInfo'][
         'agentVersion'].should.equal('1.0.0')

--- a/tests/test_ecs/test_ecs_boto3.py
+++ b/tests/test_ecs/test_ecs_boto3.py
@@ -1037,13 +1037,6 @@ def test_stop_task():
         count=1,
         startedBy='moto'
     )
-    container_instance_arn = run_response['tasks'][0].get('containerInstanceArn')
-    container_instance_description = client.describe_container_instances(
-        cluster='test_ecs_cluster',
-        containerInstances=[container_instance_arn]
-    )['containerInstances'][0]
-    remaining_resources = container_instance_description['remainingResources']
-    registered_resources = container_instance_description['registeredResources']
     stop_response = client.stop_task(
         cluster='test_ecs_cluster',
         task=run_response['tasks'][0].get('taskArn'),
@@ -1055,6 +1048,7 @@ def test_stop_task():
     stop_response['task']['lastStatus'].should.equal('STOPPED')
     stop_response['task']['desiredStatus'].should.equal('STOPPED')
     stop_response['task']['stoppedReason'].should.equal('moto testing')
+
 
 @mock_ec2
 @mock_ecs
@@ -1123,7 +1117,7 @@ def test_resource_reservation_and_release():
     remaining_resources['MEMORY'].should.equal(registered_resources['MEMORY'] - 400)
     registered_resources['PORTS'].append('80')
     remaining_resources['PORTS'].should.equal(registered_resources['PORTS'])
-    stop_response = client.stop_task(
+    client.stop_task(
         cluster='test_ecs_cluster',
         task=run_response['tasks'][0].get('taskArn'),
         reason='moto testing'
@@ -1290,6 +1284,7 @@ def test_task_definitions_unable_to_be_placed():
     )
     len(response['tasks']).should.equal(0)
 
+
 @mock_ec2
 @mock_ecs
 def test_task_definitions_with_port_clash():
@@ -1361,7 +1356,7 @@ def test_task_definitions_with_port_clash():
     response['tasks'][0]['desiredStatus'].should.equal("RUNNING")
     response['tasks'][0]['startedBy'].should.equal("moto")
     response['tasks'][0]['stoppedReason'].should.equal("")
-    
+
 
 @mock_ecs
 @mock_cloudformation


### PR DESCRIPTION
*Features:*
* Now implements a basic model of Container Instance Resources (providing defaults based on C4.Xlarges - future work to base this on the EC2 instance type to follow) - existing tests updated and new ones added for this
* Check for ability to place a task on each instance - refuse to place on a task without the `MEMORY`, `CPU` or `PORTS` reminding to place the task on the instance - new tests for this
* Reserve resources on start of a task, free up on removal - new tests added for this

*Bug Fixes:*
* Now able to use container instance ARNs for `describe_container_instances` - one new test covers this case

I'm not sure I've followed your preferred practice in all the cases, creating a few private helper methods for calculating resources given the AWS implementation as a list of dicts rather than duplicate code, happy to rework if need be.