### PR TITLE
Container Instance Resource implementation

### DIFF
--- a/moto/ecs/responses.py
+++ b/moto/ecs/responses.py
@@ -225,7 +225,9 @@ class EC2ContainerServiceResponse(BaseResponse):
         cluster_str = self._get_param('cluster')
         list_container_instance_arns = self._get_param('containerInstances')
         status_str = self._get_param('status')
-        container_instances, failures = self.ecs_backend.update_container_instances_state(cluster_str, list_container_instance_arns, status_str)
+        container_instances, failures = self.ecs_backend.update_container_instances_state(cluster_str,
+                                                                                          list_container_instance_arns,
+                                                                                          status_str)
         return json.dumps({
             'failures': [ci.response_object for ci in failures],
             'containerInstances': [ci.response_object for ci in container_instances]


### PR DESCRIPTION
*Features:*
* Now implements a basic model of Container Instance Resources (providing defaults based on C4.Xlarges - future work to base this on the EC2 instance type to follow) - existing tests updated and new ones added for this
* Check for ability to place a task on each instance - refuse to place on a task without the `MEMORY`, `CPU` or `PORTS` reminding to place the task on the instance - new tests for this
* Reserve resources on start of a task, free up on removal - new tests added for this

*Bug Fixes:*
* Now able to use container instance ARNs for `describe_container_instances` - one new test covers this case

I'm not sure I've followed your preferred practice in all the cases, creating a few private helper methods for calculating resources given the AWS implementation as a list of dicts rather than duplicate code, happy to rework if need be.