### PR TITLE
Add list user policies endpoint to iam backend.

### DIFF
--- a/moto/iam/models.py
+++ b/moto/iam/models.py
@@ -729,6 +729,10 @@ class IAMBackend(BaseBackend):
         policy = user.get_policy(policy_name)
         return policy
 
+    def list_user_policies(self, user_name):
+        user = self.get_user(user_name)
+        return user.policies.keys()
+
     def put_user_policy(self, user_name, policy_name, policy_json):
         user = self.get_user(user_name)
         user.put_policy(policy_name, policy_json)

--- a/moto/iam/responses.py
+++ b/moto/iam/responses.py
@@ -287,6 +287,12 @@ class IamResponse(BaseResponse):
             policy_document=policy_document
         )
 
+    def list_user_policies(self):
+        user_name = self._get_param('UserName')
+        policies = iam_backend.list_user_policies(user_name)
+        template = self.response_template(LIST_USER_POLICIES_TEMPLATE)
+        return template.render(policies=policies)
+
     def put_user_policy(self):
         user_name = self._get_param('UserName')
         policy_name = self._get_param('PolicyName')
@@ -853,6 +859,20 @@ GET_USER_POLICY_TEMPLATE = """<GetUserPolicyResponse>
       <RequestId>7a62c49f-347e-4fc4-9331-6e8eEXAMPLE</RequestId>
    </ResponseMetadata>
 </GetUserPolicyResponse>"""
+
+LIST_USER_POLICIES_TEMPLATE = """<ListUserPoliciesResponse>
+   <ListUserPoliciesResult>
+      <PolicyNames>
+        {% for policy in policies %}
+         <member>{{ policy }}</member>
+        {% endfor %}
+      </PolicyNames>
+   </ListUserPoliciesResult>
+   <IsTruncated>false</IsTruncated>
+   <ResponseMetadata>
+      <RequestId>7a62c49f-347e-4fc4-9331-6e8eEXAMPLE</RequestId>
+   </ResponseMetadata>
+</ListUserPoliciesResponse>"""
 
 CREATE_ACCESS_KEY_TEMPLATE = """<CreateAccessKeyResponse>
    <CreateAccessKeyResult>

--- a/tests/test_iam/test_iam.py
+++ b/tests/test_iam/test_iam.py
@@ -234,6 +234,39 @@ def test_list_users():
     user['Arn'].should.equal('arn:aws:iam::123456789012:user/my-user')
 
 
+@mock_iam()
+def test_user_policies():
+    policy_name = 'UserManagedPolicy'
+    policy_document = "{'mypolicy': 'test'}"
+    user_name = 'my-user'
+    conn = boto3.client('iam', region_name='us-east-1')
+    conn.create_user(UserName=user_name)
+    conn.put_user_policy(
+        UserName=user_name,
+        PolicyName=policy_name,
+        PolicyDocument=policy_document
+    )
+
+    policy_doc = conn.get_user_policy(
+        UserName=user_name,
+        PolicyName=policy_name
+    )
+    test = policy_document in policy_doc['PolicyDocument']
+    test.should.equal(True)
+
+    policies = conn.list_user_policies(UserName=user_name)
+    len(policies['PolicyNames']).should.equal(1)
+    policies['PolicyNames'][0].should.equal(policy_name)
+
+    conn.delete_user_policy(
+        UserName=user_name,
+        PolicyName=policy_name
+    )
+
+    policies = conn.list_user_policies(UserName=user_name)
+    len(policies['PolicyNames']).should.equal(0)
+
+
 @mock_iam_deprecated()
 def test_create_login_profile():
     conn = boto.connect_iam()


### PR DESCRIPTION
- Add response and endpoint methods.
- Add test covering put, get, delete and list user policy.

Closes #878

Note: I was a bit confused about the type being returned by get_user_policy hence the assertion based on policy doc in the string.