### PR TITLE
s3: handle WebsiteRedirectLocation

### DIFF
--- a/moto/s3/models.py
+++ b/moto/s3/models.py
@@ -25,6 +25,7 @@ class FakeKey(BaseModel):
         self.value = value
         self.last_modified = datetime.datetime.utcnow()
         self.acl = get_canned_acl('private')
+        self.website_redirect_location = None
         self._storage_class = storage if storage else "STANDARD"
         self._metadata = {}
         self._expiry = None
@@ -102,6 +103,9 @@ class FakeKey(BaseModel):
 
         if self._is_versioned:
             res['x-amz-version-id'] = str(self._version_id)
+
+        if self.website_redirect_location:
+            res['x-amz-website-redirect-location'] = self.website_redirect_location
 
         return res
 

--- a/moto/s3/responses.py
+++ b/moto/s3/responses.py
@@ -570,6 +570,7 @@ class ResponseObject(_TemplateEnvironmentMixin):
             metadata = metadata_from_headers(request.headers)
             new_key.set_metadata(metadata)
             new_key.set_acl(acl)
+            new_key.website_redirect_location = request.headers.get('x-amz-website-redirect-location')
 
         template = self.response_template(S3_OBJECT_RESPONSE)
         response_headers.update(new_key.response_dict)

--- a/tests/test_s3/test_s3.py
+++ b/tests/test_s3/test_s3.py
@@ -1046,6 +1046,19 @@ def test_boto3_key_etag():
     resp = s3.get_object(Bucket='mybucket', Key='steve')
     resp['ETag'].should.equal('"d32bda93738f7e03adb22e66c90fbc04"')
 
+@mock_s3
+def test_website_redirect_location():
+    s3 = boto3.client('s3', region_name='us-east-1')
+    s3.create_bucket(Bucket='mybucket')
+
+    s3.put_object(Bucket='mybucket', Key='steve', Body=b'is awesome')
+    resp = s3.get_object(Bucket='mybucket', Key='steve')
+    resp.get('WebsiteRedirectLocation').should.be.none
+
+    url = 'https://github.com/spulec/moto'
+    s3.put_object(Bucket='mybucket', Key='steve', Body=b'is awesome', WebsiteRedirectLocation=url)
+    resp = s3.get_object(Bucket='mybucket', Key='steve')
+    resp['WebsiteRedirectLocation'].should.equal(url)
 
 @mock_s3
 def test_boto3_list_keys_xml_escaped():


### PR DESCRIPTION
S3 keys has a special header x-amz-website-redirect-location/WebsiteRedirectLocation which results into permanent redirection when a key is accessed.

boto3 put_object/get_object key: WebsiteRedirectLocation
s3 header name: x-amz-website-redirect-location

spulec/moto#821