### PR TITLE
Return the revision in ecs.register_task_definition

### DIFF
--- a/moto/ecs/models.py
+++ b/moto/ecs/models.py
@@ -89,6 +89,7 @@ class TaskDefinition(BaseObject):
 
     def __init__(self, family, revision, container_definitions, volumes=None):
         self.family = family
+        self.revision = revision
         self.arn = 'arn:aws:ecs:us-east-1:012345678910:task-definition/{0}:{1}'.format(
             family, revision)
         self.container_definitions = container_definitions

--- a/tests/test_ecs/test_ecs_boto3.py
+++ b/tests/test_ecs/test_ecs_boto3.py
@@ -86,6 +86,7 @@ def test_register_task_definition():
         ]
     )
     type(response['taskDefinition']).should.be(dict)
+    response['taskDefinition']['revision'].should.equal(1)
     response['taskDefinition']['taskDefinitionArn'].should.equal(
         'arn:aws:ecs:us-east-1:012345678910:task-definition/test_ecs_task:1')
     response['taskDefinition']['containerDefinitions'][


### PR DESCRIPTION
This matches boto, see
http://boto3.readthedocs.io/en/latest/reference/services/ecs.html#ECS.Client.register_task_definition