### PR TITLE
Fixing metadata key on s3 operation response

### DIFF
--- a/moto/s3/models.py
+++ b/moto/s3/models.py
@@ -91,7 +91,7 @@ class FakeKey(BaseModel):
     @property
     def response_dict(self):
         res = {
-            'Etag': self.etag,
+            'ETag': self.etag,
             'last-modified': self.last_modified_RFC1123,
             'content-length': str(len(self.value)),
         }

--- a/tests/test_s3/test_server.py
+++ b/tests/test_s3/test_server.py
@@ -34,6 +34,7 @@ def test_s3_server_bucket_create():
     res = test_client.put(
         '/bar', 'http://foobaz.localhost:5000/', data='test value')
     res.status_code.should.equal(200)
+    assert 'ETag' in dict(res.headers)
 
     res = test_client.get('/bar', 'http://foobaz.localhost:5000/')
     res.status_code.should.equal(200)


### PR DESCRIPTION
ETag metadata key is being returned as "Etag" instead of "ETag". This leads to issues in some AWS SDKs using MotoServer. This change fixes the issue by updating the key to the correct format.

This closes #920