### PR TITLE
ValueError when calling boto3 list_object_versions

### DIFF
--- a/moto/s3/responses.py
+++ b/moto/s3/responses.py
@@ -224,7 +224,7 @@ class ResponseObject(_TemplateEnvironmentMixin):
                 key_list=versions,
                 bucket=bucket,
                 prefix='',
-                max_keys='',
+                max_keys=1000,
                 delimiter='',
                 is_truncated='false',
             )

--- a/tests/test_s3/test_s3.py
+++ b/tests/test_s3/test_s3.py
@@ -14,6 +14,7 @@ from boto.exception import S3CreateError, S3ResponseError
 from boto.s3.connection import S3Connection
 from boto.s3.key import Key
 from freezegun import freeze_time
+import six
 import requests
 import tests.backport_assert_raises  # noqa
 from nose.tools import assert_raises
@@ -1299,7 +1300,8 @@ def test_boto3_list_object_versions():
     bucket_name = 'mybucket'
     key = 'key-with-versions'
     s3.create_bucket(Bucket=bucket_name)
-    for body in ('v1', 'v2'):
+    items = (six.b('v1'), six.b('v2'))
+    for body in items:
         s3.put_object(
             Bucket=bucket_name,
             Key=key,
@@ -1314,7 +1316,7 @@ def test_boto3_list_object_versions():
     keys.should.equal({key})
     # Test latest object version is returned
     response = s3.get_object(Bucket=bucket_name, Key=key)
-    response['Body'].read().should.equal('v2')
+    response['Body'].read().should.equal(items[-1])
 
 
 TEST_XML = """\

--- a/tests/test_s3/test_s3.py
+++ b/tests/test_s3/test_s3.py
@@ -1293,6 +1293,30 @@ def test_boto3_multipart_etag():
     resp['ETag'].should.equal(EXPECTED_ETAG)
 
 
+@mock_s3
+def test_boto3_list_object_versions():
+    s3 = boto3.client('s3', region_name='us-east-1')
+    bucket_name = 'mybucket'
+    key = 'key-with-versions'
+    s3.create_bucket(Bucket=bucket_name)
+    for body in ('v1', 'v2'):
+        s3.put_object(
+            Bucket=bucket_name,
+            Key=key,
+            Body=body
+        )
+    response = s3.list_object_versions(
+        Bucket=bucket_name
+    )
+    # Two object versions should be returned
+    len(response['Versions']).should.equal(2)
+    keys = set([item['Key'] for item in response['Versions']])
+    keys.should.equal({key})
+    # Test latest object version is returned
+    response = s3.get_object(Bucket=bucket_name, Key=key)
+    response['Body'].read().should.equal('v2')
+
+
 TEST_XML = """\
 <?xml version="1.0" encoding="UTF-8"?>
 <ns0:WebsiteConfiguration xmlns:ns0="http://s3.amazonaws.com/doc/2006-03-01/">


### PR DESCRIPTION
When calling S3 [list_object_versions](http://boto3.readthedocs.io/en/latest/reference/services/s3.html?highlight=s3#S3.Client.list_object_versions) the following exception is raised:

```
ValueError: invalid literal for int() with base 10: ''
```

- [x] Adding a failing test to veify bug and avoid regression.
- [x] Fix error by specifying correct type for `MaxKeys` in response template.