### PR TITLE
bundled httpretty: re-normalize headers after executing callable_body

### DIFF
--- a/moto/packages/httpretty/core.py
+++ b/moto/packages/httpretty/core.py
@@ -597,6 +597,7 @@ class Entry(BaseClass):
         if self.body_is_callable:
             status, headers, self.body = self.callable_body(
                 self.request, self.info.full_url(), headers)
+            headers = self.normalize_headers(headers)
             if self.request.method != "HEAD":
                 headers.update({
                     'content-length': len(self.body)


### PR DESCRIPTION
I won't give the whole lecture about bundling dependencies, but I will say that when I've *really had to* bundle a modified dependency I've found it effective to point to it through a git submodule, allowing the forked lib to exist as its own repo which can have updates merged back & forth from the upstream with ease. The fix for this appears to have been in the upstream httpretty for quite some time.

Without this patch, in python 3.4, a `HEAD` request to an S3 object will return duplicate content type headers (`Content-Type` and `content-type`). Which is really weird to debug.

I haven't fully investigated why this only appears to happen in py3.
