### PR TITLE
Update list IAM AccessKeys

### DIFF
--- a/moto/iam/models.py
+++ b/moto/iam/models.py
@@ -177,7 +177,7 @@ class AccessKey(BaseModel):
         self.status = 'Active'
         self.create_date = datetime.strftime(
             datetime.utcnow(),
-            "%Y-%m-%d-%H-%M-%S"
+            "%Y-%m-%dT%H:%M:%SZ"
         )
 
     def get_cfn_attribute(self, attribute_name):

--- a/moto/iam/responses.py
+++ b/moto/iam/responses.py
@@ -900,6 +900,7 @@ LIST_ACCESS_KEYS_TEMPLATE = """<ListAccessKeysResponse>
             <UserName>{{ user_name }}</UserName>
             <AccessKeyId>{{ key.access_key_id }}</AccessKeyId>
             <Status>{{ key.status }}</Status>
+            <CreateDate>{{ key.create_date }}</CreateDate>
          </member>
         {% endfor %}
       </AccessKeyMetadata>

--- a/tests/test_iam/test_iam.py
+++ b/tests/test_iam/test_iam.py
@@ -299,6 +299,8 @@ def test_create_access_key():
 
 @mock_iam_deprecated()
 def test_get_all_access_keys():
+    """If no access keys exist there should be none in the response,
+    if an access key is present it should have the correct fields present"""
     conn = boto.connect_iam()
     conn.create_user('my-user')
     response = conn.get_all_access_keys('my-user')
@@ -309,10 +311,10 @@ def test_get_all_access_keys():
     )
     conn.create_access_key('my-user')
     response = conn.get_all_access_keys('my-user')
-    assert_not_equals(
-        response['list_access_keys_response'][
-            'list_access_keys_result']['access_key_metadata'],
-        []
+    assert_equals(
+        sorted(response['list_access_keys_response'][
+            'list_access_keys_result']['access_key_metadata'][0].keys()),
+        sorted(['status', 'create_date', 'user_name', 'access_key_id'])
     )
 
 


### PR DESCRIPTION
Add the creation date, including timezone info, to the data returned
when requesting all AccessKeys for an IAM user.

This fixes #75