### PR TITLE
fix warning on py2 as well

### DIFF
--- a/moto/core/models.py
+++ b/moto/core/models.py
@@ -229,10 +229,7 @@ class InstanceTrackerMeta(type):
 @six.add_metaclass(InstanceTrackerMeta)
 class BaseModel(object):
     def __new__(cls, *args, **kwargs):
-        if six.PY2:
-            instance = super(BaseModel, cls).__new__(cls, *args, **kwargs)
-        else:
-            instance = super(BaseModel, cls).__new__(cls)
+        instance = super(BaseModel, cls).__new__(cls)
         cls.instances.append(instance)
         return instance
 


### PR DESCRIPTION
object takes no constructor argument whatever the python version.
we simplify the code to not use constructor arguments

fix #942 