### PR TITLE
Fixes issue #949 - Add mock as dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ install_requires = [
     "pyaml",
     "pytz",
     "python-dateutil",
+    "mock",
 ]
 
 extras_require = {


### PR DESCRIPTION
This fixes issue #949. The fix can be verified by running the following:

```
import moto
with moto.mock_s3():
    pass
```
