### PR TITLE
Fix the error code for IAMNotFoundException to NoSuchEntity used by AWS.

### DIFF
--- a/moto/iam/exceptions.py
+++ b/moto/iam/exceptions.py
@@ -7,7 +7,7 @@ class IAMNotFoundException(RESTError):
 
     def __init__(self, message):
         super(IAMNotFoundException, self).__init__(
-            "Not Found", message)
+            "NoSuchEntity", message)
 
 
 class IAMConflictException(RESTError):


### PR DESCRIPTION
Spotted this while trying to improve some error handling code.
If you look at the AWS Reference under any method (e.g. AttachGroupPolicy) you will see that the error code for an http status code of 404 is `NoSuchEntity`.
A general rule of thumb is that these error codes are camel cased and with no spaces.

[Example with AttachGroupPolicy (see under *Errors*](http://docs.aws.amazon.com/IAM/latest/APIReference/API_AttachGroupPolicy.html)**