### PR TITLE
Add extended CloudFormation models for Lambda and DynamoDB

### DIFF
--- a/moto/cloudformation/parsing.py
+++ b/moto/cloudformation/parsing.py
@@ -7,7 +7,9 @@ import warnings
 
 from moto.autoscaling import models as autoscaling_models
 from moto.awslambda import models as lambda_models
+from moto.cloudwatch import models as cloudwatch_models
 from moto.datapipeline import models as datapipeline_models
+from moto.dynamodb import models as dynamodb_models
 from moto.ec2 import models as ec2_models
 from moto.ecs import models as ecs_models
 from moto.elb import models as elb_models
@@ -27,7 +29,10 @@ from boto.cloudformation.stack import Output
 MODEL_MAP = {
     "AWS::AutoScaling::AutoScalingGroup": autoscaling_models.FakeAutoScalingGroup,
     "AWS::AutoScaling::LaunchConfiguration": autoscaling_models.FakeLaunchConfiguration,
+    "AWS::DynamoDB::Table": dynamodb_models.Table,
+    "AWS::Lambda::EventSourceMapping": lambda_models.EventSourceMapping,
     "AWS::Lambda::Function": lambda_models.LambdaFunction,
+    "AWS::Lambda::Version": lambda_models.LambdaVersion,
     "AWS::EC2::EIP": ec2_models.ElasticAddress,
     "AWS::EC2::Instance": ec2_models.Instance,
     "AWS::EC2::InternetGateway": ec2_models.InternetGateway,
@@ -53,6 +58,7 @@ MODEL_MAP = {
     "AWS::IAM::InstanceProfile": iam_models.InstanceProfile,
     "AWS::IAM::Role": iam_models.Role,
     "AWS::KMS::Key": kms_models.Key,
+    "AWS::Logs::LogGroup": cloudwatch_models.LogGroup,
     "AWS::RDS::DBInstance": rds_models.Database,
     "AWS::RDS::DBSecurityGroup": rds_models.SecurityGroup,
     "AWS::RDS::DBSubnetGroup": rds_models.SubnetGroup,
@@ -133,7 +139,7 @@ def clean_json(resource_json, resources_map):
             try:
                 return resource.get_cfn_attribute(resource_json['Fn::GetAtt'][1])
             except NotImplementedError as n:
-                logger.warning(n.message.format(
+                logger.warning(str(n).format(
                     resource_json['Fn::GetAtt'][0]))
             except UnformattedGetAttTemplateException:
                 raise ValidationError(

--- a/moto/cloudwatch/models.py
+++ b/moto/cloudwatch/models.py
@@ -111,6 +111,27 @@ class CloudWatchBackend(BaseBackend):
         return self.metric_data
 
 
+class LogGroup(BaseModel):
+
+    def __init__(self, spec):
+        # required
+        self.name = spec['LogGroupName']
+        # optional
+        self.tags = spec.get('Tags', [])
+
+    @classmethod
+    def create_from_cloudformation_json(cls, resource_name, cloudformation_json, region_name):
+        properties = cloudformation_json['Properties']
+        spec = {
+            'LogGroupName': properties['LogGroupName']
+        }
+        optional_properties = 'Tags'.split()
+        for prop in optional_properties:
+            if prop in properties:
+                spec[prop] = properties[prop]
+        return LogGroup(spec)
+
+
 cloudwatch_backends = {}
 for region in boto.ec2.cloudwatch.regions():
     cloudwatch_backends[region.name] = CloudWatchBackend()


### PR DESCRIPTION
This PR adds extended CloudFormation models for Lambda and DynamoDB. We encountered that these classes are missing when deploying a simple sample project via *serverless* (https://github.com/serverless/serverless)

* new class `EventSourceMapping`
* new class `LambdaVersion`
* new class `LogGroup`
* new mappings in `parsing.py`

Additionally, this PR introduces an environment variable `VALIDATE_LAMBDA_S3` to allow us to configure whether creating an instance of `LambdaFunction` should necessarily raise an exception if the code does not exist in S3. This is also required to get serverless working locally. Note that the default behavior has been left unchanged (i.e., do validate if `VALIDATE_LAMBDA_S3` is not set), so there should be no issues with backwards compatibility whatsoever.