### PR TITLE
Use region list from Boto.

### DIFF
--- a/moto/ec2/models.py
+++ b/moto/ec2/models.py
@@ -5,6 +5,8 @@ import itertools
 import re
 import six
 
+import boto.ec2
+
 from collections import defaultdict
 from datetime import datetime
 from boto.ec2.instance import Instance as BotoInstance, Reservation
@@ -1143,24 +1145,7 @@ class Zone(object):
 
 
 class RegionsAndZonesBackend(object):
-    regions = [
-        Region("ap-northeast-1", "ec2.ap-northeast-1.amazonaws.com"),
-        Region("ap-northeast-2", "ec2.ap-northeast-2.amazonaws.com"),
-        Region("ap-south-1", "ec2.ap-south-1.amazonaws.com"),
-        Region("ap-southeast-1", "ec2.ap-southeast-1.amazonaws.com"),
-        Region("ap-southeast-2", "ec2.ap-southeast-2.amazonaws.com"),
-        Region("ca-central-1", "ec2.ca-central-1.amazonaws.com.cn"),
-        Region("cn-north-1", "ec2.cn-north-1.amazonaws.com.cn"),
-        Region("eu-central-1", "ec2.eu-central-1.amazonaws.com"),
-        Region("eu-west-1", "ec2.eu-west-1.amazonaws.com"),
-        Region("eu-west-2", "ec2.eu-west-2.amazonaws.com"),
-        Region("sa-east-1", "ec2.sa-east-1.amazonaws.com"),
-        Region("us-east-1", "ec2.us-east-1.amazonaws.com"),
-        Region("us-east-2", "ec2.us-east-2.amazonaws.com"),
-        Region("us-gov-west-1", "ec2.us-gov-west-1.amazonaws.com"),
-        Region("us-west-1", "ec2.us-west-1.amazonaws.com"),
-        Region("us-west-2", "ec2.us-west-2.amazonaws.com"),
-    ]
+    regions = [Region(ri.name, ri.endpoint) for ri in boto.ec2.regions()]
 
     zones = dict(
         (region, [Zone(region + c, region) for c in 'abc'])

--- a/tests/test_ec2/test_regions.py
+++ b/tests/test_ec2/test_regions.py
@@ -5,12 +5,18 @@ import boto.ec2.elb
 import sure
 from moto import mock_ec2_deprecated, mock_autoscaling_deprecated, mock_elb_deprecated
 
+from moto.ec2 import ec2_backends
+
+def test_use_boto_regions():
+    boto_regions = {r.name for r in boto.ec2.regions()}
+    moto_regions = set(ec2_backends)
+
+    moto_regions.should.equal(boto_regions)
 
 def add_servers_to_region(ami_id, count, region):
     conn = boto.ec2.connect_to_region(region)
     for index in range(count):
         conn.run_instances(ami_id)
-
 
 @mock_ec2_deprecated
 def test_add_servers_to_a_single_region():


### PR DESCRIPTION
Boto can be configured with extra regions, but moto will fail to import
if they are not in the hardcoded list in ec2/models.py. Instead, use the
region list from boto to build the ec2_backends dict to ensure all
regions are available.