### PR TITLE
Bug fix for infinite loop when WaitTimeSeconds was set to 0

### DIFF
--- a/moto/sqs/models.py
+++ b/moto/sqs/models.py
@@ -334,6 +334,8 @@ class SQSBackend(BaseBackend):
         :param string queue_name: The name of the queue to read from.
         :param int count: The maximum amount of messages to retrieve.
         :param int visibility_timeout: The number of seconds the message should remain invisible to other queue readers.
+        :param int wait_seconds_timeout:  The duration (in seconds) for which the call waits for a message to arrive in
+         the queue before returning. If a message is available, the call returns sooner than WaitTimeSeconds
         """
         queue = self.get_queue(queue_name)
         result = []
@@ -347,6 +349,10 @@ class SQSBackend(BaseBackend):
                 break
 
             if len(queue.messages) == 0:
+                # we want to break here, otherwise it will be an infinite loop
+                if wait_seconds_timeout == 0:
+                    break
+
                 import time
                 time.sleep(0.001)
                 continue

--- a/tests/test_sqs/test_sqs.py
+++ b/tests/test_sqs/test_sqs.py
@@ -208,6 +208,35 @@ def test_send_message():
     messages[1]['Body'].should.equal(body_two)
 
 
+@mock_sqs
+def test_receive_messages_with_wait_seconds_timeout_of_zero():
+    """
+    test that zero messages is returned with a wait_seconds_timeout of zero,
+    previously this created an infinite loop and nothing was returned
+    :return:
+    """
+
+    sqs = boto3.resource('sqs', region_name='us-east-1')
+    queue = sqs.create_queue(QueueName="blah")
+
+    messages = queue.receive_messages(WaitTimeSeconds=0)
+    messages.should.equal([])
+
+
+@mock_sqs
+def test_receive_messages_with_wait_seconds_timeout_of_negative_one():
+    """
+    test that zero messages is returned with a wait_seconds_timeout of negative 1
+    :return:
+    """
+
+    sqs = boto3.resource('sqs', region_name='us-east-1')
+    queue = sqs.create_queue(QueueName="blah")
+
+    messages = queue.receive_messages(WaitTimeSeconds=-1)
+    messages.should.equal([])
+
+
 @mock_sqs_deprecated
 def test_send_message_with_xml_characters():
     conn = boto.connect_sqs('the_key', 'the_secret')


### PR DESCRIPTION
There was a bug when WaitTimeSeconds was set to zero causing an infinite loop if no messages came in. Added two unit tests