### PR TITLE
Add cf parsing

### DIFF
--- a/moto/cloudformation/models.py
+++ b/moto/cloudformation/models.py
@@ -15,7 +15,7 @@ from .exceptions import ValidationError
 
 class FakeStack(BaseModel):
 
-    def __init__(self, stack_id, name, template, parameters, region_name, notification_arns=None, tags=None, role_arn=None):
+    def __init__(self, stack_id, name, template, parameters, region_name, notification_arns=None, tags=None, role_arn=None, cross_stack_resources=None):
         self.stack_id = stack_id
         self.name = name
         self.template = template
@@ -30,6 +30,7 @@ class FakeStack(BaseModel):
                               resource_status_reason="User Initiated")
 
         self.description = self.template_dict.get('Description')
+        self.cross_stack_resources = cross_stack_resources or []
         self.resource_map = self._create_resource_map()
         self.output_map = self._create_output_map()
         self._add_stack_event("CREATE_COMPLETE")
@@ -37,7 +38,7 @@ class FakeStack(BaseModel):
 
     def _create_resource_map(self):
         resource_map = ResourceMap(
-            self.stack_id, self.name, self.parameters, self.tags, self.region_name, self.template_dict)
+            self.stack_id, self.name, self.parameters, self.tags, self.region_name, self.template_dict, self.cross_stack_resources)
         resource_map.create()
         return resource_map
 
@@ -148,6 +149,7 @@ class CloudFormationBackend(BaseBackend):
             notification_arns=notification_arns,
             tags=tags,
             role_arn=role_arn,
+            cross_stack_resources=self.exports,
         )
         self.stacks[stack_id] = new_stack
         self._validate_export_uniqueness(new_stack)

--- a/moto/cloudformation/parsing.py
+++ b/moto/cloudformation/parsing.py
@@ -162,6 +162,15 @@ def clean_json(resource_json, resources_map):
                                  if cleaned_val else '{0}'.format(val))
             return resource_json['Fn::Join'][0].join(join_list)
 
+        if 'Fn::Split' in resource_json:
+            to_split = clean_json(resource_json['Fn::Split'][1], resources_map)
+            return to_split.split(resource_json['Fn::Split'][0])
+
+        if 'Fn::Select' in resource_json:
+            select_index = int(resource_json['Fn::Select'][0])
+            select_list = clean_json(resource_json['Fn::Select'][1], resources_map)
+            return select_list[select_index]
+
         cleaned_json = {}
         for key, value in resource_json.items():
             cleaned_val = clean_json(value, resources_map)

--- a/moto/cloudformation/parsing.py
+++ b/moto/cloudformation/parsing.py
@@ -522,7 +522,9 @@ class OutputMap(collections.Mapping):
         if self.outputs:
             for key, value in self._output_json_map.items():
                 if value.get('Export'):
-                    exports.append(Export(self._stack_id, value['Export'].get('Name'), value.get('Value')))
+                    cleaned_name = clean_json(value['Export'].get('Name'), self._resource_map)
+                    cleaned_value = clean_json(value.get('Value'), self._resource_map)
+                    exports.append(Export(self._stack_id, cleaned_name, cleaned_value))
         return exports
 
     def create(self):

--- a/moto/cloudformation/parsing.py
+++ b/moto/cloudformation/parsing.py
@@ -155,12 +155,8 @@ def clean_json(resource_json, resources_map):
                 return clean_json(false_value, resources_map)
 
         if 'Fn::Join' in resource_json:
-            join_list = []
-            for val in resource_json['Fn::Join'][1]:
-                cleaned_val = clean_json(val, resources_map)
-                join_list.append('{0}'.format(cleaned_val)
-                                 if cleaned_val else '{0}'.format(val))
-            return resource_json['Fn::Join'][0].join(join_list)
+            join_list = clean_json(resource_json['Fn::Join'][1], resources_map)
+            return resource_json['Fn::Join'][0].join([str(x) for x in join_list])
 
         if 'Fn::Split' in resource_json:
             to_split = clean_json(resource_json['Fn::Split'][1], resources_map)


### PR DESCRIPTION
@spulec This PR adds a few parsing options, specifically: `Fn::Split`, `Fn::Select`, `Fn::Sub`, and `Fn::ImportValue`. 
To implement `Fn::ImportValue`, I added a field, `cross_stack_resources` to `FakeStack`.

Additionally, I refactored two things. 
(1) `Fn::Join`:
It wasn't working correctly when joining on another intrinsic functions. For example, previously 
`{"Fn::Join": ['"-", {"Fn::Split": ["_", "foo_bar"]}]}` evaluated to `"Fn::Split"`, rather than `foo-bar` due to the iteration over ` {"Fn::Split": ["_", "foo_bar"]}`.
(2) `Export`:
I parsed the name and values before creating the `Export` object. It is likely one or both of those values will use some intrinsic functions.

Please let me know if you have any feedback. Thanks!
cc @hltbra 