### PR TITLE
Improve instance tag handling for ASGs

### DIFF
--- a/moto/autoscaling/models.py
+++ b/moto/autoscaling/models.py
@@ -11,6 +11,7 @@ DEFAULT_COOLDOWN = 300
 
 ASG_NAME_TAG = "aws:autoscaling:groupName"
 
+
 class InstanceState(object):
 
     def __init__(self, instance, lifecycle_state="InService"):


### PR DESCRIPTION
When you launch instances through an ASG currently, they have no tags. However, in practice, the instances get copied any tags that have `PropagateOnLaunch` set to true.

This PR adds the tag handling for propagating tags as well as for assigning the "Name" tag that AWS assigns on launch.