### PR TITLE
create_load_balancer requires port definitions

### DIFF
--- a/moto/elb/exceptions.py
+++ b/moto/elb/exceptions.py
@@ -47,3 +47,11 @@ class DuplicateLoadBalancerName(ELBClientError):
             "DuplicateLoadBalancerName",
             "The specified load balancer name already exists for this account: {0}"
             .format(name))
+
+
+class EmptyListenersError(ELBClientError):
+
+    def __init__(self):
+        super(EmptyListenersError, self).__init__(
+            "ValidationError",
+            "Listeners cannot be empty")

--- a/moto/elb/models.py
+++ b/moto/elb/models.py
@@ -16,10 +16,11 @@ from moto.compat import OrderedDict
 from moto.core import BaseBackend, BaseModel
 from moto.ec2.models import ec2_backends
 from .exceptions import (
-    LoadBalancerNotFoundError,
-    TooManyTagsError,
     BadHealthCheckDefinition,
     DuplicateLoadBalancerName,
+    EmptyListenersError,
+    LoadBalancerNotFoundError,
+    TooManyTagsError,
 )
 
 
@@ -239,6 +240,8 @@ class ELBBackend(BaseBackend):
             vpc_id = subnet.vpc_id
         if name in self.load_balancers:
             raise DuplicateLoadBalancerName(name)
+        if not ports:
+            raise EmptyListenersError()
         new_load_balancer = FakeLoadBalancer(
             name=name, zones=zones, ports=ports, scheme=scheme, subnets=subnets, vpc_id=vpc_id)
         self.load_balancers[name] = new_load_balancer

--- a/tests/test_elb/test_elb.py
+++ b/tests/test_elb/test_elb.py
@@ -15,7 +15,9 @@ from boto.ec2.elb.policies import (
     LBCookieStickinessPolicy,
     OtherPolicy,
 )
+from botocore.exceptions import ClientError
 from boto.exception import BotoServerError
+from nose.tools import assert_raises
 import sure  # noqa
 
 from moto import mock_elb, mock_ec2, mock_elb_deprecated, mock_ec2_deprecated
@@ -107,6 +109,18 @@ def test_create_and_delete_boto3_support():
     )
     list(client.describe_load_balancers()[
          'LoadBalancerDescriptions']).should.have.length_of(0)
+
+
+@mock_elb
+def test_create_load_balancer_with_no_listeners_defined():
+    client = boto3.client('elb', region_name='us-east-1')
+
+    with assert_raises(ClientError):
+        client.create_load_balancer(
+            LoadBalancerName='my-lb',
+            Listeners=[],
+            AvailabilityZones=['us-east-1a', 'us-east-1b']
+        )
 
 
 @mock_elb


### PR DESCRIPTION
Throw the appropriate error when defining a loadbalancer with no ports