### PR TITLE
Make sure the repository response_object is json serializable with images

### DIFF
--- a/moto/ecr/models.py
+++ b/moto/ecr/models.py
@@ -58,7 +58,7 @@ class Repository(BaseObject):
         response_object['repositoryName'] = self.name
         response_object['repositoryUri'] = self.uri
         # response_object['createdAt'] = self.created
-        del response_object['arn'], response_object['name']
+        del response_object['arn'], response_object['name'], response_object['images']
         return response_object
 
     @classmethod


### PR DESCRIPTION
If images had been pushed to a repository, they would be included in the
response object, and the json encoder could not serialize the Image class.

Since they are not included in the boto response, I just deleted the images
field from the response object for Repositories.

I also found a duplicate test for put_images in the ecr tests, so I combined them.