### PR TITLE
Add support for recursive emr settings

### DIFF
--- a/moto/core/responses.py
+++ b/moto/core/responses.py
@@ -414,6 +414,9 @@ class _RecursiveDictRef(object):
     def __getattr__(self, key):
         return self.dic.__getattr__(key)
 
+    def __getitem__(self, key):
+        return self.dic.__getitem__(key)
+
     def set_reference(self, key, dic):
         """Set the RecursiveDictRef object to keep reference to dict object
         (dic) at the key.

--- a/tests/test_emr/test_emr_boto3.py
+++ b/tests/test_emr/test_emr_boto3.py
@@ -64,7 +64,18 @@ def test_describe_cluster():
     args['Configurations'] = [
         {'Classification': 'yarn-site',
          'Properties': {'someproperty': 'somevalue',
-                        'someotherproperty': 'someothervalue'}}]
+                        'someotherproperty': 'someothervalue'}},
+        {'Classification': 'nested-configs',
+         'Properties': {},
+         'Configurations': [
+             {
+                 'Classification': 'nested-config',
+                 'Properties': {
+                     'nested-property': 'nested-value'
+                 }
+             }
+         ]}
+    ]
     args['Instances']['AdditionalMasterSecurityGroups'] = ['additional-master']
     args['Instances']['AdditionalSlaveSecurityGroups'] = ['additional-slave']
     args['Instances']['Ec2KeyName'] = 'mykey'
@@ -86,6 +97,10 @@ def test_describe_cluster():
     config = cl['Configurations'][0]
     config['Classification'].should.equal('yarn-site')
     config['Properties'].should.equal(args['Configurations'][0]['Properties'])
+
+    nested_config = cl['Configurations'][1]
+    nested_config['Classification'].should.equal('nested-configs')
+    nested_config['Properties'].should.equal(args['Configurations'][1]['Properties'])
 
     attrs = cl['Ec2InstanceAttributes']
     attrs['AdditionalMasterSecurityGroups'].should.equal(


### PR DESCRIPTION
- Updates _RecursiveDictRef to implement `__getitem__`, avoiding errors when using recursive settings for an emr job flow.

Previously, when using settings like the following, `moto` would throw a `TypeError: '_RecursiveDictRef' object has no attribute '__getitem__'` exception.

```
{
            "Classification": "spark-env",
            "Configurations": [
                {
                    "Classification": "export",
                    "Configurations": [],
                    "Properties": {
                        "JAVA_HOME": "/usr/lib/jvm/java-1.8.0"
                    }
                }
            ],
            "Properties": {}
        }
```

From the `boto3` docs, these recursive settings should be supported: http://boto3.readthedocs.io/en/latest/reference/services/emr.html#EMR.Client.run_job_flow

I also tested this and `boto3` correctly launched an emr cluster with these settings, so `moto` should support mocking it.