### PR TITLE
Add CLI flag to enable SSL for moto_server

### DIFF
--- a/moto/server.py
+++ b/moto/server.py
@@ -171,6 +171,12 @@ def main(argv=sys.argv[1:]):
         help='Reload server on a file change',
         default=False
     )
+    parser.add_argument(
+        '-s', '--ssl',
+        action='store_true',
+        help='Enable SSL encrypted connection (use https://... URL)',
+        default=False
+    )
 
     args = parser.parse_args(argv)
 
@@ -180,7 +186,8 @@ def main(argv=sys.argv[1:]):
     main_app.debug = True
 
     run_simple(args.host, args.port, main_app,
-               threaded=True, use_reloader=args.reload)
+               threaded=True, use_reloader=args.reload,
+               ssl_context='adhoc' if args.ssl else None)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR adds an `--ssl` flag for the `moto_server` CLI to enable encrypted connections. This is an important requirement for users that want to test their service calls via HTTPS.

The SSL certificate is generated on the fly and does not require any additional configuration. (However, as this approach uses a self-signed certificate, most clients using the server will have to be configured with a flag to skip the certificate validation).