### PR TITLE
Don't use exponential notation for SQS message timestamps

### DIFF
--- a/moto/sqs/models.py
+++ b/moto/sqs/models.py
@@ -96,7 +96,7 @@ class Message(BaseModel):
         return escape(self._body)
 
     def mark_sent(self, delay_seconds=None):
-        self.sent_timestamp = unix_time_millis()
+        self.sent_timestamp = int(unix_time_millis())
         if delay_seconds:
             self.delay(delay_seconds=delay_seconds)
 
@@ -111,7 +111,7 @@ class Message(BaseModel):
             visibility_timeout = 0
 
         if not self.approximate_first_receive_timestamp:
-            self.approximate_first_receive_timestamp = unix_time_millis()
+            self.approximate_first_receive_timestamp = int(unix_time_millis())
 
         self.approximate_receive_count += 1
 

--- a/tests/test_sqs/test_sqs.py
+++ b/tests/test_sqs/test_sqs.py
@@ -273,6 +273,25 @@ def test_send_receive_message_with_attributes():
 
 
 @mock_sqs
+def test_send_receive_message_timestamps():
+    sqs = boto3.resource('sqs', region_name='us-east-1')
+    conn = boto3.client("sqs", region_name='us-east-1')
+    conn.create_queue(QueueName="test-queue")
+    queue = sqs.Queue("test-queue")
+
+    queue.send_message(MessageBody="derp")
+    messages = conn.receive_message(
+        QueueUrl=queue.url, MaxNumberOfMessages=1)['Messages']
+
+    message = messages[0]
+    sent_timestamp = message.get('Attributes').get('SentTimestamp')
+    approximate_first_receive_timestamp = message.get('Attributes').get('ApproximateFirstReceiveTimestamp')
+
+    int.when.called_with(sent_timestamp).shouldnt.throw(ValueError)
+    int.when.called_with(approximate_first_receive_timestamp).shouldnt.throw(ValueError)
+
+
+@mock_sqs
 def test_receive_messages_with_wait_seconds_timeout_of_zero():
     """
     test that zero messages is returned with a wait_seconds_timeout of zero,


### PR DESCRIPTION
Fixes #996 

Timestamps of SQS message should not have exponential notation.