### PR TITLE
Raise error on duplicate elbv1 listener

### DIFF
--- a/moto/elb/exceptions.py
+++ b/moto/elb/exceptions.py
@@ -40,6 +40,15 @@ class BadHealthCheckDefinition(ELBClientError):
             "HealthCheck Target must begin with one of HTTP, TCP, HTTPS, SSL")
 
 
+class DuplicateListenerError(ELBClientError):
+
+    def __init__(self, name, port):
+        super(DuplicateListenerError, self).__init__(
+            "DuplicateListener",
+            "A listener already exists for {0} with LoadBalancerPort {1}, but with a different InstancePort, Protocol, or SSLCertificateId"
+            .format(name, port))
+
+
 class DuplicateLoadBalancerName(ELBClientError):
 
     def __init__(self, name):

--- a/moto/elb/models.py
+++ b/moto/elb/models.py
@@ -18,6 +18,7 @@ from moto.ec2.models import ec2_backends
 from .exceptions import (
     BadHealthCheckDefinition,
     DuplicateLoadBalancerName,
+    DuplicateListenerError,
     EmptyListenersError,
     LoadBalancerNotFoundError,
     TooManyTagsError,
@@ -257,6 +258,12 @@ class ELBBackend(BaseBackend):
                 ssl_certificate_id = port.get('sslcertificate_id')
                 for listener in balancer.listeners:
                     if lb_port == listener.load_balancer_port:
+                        if protocol != listener.protocol:
+                            raise DuplicateListenerError(name, lb_port)
+                        if instance_port != listener.instance_port:
+                            raise DuplicateListenerError(name, lb_port)
+                        if ssl_certificate_id != listener.ssl_certificate_id:
+                            raise DuplicateListenerError(name, lb_port)
                         break
                 else:
                     balancer.listeners.append(FakeListener(

--- a/tests/test_elb/test_elb.py
+++ b/tests/test_elb/test_elb.py
@@ -214,6 +214,14 @@ def test_create_and_delete_listener_boto3_support():
     balancer['ListenerDescriptions'][1]['Listener'][
         'InstancePort'].should.equal(8443)
 
+    # Creating this listener with an conflicting definition throws error
+    with assert_raises(ClientError):
+        client.create_load_balancer_listeners(
+            LoadBalancerName='my-lb',
+            Listeners=[
+                {'Protocol': 'tcp', 'LoadBalancerPort': 443, 'InstancePort': 1234}]
+        )
+
     client.delete_load_balancer_listeners(
         LoadBalancerName='my-lb',
         LoadBalancerPorts=[443])


### PR DESCRIPTION
AWS returns an error condition when a listener is defined that interferes with an existing listener on the same load balancer port.