### PR TITLE
Adding implementation_coverage.py script

### DIFF
--- a/implementation_coverage.py
+++ b/implementation_coverage.py
@@ -1,0 +1,68 @@
+import moto
+from botocore import xform_name
+from botocore.session import Session
+import boto3
+
+
+def get_moto_implementation(service_name):
+    if not hasattr(moto, service_name):
+        return None
+    module = getattr(moto, service_name)
+    if module is None:
+        return None
+    mock = getattr(module, "mock_{}".format(service_name))
+    if mock is None:
+        return None
+    backends = list(mock().backends.values())
+    if backends:
+        return backends[0]
+
+
+def calculate_implementation_coverage():
+    service_names = Session().get_available_services()
+    coverage = {}
+    for service_name in service_names:
+        moto_client = get_moto_implementation(service_name)
+        real_client = boto3.client(service_name, region_name='us-east-1')
+        implemented = []
+        not_implemented = []
+
+        operation_names = [xform_name(op) for op in real_client.meta.service_model.operation_names]
+        for op in operation_names:
+            if moto_client and op in dir(moto_client):
+                implemented.append(op)
+            else:
+                not_implemented.append(op)
+
+        coverage[service_name] = {
+            'implemented': implemented,
+            'not_implemented': not_implemented,
+        }
+    return coverage
+
+
+def print_implementation_coverage():
+    coverage = calculate_implementation_coverage()
+    for service_name in coverage:
+        implemented = coverage.get(service_name)['implemented']
+        not_implemented = coverage.get(service_name)['not_implemented']
+        operations = sorted(implemented + not_implemented)
+
+        if implemented and not_implemented:
+            percentage_implemented = int(100.0 * len(implemented) / (len(implemented) + len(not_implemented)))
+        elif implemented:
+            percentage_implemented = 100
+        else:
+            percentage_implemented = 0
+
+        print("-----------------------")
+        print("{} - {}% implemented".format(service_name, percentage_implemented))
+        print("-----------------------")
+        for op in operations:
+            if op in implemented:
+                print("[X] {}".format(op))
+            else:
+                print("[ ] {}".format(op))
+
+if __name__ == '__main__':
+    print_implementation_coverage()

--- a/implementation_coverage.py
+++ b/implementation_coverage.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 import moto
 from botocore import xform_name
 from botocore.session import Session


### PR DESCRIPTION
@spulec I wanted a way to reference which operations have yet to be implemented so we could make suggestions to, say, Google Summer of Code, or so I could pick one off and implement it from time to time. Here's a script that outputs the progress toward 100% implementation of AWS.

It might look like a lot of it is missing but I'm consistently amazed at how much Moto is, for all serviceable needs, a complete AWS. Just amazed. This project is the best and I'm so grateful for your work.

```
-----------------------
acm - 0% implemented
-----------------------
[ ] add_tags_to_certificate
[ ] delete_certificate
[ ] describe_certificate
[ ] get_certificate
[ ] import_certificate
[ ] list_certificates
[ ] list_tags_for_certificate
[ ] remove_tags_from_certificate
[ ] request_certificate
[ ] resend_validation_email
-----------------------
apigateway - 19% implemented
-----------------------
[ ] create_api_key
[ ] create_authorizer
[ ] create_base_path_mapping
[X] create_deployment
[ ] create_documentation_part
[ ] create_documentation_version
[ ] create_domain_name
[ ] create_model
[ ] create_request_validator
[X] create_resource
[X] create_rest_api
[X] create_stage
[ ] create_usage_plan
[ ] create_usage_plan_key
[ ] delete_api_key
[ ] delete_authorizer
[ ] delete_base_path_mapping
[ ] delete_client_certificate
[X] delete_deployment
[ ] delete_documentation_part
[ ] delete_documentation_version
[ ] delete_domain_name
[X] delete_integration
[X] delete_integration_response
[ ] delete_method
[X] delete_method_response
[ ] delete_model
[ ] delete_request_validator
[X] delete_resource
[X] delete_rest_api
[ ] delete_stage
[ ] delete_usage_plan
[ ] delete_usage_plan_key
[ ] flush_stage_authorizers_cache
[ ] flush_stage_cache
[ ] generate_client_certificate
[ ] get_account
[ ] get_api_key
[ ] get_api_keys
[ ] get_authorizer
[ ] get_authorizers
[ ] get_base_path_mapping
[ ] get_base_path_mappings
[ ] get_client_certificate
[ ] get_client_certificates
[X] get_deployment
[X] get_deployments
[ ] get_documentation_part
[ ] get_documentation_parts
[ ] get_documentation_version
[ ] get_documentation_versions
[ ] get_domain_name
[ ] get_domain_names
[ ] get_export
[X] get_integration
[X] get_integration_response
[X] get_method
[X] get_method_response
[ ] get_model
[ ] get_model_template
[ ] get_models
[ ] get_request_validator
[ ] get_request_validators
[X] get_resource
[ ] get_resources
[X] get_rest_api
[ ] get_rest_apis
[ ] get_sdk
[ ] get_sdk_type
[ ] get_sdk_types
[X] get_stage
[X] get_stages
[ ] get_usage
[ ] get_usage_plan
[ ] get_usage_plan_key
[ ] get_usage_plan_keys
[ ] get_usage_plans
[ ] import_api_keys
[ ] import_documentation_parts
[ ] import_rest_api
[ ] put_integration
[ ] put_integration_response
[ ] put_method
[ ] put_method_response
[ ] put_rest_api
[ ] test_invoke_authorizer
[ ] test_invoke_method
[ ] update_account
[ ] update_api_key
[ ] update_authorizer
[ ] update_base_path_mapping
[ ] update_client_certificate
[ ] update_deployment
[ ] update_documentation_part
[ ] update_documentation_version
[ ] update_domain_name
[ ] update_integration
[ ] update_integration_response
[ ] update_method
[ ] update_method_response
[ ] update_model
[ ] update_request_validator
[ ] update_resource
[ ] update_rest_api
[X] update_stage
[ ] update_usage
[ ] update_usage_plan
-----------------------
application-autoscaling - 0% implemented
-----------------------
[ ] delete_scaling_policy
[ ] deregister_scalable_target
[ ] describe_scalable_targets
[ ] describe_scaling_activities
[ ] describe_scaling_policies
[ ] put_scaling_policy
[ ] register_scalable_target
-----------------------
appstream - 0% implemented
-----------------------
[ ] associate_fleet
[ ] create_fleet
[ ] create_stack
[ ] create_streaming_url
[ ] delete_fleet
[ ] delete_stack
[ ] describe_fleets
[ ] describe_images
[ ] describe_sessions
[ ] describe_stacks
[ ] disassociate_fleet
[ ] expire_session
[ ] list_associated_fleets
[ ] list_associated_stacks
[ ] start_fleet
[ ] stop_fleet
[ ] update_fleet
[ ] update_stack
-----------------------
autoscaling - 15% implemented
-----------------------
[ ] attach_instances
[ ] attach_load_balancer_target_groups
[ ] attach_load_balancers
[ ] complete_lifecycle_action
[ ] create_auto_scaling_group
[X] create_launch_configuration
[X] create_or_update_tags
[ ] delete_auto_scaling_group
[X] delete_launch_configuration
[ ] delete_lifecycle_hook
[ ] delete_notification_configuration
[X] delete_policy
[ ] delete_scheduled_action
[ ] delete_tags
[ ] describe_account_limits
[ ] describe_adjustment_types
[ ] describe_auto_scaling_groups
[ ] describe_auto_scaling_instances
[ ] describe_auto_scaling_notification_types
[X] describe_launch_configurations
[ ] describe_lifecycle_hook_types
[ ] describe_lifecycle_hooks
[ ] describe_load_balancer_target_groups
[ ] describe_load_balancers
[ ] describe_metric_collection_types
[ ] describe_notification_configurations
[X] describe_policies
[ ] describe_scaling_activities
[ ] describe_scaling_process_types
[ ] describe_scheduled_actions
[ ] describe_tags
[ ] describe_termination_policy_types
[ ] detach_instances
[ ] detach_load_balancer_target_groups
[ ] detach_load_balancers
[ ] disable_metrics_collection
[ ] enable_metrics_collection
[ ] enter_standby
[X] execute_policy
[ ] exit_standby
[ ] put_lifecycle_hook
[ ] put_notification_configuration
[ ] put_scaling_policy
[ ] put_scheduled_update_group_action
[ ] record_lifecycle_action_heartbeat
[ ] resume_processes
[X] set_desired_capacity
[ ] set_instance_health
[ ] set_instance_protection
[ ] suspend_processes
[ ] terminate_instance_in_auto_scaling_group
[ ] update_auto_scaling_group
-----------------------
batch - 0% implemented
-----------------------
[ ] cancel_job
[ ] create_compute_environment
[ ] create_job_queue
[ ] delete_compute_environment
[ ] delete_job_queue
[ ] deregister_job_definition
[ ] describe_compute_environments
[ ] describe_job_definitions
[ ] describe_job_queues
[ ] describe_jobs
[ ] list_jobs
[ ] register_job_definition
[ ] submit_job
[ ] terminate_job
[ ] update_compute_environment
[ ] update_job_queue
-----------------------
budgets - 0% implemented
-----------------------
[ ] create_budget
[ ] create_notification
[ ] create_subscriber
[ ] delete_budget
[ ] delete_notification
[ ] delete_subscriber
[ ] describe_budget
[ ] describe_budgets
[ ] describe_notifications_for_budget
[ ] describe_subscribers_for_notification
[ ] update_budget
[ ] update_notification
[ ] update_subscriber
-----------------------
clouddirectory - 0% implemented
-----------------------
[ ] add_facet_to_object
[ ] apply_schema
[ ] attach_object
[ ] attach_policy
[ ] attach_to_index
[ ] batch_read
[ ] batch_write
[ ] create_directory
[ ] create_facet
[ ] create_index
[ ] create_object
[ ] create_schema
[ ] delete_directory
[ ] delete_facet
[ ] delete_object
[ ] delete_schema
[ ] detach_from_index
[ ] detach_object
[ ] detach_policy
[ ] disable_directory
[ ] enable_directory
[ ] get_directory
[ ] get_facet
[ ] get_object_information
[ ] get_schema_as_json
[ ] list_applied_schema_arns
[ ] list_attached_indices
[ ] list_development_schema_arns
[ ] list_directories
[ ] list_facet_attributes
[ ] list_facet_names
[ ] list_index
[ ] list_object_attributes
[ ] list_object_children
[ ] list_object_parent_paths
[ ] list_object_parents
[ ] list_object_policies
[ ] list_policy_attachments
[ ] list_published_schema_arns
[ ] list_tags_for_resource
[ ] lookup_policy
[ ] publish_schema
[ ] put_schema_from_json
[ ] remove_facet_from_object
[ ] tag_resource
[ ] untag_resource
[ ] update_facet
[ ] update_object_attributes
[ ] update_schema
-----------------------
cloudformation - 26% implemented
-----------------------
[ ] cancel_update_stack
[ ] continue_update_rollback
[ ] create_change_set
[X] create_stack
[ ] delete_change_set
[X] delete_stack
[ ] describe_account_limits
[ ] describe_change_set
[ ] describe_stack_events
[ ] describe_stack_resource
[ ] describe_stack_resources
[X] describe_stacks
[ ] estimate_template_cost
[ ] execute_change_set
[ ] get_stack_policy
[ ] get_template
[ ] get_template_summary
[ ] list_change_sets
[X] list_exports
[ ] list_imports
[X] list_stack_resources
[X] list_stacks
[ ] set_stack_policy
[ ] signal_resource
[X] update_stack
[ ] validate_template
-----------------------
cloudfront - 0% implemented
-----------------------
[ ] create_cloud_front_origin_access_identity
[ ] create_distribution
[ ] create_distribution_with_tags
[ ] create_invalidation
[ ] create_streaming_distribution
[ ] create_streaming_distribution_with_tags
[ ] delete_cloud_front_origin_access_identity
[ ] delete_distribution
[ ] delete_streaming_distribution
[ ] get_cloud_front_origin_access_identity
[ ] get_cloud_front_origin_access_identity_config
[ ] get_distribution
[ ] get_distribution_config
[ ] get_invalidation
[ ] get_streaming_distribution
[ ] get_streaming_distribution_config
[ ] list_cloud_front_origin_access_identities
[ ] list_distributions
[ ] list_distributions_by_web_acl_id
[ ] list_invalidations
[ ] list_streaming_distributions
[ ] list_tags_for_resource
[ ] tag_resource
[ ] untag_resource
[ ] update_cloud_front_origin_access_identity
[ ] update_distribution
[ ] update_streaming_distribution
-----------------------
cloudhsm - 0% implemented
-----------------------
[ ] add_tags_to_resource
[ ] create_hapg
[ ] create_hsm
[ ] create_luna_client
[ ] delete_hapg
[ ] delete_hsm
[ ] delete_luna_client
[ ] describe_hapg
[ ] describe_hsm
[ ] describe_luna_client
[ ] get_config
[ ] list_available_zones
[ ] list_hapgs
[ ] list_hsms
[ ] list_luna_clients
[ ] list_tags_for_resource
[ ] modify_hapg
[ ] modify_hsm
[ ] modify_luna_client
[ ] remove_tags_from_resource
-----------------------
cloudsearch - 0% implemented
-----------------------
[ ] build_suggesters
[ ] create_domain
[ ] define_analysis_scheme
[ ] define_expression
[ ] define_index_field
[ ] define_suggester
[ ] delete_analysis_scheme
[ ] delete_domain
[ ] delete_expression
[ ] delete_index_field
[ ] delete_suggester
[ ] describe_analysis_schemes
[ ] describe_availability_options
[ ] describe_domains
[ ] describe_expressions
[ ] describe_index_fields
[ ] describe_scaling_parameters
[ ] describe_service_access_policies
[ ] describe_suggesters
[ ] index_documents
[ ] list_domain_names
[ ] update_availability_options
[ ] update_scaling_parameters
[ ] update_service_access_policies
-----------------------
cloudsearchdomain - 0% implemented
-----------------------
[ ] search
[ ] suggest
[ ] upload_documents
-----------------------
cloudtrail - 0% implemented
-----------------------
[ ] add_tags
[ ] create_trail
[ ] delete_trail
[ ] describe_trails
[ ] get_event_selectors
[ ] get_trail_status
[ ] list_public_keys
[ ] list_tags
[ ] lookup_events
[ ] put_event_selectors
[ ] remove_tags
[ ] start_logging
[ ] stop_logging
[ ] update_trail
-----------------------
cloudwatch - 27% implemented
-----------------------
[X] delete_alarms
[ ] describe_alarm_history
[ ] describe_alarms
[ ] describe_alarms_for_metric
[ ] disable_alarm_actions
[ ] enable_alarm_actions
[ ] get_metric_statistics
[ ] list_metrics
[X] put_metric_alarm
[X] put_metric_data
[ ] set_alarm_state
-----------------------
codebuild - 0% implemented
-----------------------
[ ] batch_get_builds
[ ] batch_get_projects
[ ] create_project
[ ] delete_project
[ ] list_builds
[ ] list_builds_for_project
[ ] list_curated_environment_images
[ ] list_projects
[ ] start_build
[ ] stop_build
[ ] update_project
-----------------------
codecommit - 0% implemented
-----------------------
[ ] batch_get_repositories
[ ] create_branch
[ ] create_repository
[ ] delete_repository
[ ] get_blob
[ ] get_branch
[ ] get_commit
[ ] get_differences
[ ] get_repository
[ ] get_repository_triggers
[ ] list_branches
[ ] list_repositories
[ ] put_repository_triggers
[ ] test_repository_triggers
[ ] update_default_branch
[ ] update_repository_description
[ ] update_repository_name
-----------------------
codedeploy - 0% implemented
-----------------------
[ ] add_tags_to_on_premises_instances
[ ] batch_get_application_revisions
[ ] batch_get_applications
[ ] batch_get_deployment_groups
[ ] batch_get_deployment_instances
[ ] batch_get_deployments
[ ] batch_get_on_premises_instances
[ ] continue_deployment
[ ] create_application
[ ] create_deployment
[ ] create_deployment_config
[ ] create_deployment_group
[ ] delete_application
[ ] delete_deployment_config
[ ] delete_deployment_group
[ ] deregister_on_premises_instance
[ ] get_application
[ ] get_application_revision
[ ] get_deployment
[ ] get_deployment_config
[ ] get_deployment_group
[ ] get_deployment_instance
[ ] get_on_premises_instance
[ ] list_application_revisions
[ ] list_applications
[ ] list_deployment_configs
[ ] list_deployment_groups
[ ] list_deployment_instances
[ ] list_deployments
[ ] list_on_premises_instances
[ ] register_application_revision
[ ] register_on_premises_instance
[ ] remove_tags_from_on_premises_instances
[ ] skip_wait_time_for_instance_termination
[ ] stop_deployment
[ ] update_application
[ ] update_deployment_group
-----------------------
codepipeline - 0% implemented
-----------------------
[ ] acknowledge_job
[ ] acknowledge_third_party_job
[ ] create_custom_action_type
[ ] create_pipeline
[ ] delete_custom_action_type
[ ] delete_pipeline
[ ] disable_stage_transition
[ ] enable_stage_transition
[ ] get_job_details
[ ] get_pipeline
[ ] get_pipeline_execution
[ ] get_pipeline_state
[ ] get_third_party_job_details
[ ] list_action_types
[ ] list_pipelines
[ ] poll_for_jobs
[ ] poll_for_third_party_jobs
[ ] put_action_revision
[ ] put_approval_result
[ ] put_job_failure_result
[ ] put_job_success_result
[ ] put_third_party_job_failure_result
[ ] put_third_party_job_success_result
[ ] retry_stage_execution
[ ] start_pipeline_execution
[ ] update_pipeline
-----------------------
codestar - 0% implemented
-----------------------
[ ] associate_team_member
[ ] create_project
[ ] create_user_profile
[ ] delete_project
[ ] delete_user_profile
[ ] describe_project
[ ] describe_user_profile
[ ] disassociate_team_member
[ ] list_projects
[ ] list_resources
[ ] list_team_members
[ ] list_user_profiles
[ ] update_project
[ ] update_team_member
[ ] update_user_profile
-----------------------
cognito-identity - 0% implemented
-----------------------
[ ] create_identity_pool
[ ] delete_identities
[ ] delete_identity_pool
[ ] describe_identity
[ ] describe_identity_pool
[ ] get_credentials_for_identity
[ ] get_id
[ ] get_identity_pool_roles
[ ] get_open_id_token
[ ] get_open_id_token_for_developer_identity
[ ] list_identities
[ ] list_identity_pools
[ ] lookup_developer_identity
[ ] merge_developer_identities
[ ] set_identity_pool_roles
[ ] unlink_developer_identity
[ ] unlink_identity
[ ] update_identity_pool
-----------------------
cognito-idp - 0% implemented
-----------------------
[ ] add_custom_attributes
[ ] admin_add_user_to_group
[ ] admin_confirm_sign_up
[ ] admin_create_user
[ ] admin_delete_user
[ ] admin_delete_user_attributes
[ ] admin_disable_user
[ ] admin_enable_user
[ ] admin_forget_device
[ ] admin_get_device
[ ] admin_get_user
[ ] admin_initiate_auth
[ ] admin_list_devices
[ ] admin_list_groups_for_user
[ ] admin_remove_user_from_group
[ ] admin_reset_user_password
[ ] admin_respond_to_auth_challenge
[ ] admin_set_user_settings
[ ] admin_update_device_status
[ ] admin_update_user_attributes
[ ] admin_user_global_sign_out
[ ] change_password
[ ] confirm_device
[ ] confirm_forgot_password
[ ] confirm_sign_up
[ ] create_group
[ ] create_user_import_job
[ ] create_user_pool
[ ] create_user_pool_client
[ ] delete_group
[ ] delete_user
[ ] delete_user_attributes
[ ] delete_user_pool
[ ] delete_user_pool_client
[ ] describe_user_import_job
[ ] describe_user_pool
[ ] describe_user_pool_client
[ ] forget_device
[ ] forgot_password
[ ] get_csv_header
[ ] get_device
[ ] get_group
[ ] get_user
[ ] get_user_attribute_verification_code
[ ] global_sign_out
[ ] initiate_auth
[ ] list_devices
[ ] list_groups
[ ] list_user_import_jobs
[ ] list_user_pool_clients
[ ] list_user_pools
[ ] list_users
[ ] list_users_in_group
[ ] resend_confirmation_code
[ ] respond_to_auth_challenge
[ ] set_user_settings
[ ] sign_up
[ ] start_user_import_job
[ ] stop_user_import_job
[ ] update_device_status
[ ] update_group
[ ] update_user_attributes
[ ] update_user_pool
[ ] update_user_pool_client
[ ] verify_user_attribute
-----------------------
cognito-sync - 0% implemented
-----------------------
[ ] bulk_publish
[ ] delete_dataset
[ ] describe_dataset
[ ] describe_identity_pool_usage
[ ] describe_identity_usage
[ ] get_bulk_publish_details
[ ] get_cognito_events
[ ] get_identity_pool_configuration
[ ] list_datasets
[ ] list_identity_pool_usage
[ ] list_records
[ ] register_device
[ ] set_cognito_events
[ ] set_identity_pool_configuration
[ ] subscribe_to_dataset
[ ] unsubscribe_from_dataset
[ ] update_records
-----------------------
config - 0% implemented
-----------------------
[ ] delete_config_rule
[ ] delete_configuration_recorder
[ ] delete_delivery_channel
[ ] delete_evaluation_results
[ ] deliver_config_snapshot
[ ] describe_compliance_by_config_rule
[ ] describe_compliance_by_resource
[ ] describe_config_rule_evaluation_status
[ ] describe_config_rules
[ ] describe_configuration_recorder_status
[ ] describe_configuration_recorders
[ ] describe_delivery_channel_status
[ ] describe_delivery_channels
[ ] get_compliance_details_by_config_rule
[ ] get_compliance_details_by_resource
[ ] get_compliance_summary_by_config_rule
[ ] get_compliance_summary_by_resource_type
[ ] get_resource_config_history
[ ] list_discovered_resources
[ ] put_config_rule
[ ] put_configuration_recorder
[ ] put_delivery_channel
[ ] put_evaluations
[ ] start_config_rules_evaluation
[ ] start_configuration_recorder
[ ] stop_configuration_recorder
-----------------------
cur - 0% implemented
-----------------------
[ ] delete_report_definition
[ ] describe_report_definitions
[ ] put_report_definition
-----------------------
datapipeline - 42% implemented
-----------------------
[X] activate_pipeline
[ ] add_tags
[X] create_pipeline
[ ] deactivate_pipeline
[X] delete_pipeline
[X] describe_objects
[X] describe_pipelines
[ ] evaluate_expression
[X] get_pipeline_definition
[X] list_pipelines
[ ] poll_for_task
[X] put_pipeline_definition
[ ] query_objects
[ ] remove_tags
[ ] report_task_progress
[ ] report_task_runner_heartbeat
[ ] set_status
[ ] set_task_status
[ ] validate_pipeline_definition
-----------------------
devicefarm - 0% implemented
-----------------------
[ ] create_device_pool
[ ] create_network_profile
[ ] create_project
[ ] create_remote_access_session
[ ] create_upload
[ ] delete_device_pool
[ ] delete_network_profile
[ ] delete_project
[ ] delete_remote_access_session
[ ] delete_run
[ ] delete_upload
[ ] get_account_settings
[ ] get_device
[ ] get_device_pool
[ ] get_device_pool_compatibility
[ ] get_job
[ ] get_network_profile
[ ] get_offering_status
[ ] get_project
[ ] get_remote_access_session
[ ] get_run
[ ] get_suite
[ ] get_test
[ ] get_upload
[ ] install_to_remote_access_session
[ ] list_artifacts
[ ] list_device_pools
[ ] list_devices
[ ] list_jobs
[ ] list_network_profiles
[ ] list_offering_promotions
[ ] list_offering_transactions
[ ] list_offerings
[ ] list_projects
[ ] list_remote_access_sessions
[ ] list_runs
[ ] list_samples
[ ] list_suites
[ ] list_tests
[ ] list_unique_problems
[ ] list_uploads
[ ] purchase_offering
[ ] renew_offering
[ ] schedule_run
[ ] stop_remote_access_session
[ ] stop_run
[ ] update_device_pool
[ ] update_network_profile
[ ] update_project
-----------------------
directconnect - 0% implemented
-----------------------
[ ] allocate_connection_on_interconnect
[ ] allocate_hosted_connection
[ ] allocate_private_virtual_interface
[ ] allocate_public_virtual_interface
[ ] associate_connection_with_lag
[ ] associate_hosted_connection
[ ] associate_virtual_interface
[ ] confirm_connection
[ ] confirm_private_virtual_interface
[ ] confirm_public_virtual_interface
[ ] create_bgp_peer
[ ] create_connection
[ ] create_interconnect
[ ] create_lag
[ ] create_private_virtual_interface
[ ] create_public_virtual_interface
[ ] delete_bgp_peer
[ ] delete_connection
[ ] delete_interconnect
[ ] delete_lag
[ ] delete_virtual_interface
[ ] describe_connection_loa
[ ] describe_connections
[ ] describe_connections_on_interconnect
[ ] describe_hosted_connections
[ ] describe_interconnect_loa
[ ] describe_interconnects
[ ] describe_lags
[ ] describe_loa
[ ] describe_locations
[ ] describe_tags
[ ] describe_virtual_gateways
[ ] describe_virtual_interfaces
[ ] disassociate_connection_from_lag
[ ] tag_resource
[ ] untag_resource
[ ] update_lag
-----------------------
discovery - 0% implemented
-----------------------
[ ] associate_configuration_items_to_application
[ ] create_application
[ ] create_tags
[ ] delete_applications
[ ] delete_tags
[ ] describe_agents
[ ] describe_configurations
[ ] describe_export_configurations
[ ] describe_export_tasks
[ ] describe_tags
[ ] disassociate_configuration_items_from_application
[ ] export_configurations
[ ] get_discovery_summary
[ ] list_configurations
[ ] list_server_neighbors
[ ] start_data_collection_by_agent_ids
[ ] start_export_task
[ ] stop_data_collection_by_agent_ids
[ ] update_application
-----------------------
dms - 0% implemented
-----------------------
[ ] add_tags_to_resource
[ ] create_endpoint
[ ] create_replication_instance
[ ] create_replication_subnet_group
[ ] create_replication_task
[ ] delete_certificate
[ ] delete_endpoint
[ ] delete_replication_instance
[ ] delete_replication_subnet_group
[ ] delete_replication_task
[ ] describe_account_attributes
[ ] describe_certificates
[ ] describe_connections
[ ] describe_endpoint_types
[ ] describe_endpoints
[ ] describe_orderable_replication_instances
[ ] describe_refresh_schemas_status
[ ] describe_replication_instances
[ ] describe_replication_subnet_groups
[ ] describe_replication_tasks
[ ] describe_schemas
[ ] describe_table_statistics
[ ] import_certificate
[ ] list_tags_for_resource
[ ] modify_endpoint
[ ] modify_replication_instance
[ ] modify_replication_subnet_group
[ ] modify_replication_task
[ ] refresh_schemas
[ ] remove_tags_from_resource
[ ] start_replication_task
[ ] stop_replication_task
[ ] test_connection
-----------------------
ds - 0% implemented
-----------------------
[ ] add_ip_routes
[ ] add_tags_to_resource
[ ] cancel_schema_extension
[ ] connect_directory
[ ] create_alias
[ ] create_computer
[ ] create_conditional_forwarder
[ ] create_directory
[ ] create_microsoft_ad
[ ] create_snapshot
[ ] create_trust
[ ] delete_conditional_forwarder
[ ] delete_directory
[ ] delete_snapshot
[ ] delete_trust
[ ] deregister_event_topic
[ ] describe_conditional_forwarders
[ ] describe_directories
[ ] describe_event_topics
[ ] describe_snapshots
[ ] describe_trusts
[ ] disable_radius
[ ] disable_sso
[ ] enable_radius
[ ] enable_sso
[ ] get_directory_limits
[ ] get_snapshot_limits
[ ] list_ip_routes
[ ] list_schema_extensions
[ ] list_tags_for_resource
[ ] register_event_topic
[ ] remove_ip_routes
[ ] remove_tags_from_resource
[ ] restore_from_snapshot
[ ] start_schema_extension
[ ] update_conditional_forwarder
[ ] update_radius
[ ] verify_trust
-----------------------
dynamodb - 36% implemented
-----------------------
[ ] batch_get_item
[ ] batch_write_item
[X] create_table
[X] delete_item
[X] delete_table
[ ] describe_limits
[ ] describe_table
[ ] describe_time_to_live
[X] get_item
[ ] list_tables
[ ] list_tags_of_resource
[X] put_item
[X] query
[X] scan
[ ] tag_resource
[ ] untag_resource
[ ] update_item
[ ] update_table
[ ] update_time_to_live
-----------------------
dynamodbstreams - 0% implemented
-----------------------
[ ] describe_stream
[ ] get_records
[ ] get_shard_iterator
[ ] list_streams
-----------------------
ec2 - 42% implemented
-----------------------
[ ] accept_reserved_instances_exchange_quote
[X] accept_vpc_peering_connection
[X] allocate_address
[ ] allocate_hosts
[ ] assign_ipv6_addresses
[ ] assign_private_ip_addresses
[X] associate_address
[X] associate_dhcp_options
[ ] associate_iam_instance_profile
[X] associate_route_table
[ ] associate_subnet_cidr_block
[ ] associate_vpc_cidr_block
[ ] attach_classic_link_vpc
[X] attach_internet_gateway
[X] attach_network_interface
[X] attach_volume
[X] attach_vpn_gateway
[X] authorize_security_group_egress
[X] authorize_security_group_ingress
[ ] bundle_instance
[ ] cancel_bundle_task
[ ] cancel_conversion_task
[ ] cancel_export_task
[ ] cancel_import_task
[ ] cancel_reserved_instances_listing
[X] cancel_spot_fleet_requests
[X] cancel_spot_instance_requests
[ ] confirm_product_instance
[X] copy_image
[ ] copy_snapshot
[X] create_customer_gateway
[X] create_dhcp_options
[ ] create_egress_only_internet_gateway
[ ] create_flow_logs
[ ] create_fpga_image
[X] create_image
[ ] create_instance_export_task
[X] create_internet_gateway
[X] create_key_pair
[X] create_nat_gateway
[X] create_network_acl
[X] create_network_acl_entry
[X] create_network_interface
[ ] create_placement_group
[ ] create_reserved_instances_listing
[X] create_route
[X] create_route_table
[X] create_security_group
[X] create_snapshot
[ ] create_spot_datafeed_subscription
[X] create_subnet
[X] create_tags
[X] create_volume
[X] create_vpc
[ ] create_vpc_endpoint
[X] create_vpc_peering_connection
[X] create_vpn_connection
[ ] create_vpn_connection_route
[X] create_vpn_gateway
[X] delete_customer_gateway
[ ] delete_dhcp_options
[ ] delete_egress_only_internet_gateway
[ ] delete_flow_logs
[X] delete_internet_gateway
[X] delete_key_pair
[X] delete_nat_gateway
[X] delete_network_acl
[X] delete_network_acl_entry
[X] delete_network_interface
[ ] delete_placement_group
[X] delete_route
[X] delete_route_table
[X] delete_security_group
[X] delete_snapshot
[ ] delete_spot_datafeed_subscription
[X] delete_subnet
[X] delete_tags
[X] delete_volume
[X] delete_vpc
[ ] delete_vpc_endpoints
[X] delete_vpc_peering_connection
[X] delete_vpn_connection
[ ] delete_vpn_connection_route
[X] delete_vpn_gateway
[X] deregister_image
[ ] describe_account_attributes
[X] describe_addresses
[X] describe_availability_zones
[ ] describe_bundle_tasks
[ ] describe_classic_link_instances
[ ] describe_conversion_tasks
[ ] describe_customer_gateways
[X] describe_dhcp_options
[ ] describe_egress_only_internet_gateways
[ ] describe_export_tasks
[ ] describe_flow_logs
[ ] describe_host_reservation_offerings
[ ] describe_host_reservations
[ ] describe_hosts
[ ] describe_iam_instance_profile_associations
[ ] describe_id_format
[ ] describe_identity_id_format
[ ] describe_image_attribute
[X] describe_images
[ ] describe_import_image_tasks
[ ] describe_import_snapshot_tasks
[X] describe_instance_attribute
[ ] describe_instance_status
[ ] describe_instances
[X] describe_internet_gateways
[X] describe_key_pairs
[ ] describe_moving_addresses
[ ] describe_nat_gateways
[ ] describe_network_acls
[ ] describe_network_interface_attribute
[X] describe_network_interfaces
[ ] describe_placement_groups
[ ] describe_prefix_lists
[X] describe_regions
[ ] describe_reserved_instances
[ ] describe_reserved_instances_listings
[ ] describe_reserved_instances_modifications
[ ] describe_reserved_instances_offerings
[ ] describe_route_tables
[ ] describe_scheduled_instance_availability
[ ] describe_scheduled_instances
[ ] describe_security_group_references
[X] describe_security_groups
[ ] describe_snapshot_attribute
[X] describe_snapshots
[ ] describe_spot_datafeed_subscription
[X] describe_spot_fleet_instances
[ ] describe_spot_fleet_request_history
[X] describe_spot_fleet_requests
[X] describe_spot_instance_requests
[ ] describe_spot_price_history
[ ] describe_stale_security_groups
[ ] describe_subnets
[X] describe_tags
[ ] describe_volume_attribute
[ ] describe_volume_status
[X] describe_volumes
[ ] describe_volumes_modifications
[X] describe_vpc_attribute
[ ] describe_vpc_classic_link
[ ] describe_vpc_classic_link_dns_support
[ ] describe_vpc_endpoint_services
[ ] describe_vpc_endpoints
[ ] describe_vpc_peering_connections
[ ] describe_vpcs
[X] describe_vpn_connections
[ ] describe_vpn_gateways
[ ] detach_classic_link_vpc
[X] detach_internet_gateway
[X] detach_network_interface
[X] detach_volume
[X] detach_vpn_gateway
[ ] disable_vgw_route_propagation
[ ] disable_vpc_classic_link
[ ] disable_vpc_classic_link_dns_support
[X] disassociate_address
[ ] disassociate_iam_instance_profile
[X] disassociate_route_table
[ ] disassociate_subnet_cidr_block
[ ] disassociate_vpc_cidr_block
[ ] enable_vgw_route_propagation
[ ] enable_volume_io
[ ] enable_vpc_classic_link
[ ] enable_vpc_classic_link_dns_support
[ ] get_console_output
[ ] get_console_screenshot
[ ] get_host_reservation_purchase_preview
[ ] get_password_data
[ ] get_reserved_instances_exchange_quote
[ ] import_image
[ ] import_instance
[X] import_key_pair
[ ] import_snapshot
[ ] import_volume
[ ] modify_hosts
[ ] modify_id_format
[ ] modify_identity_id_format
[ ] modify_image_attribute
[X] modify_instance_attribute
[ ] modify_instance_placement
[X] modify_network_interface_attribute
[ ] modify_reserved_instances
[ ] modify_snapshot_attribute
[ ] modify_spot_fleet_request
[X] modify_subnet_attribute
[ ] modify_volume
[ ] modify_volume_attribute
[X] modify_vpc_attribute
[ ] modify_vpc_endpoint
[ ] modify_vpc_peering_connection_options
[ ] monitor_instances
[ ] move_address_to_vpc
[ ] purchase_host_reservation
[ ] purchase_reserved_instances_offering
[ ] purchase_scheduled_instances
[X] reboot_instances
[ ] register_image
[X] reject_vpc_peering_connection
[X] release_address
[ ] release_hosts
[ ] replace_iam_instance_profile_association
[X] replace_network_acl_association
[X] replace_network_acl_entry
[X] replace_route
[X] replace_route_table_association
[ ] report_instance_status
[X] request_spot_fleet
[X] request_spot_instances
[ ] reset_image_attribute
[ ] reset_instance_attribute
[ ] reset_network_interface_attribute
[ ] reset_snapshot_attribute
[ ] restore_address_to_classic
[X] revoke_security_group_egress
[X] revoke_security_group_ingress
[ ] run_instances
[ ] run_scheduled_instances
[X] start_instances
[X] stop_instances
[X] terminate_instances
[ ] unassign_ipv6_addresses
[ ] unassign_private_ip_addresses
[ ] unmonitor_instances
-----------------------
ecr - 35% implemented
-----------------------
[ ] batch_check_layer_availability
[ ] batch_delete_image
[ ] batch_get_image
[ ] complete_layer_upload
[X] create_repository
[X] delete_repository
[ ] delete_repository_policy
[X] describe_images
[X] describe_repositories
[ ] get_authorization_token
[ ] get_download_url_for_layer
[ ] get_repository_policy
[ ] initiate_layer_upload
[X] list_images
[X] put_image
[ ] set_repository_policy
[ ] upload_layer_part
-----------------------
ecs - 74% implemented
-----------------------
[X] create_cluster
[X] create_service
[ ] delete_attributes
[X] delete_cluster
[X] delete_service
[X] deregister_container_instance
[X] deregister_task_definition
[X] describe_clusters
[X] describe_container_instances
[X] describe_services
[X] describe_task_definition
[X] describe_tasks
[ ] discover_poll_endpoint
[ ] list_attributes
[X] list_clusters
[X] list_container_instances
[X] list_services
[ ] list_task_definition_families
[X] list_task_definitions
[X] list_tasks
[ ] put_attributes
[X] register_container_instance
[X] register_task_definition
[X] run_task
[X] start_task
[X] stop_task
[ ] submit_container_state_change
[ ] submit_task_state_change
[ ] update_container_agent
[X] update_container_instances_state
[X] update_service
-----------------------
efs - 0% implemented
-----------------------
[ ] create_file_system
[ ] create_mount_target
[ ] create_tags
[ ] delete_file_system
[ ] delete_mount_target
[ ] delete_tags
[ ] describe_file_systems
[ ] describe_mount_target_security_groups
[ ] describe_mount_targets
[ ] describe_tags
[ ] modify_mount_target_security_groups
-----------------------
elasticache - 0% implemented
-----------------------
[ ] add_tags_to_resource
[ ] authorize_cache_security_group_ingress
[ ] copy_snapshot
[ ] create_cache_cluster
[ ] create_cache_parameter_group
[ ] create_cache_security_group
[ ] create_cache_subnet_group
[ ] create_replication_group
[ ] create_snapshot
[ ] delete_cache_cluster
[ ] delete_cache_parameter_group
[ ] delete_cache_security_group
[ ] delete_cache_subnet_group
[ ] delete_replication_group
[ ] delete_snapshot
[ ] describe_cache_clusters
[ ] describe_cache_engine_versions
[ ] describe_cache_parameter_groups
[ ] describe_cache_parameters
[ ] describe_cache_security_groups
[ ] describe_cache_subnet_groups
[ ] describe_engine_default_parameters
[ ] describe_events
[ ] describe_replication_groups
[ ] describe_reserved_cache_nodes
[ ] describe_reserved_cache_nodes_offerings
[ ] describe_snapshots
[ ] list_allowed_node_type_modifications
[ ] list_tags_for_resource
[ ] modify_cache_cluster
[ ] modify_cache_parameter_group
[ ] modify_cache_subnet_group
[ ] modify_replication_group
[ ] purchase_reserved_cache_nodes_offering
[ ] reboot_cache_cluster
[ ] remove_tags_from_resource
[ ] reset_cache_parameter_group
[ ] revoke_cache_security_group_ingress
[ ] test_failover
-----------------------
elasticbeanstalk - 0% implemented
-----------------------
[ ] abort_environment_update
[ ] apply_environment_managed_action
[ ] check_dns_availability
[ ] compose_environments
[ ] create_application
[ ] create_application_version
[ ] create_configuration_template
[ ] create_environment
[ ] create_platform_version
[ ] create_storage_location
[ ] delete_application
[ ] delete_application_version
[ ] delete_configuration_template
[ ] delete_environment_configuration
[ ] delete_platform_version
[ ] describe_application_versions
[ ] describe_applications
[ ] describe_configuration_options
[ ] describe_configuration_settings
[ ] describe_environment_health
[ ] describe_environment_managed_action_history
[ ] describe_environment_managed_actions
[ ] describe_environment_resources
[ ] describe_environments
[ ] describe_events
[ ] describe_instances_health
[ ] describe_platform_version
[ ] list_available_solution_stacks
[ ] list_platform_versions
[ ] rebuild_environment
[ ] request_environment_info
[ ] restart_app_server
[ ] retrieve_environment_info
[ ] swap_environment_cnames
[ ] terminate_environment
[ ] update_application
[ ] update_application_resource_lifecycle
[ ] update_application_version
[ ] update_configuration_template
[ ] update_environment
[ ] validate_configuration_settings
-----------------------
elastictranscoder - 0% implemented
-----------------------
[ ] cancel_job
[ ] create_job
[ ] create_pipeline
[ ] create_preset
[ ] delete_pipeline
[ ] delete_preset
[ ] list_jobs_by_pipeline
[ ] list_jobs_by_status
[ ] list_pipelines
[ ] list_presets
[ ] read_job
[ ] read_pipeline
[ ] read_preset
[ ] test_role
[ ] update_pipeline
[ ] update_pipeline_notifications
[ ] update_pipeline_status
-----------------------
elb - 31% implemented
-----------------------
[ ] add_tags
[ ] apply_security_groups_to_load_balancer
[ ] attach_load_balancer_to_subnets
[X] configure_health_check
[X] create_app_cookie_stickiness_policy
[X] create_lb_cookie_stickiness_policy
[X] create_load_balancer
[X] create_load_balancer_listeners
[ ] create_load_balancer_policy
[X] delete_load_balancer
[X] delete_load_balancer_listeners
[ ] delete_load_balancer_policy
[ ] deregister_instances_from_load_balancer
[ ] describe_account_limits
[ ] describe_instance_health
[ ] describe_load_balancer_attributes
[ ] describe_load_balancer_policies
[ ] describe_load_balancer_policy_types
[X] describe_load_balancers
[ ] describe_tags
[ ] detach_load_balancer_from_subnets
[ ] disable_availability_zones_for_load_balancer
[ ] enable_availability_zones_for_load_balancer
[ ] modify_load_balancer_attributes
[ ] register_instances_with_load_balancer
[ ] remove_tags
[ ] set_load_balancer_listener_ssl_certificate
[ ] set_load_balancer_policies_for_backend_server
[X] set_load_balancer_policies_of_listener
-----------------------
elbv2 - 0% implemented
-----------------------
[ ] add_tags
[ ] create_listener
[ ] create_load_balancer
[ ] create_rule
[ ] create_target_group
[ ] delete_listener
[ ] delete_load_balancer
[ ] delete_rule
[ ] delete_target_group
[ ] deregister_targets
[ ] describe_account_limits
[ ] describe_listeners
[ ] describe_load_balancer_attributes
[ ] describe_load_balancers
[ ] describe_rules
[ ] describe_ssl_policies
[ ] describe_tags
[ ] describe_target_group_attributes
[ ] describe_target_groups
[ ] describe_target_health
[ ] modify_listener
[ ] modify_load_balancer_attributes
[ ] modify_rule
[ ] modify_target_group
[ ] modify_target_group_attributes
[ ] register_targets
[ ] remove_tags
[ ] set_ip_address_type
[ ] set_rule_priorities
[ ] set_security_groups
[ ] set_subnets
-----------------------
emr - 55% implemented
-----------------------
[ ] add_instance_fleet
[X] add_instance_groups
[X] add_job_flow_steps
[X] add_tags
[ ] cancel_steps
[ ] create_security_configuration
[ ] delete_security_configuration
[ ] describe_cluster
[X] describe_job_flows
[ ] describe_security_configuration
[X] describe_step
[X] list_bootstrap_actions
[X] list_clusters
[ ] list_instance_fleets
[X] list_instance_groups
[ ] list_instances
[ ] list_security_configurations
[X] list_steps
[ ] modify_instance_fleet
[X] modify_instance_groups
[ ] put_auto_scaling_policy
[ ] remove_auto_scaling_policy
[X] remove_tags
[X] run_job_flow
[X] set_termination_protection
[X] set_visible_to_all_users
[X] terminate_job_flows
-----------------------
es - 0% implemented
-----------------------
[ ] add_tags
[ ] create_elasticsearch_domain
[ ] delete_elasticsearch_domain
[ ] describe_elasticsearch_domain
[ ] describe_elasticsearch_domain_config
[ ] describe_elasticsearch_domains
[ ] describe_elasticsearch_instance_type_limits
[ ] list_domain_names
[ ] list_elasticsearch_instance_types
[ ] list_elasticsearch_versions
[ ] list_tags
[ ] remove_tags
[ ] update_elasticsearch_domain_config
-----------------------
events - 91% implemented
-----------------------
[X] delete_rule
[X] describe_rule
[X] disable_rule
[X] enable_rule
[X] list_rule_names_by_target
[X] list_rules
[X] list_targets_by_rule
[ ] put_events
[X] put_rule
[X] put_targets
[X] remove_targets
[X] test_event_pattern
-----------------------
firehose - 0% implemented
-----------------------
[ ] create_delivery_stream
[ ] delete_delivery_stream
[ ] describe_delivery_stream
[ ] list_delivery_streams
[ ] put_record
[ ] put_record_batch
[ ] update_destination
-----------------------
gamelift - 0% implemented
-----------------------
[ ] create_alias
[ ] create_build
[ ] create_fleet
[ ] create_game_session
[ ] create_game_session_queue
[ ] create_player_session
[ ] create_player_sessions
[ ] delete_alias
[ ] delete_build
[ ] delete_fleet
[ ] delete_game_session_queue
[ ] delete_scaling_policy
[ ] describe_alias
[ ] describe_build
[ ] describe_ec2_instance_limits
[ ] describe_fleet_attributes
[ ] describe_fleet_capacity
[ ] describe_fleet_events
[ ] describe_fleet_port_settings
[ ] describe_fleet_utilization
[ ] describe_game_session_details
[ ] describe_game_session_placement
[ ] describe_game_session_queues
[ ] describe_game_sessions
[ ] describe_instances
[ ] describe_player_sessions
[ ] describe_runtime_configuration
[ ] describe_scaling_policies
[ ] get_game_session_log_url
[ ] get_instance_access
[ ] list_aliases
[ ] list_builds
[ ] list_fleets
[ ] put_scaling_policy
[ ] request_upload_credentials
[ ] resolve_alias
[ ] search_game_sessions
[ ] start_game_session_placement
[ ] stop_game_session_placement
[ ] update_alias
[ ] update_build
[ ] update_fleet_attributes
[ ] update_fleet_capacity
[ ] update_fleet_port_settings
[ ] update_game_session
[ ] update_game_session_queue
[ ] update_runtime_configuration
-----------------------
glacier - 12% implemented
-----------------------
[ ] abort_multipart_upload
[ ] abort_vault_lock
[ ] add_tags_to_vault
[ ] complete_multipart_upload
[ ] complete_vault_lock
[X] create_vault
[ ] delete_archive
[X] delete_vault
[ ] delete_vault_access_policy
[ ] delete_vault_notifications
[ ] describe_job
[ ] describe_vault
[ ] get_data_retrieval_policy
[ ] get_job_output
[ ] get_vault_access_policy
[ ] get_vault_lock
[ ] get_vault_notifications
[X] initiate_job
[ ] initiate_multipart_upload
[ ] initiate_vault_lock
[X] list_jobs
[ ] list_multipart_uploads
[ ] list_parts
[ ] list_provisioned_capacity
[ ] list_tags_for_vault
[ ] list_vaults
[ ] purchase_provisioned_capacity
[ ] remove_tags_from_vault
[ ] set_data_retrieval_policy
[ ] set_vault_access_policy
[ ] set_vault_notifications
[ ] upload_archive
[ ] upload_multipart_part
-----------------------
health - 0% implemented
-----------------------
[ ] describe_affected_entities
[ ] describe_entity_aggregates
[ ] describe_event_aggregates
[ ] describe_event_details
[ ] describe_event_types
[ ] describe_events
-----------------------
iam - 36% implemented
-----------------------
[ ] add_client_id_to_open_id_connect_provider
[X] add_role_to_instance_profile
[X] add_user_to_group
[ ] attach_group_policy
[X] attach_role_policy
[ ] attach_user_policy
[ ] change_password
[X] create_access_key
[ ] create_account_alias
[X] create_group
[X] create_instance_profile
[X] create_login_profile
[ ] create_open_id_connect_provider
[X] create_policy
[X] create_policy_version
[X] create_role
[ ] create_saml_provider
[ ] create_service_linked_role
[ ] create_service_specific_credential
[X] create_user
[ ] create_virtual_mfa_device
[X] deactivate_mfa_device
[X] delete_access_key
[ ] delete_account_alias
[ ] delete_account_password_policy
[ ] delete_group
[ ] delete_group_policy
[ ] delete_instance_profile
[X] delete_login_profile
[ ] delete_open_id_connect_provider
[ ] delete_policy
[X] delete_policy_version
[X] delete_role
[ ] delete_role_policy
[ ] delete_saml_provider
[ ] delete_server_certificate
[ ] delete_service_specific_credential
[ ] delete_signing_certificate
[ ] delete_ssh_public_key
[X] delete_user
[X] delete_user_policy
[ ] delete_virtual_mfa_device
[ ] detach_group_policy
[ ] detach_role_policy
[ ] detach_user_policy
[X] enable_mfa_device
[ ] generate_credential_report
[ ] get_access_key_last_used
[ ] get_account_authorization_details
[ ] get_account_password_policy
[ ] get_account_summary
[ ] get_context_keys_for_custom_policy
[ ] get_context_keys_for_principal_policy
[X] get_credential_report
[X] get_group
[X] get_group_policy
[X] get_instance_profile
[ ] get_login_profile
[ ] get_open_id_connect_provider
[X] get_policy
[X] get_policy_version
[X] get_role
[X] get_role_policy
[ ] get_saml_provider
[X] get_server_certificate
[ ] get_ssh_public_key
[X] get_user
[X] get_user_policy
[ ] list_access_keys
[ ] list_account_aliases
[ ] list_attached_group_policies
[X] list_attached_role_policies
[ ] list_attached_user_policies
[ ] list_entities_for_policy
[X] list_group_policies
[X] list_groups
[ ] list_groups_for_user
[ ] list_instance_profiles
[ ] list_instance_profiles_for_role
[X] list_mfa_devices
[ ] list_open_id_connect_providers
[X] list_policies
[X] list_policy_versions
[X] list_role_policies
[ ] list_roles
[ ] list_saml_providers
[ ] list_server_certificates
[ ] list_service_specific_credentials
[ ] list_signing_certificates
[ ] list_ssh_public_keys
[X] list_user_policies
[X] list_users
[ ] list_virtual_mfa_devices
[X] put_group_policy
[X] put_role_policy
[X] put_user_policy
[ ] remove_client_id_from_open_id_connect_provider
[X] remove_role_from_instance_profile
[X] remove_user_from_group
[ ] reset_service_specific_credential
[ ] resync_mfa_device
[ ] set_default_policy_version
[ ] simulate_custom_policy
[ ] simulate_principal_policy
[ ] update_access_key
[ ] update_account_password_policy
[ ] update_assume_role_policy
[ ] update_group
[ ] update_login_profile
[ ] update_open_id_connect_provider_thumbprint
[ ] update_role_description
[ ] update_saml_provider
[ ] update_server_certificate
[ ] update_service_specific_credential
[ ] update_signing_certificate
[ ] update_ssh_public_key
[ ] update_user
[ ] upload_server_certificate
[ ] upload_signing_certificate
[ ] upload_ssh_public_key
-----------------------
importexport - 0% implemented
-----------------------
[ ] cancel_job
[ ] create_job
[ ] get_shipping_label
[ ] get_status
[ ] list_jobs
[ ] update_job
-----------------------
inspector - 0% implemented
-----------------------
[ ] add_attributes_to_findings
[ ] create_assessment_target
[ ] create_assessment_template
[ ] create_resource_group
[ ] delete_assessment_run
[ ] delete_assessment_target
[ ] delete_assessment_template
[ ] describe_assessment_runs
[ ] describe_assessment_targets
[ ] describe_assessment_templates
[ ] describe_cross_account_access_role
[ ] describe_findings
[ ] describe_resource_groups
[ ] describe_rules_packages
[ ] get_telemetry_metadata
[ ] list_assessment_run_agents
[ ] list_assessment_runs
[ ] list_assessment_targets
[ ] list_assessment_templates
[ ] list_event_subscriptions
[ ] list_findings
[ ] list_rules_packages
[ ] list_tags_for_resource
[ ] preview_agents
[ ] register_cross_account_access_role
[ ] remove_attributes_from_findings
[ ] set_tags_for_resource
[ ] start_assessment_run
[ ] stop_assessment_run
[ ] subscribe_to_event
[ ] unsubscribe_from_event
[ ] update_assessment_target
-----------------------
iot - 0% implemented
-----------------------
[ ] accept_certificate_transfer
[ ] attach_principal_policy
[ ] attach_thing_principal
[ ] cancel_certificate_transfer
[ ] create_certificate_from_csr
[ ] create_keys_and_certificate
[ ] create_policy
[ ] create_policy_version
[ ] create_thing
[ ] create_thing_type
[ ] create_topic_rule
[ ] delete_ca_certificate
[ ] delete_certificate
[ ] delete_policy
[ ] delete_policy_version
[ ] delete_registration_code
[ ] delete_thing
[ ] delete_thing_type
[ ] delete_topic_rule
[ ] deprecate_thing_type
[ ] describe_ca_certificate
[ ] describe_certificate
[ ] describe_endpoint
[ ] describe_thing
[ ] describe_thing_type
[ ] detach_principal_policy
[ ] detach_thing_principal
[ ] disable_topic_rule
[ ] enable_topic_rule
[ ] get_logging_options
[ ] get_policy
[ ] get_policy_version
[ ] get_registration_code
[ ] get_topic_rule
[ ] list_ca_certificates
[ ] list_certificates
[ ] list_certificates_by_ca
[ ] list_outgoing_certificates
[ ] list_policies
[ ] list_policy_principals
[ ] list_policy_versions
[ ] list_principal_policies
[ ] list_principal_things
[ ] list_thing_principals
[ ] list_thing_types
[ ] list_things
[ ] list_topic_rules
[ ] register_ca_certificate
[ ] register_certificate
[ ] reject_certificate_transfer
[ ] replace_topic_rule
[ ] set_default_policy_version
[ ] set_logging_options
[ ] transfer_certificate
[ ] update_ca_certificate
[ ] update_certificate
[ ] update_thing
-----------------------
iot-data - 0% implemented
-----------------------
[ ] delete_thing_shadow
[ ] get_thing_shadow
[ ] publish
[ ] update_thing_shadow
-----------------------
kinesis - 68% implemented
-----------------------
[X] add_tags_to_stream
[X] create_stream
[ ] decrease_stream_retention_period
[X] delete_stream
[ ] describe_limits
[X] describe_stream
[ ] disable_enhanced_monitoring
[ ] enable_enhanced_monitoring
[X] get_records
[X] get_shard_iterator
[ ] increase_stream_retention_period
[X] list_streams
[X] list_tags_for_stream
[X] merge_shards
[X] put_record
[X] put_records
[X] remove_tags_from_stream
[X] split_shard
[ ] update_shard_count
-----------------------
kinesisanalytics - 0% implemented
-----------------------
[ ] add_application_input
[ ] add_application_output
[ ] add_application_reference_data_source
[ ] create_application
[ ] delete_application
[ ] delete_application_output
[ ] delete_application_reference_data_source
[ ] describe_application
[ ] discover_input_schema
[ ] list_applications
[ ] start_application
[ ] stop_application
[ ] update_application
-----------------------
kms - 25% implemented
-----------------------
[ ] cancel_key_deletion
[ ] create_alias
[ ] create_grant
[X] create_key
[ ] decrypt
[X] delete_alias
[ ] delete_imported_key_material
[X] describe_key
[ ] disable_key
[X] disable_key_rotation
[ ] enable_key
[X] enable_key_rotation
[ ] encrypt
[ ] generate_data_key
[ ] generate_data_key_without_plaintext
[ ] generate_random
[X] get_key_policy
[X] get_key_rotation_status
[ ] get_parameters_for_import
[ ] import_key_material
[ ] list_aliases
[ ] list_grants
[ ] list_key_policies
[X] list_keys
[ ] list_resource_tags
[ ] list_retirable_grants
[X] put_key_policy
[ ] re_encrypt
[ ] retire_grant
[ ] revoke_grant
[ ] schedule_key_deletion
[ ] tag_resource
[ ] untag_resource
[ ] update_alias
[ ] update_key_description
-----------------------
lambda - 0% implemented
-----------------------
[ ] add_permission
[ ] create_alias
[ ] create_event_source_mapping
[ ] create_function
[ ] delete_alias
[ ] delete_event_source_mapping
[ ] delete_function
[ ] get_account_settings
[ ] get_alias
[ ] get_event_source_mapping
[ ] get_function
[ ] get_function_configuration
[ ] get_policy
[ ] invoke
[ ] invoke_async
[ ] list_aliases
[ ] list_event_source_mappings
[ ] list_functions
[ ] list_tags
[ ] list_versions_by_function
[ ] publish_version
[ ] remove_permission
[ ] tag_resource
[ ] untag_resource
[ ] update_alias
[ ] update_event_source_mapping
[ ] update_function_code
[ ] update_function_configuration
-----------------------
lex-models - 0% implemented
-----------------------
[ ] create_bot_version
[ ] create_intent_version
[ ] create_slot_type_version
[ ] delete_bot
[ ] delete_bot_alias
[ ] delete_bot_channel_association
[ ] delete_bot_version
[ ] delete_intent
[ ] delete_intent_version
[ ] delete_slot_type
[ ] delete_slot_type_version
[ ] delete_utterances
[ ] get_bot
[ ] get_bot_alias
[ ] get_bot_aliases
[ ] get_bot_channel_association
[ ] get_bot_channel_associations
[ ] get_bot_versions
[ ] get_bots
[ ] get_builtin_intent
[ ] get_builtin_intents
[ ] get_builtin_slot_types
[ ] get_intent
[ ] get_intent_versions
[ ] get_intents
[ ] get_slot_type
[ ] get_slot_type_versions
[ ] get_slot_types
[ ] get_utterances_view
[ ] put_bot
[ ] put_bot_alias
[ ] put_intent
[ ] put_slot_type
-----------------------
lex-runtime - 0% implemented
-----------------------
[ ] post_content
[ ] post_text
-----------------------
lightsail - 0% implemented
-----------------------
[ ] allocate_static_ip
[ ] attach_static_ip
[ ] close_instance_public_ports
[ ] create_domain
[ ] create_domain_entry
[ ] create_instance_snapshot
[ ] create_instances
[ ] create_instances_from_snapshot
[ ] create_key_pair
[ ] delete_domain
[ ] delete_domain_entry
[ ] delete_instance
[ ] delete_instance_snapshot
[ ] delete_key_pair
[ ] detach_static_ip
[ ] download_default_key_pair
[ ] get_active_names
[ ] get_blueprints
[ ] get_bundles
[ ] get_domain
[ ] get_domains
[ ] get_instance
[ ] get_instance_access_details
[ ] get_instance_metric_data
[ ] get_instance_port_states
[ ] get_instance_snapshot
[ ] get_instance_snapshots
[ ] get_instance_state
[ ] get_instances
[ ] get_key_pair
[ ] get_key_pairs
[ ] get_operation
[ ] get_operations
[ ] get_operations_for_resource
[ ] get_regions
[ ] get_static_ip
[ ] get_static_ips
[ ] import_key_pair
[ ] is_vpc_peered
[ ] open_instance_public_ports
[ ] peer_vpc
[ ] reboot_instance
[ ] release_static_ip
[ ] start_instance
[ ] stop_instance
[ ] unpeer_vpc
[ ] update_domain_entry
-----------------------
logs - 0% implemented
-----------------------
[ ] cancel_export_task
[ ] create_export_task
[ ] create_log_group
[ ] create_log_stream
[ ] delete_destination
[ ] delete_log_group
[ ] delete_log_stream
[ ] delete_metric_filter
[ ] delete_retention_policy
[ ] delete_subscription_filter
[ ] describe_destinations
[ ] describe_export_tasks
[ ] describe_log_groups
[ ] describe_log_streams
[ ] describe_metric_filters
[ ] describe_subscription_filters
[ ] filter_log_events
[ ] get_log_events
[ ] list_tags_log_group
[ ] put_destination
[ ] put_destination_policy
[ ] put_log_events
[ ] put_metric_filter
[ ] put_retention_policy
[ ] put_subscription_filter
[ ] tag_log_group
[ ] test_metric_filter
[ ] untag_log_group
-----------------------
machinelearning - 0% implemented
-----------------------
[ ] add_tags
[ ] create_batch_prediction
[ ] create_data_source_from_rds
[ ] create_data_source_from_redshift
[ ] create_data_source_from_s3
[ ] create_evaluation
[ ] create_ml_model
[ ] create_realtime_endpoint
[ ] delete_batch_prediction
[ ] delete_data_source
[ ] delete_evaluation
[ ] delete_ml_model
[ ] delete_realtime_endpoint
[ ] delete_tags
[ ] describe_batch_predictions
[ ] describe_data_sources
[ ] describe_evaluations
[ ] describe_ml_models
[ ] describe_tags
[ ] get_batch_prediction
[ ] get_data_source
[ ] get_evaluation
[ ] get_ml_model
[ ] predict
[ ] update_batch_prediction
[ ] update_data_source
[ ] update_evaluation
[ ] update_ml_model
-----------------------
marketplace-entitlement - 0% implemented
-----------------------
[ ] get_entitlements
-----------------------
marketplacecommerceanalytics - 0% implemented
-----------------------
[ ] generate_data_set
[ ] start_support_data_export
-----------------------
meteringmarketplace - 0% implemented
-----------------------
[ ] batch_meter_usage
[ ] meter_usage
[ ] resolve_customer
-----------------------
mturk - 0% implemented
-----------------------
[ ] accept_qualification_request
[ ] approve_assignment
[ ] associate_qualification_with_worker
[ ] create_additional_assignments_for_hit
[ ] create_hit
[ ] create_hit_type
[ ] create_hit_with_hit_type
[ ] create_qualification_type
[ ] create_worker_block
[ ] delete_hit
[ ] delete_qualification_type
[ ] delete_worker_block
[ ] disassociate_qualification_from_worker
[ ] get_account_balance
[ ] get_assignment
[ ] get_file_upload_url
[ ] get_hit
[ ] get_qualification_score
[ ] get_qualification_type
[ ] list_assignments_for_hit
[ ] list_bonus_payments
[ ] list_hits
[ ] list_hits_for_qualification_type
[ ] list_qualification_requests
[ ] list_qualification_types
[ ] list_review_policy_results_for_hit
[ ] list_reviewable_hits
[ ] list_worker_blocks
[ ] list_workers_with_qualification_type
[ ] notify_workers
[ ] reject_assignment
[ ] reject_qualification_request
[ ] send_bonus
[ ] send_test_event_notification
[ ] update_expiration_for_hit
[ ] update_hit_review_status
[ ] update_hit_type_of_hit
[ ] update_notification_settings
[ ] update_qualification_type
-----------------------
opsworks - 10% implemented
-----------------------
[ ] assign_instance
[ ] assign_volume
[ ] associate_elastic_ip
[ ] attach_elastic_load_balancer
[ ] clone_stack
[ ] create_app
[ ] create_deployment
[X] create_instance
[X] create_layer
[X] create_stack
[ ] create_user_profile
[ ] delete_app
[ ] delete_instance
[ ] delete_layer
[ ] delete_stack
[ ] delete_user_profile
[ ] deregister_ecs_cluster
[ ] deregister_elastic_ip
[ ] deregister_instance
[ ] deregister_rds_db_instance
[ ] deregister_volume
[ ] describe_agent_versions
[ ] describe_apps
[ ] describe_commands
[ ] describe_deployments
[ ] describe_ecs_clusters
[ ] describe_elastic_ips
[ ] describe_elastic_load_balancers
[X] describe_instances
[X] describe_layers
[ ] describe_load_based_auto_scaling
[ ] describe_my_user_profile
[ ] describe_permissions
[ ] describe_raid_arrays
[ ] describe_rds_db_instances
[ ] describe_service_errors
[ ] describe_stack_provisioning_parameters
[ ] describe_stack_summary
[X] describe_stacks
[ ] describe_time_based_auto_scaling
[ ] describe_user_profiles
[ ] describe_volumes
[ ] detach_elastic_load_balancer
[ ] disassociate_elastic_ip
[ ] get_hostname_suggestion
[ ] grant_access
[ ] reboot_instance
[ ] register_ecs_cluster
[ ] register_elastic_ip
[ ] register_instance
[ ] register_rds_db_instance
[ ] register_volume
[ ] set_load_based_auto_scaling
[ ] set_permission
[ ] set_time_based_auto_scaling
[X] start_instance
[ ] start_stack
[ ] stop_instance
[ ] stop_stack
[ ] unassign_instance
[ ] unassign_volume
[ ] update_app
[ ] update_elastic_ip
[ ] update_instance
[ ] update_layer
[ ] update_my_user_profile
[ ] update_rds_db_instance
[ ] update_stack
[ ] update_user_profile
[ ] update_volume
-----------------------
opsworkscm - 0% implemented
-----------------------
[ ] associate_node
[ ] create_backup
[ ] create_server
[ ] delete_backup
[ ] delete_server
[ ] describe_account_attributes
[ ] describe_backups
[ ] describe_events
[ ] describe_node_association_status
[ ] describe_servers
[ ] disassociate_node
[ ] restore_server
[ ] start_maintenance
[ ] update_server
[ ] update_server_engine_attributes
-----------------------
organizations - 0% implemented
-----------------------
[ ] accept_handshake
[ ] attach_policy
[ ] cancel_handshake
[ ] create_account
[ ] create_organization
[ ] create_organizational_unit
[ ] create_policy
[ ] decline_handshake
[ ] delete_organization
[ ] delete_organizational_unit
[ ] delete_policy
[ ] describe_account
[ ] describe_create_account_status
[ ] describe_handshake
[ ] describe_organization
[ ] describe_organizational_unit
[ ] describe_policy
[ ] detach_policy
[ ] disable_policy_type
[ ] enable_all_features
[ ] enable_policy_type
[ ] invite_account_to_organization
[ ] leave_organization
[ ] list_accounts
[ ] list_accounts_for_parent
[ ] list_children
[ ] list_create_account_status
[ ] list_handshakes_for_account
[ ] list_handshakes_for_organization
[ ] list_organizational_units_for_parent
[ ] list_parents
[ ] list_policies
[ ] list_policies_for_target
[ ] list_roots
[ ] list_targets_for_policy
[ ] move_account
[ ] remove_account_from_organization
[ ] update_organizational_unit
[ ] update_policy
-----------------------
pinpoint - 0% implemented
-----------------------
[ ] create_campaign
[ ] create_import_job
[ ] create_segment
[ ] delete_apns_channel
[ ] delete_campaign
[ ] delete_event_stream
[ ] delete_gcm_channel
[ ] delete_segment
[ ] get_apns_channel
[ ] get_application_settings
[ ] get_campaign
[ ] get_campaign_activities
[ ] get_campaign_version
[ ] get_campaign_versions
[ ] get_campaigns
[ ] get_endpoint
[ ] get_event_stream
[ ] get_gcm_channel
[ ] get_import_job
[ ] get_import_jobs
[ ] get_segment
[ ] get_segment_import_jobs
[ ] get_segment_version
[ ] get_segment_versions
[ ] get_segments
[ ] put_event_stream
[ ] update_apns_channel
[ ] update_application_settings
[ ] update_campaign
[ ] update_endpoint
[ ] update_endpoints_batch
[ ] update_gcm_channel
[ ] update_segment
-----------------------
polly - 0% implemented
-----------------------
[ ] delete_lexicon
[ ] describe_voices
[ ] get_lexicon
[ ] list_lexicons
[ ] put_lexicon
[ ] synthesize_speech
-----------------------
rds - 0% implemented
-----------------------
[ ] add_role_to_db_cluster
[ ] add_source_identifier_to_subscription
[ ] add_tags_to_resource
[ ] apply_pending_maintenance_action
[ ] authorize_db_security_group_ingress
[ ] copy_db_cluster_parameter_group
[ ] copy_db_cluster_snapshot
[ ] copy_db_parameter_group
[ ] copy_db_snapshot
[ ] copy_option_group
[ ] create_db_cluster
[ ] create_db_cluster_parameter_group
[ ] create_db_cluster_snapshot
[ ] create_db_instance
[ ] create_db_instance_read_replica
[ ] create_db_parameter_group
[ ] create_db_security_group
[ ] create_db_snapshot
[ ] create_db_subnet_group
[ ] create_event_subscription
[ ] create_option_group
[ ] delete_db_cluster
[ ] delete_db_cluster_parameter_group
[ ] delete_db_cluster_snapshot
[ ] delete_db_instance
[ ] delete_db_parameter_group
[ ] delete_db_security_group
[ ] delete_db_snapshot
[ ] delete_db_subnet_group
[ ] delete_event_subscription
[ ] delete_option_group
[ ] describe_account_attributes
[ ] describe_certificates
[ ] describe_db_cluster_parameter_groups
[ ] describe_db_cluster_parameters
[ ] describe_db_cluster_snapshot_attributes
[ ] describe_db_cluster_snapshots
[ ] describe_db_clusters
[ ] describe_db_engine_versions
[ ] describe_db_instances
[ ] describe_db_log_files
[ ] describe_db_parameter_groups
[ ] describe_db_parameters
[ ] describe_db_security_groups
[ ] describe_db_snapshot_attributes
[ ] describe_db_snapshots
[ ] describe_db_subnet_groups
[ ] describe_engine_default_cluster_parameters
[ ] describe_engine_default_parameters
[ ] describe_event_categories
[ ] describe_event_subscriptions
[ ] describe_events
[ ] describe_option_group_options
[ ] describe_option_groups
[ ] describe_orderable_db_instance_options
[ ] describe_pending_maintenance_actions
[ ] describe_reserved_db_instances
[ ] describe_reserved_db_instances_offerings
[ ] describe_source_regions
[ ] download_db_log_file_portion
[ ] failover_db_cluster
[ ] list_tags_for_resource
[ ] modify_db_cluster
[ ] modify_db_cluster_parameter_group
[ ] modify_db_cluster_snapshot_attribute
[ ] modify_db_instance
[ ] modify_db_parameter_group
[ ] modify_db_snapshot
[ ] modify_db_snapshot_attribute
[ ] modify_db_subnet_group
[ ] modify_event_subscription
[ ] modify_option_group
[ ] promote_read_replica
[ ] promote_read_replica_db_cluster
[ ] purchase_reserved_db_instances_offering
[ ] reboot_db_instance
[ ] remove_role_from_db_cluster
[ ] remove_source_identifier_from_subscription
[ ] remove_tags_from_resource
[ ] reset_db_cluster_parameter_group
[ ] reset_db_parameter_group
[ ] restore_db_cluster_from_s3
[ ] restore_db_cluster_from_snapshot
[ ] restore_db_cluster_to_point_in_time
[ ] restore_db_instance_from_db_snapshot
[ ] restore_db_instance_to_point_in_time
[ ] revoke_db_security_group_ingress
-----------------------
redshift - 20% implemented
-----------------------
[ ] authorize_cluster_security_group_ingress
[ ] authorize_snapshot_access
[ ] copy_cluster_snapshot
[X] create_cluster
[X] create_cluster_parameter_group
[X] create_cluster_security_group
[ ] create_cluster_snapshot
[X] create_cluster_subnet_group
[ ] create_event_subscription
[ ] create_hsm_client_certificate
[ ] create_hsm_configuration
[ ] create_snapshot_copy_grant
[ ] create_tags
[X] delete_cluster
[X] delete_cluster_parameter_group
[X] delete_cluster_security_group
[ ] delete_cluster_snapshot
[X] delete_cluster_subnet_group
[ ] delete_event_subscription
[ ] delete_hsm_client_certificate
[ ] delete_hsm_configuration
[ ] delete_snapshot_copy_grant
[ ] delete_tags
[X] describe_cluster_parameter_groups
[ ] describe_cluster_parameters
[X] describe_cluster_security_groups
[ ] describe_cluster_snapshots
[X] describe_cluster_subnet_groups
[ ] describe_cluster_versions
[X] describe_clusters
[ ] describe_default_cluster_parameters
[ ] describe_event_categories
[ ] describe_event_subscriptions
[ ] describe_events
[ ] describe_hsm_client_certificates
[ ] describe_hsm_configurations
[ ] describe_logging_status
[ ] describe_orderable_cluster_options
[ ] describe_reserved_node_offerings
[ ] describe_reserved_nodes
[ ] describe_resize
[ ] describe_snapshot_copy_grants
[ ] describe_table_restore_status
[ ] describe_tags
[ ] disable_logging
[ ] disable_snapshot_copy
[ ] enable_logging
[ ] enable_snapshot_copy
[ ] get_cluster_credentials
[X] modify_cluster
[ ] modify_cluster_iam_roles
[ ] modify_cluster_parameter_group
[ ] modify_cluster_subnet_group
[ ] modify_event_subscription
[ ] modify_snapshot_copy_retention_period
[ ] purchase_reserved_node_offering
[ ] reboot_cluster
[ ] reset_cluster_parameter_group
[ ] restore_from_cluster_snapshot
[ ] restore_table_from_cluster_snapshot
[ ] revoke_cluster_security_group_ingress
[ ] revoke_snapshot_access
[ ] rotate_encryption_key
-----------------------
rekognition - 0% implemented
-----------------------
[ ] compare_faces
[ ] create_collection
[ ] delete_collection
[ ] delete_faces
[ ] detect_faces
[ ] detect_labels
[ ] detect_moderation_labels
[ ] index_faces
[ ] list_collections
[ ] list_faces
[ ] search_faces
[ ] search_faces_by_image
-----------------------
resourcegroupstaggingapi - 0% implemented
-----------------------
[ ] get_resources
[ ] get_tag_keys
[ ] get_tag_values
[ ] tag_resources
[ ] untag_resources
-----------------------
route53 - 14% implemented
-----------------------
[ ] associate_vpc_with_hosted_zone
[ ] change_resource_record_sets
[X] change_tags_for_resource
[X] create_health_check
[X] create_hosted_zone
[ ] create_reusable_delegation_set
[ ] create_traffic_policy
[ ] create_traffic_policy_instance
[ ] create_traffic_policy_version
[ ] create_vpc_association_authorization
[X] delete_health_check
[X] delete_hosted_zone
[ ] delete_reusable_delegation_set
[ ] delete_traffic_policy
[ ] delete_traffic_policy_instance
[ ] delete_vpc_association_authorization
[ ] disassociate_vpc_from_hosted_zone
[ ] get_change
[ ] get_checker_ip_ranges
[ ] get_geo_location
[ ] get_health_check
[ ] get_health_check_count
[ ] get_health_check_last_failure_reason
[ ] get_health_check_status
[X] get_hosted_zone
[ ] get_hosted_zone_count
[ ] get_reusable_delegation_set
[ ] get_traffic_policy
[ ] get_traffic_policy_instance
[ ] get_traffic_policy_instance_count
[ ] list_geo_locations
[ ] list_health_checks
[ ] list_hosted_zones
[ ] list_hosted_zones_by_name
[ ] list_resource_record_sets
[ ] list_reusable_delegation_sets
[X] list_tags_for_resource
[ ] list_tags_for_resources
[ ] list_traffic_policies
[ ] list_traffic_policy_instances
[ ] list_traffic_policy_instances_by_hosted_zone
[ ] list_traffic_policy_instances_by_policy
[ ] list_traffic_policy_versions
[ ] list_vpc_association_authorizations
[ ] test_dns_answer
[ ] update_health_check
[ ] update_hosted_zone_comment
[ ] update_traffic_policy_comment
[ ] update_traffic_policy_instance
-----------------------
route53domains - 0% implemented
-----------------------
[ ] check_domain_availability
[ ] delete_tags_for_domain
[ ] disable_domain_auto_renew
[ ] disable_domain_transfer_lock
[ ] enable_domain_auto_renew
[ ] enable_domain_transfer_lock
[ ] get_contact_reachability_status
[ ] get_domain_detail
[ ] get_domain_suggestions
[ ] get_operation_detail
[ ] list_domains
[ ] list_operations
[ ] list_tags_for_domain
[ ] register_domain
[ ] renew_domain
[ ] resend_contact_reachability_email
[ ] retrieve_domain_auth_code
[ ] transfer_domain
[ ] update_domain_contact
[ ] update_domain_contact_privacy
[ ] update_domain_nameservers
[ ] update_tags_for_domain
[ ] view_billing
-----------------------
s3 - 8% implemented
-----------------------
[ ] abort_multipart_upload
[ ] complete_multipart_upload
[ ] copy_object
[X] create_bucket
[ ] create_multipart_upload
[X] delete_bucket
[ ] delete_bucket_analytics_configuration
[ ] delete_bucket_cors
[ ] delete_bucket_inventory_configuration
[ ] delete_bucket_lifecycle
[ ] delete_bucket_metrics_configuration
[X] delete_bucket_policy
[ ] delete_bucket_replication
[ ] delete_bucket_tagging
[ ] delete_bucket_website
[ ] delete_object
[ ] delete_object_tagging
[ ] delete_objects
[ ] get_bucket_accelerate_configuration
[X] get_bucket_acl
[ ] get_bucket_analytics_configuration
[ ] get_bucket_cors
[ ] get_bucket_inventory_configuration
[ ] get_bucket_lifecycle
[ ] get_bucket_lifecycle_configuration
[ ] get_bucket_location
[ ] get_bucket_logging
[ ] get_bucket_metrics_configuration
[ ] get_bucket_notification
[ ] get_bucket_notification_configuration
[X] get_bucket_policy
[ ] get_bucket_replication
[ ] get_bucket_request_payment
[ ] get_bucket_tagging
[X] get_bucket_versioning
[ ] get_bucket_website
[ ] get_object
[ ] get_object_acl
[ ] get_object_tagging
[ ] get_object_torrent
[ ] head_bucket
[ ] head_object
[ ] list_bucket_analytics_configurations
[ ] list_bucket_inventory_configurations
[ ] list_bucket_metrics_configurations
[ ] list_buckets
[ ] list_multipart_uploads
[ ] list_object_versions
[ ] list_objects
[ ] list_objects_v2
[ ] list_parts
[ ] put_bucket_accelerate_configuration
[ ] put_bucket_acl
[ ] put_bucket_analytics_configuration
[ ] put_bucket_cors
[ ] put_bucket_inventory_configuration
[ ] put_bucket_lifecycle
[ ] put_bucket_lifecycle_configuration
[ ] put_bucket_logging
[ ] put_bucket_metrics_configuration
[ ] put_bucket_notification
[ ] put_bucket_notification_configuration
[ ] put_bucket_policy
[ ] put_bucket_replication
[ ] put_bucket_request_payment
[ ] put_bucket_tagging
[ ] put_bucket_versioning
[ ] put_bucket_website
[ ] put_object
[ ] put_object_acl
[ ] put_object_tagging
[ ] restore_object
[ ] upload_part
[ ] upload_part_copy
-----------------------
sdb - 0% implemented
-----------------------
[ ] batch_delete_attributes
[ ] batch_put_attributes
[ ] create_domain
[ ] delete_attributes
[ ] delete_domain
[ ] domain_metadata
[ ] get_attributes
[ ] list_domains
[ ] put_attributes
[ ] select
-----------------------
servicecatalog - 0% implemented
-----------------------
[ ] accept_portfolio_share
[ ] associate_principal_with_portfolio
[ ] associate_product_with_portfolio
[ ] create_constraint
[ ] create_portfolio
[ ] create_portfolio_share
[ ] create_product
[ ] create_provisioning_artifact
[ ] delete_constraint
[ ] delete_portfolio
[ ] delete_portfolio_share
[ ] delete_product
[ ] delete_provisioning_artifact
[ ] describe_constraint
[ ] describe_portfolio
[ ] describe_product
[ ] describe_product_as_admin
[ ] describe_product_view
[ ] describe_provisioning_artifact
[ ] describe_provisioning_parameters
[ ] describe_record
[ ] disassociate_principal_from_portfolio
[ ] disassociate_product_from_portfolio
[ ] list_accepted_portfolio_shares
[ ] list_constraints_for_portfolio
[ ] list_launch_paths
[ ] list_portfolio_access
[ ] list_portfolios
[ ] list_portfolios_for_product
[ ] list_principals_for_portfolio
[ ] list_provisioning_artifacts
[ ] list_record_history
[ ] provision_product
[ ] reject_portfolio_share
[ ] scan_provisioned_products
[ ] search_products
[ ] search_products_as_admin
[ ] terminate_provisioned_product
[ ] update_constraint
[ ] update_portfolio
[ ] update_product
[ ] update_provisioned_product
[ ] update_provisioning_artifact
-----------------------
ses - 16% implemented
-----------------------
[ ] clone_receipt_rule_set
[ ] create_configuration_set
[ ] create_configuration_set_event_destination
[ ] create_receipt_filter
[ ] create_receipt_rule
[ ] create_receipt_rule_set
[ ] delete_configuration_set
[ ] delete_configuration_set_event_destination
[X] delete_identity
[ ] delete_identity_policy
[ ] delete_receipt_filter
[ ] delete_receipt_rule
[ ] delete_receipt_rule_set
[ ] delete_verified_email_address
[ ] describe_active_receipt_rule_set
[ ] describe_configuration_set
[ ] describe_receipt_rule
[ ] describe_receipt_rule_set
[ ] get_identity_dkim_attributes
[ ] get_identity_mail_from_domain_attributes
[ ] get_identity_notification_attributes
[ ] get_identity_policies
[ ] get_identity_verification_attributes
[X] get_send_quota
[ ] get_send_statistics
[ ] list_configuration_sets
[X] list_identities
[ ] list_identity_policies
[ ] list_receipt_filters
[ ] list_receipt_rule_sets
[X] list_verified_email_addresses
[ ] put_identity_policy
[ ] reorder_receipt_rule_set
[ ] send_bounce
[X] send_email
[X] send_raw_email
[ ] set_active_receipt_rule_set
[ ] set_identity_dkim_enabled
[ ] set_identity_feedback_forwarding_enabled
[ ] set_identity_headers_in_notifications_enabled
[ ] set_identity_mail_from_domain
[ ] set_identity_notification_topic
[ ] set_receipt_rule_position
[ ] update_configuration_set_event_destination
[ ] update_receipt_rule
[ ] verify_domain_dkim
[ ] verify_domain_identity
[X] verify_email_address
[X] verify_email_identity
-----------------------
shield - 0% implemented
-----------------------
[ ] create_protection
[ ] create_subscription
[ ] delete_protection
[ ] delete_subscription
[ ] describe_attack
[ ] describe_protection
[ ] describe_subscription
[ ] list_attacks
[ ] list_protections
-----------------------
sms - 0% implemented
-----------------------
[ ] create_replication_job
[ ] delete_replication_job
[ ] delete_server_catalog
[ ] disassociate_connector
[ ] get_connectors
[ ] get_replication_jobs
[ ] get_replication_runs
[ ] get_servers
[ ] import_server_catalog
[ ] start_on_demand_replication_run
[ ] update_replication_job
-----------------------
snowball - 0% implemented
-----------------------
[ ] cancel_cluster
[ ] cancel_job
[ ] create_address
[ ] create_cluster
[ ] create_job
[ ] describe_address
[ ] describe_addresses
[ ] describe_cluster
[ ] describe_job
[ ] get_job_manifest
[ ] get_job_unlock_code
[ ] get_snowball_usage
[ ] list_cluster_jobs
[ ] list_clusters
[ ] list_jobs
[ ] update_cluster
[ ] update_job
-----------------------
sns - 46% implemented
-----------------------
[ ] add_permission
[ ] check_if_phone_number_is_opted_out
[ ] confirm_subscription
[X] create_platform_application
[X] create_platform_endpoint
[X] create_topic
[X] delete_endpoint
[X] delete_platform_application
[X] delete_topic
[ ] get_endpoint_attributes
[ ] get_platform_application_attributes
[ ] get_sms_attributes
[ ] get_subscription_attributes
[ ] get_topic_attributes
[X] list_endpoints_by_platform_application
[ ] list_phone_numbers_opted_out
[X] list_platform_applications
[X] list_subscriptions
[ ] list_subscriptions_by_topic
[X] list_topics
[ ] opt_in_phone_number
[X] publish
[ ] remove_permission
[X] set_endpoint_attributes
[ ] set_platform_application_attributes
[ ] set_sms_attributes
[ ] set_subscription_attributes
[ ] set_topic_attributes
[X] subscribe
[X] unsubscribe
-----------------------
sqs - 41% implemented
-----------------------
[ ] add_permission
[X] change_message_visibility
[ ] change_message_visibility_batch
[X] create_queue
[X] delete_message
[ ] delete_message_batch
[X] delete_queue
[ ] get_queue_attributes
[ ] get_queue_url
[ ] list_dead_letter_source_queues
[X] list_queues
[X] purge_queue
[ ] receive_message
[ ] remove_permission
[X] send_message
[ ] send_message_batch
[ ] set_queue_attributes
-----------------------
ssm - 3% implemented
-----------------------
[ ] add_tags_to_resource
[ ] cancel_command
[ ] create_activation
[ ] create_association
[ ] create_association_batch
[ ] create_document
[ ] create_maintenance_window
[ ] create_patch_baseline
[ ] delete_activation
[ ] delete_association
[ ] delete_document
[ ] delete_maintenance_window
[X] delete_parameter
[ ] delete_patch_baseline
[ ] deregister_managed_instance
[ ] deregister_patch_baseline_for_patch_group
[ ] deregister_target_from_maintenance_window
[ ] deregister_task_from_maintenance_window
[ ] describe_activations
[ ] describe_association
[ ] describe_automation_executions
[ ] describe_available_patches
[ ] describe_document
[ ] describe_document_permission
[ ] describe_effective_instance_associations
[ ] describe_effective_patches_for_patch_baseline
[ ] describe_instance_associations_status
[ ] describe_instance_information
[ ] describe_instance_patch_states
[ ] describe_instance_patch_states_for_patch_group
[ ] describe_instance_patches
[ ] describe_maintenance_window_execution_task_invocations
[ ] describe_maintenance_window_execution_tasks
[ ] describe_maintenance_window_executions
[ ] describe_maintenance_window_targets
[ ] describe_maintenance_window_tasks
[ ] describe_maintenance_windows
[ ] describe_parameters
[ ] describe_patch_baselines
[ ] describe_patch_group_state
[ ] describe_patch_groups
[ ] get_automation_execution
[ ] get_command_invocation
[ ] get_default_patch_baseline
[ ] get_deployable_patch_snapshot_for_instance
[ ] get_document
[ ] get_inventory
[ ] get_inventory_schema
[ ] get_maintenance_window
[ ] get_maintenance_window_execution
[ ] get_maintenance_window_execution_task
[ ] get_parameter_history
[X] get_parameters
[ ] get_patch_baseline
[ ] get_patch_baseline_for_patch_group
[ ] list_associations
[ ] list_command_invocations
[ ] list_commands
[ ] list_document_versions
[ ] list_documents
[ ] list_inventory_entries
[ ] list_tags_for_resource
[ ] modify_document_permission
[ ] put_inventory
[X] put_parameter
[ ] register_default_patch_baseline
[ ] register_patch_baseline_for_patch_group
[ ] register_target_with_maintenance_window
[ ] register_task_with_maintenance_window
[ ] remove_tags_from_resource
[ ] send_command
[ ] start_automation_execution
[ ] stop_automation_execution
[ ] update_association
[ ] update_association_status
[ ] update_document
[ ] update_document_default_version
[ ] update_maintenance_window
[ ] update_managed_instance_role
[ ] update_patch_baseline
-----------------------
stepfunctions - 0% implemented
-----------------------
[ ] create_activity
[ ] create_state_machine
[ ] delete_activity
[ ] delete_state_machine
[ ] describe_activity
[ ] describe_execution
[ ] describe_state_machine
[ ] get_activity_task
[ ] get_execution_history
[ ] list_activities
[ ] list_executions
[ ] list_state_machines
[ ] send_task_failure
[ ] send_task_heartbeat
[ ] send_task_success
[ ] start_execution
[ ] stop_execution
-----------------------
storagegateway - 0% implemented
-----------------------
[ ] activate_gateway
[ ] add_cache
[ ] add_tags_to_resource
[ ] add_upload_buffer
[ ] add_working_storage
[ ] cancel_archival
[ ] cancel_retrieval
[ ] create_cached_iscsi_volume
[ ] create_nfs_file_share
[ ] create_snapshot
[ ] create_snapshot_from_volume_recovery_point
[ ] create_stored_iscsi_volume
[ ] create_tape_with_barcode
[ ] create_tapes
[ ] delete_bandwidth_rate_limit
[ ] delete_chap_credentials
[ ] delete_file_share
[ ] delete_gateway
[ ] delete_snapshot_schedule
[ ] delete_tape
[ ] delete_tape_archive
[ ] delete_volume
[ ] describe_bandwidth_rate_limit
[ ] describe_cache
[ ] describe_cached_iscsi_volumes
[ ] describe_chap_credentials
[ ] describe_gateway_information
[ ] describe_maintenance_start_time
[ ] describe_nfs_file_shares
[ ] describe_snapshot_schedule
[ ] describe_stored_iscsi_volumes
[ ] describe_tape_archives
[ ] describe_tape_recovery_points
[ ] describe_tapes
[ ] describe_upload_buffer
[ ] describe_vtl_devices
[ ] describe_working_storage
[ ] disable_gateway
[ ] list_file_shares
[ ] list_gateways
[ ] list_local_disks
[ ] list_tags_for_resource
[ ] list_tapes
[ ] list_volume_initiators
[ ] list_volume_recovery_points
[ ] list_volumes
[ ] refresh_cache
[ ] remove_tags_from_resource
[ ] reset_cache
[ ] retrieve_tape_archive
[ ] retrieve_tape_recovery_point
[ ] set_local_console_password
[ ] shutdown_gateway
[ ] start_gateway
[ ] update_bandwidth_rate_limit
[ ] update_chap_credentials
[ ] update_gateway_information
[ ] update_gateway_software_now
[ ] update_maintenance_start_time
[ ] update_nfs_file_share
[ ] update_snapshot_schedule
[ ] update_vtl_device_type
-----------------------
sts - 42% implemented
-----------------------
[X] assume_role
[ ] assume_role_with_saml
[ ] assume_role_with_web_identity
[ ] decode_authorization_message
[ ] get_caller_identity
[X] get_federation_token
[X] get_session_token
-----------------------
support - 0% implemented
-----------------------
[ ] add_attachments_to_set
[ ] add_communication_to_case
[ ] create_case
[ ] describe_attachment
[ ] describe_cases
[ ] describe_communications
[ ] describe_services
[ ] describe_severity_levels
[ ] describe_trusted_advisor_check_refresh_statuses
[ ] describe_trusted_advisor_check_result
[ ] describe_trusted_advisor_check_summaries
[ ] describe_trusted_advisor_checks
[ ] refresh_trusted_advisor_check
[ ] resolve_case
-----------------------
swf - 54% implemented
-----------------------
[ ] count_closed_workflow_executions
[ ] count_open_workflow_executions
[X] count_pending_activity_tasks
[X] count_pending_decision_tasks
[ ] deprecate_activity_type
[X] deprecate_domain
[ ] deprecate_workflow_type
[ ] describe_activity_type
[X] describe_domain
[X] describe_workflow_execution
[ ] describe_workflow_type
[ ] get_workflow_execution_history
[ ] list_activity_types
[X] list_closed_workflow_executions
[X] list_domains
[X] list_open_workflow_executions
[ ] list_workflow_types
[X] poll_for_activity_task
[X] poll_for_decision_task
[X] record_activity_task_heartbeat
[ ] register_activity_type
[X] register_domain
[ ] register_workflow_type
[ ] request_cancel_workflow_execution
[ ] respond_activity_task_canceled
[X] respond_activity_task_completed
[X] respond_activity_task_failed
[X] respond_decision_task_completed
[ ] signal_workflow_execution
[X] start_workflow_execution
[X] terminate_workflow_execution
-----------------------
waf - 0% implemented
-----------------------
[ ] create_byte_match_set
[ ] create_ip_set
[ ] create_rule
[ ] create_size_constraint_set
[ ] create_sql_injection_match_set
[ ] create_web_acl
[ ] create_xss_match_set
[ ] delete_byte_match_set
[ ] delete_ip_set
[ ] delete_rule
[ ] delete_size_constraint_set
[ ] delete_sql_injection_match_set
[ ] delete_web_acl
[ ] delete_xss_match_set
[ ] get_byte_match_set
[ ] get_change_token
[ ] get_change_token_status
[ ] get_ip_set
[ ] get_rule
[ ] get_sampled_requests
[ ] get_size_constraint_set
[ ] get_sql_injection_match_set
[ ] get_web_acl
[ ] get_xss_match_set
[ ] list_byte_match_sets
[ ] list_ip_sets
[ ] list_rules
[ ] list_size_constraint_sets
[ ] list_sql_injection_match_sets
[ ] list_web_acls
[ ] list_xss_match_sets
[ ] update_byte_match_set
[ ] update_ip_set
[ ] update_rule
[ ] update_size_constraint_set
[ ] update_sql_injection_match_set
[ ] update_web_acl
[ ] update_xss_match_set
-----------------------
waf-regional - 0% implemented
-----------------------
[ ] associate_web_acl
[ ] create_byte_match_set
[ ] create_ip_set
[ ] create_rule
[ ] create_size_constraint_set
[ ] create_sql_injection_match_set
[ ] create_web_acl
[ ] create_xss_match_set
[ ] delete_byte_match_set
[ ] delete_ip_set
[ ] delete_rule
[ ] delete_size_constraint_set
[ ] delete_sql_injection_match_set
[ ] delete_web_acl
[ ] delete_xss_match_set
[ ] disassociate_web_acl
[ ] get_byte_match_set
[ ] get_change_token
[ ] get_change_token_status
[ ] get_ip_set
[ ] get_rule
[ ] get_sampled_requests
[ ] get_size_constraint_set
[ ] get_sql_injection_match_set
[ ] get_web_acl
[ ] get_web_acl_for_resource
[ ] get_xss_match_set
[ ] list_byte_match_sets
[ ] list_ip_sets
[ ] list_resources_for_web_acl
[ ] list_rules
[ ] list_size_constraint_sets
[ ] list_sql_injection_match_sets
[ ] list_web_acls
[ ] list_xss_match_sets
[ ] update_byte_match_set
[ ] update_ip_set
[ ] update_rule
[ ] update_size_constraint_set
[ ] update_sql_injection_match_set
[ ] update_web_acl
[ ] update_xss_match_set
-----------------------
workdocs - 0% implemented
-----------------------
[ ] abort_document_version_upload
[ ] activate_user
[ ] add_resource_permissions
[ ] create_folder
[ ] create_notification_subscription
[ ] create_user
[ ] deactivate_user
[ ] delete_document
[ ] delete_folder
[ ] delete_folder_contents
[ ] delete_notification_subscription
[ ] delete_user
[ ] describe_document_versions
[ ] describe_folder_contents
[ ] describe_notification_subscriptions
[ ] describe_resource_permissions
[ ] describe_users
[ ] get_document
[ ] get_document_path
[ ] get_document_version
[ ] get_folder
[ ] get_folder_path
[ ] initiate_document_version_upload
[ ] remove_all_resource_permissions
[ ] remove_resource_permission
[ ] update_document
[ ] update_document_version
[ ] update_folder
[ ] update_user
-----------------------
workspaces - 0% implemented
-----------------------
[ ] create_tags
[ ] create_workspaces
[ ] delete_tags
[ ] describe_tags
[ ] describe_workspace_bundles
[ ] describe_workspace_directories
[ ] describe_workspaces
[ ] describe_workspaces_connection_status
[ ] modify_workspace_properties
[ ] reboot_workspaces
[ ] rebuild_workspaces
[ ] start_workspaces
[ ] stop_workspaces
[ ] terminate_workspaces
-----------------------
xray - 0% implemented
-----------------------
[ ] batch_get_traces
[ ] get_service_graph
[ ] get_trace_graph
[ ] get_trace_summaries
[ ] put_telemetry_records
[ ] put_trace_segments
```