### PR TITLE
Send JSON message to HTTP endpoint of SNS

### DIFF
--- a/moto/sns/models.py
+++ b/moto/sns/models.py
@@ -84,7 +84,7 @@ class Subscription(BaseModel):
             sqs_backends[region].send_message(queue_name, message)
         elif self.protocol in ['http', 'https']:
             post_data = self.get_post_data(message, message_id)
-            requests.post(self.endpoint, data=post_data)
+            requests.post(self.endpoint, json=post_data)
 
     def get_post_data(self, message, message_id):
         return {

--- a/tests/test_sns/test_publishing_boto3.py
+++ b/tests/test_sns/test_publishing_boto3.py
@@ -1,4 +1,7 @@
 from __future__ import unicode_literals
+
+import json
+
 from six.moves.urllib.parse import parse_qs
 
 import boto3
@@ -56,9 +59,15 @@ def test_publish_to_sqs_in_different_region():
 @freeze_time("2013-01-01")
 @mock_sns
 def test_publish_to_http():
-    responses.add(
+    def callback(request):
+        request.headers["Content-Type"].should.equal("application/json")
+        json.loads.when.called_with(request.body).should_not.throw(Exception)
+        return 200, {}, ""
+
+    responses.add_callback(
         method="POST",
         url="http://example.com/foobar",
+        callback=callback,
     )
 
     conn = boto3.client('sns', region_name='us-east-1')


### PR DESCRIPTION
By the documentation from AWS - http://docs.aws.amazon.com/sns/latest/dg/SendMessageToHttp.html , SNS would send messages to HTTP/HTTPS endpoint in JSON format. But current implementation of `moto` sends messages in form-data format.