### PR TITLE
SNS delete_topic should also delete subscriptions.

### DIFF
--- a/tests/test_sns/test_subscriptions.py
+++ b/tests/test_sns/test_subscriptions.py
@@ -34,6 +34,37 @@ def test_creating_subscription():
         "ListSubscriptionsResult"]["Subscriptions"]
     subscriptions.should.have.length_of(0)
 
+@mock_sns_deprecated
+def test_deleting_subscriptions_by_deleting_topic():
+    conn = boto.connect_sns()
+    conn.create_topic("some-topic")
+    topics_json = conn.get_all_topics()
+    topic_arn = topics_json["ListTopicsResponse"][
+        "ListTopicsResult"]["Topics"][0]['TopicArn']
+
+    conn.subscribe(topic_arn, "http", "http://example.com/")
+
+    subscriptions = conn.get_all_subscriptions()["ListSubscriptionsResponse"][
+        "ListSubscriptionsResult"]["Subscriptions"]
+    subscriptions.should.have.length_of(1)
+    subscription = subscriptions[0]
+    subscription["TopicArn"].should.equal(topic_arn)
+    subscription["Protocol"].should.equal("http")
+    subscription["SubscriptionArn"].should.contain(topic_arn)
+    subscription["Endpoint"].should.equal("http://example.com/")
+
+    # Now delete the topic
+    conn.delete_topic(topic_arn)
+
+    # And there should now be 0 topics
+    topics_json = conn.get_all_topics()
+    topics = topics_json["ListTopicsResponse"]["ListTopicsResult"]["Topics"]
+    topics.should.have.length_of(0)
+
+    # And there should be zero subscriptions left
+    subscriptions = conn.get_all_subscriptions()["ListSubscriptionsResponse"][
+        "ListSubscriptionsResult"]["Subscriptions"]
+    subscriptions.should.have.length_of(0)
 
 @mock_sns_deprecated
 def test_getting_subscriptions_by_topic():


### PR DESCRIPTION
By the documentation from AWS (http://docs.aws.amazon.com/cli/latest/reference/sns/delete-topic.html), deleting SNS should also delete all of the subscriptions. Current implementation of moto only deletes the topic.

Although in https://forums.aws.amazon.com/thread.jspa?threadID=219168 they state:

> 
> When you delete a topic, subscriptions to the topic will not be "deleted" immediately, 
> but become orphans.  SNS will periodically clean these orphans, usually every 10 hours, but not 
> guaranteed. 
> If you create a new topic with the same topic name before these orphans are cleared up, 
> the new topic will not inherit these orphans. So, no worry about them.
> 

Currently in moto, recreating the topic with same topic-name actually inherits the orphaned subscriptions.  Therefore i purpose to just delete subscriptions as topic gets deleted. 
