### PR TITLE
Allow boto3 redshift cluster subnet group creation

### DIFF
--- a/moto/redshift/responses.py
+++ b/moto/redshift/responses.py
@@ -122,6 +122,10 @@ class RedshiftResponse(BaseResponse):
         cluster_subnet_group_name = self._get_param('ClusterSubnetGroupName')
         description = self._get_param('Description')
         subnet_ids = self._get_multi_param('SubnetIds.member')
+        # There's a bug in boto3 where the subnet ids are not passed
+        # according to the AWS documentation
+        if not subnet_ids:
+            subnet_ids = self._get_multi_param('SubnetIds.SubnetIdentifier')
 
         subnet_group = self.redshift_backend.create_cluster_subnet_group(
             cluster_subnet_group_name=cluster_subnet_group_name,


### PR DESCRIPTION
Boto3 deviates from the AWS docs in the way subnets are described when
creating a Redshift cluster subnet group.

This entry in botocore nests the SubnetIds under SubnetIdentifier tags:
https://github.com/boto/botocore/blob/develop/botocore/data/redshift/2012-12-01/service-2.json#L5423-L5429
referenced here:
https://github.com/boto/botocore/blob/develop/botocore/data/redshift/2012-12-01/service-2.json#L2296

And the AWS docs do not nest them that way:
https://docs.aws.amazon.com/redshift/latest/APIReference/API_CreateClusterSubnetGroup.html

Fixes #1029