### PR TITLE
Fix receiving of messages from queues with a dot character in their name

### DIFF
--- a/moto/sqs/urls.py
+++ b/moto/sqs/urls.py
@@ -9,5 +9,5 @@ dispatch = SQSResponse().dispatch
 
 url_paths = {
     '{0}/$': dispatch,
-    '{0}/(?P<account_id>\d+)/(?P<queue_name>[a-zA-Z0-9\-_]+)': dispatch,
+    '{0}/(?P<account_id>\d+)/(?P<queue_name>[a-zA-Z0-9\-_\.]+)': dispatch,
 }


### PR DESCRIPTION
This PR changes the `url_path` regex for SQS to allow the dot character (`.`) in queue names. This change fixes https://github.com/spulec/moto/issues/866

Tests have been extended to cover the change and avoid possible regressions in the future.