### PR TITLE
Allow non-ascii characters in request URLs

### DIFF
--- a/moto/server.py
+++ b/moto/server.py
@@ -3,6 +3,7 @@ import json
 import re
 import sys
 import argparse
+import six
 
 from six.moves.urllib.parse import urlencode
 
@@ -47,6 +48,13 @@ class DomainDispatcherApplication(object):
 
     def get_application(self, environ):
         path_info = environ.get('PATH_INFO', '')
+
+        # The URL path might contain non-ASCII text, for instance unicode S3 bucket names
+        if six.PY2 and isinstance(path_info, str):
+            path_info = six.u(path_info)
+        if six.PY3 and isinstance(path_info, six.binary_type):
+            path_info = path_info.decode('utf-8')
+
         if path_info.startswith("/moto-api") or path_info == "/favicon.ico":
             host = "moto_api"
         elif path_info.startswith("/latest/meta-data/"):

--- a/tests/test_s3/test_server.py
+++ b/tests/test_s3/test_server.py
@@ -1,3 +1,5 @@
+# coding=utf-8
+
 from __future__ import unicode_literals
 import sure  # noqa
 
@@ -78,3 +80,18 @@ def test_s3_server_post_without_content_length():
 
     res = test_client.post('/', "https://tester.localhost:5000/", environ_overrides={'CONTENT_LENGTH': ''})
     res.status_code.should.equal(411)
+
+
+def test_s3_server_post_unicode_bucket_key():
+    # Make sure that we can deal with non-ascii characters in request URLs (e.g., S3 object names)
+    dispatcher = server.DomainDispatcherApplication(server.create_backend_app)
+    backend_app = dispatcher.get_application({
+        'HTTP_HOST': 's3.amazonaws.com',
+        'PATH_INFO': '/test-bucket/test-object-てすと'
+    })
+    assert backend_app
+    backend_app = dispatcher.get_application({
+        'HTTP_HOST': 's3.amazonaws.com',
+        'PATH_INFO': '/test-bucket/test-object-てすと'.encode('utf-8')
+    })
+    assert backend_app


### PR DESCRIPTION
This PR adds support for non-ASCII characters in request URLs. This is required to support, for instance, unicode bucket or object names in S3 (when using S3 path encoding).

The change has been manually tested in Python 2.x and 3.x.

A simple test has been added to test the new functionality. Note that the `PATH_INFO` contains Japanese unicode characters.