### PR TITLE
Redshift Updates

### DIFF
--- a/moto/redshift/exceptions.py
+++ b/moto/redshift/exceptions.py
@@ -56,3 +56,18 @@ class InvalidSubnetError(RedshiftClientError):
         super(InvalidSubnetError, self).__init__(
             'InvalidSubnet',
             "Subnet {0} not found.".format(subnet_identifier))
+
+
+class ClusterSnapshotNotFoundError(RedshiftClientError):
+    def __init__(self, snapshot_identifier):
+        super(ClusterSnapshotNotFoundError, self).__init__(
+            'ClusterSnapshotNotFound',
+            "Snapshot {0} not found.".format(snapshot_identifier))
+
+
+class ClusterSnapshotAlreadyExistsError(RedshiftClientError):
+    def __init__(self, snapshot_identifier):
+        super(ClusterSnapshotAlreadyExistsError, self).__init__(
+            'ClusterSnapshotAlreadyExists',
+            "Cannot create the snapshot because a snapshot with the "
+            "identifier {0} already exists".format(snapshot_identifier))

--- a/moto/redshift/responses.py
+++ b/moto/redshift/responses.py
@@ -1,10 +1,29 @@
 from __future__ import unicode_literals
 
 import json
+
 import dicttoxml
+from jinja2 import Template
+from six import iteritems
 
 from moto.core.responses import BaseResponse
 from .models import redshift_backends
+
+
+def convert_json_error_to_xml(json_error):
+    error = json.loads(json_error)
+    code = error['Error']['Code']
+    message = error['Error']['Message']
+    template = Template("""
+        <RedshiftClientError>
+            <Error>
+              <Code>{{ code }}</Code>
+              <Message>{{ message }}</Message>
+              <Type>Sender</Type>
+            </Error>
+            <RequestId>6876f774-7273-11e4-85dc-39e55ca848d1</RequestId>
+        </RedshiftClientError>""")
+    return template.render(code=code, message=message)
 
 
 class RedshiftResponse(BaseResponse):
@@ -19,6 +38,24 @@ class RedshiftResponse(BaseResponse):
         else:
             xml = dicttoxml.dicttoxml(response, attr_type=False, root=False)
             return xml.decode("utf-8")
+
+    def call_action(self):
+        status, headers, body = super(RedshiftResponse, self).call_action()
+        if status >= 400 and not self.request_json:
+            body = convert_json_error_to_xml(body)
+        return status, headers, body
+
+    def unpack_complex_list_params(self, label, names):
+        unpacked_list = list()
+        count = 1
+        while self._get_param('{0}.{1}.{2}'.format(label, count, names[0])):
+            param = dict()
+            for i in range(len(names)):
+                param[names[i]] = self._get_param(
+                    '{0}.{1}.{2}'.format(label, count, names[i]))
+            unpacked_list.append(param)
+            count += 1
+        return unpacked_list
 
     def create_cluster(self):
         cluster_kwargs = {
@@ -43,12 +80,66 @@ class RedshiftResponse(BaseResponse):
             "encrypted": self._get_param("Encrypted"),
             "region": self.region,
         }
-        cluster = self.redshift_backend.create_cluster(**cluster_kwargs)
-
+        cluster = self.redshift_backend.create_cluster(**cluster_kwargs).to_json()
+        cluster['ClusterStatus'] = 'creating'
         return self.get_response({
             "CreateClusterResponse": {
                 "CreateClusterResult": {
-                    "Cluster": cluster.to_json(),
+                    "Cluster": cluster,
+                },
+                "ResponseMetadata": {
+                    "RequestId": "384ac68d-3775-11df-8963-01868b7c937a",
+                }
+            }
+        })
+
+    def restore_from_cluster_snapshot(self):
+        snapshot_identifier = self._get_param('SnapshotIdentifier')
+        snapshots = self.redshift_backend.describe_snapshots(
+            None,
+            snapshot_identifier)
+        snapshot = snapshots[0]
+        kwargs_from_snapshot = {
+            "node_type": snapshot.cluster.node_type,
+            "master_username": snapshot.cluster.master_username,
+            "master_user_password": snapshot.cluster.master_user_password,
+            "db_name": snapshot.cluster.db_name,
+            "cluster_type": 'multi-node' if snapshot.cluster.number_of_nodes > 1 else 'single-node',
+            "availability_zone": snapshot.cluster.availability_zone,
+            "port": snapshot.cluster.port,
+            "cluster_version": snapshot.cluster.cluster_version,
+            "number_of_nodes": snapshot.cluster.number_of_nodes,
+        }
+        kwargs_from_request = {
+            "cluster_identifier": self._get_param('ClusterIdentifier'),
+            "port": self._get_int_param('Port'),
+            "availability_zone": self._get_param('AvailabilityZone'),
+            "allow_version_upgrade": self._get_bool_param(
+                'AllowVersionUpgrade'),
+            "cluster_subnet_group_name": self._get_param(
+                'ClusterSubnetGroupName'),
+            "publicly_accessible": self._get_param("PubliclyAccessible"),
+            "cluster_parameter_group_name": self._get_param(
+                'ClusterParameterGroupName'),
+            "cluster_security_groups": self._get_multi_param(
+                'ClusterSecurityGroups.member'),
+            "vpc_security_group_ids": self._get_multi_param(
+                'VpcSecurityGroupIds.member'),
+            "preferred_maintenance_window": self._get_param(
+                'PreferredMaintenanceWindow'),
+            "automated_snapshot_retention_period": self._get_int_param(
+                'AutomatedSnapshotRetentionPeriod'),
+            "region": self.region,
+            "encrypted": False,
+        }
+        kwargs_from_snapshot.update(kwargs_from_request)
+        cluster_kwargs = kwargs_from_snapshot
+        cluster = self.redshift_backend.create_cluster(**cluster_kwargs).to_json()
+        cluster['ClusterStatus'] = 'creating'
+        return self.get_response({
+            "RestoreFromClusterSnapshotResponse": {
+                "RestoreFromClusterSnapshotResult": {
+                    "Cluster": cluster,
                 },
                 "ResponseMetadata": {
                     "RequestId": "384ac68d-3775-11df-8963-01868b7c937a",
@@ -72,7 +163,7 @@ class RedshiftResponse(BaseResponse):
         })
 
     def modify_cluster(self):
-        cluster_kwargs = {
+        request_kwargs = {
             "cluster_identifier": self._get_param('ClusterIdentifier'),
             "new_cluster_identifier": self._get_param('NewClusterIdentifier'),
             "node_type": self._get_param('NodeType'),
@@ -90,6 +181,19 @@ class RedshiftResponse(BaseResponse):
             "publicly_accessible": self._get_param("PubliclyAccessible"),
             "encrypted": self._get_param("Encrypted"),
         }
+        # There's a bug in boto3 where the security group ids are not passed
+        # according to the AWS documentation
+        if not request_kwargs['vpc_security_group_ids']:
+            request_kwargs['vpc_security_group_ids'] = self._get_multi_param(
+                'VpcSecurityGroupIds.VpcSecurityGroupId')
+
+        cluster_kwargs = {}
+        # We only want parameters that were actually passed in, otherwise
+        # we'll stomp all over our cluster metadata with None values.
+        for (key, value) in iteritems(request_kwargs):
+            if value is not None and value != []:
+                cluster_kwargs[key] = value
+
         cluster = self.redshift_backend.modify_cluster(**cluster_kwargs)
 
         return self.get_response({
@@ -268,6 +372,74 @@ class RedshiftResponse(BaseResponse):
 
         return self.get_response({
             "DeleteClusterParameterGroupResponse": {
+                "ResponseMetadata": {
+                    "RequestId": "384ac68d-3775-11df-8963-01868b7c937a",
+                }
+            }
+        })
+
+    def create_cluster_snapshot(self):
+        cluster_identifier = self._get_param('ClusterIdentifier')
+        snapshot_identifier = self._get_param('SnapshotIdentifier')
+        tags = self.unpack_complex_list_params(
+            'Tags.Tag', ('Key', 'Value'))
+        snapshot = self.redshift_backend.create_snapshot(cluster_identifier,
+                                                         snapshot_identifier,
+                                                         tags)
+        return self.get_response({
+            'CreateClusterSnapshotResponse': {
+                "CreateClusterSnapshotResult": {
+                    "Snapshot": snapshot.to_json(),
+                },
+                "ResponseMetadata": {
+                    "RequestId": "384ac68d-3775-11df-8963-01868b7c937a",
+                }
+            }
+        })
+
+    def describe_cluster_snapshots(self):
+        cluster_identifier = self._get_param('ClusterIdentifier')
+        snapshot_identifier = self._get_param('DBSnapshotIdentifier')
+        snapshots = self.redshift_backend.describe_snapshots(cluster_identifier,
+                                                             snapshot_identifier)
+        return self.get_response({
+            "DescribeClusterSnapshotsResponse": {
+                "DescribeClusterSnapshotsResult": {
+                    "Snapshots": [snapshot.to_json() for snapshot in snapshots]
+                },
+                "ResponseMetadata": {
+                    "RequestId": "384ac68d-3775-11df-8963-01868b7c937a",
+                }
+            }
+        })
+
+    def delete_cluster_snapshot(self):
+        snapshot_identifier = self._get_param('SnapshotIdentifier')
+        snapshot = self.redshift_backend.delete_snapshot(snapshot_identifier)
+
+        return self.get_response({
+            "DeleteClusterSnapshotResponse": {
+                "DeleteClusterSnapshotResult": {
+                    "Snapshot": snapshot.to_json()
+                },
+                "ResponseMetadata": {
+                    "RequestId": "384ac68d-3775-11df-8963-01868b7c937a",
+                }
+            }
+        })
+
+    def describe_tags(self):
+        resource_type = self._get_param('ResourceType')
+        if resource_type != 'Snapshot':
+            raise NotImplementedError(
+                "The describe_tags action has not been fully implemented.")
+        tagged_resources = \
+            self.redshift_backend.describe_tags_for_resource_type(resource_type)
+        return self.get_response({
+            "DescribeTagsResponse": {
+                "DescribeTagsResult": {
+                    "TaggedResources": tagged_resources
+                },
                 "ResponseMetadata": {
                     "RequestId": "384ac68d-3775-11df-8963-01868b7c937a",
                 }


### PR DESCRIPTION
I'm working on a project involving Redshift and implemented a few more endpoints as well as a bit of miscellaneous clean up and bug fixes.  Let me know what you think. I could probably commit to more work on the Redshift endpoints, if you're happy with what you see.

Here's a summary of my changes:
- Implement create_cluster_snapshot endpoint
- Implement describe_cluster_snapshots endpoint
- Implement delete_cluster_snapshot endpoint
- Implement restore_from_cluster_snapshot endpoint
- Implement limited support for describe_tags endpoint
- Correctly serialize errors to json (for boto) or xml (for boto3)
- Simulate cluster spin up by returning initial status as 'creating' and subsequent statuses as 'available'
- Fix issue with modify_cluster endpoint where cluster values get set to None when omitted from request
- Add 'Endpoint' key to describe_clusters response syntax