### PR TITLE
Add proper errors to ECR calls

### DIFF
--- a/moto/ecr/exceptions.py
+++ b/moto/ecr/exceptions.py
@@ -1,0 +1,22 @@
+from __future__ import unicode_literals
+from moto.core.exceptions import RESTError
+
+
+class RepositoryNotFoundException(RESTError):
+    code = 400
+
+    def __init__(self, repository_name, registry_id):
+        super(RepositoryNotFoundException, self).__init__(
+            error_type="RepositoryNotFoundException",
+            message="The repository with name '{0}' does not exist in the registry "
+                    "with id '{1}'".format(repository_name, registry_id))
+
+
+class ImageNotFoundException(RESTError):
+    code = 400
+
+    def __init__(self, image_id, repository_name, registry_id):
+        super(ImageNotFoundException, self).__init__(
+            error_type="ImageNotFoundException",
+            message="The image with imageId {0} does not exist within the repository with name '{1}' "
+                    "in the registry with id '{2}'".format(image_id, repository_name, registry_id))

--- a/moto/ecr/responses.py
+++ b/moto/ecr/responses.py
@@ -45,7 +45,8 @@ class ECRResponse(BaseResponse):
 
     def delete_repository(self):
         repository_str = self._get_param('repositoryName')
-        repository = self.ecr_backend.delete_repository(repository_str)
+        registry_id = self._get_param('registryId')
+        repository = self.ecr_backend.delete_repository(repository_str, registry_id)
         return json.dumps({
             'repository': repository.response_object
         })

--- a/moto/sqs/models.py
+++ b/moto/sqs/models.py
@@ -59,6 +59,7 @@ class Message(BaseModel):
                 return str.encode('utf-8')
             return str
         md5 = hashlib.md5()
+        struct_format = "!I".encode('ascii')  # ensure it's a bytestring
         for name in sorted(self.message_attributes.keys()):
             attr = self.message_attributes[name]
             data_type = attr['data_type']
@@ -67,10 +68,10 @@ class Message(BaseModel):
             # Each part of each attribute is encoded right after it's
             # own length is packed into a 4-byte integer
             # 'timestamp' -> b'\x00\x00\x00\t'
-            encoded += struct.pack("!I", len(utf8(name))) + utf8(name)
+            encoded += struct.pack(struct_format, len(utf8(name))) + utf8(name)
             # The datatype is additionally given a final byte
             # representing which type it is
-            encoded += struct.pack("!I", len(data_type)) + utf8(data_type)
+            encoded += struct.pack(struct_format, len(data_type)) + utf8(data_type)
             encoded += TRANSPORT_TYPE_ENCODINGS[data_type]
 
             if data_type == 'String' or data_type == 'Number':
@@ -86,7 +87,7 @@ class Message(BaseModel):
                 # MD5 so as not to break client softwre
                 return('deadbeefdeadbeefdeadbeefdeadbeef')
 
-            encoded += struct.pack("!I", len(utf8(value))) + utf8(value)
+            encoded += struct.pack(struct_format, len(utf8(value))) + utf8(value)
 
             md5.update(encoded)
         return md5.hexdigest()

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,5 +7,5 @@ flake8
 freezegun
 flask
 boto3>=1.4.4
-botocore>=1.4.28
+botocore>=1.5.77
 six


### PR DESCRIPTION
This pull requests adds proper error handling to missing ECR images and ECR repositories. I didn't add error handling to validate the parameters. The error messages were copied from real boto3 calls.

I updated botocore to the current latest version to get the latest features from the ECR client.

P.S.: I had to change the `struct` calls in the SQS models file because of older versions of Python (I am running 2.7.6): https://bugs.python.org/issue19099

