### PR TITLE
Rds stop start

### DIFF
--- a/moto/rds2/exceptions.py
+++ b/moto/rds2/exceptions.py
@@ -58,3 +58,18 @@ class DBParameterGroupNotFoundError(RDSClientError):
         super(DBParameterGroupNotFoundError, self).__init__(
             'DBParameterGroupNotFound',
             'DB Parameter Group {0} not found.'.format(db_parameter_group_name))
+
+class InvalidDBClusterStateFaultError(RDSClientError):
+
+    def __init__(self, database_identifier):
+        super(InvalidDBClusterStateFaultError, self).__init__(
+            'InvalidDBClusterStateFault',
+            'Invalid DB type, when trying to perform StopDBInstance on {0}e. See AWS RDS documentation on rds.stop_db_instance'.format(database_identifier))
+
+class InvalidDBInstanceStateError(RDSClientError):
+
+    def __init__(self, database_identifier, istate):
+        estate = "in available state" if istate == 'stop' else "stopped, it cannot be started"
+        super(InvalidDBInstanceStateError, self).__init__(
+            'InvalidDBInstanceState',
+            'when calling the {}DBInstance operation: Instance {} is not {}.'.format(istate.title(), database_identifier, estate))

--- a/moto/rds2/exceptions.py
+++ b/moto/rds2/exceptions.py
@@ -59,12 +59,14 @@ class DBParameterGroupNotFoundError(RDSClientError):
             'DBParameterGroupNotFound',
             'DB Parameter Group {0} not found.'.format(db_parameter_group_name))
 
+
 class InvalidDBClusterStateFaultError(RDSClientError):
 
     def __init__(self, database_identifier):
         super(InvalidDBClusterStateFaultError, self).__init__(
             'InvalidDBClusterStateFault',
             'Invalid DB type, when trying to perform StopDBInstance on {0}e. See AWS RDS documentation on rds.stop_db_instance'.format(database_identifier))
+
 
 class InvalidDBInstanceStateError(RDSClientError):
 

--- a/moto/rds2/exceptions.py
+++ b/moto/rds2/exceptions.py
@@ -74,4 +74,20 @@ class InvalidDBInstanceStateError(RDSClientError):
         estate = "in available state" if istate == 'stop' else "stopped, it cannot be started"
         super(InvalidDBInstanceStateError, self).__init__(
             'InvalidDBInstanceState',
-            'when calling the {}DBInstance operation: Instance {} is not {}.'.format(istate.title(), database_identifier, estate))
+            'Instance {} is not {}.'.format(database_identifier, estate))
+
+
+class SnapshotQuotaExceededError(RDSClientError):
+
+    def __init__(self):
+        super(SnapshotQuotaExceededError, self).__init__(
+            'SnapshotQuotaExceeded',
+            'The request cannot be processed because it would exceed the maximum number of snapshots.')
+
+
+class DBSnapshotAlreadyExistsError(RDSClientError):
+
+    def __init__(self, database_snapshot_identifier):
+        super(DBSnapshotAlreadyExistsError, self).__init__(
+            'DBSnapshotAlreadyExists',
+            'Cannot create the snapshot because a snapshot with the identifier {} already exists.'.format(database_snapshot_identifier))

--- a/moto/rds2/models.py
+++ b/moto/rds2/models.py
@@ -413,7 +413,6 @@ class Snapshot(BaseModel):
         self.tags = tags or []
         self.created_at = iso_8601_datetime_with_milliseconds(datetime.datetime.now())
 
-
     @property
     def snapshot_arn(self):
         return "arn:aws:rds:{0}:1234567890:snapshot:{1}".format(self.database.region, self.snapshot_id)

--- a/moto/rds2/models.py
+++ b/moto/rds2/models.py
@@ -741,7 +741,8 @@ class RDS2Backend(BaseBackend):
                 return RDSClientError('InvalidDBClusterStateFault', 'Invalid DB type, when trying to perform StopDBInstance. See AWS RDS documentation on rds.stop_db_instance')
         if database.status != 'available':
             return RDSClientError('InvalidDBInstanceState', 'when calling the StopDBInstance operation: Instance %s is not in available state' % db_instance_identifier)
-        self.create_rds_snapshot(db_instance_identifier, db_snapshot_identifier)
+        if db_snapshot_identifier:
+            self.create_rds_snapshot(db_instance_identifier, db_snapshot_identifier)
         database.status = 'shutdown'
         return database
 

--- a/moto/rds2/models.py
+++ b/moto/rds2/models.py
@@ -733,32 +733,27 @@ class RDS2Backend(BaseBackend):
         database = self.describe_databases(db_instance_identifier)[0]
         return database
 
-    def _check_can_stop_rds_instance_(self, database=None):
+    def stop_database(self, db_instance_identifier, db_snapshot_identifier=None):
+        database = self.describe_databases(db_instance_identifier)[0]
         # todo: certain rds types not allowed to be stopped at this time.
-        if database:
-            if database.is_replica or database.multi_az:
+        if database.is_replica or database.multi_az:
                 # should be 400 error
                 return RDSClientError('InvalidDBClusterStateFault', 'Invalid DB type, when trying to perform StopDBInstance. See AWS RDS documentation on rds.stop_db_instance')
-        return True
-
-    def stop_database(self, db_instance_identifier, snapshot_name=None):
-        database = self.describe_databases(db_instance_identifier)[0]
-        self._check_can_stop_rds_instance_(database)
         if database.status != 'available':
-            return RDSClientError('InvalidDBInstanceState', 'when calling the StopDBInstance operation: Instance testdb is not in available state')
-        self.create_rds_snapshot(db_instance_identifier, db_instance_identifier)
+            return RDSClientError('InvalidDBInstanceState', 'when calling the StopDBInstance operation: Instance %s is not in available state' % db_instance_identifier)
+        self.create_rds_snapshot(db_instance_identifier, db_snapshot_identifier)
         database.status = 'shutdown'
         return database
 
     def start_database(self, db_instance_identifier):
         database = self.describe_databases(db_instance_identifier)[0]
-        if database.status != 'shutdown':
-            # should be 400 error
-            return RDSClientError('InvalidDBInstanceState', 'when calling the StartDBInstance operation: Instance {} is not stopped, it cannot be started.' % db_instance_identifier)
+        if database.status != 'shutdown':  # should be 400 error
+            return RDSClientError('InvalidDBInstanceState', 'when calling the StartDBInstance operation: Instance %s is not stopped, it cannot be started.' % db_instance_identifier)
         database.status = 'available'
         return
 
     def create_rds_snapshot(self, db_instance_identifier, db_snapshot_identifier):
+        database = self.describe_databases(db_instance_identifier)[0]
         # todo
         # DBSnapshotAlreadyExists
         # SnapshotQuotaExceeded

--- a/moto/rds2/responses.py
+++ b/moto/rds2/responses.py
@@ -424,7 +424,7 @@ REBOOT_DATABASE_TEMPLATE = """<RebootDBInstanceResponse xmlns="http://rds.amazon
   </ResponseMetadata>
 </RebootDBInstanceResponse>"""
 
-START_DATABASE_TEMPLATE = """<StartDBInstanceResponse xmlns="http://rds.amazonaws.com/doc/2014-09-01/">
+START_DATABASE_TEMPLATE = """<StartDBInstanceResponse xmlns="http://rds.amazonaws.com/doc/2014-10-31/">
   <StartDBInstanceResult>
   {{ database.to_xml() }}
   </StartDBInstanceResult>
@@ -433,7 +433,7 @@ START_DATABASE_TEMPLATE = """<StartDBInstanceResponse xmlns="http://rds.amazonaw
   </ResponseMetadata>
 </StartDBInstanceResponse>"""
 
-STOP_DATABASE_TEMPLATE = """<StopDBInstanceResponse xmlns="http://rds.amazonaws.com/doc/2014-09-01/">
+STOP_DATABASE_TEMPLATE = """<StopDBInstanceResponse xmlns="http://rds.amazonaws.com/doc/2014-10-31/">
   <StopDBInstanceResult>
   {{ database.to_xml() }}
   </StopDBInstanceResult>
@@ -442,7 +442,7 @@ STOP_DATABASE_TEMPLATE = """<StopDBInstanceResponse xmlns="http://rds.amazonaws.
   </ResponseMetadata>
 </StopDBInstanceResponse>"""
 
-DELETE_DATABASE_TEMPLATE = """<DeleteDBInstanceResponse xmlns="http://rds.amazonaws.com/doc/2014-10-31/">
+DELETE_DATABASE_TEMPLATE = """<DeleteDBInstanceResponse xmlns="http://rds.amazonaws.com/doc/2014-09-01/">
   <DeleteDBInstanceResult>
     {{ database.to_xml() }}
   </DeleteDBInstanceResult>
@@ -451,7 +451,7 @@ DELETE_DATABASE_TEMPLATE = """<DeleteDBInstanceResponse xmlns="http://rds.amazon
   </ResponseMetadata>
 </DeleteDBInstanceResponse>"""
 
-CREATE_SNAPSHOT_TEMPLATE = """<CreateDBSnapshotResponse xmlns="http://rds.amazonaws.com/doc/2014-10-31/">
+CREATE_SNAPSHOT_TEMPLATE = """<CreateDBSnapshotResponse xmlns="http://rds.amazonaws.com/doc/2014-09-01/">
   <CreateDBSnapshotResult>
   {{ snapshot.to_xml() }}
   </CreateDBSnapshotResult>

--- a/moto/rds2/responses.py
+++ b/moto/rds2/responses.py
@@ -23,6 +23,7 @@ class RDS2Response(BaseResponse):
             "db_instance_identifier": self._get_param('DBInstanceIdentifier'),
             "db_name": self._get_param("DBName"),
             "db_parameter_group_name": self._get_param("DBParameterGroupName"),
+            "db_snapshot_identifier": self._get_param('DBSnapshotIdentifier'),
             "db_subnet_group_name": self._get_param("DBSubnetGroupName"),
             "engine": self._get_param("Engine"),
             "engine_version": self._get_param("EngineVersion"),
@@ -192,6 +193,19 @@ class RDS2Response(BaseResponse):
         self.backend.remove_tags_from_resource(arn, tag_keys)
         template = self.response_template(REMOVE_TAGS_FROM_RESOURCE_TEMPLATE)
         return template.render()
+
+    def stop_db_instance(self):
+        db_instance_identifier = self._get_param('DBInstanceIdentifier')
+        db_snapshot_identifier = self._get_param('DBInstanceIdentifier')
+        database = self.backend.stop_database(db_instance_identifier, db_snapshot_identifier)
+        template = self.response_template(STOP_DATABASE_TEMPLATE)
+        return template.render(database=database)
+
+    def start_db_instance(self):
+        db_instance_identifier = self._get_param('DBInstanceIdentifier')
+        database = self.backend.start_database(db_instance_identifier)
+        template = self.response_template(START_DATABASE_TEMPLATE)
+        return template.render(database=database)
 
     def create_db_security_group(self):
         group_name = self._get_param('DBSecurityGroupName')
@@ -410,8 +424,25 @@ REBOOT_DATABASE_TEMPLATE = """<RebootDBInstanceResponse xmlns="http://rds.amazon
   </ResponseMetadata>
 </RebootDBInstanceResponse>"""
 
+START_DATABASE_TEMPLATE = """<StartDBInstanceResponse xmlns="http://rds.amazonaws.com/doc/2014-09-01/">
+  <StartDBInstanceResult>
+  {{ database.to_xml() }}
+  </StartDBInstanceResult>
+  <ResponseMetadata>
+    <RequestId>523e3218-afc7-11c3-90f5-f90431260ab9</RequestId>
+  </ResponseMetadata>
+</StartDBInstanceResponse>"""
 
-DELETE_DATABASE_TEMPLATE = """<DeleteDBInstanceResponse xmlns="http://rds.amazonaws.com/doc/2014-09-01/">
+STOP_DATABASE_TEMPLATE = """<StopDBInstanceResponse xmlns="http://rds.amazonaws.com/doc/2014-09-01/">
+  <StopDBInstanceResult>
+  {{ database.to_xml() }}
+  </StopDBInstanceResult>
+  <ResponseMetadata>
+    <RequestId>523e3218-afc7-11c3-90f5-f90431260ab8</RequestId>
+  </ResponseMetadata>
+</StopDBInstanceResponse>"""
+
+DELETE_DATABASE_TEMPLATE = """<DeleteDBInstanceResponse xmlns="http://rds.amazonaws.com/doc/2014-10-31/">
   <DeleteDBInstanceResult>
     {{ database.to_xml() }}
   </DeleteDBInstanceResult>
@@ -420,7 +451,7 @@ DELETE_DATABASE_TEMPLATE = """<DeleteDBInstanceResponse xmlns="http://rds.amazon
   </ResponseMetadata>
 </DeleteDBInstanceResponse>"""
 
-CREATE_SNAPSHOT_TEMPLATE = """<CreateDBSnapshotResponse xmlns="http://rds.amazonaws.com/doc/2014-09-01/">
+CREATE_SNAPSHOT_TEMPLATE = """<CreateDBSnapshotResponse xmlns="http://rds.amazonaws.com/doc/2014-10-31/">
   <CreateDBSnapshotResult>
   {{ snapshot.to_xml() }}
   </CreateDBSnapshotResult>

--- a/moto/rds2/responses.py
+++ b/moto/rds2/responses.py
@@ -196,7 +196,7 @@ class RDS2Response(BaseResponse):
 
     def stop_db_instance(self):
         db_instance_identifier = self._get_param('DBInstanceIdentifier')
-        db_snapshot_identifier = self._get_param('DBInstanceIdentifier')
+        db_snapshot_identifier = self._get_param('DBSnapshotIdentifier')
         database = self.backend.stop_database(db_instance_identifier, db_snapshot_identifier)
         template = self.response_template(STOP_DATABASE_TEMPLATE)
         return template.render(database=database)

--- a/tests/test_rds2/test_rds2.py
+++ b/tests/test_rds2/test_rds2.py
@@ -146,47 +146,6 @@ def test_fail_to_stop_readreplica():
 
 
 @mock_rds2
-def test_snapshotquota_exceeded():
-    import os
-    conn = boto3.client('rds', region_name='us-west-2')
-    database1 = conn.create_db_instance(DBInstanceIdentifier='db-master-1',
-                                       AllocatedStorage=10,
-                                       Engine='postgres',
-                                       DBName='staging-postgres',
-                                       DBInstanceClass='db.m1.small',
-                                       LicenseModel='license-included',
-                                       MasterUsername='root',
-                                       MasterUserPassword='hunter2',
-                                       Port=1234,
-                                       DBSecurityGroups=["my_sg"])
-    database2 = conn.create_db_instance(DBInstanceIdentifier='db-master-2',
-                                       AllocatedStorage=10,
-                                       Engine='postgres',
-                                       DBName='staging-postgres',
-                                       DBInstanceClass='db.m1.small',
-                                       LicenseModel='license-included',
-                                       MasterUsername='root',
-                                       MasterUserPassword='hunter2',
-                                       Port=1234,
-                                       DBSecurityGroups=["my_sg"])
-    database3 = conn.create_db_instance(DBInstanceIdentifier='db-master-3',
-                                       AllocatedStorage=10,
-                                       Engine='postgres',
-                                       DBName='staging-postgres',
-                                       DBInstanceClass='db.m1.small',
-                                       LicenseModel='license-included',
-                                       MasterUsername='root',
-                                       MasterUserPassword='hunter2',
-                                       Port=1234,
-                                       DBSecurityGroups=["my_sg"])
-    conn.stop_db_instance(DBInstanceIdentifier=database1['DBInstance']['DBInstanceIdentifier'], DBSnapshotIdentifier='rocky4570-rds-snap1')
-    conn.stop_db_instance(DBInstanceIdentifier=database2['DBInstance']['DBInstanceIdentifier'], DBSnapshotIdentifier='rocky4570-rds-snap2')
-    os.environ['MOTO_RDS_SNAPSHOT_LIMIT'] = '2'
-    conn.stop_db_instance.when.called_with(DBInstanceIdentifier=database3['DBInstance']['DBInstanceIdentifier'], DBSnapshotIdentifier='rocky4570-rds-snap3').should.throw(ClientError)
-    os.unsetenv('MOTO_RDS_SNAPSHOT_LIMIT')
-
-
-@mock_rds2
 def test_get_databases():
     conn = boto3.client('rds', region_name='us-west-2')
 


### PR DESCRIPTION
Basic Stop and Start RDS Instances implementation - currently doesn't create snapshot as per AWS documentation and doesn't check all instance types which are invalid for stopping/starting.