### PR TITLE
SSM get_parameters should list InvalidParameters

### DIFF
--- a/moto/ssm/responses.py
+++ b/moto/ssm/responses.py
@@ -57,6 +57,10 @@ class SimpleSystemManagerResponse(BaseResponse):
             param_data = parameter.response_object(with_decryption)
             response['Parameters'].append(param_data)
 
+        param_names = [param.name for param in result]
+        for name in names:
+            if name not in param_names:
+                response['InvalidParameters'].append(name)
         return json.dumps(response)
 
     def describe_parameters(self):

--- a/tests/test_ssm/test_ssm_boto3.py
+++ b/tests/test_ssm/test_ssm_boto3.py
@@ -161,7 +161,6 @@ def test_describe_parameters_filter_type():
             p['KeyId'] = 'a key'
         client.put_parameter(**p)
 
-
     response = client.describe_parameters(Filters=[
         {
             'Key': 'Type',
@@ -188,7 +187,6 @@ def test_describe_parameters_filter_keyid():
             p['KeyId'] = "key:%d" % i
         client.put_parameter(**p)
 
-
     response = client.describe_parameters(Filters=[
         {
             'Key': 'KeyId',
@@ -199,6 +197,20 @@ def test_describe_parameters_filter_keyid():
     response['Parameters'][0]['Name'].should.equal('param-10')
     response['Parameters'][0]['Type'].should.equal('SecureString')
     ''.should.equal(response.get('NextToken', ''))
+
+
+@mock_ssm
+def test_get_parameter_invalid():
+    client = client = boto3.client('ssm', region_name='us-east-1')
+    response = client.get_parameters(
+        Names=[
+            'invalid'
+        ],
+        WithDecryption=False)
+
+    len(response['Parameters']).should.equal(0)
+    len(response['InvalidParameters']).should.equal(1)
+    response['InvalidParameters'][0].should.equal('invalid')
 
 
 @mock_ssm


### PR DESCRIPTION
Invalid parameters should be listed in response['InvalidParameters'] for get_parameters.

http://boto3.readthedocs.io/en/latest/reference/services/ssm.html#SSM.Client.get_parameters