### PR TITLE
escape json string when sending message from sns mock to sqs mock

### DIFF
--- a/moto/sns/models.py
+++ b/moto/sns/models.py
@@ -81,7 +81,8 @@ class Subscription(BaseModel):
         if self.protocol == 'sqs':
             queue_name = self.endpoint.split(":")[-1]
             region = self.endpoint.split(":")[3]
-            sqs_backends[region].send_message(queue_name, message)
+            escaped_message = message.replace('"', '\\"')
+            sqs_backends[region].send_message(queue_name, escaped_message)
         elif self.protocol in ['http', 'https']:
             post_data = self.get_post_data(message, message_id)
             requests.post(self.endpoint, json=post_data)

--- a/tests/test_sns/test_publishing_boto3.py
+++ b/tests/test_sns/test_publishing_boto3.py
@@ -57,11 +57,11 @@ def test_publish_to_sqs_dump_json():
                 "s3SchemaVersion": "1.0"
             }
         }]
-    })
+    }, sort_keys=True)
     conn.publish(TopicArn=topic_arn, Message=message)
     queue = sqs_conn.get_queue_by_name(QueueName="test-queue")
     messages = queue.receive_messages(MaxNumberOfMessages=1)
-    expected = '{\\"Records\\": [{\\"eventVersion\\": \\"2.0\\", \\"eventSource\\": \\"aws:s3\\", \\"s3\\": {\\"s3SchemaVersion\\": \\"1.0\\"}}]}'
+    expected = u'{\\"Records\\": [{\\"eventSource\\": \\"aws:s3\\", \\"eventVersion\\": \\"2.0\\", \\"s3\\": {\\"s3SchemaVersion\\": \\"1.0\\"}}]}'
     messages[0].body.should.equal(expected)
 
 


### PR DESCRIPTION
When acquiring messages published to SQS via SNS, the message structure that can be acquired differs between when using real AWS and when mocking with moto.

