### PR TITLE
use requests version more than 2.5.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ install_requires = [
     "boto>=2.36.0",
     "boto3>=1.2.1",
     "cookies",
-    "requests>=2.0",
+    "requests>=2.5",
     "xmltodict",
     "dicttoxml",
     "six",


### PR DESCRIPTION
use requests version more than 2.5.0, because requests.request started supporting json argument from v2.4.2