### PR TITLE
Envelope sns message when sending to sqs

### DIFF
--- a/moto/sns/models.py
+++ b/moto/sns/models.py
@@ -82,7 +82,6 @@ class Subscription(BaseModel):
             queue_name = self.endpoint.split(":")[-1]
             region = self.endpoint.split(":")[3]
             enveloped_message = json.dumps(self.get_post_data(message, message_id), sort_keys=True, indent=2, separators=(',', ': '))
-            print(json.dumps(enveloped_message))
             sqs_backends[region].send_message(queue_name, enveloped_message)
         elif self.protocol in ['http', 'https']:
             post_data = self.get_post_data(message, message_id)

--- a/moto/sns/models.py
+++ b/moto/sns/models.py
@@ -81,7 +81,8 @@ class Subscription(BaseModel):
         if self.protocol == 'sqs':
             queue_name = self.endpoint.split(":")[-1]
             region = self.endpoint.split(":")[3]
-            enveloped_message = json.dumps(self.get_post_data(message, message_id), sort_keys=True, indent=2)
+            enveloped_message = json.dumps(self.get_post_data(message, message_id), sort_keys=True, indent=2, separators=(',', ': '))
+            print(json.dumps(enveloped_message))
             sqs_backends[region].send_message(queue_name, enveloped_message)
         elif self.protocol in ['http', 'https']:
             post_data = self.get_post_data(message, message_id)

--- a/moto/sns/models.py
+++ b/moto/sns/models.py
@@ -81,8 +81,8 @@ class Subscription(BaseModel):
         if self.protocol == 'sqs':
             queue_name = self.endpoint.split(":")[-1]
             region = self.endpoint.split(":")[3]
-            escaped_message = message.replace('"', '\\"')
-            sqs_backends[region].send_message(queue_name, escaped_message)
+            enveloped_message = json.dumps(self.get_post_data(message, message_id), sort_keys=True, indent=2)
+            sqs_backends[region].send_message(queue_name, enveloped_message)
         elif self.protocol in ['http', 'https']:
             post_data = self.get_post_data(message, message_id)
             requests.post(self.endpoint, json=post_data)

--- a/tests/test_sns/test_publishing.py
+++ b/tests/test_sns/test_publishing.py
@@ -2,6 +2,7 @@ from __future__ import unicode_literals
 from six.moves.urllib.parse import parse_qs
 
 import boto
+import re
 from freezegun import freeze_time
 import sure  # noqa
 
@@ -35,7 +36,8 @@ def test_publish_to_sqs():
     queue = sqs_conn.get_queue("test-queue")
     message = queue.read(1)
     expected = MESSAGE_FROM_SQS_TEMPLATE  % (message_to_publish, published_message_id, 'us-east-1')
-    message.get_body().should.equal(expected)
+    acquired_message = re.sub("\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z", '2015-01-01T12:00:00.000Z', message.get_body())
+    acquired_message.should.equal(expected)
 
 
 @mock_sqs_deprecated
@@ -61,4 +63,6 @@ def test_publish_to_sqs_in_different_region():
     queue = sqs_conn.get_queue("test-queue")
     message = queue.read(1)
     expected = MESSAGE_FROM_SQS_TEMPLATE  % (message_to_publish, published_message_id, 'us-west-1')
-    message.get_body().should.equal(expected)
+
+    acquired_message = re.sub("\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z", '2015-01-01T12:00:00.000Z', message.get_body())
+    acquired_message.should.equal(expected)

--- a/tests/test_sns/test_publishing.py
+++ b/tests/test_sns/test_publishing.py
@@ -9,6 +9,9 @@ from moto.packages.responses import responses
 from moto import mock_sns_deprecated, mock_sqs_deprecated
 
 
+MESSAGE_FROM_SQS_TEMPLATE = '{\n  "Message": "%s",\n  "MessageId": "%s",\n  "Signature": "EXAMPLElDMXvB8r9R83tGoNn0ecwd5UjllzsvSvbItzfaMpN2nk5HVSw7XnOn/49IkxDKz8YrlH2qJXj2iZB0Zo2O71c4qQk1fMUDi3LGpij7RCW7AW9vYYsSqIKRnFS94ilu7NFhUzLiieYr4BKHpdTmdD6c0esKEYBpabxDSc=",\n  "SignatureVersion": "1",\n  "SigningCertURL": "https://sns.us-east-1.amazonaws.com/SimpleNotificationService-f3ecfb7224c7233fe7bb5f59f96de52f.pem",\n  "Subject": "my subject",\n  "Timestamp": "2015-01-01T12:00:00.000Z",\n  "TopicArn": "arn:aws:sns:%s:123456789012:some-topic",\n  "Type": "Notification",\n  "UnsubscribeURL": "https://sns.us-east-1.amazonaws.com/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:us-east-1:123456789012:some-topic:2bcfbf39-05c3-41de-beaa-fcfcc21c8f55"\n}'
+
+
 @mock_sqs_deprecated
 @mock_sns_deprecated
 def test_publish_to_sqs():
@@ -24,11 +27,15 @@ def test_publish_to_sqs():
     conn.subscribe(topic_arn, "sqs",
                    "arn:aws:sqs:us-east-1:123456789012:test-queue")
 
-    conn.publish(topic=topic_arn, message="my message")
+    message_to_publish = 'my message'
+    with freeze_time("2015-01-01 12:00:00"):
+        published_message = conn.publish(topic=topic_arn, message=message_to_publish)
+    published_message_id = published_message['PublishResponse']['PublishResult']['MessageId']
 
     queue = sqs_conn.get_queue("test-queue")
     message = queue.read(1)
-    message.get_body().should.equal('my message')
+    expected = MESSAGE_FROM_SQS_TEMPLATE  % (message_to_publish, published_message_id, 'us-east-1')
+    message.get_body().should.equal(expected)
 
 
 @mock_sqs_deprecated
@@ -46,8 +53,12 @@ def test_publish_to_sqs_in_different_region():
     conn.subscribe(topic_arn, "sqs",
                    "arn:aws:sqs:us-west-2:123456789012:test-queue")
 
-    conn.publish(topic=topic_arn, message="my message")
+    message_to_publish = 'my message'
+    with freeze_time("2015-01-01 12:00:00"):
+        published_message = conn.publish(topic=topic_arn, message=message_to_publish)
+    published_message_id = published_message['PublishResponse']['PublishResult']['MessageId']
 
     queue = sqs_conn.get_queue("test-queue")
     message = queue.read(1)
-    message.get_body().should.equal('my message')
+    expected = MESSAGE_FROM_SQS_TEMPLATE  % (message_to_publish, published_message_id, 'us-west-1')
+    message.get_body().should.equal(expected)

--- a/tests/test_sns/test_publishing_boto3.py
+++ b/tests/test_sns/test_publishing_boto3.py
@@ -5,6 +5,7 @@ import json
 from six.moves.urllib.parse import parse_qs
 
 import boto3
+import re
 from freezegun import freeze_time
 import sure  # noqa
 
@@ -16,6 +17,8 @@ from freezegun import freeze_time
 MESSAGE_FROM_SQS_TEMPLATE = '{\n  "Message": "%s",\n  "MessageId": "%s",\n  "Signature": "EXAMPLElDMXvB8r9R83tGoNn0ecwd5UjllzsvSvbItzfaMpN2nk5HVSw7XnOn/49IkxDKz8YrlH2qJXj2iZB0Zo2O71c4qQk1fMUDi3LGpij7RCW7AW9vYYsSqIKRnFS94ilu7NFhUzLiieYr4BKHpdTmdD6c0esKEYBpabxDSc=",\n  "SignatureVersion": "1",\n  "SigningCertURL": "https://sns.us-east-1.amazonaws.com/SimpleNotificationService-f3ecfb7224c7233fe7bb5f59f96de52f.pem",\n  "Subject": "my subject",\n  "Timestamp": "2015-01-01T12:00:00.000Z",\n  "TopicArn": "arn:aws:sns:%s:123456789012:some-topic",\n  "Type": "Notification",\n  "UnsubscribeURL": "https://sns.us-east-1.amazonaws.com/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:us-east-1:123456789012:some-topic:2bcfbf39-05c3-41de-beaa-fcfcc21c8f55"\n}'
 
 
+from nose.plugins.attrib import attr
+@attr('slow')
 @mock_sqs
 @mock_sns
 def test_publish_to_sqs():
@@ -38,7 +41,8 @@ def test_publish_to_sqs():
     queue = sqs_conn.get_queue_by_name(QueueName="test-queue")
     messages = queue.receive_messages(MaxNumberOfMessages=1)
     expected = MESSAGE_FROM_SQS_TEMPLATE  % (message, published_message_id, 'us-east-1')
-    messages[0].body.should.equal(expected)
+    acquired_message = re.sub("\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z", u'2015-01-01T12:00:00.000Z', messages[0].body)
+    acquired_message.should.equal(expected)
 
 
 @mock_sqs
@@ -74,7 +78,8 @@ def test_publish_to_sqs_dump_json():
 
     escaped = message.replace('"', '\\"')
     expected = MESSAGE_FROM_SQS_TEMPLATE  % (escaped, published_message_id, 'us-east-1')
-    messages[0].body.should.equal(expected)
+    acquired_message = re.sub("\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z", u'2015-01-01T12:00:00.000Z', messages[0].body)
+    acquired_message.should.equal(expected)
 
 
 @mock_sqs
@@ -100,7 +105,8 @@ def test_publish_to_sqs_in_different_region():
     queue = sqs_conn.get_queue_by_name(QueueName="test-queue")
     messages = queue.receive_messages(MaxNumberOfMessages=1)
     expected = MESSAGE_FROM_SQS_TEMPLATE  % (message, published_message_id, 'us-west-1')
-    messages[0].body.should.equal(expected)
+    acquired_message = re.sub("\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z", u'2015-01-01T12:00:00.000Z', messages[0].body)
+    acquired_message.should.equal(expected)
 
 
 @freeze_time("2013-01-01")

--- a/tests/test_sns/test_publishing_boto3.py
+++ b/tests/test_sns/test_publishing_boto3.py
@@ -10,6 +10,10 @@ import sure  # noqa
 
 from moto.packages.responses import responses
 from moto import mock_sns, mock_sqs
+from freezegun import freeze_time
+
+
+MESSAGE_FROM_SQS_TEMPLATE = '{\n  "Message": "%s",\n  "MessageId": "%s",\n  "Signature": "EXAMPLElDMXvB8r9R83tGoNn0ecwd5UjllzsvSvbItzfaMpN2nk5HVSw7XnOn/49IkxDKz8YrlH2qJXj2iZB0Zo2O71c4qQk1fMUDi3LGpij7RCW7AW9vYYsSqIKRnFS94ilu7NFhUzLiieYr4BKHpdTmdD6c0esKEYBpabxDSc=",\n  "SignatureVersion": "1",\n  "SigningCertURL": "https://sns.us-east-1.amazonaws.com/SimpleNotificationService-f3ecfb7224c7233fe7bb5f59f96de52f.pem",\n  "Subject": "my subject",\n  "Timestamp": "2015-01-01T12:00:00.000Z",\n  "TopicArn": "arn:aws:sns:%s:123456789012:some-topic",\n  "Type": "Notification",\n  "UnsubscribeURL": "https://sns.us-east-1.amazonaws.com/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:us-east-1:123456789012:some-topic:2bcfbf39-05c3-41de-beaa-fcfcc21c8f55"\n}'
 
 
 @mock_sqs
@@ -26,12 +30,15 @@ def test_publish_to_sqs():
     conn.subscribe(TopicArn=topic_arn,
                    Protocol="sqs",
                    Endpoint="arn:aws:sqs:us-east-1:123456789012:test-queue")
-
-    conn.publish(TopicArn=topic_arn, Message="my message")
+    message = 'my message'
+    with freeze_time("2015-01-01 12:00:00"):
+        published_message = conn.publish(TopicArn=topic_arn, Message=message)
+    published_message_id = published_message['MessageId']
 
     queue = sqs_conn.get_queue_by_name(QueueName="test-queue")
     messages = queue.receive_messages(MaxNumberOfMessages=1)
-    messages[0].body.should.equal('my message')
+    expected = MESSAGE_FROM_SQS_TEMPLATE  % (message, published_message_id, 'us-east-1')
+    messages[0].body.should.equal(expected)
 
 
 @mock_sqs
@@ -58,10 +65,15 @@ def test_publish_to_sqs_dump_json():
             }
         }]
     }, sort_keys=True)
-    conn.publish(TopicArn=topic_arn, Message=message)
+    with freeze_time("2015-01-01 12:00:00"):
+        published_message = conn.publish(TopicArn=topic_arn, Message=message)
+    published_message_id = published_message['MessageId']
+
     queue = sqs_conn.get_queue_by_name(QueueName="test-queue")
     messages = queue.receive_messages(MaxNumberOfMessages=1)
-    expected = u'{\\"Records\\": [{\\"eventSource\\": \\"aws:s3\\", \\"eventVersion\\": \\"2.0\\", \\"s3\\": {\\"s3SchemaVersion\\": \\"1.0\\"}}]}'
+
+    escaped = message.replace('"', '\\"')
+    expected = MESSAGE_FROM_SQS_TEMPLATE  % (escaped, published_message_id, 'us-east-1')
     messages[0].body.should.equal(expected)
 
 
@@ -80,11 +92,15 @@ def test_publish_to_sqs_in_different_region():
                    Protocol="sqs",
                    Endpoint="arn:aws:sqs:us-west-2:123456789012:test-queue")
 
-    conn.publish(TopicArn=topic_arn, Message="my message")
+    message = 'my message'
+    with freeze_time("2015-01-01 12:00:00"):
+        published_message = conn.publish(TopicArn=topic_arn, Message=message)
+    published_message_id = published_message['MessageId']
 
     queue = sqs_conn.get_queue_by_name(QueueName="test-queue")
     messages = queue.receive_messages(MaxNumberOfMessages=1)
-    messages[0].body.should.equal('my message')
+    expected = MESSAGE_FROM_SQS_TEMPLATE  % (message, published_message_id, 'us-west-1')
+    messages[0].body.should.equal(expected)
 
 
 @freeze_time("2013-01-01")


### PR DESCRIPTION
According to the doc, message published to SNS is wrapped as json when sending it to SQS queue.

http://docs.aws.amazon.com/sns/latest/dg/SendMessageToSQS.html

Fixing: https://github.com/spulec/moto/issues/1063