### PR TITLE
handle short form function in cfn yaml template.

### DIFF
--- a/moto/cloudformation/models.py
+++ b/moto/cloudformation/models.py
@@ -9,7 +9,7 @@ from moto.compat import OrderedDict
 from moto.core import BaseBackend, BaseModel
 
 from .parsing import ResourceMap, OutputMap
-from .utils import generate_stack_id
+from .utils import generate_stack_id, yaml_tag_constructor
 from .exceptions import ValidationError
 
 
@@ -74,6 +74,7 @@ class FakeStack(BaseModel):
         ))
 
     def _parse_template(self):
+        yaml.add_multi_constructor('', yaml_tag_constructor)
         try:
             self.template_dict = yaml.load(self.template)
         except yaml.parser.ParserError:

--- a/moto/cloudformation/responses.py
+++ b/moto/cloudformation/responses.py
@@ -391,8 +391,7 @@ LIST_STACKS_RESOURCES_RESPONSE = """<ListStackResourcesResponse>
 
 GET_TEMPLATE_RESPONSE_TEMPLATE = """<GetTemplateResponse>
   <GetTemplateResult>
-    <TemplateBody>{{ stack.template }}
-    </TemplateBody>
+    <TemplateBody>{{ stack.template }}</TemplateBody>
   </GetTemplateResult>
   <ResponseMetadata>
     <RequestId>b9b4b068-3a41-11e5-94eb-example</RequestId>

--- a/moto/cloudformation/utils.py
+++ b/moto/cloudformation/utils.py
@@ -2,6 +2,7 @@ from __future__ import unicode_literals
 import uuid
 import six
 import random
+import yaml
 
 
 def generate_stack_id(stack_name):
@@ -13,3 +14,22 @@ def random_suffix():
     size = 12
     chars = list(range(10)) + ['A-Z']
     return ''.join(six.text_type(random.choice(chars)) for x in range(size))
+
+
+def yaml_tag_constructor(loader, tag, node):
+    """convert shorthand intrinsic function to full name
+    """
+    def _f(loader, tag, node):
+        if tag == '!GetAtt':
+            return node.value.split('.')
+        elif type(node) == yaml.SequenceNode:
+            return loader.construct_sequence(node)
+        else:
+            return node.value
+
+    if tag == '!Ref':
+        key = 'Ref'
+    else:
+        key = 'Fn::{}'.format(tag[1:])
+
+    return {key: _f(loader, tag, node)}


### PR DESCRIPTION
fix bug that create_stack fails when call it with yaml template which includes shorthand intrinsic function such as `!Join`.