### PR TITLE
Add empty string validation exception

### DIFF
--- a/moto/dynamodb2/responses.py
+++ b/moto/dynamodb2/responses.py
@@ -148,10 +148,13 @@ class DynamoHandler(BaseResponse):
         res = re.search('\"\"', json.dumps(item))
         if res:
             er = 'com.amazonaws.dynamodb.v20111205#ValidationException'
-            return 400, {'server': 'amazon.com'}, dynamo_json_dump(
-                {'__type': er,
-                'message': ('One or more parameter values were invalid: '
-                'An AttributeValue may not contain an empty string')})
+            return (400,
+                {'server': 'amazon.com'},
+                dynamo_json_dump({'__type': er,
+                                'message': ('One or more parameter values were '
+                                            'invalid:An AttributeValue may not '
+                                            'contain an empty string')}
+                                 ))
 
         overwrite = 'Expected' not in self.body
         if not overwrite:

--- a/moto/dynamodb2/responses.py
+++ b/moto/dynamodb2/responses.py
@@ -144,6 +144,16 @@ class DynamoHandler(BaseResponse):
     def put_item(self):
         name = self.body['TableName']
         item = self.body['Item']
+
+        res = re.search('\"\"', json.dumps(item))
+        if res:
+            er = 'com.amazonaws.dynamodb.v20111205#ValidationException'
+            return 400, {'server': 'amazon.com'}, dynamo_json_dump(
+                {'__type': er,
+                'message': ('One or more parameter values were invalid: '
+                'An AttributeValue may not contain an empty string')
+                })
+
         overwrite = 'Expected' not in self.body
         if not overwrite:
             expected = self.body['Expected']

--- a/moto/dynamodb2/responses.py
+++ b/moto/dynamodb2/responses.py
@@ -152,7 +152,7 @@ class DynamoHandler(BaseResponse):
                 {'server': 'amazon.com'},
                 dynamo_json_dump({'__type': er,
                                 'message': ('One or more parameter values were '
-                                            'invalid:An AttributeValue may not '
+                                            'invalid: An AttributeValue may not '
                                             'contain an empty string')}
                                  ))
 

--- a/tests/test_dynamodb2/test_dynamodb.py
+++ b/tests/test_dynamodb2/test_dynamodb.py
@@ -163,19 +163,19 @@ def test_item_add_empty_string_exception():
                       KeySchema=[{'AttributeName':'forum_name','KeyType':'HASH'}],
                       AttributeDefinitions=[{'AttributeName':'forum_name','AttributeType':'S'}],
                       ProvisionedThroughput={'ReadCapacityUnits':5,'WriteCapacityUnits':5})
-    session = boto3.Session()
-    dynamodb = session.resource('dynamodb',
-                                region_name='us-west-2',
-                                aws_access_key_id="ak",
-                                aws_secret_access_key="sk")
-    table = dynamodb.Table('TestTable')
+
     try:
-        response = table.put_item(Item={
-            'forum_name': 'LOLCat Forum',
-            'subject': 'Check this out!',
-            'Body': 'http://url_to_lolcat.gif',
-            'SentBy': "",
-            'ReceivedTime': '12/9/2011 11:36:03 PM',
-        })
+        conn.put_item(
+            TableName=name,
+            Item={
+                'forum_name': { 'S': 'LOLCat Forum' },
+                'subject': { 'S': 'Check this out!' },
+                'Body': { 'S': 'http://url_to_lolcat.gif'},
+                'SentBy': { 'S': "" },
+                'ReceivedTime': { 'S': '12/9/2011 11:36:03 PM'},
+            }
+        )
+
     except ClientError as exception:
+        exception.response['Error']['Code']
         assert exception.response['Error']['Code'] == "ValidationException"

--- a/tests/test_dynamodb2/test_dynamodb.py
+++ b/tests/test_dynamodb2/test_dynamodb.py
@@ -149,3 +149,33 @@ def test_list_not_found_table_tags():
         conn.list_tags_of_resource(ResourceArn=arn)
     except ClientError as exception:
         assert exception.response['Error']['Code'] == "ResourceNotFoundException"
+
+
+@requires_boto_gte("2.9")
+@mock_dynamodb2
+def test_item_add_empty_string_exception():
+    name = 'TestTable'
+    conn = boto3.client('dynamodb',
+                        region_name='us-west-2',
+                        aws_access_key_id="ak",
+                        aws_secret_access_key="sk")
+    conn.create_table(TableName=name,
+                      KeySchema=[{'AttributeName':'forum_name','KeyType':'HASH'}],
+                      AttributeDefinitions=[{'AttributeName':'forum_name','AttributeType':'S'}],
+                      ProvisionedThroughput={'ReadCapacityUnits':5,'WriteCapacityUnits':5})
+    session = boto3.Session()
+    dynamodb = session.resource('dynamodb',
+                                region_name='us-west-2',
+                                aws_access_key_id="ak",
+                                aws_secret_access_key="sk")
+    table = dynamodb.Table('TestTable')
+    try:
+        response = table.put_item(Item={
+            'forum_name': 'LOLCat Forum',
+            'subject': 'Check this out!',
+            'Body': 'http://url_to_lolcat.gif',
+            'SentBy': "",
+            'ReceivedTime': '12/9/2011 11:36:03 PM',
+        })
+    except ClientError as exception:
+        assert exception.response['Error']['Code'] == "ValidationException"

--- a/tests/test_dynamodb2/test_dynamodb.py
+++ b/tests/test_dynamodb2/test_dynamodb.py
@@ -164,7 +164,7 @@ def test_item_add_empty_string_exception():
                       AttributeDefinitions=[{'AttributeName':'forum_name','AttributeType':'S'}],
                       ProvisionedThroughput={'ReadCapacityUnits':5,'WriteCapacityUnits':5})
 
-    try:
+    with assert_raises(ClientError) as ex:
         conn.put_item(
             TableName=name,
             Item={
@@ -176,6 +176,8 @@ def test_item_add_empty_string_exception():
             }
         )
 
-    except ClientError as exception:
-        exception.response['Error']['Code']
-        assert exception.response['Error']['Code'] == "ValidationException"
+    ex.exception.response['Error']['Code'].should.equal('ValidationException')
+    ex.exception.response['ResponseMetadata']['HTTPStatusCode'].should.equal(400)
+    ex.exception.response['Error']['Message'].should.equal(
+        'One or more parameter values were invalid: An AttributeValue may not contain an empty string'
+    )


### PR DESCRIPTION
This is to address [this](https://github.com/spulec/moto/issues/1129) issue. It returns the correct ValidationException, with the correct response message, for attributes set to empty strings when calling the put_item method on a table. I'm very new to the moto codebase, so any feedback would be welcome. 