### PR TITLE
Refactor querystring params

### DIFF
--- a/moto/ec2/responses/amis.py
+++ b/moto/ec2/responses/amis.py
@@ -7,10 +7,7 @@ class AmisResponse(BaseResponse):
 
     def create_image(self):
         name = self.querystring.get('Name')[0]
-        if "Description" in self.querystring:
-            description = self.querystring.get('Description')[0]
-        else:
-            description = ""
+        description = self._get_param('Description', if_none='')
         instance_id = self._get_param('InstanceId')
         if self.is_not_dryrun('CreateImage'):
             image = self.ec2_backend.create_image(
@@ -19,12 +16,10 @@ class AmisResponse(BaseResponse):
             return template.render(image=image)
 
     def copy_image(self):
-        source_image_id = self.querystring.get('SourceImageId')[0]
-        source_region = self.querystring.get('SourceRegion')[0]
-        name = self.querystring.get(
-            'Name')[0] if self.querystring.get('Name') else None
-        description = self.querystring.get(
-            'Description')[0] if self.querystring.get('Description') else None
+        source_image_id = self._get_param('SourceImageId')
+        source_region = self._get_param('SourceRegion')
+        name = self._get_param('Name')
+        description = self._get_param('Description')
         if self.is_not_dryrun('CopyImage'):
             image = self.ec2_backend.copy_image(
                 source_image_id, source_region, name, description)
@@ -32,7 +27,7 @@ class AmisResponse(BaseResponse):
             return template.render(image=image)
 
     def deregister_image(self):
-        ami_id = self.querystring.get('ImageId')[0]
+        ami_id = self._get_param('ImageId')
         if self.is_not_dryrun('DeregisterImage'):
             success = self.ec2_backend.deregister_image(ami_id)
             template = self.response_template(DEREGISTER_IMAGE_RESPONSE)
@@ -48,16 +43,16 @@ class AmisResponse(BaseResponse):
         return template.render(images=images)
 
     def describe_image_attribute(self):
-        ami_id = self.querystring.get('ImageId')[0]
+        ami_id = self._get_param('ImageId')
         groups = self.ec2_backend.get_launch_permission_groups(ami_id)
         users = self.ec2_backend.get_launch_permission_users(ami_id)
         template = self.response_template(DESCRIBE_IMAGE_ATTRIBUTES_RESPONSE)
         return template.render(ami_id=ami_id, groups=groups, users=users)
 
     def modify_image_attribute(self):
-        ami_id = self.querystring.get('ImageId')[0]
-        operation_type = self.querystring.get('OperationType')[0]
-        group = self.querystring.get('UserGroup.1', [None])[0]
+        ami_id = self._get_param('ImageId')
+        operation_type = self._get_param('OperationType')
+        group = self._get_param('UserGroup.1')
         user_ids = self._get_multi_param('UserId')
         if self.is_not_dryrun('ModifyImageAttribute'):
             if (operation_type == 'add'):

--- a/moto/ec2/responses/customer_gateways.py
+++ b/moto/ec2/responses/customer_gateways.py
@@ -7,16 +7,16 @@ class CustomerGateways(BaseResponse):
 
     def create_customer_gateway(self):
         # raise NotImplementedError('CustomerGateways(AmazonVPC).create_customer_gateway is not yet implemented')
-        type = self.querystring.get('Type', None)[0]
-        ip_address = self.querystring.get('IpAddress', None)[0]
-        bgp_asn = self.querystring.get('BgpAsn', None)[0]
+        type = self._get_param('Type')
+        ip_address = self._get_param('IpAddress')
+        bgp_asn = self._get_param('BgpAsn')
         customer_gateway = self.ec2_backend.create_customer_gateway(
             type, ip_address=ip_address, bgp_asn=bgp_asn)
         template = self.response_template(CREATE_CUSTOMER_GATEWAY_RESPONSE)
         return template.render(customer_gateway=customer_gateway)
 
     def delete_customer_gateway(self):
-        customer_gateway_id = self.querystring.get('CustomerGatewayId')[0]
+        customer_gateway_id = self._get_param('CustomerGatewayId')
         delete_status = self.ec2_backend.delete_customer_gateway(
             customer_gateway_id)
         template = self.response_template(DELETE_CUSTOMER_GATEWAY_RESPONSE)

--- a/moto/ec2/responses/dhcp_options.py
+++ b/moto/ec2/responses/dhcp_options.py
@@ -2,7 +2,6 @@ from __future__ import unicode_literals
 from moto.core.responses import BaseResponse
 from moto.ec2.utils import (
     filters_from_querystring,
-    sequence_from_querystring,
     dhcp_configuration_from_querystring)
 
 
@@ -49,8 +48,7 @@ class DHCPOptions(BaseResponse):
         return template.render(delete_status=delete_status)
 
     def describe_dhcp_options(self):
-        dhcp_opt_ids = sequence_from_querystring(
-            "DhcpOptionsId", self.querystring)
+        dhcp_opt_ids = self._get_multi_param("DhcpOptionsId")
         filters = filters_from_querystring(self.querystring)
         dhcp_opts = self.ec2_backend.get_all_dhcp_options(
             dhcp_opt_ids, filters)

--- a/moto/ec2/responses/dhcp_options.py
+++ b/moto/ec2/responses/dhcp_options.py
@@ -8,8 +8,8 @@ from moto.ec2.utils import (
 class DHCPOptions(BaseResponse):
 
     def associate_dhcp_options(self):
-        dhcp_opt_id = self.querystring.get("DhcpOptionsId", [None])[0]
-        vpc_id = self.querystring.get("VpcId", [None])[0]
+        dhcp_opt_id = self._get_param('DhcpOptionsId')
+        vpc_id = self._get_param('VpcId')
 
         dhcp_opt = self.ec2_backend.describe_dhcp_options([dhcp_opt_id])[0]
         vpc = self.ec2_backend.get_vpc(vpc_id)
@@ -42,7 +42,7 @@ class DHCPOptions(BaseResponse):
         return template.render(dhcp_options_set=dhcp_options_set)
 
     def delete_dhcp_options(self):
-        dhcp_opt_id = self.querystring.get("DhcpOptionsId", [None])[0]
+        dhcp_opt_id = self._get_param('DhcpOptionsId')
         delete_status = self.ec2_backend.delete_dhcp_options_set(dhcp_opt_id)
         template = self.response_template(DELETE_DHCP_OPTIONS_RESPONSE)
         return template.render(delete_status=delete_status)

--- a/moto/ec2/responses/elastic_block_store.py
+++ b/moto/ec2/responses/elastic_block_store.py
@@ -6,9 +6,9 @@ from moto.ec2.utils import filters_from_querystring
 class ElasticBlockStore(BaseResponse):
 
     def attach_volume(self):
-        volume_id = self.querystring.get('VolumeId')[0]
-        instance_id = self.querystring.get('InstanceId')[0]
-        device_path = self.querystring.get('Device')[0]
+        volume_id = self._get_param('VolumeId')
+        instance_id = self._get_param('InstanceId')
+        device_path = self._get_param('Device')
         if self.is_not_dryrun('AttachVolume'):
             attachment = self.ec2_backend.attach_volume(
                 volume_id, instance_id, device_path)
@@ -21,18 +21,18 @@ class ElasticBlockStore(BaseResponse):
                 'ElasticBlockStore.copy_snapshot is not yet implemented')
 
     def create_snapshot(self):
-        description = self.querystring.get('Description', [None])[0]
-        volume_id = self.querystring.get('VolumeId')[0]
+        volume_id = self._get_param('VolumeId')
+        description = self._get_param('Description')
         if self.is_not_dryrun('CreateSnapshot'):
             snapshot = self.ec2_backend.create_snapshot(volume_id, description)
             template = self.response_template(CREATE_SNAPSHOT_RESPONSE)
             return template.render(snapshot=snapshot)
 
     def create_volume(self):
-        size = self.querystring.get('Size', [None])[0]
-        zone = self.querystring.get('AvailabilityZone', [None])[0]
-        snapshot_id = self.querystring.get('SnapshotId', [None])[0]
-        encrypted = self.querystring.get('Encrypted', ['false'])[0]
+        size = self._get_param('Size')
+        zone = self._get_param('AvailabilityZone')
+        snapshot_id = self._get_param('SnapshotId')
+        encrypted = self._get_param('Encrypted', if_none=False)
         if self.is_not_dryrun('CreateVolume'):
             volume = self.ec2_backend.create_volume(
                 size, zone, snapshot_id, encrypted)
@@ -40,23 +40,20 @@ class ElasticBlockStore(BaseResponse):
             return template.render(volume=volume)
 
     def delete_snapshot(self):
-        snapshot_id = self.querystring.get('SnapshotId')[0]
+        snapshot_id = self._get_param('SnapshotId')
         if self.is_not_dryrun('DeleteSnapshot'):
             self.ec2_backend.delete_snapshot(snapshot_id)
             return DELETE_SNAPSHOT_RESPONSE
 
     def delete_volume(self):
-        volume_id = self.querystring.get('VolumeId')[0]
+        volume_id = self._get_param('VolumeId')
         if self.is_not_dryrun('DeleteVolume'):
             self.ec2_backend.delete_volume(volume_id)
             return DELETE_VOLUME_RESPONSE
 
     def describe_snapshots(self):
         filters = filters_from_querystring(self.querystring)
-        # querystring for multiple snapshotids results in SnapshotId.1,
-        # SnapshotId.2 etc
-        snapshot_ids = ','.join(
-            [','.join(s[1]) for s in self.querystring.items() if 'SnapshotId' in s[0]])
+        snapshot_ids = self._get_multi_param('SnapshotId')
         snapshots = self.ec2_backend.describe_snapshots(filters=filters)
         # Describe snapshots to handle filter on snapshot_ids
         snapshots = [
@@ -66,10 +63,7 @@ class ElasticBlockStore(BaseResponse):
 
     def describe_volumes(self):
         filters = filters_from_querystring(self.querystring)
-        # querystring for multiple volumeids results in VolumeId.1, VolumeId.2
-        # etc
-        volume_ids = ','.join(
-            [','.join(v[1]) for v in self.querystring.items() if 'VolumeId' in v[0]])
+        volume_ids = self._get_multi_param('VolumeId')
         volumes = self.ec2_backend.describe_volumes(filters=filters)
         # Describe volumes to handle filter on volume_ids
         volumes = [
@@ -86,9 +80,9 @@ class ElasticBlockStore(BaseResponse):
             'ElasticBlockStore.describe_volume_status is not yet implemented')
 
     def detach_volume(self):
-        volume_id = self.querystring.get('VolumeId')[0]
-        instance_id = self.querystring.get('InstanceId')[0]
-        device_path = self.querystring.get('Device')[0]
+        volume_id = self._get_param('VolumeId')
+        instance_id = self._get_param('InstanceId')
+        device_path = self._get_param('Device')
         if self.is_not_dryrun('DetachVolume'):
             attachment = self.ec2_backend.detach_volume(
                 volume_id, instance_id, device_path)
@@ -106,7 +100,7 @@ class ElasticBlockStore(BaseResponse):
                 'ElasticBlockStore.import_volume is not yet implemented')
 
     def describe_snapshot_attribute(self):
-        snapshot_id = self.querystring.get('SnapshotId')[0]
+        snapshot_id = self._get_param('SnapshotId')
         groups = self.ec2_backend.get_create_volume_permission_groups(
             snapshot_id)
         template = self.response_template(
@@ -114,10 +108,10 @@ class ElasticBlockStore(BaseResponse):
         return template.render(snapshot_id=snapshot_id, groups=groups)
 
     def modify_snapshot_attribute(self):
-        snapshot_id = self.querystring.get('SnapshotId')[0]
-        operation_type = self.querystring.get('OperationType')[0]
-        group = self.querystring.get('UserGroup.1', [None])[0]
-        user_id = self.querystring.get('UserId.1', [None])[0]
+        snapshot_id = self._get_param('SnapshotId')
+        operation_type = self._get_param('OperationType')
+        group = self._get_param('UserGroup.1')
+        user_id = self._get_param('UserId.1')
         if self.is_not_dryrun('ModifySnapshotAttribute'):
             if (operation_type == 'add'):
                 self.ec2_backend.add_create_volume_permission(

--- a/moto/ec2/responses/elastic_ip_addresses.py
+++ b/moto/ec2/responses/elastic_ip_addresses.py
@@ -6,10 +6,7 @@ from moto.ec2.utils import filters_from_querystring
 class ElasticIPAddresses(BaseResponse):
 
     def allocate_address(self):
-        if "Domain" in self.querystring:
-            domain = self.querystring.get('Domain')[0]
-        else:
-            domain = "standard"
+        domain = self._get_param('Domain', if_none='standard')
         if self.is_not_dryrun('AllocateAddress'):
             address = self.ec2_backend.allocate_address(domain)
             template = self.response_template(ALLOCATE_ADDRESS_RESPONSE)
@@ -20,26 +17,28 @@ class ElasticIPAddresses(BaseResponse):
 
         if "InstanceId" in self.querystring:
             instance = self.ec2_backend.get_instance(
-                self.querystring['InstanceId'][0])
+                self._get_param('InstanceId'))
         elif "NetworkInterfaceId" in self.querystring:
             eni = self.ec2_backend.get_network_interface(
-                self.querystring['NetworkInterfaceId'][0])
+                self._get_param('NetworkInterfaceId'))
         else:
             self.ec2_backend.raise_error(
                 "MissingParameter", "Invalid request, expect InstanceId/NetworkId parameter.")
 
         reassociate = False
         if "AllowReassociation" in self.querystring:
-            reassociate = self.querystring['AllowReassociation'][0] == "true"
+            reassociate = self._get_param('AllowReassociation') == "true"
 
         if self.is_not_dryrun('AssociateAddress'):
             if instance or eni:
                 if "PublicIp" in self.querystring:
-                    eip = self.ec2_backend.associate_address(instance=instance, eni=eni, address=self.querystring[
-                                                             'PublicIp'][0], reassociate=reassociate)
+                    eip = self.ec2_backend.associate_address(
+                        instance=instance, eni=eni,
+                        address=self._get_param('PublicIp'), reassociate=reassociate)
                 elif "AllocationId" in self.querystring:
-                    eip = self.ec2_backend.associate_address(instance=instance, eni=eni, allocation_id=self.querystring[
-                                                             'AllocationId'][0], reassociate=reassociate)
+                    eip = self.ec2_backend.associate_address(
+                        instance=instance, eni=eni,
+                        allocation_id=self._get_param('AllocationId'), reassociate=reassociate)
                 else:
                     self.ec2_backend.raise_error(
                         "MissingParameter", "Invalid request, expect PublicIp/AllocationId parameter.")
@@ -63,10 +62,10 @@ class ElasticIPAddresses(BaseResponse):
         if self.is_not_dryrun('DisAssociateAddress'):
             if "PublicIp" in self.querystring:
                 self.ec2_backend.disassociate_address(
-                    address=self.querystring['PublicIp'][0])
+                    address=self._get_param('PublicIp'))
             elif "AssociationId" in self.querystring:
                 self.ec2_backend.disassociate_address(
-                    association_id=self.querystring['AssociationId'][0])
+                    association_id=self._get_param('AssociationId'))
             else:
                 self.ec2_backend.raise_error(
                     "MissingParameter", "Invalid request, expect PublicIp/AssociationId parameter.")
@@ -77,10 +76,10 @@ class ElasticIPAddresses(BaseResponse):
         if self.is_not_dryrun('ReleaseAddress'):
             if "PublicIp" in self.querystring:
                 self.ec2_backend.release_address(
-                    address=self.querystring['PublicIp'][0])
+                    address=self._get_param('PublicIp'))
             elif "AllocationId" in self.querystring:
                 self.ec2_backend.release_address(
-                    allocation_id=self.querystring['AllocationId'][0])
+                    allocation_id=self._get_param('AllocationId'))
             else:
                 self.ec2_backend.raise_error(
                     "MissingParameter", "Invalid request, expect PublicIp/AllocationId parameter.")

--- a/moto/ec2/responses/elastic_ip_addresses.py
+++ b/moto/ec2/responses/elastic_ip_addresses.py
@@ -1,6 +1,6 @@
 from __future__ import unicode_literals
 from moto.core.responses import BaseResponse
-from moto.ec2.utils import filters_from_querystring, sequence_from_querystring
+from moto.ec2.utils import filters_from_querystring
 
 
 class ElasticIPAddresses(BaseResponse):
@@ -51,8 +51,8 @@ class ElasticIPAddresses(BaseResponse):
             return template.render(address=eip)
 
     def describe_addresses(self):
-        allocation_ids = sequence_from_querystring('AllocationId', self.querystring)
-        public_ips = sequence_from_querystring('PublicIp', self.querystring)
+        allocation_ids = self._get_multi_param('AllocationId')
+        public_ips = self._get_multi_param('PublicIp')
         filters = filters_from_querystring(self.querystring)
         addresses = self.ec2_backend.describe_addresses(
             allocation_ids, public_ips, filters)

--- a/moto/ec2/responses/elastic_network_interfaces.py
+++ b/moto/ec2/responses/elastic_network_interfaces.py
@@ -6,9 +6,8 @@ from moto.ec2.utils import filters_from_querystring
 class ElasticNetworkInterfaces(BaseResponse):
 
     def create_network_interface(self):
-        subnet_id = self.querystring.get('SubnetId')[0]
-        private_ip_address = self.querystring.get(
-            'PrivateIpAddress', [None])[0]
+        subnet_id = self._get_param('SubnetId')
+        private_ip_address = self._get_param('PrivateIpAddress')
         groups = self._get_multi_param('SecurityGroupId')
         subnet = self.ec2_backend.get_subnet(subnet_id)
         if self.is_not_dryrun('CreateNetworkInterface'):
@@ -19,7 +18,7 @@ class ElasticNetworkInterfaces(BaseResponse):
             return template.render(eni=eni)
 
     def delete_network_interface(self):
-        eni_id = self.querystring.get('NetworkInterfaceId')[0]
+        eni_id = self._get_param('NetworkInterfaceId')
         if self.is_not_dryrun('DeleteNetworkInterface'):
             self.ec2_backend.delete_network_interface(eni_id)
             template = self.response_template(
@@ -38,9 +37,9 @@ class ElasticNetworkInterfaces(BaseResponse):
         return template.render(enis=enis)
 
     def attach_network_interface(self):
-        eni_id = self.querystring.get('NetworkInterfaceId')[0]
-        instance_id = self.querystring.get('InstanceId')[0]
-        device_index = self.querystring.get('DeviceIndex')[0]
+        eni_id = self._get_param('NetworkInterfaceId')
+        instance_id = self._get_param('InstanceId')
+        device_index = self._get_param('DeviceIndex')
         if self.is_not_dryrun('AttachNetworkInterface'):
             attachment_id = self.ec2_backend.attach_network_interface(
                 eni_id, instance_id, device_index)
@@ -49,7 +48,7 @@ class ElasticNetworkInterfaces(BaseResponse):
             return template.render(attachment_id=attachment_id)
 
     def detach_network_interface(self):
-        attachment_id = self.querystring.get('AttachmentId')[0]
+        attachment_id = self._get_param('AttachmentId')
         if self.is_not_dryrun('DetachNetworkInterface'):
             self.ec2_backend.detach_network_interface(attachment_id)
             template = self.response_template(
@@ -58,8 +57,8 @@ class ElasticNetworkInterfaces(BaseResponse):
 
     def modify_network_interface_attribute(self):
         # Currently supports modifying one and only one security group
-        eni_id = self.querystring.get('NetworkInterfaceId')[0]
-        group_id = self.querystring.get('SecurityGroupId.1')[0]
+        eni_id = self._get_param('NetworkInterfaceId')
+        group_id = self._get_param('SecurityGroupId.1')
         if self.is_not_dryrun('ModifyNetworkInterface'):
             self.ec2_backend.modify_network_interface_attribute(
                 eni_id, group_id)

--- a/moto/ec2/responses/elastic_network_interfaces.py
+++ b/moto/ec2/responses/elastic_network_interfaces.py
@@ -1,6 +1,6 @@
 from __future__ import unicode_literals
 from moto.core.responses import BaseResponse
-from moto.ec2.utils import sequence_from_querystring, filters_from_querystring
+from moto.ec2.utils import filters_from_querystring
 
 
 class ElasticNetworkInterfaces(BaseResponse):
@@ -9,7 +9,7 @@ class ElasticNetworkInterfaces(BaseResponse):
         subnet_id = self.querystring.get('SubnetId')[0]
         private_ip_address = self.querystring.get(
             'PrivateIpAddress', [None])[0]
-        groups = sequence_from_querystring('SecurityGroupId', self.querystring)
+        groups = self._get_multi_param('SecurityGroupId')
         subnet = self.ec2_backend.get_subnet(subnet_id)
         if self.is_not_dryrun('CreateNetworkInterface'):
             eni = self.ec2_backend.create_network_interface(
@@ -31,8 +31,7 @@ class ElasticNetworkInterfaces(BaseResponse):
             'ElasticNetworkInterfaces(AmazonVPC).describe_network_interface_attribute is not yet implemented')
 
     def describe_network_interfaces(self):
-        eni_ids = sequence_from_querystring(
-            'NetworkInterfaceId', self.querystring)
+        eni_ids = self._get_multi_param('NetworkInterfaceId')
         filters = filters_from_querystring(self.querystring)
         enis = self.ec2_backend.get_all_network_interfaces(eni_ids, filters)
         template = self.response_template(DESCRIBE_NETWORK_INTERFACES_RESPONSE)

--- a/moto/ec2/responses/general.py
+++ b/moto/ec2/responses/general.py
@@ -1,13 +1,11 @@
 from __future__ import unicode_literals
 from moto.core.responses import BaseResponse
-from moto.ec2.utils import instance_ids_from_querystring
 
 
 class General(BaseResponse):
 
     def get_console_output(self):
-        self.instance_ids = instance_ids_from_querystring(self.querystring)
-        instance_id = self.instance_ids[0]
+        instance_id = self._get_multi_param('InstanceId')[0]
         instance = self.ec2_backend.get_instance(instance_id)
         template = self.response_template(GET_CONSOLE_OUTPUT_RESULT)
         return template.render(instance=instance)

--- a/moto/ec2/responses/internet_gateways.py
+++ b/moto/ec2/responses/internet_gateways.py
@@ -8,8 +8,8 @@ from moto.ec2.utils import (
 class InternetGateways(BaseResponse):
 
     def attach_internet_gateway(self):
-        igw_id = self.querystring.get("InternetGatewayId", [None])[0]
-        vpc_id = self.querystring.get("VpcId", [None])[0]
+        igw_id = self._get_param('InternetGatewayId')
+        vpc_id = self._get_param('VpcId')
         if self.is_not_dryrun('AttachInternetGateway'):
             self.ec2_backend.attach_internet_gateway(igw_id, vpc_id)
             template = self.response_template(ATTACH_INTERNET_GATEWAY_RESPONSE)
@@ -22,7 +22,7 @@ class InternetGateways(BaseResponse):
             return template.render(internet_gateway=igw)
 
     def delete_internet_gateway(self):
-        igw_id = self.querystring.get("InternetGatewayId", [None])[0]
+        igw_id = self._get_param('InternetGatewayId')
         if self.is_not_dryrun('DeleteInternetGateway'):
             self.ec2_backend.delete_internet_gateway(igw_id)
             template = self.response_template(DELETE_INTERNET_GATEWAY_RESPONSE)
@@ -44,8 +44,8 @@ class InternetGateways(BaseResponse):
     def detach_internet_gateway(self):
         # TODO validate no instances with EIPs in VPC before detaching
         # raise else DependencyViolationError()
-        igw_id = self.querystring.get("InternetGatewayId", [None])[0]
-        vpc_id = self.querystring.get("VpcId", [None])[0]
+        igw_id = self._get_param('InternetGatewayId')
+        vpc_id = self._get_param('VpcId')
         if self.is_not_dryrun('DetachInternetGateway'):
             self.ec2_backend.detach_internet_gateway(igw_id, vpc_id)
             template = self.response_template(DETACH_INTERNET_GATEWAY_RESPONSE)

--- a/moto/ec2/responses/internet_gateways.py
+++ b/moto/ec2/responses/internet_gateways.py
@@ -1,7 +1,6 @@
 from __future__ import unicode_literals
 from moto.core.responses import BaseResponse
 from moto.ec2.utils import (
-    sequence_from_querystring,
     filters_from_querystring,
 )
 
@@ -32,8 +31,7 @@ class InternetGateways(BaseResponse):
     def describe_internet_gateways(self):
         filter_dict = filters_from_querystring(self.querystring)
         if "InternetGatewayId.1" in self.querystring:
-            igw_ids = sequence_from_querystring(
-                "InternetGatewayId", self.querystring)
+            igw_ids = self._get_multi_param("InternetGatewayId")
             igws = self.ec2_backend.describe_internet_gateways(
                 igw_ids, filters=filter_dict)
         else:

--- a/moto/ec2/responses/key_pairs.py
+++ b/moto/ec2/responses/key_pairs.py
@@ -1,7 +1,7 @@
 from __future__ import unicode_literals
 import six
 from moto.core.responses import BaseResponse
-from moto.ec2.utils import keypair_names_from_querystring, filters_from_querystring
+from moto.ec2.utils import filters_from_querystring
 
 
 class KeyPairs(BaseResponse):
@@ -21,7 +21,7 @@ class KeyPairs(BaseResponse):
             return self.response_template(DELETE_KEY_PAIR_RESPONSE).render(success=success)
 
     def describe_key_pairs(self):
-        names = keypair_names_from_querystring(self.querystring)
+        names = self._get_multi_param('KeyName')
         filters = filters_from_querystring(self.querystring)
         keypairs = self.ec2_backend.describe_key_pairs(names, filters)
         template = self.response_template(DESCRIBE_KEY_PAIRS_RESPONSE)

--- a/moto/ec2/responses/key_pairs.py
+++ b/moto/ec2/responses/key_pairs.py
@@ -7,14 +7,14 @@ from moto.ec2.utils import filters_from_querystring
 class KeyPairs(BaseResponse):
 
     def create_key_pair(self):
-        name = self.querystring.get('KeyName')[0]
+        name = self._get_param('KeyName')
         if self.is_not_dryrun('CreateKeyPair'):
             keypair = self.ec2_backend.create_key_pair(name)
             template = self.response_template(CREATE_KEY_PAIR_RESPONSE)
             return template.render(keypair=keypair)
 
     def delete_key_pair(self):
-        name = self.querystring.get('KeyName')[0]
+        name = self._get_param('KeyName')
         if self.is_not_dryrun('DeleteKeyPair'):
             success = six.text_type(
                 self.ec2_backend.delete_key_pair(name)).lower()
@@ -28,8 +28,8 @@ class KeyPairs(BaseResponse):
         return template.render(keypairs=keypairs)
 
     def import_key_pair(self):
-        name = self.querystring.get('KeyName')[0]
-        material = self.querystring.get('PublicKeyMaterial')[0]
+        name = self._get_param('KeyName')
+        material = self._get_param('PublicKeyMaterial')
         if self.is_not_dryrun('ImportKeyPair'):
             keypair = self.ec2_backend.import_key_pair(name, material)
             template = self.response_template(IMPORT_KEYPAIR_RESPONSE)

--- a/moto/ec2/responses/network_acls.py
+++ b/moto/ec2/responses/network_acls.py
@@ -6,22 +6,22 @@ from moto.ec2.utils import filters_from_querystring
 class NetworkACLs(BaseResponse):
 
     def create_network_acl(self):
-        vpc_id = self.querystring.get('VpcId')[0]
+        vpc_id = self._get_param('VpcId')
         network_acl = self.ec2_backend.create_network_acl(vpc_id)
         template = self.response_template(CREATE_NETWORK_ACL_RESPONSE)
         return template.render(network_acl=network_acl)
 
     def create_network_acl_entry(self):
-        network_acl_id = self.querystring.get('NetworkAclId')[0]
-        rule_number = self.querystring.get('RuleNumber')[0]
-        protocol = self.querystring.get('Protocol')[0]
-        rule_action = self.querystring.get('RuleAction')[0]
-        egress = self.querystring.get('Egress')[0]
-        cidr_block = self.querystring.get('CidrBlock')[0]
-        icmp_code = self.querystring.get('Icmp.Code', [None])[0]
-        icmp_type = self.querystring.get('Icmp.Type', [None])[0]
-        port_range_from = self.querystring.get('PortRange.From')[0]
-        port_range_to = self.querystring.get('PortRange.To')[0]
+        network_acl_id = self._get_param('NetworkAclId')
+        rule_number = self._get_param('RuleNumber')
+        protocol = self._get_param('Protocol')
+        rule_action = self._get_param('RuleAction')
+        egress = self._get_param('Egress')
+        cidr_block = self._get_param('CidrBlock')
+        icmp_code = self._get_param('Icmp.Code')
+        icmp_type = self._get_param('Icmp.Type')
+        port_range_from = self._get_param('PortRange.From')
+        port_range_to = self._get_param('PortRange.To')
 
         network_acl_entry = self.ec2_backend.create_network_acl_entry(
             network_acl_id, rule_number, protocol, rule_action,
@@ -32,30 +32,30 @@ class NetworkACLs(BaseResponse):
         return template.render(network_acl_entry=network_acl_entry)
 
     def delete_network_acl(self):
-        network_acl_id = self.querystring.get('NetworkAclId')[0]
+        network_acl_id = self._get_param('NetworkAclId')
         self.ec2_backend.delete_network_acl(network_acl_id)
         template = self.response_template(DELETE_NETWORK_ACL_ASSOCIATION)
         return template.render()
 
     def delete_network_acl_entry(self):
-        network_acl_id = self.querystring.get('NetworkAclId')[0]
-        rule_number = self.querystring.get('RuleNumber')[0]
-        egress = self.querystring.get('Egress')[0]
+        network_acl_id = self._get_param('NetworkAclId')
+        rule_number = self._get_param('RuleNumber')
+        egress = self._get_param('Egress')
         self.ec2_backend.delete_network_acl_entry(network_acl_id, rule_number, egress)
         template = self.response_template(DELETE_NETWORK_ACL_ENTRY_RESPONSE)
         return template.render()
 
     def replace_network_acl_entry(self):
-        network_acl_id = self.querystring.get('NetworkAclId')[0]
-        rule_number = self.querystring.get('RuleNumber')[0]
-        protocol = self.querystring.get('Protocol')[0]
-        rule_action = self.querystring.get('RuleAction')[0]
-        egress = self.querystring.get('Egress')[0]
-        cidr_block = self.querystring.get('CidrBlock')[0]
-        icmp_code = self.querystring.get('Icmp.Code', [None])[0]
-        icmp_type = self.querystring.get('Icmp.Type', [None])[0]
-        port_range_from = self.querystring.get('PortRange.From')[0]
-        port_range_to = self.querystring.get('PortRange.To')[0]
+        network_acl_id = self._get_param('NetworkAclId')
+        rule_number = self._get_param('RuleNumber')
+        protocol = self._get_param('Protocol')
+        rule_action = self._get_param('RuleAction')
+        egress = self._get_param('Egress')
+        cidr_block = self._get_param('CidrBlock')
+        icmp_code = self._get_param('Icmp.Code')
+        icmp_type = self._get_param('Icmp.Type')
+        port_range_from = self._get_param('PortRange.From')
+        port_range_to = self._get_param('PortRange.To')
 
         self.ec2_backend.replace_network_acl_entry(
             network_acl_id, rule_number, protocol, rule_action,
@@ -74,8 +74,8 @@ class NetworkACLs(BaseResponse):
         return template.render(network_acls=network_acls)
 
     def replace_network_acl_association(self):
-        association_id = self.querystring.get('AssociationId')[0]
-        network_acl_id = self.querystring.get('NetworkAclId')[0]
+        association_id = self._get_param('AssociationId')
+        network_acl_id = self._get_param('NetworkAclId')
 
         association = self.ec2_backend.replace_network_acl_association(
             association_id,

--- a/moto/ec2/responses/network_acls.py
+++ b/moto/ec2/responses/network_acls.py
@@ -1,7 +1,6 @@
 from __future__ import unicode_literals
 from moto.core.responses import BaseResponse
-from moto.ec2.utils import filters_from_querystring, \
-    network_acl_ids_from_querystring
+from moto.ec2.utils import filters_from_querystring
 
 
 class NetworkACLs(BaseResponse):
@@ -67,7 +66,7 @@ class NetworkACLs(BaseResponse):
         return template.render()
 
     def describe_network_acls(self):
-        network_acl_ids = network_acl_ids_from_querystring(self.querystring)
+        network_acl_ids = self._get_multi_param('NetworkAclId')
         filters = filters_from_querystring(self.querystring)
         network_acls = self.ec2_backend.get_all_network_acls(
             network_acl_ids, filters)

--- a/moto/ec2/responses/route_tables.py
+++ b/moto/ec2/responses/route_tables.py
@@ -1,29 +1,25 @@
 from __future__ import unicode_literals
 from moto.core.responses import BaseResponse
-from moto.ec2.utils import filters_from_querystring, optional_from_querystring
+from moto.ec2.utils import filters_from_querystring
 
 
 class RouteTables(BaseResponse):
 
     def associate_route_table(self):
-        route_table_id = self.querystring.get('RouteTableId')[0]
-        subnet_id = self.querystring.get('SubnetId')[0]
+        route_table_id = self._get_param('RouteTableId')
+        subnet_id = self._get_param('SubnetId')
         association_id = self.ec2_backend.associate_route_table(
             route_table_id, subnet_id)
         template = self.response_template(ASSOCIATE_ROUTE_TABLE_RESPONSE)
         return template.render(association_id=association_id)
 
     def create_route(self):
-        route_table_id = self.querystring.get('RouteTableId')[0]
-        destination_cidr_block = self.querystring.get(
-            'DestinationCidrBlock')[0]
-
-        gateway_id = optional_from_querystring('GatewayId', self.querystring)
-        instance_id = optional_from_querystring('InstanceId', self.querystring)
-        interface_id = optional_from_querystring(
-            'NetworkInterfaceId', self.querystring)
-        pcx_id = optional_from_querystring(
-            'VpcPeeringConnectionId', self.querystring)
+        route_table_id = self._get_param('RouteTableId')
+        destination_cidr_block = self._get_param('DestinationCidrBlock')
+        gateway_id = self._get_param('GatewayId')
+        instance_id = self._get_param('InstanceId')
+        interface_id = self._get_param('NetworkInterfaceId')
+        pcx_id = self._get_param('VpcPeeringConnectionId')
 
         self.ec2_backend.create_route(route_table_id, destination_cidr_block,
                                       gateway_id=gateway_id,
@@ -35,21 +31,20 @@ class RouteTables(BaseResponse):
         return template.render()
 
     def create_route_table(self):
-        vpc_id = self.querystring.get('VpcId')[0]
+        vpc_id = self._get_param('VpcId')
         route_table = self.ec2_backend.create_route_table(vpc_id)
         template = self.response_template(CREATE_ROUTE_TABLE_RESPONSE)
         return template.render(route_table=route_table)
 
     def delete_route(self):
-        route_table_id = self.querystring.get('RouteTableId')[0]
-        destination_cidr_block = self.querystring.get(
-            'DestinationCidrBlock')[0]
+        route_table_id = self._get_param('RouteTableId')
+        destination_cidr_block = self._get_param('DestinationCidrBlock')
         self.ec2_backend.delete_route(route_table_id, destination_cidr_block)
         template = self.response_template(DELETE_ROUTE_RESPONSE)
         return template.render()
 
     def delete_route_table(self):
-        route_table_id = self.querystring.get('RouteTableId')[0]
+        route_table_id = self._get_param('RouteTableId')
         self.ec2_backend.delete_route_table(route_table_id)
         template = self.response_template(DELETE_ROUTE_TABLE_RESPONSE)
         return template.render()
@@ -63,22 +58,18 @@ class RouteTables(BaseResponse):
         return template.render(route_tables=route_tables)
 
     def disassociate_route_table(self):
-        association_id = self.querystring.get('AssociationId')[0]
+        association_id = self._get_param('AssociationId')
         self.ec2_backend.disassociate_route_table(association_id)
         template = self.response_template(DISASSOCIATE_ROUTE_TABLE_RESPONSE)
         return template.render()
 
     def replace_route(self):
-        route_table_id = self.querystring.get('RouteTableId')[0]
-        destination_cidr_block = self.querystring.get(
-            'DestinationCidrBlock')[0]
-
-        gateway_id = optional_from_querystring('GatewayId', self.querystring)
-        instance_id = optional_from_querystring('InstanceId', self.querystring)
-        interface_id = optional_from_querystring(
-            'NetworkInterfaceId', self.querystring)
-        pcx_id = optional_from_querystring(
-            'VpcPeeringConnectionId', self.querystring)
+        route_table_id = self._get_param('RouteTableId')
+        destination_cidr_block = self._get_param('DestinationCidrBlock')
+        gateway_id = self._get_param('GatewayId')
+        instance_id = self._get_param('InstanceId')
+        interface_id = self._get_param('NetworkInterfaceId')
+        pcx_id = self._get_param('VpcPeeringConnectionId')
 
         self.ec2_backend.replace_route(route_table_id, destination_cidr_block,
                                        gateway_id=gateway_id,
@@ -90,8 +81,8 @@ class RouteTables(BaseResponse):
         return template.render()
 
     def replace_route_table_association(self):
-        route_table_id = self.querystring.get('RouteTableId')[0]
-        association_id = self.querystring.get('AssociationId')[0]
+        route_table_id = self._get_param('RouteTableId')
+        association_id = self._get_param('AssociationId')
         new_association_id = self.ec2_backend.replace_route_table_association(
             association_id, route_table_id)
         template = self.response_template(

--- a/moto/ec2/responses/route_tables.py
+++ b/moto/ec2/responses/route_tables.py
@@ -1,6 +1,6 @@
 from __future__ import unicode_literals
 from moto.core.responses import BaseResponse
-from moto.ec2.utils import route_table_ids_from_querystring, filters_from_querystring, optional_from_querystring
+from moto.ec2.utils import filters_from_querystring, optional_from_querystring
 
 
 class RouteTables(BaseResponse):
@@ -55,7 +55,7 @@ class RouteTables(BaseResponse):
         return template.render()
 
     def describe_route_tables(self):
-        route_table_ids = route_table_ids_from_querystring(self.querystring)
+        route_table_ids = self._get_multi_param('RouteTableId')
         filters = filters_from_querystring(self.querystring)
         route_tables = self.ec2_backend.get_all_route_tables(
             route_table_ids, filters)

--- a/moto/ec2/responses/security_groups.py
+++ b/moto/ec2/responses/security_groups.py
@@ -11,69 +11,66 @@ def try_parse_int(value, default=None):
         return default
 
 
-def process_rules_from_querystring(querystring):
-    try:
-        group_name_or_id = querystring.get('GroupName')[0]
-    except:
-        group_name_or_id = querystring.get('GroupId')[0]
-
-    querytree = {}
-    for key, value in querystring.items():
-        key_splitted = key.split('.')
-        key_splitted = [try_parse_int(e, e) for e in key_splitted]
-
-        d = querytree
-        for subkey in key_splitted[:-1]:
-            if subkey not in d:
-                d[subkey] = {}
-            d = d[subkey]
-        d[key_splitted[-1]] = value
-
-    ip_permissions = querytree.get('IpPermissions') or {}
-    for ip_permission_idx in sorted(ip_permissions.keys()):
-        ip_permission = ip_permissions[ip_permission_idx]
-
-        ip_protocol = ip_permission.get('IpProtocol', [None])[0]
-        from_port = ip_permission.get('FromPort', [None])[0]
-        to_port = ip_permission.get('ToPort', [None])[0]
-
-        ip_ranges = []
-        ip_ranges_tree = ip_permission.get('IpRanges') or {}
-        for ip_range_idx in sorted(ip_ranges_tree.keys()):
-            ip_ranges.append(ip_ranges_tree[ip_range_idx]['CidrIp'][0])
-
-        source_groups = []
-        source_group_ids = []
-        groups_tree = ip_permission.get('Groups') or {}
-        for group_idx in sorted(groups_tree.keys()):
-            group_dict = groups_tree[group_idx]
-            if 'GroupId' in group_dict:
-                source_group_ids.append(group_dict['GroupId'][0])
-            elif 'GroupName' in group_dict:
-                source_groups.append(group_dict['GroupName'][0])
-
-        yield (group_name_or_id, ip_protocol, from_port, to_port, ip_ranges,
-               source_groups, source_group_ids)
-
-
 class SecurityGroups(BaseResponse):
+
+    def _process_rules_from_querystring(self):
+        group_name_or_id = (self._get_param('GroupName') or
+                            self._get_param('GroupId'))
+
+        querytree = {}
+        for key, value in self.querystring.items():
+            key_splitted = key.split('.')
+            key_splitted = [try_parse_int(e, e) for e in key_splitted]
+
+            d = querytree
+            for subkey in key_splitted[:-1]:
+                if subkey not in d:
+                    d[subkey] = {}
+                d = d[subkey]
+            d[key_splitted[-1]] = value
+
+        ip_permissions = querytree.get('IpPermissions') or {}
+        for ip_permission_idx in sorted(ip_permissions.keys()):
+            ip_permission = ip_permissions[ip_permission_idx]
+
+            ip_protocol = ip_permission.get('IpProtocol', [None])[0]
+            from_port = ip_permission.get('FromPort', [None])[0]
+            to_port = ip_permission.get('ToPort', [None])[0]
+
+            ip_ranges = []
+            ip_ranges_tree = ip_permission.get('IpRanges') or {}
+            for ip_range_idx in sorted(ip_ranges_tree.keys()):
+                ip_ranges.append(ip_ranges_tree[ip_range_idx]['CidrIp'][0])
+
+            source_groups = []
+            source_group_ids = []
+            groups_tree = ip_permission.get('Groups') or {}
+            for group_idx in sorted(groups_tree.keys()):
+                group_dict = groups_tree[group_idx]
+                if 'GroupId' in group_dict:
+                    source_group_ids.append(group_dict['GroupId'][0])
+                elif 'GroupName' in group_dict:
+                    source_groups.append(group_dict['GroupName'][0])
+
+            yield (group_name_or_id, ip_protocol, from_port, to_port, ip_ranges,
+                   source_groups, source_group_ids)
 
     def authorize_security_group_egress(self):
         if self.is_not_dryrun('GrantSecurityGroupEgress'):
-            for args in process_rules_from_querystring(self.querystring):
+            for args in self._process_rules_from_querystring():
                 self.ec2_backend.authorize_security_group_egress(*args)
             return AUTHORIZE_SECURITY_GROUP_EGRESS_RESPONSE
 
     def authorize_security_group_ingress(self):
         if self.is_not_dryrun('GrantSecurityGroupIngress'):
-            for args in process_rules_from_querystring(self.querystring):
+            for args in self._process_rules_from_querystring():
                 self.ec2_backend.authorize_security_group_ingress(*args)
             return AUTHORIZE_SECURITY_GROUP_INGRESS_REPONSE
 
     def create_security_group(self):
-        name = self.querystring.get('GroupName')[0]
-        description = self.querystring.get('GroupDescription', [None])[0]
-        vpc_id = self.querystring.get("VpcId", [None])[0]
+        name = self._get_param('GroupName')
+        description = self._get_param('GroupDescription')
+        vpc_id = self._get_param('VpcId')
 
         if self.is_not_dryrun('CreateSecurityGroup'):
             group = self.ec2_backend.create_security_group(
@@ -86,14 +83,14 @@ class SecurityGroups(BaseResponse):
         # See
         # http://docs.aws.amazon.com/AWSEC2/latest/APIReference/ApiReference-query-DeleteSecurityGroup.html
 
-        name = self.querystring.get('GroupName')
-        sg_id = self.querystring.get('GroupId')
+        name = self._get_param('GroupName')
+        sg_id = self._get_param('GroupId')
 
         if self.is_not_dryrun('DeleteSecurityGroup'):
             if name:
-                self.ec2_backend.delete_security_group(name[0])
+                self.ec2_backend.delete_security_group(name)
             elif sg_id:
-                self.ec2_backend.delete_security_group(group_id=sg_id[0])
+                self.ec2_backend.delete_security_group(group_id=sg_id)
 
             return DELETE_GROUP_RESPONSE
 
@@ -113,7 +110,7 @@ class SecurityGroups(BaseResponse):
 
     def revoke_security_group_egress(self):
         if self.is_not_dryrun('RevokeSecurityGroupEgress'):
-            for args in process_rules_from_querystring(self.querystring):
+            for args in self._process_rules_from_querystring():
                 success = self.ec2_backend.revoke_security_group_egress(*args)
                 if not success:
                     return "Could not find a matching egress rule", dict(status=404)
@@ -121,7 +118,7 @@ class SecurityGroups(BaseResponse):
 
     def revoke_security_group_ingress(self):
         if self.is_not_dryrun('RevokeSecurityGroupIngress'):
-            for args in process_rules_from_querystring(self.querystring):
+            for args in self._process_rules_from_querystring():
                 self.ec2_backend.revoke_security_group_ingress(*args)
             return REVOKE_SECURITY_GROUP_INGRESS_REPONSE
 

--- a/moto/ec2/responses/tags.py
+++ b/moto/ec2/responses/tags.py
@@ -2,14 +2,13 @@ from __future__ import unicode_literals
 
 from moto.core.responses import BaseResponse
 from moto.ec2.models import validate_resource_ids
-from moto.ec2.utils import sequence_from_querystring, tags_from_query_string, filters_from_querystring
+from moto.ec2.utils import tags_from_query_string, filters_from_querystring
 
 
 class TagResponse(BaseResponse):
 
     def create_tags(self):
-        resource_ids = sequence_from_querystring(
-            'ResourceId', self.querystring)
+        resource_ids = self._get_multi_param('ResourceId')
         validate_resource_ids(resource_ids)
         self.ec2_backend.do_resources_exist(resource_ids)
         tags = tags_from_query_string(self.querystring)
@@ -18,8 +17,7 @@ class TagResponse(BaseResponse):
             return CREATE_RESPONSE
 
     def delete_tags(self):
-        resource_ids = sequence_from_querystring(
-            'ResourceId', self.querystring)
+        resource_ids = self._get_multi_param('ResourceId')
         validate_resource_ids(resource_ids)
         tags = tags_from_query_string(self.querystring)
         if self.is_not_dryrun('DeleteTags'):

--- a/moto/ec2/responses/virtual_private_gateways.py
+++ b/moto/ec2/responses/virtual_private_gateways.py
@@ -6,8 +6,8 @@ from moto.ec2.utils import filters_from_querystring
 class VirtualPrivateGateways(BaseResponse):
 
     def attach_vpn_gateway(self):
-        vpn_gateway_id = self.querystring.get('VpnGatewayId')[0]
-        vpc_id = self.querystring.get('VpcId')[0]
+        vpn_gateway_id = self._get_param('VpnGatewayId')
+        vpc_id = self._get_param('VpcId')
         attachment = self.ec2_backend.attach_vpn_gateway(
             vpn_gateway_id,
             vpc_id
@@ -16,13 +16,13 @@ class VirtualPrivateGateways(BaseResponse):
         return template.render(attachment=attachment)
 
     def create_vpn_gateway(self):
-        type = self.querystring.get('Type', None)[0]
+        type = self._get_param('Type')
         vpn_gateway = self.ec2_backend.create_vpn_gateway(type)
         template = self.response_template(CREATE_VPN_GATEWAY_RESPONSE)
         return template.render(vpn_gateway=vpn_gateway)
 
     def delete_vpn_gateway(self):
-        vpn_gateway_id = self.querystring.get('VpnGatewayId')[0]
+        vpn_gateway_id = self._get_param('VpnGatewayId')
         vpn_gateway = self.ec2_backend.delete_vpn_gateway(vpn_gateway_id)
         template = self.response_template(DELETE_VPN_GATEWAY_RESPONSE)
         return template.render(vpn_gateway=vpn_gateway)
@@ -34,8 +34,8 @@ class VirtualPrivateGateways(BaseResponse):
         return template.render(vpn_gateways=vpn_gateways)
 
     def detach_vpn_gateway(self):
-        vpn_gateway_id = self.querystring.get('VpnGatewayId')[0]
-        vpc_id = self.querystring.get('VpcId')[0]
+        vpn_gateway_id = self._get_param('VpnGatewayId')
+        vpc_id = self._get_param('VpcId')
         attachment = self.ec2_backend.detach_vpn_gateway(
             vpn_gateway_id,
             vpc_id

--- a/moto/ec2/responses/vpc_peering_connections.py
+++ b/moto/ec2/responses/vpc_peering_connections.py
@@ -5,16 +5,15 @@ from moto.core.responses import BaseResponse
 class VPCPeeringConnections(BaseResponse):
 
     def create_vpc_peering_connection(self):
-        vpc = self.ec2_backend.get_vpc(self.querystring.get('VpcId')[0])
-        peer_vpc = self.ec2_backend.get_vpc(
-            self.querystring.get('PeerVpcId')[0])
+        vpc = self.ec2_backend.get_vpc(self._get_param('VpcId'))
+        peer_vpc = self.ec2_backend.get_vpc(self._get_param('PeerVpcId'))
         vpc_pcx = self.ec2_backend.create_vpc_peering_connection(vpc, peer_vpc)
         template = self.response_template(
             CREATE_VPC_PEERING_CONNECTION_RESPONSE)
         return template.render(vpc_pcx=vpc_pcx)
 
     def delete_vpc_peering_connection(self):
-        vpc_pcx_id = self.querystring.get('VpcPeeringConnectionId')[0]
+        vpc_pcx_id = self._get_param('VpcPeeringConnectionId')
         vpc_pcx = self.ec2_backend.delete_vpc_peering_connection(vpc_pcx_id)
         template = self.response_template(
             DELETE_VPC_PEERING_CONNECTION_RESPONSE)
@@ -27,14 +26,14 @@ class VPCPeeringConnections(BaseResponse):
         return template.render(vpc_pcxs=vpc_pcxs)
 
     def accept_vpc_peering_connection(self):
-        vpc_pcx_id = self.querystring.get('VpcPeeringConnectionId')[0]
+        vpc_pcx_id = self._get_param('VpcPeeringConnectionId')
         vpc_pcx = self.ec2_backend.accept_vpc_peering_connection(vpc_pcx_id)
         template = self.response_template(
             ACCEPT_VPC_PEERING_CONNECTION_RESPONSE)
         return template.render(vpc_pcx=vpc_pcx)
 
     def reject_vpc_peering_connection(self):
-        vpc_pcx_id = self.querystring.get('VpcPeeringConnectionId')[0]
+        vpc_pcx_id = self._get_param('VpcPeeringConnectionId')
         self.ec2_backend.reject_vpc_peering_connection(vpc_pcx_id)
         template = self.response_template(
             REJECT_VPC_PEERING_CONNECTION_RESPONSE)

--- a/moto/ec2/responses/vpcs.py
+++ b/moto/ec2/responses/vpcs.py
@@ -1,7 +1,7 @@
 from __future__ import unicode_literals
 from moto.core.responses import BaseResponse
 from moto.core.utils import camelcase_to_underscores
-from moto.ec2.utils import filters_from_querystring, vpc_ids_from_querystring
+from moto.ec2.utils import filters_from_querystring
 
 
 class VPCs(BaseResponse):
@@ -21,7 +21,7 @@ class VPCs(BaseResponse):
         return template.render(vpc=vpc)
 
     def describe_vpcs(self):
-        vpc_ids = vpc_ids_from_querystring(self.querystring)
+        vpc_ids = self._get_multi_param('VpcId')
         filters = filters_from_querystring(self.querystring)
         vpcs = self.ec2_backend.get_all_vpcs(vpc_ids=vpc_ids, filters=filters)
         template = self.response_template(DESCRIBE_VPCS_RESPONSE)

--- a/moto/ec2/responses/vpcs.py
+++ b/moto/ec2/responses/vpcs.py
@@ -7,15 +7,14 @@ from moto.ec2.utils import filters_from_querystring
 class VPCs(BaseResponse):
 
     def create_vpc(self):
-        cidr_block = self.querystring.get('CidrBlock')[0]
-        instance_tenancy = self.querystring.get(
-            'InstanceTenancy', ['default'])[0]
+        cidr_block = self._get_param('CidrBlock')
+        instance_tenancy = self._get_param('InstanceTenancy', if_none='default')
         vpc = self.ec2_backend.create_vpc(cidr_block, instance_tenancy)
         template = self.response_template(CREATE_VPC_RESPONSE)
         return template.render(vpc=vpc)
 
     def delete_vpc(self):
-        vpc_id = self.querystring.get('VpcId')[0]
+        vpc_id = self._get_param('VpcId')
         vpc = self.ec2_backend.delete_vpc(vpc_id)
         template = self.response_template(DELETE_VPC_RESPONSE)
         return template.render(vpc=vpc)
@@ -28,15 +27,15 @@ class VPCs(BaseResponse):
         return template.render(vpcs=vpcs)
 
     def describe_vpc_attribute(self):
-        vpc_id = self.querystring.get('VpcId')[0]
-        attribute = self.querystring.get('Attribute')[0]
+        vpc_id = self._get_param('VpcId')
+        attribute = self._get_param('Attribute')
         attr_name = camelcase_to_underscores(attribute)
         value = self.ec2_backend.describe_vpc_attribute(vpc_id, attr_name)
         template = self.response_template(DESCRIBE_VPC_ATTRIBUTE_RESPONSE)
         return template.render(vpc_id=vpc_id, attribute=attribute, value=value)
 
     def modify_vpc_attribute(self):
-        vpc_id = self.querystring.get('VpcId')[0]
+        vpc_id = self._get_param('VpcId')
 
         for attribute in ('EnableDnsSupport', 'EnableDnsHostnames'):
             if self.querystring.get('%s.Value' % attribute):

--- a/moto/ec2/responses/vpn_connections.py
+++ b/moto/ec2/responses/vpn_connections.py
@@ -6,17 +6,17 @@ from moto.ec2.utils import filters_from_querystring
 class VPNConnections(BaseResponse):
 
     def create_vpn_connection(self):
-        type = self.querystring.get("Type", [None])[0]
-        cgw_id = self.querystring.get("CustomerGatewayId", [None])[0]
-        vgw_id = self.querystring.get("VPNGatewayId", [None])[0]
-        static_routes = self.querystring.get("StaticRoutesOnly", [None])[0]
+        type = self._get_param('Type')
+        cgw_id = self._get_param('CustomerGatewayId')
+        vgw_id = self._get_param('VPNGatewayId')
+        static_routes = self._get_param('StaticRoutesOnly')
         vpn_connection = self.ec2_backend.create_vpn_connection(
             type, cgw_id, vgw_id, static_routes_only=static_routes)
         template = self.response_template(CREATE_VPN_CONNECTION_RESPONSE)
         return template.render(vpn_connection=vpn_connection)
 
     def delete_vpn_connection(self):
-        vpn_connection_id = self.querystring.get('VpnConnectionId')[0]
+        vpn_connection_id = self._get_param('VpnConnectionId')
         vpn_connection = self.ec2_backend.delete_vpn_connection(
             vpn_connection_id)
         template = self.response_template(DELETE_VPN_CONNECTION_RESPONSE)

--- a/moto/ec2/responses/vpn_connections.py
+++ b/moto/ec2/responses/vpn_connections.py
@@ -1,6 +1,6 @@
 from __future__ import unicode_literals
 from moto.core.responses import BaseResponse
-from moto.ec2.utils import filters_from_querystring, sequence_from_querystring
+from moto.ec2.utils import filters_from_querystring
 
 
 class VPNConnections(BaseResponse):
@@ -23,8 +23,7 @@ class VPNConnections(BaseResponse):
         return template.render(vpn_connection=vpn_connection)
 
     def describe_vpn_connections(self):
-        vpn_connection_ids = sequence_from_querystring(
-            'VpnConnectionId', self.querystring)
+        vpn_connection_ids = self._get_multi_param('VpnConnectionId')
         filters = filters_from_querystring(self.querystring)
         vpn_connections = self.ec2_backend.get_all_vpn_connections(
             vpn_connection_ids=vpn_connection_ids, filters=filters)

--- a/moto/ec2/utils.py
+++ b/moto/ec2/utils.py
@@ -174,62 +174,6 @@ def split_route_id(route_id):
     return values[0], values[1]
 
 
-def instance_ids_from_querystring(querystring_dict):
-    instance_ids = []
-    for key, value in querystring_dict.items():
-        if 'InstanceId' in key:
-            instance_ids.append(value[0])
-    return instance_ids
-
-
-def image_ids_from_querystring(querystring_dict):
-    image_ids = []
-    for key, value in querystring_dict.items():
-        if 'ImageId' in key:
-            image_ids.append(value[0])
-    return image_ids
-
-
-def executable_users_from_querystring(querystring_dict):
-    user_ids = []
-    for key, value in querystring_dict.items():
-        if 'ExecutableBy' in key:
-            user_ids.append(value[0])
-    return user_ids
-
-
-def route_table_ids_from_querystring(querystring_dict):
-    route_table_ids = []
-    for key, value in querystring_dict.items():
-        if 'RouteTableId' in key:
-            route_table_ids.append(value[0])
-    return route_table_ids
-
-
-def network_acl_ids_from_querystring(querystring_dict):
-    network_acl_ids = []
-    for key, value in querystring_dict.items():
-        if 'NetworkAclId' in key:
-            network_acl_ids.append(value[0])
-    return network_acl_ids
-
-
-def vpc_ids_from_querystring(querystring_dict):
-    vpc_ids = []
-    for key, value in querystring_dict.items():
-        if 'VpcId' in key:
-            vpc_ids.append(value[0])
-    return vpc_ids
-
-
-def sequence_from_querystring(parameter, querystring_dict):
-    parameter_values = []
-    for key, value in querystring_dict.items():
-        if parameter in key:
-            parameter_values.append(value[0])
-    return parameter_values
-
-
 def tags_from_query_string(querystring_dict):
     prefix = 'Tag'
     suffix = 'Key'
@@ -317,14 +261,6 @@ def dict_from_querystring(parameter, querystring_dict):
             use_dict[use_dict_index][use_dict_element_property] = value[0]
 
     return use_dict
-
-
-def keypair_names_from_querystring(querystring_dict):
-    keypair_names = []
-    for key, value in querystring_dict.items():
-        if 'KeyName' in key:
-            keypair_names.append(value[0])
-    return keypair_names
 
 
 def get_object_value(obj, attr):

--- a/moto/ec2/utils.py
+++ b/moto/ec2/utils.py
@@ -230,11 +230,6 @@ def dhcp_configuration_from_querystring(querystring, option=u'DhcpConfiguration'
     return response_values
 
 
-def optional_from_querystring(parameter, querystring):
-    parameter_array = querystring.get(parameter)
-    return parameter_array[0] if parameter_array else None
-
-
 def filters_from_querystring(querystring_dict):
     response_values = {}
     for key, value in querystring_dict.items():


### PR DESCRIPTION
This PR cleans up duplication of logic between base response and ec2 util classes.
It replaces functions such as sequence_from_querystring with the inherited _get_multi_param.
It also replaces direct querystring index based access with _get_param where possible.