### PR TITLE
Shrink Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,15 @@
-FROM python:2
+FROM alpine:3.6
 
 ADD . /moto/
 ENV PYTHONUNBUFFERED 1
 
 WORKDIR /moto/
-RUN pip install ".[server]"
+RUN  apk add --no-cache python3 && \
+     python3 -m ensurepip && \
+     rm -r /usr/lib/python*/ensurepip && \
+     pip3 --no-cache-dir install --upgrade pip setuptools && \
+     pip3 --no-cache-dir install ".[server]"
 
-CMD ["moto_server"]
+ENTRYPOINT ["/usr/bin/moto_server"]
 
 EXPOSE 5000

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,6 @@ RUN  apk add --no-cache python3 && \
      pip3 --no-cache-dir install --upgrade pip setuptools && \
      pip3 --no-cache-dir install ".[server]"
 
-ENTRYPOINT ["/usr/bin/moto_server"]
+ENTRYPOINT ["/usr/bin/moto_server", "-H", "0.0.0.0"]
 
 EXPOSE 5000


### PR DESCRIPTION
Have switched the Dockerfile from using Debian to Alpine which is far smaller. Also switched to Python3 but seeing as we run tests against both I see no issue with that.

After switching to Alpine the image size has gone down from 298MB to 34MB. 
My test repo on DockerHub - https://hub.docker.com/r/terrycain/moto/

It would be nice for someone with write access or possibly it might need to be the owner to setup the project with DockerHub, its pretty easy, you link it with GitHub, then pushes to master will add to the "latest" image, and you can configure it to make tagged released based on tags. Perhaps setting up an organisation on DockerHub might be better, haven't done that so unsure if it'll be of any use.