### PR TITLE
[WIP] Initialize script for service/operation like scaffold in Ruby on Rails

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,3 +9,5 @@ flask
 boto3>=1.4.4
 botocore>=1.5.77
 six>=1.9
+prompt-toolkit==1.0.14
+click==6.7

--- a/scaffold.py
+++ b/scaffold.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python
+import os
+
+import click
+from prompt_toolkit import (
+    prompt
+)
+from prompt_toolkit.contrib.completers import WordCompleter
+from prompt_toolkit.shortcuts import print_tokens
+
+from botocore import xform_name
+from botocore.session import Session
+import boto3
+
+from implementation_coverage import (
+    get_moto_implementation
+)
+
+
+def select_service_and_operation():
+    service_names = Session().get_available_services()
+    service_completer = WordCompleter(service_names)
+    service_name = prompt('Select service: ', completer=service_completer)
+    if service_name not in service_names:
+        click.secho('{} is not valid service'.format(service_name), fg='red')
+        raise click.Abort()
+    moto_client = get_moto_implementation(service_name)
+    real_client = boto3.client(service_name, region_name='us-east-1')
+    implemented = []
+    not_implemented = []
+
+    operation_names = [xform_name(op) for op in real_client.meta.service_model.operation_names]
+    for op in operation_names:
+        if moto_client and op in dir(moto_client):
+            implemented.append(op)
+        else:
+            not_implemented.append(op)
+    operation_completer = WordCompleter(operation_names)
+
+    click.echo('==Current Implementation Status==')
+    for operation_name in operation_names:
+        check = 'X' if operation_name in implemented else ' '
+        click.secho('[{}] {}'.format(check, operation_name))
+    click.echo('=================================')
+    operation_name = prompt('Select Operation: ', completer=operation_completer)
+
+    if operation_name not in operation_names:
+        click.secho('{} is not valid operation'.format(operation_name), fg='red')
+        raise click.Abort()
+
+    if operation_name in implemented:
+        click.secho('{} is already implemented'.format(operation_name), fg='red')
+        raise click.Abort()
+    return service_name, operation_name
+
+
+def create_dirs(service, operation):
+    """create lib and test dirs if not exist
+    """
+    lib_dir = os.path.join('moto', service)
+    test_dir = os.path.join('test', 'test_{}'.format(service))
+    if os.path.exists(lib_dir):
+        return
+
+    click.secho('\tInitializing service\t', fg='green', nl=False)
+    click.secho(service)
+
+    click.secho('\tcraeting\t', fg='green', nl=False)
+    click.echo(lib_dir)
+    os.mkdirs(lib_dir)
+    # do init lib dir
+
+    if not os.path.exists(test_dir):
+        click.secho('\tcraeting\t', fg='green', nl=False)
+        click.echo(test_dir)
+        os.mkdirs(test_dir)
+        # do init test dir
+
+
+@click.command()
+def main():
+    service, operation = select_service_and_operation()
+    create_dirs(service, operation)
+
+if __name__ == '__main__':
+    main()

--- a/template/lib/__init__.py.j2
+++ b/template/lib/__init__.py.j2
@@ -1,0 +1,7 @@
+from __future__ import unicode_literals
+from .models import {{ service }}_backends
+from ..core.models import base_decorator
+
+{{ service }}_backend = {{ service }}_backends['us-east-1']
+mock_{{ service }} = base_decorator({{ service }}_backends)
+

--- a/template/lib/exceptions.py.j2
+++ b/template/lib/exceptions.py.j2
@@ -1,0 +1,4 @@
+from __future__ import unicode_literals
+from moto.core.exceptions import RESTError
+
+

--- a/template/lib/models.py.j2
+++ b/template/lib/models.py.j2
@@ -1,0 +1,20 @@
+from __future__ import unicode_literals
+import boto3
+from moto.core import BaseBackend, BaseModel
+
+
+class {{ service_class }}Backend(BaseBackend):
+    def __init__(self, region_name=None):
+        super({{ service_class }}Backend, self).__init__()
+        self.region_name = region_name
+
+    def reset(self):
+        region_name = self.region_name
+        self.__dict__ = {}
+        self.__init__(region_name)
+
+    # add methods from here
+
+
+available_regions = boto3.session.Session().get_available_regions("{{ service }}")
+{{ service }}_backends = {region: {{ service_class }}Backend for region in available_regions}

--- a/template/lib/responses.py.j2
+++ b/template/lib/responses.py.j2
@@ -1,0 +1,15 @@
+from __future__ import unicode_literals
+from moto.core.responses import BaseResponse
+from .models import {{ service }}_backends
+
+
+class {{ service_class }}Response(BaseResponse):
+    @property
+    def {{ service }}_backend(self):
+        return {{ service }}_backends[self.region]
+
+    # add methods from here
+
+
+# add teampltes from here
+

--- a/template/test/test_server.py.j2
+++ b/template/test/test_server.py.j2
@@ -1,0 +1,16 @@
+from __future__ import unicode_literals
+
+import sure  # noqa
+
+import moto.server as server
+from moto import mock_{{ service }}
+
+'''
+Test the different server responses
+'''
+
+@mock_{{ service }}
+def test_{{ service }}_list():
+    backend = server.create_backend_app("{{ service }}")
+    test_client = backend.test_client()
+    # do test

--- a/template/test/test_service.py.j2
+++ b/template/test/test_service.py.j2
@@ -1,0 +1,11 @@
+from __future__ import unicode_literals
+
+import boto3
+import sure  # noqa
+from moto import mock_{{ service }}
+
+
+@mock_{{ service }}
+def test_list():
+    # do test
+    pass


### PR DESCRIPTION
Making a script like RoR's scaffold.

Implementing new operation of boto3 to moto3 is done by:
- adding function, which name s same as boto3's,  to `models.py` and `responses.py`
- adding response template
- adding test of service
- etc...

We can make it more effective by making a script like RoR's scaffold. It'll generates appropriate functions and templates in library and test directories, and at README if possible.