### PR TITLE
fix scan return CapacityUnits

### DIFF
--- a/moto/dynamodb2/responses.py
+++ b/moto/dynamodb2/responses.py
@@ -427,7 +427,10 @@ class DynamoHandler(BaseResponse):
         result = {
             "Count": len(items),
             "Items": [item.attrs for item in items],
-            "ConsumedCapacityUnits": 1,
+            'ConsumedCapacity': {
+                'TableName': name,
+                'CapacityUnits': 1,
+            },
             "ScannedCount": scanned_count
         }
         if last_evaluated_key is not None:


### PR DESCRIPTION
I noticed that the dynamodb2 scan operation was not returning the consumed capacity object because it was incorrectly named. This fixes that.