### PR TITLE
ssm get_parameter to honot WithDecryption

### DIFF
--- a/moto/ssm/responses.py
+++ b/moto/ssm/responses.py
@@ -56,13 +56,8 @@ class SimpleSystemManagerResponse(BaseResponse):
             return json.dumps(error), dict(status=400)
 
         response = {
-            'Parameter': {
-                'Name': name,
-                'Type': result.type,
-                'Value': result.value
-            }
+            'Parameter': result.response_object(with_decryption)
         }
-
         return json.dumps(response)
 
     def get_parameters(self):


### PR DESCRIPTION
This PR fixes a bug in release 1.1.13, namely that `ssm.get_parameter()` does not honor its WithDecryption parameter.

(Note that `tox` is reporting some errors elsewhere in the codebase--not in the change I just made--which seem to be environment related. I'm sorry that I haven't been able to get a clean tox build before submitting. Will continue to investigate that separately.)
