### PR TITLE
Return consumed capacity correctly for dynamodb2.get_item, put_item, update_item

### DIFF
--- a/moto/dynamodb2/responses.py
+++ b/moto/dynamodb2/responses.py
@@ -194,7 +194,10 @@ class DynamoHandler(BaseResponse):
 
         if result:
             item_dict = result.to_json()
-            item_dict['ConsumedCapacityUnits'] = 1
+            item_dict['ConsumedCapacity'] = {
+                'TableName': name,
+                'CapacityUnits': 1
+            }
             return dynamo_json_dump(item_dict)
         else:
             er = 'com.amazonaws.dynamodb.v20111205#ResourceNotFoundException'
@@ -238,7 +241,10 @@ class DynamoHandler(BaseResponse):
             return self.error(er, 'Validation Exception')
         if item:
             item_dict = item.describe_attrs(attributes=None)
-            item_dict['ConsumedCapacityUnits'] = 0.5
+            item_dict['ConsumedCapacity'] = {
+                'TableName': name,
+                'CapacityUnits': 0.5
+            }
             return dynamo_json_dump(item_dict)
         else:
             # Item not found
@@ -523,7 +529,10 @@ class DynamoHandler(BaseResponse):
             return self.error(er, 'Validation Exception')
 
         item_dict = item.to_json()
-        item_dict['ConsumedCapacityUnits'] = 0.5
+        item_dict['ConsumedCapacity'] = {
+            'TableName': name,
+            'CapacityUnits': 0.5
+        }
         if not existing_item:
             item_dict['Attributes'] = {}
 

--- a/tests/test_dynamodb2/test_dynamodb.py
+++ b/tests/test_dynamodb2/test_dynamodb.py
@@ -405,11 +405,11 @@ def test_basic_projection_expressions_with_attr_expression_names():
     results = table.query(
         KeyConditionExpression=Key('forum_name').eq(
             'the-key'),
-        ProjectionExpression='#rl, #rt, subject',
         ExpressionAttributeNames={
             '#rl': 'body',
             '#rt': 'attachment'
             },
+        ProjectionExpression='#rl, #rt, subject'
     )
 
     assert 'body' in results['Items'][0]
@@ -418,3 +418,98 @@ def test_basic_projection_expressions_with_attr_expression_names():
     assert results['Items'][0]['subject'] == '123'
     assert 'attachment' in results['Items'][0]
     assert results['Items'][0]['attachment'] == 'something'
+
+@mock_dynamodb2
+def test_put_item_returns_consumed_capacity():
+    dynamodb = boto3.resource('dynamodb', region_name='us-east-1')
+
+    # Create the DynamoDB table.
+    table = dynamodb.create_table(
+        TableName='users',
+        KeySchema=[
+            {
+                'AttributeName': 'forum_name',
+                'KeyType': 'HASH'
+            },
+            {
+                'AttributeName': 'subject',
+                'KeyType': 'RANGE'
+            },
+        ],
+        AttributeDefinitions=[
+            {
+                'AttributeName': 'forum_name',
+                'AttributeType': 'S'
+            },
+            {
+                'AttributeName': 'subject',
+                'AttributeType': 'S'
+            },
+        ],
+        ProvisionedThroughput={
+            'ReadCapacityUnits': 5,
+            'WriteCapacityUnits': 5
+        }
+    )
+    table = dynamodb.Table('users')
+
+    response = table.put_item(Item={
+        'forum_name': 'the-key',
+        'subject': '123',
+        'body': 'some test message',
+    })
+
+    assert 'ConsumedCapacity' in response
+
+@mock_dynamodb2
+def test_update_item_returns_consumed_capacity():
+    dynamodb = boto3.resource('dynamodb', region_name='us-east-1')
+
+    # Create the DynamoDB table.
+    table = dynamodb.create_table(
+        TableName='users',
+        KeySchema=[
+            {
+                'AttributeName': 'forum_name',
+                'KeyType': 'HASH'
+            },
+            {
+                'AttributeName': 'subject',
+                'KeyType': 'RANGE'
+            },
+        ],
+        AttributeDefinitions=[
+            {
+                'AttributeName': 'forum_name',
+                'AttributeType': 'S'
+            },
+            {
+                'AttributeName': 'subject',
+                'AttributeType': 'S'
+            },
+        ],
+        ProvisionedThroughput={
+            'ReadCapacityUnits': 5,
+            'WriteCapacityUnits': 5
+        }
+    )
+    table = dynamodb.Table('users')
+
+    table.put_item(Item={
+        'forum_name': 'the-key',
+        'subject': '123',
+        'body': 'some test message',
+    })
+
+    response = table.update_item(Key={
+        'forum_name': 'the-key',
+        'subject': '123'
+        },
+        UpdateExpression='set body=:tb',
+        ExpressionAttributeValues={
+            ':tb': 'a new message'
+    })
+
+    assert 'ConsumedCapacity' in response
+    assert 'CapacityUnits' in response['ConsumedCapacity']
+    assert 'TableName' in response['ConsumedCapacity']


### PR DESCRIPTION
Very minor fix to return the consumed capacity in the proper format.