### PR TITLE
Fix parsing non V4 Authorization headers

### DIFF
--- a/moto/core/responses.py
+++ b/moto/core/responses.py
@@ -167,7 +167,7 @@ class BaseResponse(_TemplateEnvironmentMixin):
         match = re.search(self.region_regex, full_url)
         if match:
             region = match.group(1)
-        elif 'Authorization' in request.headers:
+        elif 'Authorization' in request.headers and 'AWS4' in request.headers['Authorization']:
             region = request.headers['Authorization'].split(",")[
                 0].split("/")[2]
         else:


### PR DESCRIPTION
Fixed #1192

Dont have a testcase for this one.
More info in the issue, but the gist of it is, the code relies on that the header is in the V4 format which contains a region, the other format just contains accesskey:secretkey which then results in `IndexError`s. Simple check for if were using V4 headers.