### PR TITLE
SNS Publish by phone number

### DIFF
--- a/moto/sns/models.py
+++ b/moto/sns/models.py
@@ -221,6 +221,12 @@ class SNSBackend(BaseBackend):
         except KeyError:
             raise SNSNotFoundError("Topic with arn {0} not found".format(arn))
 
+    def get_topic_from_phone_number(self, number):
+        for subscription in self.subscriptions.values():
+            if subscription.protocol == 'sms' and subscription.endpoint == number:
+                return subscription.topic.arn
+        raise SNSNotFoundError('Could not find valid subscription')
+
     def set_topic_attribute(self, topic_arn, attribute_name, attribute_value):
         topic = self.get_topic(topic_arn)
         setattr(topic, attribute_name, attribute_value)

--- a/moto/sns/utils.py
+++ b/moto/sns/utils.py
@@ -1,5 +1,8 @@
 from __future__ import unicode_literals
+import re
 import uuid
+
+E164_REGEX = re.compile(r'^\+?[1-9]\d{1,14}$')
 
 
 def make_arn_for_topic(account_id, name, region_name):
@@ -9,3 +12,7 @@ def make_arn_for_topic(account_id, name, region_name):
 def make_arn_for_subscription(topic_arn):
     subscription_id = uuid.uuid4()
     return "{0}:{1}".format(topic_arn, subscription_id)
+
+
+def is_e164(number):
+    return E164_REGEX.match(number) is not None

--- a/tests/test_sns/test_subscriptions_boto3.py
+++ b/tests/test_sns/test_subscriptions_boto3.py
@@ -12,6 +12,39 @@ from moto.sns.models import DEFAULT_PAGE_SIZE
 
 
 @mock_sns
+def test_subscribe_sms():
+    client = boto3.client('sns', region_name='us-east-1')
+    client.create_topic(Name="some-topic")
+    resp = client.create_topic(Name="some-topic")
+    arn = resp['TopicArn']
+
+    resp = client.subscribe(
+        TopicArn=arn,
+        Protocol='sms',
+        Endpoint='+15551234567'
+    )
+    resp.should.contain('SubscriptionArn')
+
+
+@mock_sns
+def test_subscribe_bad_sms():
+    client = boto3.client('sns', region_name='us-east-1')
+    client.create_topic(Name="some-topic")
+    resp = client.create_topic(Name="some-topic")
+    arn = resp['TopicArn']
+
+    try:
+        # Test invalid number
+        client.subscribe(
+            TopicArn=arn,
+            Protocol='sms',
+            Endpoint='NAA+15551234567'
+        )
+    except ClientError as err:
+        err.response['Error']['Code'].should.equal('InvalidParameter')
+
+
+@mock_sns
 def test_creating_subscription():
     conn = boto3.client('sns', region_name='us-east-1')
     conn.create_topic(Name="some-topic")


### PR DESCRIPTION
Fixes #1189 

Currently SNS.publish expects an ARN, but you can actually publish with a phone number subscribed to a topic. This patch adds in the logic to look up said subscription and get the topic arn from that. Else fail gracefully.