### PR TITLE
WIP Iam get policy

### DIFF
--- a/moto/iam/responses.py
+++ b/moto/iam/responses.py
@@ -177,6 +177,13 @@ class IamResponse(BaseResponse):
         policy_version = iam_backend.get_policy_version(policy_arn, version_id)
         template = self.response_template(GET_POLICY_VERSION_TEMPLATE)
         return template.render(policy_version=policy_version)
+  
+    def get_policy(self):
+        policyarn = self._get_param('PolicyArn')
+        policyarn = iam_backend.get_policy(
+            policyarn)
+        template = self.response_template(GET_POLICY_TEMPLATE)
+        return template.render(policyarn = policyarn)
 
     def list_policy_versions(self):
         policy_arn = self._get_param('PolicyArn')
@@ -835,6 +842,20 @@ GET_POLICY_VERSION_TEMPLATE = """<GetPolicyVersionResponse xmlns="https://iam.am
     <RequestId>20f7279f-99ee-11e1-a4c3-27EXAMPLE804</RequestId>
   </ResponseMetadata>
 </GetPolicyVersionResponse>"""
+
+GET_POLICY_TEMPLATE = """<GetPolicyResponse xmlns="https://iam.amazonaws.com/doc/2010-05-08/">
+  <GetPolicyResult>
+      <Policy>
+      <Document>{{ policyarn.document }}</Document>
+      <VersionId>{{ policyarn.version_id }}</VersionId>
+      <DefaultVersionId>{{ policyarn.default_version_id }}</DefaultVersionId>
+      <CreateDate>2017-10-04T15:45:35Z</CreateDate>
+      </Policy>
+  </GetPolicyResult>
+  <ResponseMetadata>
+    <RequestId>20f7279f-99ee-11e1-a4c3-27EXAMPLE805</RequestId>
+  </ResponseMetadata>
+</GetPolicyResponse>"""
 
 LIST_POLICY_VERSIONS_TEMPLATE = """<ListPolicyVersionsResponse xmlns="https://iam.amazonaws.com/doc/2010-05-08/">
   <ListPolicyVersionsResult>

--- a/tests/test_iam/test_iam.py
+++ b/tests/test_iam/test_iam.py
@@ -283,6 +283,22 @@ def test_get_policy_version():
         VersionId=version.get('PolicyVersion').get('VersionId'))
     retrieved.get('PolicyVersion').get('Document').should.equal({'some': 'policy'})
 
+@mock_iam
+def test_get_policy():
+    conn = boto3.client('iam', region_name='us-east-1')
+    conn.create_policy(
+        PolicyName="TestGetPolicy",
+        PolicyDocument='{"some":"policy"}')
+    version = conn.create_policy_version(
+        PolicyArn="arn:aws:iam::aws:policy/TestGetPolicy",
+        PolicyDocument='{"some":"policy"}')
+    with assert_raises(ClientError):
+        conn.get_policy(
+            PolicyArn="arn:aws:iam::aws:policy/TestGetPolicy"
+    retrieved = conn.get_policy(
+        PolicyArn="arn:aws:iam::aws:policy/TestGetPolicy",
+        VersionId=version.get('PolicyVersion').get('VersionId'))
+    retrieved.get('Policy').get('Document').should.equal({'some':'policy'})
 
 @mock_iam
 def test_list_policy_versions():


### PR DESCRIPTION
Hi all,

This is a WIP PR to implement IAM get_policy:

I include the following code, in order to implement "get_policy" method from IAM (I have not modified ..moto/iam/models.py file).

https://github.com/josenrihernand/moto/blob/master/tests/test_iam/test_iam.py#L268#L284
https://github.com/josenrihernand/moto/blob/IAM_get_policy/moto/iam/responses.py#L181#L186
https://github.com/josenrihernand/moto/blob/IAM_get_policy/moto/iam/responses.py#L846#L858

As from the test (of the get_policy method) on my local environment, I can see that I get the value:

groupPolicies = iam_conn_client.list_attached_group_policies(
GroupName = groups["GroupName"]
for attachedPolicy in groupPolicies["AttachedPolicies"]:
currentPolicy = iam_conn_client.get_policy(         ---> get_policy method works.
PolicyArn = attachedPolicy["PolicyArn"]
);

print("Attached Policy: ", attachedPolicy["PolicyArn"]); --> it works.
--> ('Attached Policy: ', 'arn:aws:iam::aws:policy/TestDBPolicy')

print("Current Policy: ", currentPolicy);	--> it also works.
--> ('Current Policy: ', {u'Policy': {u'CreateDate': datetime.datetime(2017, 10, 4, 15, 45, 35, tzinfo=tzutc()), u'DefaultVersionId': ''}, 'ResponseMetadata': {'RetryAttempts': 0, 'HTTPStatusCode': 200, 'RequestId': '20f7279f-99ee-11e1-a4c3-27EXAMPLE804', 'HTTPHeaders': {u'Content-Type': u'text/plain', u'server': u'amazon.com'}}})

However, when I run the method "get_policy_version", it fails with the following error message:

groupPolicies = iam_conn_client.list_attached_group_policies(
GroupName = groups["GroupName"]
policy_version = iam_conn_client.get_policy_version(   ----> get_policy_version fail.
PolicyArn = attachedPolicy["PolicyArn"],
VersionId = currentPolicy["Policy"]["DefaultVersionId"]
);
An error occurred (NoSuchEntity) when calling the GetPolicyVersion operation: Policy version not found

I think the cause is because the get_policy method (I implemented it on my local environment) does not return "DefaultVersionId" value.

So, I  would like to ask you some help on this. Specifically, I don't sure if the method "get_policy" was implemented well. 

Could you please check / review / test the code I included to implement get_policy ?
Could you please verify why DefaultVersionId does not return any value (and so the error Policy version not found) ?

I really would appreciate you help ! since I need to implement get_policy on moto library!

Thanks,
