### PR TITLE
Support wildcard tag filters on SecurityGroups

### DIFF
--- a/moto/ec2/models.py
+++ b/moto/ec2/models.py
@@ -109,6 +109,7 @@ from .utils import (
     random_vpn_connection_id,
     random_customer_gateway_id,
     is_tag_filter,
+    tag_filter_matches,
 )
 
 RESOURCES_DIR = os.path.join(os.path.dirname(__file__), 'resources')
@@ -1309,7 +1310,7 @@ class SecurityGroup(TaggedEC2Resource):
         elif is_tag_filter(key):
             tag_value = self.get_filter_value(key)
             if isinstance(filter_value, list):
-                return any(v in tag_value for v in filter_value)
+                return tag_filter_matches(self, key, filter_value)
             return tag_value in filter_value
         else:
             attr_name = to_attr(key)

--- a/tests/test_ec2/test_security_groups.py
+++ b/tests/test_ec2/test_security_groups.py
@@ -614,6 +614,20 @@ def test_security_group_tagging_boto3():
 
 
 @mock_ec2
+def test_security_group_wildcard_tag_filter_boto3():
+    conn = boto3.client('ec2', region_name='us-east-1')
+    sg = conn.create_security_group(GroupName="test-sg", Description="Test SG")
+    conn.create_tags(Resources=[sg['GroupId']], Tags=[
+                     {'Key': 'Test', 'Value': 'Tag'}])
+    describe = conn.describe_security_groups(
+        Filters=[{'Name': 'tag-value', 'Values': ['*']}])
+
+    tag = describe["SecurityGroups"][0]['Tags'][0]
+    tag['Value'].should.equal("Tag")
+    tag['Key'].should.equal("Test")
+
+
+@mock_ec2
 def test_authorize_and_revoke_in_bulk():
     ec2 = boto3.resource('ec2', region_name='us-west-1')
 


### PR DESCRIPTION
Use the `tag_filter_matches` function from utils, but could perhaps use `generic_filters` somehow. This solves the issue though!