### PR TITLE
Remove newlines from create-access-key response

### DIFF
--- a/moto/iam/responses.py
+++ b/moto/iam/responses.py
@@ -1159,9 +1159,7 @@ CREATE_ACCESS_KEY_TEMPLATE = """<CreateAccessKeyResponse>
          <UserName>{{ key.user_name }}</UserName>
          <AccessKeyId>{{ key.access_key_id }}</AccessKeyId>
          <Status>{{ key.status }}</Status>
-         <SecretAccessKey>
-         {{ key.secret_access_key }}
-         </SecretAccessKey>
+         <SecretAccessKey>{{ key.secret_access_key }}</SecretAccessKey>
       </AccessKey>
    </CreateAccessKeyResult>
    <ResponseMetadata>


### PR DESCRIPTION
Newlines in the iam.create_access_key response template was causing the secret key to be returned as `u'\n    vr7PlfZyCVt3QHT2fpiqeKyL8lJlzYLC  \n'` instead of `u'vr7PlfZyCVt3QHT2fpiqeKyL8lJlzYLC'`.  This likely has gone unnoticed because ultimately the secret is just a string, but we are concatenating it with other data to form a URI and the newlines are obviously problematic in that scenario.  So...merging this shouldn't break anything and it will help us.  Thanks!