### PR TITLE
Fix runningTasksCount ECS container instance attribute

### DIFF
--- a/moto/ecs/models.py
+++ b/moto/ecs/models.py
@@ -289,7 +289,7 @@ class ContainerInstance(BaseObject):
              'type': 'STRINGSET'}]
         self.container_instance_arn = "arn:aws:ecs:us-east-1:012345678910:container-instance/{0}".format(
             str(uuid.uuid1()))
-        self.pending_task_count = 0
+        self.pending_tasks_count = 0
         self.remaining_resources = [
             {'doubleValue': 0.0,
              'integerValue': 4096,
@@ -314,7 +314,7 @@ class ContainerInstance(BaseObject):
              'stringSetValue': [],
              'type': 'STRINGSET'}
         ]
-        self.running_task_count = 0
+        self.running_tasks_count = 0
         self.version_info = {
             'agentVersion': "1.0.0",
             'agentHash': '4023248',
@@ -737,7 +737,7 @@ class EC2ContainerServiceBackend(BaseBackend):
                         resource["stringSetValue"].remove(str(port))
                     else:
                         resource["stringSetValue"].append(str(port))
-        container_instance.running_task_count += resource_multiplier * 1
+        container_instance.running_tasks_count += resource_multiplier * 1
 
     def deregister_container_instance(self, cluster_str, container_instance_str, force):
         failures = []
@@ -748,11 +748,11 @@ class EC2ContainerServiceBackend(BaseBackend):
         container_instance = self.container_instances[cluster_name].get(container_instance_id)
         if container_instance is None:
             raise Exception("{0} is not a container id in the cluster")
-        if not force and container_instance.running_task_count > 0:
+        if not force and container_instance.running_tasks_count > 0:
             raise Exception("Found running tasks on the instance.")
         # Currently assume that people might want to do something based around deregistered instances
         # with tasks left running on them - but nothing if no tasks were running already
-        elif force and container_instance.running_task_count > 0:
+        elif force and container_instance.running_tasks_count > 0:
             if not self.container_instances.get('orphaned'):
                 self.container_instances['orphaned'] = {}
             self.container_instances['orphaned'][container_instance_id] = container_instance

--- a/tests/test_ecs/test_ecs_boto3.py
+++ b/tests/test_ecs/test_ecs_boto3.py
@@ -714,6 +714,9 @@ def test_describe_container_instances():
                      for ci in response['containerInstances']]
     for arn in test_instance_arns:
         response_arns.should.contain(arn)
+    for instance in response['containerInstances']:
+        instance.keys().should.contain('runningTasksCount')
+        instance.keys().should.contain('pendingTasksCount')
 
 
 @mock_ec2

--- a/tests/test_ecs/test_ecs_boto3.py
+++ b/tests/test_ecs/test_ecs_boto3.py
@@ -1210,6 +1210,7 @@ def test_resource_reservation_and_release():
     remaining_resources['MEMORY'].should.equal(registered_resources['MEMORY'] - 400)
     registered_resources['PORTS'].append('80')
     remaining_resources['PORTS'].should.equal(registered_resources['PORTS'])
+    container_instance_description['runningTasksCount'].should.equal(1)
     client.stop_task(
         cluster='test_ecs_cluster',
         task=run_response['tasks'][0].get('taskArn'),
@@ -1223,6 +1224,7 @@ def test_resource_reservation_and_release():
     remaining_resources['CPU'].should.equal(registered_resources['CPU'])
     remaining_resources['MEMORY'].should.equal(registered_resources['MEMORY'])
     remaining_resources['PORTS'].should.equal(registered_resources['PORTS'])
+    container_instance_description['runningTasksCount'].should.equal(0)
 
 
 @mock_ecs


### PR DESCRIPTION
ECS container instances have attributes of 'runningTasksCount' and 'pendingTasksCount'.
See Boto3 docs here: http://boto3.readthedocs.io/en/latest/reference/services/ecs.html#ECS.Client.describe_container_instances
REST API docs here: http://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_DescribeContainerInstances.html#API_DescribeContainerInstances_ResponseSyntax