### PR TITLE
Add autoscaling load balancer methods

### DIFF
--- a/moto/autoscaling/responses.py
+++ b/moto/autoscaling/responses.py
@@ -207,6 +207,28 @@ class AutoScalingResponse(BaseResponse):
         template = self.response_template(EXECUTE_POLICY_TEMPLATE)
         return template.render()
 
+    def attach_load_balancers(self):
+        group_name = self._get_param('AutoScalingGroupName')
+        load_balancer_names = self._get_multi_param("LoadBalancerNames.member")
+        self.autoscaling_backend.attach_load_balancers(
+            group_name, load_balancer_names)
+        template = self.response_template(ATTACH_LOAD_BALANCERS_TEMPLATE)
+        return template.render()
+
+    def describe_load_balancers(self):
+        group_name = self._get_param('AutoScalingGroupName')
+        load_balancers = self.autoscaling_backend.describe_load_balancers(group_name)
+        template = self.response_template(DESCRIBE_LOAD_BALANCERS_TEMPLATE)
+        return template.render(load_balancers=load_balancers)
+
+    def detach_load_balancers(self):
+        group_name = self._get_param('AutoScalingGroupName')
+        load_balancer_names = self._get_multi_param("LoadBalancerNames.member")
+        self.autoscaling_backend.detach_load_balancers(
+            group_name, load_balancer_names)
+        template = self.response_template(DETACH_LOAD_BALANCERS_TEMPLATE)
+        return template.render()
+
 
 CREATE_LAUNCH_CONFIGURATION_TEMPLATE = """<CreateLaunchConfigurationResponse xmlns="http://autoscaling.amazonaws.com/doc/2011-01-01/">
 <ResponseMetadata>
@@ -505,3 +527,33 @@ DELETE_POLICY_TEMPLATE = """<DeleteScalingPolicyResponse xmlns="http://autoscali
     <RequestId>70a76d42-9665-11e2-9fdf-211deEXAMPLE</RequestId>
   </ResponseMetadata>
 </DeleteScalingPolicyResponse>"""
+
+ATTACH_LOAD_BALANCERS_TEMPLATE = """<AttachLoadBalancersResponse xmlns="http://autoscaling.amazonaws.com/doc/2011-01-01/">
+<AttachLoadBalancersResult></AttachLoadBalancersResult>
+<ResponseMetadata>
+<RequestId>8d798a29-f083-11e1-bdfb-cb223EXAMPLE</RequestId>
+</ResponseMetadata>
+</AttachLoadBalancersResponse>"""
+
+DESCRIBE_LOAD_BALANCERS_TEMPLATE = """<DescribeLoadBalancersResponse xmlns="http://autoscaling.amazonaws.com/doc/2011-01-01/">
+<DescribeLoadBalancersResult>
+  <LoadBalancers>
+    {% for load_balancer in load_balancers %}
+      <member>
+        <LoadBalancerName>{{ load_balancer }}</LoadBalancerName>
+        <State>Added</State>
+      </member>
+    {% endfor %}
+  </LoadBalancers>
+</DescribeLoadBalancersResult>
+<ResponseMetadata>
+<RequestId>8d798a29-f083-11e1-bdfb-cb223EXAMPLE</RequestId>
+</ResponseMetadata>
+</DescribeLoadBalancersResponse>"""
+
+DETACH_LOAD_BALANCERS_TEMPLATE = """<DetachLoadBalancersResponse xmlns="http://autoscaling.amazonaws.com/doc/2011-01-01/">
+<DetachLoadBalancersResult></DetachLoadBalancersResult>
+<ResponseMetadata>
+<RequestId>8d798a29-f083-11e1-bdfb-cb223EXAMPLE</RequestId>
+</ResponseMetadata>
+</DetachLoadBalancersResponse>"""

--- a/moto/autoscaling/responses.py
+++ b/moto/autoscaling/responses.py
@@ -1,6 +1,7 @@
 from __future__ import unicode_literals
 
 from moto.core.responses import BaseResponse
+from moto.core.utils import amz_crc32, amzn_request_id
 from .models import autoscaling_backends
 
 
@@ -87,6 +88,8 @@ class AutoScalingResponse(BaseResponse):
         template = self.response_template(CREATE_AUTOSCALING_GROUP_TEMPLATE)
         return template.render()
 
+    @amz_crc32
+    @amzn_request_id
     def attach_instances(self):
         group_name = self._get_param('AutoScalingGroupName')
         instance_ids = self._get_multi_param("InstanceIds.member")
@@ -95,6 +98,8 @@ class AutoScalingResponse(BaseResponse):
         template = self.response_template(ATTACH_INSTANCES_TEMPLATE)
         return template.render()
 
+    @amz_crc32
+    @amzn_request_id
     def detach_instances(self):
         group_name = self._get_param('AutoScalingGroupName')
         instance_ids = self._get_multi_param("InstanceIds.member")
@@ -207,6 +212,8 @@ class AutoScalingResponse(BaseResponse):
         template = self.response_template(EXECUTE_POLICY_TEMPLATE)
         return template.render()
 
+    @amz_crc32
+    @amzn_request_id
     def attach_load_balancers(self):
         group_name = self._get_param('AutoScalingGroupName')
         load_balancer_names = self._get_multi_param("LoadBalancerNames.member")
@@ -215,12 +222,16 @@ class AutoScalingResponse(BaseResponse):
         template = self.response_template(ATTACH_LOAD_BALANCERS_TEMPLATE)
         return template.render()
 
+    @amz_crc32
+    @amzn_request_id
     def describe_load_balancers(self):
         group_name = self._get_param('AutoScalingGroupName')
         load_balancers = self.autoscaling_backend.describe_load_balancers(group_name)
         template = self.response_template(DESCRIBE_LOAD_BALANCERS_TEMPLATE)
         return template.render(load_balancers=load_balancers)
 
+    @amz_crc32
+    @amzn_request_id
     def detach_load_balancers(self):
         group_name = self._get_param('AutoScalingGroupName')
         load_balancer_names = self._get_multi_param("LoadBalancerNames.member")
@@ -331,7 +342,7 @@ ATTACH_INSTANCES_TEMPLATE = """<AttachInstancesResponse xmlns="http://autoscalin
 <AttachInstancesResult>
 </AttachInstancesResult>
 <ResponseMetadata>
-<RequestId>8d798a29-f083-11e1-bdfb-cb223EXAMPLE</RequestId>
+<RequestId>{{ requestid }}</RequestId>
 </ResponseMetadata>
 </AttachInstancesResponse>"""
 
@@ -357,7 +368,7 @@ DETACH_INSTANCES_TEMPLATE = """<DetachInstancesResponse xmlns="http://autoscalin
   </Activities>
 </DetachInstancesResult>
 <ResponseMetadata>
-<RequestId>8d798a29-f083-11e1-bdfb-cb223EXAMPLE</RequestId>
+<RequestId>{{ requestid }}</RequestId>
 </ResponseMetadata>
 </DetachInstancesResponse>"""
 
@@ -531,7 +542,7 @@ DELETE_POLICY_TEMPLATE = """<DeleteScalingPolicyResponse xmlns="http://autoscali
 ATTACH_LOAD_BALANCERS_TEMPLATE = """<AttachLoadBalancersResponse xmlns="http://autoscaling.amazonaws.com/doc/2011-01-01/">
 <AttachLoadBalancersResult></AttachLoadBalancersResult>
 <ResponseMetadata>
-<RequestId>8d798a29-f083-11e1-bdfb-cb223EXAMPLE</RequestId>
+<RequestId>{{ requestid }}</RequestId>
 </ResponseMetadata>
 </AttachLoadBalancersResponse>"""
 
@@ -547,13 +558,13 @@ DESCRIBE_LOAD_BALANCERS_TEMPLATE = """<DescribeLoadBalancersResponse xmlns="http
   </LoadBalancers>
 </DescribeLoadBalancersResult>
 <ResponseMetadata>
-<RequestId>8d798a29-f083-11e1-bdfb-cb223EXAMPLE</RequestId>
+<RequestId>{{ requestid }}</RequestId>
 </ResponseMetadata>
 </DescribeLoadBalancersResponse>"""
 
 DETACH_LOAD_BALANCERS_TEMPLATE = """<DetachLoadBalancersResponse xmlns="http://autoscaling.amazonaws.com/doc/2011-01-01/">
 <DetachLoadBalancersResult></DetachLoadBalancersResult>
 <ResponseMetadata>
-<RequestId>8d798a29-f083-11e1-bdfb-cb223EXAMPLE</RequestId>
+<RequestId>{{ requestid }}</RequestId>
 </ResponseMetadata>
 </DetachLoadBalancersResponse>"""


### PR DESCRIPTION
This adds three methods to the autoscaling service: attach_load_balancers, describe_load_balancers, and detach_load_balancers; all of which manipulate "classic" Elastic load balancers and their association to an autoscaling group. 