### PR TITLE
Fix bug with update_attached_elbs

### DIFF
--- a/moto/autoscaling/models.py
+++ b/moto/autoscaling/models.py
@@ -506,20 +506,21 @@ class AutoScalingBackend(BaseBackend):
 
         # skip this if group.load_balancers is empty
         # otherwise elb_backend.describe_load_balancers returns all available load balancers
-        if group.load_balancers:
-            try:
-                elbs = self.elb_backend.describe_load_balancers(
-                    names=group.load_balancers)
-            except LoadBalancerNotFoundError:
-                # ELBs can be deleted before their autoscaling group
-                return
+        if not group.load_balancers:
+            return
+        try:
+            elbs = self.elb_backend.describe_load_balancers(
+                names=group.load_balancers)
+        except LoadBalancerNotFoundError:
+            # ELBs can be deleted before their autoscaling group
+            return
 
-            for elb in elbs:
-                elb_instace_ids = set(elb.instance_ids)
-                self.elb_backend.register_instances(
-                    elb.name, group_instance_ids - elb_instace_ids)
-                self.elb_backend.deregister_instances(
-                    elb.name, elb_instace_ids - group_instance_ids)
+        for elb in elbs:
+            elb_instace_ids = set(elb.instance_ids)
+            self.elb_backend.register_instances(
+                elb.name, group_instance_ids - elb_instace_ids)
+            self.elb_backend.deregister_instances(
+                elb.name, elb_instace_ids - group_instance_ids)
 
     def create_or_update_tags(self, tags):
 

--- a/moto/autoscaling/models.py
+++ b/moto/autoscaling/models.py
@@ -504,19 +504,22 @@ class AutoScalingBackend(BaseBackend):
         group_instance_ids = set(
             state.instance.id for state in group.instance_states)
 
-        try:
-            elbs = self.elb_backend.describe_load_balancers(
-                names=group.load_balancers)
-        except LoadBalancerNotFoundError:
-            # ELBs can be deleted before their autoscaling group
-            return
+        # skip this if group.load_balancers is empty
+        # otherwise elb_backend.describe_load_balancers returns all available load balancers
+        if group.load_balancers:
+            try:
+                elbs = self.elb_backend.describe_load_balancers(
+                    names=group.load_balancers)
+            except LoadBalancerNotFoundError:
+                # ELBs can be deleted before their autoscaling group
+                return
 
-        for elb in elbs:
-            elb_instace_ids = set(elb.instance_ids)
-            self.elb_backend.register_instances(
-                elb.name, group_instance_ids - elb_instace_ids)
-            self.elb_backend.deregister_instances(
-                elb.name, elb_instace_ids - group_instance_ids)
+            for elb in elbs:
+                elb_instace_ids = set(elb.instance_ids)
+                self.elb_backend.register_instances(
+                    elb.name, group_instance_ids - elb_instace_ids)
+                self.elb_backend.deregister_instances(
+                    elb.name, elb_instace_ids - group_instance_ids)
 
     def create_or_update_tags(self, tags):
 

--- a/tests/test_autoscaling/test_autoscaling.py
+++ b/tests/test_autoscaling/test_autoscaling.py
@@ -498,10 +498,10 @@ def test_describe_load_balancers():
     )
 
     client = boto3.client('autoscaling', region_name='us-east-1')
-    _ = client.create_launch_configuration(
+    client.create_launch_configuration(
         LaunchConfigurationName='test_launch_configuration'
     )
-    _ = client.create_auto_scaling_group(
+    client.create_auto_scaling_group(
         AutoScalingGroupName='test_asg',
         LaunchConfigurationName='test_launch_configuration',
         LoadBalancerNames=['my-lb'],
@@ -527,7 +527,7 @@ def test_create_elb_and_autoscaling_group_no_relationship():
     ELB_NAME = 'my-elb'
 
     elb_client = boto3.client('elb', region_name='us-east-1')
-    _ = elb_client.create_load_balancer(
+    elb_client.create_load_balancer(
         LoadBalancerName=ELB_NAME,
         Listeners=[
             {'Protocol': 'tcp', 'LoadBalancerPort': 80, 'InstancePort': 8080}],
@@ -535,11 +535,11 @@ def test_create_elb_and_autoscaling_group_no_relationship():
     )
 
     client = boto3.client('autoscaling', region_name='us-east-1')
-    _ = client.create_launch_configuration(
+    client.create_launch_configuration(
         LaunchConfigurationName='test_launch_configuration'
     )
 
-    _ = client.create_auto_scaling_group(
+    client.create_auto_scaling_group(
         AutoScalingGroupName='test_asg',
         LaunchConfigurationName='test_launch_configuration',
         MinSize=0,
@@ -572,10 +572,10 @@ def test_attach_load_balancer():
     )
 
     client = boto3.client('autoscaling', region_name='us-east-1')
-    _ = client.create_launch_configuration(
+    client.create_launch_configuration(
         LaunchConfigurationName='test_launch_configuration'
     )
-    _ = client.create_auto_scaling_group(
+    client.create_auto_scaling_group(
         AutoScalingGroupName='test_asg',
         LaunchConfigurationName='test_launch_configuration',
         MinSize=0,
@@ -614,10 +614,10 @@ def test_detach_load_balancer():
     )
 
     client = boto3.client('autoscaling', region_name='us-east-1')
-    _ = client.create_launch_configuration(
+    client.create_launch_configuration(
         LaunchConfigurationName='test_launch_configuration'
     )
-    _ = client.create_auto_scaling_group(
+    client.create_auto_scaling_group(
         AutoScalingGroupName='test_asg',
         LaunchConfigurationName='test_launch_configuration',
         LoadBalancerNames=['my-lb'],

--- a/tests/test_autoscaling/test_autoscaling.py
+++ b/tests/test_autoscaling/test_autoscaling.py
@@ -520,6 +520,43 @@ def test_describe_load_balancers():
     list(response['LoadBalancers']).should.have.length_of(1)
     response['LoadBalancers'][0]['LoadBalancerName'].should.equal('my-lb')
 
+@mock_autoscaling
+@mock_elb
+def test_create_elb_and_autoscaling_group_no_relationship():
+    INSTANCE_COUNT = 2
+    ELB_NAME = 'my-elb'
+
+    elb_client = boto3.client('elb', region_name='us-east-1')
+    _ = elb_client.create_load_balancer(
+        LoadBalancerName=ELB_NAME,
+        Listeners=[
+            {'Protocol': 'tcp', 'LoadBalancerPort': 80, 'InstancePort': 8080}],
+        AvailabilityZones=['us-east-1a', 'us-east-1b']
+    )
+
+    client = boto3.client('autoscaling', region_name='us-east-1')
+    _ = client.create_launch_configuration(
+        LaunchConfigurationName='test_launch_configuration'
+    )
+
+    _ = client.create_auto_scaling_group(
+        AutoScalingGroupName='test_asg',
+        LaunchConfigurationName='test_launch_configuration',
+        MinSize=0,
+        MaxSize=INSTANCE_COUNT,
+        DesiredCapacity=INSTANCE_COUNT,
+    )
+
+    # autoscaling group and elb should have no relationship
+    response = client.describe_load_balancers(
+        AutoScalingGroupName='test_asg'
+    )
+    list(response['LoadBalancers']).should.have.length_of(0)
+    response = elb_client.describe_load_balancers(
+        LoadBalancerNames=[ELB_NAME]
+    )
+    list(response['LoadBalancerDescriptions'][0]['Instances']).should.have.length_of(0)
+
 
 @mock_autoscaling
 @mock_elb


### PR DESCRIPTION
So, I also wanted to add the elbv2 methods to autoscaling. I started on that and came across this weird bug where the `create_auto_scaling_group` method was erroneously adding the group's instances to all available ELBs when the group was created with no load balancers specified.

 In the test below, I create an ELB and an ASG. I expected the ELB to have an instance count of 0, but to my amazement I found that it had a count of the autoscaling group's desired size.

I tracked it down to models.py L511. On create, if no load balancers are specified, `group.load_balancers` is an empty list. the `elb_backend.describe_load_balancers` method returns all available elbs if you pass in nothing for it to match on. This is expected, however in this specific case it is the opposite of what we want. So, we should skip if group.load_balancers is empty.