### PR TITLE
Correct the type of a default attribute in SNS PlatformEndpoint

### DIFF
--- a/moto/sns/models.py
+++ b/moto/sns/models.py
@@ -146,7 +146,7 @@ class PlatformEndpoint(BaseModel):
         if 'Token' not in self.attributes:
             self.attributes['Token'] = self.token
         if 'Enabled' not in self.attributes:
-            self.attributes['Enabled'] = True
+            self.attributes['Enabled'] = 'True'
 
     @property
     def enabled(self):


### PR DESCRIPTION
The `Enabled` Attribute in the PlatformEndpoint of SNS current returns a boolean, however, the 'enabled' property is expecting a string as `.lower()` is called on the result.

This change simply changes the default from `True` to `'True'` so the property works as expected.