### PR TITLE
requiring minimum botocore

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,7 @@ install_requires = [
     "Jinja2>=2.8",
     "boto>=2.36.0",
     "boto3>=1.2.1",
+    "botocore>=1.7.12",
     "cookies",
     "cryptography>=2.0.0",
     "requests>=2.5",


### PR DESCRIPTION
Boto and Boto3 can be a little old but Moto will throw an error if
botocoe doesn't even know about some of the services it supports.
As of this commit Polly is new enough some users are running into
exceptions.