### PR TITLE
Prevent attaching a load balancer multiple times

### DIFF
--- a/moto/autoscaling/models.py
+++ b/moto/autoscaling/models.py
@@ -545,7 +545,8 @@ class AutoScalingBackend(BaseBackend):
 
     def attach_load_balancers(self, group_name, load_balancer_names):
         group = self.autoscaling_groups[group_name]
-        group.load_balancers.extend(load_balancer_names)
+        group.load_balancers.extend(
+            [x for x in load_balancer_names if x not in group.load_balancers])
         self.update_attached_elbs(group_name)
 
     def describe_load_balancers(self, group_name):


### PR DESCRIPTION
Hey there, I overlooked something the other day:

While attaching load balancers, we need to filter the list by determining which are already attached. This will prevent duplicates from getting added. Right now, if you use attach_load_balancer to attach an elb, then call it again, you'll end up with a duplicate.