### PR TITLE
Check if subject_alt_names is not none before checking length

### DIFF
--- a/moto/acm/responses.py
+++ b/moto/acm/responses.py
@@ -185,7 +185,7 @@ class AWSCertificateManagerResponse(BaseResponse):
         idempotency_token = self._get_param('IdempotencyToken')
         subject_alt_names = self._get_param('SubjectAlternativeNames')
 
-        if len(subject_alt_names) > 10:
+        if subject_alt_names is not None and len(subject_alt_names) > 10:
             # There is initial AWS limit of 10
             msg = 'An ACM limit has been exceeded. Need to request SAN limit to be raised'
             return json.dumps({'__type': 'LimitExceededException', 'message': msg}), dict(status=400)

--- a/tests/test_acm/test_acm.py
+++ b/tests/test_acm/test_acm.py
@@ -287,6 +287,19 @@ def test_request_certificate():
     )
     resp.should.contain('CertificateArn')
 
+@mock_acm
+def test_request_certificate_no_san():
+    client = boto3.client('acm', region_name='eu-central-1')
+
+    resp = client.request_certificate(
+        DomainName='google.com'
+    )
+    resp.should.contain('CertificateArn')
+
+    resp2 = client.describe_certificate(
+        CertificateArn=resp['CertificateArn']
+    )
+    resp2.should.contain('Certificate')
 
 # # Also tests the SAN code
 # # requires Pull: https://github.com/spulec/freezegun/pull/210


### PR DESCRIPTION
Calling describe_certificate was returning the following error:

   File "/usr/local/lib/python3.6/site-packages/moto/acm/responses.py", line 188, in request_certificate
    if len(subject_alt_names) > 10:
TypeError: object of type 'NoneType' has no len()