### PR TITLE
Fix Error in get-logs request LogEvent instance is not JSON serializable

### DIFF
--- a/moto/logs/responses.py
+++ b/moto/logs/responses.py
@@ -89,7 +89,7 @@ class LogsResponse(BaseResponse):
             self.logs_backend.get_log_events(log_group_name, log_stream_name, start_time, end_time, limit, next_token, start_from_head)
 
         return json.dumps({
-            "events": events,
+            "events": [ob.__dict__ for ob in events],
             "nextBackwardToken": next_backward_token,
             "nextForwardToken": next_foward_token
         })


### PR DESCRIPTION
When an user request get-log-events commands returns next error:

TypeError: <moto.logs.models.LogEvent instance> is not JSON serializable

Fixed bug with new list of dictionary attributes from LogEvent Object