### PR TITLE
Add ELBv2 Support  to Autoscaling Service

### DIFF
--- a/tests/test_autoscaling/test_autoscaling.py
+++ b/tests/test_autoscaling/test_autoscaling.py
@@ -599,6 +599,11 @@ def test_attach_load_balancer():
     )
     list(response['LoadBalancerDescriptions'][0]['Instances']).should.have.length_of(INSTANCE_COUNT)
 
+    response = client.describe_auto_scaling_groups(
+        AutoScalingGroupNames=["test_asg"]
+    )
+    list(response['AutoScalingGroups'][0]['LoadBalancerNames']).should.have.length_of(1)
+
 
 @mock_autoscaling
 @mock_elb

--- a/tests/test_autoscaling/test_elbv2.py
+++ b/tests/test_autoscaling/test_elbv2.py
@@ -1,0 +1,131 @@
+from __future__ import unicode_literals
+import boto3
+
+from moto import mock_autoscaling, mock_ec2,  mock_elbv2
+
+@mock_elbv2
+@mock_ec2
+@mock_autoscaling
+def test_attach_detach_target_groups():
+    INSTANCE_COUNT = 2
+    client = boto3.client('autoscaling', region_name='us-east-1')
+    elbv2_client = boto3.client('elbv2', region_name='us-east-1')
+    ec2 = boto3.resource('ec2', region_name='us-east-1')
+
+    vpc = ec2.create_vpc(CidrBlock='172.28.7.0/24', InstanceTenancy='default')
+
+    response = elbv2_client.create_target_group(
+        Name='a-target',
+        Protocol='HTTP',
+        Port=8080,
+        VpcId=vpc.id,
+        HealthCheckProtocol='HTTP',
+        HealthCheckPort='8080',
+        HealthCheckPath='/',
+        HealthCheckIntervalSeconds=5,
+        HealthCheckTimeoutSeconds=5,
+        HealthyThresholdCount=5,
+        UnhealthyThresholdCount=2,
+        Matcher={'HttpCode': '200'})
+    target_group_arn = response['TargetGroups'][0]['TargetGroupArn']
+
+    client.create_launch_configuration(
+        LaunchConfigurationName='test_launch_configuration')
+
+    # create asg, attach to target group on create
+    client.create_auto_scaling_group(
+        AutoScalingGroupName='test_asg',
+        LaunchConfigurationName='test_launch_configuration',
+        MinSize=0,
+        MaxSize=INSTANCE_COUNT,
+        DesiredCapacity=INSTANCE_COUNT,
+        TargetGroupARNs=[target_group_arn],
+        VPCZoneIdentifier=vpc.id)
+    # create asg without attaching to target group
+    client.create_auto_scaling_group(
+        AutoScalingGroupName='test_asg2',
+        LaunchConfigurationName='test_launch_configuration',
+        MinSize=0,
+        MaxSize=INSTANCE_COUNT,
+        DesiredCapacity=INSTANCE_COUNT,
+        VPCZoneIdentifier=vpc.id)
+
+    response = client.describe_load_balancer_target_groups(
+        AutoScalingGroupName='test_asg')
+    list(response['LoadBalancerTargetGroups']).should.have.length_of(1)
+
+    response = elbv2_client.describe_target_health(
+        TargetGroupArn=target_group_arn)
+    list(response['TargetHealthDescriptions']).should.have.length_of(INSTANCE_COUNT)
+
+    client.attach_load_balancer_target_groups(
+        AutoScalingGroupName='test_asg2',
+        TargetGroupARNs=[target_group_arn])
+
+    response = elbv2_client.describe_target_health(
+        TargetGroupArn=target_group_arn)
+    list(response['TargetHealthDescriptions']).should.have.length_of(INSTANCE_COUNT * 2)
+
+    response = client.detach_load_balancer_target_groups(
+        AutoScalingGroupName='test_asg2',
+        TargetGroupARNs=[target_group_arn])
+    response = elbv2_client.describe_target_health(
+        TargetGroupArn=target_group_arn)
+    list(response['TargetHealthDescriptions']).should.have.length_of(INSTANCE_COUNT)
+
+@mock_elbv2
+@mock_ec2
+@mock_autoscaling
+def test_detach_all_target_groups():
+    INSTANCE_COUNT = 2
+    client = boto3.client('autoscaling', region_name='us-east-1')
+    elbv2_client = boto3.client('elbv2', region_name='us-east-1')
+    ec2 = boto3.resource('ec2', region_name='us-east-1')
+
+    vpc = ec2.create_vpc(CidrBlock='172.28.7.0/24', InstanceTenancy='default')
+
+    response = elbv2_client.create_target_group(
+        Name='a-target',
+        Protocol='HTTP',
+        Port=8080,
+        VpcId=vpc.id,
+        HealthCheckProtocol='HTTP',
+        HealthCheckPort='8080',
+        HealthCheckPath='/',
+        HealthCheckIntervalSeconds=5,
+        HealthCheckTimeoutSeconds=5,
+        HealthyThresholdCount=5,
+        UnhealthyThresholdCount=2,
+        Matcher={'HttpCode': '200'})
+    target_group_arn = response['TargetGroups'][0]['TargetGroupArn']
+
+    client.create_launch_configuration(
+        LaunchConfigurationName='test_launch_configuration')
+
+    client.create_auto_scaling_group(
+        AutoScalingGroupName='test_asg',
+        LaunchConfigurationName='test_launch_configuration',
+        MinSize=0,
+        MaxSize=INSTANCE_COUNT,
+        DesiredCapacity=INSTANCE_COUNT,
+        TargetGroupARNs=[target_group_arn],
+        VPCZoneIdentifier=vpc.id)
+
+    response = client.describe_load_balancer_target_groups(
+        AutoScalingGroupName='test_asg')
+    list(response['LoadBalancerTargetGroups']).should.have.length_of(1)
+
+    response = elbv2_client.describe_target_health(
+        TargetGroupArn=target_group_arn)
+    list(response['TargetHealthDescriptions']).should.have.length_of(INSTANCE_COUNT)
+
+    response = client.detach_load_balancer_target_groups(
+        AutoScalingGroupName='test_asg',
+        TargetGroupARNs=[target_group_arn])
+
+    response = elbv2_client.describe_target_health(
+        TargetGroupArn=target_group_arn)
+    list(response['TargetHealthDescriptions']).should.have.length_of(0)
+    response = client.describe_load_balancer_target_groups(
+        AutoScalingGroupName='test_asg')
+    list(response['LoadBalancerTargetGroups']).should.have.length_of(0)


### PR DESCRIPTION
This adds elbv2 functionality to the autoscaling service.

The `create_auto_scaling_group` now supports target group arns, and the attach, detach, and describe methods have been implemented. 

A note about the update_auto_scaling_group method:

I noticed that the [mocked method](https://github.com/spulec/moto/blob/master/moto/autoscaling/responses.py#L148)  takes a `LoadBalancerNames` argument. This does not actually conform with the boto3 spec; the way to 'update' an existing autoscaling group with a new load balancer config is to actually use the `attach_load_balancers` method. The same thing goes for the elbv2 resource.

Since this doesn't relate strictly to the elbv2 integration, I was going to open a new PR with the fix. I thought it was worth mentioning because the v1 methods work as a rough guide for the v2 methods.