### PR TITLE
update_auto_scaling_group method incorrectly supports LoadBalancerNames

### DIFF
--- a/moto/autoscaling/models.py
+++ b/moto/autoscaling/models.py
@@ -224,7 +224,7 @@ class FakeAutoScalingGroup(BaseModel):
 
     def update(self, availability_zones, desired_capacity, max_size, min_size,
                launch_config_name, vpc_zone_identifier, default_cooldown,
-               health_check_period, health_check_type, load_balancers,
+               health_check_period, health_check_type,
                placement_group, termination_policies):
         if availability_zones:
             self.availability_zones = availability_zones
@@ -392,13 +392,13 @@ class AutoScalingBackend(BaseBackend):
                                  desired_capacity, max_size, min_size,
                                  launch_config_name, vpc_zone_identifier,
                                  default_cooldown, health_check_period,
-                                 health_check_type, load_balancers,
-                                 placement_group, termination_policies):
+                                 health_check_type, placement_group,
+                                 termination_policies):
         group = self.autoscaling_groups[name]
         group.update(availability_zones, desired_capacity, max_size,
                      min_size, launch_config_name, vpc_zone_identifier,
                      default_cooldown, health_check_period, health_check_type,
-                     load_balancers, placement_group, termination_policies)
+                     placement_group, termination_policies)
         return group
 
     def describe_autoscaling_groups(self, names):

--- a/moto/autoscaling/responses.py
+++ b/moto/autoscaling/responses.py
@@ -145,7 +145,6 @@ class AutoScalingResponse(BaseResponse):
             default_cooldown=self._get_int_param('DefaultCooldown'),
             health_check_period=self._get_int_param('HealthCheckGracePeriod'),
             health_check_type=self._get_param('HealthCheckType'),
-            load_balancers=self._get_multi_param('LoadBalancerNames.member'),
             placement_group=self._get_param('PlacementGroup'),
             termination_policies=self._get_multi_param(
                 'TerminationPolicies.member'),


### PR DESCRIPTION
the boto3 autoscaling client's `update_auto_scaling_group` method does not support modifying load balancer properties. This PR removes that parameter.