### PR TITLE
Fix scaffold to support rest-json style API

### DIFF
--- a/moto/backends.py
+++ b/moto/backends.py
@@ -36,6 +36,7 @@ from moto.ssm import ssm_backends
 from moto.sts import sts_backends
 from moto.xray import xray_backends
 from moto.batch import batch_backends
+from moto.iot import iot_backends
 
 BACKENDS = {
     'acm': acm_backends,
@@ -74,7 +75,8 @@ BACKENDS = {
     'sts': sts_backends,
     'route53': route53_backends,
     'lambda': lambda_backends,
-    'xray': xray_backends
+    'xray': xray_backends,
+    'iot': iot_backends,
 }
 
 

--- a/moto/backends.py
+++ b/moto/backends.py
@@ -38,6 +38,7 @@ from moto.xray import xray_backends
 from moto.batch import batch_backends
 from moto.iot import iot_backends
 
+
 BACKENDS = {
     'acm': acm_backends,
     'apigateway': apigateway_backends,
@@ -76,7 +77,6 @@ BACKENDS = {
     'route53': route53_backends,
     'lambda': lambda_backends,
     'xray': xray_backends,
-    'iot': iot_backends,
 }
 
 

--- a/moto/backends.py
+++ b/moto/backends.py
@@ -36,7 +36,6 @@ from moto.ssm import ssm_backends
 from moto.sts import sts_backends
 from moto.xray import xray_backends
 from moto.batch import batch_backends
-from moto.iot import iot_backends
 
 
 BACKENDS = {

--- a/moto/core/responses.py
+++ b/moto/core/responses.py
@@ -280,15 +280,13 @@ class BaseResponse(_TemplateEnvironmentMixin):
             return val[0]
 
         # try to get json body parameter
-        try:
-            j = json.loads(self.body)
-            # raise key error if key really does not exist
-            return j[param_name]
-        except ValueError:
-            pass
-        except KeyError:
-            pass
-
+        if self.body is not None:
+            try:
+                return json.loads(self.body)[param_name]
+            except ValueError:
+                pass
+            except KeyError:
+                pass
         # try to get path parameter
         if self.uri_match:
             try:

--- a/moto/core/responses.py
+++ b/moto/core/responses.py
@@ -210,13 +210,13 @@ class BaseResponse(_TemplateEnvironmentMixin):
         """
 
         # service response class should have 'SERVICE_NAME' class member,
-        # if want to get action from method and url
+        # if you want to get action from method and url
         if not hasattr(self, 'SERVICE_NAME'):
             return None
         service = self.SERVICE_NAME
         conn = boto3.client(service)
 
-        # make cache if it has not exist yet
+        # make cache if it does not exist yet
         if not hasattr(self, 'method_urls'):
             self.method_urls = defaultdict(lambda: defaultdict(str))
             op_names = conn._service_model.operation_names
@@ -284,14 +284,16 @@ class BaseResponse(_TemplateEnvironmentMixin):
             j = json.loads(self.body)
             # raise key error if key really does not exist
             return j[param_name]
-        except:
-            # do nothing if param is not found
+        except ValueError:
             pass
+        except KeyError:
+            pass
+
         # try to get path parameter
         if self.uri_match:
             try:
                 return self.uri_match.group(param_name)
-            except:
+            except IndexError:
                 # do nothing if param is not found
                 pass
         return if_none

--- a/moto/core/responses.py
+++ b/moto/core/responses.py
@@ -105,7 +105,8 @@ class _TemplateEnvironmentMixin(object):
 class BaseResponse(_TemplateEnvironmentMixin):
 
     default_region = 'us-east-1'
-    region_regex = r'\.(.+?)\.amazonaws\.com'
+    # to extract region, use [^.]
+    region_regex = r'\.([^.]+?)\.amazonaws\.com'
     aws_service_spec = None
 
     @classmethod

--- a/scripts/scaffold.py
+++ b/scripts/scaffold.py
@@ -243,7 +243,7 @@ def get_function_in_responses(service, operation, protocol):
     inputs = op_model.input_shape.members
     input_names = [to_snake_case(_) for _ in inputs.keys() if _ not in INPUT_IGNORED_IN_BACKEND]
     output_names = [to_snake_case(_) for _ in outputs.keys() if _ not in OUTPUT_IGNORED_IN_BACKEND]
-    body = 'def {}(self):\n'.format(operation)
+    body = '\ndef {}(self):\n'.format(operation)
 
     for input_name, input_type in inputs.items():
         type_name = input_type.type_name
@@ -293,7 +293,7 @@ def get_function_in_models(service, operation):
     else:
         body = 'def {}(self)\n'
     body += '    # implement here\n'
-    body += '    return {}\n'.format(', '.join(output_names))
+    body += '    return {}\n\n'.format(', '.join(output_names))
 
     return body
 

--- a/scripts/scaffold.py
+++ b/scripts/scaffold.py
@@ -217,6 +217,11 @@ def to_upper_camel_case(s):
     return ''.join([_.title() for _ in s.split('_')])
 
 
+def to_lower_camel_case(s):
+    words = s.split('_')
+    return ''.join(words[:1] + [_.title() for _ in words[1:]])
+
+
 def to_snake_case(s):
     s1 = re.sub('(.)([A-Z][a-z]+)', r'\1_\2', s)
     return re.sub('([a-z0-9])([A-Z])', r'\1_\2', s1).lower()
@@ -247,7 +252,7 @@ def get_function_in_responses(service, operation, protocol):
             arg_line_tmpl = '    {} = self._get_param("{}")\n'
         body += arg_line_tmpl.format(to_snake_case(input_name), input_name)
     if output_names:
-        body += '    {} = self.{}_backend.{}(\n'.format(','.join(output_names), service, operation)
+        body += '    {} = self.{}_backend.{}(\n'.format(', '.join(output_names), service, operation)
     else:
         body += '    self.{}_backend.{}(\n'.format(service, operation)
     for input_name in input_names:
@@ -257,11 +262,11 @@ def get_function_in_responses(service, operation, protocol):
     if protocol == 'query':
         body += '    template = self.response_template({}_TEMPLATE)\n'.format(operation.upper())
         body += '    return template.render({})\n'.format(
-            ','.join(['{}={}'.format(_, _) for _ in output_names])
+            ', '.join(['{}={}'.format(_, _) for _ in output_names])
         )
     elif protocol in ['json', 'rest-json']:
         body += '    # TODO: adjust response\n'
-        body += '    return json.dumps({})\n'.format(','.join(['{}={}'.format(_, _) for _ in output_names]))
+        body += '    return json.dumps(dict({}))\n'.format(', '.join(['{}={}'.format(to_lower_camel_case(_), _) for _ in output_names]))
     return body
 
 

--- a/scripts/scaffold.py
+++ b/scripts/scaffold.py
@@ -260,7 +260,7 @@ def get_function_in_responses(service, operation, protocol):
     if output_names:
         body += '    {} = self.{}_backend.{}(\n'.format(', '.join(output_names), get_escaped_service(service), operation)
     else:
-        body += '    self.{}_backend.{}(\n'.format(service, operation)
+        body += '    self.{}_backend.{}(\n'.format(get_escaped_service(service), operation)
     for input_name in input_names:
         body += '        {}={},\n'.format(input_name, input_name)
 

--- a/scripts/scaffold.py
+++ b/scripts/scaffold.py
@@ -236,7 +236,10 @@ def get_function_in_responses(service, operation, protocol):
 
     aws_operation_name = to_upper_camel_case(operation)
     op_model = client._service_model.operation_model(aws_operation_name)
-    outputs = op_model.output_shape.members
+    if not hasattr(op_model.output_shape, 'members'):
+        outputs = {}
+    else:
+        outputs = op_model.output_shape.members
     inputs = op_model.input_shape.members
     input_names = [to_snake_case(_) for _ in inputs.keys() if _ not in INPUT_IGNORED_IN_BACKEND]
     output_names = [to_snake_case(_) for _ in outputs.keys() if _ not in OUTPUT_IGNORED_IN_BACKEND]
@@ -279,7 +282,10 @@ def get_function_in_models(service, operation):
     aws_operation_name = to_upper_camel_case(operation)
     op_model = client._service_model.operation_model(aws_operation_name)
     inputs = op_model.input_shape.members
-    outputs = op_model.output_shape.members
+    if not hasattr(op_model.output_shape, 'members'):
+        outputs = {}
+    else:
+        outputs = op_model.output_shape.members
     input_names = [to_snake_case(_) for _ in inputs.keys() if _ not in INPUT_IGNORED_IN_BACKEND]
     output_names = [to_snake_case(_) for _ in outputs.keys() if _ not in OUTPUT_IGNORED_IN_BACKEND]
     if input_names:

--- a/scripts/scaffold.py
+++ b/scripts/scaffold.py
@@ -147,7 +147,6 @@ def append_mock_dict_to_backends_py(service):
     with open(path) as f:
         lines = [_.replace('\n', '') for _ in f.readlines()]
 
-        #     'xray': xray_backends
     if any(_ for _ in lines if re.match(".*'{}': {}_backends.*".format(service, service), _)):
         return
     filtered_lines = [_ for _ in lines if re.match(".*'.*':.*_backends.*", _)]
@@ -418,22 +417,8 @@ def insert_url(service, operation, api_protocol):
 
     # generate url pattern
     if api_protocol == 'rest-json':
-        elems = uri.split('/')
-
-        def _convert(resource):
-            if not re.match('^{.*}$', resource):
-                return resource
-            formatted_name = resource.replace('{', '').replace('}', '').replace('-', '_')
-            return '(?P<%s>[\w_-]+)' % formatted_name
-        if uri == '/':
-            func_name = 'root'
-        else:
-            func_name = [
-                to_snake_case(_.replace('{', '').replace('}', '').replace('-', '_')) for _ in elems
-            ][-1]
-        new_uri = '/'.join([_convert(_) for _ in elems])
-        new_line = "    '{0}%s/?$': response.%s," % (
-            new_uri, func_name
+        new_line = "    '{0}%s/.*?$': response.%s," % (
+            new_uri
         )
     else:
         new_line = "    '{0}%s$': %sResponse.dispatch," % (

--- a/scripts/scaffold.py
+++ b/scripts/scaffold.py
@@ -258,7 +258,7 @@ def get_function_in_responses(service, operation, protocol):
             arg_line_tmpl = '    {} = self._get_param("{}")\n'
         body += arg_line_tmpl.format(to_snake_case(input_name), input_name)
     if output_names:
-        body += '    {} = self.{}_backend.{}(\n'.format(', '.join(output_names), service, operation)
+        body += '    {} = self.{}_backend.{}(\n'.format(', '.join(output_names), get_escaped_service(service), operation)
     else:
         body += '    self.{}_backend.{}(\n'.format(service, operation)
     for input_name in input_names:

--- a/scripts/scaffold.py
+++ b/scripts/scaffold.py
@@ -245,7 +245,7 @@ def get_function_in_responses(service, operation, protocol):
     for input_name, input_type in inputs.items():
         type_name = input_type.type_name
         if type_name == 'integer':
-            arg_line_tmpl = '    {} = _get_int_param("{}")\n'
+            arg_line_tmpl = '    {} = self._get_int_param("{}")\n'
         elif type_name == 'list':
             arg_line_tmpl = '    {} = self._get_list_prefix("{}.member")\n'
         else:

--- a/scripts/template/lib/__init__.py.j2
+++ b/scripts/template/lib/__init__.py.j2
@@ -1,7 +1,7 @@
 from __future__ import unicode_literals
-from .models import {{ service }}_backends
+from .models import {{ escaped_service }}_backends
 from ..core.models import base_decorator
 
-{{ service }}_backend = {{ service }}_backends['us-east-1']
-mock_{{ service }} = base_decorator({{ service }}_backends)
+{{ escaped_service }}_backend = {{ escaped_service }}_backends['us-east-1']
+mock_{{ escaped_service }} = base_decorator({{ escaped_service }}_backends)
 

--- a/scripts/template/lib/models.py.j2
+++ b/scripts/template/lib/models.py.j2
@@ -17,4 +17,4 @@ class {{ service_class }}Backend(BaseBackend):
 
 
 available_regions = boto3.session.Session().get_available_regions("{{ service }}")
-{{ service }}_backends = {region: {{ service_class }}Backend(region) for region in available_regions}
+{{ escaped_service }}_backends = {region: {{ service_class }}Backend(region) for region in available_regions}

--- a/scripts/template/lib/responses.py.j2
+++ b/scripts/template/lib/responses.py.j2
@@ -1,6 +1,7 @@
 from __future__ import unicode_literals
 from moto.core.responses import BaseResponse
 from .models import {{ service }}_backends
+import json
 
 
 class {{ service_class }}Response(BaseResponse):

--- a/scripts/template/lib/responses.py.j2
+++ b/scripts/template/lib/responses.py.j2
@@ -1,14 +1,14 @@
 from __future__ import unicode_literals
 from moto.core.responses import BaseResponse
-from .models import {{ service }}_backends
+from .models import {{ escaped_service }}_backends
 import json
 
 
 class {{ service_class }}Response(BaseResponse):
     SERVICE_NAME = '{{ service }}'
     @property
-    def {{ service }}_backend(self):
-        return {{ service }}_backends[self.region]
+    def {{ escaped_service }}_backend(self):
+        return {{ escaped_service }}_backends[self.region]
 
     # add methods from here
 

--- a/scripts/template/lib/responses.py.j2
+++ b/scripts/template/lib/responses.py.j2
@@ -4,6 +4,7 @@ from .models import {{ service }}_backends
 
 
 class {{ service_class }}Response(BaseResponse):
+    SERVICE_NAME = '{{ service }}'
     @property
     def {{ service }}_backend(self):
         return {{ service }}_backends[self.region]

--- a/scripts/template/lib/urls.py.j2
+++ b/scripts/template/lib/urls.py.j2
@@ -5,5 +5,9 @@ url_bases = [
     "https?://{{ endpoint_prefix }}.(.+).amazonaws.com",
 ]
 
+{% if api_protocol == 'rest-json' %}
+response = {{ service_class }}Response()
+{% endif %}
+
 url_paths = {
 }

--- a/scripts/template/test/test_server.py.j2
+++ b/scripts/template/test/test_server.py.j2
@@ -3,14 +3,14 @@ from __future__ import unicode_literals
 import sure  # noqa
 
 import moto.server as server
-from moto import mock_{{ service }}
+from moto import mock_{{ escaped_service }}
 
 '''
 Test the different server responses
 '''
 
-@mock_{{ service }}
-def test_{{ service }}_list():
+@mock_{{ escaped_service }}
+def test_{{ escaped_service }}_list():
     backend = server.create_backend_app("{{ service }}")
     test_client = backend.test_client()
     # do test

--- a/scripts/template/test/test_service.py.j2
+++ b/scripts/template/test/test_service.py.j2
@@ -2,10 +2,10 @@ from __future__ import unicode_literals
 
 import boto3
 import sure  # noqa
-from moto import mock_{{ service }}
+from moto import mock_{{ escaped_service }}
 
 
-@mock_{{ service }}
+@mock_{{ escaped_service }}
 def test_list():
     # do test
     pass


### PR DESCRIPTION
I fixed scaffold script and `moto/core/responses.py` to support rest-json style API in scaffold.

# changes in core module
In `moto/core/responses.py`,  I mainly changed `_get_param` method and `_dispatch`+`_get_action` method.

**In `_get_param`**
Response class has been getting parameters only from queryparameter. In the PR, it will try to get parameters in order of queryparameter, json body and path parameter.

**In `_dispatch`+`_get_action`**
previously Response class had been dispatching request to appropriate method  based on the operation name in the request. Unfortunately, rest-api request does not include operation name in itself. In this PR, when it cannot find operation name in the request, it looks up operation name in boto3 client by request method and request uri.

# changes in scaffold
some refactors + fixes to adapt to change in core module for rest-api