### PR TITLE
Do not freeze requirement aws-xray-sdk to a specific version 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ install_requires = [
     "python-dateutil<3.0.0,>=2.1",
     "mock",
     "docker>=2.5.1",
-    "aws-xray-sdk==0.92.2"
+    "aws-xray-sdk>=0.93"
 ]
 
 extras_require = {


### PR DESCRIPTION
Use '>=' instead of '==' to allow future versions to be updated.
cf https://github.com/spulec/moto/issues/1290