### PR TITLE
Fix flake8 version to 3.4.1

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,7 +3,7 @@ mock
 nose
 sure==1.2.24
 coverage
-flake8
+flake8==3.4.1
 freezegun
 flask
 boto>=2.45.0


### PR DESCRIPTION
Fix flake8's version to 3.4.1. 
flake8 3.5.0 makes failure to current moto's code base.
```
$ make test
flake8 moto
moto/acm/responses.py:114:9: E722 do not use bare except'
moto/acm/responses.py:118:9: E722 do not use bare except'
moto/acm/responses.py:123:13: E722 do not use bare except'
moto/s3bucket_path/utils.py:8:5: E741 ambiguous variable name 'l'
moto/awslambda/models.py:258:9: E722 do not use bare except'
moto/awslambda/models.py:265:9: E722 do not use bare except'
moto/awslambda/responses.py:9:1: E722 do not use bare except'
moto/core/responses.py:286:9: E722 do not use bare except'
moto/core/responses.py:293:13: E722 do not use bare except'
make: *** [lint] Error 1
```