### PR TITLE
[DNM]Support IoT

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,8 @@ It gets even better! Moto isn't just for Python code and it isn't just for S3. L
 |------------------------------------------------------------------------------|
 | IAM                   | @mock_iam        | core endpoints done               |
 |------------------------------------------------------------------------------|
+| IoT                   | @mock_iot        | core endpoints done               |
+|------------------------------------------------------------------------------|
 | Lambda                | @mock_lambda     | basic endpoints done, requires    |
 |                       |                  | docker                            |
 |------------------------------------------------------------------------------|

--- a/moto/__init__.py
+++ b/moto/__init__.py
@@ -41,6 +41,7 @@ from .swf import mock_swf, mock_swf_deprecated  # flake8: noqa
 from .xray import mock_xray, mock_xray_client, XRaySegment  # flake8: noqa
 from .logs import mock_logs, mock_logs_deprecated # flake8: noqa
 from .batch import mock_batch  # flake8: noqa
+from .iot import mock_iot  # flake8: noqa
 
 
 try:

--- a/moto/backends.py
+++ b/moto/backends.py
@@ -77,7 +77,6 @@ BACKENDS = {
     'route53': route53_backends,
     'lambda': lambda_backends,
     'xray': xray_backends,
-    'iot': iot_backends,
 }
 
 

--- a/moto/backends.py
+++ b/moto/backends.py
@@ -38,7 +38,6 @@ from moto.xray import xray_backends
 from moto.batch import batch_backends
 from moto.iot import iot_backends
 
-
 BACKENDS = {
     'acm': acm_backends,
     'apigateway': apigateway_backends,
@@ -77,6 +76,7 @@ BACKENDS = {
     'route53': route53_backends,
     'lambda': lambda_backends,
     'xray': xray_backends,
+    'iot': iot_backends,
 }
 
 

--- a/moto/backends.py
+++ b/moto/backends.py
@@ -36,6 +36,8 @@ from moto.ssm import ssm_backends
 from moto.sts import sts_backends
 from moto.xray import xray_backends
 from moto.batch import batch_backends
+from moto.iot import iot_backends
+
 
 BACKENDS = {
     'acm': acm_backends,
@@ -74,7 +76,8 @@ BACKENDS = {
     'sts': sts_backends,
     'route53': route53_backends,
     'lambda': lambda_backends,
-    'xray': xray_backends
+    'xray': xray_backends,
+    'iot': iot_backends,
 }
 
 

--- a/moto/iot/__init__.py
+++ b/moto/iot/__init__.py
@@ -1,0 +1,6 @@
+from __future__ import unicode_literals
+from .models import iot_backends
+from ..core.models import base_decorator
+
+iot_backend = iot_backends['us-east-1']
+mock_iot = base_decorator(iot_backends)

--- a/moto/iot/exceptions.py
+++ b/moto/iot/exceptions.py
@@ -1,0 +1,22 @@
+from __future__ import unicode_literals
+from moto.core.exceptions import RESTError
+
+class IoTClientError(RESTError):
+    code = 400
+
+
+class ResourceNotFoundException(IoTClientError):
+    def __init__(self):
+        self.code = 400
+        super(ResourceNotFoundException, self).__init__(
+            "ResourceNotFoundException",
+            "The specified resource does not exist"
+        )
+
+class InvalidRequestException(IoTClientError):
+    def __init__(self):
+        self.code = 400
+        super(InvalidRequestException, self).__init__(
+            "InvalidRequestException",
+            "The request is not valid."
+        )

--- a/moto/iot/models.py
+++ b/moto/iot/models.py
@@ -1,0 +1,155 @@
+from __future__ import unicode_literals
+import time
+import boto3
+from moto.core import BaseBackend, BaseModel
+from collections import OrderedDict
+from .exceptions import (
+    ResourceNotFoundException,
+    InvalidRequestException
+)
+
+
+class FakeThing(BaseModel):
+    def __init__(self, thing_name, thing_type, attributes, region_name):
+        self.region_name = region_name
+        self.thing_name = thing_name
+        self.thing_type = thing_type
+        self.attributes = attributes
+        self.arn = 'arn:aws:iot:%s:1:thing/%s' % (self.region_name, thing_name)
+        self.version = 1
+        # TODO: we need to handle 'version'?
+
+    def to_json(self, include_default_client_id=False):
+        obj = {
+            'thingName': self.thing_name,
+            'thingTypeName': self.thing_type.thing_type_name,
+            'attributes': self.attributes,
+            'version': self.version
+        }
+        if include_default_client_id:
+            obj['defaultClientId'] = self.thing_name
+        return obj
+
+
+class FakeThingType(BaseModel):
+    def __init__(self, thing_type_name, thing_type_properties, region_name):
+        self.region_name = region_name
+        self.thing_type_name = thing_type_name
+        self.thing_type_properties = thing_type_properties
+        t = time.time()
+        self.metadata = {
+            'deprecated': False,
+            'creationData': int(t * 1000) / 1000.0
+        }
+        self.arn = 'arn:aws:iot:%s:1:thingtype/%s' % (self.region_name, thing_type_name)
+
+    def to_json(self):
+        return {
+            'thingTypeName': self.thing_type_name,
+            'thingTypeProperties': self.thing_type_properties,
+            'thingTypeMetadata': self.metadata
+        }
+
+
+class IoTBackend(BaseBackend):
+    def __init__(self, region_name=None):
+        super(IoTBackend, self).__init__()
+        self.region_name = region_name
+        self.things = OrderedDict()
+        self.thing_types = OrderedDict()
+
+    def reset(self):
+        region_name = self.region_name
+        self.__dict__ = {}
+        self.__init__(region_name)
+
+    def create_thing(self, thing_name, thing_type_name, attribute_payload):
+        thing_types = self.list_thing_types()
+        filtered_thing_types = [_ for _ in thing_types if _.thing_type_name == thing_type_name]
+        if len(filtered_thing_types) == 0:
+            raise ResourceNotFoundException()
+        thing_type = filtered_thing_types[0]
+        if attribute_payload is None:
+            attributes = {}
+        elif 'attributes' not in attribute_payload:
+            attributes = {}
+        else:
+            attributes = attribute_payload['attributes']
+        thing = FakeThing(thing_name, thing_type, attributes, self.region_name)
+        self.things[thing.arn] = thing
+        return thing.thing_name, thing.arn
+
+    def create_thing_type(self, thing_type_name, thing_type_properties):
+        if thing_type_properties is None:
+            thing_type_properties = {}
+        thing_type = FakeThingType(thing_type_name, thing_type_properties, self.region_name)
+        self.thing_types[thing_type.arn] = thing_type
+        return thing_type.thing_type_name, thing_type.arn
+
+    def list_thing_types(self, thing_type_name=None):
+        if thing_type_name:
+            # It's wierd but thing_type_name is filterd by forward match, not complete match
+            return [_ for _ in self.thing_types.values() if _.thing_type_name.startswith(thing_type_name)]
+        thing_types = self.thing_types.values()
+        return thing_types
+
+    def list_things(self, attribute_name, attribute_value, thing_type_name):
+        # TODO: filter by attributess or thing_type
+        things = self.things.values()
+        return things
+
+    def describe_thing(self, thing_name):
+        things = [_ for _ in self.things.values() if _.thing_name == thing_name]
+        if len(things) == 0:
+            raise ResourceNotFoundException()
+        return things[0]
+
+    def describe_thing_type(self, thing_type_name):
+        thing_types = [_ for _ in self.thing_types.values() if _.thing_type_name == thing_type_name]
+        if len(thing_types) == 0:
+            raise ResourceNotFoundException()
+        return thing_types[0]
+
+    def delete_thing(self, thing_name, expected_version):
+        # TODO: handle expected_version
+
+        # can raise ResourceNotFoundError
+        thing = self.describe_thing(thing_name)
+        del self.things[thing.arn]
+
+    def delete_thing_type(self, thing_type_name):
+        # can raise ResourceNotFoundError
+        thing_type = self.describe_thing_type(thing_type_name)
+        del self.thing_types[thing_type.arn]
+
+    def update_thing(self, thing_name, thing_type_name, attribute_payload, expected_version, remove_thing_type):
+        # if attributes payload = {}, nothing
+        thing = self.describe_thing(thing_name)
+        thing_type = None
+
+        if remove_thing_type and thing_type_name:
+            raise InvalidRequestException()
+
+        # thing_type
+        if thing_type_name:
+            thing_types = self.list_thing_types()
+            filtered_thing_types = [_ for _ in thing_types if _.thing_type_name == thing_type_name]
+            if len(filtered_thing_types) == 0:
+                raise ResourceNotFoundException()
+            thing_type = filtered_thing_types[0]
+            thing.thing_type = thing_type
+
+        if remove_thing_type:
+            thing.thing_type = None
+
+        # attribute
+        if attribute_payload is not None and 'attributes' in attribute_payload:
+            do_merge = attribute_payload.get('merge', False)
+            attributes = attribute_payload['attributes']
+            if not do_merge:
+                thing.attributes = attributes
+            else:
+                thing.attributes.update(attributes)
+
+available_regions = boto3.session.Session().get_available_regions("iot")
+iot_backends = {region: IoTBackend(region) for region in available_regions}

--- a/moto/iot/models.py
+++ b/moto/iot/models.py
@@ -22,7 +22,7 @@ class FakeThing(BaseModel):
         self.version = 1
         # TODO: we need to handle 'version'?
 
-    def to_json(self, include_default_client_id=False):
+    def to_dict(self, include_default_client_id=False):
         obj = {
             'thingName': self.thing_name,
             'thingTypeName': self.thing_type.thing_type_name,
@@ -46,7 +46,7 @@ class FakeThingType(BaseModel):
         }
         self.arn = 'arn:aws:iot:%s:1:thingtype/%s' % (self.region_name, thing_type_name)
 
-    def to_json(self):
+    def to_dict(self):
         return {
             'thingTypeName': self.thing_type_name,
             'thingTypeProperties': self.thing_type_properties,
@@ -70,7 +70,7 @@ class FakeCertificate(BaseModel):
         self.last_modified_date = self.creation_date
         self.ca_certificate_id = None
 
-    def to_json(self):
+    def to_dict(self):
         return {
             'certificateArn': self.arn,
             'certificateId': self.certificate_id,
@@ -78,7 +78,7 @@ class FakeCertificate(BaseModel):
             'creationDate': self.creation_date
         }
 
-    def to_description_json(self):
+    def to_description_dict(self):
         """
         You might need keys below in some situation
           - caCertificateId

--- a/moto/iot/responses.py
+++ b/moto/iot/responses.py
@@ -86,8 +86,8 @@ class IoTResponse(BaseResponse):
         self.iot_backend.delete_thing_type(
             thing_type_name=thing_type_name,
         )
-        # TODO: adjust response
         return json.dumps(dict())
+
     def update_thing(self):
         thing_name = self._get_param("thingName")
         thing_type_name = self._get_param("thingTypeName")
@@ -101,5 +101,46 @@ class IoTResponse(BaseResponse):
             expected_version=expected_version,
             remove_thing_type=remove_thing_type,
         )
-        # TODO: adjust response
+        return json.dumps(dict())
+
+    def create_keys_and_certificate(self):
+        set_as_active = self._get_param("setAsActive")
+        cert, key_pair = self.iot_backend.create_keys_and_certificate(
+            set_as_active=set_as_active,
+        )
+        return json.dumps(dict(
+            certificateArn=cert.arn,
+            certificateId=cert.certificate_id,
+            certificatePem=cert.certificate_pem,
+            keyPair=key_pair
+        ))
+    def delete_certificate(self):
+        certificate_id = self._get_param("certificateId")
+        self.iot_backend.delete_certificate(
+            certificate_id=certificate_id,
+        )
+        return json.dumps(dict())
+
+    def describe_certificate(self):
+        certificate_id = self._get_param("certificateId")
+        certificate = self.iot_backend.describe_certificate(
+            certificate_id=certificate_id,
+        )
+        return json.dumps(dict(certificateDescription=certificate.to_description_json()))
+
+    def list_certificates(self):
+        page_size = self._get_int_param("pageSize")
+        marker = self._get_param("marker")
+        ascending_order = self._get_param("ascendingOrder")
+        certificates = self.iot_backend.list_certificates()
+        # TODO: handle pagination
+        return json.dumps(dict(certificates=[_.to_json() for _ in certificates]))
+
+    def update_certificate(self):
+        certificate_id = self._get_param("certificateId")
+        new_status = self._get_param("newStatus")
+        self.iot_backend.update_certificate(
+            certificate_id=certificate_id,
+            new_status=new_status,
+        )
         return json.dumps(dict())

--- a/moto/iot/responses.py
+++ b/moto/iot/responses.py
@@ -177,3 +177,47 @@ class IoTResponse(BaseResponse):
             policy_name=policy_name,
         )
         return json.dumps(dict())
+
+    def attach_principal_policy(self):
+        policy_name = self._get_param("policyName")
+        principal = self.headers.get('x-amzn-iot-principal')
+        self.iot_backend.attach_principal_policy(
+            policy_name=policy_name,
+            principal_arn=principal,
+        )
+        # TODO: adjust response
+        return json.dumps(dict())
+
+    def detach_principal_policy(self):
+        policy_name = self._get_param("policyName")
+        principal = self.headers.get('x-amzn-iot-principal')
+        self.iot_backend.detach_principal_policy(
+            policy_name=policy_name,
+            principal_arn=principal,
+        )
+        # TODO: adjust response
+        return json.dumps(dict())
+
+    def list_principal_policies(self):
+        principal = self.headers.get('x-amzn-iot-principal')
+        marker = self._get_param("marker")
+        page_size = self._get_int_param("pageSize")
+        ascending_order = self._get_param("ascendingOrder")
+        policies = self.iot_backend.list_principal_policies(
+            principal_arn=principal
+        )
+        # TODO: handle pagination
+        next_marker = None
+        return json.dumps(dict(policies=[_.to_dict() for _ in policies], nextMarker=next_marker))
+
+    def list_policy_principals(self):
+        policy_name = self.headers.get('x-amzn-iot-policy')
+        marker = self._get_param("marker")
+        page_size = self._get_int_param("pageSize")
+        ascending_order = self._get_param("ascendingOrder")
+        principals = self.iot_backend.list_policy_principals(
+            policy_name=policy_name,
+        )
+        # TODO: handle pagination
+        next_marker = None
+        return json.dumps(dict(principals=principals, nextMarker=next_marker))

--- a/moto/iot/responses.py
+++ b/moto/iot/responses.py
@@ -144,3 +144,35 @@ class IoTResponse(BaseResponse):
             new_status=new_status,
         )
         return json.dumps(dict())
+
+    def create_policy(self):
+        policy_name = self._get_param("policyName")
+        policy_document = self._get_param("policyDocument")
+        policy = self.iot_backend.create_policy(
+            policy_name=policy_name,
+            policy_document=policy_document,
+        )
+        return json.dumps(policy.to_dict_at_creation())
+
+    def list_policies(self):
+        marker = self._get_param("marker")
+        page_size = self._get_int_param("pageSize")
+        ascending_order = self._get_param("ascendingOrder")
+        policies = self.iot_backend.list_policies()
+
+        # TODO: handle pagination
+        return json.dumps(dict(policies=[_.to_dict() for _ in policies]))
+
+    def get_policy(self):
+        policy_name = self._get_param("policyName")
+        policy = self.iot_backend.get_policy(
+            policy_name=policy_name,
+        )
+        return json.dumps(policy.to_get_dict())
+
+    def delete_policy(self):
+        policy_name = self._get_param("policyName")
+        self.iot_backend.delete_policy(
+            policy_name=policy_name,
+        )
+        return json.dumps(dict())

--- a/moto/iot/responses.py
+++ b/moto/iot/responses.py
@@ -221,3 +221,39 @@ class IoTResponse(BaseResponse):
         # TODO: handle pagination
         next_marker = None
         return json.dumps(dict(principals=principals, nextMarker=next_marker))
+
+    def attach_thing_principal(self):
+        thing_name = self._get_param("thingName")
+        principal = self.headers.get('x-amzn-principal')
+        self.iot_backend.attach_thing_principal(
+            thing_name=thing_name,
+            principal_arn=principal,
+        )
+        return json.dumps(dict())
+
+    def detach_thing_principal(self):
+        thing_name = self._get_param("thingName")
+        principal = self.headers.get('x-amzn-principal')
+        self.iot_backend.detach_thing_principal(
+            thing_name=thing_name,
+            principal_arn=principal,
+        )
+        return json.dumps(dict())
+
+    def list_principal_things(self):
+        next_token = self._get_param("nextToken")
+        max_results = self._get_int_param("maxResults")
+        principal = self.headers.get('x-amzn-principal')
+        things = self.iot_backend.list_principal_things(
+            principal_arn=principal,
+        )
+        # TODO: handle pagination
+        next_marker = None
+        return json.dumps(dict(things=things, nextToken=next_token))
+
+    def list_thing_principals(self):
+        thing_name = self._get_param("thingName")
+        principals = self.iot_backend.list_thing_principals(
+            thing_name=thing_name,
+        )
+        return json.dumps(dict(principals=principals))

--- a/moto/iot/responses.py
+++ b/moto/iot/responses.py
@@ -40,7 +40,7 @@ class IoTResponse(BaseResponse):
 
         # TODO: support next_token and max_results
         next_token = None
-        return json.dumps(dict(thingTypes=[_.to_json() for _ in thing_types], nextToken=next_token))
+        return json.dumps(dict(thingTypes=[_.to_dict() for _ in thing_types], nextToken=next_token))
 
     def list_things(self):
         previous_next_token = self._get_param("nextToken")
@@ -55,22 +55,22 @@ class IoTResponse(BaseResponse):
         )
         # TODO: support next_token and max_results
         next_token = None
-        return json.dumps(dict(things=[_.to_json() for _ in things], nextToken=next_token))
+        return json.dumps(dict(things=[_.to_dict() for _ in things], nextToken=next_token))
 
     def describe_thing(self):
         thing_name = self._get_param("thingName")
         thing = self.iot_backend.describe_thing(
             thing_name=thing_name,
         )
-        print(thing.to_json(include_default_client_id=True))
-        return json.dumps(thing.to_json(include_default_client_id=True))
+        print(thing.to_dict(include_default_client_id=True))
+        return json.dumps(thing.to_dict(include_default_client_id=True))
 
     def describe_thing_type(self):
         thing_type_name = self._get_param("thingTypeName")
         thing_type = self.iot_backend.describe_thing_type(
             thing_type_name=thing_type_name,
         )
-        return json.dumps(thing_type.to_json())
+        return json.dumps(thing_type.to_dict())
 
     def delete_thing(self):
         thing_name = self._get_param("thingName")
@@ -114,6 +114,7 @@ class IoTResponse(BaseResponse):
             certificatePem=cert.certificate_pem,
             keyPair=key_pair
         ))
+
     def delete_certificate(self):
         certificate_id = self._get_param("certificateId")
         self.iot_backend.delete_certificate(
@@ -126,7 +127,7 @@ class IoTResponse(BaseResponse):
         certificate = self.iot_backend.describe_certificate(
             certificate_id=certificate_id,
         )
-        return json.dumps(dict(certificateDescription=certificate.to_description_json()))
+        return json.dumps(dict(certificateDescription=certificate.to_description_dict()))
 
     def list_certificates(self):
         page_size = self._get_int_param("pageSize")
@@ -134,7 +135,7 @@ class IoTResponse(BaseResponse):
         ascending_order = self._get_param("ascendingOrder")
         certificates = self.iot_backend.list_certificates()
         # TODO: handle pagination
-        return json.dumps(dict(certificates=[_.to_json() for _ in certificates]))
+        return json.dumps(dict(certificates=[_.to_dict() for _ in certificates]))
 
     def update_certificate(self):
         certificate_id = self._get_param("certificateId")

--- a/moto/iot/responses.py
+++ b/moto/iot/responses.py
@@ -1,0 +1,105 @@
+from __future__ import unicode_literals
+from moto.core.responses import BaseResponse
+from .models import iot_backends
+import json
+
+
+class IoTResponse(BaseResponse):
+    SERVICE_NAME = 'iot'
+    @property
+    def iot_backend(self):
+        return iot_backends[self.region]
+
+    def create_thing(self):
+        thing_name = self._get_param("thingName")
+        thing_type_name = self._get_param("thingTypeName")
+        attribute_payload = self._get_param("attributePayload")
+        thing_name, thing_arn = self.iot_backend.create_thing(
+            thing_name=thing_name,
+            thing_type_name=thing_type_name,
+            attribute_payload=attribute_payload,
+        )
+        return json.dumps(dict(thingName=thing_name, thingArn=thing_arn))
+
+    def create_thing_type(self):
+        thing_type_name = self._get_param("thingTypeName")
+        thing_type_properties = self._get_param("thingTypeProperties")
+        thing_type_name, thing_type_arn = self.iot_backend.create_thing_type(
+            thing_type_name=thing_type_name,
+            thing_type_properties=thing_type_properties,
+        )
+        return json.dumps(dict(thingTypeName=thing_type_name, thingTypeArn=thing_type_arn))
+
+    def list_thing_types(self):
+        previous_next_token = self._get_param("nextToken")
+        max_results = self._get_int_param("maxResults")
+        thing_type_name = self._get_param("thingTypeName")
+        thing_types = self.iot_backend.list_thing_types(
+            thing_type_name=thing_type_name
+        )
+
+        # TODO: support next_token and max_results
+        next_token = None
+        return json.dumps(dict(thingTypes=[_.to_json() for _ in thing_types], nextToken=next_token))
+
+    def list_things(self):
+        previous_next_token = self._get_param("nextToken")
+        max_results = self._get_int_param("maxResults")
+        attribute_name = self._get_param("attributeName")
+        attribute_value = self._get_param("attributeValue")
+        thing_type_name = self._get_param("thingTypeName")
+        things = self.iot_backend.list_things(
+            attribute_name=attribute_name,
+            attribute_value=attribute_value,
+            thing_type_name=thing_type_name,
+        )
+        # TODO: support next_token and max_results
+        next_token = None
+        return json.dumps(dict(things=[_.to_json() for _ in things], nextToken=next_token))
+
+    def describe_thing(self):
+        thing_name = self._get_param("thingName")
+        thing = self.iot_backend.describe_thing(
+            thing_name=thing_name,
+        )
+        print(thing.to_json(include_default_client_id=True))
+        return json.dumps(thing.to_json(include_default_client_id=True))
+
+    def describe_thing_type(self):
+        thing_type_name = self._get_param("thingTypeName")
+        thing_type = self.iot_backend.describe_thing_type(
+            thing_type_name=thing_type_name,
+        )
+        return json.dumps(thing_type.to_json())
+
+    def delete_thing(self):
+        thing_name = self._get_param("thingName")
+        expected_version = self._get_param("expectedVersion")
+        self.iot_backend.delete_thing(
+            thing_name=thing_name,
+            expected_version=expected_version,
+        )
+        return json.dumps(dict())
+
+    def delete_thing_type(self):
+        thing_type_name = self._get_param("thingTypeName")
+        self.iot_backend.delete_thing_type(
+            thing_type_name=thing_type_name,
+        )
+        # TODO: adjust response
+        return json.dumps(dict())
+    def update_thing(self):
+        thing_name = self._get_param("thingName")
+        thing_type_name = self._get_param("thingTypeName")
+        attribute_payload = self._get_param("attributePayload")
+        expected_version = self._get_param("expectedVersion")
+        remove_thing_type = self._get_param("removeThingType")
+        self.iot_backend.update_thing(
+            thing_name=thing_name,
+            thing_type_name=thing_type_name,
+            attribute_payload=attribute_payload,
+            expected_version=expected_version,
+            remove_thing_type=remove_thing_type,
+        )
+        # TODO: adjust response
+        return json.dumps(dict())

--- a/moto/iot/urls.py
+++ b/moto/iot/urls.py
@@ -1,0 +1,14 @@
+from __future__ import unicode_literals
+from .responses import IoTResponse
+
+url_bases = [
+    "https?://iot.(.+).amazonaws.com",
+]
+
+
+response = IoTResponse()
+
+
+url_paths = {
+    '{0}/.*$': response.dispatch,
+}

--- a/scripts/scaffold.py
+++ b/scripts/scaffold.py
@@ -243,7 +243,7 @@ def get_function_in_responses(service, operation, protocol):
     inputs = op_model.input_shape.members
     input_names = [to_snake_case(_) for _ in inputs.keys() if _ not in INPUT_IGNORED_IN_BACKEND]
     output_names = [to_snake_case(_) for _ in outputs.keys() if _ not in OUTPUT_IGNORED_IN_BACKEND]
-    body = 'def {}(self):\n'.format(operation)
+    body = '\ndef {}(self):\n'.format(operation)
 
     for input_name, input_type in inputs.items():
         type_name = input_type.type_name
@@ -293,7 +293,7 @@ def get_function_in_models(service, operation):
     else:
         body = 'def {}(self)\n'
     body += '    # implement here\n'
-    body += '    return {}\n'.format(', '.join(output_names))
+    body += '    return {}\n\n'.format(', '.join(output_names))
 
     return body
 

--- a/scripts/scaffold.py
+++ b/scripts/scaffold.py
@@ -217,6 +217,11 @@ def to_upper_camel_case(s):
     return ''.join([_.title() for _ in s.split('_')])
 
 
+def to_lower_camel_case(s):
+    words = s.split('_')
+    return ''.join(words[:1] + [_.title() for _ in words[1:]])
+
+
 def to_snake_case(s):
     s1 = re.sub('(.)([A-Z][a-z]+)', r'\1_\2', s)
     return re.sub('([a-z0-9])([A-Z])', r'\1_\2', s1).lower()
@@ -247,7 +252,7 @@ def get_function_in_responses(service, operation, protocol):
             arg_line_tmpl = '    {} = self._get_param("{}")\n'
         body += arg_line_tmpl.format(to_snake_case(input_name), input_name)
     if output_names:
-        body += '    {} = self.{}_backend.{}(\n'.format(','.join(output_names), service, operation)
+        body += '    {} = self.{}_backend.{}(\n'.format(', '.join(output_names), service, operation)
     else:
         body += '    self.{}_backend.{}(\n'.format(service, operation)
     for input_name in input_names:
@@ -257,11 +262,11 @@ def get_function_in_responses(service, operation, protocol):
     if protocol == 'query':
         body += '    template = self.response_template({}_TEMPLATE)\n'.format(operation.upper())
         body += '    return template.render({})\n'.format(
-            ','.join(['{}={}'.format(_, _) for _ in output_names])
+            ', '.join(['{}={}'.format(_, _) for _ in output_names])
         )
     elif protocol in ['json', 'rest-json']:
         body += '    # TODO: adjust response\n'
-        body += '    return json.dumps({})\n'.format(','.join(['{}={}'.format(_, _) for _ in output_names]))
+        body += '    return json.dumps(dict({}))\n'.format(', '.join(['{}={}'.format(to_lower_camel_case(_), _) for _ in output_names]))
     return body
 
 

--- a/scripts/scaffold.py
+++ b/scripts/scaffold.py
@@ -236,7 +236,10 @@ def get_function_in_responses(service, operation, protocol):
 
     aws_operation_name = to_upper_camel_case(operation)
     op_model = client._service_model.operation_model(aws_operation_name)
-    outputs = op_model.output_shape.members
+    if not hasattr(op_model.output_shape, 'members'):
+        outputs = {}
+    else:
+        outputs = op_model.output_shape.members
     inputs = op_model.input_shape.members
     input_names = [to_snake_case(_) for _ in inputs.keys() if _ not in INPUT_IGNORED_IN_BACKEND]
     output_names = [to_snake_case(_) for _ in outputs.keys() if _ not in OUTPUT_IGNORED_IN_BACKEND]
@@ -279,7 +282,10 @@ def get_function_in_models(service, operation):
     aws_operation_name = to_upper_camel_case(operation)
     op_model = client._service_model.operation_model(aws_operation_name)
     inputs = op_model.input_shape.members
-    outputs = op_model.output_shape.members
+    if not hasattr(op_model.output_shape, 'members'):
+        outputs = {}
+    else:
+        outputs = op_model.output_shape.members
     input_names = [to_snake_case(_) for _ in inputs.keys() if _ not in INPUT_IGNORED_IN_BACKEND]
     output_names = [to_snake_case(_) for _ in outputs.keys() if _ not in OUTPUT_IGNORED_IN_BACKEND]
     if input_names:

--- a/scripts/scaffold.py
+++ b/scripts/scaffold.py
@@ -147,7 +147,6 @@ def append_mock_dict_to_backends_py(service):
     with open(path) as f:
         lines = [_.replace('\n', '') for _ in f.readlines()]
 
-        #     'xray': xray_backends
     if any(_ for _ in lines if re.match(".*'{}': {}_backends.*".format(service, service), _)):
         return
     filtered_lines = [_ for _ in lines if re.match(".*'.*':.*_backends.*", _)]
@@ -418,22 +417,8 @@ def insert_url(service, operation, api_protocol):
 
     # generate url pattern
     if api_protocol == 'rest-json':
-        elems = uri.split('/')
-
-        def _convert(resource):
-            if not re.match('^{.*}$', resource):
-                return resource
-            formatted_name = resource.replace('{', '').replace('}', '').replace('-', '_')
-            return '(?P<%s>[\w_-]+)' % formatted_name
-        if uri == '/':
-            func_name = 'root'
-        else:
-            func_name = [
-                to_snake_case(_.replace('{', '').replace('}', '').replace('-', '_')) for _ in elems
-            ][-1]
-        new_uri = '/'.join([_convert(_) for _ in elems])
-        new_line = "    '{0}%s/?$': response.%s," % (
-            new_uri, func_name
+        new_line = "    '{0}%s/.*?$': response.%s," % (
+            new_uri
         )
     else:
         new_line = "    '{0}%s$': %sResponse.dispatch," % (

--- a/scripts/scaffold.py
+++ b/scripts/scaffold.py
@@ -245,7 +245,7 @@ def get_function_in_responses(service, operation, protocol):
     for input_name, input_type in inputs.items():
         type_name = input_type.type_name
         if type_name == 'integer':
-            arg_line_tmpl = '    {} = _get_int_param("{}")\n'
+            arg_line_tmpl = '    {} = self._get_int_param("{}")\n'
         elif type_name == 'list':
             arg_line_tmpl = '    {} = self._get_list_prefix("{}.member")\n'
         else:

--- a/scripts/template/lib/responses.py.j2
+++ b/scripts/template/lib/responses.py.j2
@@ -1,6 +1,7 @@
 from __future__ import unicode_literals
 from moto.core.responses import BaseResponse
 from .models import {{ service }}_backends
+import json
 
 
 class {{ service_class }}Response(BaseResponse):

--- a/scripts/template/lib/responses.py.j2
+++ b/scripts/template/lib/responses.py.j2
@@ -4,6 +4,7 @@ from .models import {{ service }}_backends
 
 
 class {{ service_class }}Response(BaseResponse):
+    SERVICE_NAME = '{{ service }}'
     @property
     def {{ service }}_backend(self):
         return {{ service }}_backends[self.region]

--- a/scripts/template/lib/urls.py.j2
+++ b/scripts/template/lib/urls.py.j2
@@ -5,5 +5,9 @@ url_bases = [
     "https?://{{ endpoint_prefix }}.(.+).amazonaws.com",
 ]
 
+{% if api_protocol == 'rest-json' %}
+response = {{ service_class }}Response()
+{% endif %}
+
 url_paths = {
 }

--- a/tests/test_iot/test_iot.py
+++ b/tests/test_iot/test_iot.py
@@ -16,9 +16,9 @@ def test_things():
     thing_type.should.have.key('thingTypeName').which.should.equal(type_name)
     thing_type.should.have.key('thingTypeArn')
 
-    thing_types = client.list_thing_types()
-    thing_types.should.have.key('thingTypes').which.should.have.length_of(1)
-    for thing_type in thing_types['thingTypes']:
+    res = client.list_thing_types()
+    res.should.have.key('thingTypes').which.should.have.length_of(1)
+    for thing_type in res['thingTypes']:
         thing_type.should.have.key('thingTypeName').which.should_not.be.none
 
     thing_type = client.describe_thing_type(thingTypeName=type_name)
@@ -30,17 +30,17 @@ def test_things():
     thing = client.create_thing(thingName=name, thingTypeName=type_name)
     thing.should.have.key('thingName').which.should.equal(name)
     thing.should.have.key('thingArn')
-    things = client.list_things()
-    things.should.have.key('things').which.should.have.length_of(1)
-    for thing in things['things']:
+    res = client.list_things()
+    res.should.have.key('things').which.should.have.length_of(1)
+    for thing in res['things']:
         thing.should.have.key('thingName').which.should_not.be.none
 
     thing = client.update_thing(thingName=name, attributePayload={'attributes': {'k1': 'v1'}})
-    things = client.list_things()
-    things.should.have.key('things').which.should.have.length_of(1)
-    for thing in things['things']:
+    res = client.list_things()
+    res.should.have.key('things').which.should.have.length_of(1)
+    for thing in res['things']:
         thing.should.have.key('thingName').which.should_not.be.none
-    things['things'][0]['attributes'].should.have.key('k1').which.should.equal('v1')
+    res['things'][0]['attributes'].should.have.key('k1').which.should.equal('v1')
 
     thing = client.describe_thing(thingName=name)
     thing.should.have.key('thingName').which.should.equal(name)
@@ -51,13 +51,13 @@ def test_things():
 
     # delete thing
     client.delete_thing(thingName=name)
-    things = client.list_things()
-    things.should.have.key('things').which.should.have.length_of(0)
+    res = client.list_things()
+    res.should.have.key('things').which.should.have.length_of(0)
 
     # delete thing type
     client.delete_thing_type(thingTypeName=type_name)
-    thing_types = client.list_thing_types()
-    thing_types.should.have.key('thingTypes').which.should.have.length_of(0)
+    res = client.list_thing_types()
+    res.should.have.key('thingTypes').which.should.have.length_of(0)
 
 
 @mock_iot
@@ -80,9 +80,9 @@ def test_certs():
     cert_desc.should.have.key('certificatePem').which.should_not.be.none
     cert_desc.should.have.key('status').which.should.equal('ACTIVE')
 
-    certs = client.list_certificates()
-    certs.should.have.key('certificates').which.should.have.length_of(1)
-    for cert in certs['certificates']:
+    res = client.list_certificates()
+    res.should.have.key('certificates').which.should.have.length_of(1)
+    for cert in res['certificates']:
         cert.should.have.key('certificateArn').which.should_not.be.none
         cert.should.have.key('certificateId').which.should_not.be.none
         cert.should.have.key('status').which.should_not.be.none
@@ -93,8 +93,8 @@ def test_certs():
     cert_desc.should.have.key('status').which.should.equal('ACTIVE')
 
     client.delete_certificate(certificateId=cert_id)
-    certs = client.list_certificates()
-    certs.should.have.key('certificates').which.should.have.length_of(0)
+    res = client.list_certificates()
+    res.should.have.key('certificates').which.should.have.length_of(0)
 
 @mock_iot
 def test_policy():
@@ -120,5 +120,5 @@ def test_policy():
         policy.should.have.key('policyArn').which.should_not.be.none
 
     client.delete_policy(policyName=name)
-    policies = client.list_policies()
-    policies.should.have.key('policies').which.should.have.length_of(0)
+    res = client.list_policies()
+    res.should.have.key('policies').which.should.have.length_of(0)

--- a/tests/test_iot/test_iot.py
+++ b/tests/test_iot/test_iot.py
@@ -1,0 +1,60 @@
+from __future__ import unicode_literals
+
+import boto3
+import sure  # noqa
+from moto import mock_iot
+
+
+@mock_iot
+def test_list():
+    client = boto3.client('iot')
+    name = 'my-thing'
+    type_name = 'my-type-name'
+
+    # thing type
+    thing_type = client.create_thing_type(thingTypeName=type_name)
+    thing_type.should.have.key('thingTypeName').which.should.equal(type_name)
+    thing_type.should.have.key('thingTypeArn')
+
+    thing_types = client.list_thing_types()
+    thing_types.should.have.key('thingTypes').which.should.have.length_of(1)
+    for thing_type in thing_types['thingTypes']:
+        thing_type.should.have.key('thingTypeName').which.should_not.be.none
+
+    thing_type = client.describe_thing_type(thingTypeName=type_name)
+    thing_type.should.have.key('thingTypeName').which.should.equal(type_name)
+    thing_type.should.have.key('thingTypeProperties')
+    thing_type.should.have.key('thingTypeMetadata')
+
+    # thing
+    thing = client.create_thing(thingName=name, thingTypeName=type_name)
+    thing.should.have.key('thingName').which.should.equal(name)
+    thing.should.have.key('thingArn')
+    things = client.list_things()
+    things.should.have.key('things').which.should.have.length_of(1)
+    for thing in things['things']:
+        thing.should.have.key('thingName').which.should_not.be.none
+
+    thing = client.update_thing(thingName=name, attributePayload={'attributes': {'k1': 'v1'}})
+    things = client.list_things()
+    things.should.have.key('things').which.should.have.length_of(1)
+    for thing in things['things']:
+        thing.should.have.key('thingName').which.should_not.be.none
+    things['things'][0]['attributes'].should.have.key('k1').which.should.equal('v1')
+
+    thing = client.describe_thing(thingName=name)
+    thing.should.have.key('thingName').which.should.equal(name)
+    thing.should.have.key('defaultClientId')
+    thing.should.have.key('thingTypeName')
+    thing.should.have.key('attributes')
+    thing.should.have.key('version')
+
+    # delete thing
+    client.delete_thing(thingName=name)
+    things = client.list_things()
+    things.should.have.key('things').which.should.have.length_of(0)
+
+    # delete thing type
+    client.delete_thing_type(thingTypeName=type_name)
+    thing_types = client.list_thing_types()
+    thing_types.should.have.key('thingTypes').which.should.have.length_of(0)

--- a/tests/test_iot/test_iot.py
+++ b/tests/test_iot/test_iot.py
@@ -95,3 +95,30 @@ def test_certs():
     client.delete_certificate(certificateId=cert_id)
     certs = client.list_certificates()
     certs.should.have.key('certificates').which.should.have.length_of(0)
+
+@mock_iot
+def test_policy():
+    client = boto3.client('iot')
+    name = 'my-policy'
+    doc = '{}'
+    policy = client.create_policy(policyName=name, policyDocument=doc)
+    policy.should.have.key('policyName').which.should.equal(name)
+    policy.should.have.key('policyArn').which.should_not.be.none
+    policy.should.have.key('policyDocument').which.should.equal(doc)
+    policy.should.have.key('policyVersionId').which.should.equal('1')
+
+    policy = client.get_policy(policyName=name)
+    policy.should.have.key('policyName').which.should.equal(name)
+    policy.should.have.key('policyArn').which.should_not.be.none
+    policy.should.have.key('policyDocument').which.should.equal(doc)
+    policy.should.have.key('defaultVersionId').which.should.equal('1')
+
+    res = client.list_policies()
+    res.should.have.key('policies').which.should.have.length_of(1)
+    for policy in res['policies']:
+        policy.should.have.key('policyName').which.should_not.be.none
+        policy.should.have.key('policyArn').which.should_not.be.none
+
+    client.delete_policy(policyName=name)
+    policies = client.list_policies()
+    policies.should.have.key('policies').which.should.have.length_of(0)

--- a/tests/test_iot/test_iot.py
+++ b/tests/test_iot/test_iot.py
@@ -122,3 +122,32 @@ def test_policy():
     client.delete_policy(policyName=name)
     res = client.list_policies()
     res.should.have.key('policies').which.should.have.length_of(0)
+
+
+@mock_iot
+def test_principal_policy():
+    client = boto3.client('iot')
+    policy_name = 'my-policy'
+    doc = '{}'
+    policy = client.create_policy(policyName=policy_name, policyDocument=doc)
+    cert = client.create_keys_and_certificate(setAsActive=True)
+    cert_arn = cert['certificateArn']
+
+    client.attach_principal_policy(policyName=policy_name, principal=cert_arn)
+
+    res = client.list_principal_policies(principal=cert_arn)
+    res.should.have.key('policies').which.should.have.length_of(1)
+    for policy in res['policies']:
+        policy.should.have.key('policyName').which.should_not.be.none
+        policy.should.have.key('policyArn').which.should_not.be.none
+
+    res = client.list_policy_principals(policyName=policy_name)
+    res.should.have.key('principals').which.should.have.length_of(1)
+    for principal in res['principals']:
+        principal.should_not.be.none
+
+    client.detach_principal_policy(policyName=policy_name, principal=cert_arn)
+    res = client.list_principal_policies(principal=cert_arn)
+    res.should.have.key('policies').which.should.have.length_of(0)
+    res = client.list_policy_principals(policyName=policy_name)
+    res.should.have.key('principals').which.should.have.length_of(0)

--- a/tests/test_iot/test_server.py
+++ b/tests/test_iot/test_server.py
@@ -1,0 +1,16 @@
+from __future__ import unicode_literals
+
+import sure  # noqa
+
+import moto.server as server
+from moto import mock_iot
+
+'''
+Test the different server responses
+'''
+
+@mock_iot
+def test_iot_list():
+    backend = server.create_backend_app("iot")
+    test_client = backend.test_client()
+    # do test


### PR DESCRIPTION
This can go after #1291 , because this PR include the commits in the PR.

Supported basic AWS IoT operations. Error handling is not enough though.

```
-----------------------
iot - 45% implemented
-----------------------
[ ] accept_certificate_transfer
[X] attach_principal_policy
[X] attach_thing_principal
[ ] cancel_certificate_transfer
[ ] create_certificate_from_csr
[X] create_keys_and_certificate
[X] create_policy
[ ] create_policy_version
[X] create_thing
[X] create_thing_type
[ ] create_topic_rule
[ ] delete_ca_certificate
[X] delete_certificate
[X] delete_policy
[ ] delete_policy_version
[ ] delete_registration_code
[X] delete_thing
[X] delete_thing_type
[ ] delete_topic_rule
[ ] deprecate_thing_type
[ ] describe_ca_certificate
[X] describe_certificate
[ ] describe_endpoint
[X] describe_thing
[X] describe_thing_type
[X] detach_principal_policy
[X] detach_thing_principal
[ ] disable_topic_rule
[ ] enable_topic_rule
[ ] get_logging_options
[X] get_policy
[ ] get_policy_version
[ ] get_registration_code
[ ] get_topic_rule
[ ] list_ca_certificates
[X] list_certificates
[ ] list_certificates_by_ca
[ ] list_outgoing_certificates
[X] list_policies
[X] list_policy_principals
[ ] list_policy_versions
[X] list_principal_policies
[X] list_principal_things
[X] list_thing_principals
[X] list_thing_types
[X] list_things
[ ] list_topic_rules
[ ] register_ca_certificate
[ ] register_certificate
[ ] reject_certificate_transfer
[ ] replace_topic_rule
[ ] set_default_policy_version
[ ] set_logging_options
[ ] transfer_certificate
[ ] update_ca_certificate
[X] update_certificate
[X] update_thing
```

