### PR TITLE
Do not treat StartRecordName and StartRecordType as filters

### DIFF
--- a/moto/route53/models.py
+++ b/moto/route53/models.py
@@ -196,14 +196,14 @@ class FakeZone(BaseModel):
         self.rrsets = [
             record_set for record_set in self.rrsets if record_set.set_identifier != set_identifier]
 
-    def get_record_sets(self, type_filter, name_filter):
+    def get_record_sets(self, start_type, start_name):
         record_sets = list(self.rrsets)  # Copy the list
-        if type_filter:
+        if start_type:
             record_sets = [
-                record_set for record_set in record_sets if record_set._type == type_filter]
-        if name_filter:
+                record_set for record_set in record_sets if record_set._type >= start_type]
+        if start_name:
             record_sets = [
-                record_set for record_set in record_sets if record_set.name == name_filter]
+                record_set for record_set in record_sets if record_set.name >= start_name]
 
         return record_sets
 

--- a/moto/route53/responses.py
+++ b/moto/route53/responses.py
@@ -151,9 +151,9 @@ class Route53(BaseResponse):
         elif method == "GET":
             querystring = parse_qs(parsed_url.query)
             template = Template(LIST_RRSET_REPONSE)
-            type_filter = querystring.get("type", [None])[0]
-            name_filter = querystring.get("name", [None])[0]
-            record_sets = the_zone.get_record_sets(type_filter, name_filter)
+            start_type = querystring.get("type", [None])[0]
+            start_name = querystring.get("name", [None])[0]
+            record_sets = the_zone.get_record_sets(start_type, start_name)
             return 200, headers, template.render(record_sets=record_sets)
 
     def health_check_response(self, request, full_url, headers):

--- a/tests/test_route53/test_route53.py
+++ b/tests/test_route53/test_route53.py
@@ -119,8 +119,10 @@ def test_rrset():
 
     rrsets = conn.get_all_rrsets(
         zoneid, name="bar.foo.testdns.aws.com", type="A")
-    rrsets.should.have.length_of(1)
-    rrsets[0].resource_records[0].should.equal('5.6.7.8')
+    rrsets.should.have.length_of(2)
+    resource_records = [rr for rr_set in rrsets for rr in rr_set.resource_records]
+    resource_records.should.contain('1.2.3.4')
+    resource_records.should.contain('5.6.7.8')
 
     rrsets = conn.get_all_rrsets(
         zoneid, name="foo.foo.testdns.aws.com", type="A")
@@ -160,7 +162,10 @@ def test_alias_rrset():
     changes.commit()
 
     rrsets = conn.get_all_rrsets(zoneid, type="A")
-    rrsets.should.have.length_of(1)
+    rrset_records = [(rr_set.name, rr) for rr_set in rrsets for rr in rr_set.resource_records]
+    rrset_records.should.have.length_of(2)
+    rrset_records.should.contain(('foo.alias.testdns.aws.com', 'foo.testdns.aws.com'))
+    rrset_records.should.contain(('bar.alias.testdns.aws.com', 'bar.testdns.aws.com'))
     rrsets[0].resource_records[0].should.equal('foo.testdns.aws.com')
     rrsets = conn.get_all_rrsets(zoneid, type="CNAME")
     rrsets.should.have.length_of(1)
@@ -647,3 +652,60 @@ def test_change_resource_record_invalid():
 
     response = conn.list_resource_record_sets(HostedZoneId=hosted_zone_id)
     len(response['ResourceRecordSets']).should.equal(0)
+
+
+@mock_route53
+def test_list_resource_record_sets_name_type_filters():
+    conn = boto3.client('route53', region_name='us-east-1')
+    create_hosted_zone_response = conn.create_hosted_zone(
+        Name="db.",
+        CallerReference=str(hash('foo')),
+        HostedZoneConfig=dict(
+            PrivateZone=True,
+            Comment="db",
+        )
+    )
+    hosted_zone_id = create_hosted_zone_response['HostedZone']['Id']
+
+    def create_resource_record_set(rec_type, rec_name):
+        payload = {
+            'Comment': 'create {} record {}'.format(rec_type, rec_name),
+            'Changes': [
+                {
+                    'Action': 'CREATE',
+                    'ResourceRecordSet': {
+                        'Name': rec_name,
+                        'Type': rec_type,
+                        'TTL': 10,
+                        'ResourceRecords': [{
+                            'Value': '127.0.0.1'
+                        }]
+                    }
+                }
+            ]
+        }
+        conn.change_resource_record_sets(HostedZoneId=hosted_zone_id, ChangeBatch=payload)
+
+    # record_type, record_name
+    all_records = [
+        ('A', 'a.a.db'),
+        ('A', 'a.b.db'),
+        ('A', 'b.b.db'),
+        ('CNAME', 'b.b.db'),
+        ('CNAME', 'b.c.db'),
+        ('CNAME', 'c.c.db')
+    ]
+    for record_type, record_name in all_records:
+        create_resource_record_set(record_type, record_name)
+
+    start_with = 2
+    response = conn.list_resource_record_sets(
+        HostedZoneId=hosted_zone_id,
+        StartRecordType=all_records[start_with][0],
+        StartRecordName=all_records[start_with][1]
+    )
+
+    returned_records = [(record['Type'], record['Name']) for record in response['ResourceRecordSets']]
+    len(returned_records).should.equal(len(all_records) - start_with)
+    for desired_record in all_records[start_with:]:
+        returned_records.should.contain(desired_record)


### PR DESCRIPTION
Do not treat StartRecordName and StartRecordType in the Route53 list_resource_record_sets as filters.

According to [AWS API reference](http://docs.aws.amazon.com/Route53/latest/APIReference/API_ListResourceRecordSets.html) and [Boto](http://boto.readthedocs.io/en/glacier/ref/route53.html#boto.route53.connection.Route53Connection.get_all_rrsets) [documentation](http://boto3.readthedocs.io/en/latest/reference/services/route53.html#Route53.Client.list_resource_record_sets) they are to begin the record listing from, not for filtering. So their current behaviour in moto is not consistent with AWS.