### PR TITLE
Use pkg_resources to keep the package zip-safe

### DIFF
--- a/moto/ec2/models.py
+++ b/moto/ec2/models.py
@@ -3,9 +3,9 @@ from __future__ import unicode_literals
 import copy
 import itertools
 import json
-import os
 import re
 import six
+from pkg_resources import resource_filename
 
 import boto.ec2
 
@@ -112,8 +112,8 @@ from .utils import (
     tag_filter_matches,
 )
 
-RESOURCES_DIR = os.path.join(os.path.dirname(__file__), 'resources')
-INSTANCE_TYPES = json.load(open(os.path.join(RESOURCES_DIR, 'instance_types.json'), 'r'))
+RES_FILE = resource_filename(__name__, 'resources/instance_types.json')
+INSTANCE_TYPES = json.load(open(RES_FILE, 'r'))
 
 
 def utc_date_and_time():


### PR DESCRIPTION
This resolves a bug in the packaging of this package that occurs in some situation :

When `moto` is installed manually from a source distribution, in a `PYTHONDONTWRITEBYTECODE=1` environment, it ends up in the shape of a **zipfile egg** in dist-packages, as it is not marked **zip-unsafe**.
This means that importing it will result in an error, because `moto/ec2/models.py` will try to open a file in what it thinks is inside a directory, when it is actually inside a zipfile.

The package could be marked as **zip-unsafe**, but there is an even better way to solve the problem: `pkg_resources` (which is part of setuptools) that will take care (when needed) of unzipping and caching the data file, returning a valid filename which can be consumed.