### PR TITLE
Add CloudFormation support to ELB V2

### DIFF
--- a/moto/cloudformation/parsing.py
+++ b/moto/cloudformation/parsing.py
@@ -63,6 +63,7 @@ MODEL_MAP = {
     "AWS::ECS::Service": ecs_models.Service,
     "AWS::ElasticLoadBalancing::LoadBalancer": elb_models.FakeLoadBalancer,
     "AWS::ElasticLoadBalancingV2::LoadBalancer": elbv2_models.FakeLoadBalancer,
+    "AWS::ElasticLoadBalancingV2::TargetGroup": elbv2_models.FakeTargetGroup,
     "AWS::DataPipeline::Pipeline": datapipeline_models.Pipeline,
     "AWS::IAM::InstanceProfile": iam_models.InstanceProfile,
     "AWS::IAM::Role": iam_models.Role,

--- a/moto/cloudformation/parsing.py
+++ b/moto/cloudformation/parsing.py
@@ -15,6 +15,7 @@ from moto.dynamodb import models as dynamodb_models
 from moto.ec2 import models as ec2_models
 from moto.ecs import models as ecs_models
 from moto.elb import models as elb_models
+from moto.elbv2 import models as elbv2_models
 from moto.iam import models as iam_models
 from moto.kinesis import models as kinesis_models
 from moto.kms import models as kms_models
@@ -61,6 +62,7 @@ MODEL_MAP = {
     "AWS::ECS::TaskDefinition": ecs_models.TaskDefinition,
     "AWS::ECS::Service": ecs_models.Service,
     "AWS::ElasticLoadBalancing::LoadBalancer": elb_models.FakeLoadBalancer,
+    "AWS::ElasticLoadBalancingV2::LoadBalancer": elbv2_models.FakeLoadBalancer,
     "AWS::DataPipeline::Pipeline": datapipeline_models.Pipeline,
     "AWS::IAM::InstanceProfile": iam_models.InstanceProfile,
     "AWS::IAM::Role": iam_models.Role,

--- a/moto/cloudformation/parsing.py
+++ b/moto/cloudformation/parsing.py
@@ -330,7 +330,7 @@ def parse_output(output_logical_id, output_json, resources_map):
     output_json = clean_json(output_json, resources_map)
     output = Output()
     output.key = output_logical_id
-    output.value = output_json['Value']
+    output.value = clean_json(output_json['Value'], resources_map)
     output.description = output_json.get('Description')
     return output
 

--- a/moto/cloudformation/parsing.py
+++ b/moto/cloudformation/parsing.py
@@ -64,6 +64,7 @@ MODEL_MAP = {
     "AWS::ElasticLoadBalancing::LoadBalancer": elb_models.FakeLoadBalancer,
     "AWS::ElasticLoadBalancingV2::LoadBalancer": elbv2_models.FakeLoadBalancer,
     "AWS::ElasticLoadBalancingV2::TargetGroup": elbv2_models.FakeTargetGroup,
+    "AWS::ElasticLoadBalancingV2::Listener": elbv2_models.FakeListener,
     "AWS::DataPipeline::Pipeline": datapipeline_models.Pipeline,
     "AWS::IAM::InstanceProfile": iam_models.InstanceProfile,
     "AWS::IAM::Role": iam_models.Role,

--- a/moto/elbv2/models.py
+++ b/moto/elbv2/models.py
@@ -281,6 +281,7 @@ class FakeLoadBalancer(BaseModel):
         }
         return attributes[attribute_name]
 
+
 class ELBv2Backend(BaseBackend):
 
     def __init__(self, region_name=None):

--- a/moto/elbv2/models.py
+++ b/moto/elbv2/models.py
@@ -274,6 +274,12 @@ class FakeLoadBalancer(BaseModel):
         load_balancer = elbv2_backend.create_load_balancer(name, security_groups, subnet_ids, scheme=scheme)
         return load_balancer
 
+    def get_cfn_attribute(self, attribute_name):
+        attributes = {
+            'DNSName': self.dns_name,
+            'LoadBalancerName': self.name,
+        }
+        return attributes[attribute_name]
 
 class ELBv2Backend(BaseBackend):
 

--- a/moto/elbv2/models.py
+++ b/moto/elbv2/models.py
@@ -266,7 +266,7 @@ class FakeLoadBalancer(BaseModel):
 
         elbv2_backend = elbv2_backends[region_name]
 
-        name = properties.get('Name')
+        name = properties.get('Name', resource_name)
         security_groups = properties.get("SecurityGroups")
         subnet_ids = properties.get('Subnets')
         scheme = properties.get('Scheme', 'internet-facing')

--- a/moto/elbv2/models.py
+++ b/moto/elbv2/models.py
@@ -113,7 +113,10 @@ class FakeTargetGroup(BaseModel):
 
         elbv2_backend = elbv2_backends[region_name]
 
-        name = properties.get('Name')
+        # per cloudformation docs:
+        # The target group name should be shorter than 22 characters because
+        # AWS CloudFormation uses the target group name to create the name of the load balancer.
+        name = properties.get('Name', resource_name[:22])
         vpc_id = properties.get("VpcId")
         protocol = properties.get('Protocol')
         port = properties.get("Port")
@@ -364,7 +367,7 @@ class ELBv2Backend(BaseBackend):
     def create_target_group(self, name, **kwargs):
         if len(name) > 32:
             raise InvalidTargetGroupNameError(
-                "Target group name '%s' cannot be longer than '32' characters" % name
+                "Target group name '%s' cannot be longer than '22' characters" % name
             )
         if not re.match('^[a-zA-Z0-9\-]+$', name):
             raise InvalidTargetGroupNameError(

--- a/moto/elbv2/models.py
+++ b/moto/elbv2/models.py
@@ -186,6 +186,20 @@ class FakeLoadBalancer(BaseModel):
         ''' Not exposed as part of the ELB API - used for CloudFormation. '''
         elbv2_backends[region].delete_load_balancer(self.arn)
 
+    @classmethod
+    def create_from_cloudformation_json(cls, resource_name, cloudformation_json, region_name):
+        properties = cloudformation_json['Properties']
+
+        elbv2_backend = elbv2_backends[region_name]
+
+        name = properties.get('Name')
+        security_groups = properties.get("SecurityGroups")
+        subnet_ids = properties.get('Subnets')
+        scheme = properties.get('Scheme', 'internet-facing')
+
+        load_balancer = elbv2_backend.create_load_balancer(name, security_groups, subnet_ids, scheme=scheme)
+        return load_balancer
+
 
 class ELBv2Backend(BaseBackend):
 

--- a/moto/elbv2/responses.py
+++ b/moto/elbv2/responses.py
@@ -472,9 +472,14 @@ CREATE_TARGET_GROUP_TEMPLATE = """<CreateTargetGroupResponse xmlns="http://elast
         <HealthCheckTimeoutSeconds>{{ target_group.healthcheck_timeout_seconds }}</HealthCheckTimeoutSeconds>
         <HealthyThresholdCount>{{ target_group.healthy_threshold_count }}</HealthyThresholdCount>
         <UnhealthyThresholdCount>{{ target_group.unhealthy_threshold_count }}</UnhealthyThresholdCount>
+        {% if target_group.matcher %}
         <Matcher>
-          <HttpCode>200</HttpCode>
+          <HttpCode>{{ target_group.matcher['HttpCode'] }}</HttpCode>
         </Matcher>
+        {% endif %}
+        {% if target_group.target_type %}
+        <TargetType>{{ target_group.target_type }}</TargetType>
+        {% endif %}
       </member>
     </TargetGroups>
   </CreateTargetGroupResult>
@@ -635,16 +640,21 @@ DESCRIBE_TARGET_GROUPS_TEMPLATE = """<DescribeTargetGroupsResponse xmlns="http:/
         <Protocol>{{ target_group.protocol }}</Protocol>
         <Port>{{ target_group.port }}</Port>
         <VpcId>{{ target_group.vpc_id }}</VpcId>
-        <HealthCheckProtocol>{{ target_group.health_check_protocol }}</HealthCheckProtocol>
+        <HealthCheckProtocol>{{ target_group.healthcheck_protocol }}</HealthCheckProtocol>
         <HealthCheckPort>{{ target_group.healthcheck_port }}</HealthCheckPort>
         <HealthCheckPath>{{ target_group.healthcheck_path }}</HealthCheckPath>
         <HealthCheckIntervalSeconds>{{ target_group.healthcheck_interval_seconds }}</HealthCheckIntervalSeconds>
         <HealthCheckTimeoutSeconds>{{ target_group.healthcheck_timeout_seconds }}</HealthCheckTimeoutSeconds>
         <HealthyThresholdCount>{{ target_group.healthy_threshold_count }}</HealthyThresholdCount>
         <UnhealthyThresholdCount>{{ target_group.unhealthy_threshold_count }}</UnhealthyThresholdCount>
+        {% if target_group.matcher %}
         <Matcher>
-          <HttpCode>200</HttpCode>
+          <HttpCode>{{ target_group.matcher['HttpCode'] }}</HttpCode>
         </Matcher>
+        {% endif %}
+        {% if target_group.target_type %}
+        <TargetType>{{ target_group.target_type }}</TargetType>
+        {% endif %}
         <LoadBalancerArns>
           {% for load_balancer_arn in target_group.load_balancer_arns %}
           <member>{{ load_balancer_arn }}</member>

--- a/moto/elbv2/responses.py
+++ b/moto/elbv2/responses.py
@@ -572,6 +572,7 @@ DESCRIBE_LOAD_BALANCERS_TEMPLATE = """<DescribeLoadBalancersResponse xmlns="http
           <Code>provisioning</Code>
         </State>
         <Type>application</Type>
+        <IpAddressType>ipv4</IpAddressType>
       </member>
       {% endfor %}
     </LoadBalancers>

--- a/tests/test_cloudformation/test_cloudformation_stack_integration.py
+++ b/tests/test_cloudformation/test_cloudformation_stack_integration.py
@@ -2216,8 +2216,23 @@ def test_stack_elbv2_resources_integration():
     elbv2_conn = boto3.client("elbv2", "us-west-1")
 
     load_balancers = elbv2_conn.describe_load_balancers()['LoadBalancers']
-    assert len(load_balancers) == 1
-    assert load_balancers[0]['LoadBalancerName'] == 'myelbv2'
-    assert load_balancers[0]['Scheme'] == 'internet-facing'
-    assert load_balancers[0]['Type'] == 'application'
-    assert load_balancers[0]['IpAddressType'] == 'ipv4'
+    len(load_balancers).should.equal(1)
+    load_balancers[0]['LoadBalancerName'].should.equal('myelbv2')
+    load_balancers[0]['Scheme'].should.equal('internet-facing')
+    load_balancers[0]['Type'].should.equal('application')
+    load_balancers[0]['IpAddressType'].should.equal('ipv4')
+
+    target_groups = elbv2_conn.describe_target_groups()['TargetGroups']
+    len(target_groups).should.equal(1)
+    target_groups[0]['HealthCheckIntervalSeconds'].should.equal(30)
+    target_groups[0]['HealthCheckPath'].should.equal('/status')
+    target_groups[0]['HealthCheckPort'].should.equal('80')
+    target_groups[0]['HealthCheckProtocol'].should.equal('HTTP')
+    target_groups[0]['HealthCheckTimeoutSeconds'].should.equal(5)
+    target_groups[0]['HealthyThresholdCount'].should.equal(30)
+    target_groups[0]['UnhealthyThresholdCount'].should.equal(5)
+    target_groups[0]['Matcher'].should.equal({'HttpCode': '200,201'})
+    target_groups[0]['TargetGroupName'].should.equal('mytargetgroup')
+    target_groups[0]['Port'].should.equal(80)
+    target_groups[0]['Protocol'].should.equal('HTTP')
+    target_groups[0]['TargetType'].should.equal('instance')

--- a/tests/test_cloudformation/test_cloudformation_stack_integration.py
+++ b/tests/test_cloudformation/test_cloudformation_stack_integration.py
@@ -2236,3 +2236,13 @@ def test_stack_elbv2_resources_integration():
     target_groups[0]['Port'].should.equal(80)
     target_groups[0]['Protocol'].should.equal('HTTP')
     target_groups[0]['TargetType'].should.equal('instance')
+
+    listeners = elbv2_conn.describe_listeners(LoadBalancerArn=load_balancers[0]['LoadBalancerArn'])['Listeners']
+    len(listeners).should.equal(1)
+    listeners[0]['LoadBalancerArn'].should.equal(load_balancers[0]['LoadBalancerArn'])
+    listeners[0]['Port'].should.equal(80)
+    listeners[0]['Protocol'].should.equal('HTTP')
+    listeners[0]['DefaultActions'].should.equal([{
+        "Type": "forward",
+        "TargetGroupArn": target_groups[0]['TargetGroupArn']
+    }])


### PR DESCRIPTION
This pull request adds support to some ELBv2 resources (load balancer, target group, and listener).

I tested this implementation in an internal project and it works as expected. I found that outputs weren't properly evaluated (didn't support functions such as Fn::GetAtt). I fixed it to always evaluate output values.