### PR TITLE
Use S3 path style addressing when running in kubernetes

### DIFF
--- a/moto/s3/responses.py
+++ b/moto/s3/responses.py
@@ -54,8 +54,10 @@ class ResponseObject(_TemplateEnvironmentMixin):
         if not host:
             host = urlparse(request.url).netloc
 
-        if not host or host.startswith("localhost") or re.match(r"^[^.]+$", host):
-            # For localhost or local domain names, default to path-based buckets
+        if (not host or host.startswith('localhost') or
+                re.match(r'^[^.]+$', host) or re.match(r'^.*\.svc\.cluster\.local$', host)):
+            # Default to path-based buckets for (1) localhost, (2) local host names that do not
+            # contain a "." (e.g., Docker container host names), or (3) kubernetes host names
             return False
 
         match = re.match(r'^([^\[\]:]+)(:\d+)?$', host)


### PR DESCRIPTION
Use S3 path style addressing when running in [Kubernetes](https://kubernetes.io/).

Services in Kubernetes use the domain name scheme `<service_name>.<namespace>.svc.cluster.local`, hence we can simply check for the suffix `svc.cluster.local` in the target host of the request.

Without this fix, moto defaults to hostname based addressing and assumes that the domain name refers to an existing bucket, resulting in a `404` error on `ListBuckets`.