### PR TITLE
dynamodb2: Fix for ProjectionExpressions changing the data in storage

### DIFF
--- a/moto/dynamodb2/models.py
+++ b/moto/dynamodb2/models.py
@@ -1,5 +1,6 @@
 from __future__ import unicode_literals
 from collections import defaultdict
+import copy
 import datetime
 import decimal
 import json
@@ -492,7 +493,7 @@ class Table(BaseModel):
 
         if projection_expression:
             expressions = [x.strip() for x in projection_expression.split(',')]
-            for result in possible_results:
+            for result in copy.deepcopy(possible_results):
                 for attr in list(result.attrs):
                     if attr not in expressions:
                         result.attrs.pop(attr)

--- a/moto/dynamodb2/models.py
+++ b/moto/dynamodb2/models.py
@@ -493,7 +493,8 @@ class Table(BaseModel):
 
         if projection_expression:
             expressions = [x.strip() for x in projection_expression.split(',')]
-            for result in copy.deepcopy(possible_results):
+            results = copy.deepcopy(results)
+            for result in results:
                 for attr in list(result.attrs):
                     if attr not in expressions:
                         result.attrs.pop(attr)

--- a/tests/test_dynamodb2/test_dynamodb.py
+++ b/tests/test_dynamodb2/test_dynamodb.py
@@ -367,8 +367,10 @@ def test_basic_projection_expressions():
     )
 
     assert 'body' in results['Items'][0]
+    assert 'subject' not in results['Items'][0]
     assert results['Items'][0]['body'] == 'some test message'
     assert 'body' in results['Items'][1]
+    assert 'subject' not in results['Items'][1]
     assert results['Items'][1]['body'] == 'yet another test message'
 
     # The projection expression should not remove data from storage

--- a/tests/test_dynamodb2/test_dynamodb.py
+++ b/tests/test_dynamodb2/test_dynamodb.py
@@ -371,6 +371,15 @@ def test_basic_projection_expressions():
     assert 'body' in results['Items'][1]
     assert results['Items'][1]['body'] == 'yet another test message'
 
+    # The projection expression should not remove data from storage
+    results = table.query(
+        KeyConditionExpression=Key('forum_name').eq(
+            'the-key'),
+    )
+    assert 'subject' in results['Items'][0]
+    assert 'body' in results['Items'][1]
+    assert 'forum_name' in results['Items'][1]
+
 
 @mock_dynamodb2
 def test_basic_projection_expressions_with_attr_expression_names():


### PR DESCRIPTION
If you used a projection expression with a query, subsequent queries without projection expressions would return the same result because the attrs were being removed from the underlying data store when generating the query result set.