### PR TITLE
AutoScalingBackend / Implementation Coverage quirk

### DIFF
--- a/moto/autoscaling/models.py
+++ b/moto/autoscaling/models.py
@@ -185,7 +185,7 @@ class FakeAutoScalingGroup(BaseModel):
         target_group_arns = properties.get("TargetGroupARNs", [])
 
         backend = autoscaling_backends[region_name]
-        group = backend.create_autoscaling_group(
+        group = backend.create_auto_scaling_group(
             name=resource_name,
             availability_zones=properties.get("AvailabilityZones", []),
             desired_capacity=properties.get("DesiredCapacity"),
@@ -215,13 +215,13 @@ class FakeAutoScalingGroup(BaseModel):
     def delete_from_cloudformation_json(cls, resource_name, cloudformation_json, region_name):
         backend = autoscaling_backends[region_name]
         try:
-            backend.delete_autoscaling_group(resource_name)
+            backend.delete_auto_scaling_group(resource_name)
         except KeyError:
             pass
 
     def delete(self, region_name):
         backend = autoscaling_backends[region_name]
-        backend.delete_autoscaling_group(self.name)
+        backend.delete_auto_scaling_group(self.name)
 
     @property
     def physical_resource_id(self):
@@ -358,7 +358,7 @@ class AutoScalingBackend(BaseBackend):
     def delete_launch_configuration(self, launch_configuration_name):
         self.launch_configurations.pop(launch_configuration_name, None)
 
-    def create_autoscaling_group(self, name, availability_zones,
+    def create_auto_scaling_group(self, name, availability_zones,
                                  desired_capacity, max_size, min_size,
                                  launch_config_name, vpc_zone_identifier,
                                  default_cooldown, health_check_period,
@@ -402,7 +402,7 @@ class AutoScalingBackend(BaseBackend):
         self.update_attached_target_groups(group.name)
         return group
 
-    def update_autoscaling_group(self, name, availability_zones,
+    def update_auto_scaling_group(self, name, availability_zones,
                                  desired_capacity, max_size, min_size,
                                  launch_config_name, vpc_zone_identifier,
                                  default_cooldown, health_check_period,
@@ -415,18 +415,18 @@ class AutoScalingBackend(BaseBackend):
                      placement_group, termination_policies)
         return group
 
-    def describe_autoscaling_groups(self, names):
+    def describe_auto_scaling_groups(self, names):
         groups = self.autoscaling_groups.values()
         if names:
             return [group for group in groups if group.name in names]
         else:
             return list(groups)
 
-    def delete_autoscaling_group(self, group_name):
+    def delete_auto_scaling_group(self, group_name):
         self.set_desired_capacity(group_name, 0)
         self.autoscaling_groups.pop(group_name, None)
 
-    def describe_autoscaling_instances(self):
+    def describe_auto_scaling_instances(self):
         instance_states = []
         for group in self.autoscaling_groups.values():
             instance_states.extend(group.instance_states)

--- a/moto/autoscaling/responses.py
+++ b/moto/autoscaling/responses.py
@@ -67,7 +67,7 @@ class AutoScalingResponse(BaseResponse):
         return template.render()
 
     def create_auto_scaling_group(self):
-        self.autoscaling_backend.create_autoscaling_group(
+        self.autoscaling_backend.create_auto_scaling_group(
             name=self._get_param('AutoScalingGroupName'),
             availability_zones=self._get_multi_param(
                 'AvailabilityZones.member'),
@@ -160,7 +160,7 @@ class AutoScalingResponse(BaseResponse):
     def describe_auto_scaling_groups(self):
         names = self._get_multi_param("AutoScalingGroupNames.member")
         token = self._get_param("NextToken")
-        all_groups = self.autoscaling_backend.describe_autoscaling_groups(names)
+        all_groups = self.autoscaling_backend.describe_auto_scaling_groups(names)
         all_names = [group.name for group in all_groups]
         if token:
             start = all_names.index(token) + 1
@@ -177,7 +177,7 @@ class AutoScalingResponse(BaseResponse):
         return template.render(groups=groups, next_token=next_token)
 
     def update_auto_scaling_group(self):
-        self.autoscaling_backend.update_autoscaling_group(
+        self.autoscaling_backend.update_auto_scaling_group(
             name=self._get_param('AutoScalingGroupName'),
             availability_zones=self._get_multi_param(
                 'AvailabilityZones.member'),
@@ -198,7 +198,7 @@ class AutoScalingResponse(BaseResponse):
 
     def delete_auto_scaling_group(self):
         group_name = self._get_param('AutoScalingGroupName')
-        self.autoscaling_backend.delete_autoscaling_group(group_name)
+        self.autoscaling_backend.delete_auto_scaling_group(group_name)
         template = self.response_template(DELETE_AUTOSCALING_GROUP_TEMPLATE)
         return template.render()
 
@@ -218,7 +218,7 @@ class AutoScalingResponse(BaseResponse):
         return template.render()
 
     def describe_auto_scaling_instances(self):
-        instance_states = self.autoscaling_backend.describe_autoscaling_instances()
+        instance_states = self.autoscaling_backend.describe_auto_scaling_instances()
         template = self.response_template(
             DESCRIBE_AUTOSCALING_INSTANCES_TEMPLATE)
         return template.render(instance_states=instance_states)


### PR DESCRIPTION
I was curious as to why the implementation details page wasn't reporting on methods that I knew existed, so I took a look. 

For each module, the implementation script is looking up the Backend object in the services `models.py` file (e.g. for the auto scaling service the backend is called AutoScalingBackend), getting a list of methods, and comparing directly to the boto3 client. It seems that for moto itself to register that the method has been mocked (i.e. when moto is used in a test), the method contained in the `responses.py` file needs to match the boto3 client. 

It seems that both the method in `responses.py` and the method it calls in `models.py` need to be named the same? Just so the mocked method works, and the implementation script picks it up.

