### PR TITLE
fix EC2 instances ebsOptimized not handled

### DIFF
--- a/moto/ec2/models.py
+++ b/moto/ec2/models.py
@@ -377,6 +377,7 @@ class Instance(TaggedEC2Resource, BotoInstance):
         self.subnet_id = kwargs.get("subnet_id")
         in_ec2_classic = not bool(self.subnet_id)
         self.key_name = kwargs.get("key_name")
+        self.ebs_optimized = kwargs.get("ebs_optimized", False)
         self.source_dest_check = "true"
         self.launch_time = utc_date_and_time()
         self.disable_api_termination = kwargs.get("disable_api_termination", False)

--- a/moto/ec2/responses/instances.py
+++ b/moto/ec2/responses/instances.py
@@ -45,6 +45,7 @@ class InstanceResponse(BaseResponse):
         private_ip = self._get_param('PrivateIpAddress')
         associate_public_ip = self._get_param('AssociatePublicIpAddress')
         key_name = self._get_param('KeyName')
+        ebs_optimized = self._get_param('EbsOptimized')
         tags = self._parse_tag_specification("TagSpecification")
         region_name = self.region
 
@@ -54,7 +55,7 @@ class InstanceResponse(BaseResponse):
                 instance_type=instance_type, placement=placement, region_name=region_name, subnet_id=subnet_id,
                 owner_id=owner_id, key_name=key_name, security_group_ids=security_group_ids,
                 nics=nics, private_ip=private_ip, associate_public_ip=associate_public_ip,
-                tags=tags)
+                tags=tags, ebs_optimized=ebs_optimized)
 
             template = self.response_template(EC2_RUN_INSTANCES)
             return template.render(reservation=new_reservation)
@@ -242,6 +243,7 @@ EC2_RUN_INSTANCES = """<RunInstancesResponse xmlns="http://ec2.amazonaws.com/doc
           <dnsName>{{ instance.public_dns }}</dnsName>
           <reason/>
           <keyName>{{ instance.key_name }}</keyName>
+          <ebsOptimized>{{ instance.ebs_optimized }}</ebsOptimized>
           <amiLaunchIndex>0</amiLaunchIndex>
           <instanceType>{{ instance.instance_type }}</instanceType>
           <launchTime>{{ instance.launch_time }}</launchTime>
@@ -381,6 +383,7 @@ EC2_DESCRIBE_INSTANCES = """<DescribeInstancesResponse xmlns="http://ec2.amazona
                     <dnsName>{{ instance.public_dns }}</dnsName>
                     <reason>{{ instance._reason }}</reason>
                     <keyName>{{ instance.key_name }}</keyName>
+                    <ebsOptimized>{{ instance.ebs_optimized }}</ebsOptimized>
                     <amiLaunchIndex>0</amiLaunchIndex>
                     <productCodes/>
                     <instanceType>{{ instance.instance_type }}</instanceType>

--- a/tests/test_ec2/test_instances.py
+++ b/tests/test_ec2/test_instances.py
@@ -1233,3 +1233,24 @@ def test_modify_delete_on_termination():
     )
     instance.load()
     instance.block_device_mappings[0]['Ebs']['DeleteOnTermination'].should.be(True)
+
+@mock_ec2
+def test_create_instance_ebs_optimized():
+    ec2_resource = boto3.resource('ec2', region_name='eu-west-1')
+
+    instance = ec2_resource.create_instances(
+        ImageId = 'ami-12345678',
+        MaxCount = 1,
+        MinCount = 1,
+        EbsOptimized = True,
+    )[0]
+    instance.load()
+    instance.ebs_optimized.should.be(True)
+
+    instance.modify_attribute(
+        EbsOptimized={
+            'Value': False
+        }
+    )
+    instance.load()
+    instance.ebs_optimized.should.be(False)


### PR DESCRIPTION
Hi,

It appears that describe_instances not returns EbsOptimized field.

Here is a improvment which takes EbsOptimized into account during create_instances and correctly return the value with a describe_instances.
Default value is  False.

Regards,