### PR TITLE
Add proper CFN attribute handling to elbv2.FakeLoadBalancer

### DIFF
--- a/moto/elbv2/models.py
+++ b/moto/elbv2/models.py
@@ -293,11 +293,32 @@ class FakeLoadBalancer(BaseModel):
         return load_balancer
 
     def get_cfn_attribute(self, attribute_name):
-        attributes = {
-            'DNSName': self.dns_name,
-            'LoadBalancerName': self.name,
-        }
-        return attributes[attribute_name]
+        '''
+        Implemented attributes:
+        * DNSName
+        * LoadBalancerName
+
+        Not implemented:
+        * CanonicalHostedZoneID
+        * LoadBalancerFullName
+        * SecurityGroups
+
+        This method is similar to models.py:FakeLoadBalancer.get_cfn_attribute()
+        '''
+        from moto.cloudformation.exceptions import UnformattedGetAttTemplateException
+        not_implemented_yet = [
+            'CanonicalHostedZoneID',
+            'LoadBalancerFullName',
+            'SecurityGroups',
+        ]
+        if attribute_name == 'DNSName':
+            return self.dns_name
+        elif attribute_name == 'LoadBalancerName':
+            return self.name
+        elif attribute_name in not_implemented_yet:
+            raise NotImplementedError('"Fn::GetAtt" : [ "{0}" , "%s" ]"' % attribute_name)
+        else:
+            raise UnformattedGetAttTemplateException()
 
 
 class ELBv2Backend(BaseBackend):

--- a/tests/test_cloudformation/test_cloudformation_stack_integration.py
+++ b/tests/test_cloudformation/test_cloudformation_stack_integration.py
@@ -2128,6 +2128,10 @@ def test_stack_elbv2_resources_integration():
                 "Description": "Load balancer name",
                 "Value": {"Fn::GetAtt": ["alb", "LoadBalancerName"]},
             },
+            "canonicalhostedzoneid": {
+                "Description": "Load balancer canonical hosted zone ID",
+                "Value": {"Fn::GetAtt": ["alb", "CanonicalHostedZoneID"]},
+            },
         },
         "Resources": {
             "alb": {


### PR DESCRIPTION
When I originally implemented `elbv2.models.FakeLoadBalancer.get_cfn_attribute()` I didn't realize `moto` would raise an exception if anything tried to use undefined attributes. I mimicked the `elb.models.FakeLoadBalancer.get_cfn_attribute()` method (but focused on elbv2 load balancers).