### PR TITLE
Add default ecs attributes and format in response obj

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -47,3 +47,4 @@ Moto is written by Steve Pulec with contributions from:
 * [Adam Stauffer](https://github.com/adamstauffer)
 * [Guy Templeton](https://github.com/gjtempleton)
 * [Michael van Tellingen](https://github.com/mvantellingen)
+* [Jessie Nadler](https://github.com/nadlerjessie)

--- a/moto/ecs/models.py
+++ b/moto/ecs/models.py
@@ -333,7 +333,7 @@ class ContainerInstance(BaseObject):
     @property
     def response_object(self):
         response_object = self.gen_response_object()
-        response_object['attributes'] = [self._format_attribute(name, value) for name, value in response_object['attributes'].iteritems()]
+        response_object['attributes'] = [self._format_attribute(name, value) for name, value in response_object['attributes'].items()]
         return response_object
 
     def _format_attribute(self, name, value):

--- a/moto/ecs/models.py
+++ b/moto/ecs/models.py
@@ -333,7 +333,16 @@ class ContainerInstance(BaseObject):
     @property
     def response_object(self):
         response_object = self.gen_response_object()
+        response_object['attributes'] = [self._format_attribute(name, value) for name, value in response_object['attributes'].iteritems()]
         return response_object
+
+    def _format_attribute(self, name, value):
+        formatted_attr = {
+            'name': name,
+        }
+        if value is not None:
+            formatted_attr['value'] = value
+        return formatted_attr
 
 
 class ContainerInstanceFailure(BaseObject):

--- a/moto/ecs/models.py
+++ b/moto/ecs/models.py
@@ -2,6 +2,7 @@ from __future__ import unicode_literals
 import uuid
 from datetime import datetime
 from random import random, randint
+import boto3
 
 import pytz
 from moto.core.exceptions import JsonRESTError
@@ -888,6 +889,5 @@ class EC2ContainerServiceBackend(BaseBackend):
             yield task_fam
 
 
-ecs_backends = {}
-for region, ec2_backend in ec2_backends.items():
-    ecs_backends[region] = EC2ContainerServiceBackend(region)
+available_regions = boto3.session.Session().get_available_regions("ecs")
+ecs_backends = {region: EC2ContainerServiceBackend(region) for region in available_regions}

--- a/moto/ecs/models.py
+++ b/moto/ecs/models.py
@@ -321,8 +321,14 @@ class ContainerInstance(BaseObject):
             'agentHash': '4023248',
             'dockerVersion': 'DockerVersion: 1.5.0'
         }
-
-        self.attributes = {}
+        ec2_backend = ec2_backends[region_name]
+        ec2_instance = ec2_backend.get_instance(ec2_instance_id)
+        self.attributes = {
+            'ecs.ami-id': ec2_instance.image_id,
+            'ecs.availability-zone': ec2_instance.placement,
+            'ecs.instance-type': ec2_instance.instance_type,
+            'ecs.os-type': ec2_instance.platform if ec2_instance.platform == 'windows' else 'linux'  # options are windows and linux, linux is default
+        }
 
     @property
     def response_object(self):

--- a/moto/ecs/models.py
+++ b/moto/ecs/models.py
@@ -261,7 +261,7 @@ class Service(BaseObject):
 
 class ContainerInstance(BaseObject):
 
-    def __init__(self, ec2_instance_id):
+    def __init__(self, ec2_instance_id, region_name):
         self.ec2_instance_id = ec2_instance_id
         self.agent_connected = True
         self.status = 'ACTIVE'
@@ -347,12 +347,19 @@ class ContainerInstanceFailure(BaseObject):
 
 class EC2ContainerServiceBackend(BaseBackend):
 
-    def __init__(self):
+    def __init__(self, region_name):
+        super(EC2ContainerServiceBackend, self).__init__()
         self.clusters = {}
         self.task_definitions = {}
         self.tasks = {}
         self.services = {}
         self.container_instances = {}
+        self.region_name = region_name
+
+    def reset(self):
+        region_name = self.region_name
+        self.__dict__ = {}
+        self.__init__(region_name)
 
     def describe_task_definition(self, task_definition_str):
         task_definition_name = task_definition_str.split('/')[-1]
@@ -669,7 +676,7 @@ class EC2ContainerServiceBackend(BaseBackend):
         cluster_name = cluster_str.split('/')[-1]
         if cluster_name not in self.clusters:
             raise Exception("{0} is not a cluster".format(cluster_name))
-        container_instance = ContainerInstance(ec2_instance_id)
+        container_instance = ContainerInstance(ec2_instance_id, self.region_name)
         if not self.container_instances.get(cluster_name):
             self.container_instances[cluster_name] = {}
         container_instance_id = container_instance.container_instance_arn.split(
@@ -868,4 +875,4 @@ class EC2ContainerServiceBackend(BaseBackend):
 
 ecs_backends = {}
 for region, ec2_backend in ec2_backends.items():
-    ecs_backends[region] = EC2ContainerServiceBackend()
+    ecs_backends[region] = EC2ContainerServiceBackend(region)

--- a/tests/test_ecs/test_ecs_boto3.py
+++ b/tests/test_ecs/test_ecs_boto3.py
@@ -1867,7 +1867,9 @@ def test_describe_container_instances_with_attributes():
         attribute.pop('targetId', None)
         attribute.pop('targetType', None)
         cleaned_attributes.append(attribute)
-    assert sorted(described_instance['containerInstances'][0]['attributes']) == sorted(default_attributes + cleaned_attributes)
+    described_attributes = sorted(described_instance['containerInstances'][0]['attributes'], key=lambda item: item['name'])
+    expected_attributes = sorted(default_attributes + cleaned_attributes, key=lambda item: item['name'])
+    assert described_attributes == expected_attributes
 
 
 def _fetch_container_instance_resources(container_instance_description):

--- a/tests/test_ecs/test_ecs_boto3.py
+++ b/tests/test_ecs/test_ecs_boto3.py
@@ -1800,12 +1800,13 @@ def test_default_container_instance_attributes():
 
     default_attributes = response['containerInstance']['attributes']
     assert len(default_attributes) == 4
-    assert sorted(default_attributes) == sorted([
+    expected_result = [
         {'name': 'ecs.availability-zone', 'value': test_instance.placement['AvailabilityZone']},
         {'name': 'ecs.ami-id', 'value': test_instance.image_id},
         {'name': 'ecs.instance-type', 'value': test_instance.instance_type},
         {'name': 'ecs.os-type', 'value': test_instance.platform or 'linux'}
-    ])
+    ]
+    assert sorted(default_attributes, key=lambda item: item['name']) == sorted(expected_result, key=lambda item: item['name'])
 
 
 @mock_ec2


### PR DESCRIPTION
This PR does two things:

1) It adds the built-in attributes automatically applied by ECS. More on that in the docs, [here](http://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-placement-constraints.html#attributes).
   - Note: In order to do that I had to initialize the EC2ContainerServiceBackend and ContainerInstance with `region_name`.
2) Formats the `ContainerInstance` attributes to be consistent with the `describe_container_instances` [response](http://boto3.readthedocs.io/en/latest/reference/services/ecs.html#ECS.Client.describe_container_instances).
   - Note: I didn't exactly implement it the way the docs suggest with `targetType` and `targetId` because I do not see that when I call `describe_container_instances` locally, I only see `name` and `value` (optional). Please let me know if you can get boto3 to return those values and think I should include them.

Thanks!

cc @spulec 