### PR TITLE
Improve SSM PutParameter & DescribeParameters actions

### DIFF
--- a/moto/ssm/responses.py
+++ b/moto/ssm/responses.py
@@ -117,7 +117,7 @@ class SimpleSystemManagerResponse(BaseResponse):
 
         end = token + page_size
         for parameter in result[token:]:
-            param_data = parameter.response_object(False)
+            param_data = parameter.describe_response_object(False)
             add = False
 
             if filters:


### PR DESCRIPTION
Some softwares like https://github.com/segmentio/chamber rely on the following fields in the SSM.DescribeParameters action:
- Version
- Description
- LastModifiedDate
- LastModifiedUser

Also move `KeyId` only in DescribeParameters response as in the official AWS API.