### PR TITLE
Set default value to elbv2 FakeTargetGroup

### DIFF
--- a/moto/elbv2/models.py
+++ b/moto/elbv2/models.py
@@ -61,18 +61,20 @@ class FakeTargetGroup(BaseModel):
                  unhealthy_threshold_count='2',
                  matcher=None,
                  target_type=None):
+
+        # TODO: default values differs when you add Network Load balancer
         self.name = name
         self.arn = arn
         self.vpc_id = vpc_id
         self.protocol = protocol
         self.port = port
-        self.healthcheck_protocol = healthcheck_protocol
+        self.healthcheck_protocol = healthcheck_protocol or 'HTTP'
         self.healthcheck_port = healthcheck_port
-        self.healthcheck_path = healthcheck_path
-        self.healthcheck_interval_seconds = healthcheck_interval_seconds
-        self.healthcheck_timeout_seconds = healthcheck_timeout_seconds
-        self.healthy_threshold_count = healthy_threshold_count
-        self.unhealthy_threshold_count = unhealthy_threshold_count
+        self.healthcheck_path = healthcheck_path or '/'
+        self.healthcheck_interval_seconds = healthcheck_interval_seconds or 30
+        self.healthcheck_timeout_seconds = healthcheck_timeout_seconds or 5
+        self.healthy_threshold_count = healthy_threshold_count or 5
+        self.unhealthy_threshold_count = unhealthy_threshold_count or 2
         self.load_balancer_arns = []
         self.tags = {}
         if matcher is None:


### PR DESCRIPTION
Setting `None` to property of FakeTargergroup in ElbV2 class breaks response of create_target_group sometimes.
So, set aws's default values to them


The error status is as below.
```
======================================================================
ERROR: test_elbv2.test_create_target_group_without_non_required_parameters
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/local/lib/python3.6/site-packages/nose/case.py", line 198, in runTest
    self.test(*self.arg)
  File "/app/moto/core/models.py", line 71, in wrapper
    result = func(*args, **kwargs)
  File "/app/moto/core/models.py", line 71, in wrapper
    result = func(*args, **kwargs)
  File "/app/tests/test_elbv2/test_elbv2.py", line 453, in test_create_target_group_without_non_required_parameters
    Matcher={'HttpCode': '200'})
  File "/usr/local/lib/python3.6/site-packages/botocore/client.py", line 312, in _api_call
    return self._make_api_call(operation_name, kwargs)
  File "/usr/local/lib/python3.6/site-packages/botocore/client.py", line 592, in _make_api_call
    operation_model, request_dict)
  File "/usr/local/lib/python3.6/site-packages/botocore/endpoint.py", line 141, in make_request
    return self._send_request(request_dict, operation_model)
  File "/usr/local/lib/python3.6/site-packages/botocore/endpoint.py", line 168, in _send_request
    request, operation_model, attempts)
  File "/usr/local/lib/python3.6/site-packages/botocore/endpoint.py", line 233, in _get_response
    response_dict, operation_model.output_shape)
  File "/usr/local/lib/python3.6/site-packages/botocore/parsers.py", line 212, in parse
    parsed = self._do_parse(response, shape)
  File "/usr/local/lib/python3.6/site-packages/botocore/parsers.py", line 462, in _do_parse
    parsed = self._parse_shape(shape, start)
  File "/usr/local/lib/python3.6/site-packages/botocore/parsers.py", line 261, in _parse_shape
    return handler(shape, node)
  File "/usr/local/lib/python3.6/site-packages/botocore/parsers.py", line 330, in _handle_structure
    member_shape, member_node)
  File "/usr/local/lib/python3.6/site-packages/botocore/parsers.py", line 261, in _parse_shape
    return handler(shape, node)
  File "/usr/local/lib/python3.6/site-packages/botocore/parsers.py", line 314, in _handle_list
    return super(BaseXMLResponseParser, self)._handle_list(shape, node)
  File "/usr/local/lib/python3.6/site-packages/botocore/parsers.py", line 269, in _handle_list
    parsed.append(self._parse_shape(member_shape, item))
  File "/usr/local/lib/python3.6/site-packages/botocore/parsers.py", line 261, in _parse_shape
    return handler(shape, node)
  File "/usr/local/lib/python3.6/site-packages/botocore/parsers.py", line 330, in _handle_structure
    member_shape, member_node)
  File "/usr/local/lib/python3.6/site-packages/botocore/parsers.py", line 261, in _parse_shape
    return handler(shape, node)
  File "/usr/local/lib/python3.6/site-packages/botocore/parsers.py", line 150, in _get_text_content
    return func(self, shape, text)
  File "/usr/local/lib/python3.6/site-packages/botocore/parsers.py", line 419, in _handle_integer
    return int(text)
ValueError: invalid literal for int() with base 10: 'None'
```