### PR TITLE
tweak elbv2 FakeTargetgroups's default value

### DIFF
--- a/moto/elbv2/models.py
+++ b/moto/elbv2/models.py
@@ -52,13 +52,13 @@ class FakeTargetGroup(BaseModel):
                  vpc_id,
                  protocol,
                  port,
-                 healthcheck_protocol='HTTP',
-                 healthcheck_port='traffic-port',
-                 healthcheck_path='/',
-                 healthcheck_interval_seconds='30',
-                 healthcheck_timeout_seconds='5',
-                 healthy_threshold_count='5',
-                 unhealthy_threshold_count='2',
+                 healthcheck_protocol=None,
+                 healthcheck_port=None,
+                 healthcheck_path=None,
+                 healthcheck_interval_seconds=None,
+                 healthcheck_timeout_seconds=None,
+                 healthy_threshold_count=None,
+                 unhealthy_threshold_count=None,
                  matcher=None,
                  target_type=None):
 
@@ -69,7 +69,7 @@ class FakeTargetGroup(BaseModel):
         self.protocol = protocol
         self.port = port
         self.healthcheck_protocol = healthcheck_protocol or 'HTTP'
-        self.healthcheck_port = healthcheck_port
+        self.healthcheck_port = healthcheck_port or 'traffic-port'
         self.healthcheck_path = healthcheck_path or '/'
         self.healthcheck_interval_seconds = healthcheck_interval_seconds or 30
         self.healthcheck_timeout_seconds = healthcheck_timeout_seconds or 5


### PR DESCRIPTION
@terrycain  
Small fix for [earlier PR](https://github.com/spulec/moto/pull/1349).

As `FakeTargetgroup`'s default values are defined as default value of method parameter (modified to be so in #1343), aws's default parameters are now defined in two places.

So, I set `None` as default values in method parameter and set instance member's value to aws's default value in initialization phase if passed parameters are 'None'.
When service is called directly from `elbv2` client, not from cfn, these optional parameter are passed as `None`. So we have to check if passed parameters are None and set to default values if some of them are None.
