### PR TITLE
fix KeyError in delete_alias in the KmsBackend.

### DIFF
--- a/moto/kms/models.py
+++ b/moto/kms/models.py
@@ -103,6 +103,7 @@ class KmsBackend(BaseBackend):
         self.key_to_aliases[target_key_id].add(alias_name)
 
     def delete_alias(self, alias_name):
+        """Delete the alias."""
         for aliases in self.key_to_aliases.values():
             if alias_name in aliases:
                 aliases.remove(alias_name)

--- a/moto/kms/models.py
+++ b/moto/kms/models.py
@@ -104,7 +104,8 @@ class KmsBackend(BaseBackend):
 
     def delete_alias(self, alias_name):
         for aliases in self.key_to_aliases.values():
-            aliases.remove(alias_name)
+            if alias_name in aliases:
+                aliases.remove(alias_name)
 
     def get_all_aliases(self):
         return self.key_to_aliases

--- a/tests/test_kms/test_kms.py
+++ b/tests/test_kms/test_kms.py
@@ -491,7 +491,14 @@ def test__delete_alias():
     key_id = create_resp['KeyMetadata']['KeyId']
     alias = 'alias/my-alias'
 
+    # added another alias here to make sure that the deletion of the alias can
+    # be done when there are multiple existing aliases.
+    another_create_resp = kms.create_key()
+    another_key_id = create_resp['KeyMetadata']['KeyId']
+    another_alias = 'alias/another-alias'
+
     kms.create_alias(alias, key_id)
+    kms.create_alias(another_alias, another_key_id)
 
     resp = kms.delete_alias(alias)
 


### PR DESCRIPTION
If there're several aliases in the backend, previously we will bump into an unexpected KeyError here.

I haven't created a unit test for this little change. If the devs are inclined to add one, I'd be happy to do it.