### PR TITLE
modify_db_instance should be able to rename DB instances

### DIFF
--- a/moto/rds/responses.py
+++ b/moto/rds/responses.py
@@ -29,6 +29,7 @@ class RDSResponse(BaseResponse):
             "master_password": self._get_param('MasterUserPassword'),
             "master_username": self._get_param('MasterUsername'),
             "multi_az": self._get_bool_param("MultiAZ"),
+            "new_db_instance_identifier": self._get_param('NewDBInstanceIdentifier'),
             # OptionGroupName
             "port": self._get_param('Port'),
             # PreferredBackupWindow

--- a/moto/rds2/models.py
+++ b/moto/rds2/models.py
@@ -736,6 +736,10 @@ class RDS2Backend(BaseBackend):
 
     def modify_database(self, db_instance_identifier, db_kwargs):
         database = self.describe_databases(db_instance_identifier)[0]
+        if 'new_db_instance_identifier' in db_kwargs:
+            del self.databases[db_instance_identifier]
+            db_instance_identifier = db_kwargs['db_instance_identifier'] = db_kwargs.pop('new_db_instance_identifier')
+            self.databases[db_instance_identifier] = database
         database.update(db_kwargs)
         return database
 

--- a/moto/rds2/responses.py
+++ b/moto/rds2/responses.py
@@ -33,6 +33,7 @@ class RDS2Response(BaseResponse):
             "master_user_password": self._get_param('MasterUserPassword'),
             "master_username": self._get_param('MasterUsername'),
             "multi_az": self._get_bool_param("MultiAZ"),
+            "new_db_instance_identifier": self._get_param('NewDBInstanceIdentifier'),
             # OptionGroupName
             "port": self._get_param('Port'),
             # PreferredBackupWindow


### PR DESCRIPTION
Fix the RDS and RDS2 backends to recognize the NewDBInstanceIdentifier argument and update their models accordingly.