### PR TITLE
modify_db_instance should be able to rename DB instances

### DIFF
--- a/moto/rds/responses.py
+++ b/moto/rds/responses.py
@@ -107,6 +107,9 @@ class RDSResponse(BaseResponse):
     def modify_db_instance(self):
         db_instance_identifier = self._get_param('DBInstanceIdentifier')
         db_kwargs = self._get_db_kwargs()
+        new_db_instance_identifier = self._get_param('NewDBInstanceIdentifier')
+        if new_db_instance_identifier:
+            db_kwargs['new_db_instance_identifier'] = new_db_instance_identifier
         database = self.backend.modify_database(
             db_instance_identifier, db_kwargs)
         template = self.response_template(MODIFY_DATABASE_TEMPLATE)

--- a/moto/rds2/models.py
+++ b/moto/rds2/models.py
@@ -736,6 +736,10 @@ class RDS2Backend(BaseBackend):
 
     def modify_database(self, db_instance_identifier, db_kwargs):
         database = self.describe_databases(db_instance_identifier)[0]
+        if 'new_db_instance_identifier' in db_kwargs:
+            del self.databases[db_instance_identifier]
+            db_instance_identifier = db_kwargs['db_instance_identifier'] = db_kwargs.pop('new_db_instance_identifier')
+            self.databases[db_instance_identifier] = database
         database.update(db_kwargs)
         return database
 

--- a/moto/rds2/responses.py
+++ b/moto/rds2/responses.py
@@ -135,6 +135,9 @@ class RDS2Response(BaseResponse):
     def modify_db_instance(self):
         db_instance_identifier = self._get_param('DBInstanceIdentifier')
         db_kwargs = self._get_db_kwargs()
+        new_db_instance_identifier = self._get_param('NewDBInstanceIdentifier')
+        if new_db_instance_identifier:
+            db_kwargs['new_db_instance_identifier'] = new_db_instance_identifier
         database = self.backend.modify_database(
             db_instance_identifier, db_kwargs)
         template = self.response_template(MODIFY_DATABASE_TEMPLATE)


### PR DESCRIPTION
Fix the RDS and RDS2 backends to recognize the NewDBInstanceIdentifier argument and update their models accordingly.

Added a unit test to be sure this time.