### PR TITLE
Add cloudformation update from s3 support

### DIFF
--- a/moto/cloudformation/parsing.py
+++ b/moto/cloudformation/parsing.py
@@ -453,8 +453,8 @@ class ResourceMap(collections.Mapping):
                 resource_name, resource_json, self, self._region_name)
             self._parsed_resources[resource_name] = new_resource
 
-        removed_resource_nams = set(old_template) - set(new_template)
-        for resource_name in removed_resource_nams:
+        removed_resource_names = set(old_template) - set(new_template)
+        for resource_name in removed_resource_names:
             resource_json = old_template[resource_name]
             parse_and_delete_resource(
                 resource_name, resource_json, self, self._region_name)

--- a/moto/cloudformation/responses.py
+++ b/moto/cloudformation/responses.py
@@ -161,11 +161,15 @@ class CloudFormationResponse(BaseResponse):
     def update_stack(self):
         stack_name = self._get_param('StackName')
         role_arn = self._get_param('RoleARN')
+        template_url = self._get_param('TemplateURL')
         if self._get_param('UsePreviousTemplate') == "true":
             stack_body = self.cloudformation_backend.get_stack(
                 stack_name).template
+        elif template_url:
+            stack_body = self._get_stack_from_s3_url(template_url)
         else:
             stack_body = self._get_param('TemplateBody')
+
         parameters = dict([
             (parameter['parameter_key'], parameter['parameter_value'])
             for parameter

--- a/moto/ec2/models.py
+++ b/moto/ec2/models.py
@@ -507,6 +507,22 @@ class Instance(TaggedEC2Resource, BotoInstance):
             instance.add_tag(tag["Key"], tag["Value"])
         return instance
 
+    @classmethod
+    def delete_from_cloudformation_json(cls, resource_name, cloudformation_json, region_name):
+        ec2_backend = ec2_backends[region_name]
+        all_instances = ec2_backend.all_instances()
+
+        # the resource_name for instances is the stack name, logical id, and random suffix separated
+        # by hyphens.  So to lookup the instances using the 'aws:cloudformation:logical-id' tag, we need to
+        # extract the logical-id from the resource_name
+        logical_id = resource_name.split('-')[1]
+
+        for instance in all_instances:
+            instance_tags = instance.get_tags()
+            for tag in instance_tags:
+                if tag['key'] == 'aws:cloudformation:logical-id' and tag['value'] == logical_id:
+                    instance.delete(region_name)
+
     @property
     def physical_resource_id(self):
         return self.id

--- a/tests/test_cloudformation/test_cloudformation_stack_crud_boto3.py
+++ b/tests/test_cloudformation/test_cloudformation_stack_crud_boto3.py
@@ -1,18 +1,13 @@
 from __future__ import unicode_literals
 
-import boto3
-import boto
-import boto.s3
-import boto.s3.key
-from botocore.exceptions import ClientError
-from moto import mock_cloudformation, mock_s3, mock_sqs
-
 import json
-import sure  # noqa
+
+import boto3
+from botocore.exceptions import ClientError
 # Ensure 'assert_raises' context manager support for Python 2.6
-import tests.backport_assert_raises  # noqa
 from nose.tools import assert_raises
-import random
+
+from moto import mock_cloudformation, mock_s3, mock_sqs, mock_ec2
 
 dummy_template = {
     "AWSTemplateFormatVersion": "2010-09-09",
@@ -39,7 +34,6 @@ dummy_template = {
     }
 }
 
-
 dummy_template_yaml = """---
 AWSTemplateFormatVersion: 2010-09-09
 Description: Stack1 with yaml template
@@ -57,7 +51,6 @@ Resources:
           Value: Name tag for tests
 """
 
-
 dummy_template_yaml_with_short_form_func = """---
 AWSTemplateFormatVersion: 2010-09-09
 Description: Stack1 with yaml template
@@ -74,7 +67,6 @@ Resources:
         - Key: Name
           Value: Name tag for tests
 """
-
 
 dummy_template_yaml_with_ref = """---
 AWSTemplateFormatVersion: 2010-09-09
@@ -131,12 +123,12 @@ dummy_output_template = {
             }
         }
     },
-    "Outputs" : {
-        "StackVPC" : {
-            "Description" : "The ID of the VPC",
-            "Value" : "VPCID",
-            "Export" : {
-                "Name" : "My VPC ID"
+    "Outputs": {
+        "StackVPC": {
+            "Description": "The ID of the VPC",
+            "Value": "VPCID",
+            "Export": {
+                "Name": "My VPC ID"
             }
         }
     }
@@ -156,7 +148,7 @@ dummy_import_template = {
 }
 
 dummy_template_json = json.dumps(dummy_template)
-dummy_update_template_json = json.dumps(dummy_template)
+dummy_update_template_json = json.dumps(dummy_update_template)
 dummy_output_template_json = json.dumps(dummy_output_template)
 dummy_import_template_json = json.dumps(dummy_import_template)
 
@@ -382,6 +374,7 @@ def test_delete_stack_from_resource():
 
 
 @mock_cloudformation
+@mock_ec2
 def test_delete_stack_by_name():
     cf_conn = boto3.client('cloudformation', region_name='us-east-1')
     cf_conn.create_stack(
@@ -412,6 +405,7 @@ def test_describe_deleted_stack():
 
 
 @mock_cloudformation
+@mock_ec2
 def test_describe_updated_stack():
     cf_conn = boto3.client('cloudformation', region_name='us-east-1')
     cf_conn.create_stack(
@@ -502,6 +496,7 @@ def test_stack_tags():
 
 
 @mock_cloudformation
+@mock_ec2
 def test_stack_events():
     cf = boto3.resource('cloudformation', region_name='us-east-1')
     stack = cf.create_stack(


### PR DESCRIPTION
Updating a cloudformation stack from a template body works, but not from an s3 template url.  This adds support for updating a stack from the s3 url.

In the process, I ended up finding a bug where the `dummy_update_template_json` in tests/test_cloudformation/test_cloudformation_stack_crud_boto3.py was pointed at the wrong template, so I fixed that and needed to add support for cloudformation deleting an ec2 instances to get the tests to pass afterwards.