### PR TITLE
Allow AMIs to be read from a custom file path

### DIFF
--- a/moto/ec2/models.py
+++ b/moto/ec2/models.py
@@ -4,6 +4,7 @@ import copy
 import itertools
 import ipaddress
 import json
+import os
 import re
 import six
 import warnings
@@ -117,7 +118,8 @@ INSTANCE_TYPES = json.load(
     open(resource_filename(__name__, 'resources/instance_types.json'), 'r')
 )
 AMIS = json.load(
-    open(resource_filename(__name__, 'resources/amis.json'), 'r')
+    open(os.environ.get('MOTO_AMIS_PATH') or resource_filename(
+         __name__, 'resources/amis.json'), 'r')
 )
 
 


### PR DESCRIPTION
Currently, AMI info is retrieved for AMIs from `eu-west-1` region only(https://github.com/spulec/moto/blob/master/scripts/get_amis.py#L13). With this change, allow people to create their own list of available AMIs by exporting `MOTO_AMIS_PATH` env var that points to a file with the format like [amis.json](https://github.com/spulec/moto/blob/master/moto/ec2/resources/amis.json).