### PR TITLE
cast MaxRecords to int on  describe_db_instances

### DIFF
--- a/moto/rds2/responses.py
+++ b/moto/rds2/responses.py
@@ -123,7 +123,7 @@ class RDS2Response(BaseResponse):
             start = all_ids.index(marker) + 1
         else:
             start = 0
-        page_size = self._get_param('MaxRecords', 50)  # the default is 100, but using 50 to make testing easier
+        page_size = int(self._get_param('MaxRecords', 50))  # the default is 100, but using 50 to make testing easier
         instances_resp = all_instances[start:start + page_size]
         next_marker = None
         if len(all_instances) > start + page_size:

--- a/moto/rds2/responses.py
+++ b/moto/rds2/responses.py
@@ -123,7 +123,7 @@ class RDS2Response(BaseResponse):
             start = all_ids.index(marker) + 1
         else:
             start = 0
-        page_size = int(self._get_param('MaxRecords', 50))  # the default is 100, but using 50 to make testing easier
+        page_size = self._get_int_param('MaxRecords', 50)  # the default is 100, but using 50 to make testing easier
         instances_resp = all_instances[start:start + page_size]
         next_marker = None
         if len(all_instances) > start + page_size:

--- a/tests/test_rds2/test_rds2.py
+++ b/tests/test_rds2/test_rds2.py
@@ -197,6 +197,8 @@ def test_get_databases_paginated():
     resp2 = conn.describe_db_instances(Marker=resp["Marker"])
     resp2["DBInstances"].should.have.length_of(1)
 
+    resp3 = conn.describe_db_instances(MaxRecords=100)
+    resp3["DBInstances"].should.have.length_of(51)
 
 @mock_rds2
 def test_describe_non_existant_database():


### PR DESCRIPTION
I couldn't call describe_db_instance with MaxRecords in rds2

boto3 expect MaxRecords argument as Integer, but rds2 use the variable as string
http://boto3.readthedocs.io/en/latest/reference/services/rds.html#RDS.Client.describe_db_instances

  
 