### PR TITLE
Fix co-operative inheritance for ec2 model

### DIFF
--- a/moto/ec2/models.py
+++ b/moto/ec2/models.py
@@ -3722,6 +3722,7 @@ class NatGateway(object):
 class NatGatewayBackend(object):
     def __init__(self):
         self.nat_gateways = {}
+        super(NatGatewayBackend, self).__init__()
 
     def get_all_nat_gateways(self, filters):
         return self.nat_gateways.values()


### PR DESCRIPTION
Small change to fix co-operative inheritance model for ec2 model.

I was working on a private fork for work and spent a lot of time trying to get my new features to work before I realised that NatGatewayBackend wasn't calling super() and breaking the chain.

Hopefully this will save someone some time in the future.