### PR TITLE
Bump flake8 version and handle new lint errors

### DIFF
--- a/moto/acm/responses.py
+++ b/moto/acm/responses.py
@@ -111,16 +111,16 @@ class AWSCertificateManagerResponse(BaseResponse):
         # actual data
         try:
             certificate = base64.standard_b64decode(certificate)
-        except:
+        except Exception:
             return AWSValidationException('The certificate is not PEM-encoded or is not valid.').response()
         try:
             private_key = base64.standard_b64decode(private_key)
-        except:
+        except Exception:
             return AWSValidationException('The private key is not PEM-encoded or is not valid.').response()
         if chain is not None:
             try:
                 chain = base64.standard_b64decode(chain)
-            except:
+            except Exception:
                 return AWSValidationException('The certificate chain is not PEM-encoded or is not valid.').response()
 
         try:

--- a/moto/awslambda/models.py
+++ b/moto/awslambda/models.py
@@ -265,14 +265,14 @@ class LambdaFunction(BaseModel):
     def convert(s):
         try:
             return str(s, encoding='utf-8')
-        except:
+        except Exception:
             return s
 
     @staticmethod
     def is_json(test_str):
         try:
             response = json.loads(test_str)
-        except:
+        except Exception:
             response = test_str
         return response
 

--- a/moto/awslambda/responses.py
+++ b/moto/awslambda/responses.py
@@ -4,7 +4,7 @@ import json
 
 try:
     from urllib import unquote
-except:
+except ImportError:
     from urllib.parse import unquote
 
 from moto.core.utils import amz_crc32, amzn_request_id

--- a/moto/s3bucket_path/utils.py
+++ b/moto/s3bucket_path/utils.py
@@ -3,12 +3,12 @@ from six.moves.urllib.parse import urlparse
 
 
 def bucket_name_from_url(url):
-    pth = urlparse(url).path.lstrip("/")
+    path = urlparse(url).path.lstrip("/")
 
-    l = pth.lstrip("/").split("/")
-    if len(l) == 0 or l[0] == "":
+    parts = path.lstrip("/").split("/")
+    if len(parts) == 0 or parts[0] == "":
         return None
-    return l[0]
+    return parts[0]
 
 
 def parse_key_name(path):

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,7 +3,7 @@ mock
 nose
 sure==1.2.24
 coverage
-flake8==3.4.1
+flake8==3.5.0
 freezegun
 flask
 boto>=2.45.0


### PR DESCRIPTION
Use latest version of flake8 (not sure exactly why this needs pinning - newer versions are catching real issues) and fix the violations it mentions.

The bare exceptions will catch things such as keyboard interrupts which is bad behaviour.