### PR TITLE
Validate default AMI values after image creation

### DIFF
--- a/moto/ec2/models.py
+++ b/moto/ec2/models.py
@@ -1033,29 +1033,28 @@ class TagBackend(object):
 class Ami(TaggedEC2Resource):
     def __init__(self, ec2_backend, ami_id, instance=None, source_ami=None,
                  name=None, description=None, owner_id=None,
-
                  public=False, virtualization_type=None, architecture=None,
-                 state='available', creation_date=None, platform=None,
-                 image_type='machine', image_location=None, hypervisor=None,
-                 root_device_type=None, root_device_name=None, sriov='simple',
+                 state=None, creation_date=None, platform=None,
+                 image_type=None, image_location=None, hypervisor=None,
+                 root_device_type=None, root_device_name=None, sriov=None,
                  region_name='us-east-1a'
                  ):
         self.ec2_backend = ec2_backend
         self.id = ami_id
-        self.state = state
+        self.state = state or 'available'
         self.name = name
-        self.image_type = image_type
-        self.image_location = image_location
+        self.image_type = image_type or 'machine'
+        self.image_location = image_location or "amazon/getting-started"
         self.owner_id = owner_id
         self.description = description
-        self.virtualization_type = virtualization_type
-        self.architecture = architecture
+        self.virtualization_type = virtualization_type or "hvm"
+        self.architecture = architecture or "Z"
         self.kernel_id = None
         self.platform = platform
-        self.hypervisor = hypervisor
-        self.root_device_name = root_device_name
-        self.root_device_type = root_device_type
-        self.sriov = sriov
+        self.hypervisor = hypervisor or "xen"
+        self.root_device_name = root_device_name or "/dev/sda1"
+        self.root_device_type = root_device_type or "ebs"
+        self.sriov = sriov or 'simple'
         self.creation_date = utc_date_and_time() if creation_date is None else creation_date
 
         if instance:

--- a/tests/test_ec2/test_amis.py
+++ b/tests/test_ec2/test_amis.py
@@ -41,6 +41,14 @@ def test_ami_create_and_delete():
     image.kernel_id.should.equal(instance.kernel)
     image.platform.should.equal(instance.platform)
     image.creationDate.should_not.be.none
+
+    # image properties should have sane values
+    image.virtualization_type.should_not.be.none
+    image.architecture.should_not.be.none
+    image.root_device_name.should.contain("/dev")
+    image.root_device_type.should_not.be.none
+    image.state.should.be.within(['available', 'pending', 'failed'])
+
     instance.terminate()
 
     # Validate auto-created volume and snapshot


### PR DESCRIPTION
This PR makes sure that AMIs have some values for certain mandatory properties, such as root_device_name.