### PR TITLE
releasing version 1.2.0

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.1.25
+current_version = 1.2.0
 
 [bumpversion:file:setup.py]
 

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,0 +1,8 @@
+[bumpversion]
+current_version = 1.1.25
+
+[bumpversion:file:setup.py]
+
+[bumpversion:file:moto/__init__.py]
+
+[bumpversion:file:setup.cfg]

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -5,4 +5,3 @@ current_version = 1.1.25
 
 [bumpversion:file:moto/__init__.py]
 
-[bumpversion:file:setup.cfg]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,17 @@
 Moto Changelog
 ===================
 
-Latest
+1.2.0
 ------
+
     * Implemented signal_workflow_execution for SWF
     * Wired SWF backend to the moto server
-    * Fixed incorrect handling of task list parameter on start_workflow_execution
+    * Revamped lambda function storage to do versioning
+    * IOT improvements
+    * RDS improvements
+    * Implemented CloudWatch get_metric_statistics
+    * Improved Cloudformation EC2 support
+    * Implemented Cloudformation change_set endpoints
     
 1.1.25
 -----

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Moto Changelog
 1.2.0
 ------
 
+    * Supports filtering AMIs by self
     * Implemented signal_workflow_execution for SWF
     * Wired SWF backend to the moto server
     * Revamped lambda function storage to do versioning

--- a/moto/__init__.py
+++ b/moto/__init__.py
@@ -3,7 +3,7 @@ import logging
 # logging.getLogger('boto').setLevel(logging.CRITICAL)
 
 __title__ = 'moto'
-__version__ = '1.0.1'
+__version__ = '1.2.0',
 
 from .acm import mock_acm  # flake8: noqa
 from .apigateway import mock_apigateway, mock_apigateway_deprecated  # flake8: noqa

--- a/moto/__init__.py
+++ b/moto/__init__.py
@@ -3,7 +3,7 @@ import logging
 # logging.getLogger('boto').setLevel(logging.CRITICAL)
 
 __title__ = 'moto'
-__version__ = '1.2.0',
+__version__ = '1.1.25',
 
 from .acm import mock_acm  # flake8: noqa
 from .apigateway import mock_apigateway, mock_apigateway_deprecated  # flake8: noqa

--- a/moto/__init__.py
+++ b/moto/__init__.py
@@ -3,7 +3,7 @@ import logging
 # logging.getLogger('boto').setLevel(logging.CRITICAL)
 
 __title__ = 'moto'
-__version__ = '1.1.25',
+__version__ = '1.2.0',
 
 from .acm import mock_acm  # flake8: noqa
 from .apigateway import mock_apigateway, mock_apigateway_deprecated  # flake8: noqa

--- a/scripts/bump_version
+++ b/scripts/bump_version
@@ -1,6 +1,8 @@
 #!/bin/bash
 
 main() {
+  set -euo pipefail  # Bash safemode
+
   local version=$1
   if [[ -z "${version}" ]]; then
     echo "USAGE: $0 1.3.2"
@@ -15,7 +17,7 @@ main() {
 
   git checkout -b version-${version}
   # Commit the new version
-  git commit setup.py moto/__init__.py -m "bumping to version ${version}"
+  git commit -a -m "bumping to version ${version}"
   # Commit an updated IMPLEMENTATION_COVERAGE.md
   make implementation_coverage || true
   # Open a PR

--- a/scripts/bump_version
+++ b/scripts/bump_version
@@ -10,10 +10,8 @@ main() {
     return 1
   fi
 
-  # TODO: replace this with the bumpversion pip package, I couldn't
-  # figure out how to use that for these files
-  sed -i '' "s/version=.*$/version='${version}',/g" setup.py
-  sed -i '' "s/__version__ = .*$/__version__ = '${version}',/g" moto/__init__.py
+  &>/dev/null which bumpversion || pip install bumpversion
+  bumpversion --new-version ${version} patch
 
   git checkout -b version-${version}
   # Commit the new version

--- a/scripts/bump_version
+++ b/scripts/bump_version
@@ -17,7 +17,7 @@ main() {
 
   git checkout -b version-${version}
   # Commit the new version
-  git commit setup.py -m "bumping to version ${version}"
+  git commit setup.py moto/__init__.py -m "bumping to version ${version}"
   # Commit an updated IMPLEMENTATION_COVERAGE.md
   make implementation_coverage || true
   # Open a PR

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ else:
 
 setup(
     name='moto',
-    version='1.1.25',
+    version='1.2.0',
     description='A library that allows your python tests to easily'
                 ' mock out the boto library',
     author='Steve Pulec',


### PR DESCRIPTION
@georgeionita @terrycain @spulec @jbbarth 

I updated CHAGELOG.md with the changes since the last release and since 1.1.25 was getting to be a pretty high patch number I've opened this PR as version 1.2.0. No major changes though.

I'm using `script/bump_version` because I couldn't figure out the bumpversion package and if any of you know how to get that package to write to the two files containing the version I'd love to see it. Otherwise this works.