### PR TITLE
Return 404 error on missing action

### DIFF
--- a/moto/core/responses.py
+++ b/moto/core/responses.py
@@ -272,6 +272,9 @@ class BaseResponse(_TemplateEnvironmentMixin):
                     headers['status'] = str(headers['status'])
                 return status, headers, body
 
+        if not action:
+            return 404, headers, ''
+
         raise NotImplementedError(
             "The {0} action has not been implemented".format(action))
 

--- a/moto/core/utils.py
+++ b/moto/core/utils.py
@@ -18,6 +18,8 @@ def camelcase_to_underscores(argument):
     python underscore variable like the_new_attribute'''
     result = ''
     prev_char_title = True
+    if not argument:
+        return argument
     for index, char in enumerate(argument):
         try:
             next_char_title = argument[index + 1].istitle()


### PR DESCRIPTION
In the current implementation, an invalid client request results in a 500 error, instead of a 4xx style error. Steps to reproduce:
```
$ moto_server cloudwatch
$ curl http://localhost:5000
```
... results in this error:
```
<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 3.2 Final//EN">
<title>500 Internal Server Error</title>
<h1>Internal Server Error</h1>
<p>The server encountered an internal error and was unable to complete your request.  Either the server is overloaded or there is an error in the application.</p>
```
... with the following stack trace:
```
...
  File "/Library/Python/2.7/site-packages/flask/app.py", line 1461, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File "/Library/Python/2.7/site-packages/moto/core/utils.py", line 137, in __call__
    result = self.callback(request, request.url, {})
  File "/Library/Python/2.7/site-packages/moto/core/responses.py", line 114, in dispatch
    return cls()._dispatch(*args, **kwargs)
  File "/Library/Python/2.7/site-packages/moto/core/responses.py", line 182, in _dispatch
    return self.call_action()
  File "/Library/Python/2.7/site-packages/moto/core/responses.py", line 251, in call_action
    action = camelcase_to_underscores(self._get_action())
  File "/Library/Python/2.7/site-packages/moto/core/utils.py", line 21, in camelcase_to_underscores
    for index, char in enumerate(argument):
TypeError: 'NoneType' object is not iterable
```

This PR contains a small fix to return a 404 error if the client request does not contain a valid action.