### PR TITLE
describe_regions: handle region-names parameter

### DIFF
--- a/moto/ec2/models.py
+++ b/moto/ec2/models.py
@@ -1261,8 +1261,15 @@ class RegionsAndZonesBackend(object):
         (region, [Zone(region + c, region) for c in 'abc'])
         for region in [r.name for r in regions])
 
-    def describe_regions(self):
-        return self.regions
+    def describe_regions(self, region_names=[]):
+        if len(region_names) == 0:
+            return self.regions
+        ret = []
+        for name in region_names:
+            for region in self.regions:
+                if region.name == name:
+                    ret.append(region)
+        return ret
 
     def describe_availability_zones(self):
         return self.zones[self.region_name]

--- a/moto/ec2/responses/availability_zones_and_regions.py
+++ b/moto/ec2/responses/availability_zones_and_regions.py
@@ -10,7 +10,8 @@ class AvailabilityZonesAndRegions(BaseResponse):
         return template.render(zones=zones)
 
     def describe_regions(self):
-        regions = self.ec2_backend.describe_regions()
+        region_names = self._get_multi_param('RegionName')
+        regions = self.ec2_backend.describe_regions(region_names)
         template = self.response_template(DESCRIBE_REGIONS_RESPONSE)
         return template.render(regions=regions)
 

--- a/tests/test_ec2/test_availability_zones_and_regions.py
+++ b/tests/test_ec2/test_availability_zones_and_regions.py
@@ -36,6 +36,11 @@ def test_boto3_describe_regions():
     for rec in resp['Regions']:
         rec['Endpoint'].should.contain(rec['RegionName'])
 
+    test_region = 'us-east-1' 
+    resp = ec2.describe_regions(RegionNames=[test_region])
+    resp['Regions'].should.have.length_of(1)
+    resp['Regions'][0].should.have.key('RegionName').which.should.equal(test_region)
+
 
 @mock_ec2
 def test_boto3_availability_zones():


### PR DESCRIPTION
I have been testing terraform against moto, this PR helps fix the terraform construct

```
data "aws_region" {
   current = true
}
```

That code uses the RegionNames parameter to limit the return to just the current region