### PR TITLE
Cloudformation vpc add tags

### DIFF
--- a/moto/ec2/models.py
+++ b/moto/ec2/models.py
@@ -2004,6 +2004,11 @@ class VPC(TaggedEC2Resource):
             cidr_block=properties['CidrBlock'],
             instance_tenancy=properties.get('InstanceTenancy', 'default')
         )
+        for tag in properties.get("Tags", []):
+            tag_key = tag["Key"]
+            tag_value = tag["Value"]
+            vpc.add_tag(tag_key, tag_value)
+
         return vpc
 
     @property

--- a/tests/test_cloudformation/test_cloudformation_stack_integration.py
+++ b/tests/test_cloudformation/test_cloudformation_stack_integration.py
@@ -752,6 +752,9 @@ def test_vpc_single_instance_in_subnet():
     security_group.vpc_id.should.equal(vpc.id)
 
     stack = conn.describe_stacks()[0]
+
+    vpc.tags.should.have.key('Application').which.should.equal(stack.stack_id)
+
     resources = stack.describe_resources()
     vpc_resource = [
         resource for resource in resources if resource.resource_type == 'AWS::EC2::VPC'][0]


### PR DESCRIPTION
I found when creating a vpc via cloudformation tags where not being applied.  This fixes that.