### PR TITLE
SNS: do not duplicate subscriptions

### DIFF
--- a/tests/test_sns/test_subscriptions_boto3.py
+++ b/tests/test_sns/test_subscriptions_boto3.py
@@ -25,6 +25,23 @@ def test_subscribe_sms():
     )
     resp.should.contain('SubscriptionArn')
 
+@mock_sns
+def test_double_subscription():
+    client = boto3.client('sns', region_name='us-east-1')
+    client.create_topic(Name="some-topic")
+    resp = client.create_topic(Name="some-topic")
+    arn = resp['TopicArn']
+
+    do_subscribe_sqs = lambda sqs_arn: client.subscribe(
+        TopicArn=arn,
+        Protocol='sqs',
+        Endpoint=sqs_arn
+    )
+    resp1 = do_subscribe_sqs('arn:aws:sqs:elasticmq:000000000000:foo')
+    resp2 = do_subscribe_sqs('arn:aws:sqs:elasticmq:000000000000:foo')
+
+    resp1['SubscriptionArn'].should.equal(resp2['SubscriptionArn'])
+
 
 @mock_sns
 def test_subscribe_bad_sms():


### PR DESCRIPTION
Hi.

This is apparently is a bug. If I try to create 2 subscriptions between a topic and an endpoint, Amazon will create only a single one and on the 2nd call will return the ARN of the 1st one.

Though, I couldn't any description of it in the docs (event [stackoverflow](https://stackoverflow.com/questions/48016591/amazon-sns-multiple-subscriptions-of-the-same-endpoint) didn't help.) But the experiments show that this is the behavior they have.