### PR TITLE
S3 Ignore Subdomain for Bucketname Flag

### DIFF
--- a/moto/s3/responses.py
+++ b/moto/s3/responses.py
@@ -60,7 +60,7 @@ class ResponseObject(_TemplateEnvironmentMixin):
         if (not host or host.startswith('localhost') or host.startswith('localstack') or
                 re.match(r'^[^.]+$', host) or re.match(r'^.*\.svc\.cluster\.local$', host)):
             # Default to path-based buckets for (1) localhost, (2) localstack hosts (e.g. localstack.dev),
-            # (3) local host names that do not contain a "." (e.g., Docker container host names), or 
+            # (3) local host names that do not contain a "." (e.g., Docker container host names), or
             # (4) kubernetes host names
             return False
 

--- a/moto/s3/responses.py
+++ b/moto/s3/responses.py
@@ -57,10 +57,11 @@ class ResponseObject(_TemplateEnvironmentMixin):
         if not host:
             host = urlparse(request.url).netloc
 
-        if (not host or host.startswith('localhost') or
+        if (not host or host.startswith('localhost') or host.startswith('localstack') or
                 re.match(r'^[^.]+$', host) or re.match(r'^.*\.svc\.cluster\.local$', host)):
-            # Default to path-based buckets for (1) localhost, (2) local host names that do not
-            # contain a "." (e.g., Docker container host names), or (3) kubernetes host names
+            # Default to path-based buckets for (1) localhost, (2) localstack hosts (e.g. localstack.dev),
+            # (3) local host names that do not contain a "." (e.g., Docker container host names), or 
+            # (4) kubernetes host names
             return False
 
         match = re.match(r'^([^\[\]:]+)(:\d+)?$', host)

--- a/moto/s3/utils.py
+++ b/moto/s3/utils.py
@@ -1,5 +1,5 @@
 from __future__ import unicode_literals
-
+import os
 from boto.s3.key import Key
 import re
 import six
@@ -10,6 +10,8 @@ bucket_name_regex = re.compile("(.+).s3(.*).amazonaws.com")
 
 
 def bucket_name_from_url(url):
+    if os.environ.get('S3_IGNORE_SUBDOMAIN_BUCKETNAME', '') in ['1', 'true']:
+        return None
     domain = urlparse(url).netloc
 
     if domain.startswith('www.'):

--- a/tests/test_s3/test_s3_utils.py
+++ b/tests/test_s3/test_s3_utils.py
@@ -1,4 +1,5 @@
 from __future__ import unicode_literals
+import os
 from sure import expect
 from moto.s3.utils import bucket_name_from_url, _VersionedKeyStore
 
@@ -15,6 +16,12 @@ def test_localhost_bucket():
 def test_localhost_without_bucket():
     expect(bucket_name_from_url(
         'https://www.localhost:5000/def')).should.equal(None)
+
+def test_force_ignore_subdomain_for_bucketnames():
+    os.environ['S3_IGNORE_SUBDOMAIN_BUCKETNAME'] = '1'
+    expect(bucket_name_from_url('https://subdomain.localhost:5000/abc/resource')).should.equal(None)
+    del(os.environ['S3_IGNORE_SUBDOMAIN_BUCKETNAME'])
+    
 
 
 def test_versioned_key_store():


### PR DESCRIPTION
Some circumstances need subdomains to be ignored rather that interpreted as bucketname, this patch allows such behaviour to be configured.