### PR TITLE
Add missing target_group stickiness attributes

### DIFF
--- a/moto/elbv2/models.py
+++ b/moto/elbv2/models.py
@@ -86,6 +86,8 @@ class FakeTargetGroup(BaseModel):
         self.attributes = {
             'deregistration_delay.timeout_seconds': 300,
             'stickiness.enabled': 'false',
+            'stickiness.type': 'lb_cookie',
+            'stickiness.lb_cookie.duration_seconds': 604800,
         }
 
         self.targets = OrderedDict()


### PR DESCRIPTION
As per the output section at:
https://docs.aws.amazon.com/cli/latest/reference/elbv2/modify-target-group-attributes.html
there are two additional stickiness attributes available to a target group.

I noticed these were missing because I was testing some ansible roles using the moto_server for elbv2 and the ansible target_group module barfed when trying to read back these attributes.