### PR TITLE
Change name of 'state' attribute of 'FakeAlarm' CloudWatch model to '…

### DIFF
--- a/moto/cloudwatch/models.py
+++ b/moto/cloudwatch/models.py
@@ -74,18 +74,18 @@ class FakeAlarm(BaseModel):
 
         self.state_reason = ''
         self.state_reason_data = '{}'
-        self.state = 'OK'
+        self.state_value = 'OK'
         self.state_updated_timestamp = datetime.utcnow()
 
     def update_state(self, reason, reason_data, state_value):
         # History type, that then decides what the rest of the items are, can be one of ConfigurationUpdate | StateUpdate | Action
         self.history.append(
-            ('StateUpdate', self.state_reason, self.state_reason_data, self.state, self.state_updated_timestamp)
+            ('StateUpdate', self.state_reason, self.state_reason_data, self.state_value, self.state_updated_timestamp)
         )
 
         self.state_reason = reason
         self.state_reason_data = reason_data
-        self.state = state_value
+        self.state_value = state_value
         self.state_updated_timestamp = datetime.utcnow()
 
 
@@ -221,7 +221,7 @@ class CloudWatchBackend(BaseBackend):
         ]
 
     def get_alarms_by_state_value(self, target_state):
-        return filter(lambda alarm: alarm.state == target_state, self.alarms.values())
+        return filter(lambda alarm: alarm.state_value == target_state, self.alarms.values())
 
     def delete_alarms(self, alarm_names):
         for alarm_name in alarm_names:

--- a/tests/test_cloudwatch/test_cloudwatch_boto3.py
+++ b/tests/test_cloudwatch/test_cloudwatch_boto3.py
@@ -127,12 +127,14 @@ def test_alarm_state():
     )
     len(resp['MetricAlarms']).should.equal(1)
     resp['MetricAlarms'][0]['AlarmName'].should.equal('testalarm1')
+    resp['MetricAlarms'][0]['StateValue'].should.equal('ALARM')
 
     resp = client.describe_alarms(
         StateValue='OK'
     )
     len(resp['MetricAlarms']).should.equal(1)
     resp['MetricAlarms'][0]['AlarmName'].should.equal('testalarm2')
+    resp['MetricAlarms'][0]['StateValue'].should.equal('OK')
 
     # Just for sanity
     resp = client.describe_alarms()


### PR DESCRIPTION
…state_value'. This ensures that the 'StateValue' returned by 'describe_alarms' is correct.

The 'DESCRIBE_ALARMS_TEMPLATE' response template references a 'state_value' attribute on the 'FakeAlarm' model which does not exist; it is named 'state'.
This commit updates the attribute to be called 'state_value', in-line with the naming convention used elsewhere.