### PR TITLE
Fix cloudwatch logs' response error

### DIFF
--- a/moto/logs/responses.py
+++ b/moto/logs/responses.py
@@ -87,9 +87,8 @@ class LogsResponse(BaseResponse):
 
         events, next_backward_token, next_foward_token = \
             self.logs_backend.get_log_events(log_group_name, log_stream_name, start_time, end_time, limit, next_token, start_from_head)
-
         return json.dumps({
-            "events": [ob.__dict__ for ob in events],
+            "events": events,
             "nextBackwardToken": next_backward_token,
             "nextForwardToken": next_foward_token
         })

--- a/tests/test_logs/test_logs.py
+++ b/tests/test_logs/test_logs.py
@@ -12,3 +12,30 @@ def test_log_group_create():
     log_group_name = 'dummy'
     response = conn.create_log_group(logGroupName=log_group_name)
     response = conn.delete_log_group(logGroupName=log_group_name)
+
+
+@mock_logs
+def test_put_logs():
+    conn = boto3.client('logs', 'us-west-2')
+    log_group_name = 'dummy'
+    log_stream_name = 'stream'
+    conn.create_log_group(logGroupName=log_group_name)
+    conn.create_log_stream(
+        logGroupName=log_group_name,
+        logStreamName=log_stream_name
+    )
+    messages = [
+        {'timestamp': 0, 'message': 'hello'},
+        {'timestamp': 0, 'message': 'world'}
+    ]
+    conn.put_log_events(
+        logGroupName=log_group_name,
+        logStreamName=log_stream_name,
+        logEvents=messages
+    )
+    res = conn.get_log_events(
+        logGroupName=log_group_name,
+        logStreamName=log_stream_name
+    )
+    events = res['events']
+    events.should.have.length_of(2)


### PR DESCRIPTION
As Cloudwatch logs mock have error with response, fixed it.

```
  File "/Users/kawasakitoshiya/.pyenv/versions/3.6.0/lib/python3.6/site-packages/botocore/client.py", line 312, in _api_call
    return self._make_api_call(operation_name, kwargs)
  File "/Users/kawasakitoshiya/.pyenv/versions/3.6.0/lib/python3.6/site-packages/botocore/client.py", line 588, in _make_api_call
    operation_model, request_dict)
  File "/Users/kawasakitoshiya/.pyenv/versions/3.6.0/lib/python3.6/site-packages/botocore/endpoint.py", line 141, in make_request
    return self._send_request(request_dict, operation_model)
  File "/Users/kawasakitoshiya/.pyenv/versions/3.6.0/lib/python3.6/site-packages/botocore/endpoint.py", line 170, in _send_request
    success_response, exception):
  File "/Users/kawasakitoshiya/.pyenv/versions/3.6.0/lib/python3.6/site-packages/botocore/endpoint.py", line 249, in _needs_retry
    caught_exception=caught_exception, request_dict=request_dict)
  File "/Users/kawasakitoshiya/.pyenv/versions/3.6.0/lib/python3.6/site-packages/botocore/hooks.py", line 227, in emit
    return self._emit(event_name, kwargs)
  File "/Users/kawasakitoshiya/.pyenv/versions/3.6.0/lib/python3.6/site-packages/botocore/hooks.py", line 210, in _emit
    response = handler(**kwargs)
  File "/Users/kawasakitoshiya/.pyenv/versions/3.6.0/lib/python3.6/site-packages/botocore/retryhandler.py", line 183, in __call__
    if self._checker(attempts, response, caught_exception):
  File "/Users/kawasakitoshiya/.pyenv/versions/3.6.0/lib/python3.6/site-packages/botocore/retryhandler.py", line 251, in __call__
    caught_exception)
  File "/Users/kawasakitoshiya/.pyenv/versions/3.6.0/lib/python3.6/site-packages/botocore/retryhandler.py", line 269, in _should_retry
    return self._checker(attempt_number, response, caught_exception)
  File "/Users/kawasakitoshiya/.pyenv/versions/3.6.0/lib/python3.6/site-packages/botocore/retryhandler.py", line 317, in __call__
    caught_exception)
  File "/Users/kawasakitoshiya/.pyenv/versions/3.6.0/lib/python3.6/site-packages/botocore/retryhandler.py", line 223, in __call__
    attempt_number, caught_exception)
  File "/Users/kawasakitoshiya/.pyenv/versions/3.6.0/lib/python3.6/site-packages/botocore/retryhandler.py", line 359, in _check_caught_exception
    raise caught_exception
  File "/Users/kawasakitoshiya/.pyenv/versions/3.6.0/lib/python3.6/site-packages/botocore/endpoint.py", line 204, in _get_response
    proxies=self.proxies, timeout=self.timeout)
  File "/Users/kawasakitoshiya/.pyenv/versions/3.6.0/lib/python3.6/site-packages/botocore/vendored/requests/sessions.py", line 573, in send
    r = adapter.send(request, **kwargs)
  File "/Users/kawasakitoshiya/workspace/moto/moto/packages/responses/responses.py", line 308, in unbound_on_send
    return self._on_request(adapter, request, *a, **kwargs)
  File "/Users/kawasakitoshiya/workspace/moto/moto/packages/responses/responses.py", line 261, in _on_request
    status, r_headers, body = match['callback'](request)
  File "/Users/kawasakitoshiya/workspace/moto/moto/core/utils.py", line 170, in __call__
    result = self.callback(request, request.url, request.headers)
  File "/Users/kawasakitoshiya/workspace/moto/moto/core/responses.py", line 115, in dispatch
    return cls()._dispatch(*args, **kwargs)
  File "/Users/kawasakitoshiya/workspace/moto/moto/core/responses.py", line 183, in _dispatch
    return self.call_action()
  File "/Users/kawasakitoshiya/workspace/moto/moto/core/responses.py", line 257, in call_action
    response = method()
  File "/Users/kawasakitoshiya/workspace/moto/moto/logs/responses.py", line 92, in get_log_events
    "events": [ob.__dict__ for ob in events],
  File "/Users/kawasakitoshiya/workspace/moto/moto/logs/responses.py", line 92, in <listcomp>
    "events": [ob.__dict__ for ob in events],
AttributeError: 'dict' object has no attribute '__dict__'
```