### PR TITLE
add tags when creating ebs volume

### DIFF
--- a/moto/ec2/responses/elastic_block_store.py
+++ b/moto/ec2/responses/elastic_block_store.py
@@ -32,10 +32,13 @@ class ElasticBlockStore(BaseResponse):
         size = self._get_param('Size')
         zone = self._get_param('AvailabilityZone')
         snapshot_id = self._get_param('SnapshotId')
+        tags = self._parse_tag_specification("TagSpecification")
+        volume_tags = tags.get('image', {})
         encrypted = self._get_param('Encrypted', if_none=False)
         if self.is_not_dryrun('CreateVolume'):
             volume = self.ec2_backend.create_volume(
                 size, zone, snapshot_id, encrypted)
+            volume.add_tags(volume_tags)
             template = self.response_template(CREATE_VOLUME_RESPONSE)
             return template.render(volume=volume)
 
@@ -139,6 +142,16 @@ CREATE_VOLUME_RESPONSE = """<CreateVolumeResponse xmlns="http://ec2.amazonaws.co
   <availabilityZone>{{ volume.zone.name }}</availabilityZone>
   <status>creating</status>
   <createTime>{{ volume.create_time}}</createTime>
+  <tagSet>
+    {% for tag in volume.get_tags() %}
+        <item>
+        <resourceId>{{ tag.resource_id }}</resourceId>
+        <resourceType>{{ tag.resource_type }}</resourceType>
+        <key>{{ tag.key }}</key>
+        <value>{{ tag.value }}</value>
+        </item>
+    {% endfor %}
+  </tagSet>
   <volumeType>standard</volumeType>
 </CreateVolumeResponse>"""
 

--- a/tests/test_cloudformation/test_cloudformation_stack_crud_boto3.py
+++ b/tests/test_cloudformation/test_cloudformation_stack_crud_boto3.py
@@ -160,7 +160,7 @@ def test_boto3_create_stack():
         TemplateBody=dummy_template_json,
     )
 
-    cf_conn.get_template(StackName="test_stack")['TemplateBody'].should.equal(
+    json.loads(json.dumps(cf_conn.get_template(StackName="test_stack")['TemplateBody'])).should.equal(
         dummy_template)
 
 
@@ -270,9 +270,10 @@ def test_create_stack_from_s3_url():
         StackName='stack_from_url',
         TemplateURL=key_url,
     )
-
-    cf_conn.get_template(StackName="stack_from_url")[
-        'TemplateBody'].should.equal(dummy_template)
+    # from IPython import embed
+    # embed()
+    json.loads(json.dumps(cf_conn.get_template(StackName="stack_from_url")[
+        'TemplateBody'])).should.equal(dummy_template)
 
 
 @mock_cloudformation
@@ -306,8 +307,8 @@ def test_update_stack_from_s3_url():
         TemplateURL=key_url,
     )
 
-    cf_conn.get_template(StackName="update_stack_from_url")[
-        'TemplateBody'].should.equal(dummy_update_template)
+    json.loads(json.dumps(cf_conn.get_template(StackName="update_stack_from_url")[
+        'TemplateBody'])).should.equal(dummy_update_template)
 
 
 @mock_cloudformation

--- a/tests/test_ec2/test_tags.py
+++ b/tests/test_ec2/test_tags.py
@@ -4,11 +4,12 @@ from nose.tools import assert_raises
 import itertools
 
 import boto
+import boto3
 from boto.exception import EC2ResponseError
 from boto.ec2.instance import Reservation
 import sure  # noqa
 
-from moto import mock_ec2_deprecated
+from moto import mock_ec2_deprecated, mock_ec2
 from nose.tools import assert_raises
 
 
@@ -385,3 +386,26 @@ def test_filter_instances_by_wildcard_tags():
 
     reservations = conn.get_all_instances(filters={'tag-value': 'Value*'})
     reservations.should.have.length_of(2)
+
+
+@mock_ec2
+def test_create_volume_with_tags():
+    client = boto3.client('ec2', 'us-west-2')
+    response = client.create_volume(
+            AvailabilityZone='us-west-2',
+            Encrypted=False,
+            Size=40,
+            TagSpecifications=[
+                {
+                    'ResourceType': 'image',
+                    'Tags': [
+                        {
+                            'Key': 'TEST_TAG',
+                            'Value': 'TEST_VALUE'
+                        }
+                    ],
+                }
+            ]
+        )
+    
+    assert response['Tags'][0]['Key'] == 'TEST_TAG'


### PR DESCRIPTION
This allows adding tags to an ebs volume object when calling create_volume, see #1431 