### PR TITLE
Remove unneeded comments and fix test code on cloudformationstack tests 

### DIFF
--- a/tests/test_cloudformation/test_cloudformation_stack_crud_boto3.py
+++ b/tests/test_cloudformation/test_cloudformation_stack_crud_boto3.py
@@ -270,8 +270,6 @@ def test_create_stack_from_s3_url():
         StackName='stack_from_url',
         TemplateURL=key_url,
     )
-    # from IPython import embed
-    # embed()
     json.loads(json.dumps(cf_conn.get_template(StackName="stack_from_url")[
         'TemplateBody'])).should.equal(dummy_template)
 

--- a/tests/test_cloudformation/test_cloudformation_stack_crud_boto3.py
+++ b/tests/test_cloudformation/test_cloudformation_stack_crud_boto3.py
@@ -1,6 +1,7 @@
 from __future__ import unicode_literals
 
 import json
+from collections import OrderedDict
 
 import boto3
 from botocore.exceptions import ClientError
@@ -160,8 +161,8 @@ def test_boto3_create_stack():
         TemplateBody=dummy_template_json,
     )
 
-    json.loads(json.dumps(cf_conn.get_template(StackName="test_stack")['TemplateBody'])).should.equal(
-        dummy_template)
+    cf_conn.get_template(StackName="test_stack")['TemplateBody'].should.equal(
+        json.loads(dummy_template_json, object_pairs_hook=OrderedDict))
 
 
 @mock_cloudformation
@@ -270,8 +271,8 @@ def test_create_stack_from_s3_url():
         StackName='stack_from_url',
         TemplateURL=key_url,
     )
-    json.loads(json.dumps(cf_conn.get_template(StackName="stack_from_url")[
-        'TemplateBody'])).should.equal(dummy_template)
+    cf_conn.get_template(StackName="stack_from_url")['TemplateBody'].should.equal(
+        json.loads(dummy_template_json, object_pairs_hook=OrderedDict))
 
 
 @mock_cloudformation
@@ -305,8 +306,8 @@ def test_update_stack_from_s3_url():
         TemplateURL=key_url,
     )
 
-    json.loads(json.dumps(cf_conn.get_template(StackName="update_stack_from_url")[
-        'TemplateBody'])).should.equal(dummy_update_template)
+    cf_conn.get_template(StackName="update_stack_from_url")[ 'TemplateBody'].should.equal(
+        json.loads(dummy_update_template_json, object_pairs_hook=OrderedDict))
 
 
 @mock_cloudformation


### PR DESCRIPTION
@dbfr3qs  cc: @JackDanger 
thank you for the commit https://github.com/spulec/moto/pull/1432/commits/7d0733ad1026e8d251e90d82aa4a3afdafbd51b5 to fix bug
but, the commit has unneeded comments for debug.
This pull requests  remove the comment.

btw, I think that we should fix test code. 
The test expect return type is" Ordered Dict". however, the code convert return value "Ordered Dict" to "Dict".
the code have to check the result as   "Ordered Dict"
