### PR TITLE
add elasticloadbalancer:loadbalancer to resourcegroupstaggingapi

### DIFF
--- a/tests/test_resourcegroupstaggingapi/test_resourcegroupstaggingapi.py
+++ b/tests/test_resourcegroupstaggingapi/test_resourcegroupstaggingapi.py
@@ -2,7 +2,7 @@ from __future__ import unicode_literals
 
 import boto3
 import sure  # noqa
-from moto import mock_resourcegroupstaggingapi, mock_s3, mock_ec2
+from moto import mock_resourcegroupstaggingapi, mock_s3, mock_ec2, mock_elbv2
 
 
 @mock_s3
@@ -222,5 +222,64 @@ def test_get_tag_values_ec2():
 
     resp['TagValues'].should.contain('MY_VALUE1')
     resp['TagValues'].should.contain('MY_VALUE4')
+
+@mock_ec2
+@mock_elbv2
+@mock_resourcegroupstaggingapi
+def test_get_resources_elbv2():
+    conn = boto3.client('elbv2', region_name='us-east-1')
+    ec2 = boto3.resource('ec2', region_name='us-east-1')
+
+    security_group = ec2.create_security_group(
+        GroupName='a-security-group', Description='First One')
+    vpc = ec2.create_vpc(CidrBlock='172.28.7.0/24', InstanceTenancy='default')
+    subnet1 = ec2.create_subnet(
+        VpcId=vpc.id,
+        CidrBlock='172.28.7.192/26',
+        AvailabilityZone='us-east-1a')
+    subnet2 = ec2.create_subnet(
+        VpcId=vpc.id,
+        CidrBlock='172.28.7.192/26',
+        AvailabilityZone='us-east-1b')
+
+    conn.create_load_balancer(
+        Name='my-lb',
+        Subnets=[subnet1.id, subnet2.id],
+        SecurityGroups=[security_group.id],
+        Scheme='internal',
+        Tags=[
+            {
+                'Key': 'key_name', 
+                'Value': 'a_value'
+            },
+            {
+                'Key': 'key_2',
+                'Value': 'val2'
+            }
+            ]
+        )
+
+    conn.create_load_balancer(
+        Name='my-other-lb',
+        Subnets=[subnet1.id, subnet2.id],
+        SecurityGroups=[security_group.id],
+        Scheme='internal',
+        )
+
+    rtapi = boto3.client('resourcegroupstaggingapi', region_name='us-east-1')
+
+    resp = rtapi.get_resources(ResourceTypeFilters=['elasticloadbalancer:loadbalancer'])
+
+    resp['ResourceTagMappingList'].should.have.length_of(2)
+    resp['ResourceTagMappingList'][0]['ResourceARN'].should.contain('loadbalancer/')
+    resp = rtapi.get_resources(
+        ResourceTypeFilters=['elasticloadbalancer:loadbalancer'],
+        TagFilters=[{
+                'Key': 'key_name'
+            }]
+        )
+
+    resp['ResourceTagMappingList'].should.have.length_of(1)
+    resp['ResourceTagMappingList'][0]['Tags'].should.contain({'Key': 'key_name', 'Value': 'a_value'})
 
     # TODO test pagenation


### PR DESCRIPTION
This just adds the ability to query the resourcegroupstaggingapi for elastic load balancers.

I noticed that if you have more than one instance of a supported resource and you call get_resources without any filtering that you would not get a complete list of all the existing resources according to the resource type filter. I have altered tag_filter to simply return true if there are no tag filters. Note that  in the implementation I have added, I have chosen not to simply continue if there are no tags, only when tag_filter(tags) returns false. I'm pretty sure the api will return all resources even if they aren't tagged when there are no tag filters, I have not changed this in any of the ec2 related code.

Tests are passing, hopefully this does not break anything for anyone.