### PR TITLE
Change `'image'` for `'volume'` when getting tags

### DIFF
--- a/moto/ec2/responses/elastic_block_store.py
+++ b/moto/ec2/responses/elastic_block_store.py
@@ -33,7 +33,7 @@ class ElasticBlockStore(BaseResponse):
         zone = self._get_param('AvailabilityZone')
         snapshot_id = self._get_param('SnapshotId')
         tags = self._parse_tag_specification("TagSpecification")
-        volume_tags = tags.get('image', {})
+        volume_tags = tags.get('volume', {})
         encrypted = self._get_param('Encrypted', if_none=False)
         if self.is_not_dryrun('CreateVolume'):
             volume = self.ec2_backend.create_volume(

--- a/tests/test_ec2/test_tags.py
+++ b/tests/test_ec2/test_tags.py
@@ -397,7 +397,7 @@ def test_create_volume_with_tags():
             Size=40,
             TagSpecifications=[
                 {
-                    'ResourceType': 'image',
+                    'ResourceType': 'volume',
                     'Tags': [
                         {
                             'Key': 'TEST_TAG',


### PR DESCRIPTION
The AWS docs say that: "Currently, the resource types that support tagging on creation are instance and volume." Calling `create_volume` and passing `image` as the resource type in tag specifications causes an `InvalidParameterValue` error.