### PR TITLE
Redshift: Add Cross Region Snapshot Functionality

### DIFF
--- a/moto/redshift/exceptions.py
+++ b/moto/redshift/exceptions.py
@@ -93,3 +93,22 @@ class ResourceNotFoundFaultError(RedshiftClientError):
             msg = message
         super(ResourceNotFoundFaultError, self).__init__(
             'ResourceNotFoundFault', msg)
+
+
+class SnapshotCopyDisabledFaultError(RedshiftClientError):
+    def __init__(self, cluster_identifier):
+        super(SnapshotCopyDisabledFaultError, self).__init__(
+            'SnapshotCopyDisabledFault',
+            "Cannot modify retention period because snapshot copy is disabled on Cluster {0}.".format(cluster_identifier))
+
+class SnapshotCopyAlreadyDisabledFaultError(RedshiftClientError):
+    def __init__(self, cluster_identifier):
+        super(SnapshotCopyAlreadyDisabledFaultError, self).__init__(
+            'SnapshotCopyAlreadyDisabledFault',
+            "Snapshot Copy is already disabled on Cluster {0}.".format(cluster_identifier))
+
+class SnapshotCopyAlreadyEnabledFaultError(RedshiftClientError):
+    def __init__(self, cluster_identifier):
+        super(SnapshotCopyAlreadyEnabledFaultError, self).__init__(
+            'SnapshotCopyAlreadyEnabledFault',
+            "Snapshot Copy is already enabled on Cluster {0}.".format(cluster_identifier))

--- a/moto/redshift/exceptions.py
+++ b/moto/redshift/exceptions.py
@@ -101,11 +101,13 @@ class SnapshotCopyDisabledFaultError(RedshiftClientError):
             'SnapshotCopyDisabledFault',
             "Cannot modify retention period because snapshot copy is disabled on Cluster {0}.".format(cluster_identifier))
 
+
 class SnapshotCopyAlreadyDisabledFaultError(RedshiftClientError):
     def __init__(self, cluster_identifier):
         super(SnapshotCopyAlreadyDisabledFaultError, self).__init__(
             'SnapshotCopyAlreadyDisabledFault',
             "Snapshot Copy is already disabled on Cluster {0}.".format(cluster_identifier))
+
 
 class SnapshotCopyAlreadyEnabledFaultError(RedshiftClientError):
     def __init__(self, cluster_identifier):

--- a/moto/redshift/models.py
+++ b/moto/redshift/models.py
@@ -4,6 +4,7 @@ import copy
 import datetime
 
 import boto.redshift
+from botocore.exceptions import ClientError
 from moto.compat import OrderedDict
 from moto.core import BaseBackend, BaseModel
 from moto.core.utils import iso_8601_datetime_with_milliseconds
@@ -430,6 +431,12 @@ class RedshiftBackend(BaseBackend):
         cluster_identifier = kwargs['cluster_identifier']
         cluster = self.clusters[cluster_identifier]
         if not hasattr(cluster, 'cluster_snapshot_copy_status'):
+            if cluster.encrypted == 'true' and kwargs['snapshot_copy_grant_name'] is None:
+                raise ClientError(
+                    'InvalidParameterValue',
+                    'SnapshotCopyGrantName is required for Snapshot Copy '
+                    'on KMS encrypted clusters.'
+                )
             status = {
                 'DestinationRegion': kwargs['destination_region'],
                 'RetentionPeriod': kwargs['retention_period'],

--- a/moto/redshift/models.py
+++ b/moto/redshift/models.py
@@ -226,7 +226,6 @@ class Cluster(TaggableResourceMixin, BaseModel):
             "NodeType": self.node_type,
             "ClusterIdentifier": self.cluster_identifier,
             "AllowVersionUpgrade": self.allow_version_upgrade,
-
             "Endpoint": {
                 "Address": self.endpoint,
                 "Port": self.port

--- a/moto/redshift/responses.py
+++ b/moto/redshift/responses.py
@@ -501,3 +501,58 @@ class RedshiftResponse(BaseResponse):
                 }
             }
         })
+
+    def enable_snapshot_copy(self):
+        snapshot_copy_kwargs = {
+            'cluster_identifier': self._get_param('ClusterIdentifier'),
+            'destination_region': self._get_param('DestinationRegion'),
+            'retention_period': self._get_param('RetentionPeriod'),
+            'snapshot_copy_grant_name': self._get_param('SnapshotCopyGrantName'),
+        }
+        cluster = self.redshift_backend.enable_snapshot_copy(**snapshot_copy_kwargs)
+
+        return self.get_response({
+            "EnableSnapshotCopyResponse": {
+                "EnableSnapshotCopyResult": {
+                    "Cluster": cluster.to_json()
+                },
+                "ResponseMetadata": {
+                    "RequestId": "384ac68d-3775-11df-8963-01868b7c937a",
+                }
+            }
+        })
+
+    def disable_snapshot_copy(self):
+        snapshot_copy_kwargs = {
+            'cluster_identifier': self._get_param('ClusterIdentifier'),
+        }
+        cluster = self.redshift_backend.disable_snapshot_copy(**snapshot_copy_kwargs)
+
+        return self.get_response({
+            "DisableSnapshotCopyResponse": {
+                "DisableSnapshotCopyResult": {
+                    "Cluster": cluster.to_json()
+                },
+                "ResponseMetadata": {
+                    "RequestId": "384ac68d-3775-11df-8963-01868b7c937a",
+                }
+            }
+        })
+
+    def modify_snapshot_copy_retention_period(self):
+        snapshot_copy_kwargs = {
+            'cluster_identifier': self._get_param('ClusterIdentifier'),
+            'retention_period': self._get_param('RetentionPeriod'),
+        }
+        cluster = self.redshift_backend.modify_snapshot_copy_retention_period(**snapshot_copy_kwargs)
+
+        return self.get_response({
+            "ModifySnapshotCopyRetentionPeriodResponse": {
+                "ModifySnapshotCopyRetentionPeriodResult": {
+                    "Clusters": [cluster.to_json()]
+                },
+                "ResponseMetadata": {
+                    "RequestId": "384ac68d-3775-11df-8963-01868b7c937a",
+                }
+            }
+            })

--- a/moto/redshift/responses.py
+++ b/moto/redshift/responses.py
@@ -555,4 +555,4 @@ class RedshiftResponse(BaseResponse):
                     "RequestId": "384ac68d-3775-11df-8963-01868b7c937a",
                 }
             }
-            })
+        })

--- a/moto/redshift/responses.py
+++ b/moto/redshift/responses.py
@@ -506,7 +506,7 @@ class RedshiftResponse(BaseResponse):
         snapshot_copy_kwargs = {
             'cluster_identifier': self._get_param('ClusterIdentifier'),
             'destination_region': self._get_param('DestinationRegion'),
-            'retention_period': self._get_param('RetentionPeriod'),
+            'retention_period': self._get_param('RetentionPeriod', 7),
             'snapshot_copy_grant_name': self._get_param('SnapshotCopyGrantName'),
         }
         cluster = self.redshift_backend.enable_snapshot_copy(**snapshot_copy_kwargs)

--- a/tests/test_redshift/test_redshift.py
+++ b/tests/test_redshift/test_redshift.py
@@ -1047,12 +1047,13 @@ def test_tagged_resource_not_found_error():
 def test_enable_snapshot_copy():
     client = boto3.client('redshift', region_name='us-east-1')
     client.create_cluster(
-        DBName='test',
         ClusterIdentifier='test',
         ClusterType='single-node',
-        NodeType='ds2.xlarge',
+        DBName='test',
+        Encrypted=True,
         MasterUsername='user',
         MasterUserPassword='password',
+        NodeType='ds2.xlarge',
     )
     client.enable_snapshot_copy(
         ClusterIdentifier='test',
@@ -1065,6 +1066,27 @@ def test_enable_snapshot_copy():
     cluster_snapshot_copy_status['RetentionPeriod'].should.equal(3)
     cluster_snapshot_copy_status['DestinationRegion'].should.equal('us-west-2')
     cluster_snapshot_copy_status['SnapshotCopyGrantName'].should.equal('copy-us-east-1-to-us-west-2')
+
+
+@mock_redshift
+def test_enable_snapshot_copy_unencrypted():
+    client = boto3.client('redshift', region_name='us-east-1')
+    client.create_cluster(
+        ClusterIdentifier='test',
+        ClusterType='single-node',
+        DBName='test',
+        MasterUsername='user',
+        MasterUserPassword='password',
+        NodeType='ds2.xlarge',
+    )
+    client.enable_snapshot_copy(
+        ClusterIdentifier='test',
+        DestinationRegion='us-west-2',
+    )
+    response = client.describe_clusters(ClusterIdentifier='test')
+    cluster_snapshot_copy_status = response['Clusters'][0]['ClusterSnapshotCopyStatus']
+    cluster_snapshot_copy_status['RetentionPeriod'].should.equal(7)
+    cluster_snapshot_copy_status['DestinationRegion'].should.equal('us-west-2')
 
 
 @mock_redshift

--- a/tests/test_redshift/test_redshift.py
+++ b/tests/test_redshift/test_redshift.py
@@ -1090,6 +1090,7 @@ def test_disable_snapshot_copy():
     response = client.describe_clusters(ClusterIdentifier='test')
     response['Clusters'][0].shouldnt.contain('ClusterSnapshotCopyStatus')
 
+
 @mock_redshift
 def test_modify_snapshot_copy_retention_period():
     client = boto3.client('redshift', region_name='us-east-1')


### PR DESCRIPTION
This adds three methods to the boto3 redshift client, dealing with cross-region snapshot copies.