### PR TITLE
Redshift: Add Copy Grant Functionality

### DIFF
--- a/moto/redshift/exceptions.py
+++ b/moto/redshift/exceptions.py
@@ -58,6 +58,21 @@ class InvalidSubnetError(RedshiftClientError):
             "Subnet {0} not found.".format(subnet_identifier))
 
 
+class SnapshotCopyGrantAlreadyExistsFaultError(RedshiftClientError):
+    def __init__(self, snapshot_copy_grant_name):
+        super(SnapshotCopyGrantAlreadyExistsFaultError, self).__init__(
+            'SnapshotCopyGrantAlreadyExistsFault',
+            "Cannot create the snapshot copy grant because a grant "
+            "with the identifier '{0}' already exists".format(snapshot_copy_grant_name))
+
+
+class SnapshotCopyGrantNotFoundFaultError(RedshiftClientError):
+    def __init__(self, snapshot_copy_grant_name):
+        super(SnapshotCopyGrantNotFoundFaultError, self).__init__(
+            'SnapshotCopyGrantNotFoundFault',
+            "Snapshot copy grant not found: {0}".format(snapshot_copy_grant_name))
+
+
 class ClusterSnapshotNotFoundError(RedshiftClientError):
     def __init__(self, snapshot_identifier):
         super(ClusterSnapshotNotFoundError, self).__init__(

--- a/moto/redshift/models.py
+++ b/moto/redshift/models.py
@@ -237,10 +237,9 @@ class SnapshotCopyGrant(TaggableResourceMixin, BaseModel):
 
     resource_type = 'snapshotcopygrant'
 
-    def __init__(self, snapshot_copy_grant_name, kms_key_id, region_name):
+    def __init__(self, snapshot_copy_grant_name, kms_key_id):
         self.snapshot_copy_grant_name = snapshot_copy_grant_name
         self.kms_key_id = kms_key_id
-        self.region_name = region_name
 
     def to_json(self):
         return {
@@ -590,20 +589,16 @@ class RedshiftBackend(BaseBackend):
     def create_snapshot_copy_grant(self, **kwargs):
         snapshot_copy_grant_name = kwargs['snapshot_copy_grant_name']
         kms_key_id = kwargs['kms_key_id']
-        region_name = kwargs['region_name']
         if snapshot_copy_grant_name not in self.snapshot_copy_grants:
-            snapshot_copy_grant = SnapshotCopyGrant(snapshot_copy_grant_name,
-                                                    kms_key_id, region_name)
+            snapshot_copy_grant = SnapshotCopyGrant(snapshot_copy_grant_name, kms_key_id)
             self.snapshot_copy_grants[snapshot_copy_grant_name] = snapshot_copy_grant
             return snapshot_copy_grant
-
         raise SnapshotCopyGrantAlreadyExistsFaultError(snapshot_copy_grant_name)
 
     def delete_snapshot_copy_grant(self, **kwargs):
         snapshot_copy_grant_name = kwargs['snapshot_copy_grant_name']
         if snapshot_copy_grant_name in self.snapshot_copy_grants:
             return self.snapshot_copy_grants.pop(snapshot_copy_grant_name)
-
         raise SnapshotCopyGrantNotFoundFaultError(snapshot_copy_grant_name)
 
     def describe_snapshot_copy_grants(self, **kwargs):

--- a/moto/redshift/models.py
+++ b/moto/redshift/models.py
@@ -233,6 +233,7 @@ class Cluster(TaggableResourceMixin, BaseModel):
             "Tags": self.tags
         }
 
+
 class SnapshotCopyGrant(TaggableResourceMixin, BaseModel):
 
     resource_type = 'snapshotcopygrant'
@@ -246,7 +247,6 @@ class SnapshotCopyGrant(TaggableResourceMixin, BaseModel):
             "SnapshotCopyGrantName": self.snapshot_copy_grant_name,
             "KmsKeyId": self.kms_key_id
         }
-
 
 
 class SubnetGroup(TaggableResourceMixin, BaseModel):

--- a/moto/redshift/responses.py
+++ b/moto/redshift/responses.py
@@ -457,6 +457,55 @@ class RedshiftResponse(BaseResponse):
             }
         })
 
+    def create_snapshot_copy_grant(self):
+        copy_grant_kwargs = {
+            'snapshot_copy_grant_name': self._get_param('SnapshotCopyGrantName'),
+            'kms_key_id': self._get_param('KmsKeyId'),
+            'region_name': self._get_param('Region'),
+        }
+
+        copy_grant = self.redshift_backend.create_snapshot_copy_grant(**copy_grant_kwargs)
+        return self.get_response({
+            "CreateSnapshotCopyGrantResponse": {
+                "CreateSnapshotCopyGrantResult": {
+                    "SnapshotCopyGrant": copy_grant.to_json()
+                },
+                "ResponseMetadata": {
+                    "RequestId": "384ac68d-3775-11df-8963-01868b7c937a",
+                }
+            }
+        })
+
+    def delete_snapshot_copy_grant(self):
+        copy_grant_kwargs = {
+            'snapshot_copy_grant_name': self._get_param('SnapshotCopyGrantName'),
+        }
+        self.redshift_backend.delete_snapshot_copy_grant(**copy_grant_kwargs)
+        return self.get_response({
+            "DeleteSnapshotCopyGrantResponse": {
+                "ResponseMetadata": {
+                    "RequestId": "384ac68d-3775-11df-8963-01868b7c937a",
+                }
+            }
+        })
+
+    def describe_snapshot_copy_grants(self):
+        copy_grant_kwargs = {
+            'snapshot_copy_grant_name': self._get_param('SnapshotCopyGrantName'),
+        }
+
+        copy_grants = self.redshift_backend.describe_snapshot_copy_grants(**copy_grant_kwargs)
+        return self.get_response({
+            "DescribeSnapshotCopyGrantsResponse": {
+                "DescribeSnapshotCopyGrantsResult": {
+                    "SnapshotCopyGrants": [copy_grant.to_json() for copy_grant in copy_grants]
+                },
+                "ResponseMetadata": {
+                    "RequestId": "384ac68d-3775-11df-8963-01868b7c937a",
+                }
+            }
+        })
+
     def create_tags(self):
         resource_name = self._get_param('ResourceName')
         tags = self.unpack_complex_list_params('Tags.Tag', ('Key', 'Value'))


### PR DESCRIPTION
This builds off of https://github.com/spulec/moto/pull/1451. That PR should also probably be reviewed/merged first.

To copy KMS-enabled snapshots cross region, you need to create a copy grant allowing the redshift service to use a KMS key in the destination region. This PR is adding that functionality. 

As you can see in the tests, there's no validation around the given kms key when creating these snapshot grants. It didn't look too bad to wire that up, however that mixed with what I have here was rather large, so I'll add the validation later. 