### PR TITLE
Snapshot search bug

### DIFF
--- a/moto/core/responses.py
+++ b/moto/core/responses.py
@@ -345,6 +345,10 @@ class BaseResponse(_TemplateEnvironmentMixin):
             if is_tracked(name) or not name.startswith(param_prefix):
                 continue
 
+            if len(name) > len(param_prefix) and \
+                    not name[len(param_prefix):].startswith('.'):
+                continue
+
             match = self.param_list_regex.search(name[len(param_prefix):]) if len(name) > len(param_prefix) else None
             if match:
                 prefix = param_prefix + match.group(1)

--- a/tests/test_ec2/test_elastic_block_store.py
+++ b/tests/test_ec2/test_elastic_block_store.py
@@ -5,10 +5,11 @@ from nose.tools import assert_raises
 
 from moto.ec2 import ec2_backends
 import boto
+import boto3
 from boto.exception import EC2ResponseError
 import sure  # noqa
 
-from moto import mock_ec2_deprecated
+from moto import mock_ec2_deprecated, mock_ec2
 
 
 @mock_ec2_deprecated
@@ -579,3 +580,25 @@ def test_volume_tag_escaping():
 
     snaps = [snap for snap in conn.get_all_snapshots() if snap.id == snapshot.id]
     dict(snaps[0].tags).should.equal({'key': '</closed>'})
+
+
+@mock_ec2
+def test_search_for_many_snapshots():
+    ec2_client = boto3.client('ec2', region_name='eu-west-1')
+
+    volume_response = ec2_client.create_volume(
+        AvailabilityZone='eu-west-1a', Size=10
+    )
+
+    snapshot_ids = []
+    for i in range(1, 20):
+        create_snapshot_response = ec2_client.create_snapshot(
+            VolumeId=volume_response['VolumeId']
+        )
+        snapshot_ids.append(create_snapshot_response['SnapshotId'])
+
+    snapshots_response = ec2_client.describe_snapshots(
+        SnapshotIds=snapshot_ids
+    )
+
+    assert len(snapshots_response['Snapshots']) == len(snapshot_ids)


### PR DESCRIPTION
When I tried to search for a long list of snapshots by ID I got the following error:
```
...
    moto/ec2/models.py line 1957 in describe_snapshots
      unknown_ids = set(snapshot_ids) - set(matches)
   TypeError: unhashable type: 'dict'
```

This fixes that and preserves the original correct behaviour.