### PR TITLE
Fix the S3 HEAD response body

### DIFF
--- a/moto/s3/responses.py
+++ b/moto/s3/responses.py
@@ -172,7 +172,7 @@ class ResponseObject(_TemplateEnvironmentMixin):
             # HEAD (which the real API responds with), and instead
             # raises NoSuchBucket, leading to inconsistency in
             # error response between real and mocked responses.
-            return 404, {}, "Not Found"
+            return 404, {}, ""
         return 200, {}, ""
 
     def _bucket_response_get(self, bucket_name, querystring, headers):


### PR DESCRIPTION
This PR is a minor fix for the S3 bucket HEAD response to return an empty body when the bucket does not exist, so that `botocore` would not complain about being unable to parse the body into XML. The real AWS API returns an empty body, so this is the correct mock response.