### PR TITLE
Make SpotPrice optional when requesting a spot fleet

### DIFF
--- a/moto/ec2/models.py
+++ b/moto/ec2/models.py
@@ -2943,7 +2943,7 @@ class SpotFleetRequest(TaggedEC2Resource):
             'Properties']['SpotFleetRequestConfigData']
         ec2_backend = ec2_backends[region_name]
 
-        spot_price = properties['SpotPrice']
+        spot_price = properties.get('SpotPrice')
         target_capacity = properties['TargetCapacity']
         iam_fleet_role = properties['IamFleetRole']
         allocation_strategy = properties['AllocationStrategy']
@@ -2977,7 +2977,8 @@ class SpotFleetRequest(TaggedEC2Resource):
                 launch_spec_index += 1
         else:  # lowestPrice
             cheapest_spec = sorted(
-                self.launch_specs, key=lambda spec: float(spec.spot_price))[0]
+                # FIXME: change `+inf` to the on demand price scaled to weighted capacity when it's not present
+                self.launch_specs, key=lambda spec: float(spec.spot_price or '+inf'))[0]
             weight_so_far = weight_to_add + (weight_to_add % cheapest_spec.weighted_capacity)
             weight_map[cheapest_spec] = int(
                 weight_so_far // cheapest_spec.weighted_capacity)

--- a/moto/ec2/responses/spot_fleets.py
+++ b/moto/ec2/responses/spot_fleets.py
@@ -40,7 +40,7 @@ class SpotFleets(BaseResponse):
 
     def request_spot_fleet(self):
         spot_config = self._get_dict_param("SpotFleetRequestConfig.")
-        spot_price = spot_config['spot_price']
+        spot_price = spot_config.get('spot_price')
         target_capacity = spot_config['target_capacity']
         iam_fleet_role = spot_config['iam_fleet_role']
         allocation_strategy = spot_config['allocation_strategy']
@@ -78,7 +78,9 @@ DESCRIBE_SPOT_FLEET_TEMPLATE = """<DescribeSpotFleetRequestsResponse xmlns="http
             <spotFleetRequestId>{{ request.id }}</spotFleetRequestId>
             <spotFleetRequestState>{{ request.state }}</spotFleetRequestState>
             <spotFleetRequestConfig>
+                {% if request.spot_price %}
                 <spotPrice>{{ request.spot_price }}</spotPrice>
+                {% endif %}
                 <targetCapacity>{{ request.target_capacity }}</targetCapacity>
                 <iamFleetRole>{{ request.iam_fleet_role }}</iamFleetRole>
                 <allocationStrategy>{{ request.allocation_strategy }}</allocationStrategy>
@@ -93,7 +95,9 @@ DESCRIBE_SPOT_FLEET_TEMPLATE = """<DescribeSpotFleetRequestsResponse xmlns="http
                         <iamInstanceProfile><arn>{{ launch_spec.iam_instance_profile }}</arn></iamInstanceProfile>
                         <keyName>{{ launch_spec.key_name }}</keyName>
                         <monitoring><enabled>{{ launch_spec.monitoring }}</enabled></monitoring>
+                        {% if launch_spec.spot_price %}
                         <spotPrice>{{ launch_spec.spot_price }}</spotPrice>
+                        {% endif %}
                         <userData>{{ launch_spec.user_data }}</userData>
                         <weightedCapacity>{{ launch_spec.weighted_capacity }}</weightedCapacity>
                         <groupSet>

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,7 +8,7 @@ freezegun
 flask
 boto>=2.45.0
 boto3>=1.4.4
-botocore>=1.5.77
+botocore>=1.8.36
 six>=1.9
 prompt-toolkit==1.0.14
 click==6.7


### PR DESCRIPTION
When price is omitted, AWS will default to the on-demand price.

Documentation:
* https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_SpotFleetRequestConfigData.html
* https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_SpotFleetLaunchSpecification.html