### PR TITLE
Make putparameter behaviour consistent with real endpoint

### DIFF
--- a/moto/ssm/models.py
+++ b/moto/ssm/models.py
@@ -124,6 +124,7 @@ class SimpleSystemManagerBackend(BaseBackend):
         last_modified_date = time.time()
         self._parameters[name] = Parameter(
             name, value, type, description, keyid, last_modified_date, version)
+        return version
 
     def add_tags_to_resource(self, resource_type, resource_id, tags):
         for key, value in tags.items():

--- a/moto/ssm/responses.py
+++ b/moto/ssm/responses.py
@@ -162,9 +162,18 @@ class SimpleSystemManagerResponse(BaseResponse):
         keyid = self._get_param('KeyId')
         overwrite = self._get_param('Overwrite', False)
 
-        self.ssm_backend.put_parameter(
+        result = self.ssm_backend.put_parameter(
             name, description, value, type_, keyid, overwrite)
-        return json.dumps({})
+
+        if result is None:
+            error = {
+                '__type': 'ParameterAlreadyExists',
+                'message': 'Parameter {0} already exists.'.format(name)
+            }
+            return json.dumps(error), dict(status=400)
+
+        response = {'Version': result}
+        return json.dumps(response)
 
     def add_tags_to_resource(self):
         resource_id = self._get_param('ResourceId')


### PR DESCRIPTION
This patch makes SSM PutParameter behaviour consistent with the real endpoint in SSM.

It will return a response containing a 'Version'-key on successful calls and can now also return a ParameterAlreadyExists error if you attempt to Put a parameter that already exists (and overwrite is set to False).

Also reworked the tests to account for this functionality.