### PR TITLE
[awslambda] Return the function's unqualified ARN when a qualifier is not specified.

### DIFF
--- a/moto/awslambda/utils.py
+++ b/moto/awslambda/utils.py
@@ -7,6 +7,10 @@ def make_function_arn(region, account, name, version='1'):
     return 'arn:aws:lambda:{0}:{1}:function:{2}:{3}'.format(region, account, name, version)
 
 
+def make_unqualified_function_arn(region, account, name):
+    return 'arn:aws:lambda:{0}:{1}:function:{2}'.format(region, account, name)
+
+
 def split_function_arn(arn):
     arn = arn.replace('arn:aws:lambda:')
 

--- a/tests/test_awslambda/test_lambda.py
+++ b/tests/test_awslambda/test_lambda.py
@@ -323,7 +323,7 @@ def test_get_function():
     result['Configuration']['CodeSha256'].should.equal(hashlib.sha256(zip_content).hexdigest())
     result['Configuration']['CodeSize'].should.equal(len(zip_content))
     result['Configuration']['Description'].should.equal('test lambda function')
-    result['Configuration'].should.contain('FunctionArn')
+    result['Configuration']['FunctionArn'].should.equal('arn:aws:lambda:{}:123456789012:function:testFunction'.format(_lambda_region))
     result['Configuration']['FunctionName'].should.equal('testFunction')
     result['Configuration']['Handler'].should.equal('lambda_function.lambda_handler')
     result['Configuration']['MemorySize'].should.equal(128)
@@ -336,6 +336,7 @@ def test_get_function():
     # Test get function with
     result = conn.get_function(FunctionName='testFunction', Qualifier='$LATEST')
     result['Configuration']['Version'].should.equal('$LATEST')
+    result['Configuration']['FunctionArn'].should.equal('arn:aws:lambda:{}:123456789012:function:testFunction:$LATEST'.format(_lambda_region))
 
 
 @mock_lambda
@@ -525,7 +526,6 @@ def lambda_handler(event, context):
         InvocationType='RequestResponse',
         LogType='Tail'
     )
-
     assert 'FunctionError' in result
     assert result['FunctionError'] == 'Handled'
 
@@ -634,7 +634,7 @@ def test_invoke_async_function():
     )
 
     success_result = conn.invoke_async(
-        FunctionName='testFunction', 
+        FunctionName='testFunction',
         InvokeArgs=json.dumps({'test': 'event'})
         )
 


### PR DESCRIPTION
`get_function` should return the function's unqualified ARN (i.e. without version) when a qualifier is not specified.
See: https://docs.aws.amazon.com/lambda/latest/dg/API_GetFunction.html.
I also had to make other updates to awslambda.
Updated the 'volumes' parameter when calling the run method on the docker ContainerCollection.
The previous value appears to be invalid: https://github.com/docker/docker-py/blob/master/docker/models/containers.py#L468
Updated the retrieval of `exit_code` in `_invoke_lambda`. `container.wai`t returns a dict with a 'StatusCode', not an exit_code.
See: https://github.com/docker/docker-py/blob/master/docker/models/containers.py#L441