### PR TITLE
XML escaping in EMR responses

### DIFF
--- a/moto/emr/responses.py
+++ b/moto/emr/responses.py
@@ -462,10 +462,10 @@ DESCRIBE_JOB_FLOWS_TEMPLATE = """<DescribeJobFlowsResponse xmlns="http://elastic
               <ScriptBootstrapAction>
                 <Args>
                   {% for arg in bootstrap_action.args %}
-                  <member>{{ arg }}</member>
+                  <member>{{ arg | escape }}</member>
                   {% endfor %}
                 </Args>
-                <Path>{{ bootstrap_action.script_path }}</Path>
+                <Path>{{ bootstrap_action.script_path | escape }}</Path>
               </ScriptBootstrapAction>
             </BootstrapActionConfig>
           </member>
@@ -568,12 +568,12 @@ DESCRIBE_JOB_FLOWS_TEMPLATE = """<DescribeJobFlowsResponse xmlns="http://elastic
                 <MainClass>{{ step.main_class }}</MainClass>
                 <Args>
                   {% for arg in step.args %}
-                  <member>{{ arg }}</member>
+                  <member>{{ arg | escape }}</member>
                   {% endfor %}
                 </Args>
                 <Properties/>
               </HadoopJarStep>
-              <Name>{{ step.name }}</Name>
+              <Name>{{ step.name | escape }}</Name>
             </StepConfig>
           </member>
           {% endfor %}
@@ -596,7 +596,7 @@ DESCRIBE_STEP_TEMPLATE = """<DescribeStepResponse xmlns="http://elasticmapreduce
       <Config>
         <Args>
           {% for arg in step.args %}
-          <member>{{ arg }}</member>
+          <member>{{ arg | escape }}</member>
           {% endfor %}
         </Args>
         <Jar>{{ step.jar }}</Jar>
@@ -605,13 +605,13 @@ DESCRIBE_STEP_TEMPLATE = """<DescribeStepResponse xmlns="http://elasticmapreduce
           {% for key, val in step.properties.items() %}
           <member>
             <key>{{ key }}</key>
-            <value>{{ val }}</value>
+            <value>{{ val | escape }}</value>
           </member>
           {% endfor %}
         </Properties>
       </Config>
       <Id>{{ step.id }}</Id>
-      <Name>{{ step.name }}</Name>
+      <Name>{{ step.name | escape }}</Name>
       <Status>
 <!-- does not exist for botocore 1.4.28
         <FailureDetails>
@@ -646,7 +646,7 @@ LIST_BOOTSTRAP_ACTIONS_TEMPLATE = """<ListBootstrapActionsResponse xmlns="http:/
       <member>
         <Args>
           {% for arg in bootstrap_action.args %}
-          <member>{{ arg }}</member>
+          <member>{{ arg | escape }}</member>
           {% endfor %}
         </Args>
         <Name>{{ bootstrap_action.name }}</Name>
@@ -760,22 +760,22 @@ LIST_STEPS_TEMPLATE = """<ListStepsResponse xmlns="http://elasticmapreduce.amazo
         <Config>
           <Args>
             {% for arg in step.args %}
-            <member>{{ arg }}</member>
+            <member>{{ arg | escape }}</member>
             {% endfor %}
           </Args>
-          <Jar>{{ step.jar }}</Jar>
+          <Jar>{{ step.jar | escape }}</Jar>
           <MainClass/>
           <Properties>
             {% for key, val in step.properties.items() %}
             <member>
               <key>{{ key }}</key>
-              <value>{{ val }}</value>
+              <value>{{ val | escape }}</value>
             </member>
             {% endfor %}
           </Properties>
         </Config>
         <Id>{{ step.id }}</Id>
-        <Name>{{ step.name }}</Name>
+        <Name>{{ step.name | escape }}</Name>
         <Status>
 <!-- does not exist for botocore 1.4.28
           <FailureDetails>

--- a/tests/test_emr/test_emr.py
+++ b/tests/test_emr/test_emr.py
@@ -443,7 +443,7 @@ def test_bootstrap_actions():
         BootstrapAction(
             name='bs1',
             path='path/to/script',
-            bootstrap_action_args=['arg1', 'arg2']),
+            bootstrap_action_args=['arg1', 'arg2&arg3']),
         BootstrapAction(
             name='bs2',
             path='path/to/anotherscript',
@@ -551,7 +551,7 @@ def test_steps():
             input='s3n://elasticmapreduce/samples/wordcount/input',
             output='s3n://output_bucket/output/wordcount_output'),
         StreamingStep(
-            name='My wordcount example2',
+            name='My wordcount example & co.',
             mapper='s3n://elasticmapreduce/samples/wordcount/wordSplitter2.py',
             reducer='aggregate',
             input='s3n://elasticmapreduce/samples/wordcount/input2',


### PR DESCRIPTION
Some of our steps include a literal `&` and this caused the EMR list_steps call to fail due to invalid xml.

This adds a fix to the template and tests.

(Sorry, this was edited via Github web-ui so is done as two commits. I can squash if desired.)