### PR TITLE
Allow slightly older Jinja2 dep for project compatability

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ import sys
 
 
 install_requires = [
-    "Jinja2>=2.8",
+    "Jinja2>=2.7.3",
     "boto>=2.36.0",
     "boto3>=1.2.1",
     "botocore>=1.7.12",


### PR DESCRIPTION
(see also https://github.com/spulec/moto/issues/1472)

In commit 4157abe8de154b7ff00c79d6427c0d774889da3f, the Jinja2 dep in `setup.py` was changed from being unpinned to requiring version 2.8 or newer. That change was made in response to issue https://github.com/spulec/moto/issues/728, which pointed out that the use of `lstrip_blocks` needed to be supported. Support for that option was added in Jinja 2.7, so it seems like the best option here (unless 2.8 is truly required by moto) would be to allow Jinja 2.7.3 and newer -- preventing dependency resolution conflicts in Python projects that pin Jinja2 2.7.3 but also need to use moto.