### PR TITLE
Use the TemplateBody by default it exist

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -49,3 +49,4 @@ Moto is written by Steve Pulec with contributions from:
 * [Michael van Tellingen](https://github.com/mvantellingen)
 * [Jessie Nadler](https://github.com/nadlerjessie)
 * [Alex Morken](https://github.com/alexmorken)
+* [Clive Li](https://github.com/cliveli)

--- a/moto/cloudformation/responses.py
+++ b/moto/cloudformation/responses.py
@@ -221,13 +221,12 @@ class CloudFormationResponse(BaseResponse):
         stack_name = self._get_param('StackName')
         role_arn = self._get_param('RoleARN')
         template_url = self._get_param('TemplateURL')
+        stack_body = self._get_param('TemplateBody')
         if self._get_param('UsePreviousTemplate') == "true":
             stack_body = self.cloudformation_backend.get_stack(
                 stack_name).template
-        elif template_url:
+        elif not stack_body and template_url:
             stack_body = self._get_stack_from_s3_url(template_url)
-        else:
-            stack_body = self._get_param('TemplateBody')
 
         parameters = dict([
             (parameter['parameter_key'], parameter['parameter_value'])


### PR DESCRIPTION
serverless cli use the PUT + TemplateBody + TemplateURL to upload cloudformation template

This fix try to get the TemplateBody from the request first, if not exist, fetch the one from s3 bucket

And it fix the issue reported to localstack here
[https://github.com/localstack/localstack/issues/580](https://github.com/localstack/localstack/issues/580)