### PR TITLE
Change lambda backend to support docker-py dependency changes

### DIFF
--- a/moto/awslambda/models.py
+++ b/moto/awslambda/models.py
@@ -104,7 +104,7 @@ class _DockerDataVolumeContext:
 
             # It doesn't exist so we need to create it
             self._vol_ref.volume = self._lambda_func.docker_client.volumes.create(self._lambda_func.code_sha_256)
-            container = self._lambda_func.docker_client.containers.run('alpine', 'sleep 100', volumes={self.name: '/tmp/data'}, detach=True)
+            container = self._lambda_func.docker_client.containers.run('alpine', 'sleep 100', volumes={self.name: {'bind': '/tmp/data', 'mode': 'rw'}}, detach=True)
             try:
                 tar_bytes = zip2tar(self._lambda_func.code_bytes)
                 container.put_archive('/tmp/data', tar_bytes)
@@ -309,7 +309,7 @@ class LambdaFunction(BaseModel):
                 finally:
                     if container:
                         try:
-                            exit_code = container.wait(timeout=300)
+                            exit_code = container.wait(timeout=300)['StatusCode']
                         except requests.exceptions.ReadTimeout:
                             exit_code = -1
                             container.stop()


### PR DESCRIPTION
There are breaking changes in docker-py 3.0.0 as depicted [here](https://github.com/docker/docker-py/releases). We were using 2.7.0 and on Feb 1st Travis started picking up the 3.x.x version so the builds are failing. We can either limit the version of docker dependency in setup.py to <3.0.0 or support the breaking changes and upgrade docker dependency. I think the latter would be preferable since the changes are relatively small and lambda tests are green.