### PR TITLE
Fix MaxRecords compare issue

### DIFF
--- a/moto/autoscaling/responses.py
+++ b/moto/autoscaling/responses.py
@@ -166,7 +166,7 @@ class AutoScalingResponse(BaseResponse):
             start = all_names.index(token) + 1
         else:
             start = 0
-        max_records = self._get_param("MaxRecords", 50)
+        max_records = int(self._get_param("MaxRecords", 50))
         if max_records > 100:
             raise ValueError
         groups = all_groups[start:start + max_records]


### PR DESCRIPTION
When setting `MaxRecords` when issuing `describe_autoscaling_groups` I'm encountering the following error:
```
self = <moto.autoscaling.responses.AutoScalingResponse object at 0x10d2d75c0>

    def describe_auto_scaling_groups(self):
        names = self._get_multi_param("AutoScalingGroupNames.member")
        token = self._get_param("NextToken")
        all_groups = self.autoscaling_backend.describe_auto_scaling_groups(names)
        all_names = [group.name for group in all_groups]
        if token:
            start = all_names.index(token) + 1
        else:
            start = 0
        max_records = self._get_param("MaxRecords", 50)
>       if max_records > 100:
E       TypeError: '>' not supported between instances of 'str' and 'int'
```

Here is my call:
`asg_client.describe_auto_scaling_groups(MaxRecords=100)`


This issue seems to be introduced after 0.4.31. I've tested the fix on 1.2.0.