### PR TITLE
According to what I said on spulec/moto#1026 Add a unittest and attem…

### DIFF
--- a/moto/core/models.py
+++ b/moto/core/models.py
@@ -130,7 +130,8 @@ class ResponsesMockAWS(BaseMockAWS):
         responses.reset()
 
     def enable_patching(self):
-        responses.start()
+        if BaseMockAWS.nested_count == 1:
+            responses.start()
         for method in RESPONSES_METHODS:
             for backend in self.backends_for_urls.values():
                 for key, value in backend.urls.items():

--- a/tests/test_core/test_nested.py
+++ b/tests/test_core/test_nested.py
@@ -4,8 +4,10 @@ import unittest
 from boto.sqs.connection import SQSConnection
 from boto.sqs.message import Message
 from boto.ec2 import EC2Connection
+import requests
 
-from moto import mock_sqs_deprecated, mock_ec2_deprecated
+from moto import mock_sqs_deprecated, mock_ec2_deprecated, mock_sqs, mock_sns
+from moto.packages import httpretty
 
 
 class TestNestedDecorators(unittest.TestCase):
@@ -24,6 +26,17 @@ class TestNestedDecorators(unittest.TestCase):
     @mock_ec2_deprecated
     def test_nested(self):
         self.setup_sqs_queue()
-
         conn = EC2Connection()
         conn.run_instances('ami-123456')
+
+    @mock_sqs
+    @mock_sns
+    def test_multiple_mocks_part1(self):
+        pass
+
+    @httpretty.activate
+    def test_multiple_mocks_part2(self):
+        httpretty.register_uri(httpretty.GET, 'http://www.google.com')
+        response = requests.get('http://www.google.com')
+        assert(response.status_code == 200)
+        assert(response.text == 'HTTPretty :)')


### PR DESCRIPTION
This isn't the whole fix, but it does expose the problem a bit better.  Using HTTPretty, it checks to see if it's enabled already before it enables it.  There doesn't seem to be a way for the MockResponse object to do that easily without adding new code to the fork, or by introspecting class attributes.  This makes my test pass, but breaks many other tests.