### PR TITLE
ELBv2.create_listener links TargetGroup to LB

### DIFF
--- a/moto/elbv2/models.py
+++ b/moto/elbv2/models.py
@@ -486,6 +486,10 @@ class ELBv2Backend(BaseBackend):
         arn = load_balancer_arn.replace(':loadbalancer/', ':listener/') + "/%s%s" % (port, id(self))
         listener = FakeListener(load_balancer_arn, arn, protocol, port, ssl_policy, certificate, default_actions)
         balancer.listeners[listener.arn] = listener
+        for action in default_actions:
+            if action['target_group_arn'] in self.target_groups.keys():
+                target_group = self.target_groups[action['target_group_arn']]
+                target_group.load_balancer_arns.append(load_balancer_arn)
         return listener
 
     def describe_load_balancers(self, arns, names):

--- a/tests/test_elbv2/test_elbv2.py
+++ b/tests/test_elbv2/test_elbv2.py
@@ -340,6 +340,10 @@ def test_create_target_group_and_listeners():
         'Type': 'forward'}])
     http_listener_arn = listener.get('ListenerArn')
 
+    response = conn.describe_target_groups(LoadBalancerArn=load_balancer_arn,
+                                           Names=['a-target'])
+    response.get('TargetGroups').should.have.length_of(1)
+
     # And another with SSL
     response = conn.create_listener(
         LoadBalancerArn=load_balancer_arn,


### PR DESCRIPTION
In order to search target_groups by LB, we need this link in place.

Resolves #1500