### PR TITLE
add UsePreviousValue support for parameters when updating a CloudFormation stack

### DIFF
--- a/moto/cloudformation/responses.py
+++ b/moto/cloudformation/responses.py
@@ -222,17 +222,24 @@ class CloudFormationResponse(BaseResponse):
         role_arn = self._get_param('RoleARN')
         template_url = self._get_param('TemplateURL')
         stack_body = self._get_param('TemplateBody')
+        stack = self.cloudformation_backend.get_stack(stack_name)
         if self._get_param('UsePreviousTemplate') == "true":
-            stack_body = self.cloudformation_backend.get_stack(
-                stack_name).template
+            stack_body = stack.template
         elif not stack_body and template_url:
             stack_body = self._get_stack_from_s3_url(template_url)
 
+        incoming_params = self._get_list_prefix("Parameters.member")
         parameters = dict([
             (parameter['parameter_key'], parameter['parameter_value'])
             for parameter
-            in self._get_list_prefix("Parameters.member")
+            in incoming_params if 'parameter_value' in parameter
         ])
+        previous = dict([
+            (parameter['parameter_key'], stack.parameters[parameter['parameter_key']])
+            for parameter
+            in incoming_params if 'use_previous_value' in parameter
+        ])
+        parameters.update(previous)
         # boto3 is supposed to let you clear the tags by passing an empty value, but the request body doesn't
         # end up containing anything we can use to differentiate between passing an empty value versus not
         # passing anything. so until that changes, moto won't be able to clear tags, only update them.


### PR DESCRIPTION
This adds support for the UsePreviousValue field of the CloudFormation Parameter data type when updating a CloudFormation stack as described at https://docs.aws.amazon.com/AWSCloudFormation/latest/APIReference/API_Parameter.html

I hope this is helpful. I have been using moto _alot_ lately, and I'm glad to be able to contribute in some small way!