### PR TITLE
Changed docker version pinning to not pick up breaking changes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ install_requires = [
     "pytz",
     "python-dateutil<3.0.0,>=2.1",
     "mock",
-    "docker>=2.5.1",
+    "docker~=2.5",
     "jsondiff==1.1.1",
     "aws-xray-sdk<0.96,>=0.93",
 ]


### PR DESCRIPTION
Docker 3.x.x seems to be not backwards compatible in this usage. Switched to pinning to "compatible with" rather than "greater than". Also removed patch version so it will use any 2.x.x greater than or equal to 2.5.

This addresses an issue that would manifest as:
```Traceback (most recent call last):
  File "/Users/ereinecke/envs/service-env/lib/python3.6/site-packages/moto/awslambda/models.py", line 301, in _invoke_lambda
    with _DockerDataVolumeContext(self) as data_vol:
  File "/Users/ereinecke/envs/service-env/lib/python3.6/site-packages/moto/awslambda/models.py", line 107, in __enter__
    container = self._lambda_func.docker_client.containers.run('alpine', 'sleep 100', volumes={self.name: '/tmp/data'}, detach=True)
  File "/Users/ereinecke/envs/service-env/lib/python3.6/site-packages/docker/models/containers.py", line 756, in run
    detach=detach, **kwargs)
  File "/Users/ereinecke/envs/service-env/lib/python3.6/site-packages/docker/models/containers.py", line 813, in create
    create_kwargs = _create_container_args(kwargs)
  File "/Users/ereinecke/envs/service-env/lib/python3.6/site-packages/docker/models/containers.py", line 1017, in _create_container_args
    v.get('bind') for v in volumes.values()
  File "/Users/ereinecke/envs/service-env/lib/python3.6/site-packages/docker/models/containers.py", line 1017, in <listcomp>
    v.get('bind') for v in volumes.values()
AttributeError: 'str' object has no attribute 'get'```

Note with any docker module version (2.5.1 included) I get this exception in unittests:
```
ERROR: test_lambda.test_invoke_requestresponse_function
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/ereinecke/envs/moto/lib/python3.6/site-packages/nose/case.py", line 198, in runTest
    self.test(*self.arg)
  File "/Users/ereinecke/Projects/github/moto/moto/core/models.py", line 71, in wrapper
    result = func(*args, **kwargs)
  File "/Users/ereinecke/Projects/github/moto/tests/test_awslambda/test_lambda.py", line 81, in test_invoke_requestresponse_function
    base64.b64decode(success_result["LogResult"]).decode('utf-8'))
  File "/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/json/__init__.py", line 354, in loads
    return _default_decoder.decode(s)
  File "/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/json/decoder.py", line 339, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
  File "/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/json/decoder.py", line 357, in raw_decode
    raise JSONDecodeError("Expecting value", s, err.value) from None
json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
```