### PR TITLE
Add suspend processes to AutoScaling service

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -50,3 +50,4 @@ Moto is written by Steve Pulec with contributions from:
 * [Jessie Nadler](https://github.com/nadlerjessie)
 * [Alex Morken](https://github.com/alexmorken)
 * [Clive Li](https://github.com/cliveli)
+* [Jim Shields](https://github.com/jimjshields)

--- a/moto/autoscaling/models.py
+++ b/moto/autoscaling/models.py
@@ -179,6 +179,7 @@ class FakeAutoScalingGroup(BaseModel):
         self.placement_group = placement_group
         self.termination_policies = termination_policies
 
+        self.suspended_processes = []
         self.instance_states = []
         self.tags = tags if tags else []
         self.set_desired_capacity(desired_capacity)
@@ -620,6 +621,10 @@ class AutoScalingBackend(BaseBackend):
         for target_group in target_group_arns:
             asg_targets = [{'id': x.instance.id} for x in group.instance_states]
             self.elbv2_backend.deregister_targets(target_group, (asg_targets))
+
+    def suspend_processes(self, group_name, scaling_processes):
+        group = self.autoscaling_groups[group_name]
+        group.suspended_processes = scaling_processes or []
 
 
 autoscaling_backends = {}

--- a/moto/autoscaling/responses.py
+++ b/moto/autoscaling/responses.py
@@ -283,6 +283,13 @@ class AutoScalingResponse(BaseResponse):
         template = self.response_template(DETACH_LOAD_BALANCERS_TEMPLATE)
         return template.render()
 
+    def suspend_processes(self):
+        autoscaling_group_name = self._get_param('AutoScalingGroupName')
+        scaling_processes = self._get_multi_param('ScalingProcesses.member')
+        self.autoscaling_backend.suspend_processes(autoscaling_group_name, scaling_processes)
+        template = self.response_template(SUSPEND_PROCESSES_TEMPLATE)
+        return template.render()
+
 
 CREATE_LAUNCH_CONFIGURATION_TEMPLATE = """<CreateLaunchConfigurationResponse xmlns="http://autoscaling.amazonaws.com/doc/2011-01-01/">
 <ResponseMetadata>
@@ -463,7 +470,14 @@ DESCRIBE_AUTOSCALING_GROUPS_TEMPLATE = """<DescribeAutoScalingGroupsResponse xml
           </member>
           {% endfor %}
         </Tags>
-        <SuspendedProcesses/>
+        <SuspendedProcesses>
+          {% for suspended_process in group.suspended_processes %}
+          <member>
+            <ProcessName>{{suspended_process}}</ProcessName>
+            <SuspensionReason></SuspensionReason>
+          </member>
+          {% endfor %}
+        </SuspendedProcesses>
         <AutoScalingGroupName>{{ group.name }}</AutoScalingGroupName>
         <HealthCheckType>{{ group.health_check_type }}</HealthCheckType>
         <CreatedTime>2013-05-06T17:47:15.107Z</CreatedTime>
@@ -643,6 +657,12 @@ DETACH_LOAD_BALANCERS_TEMPLATE = """<DetachLoadBalancersResponse xmlns="http://a
 <RequestId>{{ requestid }}</RequestId>
 </ResponseMetadata>
 </DetachLoadBalancersResponse>"""
+
+SUSPEND_PROCESSES_TEMPLATE = """<SuspendProcessesResponse xmlns="http://autoscaling.amazonaws.com/doc/2011-01-01/">
+<ResponseMetadata>
+   <RequestId>7c6e177f-f082-11e1-ac58-3714bEXAMPLE</RequestId>
+</ResponseMetadata>
+</SuspendProcessesResponse>"""
 
 SET_INSTANCE_HEALTH_TEMPLATE = """<SetInstanceHealthResponse xmlns="http://autoscaling.amazonaws.com/doc/2011-01-01/">
 <SetInstanceHealthResponse></SetInstanceHealthResponse>


### PR DESCRIPTION
This is to address https://github.com/spulec/moto/issues/1370. Let me know if you have any feedback, happy to add more tests if necessary!

* Implement `suspend_processes` in `autoscaling.models` and `autoscaling.responses`
* Use suggested test from https://github.com/spulec/moto/issues/1370