### PR TITLE
Tighten upper bound on python-dateutil to match botocore

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ install_requires = [
     "werkzeug",
     "pyaml",
     "pytz",
-    "python-dateutil<3.0.0,>=2.1",
+    "python-dateutil<2.7.0,>=2.1",
     "mock",
     "docker>=2.5.1",
     "jsondiff==1.1.1",


### PR DESCRIPTION
Due to:

https://github.com/boto/botocore/commit/90d7692702be1a423af15e0f49b58365f2a400f2

The following is seen when trying to run `pip3 --no-cache-dir install ".[server]"` for the `Dockerfile` in this repo.

```python
Traceback (most recent call last):
  File "/usr/lib/python3.6/site-packages/pkg_resources/__init__.py", line 574, in _build_master
    ws.require(__requires__)
  File "/usr/lib/python3.6/site-packages/pkg_resources/__init__.py", line 892, in require
    needed = self.resolve(parse_requirements(requirements))
  File "/usr/lib/python3.6/site-packages/pkg_resources/__init__.py", line 783, in resolve
    raise VersionConflict(dist, req).with_context(dependent_req)
pkg_resources.ContextualVersionConflict: (python-dateutil 2.7.0 (/usr/lib/python3.6/site-packages), Requirement.parse('python-dateutil<2.7.0,>=2.1'), {'botocore'})
```