### PR TITLE
Added Filtering support for S3 lifecycle

### DIFF
--- a/moto/s3/models.py
+++ b/moto/s3/models.py
@@ -415,7 +415,7 @@ class FakeBucket(BaseModel):
             # Pull out the filter:
             lc_filter = None
             if rule.get("Filter"):
-                # Can't have both filter and prefix (Need to check for the presence of the Key):
+                # Can't have both `Filter` and `Prefix` (need to check for the presence of the key):
                 try:
                     if rule["Prefix"] or not rule["Prefix"]:
                         raise MalformedXML()

--- a/moto/s3/responses.py
+++ b/moto/s3/responses.py
@@ -1177,6 +1177,28 @@ S3_BUCKET_LIFECYCLE_CONFIGURATION = """<?xml version="1.0" encoding="UTF-8"?>
     <Rule>
         <ID>{{ rule.id }}</ID>
         <Prefix>{{ rule.prefix if rule.prefix != None }}</Prefix>
+        {% if rule.filter %}
+        <Filter>
+            <Prefix>{{ rule.filter.prefix }}</Prefix>
+            {% if rule.filter.tag %}
+            <Tag>
+                <Key>{{ rule.filter.tag.key }}</Key>
+                <Value>{{ rule.filter.tag.value }}</Value>
+            </Tag>
+            {% endif %}
+            {% if rule.filter.and_filter %}
+            <And>
+                <Prefix>{{ rule.filter.and_filter.prefix }}</Prefix>
+                {% for tag in rule.filter.and_filter.tags %}
+                <Tag>
+                    <Key>{{ tag.key }}</Key>
+                    <Value>{{ tag.value }}</Value>
+                </Tag>
+                {% endfor %}
+            </And>
+            {% endif %}
+        </Filter>
+        {% endif %}
         <Status>{{ rule.status }}</Status>
         {% if rule.storage_class %}
         <Transition>
@@ -1189,13 +1211,16 @@ S3_BUCKET_LIFECYCLE_CONFIGURATION = """<?xml version="1.0" encoding="UTF-8"?>
            <StorageClass>{{ rule.storage_class }}</StorageClass>
         </Transition>
         {% endif %}
-        {% if rule.expiration_days or rule.expiration_date %}
+        {% if rule.expiration_days or rule.expiration_date or rule.expired_object_delete_marker %}
         <Expiration>
             {% if rule.expiration_days %}
                <Days>{{ rule.expiration_days }}</Days>
             {% endif %}
             {% if rule.expiration_date %}
                <Date>{{ rule.expiration_date }}</Date>
+            {% endif %}
+            {% if rule.expired_object_delete_marker %}
+                <ExpiredObjectDeleteMarker>{{ rule.expired_object_delete_marker }}</ExpiredObjectDeleteMarker>
             {% endif %}
         </Expiration>
         {% endif %}

--- a/moto/s3/responses.py
+++ b/moto/s3/responses.py
@@ -1176,7 +1176,6 @@ S3_BUCKET_LIFECYCLE_CONFIGURATION = """<?xml version="1.0" encoding="UTF-8"?>
     {% for rule in rules %}
     <Rule>
         <ID>{{ rule.id }}</ID>
-        <Prefix>{{ rule.prefix if rule.prefix != None }}</Prefix>
         {% if rule.filter %}
         <Filter>
             <Prefix>{{ rule.filter.prefix }}</Prefix>
@@ -1198,6 +1197,8 @@ S3_BUCKET_LIFECYCLE_CONFIGURATION = """<?xml version="1.0" encoding="UTF-8"?>
             </And>
             {% endif %}
         </Filter>
+        {% else %}
+        <Prefix>{{ rule.prefix if rule.prefix != None }}</Prefix>
         {% endif %}
         <Status>{{ rule.status }}</Status>
         {% if rule.storage_class %}

--- a/setup.py
+++ b/setup.py
@@ -8,8 +8,8 @@ import sys
 install_requires = [
     "Jinja2>=2.7.3",
     "boto>=2.36.0",
-    "boto3>=1.2.1",
-    "botocore>=1.7.12",
+    "boto3>=1.6.16",
+    "botocore>=1.9.16",
     "cookies",
     "cryptography>=2.0.0",
     "requests>=2.5",

--- a/tests/test_s3/test_s3_lifecycle.py
+++ b/tests/test_s3/test_s3_lifecycle.py
@@ -1,12 +1,16 @@
 from __future__ import unicode_literals
 
 import boto
+import boto3
 from boto.exception import S3ResponseError
 from boto.s3.lifecycle import Lifecycle, Transition, Expiration, Rule
 
 import sure  # noqa
+from botocore.exceptions import ClientError
+from datetime import datetime
+from nose.tools import assert_raises
 
-from moto import mock_s3_deprecated
+from moto import mock_s3_deprecated, mock_s3
 
 
 @mock_s3_deprecated
@@ -24,6 +28,152 @@ def test_lifecycle_create():
     lifecycle.prefix.should.equal('')
     lifecycle.status.should.equal('Enabled')
     list(lifecycle.transition).should.equal([])
+
+
+@mock_s3
+def test_lifecycle_with_filters():
+    client = boto3.client("s3")
+    client.create_bucket(Bucket="bucket")
+
+    # Create a lifecycle rule with a Filter (no tags):
+    lfc = {
+        "Rules": [
+            {
+                "Expiration": {
+                    "Days": 7
+                },
+                "ID": "wholebucket",
+                "Filter": {
+                    "Prefix": ""
+                },
+                "Status": "Enabled"
+            }
+        ]
+    }
+    client.put_bucket_lifecycle_configuration(Bucket="bucket", LifecycleConfiguration=lfc)
+    result = client.get_bucket_lifecycle_configuration(Bucket="bucket")
+    assert len(result["Rules"]) == 1
+    assert result["Rules"][0]["Filter"]["Prefix"] == ''
+    assert not result["Rules"][0]["Filter"].get("And")
+    assert not result["Rules"][0]["Filter"].get("Tag")
+
+    # With a tag:
+    lfc["Rules"][0]["Filter"]["Tag"] = {
+        "Key": "mytag",
+        "Value": "mytagvalue"
+    }
+    client.put_bucket_lifecycle_configuration(Bucket="bucket", LifecycleConfiguration=lfc)
+    result = client.get_bucket_lifecycle_configuration(Bucket="bucket")
+    assert len(result["Rules"]) == 1
+    assert result["Rules"][0]["Filter"]["Prefix"] == ''
+    assert not result["Rules"][0]["Filter"].get("And")
+    assert result["Rules"][0]["Filter"]["Tag"]["Key"] == "mytag"
+    assert result["Rules"][0]["Filter"]["Tag"]["Value"] == "mytagvalue"
+
+    # With And (single tag):
+    lfc["Rules"][0]["Filter"]["And"] = {
+        "Prefix": "some/prefix",
+        "Tags": [
+            {
+                "Key": "mytag",
+                "Value": "mytagvalue"
+            }
+        ]
+    }
+    client.put_bucket_lifecycle_configuration(Bucket="bucket", LifecycleConfiguration=lfc)
+    result = client.get_bucket_lifecycle_configuration(Bucket="bucket")
+    assert len(result["Rules"]) == 1
+    assert result["Rules"][0]["Filter"]["Prefix"] == ""
+    assert result["Rules"][0]["Filter"]["And"]["Prefix"] == "some/prefix"
+    assert len(result["Rules"][0]["Filter"]["And"]["Tags"]) == 1
+    assert result["Rules"][0]["Filter"]["And"]["Tags"][0]["Key"] == "mytag"
+    assert result["Rules"][0]["Filter"]["And"]["Tags"][0]["Value"] == "mytagvalue"
+    assert result["Rules"][0]["Filter"]["Tag"]["Key"] == "mytag"
+    assert result["Rules"][0]["Filter"]["Tag"]["Value"] == "mytagvalue"
+
+    # With multiple And tags:
+    lfc["Rules"][0]["Filter"]["And"] = {
+        "Prefix": "some/prefix",
+        "Tags": [
+            {
+                "Key": "mytag",
+                "Value": "mytagvalue"
+            },
+            {
+                "Key": "mytag2",
+                "Value": "mytagvalue2"
+            }
+        ]
+    }
+    client.put_bucket_lifecycle_configuration(Bucket="bucket", LifecycleConfiguration=lfc)
+    result = client.get_bucket_lifecycle_configuration(Bucket="bucket")
+    assert len(result["Rules"]) == 1
+    assert result["Rules"][0]["Filter"]["Prefix"] == ""
+    assert result["Rules"][0]["Filter"]["And"]["Prefix"] == "some/prefix"
+    assert len(result["Rules"][0]["Filter"]["And"]["Tags"]) == 2
+    assert result["Rules"][0]["Filter"]["And"]["Tags"][0]["Key"] == "mytag"
+    assert result["Rules"][0]["Filter"]["And"]["Tags"][0]["Value"] == "mytagvalue"
+    assert result["Rules"][0]["Filter"]["Tag"]["Key"] == "mytag"
+    assert result["Rules"][0]["Filter"]["Tag"]["Value"] == "mytagvalue"
+    assert result["Rules"][0]["Filter"]["And"]["Tags"][1]["Key"] == "mytag2"
+    assert result["Rules"][0]["Filter"]["And"]["Tags"][1]["Value"] == "mytagvalue2"
+    assert result["Rules"][0]["Filter"]["Tag"]["Key"] == "mytag"
+    assert result["Rules"][0]["Filter"]["Tag"]["Value"] == "mytagvalue"
+
+    # Can't have both filter and prefix:
+    lfc["Rules"][0]["Prefix"] = ''
+    with assert_raises(ClientError) as err:
+        client.put_bucket_lifecycle_configuration(Bucket="bucket", LifecycleConfiguration=lfc)
+    assert err.exception.response["Error"]["Code"] == "MalformedXML"
+
+    lfc["Rules"][0]["Prefix"] = 'some/path'
+    with assert_raises(ClientError) as err:
+        client.put_bucket_lifecycle_configuration(Bucket="bucket", LifecycleConfiguration=lfc)
+    assert err.exception.response["Error"]["Code"] == "MalformedXML"
+
+
+@mock_s3
+def test_lifecycle_with_eodm():
+    client = boto3.client("s3")
+    client.create_bucket(Bucket="bucket")
+
+    lfc = {
+        "Rules": [
+            {
+                "Expiration": {
+                    "ExpiredObjectDeleteMarker": True
+                },
+                "ID": "wholebucket",
+                "Filter": {
+                    "Prefix": ""
+                },
+                "Status": "Enabled"
+            }
+        ]
+    }
+    client.put_bucket_lifecycle_configuration(Bucket="bucket", LifecycleConfiguration=lfc)
+    result = client.get_bucket_lifecycle_configuration(Bucket="bucket")
+    assert len(result["Rules"]) == 1
+    assert result["Rules"][0]["Expiration"]["ExpiredObjectDeleteMarker"]
+
+    # Set to False:
+    lfc["Rules"][0]["Expiration"]["ExpiredObjectDeleteMarker"] = False
+    client.put_bucket_lifecycle_configuration(Bucket="bucket", LifecycleConfiguration=lfc)
+    result = client.get_bucket_lifecycle_configuration(Bucket="bucket")
+    assert len(result["Rules"]) == 1
+    assert not result["Rules"][0]["Expiration"]["ExpiredObjectDeleteMarker"]
+
+    # With failure:
+    lfc["Rules"][0]["Expiration"]["Days"] = 7
+    with assert_raises(ClientError) as err:
+        client.put_bucket_lifecycle_configuration(Bucket="bucket", LifecycleConfiguration=lfc)
+    assert err.exception.response["Error"]["Code"] == "MalformedXML"
+    del lfc["Rules"][0]["Expiration"]["Days"]
+
+    lfc["Rules"][0]["Expiration"]["Date"] = datetime(2015, 1, 1)
+    with assert_raises(ClientError) as err:
+        client.put_bucket_lifecycle_configuration(Bucket="bucket", LifecycleConfiguration=lfc)
+    assert err.exception.response["Error"]["Code"] == "MalformedXML"
 
 
 @mock_s3_deprecated


### PR DESCRIPTION
Added Filtering support for S3 lifecycle and also added `ExpiredObjectDeleteMarker`.

Note: The `Filter` feature is pretty new, so I bumped up the `boto3` and `botocore` versions to the latest. @JackDanger Please let me know if this is a problem.

closes #1533
closes #1479