### PR TITLE
Fix ApiGateway key identification

### DIFF
--- a/moto/apigateway/models.py
+++ b/moto/apigateway/models.py
@@ -563,17 +563,17 @@ class APIGatewayBackend(BaseBackend):
 
     def create_apikey(self, payload):
         key = ApiKey(**payload)
-        self.keys[key['value']] = key
+        self.keys[key['id']] = key
         return key
 
     def get_apikeys(self):
         return list(self.keys.values())
 
-    def get_apikey(self, value):
-        return self.keys[value]
+    def get_apikey(self, api_key_id):
+        return self.keys[api_key_id]
 
-    def delete_apikey(self, value):
-        self.keys.pop(value)
+    def delete_apikey(self, api_key_id):
+        self.keys.pop(api_key_id)
         return {}
 
 

--- a/tests/test_apigateway/test_apigateway.py
+++ b/tests/test_apigateway/test_apigateway.py
@@ -976,22 +976,22 @@ def test_api_keys():
     apikey_name = 'TESTKEY1'
     payload = {'value': apikey_value, 'name': apikey_name}
     response = client.create_api_key(**payload)
-    apikey = client.get_api_key(apiKey=payload['value'])
+    apikey = client.get_api_key(apiKey=response['id'])
     apikey['name'].should.equal(apikey_name)
     apikey['value'].should.equal(apikey_value)
 
     apikey_name = 'TESTKEY2'
     payload = {'name': apikey_name, 'generateDistinctId': True}
     response = client.create_api_key(**payload)
-    apikey = client.get_api_key(apiKey=response['value'])
+    apikey_id = response['id']
+    apikey = client.get_api_key(apiKey=apikey_id)
     apikey['name'].should.equal(apikey_name)
     len(apikey['value']).should.equal(40)
-    apikey_value = apikey['value']
 
     response = client.get_api_keys()
     len(response['items']).should.equal(2)
 
-    client.delete_api_key(apiKey=apikey_value)
+    client.delete_api_key(apiKey=apikey_id)
 
     response = client.get_api_keys()
     len(response['items']).should.equal(1)


### PR DESCRIPTION
Hello :), here is my firt PR that fixes an issue with API Gateway keys identification

API Gateway keys are identified by their ids and not their values

- https://docs.aws.amazon.com/cli/latest/reference/apigateway/get-api-key.html#examples
- http://boto3.readthedocs.io/en/latest/reference/services/apigateway.html#APIGateway.Client.get_api_key