### PR TITLE
Fix AttributeError in filter_log_events

### DIFF
--- a/moto/logs/models.py
+++ b/moto/logs/models.py
@@ -184,7 +184,7 @@ class LogGroup:
             events += stream.filter_log_events(log_group_name, log_stream_names, start_time, end_time, limit, next_token, filter_pattern, interleaved)
 
         if interleaved:
-            events = sorted(events, key=lambda event: event.timestamp)
+            events = sorted(events, key=lambda event: event['timestamp'])
 
         if next_token is None:
             next_token = 0

--- a/tests/test_logs/test_logs.py
+++ b/tests/test_logs/test_logs.py
@@ -86,3 +86,31 @@ def test_put_logs():
     )
     events = res['events']
     events.should.have.length_of(2)
+
+
+@mock_logs
+def test_filter_logs_interleaved():
+    conn = boto3.client('logs', 'us-west-2')
+    log_group_name = 'dummy'
+    log_stream_name = 'stream'
+    conn.create_log_group(logGroupName=log_group_name)
+    conn.create_log_stream(
+        logGroupName=log_group_name,
+        logStreamName=log_stream_name
+    )
+    messages = [
+        {'timestamp': 0, 'message': 'hello'},
+        {'timestamp': 0, 'message': 'world'}
+    ]
+    conn.put_log_events(
+        logGroupName=log_group_name,
+        logStreamName=log_stream_name,
+        logEvents=messages
+    )
+    res = conn.filter_log_events(
+        logGroupName=log_group_name,
+        logStreamNames=[log_stream_name],
+        interleaved=True,
+    )
+    events = res['events']
+    events.should.have.length_of(2)


### PR DESCRIPTION
An AttributeError would be thrown if the `interleaved` parameter was
passed.