### PR TITLE
Implementation of generate_data_key KMS Endpoints

### DIFF
--- a/IMPLEMENTATION_COVERAGE.md
+++ b/IMPLEMENTATION_COVERAGE.md
@@ -2458,12 +2458,12 @@
 - [ ] update_data_retention
 - [ ] update_stream
 
-## kms - 25% implemented
+## kms - 40% implemented
 - [ ] cancel_key_deletion
-- [ ] create_alias
+- [X] create_alias
 - [ ] create_grant
 - [X] create_key
-- [ ] decrypt
+- [X] decrypt
 - [X] delete_alias
 - [ ] delete_imported_key_material
 - [X] describe_key
@@ -2471,7 +2471,7 @@
 - [X] disable_key_rotation
 - [ ] enable_key
 - [X] enable_key_rotation
-- [ ] encrypt
+- [X] encrypt
 - [ ] generate_data_key
 - [ ] generate_data_key_without_plaintext
 - [ ] generate_random
@@ -2479,9 +2479,9 @@
 - [X] get_key_rotation_status
 - [ ] get_parameters_for_import
 - [ ] import_key_material
-- [ ] list_aliases
+- [X] list_aliases
 - [ ] list_grants
-- [ ] list_key_policies
+- [X] list_key_policies
 - [X] list_keys
 - [ ] list_resource_tags
 - [ ] list_retirable_grants

--- a/IMPLEMENTATION_COVERAGE.md
+++ b/IMPLEMENTATION_COVERAGE.md
@@ -2472,8 +2472,8 @@
 - [ ] enable_key
 - [X] enable_key_rotation
 - [X] encrypt
-- [ ] generate_data_key
-- [ ] generate_data_key_without_plaintext
+- [X] generate_data_key
+- [X] generate_data_key_without_plaintext
 - [ ] generate_random
 - [X] get_key_policy
 - [X] get_key_rotation_status

--- a/moto/kms/models.py
+++ b/moto/kms/models.py
@@ -1,7 +1,8 @@
 from __future__ import unicode_literals
 
 import base64
-from math import ceil
+import string
+import random
 import boto.kms
 from moto.core import BaseBackend, BaseModel
 from .utils import generate_key_id
@@ -146,10 +147,13 @@ class KmsBackend(BaseBackend):
     def decrypt(data):
         return base64.b64decode(data).decode("utf-8")
 
+    @staticmethod
+    def __random_char_gen(length):
+        return ''.join(random.choice(string.ascii_letters + string.digits) for _ in range(length))
+
     def generate_data_key(self, key_id, key_spec, key_length):
         """
-        This method simply uses the reverse of the key_id (if it exists)
-        X many times to equal the required number of bits.
+        This method simply returns a random generated string of specified length
         """
         if self.alias_exists(key_id):
             key = self.key_to_aliases[self.get_key_id(key_id)]
@@ -159,7 +163,6 @@ class KmsBackend(BaseBackend):
         if not self.keys[key]:
             return None
 
-        data_key = key_id[::-1]
         if key_spec == 'AES_128':
             key_length = 128
         elif key_spec == 'AES_256':
@@ -167,8 +170,7 @@ class KmsBackend(BaseBackend):
         else:
             key_length = int(key_length)
 
-        return (data_key *
-                int((ceil((key_length / float(len(data_key)))) + 1)))[:key_length]
+        return self.__random_char_gen(key_length)
 
 
 kms_backends = {}

--- a/moto/kms/models.py
+++ b/moto/kms/models.py
@@ -166,10 +166,7 @@ class KmsBackend(BaseBackend):
         else:
             key_length = int(key_length)
 
-        repeat_count = key_length / len(data_key)
-        repeat_count = (1, repeat_count)[repeat_count == 0]
-        data_key = data_key * repeat_count
-        return data_key[:key_length]
+        return (data_key * ((key_length / len(data_key)) + 1))[:key_length]
 
 
 kms_backends = {}

--- a/moto/kms/models.py
+++ b/moto/kms/models.py
@@ -1,6 +1,7 @@
 from __future__ import unicode_literals
 
 import base64
+from math import ceil
 import boto.kms
 from moto.core import BaseBackend, BaseModel
 from .utils import generate_key_id
@@ -166,7 +167,8 @@ class KmsBackend(BaseBackend):
         else:
             key_length = int(key_length)
 
-        return (data_key * ((key_length / len(data_key)) + 1))[:key_length]
+        return (data_key *
+                int((ceil((key_length / float(len(data_key)))) + 1)))[:key_length]
 
 
 kms_backends = {}

--- a/moto/kms/responses.py
+++ b/moto/kms/responses.py
@@ -264,6 +264,7 @@ class KmsResponse(BaseResponse):
                 'message': "Key 'arn:aws:kms:{region}:012345678912:key/{key_id}' does not exist".format(region=self.region, key_id=key_id),
                 '__type': 'NotFoundException'})
 
+
 def _assert_valid_key_id(key_id):
     if not re.match(r'^[A-F0-9]{8}-[A-F0-9]{4}-[A-F0-9]{4}-[A-F0-9]{4}-[A-F0-9]{12}$', key_id, re.IGNORECASE):
         raise JSONResponseError(404, 'Not Found', body={

--- a/moto/kms/responses.py
+++ b/moto/kms/responses.py
@@ -239,7 +239,7 @@ class KmsResponse(BaseResponse):
             data_key = self.kms_backend.generate_data_key(key_id, key_spec, key_length)
             crypto_key = self.kms_backend.encrypt(data_key)
             return json.dumps({
-                "Plaintext:": data_key,
+                "Plaintext": data_key,
                 "CiphertextBlob": crypto_key,
                 "KeyId": self.kms_backend.get_key_id(key_id)})
         except KeyError:

--- a/tests/test_kms/test_kms.py
+++ b/tests/test_kms/test_kms.py
@@ -643,5 +643,6 @@ def test_kms_generate_data_key_without_plaintext():
     data_key_response = client.generate_data_key_without_plaintext(KeyId=key_id,
                                                                    KeySpec='AES_256')
     data_key_response.should_not.have_key('Plaintext')
-    data_key_response.should.have_key('CiphertextBlob').not.being.none
+    data_key_response.should.have_key('CiphertextBlob')
+    data_key_response['CiphertextBlob'].should_not.be.equal(None)
 

--- a/tests/test_kms/test_kms.py
+++ b/tests/test_kms/test_kms.py
@@ -622,9 +622,9 @@ def test_kms_encrypt_boto3():
 @mock_kms
 def test_kms_generate_data_key():
     client = boto3.client('kms', region_name='us-east-1')
-    creation_response = client.create_key(policy="my policy",
-                                          description="my key",
-                                          key_usage='data_key_test')
+    creation_response = client.create_key(Policy="my policy",
+                                          Description="my key",
+                                          KeyUsage='data_key_test')
     key_id = creation_response['KeyMetadata']['KeyId']
     data_key_response = client.generate_data_key(KeyId=key_id, KeySpec='AES_256')
     data_key_response['KeyId'].should.equal(key_id)
@@ -636,9 +636,9 @@ def test_kms_generate_data_key():
 @mock_kms
 def test_kms_generate_data_key_without_plaintext():
     client = boto3.client('kms', region_name='us-east-1')
-    creation_response = client.create_key(policy="my policy",
-                                          description="my key",
-                                          key_usage='data_key_test_no_ws')
+    creation_response = client.create_key(Policy="my policy",
+                                          Description="my key",
+                                          KeyUsage='data_key_test_no_ws')
     key_id = creation_response['KeyMetadata']['KeyId']
     data_key_response = client.generate_data_key_without_plaintext(KeyId=key_id,
                                                                    KeySpec='AES_256')

--- a/tests/test_kms/test_kms.py
+++ b/tests/test_kms/test_kms.py
@@ -643,6 +643,6 @@ def test_kms_generate_data_key_without_plaintext():
     data_key_response = client.generate_data_key_without_plaintext(KeyId=key_id,
                                                                    KeySpec='AES_256')
     data_key_response.should_not.have.key('Plaintext')
-    data_key_response.should.have_key('CiphertextBlob')
+    data_key_response.should.have.key('CiphertextBlob')
     data_key_response['CiphertextBlob'].should_not.be.equal(None)
 

--- a/tests/test_kms/test_kms.py
+++ b/tests/test_kms/test_kms.py
@@ -642,7 +642,7 @@ def test_kms_generate_data_key_without_plaintext():
     key_id = creation_response['KeyMetadata']['KeyId']
     data_key_response = client.generate_data_key_without_plaintext(KeyId=key_id,
                                                                    KeySpec='AES_256')
-    data_key_response.should_not.have_key('Plaintext')
+    data_key_response.should_not.have.key('Plaintext')
     data_key_response.should.have_key('CiphertextBlob')
     data_key_response['CiphertextBlob'].should_not.be.equal(None)
 


### PR DESCRIPTION
This pull request implements the `generate_data_key` & `generate_data_key_without_plaintext` endpoints for the KMS service, along with tests.

I also refactored the "encryption"/"decryption" components so they can be reused more easily by other endpoints within the service.  I don't typically program in Python, so all comments/criticism are welcome!

Additionally, I've updated the KMS section of the implementation overage document.

I created this PR in response to my ticket #1518 