### PR TITLE
Fix/lambda backend

### DIFF
--- a/moto/awslambda/responses.py
+++ b/moto/awslambda/responses.py
@@ -107,8 +107,8 @@ class LambdaResponse(BaseResponse):
         path = request.path if hasattr(request, 'path') else request.path_url
         function_name = path.split('/')[-2]
         if self.lambda_backend.get_function(function_name):
-            function = self.lambda_backend.get_function(function_name)
-            return 200, {}, json.dumps(dict(Policy="{\"Statement\":[" + function.policy + "]}"))
+            lambda_function = self.lambda_backend.get_function(function_name)
+            return 200, {}, json.dumps(dict(Policy="{\"Statement\":[" + lambda_function.policy + "]}"))
         else:
             return 404, {}, "{}"
 

--- a/moto/awslambda/responses.py
+++ b/moto/awslambda/responses.py
@@ -94,24 +94,20 @@ class LambdaResponse(BaseResponse):
             return self._add_policy(request, full_url, headers)
 
     def _add_policy(self, request, full_url, headers):
-        lambda_backend = self.get_lambda_backend(full_url)
-
         path = request.path if hasattr(request, 'path') else request.path_url
         function_name = path.split('/')[-2]
-        if lambda_backend.has_function(function_name):
+        if self.lambda_backend.get_function(function_name):
             policy = request.body.decode('utf8')
-            lambda_backend.add_policy(function_name, policy)
+            self.lambda_backend.add_policy(function_name, policy)
             return 200, {}, json.dumps(dict(Statement=policy))
         else:
             return 404, {}, "{}"
 
     def _get_policy(self, request, full_url, headers):
-        lambda_backend = self.get_lambda_backend(full_url)
-
         path = request.path if hasattr(request, 'path') else request.path_url
         function_name = path.split('/')[-2]
-        if lambda_backend.has_function(function_name):
-            function = lambda_backend.get_function(function_name)
+        if self.lambda_backend.get_function(function_name):
+            function = self.lambda_backend.get_function(function_name)
             return 200, {}, json.dumps(dict(Policy="{\"Statement\":[" + function.policy + "]}"))
         else:
             return 404, {}, "{}"


### PR DESCRIPTION
- Fix error when use this code:
```
client = boto3.client('lambda')
client.get_policy([...])
```
 and moto rise:
```
moto/awslambda/responses.py", line 109, in _get_policy
    lambda_backend = self.get_lambda_backend(full_url)
Exception: 'LambdaResponse' object has no attribute 'get_lambda_backend'
```

- fix shadows built-in name in `moto/awslambda/responses.py`