### PR TITLE
Issue #1539 : Fixing dynamodb filtering (contains, begins with)

### DIFF
--- a/moto/dynamodb2/comparisons.py
+++ b/moto/dynamodb2/comparisons.py
@@ -176,6 +176,8 @@ def get_filter_expression(expr, names, values):
 
             next_token = six.next(token_iterator)
             while next_token != ')':
+                if next_token in values_map:
+                    next_token = values_map[next_token]
                 function_list.append(next_token)
                 next_token = six.next(token_iterator)
 


### PR DESCRIPTION
Currently contains and begins with are not respecting the given filter value