### PR TITLE
Fix/cloud watch fix put metric data with timestamp bug

### DIFF
--- a/moto/cloudwatch/models.py
+++ b/moto/cloudwatch/models.py
@@ -1,12 +1,13 @@
 
 import json
-from moto.core.utils import iso_8601_datetime_with_milliseconds
+from moto.core.utils import iso_8601_datetime_without_milliseconds
 from moto.core import BaseBackend, BaseModel
 from moto.core.exceptions import RESTError
 import boto.ec2.cloudwatch
 from datetime import datetime, timedelta
 from dateutil.tz import tzutc
 from .utils import make_arn_for_dashboard
+from dateutil import parser
 
 DEFAULT_ACCOUNT_ID = 123456789012
 
@@ -125,7 +126,7 @@ class Dashboard(BaseModel):
 
 class Statistics:
     def __init__(self, stats, dt):
-        self.timestamp = iso_8601_datetime_with_milliseconds(dt)
+        self.timestamp = iso_8601_datetime_without_milliseconds(dt)
         self.values = []
         self.stats = stats
 
@@ -230,7 +231,7 @@ class CloudWatchBackend(BaseBackend):
     def put_metric_data(self, namespace, metric_data):
         for metric_member in metric_data:
             self.metric_data.append(MetricDatum(
-                namespace, metric_member['MetricName'], float(metric_member['Value']), metric_member.get('Dimensions.member', _EMPTY_LIST), metric_member.get('Timestamp')))
+                namespace, metric_member['MetricName'], float(metric_member['Value']), metric_member.get('Dimensions.member', _EMPTY_LIST), parser.parse(metric_member.get('Timestamp'))))
 
     def get_metric_statistics(self, namespace, metric_name, start_time, end_time, period, stats):
         period_delta = timedelta(seconds=period)

--- a/moto/cloudwatch/responses.py
+++ b/moto/cloudwatch/responses.py
@@ -276,32 +276,34 @@ GET_METRIC_STATISTICS_TEMPLATE = """<GetMetricStatisticsResponse xmlns="http://m
       <Datapoints>
         {% for datapoint in datapoints %}
             <Datapoint>
-              {% if datapoint.sum is not none %}
-              <Sum>{{ datapoint.sum }}</Sum>
-              {% endif %}
+                <member>
+                  {% if datapoint.sum is not none %}
+                  <Sum>{{ datapoint.sum }}</Sum>
+                  {% endif %}
 
-              {% if datapoint.average is not none %}
-              <Average>{{ datapoint.average }}</Average>
-              {% endif %}
+                  {% if datapoint.average is not none %}
+                  <Average>{{ datapoint.average }}</Average>
+                  {% endif %}
 
-              {% if datapoint.maximum is not none %}
-              <Maximum>{{ datapoint.maximum }}</Maximum>
-              {% endif %}
+                  {% if datapoint.maximum is not none %}
+                  <Maximum>{{ datapoint.maximum }}</Maximum>
+                  {% endif %}
 
-              {% if datapoint.minimum is not none %}
-              <Minimum>{{ datapoint.minimum }}</Minimum>
-              {% endif %}
+                  {% if datapoint.minimum is not none %}
+                  <Minimum>{{ datapoint.minimum }}</Minimum>
+                  {% endif %}
 
-              {% if datapoint.sample_count is not none %}
-              <SampleCount>{{ datapoint.sample_count }}</SampleCount>
-              {% endif %}
+                  {% if datapoint.sample_count is not none %}
+                  <SampleCount>{{ datapoint.sample_count }}</SampleCount>
+                  {% endif %}
 
-              {% if datapoint.extended_statistics is not none %}
-              <ExtendedStatistics>{{ datapoint.extended_statistics }}</ExtendedStatistics>
-              {% endif %}
+                  {% if datapoint.extended_statistics is not none %}
+                  <ExtendedStatistics>{{ datapoint.extended_statistics }}</ExtendedStatistics>
+                  {% endif %}
 
-              <Timestamp>{{ datapoint.timestamp }}</Timestamp>
-              <Unit>{{ datapoint.unit }}</Unit>
+                  <Timestamp>{{ datapoint.timestamp }}</Timestamp>
+                  <Unit>{{ datapoint.unit }}</Unit>
+                </member>
             </Datapoint>
         {% endfor %}
       </Datapoints>

--- a/tests/test_cloudwatch/test_cloudwatch.py
+++ b/tests/test_cloudwatch/test_cloudwatch.py
@@ -120,7 +120,7 @@ def test_get_metric_statistics():
     datapoint = datapoints[0]
     datapoint.should.have.key('Minimum').which.should.equal(1.5)
     datapoint.should.have.key('Timestamp').which.should.equal(metric_timestamp)
-
+    
 
 @mock_cloudwatch_deprecated
 def test_describe_alarms():

--- a/tests/test_cloudwatch/test_cloudwatch.py
+++ b/tests/test_cloudwatch/test_cloudwatch.py
@@ -1,8 +1,6 @@
 import boto
 from boto.ec2.cloudwatch.alarm import MetricAlarm
-import boto3
-from datetime import datetime, timedelta
-import pytz
+from datetime import datetime
 import sure  # noqa
 
 from moto import mock_cloudwatch_deprecated
@@ -93,6 +91,7 @@ def test_put_metric_data():
     dict(metric.dimensions).should.equal(
         {'InstanceId': ['i-0123456,i-0123457']})
 
+
 @mock_cloudwatch_deprecated
 def test_get_metric_statistics():
     conn = boto.connect_cloudwatch()
@@ -108,12 +107,12 @@ def test_get_metric_statistics():
     )
 
     metric_kwargs = dict(
-        namespace= 'tester',
-        metric_name= 'metric',
-        start_time= metric_timestamp,
-        end_time= datetime.now(),
-        period= 3600,
-        statistics= ['Minimum']
+        namespace='tester',
+        metric_name='metric',
+        start_time=metric_timestamp,
+        end_time=datetime.now(),
+        period=3600,
+        statistics=['Minimum']
     )
 
     datapoints = conn.get_metric_statistics(**metric_kwargs)
@@ -121,6 +120,7 @@ def test_get_metric_statistics():
     datapoint = datapoints[0]
     datapoint.should.have.key('Minimum').which.should.equal(1.5)
     datapoint.should.have.key('Timestamp').which.should.equal(metric_timestamp)
+
 
 @mock_cloudwatch_deprecated
 def test_describe_alarms():

--- a/tests/test_cloudwatch/test_cloudwatch.py
+++ b/tests/test_cloudwatch/test_cloudwatch.py
@@ -93,6 +93,34 @@ def test_put_metric_data():
     dict(metric.dimensions).should.equal(
         {'InstanceId': ['i-0123456,i-0123457']})
 
+@mock_cloudwatch_deprecated
+def test_get_metric_statistics():
+    conn = boto.connect_cloudwatch()
+
+    metric_timestamp = datetime(2018, 4, 9, 13, 0, 0, 0)
+
+    conn.put_metric_data(
+        namespace='tester',
+        name='metric',
+        value=1.5,
+        dimensions={'InstanceId': ['i-0123456,i-0123457']},
+        timestamp=metric_timestamp
+    )
+
+    metric_kwargs = dict(
+        namespace= 'tester',
+        metric_name= 'metric',
+        start_time= metric_timestamp,
+        end_time= datetime.now(),
+        period= 3600,
+        statistics= ['Minimum']
+    )
+
+    datapoints = conn.get_metric_statistics(**metric_kwargs)
+    datapoints.should.have.length_of(1)
+    datapoint = datapoints[0]
+    datapoint.should.have.key('Minimum').which.should.equal(1.5)
+    datapoint.should.have.key('Timestamp').which.should.equal(metric_timestamp)
 
 @mock_cloudwatch_deprecated
 def test_describe_alarms():


### PR DESCRIPTION
Cloud Watch put metric data method was using string in timestamp parameter.
It caused error when try to get metric statistic data with timestamp.
Fix put metric data method and change response of get metric statistic data.