### PR TITLE
Fix Unicode problem while reading AWSServiceSpec

### DIFF
--- a/moto/core/responses.py
+++ b/moto/core/responses.py
@@ -574,7 +574,7 @@ class AWSServiceSpec(object):
 
     def __init__(self, path):
         self.path = resource_filename('botocore', path)
-        with open(self.path) as f:
+        with open(self.path, "rb") as f:
             spec = json.load(f)
         self.metadata = spec['metadata']
         self.operations = spec['operations']


### PR DESCRIPTION
Hey, I was facing annoying problem while trying to execute it on python3

```UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 78357```

I was referred to the modified line in the code, I changed it from the standard 'r' which is the default to 'rb' and everything is working like it should now.



