### PR TITLE
Correctly generate resource name for target groups when using cloudformation

### DIFF
--- a/moto/cloudformation/parsing.py
+++ b/moto/cloudformation/parsing.py
@@ -96,6 +96,7 @@ NAME_TYPE_MAP = {
     "AWS::ElasticBeanstalk::Application": "ApplicationName",
     "AWS::ElasticBeanstalk::Environment": "EnvironmentName",
     "AWS::ElasticLoadBalancing::LoadBalancer": "LoadBalancerName",
+    "AWS::ElasticLoadBalancingV2::TargetGroup": "Name",
     "AWS::RDS::DBInstance": "DBInstanceIdentifier",
     "AWS::S3::Bucket": "BucketName",
     "AWS::SNS::Topic": "TopicName",
@@ -244,6 +245,18 @@ def resource_name_property_from_type(resource_type):
     return NAME_TYPE_MAP.get(resource_type)
 
 
+def generate_resource_name(resource_type, stack_name, logical_id):
+    if resource_type == "AWS::ElasticLoadBalancingV2::TargetGroup":
+        # Target group names need to be less than 32 characters, so when cloudformation creates a name for you
+        # it makes sure to stay under that limit
+        name_prefix = '{0}-{1}'.format(stack_name, logical_id)
+        my_random_suffix = random_suffix()
+        truncated_name_prefix = name_prefix[0:32 - (len(my_random_suffix) + 1)]
+        return '{0}-{1}'.format(truncated_name_prefix, my_random_suffix)
+    else:
+        return '{0}-{1}-{2}'.format(stack_name, logical_id, random_suffix())
+
+
 def parse_resource(logical_id, resource_json, resources_map):
     resource_type = resource_json['Type']
     resource_class = resource_class_from_type(resource_type)
@@ -258,15 +271,12 @@ def parse_resource(logical_id, resource_json, resources_map):
         if 'Properties' not in resource_json:
             resource_json['Properties'] = dict()
         if resource_name_property not in resource_json['Properties']:
-            resource_json['Properties'][resource_name_property] = '{0}-{1}-{2}'.format(
-                resources_map.get('AWS::StackName'),
-                logical_id,
-                random_suffix())
+            resource_json['Properties'][resource_name_property] = generate_resource_name(
+                resource_type, resources_map.get('AWS::StackName'), logical_id)
         resource_name = resource_json['Properties'][resource_name_property]
     else:
-        resource_name = '{0}-{1}-{2}'.format(resources_map.get('AWS::StackName'),
-                                             logical_id,
-                                             random_suffix())
+        resource_name = generate_resource_name(resource_type, resources_map.get('AWS::StackName'), logical_id)
+
     return resource_class, resource_json, resource_name
 
 

--- a/moto/cloudformation/parsing.py
+++ b/moto/cloudformation/parsing.py
@@ -252,6 +252,10 @@ def generate_resource_name(resource_type, stack_name, logical_id):
         name_prefix = '{0}-{1}'.format(stack_name, logical_id)
         my_random_suffix = random_suffix()
         truncated_name_prefix = name_prefix[0:32 - (len(my_random_suffix) + 1)]
+        # if the truncated name ends in a dash, we'll end up with a double dash in the final name, which is
+        # not allowed
+        if truncated_name_prefix.endswith('-'):
+            truncated_name_prefix = truncated_name_prefix[:-1]
         return '{0}-{1}'.format(truncated_name_prefix, my_random_suffix)
     else:
         return '{0}-{1}-{2}'.format(stack_name, logical_id, random_suffix())

--- a/moto/elbv2/models.py
+++ b/moto/elbv2/models.py
@@ -124,10 +124,7 @@ class FakeTargetGroup(BaseModel):
 
         elbv2_backend = elbv2_backends[region_name]
 
-        # per cloudformation docs:
-        # The target group name should be shorter than 22 characters because
-        # AWS CloudFormation uses the target group name to create the name of the load balancer.
-        name = properties.get('Name', resource_name[:22])
+        name = properties.get('Name')
         vpc_id = properties.get("VpcId")
         protocol = properties.get('Protocol')
         port = properties.get("Port")
@@ -437,7 +434,7 @@ class ELBv2Backend(BaseBackend):
     def create_target_group(self, name, **kwargs):
         if len(name) > 32:
             raise InvalidTargetGroupNameError(
-                "Target group name '%s' cannot be longer than '22' characters" % name
+                "Target group name '%s' cannot be longer than '32' characters" % name
             )
         if not re.match('^[a-zA-Z0-9\-]+$', name):
             raise InvalidTargetGroupNameError(

--- a/tests/test_elbv2/test_elbv2.py
+++ b/tests/test_elbv2/test_elbv2.py
@@ -1584,5 +1584,5 @@ def test_create_target_groups_through_cloudformation():
     # and one named MyTargetGroup
     assert len([tg for tg in target_group_dicts if tg['TargetGroupName'] == 'MyTargetGroup']) == 1
     assert len(
-        [tg for tg in target_group_dicts if tg['TargetGroupName'].startswith('test-stack-test')]
+        [tg for tg in target_group_dicts if tg['TargetGroupName'].startswith('test-stack')]
     ) == 2


### PR DESCRIPTION
They need to have less than 32 character names, so when you don't specify a name
cloudformation generates a name that is less than 32 characters.