### PR TITLE
Fixing create_key_and_certificate boolean parameter

### DIFF
--- a/moto/iot/responses.py
+++ b/moto/iot/responses.py
@@ -103,7 +103,7 @@ class IoTResponse(BaseResponse):
         return json.dumps(dict())
 
     def create_keys_and_certificate(self):
-        set_as_active = self._get_param("setAsActive")
+        set_as_active = self._get_bool_param("setAsActive")
         cert, key_pair = self.iot_backend.create_keys_and_certificate(
             set_as_active=set_as_active,
         )

--- a/tests/test_iot/test_iot.py
+++ b/tests/test_iot/test_iot.py
@@ -97,6 +97,23 @@ def test_certs():
     res.should.have.key('certificates').which.should.have.length_of(0)
 
 @mock_iot
+def test_certs_create_inactive():
+    client = boto3.client('iot', region_name='ap-northeast-1')
+    cert = client.create_keys_and_certificate(setAsActive=False)
+    cert_id = cert['certificateId']
+
+    cert = client.describe_certificate(certificateId=cert_id)
+    cert.should.have.key('certificateDescription')
+    cert_desc = cert['certificateDescription']
+    cert_desc.should.have.key('status').which.should.equal('INACTIVE')
+
+    client.update_certificate(certificateId=cert_id, newStatus='ACTIVE')
+    cert = client.describe_certificate(certificateId=cert_id)
+    cert.should.have.key('certificateDescription')
+    cert_desc = cert['certificateDescription']
+    cert_desc.should.have.key('status').which.should.equal('ACTIVE')
+
+@mock_iot
 def test_policy():
     client = boto3.client('iot', region_name='ap-northeast-1')
     name = 'my-policy'


### PR DESCRIPTION
create_key_and_certificate's setAsActive was getting pulled in as a string. Updating code to pull the parameter in as boolean.