### PR TITLE
Fix missing MessageGroupId and MessageDeduplicationId

### DIFF
--- a/moto/sqs/models.py
+++ b/moto/sqs/models.py
@@ -38,6 +38,8 @@ class Message(BaseModel):
         self.sent_timestamp = None
         self.approximate_first_receive_timestamp = None
         self.approximate_receive_count = 0
+        self.deduplication_id = None
+        self.group_id = None
         self.visible_at = 0
         self.delayed_until = 0
 
@@ -400,7 +402,7 @@ class SQSBackend(BaseBackend):
         queue._set_attributes(attributes)
         return queue
 
-    def send_message(self, queue_name, message_body, message_attributes=None, delay_seconds=None):
+    def send_message(self, queue_name, message_body, message_attributes=None, delay_seconds=None, deduplication_id=None, group_id=None):
 
         queue = self.get_queue(queue_name)
 
@@ -411,6 +413,12 @@ class SQSBackend(BaseBackend):
 
         message_id = get_random_message_id()
         message = Message(message_id, message_body)
+
+        # Attributes, but not *message* attributes
+        if deduplication_id is not None:
+            message.deduplication_id = deduplication_id
+        if group_id is not None:
+            message.group_id = group_id
 
         if message_attributes:
             message.message_attributes = message_attributes

--- a/tests/test_sqs/test_sqs.py
+++ b/tests/test_sqs/test_sqs.py
@@ -171,6 +171,28 @@ def test_message_with_complex_attributes():
 
 
 @mock_sqs
+def test_send_message_with_message_group_id():
+    sqs = boto3.resource('sqs', region_name='us-east-1')
+    queue = sqs.create_queue(QueueName="test-group-id.fifo",
+                             Attributes={'FifoQueue': 'true'})
+
+    sent = queue.send_message(
+        MessageBody="mydata",
+        MessageDeduplicationId="dedupe_id_1",
+        MessageGroupId="group_id_1",
+    )
+
+    messages = queue.receive_messages()
+    messages.should.have.length_of(1)
+
+    message_attributes = messages[0].attributes
+    message_attributes.should.contain('MessageGroupId')
+    message_attributes['MessageGroupId'].should.equal('group_id_1')
+    message_attributes.should.contain('MessageDeduplicationId')
+    message_attributes['MessageDeduplicationId'].should.equal('dedupe_id_1')
+
+
+@mock_sqs
 def test_send_message_with_unicode_characters():
     body_one = 'Héllo!😀'
 


### PR DESCRIPTION
Solves issue detailed in #1578, where some system-level attributes on a message don't survive the mock queuing.

Does **not** change or enhance FIFO queue behavior for true deduplication or groups.