### PR TITLE
Add tests for message attribute validation in SNS

### DIFF
--- a/moto/sns/responses.py
+++ b/moto/sns/responses.py
@@ -55,11 +55,12 @@ class SNSResponse(BaseResponse):
                     "attribute type, the set of supported type prefixes is "
                     "Binary, Number, and String.".format(name))
 
+            transform_value = None
             if 'StringValue' in value:
-                value = value['StringValue']
-            elif 'BinaryValue' in 'Value':
-                value = value['BinaryValue']
-            if not value:
+                transform_value = value['StringValue']
+            elif 'BinaryValue' in value:
+                transform_value = value['BinaryValue']
+            if not transform_value:
                 raise InvalidParameterValue(
                     "The message attribute '{0}' must contain non-empty "
                     "message attribute value for message attribute "
@@ -67,7 +68,7 @@ class SNSResponse(BaseResponse):
 
             # transformation
             transformed_message_attributes[name] = {
-                'Type': data_type, 'Value': value
+                'Type': data_type, 'Value': transform_value
             }
 
         return transformed_message_attributes
@@ -283,10 +284,7 @@ class SNSResponse(BaseResponse):
         phone_number = self._get_param('PhoneNumber')
         subject = self._get_param('Subject')
 
-        try:
-            message_attributes = self._parse_message_attributes()
-        except InvalidParameterValue as e:
-            return self._error(e.description), dict(status=e.code)
+        message_attributes = self._parse_message_attributes()
 
         if phone_number is not None:
             # Check phone is correct syntax (e164)

--- a/tests/test_sns/test_publishing_boto3.py
+++ b/tests/test_sns/test_publishing_boto3.py
@@ -231,7 +231,9 @@ def test_publish_to_sqs_in_different_region():
 def test_publish_to_http():
     def callback(request):
         request.headers["Content-Type"].should.equal("application/json")
-        json.loads.when.called_with(request.body).should_not.throw(Exception)
+        json.loads.when.called_with(
+            request.body.decode()
+        ).should_not.throw(Exception)
         return 200, {}, ""
 
     responses.add_callback(


### PR DESCRIPTION
Fixes regression in test coverage from #1574 

Fixes up bug in return value of moto.sns.responses.SNSResponse._parse_message_attributes due to accidental recycling of a variable.