### PR TITLE
Fix rds.describe_db_snapshots bugs

### DIFF
--- a/moto/rds2/models.py
+++ b/moto/rds2/models.py
@@ -722,10 +722,11 @@ class RDS2Backend(BaseBackend):
 
     def describe_snapshots(self, db_instance_identifier, db_snapshot_identifier):
         if db_instance_identifier:
+            db_instance_snapshots = []
             for snapshot in self.snapshots.values():
                 if snapshot.database.db_instance_identifier == db_instance_identifier:
-                    return [snapshot]
-            raise DBSnapshotNotFoundError()
+                    db_instance_snapshots.append(snapshot)
+            return db_instance_snapshots
 
         if db_snapshot_identifier:
             if db_snapshot_identifier in self.snapshots:

--- a/tests/test_rds2/test_rds2.py
+++ b/tests/test_rds2/test_rds2.py
@@ -350,8 +350,6 @@ def test_describe_db_snapshots():
                             MasterUserPassword='hunter2',
                             Port=1234,
                             DBSecurityGroups=["my_sg"])
-    conn.describe_db_snapshots.when.called_with(
-        DBInstanceIdentifier="db-primary-1").should.throw(ClientError)
 
     created = conn.create_db_snapshot(DBInstanceIdentifier='db-primary-1',
                                       DBSnapshotIdentifier='snapshot-1').get('DBSnapshot')
@@ -365,6 +363,11 @@ def test_describe_db_snapshots():
     snapshot = by_snapshot_id[0]
     snapshot.should.equal(created)
     snapshot.get('Engine').should.equal('postgres')
+
+    conn.create_db_snapshot(DBInstanceIdentifier='db-primary-1',
+                            DBSnapshotIdentifier='snapshot-2')
+    snapshots = conn.describe_db_snapshots(DBInstanceIdentifier='db-primary-1').get('DBSnapshots')
+    snapshots.should.have.length_of(2)
 
 
 @mock_rds2


### PR DESCRIPTION
* Correctly return all snapshots for a given DBInstanceIdentifier.
* If an invalid DBInstanceIdentifier is passed in, return an empty array
  instead of raising a ClientError (which is what AWS actually does).

Fixes #1569