### PR TITLE
Fix Cloudformation not accepting non-JSON SQS redrive policy

### DIFF
--- a/moto/sqs/models.py
+++ b/moto/sqs/models.py
@@ -232,11 +232,18 @@ class Queue(BaseModel):
 
         self.last_modified_timestamp = now
 
-    def _setup_dlq(self, policy_json):
-        try:
-            self.redrive_policy = json.loads(policy_json)
-        except ValueError:
-            raise RESTError('InvalidParameterValue', 'Redrive policy does not contain valid json')
+    def _setup_dlq(self, policy):
+
+        if isinstance(policy, six.text_type):
+            try:
+                self.redrive_policy = json.loads(policy)
+            except ValueError:
+                raise RESTError('InvalidParameterValue', 'Redrive policy is not a dict or valid json')
+        elif isinstance(policy, dict):
+            self.redrive_policy = policy
+        else:
+            raise RESTError('InvalidParameterValue', 'Redrive policy is not a dict or valid json')
+
 
         if 'deadLetterTargetArn' not in self.redrive_policy:
             raise RESTError('InvalidParameterValue', 'Redrive policy does not contain deadLetterTargetArn')

--- a/moto/sqs/models.py
+++ b/moto/sqs/models.py
@@ -244,7 +244,6 @@ class Queue(BaseModel):
         else:
             raise RESTError('InvalidParameterValue', 'Redrive policy is not a dict or valid json')
 
-
         if 'deadLetterTargetArn' not in self.redrive_policy:
             raise RESTError('InvalidParameterValue', 'Redrive policy does not contain deadLetterTargetArn')
         if 'maxReceiveCount' not in self.redrive_policy:


### PR DESCRIPTION
Adds a unit-test for issue #1393 and fixes it. 

Note that this is focused towards the CloudFormation use-case, and not the SQS client or resource APIs. Those other ways of creating queues may still have their own validation requirements, which may-or-may-not still need to require JSON-only inputs.