### PR TITLE
Allow dateutil below 3.0.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ install_requires = [
     "werkzeug",
     "pyaml",
     "pytz",
-    "python-dateutil<2.7.0,>=2.1",
+    "python-dateutil<3.0.0,>=2.1",
     "mock",
     "docker>=2.5.1",
     "jsondiff==1.1.1",


### PR DESCRIPTION
The `dateutil` dependency was tightened in #1519, in order to match `botocore`. However, it looks like `botocore` is working on loosening that dependency for Python 2.7 and above: https://github.com/boto/botocore/pull/1433. Therefore it makes sense that this project should _also_ loosen its dependencies, and since we don't support Python 2.6 or below, we can do so more simply.