### PR TITLE
Default TimeoutSeconds to 1 hour

### DIFF
--- a/moto/ssm/models.py
+++ b/moto/ssm/models.py
@@ -144,7 +144,7 @@ class SimpleSystemManagerBackend(BaseBackend):
     def send_command(self, **kwargs):
         instances = kwargs.get('InstanceIds', [])
         now = datetime.datetime.now()
-        expires_after = now + datetime.timedelta(0, int(kwargs['TimeoutSeconds']))
+        expires_after = now + datetime.timedelta(0, int(kwargs.get('TimeoutSeconds', 3600)))
         return {
             'Command': {
                 'CommandId': str(uuid.uuid4()),

--- a/tests/test_ssm/test_ssm_boto3.py
+++ b/tests/test_ssm/test_ssm_boto3.py
@@ -481,7 +481,6 @@ def test_send_command():
     response = client.send_command(
         InstanceIds=['i-123456'],
         DocumentName=ssm_document,
-        TimeoutSeconds=60,
         Parameters=params,
         OutputS3Region='us-east-2',
         OutputS3BucketName='the-bucket',


### PR DESCRIPTION
TimeoutSeconds isn't a required field so we can't rely on it being there.
Quick tests against the AWS API show that when it's not specified the ExpiresAfter field seems to be 1 hour after the request.

Closes https://github.com/spulec/moto/issues/1591