### PR TITLE
Implement describe_log_groups() method for CloudWatchLogs

### DIFF
--- a/moto/logs/responses.py
+++ b/moto/logs/responses.py
@@ -33,6 +33,18 @@ class LogsResponse(BaseResponse):
         self.logs_backend.delete_log_group(log_group_name)
         return ''
 
+    def describe_log_groups(self):
+        log_group_name_prefix = self._get_param('logGroupNamePrefix')
+        next_token = self._get_param('nextToken')
+        limit = self._get_param('limit', 50)
+        assert limit <= 50
+        groups, next_token = self.logs_backend.describe_log_groups(
+            limit, log_group_name_prefix, next_token)
+        return json.dumps({
+            "logGroups": groups,
+            "nextToken": next_token
+        })
+
     def create_log_stream(self):
         log_group_name = self._get_param('logGroupName')
         log_stream_name = self._get_param('logStreamName')

--- a/tests/test_logs/test_logs.py
+++ b/tests/test_logs/test_logs.py
@@ -13,6 +13,10 @@ def test_log_group_create():
     conn = boto3.client('logs', 'us-west-2')
     log_group_name = 'dummy'
     response = conn.create_log_group(logGroupName=log_group_name)
+
+    response = conn.describe_log_groups(logGroupNamePrefix=log_group_name)
+    assert len(response['logGroups']) == 1
+
     response = conn.delete_log_group(logGroupName=log_group_name)
 
 


### PR DESCRIPTION
### What's this patch?

This patch teaches `LogsResponse` class how to handle the DescribeLogGroups
request, so that we can mock out the `boto.describe_log_groups()` call.

With this change in place, we can write as below:

```python
@mock_logs
def test_log_group():
    conn = boto3.client('logs', 'us-west-2')

    some_method_to_init_log_groups()

    resp = conn.describe_log_groups(logGroupNamePrefix='myapp')
    assert ...
```

This should be fairly useful for a number of programs which handles
CloudWatchLogs.

### Note

The basic support this patch adds should solve #1554.