### PR TITLE
AWSServiceSpec: Fix `TypeError` exceptions within json.load()

### DIFF
--- a/moto/core/responses.py
+++ b/moto/core/responses.py
@@ -5,6 +5,7 @@ import datetime
 import json
 import logging
 import re
+import io
 
 import pytz
 from moto.core.exceptions import DryRunClientError
@@ -622,7 +623,7 @@ class AWSServiceSpec(object):
 
     def __init__(self, path):
         self.path = resource_filename('botocore', path)
-        with open(self.path, "rb") as f:
+        with io.open(self.path, 'r', encoding='utf-8') as f:
             spec = json.load(f)
         self.metadata = spec['metadata']
         self.operations = spec['operations']


### PR DESCRIPTION
### Problem

The load() method provided by the built-in JSON module does not accept a
byte-type value in Python 3.5 (or versions before), and will raise an exception
if one is passed.

Because of this reason, the current implementation can cause errors like below
depending on Python version in use:

```python
Traceback (most recent call last):
  ...
  File "/url/lib/python3.5/moto/moto/emr/responses.py", line 47, in ElasticMapReduceResponse
    aws_service_spec = AWSServiceSpec('data/emr/2009-03-31/service-2.json')
  File "/url/lib/python3.5/moto/moto/core/responses.py", line 626, in __init__
    spec = json.load(f)
  File "/usr/lib/python3.5/json/__init__.py", line 268, in load
    parse_constant=parse_constant, object_pairs_hook=object_pairs_hook, **kw)
  File "/usr/lib/python3.5/json/__init__.py", line 312, in loads
    s.__class__.__name__))
TypeError: the JSON object must be str, not 'bytes'
```

### Solution

For better compatibility, we'd better decode the content of the JSON file before
passing it to the parser, instead of letting the module to guess the encoding.