### PR TITLE
SQS add missing validation to ReceiveMessage

### DIFF
--- a/moto/sqs/responses.py
+++ b/moto/sqs/responses.py
@@ -338,6 +338,14 @@ class SQSResponse(BaseResponse):
         except TypeError:
             wait_time = queue.receive_message_wait_time_seconds
 
+        if wait_time < 0 or wait_time > 20:
+            return self._error(
+                "InvalidParameterValue",
+                "An error occurred (InvalidParameterValue) when calling "
+                "the ReceiveMessage operation: Value %s for parameter "
+                "WaitTimeSeconds is invalid. Reason: must be &lt;= 0 and "
+                "&gt;= 20 if provided." % wait_time)
+
         try:
             visibility_timeout = self._get_validated_visibility_timeout()
         except TypeError:

--- a/moto/sqs/responses.py
+++ b/moto/sqs/responses.py
@@ -325,6 +325,14 @@ class SQSResponse(BaseResponse):
         except TypeError:
             message_count = DEFAULT_RECEIVED_MESSAGES
 
+        if message_count < 1 or message_count > 10:
+            return self._error(
+                "InvalidParameterValue",
+                "An error occurred (InvalidParameterValue) when calling "
+                "the ReceiveMessage operation: Value %s for parameter "
+                "MaxNumberOfMessages is invalid. Reason: must be between "
+                "1 and 10, if provided." % message_count)
+
         try:
             wait_time = int(self.querystring.get("WaitTimeSeconds")[0])
         except TypeError:

--- a/tests/test_sqs/test_sqs.py
+++ b/tests/test_sqs/test_sqs.py
@@ -379,6 +379,21 @@ def test_send_receive_message_timestamps():
 
 
 @mock_sqs
+def test_max_number_of_messages_invalid_param():
+    sqs = boto3.resource('sqs', region_name='us-east-1')
+    queue = sqs.create_queue(QueueName='test-queue')
+
+    with assert_raises(ClientError):
+        queue.receive_messages(MaxNumberOfMessages=11)
+
+    with assert_raises(ClientError):
+        queue.receive_messages(MaxNumberOfMessages=0)
+
+    # no error but also no messages returned
+    queue.receive_messages(MaxNumberOfMessages=1, WaitTimeSeconds=0)
+
+
+@mock_sqs
 def test_receive_messages_with_wait_seconds_timeout_of_zero():
     """
     test that zero messages is returned with a wait_seconds_timeout of zero,

--- a/tests/test_sqs/test_sqs.py
+++ b/tests/test_sqs/test_sqs.py
@@ -394,6 +394,21 @@ def test_max_number_of_messages_invalid_param():
 
 
 @mock_sqs
+def test_wait_time_seconds_invalid_param():
+    sqs = boto3.resource('sqs', region_name='us-east-1')
+    queue = sqs.create_queue(QueueName='test-queue')
+
+    with assert_raises(ClientError):
+        queue.receive_messages(WaitTimeSeconds=-1)
+
+    with assert_raises(ClientError):
+        queue.receive_messages(WaitTimeSeconds=21)
+
+    # no error but also no messages returned
+    queue.receive_messages(WaitTimeSeconds=0)
+
+
+@mock_sqs
 def test_receive_messages_with_wait_seconds_timeout_of_zero():
     """
     test that zero messages is returned with a wait_seconds_timeout of zero,
@@ -405,20 +420,6 @@ def test_receive_messages_with_wait_seconds_timeout_of_zero():
     queue = sqs.create_queue(QueueName="blah")
 
     messages = queue.receive_messages(WaitTimeSeconds=0)
-    messages.should.equal([])
-
-
-@mock_sqs
-def test_receive_messages_with_wait_seconds_timeout_of_negative_one():
-    """
-    test that zero messages is returned with a wait_seconds_timeout of negative 1
-    :return:
-    """
-
-    sqs = boto3.resource('sqs', region_name='us-east-1')
-    queue = sqs.create_queue(QueueName="blah")
-
-    messages = queue.receive_messages(WaitTimeSeconds=-1)
     messages.should.equal([])
 
 


### PR DESCRIPTION
Motivation - I noticed that it was possible to fetch more than 10 messages from an SQS queue with moto, where as AWS enforces a limit of between 1 and 10. 

Also updated WaitTimeSeconds validation while I was near by.