### PR TITLE
adding reallocate address support eip

### DIFF
--- a/moto/ec2/models.py
+++ b/moto/ec2/models.py
@@ -3161,8 +3161,8 @@ class SpotFleetBackend(object):
 class ElasticAddress(object):
     def __init__(self, domain, reallocate_address=None):
         self.reallocate_address = reallocate_address
-        self.allocation_id = random_eip_allocation_id() if domain == "vpc" else None
         self.domain = domain
+        self.allocation_id = random_eip_allocation_id() if domain == "vpc" else None
         self.instance = None
         self.eni = None
         self.association_id = None

--- a/moto/ec2/models.py
+++ b/moto/ec2/models.py
@@ -3227,7 +3227,7 @@ class ElasticAddressBackend(object):
         self.addresses = []
         super(ElasticAddressBackend, self).__init__()
 
-    def allocate_address(self, domain, address=None):
+    def allocate_address(self, domain, address):
         if domain not in ['standard', 'vpc']:
             raise InvalidDomainError(domain)
         to_append_address = ElasticAddress(domain, address)

--- a/moto/ec2/models.py
+++ b/moto/ec2/models.py
@@ -3160,16 +3160,17 @@ class SpotFleetBackend(object):
 
 class ElasticAddress(object):
     def __init__(self, domain, reallocate_address=None):
-        if not self.reallocate_address:
-            self.public_ip = self.reallocate_address
-        else:
-            self.public_ip = random_ip()
-
+        self.reallocate_address = reallocate_address
         self.allocation_id = random_eip_allocation_id() if domain == "vpc" else None
         self.domain = domain
         self.instance = None
         self.eni = None
         self.association_id = None
+
+        if not self.reallocate_address:
+            self.public_ip = self.reallocate_address
+        else:
+            self.public_ip = random_ip()
 
     @classmethod
     def create_from_cloudformation_json(cls, resource_name, cloudformation_json, region_name):

--- a/moto/ec2/models.py
+++ b/moto/ec2/models.py
@@ -3159,9 +3159,7 @@ class SpotFleetBackend(object):
 
 
 class ElasticAddress(object):
-    def __init__(self, domain, **kwargs):
-        self.reallocate_address = kwargs.get("reallocate_address", None)
-
+    def __init__(self, domain, reallocate_address=None):
         if not self.reallocate_address:
             self.public_ip = self.reallocate_address
         else:
@@ -3228,10 +3226,9 @@ class ElasticAddressBackend(object):
         self.addresses = []
         super(ElasticAddressBackend, self).__init__()
 
-    def allocate_address(self, domain, **kwargs):
+    def allocate_address(self, domain, reallocate_address=None):
         if domain not in ['standard', 'vpc']:
             raise InvalidDomainError(domain)
-        reallocate_address = kwargs.get("reallocate_address", None)
         address = ElasticAddress(domain, reallocate_address)
         self.addresses.append(address)
         return address

--- a/moto/ec2/models.py
+++ b/moto/ec2/models.py
@@ -3159,8 +3159,8 @@ class SpotFleetBackend(object):
 
 
 class ElasticAddress(object):
-    def __init__(self, domain, reallocate_address):
-        self.reallocate_address = reallocate_address
+    def __init__(self, domain, **kwargs):
+        self.reallocate_address = kwargs.get("reallocate_address", None)
 
         if not self.reallocate_address:
             self.public_ip = self.reallocate_address
@@ -3228,11 +3228,11 @@ class ElasticAddressBackend(object):
         self.addresses = []
         super(ElasticAddressBackend, self).__init__()
 
-    def allocate_address(self, domain, reallocate_address):
+    def allocate_address(self, domain, **kwargs):
         if domain not in ['standard', 'vpc']:
             raise InvalidDomainError(domain)
-
-        address = ElasticAddress(domain)
+        reallocate_address = kwargs.get("reallocate_address", None)
+        address = ElasticAddress(domain, reallocate_address)
         self.addresses.append(address)
         return address
 

--- a/moto/ec2/models.py
+++ b/moto/ec2/models.py
@@ -3159,8 +3159,14 @@ class SpotFleetBackend(object):
 
 
 class ElasticAddress(object):
-    def __init__(self, domain):
-        self.public_ip = random_ip()
+    def __init__(self, domain, reallocate_address):
+        self.reallocate_address = reallocate_address
+
+        if not self.reallocate_address:
+            self.public_ip = self.reallocate_address
+        else:
+            self.public_ip = random_ip()
+
         self.allocation_id = random_eip_allocation_id() if domain == "vpc" else None
         self.domain = domain
         self.instance = None
@@ -3222,7 +3228,7 @@ class ElasticAddressBackend(object):
         self.addresses = []
         super(ElasticAddressBackend, self).__init__()
 
-    def allocate_address(self, domain):
+    def allocate_address(self, domain, reallocate_address):
         if domain not in ['standard', 'vpc']:
             raise InvalidDomainError(domain)
 

--- a/moto/ec2/models.py
+++ b/moto/ec2/models.py
@@ -3159,8 +3159,8 @@ class SpotFleetBackend(object):
 
 
 class ElasticAddress(object):
-    def __init__(self, domain, reallocate_address=None):
-        self.reallocate_address = reallocate_address
+    def __init__(self, domain, address=None):
+        self.reallocate_address = address
         self.domain = domain
         self.allocation_id = random_eip_allocation_id() if domain == "vpc" else None
         self.instance = None
@@ -3227,12 +3227,12 @@ class ElasticAddressBackend(object):
         self.addresses = []
         super(ElasticAddressBackend, self).__init__()
 
-    def allocate_address(self, domain, reallocate_address=None):
+    def allocate_address(self, domain, address=None):
         if domain not in ['standard', 'vpc']:
             raise InvalidDomainError(domain)
-        address = ElasticAddress(domain, reallocate_address)
-        self.addresses.append(address)
-        return address
+        to_append_address = ElasticAddress(domain, address)
+        self.addresses.append(to_append_address)
+        return to_append_address
 
     def address_by_ip(self, ips):
         eips = [address for address in self.addresses

--- a/moto/ec2/models.py
+++ b/moto/ec2/models.py
@@ -3230,7 +3230,7 @@ class ElasticAddressBackend(object):
     def allocate_address(self, domain, address=None):
         if domain not in ['standard', 'vpc']:
             raise InvalidDomainError(domain)
-        to_append_address = ElasticAddress(self, domain=domain, address=address)
+        to_append_address = ElasticAddress(domain=domain, address=address)
         self.addresses.append(to_append_address)
         return to_append_address
 

--- a/moto/ec2/models.py
+++ b/moto/ec2/models.py
@@ -3227,10 +3227,10 @@ class ElasticAddressBackend(object):
         self.addresses = []
         super(ElasticAddressBackend, self).__init__()
 
-    def allocate_address(self, domain, address):
+    def allocate_address(self, domain, address=None):
         if domain not in ['standard', 'vpc']:
             raise InvalidDomainError(domain)
-        to_append_address = ElasticAddress(domain, address)
+        to_append_address = ElasticAddress(self, domain=domain, address=address)
         self.addresses.append(to_append_address)
         return to_append_address
 

--- a/moto/ec2/responses/elastic_ip_addresses.py
+++ b/moto/ec2/responses/elastic_ip_addresses.py
@@ -9,7 +9,7 @@ class ElasticIPAddresses(BaseResponse):
         domain = self._get_param('Domain', if_none='standard')
         reallocate_address = self._get_param('Address', if_none=None)
         if self.is_not_dryrun('AllocateAddress'):
-            address = self.ec2_backend.allocate_address(domain, reallocate_address)
+            address = self.ec2_backend.allocate_address(domain, address=reallocate_address)
             template = self.response_template(ALLOCATE_ADDRESS_RESPONSE)
             return template.render(address=address)
 

--- a/moto/ec2/responses/elastic_ip_addresses.py
+++ b/moto/ec2/responses/elastic_ip_addresses.py
@@ -7,8 +7,9 @@ class ElasticIPAddresses(BaseResponse):
 
     def allocate_address(self):
         domain = self._get_param('Domain', if_none='standard')
+        reallocate_address = self._get_param('Address', if_none=None)
         if self.is_not_dryrun('AllocateAddress'):
-            address = self.ec2_backend.allocate_address(domain)
+            address = self.ec2_backend.allocate_address(domain, reallocate_address)
             template = self.response_template(ALLOCATE_ADDRESS_RESPONSE)
             return template.render(address=address)
 

--- a/moto/ec2/responses/elastic_ip_addresses.py
+++ b/moto/ec2/responses/elastic_ip_addresses.py
@@ -9,7 +9,8 @@ class ElasticIPAddresses(BaseResponse):
         domain = self._get_param('Domain', if_none='standard')
         reallocate_address = self._get_param('Address', if_none=None)
         if self.is_not_dryrun('AllocateAddress'):
-            address = self.ec2_backend.allocate_address(domain, address=reallocate_address)
+            address = self.ec2_backend.allocate_address(domain=domain,
+                                                        address=reallocate_address)
             template = self.response_template(ALLOCATE_ADDRESS_RESPONSE)
             return template.render(address=address)
 

--- a/tests/test_ec2/test_elastic_ip_addresses.py
+++ b/tests/test_ec2/test_elastic_ip_addresses.py
@@ -60,6 +60,11 @@ def test_eip_allocate_vpc():
     vpc.should.be.a(boto.ec2.address.Address)
     vpc.domain.should.be.equal("vpc")
     logging.debug("vpc alloc_id:".format(vpc.allocation_id))
+
+    vpc = conn.allocate_address(domain="vpc", address="127.234.30.1")
+    vpc.should.be.a(boto.ec2.address.Address)
+    vpc.public_ip.should.be.equal("127.234.30.1")
+    logging.debug("vpc public_id:".format(vpc.public_ip))
     vpc.release()
 
 

--- a/tests/test_ec2/test_elastic_ip_addresses.py
+++ b/tests/test_ec2/test_elastic_ip_addresses.py
@@ -61,7 +61,7 @@ def test_eip_allocate_vpc():
     vpc.domain.should.be.equal("vpc")
     logging.debug("vpc alloc_id:".format(vpc.allocation_id))
 
-    vpc = conn.allocate_address(domain="vpc", address="127.234.30.1")
+    vpc = conn.allocate_address(domain="vpc", reallocate_address="127.234.30.1")
     vpc.should.be.a(boto.ec2.address.Address)
     vpc.public_ip.should.be.equal("127.234.30.1")
     logging.debug("vpc public_id:".format(vpc.public_ip))

--- a/tests/test_ec2/test_elastic_ip_addresses.py
+++ b/tests/test_ec2/test_elastic_ip_addresses.py
@@ -61,7 +61,7 @@ def test_eip_allocate_vpc():
     vpc.domain.should.be.equal("vpc")
     logging.debug("vpc alloc_id:".format(vpc.allocation_id))
 
-    vpc = conn.allocate_address(domain="vpc", reallocate_address="127.234.30.1")
+    vpc = conn.allocate_address(domain="vpc", address="127.234.30.1")
     vpc.should.be.a(boto.ec2.address.Address)
     vpc.public_ip.should.be.equal("127.234.30.1")
     logging.debug("vpc public_id:".format(vpc.public_ip))


### PR DESCRIPTION
Usage:

from boto3 docs:
```
response = client.allocate_address(
    Domain='vpc'|'standard',
    #Adding support for address 
    Address='string', 
    DryRun=True|False
)
```
```
Address (string) -- [EC2-VPC] The Elastic IP address to recover. <-- adding support for this.
```
We will just assume the address is available for recovery.
