### PR TITLE
Issue 1615 - missing Value should not kill put_metric_data

### DIFF
--- a/moto/cloudwatch/models.py
+++ b/moto/cloudwatch/models.py
@@ -230,7 +230,7 @@ class CloudWatchBackend(BaseBackend):
     def put_metric_data(self, namespace, metric_data):
         for metric_member in metric_data:
             self.metric_data.append(MetricDatum(
-                namespace, metric_member['MetricName'], float(metric_member['Value']), metric_member.get('Dimensions.member', _EMPTY_LIST), metric_member.get('Timestamp')))
+                namespace, metric_member['MetricName'], float(metric_member.get('Value', 0)), metric_member.get('Dimensions.member', _EMPTY_LIST), metric_member.get('Timestamp')))
 
     def get_metric_statistics(self, namespace, metric_name, start_time, end_time, period, stats):
         period_delta = timedelta(seconds=period)

--- a/tests/test_cloudwatch/test_cloudwatch_boto3.py
+++ b/tests/test_cloudwatch/test_cloudwatch_boto3.py
@@ -162,6 +162,37 @@ def test_put_metric_data_no_dimensions():
     metric['MetricName'].should.equal('metric')
 
 
+
+@mock_cloudwatch
+def test_put_metric_data_with_statistics():
+    conn = boto3.client('cloudwatch', region_name='us-east-1')
+
+    conn.put_metric_data(
+        Namespace='tester',
+        MetricData=[
+            dict(
+                MetricName='statmetric',
+                Timestamp=datetime(2015, 1, 1),
+                # no Value to test  https://github.com/spulec/moto/issues/1615
+                StatisticValues=dict(
+                    SampleCount=123.0,
+                    Sum=123.0,
+                    Minimum=123.0,
+                    Maximum=123.0
+                ),
+                Unit='Milliseconds',
+                StorageResolution=123
+            )
+        ]
+    )
+
+    metrics = conn.list_metrics()['Metrics']
+    metrics.should.have.length_of(1)
+    metric = metrics[0]
+    metric['Namespace'].should.equal('tester')
+    metric['MetricName'].should.equal('statmetric')
+    # TODO: test statistics - https://github.com/spulec/moto/issues/1615
+
 @mock_cloudwatch
 def test_get_metric_statistics():
     conn = boto3.client('cloudwatch', region_name='us-east-1')


### PR DESCRIPTION
While this doesn't implement statistics, it should stop `put_metric_data` from erroring on a `KeyValue` when the `Value` attribute is missing.  

Issue: https://github.com/spulec/moto/issues/1615