### PR TITLE
Accept paths to user-controlled SSL cert

### DIFF
--- a/moto/server.py
+++ b/moto/server.py
@@ -186,9 +186,18 @@ def main(argv=sys.argv[1:]):
     parser.add_argument(
         '-s', '--ssl',
         action='store_true',
-        help='Enable SSL encrypted connection (use https://... URL)',
+        help='Enable SSL encrypted connection with auto-generated certificate (use https://... URL)',
         default=False
     )
+    parser.add_argument(
+        '-c', '--ssl-cert', type=str,
+        help='Path to SSL certificate',
+        default=None)
+    parser.add_argument(
+        '-k', '--ssl-key', type=str,
+        help='Path to SSL private key',
+        default=None)
+
 
     args = parser.parse_args(argv)
 
@@ -197,9 +206,15 @@ def main(argv=sys.argv[1:]):
         create_backend_app, service=args.service)
     main_app.debug = True
 
+    ssl_context = None
+    if args.ssl_key and args.ssl_cert:
+        ssl_context = (args.ssl_cert, args.ssl_key)
+    elif args.ssl:
+        ssl_context = 'adhoc'
+
     run_simple(args.host, args.port, main_app,
                threaded=True, use_reloader=args.reload,
-               ssl_context='adhoc' if args.ssl else None)
+               ssl_context=ssl_context)
 
 
 if __name__ == '__main__':

--- a/moto/server.py
+++ b/moto/server.py
@@ -198,7 +198,6 @@ def main(argv=sys.argv[1:]):
         help='Path to SSL private key',
         default=None)
 
-
     args = parser.parse_args(argv)
 
     # Wrap the main application


### PR DESCRIPTION
This PR makes it so the user can control the SSL certificate used by moto_server. This is particularly useful to whitelist the certificate when writing blackbox tests: for example, being able to pass in an `AWS_CA_BUNDLE` for boto, or `REQUESTS_CA_BUNDLE` for requests, which points at your self-signed certificate.

The existing behavior is unchanged: run with an auto-generated SSL certificate by doing
```
$ moto_server --ssl
```

Now you can alternately specify the certificate and private key files:
```
$ moto_server --ssl-key key.pem --ssl-cert cert.pem
```

