### PR TITLE
Allow dashes, underscores in SNS topic creates for first/last characters

### DIFF
--- a/moto/sns/models.py
+++ b/moto/sns/models.py
@@ -240,7 +240,7 @@ class SNSBackend(BaseBackend):
         self.sms_attributes.update(attrs)
 
     def create_topic(self, name):
-        fails_constraints = not re.match(r'^[a-zA-Z0-9\_\-]{0,256}$', name)
+        fails_constraints = not re.match(r'^[a-zA-Z0-9_-]{0,256}$', name)
         if fails_constraints:
             raise InvalidParameterValue("Topic names must be made up of only uppercase and lowercase ASCII letters, numbers, underscores, and hyphens, and must be between 1 and 256 characters long.")
         candidate_topic = Topic(name, self)

--- a/moto/sns/models.py
+++ b/moto/sns/models.py
@@ -240,7 +240,7 @@ class SNSBackend(BaseBackend):
         self.sms_attributes.update(attrs)
 
     def create_topic(self, name):
-        fails_constraints = not re.match(r'^[a-zA-Z0-9_-]{0,256}$', name)
+        fails_constraints = not re.match(r'^[a-zA-Z0-9_-]{1,256}$', name)
         if fails_constraints:
             raise InvalidParameterValue("Topic names must be made up of only uppercase and lowercase ASCII letters, numbers, underscores, and hyphens, and must be between 1 and 256 characters long.")
         candidate_topic = Topic(name, self)

--- a/moto/sns/models.py
+++ b/moto/sns/models.py
@@ -240,7 +240,7 @@ class SNSBackend(BaseBackend):
         self.sms_attributes.update(attrs)
 
     def create_topic(self, name):
-        fails_constraints = not re.match(r'^[a-zA-Z0-9](?:[A-Za-z0-9_-]{0,253}[a-zA-Z0-9])?$', name)
+        fails_constraints = not re.match(r'^[a-zA-Z0-9\_\-]{0,256}$', name)
         if fails_constraints:
             raise InvalidParameterValue("Topic names must be made up of only uppercase and lowercase ASCII letters, numbers, underscores, and hyphens, and must be between 1 and 256 characters long.")
         candidate_topic = Topic(name, self)

--- a/tests/test_sns/test_topics_boto3.py
+++ b/tests/test_sns/test_topics_boto3.py
@@ -13,23 +13,24 @@ from moto.sns.models import DEFAULT_TOPIC_POLICY, DEFAULT_EFFECTIVE_DELIVERY_POL
 @mock_sns
 def test_create_and_delete_topic():
     conn = boto3.client("sns", region_name="us-east-1")
-    conn.create_topic(Name="some-topic")
+    for topic_name in ('some-topic', '-some-topic-', '_some-topic_', 'a' * 256):
+        conn.create_topic(Name=topic_name)
 
-    topics_json = conn.list_topics()
-    topics = topics_json["Topics"]
-    topics.should.have.length_of(1)
-    topics[0]['TopicArn'].should.equal(
-        "arn:aws:sns:{0}:123456789012:some-topic"
-        .format(conn._client_config.region_name)
-    )
+        topics_json = conn.list_topics()
+        topics = topics_json["Topics"]
+        topics.should.have.length_of(1)
+        topics[0]['TopicArn'].should.equal(
+            "arn:aws:sns:{0}:123456789012:{1}"
+            .format(conn._client_config.region_name, topic_name)
+        )
 
-    # Delete the topic
-    conn.delete_topic(TopicArn=topics[0]['TopicArn'])
+        # Delete the topic
+        conn.delete_topic(TopicArn=topics[0]['TopicArn'])
 
-    # And there should now be 0 topics
-    topics_json = conn.list_topics()
-    topics = topics_json["Topics"]
-    topics.should.have.length_of(0)
+        # And there should now be 0 topics
+        topics_json = conn.list_topics()
+        topics = topics_json["Topics"]
+        topics.should.have.length_of(0)
 
 @mock_sns
 def test_create_topic_should_be_indempodent():


### PR DESCRIPTION
This change updates the regex to simply `^[a-zA-Z0-9_-]{1,256}$` as AWS does not have prohibitions against starting/ending the topic name with underscores and/or dashes.

Fixes #1619 