### PR TITLE
Support assignment of nested attributes if only the topmost value exists

### DIFF
--- a/moto/dynamodb2/models.py
+++ b/moto/dynamodb2/models.py
@@ -176,16 +176,17 @@ class Item(BaseModel):
                         key_parts = key.split('.')
                         attr = key_parts.pop(0)
                         if attr not in self.attrs:
-                            raise ValueError()
+                            raise ValueError
 
                         last_val = self.attrs[attr].value
                         for key_part in key_parts:
                             # Hack but it'll do, traverses into a dict
-                            if list(last_val.keys())[0] == 'M':
-                                last_val = last_val['M']
+                            last_val_type = list(last_val.keys())
+                            if last_val_type and last_val_type[0] == 'M':
+                                    last_val = last_val['M']
 
                             if key_part not in last_val:
-                                raise ValueError()
+                                last_val[key_part] = {'M': {}}
 
                             last_val = last_val[key_part]
 

--- a/tests/test_dynamodb2/test_dynamodb.py
+++ b/tests/test_dynamodb2/test_dynamodb.py
@@ -1053,7 +1053,7 @@ def test_query_missing_expr_names():
 @mock_dynamodb2
 def test_update_item_on_map():
     dynamodb = boto3.resource('dynamodb', region_name='us-east-1')
-    client = boto3.client('dynamodb')
+    client = boto3.client('dynamodb', region_name='us-east-1')
 
     # Create the DynamoDB table.
     dynamodb.create_table(


### PR DESCRIPTION
To mirror behavior of actual dynamodb as demonstrated as follows:

```
>>> item = client.get_item(TableName=os.getenv('DB_TABLE'), Key={'request_id': {'S':'test_request'}})
>>> item['Item']['myexistingattr']
{'M': {'existingkey': {'S': 'thing'}}}
>>> client.update_item(Key={'request_id': {'S':'test_request'}}, TableName=(os.getenv('DB_TABLE')), UpdateExpression='SET myexistingattr.#newkey=:newvalue', ExpressionAttributeNames={'#newkey': 'newkey'}, ExpressionAttributeValues={':newvalue': {'S': 'newvalue'}})
{'ResponseMetadata': {'RequestId': '98AILFCCDKGSMCAUCLO7EC9DGRVV4KQNSO5AEMVJF66Q9ASUAAJG', 'HTTPStatusCode': 200, 'HTTPHeaders': {'server': 'Server', 'date': 'Tue, 08 May 2018 09:19:54 GMT', 'content-type': 'application/x-amz-json-1.0', 'content-length': '2', 'connection': 'keep-alive', 'x-amzn-requestid': '98AILFCCDKGSMCAUCLO7EC9DGRVV4KQNSO5AEMVJF66Q9ASUAAJG', 'x-amz-crc32': '2745614147'}, 'RetryAttempts': 0}}
>>> item = client.get_item(TableName=os.getenv('DB_TABLE'), Key={'request_id': {'S':'test_request'}})
>>> item['Item']['myexistingattr']
{'M': {'existingkey': {'S': 'thing'}, 'newkey': {'S': 'newvalue'}}}
>>> 
```

Leaving parent attribute validator in place because parent attribute is validated regardless of escaping the name:
```
>>> client.update_item(Key={'request_id': {'S':'test_request'}}, TableName=(os.getenv('DB_TABLE')), UpdateExpression='SET #mynonexistentattr.#newkey=:newvalue', ExpressionAttributeNames={'#mynonexistentattr': 'mynonexistentattr', '#newkey': 'newkey'}, ExpressionAttributeValues={':newvalue': {'S': 'newvalue'}})
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/Mau/Library/Python/3.6/lib/python/site-packages/botocore/client.py", line 314, in _api_call
    return self._make_api_call(operation_name, kwargs)
  File "/Users/Mau/Library/Python/3.6/lib/python/site-packages/botocore/client.py", line 612, in _make_api_call
    raise error_class(parsed_response, operation_name)
botocore.exceptions.ClientError: An error occurred (ValidationException) when calling the UpdateItem operation: The document path provided in the update expression is invalid for update
```

Fixes issue #1628 