### PR TITLE
New line in LaunchConfigurationARN

### DIFF
--- a/moto/autoscaling/responses.py
+++ b/moto/autoscaling/responses.py
@@ -516,8 +516,7 @@ DESCRIBE_AUTOSCALING_GROUPS_TEMPLATE = """<DescribeAutoScalingGroupsResponse xml
         {% endif %}
         <HealthCheckGracePeriod>{{ group.health_check_period }}</HealthCheckGracePeriod>
         <DefaultCooldown>{{ group.default_cooldown }}</DefaultCooldown>
-        <AutoScalingGroupARN>arn:aws:autoscaling:us-east-1:803981987763:autoScalingGroup:ca861182-c8f9-4ca7-b1eb-cd35505f5ebb
-        :autoScalingGroupName/{{ group.name }}</AutoScalingGroupARN>
+        <AutoScalingGroupARN>arn:aws:autoscaling:us-east-1:803981987763:autoScalingGroup:ca861182-c8f9-4ca7-b1eb-cd35505f5ebb:autoScalingGroupName/{{ group.name }}</AutoScalingGroupARN>
         {% if group.termination_policies %}
         <TerminationPolicies>
           {% for policy in group.termination_policies %}

--- a/moto/autoscaling/responses.py
+++ b/moto/autoscaling/responses.py
@@ -320,8 +320,7 @@ DESCRIBE_LAUNCH_CONFIGURATIONS_TEMPLATE = """<DescribeLaunchConfigurationsRespon
             <UserData/>
           {% endif %}
           <InstanceType>{{ launch_configuration.instance_type }}</InstanceType>
-          <LaunchConfigurationARN>arn:aws:autoscaling:us-east-1:803981987763:launchConfiguration:
-          9dbbbf87-6141-428a-a409-0752edbe6cad:launchConfigurationName/{{ launch_configuration.name }}</LaunchConfigurationARN>
+          <LaunchConfigurationARN>arn:aws:autoscaling:us-east-1:803981987763:launchConfiguration:9dbbbf87-6141-428a-a409-0752edbe6cad:launchConfigurationName/{{ launch_configuration.name }}</LaunchConfigurationARN>
           {% if launch_configuration.block_device_mappings %}
             <BlockDeviceMappings>
             {% for mount_point, mapping in launch_configuration.block_device_mappings.items() %}


### PR DESCRIPTION
The statement that defines LaunchConfigurationARN had a newline and whitespace prefix

The ARN reported in describe_launch_configurations has this newline and white space.
Arns should not have whitespace or newlines!

    import boto3,json
    from moto import mock_autoscaling
    from six import string_types
    
    
    
    mock = mock_autoscaling()
    mock.start()
    
    moto_autoscaling = boto3.client('autoscaling')
    
    moto_lc = moto_autoscaling.create_launch_configuration(
        LaunchConfigurationName="test-lc",
        ImageId="ami-12345678",
        SecurityGroups=["sg-12345678"]
    )
    
    arn = moto_autoscaling.describe_launch_configurations(LaunchConfigurationNames=["test-lc"])['LaunchConfigurations'][0]['LaunchConfigurationARN']
    
    print arn
    if ' ' in arn:
      print "Has spaces"
    
    if '\n' in arn:
      print "Has newline"
      
    


This code returns:

    arn:aws:autoscaling:us-east-1:803981987763:launchConfiguration:
              9dbbbf87-6141-428a-a409-0752edbe6cad:launchConfigurationName/test-lc
    Has spaces
    Has newline


what me would expect to see:

    arn:aws:autoscaling:us-east-1:803981987763:launchConfiguration:9dbbbf87-6141-428a-a409-0752edbe6cad:launchConfigurationName/test-lc
