### PR TITLE
Sanitizing ETag before comparison

### DIFF
--- a/moto/s3/models.py
+++ b/moto/s3/models.py
@@ -172,11 +172,11 @@ class FakeMultipart(BaseModel):
         count = 0
         for pn, etag in body:
             part = self.parts.get(pn)
-            if part is None or part.etag != etag:
+            part_etag = part.etag.replace('"', '')
+            if part is None or part_etag != etag:
                 raise InvalidPart()
             if last is not None and len(last.value) < UPLOAD_PART_MIN_SIZE:
                 raise EntityTooSmall()
-            part_etag = part.etag.replace('"', '')
             md5s.extend(decode_hex(part_etag)[0])
             total.extend(part.value)
             last = part


### PR DESCRIPTION
Moved the stripping of the quotes before the checking of the content of the `etag` vs the stored `part.etag`.

There is a strangeness in the comparison between the received and stored etag. RFC tells us that an etag should always have double quotes surrounding it, but moto accepts both versions, and just works with this, happily. I assume this doesn't triggers that many times, as these etags are mainly generated by the same client-software, and will be always the same (either with or without quotes). Nonetheless, this should be addressed - either by rejecting none-quoted etags, or by cleaning the code to work consistent (always add/strip them internally, and emit the correct format - working with weak etags might be a problem here).

For us we fixed it by making this little change, and moving the etag-quote-stripping a bit earlier in the process. 

The use case was actually Evaporate.JS.