### PR TITLE
Add RawMessageDelivery for SNS subscriptions (fixes #1571)

### DIFF
--- a/moto/sns/models.py
+++ b/moto/sns/models.py
@@ -94,7 +94,10 @@ class Subscription(BaseModel):
         if self.protocol == 'sqs':
             queue_name = self.endpoint.split(":")[-1]
             region = self.endpoint.split(":")[3]
-            enveloped_message = json.dumps(self.get_post_data(message, message_id, subject, message_attributes=message_attributes), sort_keys=True, indent=2, separators=(',', ': '))
+            if self.attributes.get('RawMessageDelivery') != 'true':
+                enveloped_message = json.dumps(self.get_post_data(message, message_id, subject, message_attributes=message_attributes), sort_keys=True, indent=2, separators=(',', ': '))
+            else:
+                enveloped_message = message
             sqs_backends[region].send_message(queue_name, enveloped_message)
         elif self.protocol in ['http', 'https']:
             post_data = self.get_post_data(message, message_id, subject)

--- a/tests/test_sns/test_publishing_boto3.py
+++ b/tests/test_sns/test_publishing_boto3.py
@@ -44,6 +44,29 @@ def test_publish_to_sqs():
 
 @mock_sqs
 @mock_sns
+def test_publish_to_sqs_raw():
+    sns = boto3.resource('sns', region_name='us-east-1')
+    topic = sns.create_topic(Name='some-topic')
+
+    sqs = boto3.resource('sqs', region_name='us-east-1')
+    queue = sqs.create_queue(QueueName='test-queue')
+
+    subscription = topic.subscribe(
+        Protocol='sqs', Endpoint=queue.attributes['QueueArn'])
+
+    subscription.set_attributes(
+        AttributeName='RawMessageDelivery', AttributeValue='true')
+
+    message = 'my message'
+    with freeze_time("2015-01-01 12:00:00"):
+        topic.publish(Message=message)
+
+    messages = queue.receive_messages(MaxNumberOfMessages=1)
+    messages[0].body.should.equal(message)
+
+
+@mock_sqs
+@mock_sns
 def test_publish_to_sqs_bad():
     conn = boto3.client('sns', region_name='us-east-1')
     conn.create_topic(Name="some-topic")


### PR DESCRIPTION
Currently, `RawMessageDelivery` is assumed to be `false` for all calls to `Subscription.publish`. This PR adds a check and skips the envelope if it is given.