### PR TITLE
Change SNS HTTP headers to actual setting

### DIFF
--- a/moto/sns/models.py
+++ b/moto/sns/models.py
@@ -101,7 +101,7 @@ class Subscription(BaseModel):
             sqs_backends[region].send_message(queue_name, enveloped_message)
         elif self.protocol in ['http', 'https']:
             post_data = self.get_post_data(message, message_id, subject)
-            requests.post(self.endpoint, json=post_data)
+            requests.post(self.endpoint, json=post_data, headers={'Content-Type': 'text/plain; charset=UTF-8'})
         elif self.protocol == 'lambda':
             # TODO: support bad function name
             # http://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html

--- a/tests/test_sns/test_publishing_boto3.py
+++ b/tests/test_sns/test_publishing_boto3.py
@@ -253,7 +253,7 @@ def test_publish_to_sqs_in_different_region():
 @mock_sns
 def test_publish_to_http():
     def callback(request):
-        request.headers["Content-Type"].should.equal("application/json")
+        request.headers["Content-Type"].should.equal("text/plain; charset=UTF-8")
         json.loads.when.called_with(
             request.body.decode()
         ).should_not.throw(Exception)


### PR DESCRIPTION
I found different HTTP headers between moto SNS and actual AWS SNS environment.
It may cause production environment not working but working in testing environment
in some situation (e.g : HTTP servers parse header to identify format from AWS).

SNS should send JSON format but HTTP headers in `Content-Type` should not be `application/json`.
It should be `text/plain; charset=UTF-8`.

Related: #1027 

Reference
Sending Amazon SNS Messages to HTTP/HTTPS Endpoints
https://docs.aws.amazon.com/sns/latest/dg/SendMessageToHttp.html
Appendix: Message and JSON Formats - HTTP/HTTPS Headers
https://docs.aws.amazon.com/sns/latest/dg/json-formats.html#http-header