### PR TITLE
Make dynamodb table indexes a list

### DIFF
--- a/moto/dynamodb2/models.py
+++ b/moto/dynamodb2/models.py
@@ -706,7 +706,9 @@ class DynamoDBBackend(BaseBackend):
 
                 gsis_by_name[gsi_to_create['IndexName']] = gsi_to_create
 
-        table.global_indexes = gsis_by_name.values()
+        # in python 3.6, dict.values() returns a dict_values object, but we expect it to be a list in other
+        # parts of the codebase
+        table.global_indexes = list(gsis_by_name.values())
         return table
 
     def put_item(self, table_name, item_attrs, expected=None, overwrite=False):

--- a/tests/test_dynamodb2/test_dynamodb.py
+++ b/tests/test_dynamodb2/test_dynamodb.py
@@ -6,7 +6,6 @@ import boto3
 from boto3.dynamodb.conditions import Attr
 import sure  # noqa
 import requests
-from pytest import raises
 from moto import mock_dynamodb2, mock_dynamodb2_deprecated
 from moto.dynamodb2 import dynamodb_backend2
 from boto.exception import JSONResponseError
@@ -1119,7 +1118,7 @@ def test_update_item_on_map():
     })
 
     # Test nested value for a nonexistent attribute.
-    with raises(client.exceptions.ConditionalCheckFailedException):
+    with assert_raises(client.exceptions.ConditionalCheckFailedException):
         table.update_item(Key={
             'forum_name': 'the-key',
             'subject': '123'


### PR DESCRIPTION
When you create a global index via the table resource `update` command, it was getting stored as a `dict_values` object, but most of the codebase expected a list.

I added a test and fixed the problem.

I also fixed an invalid import of pytest - as reported in #1674, travis isn't running the `test_dynamodb2` tests, so this import error was not caught.  I'm not sure why travis isn't running those tests, nor do I know what other tests it is missing.