### PR TITLE
Add support for CloudFormation Fn::GetAtt to KMS Key

### DIFF
--- a/moto/kms/models.py
+++ b/moto/kms/models.py
@@ -58,6 +58,12 @@ class Key(BaseModel):
 
         return key
 
+    def get_cfn_attribute(self, attribute_name):
+        from moto.cloudformation.exceptions import UnformattedGetAttTemplateException
+        if attribute_name == 'Arn':
+            return self.arn
+        raise UnformattedGetAttTemplateException()
+
 
 class KmsBackend(BaseBackend):
 

--- a/tests/test_cloudformation/fixtures/kms_key.py
+++ b/tests/test_cloudformation/fixtures/kms_key.py
@@ -1,0 +1,39 @@
+from __future__ import unicode_literals
+
+template = {
+    "AWSTemplateFormatVersion": "2010-09-09",
+
+    "Description": "AWS CloudFormation Sample Template to create a KMS Key.  The Fn::GetAtt is used to retrieve the ARN",
+
+    "Resources" : {
+        "myKey" : {
+            "Type" : "AWS::KMS::Key",
+            "Properties" : {
+                "Description": "Sample KmsKey",
+                "EnableKeyRotation": False,
+                "Enabled": True,
+                "KeyPolicy" : {
+                    "Version": "2012-10-17",
+                    "Id": "key-default-1",
+                    "Statement": [
+                        {
+                        "Sid": "Enable IAM User Permissions",
+                        "Effect": "Allow",
+                        "Principal": {
+                            "AWS": { "Fn::Join" : ["" , ["arn:aws:iam::", {"Ref" : "AWS::AccountId"} ,":root" ]] }
+                        },
+                        "Action": "kms:*",
+                        "Resource": "*"
+                        }
+                    ]
+                }
+            }
+        }
+    },
+    "Outputs" : {
+        "KeyArn" : {
+            "Description": "Generated Key Arn",
+            "Value" : { "Fn::GetAtt" : [ "myKey", "Arn" ] }
+        }
+    }
+}

--- a/tests/test_cloudformation/test_stack_parsing.py
+++ b/tests/test_cloudformation/test_stack_parsing.py
@@ -254,6 +254,21 @@ def test_parse_stack_with_get_attribute_outputs():
     output.should.be.a(Output)
     output.value.should.equal("my-queue")
 
+def test_parse_stack_with_get_attribute_kms():
+    from .fixtures.kms_key import template
+
+    template_json = json.dumps(template)
+    stack = FakeStack(
+        stack_id="test_id",
+        name="test_stack",
+        template=template_json,
+        parameters={},
+        region_name='us-west-1')
+
+    stack.output_map.should.have.length_of(1)
+    list(stack.output_map.keys())[0].should.equal('KeyArn')
+    output = list(stack.output_map.values())[0]
+    output.should.be.a(Output)
 
 def test_parse_stack_with_get_availability_zones():
     stack = FakeStack(


### PR DESCRIPTION
This PR adds support for using Fn:GetAtt in CloudFormation templates referencing a KMS Key.

Example CloudFormation template
```
{
    "AWSTemplateFormatVersion": "2010-09-09",

    "Description": "AWS CloudFormation Sample Template to create a KMS Key.  The Fn::GetAtt is used to retrieve the ARN",

    "Resources" : {
        "myKey" : {
            "Type" : "AWS::KMS::Key",
            "Properties" : {
                "Description": "Sample KmsKey",
                "EnableKeyRotation": False,
                "Enabled": True,
                "KeyPolicy" : {
                    "Version": "2012-10-17",
                    "Id": "key-default-1",
                    "Statement": [
                        {
                        "Sid": "Enable IAM User Permissions",
                        "Effect": "Allow",
                        "Principal": {
                            "AWS": { "Fn::Join" : ["" , ["arn:aws:iam::", {"Ref" : "AWS::AccountId"} ,":root" ]] }
                        },
                        "Action": "kms:*",
                        "Resource": "*"
                        }
                    ]
                }
            }
        }
    },
    "Outputs" : {
        "KeyArn" : {
            "Description": "Generated Key Arn",
            "Value" : { "Fn::GetAtt" : [ "myKey", "Arn" ] }
        }
    }
}
```