### PR TITLE
WIP: Support Route53 alias records

### DIFF
--- a/moto/route53/models.py
+++ b/moto/route53/models.py
@@ -85,6 +85,7 @@ class RecordSet(BaseModel):
         self.health_check = kwargs.get('HealthCheckId')
         self.hosted_zone_name = kwargs.get('HostedZoneName')
         self.hosted_zone_id = kwargs.get('HostedZoneId')
+        self.alias_target = kwargs.get('AliasTarget')
 
     @classmethod
     def create_from_cloudformation_json(cls, resource_name, cloudformation_json, region_name):
@@ -143,6 +144,13 @@ class RecordSet(BaseModel):
                 {% if record_set.ttl %}
                     <TTL>{{ record_set.ttl }}</TTL>
                 {% endif %}
+                {% if record_set.alias_target %}
+                <AliasTarget>
+                    <HostedZoneId>{{ record_set.alias_target['HostedZoneId'] }}</HostedZoneId>
+                    <DNSName>{{ record_set.alias_target['DNSName'] }}</DNSName>
+                    <EvaluateTargetHealth>{{ record_set.alias_target['EvaluateTargetHealth'] }}</EvaluateTargetHealth>
+                </AliasTarget>
+                {% else %}
                 <ResourceRecords>
                     {% for record in record_set.records %}
                     <ResourceRecord>
@@ -150,6 +158,7 @@ class RecordSet(BaseModel):
                     </ResourceRecord>
                     {% endfor %}
                 </ResourceRecords>
+                {% endif %}
                 {% if record_set.health_check %}
                     <HealthCheckId>{{ record_set.health_check }}</HealthCheckId>
                 {% endif %}

--- a/moto/route53/models.py
+++ b/moto/route53/models.py
@@ -150,7 +150,7 @@ class RecordSet(BaseModel):
                     <DNSName>{{ record_set.alias_target['DNSName'] }}</DNSName>
                     <EvaluateTargetHealth>{{ record_set.alias_target['EvaluateTargetHealth'] }}</EvaluateTargetHealth>
                 </AliasTarget>
-                {% else %}
+                {% endif %}
                 <ResourceRecords>
                     {% for record in record_set.records %}
                     <ResourceRecord>
@@ -158,7 +158,6 @@ class RecordSet(BaseModel):
                     </ResourceRecord>
                     {% endfor %}
                 </ResourceRecords>
-                {% endif %}
                 {% if record_set.health_check %}
                     <HealthCheckId>{{ record_set.health_check }}</HealthCheckId>
                 {% endif %}

--- a/moto/route53/responses.py
+++ b/moto/route53/responses.py
@@ -132,6 +132,8 @@ class Route53(BaseResponse):
                             # or may not be a list
                             resource_records = [resource_records]
                         record_set['ResourceRecords'] = [x['Value'] for x in resource_records]
+                    elif 'AliasTarget' in record_set:
+                        record_set['ResourceRecords'] = [record_set['AliasTarget']['DNSName']]
                     if action == 'CREATE':
                         the_zone.add_rrset(record_set)
                     else:

--- a/moto/route53/responses.py
+++ b/moto/route53/responses.py
@@ -131,10 +131,7 @@ class Route53(BaseResponse):
                             # Depending on how many records there are, this may
                             # or may not be a list
                             resource_records = [resource_records]
-                        record_values = [x['Value'] for x in resource_records]
-                    elif 'AliasTarget' in record_set:
-                        record_values = [record_set['AliasTarget']['DNSName']]
-                    record_set['ResourceRecords'] = record_values
+                        record_set['ResourceRecords'] = [x['Value'] for x in resource_records]
                     if action == 'CREATE':
                         the_zone.add_rrset(record_set)
                     else:


### PR DESCRIPTION
Work in Progress MR for #1599 

Also looks like there is a use before assignment that was occurring in `moto/route53/responses.py` on line 137 before my changes. As the RecordSet class handles the empty case cleanly, and the `elif` case is not correct, I simplified the assignment. 

I haven't added tests, so marked it with WIP. I did have a little proof of concept script based on the problem I'd run into, which is

```
import boto3
import moto

mroute = moto.mock_route53()
mroute.start()

client = boto3.client('route53')

hosted_zone_response = client.create_hosted_zone(
	Name='example.com',
	CallerReference='testing'
)
hosted_zone_id = hosted_zone_response.get('HostedZone', {}).get('Id')

create_response = client.change_resource_record_sets(
	HostedZoneId=hosted_zone_id,
	ChangeBatch={
		'Changes': [
			{
				'Action': 'UPSERT',
				'ResourceRecordSet': {
					'Name': 'test.example.com',
					'Type': 'A',
					'AliasTarget': {
						'DNSName': 'other.example.com',
						'HostedZoneId': hosted_zone_id,
						'EvaluateTargetHealth': False
					}
				}
			}
		]
	}
)

print(client.list_resource_record_sets(HostedZoneId=hosted_zone_id))
```

Before these changes, the response would match that detailed in my comment on #1599. It now returns correctly.