### PR TITLE
Improve ECS update_service and describing tasks.

### DIFF
--- a/moto/ecs/exceptions.py
+++ b/moto/ecs/exceptions.py
@@ -1,0 +1,11 @@
+from __future__ import unicode_literals
+from moto.core.exceptions import RESTError
+
+
+class ServiceNotFoundException(RESTError):
+    code = 400
+
+    def __init__(self, service_name):
+        super(ServiceNotFoundException, self).__init__(
+            error_type="ServiceNotFoundException",
+            message="The service {0} does not exist".format(service_name))


### PR DESCRIPTION
- Have `update_service` throw the correct error if the service doesn't exist
- Allow `describe_tasks` to accept the task id in addition to ARNs.