### PR TITLE
Updated index.rst to fix overflow

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -34,11 +34,11 @@ Currently implemented Services:
 | - DynamoDB2           | - @mock_dynamodb2   | - core endpoints + partial indexes|
 +-----------------------+---------------------+-----------------------------------+
 | EC2                   | @mock_ec2           | core endpoints done               |
-|     - AMI             |                     | core endpoints done               |
-|     - EBS             |                     | core endpoints done               |
-|     - Instances       |                     | all  endpoints done               |
-|     - Security Groups |                     | core endpoints done               |
-|     - Tags            |                     | all  endpoints done               |
+|     - AMI             |                     |     - core endpoints done         |
+|     - EBS             |                     |     - core endpoints done         |
+|     - Instances       |                     |     - all  endpoints done         |
+|     - Security Groups |                     |     - core endpoints done         |
+|     - Tags            |                     |     - all  endpoints done         |
 +-----------------------+---------------------+-----------------------------------+
 | ECS                   | @mock_ecs           | basic endpoints done              |
 +-----------------------+---------------------+-----------------------------------+


### PR DESCRIPTION
The EC2 endpoint status was overflowing and creating a scroll bar on my screen. It was bugging me so I fixed it via the GitHub web interface. Will test to ensure it builds correctly when I get home from work, but it does render correctly on GitHub's preview.