### PR TITLE
APIGateway - Generate API key value when no value provided

### DIFF
--- a/moto/apigateway/models.py
+++ b/moto/apigateway/models.py
@@ -300,11 +300,7 @@ class ApiKey(BaseModel, dict):
                  generateDistinctId=False, value=None, stageKeys=None, customerId=None):
         super(ApiKey, self).__init__()
         self['id'] = create_id()
-        if generateDistinctId:
-            # Best guess of what AWS does internally
-            self['value'] = ''.join(random.sample(string.ascii_letters + string.digits, 40))
-        else:
-            self['value'] = value
+        self['value'] = value if value else ''.join(random.sample(string.ascii_letters + string.digits, 40))
         self['name'] = name
         self['customerId'] = customerId
         self['description'] = description

--- a/tests/test_apigateway/test_apigateway.py
+++ b/tests/test_apigateway/test_apigateway.py
@@ -981,7 +981,7 @@ def test_api_keys():
     apikey['value'].should.equal(apikey_value)
 
     apikey_name = 'TESTKEY2'
-    payload = {'name': apikey_name, 'generateDistinctId': True}
+    payload = {'name': apikey_name }
     response = client.create_api_key(**payload)
     apikey_id = response['id']
     apikey = client.get_api_key(apiKey=apikey_id)


### PR DESCRIPTION
On AWS when creating an API key if a value is not provided then AWS generates a value for you.

Example:

`aws apigateway create-api-key --name "Test"`

Returns:

```
{
    "name": "Test",
    "enabled": true,
    "value": "dsasDDsn7qweQWE2r327lq44nLRNq0AsdAd",
    "stageKeys": [],
    "lastUpdatedDate": 1531220553,
    "createdDate": 1531220553,
    "id": "twvchui76ac"
}
```

On moto the value was only generated when the `--generate-distinct-id` flag was passed, which is a bug.

This PR fixed this.