### PR TITLE
feature: add parameters back to Message models

### DIFF
--- a/moto/ses/models.py
+++ b/moto/ses/models.py
@@ -13,14 +13,21 @@ RECIPIENT_LIMIT = 50
 
 class Message(BaseModel):
 
-    def __init__(self, message_id):
+    def __init__(self, message_id, source, subject, body, destinations):
         self.id = message_id
+        self.source = source
+        self.subject = subject
+        self.body = body
+        self.destinations = destinations
 
 
 class RawMessage(BaseModel):
 
-    def __init__(self, message_id):
+    def __init__(self, message_id, source, destinations, raw_data):
         self.id = message_id
+        self.source = source
+        self.destinations = destinations
+        self.raw_data = raw_data
 
 
 class SESQuota(BaseModel):
@@ -79,7 +86,7 @@ class SESBackend(BaseBackend):
             )
 
         message_id = get_random_message_id()
-        message = Message(message_id)
+        message = Message(message_id, source, subject, body, destinations)
         self.sent_messages.append(message)
         self.sent_message_count += recipient_count
         return message
@@ -116,7 +123,7 @@ class SESBackend(BaseBackend):
 
         self.sent_message_count += recipient_count
         message_id = get_random_message_id()
-        message = RawMessage(message_id)
+        message = RawMessage(message_id, source, destinations, raw_data)
         self.sent_messages.append(message)
         return message
 


### PR DESCRIPTION
These were removed in #560 but I think we should keep them around. I work with a test suite that makes liberal use of snapshots & I would like to use this style of testing with moto. It is useful to check that you sent the right thing to the right people.