### PR TITLE
Python 3.7 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,19 @@ python:
 env:
     - TEST_SERVER_MODE=false
     - TEST_SERVER_MODE=true
+# Due to incomplete Python 3.7 support on Travis CI (
+# https://github.com/travis-ci/travis-ci/issues/9815),
+# using a matrix is necessary
+matrix:
+  include:
+    - python: 3.7
+      env: TEST_SERVER_MODE=false
+      dist: xenial
+      sudo: true
+    - python: 3.7
+      env: TEST_SERVER_MODE=true
+      dist: xenial
+      sudo: true
 before_install:
   - export BOTO_CONFIG=/dev/null
 install:

--- a/moto/packages/httpretty/core.py
+++ b/moto/packages/httpretty/core.py
@@ -85,6 +85,7 @@ old_socksocket = None
 old_ssl_wrap_socket = None
 old_sslwrap_simple = None
 old_sslsocket = None
+old_sslcontext_wrap_socket = None
 
 if PY3:  # pragma: no cover
     basestring = (bytes, str)
@@ -100,6 +101,10 @@ try:  # pragma: no cover
     if not PY3:
         old_sslwrap_simple = ssl.sslwrap_simple
     old_sslsocket = ssl.SSLSocket
+    try:
+        old_sslcontext_wrap_socket = ssl.SSLContext.wrap_socket
+    except AttributeError:
+        pass
 except ImportError:  # pragma: no cover
     ssl = None
 
@@ -281,7 +286,7 @@ class fakesock(object):
             return {
                 'notAfter': shift.strftime('%b %d %H:%M:%S GMT'),
                 'subjectAltName': (
-                    ('DNS', '*%s' % self._host),
+                    ('DNS', '*.%s' % self._host),
                     ('DNS', self._host),
                     ('DNS', '*'),
                 ),
@@ -772,7 +777,7 @@ class URIMatcher(object):
 
     def __init__(self, uri, entries, match_querystring=False):
         self._match_querystring = match_querystring
-        if type(uri).__name__ == 'SRE_Pattern':
+        if type(uri).__name__ in ('SRE_Pattern', 'Pattern'):
             self.regex = uri
             result = urlsplit(uri.pattern)
             if result.scheme == 'https':
@@ -1012,6 +1017,10 @@ class httpretty(HttpBaseClass):
         if ssl:
             ssl.wrap_socket = old_ssl_wrap_socket
             ssl.SSLSocket = old_sslsocket
+            try:
+                ssl.SSLContext.wrap_socket = old_sslcontext_wrap_socket
+            except AttributeError:
+                pass
             ssl.__dict__['wrap_socket'] = old_ssl_wrap_socket
             ssl.__dict__['SSLSocket'] = old_sslsocket
 
@@ -1057,6 +1066,14 @@ class httpretty(HttpBaseClass):
         if ssl:
             ssl.wrap_socket = fake_wrap_socket
             ssl.SSLSocket = FakeSSLSocket
+
+            try:
+                def fake_sslcontext_wrap_socket(cls, *args, **kwargs):
+                    return fake_wrap_socket(*args, **kwargs)
+
+                ssl.SSLContext.wrap_socket = fake_sslcontext_wrap_socket
+            except AttributeError:
+                pass
 
             ssl.__dict__['wrap_socket'] = fake_wrap_socket
             ssl.__dict__['SSLSocket'] = FakeSSLSocket

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,7 @@
 -r requirements.txt
 mock
 nose
-sure==1.2.24
+sure==1.4.11
 coverage
 flake8==3.5.0
 freezegun
@@ -13,5 +13,5 @@ six>=1.9
 prompt-toolkit==1.0.14
 click==6.7
 inflection==0.3.1
-lxml==4.0.0
+lxml==4.2.3
 beautifulsoup4==4.6.0


### PR DESCRIPTION
Fixes #1706

`.travis.yml` is so complicated as Python 3.7 is not fully supported on Travis CI. See https://github.com/travis-ci/travis-ci/issues/9815