### PR TITLE
Skip freeze_time tests in server mode

### DIFF
--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,5 +1,6 @@
 from __future__ import unicode_literals
 import boto
+from moto import settings
 from nose.plugins.skip import SkipTest
 import six
 
@@ -34,3 +35,17 @@ class disable_on_py3(object):
         if not six.PY3:
             return test
         return skip_test
+
+
+def skip_in_server_mode(test):
+    """Decorator for skipping a test when running in server mode.
+
+    Typically, some library behaviour can only be tested inside the local
+    process (eg. by manipulating time with freezegun). If we try to test
+    this behaviour with an external process running in server mode, then
+    the test is likely to fail inconsistently.
+    """
+
+    if settings.TEST_SERVER_MODE:
+        return skip_test
+    return test

--- a/tests/test_acm/test_acm.py
+++ b/tests/test_acm/test_acm.py
@@ -316,6 +316,7 @@ def test_request_certificate_no_san():
 
 # # Also tests the SAN code
 # # requires Pull: https://github.com/spulec/freezegun/pull/210
+# @skip_in_server_mode
 # @freeze_time("2012-01-01 12:00:00", as_arg=True)
 # @mock_acm
 # def test_request_certificate(frozen_time):
@@ -346,6 +347,7 @@ def test_request_certificate_no_san():
 #
 #
 # # requires Pull: https://github.com/spulec/freezegun/pull/210
+# @skip_in_server_mode
 # @freeze_time("2012-01-01 12:00:00", as_arg=True)
 # @mock_acm
 # def test_request_certificate(frozen_time):

--- a/tests/test_apigateway/test_apigateway.py
+++ b/tests/test_apigateway/test_apigateway.py
@@ -8,9 +8,12 @@ import sure  # noqa
 from botocore.exceptions import ClientError
 
 import responses
+
+from tests.helpers import skip_in_server_mode
 from moto import mock_apigateway, settings
 
 
+@skip_in_server_mode
 @freeze_time("2015-01-01")
 @mock_apigateway
 def test_create_and_get_rest_api():

--- a/tests/test_awslambda/test_lambda.py
+++ b/tests/test_awslambda/test_lambda.py
@@ -11,6 +11,8 @@ import zipfile
 import sure  # noqa
 
 from freezegun import freeze_time
+
+from tests.helpers import skip_in_server_mode
 from moto import mock_lambda, mock_s3, mock_ec2, mock_sns, mock_logs, settings
 
 _lambda_region = 'us-west-2'
@@ -244,6 +246,7 @@ def test_create_based_on_s3_with_missing_bucket():
     ).should.throw(botocore.client.ClientError)
 
 
+@skip_in_server_mode
 @mock_lambda
 @mock_s3
 @freeze_time('2015-01-01 00:00:00')
@@ -299,6 +302,7 @@ def test_create_function_from_aws_bucket():
     })
 
 
+@skip_in_server_mode
 @mock_lambda
 @freeze_time('2015-01-01 00:00:00')
 def test_create_function_from_zipfile():
@@ -344,6 +348,7 @@ def test_create_function_from_zipfile():
     })
 
 
+@skip_in_server_mode
 @mock_lambda
 @mock_s3
 @freeze_time('2015-01-01 00:00:00')
@@ -480,6 +485,7 @@ def test_publish():
     function_list['Functions'][0]['FunctionArn'].should.contain('testFunction:$LATEST')
 
 
+@skip_in_server_mode
 @mock_lambda
 @mock_s3
 @freeze_time('2015-01-01 00:00:00')
@@ -700,6 +706,7 @@ def test_invoke_async_function():
     success_result['Status'].should.equal(202)
 
 
+@skip_in_server_mode
 @mock_lambda
 @freeze_time('2015-01-01 00:00:00')
 def test_get_function_created_with_zipfile():

--- a/tests/test_dynamodb/test_dynamodb_table_with_range_key.py
+++ b/tests/test_dynamodb/test_dynamodb_table_with_range_key.py
@@ -4,6 +4,7 @@ import boto
 import sure  # noqa
 from freezegun import freeze_time
 
+from tests.helpers import skip_in_server_mode
 from moto import mock_dynamodb_deprecated
 
 from boto.dynamodb import condition
@@ -28,6 +29,7 @@ def create_table(conn):
     return table
 
 
+@skip_in_server_mode
 @freeze_time("2012-01-14")
 @mock_dynamodb_deprecated
 def test_create_table():

--- a/tests/test_dynamodb/test_dynamodb_table_without_range_key.py
+++ b/tests/test_dynamodb/test_dynamodb_table_without_range_key.py
@@ -4,6 +4,7 @@ import boto
 import sure  # noqa
 from freezegun import freeze_time
 
+from tests.helpers import skip_in_server_mode
 from moto import mock_dynamodb_deprecated
 
 from boto.dynamodb import condition
@@ -26,6 +27,7 @@ def create_table(conn):
     return table
 
 
+@skip_in_server_mode
 @freeze_time("2012-01-14")
 @mock_dynamodb_deprecated
 def test_create_table():

--- a/tests/test_dynamodb2/test_dynamodb_table_with_range_key.py
+++ b/tests/test_dynamodb2/test_dynamodb_table_with_range_key.py
@@ -10,7 +10,8 @@ import sure  # noqa
 from freezegun import freeze_time
 from moto import mock_dynamodb2, mock_dynamodb2_deprecated
 from boto.exception import JSONResponseError
-from tests.helpers import requires_boto_gte
+from tests.helpers import requires_boto_gte, skip_in_server_mode
+
 try:
     from boto.dynamodb2.fields import GlobalAllIndex, HashKey, RangeKey, AllIndex
     from boto.dynamodb2.table import Item, Table
@@ -61,6 +62,7 @@ def iterate_results(res):
         pass
 
 
+@skip_in_server_mode
 @requires_boto_gte("2.9")
 @mock_dynamodb2_deprecated
 @freeze_time("2012-01-14")
@@ -91,6 +93,7 @@ def test_create_table():
     table.describe().should.equal(expected)
 
 
+@skip_in_server_mode
 @requires_boto_gte("2.9")
 @mock_dynamodb2_deprecated
 @freeze_time("2012-01-14")

--- a/tests/test_dynamodb2/test_dynamodb_table_without_range_key.py
+++ b/tests/test_dynamodb2/test_dynamodb_table_without_range_key.py
@@ -7,7 +7,7 @@ import sure  # noqa
 from freezegun import freeze_time
 from boto.exception import JSONResponseError
 from moto import mock_dynamodb2, mock_dynamodb2_deprecated
-from tests.helpers import requires_boto_gte
+from tests.helpers import requires_boto_gte, skip_in_server_mode
 import botocore
 try:
     from boto.dynamodb2.fields import HashKey
@@ -28,6 +28,7 @@ def create_table():
     return table
 
 
+@skip_in_server_mode
 @requires_boto_gte("2.9")
 @mock_dynamodb2_deprecated
 @freeze_time("2012-01-14")

--- a/tests/test_ec2/test_elastic_block_store.py
+++ b/tests/test_ec2/test_elastic_block_store.py
@@ -589,7 +589,7 @@ def test_volume_tag_escaping():
     dict(snaps[0].tags).should.equal({'key': '</closed>'})
 
 
-@freeze_time
+@freeze_time("2015-01-01 12:00:00")
 @mock_ec2
 def test_copy_snapshot():
     ec2_client = boto3.client('ec2', region_name='eu-west-1')

--- a/tests/test_ec2/test_elastic_block_store.py
+++ b/tests/test_ec2/test_elastic_block_store.py
@@ -3,6 +3,7 @@ from __future__ import unicode_literals
 import tests.backport_assert_raises
 from nose.tools import assert_raises
 
+from tests.helpers import skip_in_server_mode
 from moto.ec2 import ec2_backends
 import boto
 import boto3
@@ -589,6 +590,7 @@ def test_volume_tag_escaping():
     dict(snaps[0].tags).should.equal({'key': '</closed>'})
 
 
+@skip_in_server_mode
 @freeze_time("2015-01-01 12:00:00")
 @mock_ec2
 def test_copy_snapshot():

--- a/tests/test_ec2/test_instances.py
+++ b/tests/test_ec2/test_instances.py
@@ -16,7 +16,7 @@ from freezegun import freeze_time
 import sure  # noqa
 
 from moto import mock_ec2_deprecated, mock_ec2
-from tests.helpers import requires_boto_gte
+from tests.helpers import requires_boto_gte, skip_in_server_mode
 
 
 ################ Test Readme ###############
@@ -39,6 +39,7 @@ def test_add_servers():
 ############################################
 
 
+@skip_in_server_mode
 @freeze_time("2014-01-01 05:00:00")
 @mock_ec2_deprecated
 def test_instance_launch_and_terminate():
@@ -100,6 +101,7 @@ def test_terminate_empty_instances():
         []).should.throw(EC2ResponseError)
 
 
+@skip_in_server_mode
 @freeze_time("2014-01-01 05:00:00")
 @mock_ec2_deprecated
 def test_instance_attach_volume():

--- a/tests/test_elbv2/test_elbv2.py
+++ b/tests/test_elbv2/test_elbv2.py
@@ -8,7 +8,7 @@ from botocore.exceptions import ClientError
 from nose.tools import assert_raises
 import sure  # noqa
 
-from moto import mock_elbv2, mock_ec2, mock_acm, mock_cloudformation
+from moto import mock_elbv2, mock_ec2, mock_acm, mock_cloudformation, settings
 from moto.elbv2 import elbv2_backends
 
 
@@ -1488,7 +1488,7 @@ def test_modify_listener_http_to_https():
     len(response['Listeners'][0]['Certificates']).should.equal(2)
 
     # Check default cert, can't do this in server mode
-    if os.environ.get('TEST_SERVER_MODE', 'false').lower() == 'false':
+    if not settings.TEST_SERVER_MODE:
         listener = elbv2_backends['eu-central-1'].load_balancers[load_balancer_arn].listeners[listener_arn]
         listener.certificate.should.equal(yahoo_arn)
 

--- a/tests/test_opsworks/test_apps.py
+++ b/tests/test_opsworks/test_apps.py
@@ -4,9 +4,11 @@ from freezegun import freeze_time
 import sure  # noqa
 import re
 
+from tests.helpers import skip_in_server_mode
 from moto import mock_opsworks
 
 
+@skip_in_server_mode
 @freeze_time("2015-01-01")
 @mock_opsworks
 def test_create_app_response():
@@ -59,6 +61,7 @@ def test_create_app_response():
         Exception, "nothere"
     )
 
+@skip_in_server_mode
 @freeze_time("2015-01-01")
 @mock_opsworks
 def test_describe_apps():

--- a/tests/test_opsworks/test_layers.py
+++ b/tests/test_opsworks/test_layers.py
@@ -4,9 +4,11 @@ from freezegun import freeze_time
 import sure  # noqa
 import re
 
+from tests.helpers import skip_in_server_mode
 from moto import mock_opsworks
 
 
+@skip_in_server_mode
 @freeze_time("2015-01-01")
 @mock_opsworks
 def test_create_layer_response():
@@ -73,6 +75,7 @@ def test_create_layer_response():
     )
 
 
+@skip_in_server_mode
 @freeze_time("2015-01-01")
 @mock_opsworks
 def test_describe_layers():

--- a/tests/test_s3/test_s3.py
+++ b/tests/test_s3/test_s3.py
@@ -26,6 +26,7 @@ from nose.tools import assert_raises
 
 import sure  # noqa
 
+from tests.helpers import skip_in_server_mode
 from moto import settings, mock_s3, mock_s3_deprecated
 import moto.s3.models as s3model
 
@@ -420,6 +421,7 @@ def test_copy_key_replace_metadata():
         "new-key").get_metadata('momd').should.equal('Mometadatastring')
 
 
+@skip_in_server_mode
 @freeze_time("2012-01-01 12:00:00")
 @mock_s3_deprecated
 def test_last_modified():
@@ -698,6 +700,7 @@ def test_copy_key_reduced_redundancy():
     keys['the-key'].storage_class.should.equal("STANDARD")
 
 
+@skip_in_server_mode
 @freeze_time("2012-01-01 12:00:00")
 @mock_s3_deprecated
 def test_restore_key():
@@ -719,6 +722,7 @@ def test_restore_key():
     key.expiry_date.should.equal("Tue, 03 Jan 2012 12:00:00 GMT")
 
 
+@skip_in_server_mode
 @freeze_time("2012-01-01 12:00:00")
 @mock_s3_deprecated
 def test_restore_key_headers():

--- a/tests/test_s3bucket_path/test_s3bucket_path.py
+++ b/tests/test_s3bucket_path/test_s3bucket_path.py
@@ -12,6 +12,7 @@ import requests
 
 import sure  # noqa
 
+from tests.helpers import skip_in_server_mode
 from moto import mock_s3, mock_s3_deprecated
 
 
@@ -128,6 +129,7 @@ def test_set_metadata():
     bucket.get_key('the-key').get_metadata('md').should.equal('Metadatastring')
 
 
+@skip_in_server_mode
 @freeze_time("2012-01-01 12:00:00")
 @mock_s3_deprecated
 def test_last_modified():

--- a/tests/test_sns/test_publishing.py
+++ b/tests/test_sns/test_publishing.py
@@ -6,12 +6,14 @@ import re
 from freezegun import freeze_time
 import sure  # noqa
 
+from tests.helpers import skip_in_server_mode
 from moto import mock_sns_deprecated, mock_sqs_deprecated
 
 
 MESSAGE_FROM_SQS_TEMPLATE = '{\n  "Message": "%s",\n  "MessageId": "%s",\n  "Signature": "EXAMPLElDMXvB8r9R83tGoNn0ecwd5UjllzsvSvbItzfaMpN2nk5HVSw7XnOn/49IkxDKz8YrlH2qJXj2iZB0Zo2O71c4qQk1fMUDi3LGpij7RCW7AW9vYYsSqIKRnFS94ilu7NFhUzLiieYr4BKHpdTmdD6c0esKEYBpabxDSc=",\n  "SignatureVersion": "1",\n  "SigningCertURL": "https://sns.us-east-1.amazonaws.com/SimpleNotificationService-f3ecfb7224c7233fe7bb5f59f96de52f.pem",\n  "Subject": "%s",\n  "Timestamp": "2015-01-01T12:00:00.000Z",\n  "TopicArn": "arn:aws:sns:%s:123456789012:some-topic",\n  "Type": "Notification",\n  "UnsubscribeURL": "https://sns.us-east-1.amazonaws.com/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:us-east-1:123456789012:some-topic:2bcfbf39-05c3-41de-beaa-fcfcc21c8f55"\n}'
 
 
+@skip_in_server_mode
 @mock_sqs_deprecated
 @mock_sns_deprecated
 def test_publish_to_sqs():
@@ -40,6 +42,7 @@ def test_publish_to_sqs():
     acquired_message.should.equal(expected)
 
 
+@skip_in_server_mode
 @mock_sqs_deprecated
 @mock_sns_deprecated
 def test_publish_to_sqs_in_different_region():

--- a/tests/test_sns/test_publishing_boto3.py
+++ b/tests/test_sns/test_publishing_boto3.py
@@ -11,12 +11,15 @@ import sure  # noqa
 import responses
 from botocore.exceptions import ClientError
 from nose.tools import assert_raises
+
+from tests.helpers import skip_in_server_mode
 from moto import mock_sns, mock_sqs
 
 
 MESSAGE_FROM_SQS_TEMPLATE = '{\n  "Message": "%s",\n  "MessageId": "%s",\n  "Signature": "EXAMPLElDMXvB8r9R83tGoNn0ecwd5UjllzsvSvbItzfaMpN2nk5HVSw7XnOn/49IkxDKz8YrlH2qJXj2iZB0Zo2O71c4qQk1fMUDi3LGpij7RCW7AW9vYYsSqIKRnFS94ilu7NFhUzLiieYr4BKHpdTmdD6c0esKEYBpabxDSc=",\n  "SignatureVersion": "1",\n  "SigningCertURL": "https://sns.us-east-1.amazonaws.com/SimpleNotificationService-f3ecfb7224c7233fe7bb5f59f96de52f.pem",\n  "Subject": "my subject",\n  "Timestamp": "2015-01-01T12:00:00.000Z",\n  "TopicArn": "arn:aws:sns:%s:123456789012:some-topic",\n  "Type": "Notification",\n  "UnsubscribeURL": "https://sns.us-east-1.amazonaws.com/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:us-east-1:123456789012:some-topic:2bcfbf39-05c3-41de-beaa-fcfcc21c8f55"\n}'
 
 
+@skip_in_server_mode
 @mock_sqs
 @mock_sns
 def test_publish_to_sqs():
@@ -43,6 +46,7 @@ def test_publish_to_sqs():
     acquired_message.should.equal(expected)
 
 
+@skip_in_server_mode
 @mock_sqs
 @mock_sns
 def test_publish_to_sqs_raw():
@@ -186,6 +190,7 @@ def test_publish_bad_sms():
         err.response['Error']['Code'].should.equal('ParameterValueInvalid')
 
 
+@skip_in_server_mode
 @mock_sqs
 @mock_sns
 def test_publish_to_sqs_dump_json():
@@ -223,6 +228,7 @@ def test_publish_to_sqs_dump_json():
     acquired_message.should.equal(expected)
 
 
+@skip_in_server_mode
 @mock_sqs
 @mock_sns
 def test_publish_to_sqs_in_different_region():
@@ -250,6 +256,7 @@ def test_publish_to_sqs_in_different_region():
     acquired_message.should.equal(expected)
 
 
+@skip_in_server_mode
 @freeze_time("2013-01-01")
 @mock_sns
 def test_publish_to_http():
@@ -279,6 +286,7 @@ def test_publish_to_http():
         TopicArn=topic_arn, Message="my message", Subject="my subject")
 
 
+@skip_in_server_mode
 @mock_sqs
 @mock_sns
 def test_publish_subject():

--- a/tests/test_sqs/test_sqs.py
+++ b/tests/test_sqs/test_sqs.py
@@ -20,7 +20,6 @@ from moto import settings, mock_sqs, mock_sqs_deprecated
 from tests.helpers import requires_boto_gte, skip_in_server_mode
 import tests.backport_assert_raises  # noqa
 from nose.tools import assert_raises
-from nose import SkipTest
 
 
 @mock_sqs
@@ -840,9 +839,6 @@ def test_delete_message_after_visibility_timeout():
 @skip_in_server_mode
 @mock_sqs
 def test_batch_change_message_visibility():
-    if settings.TEST_SERVER_MODE:
-        raise SkipTest('Cant manipulate time in server mode')
-
     with freeze_time("2015-01-01 12:00:00"):
         sqs = boto3.client('sqs', region_name='us-east-1')
         resp = sqs.create_queue(
@@ -971,9 +967,6 @@ def test_create_fifo_queue_with_dlq():
 @skip_in_server_mode
 @mock_sqs
 def test_queue_with_dlq():
-    if settings.TEST_SERVER_MODE:
-        raise SkipTest('Cant manipulate time in server mode')
-
     sqs = boto3.client('sqs', region_name='us-east-1')
 
     with freeze_time("2015-01-01 12:00:00"):
@@ -1158,9 +1151,6 @@ def test_receive_messages_with_message_group_id_on_requeue():
 @skip_in_server_mode
 @mock_sqs
 def test_receive_messages_with_message_group_id_on_visibility_timeout():
-    if settings.TEST_SERVER_MODE:
-        raise SkipTest('Cant manipulate time in server mode')
-
     with freeze_time("2015-01-01 12:00:00"):
         sqs = boto3.resource('sqs', region_name='us-east-1')
         queue = sqs.create_queue(QueueName="test-queue.fifo",

--- a/tests/test_sqs/test_sqs.py
+++ b/tests/test_sqs/test_sqs.py
@@ -839,7 +839,7 @@ def test_delete_message_after_visibility_timeout():
 
 @mock_sqs
 def test_batch_change_message_visibility():
-    if os.environ.get('TEST_SERVER_MODE', 'false').lower() == 'true':
+    if settings.TEST_SERVER_MODE:
         raise SkipTest('Cant manipulate time in server mode')
 
     with freeze_time("2015-01-01 12:00:00"):
@@ -969,7 +969,7 @@ def test_create_fifo_queue_with_dlq():
 
 @mock_sqs
 def test_queue_with_dlq():
-    if os.environ.get('TEST_SERVER_MODE', 'false').lower() == 'true':
+    if settings.TEST_SERVER_MODE:
         raise SkipTest('Cant manipulate time in server mode')
 
     sqs = boto3.client('sqs', region_name='us-east-1')
@@ -1155,7 +1155,7 @@ def test_receive_messages_with_message_group_id_on_requeue():
 
 @mock_sqs
 def test_receive_messages_with_message_group_id_on_visibility_timeout():
-    if os.environ.get('TEST_SERVER_MODE', 'false').lower() == 'true':
+    if settings.TEST_SERVER_MODE:
         raise SkipTest('Cant manipulate time in server mode')
 
     with freeze_time("2015-01-01 12:00:00"):

--- a/tests/test_sqs/test_sqs.py
+++ b/tests/test_sqs/test_sqs.py
@@ -17,7 +17,7 @@ import time
 import uuid
 
 from moto import settings, mock_sqs, mock_sqs_deprecated
-from tests.helpers import requires_boto_gte
+from tests.helpers import requires_boto_gte, skip_in_server_mode
 import tests.backport_assert_raises  # noqa
 from nose.tools import assert_raises
 from nose import SkipTest
@@ -837,6 +837,7 @@ def test_delete_message_after_visibility_timeout():
     assert new_queue.count() == 0
 
 
+@skip_in_server_mode
 @mock_sqs
 def test_batch_change_message_visibility():
     if settings.TEST_SERVER_MODE:
@@ -967,6 +968,7 @@ def test_create_fifo_queue_with_dlq():
         )
 
 
+@skip_in_server_mode
 @mock_sqs
 def test_queue_with_dlq():
     if settings.TEST_SERVER_MODE:
@@ -1153,6 +1155,7 @@ def test_receive_messages_with_message_group_id_on_requeue():
     messages[0].message_id.should.equal(message.message_id)
 
 
+@skip_in_server_mode
 @mock_sqs
 def test_receive_messages_with_message_group_id_on_visibility_timeout():
     if settings.TEST_SERVER_MODE:

--- a/tests/test_sts/test_sts.py
+++ b/tests/test_sts/test_sts.py
@@ -6,9 +6,11 @@ import boto3
 from freezegun import freeze_time
 import sure  # noqa
 
+from tests.helpers import skip_in_server_mode
 from moto import mock_sts, mock_sts_deprecated
 
 
+@skip_in_server_mode
 @freeze_time("2012-01-01 12:00:00")
 @mock_sts_deprecated
 def test_get_session_token():
@@ -22,6 +24,7 @@ def test_get_session_token():
     token.secret_key.should.equal("wJalrXUtnFEMI/K7MDENG/bPxRfiCYzEXAMPLEKEY")
 
 
+@skip_in_server_mode
 @freeze_time("2012-01-01 12:00:00")
 @mock_sts_deprecated
 def test_get_federation_token():
@@ -39,6 +42,7 @@ def test_get_federation_token():
     token.federated_user_id.should.equal("123456789012:Bob")
 
 
+@skip_in_server_mode
 @freeze_time("2012-01-01 12:00:00")
 @mock_sts_deprecated
 def test_assume_role():

--- a/tests/test_swf/models/test_activity_task.py
+++ b/tests/test_swf/models/test_activity_task.py
@@ -1,6 +1,7 @@
 from freezegun import freeze_time
 import sure  # noqa
 
+from tests.helpers import skip_in_server_mode
 from moto.swf.exceptions import SWFWorkflowExecutionClosedError
 from moto.swf.models import (
     ActivityTask,
@@ -69,6 +70,7 @@ def test_activity_task_full_dict_representation():
     fd["startedEventId"].should.equal(1234)
 
 
+@skip_in_server_mode
 def test_activity_task_reset_heartbeat_clock():
     wfe = make_workflow_execution()
 
@@ -90,6 +92,7 @@ def test_activity_task_reset_heartbeat_clock():
     task.last_heartbeat_timestamp.should.equal(1420117200.0)
 
 
+@skip_in_server_mode
 def test_activity_task_first_timeout():
     wfe = make_workflow_execution()
 
@@ -112,6 +115,7 @@ def test_activity_task_first_timeout():
         task.timeout_type.should.equal("HEARTBEAT")
 
 
+@skip_in_server_mode
 def test_activity_task_cannot_timeout_on_closed_workflow_execution():
     with freeze_time("2015-01-01 12:00:00"):
         wfe = make_workflow_execution()

--- a/tests/test_swf/models/test_decision_task.py
+++ b/tests/test_swf/models/test_decision_task.py
@@ -2,6 +2,7 @@ from boto.swf.exceptions import SWFResponseError
 from freezegun import freeze_time
 from sure import expect
 
+from tests.helpers import skip_in_server_mode
 from moto.swf.models import DecisionTask, Timeout
 from moto.swf.exceptions import SWFWorkflowExecutionClosedError
 
@@ -35,6 +36,7 @@ def test_decision_task_full_dict_representation():
     fd["startedEventId"].should.equal(1234)
 
 
+@skip_in_server_mode
 def test_decision_task_first_timeout():
     wfe = make_workflow_execution()
     dt = DecisionTask(wfe, 123)
@@ -52,6 +54,7 @@ def test_decision_task_first_timeout():
     dt.first_timeout().should.be.none
 
 
+@skip_in_server_mode
 def test_decision_task_cannot_timeout_on_closed_workflow_execution():
     with freeze_time("2015-01-01 12:00:00"):
         wfe = make_workflow_execution()

--- a/tests/test_swf/models/test_history_event.py
+++ b/tests/test_swf/models/test_history_event.py
@@ -1,9 +1,11 @@
 from freezegun import freeze_time
 import sure  # noqa
 
+from tests.helpers import skip_in_server_mode
 from moto.swf.models import HistoryEvent
 
 
+@skip_in_server_mode
 @freeze_time("2015-01-01 12:00:00")
 def test_history_event_creation():
     he = HistoryEvent(123, "DecisionTaskStarted", scheduled_event_id=2)
@@ -12,6 +14,7 @@ def test_history_event_creation():
     he.event_timestamp.should.equal(1420113600.0)
 
 
+@skip_in_server_mode
 @freeze_time("2015-01-01 12:00:00")
 def test_history_event_to_dict_representation():
     he = HistoryEvent(123, "DecisionTaskStarted", scheduled_event_id=2)

--- a/tests/test_swf/models/test_timeout.py
+++ b/tests/test_swf/models/test_timeout.py
@@ -1,11 +1,13 @@
 from freezegun import freeze_time
 import sure  # noqa
 
+from tests.helpers import skip_in_server_mode
 from moto.swf.models import Timeout
 
 from ..utils import make_workflow_execution
 
 
+@skip_in_server_mode
 def test_timeout_creation():
     wfe = make_workflow_execution()
 

--- a/tests/test_swf/models/test_workflow_execution.py
+++ b/tests/test_swf/models/test_workflow_execution.py
@@ -1,6 +1,7 @@
 from freezegun import freeze_time
 import sure  # noqa
 
+from tests.helpers import skip_in_server_mode
 from moto.swf.models import (
     ActivityType,
     Timeout,
@@ -189,6 +190,7 @@ def test_workflow_execution_history_events_ids():
     ids.should.equal([1, 2, 3])
 
 
+@skip_in_server_mode
 @freeze_time("2015-01-01 12:00:00")
 def test_workflow_execution_start():
     wfe = make_workflow_execution()
@@ -201,6 +203,7 @@ def test_workflow_execution_start():
     wfe.events()[1].event_type.should.equal("DecisionTaskScheduled")
 
 
+@skip_in_server_mode
 @freeze_time("2015-01-02 12:00:00")
 def test_workflow_execution_complete():
     wfe = make_workflow_execution()
@@ -214,6 +217,7 @@ def test_workflow_execution_complete():
     wfe.events()[-1].event_attributes["result"].should.equal("foo")
 
 
+@skip_in_server_mode
 @freeze_time("2015-01-02 12:00:00")
 def test_workflow_execution_fail():
     wfe = make_workflow_execution()
@@ -228,6 +232,7 @@ def test_workflow_execution_fail():
     wfe.events()[-1].event_attributes["reason"].should.equal("my rules")
 
 
+@skip_in_server_mode
 @freeze_time("2015-01-01 12:00:00")
 def test_workflow_execution_schedule_activity_task():
     wfe = make_workflow_execution()
@@ -453,6 +458,7 @@ def test_terminate():
     last_event.event_attributes["childPolicy"].should.equal("ABANDON")
 
 
+@skip_in_server_mode
 def test_first_timeout():
     wfe = make_workflow_execution()
     wfe.first_timeout().should.be.none
@@ -468,6 +474,7 @@ def test_first_timeout():
 
 # See moto/swf/models/workflow_execution.py "_process_timeouts()" for more
 # details
+@skip_in_server_mode
 def test_timeouts_are_processed_in_order_and_reevaluated():
     # Let's make a Workflow Execution with the following properties:
     # - execution start to close timeout of 8 mins

--- a/tests/test_swf/responses/test_activity_tasks.py
+++ b/tests/test_swf/responses/test_activity_tasks.py
@@ -2,6 +2,7 @@ from boto.swf.exceptions import SWFResponseError
 from freezegun import freeze_time
 import sure  # noqa
 
+from tests.helpers import skip_in_server_mode
 from moto import mock_swf_deprecated
 from moto.swf import swf_backend
 
@@ -205,6 +206,7 @@ def test_record_activity_task_heartbeat_with_wrong_token():
     ).should.throw(SWFResponseError)
 
 
+@skip_in_server_mode
 @mock_swf_deprecated
 def test_record_activity_task_heartbeat_sets_details_in_case_of_timeout():
     conn = setup_workflow()

--- a/tests/test_swf/responses/test_decision_tasks.py
+++ b/tests/test_swf/responses/test_decision_tasks.py
@@ -2,6 +2,7 @@ from boto.swf.exceptions import SWFResponseError
 from freezegun import freeze_time
 import sure  # noqa
 
+from tests.helpers import skip_in_server_mode
 from moto import mock_swf_deprecated
 from moto.swf import swf_backend
 
@@ -287,6 +288,7 @@ def test_respond_decision_task_completed_with_fail_workflow_execution():
     attrs["details"].should.equal("foo")
 
 
+@skip_in_server_mode
 @mock_swf_deprecated
 @freeze_time("2015-01-01 12:00:00")
 def test_respond_decision_task_completed_with_schedule_activity_task():

--- a/tests/test_swf/responses/test_timeouts.py
+++ b/tests/test_swf/responses/test_timeouts.py
@@ -1,6 +1,7 @@
 from freezegun import freeze_time
 import sure  # noqa
 
+from tests.helpers import skip_in_server_mode
 from moto import mock_swf_deprecated
 
 from ..utils import setup_workflow, SCHEDULE_ACTIVITY_TASK_DECISION
@@ -8,6 +9,7 @@ from ..utils import setup_workflow, SCHEDULE_ACTIVITY_TASK_DECISION
 
 # Activity Task Heartbeat timeout
 # Default value in workflow helpers: 5 mins
+@skip_in_server_mode
 @mock_swf_deprecated
 def test_activity_task_heartbeat_timeout():
     with freeze_time("2015-01-01 12:00:00"):
@@ -41,6 +43,7 @@ def test_activity_task_heartbeat_timeout():
 
 # Decision Task Start to Close timeout
 # Default value in workflow helpers: 5 mins
+@skip_in_server_mode
 @mock_swf_deprecated
 def test_decision_task_start_to_close_timeout():
     pass
@@ -77,6 +80,7 @@ def test_decision_task_start_to_close_timeout():
 
 # Workflow Execution Start to Close timeout
 # Default value in workflow helpers: 2 hours
+@skip_in_server_mode
 @mock_swf_deprecated
 def test_workflow_execution_start_to_close_timeout():
     pass


### PR DESCRIPTION
Skip tests that use `freeze_time` when testing server mode. This is because freeze_time is unable to affect the time on the external server process, which makes the tests fragile and liable to incorrectly fail on a time comparison