### PR TITLE
bugfix: support name-addr mailbox form

### DIFF
--- a/moto/ses/models.py
+++ b/moto/ses/models.py
@@ -49,7 +49,8 @@ class SESBackend(BaseBackend):
         self.sent_messages = []
         self.sent_message_count = 0
 
-    def _is_verified_address(self, address):
+    def _is_verified_address(self, source):
+        _, address = parseaddr(source)
         if address in self.addresses:
             return True
         user, host = address.split('@', 1)


### PR DESCRIPTION
Closes #1738. It is not clear in the docs but you can use this form with both `SendEmail` and `SendRawEmail`.