### PR TITLE
BugFix dynamodb2 update_item with empty string Fixes#1744

### DIFF
--- a/tests/test_dynamodb2/test_dynamodb.py
+++ b/tests/test_dynamodb2/test_dynamodb.py
@@ -203,6 +203,48 @@ def test_item_add_empty_string_exception():
 
 @requires_boto_gte("2.9")
 @mock_dynamodb2
+def test_update_item_with_empty_string_exception():
+    name = 'TestTable'
+    conn = boto3.client('dynamodb',
+                        region_name='us-west-2',
+                        aws_access_key_id="ak",
+                        aws_secret_access_key="sk")
+    conn.create_table(TableName=name,
+                      KeySchema=[{'AttributeName':'forum_name','KeyType':'HASH'}],
+                      AttributeDefinitions=[{'AttributeName':'forum_name','AttributeType':'S'}],
+                      ProvisionedThroughput={'ReadCapacityUnits':5,'WriteCapacityUnits':5})
+
+    conn.put_item(
+        TableName=name,
+        Item={
+            'forum_name': { 'S': 'LOLCat Forum' },
+            'subject': { 'S': 'Check this out!' },
+            'Body': { 'S': 'http://url_to_lolcat.gif'},
+            'SentBy': { 'S': "test" },
+            'ReceivedTime': { 'S': '12/9/2011 11:36:03 PM'},
+        }
+    )
+
+    with assert_raises(ClientError) as ex:
+        conn.update_item(
+            TableName=name,
+            Key={
+                'forum_name': { 'S': 'LOLCat Forum'},
+            },
+            UpdateExpression='set Body=:Body',
+            ExpressionAttributeValues={
+                ':Body': {'S': ''}
+            })
+
+    ex.exception.response['Error']['Code'].should.equal('ValidationException')
+    ex.exception.response['ResponseMetadata']['HTTPStatusCode'].should.equal(400)
+    ex.exception.response['Error']['Message'].should.equal(
+        'One or more parameter values were invalid: An AttributeValue may not contain an empty string'
+    )
+
+
+@requires_boto_gte("2.9")
+@mock_dynamodb2
 def test_query_invalid_table():
     conn = boto3.client('dynamodb',
                         region_name='us-west-2',


### PR DESCRIPTION
Dynamodb2 update_item does not raise validation exception for attribute values set to empty strings


This pull requests fixes issue #1744
and raises ClientError, when using the update_item  method with empty string on DynamoDB2