### PR TITLE
Implement IAM get_policy and correct policy version behavior

### DIFF
--- a/moto/iam/models.py
+++ b/moto/iam/models.py
@@ -72,11 +72,11 @@ class ManagedPolicy(Policy):
 
     def attach_to(self, obj):
         self.attachment_count += 1
-        obj.managed_policies[self.name] = self
+        obj.managed_policies[self.arn] = self
 
     def detach_from(self, obj):
         self.attachment_count -= 1
-        del obj.managed_policies[self.name]
+        del obj.managed_policies[self.arn]
 
     @property
     def arn(self):
@@ -477,11 +477,13 @@ class IAMBackend(BaseBackend):
             document=policy_document,
             path=path,
         )
-        self.managed_policies[policy.name] = policy
+        self.managed_policies[policy.arn] = policy
         return policy
 
-    def get_policy(self, policy_name):
-        return self.managed_policies.get(policy_name)
+    def get_policy(self, policy_arn):
+        if policy_arn not in self.managed_policies:
+            raise IAMNotFoundException("Policy {0} not found".format(policy_arn))
+        return self.managed_policies.get(policy_arn)
 
     def list_attached_role_policies(self, role_name, marker=None, max_items=100, path_prefix='/'):
         policies = self.get_role(role_name).managed_policies.values()
@@ -575,9 +577,7 @@ class IAMBackend(BaseBackend):
         return role.policies.keys()
 
     def create_policy_version(self, policy_arn, policy_document, set_as_default):
-        policy_name = policy_arn.split(':')[-1]
-        policy_name = policy_name.split('/')[1]
-        policy = self.get_policy(policy_name)
+        policy = self.get_policy(policy_arn)
         if not policy:
             raise IAMNotFoundException("Policy not found")
         version = PolicyVersion(policy_arn, policy_document, set_as_default)
@@ -587,9 +587,7 @@ class IAMBackend(BaseBackend):
         return version
 
     def get_policy_version(self, policy_arn, version_id):
-        policy_name = policy_arn.split(':')[-1]
-        policy_name = policy_name.split('/')[1]
-        policy = self.get_policy(policy_name)
+        policy = self.get_policy(policy_arn)
         if not policy:
             raise IAMNotFoundException("Policy not found")
         for version in policy.versions:
@@ -598,17 +596,13 @@ class IAMBackend(BaseBackend):
         raise IAMNotFoundException("Policy version not found")
 
     def list_policy_versions(self, policy_arn):
-        policy_name = policy_arn.split(':')[-1]
-        policy_name = policy_name.split('/')[1]
-        policy = self.get_policy(policy_name)
+        policy = self.get_policy(policy_arn)
         if not policy:
             raise IAMNotFoundException("Policy not found")
         return policy.versions
 
     def delete_policy_version(self, policy_arn, version_id):
-        policy_name = policy_arn.split(':')[-1]
-        policy_name = policy_name.split('/')[1]
-        policy = self.get_policy(policy_name)
+        policy = self.get_policy(policy_arn)
         if not policy:
             raise IAMNotFoundException("Policy not found")
         for i, v in enumerate(policy.versions):

--- a/moto/iam/models.py
+++ b/moto/iam/models.py
@@ -37,7 +37,6 @@ class Policy(BaseModel):
                  description=None,
                  document=None,
                  path=None):
-        #self.document = document or {}
         self.name = name
 
         self.attachment_count = 0

--- a/moto/iam/responses.py
+++ b/moto/iam/responses.py
@@ -62,7 +62,7 @@ class IamResponse(BaseResponse):
         policy_arn = self._get_param('PolicyArn')
         policy = iam_backend.get_policy(policy_arn)
         template = self.response_template(GET_POLICY_TEMPLATE)
-        return template.render(policy=policy)    
+        return template.render(policy=policy)
 
     def list_attached_role_policies(self):
         marker = self._get_param('Marker')
@@ -611,7 +611,7 @@ GET_POLICY_TEMPLATE = """<GetPolicyResponse>
   <GetPolicyResult>
     <Policy>
       <PolicyName>{{ policy.name }}</PolicyName>
-      <Description>{{ policy.description }}</Description> 
+      <Description>{{ policy.description }}</Description>
       <DefaultVersionId>{{ policy.default_version_id }}</DefaultVersionId>
       <PolicyId>{{ policy.id }}</PolicyId>
       <Path>{{ policy.path }}</Path>

--- a/moto/iam/responses.py
+++ b/moto/iam/responses.py
@@ -58,6 +58,12 @@ class IamResponse(BaseResponse):
         template = self.response_template(CREATE_POLICY_TEMPLATE)
         return template.render(policy=policy)
 
+    def get_policy(self):
+        policy_arn = self._get_param('PolicyArn')
+        policy = iam_backend.get_policy(policy_arn)
+        template = self.response_template(GET_POLICY_TEMPLATE)
+        return template.render(policy=policy)    
+
     def list_attached_role_policies(self):
         marker = self._get_param('Marker')
         max_items = self._get_int_param('MaxItems', 100)
@@ -600,6 +606,25 @@ CREATE_POLICY_TEMPLATE = """<CreatePolicyResponse>
     <RequestId>7a62c49f-347e-4fc4-9331-6e8eEXAMPLE</RequestId>
   </ResponseMetadata>
 </CreatePolicyResponse>"""
+
+GET_POLICY_TEMPLATE = """<GetPolicyResponse>
+  <GetPolicyResult>
+    <Policy>
+      <PolicyName>{{ policy.name }}</PolicyName>
+      <Description>{{ policy.description }}</Description> 
+      <DefaultVersionId>{{ policy.default_version_id }}</DefaultVersionId>
+      <PolicyId>{{ policy.id }}</PolicyId>
+      <Path>{{ policy.path }}</Path>
+      <Arn>{{ policy.arn }}</Arn>
+      <AttachmentCount>{{ policy.attachment_count }}</AttachmentCount>
+      <CreateDate>{{ policy.create_datetime.isoformat() }}</CreateDate>
+      <UpdateDate>{{ policy.update_datetime.isoformat() }}</UpdateDate>
+    </Policy>
+  </GetPolicyResult>
+  <ResponseMetadata>
+    <RequestId>684f0917-3d22-11e4-a4a0-cffb9EXAMPLE</RequestId>
+  </ResponseMetadata>
+</GetPolicyResponse>"""
 
 LIST_ATTACHED_ROLE_POLICIES_TEMPLATE = """<ListAttachedRolePoliciesResponse>
   <ListAttachedRolePoliciesResult>

--- a/tests/test_iam/test_iam.py
+++ b/tests/test_iam/test_iam.py
@@ -296,6 +296,7 @@ def test_get_policy():
         PolicyArn="arn:aws:iam::123456789012:policy/TestGetPolicy")
     response['Policy']['Arn'].should.equal("arn:aws:iam::123456789012:policy/TestGetPolicy")
 
+
 @mock_iam
 def test_get_policy_version():
     conn = boto3.client('iam', region_name='us-east-1')
@@ -323,17 +324,22 @@ def test_list_policy_versions():
             PolicyArn="arn:aws:iam::123456789012:policy/TestListPolicyVersions")
     conn.create_policy(
         PolicyName="TestListPolicyVersions",
-        PolicyDocument='{"some":"policy"}')
-    conn.create_policy_version(
-        PolicyArn="arn:aws:iam::123456789012:policy/TestListPolicyVersions",
         PolicyDocument='{"first":"policy"}')
+    versions = conn.list_policy_versions(
+        PolicyArn="arn:aws:iam::123456789012:policy/TestListPolicyVersions")
+    versions.get('Versions')[0].get('VersionId').should.equal('v1')
+    
     conn.create_policy_version(
         PolicyArn="arn:aws:iam::123456789012:policy/TestListPolicyVersions",
         PolicyDocument='{"second":"policy"}')
+    conn.create_policy_version(
+        PolicyArn="arn:aws:iam::123456789012:policy/TestListPolicyVersions",
+        PolicyDocument='{"third":"policy"}')
     versions = conn.list_policy_versions(
         PolicyArn="arn:aws:iam::123456789012:policy/TestListPolicyVersions")
-    versions.get('Versions')[0].get('Document').should.equal({'first': 'policy'})
+    print(versions.get('Versions'))
     versions.get('Versions')[1].get('Document').should.equal({'second': 'policy'})
+    versions.get('Versions')[2].get('Document').should.equal({'third': 'policy'})
 
 
 @mock_iam
@@ -341,20 +347,20 @@ def test_delete_policy_version():
     conn = boto3.client('iam', region_name='us-east-1')
     conn.create_policy(
         PolicyName="TestDeletePolicyVersion",
-        PolicyDocument='{"some":"policy"}')
+        PolicyDocument='{"first":"policy"}')
     conn.create_policy_version(
         PolicyArn="arn:aws:iam::123456789012:policy/TestDeletePolicyVersion",
-        PolicyDocument='{"first":"policy"}')
+        PolicyDocument='{"second":"policy"}')
     with assert_raises(ClientError):
         conn.delete_policy_version(
             PolicyArn="arn:aws:iam::123456789012:policy/TestDeletePolicyVersion",
             VersionId='v2-nope-this-does-not-exist')
     conn.delete_policy_version(
         PolicyArn="arn:aws:iam::123456789012:policy/TestDeletePolicyVersion",
-        VersionId='v1')
+        VersionId='v2')
     versions = conn.list_policy_versions(
         PolicyArn="arn:aws:iam::123456789012:policy/TestDeletePolicyVersion")
-    len(versions.get('Versions')).should.equal(0)
+    len(versions.get('Versions')).should.equal(1)
 
 
 @mock_iam_deprecated()

--- a/tests/test_iam/test_iam.py
+++ b/tests/test_iam/test_iam.py
@@ -286,6 +286,15 @@ def test_create_policy_versions():
         PolicyDocument='{"some":"policy"}')
     version.get('PolicyVersion').get('Document').should.equal({'some': 'policy'})
 
+@mock_iam
+def test_get_policy():
+    conn = boto3.client('iam', region_name='us-east-1')
+    response = conn.create_policy(
+        PolicyName="TestGetPolicy",
+        PolicyDocument='{"some":"policy"}')
+    policy = conn.get_policy(
+        PolicyArn="arn:aws:iam::123456789012:policy/TestGetPolicy")
+    response['Policy']['Arn'].should.equal("arn:aws:iam::123456789012:policy/TestGetPolicy")
 
 @mock_iam
 def test_get_policy_version():


### PR DESCRIPTION
This pull request addresses two issues with respect to IAM managed policies:
* Resolves #1434, #1240 and #1238 by implementing the get_policy method, along with the appropriate test case.
* Corrects a deviation in behavior with respect to the IAM API for policy versions. [According to AWS](https://docs.aws.amazon.com/IAM/latest/APIReference/API_CreatePolicy.html) and my own tests, when CreatePolicy is called, the PolicyDocument that is provided automatically becomes the first policy version. Therefore, list_policy_versions should always return at least one version, even before additional create_policy_versions are called. The test cases have been updated as well as the model behavior.