### PR TITLE
Force receive_message_wait_time_seconds to be int

### DIFF
--- a/moto/sqs/responses.py
+++ b/moto/sqs/responses.py
@@ -336,7 +336,7 @@ class SQSResponse(BaseResponse):
         try:
             wait_time = int(self.querystring.get("WaitTimeSeconds")[0])
         except TypeError:
-            wait_time = queue.receive_message_wait_time_seconds
+            wait_time = int(queue.receive_message_wait_time_seconds)
 
         if wait_time < 0 or wait_time > 20:
             return self._error(

--- a/tests/test_sqs/test_sqs.py
+++ b/tests/test_sqs/test_sqs.py
@@ -1195,3 +1195,16 @@ def test_receive_messages_with_message_group_id_on_visibility_timeout():
         messages = queue.receive_messages()
         messages.should.have.length_of(1)
         messages[0].message_id.should.equal(message.message_id)
+
+@mock_sqs
+def test_receive_message_for_queue_with_receive_message_wait_time_seconds_set():
+    sqs = boto3.resource('sqs', region_name='us-east-1')
+
+    queue = sqs.create_queue(
+        QueueName='test-queue',
+        Attributes={
+            'ReceiveMessageWaitTimeSeconds': '2',
+        }
+    )
+
+    queue.receive_messages()


### PR DESCRIPTION
Fixes https://github.com/spulec/moto/issues/1762

When a queue is created with the ReceiveMessageWaitTimeSeconds
attribute the value is never converted to an integer. When the
ReceiveMessage action is called it tries to compare the string
ReceiveMessageWaitTimeSeconds with the min and max wait times which
raises a TypeError.

The solution is to convert this value to an integer before comparing.

