### PR TITLE
Issue 1770: Deal with the friendly name properly

### DIFF
--- a/moto/secretsmanager/models.py
+++ b/moto/secretsmanager/models.py
@@ -41,12 +41,12 @@ class SecretsManagerBackend(BaseBackend):
 
     def get_secret_value(self, secret_id, version_id, version_stage):
 
-        if self.secret_id == '':
+        if secret_id not in (self.secret_id, self.name):
             raise ResourceNotFoundException()
 
         response = json.dumps({
             "ARN": secret_arn(self.region, self.secret_id),
-            "Name": self.secret_id,
+            "Name": self.name,
             "VersionId": "A435958A-D821-4193-B719-B7769357AER4",
             "SecretString": self.secret_string,
             "VersionStages": [
@@ -61,10 +61,11 @@ class SecretsManagerBackend(BaseBackend):
 
         self.secret_string = secret_string
         self.secret_id = name
+        self.name = name
 
         response = json.dumps({
             "ARN": secret_arn(self.region, name),
-            "Name": self.secret_id,
+            "Name": self.name,
             "VersionId": "A435958A-D821-4193-B719-B7769357AER4",
         })
 

--- a/tests/test_secretsmanager/test_secretsmanager.py
+++ b/tests/test_secretsmanager/test_secretsmanager.py
@@ -26,6 +26,15 @@ def test_get_secret_that_does_not_exist():
         result = conn.get_secret_value(SecretId='i-dont-exist')
 
 @mock_secretsmanager
+def test_get_secret_with_mismatched_id():
+    conn = boto3.client('secretsmanager', region_name='us-west-2')
+    create_secret = conn.create_secret(Name='java-util-test-password',
+                                       SecretString="foosecret")
+
+    with assert_raises(ClientError):
+        result = conn.get_secret_value(SecretId='i-dont-exist')
+
+@mock_secretsmanager
 def test_create_secret():
     conn = boto3.client('secretsmanager', region_name='us-east-1')
 


### PR DESCRIPTION
- Save friendly name in create_secret.
- Reference the saved friendly name in responses that have "Name" field.
- Verify the received secret_id matches the current value. Don't just
test for an empty string.
- Add test for mismatched secret_id.