### PR TITLE
nextSequenceToken that return by cloudwatch logs putLogEvents should be string, not int.

### DIFF
--- a/moto/logs/models.py
+++ b/moto/logs/models.py
@@ -86,7 +86,7 @@ class LogStream:
         self.events += [LogEvent(self.lastIngestionTime, log_event) for log_event in log_events]
         self.uploadSequenceToken += 1
 
-        return self.uploadSequenceToken
+        return '{:056d}'.format(self.uploadSequenceToken)
 
     def get_log_events(self, log_group_name, log_stream_name, start_time, end_time, limit, next_token, start_from_head):
         def filter_func(event):

--- a/tests/test_logs/test_logs.py
+++ b/tests/test_logs/test_logs.py
@@ -1,5 +1,6 @@
 import boto3
 import sure  # noqa
+import six
 from botocore.exceptions import ClientError
 
 from moto import mock_logs, settings
@@ -47,7 +48,7 @@ def test_exceptions():
         logEvents=[
             {
                 'timestamp': 0,
-            'message': 'line'
+                'message': 'line'
             },
         ],
     )
@@ -79,7 +80,7 @@ def test_put_logs():
         {'timestamp': 0, 'message': 'hello'},
         {'timestamp': 0, 'message': 'world'}
     ]
-    conn.put_log_events(
+    putRes = conn.put_log_events(
         logGroupName=log_group_name,
         logStreamName=log_stream_name,
         logEvents=messages
@@ -89,6 +90,9 @@ def test_put_logs():
         logStreamName=log_stream_name
     )
     events = res['events']
+    nextSequenceToken = putRes['nextSequenceToken']
+    assert isinstance(nextSequenceToken, six.string_types) == True
+    assert len(nextSequenceToken) == 56
     events.should.have.length_of(2)
 
 


### PR DESCRIPTION
according to aws api docs (https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_PutLogEvents.html#CWL-PutLogEvents-request-sequenceToken), nextSequenceToken's type should be string, not int.