### PR TITLE
Fix the `StatusCode` returned by lambda invoke

### DIFF
--- a/moto/awslambda/responses.py
+++ b/moto/awslambda/responses.py
@@ -122,7 +122,15 @@ class LambdaResponse(BaseResponse):
         if fn:
             payload = fn.invoke(self.body, self.headers, response_headers)
             response_headers['Content-Length'] = str(len(payload))
-            return 202, response_headers, payload
+
+            if request.headers['X-Amz-Invocation-Type'] == 'Event':
+                status_code = 202
+            elif request.headers['X-Amz-Invocation-Type'] == 'DryRun':
+                status_code = 204
+            else:
+                status_code = 200
+
+            return status_code, response_headers, payload
         else:
             return 404, response_headers, "{}"
 

--- a/tests/test_awslambda/test_lambda.py
+++ b/tests/test_awslambda/test_lambda.py
@@ -86,7 +86,7 @@ def test_invoke_requestresponse_function():
     success_result = conn.invoke(FunctionName='testFunction', InvocationType='RequestResponse',
                                  Payload=json.dumps(in_data))
 
-    success_result["StatusCode"].should.equal(202)
+    success_result["StatusCode"].should.equal(200)
     result_obj = json.loads(
         base64.b64decode(success_result["LogResult"]).decode('utf-8'))
 
@@ -123,6 +123,37 @@ def test_invoke_event_function():
     success_result = conn.invoke(
         FunctionName='testFunction', InvocationType='Event', Payload=json.dumps(in_data))
     success_result["StatusCode"].should.equal(202)
+    json.loads(success_result['Payload'].read().decode(
+        'utf-8')).should.equal({})
+
+
+@mock_lambda
+def test_invoke_dryrun_function():
+    conn = boto3.client('lambda', 'us-west-2')
+    conn.create_function(
+        FunctionName='testFunction',
+        Runtime='python2.7',
+        Role='test-iam-role',
+        Handler='lambda_function.lambda_handler',
+        Code={
+            'ZipFile': get_test_zip_file1(),
+        },
+        Description='test lambda function',
+        Timeout=3,
+        MemorySize=128,
+        Publish=True,
+    )
+
+    conn.invoke.when.called_with(
+        FunctionName='notAFunction',
+        InvocationType='Event',
+        Payload='{}'
+    ).should.throw(botocore.client.ClientError)
+
+    in_data = {'msg': 'So long and thanks for all the fish'}
+    success_result = conn.invoke(
+        FunctionName='testFunction', InvocationType='DryRun', Payload=json.dumps(in_data))
+    success_result["StatusCode"].should.equal(204)
     json.loads(success_result['Payload'].read().decode(
         'utf-8')).should.equal({})
 


### PR DESCRIPTION
According to the AWS documentation:
```
The HTTP status code will be in the 200 range for successful request.
For the RequestResponse invocation type this status code will be 200.
For the Event invocation type this status code will be 202.
For the DryRun invocation type the status code will be 204.
```