### PR TITLE
More accurate Filter and Transition rules for S3 Lifecycle Policy

### DIFF
--- a/moto/s3/models.py
+++ b/moto/s3/models.py
@@ -331,12 +331,14 @@ class LifecycleAndFilter(BaseModel):
         self.prefix = prefix or ''
         self.tags = tags
 
+
 class LifecycleTransition(BaseModel):
 
     def __init__(self, transition_days=None, transition_date=None, storage_class=None):
         self.transition_days = transition_days
         self.transition_date = transition_date
         self.storage_class = storage_class
+
 
 class LifecycleRule(BaseModel):
 
@@ -451,13 +453,14 @@ class FakeBucket(BaseModel):
 
                 filter_prefix = rule["Filter"].get("Prefix")
 
-                #Must have exactly one of the Prefix, Tag, or And filters
+                # Must have exactly one of the Prefix, Tag, or And filters
                 if sum(bool(arg) for arg in [filter_prefix, filter_tag, and_filter]) != 1:
                     raise MalformedXML()
 
                 lc_filter = LifecycleFilter(prefix=filter_prefix, tag=filter_tag, and_filter=and_filter)
 
             uses_ia = [False]
+
             def validate_transition(transition, uses_ia):
                 if transition:
                     storage_class = transition.get('StorageClass')

--- a/moto/s3/responses.py
+++ b/moto/s3/responses.py
@@ -1204,6 +1204,7 @@ S3_BUCKET_LIFECYCLE_CONFIGURATION = """<?xml version="1.0" encoding="UTF-8"?>
         <Prefix>{{ rule.prefix if rule.prefix != None }}</Prefix>
         {% endif %}
         <Status>{{ rule.status }}</Status>
+        {% if rule.transitions %}
         {% for transition in rule.transitions %}
         {% if transition.storage_class %}
         <Transition>
@@ -1217,6 +1218,7 @@ S3_BUCKET_LIFECYCLE_CONFIGURATION = """<?xml version="1.0" encoding="UTF-8"?>
         </Transition>
         {% endif %}
         {% endfor %}
+        {% endif %}
         {% if rule.expiration_days or rule.expiration_date or rule.expired_object_delete_marker %}
         <Expiration>
             {% if rule.expiration_days %}

--- a/moto/s3/responses.py
+++ b/moto/s3/responses.py
@@ -1204,17 +1204,19 @@ S3_BUCKET_LIFECYCLE_CONFIGURATION = """<?xml version="1.0" encoding="UTF-8"?>
         <Prefix>{{ rule.prefix if rule.prefix != None }}</Prefix>
         {% endif %}
         <Status>{{ rule.status }}</Status>
-        {% if rule.storage_class %}
+        {% for transition in rule.transitions %}
+        {% if transition.storage_class %}
         <Transition>
-            {% if rule.transition_days %}
-               <Days>{{ rule.transition_days }}</Days>
+            {% if transition.transition_days %}
+               <Days>{{ transition.transition_days }}</Days>
             {% endif %}
-            {% if rule.transition_date %}
-               <Date>{{ rule.transition_date }}</Date>
+            {% if transition.transition_date %}
+               <Date>{{ transition.transition_date }}</Date>
             {% endif %}
-           <StorageClass>{{ rule.storage_class }}</StorageClass>
+            <StorageClass>{{ transition.storage_class }}</StorageClass>
         </Transition>
         {% endif %}
+        {% endfor %}
         {% if rule.expiration_days or rule.expiration_date or rule.expired_object_delete_marker %}
         <Expiration>
             {% if rule.expiration_days %}

--- a/tests/test_s3/test_s3_lifecycle.py
+++ b/tests/test_s3/test_s3_lifecycle.py
@@ -74,8 +74,8 @@ def test_lifecycle_with_filters():
         "Key": "mytag",
         "Value": "mytagvalue"
     }
-    #A Filter must have exactly one of Prefix, Tag, or And specified.
-    #https://boto3.readthedocs.io/en/latest/reference/services/s3.html#S3.Client.put_bucket_lifecycle_configuration
+    # A Filter must have exactly one of Prefix, Tag, or And specified.
+    # https://boto3.readthedocs.io/en/latest/reference/services/s3.html#S3.Client.put_bucket_lifecycle_configuration
     del lfc["Rules"][0]["Filter"]["Prefix"]
     client.put_bucket_lifecycle_configuration(Bucket="bucket", LifecycleConfiguration=lfc)
     result = client.get_bucket_lifecycle_configuration(Bucket="bucket")
@@ -97,8 +97,9 @@ def test_lifecycle_with_filters():
             }
         ]
     }
-    #A Filter must have exactly one of Prefix, Tag, or And specified.
-    #https://boto3.readthedocs.io/en/latest/reference/services/s3.html#S3.Client.put_bucket_lifecycle_configuration    del lfc["Rules"][0]["Filter"]["Tag"]
+    # A Filter must have exactly one of Prefix, Tag, or And specified.
+    # https://boto3.readthedocs.io/en/latest/reference/services/s3.html#S3.Client.put_bucket_lifecycle_configuration
+    del lfc["Rules"][0]["Filter"]["Tag"]
     client.put_bucket_lifecycle_configuration(Bucket="bucket", LifecycleConfiguration=lfc)
     result = client.get_bucket_lifecycle_configuration(Bucket="bucket")
     assert len(result["Rules"]) == 1


### PR DESCRIPTION
Changes S3 Lifecycle Rule construction to be more accurate to the Boto3 documentation.
Specifically:
"A Filter must have exactly one of Prefix, Tag, or And specified."
and
"Transitions (list) --"
https://boto3.readthedocs.io/en/latest/reference/services/s3.html#S3.Client.put_bucket_lifecycle_configuration

In addition, adds validation for some multiple-transition scenario constraints, as per the official S3 docs:
https://docs.aws.amazon.com/AmazonS3/latest/dev/lifecycle-transition-general-considerations.html#lifecycle-general-considerations-transition-sc