### PR TITLE
RFC: Change setup.py to require older version of botocore with compatible implementation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ install_requires = [
     "Jinja2>=2.7.3",
     "boto>=2.36.0",
     "boto3>=1.6.16",
-    "botocore>=1.9.16",
+    "botocore>=1.9.16,<1.11",
     "cookies",
     "cryptography>=2.0.0",
     "requests>=2.5",


### PR DESCRIPTION
Mitigate #1793 by restricting maximum version for botocore.

botocore v1.11.0 [changed it's internal implementation](https://github.com/boto/botocore/pull/1495) so that it now uses a different library for HTTP requests. This means that moto's mocking will not work, and test code will inadvertently call the live AWS service.

As an interim solution to reduce the impact of this breakage, we restrict the "required" (ie. recommended) version of botocore so that users will be less likely to use an incompatible version, and will receive a pip warning when they do.