### PR TITLE
Fix small issue in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ def test_my_model_save():
 
     body = conn.Object('mybucket', 'steve').get()['Body'].read().decode("utf-8")
 
-    assert body == b'is awesome'
+    assert body == 'is awesome'
 ```
 
 With the decorator wrapping the test, all the calls to s3 are automatically mocked out. The mock keeps the state of the buckets and keys.


### PR DESCRIPTION
While I was checking moto library I found a small typo in the first example. This PR fix it.