### PR TITLE
Add AWS::Partition as a variable available to CloudFormation templates

### DIFF
--- a/moto/cloudformation/parsing.py
+++ b/moto/cloudformation/parsing.py
@@ -387,6 +387,7 @@ class ResourceMap(collections.Mapping):
             "AWS::StackName": stack_name,
             "AWS::URLSuffix": "amazonaws.com",
             "AWS::NoValue": None,
+            "AWS::Partition": "aws",
         }
 
     def __getitem__(self, key):


### PR DESCRIPTION
This PR closes #1816 by adding the AWS::Partition resource to CloudFormation templates. According to https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/pseudo-parameter-reference.html#cfn-pseudo-param-partition, the default value is `aws`.