### PR TITLE
Filter event log ids should be strings

### DIFF
--- a/moto/logs/models.py
+++ b/moto/logs/models.py
@@ -19,7 +19,7 @@ class LogEvent:
 
     def to_filter_dict(self):
         return {
-            "eventId": self.eventId,
+            "eventId": str(self.eventId),
             "ingestionTime": self.ingestionTime,
             # "logStreamName":
             "message": self.message,

--- a/tests/test_logs/test_logs.py
+++ b/tests/test_logs/test_logs.py
@@ -121,4 +121,8 @@ def test_filter_logs_interleaved():
         interleaved=True,
     )
     events = res['events']
-    events.should.have.length_of(2)
+    for original_message, resulting_event in zip(messages, events):
+        resulting_event['eventId'].should.equal(str(resulting_event['eventId']))
+        resulting_event['timestamp'].should.equal(original_message['timestamp'])
+        resulting_event['message'].should.equal(original_message['message'])
+


### PR DESCRIPTION
Based on the boto docs, eventId should be returned as a string.
https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/logs.html#CloudWatchLogs.Client.filter_log_events