### PR TITLE
Fixes #1857 Ensures a UserPool Id starts like {region}_

### DIFF
--- a/moto/cognitoidp/models.py
+++ b/moto/cognitoidp/models.py
@@ -24,7 +24,7 @@ class CognitoIdpUserPool(BaseModel):
 
     def __init__(self, region, name, extended_config):
         self.region = region
-        self.id = str(uuid.uuid4())
+        self.id = "{}_{}".format(self.region, str(uuid.uuid4().hex))
         self.name = name
         self.status = None
         self.extended_config = extended_config or {}

--- a/tests/test_cognitoidp/test_cognitoidp.py
+++ b/tests/test_cognitoidp/test_cognitoidp.py
@@ -24,6 +24,7 @@ def test_create_user_pool():
     )
 
     result["UserPool"]["Id"].should_not.be.none
+    result["UserPool"]["Id"].should.match(r'[\w-]+_[0-9a-zA-Z]+')
     result["UserPool"]["Name"].should.equal(name)
     result["UserPool"]["LambdaConfig"]["PreSignUp"].should.equal(value)
 


### PR DESCRIPTION
To resolve #1857 this commit changes the format of the id string generated for a new user pool. It prefixes the id with the region, followed by an _ then the uuid as a hex. This matches the AWS id format for user pools, validating against the pattern declared in the API documentation (https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_UserPoolType.html)
