### PR TITLE
Fixes for cognito identity library

### DIFF
--- a/moto/cognitoidentity/responses.py
+++ b/moto/cognitoidentity/responses.py
@@ -3,6 +3,7 @@ from __future__ import unicode_literals
 from moto.core.responses import BaseResponse
 
 from .models import cognitoidentity_backends
+from .utils import get_random_identity_id
 
 
 class CognitoIdentityResponse(BaseResponse):
@@ -31,4 +32,6 @@ class CognitoIdentityResponse(BaseResponse):
         return cognitoidentity_backends[self.region].get_credentials_for_identity(self._get_param('IdentityId'))
 
     def get_open_id_token_for_developer_identity(self):
-        return cognitoidentity_backends[self.region].get_open_id_token_for_developer_identity(self._get_param('IdentityId'))
+        return cognitoidentity_backends[self.region].get_open_id_token_for_developer_identity(
+            self._get_param('IdentityId') or get_random_identity_id(self.region)
+        )

--- a/moto/cognitoidentity/utils.py
+++ b/moto/cognitoidentity/utils.py
@@ -2,4 +2,4 @@ from moto.core.utils import get_random_hex
 
 
 def get_random_identity_id(region):
-    return "{0}:{0}".format(region, get_random_hex(length=19))
+    return "{0}:{1}".format(region, get_random_hex(length=19))

--- a/tests/test_cognitoidentity/test_cognitoidentity.py
+++ b/tests/test_cognitoidentity/test_cognitoidentity.py
@@ -31,6 +31,7 @@ def test_create_identity_pool():
 # testing a helper function
 def test_get_random_identity_id():
     assert len(get_random_identity_id('us-west-2')) > 0
+    assert len(get_random_identity_id('us-west-2').split(':')[1]) == 19
 
 
 @mock_cognitoidentity
@@ -69,3 +70,16 @@ def test_get_open_id_token_for_developer_identity():
     )
     assert len(result['Token'])
     assert result['IdentityId'] == '12345'
+
+@mock_cognitoidentity
+def test_get_open_id_token_for_developer_identity_when_no_explicit_identity_id():
+    conn = boto3.client('cognito-identity', 'us-west-2')
+    result = conn.get_open_id_token_for_developer_identity(
+        IdentityPoolId='us-west-2:12345',
+        Logins={
+            'someurl': '12345'
+        },
+        TokenDuration=123
+    )
+    assert len(result['Token']) > 0
+    assert len(result['IdentityId']) > 0


### PR DESCRIPTION
Fix a typo in generating random identity_ids

And fix the behavior of `get_open_id_token_for_developer_identity`. This method doesn't require a IdentityId, if called without it the cognito service will find or create the identity_id corresponding to the user id in the Logins object. So this stub should still return one even if not passed in.


I also added tests cases for these changes, but I'm not sure how to run the tests locally. I tried installing requirements-dev.txt and running `nosetests tests/test_cognitoidentity/test_cognitoidentity.py`  but I'm getting boto credential errors. It would be good to add instructions for running the tests locally to either the README or CONTRIBUTING files.