### PR TITLE
Allow spaces to if_not_exists, attribute_exists and attribute_not_exists

### DIFF
--- a/moto/dynamodb2/models.py
+++ b/moto/dynamodb2/models.py
@@ -154,7 +154,7 @@ class Item(BaseModel):
                     # If not exists, changes value to a default if needed, else its the same as it was
                     if value.startswith('if_not_exists'):
                         # Function signature
-                        match = re.match(r'.*if_not_exists\((?P<path>.+),\s*(?P<default>.+)\).*', value)
+                        match = re.match(r'.*if_not_exists\s*\((?P<path>.+),\s*(?P<default>.+)\).*', value)
                         if not match:
                             raise TypeError
 

--- a/moto/dynamodb2/responses.py
+++ b/moto/dynamodb2/responses.py
@@ -204,9 +204,9 @@ class DynamoHandler(BaseResponse):
                 if cond_items:
                     expected = {}
                     overwrite = False
-                    exists_re = re.compile('^attribute_exists\((.*)\)$')
+                    exists_re = re.compile('^attribute_exists\s*\((.*)\)$')
                     not_exists_re = re.compile(
-                        '^attribute_not_exists\((.*)\)$')
+                        '^attribute_not_exists\s*\((.*)\)$')
 
                 for cond in cond_items:
                     exists_m = exists_re.match(cond)
@@ -556,9 +556,9 @@ class DynamoHandler(BaseResponse):
 
                 if cond_items:
                     expected = {}
-                    exists_re = re.compile('^attribute_exists\((.*)\)$')
+                    exists_re = re.compile('^attribute_exists\s*\((.*)\)$')
                     not_exists_re = re.compile(
-                        '^attribute_not_exists\((.*)\)$')
+                        '^attribute_not_exists\s*\((.*)\)$')
 
                 for cond in cond_items:
                     exists_m = exists_re.match(cond)

--- a/tests/test_dynamodb2/test_dynamodb.py
+++ b/tests/test_dynamodb2/test_dynamodb.py
@@ -1220,7 +1220,8 @@ def test_update_if_not_exists():
         'forum_name': 'the-key',
         'subject': '123'
         },
-        UpdateExpression='SET created_at = if_not_exists(created_at, :created_at)',
+        # if_not_exists without space
+        UpdateExpression='SET created_at=if_not_exists(created_at,:created_at)',
         ExpressionAttributeValues={
             ':created_at': 123
         }
@@ -1233,7 +1234,8 @@ def test_update_if_not_exists():
         'forum_name': 'the-key',
         'subject': '123'
         },
-        UpdateExpression='SET created_at = if_not_exists(created_at, :created_at)',
+        # if_not_exists with space
+        UpdateExpression='SET created_at = if_not_exists (created_at, :created_at)',
         ExpressionAttributeValues={
             ':created_at': 456
         }

--- a/tests/test_dynamodb2/test_dynamodb.py
+++ b/tests/test_dynamodb2/test_dynamodb.py
@@ -700,8 +700,8 @@ def test_filter_expression():
     filter_expr = moto.dynamodb2.comparisons.get_filter_expression('Id IN :v0', {}, {':v0': {'NS': [7, 8, 9]}})
     filter_expr.expr(row1).should.be(True)
 
-    # attribute function tests
-    filter_expr = moto.dynamodb2.comparisons.get_filter_expression('attribute_exists(Id) AND attribute_not_exists(User)', {}, {})
+    # attribute function tests (with extra spaces)
+    filter_expr = moto.dynamodb2.comparisons.get_filter_expression('attribute_exists(Id) AND attribute_not_exists (User)', {}, {})
     filter_expr.expr(row1).should.be(True)
 
     filter_expr = moto.dynamodb2.comparisons.get_filter_expression('attribute_type(Id, N)', {}, {})


### PR DESCRIPTION
# TL;DR

- PynamoDB generate `if_not_exists`, `attribute_exists` and `attribute_not_exists`  with [extra spaces](https://github.com/pynamodb/PynamoDB/blob/3.3.1/pynamodb/expressions/operand.py#L173)
- DynamoDB (and [DynamoDB local](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DynamoDBLocal.html)) works fine but moto does not work `if_not_exists` with extra spaces.