### PR TITLE
Fix wrong type if exists

### DIFF
--- a/moto/dynamodb2/models.py
+++ b/moto/dynamodb2/models.py
@@ -162,12 +162,13 @@ class Item(BaseModel):
 
                         # If it already exists, get its value so we dont overwrite it
                         if path in self.attrs:
-                            value = self.attrs[path].cast_value
+                            value = self.attrs[path]
 
-                    if value in expression_attribute_values:
-                        value = DynamoType(expression_attribute_values[value])
-                    else:
-                        value = DynamoType({"S": value})
+                    if type(value) != DynamoType:
+                        if value in expression_attribute_values:
+                            value = DynamoType(expression_attribute_values[value])
+                        else:
+                            value = DynamoType({"S": value})
 
                     if '.' not in key:
                         self.attrs[key] = value


### PR DESCRIPTION
- `cast_value` s are always `"S"` (string type) value
- Because `cast_value` does not in `expression_attribute_values`