### PR TITLE
Adds keyId support to apigateway get_usage_plans

### DIFF
--- a/moto/apigateway/models.py
+++ b/moto/apigateway/models.py
@@ -606,8 +606,15 @@ class APIGatewayBackend(BaseBackend):
         self.usage_plans[plan['id']] = plan
         return plan
 
-    def get_usage_plans(self):
-        return list(self.usage_plans.values())
+    def get_usage_plans(self, api_key_id=None):
+        plans = list(self.usage_plans.values())
+        if api_key_id is not None:
+            plans = [
+                plan
+                for plan in plans
+                if self.usage_plan_keys.get(plan['id'], {}).get(api_key_id, False)
+            ]
+        return plans
 
     def get_usage_plan(self, usage_plan_id):
         return self.usage_plans[usage_plan_id]

--- a/moto/apigateway/responses.py
+++ b/moto/apigateway/responses.py
@@ -255,7 +255,8 @@ class APIGatewayResponse(BaseResponse):
         if self.method == 'POST':
             usage_plan_response = self.backend.create_usage_plan(json.loads(self.body))
         elif self.method == 'GET':
-            usage_plans_response = self.backend.get_usage_plans()
+            api_key_id = self.querystring.get("keyId", [None])[0]
+            usage_plans_response = self.backend.get_usage_plans(api_key_id=api_key_id)
             return 200, {}, json.dumps({"item": usage_plans_response})
         return 200, {}, json.dumps(usage_plan_response)
 


### PR DESCRIPTION
to resolve #1881 

apigateway is able to filter the result set, returning only usage plans
with the given keyId.

This commit supports filtering the usage plans returned to the user by
filtering the list of usage plans by checking for usage plan keys