### PR TITLE
Missing users now raise a UserNotFoundException

### DIFF
--- a/moto/cognitoidp/models.py
+++ b/moto/cognitoidp/models.py
@@ -383,7 +383,7 @@ class CognitoIdpBackend(BaseBackend):
             raise ResourceNotFoundError(user_pool_id)
 
         if username not in user_pool.users:
-            raise ResourceNotFoundError(username)
+            raise UserNotFoundError(username)
 
         return user_pool.users[username]
 
@@ -408,7 +408,7 @@ class CognitoIdpBackend(BaseBackend):
             raise ResourceNotFoundError(user_pool_id)
 
         if username not in user_pool.users:
-            raise ResourceNotFoundError(username)
+            raise UserNotFoundError(username)
 
         del user_pool.users[username]
 

--- a/tests/test_cognitoidp/test_cognitoidp.py
+++ b/tests/test_cognitoidp/test_cognitoidp.py
@@ -369,6 +369,22 @@ def test_admin_get_user():
 
 
 @mock_cognitoidp
+def test_admin_get_missing_user():
+    conn = boto3.client("cognito-idp", "us-west-2")
+
+    username = str(uuid.uuid4())
+    user_pool_id = conn.create_user_pool(PoolName=str(uuid.uuid4()))["UserPool"]["Id"]
+
+    caught = False
+    try:
+        conn.admin_get_user(UserPoolId=user_pool_id, Username=username)
+    except conn.exceptions.UserNotFoundException:
+        caught = True
+
+    caught.should.be.true
+
+
+@mock_cognitoidp
 def test_list_users():
     conn = boto3.client("cognito-idp", "us-west-2")
 
@@ -423,7 +439,7 @@ def test_admin_delete_user():
     caught = False
     try:
         conn.admin_get_user(UserPoolId=user_pool_id, Username=username)
-    except conn.exceptions.ResourceNotFoundException:
+    except conn.exceptions.UserNotFoundException:
         caught = True
 
     caught.should.be.true


### PR DESCRIPTION
resolves #1831

A missing user in a cognito user pool has raises a UserNotFoundException,
not a ResourceNotFoundException. This commit corrects the behaviour so
that the correct exception is raised