### PR TITLE
remove the marker since this is truncated

### DIFF
--- a/moto/iam/responses.py
+++ b/moto/iam/responses.py
@@ -1386,10 +1386,6 @@ GET_ACCOUNT_AUTHORIZATION_DETAILS_TEMPLATE = """<GetAccountAuthorizationDetailsR
       </member>
     {% endfor %}
     </UserDetailList>
-    <Marker>
-      EXAMPLEkakv9BCuUNFDtxWSyfzetYwEx2ADc8dnzfvERF5S6YMvXKx41t6gCl/eeaCX3Jo94/
-      bKqezEAg8TEVS99EKFLxm3jtbpl25FDWEXAMPLE
-    </Marker>
     <GroupDetailList>
     {% for group in groups %}
       <member>


### PR DESCRIPTION
remove the marker since this is truncated.

The original PR I left the marker in which can break some code depending on how pagination is implemented.