### PR TITLE
Add a long description to setup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,21 @@
 #!/usr/bin/env python
 from __future__ import unicode_literals
+import codecs
+import os
+import re
 import setuptools
 from setuptools import setup, find_packages
 import sys
+
+
+# Borrowed from pip at https://github.com/pypa/pip/blob/62c27dee45625e1b63d1e023b0656310f276e050/setup.py#L11-L15
+here = os.path.abspath(os.path.dirname(__file__))
+
+def read(*parts):
+    # intentionally *not* adding an encoding option to open, See:
+    #   https://github.com/pypa/virtualenv/issues/201#issuecomment-3145690
+    with codecs.open(os.path.join(here, *parts), 'r') as fp:
+        return fp.read()
 
 
 install_requires = [
@@ -43,6 +56,8 @@ setup(
     version='1.3.6',
     description='A library that allows your python tests to easily'
                 ' mock out the boto library',
+    long_description=read('README.md'),
+    long_description_content_type='text/markdown',
     author='Steve Pulec',
     author_email='spulec@gmail.com',
     url='https://github.com/spulec/moto',


### PR DESCRIPTION
Include the readme as the `long_description` argument to `setup` and set
its content type appropriately. This allows PyPI to render the content
correctly.