### PR TITLE
Without double quotes, pip would not install

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,7 +259,7 @@ It uses flask, which isn't a default dependency. You can install the
 server 'extra' package with:
 
 ```python
-pip install moto[server]
+pip install "moto[server]"
 ```
 
 You can then start it running a service:


### PR DESCRIPTION
On my system without quotes:

```
pip install moto[server]
zsh: no matches found: moto[server] 
```

with quotes:

```
pip install "moto[server]"
Requirement already satisfied: moto[server] [..] 
```