### PR TITLE
Dynamodb ne

### DIFF
--- a/moto/dynamodb2/comparisons.py
+++ b/moto/dynamodb2/comparisons.py
@@ -383,7 +383,7 @@ class OpNotEqual(Op):
     def expr(self, item):
         lhs = self._lhs(item)
         rhs = self._rhs(item)
-        return lhs == rhs
+        return lhs != rhs
 
 
 class OpLessThanOrEqual(Op):

--- a/tests/test_dynamodb2/test_dynamodb.py
+++ b/tests/test_dynamodb2/test_dynamodb.py
@@ -815,6 +815,16 @@ def test_scan_filter():
     )
     assert response['Count'] == 1
 
+    response = table.scan(
+        FilterExpression=Attr('app').ne('app2')
+    )
+    assert response['Count'] == 1
+
+    response = table.scan(
+        FilterExpression=Attr('app').ne('app1')
+    )
+    assert response['Count'] == 0
+
 
 @mock_dynamodb2
 def test_scan_filter2():
@@ -869,6 +879,26 @@ def test_scan_filter3():
     table = dynamodb.Table('test1')
     response = table.scan(
         FilterExpression=Attr('active').eq(True)
+    )
+    assert response['Count'] == 1
+
+    response = table.scan(
+        FilterExpression=Attr('active').ne(True)
+    )
+    assert response['Count'] == 0
+
+    response = table.scan(
+        FilterExpression=Attr('active').ne(False)
+    )
+    assert response['Count'] == 1
+
+    response = table.scan(
+        FilterExpression=Attr('app').ne(1)
+    )
+    assert response['Count'] == 0
+
+    response = table.scan(
+        FilterExpression=Attr('app').ne(2)
     )
     assert response['Count'] == 1
 


### PR DESCRIPTION
This addresses a bug in using not equals (ne) in Dynamodb filter expressions. Seems to have been a simple typo. I added tests for not equals as well as implemented this fix.
Addresses #1743