### PR TITLE
Add support for ReturnValues in dynamodb2 put_item

### DIFF
--- a/moto/dynamodb2/models.py
+++ b/moto/dynamodb2/models.py
@@ -428,11 +428,12 @@ class Table(BaseModel):
                     for t in dynamo_types:
                         if not comparison_func(current_attr[key].value, t.value):
                             raise ValueError('The conditional request failed')
+        prev_item = self.get_item(hash_value, range_value) or {}
         if range_value:
             self.items[hash_value][range_value] = item
         else:
             self.items[hash_value] = item
-        return item
+        return prev_item
 
     def __nonzero__(self):
         return True


### PR DESCRIPTION
This is a fix for issue https://github.com/spulec/moto/issues/1404

`put_item` currently always returns the new item but the return value should be either `NONE` or `ALL_OLD`.  This also applies to other actions like `update_item` but I wanted to look at one for now.

Here's a notebook showing the behaviour using a real dynamodb and a mock: https://gist.github.com/Ben-Wu/0a0d09cbe2c8f365ef78e5960525c115