### PR TITLE
Support full ARN in update_container_instance_state calls

### DIFF
--- a/moto/ecs/models.py
+++ b/moto/ecs/models.py
@@ -769,6 +769,8 @@ class EC2ContainerServiceBackend(BaseBackend):
                             Container instances status should be one of [ACTIVE,DRAINING]")
         failures = []
         container_instance_objects = []
+        list_container_instance_ids = [x.split('/')[-1]
+                            for x in list_container_instance_ids]
         for container_instance_id in list_container_instance_ids:
             container_instance = self.container_instances[cluster_name].get(container_instance_id, None)
             if container_instance is not None:

--- a/tests/test_ecs/test_ecs_boto3.py
+++ b/tests/test_ecs/test_ecs_boto3.py
@@ -912,6 +912,65 @@ def test_update_container_instances_state():
 
 @mock_ec2
 @mock_ecs
+def test_update_container_instances_state_by_arn():
+    ecs_client = boto3.client('ecs', region_name='us-east-1')
+    ec2 = boto3.resource('ec2', region_name='us-east-1')
+
+    test_cluster_name = 'test_ecs_cluster'
+    _ = ecs_client.create_cluster(
+        clusterName=test_cluster_name
+    )
+
+    instance_to_create = 3
+    test_instance_arns = []
+    for i in range(0, instance_to_create):
+        test_instance = ec2.create_instances(
+            ImageId="ami-1234abcd",
+            MinCount=1,
+            MaxCount=1,
+        )[0]
+
+        instance_id_document = json.dumps(
+            ec2_utils.generate_instance_identity_document(test_instance)
+        )
+
+        response = ecs_client.register_container_instance(
+            cluster=test_cluster_name,
+            instanceIdentityDocument=instance_id_document)
+
+        test_instance_arns.append(response['containerInstance']['containerInstanceArn'])
+
+    response = ecs_client.update_container_instances_state(cluster=test_cluster_name,
+                                                           containerInstances=test_instance_arns,
+                                                           status='DRAINING')
+    len(response['failures']).should.equal(0)
+    len(response['containerInstances']).should.equal(instance_to_create)
+    response_statuses = [ci['status'] for ci in response['containerInstances']]
+    for status in response_statuses:
+        status.should.equal('DRAINING')
+    response = ecs_client.update_container_instances_state(cluster=test_cluster_name,
+                                                           containerInstances=test_instance_arns,
+                                                           status='DRAINING')
+    len(response['failures']).should.equal(0)
+    len(response['containerInstances']).should.equal(instance_to_create)
+    response_statuses = [ci['status'] for ci in response['containerInstances']]
+    for status in response_statuses:
+        status.should.equal('DRAINING')
+    response = ecs_client.update_container_instances_state(cluster=test_cluster_name,
+                                                           containerInstances=test_instance_arns,
+                                                           status='ACTIVE')
+    len(response['failures']).should.equal(0)
+    len(response['containerInstances']).should.equal(instance_to_create)
+    response_statuses = [ci['status'] for ci in response['containerInstances']]
+    for status in response_statuses:
+        status.should.equal('ACTIVE')
+    ecs_client.update_container_instances_state.when.called_with(cluster=test_cluster_name,
+                                                                 containerInstances=test_instance_arns,
+                                                                 status='test_status').should.throw(Exception)
+
+
+@mock_ec2
+@mock_ecs
 def test_run_task():
     client = boto3.client('ecs', region_name='us-east-1')
     ec2 = boto3.resource('ec2', region_name='us-east-1')


### PR DESCRIPTION
Fixes #1009 

Converts a container instance full arn into a container instance id, so that these can be arns work as expected.

**Test Results**
```
$ nosetests tests/test_ecs
Coverage.py warning: --include is ignored because --source is set (include-ignored)
...........................................
Name                                                   Stmts   Miss  Cover
--------------------------------------------------------------------------
moto/__init__.py                                          54      2    96%
moto/acm/__init__.py                                       5      0   100%
moto/acm/models.py                                       200     27    86%
moto/acm/utils.py                                          3      0   100%
moto/apigateway/__init__.py                                6      0   100%
moto/apigateway/exceptions.py                             10      0   100%
moto/apigateway/models.py                                424     19    96%
moto/apigateway/utils.py                                   7      0   100%
moto/autoscaling/__init__.py                               6      0   100%
moto/autoscaling/exceptions.py                             8      1    88%
moto/autoscaling/models.py                               367     37    90%
moto/awslambda/__init__.py                                 6      0   100%
moto/awslambda/models.py                                 401    147    63%
moto/awslambda/utils.py                                    8      3    62%
moto/backends.py                                          54      6    89%
moto/batch/__init__.py                                     5      0   100%
moto/batch/exceptions.py                                  23      4    83%
moto/batch/models.py                                     586    489    17%
moto/batch/utils.py                                       13      8    38%
moto/cloudformation/__init__.py                            6      0   100%
moto/cloudformation/exceptions.py                         24     11    54%
moto/cloudformation/models.py                            185     72    61%
moto/cloudformation/parsing.py                           350    157    55%
moto/cloudformation/responses.py                         168     88    48%
moto/cloudformation/urls.py                                4      0   100%
moto/cloudformation/utils.py                              26     12    54%
moto/cloudwatch/__init__.py                                5      0   100%
moto/cloudwatch/models.py                                196    138    30%
moto/cloudwatch/utils.py                                   3      1    67%
moto/cognitoidentity/__init__.py                           6      0   100%
moto/cognitoidentity/models.py                            49     26    47%
moto/cognitoidentity/utils.py                              3      1    67%
moto/cognitoidp/__init__.py                                5      0   100%
moto/cognitoidp/exceptions.py                             15      6    60%
moto/cognitoidp/models.py                                337    260    23%
moto/compat.py                                             4      2    50%
moto/core/__init__.py                                      3      0   100%
moto/core/exceptions.py                                   24      3    88%
moto/core/models.py                                      287     90    69%
moto/core/responses.py                                   542    302    44%
moto/core/urls.py                                          5      0   100%
moto/core/utils.py                                       172     38    78%
moto/datapipeline/__init__.py                              6      0   100%
moto/datapipeline/models.py                               74     42    43%
moto/datapipeline/utils.py                                18     13    28%
moto/dynamodb/__init__.py                                  5      0   100%
moto/dynamodb/comparisons.py                               4      1    75%
moto/dynamodb/models.py                                  206    158    23%
moto/dynamodb2/__init__.py                                 6      0   100%
moto/dynamodb2/comparisons.py                            316    232    27%
moto/dynamodb2/models.py                                 594    515    13%
moto/ec2/__init__.py                                       6      0   100%
moto/ec2/exceptions.py                                   145     46    68%
moto/ec2/models.py                                      2537   1569    38%
moto/ec2/responses/__init__.py                            39      0   100%
moto/ec2/responses/account_attributes.py                   7      2    71%
moto/ec2/responses/amazon_dev_pay.py                       4      0   100%
moto/ec2/responses/amis.py                                63     44    30%
moto/ec2/responses/availability_zones_and_regions.py      14      7    50%
moto/ec2/responses/customer_gateways.py                   24     14    42%
moto/ec2/responses/dhcp_options.py                        37     25    32%
moto/ec2/responses/elastic_block_store.py                109     77    29%
moto/ec2/responses/elastic_ip_addresses.py                61     47    23%
moto/ec2/responses/elastic_network_interfaces.py          54     36    33%
moto/ec2/responses/general.py                             11      6    45%
moto/ec2/responses/instances.py                          153     88    42%
moto/ec2/responses/internet_gateways.py                   42     28    33%
moto/ec2/responses/ip_addresses.py                         7      2    71%
moto/ec2/responses/key_pairs.py                           33     20    39%
moto/ec2/responses/monitoring.py                           7      2    71%
moto/ec2/responses/nat_gateways.py                        23     13    43%
moto/ec2/responses/network_acls.py                        68     50    26%
moto/ec2/responses/placement_groups.py                     8      2    75%
moto/ec2/responses/reserved_instances.py                  12      3    75%
moto/ec2/responses/route_tables.py                        72     50    31%
moto/ec2/responses/security_groups.py                    100     79    21%
moto/ec2/responses/spot_fleets.py                         41     28    32%
moto/ec2/responses/spot_instances.py                      46     32    30%
moto/ec2/responses/subnets.py                             32     13    59%
moto/ec2/responses/tags.py                                28     17    39%
moto/ec2/responses/virtual_private_gateways.py            36     22    39%
moto/ec2/responses/vm_export.py                            6      0   100%
moto/ec2/responses/vm_import.py                            7      0   100%
moto/ec2/responses/vpc_peering_connections.py             36     23    36%
moto/ec2/responses/vpcs.py                                67     39    42%
moto/ec2/responses/vpn_connections.py                     28     16    43%
moto/ec2/responses/windows.py                              7      0   100%
moto/ec2/urls.py                                           4      0   100%
moto/ec2/utils.py                                        273    143    48%
moto/ecr/__init__.py                                       6      0   100%
moto/ecr/exceptions.py                                    10      2    80%
moto/ecr/models.py                                       200    158    21%
moto/ecs/__init__.py                                       6      0   100%
moto/ecs/exceptions.py                                     6      0   100%
moto/ecs/models.py                                       600     63    90%
moto/ecs/responses.py                                    178      7    96%
moto/ecs/urls.py                                           4      0   100%
moto/elb/__init__.py                                       6      0   100%
moto/elb/exceptions.py                                    28      8    71%
moto/elb/models.py                                       266    140    47%
moto/elbv2/__init__.py                                     5      0   100%
moto/elbv2/exceptions.py                                  73     23    68%
moto/elbv2/models.py                                     571    429    25%
moto/elbv2/utils.py                                        4      1    75%
moto/emr/__init__.py                                       6      0   100%
moto/emr/exceptions.py                                     4      0   100%
moto/emr/models.py                                       278    215    23%
moto/emr/utils.py                                         39     29    26%
moto/events/__init__.py                                    4      0   100%
moto/events/models.py                                    165    125    24%
moto/glacier/__init__.py                                   6      0   100%
moto/glacier/models.py                                   128     87    32%
moto/glacier/utils.py                                     12      6    50%
moto/glue/__init__.py                                      4      0   100%
moto/glue/exceptions.py                                   31      9    71%
moto/glue/models.py                                       99     71    28%
moto/iam/__init__.py                                       5      0   100%
moto/iam/aws_managed_policies.py                           1      0   100%
moto/iam/exceptions.py                                    14      3    79%
moto/iam/models.py                                       602    428    29%
moto/iam/utils.py                                         14      5    64%
moto/instance_metadata/__init__.py                         3      0   100%
moto/instance_metadata/models.py                           4      0   100%
moto/instance_metadata/responses.py                       23     16    30%
moto/instance_metadata/urls.py                             5      0   100%
moto/iot/__init__.py                                       5      0   100%
moto/iot/exceptions.py                                    16      6    62%
moto/iot/models.py                                       386    293    24%
moto/iotdata/__init__.py                                   5      0   100%
moto/iotdata/exceptions.py                                12      4    67%
moto/iotdata/models.py                                   115     89    23%
moto/kinesis/__init__.py                                   6      0   100%
moto/kinesis/exceptions.py                                21      8    62%
moto/kinesis/models.py                                   274    207    24%
moto/kinesis/utils.py                                     19     14    26%
moto/kms/__init__.py                                       6      0   100%
moto/kms/models.py                                       114     73    36%
moto/kms/utils.py                                          4      1    75%
moto/logs/__init__.py                                      4      0   100%
moto/logs/exceptions.py                                   16      6    62%
moto/logs/models.py                                      192    125    35%
moto/opsworks/__init__.py                                  6      0   100%
moto/opsworks/exceptions.py                               11      4    64%
moto/opsworks/models.py                                  318    272    14%
moto/organizations/__init__.py                             5      0   100%
moto/organizations/models.py                             135     89    34%
moto/organizations/utils.py                               26      5    81%
moto/packages/__init__.py                                  0      0   100%
moto/packages/httpretty/__init__.py                       25     25     0%
moto/packages/httpretty/compat.py                         38     38     0%
moto/packages/httpretty/core.py                          610    610     0%
moto/packages/httpretty/errors.py                          6      6     0%
moto/packages/httpretty/http.py                           28     28     0%
moto/packages/httpretty/utils.py                          14     14     0%
moto/polly/__init__.py                                     5      0   100%
moto/polly/models.py                                      67     42    37%
moto/polly/resources.py                                    3      0   100%
moto/polly/utils.py                                        3      1    67%
moto/rds/__init__.py                                       6      0   100%
moto/rds/models.py                                       175    134    23%
moto/rds2/__init__.py                                      6      0   100%
moto/rds2/exceptions.py                                   36     13    64%
moto/rds2/models.py                                      682    550    19%
moto/redshift/__init__.py                                  6      0   100%
moto/redshift/exceptions.py                               55     21    62%
moto/redshift/models.py                                  389    278    29%
moto/resourcegroupstaggingapi/__init__.py                  5      0   100%
moto/resourcegroupstaggingapi/models.py                  277    239    14%
moto/route53/__init__.py                                   5      0   100%
moto/route53/models.py                                   174    123    29%
moto/s3/__init__.py                                        5      0   100%
moto/s3/exceptions.py                                     74     14    81%
moto/s3/models.py                                        609    381    37%
moto/s3/utils.py                                          97     31    68%
moto/secretsmanager/__init__.py                            5      0   100%
moto/secretsmanager/exceptions.py                         14      4    71%
moto/secretsmanager/models.py                             84     54    36%
moto/secretsmanager/utils.py                              44     35    20%
moto/ses/__init__.py                                       5      0   100%
moto/ses/exceptions.py                                     6      1    83%
moto/ses/models.py                                        88     56    36%
moto/ses/utils.py                                          7      2    71%
moto/settings.py                                           2      0   100%
moto/sns/__init__.py                                       6      0   100%
moto/sns/exceptions.py                                    22      5    77%
moto/sns/models.py                                       289    132    54%
moto/sns/utils.py                                         11      1    91%
moto/sqs/__init__.py                                       6      0   100%
moto/sqs/exceptions.py                                    19      2    89%
moto/sqs/models.py                                       376    302    20%
moto/sqs/utils.py                                         32     26    19%
moto/ssm/__init__.py                                       5      0   100%
moto/ssm/models.py                                       218    168    23%
moto/sts/__init__.py                                       5      0   100%
moto/sts/models.py                                        33     18    45%
moto/swf/__init__.py                                       6      0   100%
moto/swf/constants.py                                      1      0   100%
moto/swf/exceptions.py                                    58     32    45%
moto/swf/models/__init__.py                              231    182    21%
moto/swf/models/activity_task.py                          58     39    33%
moto/swf/models/activity_type.py                           6      2    67%
moto/swf/models/decision_task.py                          53     36    32%
moto/swf/models/domain.py                                 72     55    24%
moto/swf/models/generic_type.py                           39     29    26%
moto/swf/models/history_event.py                          29     20    31%
moto/swf/models/timeout.py                                 9      4    56%
moto/swf/models/workflow_execution.py                    294    243    17%
moto/swf/models/workflow_type.py                           6      2    67%
moto/swf/utils.py                                          2      1    50%
moto/xray/__init__.py                                      6      0   100%
moto/xray/exceptions.py                                   26     15    42%
moto/xray/mock_client.py                                  39     24    38%
moto/xray/models.py                                      146    109    25%
--------------------------------------------------------------------------
TOTAL                                                  20945  12622    40%
----------------------------------------------------------------------
Ran 43 tests in 7.099s

OK
```