### PR TITLE
Pin boto3/botocore to latest working versions for dev.

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,9 +6,6 @@ coverage
 flake8==3.5.0
 freezegun
 flask
-boto>=2.45.0
-boto3>=1.4.4
-botocore>=1.8.36
 six>=1.9
 prompt-toolkit==1.0.14
 click==6.7


### PR DESCRIPTION
When installing dev requirements boto changes mean [real resources are created on AWS](https://github.com/spulec/moto/issues/1793) This removes the separate requirements in requirements-dev.txt upgrading boto from the versions pinned by #1801 in setup.py.