### PR TITLE
Be able to change user attributes in cognito-idp.

### DIFF
--- a/IMPLEMENTATION_COVERAGE.md
+++ b/IMPLEMENTATION_COVERAGE.md
@@ -827,13 +827,13 @@
 - [ ] unlink_identity
 - [ ] update_identity_pool
 
-## cognito-idp - 34% implemented
+## cognito-idp - 37% implemented
 - [ ] add_custom_attributes
 - [X] admin_add_user_to_group
 - [ ] admin_confirm_sign_up
 - [X] admin_create_user
 - [X] admin_delete_user
-- [ ] admin_delete_user_attributes
+- [X] admin_delete_user_attributes
 - [ ] admin_disable_provider_for_user
 - [X] admin_disable_user
 - [X] admin_enable_user
@@ -852,7 +852,7 @@
 - [ ] admin_set_user_settings
 - [ ] admin_update_auth_event_feedback
 - [ ] admin_update_device_status
-- [ ] admin_update_user_attributes
+- [X] admin_update_user_attributes
 - [ ] admin_user_global_sign_out
 - [ ] associate_software_token
 - [X] change_password

--- a/moto/cognitoidp/responses.py
+++ b/moto/cognitoidp/responses.py
@@ -268,6 +268,30 @@ class CognitoIdpResponse(BaseResponse):
             response["PaginationToken"] = str(token)
         return json.dumps(response)
 
+    def admin_update_user_attributes(self):
+        user_pool_id = self._get_param("UserPoolId")
+        username = self._get_param("Username")
+        attributes = self._get_param("UserAttributes")
+        cognitoidp_backends[self.region].admin_update_user_attributes(
+            user_pool_id,
+            username,
+            attributes,
+        )
+
+        return ""
+
+    def admin_delete_user_attributes(self):
+        user_pool_id = self._get_param("UserPoolId")
+        username = self._get_param("Username")
+        attributes = self._get_param("UserAttributeNames")
+        cognitoidp_backends[self.region].admin_delete_user_attributes(
+            user_pool_id,
+            username,
+            attributes,
+        )
+
+        return ""
+
     def admin_disable_user(self):
         user_pool_id = self._get_param("UserPoolId")
         username = self._get_param("Username")


### PR DESCRIPTION
Update existing partial implementation to store attributes as a Python dict, and only convert to a list-of-name-value-pairs when required