### PR TITLE
Go easier on the CPU when moto sqs is idle

### DIFF
--- a/moto/sqs/models.py
+++ b/moto/sqs/models.py
@@ -534,7 +534,7 @@ class SQSBackend(BaseBackend):
                     break
 
                 import time
-                time.sleep(0.001)
+                time.sleep(0.01)
                 continue
 
             previous_result_count = len(result)


### PR DESCRIPTION
For our local development setup we have found that moto is using around 25% CPU constantly. Digging in with gdb it turned out that it was burning that CPU in the sleeping loop. Here i'm increasing the sleep by 10x which brings the idle CPU usage down by 10x (to ~2%).

I'm not familiar enough with the moto/sqs codebase to know if lengthening this sleep will have an adverse effect; however, in other Python dev I've noticed that (in Python 2.7 anyway..) Python threading won't context switch a thread until a sleep of at least 0.01 seconds is performed (shockingly long!). So based on this guesswork I suspect sleeping for 0.01 seconds won't cause any grief.