### PR TITLE
Make CreatedDate an integer as per AWS API spec

### DIFF
--- a/moto/secretsmanager/models.py
+++ b/moto/secretsmanager/models.py
@@ -31,7 +31,7 @@ class SecretsManagerBackend(BaseBackend):
         self.region = region_name
         self.secret_id = kwargs.get('secret_id', '')
         self.name = kwargs.get('name', '')
-        self.createdate = int(time.time())
+        self.created_date = int(time.time())
         self.secret_string = ''
         self.rotation_enabled = False
         self.rotation_lambda_arn = ''
@@ -59,7 +59,7 @@ class SecretsManagerBackend(BaseBackend):
             "VersionStages": [
                 "AWSCURRENT",
             ],
-            "CreatedDate": "2018-05-23 13:16:57.198000"
+            "CreatedDate": self.created_date,
         })
 
         return response


### PR DESCRIPTION
[AWS SecretsManager API documentation](https://docs.aws.amazon.com/secretsmanager/latest/apireference/API_GetSecretValue.html#SecretsManager-GetSecretValue-response-CreatedDate).

```json
{
   "ARN": "string",
   "CreatedDate": number,
   "Name": "string",
   "SecretBinary": blob,
   "SecretString": "string",
   "VersionId": "string",
   "VersionStages": [ "string" ]
}
```

In particular the value should be a number rather than an ISO-8601 date format.

How we're testing this currently using the Boto3 library means we're not able to confirm the correct return type as we use Boto3 to get a client. 

Boto3 appears to convert any response to it's own format. 