### PR TITLE
Update to jose 3.x

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ install_requires = [
     "pyaml",
     "pytz",
     "python-dateutil<3.0.0,>=2.1",
-    "python-jose<3.0.0",
+    "python-jose<4.0.0",
     "mock",
     "docker>=2.5.1",
     "jsondiff==1.1.1",


### PR DESCRIPTION
I'm working with an environment that is using jose 3.x for things, and it appears that forcing versions >3.0.0 was a legacy from before 3.x came out.

It appears that the usage of jose in moto works just fine with jose 3.0.1