### PR TITLE
#1923 Allow to create images with creation date in past (for testing purposes)

### DIFF
--- a/moto/ec2/models.py
+++ b/moto/ec2/models.py
@@ -1150,6 +1150,7 @@ class AmiBackend(object):
 
         ami = Ami(self, ami_id, instance=instance, source_ami=None,
                   name=name, description=description,
+                  creation_date=None,
                   owner_id=context.get_current_user() if context else '111122223333')
         self.amis[ami_id] = ami
         return ami


### PR DESCRIPTION
This PR is to address issue reported in #1923.

Reason: In order to test some clean up scripts I need to be able to create in test fixture some AMIs (properly named, tagged, etc.) but with creation date in the past.

The test script checks the datetime of AMI as a criteria what to keep and what to delete.