### PR TITLE
Add pyOpenSSL to Dockerfile for SSL capabilities

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,8 @@ RUN apk add --no-cache --update \
     python3-dev \
     libffi-dev \
     openssl-dev \
-    python3
+    python3 \
+    pyOpenSSL
 
 ADD . /moto/
 ENV PYTHONUNBUFFERED 1

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,7 @@ install_requires = [
     "jsondiff==1.1.1",
     "aws-xray-sdk<0.96,>=0.93",
     "responses>=0.9.0",
+    "idna<2.8,>=2.5",
 ]
 
 extras_require = {


### PR DESCRIPTION
Add `pyOpenSSL` to allow for SSL/https moto server mode.