### PR TITLE
Loosen aws-xray-sdk requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ install_requires = [
     "mock",
     "docker>=2.5.1",
     "jsondiff==1.1.1",
-    "aws-xray-sdk<0.96,>=0.93",
+    "aws-xray-sdk!=0.96,>=0.93",
     "responses>=0.9.0",
 ]
 


### PR DESCRIPTION
Fixes spulec/moto#1947.

This was originally locked down in 31eac49e1555c5345021a252cb0c95043197ea16.