### PR TITLE
Add default path to Role & InstanceProfile

### DIFF
--- a/moto/iam/models.py
+++ b/moto/iam/models.py
@@ -114,7 +114,7 @@ class Role(BaseModel):
         self.id = role_id
         self.name = name
         self.assume_role_policy_document = assume_role_policy_document
-        self.path = path
+        self.path = path or '/'
         self.policies = {}
         self.managed_policies = {}
 
@@ -166,7 +166,7 @@ class InstanceProfile(BaseModel):
     def __init__(self, instance_profile_id, name, path, roles):
         self.id = instance_profile_id
         self.name = name
-        self.path = path
+        self.path = path or '/'
         self.roles = roles if roles else []
 
     @classmethod


### PR DESCRIPTION
[`iam.client.create_instance_profile()`](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/iam.html#IAM.Client.create_instance_profile) and [`iam.client.create_role()`](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/iam.html#IAM.Client.create_role) both have default paths of `/` if `Path` is omitted.

In moto, the `arn` property for both [Role](https://github.com/spulec/moto/blob/master/moto/iam/models.py#L139-L141) and [InstanceProfile](https://github.com/spulec/moto/blob/master/moto/iam/models.py#L183-L185) both depend on `self.path` being set during initialization, so if the path is omitted, moto will transform the arn to look something like this: `arn:aws:iam::123456789012:instance-profileNoneExampleInstanceProfile`.

This PR sets the default path to `/` for both Role and InstanceProfile if one is not specified.

