### PR TITLE
Mock AWS credentials

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,8 +23,6 @@ matrix:
       sudo: true
 before_install:
   - export BOTO_CONFIG=/dev/null
-  - export AWS_SECRET_ACCESS_KEY=foobar_secret
-  - export AWS_ACCESS_KEY_ID=foobar_key
 install:
   # We build moto first so the docker container doesn't try to compile it as well, also note we don't use
   # -d for docker run so the logs show up in travis

--- a/moto/core/models.py
+++ b/moto/core/models.py
@@ -4,6 +4,7 @@ from __future__ import absolute_import
 
 import functools
 import inspect
+import os
 import re
 import six
 from io import BytesIO
@@ -19,6 +20,11 @@ from .utils import (
     convert_regex_to_flask_path,
     convert_flask_to_responses_response,
 )
+
+
+# "Mock" the AWS credentials as they can't be mocked in Botocore currently
+os.environ.setdefault("AWS_ACCESS_KEY_ID", "foobar_key")
+os.environ.setdefault("AWS_SECRET_ACCESS_KEY", "foobar_secret")
 
 
 class BaseMockAWS(object):


### PR DESCRIPTION
This should allow Moto-users to keep using existing tests without having to export dummy credentials from v1.3.7 onward. See also https://github.com/spulec/moto/issues/1924