### PR TITLE
Check for stack name in use when creating stack

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -54,3 +54,4 @@ Moto is written by Steve Pulec with contributions from:
 * [William Richard](https://github.com/william-richard)
 * [Alex Casalboni](https://github.com/alexcasalboni)
 * [Jon Beilke](https://github.com/jrbeilke)
+* [Graham Lyons](https://github.com/grahamlyons)

--- a/moto/cloudformation/models.py
+++ b/moto/cloudformation/models.py
@@ -157,8 +157,7 @@ class CloudFormationBackend(BaseBackend):
                     {'Error': {
                         'Message': 'Stack [{}] already exists'.format(name),
                         'Code': 'AlreadyExistsException',
-                        }
-                    },
+                    }},
                     'CreateStack',
                 )
         stack_id = generate_stack_id(name)

--- a/moto/cloudformation/models.py
+++ b/moto/cloudformation/models.py
@@ -155,10 +155,8 @@ class CloudFormationBackend(BaseBackend):
             if stack.name == name:
                 raise ClientError(
                     {'Error': {
-                        'Message': 'An error occurred (AlreadyExistsException)'
-                            ' when calling the CreateStack operation: '
-                            'Stack [{}] already exists'.format(name),
-                        'Code': 400,
+                        'Message': 'Stack [{}] already exists'.format(name),
+                        'Code': 'AlreadyExistsException',
                         }
                     },
                     'CreateStack',

--- a/tests/test_cloudformation/test_cloudformation_stack_crud.py
+++ b/tests/test_cloudformation/test_cloudformation_stack_crud.py
@@ -105,14 +105,14 @@ def test_create_stack_hosted_zone_by_id():
         },
     }
     conn.create_stack(
-        "test_stack",
+        "test_stack_0",
         template_body=json.dumps(dummy_template),
         parameters={}.items()
     )
     r53_conn = boto.connect_route53()
     zone_id = r53_conn.get_zones()[0].id
     conn.create_stack(
-        "test_stack",
+        "test_stack_1",
         template_body=json.dumps(dummy_template2),
         parameters={"ZoneId": zone_id}.items()
     )

--- a/tests/test_cloudformation/test_cloudformation_stack_crud_boto3.py
+++ b/tests/test_cloudformation/test_cloudformation_stack_crud_boto3.py
@@ -198,6 +198,21 @@ def test_boto3_create_stack():
 
 
 @mock_cloudformation
+def test_boto3_create_duplicate_stack():
+    cf_conn = boto3.client('cloudformation', region_name='us-east-1')
+    cf_conn.create_stack(
+        StackName="test_stack",
+        TemplateBody=dummy_template_json,
+    )
+
+    with assert_raises(ClientError):
+        cf_conn.create_stack(
+            StackName="test_stack",
+            TemplateBody=dummy_template_json,
+        )
+
+
+@mock_cloudformation
 def test_boto3_create_stack_with_yaml():
     cf_conn = boto3.client('cloudformation', region_name='us-east-1')
     cf_conn.create_stack(
@@ -425,7 +440,7 @@ def test_describe_stack_pagination():
     conn = boto3.client('cloudformation', region_name='us-east-1')
     for i in range(100):
         conn.create_stack(
-            StackName="test_stack",
+            StackName="test_stack_{}".format(i),
             TemplateBody=dummy_template_json,
         )
 
@@ -716,7 +731,7 @@ def test_list_exports_with_token():
         # Add index to ensure name is unique
         dummy_output_template['Outputs']['StackVPC']['Export']['Name'] += str(i)
         cf.create_stack(
-            StackName="test_stack",
+            StackName="test_stack_{}".format(i),
             TemplateBody=json.dumps(dummy_output_template),
         )
     exports = cf.list_exports()


### PR DESCRIPTION
The AWS API requires that stack names are unique within a region.
Without this logic moto allows stacks with duplicate names to be created, albeit with differing IDs.

Fixes #1954 