### PR TITLE
Fix the instantiation of `ClientError`

### DIFF
--- a/moto/redshift/models.py
+++ b/moto/redshift/models.py
@@ -476,10 +476,9 @@ class RedshiftBackend(BaseBackend):
                 raise ClientError(
                     {'Error': {
                         'Message': 'SnapshotCopyGrantName is required for '
-                            'Snapshot Copy on KMS encrypted clusters.',
+                                   'Snapshot Copy on KMS encrypted clusters.',
                         'Code': 'SnapshotCopyGrantNotFoundFault',
-                        }
-                    },
+                    }},
                     'EnableSnapshotCopy',
                 )
             status = {

--- a/moto/redshift/models.py
+++ b/moto/redshift/models.py
@@ -474,9 +474,13 @@ class RedshiftBackend(BaseBackend):
         if not hasattr(cluster, 'cluster_snapshot_copy_status'):
             if cluster.encrypted == 'true' and kwargs['snapshot_copy_grant_name'] is None:
                 raise ClientError(
-                    'InvalidParameterValue',
-                    'SnapshotCopyGrantName is required for Snapshot Copy '
-                    'on KMS encrypted clusters.'
+                    {'Error': {
+                        'Message': 'SnapshotCopyGrantName is required for '
+                            'Snapshot Copy on KMS encrypted clusters.',
+                        'Code': 'SnapshotCopyGrantNotFoundFault',
+                        }
+                    },
+                    'EnableSnapshotCopy',
                 )
             status = {
                 'DestinationRegion': kwargs['destination_region'],


### PR DESCRIPTION
The previous code would throw an exception if it was executed. The `ClientError` class takes a `dict` as the first argument so passing a `str` gives an error like this:

```
...
  File "/home/foo/top-secret-work/moto/moto/redshift/models.py", line 478, in enable_snapshot_copy
    'SnapshotCopyGrantName is required for Snapshot Copy '
  File "/usr/local/lib/python3.7/site-packages/botocore/exceptions.py", line 396, in __init__
    error = error_response.get('Error', {})
AttributeError: 'str' object has no attribute 'get'
```