### PR TITLE
Add a trailing dot to the Name of Route53 ResourceRecordSet

### DIFF
--- a/moto/route53/responses.py
+++ b/moto/route53/responses.py
@@ -123,6 +123,9 @@ class Route53(BaseResponse):
                     """ % (record_set['Name'], the_zone.name)
                     return 400, headers, error_msg
 
+                if not record_set['Name'].endswith('.'):
+                    record_set['Name'] += '.'
+
                 if action in ('CREATE', 'UPSERT'):
                     if 'ResourceRecords' in record_set:
                         resource_records = list(

--- a/tests/test_route53/test_route53.py
+++ b/tests/test_route53/test_route53.py
@@ -164,8 +164,8 @@ def test_alias_rrset():
     rrsets = conn.get_all_rrsets(zoneid, type="A")
     rrset_records = [(rr_set.name, rr) for rr_set in rrsets for rr in rr_set.resource_records]
     rrset_records.should.have.length_of(2)
-    rrset_records.should.contain(('foo.alias.testdns.aws.com', 'foo.testdns.aws.com'))
-    rrset_records.should.contain(('bar.alias.testdns.aws.com', 'bar.testdns.aws.com'))
+    rrset_records.should.contain(('foo.alias.testdns.aws.com.', 'foo.testdns.aws.com'))
+    rrset_records.should.contain(('bar.alias.testdns.aws.com.', 'bar.testdns.aws.com'))
     rrsets[0].resource_records[0].should.equal('foo.testdns.aws.com')
     rrsets = conn.get_all_rrsets(zoneid, type="CNAME")
     rrsets.should.have.length_of(1)
@@ -525,7 +525,7 @@ def test_change_resource_record_sets_crud_valid():
             {
                 'Action': 'CREATE',
                 'ResourceRecordSet': {
-                    'Name': 'prod.redis.db',
+                    'Name': 'prod.redis.db.',
                     'Type': 'A',
                     'TTL': 10,
                     'ResourceRecords': [{
@@ -540,7 +540,7 @@ def test_change_resource_record_sets_crud_valid():
     response = conn.list_resource_record_sets(HostedZoneId=hosted_zone_id)
     len(response['ResourceRecordSets']).should.equal(1)
     a_record_detail = response['ResourceRecordSets'][0]
-    a_record_detail['Name'].should.equal('prod.redis.db')
+    a_record_detail['Name'].should.equal('prod.redis.db.')
     a_record_detail['Type'].should.equal('A')
     a_record_detail['TTL'].should.equal(10)
     a_record_detail['ResourceRecords'].should.equal([{'Value': '127.0.0.1'}])
@@ -552,7 +552,7 @@ def test_change_resource_record_sets_crud_valid():
             {
                 'Action': 'UPSERT',
                 'ResourceRecordSet': {
-                    'Name': 'prod.redis.db',
+                    'Name': 'prod.redis.db.',
                     'Type': 'CNAME',
                     'TTL': 60,
                     'ResourceRecords': [{
@@ -567,7 +567,7 @@ def test_change_resource_record_sets_crud_valid():
     response = conn.list_resource_record_sets(HostedZoneId=hosted_zone_id)
     len(response['ResourceRecordSets']).should.equal(1)
     cname_record_detail = response['ResourceRecordSets'][0]
-    cname_record_detail['Name'].should.equal('prod.redis.db')
+    cname_record_detail['Name'].should.equal('prod.redis.db.')
     cname_record_detail['Type'].should.equal('CNAME')
     cname_record_detail['TTL'].should.equal(60)
     cname_record_detail['ResourceRecords'].should.equal([{'Value': '192.168.1.1'}])
@@ -688,12 +688,12 @@ def test_list_resource_record_sets_name_type_filters():
 
     # record_type, record_name
     all_records = [
-        ('A', 'a.a.db'),
-        ('A', 'a.b.db'),
-        ('A', 'b.b.db'),
-        ('CNAME', 'b.b.db'),
-        ('CNAME', 'b.c.db'),
-        ('CNAME', 'c.c.db')
+        ('A', 'a.a.db.'),
+        ('A', 'a.b.db.'),
+        ('A', 'b.b.db.'),
+        ('CNAME', 'b.b.db.'),
+        ('CNAME', 'b.c.db.'),
+        ('CNAME', 'c.c.db.')
     ]
     for record_type, record_name in all_records:
         create_resource_record_set(record_type, record_name)


### PR DESCRIPTION
Hi!

[AWS docs says](https://docs.aws.amazon.com/cli/latest/reference/route53/list-resource-record-sets.html) 

> AWS Route53 treats www.example.com (without a trailing dot)
> and www.example.com. (with a trailing dot) as identical.

Hence, after creating a `www.example.com` record, `www.example.com.` name is saved in Route53.

```sh
# AWS Route53
$ cat sample.json
{
  "Changes": [
    {
      "Action": "CREATE",
      "ResourceRecordSet": {
        "Name": "foo.local", # without a trailing dot
        "Type": "A",
        "TTL": 1200,
        "ResourceRecords": [
          {
            "Value": "192.168.10.1"
          }
        ]
      }
    }
  ]
}
$ aws route53 change-resource-record-sets --hosted-zone-id $HOSTED_ZONE_ID --change-batch file://sample.json
$ aws route53 list-resource-record-sets --hosted-zone-id $HOSTED_ZONE_ID
{
# snip
        {
            "ResourceRecords": [
                {
                    "Value": "192.168.10.1"
                }
            ],
            "Type": "A",
            "Name": "foo.local.", # with a trailing dot
            "TTL": 1200
        }
    ]
}
$
```

But moto treats `www.example.com` and `www.example.com.` as different.

```sh
# moto route53 server
$ aws route53 --endpoint-url http://localhost:5000 change-resource-record-sets --hosted-zone-id $HOSTED_ZONE_ID --change-batch file://sample.json
$ aws --endpoint-url http://localhost:5000 route53 list-resource-record-sets --hosted-zone-id $HOSTED_ZONE_ID
{
    "ResourceRecordSets": [
        {
            "ResourceRecords": [
                {
                    "Value": "192.168.10.1"
                }
            ],
            "Type": "A",
            "Name": "foo.local", # without a trailing dot
            "TTL": 1200
        }
    ]
}
$
```

This PR fixes the above moto behavior and make moto route53 treat `www.example.com` and `www.example.com.` as identical.