### PR TITLE
Fix 1959 location constraint us east 1

### DIFF
--- a/moto/s3/responses.py
+++ b/moto/s3/responses.py
@@ -432,8 +432,19 @@ class ResponseObject(_TemplateEnvironmentMixin):
 
         else:
             if body:
+                # us-east-1, the default AWS region behaves a bit differently
+                # - you should not use it as a location constraint --> it fails
+                # - querying the location constraint returns None
                 try:
-                    region_name = xmltodict.parse(body)['CreateBucketConfiguration']['LocationConstraint']
+                    forced_region = xmltodict.parse(body)['CreateBucketConfiguration']['LocationConstraint']
+
+                    if forced_region == DEFAULT_REGION_NAME:
+                        raise S3ClientError(
+                            'InvalidLocationConstraint',
+                            'The specified location-constraint is not valid'
+                        )
+                    else:
+                        region_name = forced_region
                 except KeyError:
                     pass
 

--- a/moto/s3/responses.py
+++ b/moto/s3/responses.py
@@ -193,7 +193,13 @@ class ResponseObject(_TemplateEnvironmentMixin):
         elif 'location' in querystring:
             bucket = self.backend.get_bucket(bucket_name)
             template = self.response_template(S3_BUCKET_LOCATION)
-            return template.render(location=bucket.location)
+
+            location = bucket.location
+            # us-east-1 is different - returns a None location
+            if location == DEFAULT_REGION_NAME:
+                location = None
+
+            return template.render(location=location)
         elif 'lifecycle' in querystring:
             bucket = self.backend.get_bucket(bucket_name)
             if not bucket.rules:
@@ -1187,7 +1193,7 @@ S3_DELETE_BUCKET_WITH_ITEMS_ERROR = """<?xml version="1.0" encoding="UTF-8"?>
 </Error>"""
 
 S3_BUCKET_LOCATION = """<?xml version="1.0" encoding="UTF-8"?>
-<LocationConstraint xmlns="http://s3.amazonaws.com/doc/2006-03-01/">{{ location }}</LocationConstraint>"""
+<LocationConstraint xmlns="http://s3.amazonaws.com/doc/2006-03-01/">{% if location != None %}{{ location }}{% endif %}</LocationConstraint>"""
 
 S3_BUCKET_LIFECYCLE_CONFIGURATION = """<?xml version="1.0" encoding="UTF-8"?>
 <LifecycleConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/">

--- a/tests/test_s3/test_s3.py
+++ b/tests/test_s3/test_s3.py
@@ -1301,6 +1301,16 @@ def test_bucket_create_duplicate():
 
 
 @mock_s3
+def test_bucket_create_force_us_east_1():
+    s3 = boto3.resource('s3', region_name='us-east-1')
+    with assert_raises(ClientError) as exc:
+        s3.create_bucket(Bucket="blah", CreateBucketConfiguration={
+            'LocationConstraint': 'us-east-1',
+        })
+    exc.exception.response['Error']['Code'].should.equal('InvalidLocationConstraint')
+
+
+@mock_s3
 def test_boto3_bucket_create_eu_central():
     s3 = boto3.resource('s3', region_name='eu-central-1')
     s3.create_bucket(Bucket="blah")

--- a/tests/test_s3/test_s3.py
+++ b/tests/test_s3/test_s3.py
@@ -978,6 +978,15 @@ def test_bucket_location():
 
 
 @mock_s3_deprecated
+def test_bucket_location_us_east_1():
+    cli = boto3.client('s3')
+    bucket_name = 'mybucket'
+    # No LocationConstraint ==> us-east-1
+    cli.create_bucket(Bucket=bucket_name)
+    cli.get_bucket_location(Bucket=bucket_name)['LocationConstraint'].should.equal(None)
+
+
+@mock_s3_deprecated
 def test_ranged_get():
     conn = boto.connect_s3()
     bucket = conn.create_bucket('mybucket')

--- a/tox.ini
+++ b/tox.ini
@@ -8,6 +8,10 @@ deps =
 commands =
     {envpython} setup.py test
     nosetests {posargs}
+setenv =
+    AWS_ACCESS_KEY_ID=dummy_key
+    AWS_SECRET_ACCESS_KEY=dummy_secret
+    AWS_DEFAULT_REGION=us-east-1
 
 [flake8]
 ignore = E128,E501


### PR DESCRIPTION
Should fix #1959 

* First commit forces some dummy credentials in tox tests. This is because some users (like me) are using "hidden" credentials through aws-vault and I would expect the test to not depend on the developer setup.

* Makes LocationConstraint behaves "properly" (i.e. inconsistently :) ) for us-east-1