### PR TITLE
Check bucket name length at CreateBucket

### DIFF
--- a/moto/s3/exceptions.py
+++ b/moto/s3/exceptions.py
@@ -178,3 +178,13 @@ class InvalidStorageClass(S3ClientError):
             "InvalidStorageClass",
             "The storage class you specified is not valid",
             *args, **kwargs)
+
+
+class InvalidBucketName(S3ClientError):
+    code = 400
+
+    def __init__(self, *args, **kwargs):
+        super(InvalidBucketName, self).__init__(
+            "InvalidBucketName",
+            "The specified bucket is not valid.",
+            *args, **kwargs)

--- a/moto/s3/models.py
+++ b/moto/s3/models.py
@@ -14,10 +14,13 @@ import six
 from bisect import insort
 from moto.core import BaseBackend, BaseModel
 from moto.core.utils import iso_8601_datetime_with_milliseconds, rfc_1123_datetime
-from .exceptions import BucketAlreadyExists, MissingBucket, InvalidPart, EntityTooSmall, MissingKey, \
-    InvalidNotificationDestination, MalformedXML, InvalidStorageClass
+from .exceptions import BucketAlreadyExists, MissingBucket, InvalidBucketName, InvalidPart, \
+        EntityTooSmall, MissingKey, InvalidNotificationDestination, MalformedXML, \
+        InvalidStorageClass
 from .utils import clean_key_name, _VersionedKeyStore
 
+MAX_BUCKET_NAME_LENGTH = 63
+MIN_BUCKET_NAME_LENGTH = 3
 UPLOAD_ID_BYTES = 43
 UPLOAD_PART_MIN_SIZE = 5242880
 STORAGE_CLASS = ["STANDARD", "REDUCED_REDUNDANCY", "STANDARD_IA", "ONEZONE_IA"]
@@ -634,6 +637,8 @@ class S3Backend(BaseBackend):
     def create_bucket(self, bucket_name, region_name):
         if bucket_name in self.buckets:
             raise BucketAlreadyExists(bucket=bucket_name)
+        if not MIN_BUCKET_NAME_LENGTH <= len(bucket_name) <= MAX_BUCKET_NAME_LENGTH:
+            raise InvalidBucketName()
         new_bucket = FakeBucket(name=bucket_name, region_name=region_name)
         self.buckets[bucket_name] = new_bucket
         return new_bucket

--- a/tests/test_s3/test_s3.py
+++ b/tests/test_s3/test_s3.py
@@ -2581,3 +2581,17 @@ TEST_XML = """\
     </ns0:RoutingRules>
 </ns0:WebsiteConfiguration>
 """
+
+@mock_s3
+def test_boto3_bucket_name_too_long():
+    s3 = boto3.client('s3', region_name='us-east-1')
+    with assert_raises(ClientError) as exc:
+        s3.create_bucket(Bucket='x'*64)
+    exc.exception.response['Error']['Code'].should.equal('InvalidBucketName')
+
+@mock_s3
+def test_boto3_bucket_name_too_short():
+    s3 = boto3.client('s3', region_name='us-east-1')
+    with assert_raises(ClientError) as exc:
+        s3.create_bucket(Bucket='x'*2)
+    exc.exception.response['Error']['Code'].should.equal('InvalidBucketName')


### PR DESCRIPTION
Check that s3 bucket names follow the documented length restriction:

'Bucket names must be at least 3 and no more than 63 characters long.'

See https://docs.aws.amazon.com/AmazonS3/latest/dev/BucketRestrictions.html