### PR TITLE
 Add AllowedPattern to SSM describe_parameters response

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,4 +15,4 @@ python_env
 .ropeproject/
 .pytest_cache/
 venv/
-
+.python-version

--- a/moto/ssm/models.py
+++ b/moto/ssm/models.py
@@ -14,10 +14,12 @@ import itertools
 
 
 class Parameter(BaseModel):
-    def __init__(self, name, value, type, description, keyid, last_modified_date, version):
+    def __init__(self, name, value, type, description, allowed_pattern, keyid,
+            last_modified_date, version):
         self.name = name
         self.type = type
         self.description = description
+        self.allowed_pattern = allowed_pattern
         self.keyid = keyid
         self.last_modified_date = last_modified_date
         self.version = version
@@ -58,6 +60,10 @@ class Parameter(BaseModel):
 
         if self.keyid:
             r['KeyId'] = self.keyid
+
+        if self.allowed_pattern:
+            r['AllowedPattern'] = self.allowed_pattern
+
         return r
 
 
@@ -291,7 +297,8 @@ class SimpleSystemManagerBackend(BaseBackend):
             return self._parameters[name]
         return None
 
-    def put_parameter(self, name, description, value, type, keyid, overwrite):
+    def put_parameter(self, name, description, value, type, allowed_pattern,
+            keyid, overwrite):
         previous_parameter = self._parameters.get(name)
         version = 1
 
@@ -302,8 +309,8 @@ class SimpleSystemManagerBackend(BaseBackend):
                 return
 
         last_modified_date = time.time()
-        self._parameters[name] = Parameter(
-            name, value, type, description, keyid, last_modified_date, version)
+        self._parameters[name] = Parameter(name, value, type, description,
+            allowed_pattern, keyid, last_modified_date, version)
         return version
 
     def add_tags_to_resource(self, resource_type, resource_id, tags):

--- a/moto/ssm/responses.py
+++ b/moto/ssm/responses.py
@@ -160,11 +160,12 @@ class SimpleSystemManagerResponse(BaseResponse):
         description = self._get_param('Description')
         value = self._get_param('Value')
         type_ = self._get_param('Type')
+        allowed_pattern = self._get_param('AllowedPattern')
         keyid = self._get_param('KeyId')
         overwrite = self._get_param('Overwrite', False)
 
         result = self.ssm_backend.put_parameter(
-            name, description, value, type_, keyid, overwrite)
+            name, description, value, type_, allowed_pattern, keyid, overwrite)
 
         if result is None:
             error = {

--- a/tests/test_ssm/test_ssm_boto3.py
+++ b/tests/test_ssm/test_ssm_boto3.py
@@ -319,13 +319,15 @@ def test_describe_parameters():
         Name='test',
         Description='A test parameter',
         Value='value',
-        Type='String')
+        Type='String',
+        AllowedPattern=r'.*')
 
     response = client.describe_parameters()
 
     len(response['Parameters']).should.equal(1)
     response['Parameters'][0]['Name'].should.equal('test')
     response['Parameters'][0]['Type'].should.equal('String')
+    response['Parameters'][0]['AllowedPattern'].should.equal(r'.*')
 
 
 @mock_ssm


### PR DESCRIPTION
Addresses issue #1955 by adding `AllowedPattern` as an argument to `put_parameter` and as a returned field to `describe_parameters`.