### PR TITLE
Add instance AZ support in autoscaling

### DIFF
--- a/moto/autoscaling/responses.py
+++ b/moto/autoscaling/responses.py
@@ -486,7 +486,7 @@ DESCRIBE_AUTOSCALING_GROUPS_TEMPLATE = """<DescribeAutoScalingGroupsResponse xml
           {% for instance_state in group.instance_states %}
           <member>
             <HealthStatus>{{ instance_state.health_status }}</HealthStatus>
-            <AvailabilityZone>us-east-1e</AvailabilityZone>
+            <AvailabilityZone>{{ instance_state.instance.placement }}</AvailabilityZone>
             <InstanceId>{{ instance_state.instance.id }}</InstanceId>
             <LaunchConfigurationName>{{ group.launch_config_name }}</LaunchConfigurationName>
             <LifecycleState>{{ instance_state.lifecycle_state }}</LifecycleState>
@@ -561,7 +561,7 @@ DESCRIBE_AUTOSCALING_INSTANCES_TEMPLATE = """<DescribeAutoScalingInstancesRespon
       <member>
         <HealthStatus>{{ instance_state.health_status }}</HealthStatus>
         <AutoScalingGroupName>{{ instance_state.instance.autoscaling_group.name }}</AutoScalingGroupName>
-        <AvailabilityZone>us-east-1e</AvailabilityZone>
+        <AvailabilityZone>{{ instance_state.instance.placement }}</AvailabilityZone>
         <InstanceId>{{ instance_state.instance.id }}</InstanceId>
         <LaunchConfigurationName>{{ instance_state.instance.autoscaling_group.launch_config_name }}</LaunchConfigurationName>
         <LifecycleState>{{ instance_state.lifecycle_state }}</LifecycleState>

--- a/tests/test_autoscaling/test_autoscaling.py
+++ b/tests/test_autoscaling/test_autoscaling.py
@@ -42,7 +42,10 @@ def test_create_autoscaling_group():
         launch_config=config,
         load_balancers=["test_lb"],
         placement_group="test_placement",
-        vpc_zone_identifier=f"{mocked_networking['subnet1']},{mocked_networking['subnet2']}",
+        vpc_zone_identifier="{subnet1},{subnet2}".format(
+            subnet1=mocked_networking['subnet1'],
+            subnet2=mocked_networking['subnet2'],
+        ),
         termination_policies=["OldestInstance", "NewestInstance"],
         tags=[Tag(
             resource_id='tester_group',
@@ -62,7 +65,10 @@ def test_create_autoscaling_group():
     group.max_size.should.equal(2)
     group.min_size.should.equal(2)
     group.instances.should.have.length_of(2)
-    group.vpc_zone_identifier.should.equal(f"{mocked_networking['subnet1']},{mocked_networking['subnet2']}")
+    group.vpc_zone_identifier.should.equal("{subnet1},{subnet2}".format(
+        subnet1=mocked_networking['subnet1'],
+        subnet2=mocked_networking['subnet2'],
+    ))
     group.launch_config_name.should.equal('tester')
     group.default_cooldown.should.equal(60)
     group.health_check_period.should.equal(100)
@@ -792,7 +798,10 @@ def test_update_autoscaling_group_boto3():
     response = client.update_auto_scaling_group(
         AutoScalingGroupName='test_asg',
         MinSize=1,
-        VPCZoneIdentifier=f"{mocked_networking['subnet1']},{mocked_networking['subnet2']}",
+        VPCZoneIdentifier="{subnet1},{subnet2}".format(
+            subnet1=mocked_networking['subnet1'],
+            subnet2=mocked_networking['subnet2'],
+        ),
     )
 
     response = client.describe_auto_scaling_groups(

--- a/tests/test_autoscaling/test_autoscaling.py
+++ b/tests/test_autoscaling/test_autoscaling.py
@@ -32,7 +32,7 @@ def test_create_autoscaling_group():
 
     group = AutoScalingGroup(
         name='tester_group',
-        availability_zones=['us-east-1c', 'us-east-1b'],
+        availability_zones=['us-east-1a', 'us-east-1b'],
         default_cooldown=60,
         desired_capacity=2,
         health_check_period=100,
@@ -42,7 +42,7 @@ def test_create_autoscaling_group():
         launch_config=config,
         load_balancers=["test_lb"],
         placement_group="test_placement",
-        vpc_zone_identifier=mocked_networking['subnet1'],
+        vpc_zone_identifier=f"{mocked_networking['subnet1']},{mocked_networking['subnet2']}",
         termination_policies=["OldestInstance", "NewestInstance"],
         tags=[Tag(
             resource_id='tester_group',
@@ -57,12 +57,12 @@ def test_create_autoscaling_group():
     group = conn.get_all_groups()[0]
     group.name.should.equal('tester_group')
     set(group.availability_zones).should.equal(
-        set(['us-east-1c', 'us-east-1b']))
+        set(['us-east-1a', 'us-east-1b']))
     group.desired_capacity.should.equal(2)
     group.max_size.should.equal(2)
     group.min_size.should.equal(2)
     group.instances.should.have.length_of(2)
-    group.vpc_zone_identifier.should.equal(mocked_networking['subnet1'])
+    group.vpc_zone_identifier.should.equal(f"{mocked_networking['subnet1']},{mocked_networking['subnet2']}")
     group.launch_config_name.should.equal('tester')
     group.default_cooldown.should.equal(60)
     group.health_check_period.should.equal(100)
@@ -109,7 +109,7 @@ def test_create_autoscaling_groups_defaults():
     group.launch_config_name.should.equal('tester')
 
     # Defaults
-    list(group.availability_zones).should.equal([])
+    list(group.availability_zones).should.equal(['us-east-1a'])  # subnet1
     group.desired_capacity.should.equal(2)
     group.vpc_zone_identifier.should.equal(mocked_networking['subnet1'])
     group.default_cooldown.should.equal(300)
@@ -217,7 +217,6 @@ def test_autoscaling_update():
 
     group = AutoScalingGroup(
         name='tester_group',
-        availability_zones=['us-east-1c', 'us-east-1b'],
         desired_capacity=2,
         max_size=2,
         min_size=2,
@@ -227,13 +226,16 @@ def test_autoscaling_update():
     conn.create_auto_scaling_group(group)
 
     group = conn.get_all_groups()[0]
+    group.availability_zones.should.equal(['us-east-1a'])
     group.vpc_zone_identifier.should.equal(mocked_networking['subnet1'])
 
-    group.vpc_zone_identifier = 'subnet-5678efgh'
+    group.availability_zones = ['us-east-1b']
+    group.vpc_zone_identifier = mocked_networking['subnet2']
     group.update()
 
     group = conn.get_all_groups()[0]
-    group.vpc_zone_identifier.should.equal('subnet-5678efgh')
+    group.availability_zones.should.equal(['us-east-1b'])
+    group.vpc_zone_identifier.should.equal(mocked_networking['subnet2'])
 
 
 @mock_autoscaling_deprecated
@@ -249,7 +251,7 @@ def test_autoscaling_tags_update():
 
     group = AutoScalingGroup(
         name='tester_group',
-        availability_zones=['us-east-1c', 'us-east-1b'],
+        availability_zones=['us-east-1a'],
         desired_capacity=2,
         max_size=2,
         min_size=2,
@@ -309,7 +311,7 @@ def test_autoscaling_group_delete():
 @mock_autoscaling_deprecated
 def test_autoscaling_group_describe_instances():
     mocked_networking = setup_networking_deprecated()
-    conn = boto.connect_autoscale()
+    conn = boto.ec2.autoscale.connect_to_region('us-east-1')
     config = LaunchConfiguration(
         name='tester',
         image_id='ami-abcd1234',
@@ -332,7 +334,7 @@ def test_autoscaling_group_describe_instances():
     instances[0].health_status.should.equal('Healthy')
     autoscale_instance_ids = [instance.instance_id for instance in instances]
 
-    ec2_conn = boto.connect_ec2()
+    ec2_conn = boto.ec2.connect_to_region('us-east-1')
     reservations = ec2_conn.get_all_instances()
     instances = reservations[0].instances
     instances.should.have.length_of(2)
@@ -355,7 +357,7 @@ def test_set_desired_capacity_up():
 
     group = AutoScalingGroup(
         name='tester_group',
-        availability_zones=['us-east-1c', 'us-east-1b'],
+        availability_zones=['us-east-1a'],
         desired_capacity=2,
         max_size=2,
         min_size=2,
@@ -391,7 +393,7 @@ def test_set_desired_capacity_down():
 
     group = AutoScalingGroup(
         name='tester_group',
-        availability_zones=['us-east-1c', 'us-east-1b'],
+        availability_zones=['us-east-1a'],
         desired_capacity=2,
         max_size=2,
         min_size=2,
@@ -427,7 +429,7 @@ def test_set_desired_capacity_the_same():
 
     group = AutoScalingGroup(
         name='tester_group',
-        availability_zones=['us-east-1c', 'us-east-1b'],
+        availability_zones=['us-east-1a'],
         desired_capacity=2,
         max_size=2,
         min_size=2,
@@ -733,8 +735,42 @@ def test_describe_autoscaling_groups_boto3():
         AutoScalingGroupNames=["test_asg"]
     )
     response['ResponseMetadata']['HTTPStatusCode'].should.equal(200)
-    response['AutoScalingGroups'][0][
-        'AutoScalingGroupName'].should.equal('test_asg')
+    group = response['AutoScalingGroups'][0]
+    group['AutoScalingGroupName'].should.equal('test_asg')
+    group['AvailabilityZones'].should.equal(['us-east-1a'])
+    group['VPCZoneIdentifier'].should.equal(mocked_networking['subnet1'])
+    for instance in group['Instances']:
+        instance['AvailabilityZone'].should.equal('us-east-1a')
+
+
+@mock_autoscaling
+def test_describe_autoscaling_instances_boto3():
+    mocked_networking = setup_networking()
+    client = boto3.client('autoscaling', region_name='us-east-1')
+    _ = client.create_launch_configuration(
+        LaunchConfigurationName='test_launch_configuration'
+    )
+    _ = client.create_auto_scaling_group(
+        AutoScalingGroupName='test_asg',
+        LaunchConfigurationName='test_launch_configuration',
+        MinSize=0,
+        MaxSize=20,
+        DesiredCapacity=5,
+        VPCZoneIdentifier=mocked_networking['subnet1'],
+    )
+
+    response = client.describe_auto_scaling_groups(
+        AutoScalingGroupNames=["test_asg"]
+    )
+    instance_ids = [
+        instance['InstanceId']
+        for instance in response['AutoScalingGroups'][0]['Instances']
+    ]
+
+    response = client.describe_auto_scaling_instances(InstanceIds=instance_ids)
+    for instance in response['AutoScalingInstances']:
+        instance['AutoScalingGroupName'].should.equal('test_asg')
+        instance['AvailabilityZone'].should.equal('us-east-1a')
 
 
 @mock_autoscaling
@@ -756,12 +792,15 @@ def test_update_autoscaling_group_boto3():
     response = client.update_auto_scaling_group(
         AutoScalingGroupName='test_asg',
         MinSize=1,
+        VPCZoneIdentifier=f"{mocked_networking['subnet1']},{mocked_networking['subnet2']}",
     )
 
     response = client.describe_auto_scaling_groups(
         AutoScalingGroupNames=["test_asg"]
     )
-    response['AutoScalingGroups'][0]['MinSize'].should.equal(1)
+    group = response['AutoScalingGroups'][0]
+    group['MinSize'].should.equal(1)
+    set(group['AvailabilityZones']).should.equal({'us-east-1a', 'us-east-1b'})
 
 
 @mock_autoscaling

--- a/tests/test_autoscaling/test_elbv2.py
+++ b/tests/test_autoscaling/test_elbv2.py
@@ -106,7 +106,7 @@ def test_detach_all_target_groups():
         MaxSize=INSTANCE_COUNT,
         DesiredCapacity=INSTANCE_COUNT,
         TargetGroupARNs=[target_group_arn],
-        VPCZoneIdentifier=mocked_networking['vpc'])
+        VPCZoneIdentifier=mocked_networking['subnet1'])
 
     response = client.describe_load_balancer_target_groups(
         AutoScalingGroupName='test_asg')

--- a/tests/test_autoscaling/utils.py
+++ b/tests/test_autoscaling/utils.py
@@ -1,5 +1,6 @@
 import boto
 import boto3
+from boto import vpc as boto_vpc
 from moto import mock_ec2, mock_ec2_deprecated
 
 
@@ -19,9 +20,14 @@ def setup_networking():
 
 @mock_ec2_deprecated
 def setup_networking_deprecated():
-    conn = boto.connect_vpc()
+    conn = boto_vpc.connect_to_region('us-east-1')
     vpc = conn.create_vpc("10.11.0.0/16")
-    subnet1 = conn.create_subnet(vpc.id, "10.11.1.0/24")
-    subnet2 = conn.create_subnet(vpc.id, "10.11.2.0/24")
+    subnet1 = conn.create_subnet(
+        vpc.id,
+        "10.11.1.0/24",
+        availability_zone='us-east-1a')
+    subnet2 = conn.create_subnet(
+        vpc.id,
+        "10.11.2.0/24",
+        availability_zone='us-east-1b')
     return {'vpc': vpc.id, 'subnet1': subnet1.id, 'subnet2': subnet2.id}
-


### PR DESCRIPTION
This issue refers to/fixes #1984.

### Fix
- I have made changes to ASG initialization that properly sets and updates availability zones (both direct setting, and if there are VPC identifiers that need to be taken into account).
- I have made changes to propagate one of an ASG's availability zone to its instances when creating them.
- I have made changes to the return templates for an ASG's describe methods (`describe_auto_scaling_groups`, `describe_auto_scaling_instances`) so that instead of returning a hardcoded AZ (`us-east-1e`), a 'real' AZ is returned.
- I have written tests for the above changes.