### PR TITLE
Bugfix for filtering EC2 AMIs with is-public (values should be lowercase)

### DIFF
--- a/moto/ec2/models.py
+++ b/moto/ec2/models.py
@@ -1115,7 +1115,7 @@ class Ami(TaggedEC2Resource):
         elif filter_name == 'image-id':
             return self.id
         elif filter_name == 'is-public':
-            return str(self.is_public)
+            return self.is_public_string
         elif filter_name == 'state':
             return self.state
         elif filter_name == 'name':

--- a/tests/test_ec2/test_amis.py
+++ b/tests/test_ec2/test_amis.py
@@ -258,11 +258,11 @@ def test_ami_filters():
     amis_by_name = conn.get_all_images(filters={'name': imageA.name})
     set([ami.id for ami in amis_by_name]).should.equal(set([imageA.id]))
 
-    amis_by_public = conn.get_all_images(filters={'is-public': True})
+    amis_by_public = conn.get_all_images(filters={'is-public': 'true'})
     set([ami.id for ami in amis_by_public]).should.contain(imageB.id)
     len(amis_by_public).should.equal(35)
 
-    amis_by_nonpublic = conn.get_all_images(filters={'is-public': False})
+    amis_by_nonpublic = conn.get_all_images(filters={'is-public': 'false'})
     set([ami.id for ami in amis_by_nonpublic]).should.contain(imageA.id)
     len(amis_by_nonpublic).should.equal(1)
 


### PR DESCRIPTION
resolves #1988 