### PR TITLE
Replace pyaml with PyYAML dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ install_requires = [
     "xmltodict",
     "six>1.9",
     "werkzeug",
-    "pyaml",
+    "PyYAML",
     "pytz",
     "python-dateutil<3.0.0,>=2.1",
     "python-jose<3.0.0",


### PR DESCRIPTION
[fix #1991]

Note: I tried simply removing the pyaml dependency and saw travis tests fail, but replacing it with PyYAML allows them to continue to pass.