### PR TITLE
Add idna version depencies.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,7 @@ install_requires = [
     "jsondiff==1.1.1",
     "aws-xray-sdk!=0.96,>=0.93",
     "responses>=0.9.0",
+    "idna<2.8,>=2.5",
 ]
 
 extras_require = {


### PR DESCRIPTION
The current setup will install `idna==2.8` which will cause `requests` to have an incompatible dependency:

```
requests 2.20.1 has requirement idna<2.8,>=2.5, but you'll have idna 2.8 which is incompatible.
```