### PR TITLE
Displays the correct number of available IP addresses for a subnet

### DIFF
--- a/moto/ec2/models.py
+++ b/moto/ec2/models.py
@@ -2323,7 +2323,7 @@ class Subnet(TaggedEC2Resource):
         self.vpc_id = vpc_id
         self.cidr_block = cidr_block
         self.cidr = ipaddress.ip_network(six.text_type(self.cidr_block))
-        self.available_ips = ipaddress.IPv4Network(cidr_block).num_addresses - 5
+        self.available_ip_addresses = str(ipaddress.IPv4Network(six.text_type(self.cidr_block)).num_addresses - 5)
         self._availability_zone = availability_zone
         self.default_for_az = default_for_az
         self.map_public_ip_on_launch = map_public_ip_on_launch

--- a/moto/ec2/models.py
+++ b/moto/ec2/models.py
@@ -2323,6 +2323,7 @@ class Subnet(TaggedEC2Resource):
         self.vpc_id = vpc_id
         self.cidr_block = cidr_block
         self.cidr = ipaddress.ip_network(six.text_type(self.cidr_block))
+        self.available_ips = ipaddress.IPv4Network(cidr_block).num_addresses - 5
         self._availability_zone = availability_zone
         self.default_for_az = default_for_az
         self.map_public_ip_on_launch = map_public_ip_on_launch

--- a/moto/ec2/responses/subnets.py
+++ b/moto/ec2/responses/subnets.py
@@ -48,7 +48,7 @@ CREATE_SUBNET_RESPONSE = """
     <state>pending</state>
     <vpcId>{{ subnet.vpc_id }}</vpcId>
     <cidrBlock>{{ subnet.cidr_block }}</cidrBlock>
-    <availableIpAddressCount>251</availableIpAddressCount>
+    <availableIpAddressCount>{{ subnet.available_ip_addresses }}</availableIpAddressCount>
     <availabilityZone>{{ subnet.availability_zone }}</availabilityZone>
     <tagSet>
       {% for tag in subnet.get_tags() %}
@@ -79,7 +79,7 @@ DESCRIBE_SUBNETS_RESPONSE = """
         <state>available</state>
         <vpcId>{{ subnet.vpc_id }}</vpcId>
         <cidrBlock>{{ subnet.cidr_block }}</cidrBlock>
-        <availableIpAddressCount>251</availableIpAddressCount>
+        <availableIpAddressCount>{{ subnet.available_ip_addresses }}</availableIpAddressCount>
         <availabilityZone>{{ subnet.availability_zone }}</availabilityZone>
         <defaultForAz>{{ subnet.default_for_az }}</defaultForAz>
         <mapPublicIpOnLaunch>{{ subnet.map_public_ip_on_launch }}</mapPublicIpOnLaunch>


### PR DESCRIPTION
Fixes issue #2002 

create_subnet and describe_subnets displays the correct number of
available IP addresses. The module currently has '251' hardcoded.
This fix shows available IPs minus 5, which are reserved in each
subnet by AWS.

https://docs.aws.amazon.com/vpc/latest/userguide/VPC_Subnets.html#vpc-sizing-ipv4