### PR TITLE
Enable SES feedback via SNS

### DIFF
--- a/moto/ses/feedback.py
+++ b/moto/ses/feedback.py
@@ -1,0 +1,81 @@
+"""
+SES Feedback messages
+Extracted from https://docs.aws.amazon.com/ses/latest/DeveloperGuide/notification-contents.html
+"""
+COMMON_MAIL = {
+    "notificationType": "Bounce, Complaint, or Delivery.",
+    "mail": {
+        "timestamp": "2018-10-08T14:05:45 +0000",
+        "messageId": "000001378603177f-7a5433e7-8edb-42ae-af10-f0181f34d6ee-000000",
+        "source": "sender@example.com",
+        "sourceArn": "arn:aws:ses:us-west-2:888888888888:identity/example.com",
+        "sourceIp": "127.0.3.0",
+        "sendingAccountId": "123456789012",
+        "destination": [
+            "recipient@example.com"
+        ],
+        "headersTruncated": False,
+        "headers": [
+            {
+                "name": "From",
+                "value": "\"Sender Name\" <sender@example.com>"
+            },
+            {
+                "name": "To",
+                "value": "\"Recipient Name\" <recipient@example.com>"
+            }
+        ],
+        "commonHeaders": {
+            "from": [
+                "Sender Name <sender@example.com>"
+            ],
+            "date": "Mon, 08 Oct 2018 14:05:45 +0000",
+            "to": [
+                "Recipient Name <recipient@example.com>"
+            ],
+            "messageId": " custom-message-ID",
+            "subject": "Message sent using Amazon SES"
+        }
+    }
+}
+BOUNCE = {
+    "bounceType": "Permanent",
+    "bounceSubType": "General",
+    "bouncedRecipients": [
+        {
+            "status": "5.0.0",
+            "action": "failed",
+            "diagnosticCode": "smtp; 550 user unknown",
+            "emailAddress": "recipient1@example.com"
+        },
+        {
+            "status": "4.0.0",
+            "action": "delayed",
+            "emailAddress": "recipient2@example.com"
+        }
+    ],
+    "reportingMTA": "example.com",
+    "timestamp": "2012-05-25T14:59:38.605Z",
+    "feedbackId": "000001378603176d-5a4b5ad9-6f30-4198-a8c3-b1eb0c270a1d-000000",
+    "remoteMtaIp": "127.0.2.0"
+}
+COMPLAINT = {
+    "userAgent": "AnyCompany Feedback Loop (V0.01)",
+    "complainedRecipients": [
+            {
+                "emailAddress": "recipient1@example.com"
+            }
+    ],
+    "complaintFeedbackType": "abuse",
+    "arrivalDate": "2009-12-03T04:24:21.000-05:00",
+    "timestamp": "2012-05-25T14:59:38.623Z",
+    "feedbackId": "000001378603177f-18c07c78-fa81-4a58-9dd1-fedc3cb8f49a-000000"
+}
+DELIVERY = {
+    "timestamp": "2014-05-28T22:41:01.184Z",
+    "processingTimeMillis": 546,
+    "recipients": ["success@simulator.amazonses.com"],
+    "smtpResponse": "250 ok:  Message 64111812 accepted",
+    "reportingMTA": "a8-70.smtp-out.amazonses.com",
+    "remoteMtaIp": "127.0.2.0"
+}

--- a/moto/ses/models.py
+++ b/moto/ses/models.py
@@ -4,11 +4,38 @@ import email
 from email.utils import parseaddr
 
 from moto.core import BaseBackend, BaseModel
+from moto.sns.models import sns_backends
 from .exceptions import MessageRejectedError
 from .utils import get_random_message_id
-
+from .feedback import COMMON_MAIL, BOUNCE, COMPLAINT, DELIVERY
 
 RECIPIENT_LIMIT = 50
+
+class SESFeedback(BaseModel):
+
+    BOUNCE = "Bounce"
+    COMPLAINT = "Complaint"
+    DELIVERY = "Delivery"
+
+    SUCCESS_ADDR = "success"
+    BOUNCE_ADDR = "bounce"
+    COMPLAINT_ADDR = "complaint"
+
+    FEEDBACK_SUCCESS_MSG = {"test": "success"}
+    FEEDBACK_BOUNCE_MSG = {"test": "bounce"}
+    FEEDBACK_COMPLAINT_MSG = {"test": "complaint"}
+
+    @staticmethod
+    def generate_message(msg_type):
+        msg = dict(COMMON_MAIL)
+        if msg_type == SESFeedback.BOUNCE:
+            msg["bounce"] = BOUNCE
+        elif msg_type == SESFeedback.COMPLAINT:
+            msg["complaint"] = COMPLAINT
+        elif msg_type == SESFeedback.DELIVERY:
+            msg["delivery"] = DELIVERY
+
+        return msg
 
 
 class Message(BaseModel):
@@ -48,6 +75,7 @@ class SESBackend(BaseBackend):
         self.domains = []
         self.sent_messages = []
         self.sent_message_count = 0
+        self.sns_topics = {}
 
     def _is_verified_address(self, source):
         _, address = parseaddr(source)
@@ -77,7 +105,7 @@ class SESBackend(BaseBackend):
         else:
             self.domains.remove(identity)
 
-    def send_email(self, source, subject, body, destinations):
+    def send_email(self, source, subject, body, destinations, region):
         recipient_count = sum(map(len, destinations.values()))
         if recipient_count > RECIPIENT_LIMIT:
             raise MessageRejectedError('Too many recipients.')
@@ -86,13 +114,52 @@ class SESBackend(BaseBackend):
                 "Email address not verified %s" % source
             )
 
+        self.__process_sns_feedback__(source, destinations, region)
+
         message_id = get_random_message_id()
         message = Message(message_id, source, subject, body, destinations)
         self.sent_messages.append(message)
         self.sent_message_count += recipient_count
         return message
 
-    def send_raw_email(self, source, destinations, raw_data):
+    def __type_of_message__(self, destinations):
+        """Checks the destination for any special address that could indicate delivery, complaint or bounce
+        like in SES simualtor"""
+        alladdress = destinations.get("ToAddresses", []) + destinations.get("CcAddresses", []) + destinations.get("BccAddresses", [])
+        for addr in alladdress:
+            if SESFeedback.SUCCESS_ADDR in addr:
+                return SESFeedback.DELIVERY
+            elif SESFeedback.COMPLAINT_ADDR in addr:
+                return SESFeedback.COMPLAINT
+            elif SESFeedback.BOUNCE_ADDR in addr:
+                return SESFeedback.BOUNCE
+
+        return None
+
+    def __generate_feedback__(self, msg_type):
+        """Generates the SNS message for the feedback"""
+        return SESFeedback.generate_message(msg_type)
+
+    def __process_sns_feedback__(self, source, destinations, region):
+        domain = str(source)
+        if "@" in domain:
+            domain = domain.split("@")[1]
+        print(domain, self.sns_topics)
+        if domain in self.sns_topics:
+            print("SNS Feedback configured for %s => %s" % (domain, self.sns_topics[domain]))
+            msg_type = self.__type_of_message__(destinations)
+            print("Message type for destinations %s => %s" % (destinations, msg_type))
+            if msg_type is not None:
+                sns_topic = self.sns_topics[domain].get(msg_type, None)
+                if sns_topic is not None:
+                    message = self.__generate_feedback__(msg_type)
+                    if message:
+                        print("Message generated for %s => %s" % (message, msg_type))
+                        sns_backends[region].publish(sns_topic, message)
+        else:
+            print("SNS Feedback not configured")
+
+    def send_raw_email(self, source, destinations, raw_data, region):
         if source is not None:
             _, source_email_address = parseaddr(source)
             if source_email_address not in self.addresses:
@@ -122,6 +189,8 @@ class SESBackend(BaseBackend):
         if recipient_count > RECIPIENT_LIMIT:
             raise MessageRejectedError('Too many recipients.')
 
+        self.__process_sns_feedback__(source, destinations, region)
+
         self.sent_message_count += recipient_count
         message_id = get_random_message_id()
         message = RawMessage(message_id, source, destinations, raw_data)
@@ -130,6 +199,17 @@ class SESBackend(BaseBackend):
 
     def get_send_quota(self):
         return SESQuota(self.sent_message_count)
+
+    def set_identity_notification_topic(self, identity, notification_type, sns_topic):
+        identity_sns_topics = self.sns_topics.get(identity, {})
+        if sns_topic is None:
+            del identity_sns_topics[notification_type]
+        else:
+            identity_sns_topics[notification_type] = sns_topic
+
+        self.sns_topics[identity] = identity_sns_topics
+
+        return {}
 
 
 ses_backend = SESBackend()

--- a/moto/ses/models.py
+++ b/moto/ses/models.py
@@ -11,6 +11,7 @@ from .feedback import COMMON_MAIL, BOUNCE, COMPLAINT, DELIVERY
 
 RECIPIENT_LIMIT = 50
 
+
 class SESFeedback(BaseModel):
 
     BOUNCE = "Bounce"

--- a/moto/ses/models.py
+++ b/moto/ses/models.py
@@ -145,20 +145,14 @@ class SESBackend(BaseBackend):
         domain = str(source)
         if "@" in domain:
             domain = domain.split("@")[1]
-        print(domain, self.sns_topics)
         if domain in self.sns_topics:
-            print("SNS Feedback configured for %s => %s" % (domain, self.sns_topics[domain]))
             msg_type = self.__type_of_message__(destinations)
-            print("Message type for destinations %s => %s" % (destinations, msg_type))
             if msg_type is not None:
                 sns_topic = self.sns_topics[domain].get(msg_type, None)
                 if sns_topic is not None:
                     message = self.__generate_feedback__(msg_type)
                     if message:
-                        print("Message generated for %s => %s" % (message, msg_type))
                         sns_backends[region].publish(sns_topic, message)
-        else:
-            print("SNS Feedback not configured")
 
     def send_raw_email(self, source, destinations, raw_data, region):
         if source is not None:

--- a/moto/ses/responses.py
+++ b/moto/ses/responses.py
@@ -70,7 +70,7 @@ class EmailResponse(BaseResponse):
                     break
                 destinations[dest_type].append(address[0])
 
-        message = ses_backend.send_email(source, subject, body, destinations)
+        message = ses_backend.send_email(source, subject, body, destinations, self.region)
         template = self.response_template(SEND_EMAIL_RESPONSE)
         return template.render(message=message)
 
@@ -92,7 +92,7 @@ class EmailResponse(BaseResponse):
                 break
             destinations.append(address[0])
 
-        message = ses_backend.send_raw_email(source, destinations, raw_data)
+        message = ses_backend.send_raw_email(source, destinations, raw_data, self.region)
         template = self.response_template(SEND_RAW_EMAIL_RESPONSE)
         return template.render(message=message)
 
@@ -100,6 +100,18 @@ class EmailResponse(BaseResponse):
         quota = ses_backend.get_send_quota()
         template = self.response_template(GET_SEND_QUOTA_RESPONSE)
         return template.render(quota=quota)
+
+    def set_identity_notification_topic(self):
+
+        identity = self.querystring.get("Identity")[0]
+        not_type = self.querystring.get("NotificationType")[0]
+        sns_topic = self.querystring.get("SnsTopic")
+        if sns_topic:
+            sns_topic = sns_topic[0]
+
+        ses_backend.set_identity_notification_topic(identity, not_type, sns_topic)
+        template = self.response_template(SET_IDENTITY_NOTIFICATION_TOPIC_RESPONSE)
+        return template.render()
 
 
 VERIFY_EMAIL_IDENTITY = """<VerifyEmailIdentityResponse xmlns="http://ses.amazonaws.com/doc/2010-12-01/">
@@ -200,3 +212,10 @@ GET_SEND_QUOTA_RESPONSE = """<GetSendQuotaResponse xmlns="http://ses.amazonaws.c
     <RequestId>273021c6-c866-11e0-b926-699e21c3af9e</RequestId>
   </ResponseMetadata>
 </GetSendQuotaResponse>"""
+
+SET_IDENTITY_NOTIFICATION_TOPIC_RESPONSE = """<SetIdentityNotificationTopicResponse xmlns="http://ses.amazonaws.com/doc/2010-12-01/">
+  <SetIdentityNotificationTopicResult/>
+  <ResponseMetadata>
+    <RequestId>47e0ef1a-9bf2-11e1-9279-0100e8cf109a</RequestId>
+  </ResponseMetadata>
+</SetIdentityNotificationTopicResponse>"""

--- a/tests/test_ses/test_ses_sns_boto3.py
+++ b/tests/test_ses/test_ses_sns_boto3.py
@@ -1,0 +1,114 @@
+from __future__ import unicode_literals
+
+import boto3
+import json
+from botocore.exceptions import ClientError
+from six.moves.email_mime_multipart import MIMEMultipart
+from six.moves.email_mime_text import MIMEText
+
+import sure  # noqa
+from nose import tools
+from moto import mock_ses, mock_sns, mock_sqs
+from moto.ses.models import SESFeedback
+
+
+@mock_ses
+def test_enable_disable_ses_sns_communication():
+    conn = boto3.client('ses', region_name='us-east-1')
+    conn.set_identity_notification_topic(
+        Identity='test.com',
+        NotificationType='Bounce',
+        SnsTopic='the-arn'
+    )
+    conn.set_identity_notification_topic(
+        Identity='test.com',
+        NotificationType='Bounce'
+    )
+
+
+def __setup_feedback_env__(ses_conn, sns_conn, sqs_conn, domain, topic, queue, region, expected_msg):
+    """Setup the AWS environment to test the SES SNS Feedback"""
+    # Environment setup
+    # Create SQS queue
+    sqs_conn.create_queue(QueueName=queue)
+    # Create SNS topic
+    create_topic_response = sns_conn.create_topic(Name=topic)
+    topic_arn = create_topic_response["TopicArn"]
+    # Subscribe the SNS topic to the SQS queue
+    sns_conn.subscribe(TopicArn=topic_arn,
+                   Protocol="sqs",
+                   Endpoint="arn:aws:sqs:%s:123456789012:%s" % (region, queue))
+    # Verify SES domain
+    ses_conn.verify_domain_identity(Domain=domain)
+    # Setup SES notification topic
+    if expected_msg is not None:
+        ses_conn.set_identity_notification_topic(
+            Identity=domain,
+            NotificationType=expected_msg,
+            SnsTopic=topic_arn
+        )
+
+
+def __test_sns_feedback__(addr, expected_msg):
+    region_name = "us-east-1"
+    ses_conn = boto3.client('ses', region_name=region_name)
+    sns_conn = boto3.client('sns', region_name=region_name)
+    sqs_conn = boto3.resource('sqs', region_name=region_name)
+    domain = "example.com"
+    topic = "bounce-arn-feedback"
+    queue = "feedback-test-queue"
+
+    __setup_feedback_env__(ses_conn, sns_conn, sqs_conn, domain, topic, queue, region_name, expected_msg)
+
+    # Send the message
+    kwargs = dict(
+        Source="test@" + domain,
+        Destination={
+            "ToAddresses": [addr + "@" + domain],
+            "CcAddresses": ["test_cc@" + domain],
+            "BccAddresses": ["test_bcc@" + domain],
+        },
+        Message={
+            "Subject": {"Data": "test subject"},
+            "Body": {"Text": {"Data": "test body"}}
+        }
+    )
+    ses_conn.send_email(**kwargs)
+
+    # Wait for messages in the queues
+    queue = sqs_conn.get_queue_by_name(QueueName=queue)
+    messages = queue.receive_messages(MaxNumberOfMessages=1)
+    if expected_msg is not None:
+        msg = messages[0].body
+        msg = json.loads(msg)
+        assert msg["Message"] == SESFeedback.generate_message(expected_msg)
+    else:
+        assert len(messages) == 0
+
+
+@mock_sqs
+@mock_sns
+@mock_ses
+def test_no_sns_feedback():
+    __test_sns_feedback__("test", None)
+
+
+@mock_sqs
+@mock_sns
+@mock_ses
+def test_sns_feedback_bounce():
+    __test_sns_feedback__(SESFeedback.BOUNCE_ADDR, SESFeedback.BOUNCE)
+
+
+@mock_sqs
+@mock_sns
+@mock_ses
+def test_sns_feedback_complaint():
+    __test_sns_feedback__(SESFeedback.COMPLAINT_ADDR, SESFeedback.COMPLAINT)
+
+
+@mock_sqs
+@mock_sns
+@mock_ses
+def test_sns_feedback_delivery():
+    __test_sns_feedback__(SESFeedback.SUCCESS_ADDR, SESFeedback.DELIVERY)


### PR DESCRIPTION
Enable SES feedback (Delivery, Bounce, Complaint) via SNS topic.
- SES implements the AWS SES API method set_identity_notification_topic that will save the topic configuration

- `send_email` and `send_raw_email` check the SNS Topic configuration

- The SES feedback messages are static and are extracted from https://docs.aws.amazon.com/ses/latest/DeveloperGuide/notification-contents.html