### PR TITLE
Correctly returning ami launch index

### DIFF
--- a/moto/ec2/models.py
+++ b/moto/ec2/models.py
@@ -388,6 +388,7 @@ class Instance(TaggedEC2Resource, BotoInstance):
         self.ebs_optimized = kwargs.get("ebs_optimized", False)
         self.source_dest_check = "true"
         self.launch_time = utc_date_and_time()
+        self.ami_launch_index = kwargs.get("ami_launch_index", 0)
         self.disable_api_termination = kwargs.get("disable_api_termination", False)
         self._spot_fleet_id = kwargs.get("spot_fleet_id", None)
         associate_public_ip = kwargs.get("associate_public_ip", False)

--- a/moto/ec2/models.py
+++ b/moto/ec2/models.py
@@ -720,6 +720,7 @@ class InstanceBackend(object):
         instance_tags = tags.get('instance', {})
 
         for index in range(count):
+            kwargs["ami_launch_index"] = index
             new_instance = Instance(
                 self,
                 image_id,

--- a/moto/ec2/responses/instances.py
+++ b/moto/ec2/responses/instances.py
@@ -244,7 +244,7 @@ EC2_RUN_INSTANCES = """<RunInstancesResponse xmlns="http://ec2.amazonaws.com/doc
           <reason/>
           <keyName>{{ instance.key_name }}</keyName>
           <ebsOptimized>{{ instance.ebs_optimized }}</ebsOptimized>
-          <amiLaunchIndex>0</amiLaunchIndex>
+          <amiLaunchIndex>{{ instance.ami_launch_index }}</amiLaunchIndex>
           <instanceType>{{ instance.instance_type }}</instanceType>
           <launchTime>{{ instance.launch_time }}</launchTime>
           <placement>
@@ -384,7 +384,7 @@ EC2_DESCRIBE_INSTANCES = """<DescribeInstancesResponse xmlns="http://ec2.amazona
                     <reason>{{ instance._reason }}</reason>
                     <keyName>{{ instance.key_name }}</keyName>
                     <ebsOptimized>{{ instance.ebs_optimized }}</ebsOptimized>
-                    <amiLaunchIndex>0</amiLaunchIndex>
+                    <amiLaunchIndex>{{ instance.ami_launch_index }}</amiLaunchIndex>
                     <productCodes/>
                     <instanceType>{{ instance.instance_type }}</instanceType>
                     <launchTime>{{ instance.launch_time }}</launchTime>

--- a/tests/test_ec2/test_instances.py
+++ b/tests/test_ec2/test_instances.py
@@ -1254,3 +1254,18 @@ def test_create_instance_ebs_optimized():
     )
     instance.load()
     instance.ebs_optimized.should.be(False)
+
+@mock_ec2
+def test_run_multiple_instances_in_same_command():
+    instance_count = 4
+    client = boto3.client('ec2', region_name='us-east-1')
+    client.run_instances(ImageId='ami-1234abcd',
+                          MinCount=instance_count,
+                          MaxCount=instance_count)
+    reservations = client.describe_instances()['Reservations']
+
+    reservations[0]['Instances'].should.have.length_of(instance_count)
+
+    instances = reservations[0]['Instances']
+    for i in range(0, instance_count):
+        instances[i]['AmiLaunchIndex'].should.be(i)


### PR DESCRIPTION
The `run-instances` command returned a constant 0 in the `AmiLaunchIndex` field for every created instance even if multiple instances were created in the same command (specifying the `--count` option with a value other than 1). This PR fixes this, the launch indexes are returned properly.