### PR TITLE
Fix sending the Request ID in the response body

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -54,3 +54,4 @@ Moto is written by Steve Pulec with contributions from:
 * [William Richard](https://github.com/william-richard)
 * [Alex Casalboni](https://github.com/alexcasalboni)
 * [Jon Beilke](https://github.com/jrbeilke)
+* [Robert Lewis](https://github.com/ralewis85)

--- a/moto/autoscaling/responses.py
+++ b/moto/autoscaling/responses.py
@@ -404,7 +404,7 @@ ATTACH_LOAD_BALANCER_TARGET_GROUPS_TEMPLATE = """<AttachLoadBalancerTargetGroups
 <AttachLoadBalancerTargetGroupsResult>
 </AttachLoadBalancerTargetGroupsResult>
 <ResponseMetadata>
-<RequestId>{{ requestid }}</RequestId>
+<RequestId></RequestId>
 </ResponseMetadata>
 </AttachLoadBalancerTargetGroupsResponse>"""
 
@@ -412,7 +412,7 @@ ATTACH_INSTANCES_TEMPLATE = """<AttachInstancesResponse xmlns="http://autoscalin
 <AttachInstancesResult>
 </AttachInstancesResult>
 <ResponseMetadata>
-<RequestId>{{ requestid }}</RequestId>
+<RequestId></RequestId>
 </ResponseMetadata>
 </AttachInstancesResponse>"""
 
@@ -428,7 +428,7 @@ DESCRIBE_LOAD_BALANCER_TARGET_GROUPS = """<DescribeLoadBalancerTargetGroupsRespo
   </LoadBalancerTargetGroups>
 </DescribeLoadBalancerTargetGroupsResult>
 <ResponseMetadata>
-<RequestId>{{ requestid }}</RequestId>
+<RequestId></RequestId>
 </ResponseMetadata>
 </DescribeLoadBalancerTargetGroupsResponse>"""
 
@@ -454,7 +454,7 @@ DETACH_INSTANCES_TEMPLATE = """<DetachInstancesResponse xmlns="http://autoscalin
   </Activities>
 </DetachInstancesResult>
 <ResponseMetadata>
-<RequestId>{{ requestid }}</RequestId>
+<RequestId></RequestId>
 </ResponseMetadata>
 </DetachInstancesResponse>"""
 
@@ -462,7 +462,7 @@ DETACH_LOAD_BALANCER_TARGET_GROUPS_TEMPLATE = """<DetachLoadBalancerTargetGroups
 <DetachLoadBalancerTargetGroupsResult>
 </DetachLoadBalancerTargetGroupsResult>
 <ResponseMetadata>
-<RequestId>{{ requestid }}</RequestId>
+<RequestId></RequestId>
 </ResponseMetadata>
 </DetachLoadBalancerTargetGroupsResponse>"""
 
@@ -654,7 +654,7 @@ DELETE_POLICY_TEMPLATE = """<DeleteScalingPolicyResponse xmlns="http://autoscali
 ATTACH_LOAD_BALANCERS_TEMPLATE = """<AttachLoadBalancersResponse xmlns="http://autoscaling.amazonaws.com/doc/2011-01-01/">
 <AttachLoadBalancersResult></AttachLoadBalancersResult>
 <ResponseMetadata>
-<RequestId>{{ requestid }}</RequestId>
+<RequestId></RequestId>
 </ResponseMetadata>
 </AttachLoadBalancersResponse>"""
 
@@ -670,14 +670,14 @@ DESCRIBE_LOAD_BALANCERS_TEMPLATE = """<DescribeLoadBalancersResponse xmlns="http
   </LoadBalancers>
 </DescribeLoadBalancersResult>
 <ResponseMetadata>
-<RequestId>{{ requestid }}</RequestId>
+<RequestId></RequestId>
 </ResponseMetadata>
 </DescribeLoadBalancersResponse>"""
 
 DETACH_LOAD_BALANCERS_TEMPLATE = """<DetachLoadBalancersResponse xmlns="http://autoscaling.amazonaws.com/doc/2011-01-01/">
 <DetachLoadBalancersResult></DetachLoadBalancersResult>
 <ResponseMetadata>
-<RequestId>{{ requestid }}</RequestId>
+<RequestId></RequestId>
 </ResponseMetadata>
 </DetachLoadBalancersResponse>"""
 
@@ -690,13 +690,13 @@ SUSPEND_PROCESSES_TEMPLATE = """<SuspendProcessesResponse xmlns="http://autoscal
 SET_INSTANCE_HEALTH_TEMPLATE = """<SetInstanceHealthResponse xmlns="http://autoscaling.amazonaws.com/doc/2011-01-01/">
 <SetInstanceHealthResponse></SetInstanceHealthResponse>
 <ResponseMetadata>
-<RequestId>{{ requestid }}</RequestId>
+<RequestId></RequestId>
 </ResponseMetadata>
 </SetInstanceHealthResponse>"""
 
 SET_INSTANCE_PROTECTION_TEMPLATE = """<SetInstanceProtectionResponse xmlns="http://autoscaling.amazonaws.com/doc/2011-01-01/">
 <SetInstanceProtectionResult></SetInstanceProtectionResult>
 <ResponseMetadata>
-<RequestId>{{ requestid }}</RequestId>
+<RequestId></RequestId>
 </ResponseMetadata>
 </SetInstanceProtectionResponse>"""

--- a/moto/core/utils.py
+++ b/moto/core/utils.py
@@ -280,7 +280,7 @@ def amzn_request_id(f):
 
         # Update request ID in XML
         try:
-            body = body.replace('{{ requestid }}', request_id)
+            body = re.sub(r'(?<=<RequestId>).*(?=<\/RequestId>)', request_id, body)
         except Exception:  # Will just ignore if it cant work on bytes (which are str's on python2)
             pass
 

--- a/moto/sqs/responses.py
+++ b/moto/sqs/responses.py
@@ -420,7 +420,7 @@ CREATE_QUEUE_RESPONSE = """<CreateQueueResponse>
         <VisibilityTimeout>{{ queue.visibility_timeout }}</VisibilityTimeout>
     </CreateQueueResult>
     <ResponseMetadata>
-        <RequestId>{{ requestid }}</RequestId>
+        <RequestId></RequestId>
     </ResponseMetadata>
 </CreateQueueResponse>"""
 
@@ -429,7 +429,7 @@ GET_QUEUE_URL_RESPONSE = """<GetQueueUrlResponse>
         <QueueUrl>{{ queue.url(request_url) }}</QueueUrl>
     </GetQueueUrlResult>
     <ResponseMetadata>
-        <RequestId>{{ requestid }}</RequestId>
+        <RequestId></RequestId>
     </ResponseMetadata>
 </GetQueueUrlResponse>"""
 
@@ -440,13 +440,13 @@ LIST_QUEUES_RESPONSE = """<ListQueuesResponse>
         {% endfor %}
     </ListQueuesResult>
     <ResponseMetadata>
-        <RequestId>{{ requestid }}</RequestId>
+        <RequestId></RequestId>
     </ResponseMetadata>
 </ListQueuesResponse>"""
 
 DELETE_QUEUE_RESPONSE = """<DeleteQueueResponse>
     <ResponseMetadata>
-        <RequestId>{{ requestid }}</RequestId>
+        <RequestId></RequestId>
     </ResponseMetadata>
 </DeleteQueueResponse>"""
 
@@ -460,13 +460,13 @@ GET_QUEUE_ATTRIBUTES_RESPONSE = """<GetQueueAttributesResponse>
     {% endfor %}
   </GetQueueAttributesResult>
   <ResponseMetadata>
-    <RequestId>{{ requestid }}</RequestId>
+    <RequestId></RequestId>
   </ResponseMetadata>
 </GetQueueAttributesResponse>"""
 
 SET_QUEUE_ATTRIBUTE_RESPONSE = """<SetQueueAttributesResponse>
     <ResponseMetadata>
-        <RequestId>{{ requestid }}</RequestId>
+        <RequestId></RequestId>
     </ResponseMetadata>
 </SetQueueAttributesResponse>"""
 
@@ -483,7 +483,7 @@ SEND_MESSAGE_RESPONSE = """<SendMessageResponse>
         </MessageId>
     </SendMessageResult>
     <ResponseMetadata>
-        <RequestId>{{ requestid }}</RequestId>
+        <RequestId></RequestId>
     </ResponseMetadata>
 </SendMessageResponse>"""
 
@@ -543,7 +543,7 @@ RECEIVE_MESSAGE_RESPONSE = """<ReceiveMessageResponse>
     {% endfor %}
   </ReceiveMessageResult>
   <ResponseMetadata>
-    <RequestId>{{ requestid }}</RequestId>
+    <RequestId></RequestId>
   </ResponseMetadata>
 </ReceiveMessageResponse>"""
 
@@ -561,13 +561,13 @@ SEND_MESSAGE_BATCH_RESPONSE = """<SendMessageBatchResponse>
     {% endfor %}
 </SendMessageBatchResult>
 <ResponseMetadata>
-    <RequestId>{{ requestid }}</RequestId>
+    <RequestId></RequestId>
 </ResponseMetadata>
 </SendMessageBatchResponse>"""
 
 DELETE_MESSAGE_RESPONSE = """<DeleteMessageResponse>
     <ResponseMetadata>
-        <RequestId>{{ requestid }}</RequestId>
+        <RequestId></RequestId>
     </ResponseMetadata>
 </DeleteMessageResponse>"""
 
@@ -580,13 +580,13 @@ DELETE_MESSAGE_BATCH_RESPONSE = """<DeleteMessageBatchResponse>
         {% endfor %}
     </DeleteMessageBatchResult>
     <ResponseMetadata>
-        <RequestId>{{ requestid }}</RequestId>
+        <RequestId></RequestId>
     </ResponseMetadata>
 </DeleteMessageBatchResponse>"""
 
 CHANGE_MESSAGE_VISIBILITY_RESPONSE = """<ChangeMessageVisibilityResponse>
     <ResponseMetadata>
-        <RequestId>{{ requestid }}</RequestId>
+        <RequestId></RequestId>
     </ResponseMetadata>
 </ChangeMessageVisibilityResponse>"""
 
@@ -613,7 +613,7 @@ CHANGE_MESSAGE_VISIBILITY_BATCH_RESPONSE = """<ChangeMessageVisibilityBatchRespo
 
 PURGE_QUEUE_RESPONSE = """<PurgeQueueResponse>
     <ResponseMetadata>
-        <RequestId>{{ requestid }}</RequestId>
+        <RequestId></RequestId>
     </ResponseMetadata>
 </PurgeQueueResponse>"""
 

--- a/tests/test_autoscaling/test_autoscaling.py
+++ b/tests/test_autoscaling/test_autoscaling.py
@@ -543,6 +543,7 @@ def test_describe_load_balancers():
     )
 
     response = client.describe_load_balancers(AutoScalingGroupName='test_asg')
+    assert response['ResponseMetadata']['RequestId']
     list(response['LoadBalancers']).should.have.length_of(1)
     response['LoadBalancers'][0]['LoadBalancerName'].should.equal('my-lb')
 

--- a/tests/test_sqs/test_sqs.py
+++ b/tests/test_sqs/test_sqs.py
@@ -416,7 +416,9 @@ def test_send_receive_message_timestamps():
     conn.create_queue(QueueName="test-queue")
     queue = sqs.Queue("test-queue")
 
-    queue.send_message(MessageBody="derp")
+    response = queue.send_message(MessageBody="derp")
+    assert response['ResponseMetadata']['RequestId']
+
     messages = conn.receive_message(
         QueueUrl=queue.url, MaxNumberOfMessages=1)['Messages']
 


### PR DESCRIPTION
I noticed moto does not mimic the behavior of boto when it comes to returning the correct request ID in the response body.  Some services work, but those using XML templates that get rendered by Jinja unfortunately are broken.  This PR fixes that inconsistency.

## Root cause

The XML templates contain the text `{{ requestid }}`.  When the template is rendered that text is removed.  When removed, the decorator `@amzn_request_id` executes and is unable to find the `{{ requestid }}` text to be replaced.  The example below highlights how the `RequestId` is missing despite `x-amzn-requestid` being populated.

## How does this PR fix the issue?

This PR removes the need for `{{ requestid }}` to appear in the XML templates.  Instead, the `@amzn_request_id` decorator looks for the `<RequestId></RequestId>` tag and populates the Request ID between that tag.

## Example response body

Before: 

`{'TagDescriptions': [{'ResourceArn': 'arn:aws:elasticloadbalancing:us-east-1:1:loadbalancer/my-lb/10dc6c495c0c9188', 'Tags': [{'Key': 'key_name', 'Value': 'a_value'}]}], 'ResponseMetadata': {'RequestId': None, 'HTTPStatusCode': 200, 'HTTPHeaders': {'server': 'amazon.com', 'x-amzn-requestid': 'CKP4OYC04TNZ72RCK4KCY3OA4OWUQVAH9V65T1KLOT0R4IL5CLVT'}, 'RetryAttempts': 0}}`

After:

`{'TagDescriptions': [{'ResourceArn': 'arn:aws:elasticloadbalancing:us-east-1:1:loadbalancer/my-lb/10dc6c495c0c9188', 'Tags': [{'Key': 'key_name', 'Value': 'a_value'}]}], 'ResponseMetadata': {'RequestId': 'SK9CB4A2HN82YO6WE3TP5RSDHNSD0R0IPI184JERMW74NFP46OZX', 'HTTPStatusCode': 200, 'HTTPHeaders': {'server': 'amazon.com', 'x-amzn-requestid': 'SK9CB4A2HN82YO6WE3TP5RSDHNSD0R0IPI184JERMW74NFP46OZX'}, 'RetryAttempts': 0}}`