### PR TITLE
Network ACL fixes

### DIFF
--- a/moto/ec2/models.py
+++ b/moto/ec2/models.py
@@ -3560,7 +3560,21 @@ class NetworkAclBackend(object):
         self.get_vpc(vpc_id)
         network_acl = NetworkAcl(self, network_acl_id, vpc_id, default)
         self.network_acls[network_acl_id] = network_acl
+        if default:
+            self.add_default_entries(network_acl_id)
         return network_acl
+
+    def add_default_entries(self, network_acl_id):
+        default_acl_entries = [
+            {'rule_number': 100, 'rule_action': 'allow', 'egress': 'true'},
+            {'rule_number': 32767, 'rule_action': 'deny', 'egress': 'true'},
+            {'rule_number': 100, 'rule_action': 'allow', 'egress': 'false'},
+            {'rule_number': 32767, 'rule_action': 'deny', 'egress': 'false'}
+        ]
+        for entry in default_acl_entries:
+            self.create_network_acl_entry(network_acl_id=network_acl_id, rule_number=entry['rule_number'], protocol='-1',
+                                          rule_action=entry['rule_action'], egress=entry['egress'], cidr_block='0.0.0.0/0',
+                                          icmp_code=None, icmp_type=None, port_range_from=None, port_range_to=None)
 
     def get_all_network_acls(self, network_acl_ids=None, filters=None):
         network_acls = self.network_acls.values()

--- a/moto/ec2/models.py
+++ b/moto/ec2/models.py
@@ -2464,7 +2464,7 @@ class SubnetBackend(object):
                         default_for_az, map_public_ip_on_launch)
 
         # AWS associates a new subnet with the default Network ACL
-        self.associate_default_network_acl_with_subnet(subnet_id)
+        self.associate_default_network_acl_with_subnet(subnet_id, vpc_id)
         self.subnets[availability_zone][subnet_id] = subnet
         return subnet
 
@@ -3636,9 +3636,9 @@ class NetworkAclBackend(object):
         new_acl.associations[new_assoc_id] = association
         return association
 
-    def associate_default_network_acl_with_subnet(self, subnet_id):
+    def associate_default_network_acl_with_subnet(self, subnet_id, vpc_id):
         association_id = random_network_acl_subnet_association_id()
-        acl = next(acl for acl in self.network_acls.values() if acl.default)
+        acl = next(acl for acl in self.network_acls.values() if acl.default and acl.vpc_id == vpc_id)
         acl.associations[association_id] = NetworkAclAssociation(self, association_id,
                                                                  subnet_id, acl.id)
 

--- a/tests/test_ec2/test_network_acls.py
+++ b/tests/test_ec2/test_network_acls.py
@@ -1,8 +1,9 @@
 from __future__ import unicode_literals
 import boto
+import boto3
 import sure  # noqa
 
-from moto import mock_ec2_deprecated
+from moto import mock_ec2_deprecated, mock_ec2
 
 
 @mock_ec2_deprecated
@@ -173,3 +174,19 @@ def test_network_acl_tagging():
                             if na.id == network_acl.id)
     test_network_acl.tags.should.have.length_of(1)
     test_network_acl.tags["a key"].should.equal("some value")
+
+
+@mock_ec2
+def test_new_subnet_in_new_vpc_associates_with_default_network_acl():
+    ec2 = boto3.resource('ec2', region_name='us-west-1')
+    new_vpc = ec2.create_vpc(CidrBlock='10.0.0.0/16')
+    new_vpc.reload()
+
+    subnet = ec2.create_subnet(VpcId=new_vpc.id, CidrBlock='10.0.0.0/24')
+    subnet.reload()
+
+    new_vpcs_default_network_acl = next(iter(new_vpc.network_acls.all()), None)
+    new_vpcs_default_network_acl.reload()
+    new_vpcs_default_network_acl.vpc_id.should.equal(new_vpc.id)
+    new_vpcs_default_network_acl.associations.should.have.length_of(1)
+    new_vpcs_default_network_acl.associations[0]['SubnetId'].should.equal(subnet.id)


### PR DESCRIPTION
I fixed the following smaller inaccuracies/differences from AWS:

- When creating a subnet in a non-default VPC, it was associated with a network ACL from a different VPC than the one the subnet was created in. This was caused by the first (default) VPC's default network ACL being associated with all new subnets regardless of what VPC it was created in.
- When a default network ACL gets created, a number (4) of default routes are automatically added to it. Refer to [the official documentation](https://docs.aws.amazon.com/vpc/latest/userguide/vpc-network-acls.html#default-network-acl).