### PR TITLE
Autoscaling instance azs

### DIFF
--- a/moto/autoscaling/models.py
+++ b/moto/autoscaling/models.py
@@ -280,7 +280,7 @@ class FakeAutoScalingGroup(BaseModel):
             self.min_size = min_size
 
         if launch_config_name:
-            self.launch_config = self.autoscaling_backenaunch_configurations[
+            self.launch_config = self.autoscaling_backend.launch_configurations[
                 launch_config_name]
             self.launch_config_name = launch_config_name
         if health_check_period is not None:

--- a/moto/autoscaling/responses.py
+++ b/moto/autoscaling/responses.py
@@ -486,7 +486,7 @@ DESCRIBE_AUTOSCALING_GROUPS_TEMPLATE = """<DescribeAutoScalingGroupsResponse xml
           {% for instance_state in group.instance_states %}
           <member>
             <HealthStatus>{{ instance_state.health_status }}</HealthStatus>
-            <AvailabilityZone>us-east-1e</AvailabilityZone>
+            <AvailabilityZone>{{ instance_state.instance.placement }}</AvailabilityZone>
             <InstanceId>{{ instance_state.instance.id }}</InstanceId>
             <LaunchConfigurationName>{{ group.launch_config_name }}</LaunchConfigurationName>
             <LifecycleState>{{ instance_state.lifecycle_state }}</LifecycleState>
@@ -561,7 +561,7 @@ DESCRIBE_AUTOSCALING_INSTANCES_TEMPLATE = """<DescribeAutoScalingInstancesRespon
       <member>
         <HealthStatus>{{ instance_state.health_status }}</HealthStatus>
         <AutoScalingGroupName>{{ instance_state.instance.autoscaling_group.name }}</AutoScalingGroupName>
-        <AvailabilityZone>us-east-1e</AvailabilityZone>
+        <AvailabilityZone>{{ instance_state.instance.placement }}</AvailabilityZone>
         <InstanceId>{{ instance_state.instance.id }}</InstanceId>
         <LaunchConfigurationName>{{ instance_state.instance.autoscaling_group.launch_config_name }}</LaunchConfigurationName>
         <LifecycleState>{{ instance_state.lifecycle_state }}</LifecycleState>

--- a/tests/test_autoscaling/test_autoscaling.py
+++ b/tests/test_autoscaling/test_autoscaling.py
@@ -42,7 +42,10 @@ def test_create_autoscaling_group():
         launch_config=config,
         load_balancers=["test_lb"],
         placement_group="test_placement",
-        vpc_zone_identifier=f"{mocked_networking['subnet1']},{mocked_networking['subnet2']}",
+        vpc_zone_identifier="{subnet1},{subnet2}".format(
+            subnet1=mocked_networking['subnet1'],
+            subnet2=mocked_networking['subnet2'],
+        ),
         termination_policies=["OldestInstance", "NewestInstance"],
         tags=[Tag(
             resource_id='tester_group',
@@ -62,7 +65,10 @@ def test_create_autoscaling_group():
     group.max_size.should.equal(2)
     group.min_size.should.equal(2)
     group.instances.should.have.length_of(2)
-    group.vpc_zone_identifier.should.equal(f"{mocked_networking['subnet1']},{mocked_networking['subnet2']}")
+    group.vpc_zone_identifier.should.equal("{subnet1},{subnet2}".format(
+        subnet1=mocked_networking['subnet1'],
+        subnet2=mocked_networking['subnet2'],
+    ))
     group.launch_config_name.should.equal('tester')
     group.default_cooldown.should.equal(60)
     group.health_check_period.should.equal(100)
@@ -792,7 +798,10 @@ def test_update_autoscaling_group_boto3():
     response = client.update_auto_scaling_group(
         AutoScalingGroupName='test_asg',
         MinSize=1,
-        VPCZoneIdentifier=f"{mocked_networking['subnet1']},{mocked_networking['subnet2']}",
+        VPCZoneIdentifier="{subnet1},{subnet2}".format(
+            subnet1=mocked_networking['subnet1'],
+            subnet2=mocked_networking['subnet2'],
+        ),
     )
 
     response = client.describe_auto_scaling_groups(

--- a/tests/test_autoscaling/test_autoscaling.py
+++ b/tests/test_autoscaling/test_autoscaling.py
@@ -32,7 +32,7 @@ def test_create_autoscaling_group():
 
     group = AutoScalingGroup(
         name='tester_group',
-        availability_zones=['us-east-1c', 'us-east-1b'],
+        availability_zones=['us-east-1a', 'us-east-1b'],
         default_cooldown=60,
         desired_capacity=2,
         health_check_period=100,
@@ -42,7 +42,7 @@ def test_create_autoscaling_group():
         launch_config=config,
         load_balancers=["test_lb"],
         placement_group="test_placement",
-        vpc_zone_identifier=mocked_networking['subnet1'],
+        vpc_zone_identifier=f"{mocked_networking['subnet1']},{mocked_networking['subnet2']}",
         termination_policies=["OldestInstance", "NewestInstance"],
         tags=[Tag(
             resource_id='tester_group',
@@ -57,12 +57,12 @@ def test_create_autoscaling_group():
     group = conn.get_all_groups()[0]
     group.name.should.equal('tester_group')
     set(group.availability_zones).should.equal(
-        set(['us-east-1c', 'us-east-1b']))
+        set(['us-east-1a', 'us-east-1b']))
     group.desired_capacity.should.equal(2)
     group.max_size.should.equal(2)
     group.min_size.should.equal(2)
     group.instances.should.have.length_of(2)
-    group.vpc_zone_identifier.should.equal(mocked_networking['subnet1'])
+    group.vpc_zone_identifier.should.equal(f"{mocked_networking['subnet1']},{mocked_networking['subnet2']}")
     group.launch_config_name.should.equal('tester')
     group.default_cooldown.should.equal(60)
     group.health_check_period.should.equal(100)
@@ -109,7 +109,7 @@ def test_create_autoscaling_groups_defaults():
     group.launch_config_name.should.equal('tester')
 
     # Defaults
-    list(group.availability_zones).should.equal([])
+    list(group.availability_zones).should.equal(['us-east-1a'])  # subnet1
     group.desired_capacity.should.equal(2)
     group.vpc_zone_identifier.should.equal(mocked_networking['subnet1'])
     group.default_cooldown.should.equal(300)
@@ -217,7 +217,6 @@ def test_autoscaling_update():
 
     group = AutoScalingGroup(
         name='tester_group',
-        availability_zones=['us-east-1c', 'us-east-1b'],
         desired_capacity=2,
         max_size=2,
         min_size=2,
@@ -227,13 +226,16 @@ def test_autoscaling_update():
     conn.create_auto_scaling_group(group)
 
     group = conn.get_all_groups()[0]
+    group.availability_zones.should.equal(['us-east-1a'])
     group.vpc_zone_identifier.should.equal(mocked_networking['subnet1'])
 
-    group.vpc_zone_identifier = 'subnet-5678efgh'
+    group.availability_zones = ['us-east-1b']
+    group.vpc_zone_identifier = mocked_networking['subnet2']
     group.update()
 
     group = conn.get_all_groups()[0]
-    group.vpc_zone_identifier.should.equal('subnet-5678efgh')
+    group.availability_zones.should.equal(['us-east-1b'])
+    group.vpc_zone_identifier.should.equal(mocked_networking['subnet2'])
 
 
 @mock_autoscaling_deprecated
@@ -249,7 +251,7 @@ def test_autoscaling_tags_update():
 
     group = AutoScalingGroup(
         name='tester_group',
-        availability_zones=['us-east-1c', 'us-east-1b'],
+        availability_zones=['us-east-1a'],
         desired_capacity=2,
         max_size=2,
         min_size=2,
@@ -309,7 +311,7 @@ def test_autoscaling_group_delete():
 @mock_autoscaling_deprecated
 def test_autoscaling_group_describe_instances():
     mocked_networking = setup_networking_deprecated()
-    conn = boto.connect_autoscale()
+    conn = boto.ec2.autoscale.connect_to_region('us-east-1')
     config = LaunchConfiguration(
         name='tester',
         image_id='ami-abcd1234',
@@ -332,7 +334,7 @@ def test_autoscaling_group_describe_instances():
     instances[0].health_status.should.equal('Healthy')
     autoscale_instance_ids = [instance.instance_id for instance in instances]
 
-    ec2_conn = boto.connect_ec2()
+    ec2_conn = boto.ec2.connect_to_region('us-east-1')
     reservations = ec2_conn.get_all_instances()
     instances = reservations[0].instances
     instances.should.have.length_of(2)
@@ -355,7 +357,7 @@ def test_set_desired_capacity_up():
 
     group = AutoScalingGroup(
         name='tester_group',
-        availability_zones=['us-east-1c', 'us-east-1b'],
+        availability_zones=['us-east-1a'],
         desired_capacity=2,
         max_size=2,
         min_size=2,
@@ -391,7 +393,7 @@ def test_set_desired_capacity_down():
 
     group = AutoScalingGroup(
         name='tester_group',
-        availability_zones=['us-east-1c', 'us-east-1b'],
+        availability_zones=['us-east-1a'],
         desired_capacity=2,
         max_size=2,
         min_size=2,
@@ -427,7 +429,7 @@ def test_set_desired_capacity_the_same():
 
     group = AutoScalingGroup(
         name='tester_group',
-        availability_zones=['us-east-1c', 'us-east-1b'],
+        availability_zones=['us-east-1a'],
         desired_capacity=2,
         max_size=2,
         min_size=2,
@@ -733,8 +735,42 @@ def test_describe_autoscaling_groups_boto3():
         AutoScalingGroupNames=["test_asg"]
     )
     response['ResponseMetadata']['HTTPStatusCode'].should.equal(200)
-    response['AutoScalingGroups'][0][
-        'AutoScalingGroupName'].should.equal('test_asg')
+    group = response['AutoScalingGroups'][0]
+    group['AutoScalingGroupName'].should.equal('test_asg')
+    group['AvailabilityZones'].should.equal(['us-east-1a'])
+    group['VPCZoneIdentifier'].should.equal(mocked_networking['subnet1'])
+    for instance in group['Instances']:
+        instance['AvailabilityZone'].should.equal('us-east-1a')
+
+
+@mock_autoscaling
+def test_describe_autoscaling_instances_boto3():
+    mocked_networking = setup_networking()
+    client = boto3.client('autoscaling', region_name='us-east-1')
+    _ = client.create_launch_configuration(
+        LaunchConfigurationName='test_launch_configuration'
+    )
+    _ = client.create_auto_scaling_group(
+        AutoScalingGroupName='test_asg',
+        LaunchConfigurationName='test_launch_configuration',
+        MinSize=0,
+        MaxSize=20,
+        DesiredCapacity=5,
+        VPCZoneIdentifier=mocked_networking['subnet1'],
+    )
+
+    response = client.describe_auto_scaling_groups(
+        AutoScalingGroupNames=["test_asg"]
+    )
+    instance_ids = [
+        instance['InstanceId']
+        for instance in response['AutoScalingGroups'][0]['Instances']
+    ]
+
+    response = client.describe_auto_scaling_instances(InstanceIds=instance_ids)
+    for instance in response['AutoScalingInstances']:
+        instance['AutoScalingGroupName'].should.equal('test_asg')
+        instance['AvailabilityZone'].should.equal('us-east-1a')
 
 
 @mock_autoscaling
@@ -756,12 +792,15 @@ def test_update_autoscaling_group_boto3():
     response = client.update_auto_scaling_group(
         AutoScalingGroupName='test_asg',
         MinSize=1,
+        VPCZoneIdentifier=f"{mocked_networking['subnet1']},{mocked_networking['subnet2']}",
     )
 
     response = client.describe_auto_scaling_groups(
         AutoScalingGroupNames=["test_asg"]
     )
-    response['AutoScalingGroups'][0]['MinSize'].should.equal(1)
+    group = response['AutoScalingGroups'][0]
+    group['MinSize'].should.equal(1)
+    set(group['AvailabilityZones']).should.equal({'us-east-1a', 'us-east-1b'})
 
 
 @mock_autoscaling

--- a/tests/test_autoscaling/test_elbv2.py
+++ b/tests/test_autoscaling/test_elbv2.py
@@ -106,7 +106,7 @@ def test_detach_all_target_groups():
         MaxSize=INSTANCE_COUNT,
         DesiredCapacity=INSTANCE_COUNT,
         TargetGroupARNs=[target_group_arn],
-        VPCZoneIdentifier=mocked_networking['vpc'])
+        VPCZoneIdentifier=mocked_networking['subnet1'])
 
     response = client.describe_load_balancer_target_groups(
         AutoScalingGroupName='test_asg')

--- a/tests/test_autoscaling/utils.py
+++ b/tests/test_autoscaling/utils.py
@@ -1,5 +1,6 @@
 import boto
 import boto3
+from boto import vpc as boto_vpc
 from moto import mock_ec2, mock_ec2_deprecated
 
 
@@ -19,9 +20,14 @@ def setup_networking():
 
 @mock_ec2_deprecated
 def setup_networking_deprecated():
-    conn = boto.connect_vpc()
+    conn = boto_vpc.connect_to_region('us-east-1')
     vpc = conn.create_vpc("10.11.0.0/16")
-    subnet1 = conn.create_subnet(vpc.id, "10.11.1.0/24")
-    subnet2 = conn.create_subnet(vpc.id, "10.11.2.0/24")
+    subnet1 = conn.create_subnet(
+        vpc.id,
+        "10.11.1.0/24",
+        availability_zone='us-east-1a')
+    subnet2 = conn.create_subnet(
+        vpc.id,
+        "10.11.2.0/24",
+        availability_zone='us-east-1b')
     return {'vpc': vpc.id, 'subnet1': subnet1.id, 'subnet2': subnet2.id}
-

--- a/tests/test_ec2/test_elastic_block_store.py
+++ b/tests/test_ec2/test_elastic_block_store.py
@@ -16,7 +16,7 @@ from moto import mock_ec2_deprecated, mock_ec2
 
 @mock_ec2_deprecated
 def test_create_and_delete_volume():
-    conn = boto.connect_ec2('the_key', 'the_secret')
+    conn = boto.ec2.connect_to_region("us-east-1")
     volume = conn.create_volume(80, "us-east-1a")
 
     all_volumes = conn.get_all_volumes()
@@ -52,7 +52,7 @@ def test_create_and_delete_volume():
 
 @mock_ec2_deprecated
 def test_create_encrypted_volume_dryrun():
-    conn = boto.connect_ec2('the_key', 'the_secret')
+    conn = boto.ec2.connect_to_region("us-east-1")
     with assert_raises(EC2ResponseError) as ex:
         conn.create_volume(80, "us-east-1a", encrypted=True, dry_run=True)
     ex.exception.error_code.should.equal('DryRunOperation')
@@ -63,7 +63,7 @@ def test_create_encrypted_volume_dryrun():
 
 @mock_ec2_deprecated
 def test_create_encrypted_volume():
-    conn = boto.connect_ec2('the_key', 'the_secret')
+    conn = boto.ec2.connect_to_region("us-east-1")
     volume = conn.create_volume(80, "us-east-1a", encrypted=True)
 
     with assert_raises(EC2ResponseError) as ex:
@@ -79,7 +79,7 @@ def test_create_encrypted_volume():
 
 @mock_ec2_deprecated
 def test_filter_volume_by_id():
-    conn = boto.connect_ec2('the_key', 'the_secret')
+    conn = boto.ec2.connect_to_region("us-east-1")
     volume1 = conn.create_volume(80, "us-east-1a")
     volume2 = conn.create_volume(36, "us-east-1b")
     volume3 = conn.create_volume(20, "us-east-1c")
@@ -99,7 +99,7 @@ def test_filter_volume_by_id():
 
 @mock_ec2_deprecated
 def test_volume_filters():
-    conn = boto.connect_ec2('the_key', 'the_secret')
+    conn = boto.ec2.connect_to_region("us-east-1")
 
     reservation = conn.run_instances('ami-1234abcd')
     instance = reservation.instances[0]
@@ -196,7 +196,7 @@ def test_volume_filters():
 
 @mock_ec2_deprecated
 def test_volume_attach_and_detach():
-    conn = boto.connect_ec2('the_key', 'the_secret')
+    conn = boto.ec2.connect_to_region("us-east-1")
     reservation = conn.run_instances('ami-1234abcd')
     instance = reservation.instances[0]
     volume = conn.create_volume(80, "us-east-1a")
@@ -252,7 +252,7 @@ def test_volume_attach_and_detach():
 
 @mock_ec2_deprecated
 def test_create_snapshot():
-    conn = boto.connect_ec2('the_key', 'the_secret')
+    conn = boto.ec2.connect_to_region("us-east-1")
     volume = conn.create_volume(80, "us-east-1a")
 
     with assert_raises(EC2ResponseError) as ex:
@@ -291,7 +291,7 @@ def test_create_snapshot():
 
 @mock_ec2_deprecated
 def test_create_encrypted_snapshot():
-    conn = boto.connect_ec2('the_key', 'the_secret')
+    conn = boto.ec2.connect_to_region("us-east-1")
     volume = conn.create_volume(80, "us-east-1a", encrypted=True)
     snapshot = volume.create_snapshot('a test snapshot')
     snapshot.update()
@@ -306,7 +306,7 @@ def test_create_encrypted_snapshot():
 
 @mock_ec2_deprecated
 def test_filter_snapshot_by_id():
-    conn = boto.connect_ec2('the_key', 'the_secret')
+    conn = boto.ec2.connect_to_region("us-east-1")
     volume1 = conn.create_volume(36, "us-east-1a")
     snap1 = volume1.create_snapshot('a test snapshot 1')
     volume2 = conn.create_volume(42, 'us-east-1a')
@@ -333,7 +333,7 @@ def test_filter_snapshot_by_id():
 
 @mock_ec2_deprecated
 def test_snapshot_filters():
-    conn = boto.connect_ec2('the_key', 'the_secret')
+    conn = boto.ec2.connect_to_region("us-east-1")
     volume1 = conn.create_volume(20, "us-east-1a", encrypted=False)
     volume2 = conn.create_volume(25, "us-east-1a", encrypted=True)
 
@@ -399,7 +399,7 @@ def test_snapshot_filters():
 def test_snapshot_attribute():
     import copy
 
-    conn = boto.connect_ec2('the_key', 'the_secret')
+    conn = boto.ec2.connect_to_region("us-east-1")
     volume = conn.create_volume(80, "us-east-1a")
     snapshot = volume.create_snapshot()
 
@@ -502,7 +502,7 @@ def test_snapshot_attribute():
 
 @mock_ec2_deprecated
 def test_create_volume_from_snapshot():
-    conn = boto.connect_ec2('the_key', 'the_secret')
+    conn = boto.ec2.connect_to_region("us-east-1")
     volume = conn.create_volume(80, "us-east-1a")
     snapshot = volume.create_snapshot('a test snapshot')
 
@@ -524,7 +524,7 @@ def test_create_volume_from_snapshot():
 
 @mock_ec2_deprecated
 def test_create_volume_from_encrypted_snapshot():
-    conn = boto.connect_ec2('the_key', 'the_secret')
+    conn = boto.ec2.connect_to_region("us-east-1")
     volume = conn.create_volume(80, "us-east-1a", encrypted=True)
 
     snapshot = volume.create_snapshot('a test snapshot')
@@ -569,7 +569,7 @@ def test_modify_attribute_blockDeviceMapping():
 
 @mock_ec2_deprecated
 def test_volume_tag_escaping():
-    conn = boto.connect_ec2('the_key', 'the_secret')
+    conn = boto.ec2.connect_to_region("us-east-1")
     vol = conn.create_volume(10, 'us-east-1a')
     snapshot = conn.create_snapshot(vol.id, 'Desc')
 

--- a/tests/test_ec2/test_instances.py
+++ b/tests/test_ec2/test_instances.py
@@ -42,7 +42,7 @@ def test_add_servers():
 @freeze_time("2014-01-01 05:00:00")
 @mock_ec2_deprecated
 def test_instance_launch_and_terminate():
-    conn = boto.connect_ec2('the_key', 'the_secret')
+    conn = boto.ec2.connect_to_region("us-east-1")
 
     with assert_raises(EC2ResponseError) as ex:
         reservation = conn.run_instances('ami-1234abcd', dry_run=True)
@@ -820,7 +820,7 @@ def test_run_instance_with_instance_type():
 
 @mock_ec2_deprecated
 def test_run_instance_with_default_placement():
-    conn = boto.connect_ec2('the_key', 'the_secret')
+    conn = boto.ec2.connect_to_region("us-east-1")
     reservation = conn.run_instances('ami-1234abcd')
     instance = reservation.instances[0]
 

--- a/tests/test_ec2/test_regions.py
+++ b/tests/test_ec2/test_regions.py
@@ -68,8 +68,10 @@ def test_create_autoscaling_group():
         image_id='ami-abcd1234',
         instance_type='m1.small',
     )
-    us_conn.create_launch_configuration(config)
+    x = us_conn.create_launch_configuration(config)
 
+    us_subnet_id = list(ec2_backends['us-east-1'].subnets['us-east-1c'].keys())[0]
+    ap_subnet_id = list(ec2_backends['ap-northeast-1'].subnets['ap-northeast-1a'].keys())[0]
     group = boto.ec2.autoscale.AutoScalingGroup(
         name='us_tester_group',
         availability_zones=['us-east-1c'],
@@ -82,7 +84,7 @@ def test_create_autoscaling_group():
         launch_config=config,
         load_balancers=["us_test_lb"],
         placement_group="us_test_placement",
-        vpc_zone_identifier='subnet-1234abcd',
+        vpc_zone_identifier=us_subnet_id,
         termination_policies=["OldestInstance", "NewestInstance"],
     )
     us_conn.create_auto_scaling_group(group)
@@ -107,7 +109,7 @@ def test_create_autoscaling_group():
         launch_config=config,
         load_balancers=["ap_test_lb"],
         placement_group="ap_test_placement",
-        vpc_zone_identifier='subnet-5678efgh',
+        vpc_zone_identifier=ap_subnet_id,
         termination_policies=["OldestInstance", "NewestInstance"],
     )
     ap_conn.create_auto_scaling_group(group)
@@ -121,7 +123,7 @@ def test_create_autoscaling_group():
     us_group.desired_capacity.should.equal(2)
     us_group.max_size.should.equal(2)
     us_group.min_size.should.equal(2)
-    us_group.vpc_zone_identifier.should.equal('subnet-1234abcd')
+    us_group.vpc_zone_identifier.should.equal(us_subnet_id)
     us_group.launch_config_name.should.equal('us_tester')
     us_group.default_cooldown.should.equal(60)
     us_group.health_check_period.should.equal(100)
@@ -137,7 +139,7 @@ def test_create_autoscaling_group():
     ap_group.desired_capacity.should.equal(2)
     ap_group.max_size.should.equal(2)
     ap_group.min_size.should.equal(2)
-    ap_group.vpc_zone_identifier.should.equal('subnet-5678efgh')
+    ap_group.vpc_zone_identifier.should.equal(ap_subnet_id)
     ap_group.launch_config_name.should.equal('ap_tester')
     ap_group.default_cooldown.should.equal(60)
     ap_group.health_check_period.should.equal(100)

--- a/tests/test_elb/test_elb.py
+++ b/tests/test_elb/test_elb.py
@@ -21,7 +21,7 @@ from moto import mock_elb, mock_ec2, mock_elb_deprecated, mock_ec2_deprecated
 @mock_ec2_deprecated
 def test_create_load_balancer():
     conn = boto.connect_elb()
-    ec2 = boto.connect_ec2('the_key', 'the_secret')
+    ec2 = boto.ec2.connect_to_region("us-east-1")
 
     security_group = ec2.create_security_group('sg-abc987', 'description')
 


### PR DESCRIPTION
This is picking up @kawaiwanyelp's #1985, we can close the other one.  The change in that PR said:

> This issue refers to/fixes #1984.

> * I have made changes to ASG initialization that properly sets and updates availability zones (both direct setting, and if there are VPC identifiers that need to be taken into account).
> * I have made changes to propagate one of an ASG's availability zone to its instances when creating them.
> * I have made changes to the return templates for an ASG's describe methods (describe_auto_scaling_groups, describe_auto_scaling_instances) so that instead of returning a hardcoded AZ (us-east-1e), a 'real' AZ is returned.
> * I have written tests for the above changes.

In addition to the above changes, I'm going through and fixing tests that were broken by the change.  All the broken tests appear to have been relying on a "default" region being set, but we now need a region to be set explicitly.