### PR TITLE
ECR now uses api.ecr as its endpoint.

### DIFF
--- a/moto/ecr/urls.py
+++ b/moto/ecr/urls.py
@@ -3,6 +3,7 @@ from .responses import ECRResponse
 
 url_bases = [
     "https?://ecr.(.+).amazonaws.com",
+    "https?://api.ecr.(.+).amazonaws.com",
 ]
 
 url_paths = {


### PR DESCRIPTION
This changed in botocore 1.12.85. See https://github.com/boto/botocore/commit/b5fa8a51393e24fbc7337a357a2d51a0f750c627

This fixes https://github.com/spulec/moto/issues/2035