### PR TITLE
Adding support for Public Key Infrastructure features for AWS IoT

### DIFF
--- a/moto/iot/responses.py
+++ b/moto/iot/responses.py
@@ -192,6 +192,65 @@ class IoTResponse(BaseResponse):
         )
         return json.dumps(dict())
 
+    def register_ca_certificate(self):
+        ca_certificate = self._get_param("caCertificate")
+        verification_cert = self._get_param("verificationCertificate")
+        set_as_active = self._get_param("setAsActive")
+        cert_arn, cert_id = self.iot_backend.register_ca_certificate(
+            ca_certificate=ca_certificate.encode("utf-8"),
+            verification_cert=verification_cert,
+            set_as_active=set_as_active,
+        )
+        return json.dumps(dict(certificateArn=cert_arn, certificateId=cert_id))
+
+    def register_certificate(self):
+        certificate_pem = self._get_param("certificatePem")
+        ca_certificate_pem = self._get_param("caCertificatePem")
+        status = self._get_param("status")
+        cert_arn, cert_id = self.iot_backend.register_certificate(
+            certificate_pem=certificate_pem ,
+            ca_certificate_pem=ca_certificate_pem,
+            status=status,
+        )
+        return json.dumps(dict(certificateArn=cert_arn, certificateId=cert_id))
+
+    def describe_ca_certificate(self):
+        certificate_id = self._get_param("caCertificateId")
+        certificate = self.iot_backend.describe_ca_certificate(
+            certificate_id=certificate_id,
+        )
+        return json.dumps(dict(certificateDescription=certificate.to_description_dict()))
+
+    def list_certificates_by_ca(self):
+        certificate_id = self._get_param("caCertificateId")
+        cert_list = self.iot_backend.list_certificates_by_ca(
+            certificate_id=certificate_id
+        )
+        return json.dumps(dict(certificates=cert_list))
+
+    def delete_ca_certificate(self):
+        certificate_id = self._get_param("caCertificateId")
+        self.iot_backend.delete_ca_certificate(
+            certificate_id=certificate_id
+        )
+        return json.dumps(dict())
+
+    def update_ca_certificate(self):
+        certificate_id = self._get_param("caCertificateId")
+        new_status = self._get_param("newStatus")
+        self.iot_backend.update_ca_certificate(
+            certificate_id=certificate_id,
+            new_status=new_status
+        )
+        return json.dumps(dict())
+
+    def get_registration_code(self):
+        code = self.iot_backend.get_registration_code()
+        return json.dumps(dict(registrationCode=code))
+
+    def list_ca_certificates(self):
+        return json.dumps(dict(certificates=self.iot_backend.list_ca_certificates()))
+
     def create_policy(self):
         policy_name = self._get_param("policyName")
         policy_document = self._get_param("policyDocument")

--- a/moto/iot/utils.py
+++ b/moto/iot/utils.py
@@ -1,0 +1,20 @@
+from .exceptions import (
+    InvalidRequestException,
+)
+
+import binascii
+from cryptography import x509
+from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.primitives import hashes
+
+
+def get_certificate_fingerprint(certificate_pem):
+    try:
+        cert = x509.load_pem_x509_certificate(certificate_pem.encode("utf-8"), default_backend())
+    except Exception as err:
+        raise InvalidRequestException('Error loading CA certificate, error = {}'.format(err.message))
+    return binascii.hexlify(cert.fingerprint(hashes.SHA256()))
+
+
+def get_ca_arn(region_name, certificate_id):
+    return 'arn:aws:iot:%s:1:cacert/%s' % (region_name, certificate_id)


### PR DESCRIPTION
Moto library lacks support for some of the PKI (Public Key Infrastructure) features for AWS IoT, especially supporting one's own certificate authorities versus using default AWS IOT certificate authority to sign device certificates. We have implemented Moto APIs for mocking certificate authorities. We have implemented following functionality in this commit.

-  Mocking CA data structure to sign device CA.
- Implemented list_things, register_ca_certificate, register_certificate, describe_ca_certificate, list_certificates_by_ca, delete_ca_certificate, update_ca_certificate, get_registration_code APIs Returning ca_certificate_id for FakeDeviceCert to match actual iot responses for device certificate