### PR TITLE
update describe_listener to handle multiple load balancers

### DIFF
--- a/moto/elbv2/models.py
+++ b/moto/elbv2/models.py
@@ -578,7 +578,7 @@ class ELBv2Backend(BaseBackend):
         for load_balancer in self.load_balancers.values():
             for listener_arn in listener_arns:
                 listener = load_balancer.listeners.get(listener_arn)
-                if listener: 
+                if listener:
                     matched.append(listener)
         if not matched:
             raise ListenerNotFoundError()

--- a/moto/elbv2/models.py
+++ b/moto/elbv2/models.py
@@ -578,9 +578,10 @@ class ELBv2Backend(BaseBackend):
         for load_balancer in self.load_balancers.values():
             for listener_arn in listener_arns:
                 listener = load_balancer.listeners.get(listener_arn)
-                if not listener:
-                    raise ListenerNotFoundError()
-                matched.append(listener)
+                if listener: 
+                    matched.append(listener)
+        if not matched:
+            raise ListenerNotFoundError()
         return matched
 
     def delete_load_balancer(self, arn):


### PR DESCRIPTION
[Issue #2067](https://github.com/spulec/moto/issues/2067) proposed fix. 

I thought I'd throw this into a PR quickly.

* Remove error raising from within nested loop when trying to discover listeners across multiple load balancers
* Check for populated matches after loop execution and raise error if not where found.
* Tests added (edited)