### PR TITLE
Returns an empty list when the cluster does not exist

### DIFF
--- a/moto/ecs/models.py
+++ b/moto/ecs/models.py
@@ -428,9 +428,6 @@ class EC2ContainerServiceBackend(BaseBackend):
                 if cluster_name in self.clusters:
                     list_clusters.append(
                         self.clusters[cluster_name].response_object)
-                else:
-                    raise Exception(
-                        "{0} is not a cluster".format(cluster_name))
         return list_clusters
 
     def delete_cluster(self, cluster_str):

--- a/moto/ecs/responses.py
+++ b/moto/ecs/responses.py
@@ -45,10 +45,10 @@ class EC2ContainerServiceResponse(BaseResponse):
 
     def describe_clusters(self):
         list_clusters_name = self._get_param('clusters')
-        clusters = self.ecs_backend.describe_clusters(list_clusters_name)
+        clusters, failures = self.ecs_backend.describe_clusters(list_clusters_name)
         return json.dumps({
             'clusters': clusters,
-            'failures': []
+            'failures': [cluster.response_object for cluster in failures]
         })
 
     def delete_cluster(self):

--- a/tests/test_ecs/test_ecs_boto3.py
+++ b/tests/test_ecs/test_ecs_boto3.py
@@ -48,6 +48,15 @@ def test_list_clusters():
 
 
 @mock_ecs
+def test_describe_clusters():
+    client = boto3.client('ecs', region_name='us-east-1')
+    response = client.describe_clusters(clusters=["some-cluster"])
+    response['failures'].should.contain({
+        'arn': 'arn:aws:ecs:us-east-1:012345678910:cluster/some-cluster',
+        'reason': 'MISSING'
+    })
+
+@mock_ecs
 def test_delete_cluster():
     client = boto3.client('ecs', region_name='us-east-1')
     _ = client.create_cluster(


### PR DESCRIPTION
[describe_cluster](https://docs.aws.amazon.com/sdk-for-ruby/v3/api/Aws/ECS/Client.html#describe_clusters-instance_method) is supposed to return an empty array of clusters when given the name of a cluster that does not exist.

```
$ aws ecs describe-clusters --clusters "foobar"
{
    "clusters": [],
    "failures": [
        {
            "arn": "arn:aws:ecs:us-east-1:123456:cluster/foobar",
            "reason": "MISSING"
        }
    ]
}
```