### PR TITLE
Fix sorting of log groups

### DIFF
--- a/moto/logs/models.py
+++ b/moto/logs/models.py
@@ -242,7 +242,8 @@ class LogsBackend(BaseBackend):
         if next_token is None:
             next_token = 0
 
-        groups = sorted(group.to_describe_dict() for name, group in self.groups.items() if name.startswith(log_group_name_prefix))
+        groups = [group.to_describe_dict() for name, group in self.groups.items() if name.startswith(log_group_name_prefix)]
+        groups = sorted(groups, key=lambda x: x['creationTime'], reverse=True)
         groups_page = groups[next_token:next_token + limit]
 
         next_token += limit


### PR DESCRIPTION
Fix sorting of log groups - use `creationTime` as the sort key.

python3 doesn't support sorting of lists that contain dicts:
```
$ python3 -c 'sorted([{}, {}])'
Traceback (most recent call last):
  File "<string>", line 1, in <module>
TypeError: '<' not supported between instances of 'dict' and 'dict'
```

Only a minor change - would be great if we could get this merged @mikegrima @spulec . Thanks!