### PR TITLE
Add model for AWS Step Functions state machine

### DIFF
--- a/moto/stepfunctions/models.py
+++ b/moto/stepfunctions/models.py
@@ -1,0 +1,20 @@
+from moto.core import BaseModel
+
+
+class StateMachine(BaseModel):
+
+    def __init__(self, name, definition=None, role_arn=None):
+        super(StateMachine, self).__init__()
+        self.name = name
+        self.role_arn = role_arn
+        self.status = 'ACTIVE'
+        self.definition = definition or '{}'
+
+    @classmethod
+    def create_from_cloudformation_json(cls, resource_name, cloudformation_json, region_name):
+        props = cloudformation_json['Properties']
+        name = props.get('StateMachineName') or resource_name
+        definition = props.get('DefinitionString')
+        role_arn = props.get('RoleArn')
+        # TODO: create backend implementation and keep a reference to this StateMachine instance
+        return StateMachine(name, definition=definition, role_arn=role_arn)


### PR DESCRIPTION
This PR is a first attempt at providing support for AWS StepFunctions. For now, this PR only adds a new class `StateMachine` to represent a state machine entity.

Background: We're using `moto`'s domain model to support CloudFormation deployments in LocalStack. Currently the code in this PR is also included in the [LocalStack repo](https://github.com/localstack/localstack/blob/master/localstack/stepfunctions/models.py), but in fact it should really live in this repo (in moto).

The main reason we'd like to migrate this code into this repo is that moto makes certain assumptions about the location (module) of classes that derive from `BaseModel`, which [requires models to be in a package in the first level under the root package](https://github.com/spulec/moto/blob/master/moto/core/models.py#L451) (whereas we generally keep model classes in the second level under the root package):

```
service = cls.__module__.split(".")[1]
```

Hopefully you guys can accept this PR, and perhaps it can be useful as a first step towards supporting AWS StepFunctions in moto.