### PR TITLE
Add Config mock to init

### DIFF
--- a/moto/__init__.py
+++ b/moto/__init__.py
@@ -13,6 +13,7 @@ from .cloudformation import mock_cloudformation, mock_cloudformation_deprecated 
 from .cloudwatch import mock_cloudwatch, mock_cloudwatch_deprecated  # flake8: noqa
 from .cognitoidentity import mock_cognitoidentity, mock_cognitoidentity_deprecated  # flake8: noqa
 from .cognitoidp import mock_cognitoidp, mock_cognitoidp_deprecated  # flake8: noqa
+from .config import mock_config  # flake8: noqa
 from .datapipeline import mock_datapipeline, mock_datapipeline_deprecated  # flake8: noqa
 from .dynamodb import mock_dynamodb, mock_dynamodb_deprecated  # flake8: noqa
 from .dynamodb2 import mock_dynamodb2, mock_dynamodb2_deprecated  # flake8: noqa


### PR DESCRIPTION
Forgot to add Config to the `__init__.py`.

This makes it properly importable for unit tests.