### PR TITLE
Fix describe volumes response with no tags

### DIFF
--- a/moto/ec2/responses/elastic_block_store.py
+++ b/moto/ec2/responses/elastic_block_store.py
@@ -150,16 +150,18 @@ CREATE_VOLUME_RESPONSE = """<CreateVolumeResponse xmlns="http://ec2.amazonaws.co
   <availabilityZone>{{ volume.zone.name }}</availabilityZone>
   <status>creating</status>
   <createTime>{{ volume.create_time}}</createTime>
-  <tagSet>
-    {% for tag in volume.get_tags() %}
-        <item>
-        <resourceId>{{ tag.resource_id }}</resourceId>
-        <resourceType>{{ tag.resource_type }}</resourceType>
-        <key>{{ tag.key }}</key>
-        <value>{{ tag.value }}</value>
-        </item>
-    {% endfor %}
-  </tagSet>
+  {% if volume.get_tags() %}
+    <tagSet>
+      {% for tag in volume.get_tags() %}
+          <item>
+          <resourceId>{{ tag.resource_id }}</resourceId>
+          <resourceType>{{ tag.resource_type }}</resourceType>
+          <key>{{ tag.key }}</key>
+          <value>{{ tag.value }}</value>
+          </item>
+      {% endfor %}
+    </tagSet>
+  {% endif %}
   <volumeType>standard</volumeType>
 </CreateVolumeResponse>"""
 
@@ -191,16 +193,18 @@ DESCRIBE_VOLUMES_RESPONSE = """<DescribeVolumesResponse xmlns="http://ec2.amazon
                     </item>
                 {% endif %}
              </attachmentSet>
-             <tagSet>
-               {% for tag in volume.get_tags() %}
-                 <item>
-                   <resourceId>{{ tag.resource_id }}</resourceId>
-                   <resourceType>{{ tag.resource_type }}</resourceType>
-                   <key>{{ tag.key }}</key>
-                   <value>{{ tag.value }}</value>
-                 </item>
-               {% endfor %}
-             </tagSet>
+             {% if volume.get_tags() %}
+               <tagSet>
+                 {% for tag in volume.get_tags() %}
+                   <item>
+                     <resourceId>{{ tag.resource_id }}</resourceId>
+                     <resourceType>{{ tag.resource_type }}</resourceType>
+                     <key>{{ tag.key }}</key>
+                     <value>{{ tag.value }}</value>
+                   </item>
+                 {% endfor %}
+               </tagSet>
+             {% endif %}
              <volumeType>standard</volumeType>
           </item>
       {% endfor %}


### PR DESCRIPTION
This PR modifies the response format of the ec2 calls `create_volume` and
`describe_volumes` to resolve https://github.com/spulec/moto/issues/2097. A test case is also included.

When an EBS volume has no tags, calls to the aws ec2 endpoints `create_volume`
and `describe_volumes` do not include the `Tags` key in the
`response.Volumes[]` object.

However, moto does include the `Tags` key in this case. This discrepancy
in behaviour can result in code passing a moto test but failing in
production.

Sample snippets that trigger this condition:

```
def create_volume_and_then_get_tags_from_response():
    client = boto3.client('ec2', region_name='us-east-1')
    volume_response = client.create_volume(
        Size=10,
        AvailabilityZone='us-east-1a'
    )
    keys = volume_response['Keys']
```

```
def create_volume_and_then_get_tags_from_describe_volumes():
    client = boto3.client('ec2', region_name='us-east-1')
    volume_response = client.create_volume(
        Size=10,
        AvailabilityZone='us-east-1a'
    )
    volume_describe_response = client.describe_volumes()
    keys = volume_describe_response['Volumes'][0]['Keys']
```

Both sample snippets will succeed in a moto test, but fail with a
`KeyError` when using the aws api.

When this PR is merged, the `Tags` key will not be included in responses if
the volume has no tags.