### PR TITLE
Add glue.delete_table endpoint, for allowing tables to be deleted

### DIFF
--- a/moto/glue/models.py
+++ b/moto/glue/models.py
@@ -56,6 +56,14 @@ class GlueBackend(BaseBackend):
         database = self.get_database(database_name)
         return [table for table_name, table in database.tables.items()]
 
+    def delete_table(self, database_name, table_name):
+        database = self.get_database(database_name)
+        try:
+            del database.tables[table_name]
+        except KeyError:
+            raise TableNotFoundException(table_name)
+        return {}
+
 
 class FakeDatabase(BaseModel):
 

--- a/moto/glue/responses.py
+++ b/moto/glue/responses.py
@@ -90,7 +90,6 @@ class GlueResponse(BaseResponse):
         resp = self.glue_backend.delete_table(database_name, table_name)
         return json.dumps(resp)
 
-
     def get_partitions(self):
         database_name = self.parameters.get('DatabaseName')
         table_name = self.parameters.get('TableName')

--- a/moto/glue/responses.py
+++ b/moto/glue/responses.py
@@ -84,6 +84,13 @@ class GlueResponse(BaseResponse):
             ]
         })
 
+    def delete_table(self):
+        database_name = self.parameters.get('DatabaseName')
+        table_name = self.parameters.get('Name')
+        resp = self.glue_backend.delete_table(database_name, table_name)
+        return json.dumps(resp)
+
+
     def get_partitions(self):
         database_name = self.parameters.get('DatabaseName')
         table_name = self.parameters.get('TableName')

--- a/tests/test_glue/test_datacatalog.py
+++ b/tests/test_glue/test_datacatalog.py
@@ -210,6 +210,28 @@ def test_get_table_when_database_not_exits():
 
 
 @mock_glue
+def test_delete_table():
+    client = boto3.client('glue', region_name='us-east-1')
+    database_name = 'myspecialdatabase'
+    helpers.create_database(client, database_name)
+
+    table_name = 'myspecialtable'
+    table_input = helpers.create_table_input(database_name, table_name)
+    helpers.create_table(client, database_name, table_name, table_input)
+
+    result = client.delete_table(DatabaseName=database_name, Name=table_name)
+    result['ResponseMetadata']['HTTPStatusCode'].should.equal(200)
+
+    # confirm table is deleted
+    with assert_raises(ClientError) as exc:
+        helpers.get_table(client, database_name, table_name)
+
+    exc.exception.response['Error']['Code'].should.equal('EntityNotFoundException')
+    exc.exception.response['Error']['Message'].should.match('Table myspecialtable not found')
+
+
+
+@mock_glue
 def test_get_partitions_empty():
     client = boto3.client('glue', region_name='us-east-1')
     database_name = 'myspecialdatabase'

--- a/tests/test_glue/test_datacatalog.py
+++ b/tests/test_glue/test_datacatalog.py
@@ -230,7 +230,6 @@ def test_delete_table():
     exc.exception.response['Error']['Message'].should.match('Table myspecialtable not found')
 
 
-
 @mock_glue
 def test_get_partitions_empty():
     client = boto3.client('glue', region_name='us-east-1')


### PR DESCRIPTION
As the title says, this just adds the `delete_table` call to glue.