### PR TITLE
Fix lambda publish_version returns wrong status code

### DIFF
--- a/moto/awslambda/responses.py
+++ b/moto/awslambda/responses.py
@@ -183,7 +183,7 @@ class LambdaResponse(BaseResponse):
         fn = self.lambda_backend.publish_function(function_name)
         if fn:
             config = fn.get_configuration()
-            return 200, {}, json.dumps(config)
+            return 201, {}, json.dumps(config)
         else:
             return 404, {}, "{}"
 

--- a/tests/test_awslambda/test_lambda.py
+++ b/tests/test_awslambda/test_lambda.py
@@ -4,6 +4,7 @@ import base64
 import botocore.client
 import boto3
 import hashlib
+from http import HTTPStatus
 import io
 import json
 import time
@@ -471,7 +472,8 @@ def test_publish():
     function_list['Functions'].should.have.length_of(1)
     latest_arn = function_list['Functions'][0]['FunctionArn']
 
-    conn.publish_version(FunctionName='testFunction')
+    res = conn.publish_version(FunctionName='testFunction')
+    assert res['ResponseMetadata']['HTTPStatusCode'] == HTTPStatus.CREATED
 
     function_list = conn.list_functions()
     function_list['Functions'].should.have.length_of(2)
@@ -853,8 +855,8 @@ def test_list_versions_by_function():
         Publish=True,
     )
 
-    conn.publish_version(FunctionName='testFunction')
-
+    res = conn.publish_version(FunctionName='testFunction')
+    assert res['ResponseMetadata']['HTTPStatusCode'] == HTTPStatus.CREATED
     versions = conn.list_versions_by_function(FunctionName='testFunction')
 
     assert versions['Versions'][0]['FunctionArn'] == 'arn:aws:lambda:us-west-2:123456789012:function:testFunction:$LATEST'

--- a/tests/test_awslambda/test_lambda.py
+++ b/tests/test_awslambda/test_lambda.py
@@ -4,7 +4,6 @@ import base64
 import botocore.client
 import boto3
 import hashlib
-from http import HTTPStatus
 import io
 import json
 import time
@@ -473,7 +472,7 @@ def test_publish():
     latest_arn = function_list['Functions'][0]['FunctionArn']
 
     res = conn.publish_version(FunctionName='testFunction')
-    assert res['ResponseMetadata']['HTTPStatusCode'] == HTTPStatus.CREATED
+    assert res['ResponseMetadata']['HTTPStatusCode'] == 201
 
     function_list = conn.list_functions()
     function_list['Functions'].should.have.length_of(2)
@@ -856,7 +855,7 @@ def test_list_versions_by_function():
     )
 
     res = conn.publish_version(FunctionName='testFunction')
-    assert res['ResponseMetadata']['HTTPStatusCode'] == HTTPStatus.CREATED
+    assert res['ResponseMetadata']['HTTPStatusCode'] == 201
     versions = conn.list_versions_by_function(FunctionName='testFunction')
 
     assert versions['Versions'][0]['FunctionArn'] == 'arn:aws:lambda:us-west-2:123456789012:function:testFunction:$LATEST'


### PR DESCRIPTION
This pull request fix #2113.
moto must return Http status code 201 when lambda publish_version has succeeded