### PR TITLE
Add get_cfn_attribute support for ECS Cluster and Service

### DIFF
--- a/moto/ecs/models.py
+++ b/moto/ecs/models.py
@@ -94,6 +94,12 @@ class Cluster(BaseObject):
             # no-op when nothing changed between old and new resources
             return original_resource
 
+    def get_cfn_attribute(self, attribute_name):
+        from moto.cloudformation.exceptions import UnformattedGetAttTemplateException
+        if attribute_name == 'Arn':
+            return self.arn
+        raise UnformattedGetAttTemplateException()
+
 
 class TaskDefinition(BaseObject):
 
@@ -270,6 +276,12 @@ class Service(BaseObject):
                 cluster_name, new_service_name, task_definition, desired_count)
         else:
             return ecs_backend.update_service(cluster_name, service_name, task_definition, desired_count)
+
+    def get_cfn_attribute(self, attribute_name):
+        from moto.cloudformation.exceptions import UnformattedGetAttTemplateException
+        if attribute_name == 'Name':
+            return self.name
+        raise UnformattedGetAttTemplateException()
 
 
 class ContainerInstance(BaseObject):

--- a/moto/iam/models.py
+++ b/moto/iam/models.py
@@ -213,7 +213,7 @@ class InstanceProfile(BaseModel):
     def get_cfn_attribute(self, attribute_name):
         from moto.cloudformation.exceptions import UnformattedGetAttTemplateException
         if attribute_name == 'Arn':
-            raise NotImplementedError('"Fn::GetAtt" : [ "{0}" , "Arn" ]"')
+            return self.arn
         raise UnformattedGetAttTemplateException()
 
 


### PR DESCRIPTION
This adds `get_cfn_attribute` methods for ECS clusters and services.

Supported `Fn::GetAtt` attributes are in the [docs](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-getatt.html), a screen grab of the ECS ones are below

![Screen Shot 2019-03-25 at 7 17 23 PM](https://user-images.githubusercontent.com/13579204/54960365-a7948b80-4f32-11e9-8495-62843d0c2187.png)


EDIT: I also fixed the `get_cfn_response` return for iam instance profiles. I'm happy to rename this branch if you'd prefer as it's no longer just ECS outputs!