### PR TITLE
Add private IP to every NetworkInterface

### DIFF
--- a/moto/ec2/models.py
+++ b/moto/ec2/models.py
@@ -189,7 +189,7 @@ class NetworkInterface(TaggedEC2Resource):
         self.ec2_backend = ec2_backend
         self.id = random_eni_id()
         self.device_index = device_index
-        self.private_ip_address = private_ip_address
+        self.private_ip_address = private_ip_address or random_private_ip()
         self.subnet = subnet
         self.instance = None
         self.attachment_id = None

--- a/tests/test_cloudformation/fixtures/vpc_eni.py
+++ b/tests/test_cloudformation/fixtures/vpc_eni.py
@@ -29,6 +29,10 @@ template = {
         "NinjaENI": {
             "Description": "Elastic IP mapping to Auto-Scaling Group",
             "Value": {"Ref": "ENI"}
+        },
+        "ENIIpAddress": {
+            "Description": "ENI's Private IP address",
+            "Value": {"Fn::GetAtt": ["ENI", "PrimaryPrivateIpAddress"]}
         }
     }
 }

--- a/tests/test_ec2/test_elastic_network_interfaces.py
+++ b/tests/test_ec2/test_elastic_network_interfaces.py
@@ -355,9 +355,13 @@ def test_elastic_network_interfaces_cloudformation():
     )
     ec2_conn = boto.ec2.connect_to_region("us-west-1")
     eni = ec2_conn.get_all_network_interfaces()[0]
+    eni.private_ip_addresses.should.have.length_of(1)
 
     stack = conn.describe_stacks()[0]
     resources = stack.describe_resources()
     cfn_eni = [resource for resource in resources if resource.resource_type ==
                'AWS::EC2::NetworkInterface'][0]
     cfn_eni.physical_resource_id.should.equal(eni.id)
+
+    outputs = {output.key: output.value for output in stack.outputs}
+    outputs['ENIIpAddress'].should.equal(eni.private_ip_addresses[0].private_ip_address)

--- a/tests/test_ec2/test_elastic_network_interfaces.py
+++ b/tests/test_ec2/test_elastic_network_interfaces.py
@@ -36,7 +36,8 @@ def test_elastic_network_interfaces():
     all_enis.should.have.length_of(1)
     eni = all_enis[0]
     eni.groups.should.have.length_of(0)
-    eni.private_ip_addresses.should.have.length_of(0)
+    eni.private_ip_addresses.should.have.length_of(1)
+    eni.private_ip_addresses[0].private_ip_address.startswith('10.').should.be.true
 
     with assert_raises(EC2ResponseError) as ex:
         conn.delete_network_interface(eni.id, dry_run=True)


### PR DESCRIPTION
AWS always assigns an IP to ENIs, but moto was storing `None` by default. I caught this problem when I was using CloudFormation Outputs to store the [`PrimaryPrivateIpAddress ` attribute](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-network-interface.html).

I ran the following code against a test AWS account and confirmed it always has a primary IP (I changed the IP value in the example):
```python
>>> import boto
>>> vpc = boto.connect_vpc()
>>> eni = vpc.create_network_interface(subnet_id)
>>> eni.private_ip_addresses
[PrivateIPAddress(10.1.2.3, primary=True)]
```