### PR TITLE
add KeyId value to kms.responses.encrypt and kms.responses.decrypt

### DIFF
--- a/moto/kms/responses.py
+++ b/moto/kms/responses.py
@@ -249,11 +249,11 @@ class KmsResponse(BaseResponse):
         value = self.parameters.get("Plaintext")
         if isinstance(value, six.text_type):
             value = value.encode('utf-8')
-        return json.dumps({"CiphertextBlob": base64.b64encode(value).decode("utf-8")})
+        return json.dumps({"CiphertextBlob": base64.b64encode(value).decode("utf-8"), 'KeyId': 'key_id'})
 
     def decrypt(self):
         value = self.parameters.get("CiphertextBlob")
-        return json.dumps({"Plaintext": base64.b64decode(value).decode("utf-8")})
+        return json.dumps({"Plaintext": base64.b64decode(value).decode("utf-8"), 'KeyId': 'key_id'})
 
     def disable_key(self):
         key_id = self.parameters.get('KeyId')

--- a/tests/test_kms/test_kms.py
+++ b/tests/test_kms/test_kms.py
@@ -171,6 +171,7 @@ def test_encrypt():
     conn = boto.kms.connect_to_region("us-west-2")
     response = conn.encrypt('key_id', 'encryptme'.encode('utf-8'))
     response['CiphertextBlob'].should.equal(b'ZW5jcnlwdG1l')
+    response['KeyId'].should.equal('key_id')
 
 
 @mock_kms_deprecated
@@ -178,6 +179,7 @@ def test_decrypt():
     conn = boto.kms.connect_to_region('us-west-2')
     response = conn.decrypt('ZW5jcnlwdG1l'.encode('utf-8'))
     response['Plaintext'].should.equal(b'encryptme')
+    response['KeyId'].should.equal('key_id')
 
 
 @mock_kms_deprecated


### PR DESCRIPTION
add KeyId value to [kms.responses.encrypt](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/kms.html#KMS.Client.encrypt) and [kms.responses.decrypt](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/kms.html#KMS.Client.decrypt) per boto docs:

*Encrypt*

> Return type
> dict
> 
> Returns
> Response Syntax
> 
> {
>     'CiphertextBlob': b'bytes',
>     'KeyId': 'string'
> }
> Response Structure
> 
> (dict) --
> 
> CiphertextBlob (bytes) --
> 
> The encrypted plaintext. When you use the HTTP API or the AWS CLI, the value is Base64-encdoded. Otherwise, it is not encoded.
> 
> KeyId (string) --
> 
> The ID of the key used during encryption.

*Decrypt*

> Return type
> dict
> 
> Returns
> Response Syntax
> 
> {
>     'KeyId': 'string',
>     'Plaintext': b'bytes'
> }
> Response Structure
> 
> (dict) --
> 
> KeyId (string) --
> 
> ARN of the key used to perform the decryption. This value is returned if no errors are encountered during the operation.
> 
> Plaintext (bytes) --
> 
> Decrypted plaintext data. When you use the HTTP API or the AWS CLI, the value is Base64-encdoded. Otherwise, it is not encoded.

fixes #1784 