### PR TITLE
Fix #2129 EC2 tag should raise ClientError when resource is empty

### DIFF
--- a/moto/ec2/models.py
+++ b/moto/ec2/models.py
@@ -134,6 +134,8 @@ def utc_date_and_time():
 
 
 def validate_resource_ids(resource_ids):
+    if not resource_ids:
+        raise MissingParameterError(parameter='resourceIdSet')
     for resource_id in resource_ids:
         if not is_valid_resource_id(resource_id):
             raise InvalidID(resource_id=resource_id)

--- a/tests/test_ec2/test_tags.py
+++ b/tests/test_ec2/test_tags.py
@@ -5,6 +5,7 @@ import itertools
 
 import boto
 import boto3
+from botocore.exceptions import ClientError
 from boto.exception import EC2ResponseError
 from boto.ec2.instance import Reservation
 import sure  # noqa
@@ -451,3 +452,31 @@ def test_create_snapshot_with_tags():
     }]
 
     assert snapshot['Tags'] == expected_tags
+
+
+@mock_ec2
+def test_create_tag_empty_resource():
+    # create ec2 client in us-west-1
+    client = boto3.client('ec2', region_name='us-west-1')
+    # create tag with empty resource
+    with assert_raises(ClientError) as ex:
+        client.create_tags(
+            Resources=[],
+            Tags=[{'Key': 'Value'}]
+        )
+    ex.exception.response['Error']['Code'].should.equal('MissingParameter')
+    ex.exception.response['Error']['Message'].should.equal('The request must contain the parameter resourceIdSet')
+
+
+@mock_ec2
+def test_delete_tag_empty_resource():
+    # create ec2 client in us-west-1
+    client = boto3.client('ec2', region_name='us-west-1')
+    # delete tag with empty resource
+    with assert_raises(ClientError) as ex:
+        client.delete_tags(
+            Resources=[],
+            Tags=[{'Key': 'Value'}]
+        )
+    ex.exception.response['Error']['Code'].should.equal('MissingParameter')
+    ex.exception.response['Error']['Message'].should.equal('The request must contain the parameter resourceIdSet')


### PR DESCRIPTION
Raise MissingParameterError exception in models/validate_resource_ids of ec2.

Add ec2 create tag with empty resource test case.
Add ec2 delete tag with empty resource test case.

Related: #2129

Reference
boto3 create_tags
https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/ec2.html#EC2.Client.create_tags

boto3 delete_tags
https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/ec2.html#EC2.Client.delete_tags

Amazon EC2 API Reference Actions CreateTags
https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_CreateTags.html

Amazon EC2 API Reference Actions DeleteTags
https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DeleteTags.html