### PR TITLE
use yaml.safe_load instead of yaml.load

### DIFF
--- a/moto/cloudformation/models.py
+++ b/moto/cloudformation/models.py
@@ -85,7 +85,7 @@ class FakeStack(BaseModel):
     def _parse_template(self):
         yaml.add_multi_constructor('', yaml_tag_constructor)
         try:
-            self.template_dict = yaml.load(self.template, Loader=yaml.Loader)
+            self.template_dict = yaml.safe_load(self.template, Loader=yaml.Loader)
         except yaml.parser.ParserError:
             self.template_dict = json.loads(self.template, Loader=yaml.Loader)
 

--- a/moto/cloudformation/responses.py
+++ b/moto/cloudformation/responses.py
@@ -336,7 +336,7 @@ class CloudFormationResponse(BaseResponse):
         except (ValueError, KeyError):
             pass
         try:
-            description = yaml.load(self._get_param('TemplateBody'))['Description']
+            description = yaml.safe_load(self._get_param('TemplateBody'))['Description']
         except (yaml.ParserError, KeyError):
             pass
         template = self.response_template(VALIDATE_STACK_RESPONSE_TEMPLATE)

--- a/tests/test_cloudformation/test_stack_parsing.py
+++ b/tests/test_cloudformation/test_stack_parsing.py
@@ -449,7 +449,7 @@ def test_short_form_func_in_yaml_teamplate():
     KeySub: !Sub A
     """
     yaml.add_multi_constructor('', yaml_tag_constructor, Loader=yaml.Loader)
-    template_dict = yaml.load(template, Loader=yaml.Loader)
+    template_dict = yaml.safe_load(template, Loader=yaml.Loader)
     key_and_expects = [
         ['KeyRef', {'Ref': 'foo'}],
         ['KeyB64', {'Fn::Base64': 'valueToEncode'}],


### PR DESCRIPTION
The old method `yaml.load` in these files are now deprecated in favour of other APIs, detailed here: https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation