### PR TITLE
Issue #2141 Adding owner-id to the filter for Snapshot

### DIFF
--- a/moto/ec2/models.py
+++ b/moto/ec2/models.py
@@ -1877,6 +1877,8 @@ class Snapshot(TaggedEC2Resource):
             return str(self.encrypted).lower()
         elif filter_name == 'status':
             return self.status
+        elif filter_name == 'owner-id':
+            return self.owner_id
         else:
             return super(Snapshot, self).get_filter_value(
                 filter_name, 'DescribeSnapshots')

--- a/tests/test_ec2/test_elastic_block_store.py
+++ b/tests/test_ec2/test_elastic_block_store.py
@@ -394,6 +394,11 @@ def test_snapshot_filters():
     set([snap.id for snap in snapshots_by_encrypted]
         ).should.equal({snapshot3.id})
 
+    snapshots_by_owner_id = conn.get_all_snapshots(
+        filters={'owner-id': '123456789012'})
+    set([snap.id for snap in snapshots_by_owner_id]
+        ).should.equal({snapshot1.id})
+
 
 @mock_ec2_deprecated
 def test_snapshot_attribute():

--- a/tests/test_ec2/test_elastic_block_store.py
+++ b/tests/test_ec2/test_elastic_block_store.py
@@ -397,7 +397,7 @@ def test_snapshot_filters():
     snapshots_by_owner_id = conn.get_all_snapshots(
         filters={'owner-id': '123456789012'})
     set([snap.id for snap in snapshots_by_owner_id]
-        ).should.equal({snapshot1.id})
+        ).should.equal({snapshot1.id, snapshot2.id, snapshot3.id})
 
 
 @mock_ec2_deprecated


### PR DESCRIPTION
This is in reference to issue #2141.  Making the owner-id filter available when querying for a Snapshot.
https://github.com/spulec/moto/issues/2141

**Update: May 24, 2019**
This issue and PR have been up for quite some time. The tests pass and I sure would like to be able to use the code. I have received no feedback so far. What does it take to get this done?