### PR TITLE
Security: CVE-2019-10906

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ def read(*parts):
 
 
 install_requires = [
-    "Jinja2>=2.7.3",
+    "Jinja2>=2.10.1",
     "boto>=2.36.0",
     "boto3>=1.9.86",
     "botocore>=1.12.86",


### PR DESCRIPTION
Given how moto is intended to be used, and how it uses Jinja2, [CVE-2019-10906](https://nvd.nist.gov/vuln/detail/CVE-2019-10906) is unlikely to affect many users, but we should use a secure version anyway just in case moto is being used in unforeseen ways.
