### PR TITLE
A fix for tags not mimicking AWS

### DIFF
--- a/moto/ec2/responses/instances.py
+++ b/moto/ec2/responses/instances.py
@@ -450,6 +450,7 @@ EC2_DESCRIBE_INSTANCES = """<DescribeInstancesResponse xmlns="http://ec2.amazona
                     </blockDeviceMapping>
                     <virtualizationType>{{ instance.virtualization_type }}</virtualizationType>
                     <clientToken>ABCDE1234567890123</clientToken>
+                    {% if instance.get_tags() != [] %}
                     <tagSet>
                       {% for tag in instance.get_tags() %}
                         <item>
@@ -460,6 +461,7 @@ EC2_DESCRIBE_INSTANCES = """<DescribeInstancesResponse xmlns="http://ec2.amazona
                         </item>
                       {% endfor %}
                     </tagSet>
+                    {% endif %}
                     <hypervisor>xen</hypervisor>
                     <networkInterfaceSet>
                       {% for nic in instance.nics.values() %}

--- a/moto/ec2/responses/instances.py
+++ b/moto/ec2/responses/instances.py
@@ -450,7 +450,7 @@ EC2_DESCRIBE_INSTANCES = """<DescribeInstancesResponse xmlns="http://ec2.amazona
                     </blockDeviceMapping>
                     <virtualizationType>{{ instance.virtualization_type }}</virtualizationType>
                     <clientToken>ABCDE1234567890123</clientToken>
-                    {% if instance.get_tags() != [] %}
+                    {% if not instance.get_tags() %}
                     <tagSet>
                       {% for tag in instance.get_tags() %}
                         <item>

--- a/moto/ec2/responses/instances.py
+++ b/moto/ec2/responses/instances.py
@@ -450,7 +450,7 @@ EC2_DESCRIBE_INSTANCES = """<DescribeInstancesResponse xmlns="http://ec2.amazona
                     </blockDeviceMapping>
                     <virtualizationType>{{ instance.virtualization_type }}</virtualizationType>
                     <clientToken>ABCDE1234567890123</clientToken>
-                    {% if not instance.get_tags() %}
+                    {% if instance.get_tags() %}
                     <tagSet>
                       {% for tag in instance.get_tags() %}
                         <item>


### PR DESCRIPTION
This is a very simple fix for the tags problem metioned in #2148 be aware a similar problem may occur in other places. It is also not easy to find what it should act like aside from probing boto3 this means a similar problem will no doubt have to be fixed at somepoint in the future.

The fix is increadibly simple all it does is remove tagSet from the response when there are no tags to be contained within it. This means it acts the same as AWS and by virtue boto3.