### PR TITLE
[iam] create_policy_version: Fix version id calculation

### DIFF
--- a/moto/iam/models.py
+++ b/moto/iam/models.py
@@ -48,7 +48,13 @@ class Policy(BaseModel):
         self.description = description or ''
         self.id = random_policy_id()
         self.path = path or '/'
-        self.default_version_id = default_version_id or 'v1'
+
+        if default_version_id:
+            self.default_version_id = default_version_id
+            self.next_version_num = int(default_version_id.lstrip('v')) + 1
+        else:
+            self.default_version_id = 'v1'
+            self.next_version_num = 2
         self.versions = [PolicyVersion(self.arn, document, True)]
 
         self.create_datetime = datetime.now(pytz.utc)
@@ -716,7 +722,8 @@ class IAMBackend(BaseBackend):
             raise IAMNotFoundException("Policy not found")
         version = PolicyVersion(policy_arn, policy_document, set_as_default)
         policy.versions.append(version)
-        version.version_id = 'v{0}'.format(len(policy.versions))
+        version.version_id = 'v{0}'.format(policy.next_version_num)
+        policy.next_version_num += 1
         if set_as_default:
             policy.default_version_id = version.version_id
         return version

--- a/tests/test_iam/test_iam.py
+++ b/tests/test_iam/test_iam.py
@@ -303,8 +303,17 @@ def test_create_policy_versions():
         PolicyDocument='{"some":"policy"}')
     version = conn.create_policy_version(
         PolicyArn="arn:aws:iam::123456789012:policy/TestCreatePolicyVersion",
-        PolicyDocument='{"some":"policy"}')
+        PolicyDocument='{"some":"policy"}',
+        SetAsDefault=True)
     version.get('PolicyVersion').get('Document').should.equal({'some': 'policy'})
+    version.get('PolicyVersion').get('VersionId').should.equal("v2")
+    conn.delete_policy_version(
+        PolicyArn="arn:aws:iam::123456789012:policy/TestCreatePolicyVersion",
+        VersionId="v1")
+    version = conn.create_policy_version(
+        PolicyArn="arn:aws:iam::123456789012:policy/TestCreatePolicyVersion",
+        PolicyDocument='{"some":"policy"}')
+    version.get('PolicyVersion').get('VersionId').should.equal("v3")
 
 
 @mock_iam


### PR DESCRIPTION
When creating a new IAM policy version with create_policy_version,
we cannot use the length of the versions list to calculate VersionId.
Keep track of the next version id to use as a non-decreasing counter.

Fixes #2157