### PR TITLE
Add test to verify create_role path defaults to /

### DIFF
--- a/tests/test_iam/test_iam.py
+++ b/tests/test_iam/test_iam.py
@@ -1287,4 +1287,9 @@ def test_list_entities_for_policy():
     assert response['PolicyRoles'] == [{'RoleName': 'my-role'}]
 
 
+@mock_iam()
+def test_create_role_no_path():
+    conn = boto3.client('iam', region_name='us-east-1')
+    resp = conn.create_role(RoleName='my-role', AssumeRolePolicyDocument='some policy', Description='test')
+    resp.get('Role').get('Arn').should.equal('arn:aws:iam::123456789012:role/my-role')
 


### PR DESCRIPTION
When testing that a role ARN is created as expected, if path is not passed to the create_role call then the ARN is returned with None for the path. 

```
iam_client = boto3.client('iam')
iam_client.create_role(
    RoleName="test-role",
    AssumeRolePolicyDocument=json.dumps(policy_document),
    Description="test-description")
resp = iam_client.get_role(RoleName="test-role")
print(resp['Role']['Arn'])
```

results in `arn:aws:iam::123456789012:roleNonetest-role` being printed.