### PR TITLE
BUG FIX: Use cast_value when comparing DynamoType

### DIFF
--- a/moto/dynamodb2/models.py
+++ b/moto/dynamodb2/models.py
@@ -45,16 +45,16 @@ class DynamoType(object):
         )
 
     def __lt__(self, other):
-        return self.value < other.value
+        return self.cast_value < other.cast_value
 
     def __le__(self, other):
-        return self.value <= other.value
+        return self.cast_value <= other.cast_value
 
     def __gt__(self, other):
-        return self.value > other.value
+        return self.cast_value > other.cast_value
 
     def __ge__(self, other):
-        return self.value >= other.value
+        return self.cast_value >= other.cast_value
 
     def __repr__(self):
         return "DynamoType: {0}".format(self.to_json())


### PR DESCRIPTION
When returning results in `query` method, results are sorted by `range_key`.
```
results.sort(key=lambda item: item.range_key)
```

However, when comparing `range_key`, it uses `DynamoType.value` instead of `DynamoType.cast_value`. It causes errors when `DynamoType` is a number.
```
>>> '10' > '2'
False
```