### PR TITLE
Update instances.py

### DIFF
--- a/moto/ec2/responses/instances.py
+++ b/moto/ec2/responses/instances.py
@@ -576,8 +576,8 @@ EC2_START_INSTANCES = """
       <item>
         <instanceId>{{ instance.id }}</instanceId>
         <previousState>
-          <code>16</code>
-          <name>running</name>
+          <code>80</code>
+          <name>stopped</name>
         </previousState>
         <currentState>
           <code>0</code>


### PR DESCRIPTION
This didn't seem quite right.
Pending status can be preceded only by the first launch or stopped state, according to https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-lifecycle.html