### PR TITLE
Uniform IAM datetime ISO 8601 handling

### DIFF
--- a/moto/iam/models.py
+++ b/moto/iam/models.py
@@ -8,9 +8,8 @@ import re
 from cryptography import x509
 from cryptography.hazmat.backends import default_backend
 
-import pytz
 from moto.core import BaseBackend, BaseModel
-from moto.core.utils import iso_8601_datetime_without_milliseconds
+from moto.core.utils import iso_8601_datetime_without_milliseconds, iso_8601_datetime_with_milliseconds
 
 from .aws_managed_policies import aws_managed_policies_data
 from .exceptions import IAMNotFoundException, IAMConflictException, IAMReportNotPresentException, MalformedCertificate, \
@@ -27,10 +26,14 @@ class MFADevice(object):
                  serial_number,
                  authentication_code_1,
                  authentication_code_2):
-        self.enable_date = datetime.now(pytz.utc)
+        self.enable_date = datetime.utcnow()
         self.serial_number = serial_number
         self.authentication_code_1 = authentication_code_1
         self.authentication_code_2 = authentication_code_2
+
+    @property
+    def enabled_iso_8601(self):
+        return iso_8601_datetime_without_milliseconds(self.enable_date)
 
 
 class Policy(BaseModel):
@@ -57,8 +60,16 @@ class Policy(BaseModel):
             self.next_version_num = 2
         self.versions = [PolicyVersion(self.arn, document, True)]
 
-        self.create_datetime = datetime.now(pytz.utc)
-        self.update_datetime = datetime.now(pytz.utc)
+        self.create_date = datetime.utcnow()
+        self.update_date = datetime.utcnow()
+
+    @property
+    def created_iso_8601(self):
+        return iso_8601_datetime_with_milliseconds(self.create_date)
+
+    @property
+    def updated_iso_8601(self):
+        return iso_8601_datetime_with_milliseconds(self.update_date)
 
 
 class SAMLProvider(BaseModel):
@@ -82,7 +93,11 @@ class PolicyVersion(object):
         self.is_default = is_default
         self.version_id = 'v1'
 
-        self.create_datetime = datetime.now(pytz.utc)
+        self.create_date = datetime.utcnow()
+
+    @property
+    def created_iso_8601(self):
+        return iso_8601_datetime_with_milliseconds(self.create_date)
 
 
 class ManagedPolicy(Policy):
@@ -138,9 +153,13 @@ class Role(BaseModel):
         self.path = path or '/'
         self.policies = {}
         self.managed_policies = {}
-        self.create_date = datetime.now(pytz.utc)
+        self.create_date = datetime.utcnow()
         self.tags = {}
         self.description = ""
+
+    @property
+    def created_iso_8601(self):
+        return iso_8601_datetime_with_milliseconds(self.create_date)
 
     @classmethod
     def create_from_cloudformation_json(cls, resource_name, cloudformation_json, region_name):
@@ -195,7 +214,11 @@ class InstanceProfile(BaseModel):
         self.name = name
         self.path = path or '/'
         self.roles = roles if roles else []
-        self.create_date = datetime.now(pytz.utc)
+        self.create_date = datetime.utcnow()
+
+    @property
+    def created_iso_8601(self):
+        return iso_8601_datetime_with_milliseconds(self.create_date)
 
     @classmethod
     def create_from_cloudformation_json(cls, resource_name, cloudformation_json, region_name):
@@ -247,8 +270,12 @@ class SigningCertificate(BaseModel):
         self.id = id
         self.user_name = user_name
         self.body = body
-        self.upload_date = datetime.strftime(datetime.utcnow(), "%Y-%m-%d-%H-%M-%S")
+        self.upload_date = datetime.utcnow()
         self.status = 'Active'
+
+    @property
+    def uploaded_iso_8601(self):
+        return iso_8601_datetime_without_milliseconds(self.upload_date)
 
 
 class AccessKey(BaseModel):
@@ -258,14 +285,16 @@ class AccessKey(BaseModel):
         self.access_key_id = random_access_key()
         self.secret_access_key = random_alphanumeric(32)
         self.status = 'Active'
-        self.create_date = datetime.strftime(
-            datetime.utcnow(),
-            "%Y-%m-%dT%H:%M:%SZ"
-        )
-        self.last_used = datetime.strftime(
-            datetime.utcnow(),
-            "%Y-%m-%dT%H:%M:%SZ"
-        )
+        self.create_date = datetime.utcnow()
+        self.last_used = datetime.utcnow()
+
+    @property
+    def created_iso_8601(self):
+        return iso_8601_datetime_without_milliseconds(self.create_date)
+
+    @property
+    def last_used_iso_8601(self):
+        return iso_8601_datetime_without_milliseconds(self.last_used)
 
     def get_cfn_attribute(self, attribute_name):
         from moto.cloudformation.exceptions import UnformattedGetAttTemplateException
@@ -280,14 +309,15 @@ class Group(BaseModel):
         self.name = name
         self.id = random_resource_id()
         self.path = path
-        self.created = datetime.strftime(
-            datetime.utcnow(),
-            "%Y-%m-%d-%H-%M-%S"
-        )
+        self.create_date = datetime.utcnow()
 
         self.users = []
         self.managed_policies = {}
         self.policies = {}
+
+    @property
+    def created_iso_8601(self):
+        return iso_8601_datetime_with_milliseconds(self.create_date)
 
     def get_cfn_attribute(self, attribute_name):
         from moto.cloudformation.exceptions import UnformattedGetAttTemplateException
@@ -302,10 +332,6 @@ class Group(BaseModel):
 
         else:
             return "arn:aws:iam::{0}:group/{1}/{2}".format(ACCOUNT_ID, self.path, self.name)
-
-    @property
-    def create_date(self):
-        return self.created
 
     def get_policy(self, policy_name):
         try:
@@ -332,7 +358,7 @@ class User(BaseModel):
         self.name = name
         self.id = random_resource_id()
         self.path = path if path else "/"
-        self.created = datetime.utcnow()
+        self.create_date = datetime.utcnow()
         self.mfa_devices = {}
         self.policies = {}
         self.managed_policies = {}
@@ -347,7 +373,7 @@ class User(BaseModel):
 
     @property
     def created_iso_8601(self):
-        return iso_8601_datetime_without_milliseconds(self.created)
+        return iso_8601_datetime_with_milliseconds(self.create_date)
 
     def get_policy(self, policy_name):
         policy_json = None
@@ -418,7 +444,7 @@ class User(BaseModel):
 
     def to_csv(self):
         date_format = '%Y-%m-%dT%H:%M:%S+00:00'
-        date_created = self.created
+        date_created = self.create_date
         # aagrawal,arn:aws:iam::509284790694:user/aagrawal,2014-09-01T22:28:48+00:00,true,2014-11-12T23:36:49+00:00,2014-09-03T18:59:00+00:00,N/A,false,true,2014-09-01T22:28:48+00:00,false,N/A,false,N/A,false,N/A
         if not self.password:
             password_enabled = 'false'
@@ -1042,7 +1068,7 @@ class IAMBackend(BaseBackend):
             if key.access_key_id == access_key_id:
                 return {
                     'user_name': key.user_name,
-                    'last_used': key.last_used
+                    'last_used': key.last_used_iso_8601,
                 }
         else:
             raise IAMNotFoundException(

--- a/moto/iam/responses.py
+++ b/moto/iam/responses.py
@@ -816,12 +816,12 @@ CREATE_POLICY_TEMPLATE = """<CreatePolicyResponse>
     <Policy>
       <Arn>{{ policy.arn }}</Arn>
       <AttachmentCount>{{ policy.attachment_count }}</AttachmentCount>
-      <CreateDate>{{ policy.create_datetime.isoformat() }}</CreateDate>
+      <CreateDate>{{ policy.created_iso_8601 }}</CreateDate>
       <DefaultVersionId>{{ policy.default_version_id }}</DefaultVersionId>
       <Path>{{ policy.path }}</Path>
       <PolicyId>{{ policy.id }}</PolicyId>
       <PolicyName>{{ policy.name }}</PolicyName>
-      <UpdateDate>{{ policy.update_datetime.isoformat() }}</UpdateDate>
+      <UpdateDate>{{ policy.updated_iso_8601 }}</UpdateDate>
     </Policy>
   </CreatePolicyResult>
   <ResponseMetadata>
@@ -839,8 +839,8 @@ GET_POLICY_TEMPLATE = """<GetPolicyResponse>
       <Path>{{ policy.path }}</Path>
       <Arn>{{ policy.arn }}</Arn>
       <AttachmentCount>{{ policy.attachment_count }}</AttachmentCount>
-      <CreateDate>{{ policy.create_datetime.isoformat() }}</CreateDate>
-      <UpdateDate>{{ policy.update_datetime.isoformat() }}</UpdateDate>
+      <CreateDate>{{ policy.created_iso_8601 }}</CreateDate>
+      <UpdateDate>{{ policy.updated_iso_8601 }}</UpdateDate>
     </Policy>
   </GetPolicyResult>
   <ResponseMetadata>
@@ -927,12 +927,12 @@ LIST_POLICIES_TEMPLATE = """<ListPoliciesResponse>
       <member>
         <Arn>{{ policy.arn }}</Arn>
         <AttachmentCount>{{ policy.attachment_count }}</AttachmentCount>
-        <CreateDate>{{ policy.create_datetime.isoformat() }}</CreateDate>
+        <CreateDate>{{ policy.created_iso_8601 }}</CreateDate>
         <DefaultVersionId>{{ policy.default_version_id }}</DefaultVersionId>
         <Path>{{ policy.path }}</Path>
         <PolicyId>{{ policy.id }}</PolicyId>
         <PolicyName>{{ policy.name }}</PolicyName>
-        <UpdateDate>{{ policy.update_datetime.isoformat() }}</UpdateDate>
+        <UpdateDate>{{ policy.updated_iso_8601 }}</UpdateDate>
       </member>
       {% endfor %}
     </Policies>
@@ -956,7 +956,7 @@ CREATE_INSTANCE_PROFILE_TEMPLATE = """<CreateInstanceProfileResponse xmlns="http
       <InstanceProfileName>{{ profile.name }}</InstanceProfileName>
       <Path>{{ profile.path }}</Path>
       <Arn>{{ profile.arn }}</Arn>
-      <CreateDate>{{ profile.create_date }}</CreateDate>
+      <CreateDate>{{ profile.created_iso_8601 }}</CreateDate>
     </InstanceProfile>
   </CreateInstanceProfileResult>
   <ResponseMetadata>
@@ -975,7 +975,7 @@ GET_INSTANCE_PROFILE_TEMPLATE = """<GetInstanceProfileResponse xmlns="https://ia
           <Arn>{{ role.arn }}</Arn>
           <RoleName>{{ role.name }}</RoleName>
           <AssumeRolePolicyDocument>{{ role.assume_role_policy_document }}</AssumeRolePolicyDocument>
-          <CreateDate>{{ role.create_date }}</CreateDate>
+          <CreateDate>{{ role.created_iso_8601 }}</CreateDate>
           <RoleId>{{ role.id }}</RoleId>
         </member>
         {% endfor %}
@@ -983,7 +983,7 @@ GET_INSTANCE_PROFILE_TEMPLATE = """<GetInstanceProfileResponse xmlns="https://ia
       <InstanceProfileName>{{ profile.name }}</InstanceProfileName>
       <Path>{{ profile.path }}</Path>
       <Arn>{{ profile.arn }}</Arn>
-      <CreateDate>{{ profile.create_date }}</CreateDate>
+      <CreateDate>{{ profile.created_iso_8601 }}</CreateDate>
     </InstanceProfile>
   </GetInstanceProfileResult>
   <ResponseMetadata>
@@ -998,7 +998,7 @@ CREATE_ROLE_TEMPLATE = """<CreateRoleResponse xmlns="https://iam.amazonaws.com/d
       <Arn>{{ role.arn }}</Arn>
       <RoleName>{{ role.name }}</RoleName>
       <AssumeRolePolicyDocument>{{ role.assume_role_policy_document }}</AssumeRolePolicyDocument>
-      <CreateDate>{{ role.create_date }}</CreateDate>
+      <CreateDate>{{ role.created_iso_8601 }}</CreateDate>
       <RoleId>{{ role.id }}</RoleId>
     </Role>
   </CreateRoleResult>
@@ -1033,7 +1033,7 @@ UPDATE_ROLE_DESCRIPTION_TEMPLATE = """<UpdateRoleDescriptionResponse xmlns="http
       <Arn>{{ role.arn }}</Arn>
       <RoleName>{{ role.name }}</RoleName>
       <AssumeRolePolicyDocument>{{ role.assume_role_policy_document }}</AssumeRolePolicyDocument>
-      <CreateDate>{{ role.create_date.isoformat() }}</CreateDate>
+      <CreateDate>{{ role.created_iso_8601 }}</CreateDate>
       <RoleId>{{ role.id }}</RoleId>
       {% if role.tags %}
       <Tags>
@@ -1059,7 +1059,7 @@ GET_ROLE_TEMPLATE = """<GetRoleResponse xmlns="https://iam.amazonaws.com/doc/201
       <Arn>{{ role.arn }}</Arn>
       <RoleName>{{ role.name }}</RoleName>
       <AssumeRolePolicyDocument>{{ role.assume_role_policy_document }}</AssumeRolePolicyDocument>
-      <CreateDate>{{ role.create_date }}</CreateDate>
+      <CreateDate>{{ role.created_iso_8601 }}</CreateDate>
       <RoleId>{{ role.id }}</RoleId>
       {% if role.tags %}
       <Tags>
@@ -1100,7 +1100,7 @@ LIST_ROLES_TEMPLATE = """<ListRolesResponse xmlns="https://iam.amazonaws.com/doc
         <Arn>{{ role.arn }}</Arn>
         <RoleName>{{ role.name }}</RoleName>
         <AssumeRolePolicyDocument>{{ role.assume_role_policy_document }}</AssumeRolePolicyDocument>
-        <CreateDate>{{ role.create_date }}</CreateDate>
+        <CreateDate>{{ role.created_iso_8601 }}</CreateDate>
         <RoleId>{{ role.id }}</RoleId>
       </member>
       {% endfor %}
@@ -1131,7 +1131,7 @@ CREATE_POLICY_VERSION_TEMPLATE = """<CreatePolicyVersionResponse xmlns="https://
       <Document>{{ policy_version.document }}</Document>
       <VersionId>{{ policy_version.version_id }}</VersionId>
       <IsDefaultVersion>{{ policy_version.is_default }}</IsDefaultVersion>
-      <CreateDate>{{ policy_version.create_datetime }}</CreateDate>
+      <CreateDate>{{ policy_version.created_iso_8601 }}</CreateDate>
     </PolicyVersion>
   </CreatePolicyVersionResult>
   <ResponseMetadata>
@@ -1145,7 +1145,7 @@ GET_POLICY_VERSION_TEMPLATE = """<GetPolicyVersionResponse xmlns="https://iam.am
       <Document>{{ policy_version.document }}</Document>
       <VersionId>{{ policy_version.version_id }}</VersionId>
       <IsDefaultVersion>{{ policy_version.is_default }}</IsDefaultVersion>
-      <CreateDate>{{ policy_version.create_datetime }}</CreateDate>
+      <CreateDate>{{ policy_version.created_iso_8601 }}</CreateDate>
     </PolicyVersion>
   </GetPolicyVersionResult>
   <ResponseMetadata>
@@ -1162,7 +1162,7 @@ LIST_POLICY_VERSIONS_TEMPLATE = """<ListPolicyVersionsResponse xmlns="https://ia
         <Document>{{ policy_version.document }}</Document>
         <VersionId>{{ policy_version.version_id }}</VersionId>
         <IsDefaultVersion>{{ policy_version.is_default }}</IsDefaultVersion>
-        <CreateDate>{{ policy_version.create_datetime }}</CreateDate>
+        <CreateDate>{{ policy_version.created_iso_8601 }}</CreateDate>
       </member>
       {% endfor %}
     </Versions>
@@ -1186,7 +1186,7 @@ LIST_INSTANCE_PROFILES_TEMPLATE = """<ListInstanceProfilesResponse xmlns="https:
             <Arn>{{ role.arn }}</Arn>
             <RoleName>{{ role.name }}</RoleName>
             <AssumeRolePolicyDocument>{{ role.assume_role_policy_document }}</AssumeRolePolicyDocument>
-            <CreateDate>{{ role.create_date }}</CreateDate>
+            <CreateDate>{{ role.created_iso_8601 }}</CreateDate>
             <RoleId>{{ role.id }}</RoleId>
           </member>
           {% endfor %}
@@ -1194,7 +1194,7 @@ LIST_INSTANCE_PROFILES_TEMPLATE = """<ListInstanceProfilesResponse xmlns="https:
         <InstanceProfileName>{{ instance.name }}</InstanceProfileName>
         <Path>{{ instance.path }}</Path>
         <Arn>{{ instance.arn }}</Arn>
-        <CreateDate>{{ instance.create_date }}</CreateDate>
+        <CreateDate>{{ instance.created_iso_8601 }}</CreateDate>
       </member>
       {% endfor %}
     </InstanceProfiles>
@@ -1273,7 +1273,7 @@ CREATE_GROUP_TEMPLATE = """<CreateGroupResponse>
          <GroupName>{{ group.name }}</GroupName>
          <GroupId>{{ group.id }}</GroupId>
          <Arn>{{ group.arn }}</Arn>
-         <CreateDate>{{ group.create_date }}</CreateDate>
+         <CreateDate>{{ group.created_iso_8601 }}</CreateDate>
       </Group>
    </CreateGroupResult>
    <ResponseMetadata>
@@ -1288,7 +1288,7 @@ GET_GROUP_TEMPLATE = """<GetGroupResponse>
          <GroupName>{{ group.name }}</GroupName>
          <GroupId>{{ group.id }}</GroupId>
          <Arn>{{ group.arn }}</Arn>
-         <CreateDate>{{ group.create_date }}</CreateDate>
+         <CreateDate>{{ group.created_iso_8601 }}</CreateDate>
       </Group>
       <Users>
         {% for user in group.users %}
@@ -1495,7 +1495,7 @@ LIST_ACCESS_KEYS_TEMPLATE = """<ListAccessKeysResponse>
             <UserName>{{ user_name }}</UserName>
             <AccessKeyId>{{ key.access_key_id }}</AccessKeyId>
             <Status>{{ key.status }}</Status>
-            <CreateDate>{{ key.create_date }}</CreateDate>
+            <CreateDate>{{ key.created_iso_8601 }}</CreateDate>
          </member>
         {% endfor %}
       </AccessKeyMetadata>
@@ -1563,7 +1563,7 @@ LIST_INSTANCE_PROFILES_FOR_ROLE_TEMPLATE = """<ListInstanceProfilesForRoleRespon
         <Arn>{{ role.arn }}</Arn>
         <RoleName>{{ role.name }}</RoleName>
         <AssumeRolePolicyDocument>{{ role.assume_policy_document }}</AssumeRolePolicyDocument>
-        <CreateDate>{{ role.create_date }}</CreateDate>
+        <CreateDate>{{ role.created_iso_8601 }}</CreateDate>
         <RoleId>{{ role.id }}</RoleId>
       </member>
       {% endfor %}
@@ -1571,7 +1571,7 @@ LIST_INSTANCE_PROFILES_FOR_ROLE_TEMPLATE = """<ListInstanceProfilesForRoleRespon
     <InstanceProfileName>{{ profile.name }}</InstanceProfileName>
     <Path>{{ profile.path }}</Path>
     <Arn>{{ profile.arn }}</Arn>
-    <CreateDate>{{ profile.create_date }}</CreateDate>
+    <CreateDate>{{ profile.created_iso_8601 }}</CreateDate>
     </member>
     {% endfor %}
   </InstanceProfiles>
@@ -1690,7 +1690,7 @@ GET_ACCOUNT_AUTHORIZATION_DETAILS_TEMPLATE = """<GetAccountAuthorizationDetailsR
         <GroupName>{{ group.name }}</GroupName>
         <Path>{{ group.path }}</Path>
         <Arn>{{ group.arn }}</Arn>
-        <CreateDate>{{ group.create_date }}</CreateDate>
+        <CreateDate>{{ group.created_iso_8601 }}</CreateDate>
         <GroupPolicyList>
         {% for policy in group.policies %}
             <member>
@@ -1740,7 +1740,7 @@ GET_ACCOUNT_AUTHORIZATION_DETAILS_TEMPLATE = """<GetAccountAuthorizationDetailsR
                 <Arn>{{ role.arn }}</Arn>
                 <RoleName>{{ role.name }}</RoleName>
                 <AssumeRolePolicyDocument>{{ role.assume_role_policy_document }}</AssumeRolePolicyDocument>
-                <CreateDate>{{ role.create_date }}</CreateDate>
+                <CreateDate>{{ role.created_iso_8601 }}</CreateDate>
                 <RoleId>{{ role.id }}</RoleId>
               </member>
               {% endfor %}
@@ -1748,7 +1748,7 @@ GET_ACCOUNT_AUTHORIZATION_DETAILS_TEMPLATE = """<GetAccountAuthorizationDetailsR
             <InstanceProfileName>{{ profile.name }}</InstanceProfileName>
             <Path>{{ profile.path }}</Path>
             <Arn>{{ profile.arn }}</Arn>
-            <CreateDate>{{ profile.create_date }}</CreateDate>
+            <CreateDate>{{ profile.created_iso_8601 }}</CreateDate>
             </member>
             {% endfor %}
         </InstanceProfileList>
@@ -1756,7 +1756,7 @@ GET_ACCOUNT_AUTHORIZATION_DETAILS_TEMPLATE = """<GetAccountAuthorizationDetailsR
         <Arn>{{ role.arn }}</Arn>
         <RoleName>{{ role.name }}</RoleName>
         <AssumeRolePolicyDocument>{{ role.assume_role_policy_document }}</AssumeRolePolicyDocument>
-        <CreateDate>{{ role.create_date }}</CreateDate>
+        <CreateDate>{{ role.created_iso_8601 }}</CreateDate>
         <RoleId>{{ role.id }}</RoleId>
       </member>
     {% endfor %}
@@ -1774,15 +1774,15 @@ GET_ACCOUNT_AUTHORIZATION_DETAILS_TEMPLATE = """<GetAccountAuthorizationDetailsR
             <Document>{{ policy_version.document }}</Document>
             <IsDefaultVersion>{{ policy_version.is_default }}</IsDefaultVersion>
             <VersionId>{{ policy_version.version_id }}</VersionId>
-            <CreateDate>{{ policy_version.create_datetime }}</CreateDate>
+            <CreateDate>{{ policy_version.created_iso_8601 }}</CreateDate>
           </member>
         {% endfor %}
         </PolicyVersionList>
         <Arn>{{ policy.arn }}</Arn>
         <AttachmentCount>1</AttachmentCount>
-        <CreateDate>{{ policy.create_datetime }}</CreateDate>
+        <CreateDate>{{ policy.created_iso_8601 }}</CreateDate>
         <IsAttachable>true</IsAttachable>
-        <UpdateDate>{{ policy.update_datetime }}</UpdateDate>
+        <UpdateDate>{{ policy.updated_iso_8601 }}</UpdateDate>
       </member>
     {% endfor %}
     </Policies>


### PR DESCRIPTION
`str(datetime.utcnow())` returns a timestamp that's not of the same format as the AWS SDK uses, in short it's missing the `T` between the date and the time.

This causes issues for e.g. Terraform and probably other AWS Go SDK users. There seems to be some differences between endpoints whether they return milliseconds or not, the AWS API docs were reviewed and the decision whether to return timestamps with milliseconds or not based on the example response documented.

As the timstamps are generated for uniqueness rather than being hardcoded and then directly cast to a UTC (Z) formed timestamp pytz was removed as timezone correctness is probably not important.