### PR TITLE
Handle UnicodeEncodeError when parsing querystring

### DIFF
--- a/moto/core/responses.py
+++ b/moto/core/responses.py
@@ -152,11 +152,18 @@ class BaseResponse(_TemplateEnvironmentMixin):
                 for key, value in flat.items():
                     querystring[key] = [value]
             elif self.body:
-                querystring.update(parse_qs(raw_body, keep_blank_values=True))
+                try:
+                    querystring.update(parse_qs(raw_body, keep_blank_values=True))
+                except UnicodeEncodeError:
+                    pass  # ignore encoding errors, as the body may not contain a legitimate querystring
         if not querystring:
             querystring.update(headers)
 
-        querystring = _decode_dict(querystring)
+        try:
+            querystring = _decode_dict(querystring)
+        except UnicodeDecodeError:
+            pass  # ignore decoding errors, as the body may not contain a legitimate querystring
+
         self.uri = full_url
         self.path = urlparse(full_url).path
         self.querystring = querystring

--- a/tests/test_core/test_responses.py
+++ b/tests/test_core/test_responses.py
@@ -2,7 +2,9 @@ from __future__ import unicode_literals
 
 import sure  # noqa
 
-from moto.core.responses import AWSServiceSpec
+from botocore.awsrequest import AWSPreparedRequest
+
+from moto.core.responses import AWSServiceSpec, BaseResponse
 from moto.core.responses import flatten_json_request_body
 
 
@@ -79,3 +81,9 @@ def test_flatten_json_request_body():
             i += 1
             key = keyfmt.format(idx + 1, i)
         props.should.equal(body['Configurations'][idx]['Properties'])
+
+
+def test_parse_qs_unicode_decode_error():
+    body = b'{"key": "%D0"}, "C": "#0 = :0"}'
+    request = AWSPreparedRequest('GET', 'http://request', {'foo': 'bar'}, body, False)
+    BaseResponse().setup_class(request, request.url, request.headers)


### PR DESCRIPTION
It seems like we always call `parse_qs` on the request body, which may raise a `UnicodeEncodeError` for some bodies. I observed this happening with polylines in particular when using this with DynamoDB.

This just ignores those errors, as if it happens then we wouldn't usually look at the querystring anyway.