### PR TITLE
SNS models.py _get_values_nexttoken doesn't handle next_token empty string

### DIFF
--- a/moto/sns/models.py
+++ b/moto/sns/models.py
@@ -206,7 +206,7 @@ class SNSBackend(BaseBackend):
             return candidate_topic
 
     def _get_values_nexttoken(self, values_map, next_token=None):
-        if next_token is None:
+        if next_token is None or not next_token:
             next_token = 0
         next_token = int(next_token)
         values = list(values_map.values())[


### PR DESCRIPTION
Hello,

I have submitted a fix to this issue over at [localstack](https://github.com/localstack/moto/pull/1)'s fork of this project,  I figured I'd submit this here as well since it seems to be more of a bug in moto than localstack.  Please forgive me for reproducing this issue with localstack and not just moto, but I think it's pretty clear what's going on.

Here's a copy of that issue:

---

I'm using the aws .net sdk to connect to sns - AWSSDK.SimpleNotificationService v3.3.101.1

debug output from localstack docker image 0.9.0:
```
127.0.0.1 - - [30/Apr/2019 16:43:39] "POST / HTTP/1.1" 500 -
Error on request:
Traceback (most recent call last):
File "/opt/code/localstack/.venv/lib/python2.7/site-packages/werkzeug/serving.py", line 270, in run_wsgi
execute(self.server.app)
File "/opt/code/localstack/.venv/lib/python2.7/site-packages/werkzeug/serving.py", line 258, in execute
application_iter = app(environ, start_response)
File "/opt/code/localstack/.venv/lib/python2.7/site-packages/moto/server.py", line 101, in __call__
return backend_app(environ, start_response)
File "/opt/code/localstack/.venv/lib/python2.7/site-packages/flask/app.py", line 1997, in __call__
return self.wsgi_app(environ, start_response)
File "/opt/code/localstack/.venv/lib/python2.7/site-packages/flask/app.py", line 1985, in wsgi_app
response = self.handle_exception(e)
File "/opt/code/localstack/.venv/lib/python2.7/site-packages/flask/app.py", line 1540, in handle_exception
reraise(exc_type, exc_value, tb)
File "/opt/code/localstack/.venv/lib/python2.7/site-packages/flask/app.py", line 1982, in wsgi_app
response = self.full_dispatch_request()
File "/opt/code/localstack/.venv/lib/python2.7/site-packages/flask/app.py", line 1614, in full_dispatch_request
rv = self.handle_user_exception(e)
File "/opt/code/localstack/.venv/lib/python2.7/site-packages/flask/app.py", line 1517, in handle_user_exception
reraise(exc_type, exc_value, tb)
File "/opt/code/localstack/.venv/lib/python2.7/site-packages/flask/app.py", line 1612, in full_dispatch_request
rv = self.dispatch_request()
File "/opt/code/localstack/.venv/lib/python2.7/site-packages/flask/app.py", line 1598, in dispatch_request
return self.view_functions[rule.endpoint](**req.view_args)
File "/opt/code/localstack/.venv/lib/python2.7/site-packages/moto/core/utils.py", line 140, in __call__
result = self.callback(request, request.url, {})
File "/opt/code/localstack/.venv/lib/python2.7/site-packages/moto/core/responses.py", line 117, in dispatch
return cls()._dispatch(*args, **kwargs)
File "/opt/code/localstack/.venv/lib/python2.7/site-packages/moto/core/responses.py", line 200, in _dispatch
return self.call_action()
File "/opt/code/localstack/.venv/lib/python2.7/site-packages/moto/core/responses.py", line 274, in call_action
response = method()
File "/opt/code/localstack/.venv/lib/python2.7/site-packages/moto/sns/responses.py", line 97, in list_topics
topics, next_token = self.backend.list_topics(next_token=next_token)
File "/opt/code/localstack/.venv/lib/python2.7/site-packages/moto/sns/models.py", line 273, in list_topics
return self._get_values_nexttoken(self.topics, next_token)
File "/opt/code/localstack/.venv/lib/python2.7/site-packages/moto/sns/models.py", line 260, in _get_values_nexttoken
next_token = int(next_token)
ValueError: invalid literal for int() with base 10: ''
```
I believe this is the culprit. I'm using this FindTopic api call which wraps the ListTopics api and sets the NextToken to empty string for the first request. Moto is defaulting this value to 0 when next_token is null, but not empty.  Moto tries to parse the empty string as an int and this throws an error.

https://github.com/aws/aws-sdk-net/blob/master/sdk/src/Services/SimpleNotificationService/Custom/_async/AmazonSimpleNotificationServiceClient.Extensions.cs#L159