### PR TITLE
Updated delete_cluster() for redshift

### DIFF
--- a/moto/redshift/models.py
+++ b/moto/redshift/models.py
@@ -548,13 +548,13 @@ class RedshiftBackend(BaseBackend):
         cluster_snapshot_identifer = cluster_kwargs.pop("final_cluster_snapshot_identifier")
 
         if cluster_identifier in self.clusters:
-            if cluster_skip_final_snapshot is False and cluster_snapshot_identifer is None:  # create a snapshot
+            if cluster_skip_final_snapshot is False and cluster_snapshot_identifer is None:
                 raise ClientError(
                     "InvalidParameterValue",
                     'FinalSnapshotIdentifier is required for Snapshot copy '
                     'when SkipFinalSnapshot is False'
                 )
-            else:
+            elif cluster_skip_final_snapshot is False and cluster_snapshot_identifer is not None:  # create snapshot
                 cluster = self.describe_clusters(cluster_identifier)[0]
                 self.create_cluster_snapshot(
                     cluster_identifier,

--- a/moto/redshift/responses.py
+++ b/moto/redshift/responses.py
@@ -240,8 +240,13 @@ class RedshiftResponse(BaseResponse):
         })
 
     def delete_cluster(self):
-        cluster_identifier = self._get_param("ClusterIdentifier")
-        cluster = self.redshift_backend.delete_cluster(cluster_identifier)
+        request_kwargs = {
+            "cluster_identifier": self._get_param("ClusterIdentifier"),
+            "final_cluster_snapshot_identifier": self._get_param("FinalClusterSnapshotIdentifier"),
+            "skip_final_snapshot": self._get_bool_param("SkipFinalClusterSnapshot")
+        }
+
+        cluster = self.redshift_backend.delete_cluster(**request_kwargs)
 
         return self.get_response({
             "DeleteClusterResponse": {

--- a/tests/test_redshift/test_redshift.py
+++ b/tests/test_redshift/test_redshift.py
@@ -9,7 +9,6 @@ from boto.redshift.exceptions import (
     ClusterParameterGroupNotFound,
     ClusterSecurityGroupNotFound,
     ClusterSubnetGroupNotFound,
-    InvalidParameterCombinationFault,
     InvalidSubnet
 )
 from botocore.exceptions import (


### PR DESCRIPTION
When running:
```python
client.delete_cluster(ClusterIdentifier="identifier", SkipFinalClusterSnapshot=False, FinalClusterSnapshotIdentifier="Identifier-snapshot")
```

It would delete the cluster but not create the final snapshot. I have extended the functionality of `delete_cluster` such that a final snapshot will be generated. 

[boto3's delete_cluster reference](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/redshift.html?highlight=redshift#Redshift.Client.delete_cluster)