### PR TITLE
fix #2190

### DIFF
--- a/moto/awslambda/models.py
+++ b/moto/awslambda/models.py
@@ -503,7 +503,7 @@ class LambdaStorage(object):
     def list_versions_by_function(self, name):
         if name not in self._functions:
             return None
-        return [self._functions[name]['latest']]
+        return [self._functions[name]['latest']] + self._functions[name]['versions']
 
     def get_arn(self, arn):
         return self._arns.get(arn, None)
@@ -604,6 +604,9 @@ class LambdaBackend(BaseBackend):
 
         self._lambdas.put_function(fn)
 
+        if spec.get('Publish'):
+            ver = self.publish_function(function_name)
+            fn.version = ver.version
         return fn
 
     def publish_function(self, function_name):

--- a/tests/test_awslambda/test_lambda.py
+++ b/tests/test_awslambda/test_lambda.py
@@ -701,7 +701,7 @@ def test_invoke_async_function():
     )
 
     success_result = conn.invoke_async(
-        FunctionName='testFunction', 
+        FunctionName='testFunction',
         InvokeArgs=json.dumps({'test': 'event'})
         )
 
@@ -842,7 +842,7 @@ def test_list_versions_by_function():
     conn.create_function(
         FunctionName='testFunction',
         Runtime='python2.7',
-        Role='test-iam-role',
+        Role='arn:aws:iam::123456789012:role/test-iam-role',
         Handler='lambda_function.lambda_handler',
         Code={
             'S3Bucket': 'test-bucket',
@@ -857,8 +857,28 @@ def test_list_versions_by_function():
     res = conn.publish_version(FunctionName='testFunction')
     assert res['ResponseMetadata']['HTTPStatusCode'] == 201
     versions = conn.list_versions_by_function(FunctionName='testFunction')
-
+    assert len(versions['Versions']) == 3
     assert versions['Versions'][0]['FunctionArn'] == 'arn:aws:lambda:us-west-2:123456789012:function:testFunction:$LATEST'
+    assert versions['Versions'][1]['FunctionArn'] == 'arn:aws:lambda:us-west-2:123456789012:function:testFunction:1'
+    assert versions['Versions'][1]['FunctionArn'] == 'arn:aws:lambda:us-west-2:123456789012:function:testFunction:2'
+
+    conn.create_function(
+        FunctionName='testFunction_2',
+        Runtime='python2.7',
+        Role='arn:aws:iam::123456789012:role/test-iam-role',
+        Handler='lambda_function.lambda_handler',
+        Code={
+            'S3Bucket': 'test-bucket',
+            'S3Key': 'test.zip',
+        },
+        Description='test lambda function',
+        Timeout=3,
+        MemorySize=128,
+        Publish=False,
+    )
+    versions = conn.list_versions_by_function(FunctionName='testFunction_2')
+    assert len(versions['Versions']) == 1
+    assert versions['Versions'][0]['FunctionArn'] == 'arn:aws:lambda:us-west-2:123456789012:function:testFunction_2:$LATEST'
 
 
 @mock_lambda


### PR DESCRIPTION
fix #2190 
- `list_versions_by_function` return published version not only $LATEST
- when `create_function` called with `Publish=True,` Lambda Backend will automaticaly publish new function version.