### PR TITLE
fix #2190 lambda list_versions_by_function should  return published function versions

### DIFF
--- a/moto/awslambda/models.py
+++ b/moto/awslambda/models.py
@@ -30,7 +30,7 @@ from moto.s3.models import s3_backend
 from moto.logs.models import logs_backends
 from moto.s3.exceptions import MissingBucket, MissingKey
 from moto import settings
-from .utils import make_function_arn
+from .utils import make_function_arn, make_function_ver_arn
 
 logger = logging.getLogger(__name__)
 
@@ -215,12 +215,12 @@ class LambdaFunction(BaseModel):
                 self.code_size = key.size
                 self.code_sha_256 = hashlib.sha256(key.value).hexdigest()
 
-        self.function_arn = make_function_arn(self.region, ACCOUNT_ID, self.function_name, version)
+        self.function_arn = make_function_arn(self.region, ACCOUNT_ID, self.function_name)
 
         self.tags = dict()
 
     def set_version(self, version):
-        self.function_arn = make_function_arn(self.region, ACCOUNT_ID, self.function_name, version)
+        self.function_arn = make_function_ver_arn(self.region, ACCOUNT_ID, self.function_name, version)
         self.version = version
         self.last_modified = datetime.datetime.utcnow().strftime('%Y-%m-%d %H:%M:%S')
 
@@ -503,7 +503,10 @@ class LambdaStorage(object):
     def list_versions_by_function(self, name):
         if name not in self._functions:
             return None
-        return [self._functions[name]['latest']]
+
+        latest = copy.copy(self._functions[name]['latest'])
+        latest.function_arn += ':$LATEST'
+        return [latest] + self._functions[name]['versions']
 
     def get_arn(self, arn):
         return self._arns.get(arn, None)
@@ -535,6 +538,7 @@ class LambdaStorage(object):
         fn.set_version(new_version)
 
         self._functions[name]['versions'].append(fn)
+        self._arns[fn.function_arn] = fn
         return fn
 
     def del_function(self, name, qualifier=None):
@@ -604,6 +608,9 @@ class LambdaBackend(BaseBackend):
 
         self._lambdas.put_function(fn)
 
+        if spec.get('Publish'):
+            ver = self.publish_function(function_name)
+            fn.version = ver.version
         return fn
 
     def publish_function(self, function_name):

--- a/moto/awslambda/responses.py
+++ b/moto/awslambda/responses.py
@@ -150,7 +150,7 @@ class LambdaResponse(BaseResponse):
 
         for fn in self.lambda_backend.list_functions():
             json_data = fn.get_configuration()
-
+            json_data['Version'] = '$LATEST'
             result['Functions'].append(json_data)
 
         return 200, {}, json.dumps(result)
@@ -204,7 +204,10 @@ class LambdaResponse(BaseResponse):
 
         if fn:
             code = fn.get_code()
-
+            if qualifier is None or qualifier == '$LATEST':
+                code['Configuration']['Version'] = '$LATEST'
+            if qualifier == '$LATEST':
+                code['Configuration']['FunctionArn'] += ':$LATEST'
             return 200, {}, json.dumps(code)
         else:
             return 404, {}, "{}"

--- a/moto/awslambda/utils.py
+++ b/moto/awslambda/utils.py
@@ -3,8 +3,13 @@ from collections import namedtuple
 ARN = namedtuple('ARN', ['region', 'account', 'function_name', 'version'])
 
 
-def make_function_arn(region, account, name, version='1'):
-    return 'arn:aws:lambda:{0}:{1}:function:{2}:{3}'.format(region, account, name, version)
+def make_function_arn(region, account, name):
+    return 'arn:aws:lambda:{0}:{1}:function:{2}'.format(region, account, name)
+
+
+def make_function_ver_arn(region, account, name, version='1'):
+    arn = make_function_arn(region, account, name)
+    return '{0}:{1}'.format(arn, version)
 
 
 def split_function_arn(arn):


### PR DESCRIPTION
fix #2190

- list_versions_by_function return published version not only $LATEST
- when create_function called with Publish=True, Lambda Backend will automaticaly publish new function version.
- fixed some wrong existing test case and lambda backend behavior.Because  I fix this issue, those test case will fail
  - Some api response that control lambda function, will return arn that not contains lambda version.
For example get_function without qualifier,create_function.
  - And Some api response that control lambda version, will return arn that contains lambda version.
For example get_function with qualifier,list_versions_by_function.