### PR TITLE
Bug batch describe job fail

### DIFF
--- a/moto/batch/models.py
+++ b/moto/batch/models.py
@@ -289,10 +289,11 @@ class Job(threading.Thread, BaseModel):
             'jobId': self.job_id,
             'jobName': self.job_name,
             'jobQueue': self.job_queue.arn,
-            'startedAt': datetime2int(self.job_started_at),
             'status': self.job_state,
             'dependsOn': []
         }
+        if result['status'] not in ['SUBMITTED', 'PENDING', 'RUNNABLE', 'STARTING']:
+            result['startedAt'] = datetime2int(self.job_started_at)
         if self.job_stopped:
             result['stoppedAt'] = datetime2int(self.job_stopped_at)
             result['container'] = {}

--- a/tests/test_batch/test_batch.py
+++ b/tests/test_batch/test_batch.py
@@ -643,7 +643,8 @@ def test_describe_task_definition():
 
 
 # SLOW TESTS
-@expected_failure
+
+# @expected_failure
 @mock_logs
 @mock_ec2
 @mock_ecs


### PR DESCRIPTION
It fixes the issue #2201.
I have tested the actual AWS behavior with boto3 and it turned out it doesn't return 'startedAt' from describe_jobs for not-yet-started jobs. This pull request makes moto to reflect that behavior.