### PR TITLE
Fix for #1870 thanks to dslaw

### DIFF
--- a/moto/core/responses.py
+++ b/moto/core/responses.py
@@ -98,7 +98,7 @@ class _TemplateEnvironmentMixin(object):
         template_id = id(source)
         if not self.contains_template(template_id):
             # Real response body of AWS APIs dont have whitespace between tags
-            collapsed = "".join(line.strip() for line in source.split("\n"))
+            collapsed = "".join(line.lstrip() for line in source.split("\n"))
             self.loader.update({template_id: collapsed})
             self.environment = Environment(loader=self.loader, autoescape=self.should_autoescape, trim_blocks=True,
                                            lstrip_blocks=True)

--- a/moto/core/responses.py
+++ b/moto/core/responses.py
@@ -97,7 +97,9 @@ class _TemplateEnvironmentMixin(object):
     def response_template(self, source):
         template_id = id(source)
         if not self.contains_template(template_id):
-            self.loader.update({template_id: source})
+            # Real response body of AWS APIs dont have whitespace between tags
+            collapsed = "".join(line.strip() for line in source.split("\n"))
+            self.loader.update({template_id: collapsed})
             self.environment = Environment(loader=self.loader, autoescape=self.should_autoescape, trim_blocks=True,
                                            lstrip_blocks=True)
         return self.environment.get_template(template_id)


### PR DESCRIPTION
Fix for #1870 

I think modifying the jinja templates wont get rid of the problem since there is nothing ensuring that those are always whitespace free.

I also don't know what the tests(if any) should look like since this is a quirk that is only apparent when interfacing with Moto through Pyspark. Pyspark tests are notoriously slow and bloated and noisy.