### PR TITLE
#2212 add support for delete on update_with_attribute_updates

### DIFF
--- a/moto/dynamodb2/models.py
+++ b/moto/dynamodb2/models.py
@@ -306,7 +306,7 @@ class Item(BaseModel):
                         'ADD not supported for %s' % ', '.join(update_action['Value'].keys()))
             else:
                 raise NotImplementedError(
-                        '%s action not support for update_with_attribute_updates' % action)
+                    '%s action not support for update_with_attribute_updates' % action)
 
 
 class StreamRecord(BaseModel):

--- a/moto/dynamodb2/models.py
+++ b/moto/dynamodb2/models.py
@@ -294,6 +294,19 @@ class Item(BaseModel):
                     # TODO: implement other data types
                     raise NotImplementedError(
                         'ADD not supported for %s' % ', '.join(update_action['Value'].keys()))
+            elif action == 'DELETE':
+                if set(update_action['Value'].keys()) == set(['SS']):
+                    existing = self.attrs.get(attribute_name, DynamoType({"SS": {}}))
+                    new_set = set(existing.value).difference(set(new_value))
+                    self.attrs[attribute_name] = DynamoType({
+                        "SS": list(new_set)
+                    })
+                else:
+                    raise NotImplementedError(
+                        'ADD not supported for %s' % ', '.join(update_action['Value'].keys()))
+            else:
+                raise NotImplementedError(
+                        '%s action not support for update_with_attribute_updates' % action)
 
 
 class StreamRecord(BaseModel):

--- a/tests/test_dynamodb2/test_dynamodb_table_with_range_key.py
+++ b/tests/test_dynamodb2/test_dynamodb_table_with_range_key.py
@@ -1344,6 +1344,34 @@ def test_update_item_add_value_string_set():
         'subject': '123',
     })
 
+@mock_dynamodb2
+def test_update_item_delete_value_string_set():
+    table = _create_table_with_range_key()
+
+    table.put_item(Item={
+        'forum_name': 'the-key',
+        'subject': '123',
+        'string_set': set(['str1', 'str2']),
+    })
+
+    item_key = {'forum_name': 'the-key', 'subject': '123'}
+    table.update_item(
+        Key=item_key,
+        AttributeUpdates={
+            'string_set': {
+                'Action': u'DELETE',
+                'Value': set(['str2']),
+            },
+        },
+    )
+
+    returned_item = dict((k, str(v) if isinstance(v, Decimal) else v)
+                         for k, v in table.get_item(Key=item_key)['Item'].items())
+    dict(returned_item).should.equal({
+        'string_set': set(['str1']),
+        'forum_name': 'the-key',
+        'subject': '123',
+    })
 
 @mock_dynamodb2
 def test_update_item_add_value_does_not_exist_is_created():


### PR DESCRIPTION
Fixes #2212. Raises exceptions properly when functions are attempted that don't have support yet, to prevent confusion.