### PR TITLE
Fix lambda test failures in travis

### DIFF
--- a/moto/awslambda/models.py
+++ b/moto/awslambda/models.py
@@ -45,7 +45,7 @@ except ImportError:
 
 _stderr_regex = re.compile(r'START|END|REPORT RequestId: .*')
 _orig_adapter_send = requests.adapters.HTTPAdapter.send
-docker_3 = docker.__version__.startswith("3")
+docker_3 = docker.__version__[0] >= '3'
 
 
 def zip2tar(zip_bytes):


### PR DESCRIPTION
Change docker library version check so that it sends the correct arguments for library versions 3+

@mikegrima mind reviewing before I merge.