### PR TITLE
SecretsManager secret value binary support

### DIFF
--- a/moto/secretsmanager/responses.py
+++ b/moto/secretsmanager/responses.py
@@ -21,10 +21,12 @@ class SecretsManagerResponse(BaseResponse):
     def create_secret(self):
         name = self._get_param('Name')
         secret_string = self._get_param('SecretString')
+        secret_binary = self._get_param('SecretBinary')
         tags = self._get_param('Tags', if_none=[])
         return secretsmanager_backends[self.region].create_secret(
             name=name,
             secret_string=secret_string,
+            secret_binary=secret_binary,
             tags=tags
         )
 

--- a/tests/test_secretsmanager/test_secretsmanager.py
+++ b/tests/test_secretsmanager/test_secretsmanager.py
@@ -9,6 +9,7 @@ import unittest
 import pytz
 from datetime import datetime
 from nose.tools import assert_raises
+from six import b
 
 DEFAULT_SECRET_NAME = 'test-secret'
 
@@ -21,6 +22,15 @@ def test_get_secret_value():
                                        SecretString="foosecret")
     result = conn.get_secret_value(SecretId='java-util-test-password')
     assert result['SecretString'] == 'foosecret'
+
+@mock_secretsmanager
+def test_get_secret_value_binary():
+    conn = boto3.client('secretsmanager', region_name='us-west-2')
+
+    create_secret = conn.create_secret(Name='java-util-test-password',
+                                       SecretBinary=b("foosecret"))
+    result = conn.get_secret_value(SecretId='java-util-test-password')
+    assert result['SecretBinary'] == b('foosecret')
 
 @mock_secretsmanager
 def test_get_secret_that_does_not_exist():


### PR DESCRIPTION
Adds binary values (SecretBinary parameter) support for the following operations in SecretsManager:
* [create_secret](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/secretsmanager.html#SecretsManager.Client.create_secret)
* [get_secret_value](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/secretsmanager.html#SecretsManager.Client.get_secret_value)