### PR TITLE
Add glue.batch_delete_table, and fix glue.batch_create_partition to respond correctly

### DIFF
--- a/moto/glue/responses.py
+++ b/moto/glue/responses.py
@@ -100,7 +100,7 @@ class GlueResponse(BaseResponse):
         errors = []
         for table_name in self.parameters.get('TablesToDelete'):
             try:
-                resp = self.glue_backend.delete_table(database_name, table_name)
+                self.glue_backend.delete_table(database_name, table_name)
             except TableNotFoundException:
                 errors.append({
                     "TableName": table_name,

--- a/moto/glue/responses.py
+++ b/moto/glue/responses.py
@@ -145,7 +145,11 @@ class GlueResponse(BaseResponse):
                     }
                 })
 
-        return json.dumps({"Errors": errors_output})
+        out = {}
+        if errors_output:
+            out["Errors"] = errors_output
+
+        return json.dumps(out)
 
     def update_partition(self):
         database_name = self.parameters.get('DatabaseName')

--- a/tests/test_glue/test_datacatalog.py
+++ b/tests/test_glue/test_datacatalog.py
@@ -229,6 +229,26 @@ def test_delete_table():
     exc.exception.response['Error']['Code'].should.equal('EntityNotFoundException')
     exc.exception.response['Error']['Message'].should.match('Table myspecialtable not found')
 
+@mock_glue
+def test_batch_delete_table():
+    client = boto3.client('glue', region_name='us-east-1')
+    database_name = 'myspecialdatabase'
+    helpers.create_database(client, database_name)
+
+    table_name = 'myspecialtable'
+    table_input = helpers.create_table_input(database_name, table_name)
+    helpers.create_table(client, database_name, table_name, table_input)
+
+    result = client.batch_delete_table(DatabaseName=database_name, TablesToDelete=[table_name])
+    result['ResponseMetadata']['HTTPStatusCode'].should.equal(200)
+
+    # confirm table is deleted
+    with assert_raises(ClientError) as exc:
+        helpers.get_table(client, database_name, table_name)
+
+    exc.exception.response['Error']['Code'].should.equal('EntityNotFoundException')
+    exc.exception.response['Error']['Message'].should.match('Table myspecialtable not found')
+
 
 @mock_glue
 def test_get_partitions_empty():


### PR DESCRIPTION
I added the `batch_delete_table` endpoint for glue, and while adding that realized the `batch_create_partition` endpoint wasn't correct.

`batch_create_partition` always returned a dict with the `Errors` key, which should only be present when errors actually occur.