### PR TITLE
Fixed policy version's Document type for AWS managed policies

### DIFF
--- a/moto/iam/models.py
+++ b/moto/iam/models.py
@@ -131,7 +131,7 @@ class AWSManagedPolicy(ManagedPolicy):
         return cls(name,
                    default_version_id=data.get('DefaultVersionId'),
                    path=data.get('Path'),
-                   document=data.get('Document'),
+                   document=json.dumps(data.get('Document')),
                    create_date=datetime.strptime(data.get('CreateDate'), "%Y-%m-%dT%H:%M:%S+00:00"),
                    update_date=datetime.strptime(data.get('UpdateDate'), "%Y-%m-%dT%H:%M:%S+00:00"))
 

--- a/tests/test_iam/test_iam.py
+++ b/tests/test_iam/test_iam.py
@@ -369,6 +369,7 @@ def test_get_aws_managed_policy_version():
         PolicyArn=managed_policy_arn,
         VersionId="v1")
     retrieved['PolicyVersion']['CreateDate'].replace(tzinfo=None).should.equal(managed_policy_version_create_date)
+    retrieved['PolicyVersion']['Document'].should.be.an(dict)
 
 
 @mock_iam
@@ -384,6 +385,7 @@ def test_get_aws_managed_policy_v4_version():
         PolicyArn=managed_policy_arn,
         VersionId="v4")
     retrieved['PolicyVersion']['CreateDate'].replace(tzinfo=None).should.equal(managed_policy_version_create_date)
+    retrieved['PolicyVersion']['Document'].should.be.an(dict)
 
 
 @mock_iam


### PR DESCRIPTION
My previous fix (#2231) accidentally returned policy version's Document for AWS managed policies as Python `dict`s which did not get converted successfully. This is fixed now by returning them as properly converted strings.