### PR TITLE
#1834 Fix DynamoDB UpdateExpression support for REMOVE on nested maps

### DIFF
--- a/moto/dynamodb2/models.py
+++ b/moto/dynamodb2/models.py
@@ -149,6 +149,29 @@ class Item(BaseModel):
                     value = re.sub(r'{0}\b'.format(k), v, value)
 
                 if action == "REMOVE":
+                    key  = value
+                    if '.' not in key:
+                        self.attrs.pop(value, None)
+                    else:
+                        # Handle nested dict updates
+                        key_parts = key.split('.')
+                        attr = key_parts.pop(0)
+                        if attr not in self.attrs:
+                            raise ValueError
+
+                        last_val = self.attrs[attr].value
+                        for key_part in key_parts[:-1]:
+                            # Hack but it'll do, traverses into a dict
+                            last_val_type = list(last_val.keys())
+                            if last_val_type and last_val_type[0] == 'M':
+                                    last_val = last_val['M']
+
+                            if key_part not in last_val:
+                                last_val[key_part] = {'M': {}}
+
+                            last_val = last_val[key_part]
+
+                        last_val.pop(key_parts[-1], None)
                     self.attrs.pop(value, None)
                 elif action == 'SET':
                     key, value = value.split("=", 1)

--- a/moto/dynamodb2/models.py
+++ b/moto/dynamodb2/models.py
@@ -149,7 +149,7 @@ class Item(BaseModel):
                     value = re.sub(r'{0}\b'.format(k), v, value)
 
                 if action == "REMOVE":
-                    key  = value
+                    key = value
                     if '.' not in key:
                         self.attrs.pop(value, None)
                     else:

--- a/tests/test_dynamodb2/test_dynamodb_table_without_range_key.py
+++ b/tests/test_dynamodb2/test_dynamodb_table_without_range_key.py
@@ -451,6 +451,35 @@ def test_update_item_remove():
 
 
 @mock_dynamodb2_deprecated
+def test_update_item_nested_remove():
+    conn = boto.dynamodb2.connect_to_region("us-east-1")
+    table = Table.create('messages', schema=[
+        HashKey('username')
+    ])
+
+    data = {
+        'username': "steve",
+        'Meta': {
+            'FullName': 'Steve Urkel'    
+        }
+    }
+    table.put_item(data=data)
+    key_map = {
+        'username': {"S": "steve"}
+    }
+
+    # Then remove the SentBy field
+    conn.update_item("messages", key_map,
+                     update_expression="REMOVE Meta.FullName")
+
+    returned_item = table.get_item(username="steve")
+    dict(returned_item).should.equal({
+        'username': "steve",
+        'Meta': {}
+    })
+
+
+@mock_dynamodb2_deprecated
 def test_update_item_set():
     conn = boto.dynamodb2.connect_to_region("us-east-1")
     table = Table.create('messages', schema=[

--- a/tests/test_dynamodb2/test_dynamodb_table_without_range_key.py
+++ b/tests/test_dynamodb2/test_dynamodb_table_without_range_key.py
@@ -480,7 +480,7 @@ def test_update_item_nested_remove():
 
 
 @mock_dynamodb2_deprecated
-def test_update_item_nested_remove():
+def test_update_item_double_nested_remove():
     conn = boto.dynamodb2.connect_to_region("us-east-1")
     table = Table.create('messages', schema=[
         HashKey('username')

--- a/tests/test_dynamodb2/test_dynamodb_table_without_range_key.py
+++ b/tests/test_dynamodb2/test_dynamodb_table_without_range_key.py
@@ -480,6 +480,41 @@ def test_update_item_nested_remove():
 
 
 @mock_dynamodb2_deprecated
+def test_update_item_nested_remove():
+    conn = boto.dynamodb2.connect_to_region("us-east-1")
+    table = Table.create('messages', schema=[
+        HashKey('username')
+    ])
+
+    data = {
+        'username': "steve",
+        'Meta': {
+            'Name': {
+                'First': 'Steve',
+                'Last': 'Urkel'
+            }
+        }
+    }
+    table.put_item(data=data)
+    key_map = {
+        'username': {"S": "steve"}
+    }
+
+    # Then remove the Meta.FullName field
+    conn.update_item("messages", key_map,
+                     update_expression="REMOVE Meta.Name.First")
+
+    returned_item = table.get_item(username="steve")
+    dict(returned_item).should.equal({
+        'username': "steve",
+        'Meta': {
+            'Name': {
+                'Last': 'Urkel'
+            }
+        }
+    })
+
+@mock_dynamodb2_deprecated
 def test_update_item_set():
     conn = boto.dynamodb2.connect_to_region("us-east-1")
     table = Table.create('messages', schema=[

--- a/tests/test_dynamodb2/test_dynamodb_table_without_range_key.py
+++ b/tests/test_dynamodb2/test_dynamodb_table_without_range_key.py
@@ -468,7 +468,7 @@ def test_update_item_nested_remove():
         'username': {"S": "steve"}
     }
 
-    # Then remove the SentBy field
+    # Then remove the Meta.FullName field
     conn.update_item("messages", key_map,
                      update_expression="REMOVE Meta.FullName")
 


### PR DESCRIPTION
This adds nested map support to the REMOVE operation on dynamodb2, fixing #1834 