### PR TITLE
Delete ECR image when it has no tags

### DIFF
--- a/moto/ecr/models.py
+++ b/moto/ecr/models.py
@@ -403,7 +403,10 @@ class ECRBackend(BaseBackend):
                     image_found = True
                     repository.images[num].image_tag = image_id["imageTag"]
                     response["imageIds"].append(image.response_batch_delete_image)
-                    repository.images[num].remove_tag(image_id["imageTag"])
+                    if len(image.image_tags) > 1:
+                        repository.images[num].remove_tag(image_id["imageTag"])
+                    else:
+                        repository.images.remove(image)
 
                 if not image_found:
                     failure_response = {


### PR DESCRIPTION
This should fix the bug identified in #2246 

This is a bug fix to my initial work when implementing
batch_delete_image. Deleting the last tag for a given image should
delete the image from the backend.

I also cleaned up the tests previously-added in the initial
implementation.