### PR TITLE
Raising MalformedXML exception when using boto3 client and s3.delete_objects()

### DIFF
--- a/moto/s3/responses.py
+++ b/moto/s3/responses.py
@@ -566,6 +566,8 @@ class ResponseObject(_TemplateEnvironmentMixin):
         keys = minidom.parseString(body).getElementsByTagName('Key')
         deleted_names = []
         error_names = []
+        if len(keys) == 0:
+            raise MalformedXML()
 
         for k in keys:
             key_name = k.firstChild.nodeValue

--- a/tests/test_s3/test_s3.py
+++ b/tests/test_s3/test_s3.py
@@ -648,6 +648,7 @@ def test_delete_keys_with_invalid():
     Key(bucket=bucket, name='file3').set_contents_from_string('abc')
     Key(bucket=bucket, name='file4').set_contents_from_string('abc')
 
+    # non-existing key case
     result = bucket.delete_keys(['abc', 'file3'])
 
     result.deleted.should.have.length_of(1)
@@ -655,6 +656,17 @@ def test_delete_keys_with_invalid():
     keys = bucket.get_all_keys()
     keys.should.have.length_of(3)
     keys[0].name.should.equal('file1')
+
+    # empty keys and boto2 client
+    result = bucket.delete_keys([])
+
+    result.deleted.should.have.length_of(0)
+    result.errors.should.have.length_of(0)
+
+    # empty keys and boto3 client
+    with assert_raises(ClientError) as err:
+        boto3.client('s3').delete_objects(Bucket='foobar', Delete={'Objects': []})
+    assert err.exception.response["Error"]["Code"] == "MalformedXML"
 
 
 @mock_s3_deprecated

--- a/tests/test_s3/test_s3.py
+++ b/tests/test_s3/test_s3.py
@@ -639,7 +639,7 @@ def test_delete_keys():
 
 
 @mock_s3_deprecated
-def test_delete_keys_with_invalid():
+def test_delete_keys_invalid():
     conn = boto.connect_s3('the_key', 'the_secret')
     bucket = conn.create_bucket('foobar')
 
@@ -657,13 +657,14 @@ def test_delete_keys_with_invalid():
     keys.should.have.length_of(3)
     keys[0].name.should.equal('file1')
 
-    # empty keys and boto2 client
+    # empty keys
     result = bucket.delete_keys([])
 
     result.deleted.should.have.length_of(0)
     result.errors.should.have.length_of(0)
 
-    # empty keys and boto3 client
+@mock_s3
+def test_boto3_delete_empty_keys_list():
     with assert_raises(ClientError) as err:
         boto3.client('s3').delete_objects(Bucket='foobar', Delete={'Objects': []})
     assert err.exception.response["Error"]["Code"] == "MalformedXML"


### PR DESCRIPTION
This PR fixes the S3 behavior when the `delete_objects()` (via boto3) is called without parameters. According to the AWS API usage, it should raise an exception:
```
>>> import boto3
>>> boto3.client('s3').delete_objects(Bucket='bucket-name-here', Delete={'Objects': []})
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Library/Frameworks/Python.framework/Versions/3.7/lib/python3.7/site-packages/botocore/client.py", line 324, in _api_call
    return self._make_api_call(operation_name, kwargs)
  File "/Library/Frameworks/Python.framework/Versions/3.7/lib/python3.7/site-packages/botocore/client.py", line 622, in _make_api_call
    raise error_class(parsed_response, operation_name)
botocore.exceptions.ClientError: An error occurred (MalformedXML) when calling the DeleteObjects operation: The XML you provided was not well-formed or did not validate against our published schema
```