### PR TITLE
Fixed random_suffix()

### DIFF
--- a/moto/cloudformation/utils.py
+++ b/moto/cloudformation/utils.py
@@ -4,6 +4,7 @@ import six
 import random
 import yaml
 import os
+import string
 
 from cfnlint import decode, core
 
@@ -29,7 +30,7 @@ def generate_stackset_arn(stackset_id, region_name):
 
 def random_suffix():
     size = 12
-    chars = list(range(10)) + ['A-Z']
+    chars = list(range(10)) + list(string.ascii_uppercase)
     return ''.join(six.text_type(random.choice(chars)) for x in range(size))
 
 


### PR DESCRIPTION
The bug: `random.choice` cannot interpret `'A-Z'`, it requires all the individual characters in the parameter list.
This should resolve the sometimes failing `test_create_target_groups_through_cloudformation` test case.