### PR TITLE
ELBv2 LBs names must be 32 char or shorter

### DIFF
--- a/moto/cloudformation/parsing.py
+++ b/moto/cloudformation/parsing.py
@@ -246,7 +246,8 @@ def resource_name_property_from_type(resource_type):
 
 
 def generate_resource_name(resource_type, stack_name, logical_id):
-    if resource_type == "AWS::ElasticLoadBalancingV2::TargetGroup":
+    if resource_type in ["AWS::ElasticLoadBalancingV2::TargetGroup",
+                         "AWS::ElasticLoadBalancingV2::LoadBalancer"]:
         # Target group names need to be less than 32 characters, so when cloudformation creates a name for you
         # it makes sure to stay under that limit
         name_prefix = '{0}-{1}'.format(stack_name, logical_id)


### PR DESCRIPTION
Per the AWS docs, load balancers are also restricted to a name of <= 32 char 

https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticloadbalancingv2-loadbalancer.html
`The name of the load balancer. This name must be unique per region per account, can have a maximum of 32 characters, must contain only alphanumeric characters or hyphens, must not begin or end with a hyphen, and must not begin with "internal-".`

In my specific case, I was using CF to make the both an NLB and target group and my target group was inheriting it's name from the NLB.  
Down in the target group code, it failed name validation for length.  

I'm suspicious there may be a secondary issue in the ELBv2 code as I would have expected a name too long error for the NLB.  Though, this may be an order of operations issue related to my edge case (where in CF, I set the TG name to the NLB name) 