### PR TITLE
ProjectionExpression works with table.scan()

### DIFF
--- a/moto/dynamodb2/models.py
+++ b/moto/dynamodb2/models.py
@@ -985,6 +985,9 @@ class DynamoDBBackend(BaseBackend):
         else:
             filter_expression = Op(None, None)  # Will always eval to true
 
+        projection_expression = ','.join([expr_names[attr] if attr in expr_names else attr
+                                          for attr in projection_expression.replace(' ', '').split(',')])
+
         return table.scan(scan_filters, limit, exclusive_start_key, filter_expression, index_name, projection_expression)
 
     def update_item(self, table_name, key, update_expression, attribute_updates, expression_attribute_names,

--- a/moto/dynamodb2/models.py
+++ b/moto/dynamodb2/models.py
@@ -985,8 +985,7 @@ class DynamoDBBackend(BaseBackend):
         else:
             filter_expression = Op(None, None)  # Will always eval to true
 
-        projection_expression = ','.join([expr_names[attr] if attr in expr_names else attr
-                                          for attr in projection_expression.replace(' ', '').split(',')])
+        projection_expression = ','.join([expr_names.get(attr, attr) for attr in projection_expression.replace(' ', '').split(',')])
 
         return table.scan(scan_filters, limit, exclusive_start_key, filter_expression, index_name, projection_expression)
 

--- a/moto/dynamodb2/responses.py
+++ b/moto/dynamodb2/responses.py
@@ -558,7 +558,7 @@ class DynamoHandler(BaseResponse):
         filter_expression = self.body.get('FilterExpression')
         expression_attribute_values = self.body.get('ExpressionAttributeValues', {})
         expression_attribute_names = self.body.get('ExpressionAttributeNames', {})
-
+        projection_expression = self.body.get('ProjectionExpression')
         exclusive_start_key = self.body.get('ExclusiveStartKey')
         limit = self.body.get("Limit")
         index_name = self.body.get('IndexName')
@@ -570,7 +570,8 @@ class DynamoHandler(BaseResponse):
                                                                                   filter_expression,
                                                                                   expression_attribute_names,
                                                                                   expression_attribute_values,
-                                                                                  index_name)
+                                                                                  index_name,
+                                                                                  projection_expression)
         except InvalidIndexNameError as err:
             er = 'com.amazonaws.dynamodb.v20111205#ValidationException'
             return self.error(er, str(err))

--- a/moto/dynamodb2/responses.py
+++ b/moto/dynamodb2/responses.py
@@ -558,7 +558,7 @@ class DynamoHandler(BaseResponse):
         filter_expression = self.body.get('FilterExpression')
         expression_attribute_values = self.body.get('ExpressionAttributeValues', {})
         expression_attribute_names = self.body.get('ExpressionAttributeNames', {})
-        projection_expression = self.body.get('ProjectionExpression')
+        projection_expression = self.body.get('ProjectionExpression', '')
         exclusive_start_key = self.body.get('ExclusiveStartKey')
         limit = self.body.get("Limit")
         index_name = self.body.get('IndexName')

--- a/tests/test_dynamodb2/test_dynamodb.py
+++ b/tests/test_dynamodb2/test_dynamodb.py
@@ -522,10 +522,10 @@ def test_basic_projection_expressions_using_scan():
 
     assert 'body' in results['Items'][0]
     assert 'subject' not in results['Items'][0]
-    assert results['Items'][0]['body'] == 'some test message'
+    assert 'forum_name' not in results['Items'][0]
     assert 'body' in results['Items'][1]
     assert 'subject' not in results['Items'][1]
-    assert results['Items'][1]['body'] == 'yet another test message'
+    assert 'forum_name' not in results['Items'][1]
 
     # The projection expression should not remove data from storage
     results = table.query(
@@ -536,6 +536,7 @@ def test_basic_projection_expressions_using_scan():
     assert 'body' in results['Items'][1]
     assert 'forum_name' in results['Items'][1]
 
+test_basic_projection_expressions_using_scan()
 
 @mock_dynamodb2
 def test_basic_projection_expressions_with_attr_expression_names():

--- a/tests/test_dynamodb2/test_dynamodb.py
+++ b/tests/test_dynamodb2/test_dynamodb.py
@@ -452,6 +452,90 @@ def test_basic_projection_expressions():
     assert 'body' in results['Items'][1]
     assert 'forum_name' in results['Items'][1]
 
+@mock_dynamodb2
+def test_basic_projection_expressions_using_scan():
+    dynamodb = boto3.resource('dynamodb', region_name='us-east-1')
+
+    # Create the DynamoDB table.
+    table = dynamodb.create_table(
+        TableName='users',
+        KeySchema=[
+            {
+                'AttributeName': 'forum_name',
+                'KeyType': 'HASH'
+            },
+            {
+                'AttributeName': 'subject',
+                'KeyType': 'RANGE'
+            },
+        ],
+        AttributeDefinitions=[
+            {
+                'AttributeName': 'forum_name',
+                'AttributeType': 'S'
+            },
+            {
+                'AttributeName': 'subject',
+                'AttributeType': 'S'
+            },
+        ],
+        ProvisionedThroughput={
+            'ReadCapacityUnits': 5,
+            'WriteCapacityUnits': 5
+        }
+    )
+    table = dynamodb.Table('users')
+
+    table.put_item(Item={
+        'forum_name': 'the-key',
+        'subject': '123',
+        'body': 'some test message'
+    })
+
+    table.put_item(Item={
+        'forum_name': 'not-the-key',
+        'subject': '123',
+        'body': 'some other test message'
+    })
+    # Test a query returning all items
+    results = table.scan(
+        FilterExpression=Key('forum_name').eq(
+            'the-key'),
+        ProjectionExpression='body, subject'
+    )
+
+    assert 'body' in results['Items'][0]
+    assert results['Items'][0]['body'] == 'some test message'
+    assert 'subject' in results['Items'][0]
+
+    table.put_item(Item={
+        'forum_name': 'the-key',
+        'subject': '1234',
+        'body': 'yet another test message'
+    })
+
+    results = table.scan(
+        FilterExpression=Key('forum_name').eq(
+            'the-key'),
+        ProjectionExpression='body'
+    )
+
+    assert 'body' in results['Items'][0]
+    assert 'subject' not in results['Items'][0]
+    assert results['Items'][0]['body'] == 'some test message'
+    assert 'body' in results['Items'][1]
+    assert 'subject' not in results['Items'][1]
+    assert results['Items'][1]['body'] == 'yet another test message'
+
+    # The projection expression should not remove data from storage
+    results = table.query(
+        KeyConditionExpression=Key('forum_name').eq(
+            'the-key'),
+    )
+    assert 'subject' in results['Items'][0]
+    assert 'body' in results['Items'][1]
+    assert 'forum_name' in results['Items'][1]
+
 
 @mock_dynamodb2
 def test_basic_projection_expressions_with_attr_expression_names():

--- a/tests/test_dynamodb2/test_dynamodb.py
+++ b/tests/test_dynamodb2/test_dynamodb.py
@@ -536,7 +536,6 @@ def test_basic_projection_expressions_using_scan():
     assert 'body' in results['Items'][1]
     assert 'forum_name' in results['Items'][1]
 
-test_basic_projection_expressions_using_scan()
 
 @mock_dynamodb2
 def test_basic_projection_expressions_with_attr_expression_names():


### PR DESCRIPTION
Ability to use ProjectionExpression with dynamodb.scan().

ProjectionExpression is not implemented for table.scan() but is for table.query() - took the majority of my inspiration for this from the query function.

#1491 