### PR TITLE
Unpin PyYAML

### DIFF
--- a/moto/cloudformation/models.py
+++ b/moto/cloudformation/models.py
@@ -229,7 +229,7 @@ class FakeStack(BaseModel):
     def _parse_template(self):
         yaml.add_multi_constructor('', yaml_tag_constructor)
         try:
-            self.template_dict = yaml.load(self.template, Loader=yaml.Loader)
+            self.template_dict = yaml.load(self.template, Loader=yaml.FullLoader)
         except yaml.parser.ParserError:
             self.template_dict = json.loads(self.template, Loader=yaml.Loader)
 

--- a/moto/cloudformation/responses.py
+++ b/moto/cloudformation/responses.py
@@ -336,7 +336,7 @@ class CloudFormationResponse(BaseResponse):
         except (ValueError, KeyError):
             pass
         try:
-            description = yaml.load(self._get_param('TemplateBody'))['Description']
+            description = yaml.full_load(self._get_param('TemplateBody'))['Description']
         except (yaml.ParserError, KeyError):
             pass
         template = self.response_template(VALIDATE_STACK_RESPONSE_TEMPLATE)

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ install_requires = [
     "xmltodict",
     "six>1.9",
     "werkzeug",
-    "PyYAML==3.13",
+    "PyYAML>=5.1",
     "pytz",
     "python-dateutil<3.0.0,>=2.1",
     "python-jose<4.0.0",

--- a/tests/test_cloudformation/test_stack_parsing.py
+++ b/tests/test_cloudformation/test_stack_parsing.py
@@ -476,8 +476,8 @@ def test_short_form_func_in_yaml_teamplate():
     KeySplit: !Split [A, B]
     KeySub: !Sub A
     """
-    yaml.add_multi_constructor('', yaml_tag_constructor, Loader=yaml.Loader)
-    template_dict = yaml.load(template, Loader=yaml.Loader)
+    yaml.add_multi_constructor('', yaml_tag_constructor, Loader=yaml.FullLoader)
+    template_dict = yaml.load(template, Loader=yaml.FullLoader)
     key_and_expects = [
         ['KeyRef', {'Ref': 'foo'}],
         ['KeyB64', {'Fn::Base64': 'valueToEncode'}],


### PR DESCRIPTION
Ever since PyYAML was pinned at `==3.13`, I've been unable to upgrade my service that depends on Moto due to dependency version conflicts. Many libraries depend on `PyYAML>=5.1` due to [a security issue](https://nvd.nist.gov/vuln/detail/CVE-2017-18342) that was raised against older versions of the library.

This PR makes simple changes to make Moto compatible with PyYAML 5.1. This is my first time contributing to this repository, so let me know if there's anything I should be doing differently. Thanks!