### PR TITLE
Adds failing test for socket.socketpair()

### DIFF
--- a/tests/test_core/test_socket.py
+++ b/tests/test_core/test_socket.py
@@ -1,0 +1,48 @@
+import unittest
+from moto import mock_dynamodb2_deprecated, mock_dynamodb2
+import socket
+
+from six import PY3
+
+
+class TestSocketPair(unittest.TestCase):
+
+    @mock_dynamodb2_deprecated
+    def test_asyncio_deprecated(self):
+        if PY3:
+            self.assertIn(
+                'moto.packages.httpretty.core.fakesock.socket',
+                str(socket.socket),
+                'Our mock should be present'
+            )
+            import asyncio
+            self.assertIsNotNone(asyncio.get_event_loop())
+
+    @mock_dynamodb2_deprecated
+    def test_socket_pair_deprecated(self):
+
+        # In Python2, the fakesocket is not set, for some reason.
+        if PY3:
+            self.assertIn(
+                'moto.packages.httpretty.core.fakesock.socket',
+                str(socket.socket),
+                'Our mock should be present'
+            )
+        a, b = socket.socketpair()
+        self.assertIsNotNone(a)
+        self.assertIsNotNone(b)
+        if a:
+            a.close()
+        if b:
+            b.close()
+
+
+    @mock_dynamodb2
+    def test_socket_pair(self):
+        a, b = socket.socketpair()
+        self.assertIsNotNone(a)
+        self.assertIsNotNone(b)
+        if a:
+            a.close()
+        if b:
+            b.close()


### PR DESCRIPTION
This PR includes changes to make the fake socket actually conform to the socket.socket module API on Python 3. Previously, the `fd` argument was not supported, which resulted in effectively breaking Python's asyncio module (which creates a `socket.socketpair` while the mock was active.

Resulting exception under Py3: https://travis-ci.org/spulec/moto/jobs/553839413#L5184
```
======================================================================
ERROR: test_asyncio_deprecated (test_socket.TestSocketPair)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/travis/build/spulec/moto/moto/core/models.py", line 80, in wrapper
    result = func(*args, **kwargs)
  File "/home/travis/build/spulec/moto/tests/test_core/test_socket.py", line 19, in test_asyncio_deprecated
    self.assertIsNotNone(asyncio.get_event_loop())
  File "/opt/python/3.7.1/lib/python3.7/asyncio/events.py", line 640, in get_event_loop
    self.set_event_loop(self.new_event_loop())
  File "/opt/python/3.7.1/lib/python3.7/asyncio/events.py", line 660, in new_event_loop
    return self._loop_factory()
  File "/opt/python/3.7.1/lib/python3.7/asyncio/unix_events.py", line 51, in __init__
    super().__init__(selector)
  File "/opt/python/3.7.1/lib/python3.7/asyncio/selector_events.py", line 66, in __init__
    self._make_self_pipe()
  File "/opt/python/3.7.1/lib/python3.7/asyncio/selector_events.py", line 113, in _make_self_pipe
    self._ssock, self._csock = socket.socketpair()
  File "/opt/python/3.7.1/lib/python3.7/socket.py", line 492, in socketpair
    a = socket(family, type, proto, a.detach())
TypeError: __init__() takes from 1 to 4 positional arguments but 5 were given
-------------------- >> begin captured logging << --------------------
asyncio: DEBUG: Using selector: EpollSelector
--------------------- >> end captured logging << ---------------------
======================================================================
ERROR: test_socket_pair_deprecated (test_socket.TestSocketPair)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/travis/build/spulec/moto/moto/core/models.py", line 80, in wrapper
    result = func(*args, **kwargs)
  File "/home/travis/build/spulec/moto/tests/test_core/test_socket.py", line 28, in test_socket_pair_deprecated
    a, b = socket.socketpair()
  File "/opt/python/3.7.1/lib/python3.7/socket.py", line 492, in socketpair
    a = socket(family, type, proto, a.detach())
TypeError: __init__() takes from 1 to 4 positional arguments but 5 were given
```

I will also upstream the change in HTTPretty, where this code originated from. 