### PR TITLE
bump PyYAML minimum version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ install_requires = [
     "xmltodict",
     "six>1.9",
     "werkzeug",
-    "PyYAML",
+    "PyYAML>=5.1",
     "pytz",
     "python-dateutil<3.0.0,>=2.1",
     "python-jose<4.0.0",


### PR DESCRIPTION
This is to address the `load` vs `safe_load` issue detailed in this CVE[1] now that PyYAML finally has non-beta versions with this fix.

[1] https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-18342