### PR TITLE
not requiring the provisioned throughput key

### DIFF
--- a/moto/dynamodb2/responses.py
+++ b/moto/dynamodb2/responses.py
@@ -166,7 +166,7 @@ class DynamoHandler(BaseResponse):
                                    when BillingMode is PAY_PER_REQUEST')
             throughput = None
         else:         # Provisioned (default billing mode)
-            throughput = body["ProvisionedThroughput"]
+            throughput = body.get("ProvisionedThroughput")
         # getting the schema
         key_schema = body['KeySchema']
         # getting attribute definition


### PR DESCRIPTION
The golang client doesn't send this parameter by default, resulting in a `KeyError` in moto