### PR TITLE
Example of using a moto server with Scala

### DIFF
--- a/other_langs/sqsSample.scala
+++ b/other_langs/sqsSample.scala
@@ -1,0 +1,25 @@
+package com.amazonaws.examples
+
+import com.amazonaws.client.builder.AwsClientBuilder
+import com.amazonaws.regions.{Region, Regions}
+import com.amazonaws.services.sqs.AmazonSQSClientBuilder
+
+import scala.jdk.CollectionConverters._
+
+object QueueTest extends App {
+  val region = Region.getRegion(Regions.US_WEST_2).getName
+  val serviceEndpoint = "http://localhost:5000"
+
+  val amazonSqs =  AmazonSQSClientBuilder.standard()
+    .withEndpointConfiguration(
+      new AwsClientBuilder.EndpointConfiguration(serviceEndpoint, region))
+    .build
+
+  val queueName = "my-first-queue"
+  amazonSqs.createQueue(queueName)
+
+  val urls = amazonSqs.listQueues().getQueueUrls.asScala
+  println("Listing queues")
+  println(urls.map(url => s" - $url").mkString(System.lineSeparator))
+  println()
+}


### PR DESCRIPTION
This is an example of a stand-alone server configuration using Scala.
The application logic is the same as for a [Java example](https://github.com/spulec/moto/blob/master/other_langs/sqsSample.java_langs/sqsSample.java). It also uses AWS SDK for Java. However, the Java example uses deprecated API, so the implementation for Scala is slightly different.