### PR TITLE
Raise exception if a role policy is not found

### DIFF
--- a/moto/iam/models.py
+++ b/moto/iam/models.py
@@ -685,6 +685,7 @@ class IAMBackend(BaseBackend):
         for p, d in role.policies.items():
             if p == policy_name:
                 return p, d
+        raise IAMNotFoundException("Policy Document {0} not attached to role {1}".format(policy_name, role_name))
 
     def list_role_policies(self, role_name):
         role = self.get_role(role_name)

--- a/tests/test_iam/test_iam.py
+++ b/tests/test_iam/test_iam.py
@@ -311,6 +311,15 @@ def test_put_role_policy():
     policy.should.equal("test policy")
 
 
+@mock_iam
+def test_get_role_policy():
+    conn = boto3.client('iam', region_name='us-east-1')
+    conn.create_role(
+        RoleName="my-role", AssumeRolePolicyDocument="some policy", Path="my-path")
+    with assert_raises(conn.exceptions.NoSuchEntityException):
+        conn.get_role_policy(RoleName="my-role", PolicyName="does-not-exist")
+
+
 @mock_iam_deprecated()
 def test_update_assume_role_policy():
     conn = boto.connect_iam()


### PR DESCRIPTION
This change raises an exception if an inline policy of a role could not be found.
Also adds a test to validate the behaviour.

Fixes #2254 