### PR TITLE
AssumeRole returns randomly generated credentials.

### DIFF
--- a/moto/sts/models.py
+++ b/moto/sts/models.py
@@ -2,6 +2,7 @@ from __future__ import unicode_literals
 import datetime
 from moto.core import BaseBackend, BaseModel
 from moto.core.utils import iso_8601_datetime_with_milliseconds
+from moto.sts.utils import random_access_key_id, random_secret_access_key, random_session_token
 
 
 class Token(BaseModel):
@@ -26,6 +27,9 @@ class AssumedRole(BaseModel):
         now = datetime.datetime.utcnow()
         self.expiration = now + datetime.timedelta(seconds=duration)
         self.external_id = external_id
+        self.access_key_id = "ASIA" + random_access_key_id()
+        self.secret_access_key = random_secret_access_key()
+        self.session_token = random_session_token()
 
     @property
     def expiration_ISO8601(self):

--- a/moto/sts/responses.py
+++ b/moto/sts/responses.py
@@ -84,10 +84,10 @@ ASSUME_ROLE_RESPONSE = """<AssumeRoleResponse xmlns="https://sts.amazonaws.com/d
 2011-06-15/">
   <AssumeRoleResult>
     <Credentials>
-      <SessionToken>BQoEXAMPLEH4aoAH0gNCAPyJxz4BlCFFxWNE1OPTgk5TthT+FvwqnKwRcOIfrRh3c/LTo6UDdyJwOOvEVPvLXCrrrUtdnniCEXAMPLE/IvU1dYUg2RVAJBanLiHb4IgRmpRV3zrkuWJOgQs8IZZaIv2BXIa2R4OlgkBN9bkUDNCJiBeb/AXlzBBko7b15fjrBs2+cTQtpZ3CYWFXG8C5zqx37wnOE49mRl/+OtkIKGO7fAE</SessionToken>
-      <SecretAccessKey>aJalrXUtnFEMI/K7MDENG/bPxRfiCYzEXAMPLEKEY</SecretAccessKey>
+      <SessionToken>{{ role.session_token }}</SessionToken>
+      <SecretAccessKey>{{ role.secret_access_key }}</SecretAccessKey>
       <Expiration>{{ role.expiration_ISO8601 }}</Expiration>
-      <AccessKeyId>AKIAIOSFODNN7EXAMPLE</AccessKeyId>
+      <AccessKeyId>{{ role.access_key_id }}</AccessKeyId>
     </Credentials>
     <AssumedRoleUser>
       <Arn>{{ role.arn }}</Arn>

--- a/moto/sts/utils.py
+++ b/moto/sts/utils.py
@@ -1,0 +1,25 @@
+import base64
+import os
+import random
+import string
+
+import six
+
+ACCOUNT_SPECIFIC_ACCESS_KEY_PREFIX = "8NWMTLYQ"
+SESSION_TOKEN_PREFIX = "FQoGZXIvYXdzEBYaD"
+
+
+def random_access_key_id():
+    return ACCOUNT_SPECIFIC_ACCESS_KEY_PREFIX + ''.join(six.text_type(
+        random.choice(
+            string.ascii_uppercase + string.digits
+        )) for _ in range(8)
+    )
+
+
+def random_secret_access_key():
+    return base64.b64encode(os.urandom(30)).decode()
+
+
+def random_session_token():
+    return SESSION_TOKEN_PREFIX + base64.b64encode(os.urandom(266))[len(SESSION_TOKEN_PREFIX):].decode()

--- a/tests/test_sts/test_sts.py
+++ b/tests/test_sts/test_sts.py
@@ -64,11 +64,11 @@ def test_assume_role():
 
     credentials = role.credentials
     credentials.expiration.should.equal('2012-01-01T12:02:03.000Z')
-    credentials.session_token.should.equal(
-        "BQoEXAMPLEH4aoAH0gNCAPyJxz4BlCFFxWNE1OPTgk5TthT+FvwqnKwRcOIfrRh3c/LTo6UDdyJwOOvEVPvLXCrrrUtdnniCEXAMPLE/IvU1dYUg2RVAJBanLiHb4IgRmpRV3zrkuWJOgQs8IZZaIv2BXIa2R4OlgkBN9bkUDNCJiBeb/AXlzBBko7b15fjrBs2+cTQtpZ3CYWFXG8C5zqx37wnOE49mRl/+OtkIKGO7fAE")
-    credentials.access_key.should.equal("AKIAIOSFODNN7EXAMPLE")
-    credentials.secret_key.should.equal(
-        "aJalrXUtnFEMI/K7MDENG/bPxRfiCYzEXAMPLEKEY")
+    credentials.session_token.should.have.length_of(356)
+    assert credentials.session_token.startswith("FQoGZXIvYXdzE")
+    credentials.access_key.should.have.length_of(20)
+    assert credentials.access_key.startswith("ASIA")
+    credentials.secret_key.should.have.length_of(40)
 
     role.user.arn.should.equal("arn:aws:iam::123456789012:role/test-role")
     role.user.assume_role_id.should.contain("session-name")


### PR DESCRIPTION
Previously, the operation AssumeRole returned fixed hardcoded credentials. This PR fixes this by using randomly generated credentials, which are in the same format as the ones from AWS.