### PR TITLE
Cleanup responses mocking. Closes #1567

### DIFF
--- a/moto/apigateway/models.py
+++ b/moto/apigateway/models.py
@@ -388,10 +388,16 @@ class RestAPI(BaseModel):
         stage_url_upper = STAGE_URL.format(api_id=self.id.upper(),
             region_name=self.region_name, stage_name=stage_name)
 
-        responses.add_callback(responses.GET, stage_url_lower,
-                               callback=self.resource_callback)
-        responses.add_callback(responses.GET, stage_url_upper,
-                               callback=self.resource_callback)
+        for url in [stage_url_lower, stage_url_upper]:
+            responses._default_mock._matches.insert(0,
+                responses.CallbackResponse(
+                    url=url,
+                    method=responses.GET,
+                    callback=self.resource_callback,
+                    content_type="text/plain",
+                    match_querystring=False,
+                )
+            )
 
     def create_stage(self, name, deployment_id, variables=None, description='', cacheClusterEnabled=None, cacheClusterSize=None):
         if variables is None:

--- a/tests/test_core/test_request_mocking.py
+++ b/tests/test_core/test_request_mocking.py
@@ -1,0 +1,21 @@
+import requests
+import sure  # noqa
+
+import boto3
+from moto import mock_sqs
+
+
+@mock_sqs
+def test_passthrough_requests():
+    conn = boto3.client("sqs", region_name='us-west-1')
+    conn.create_queue(QueueName="queue1")
+
+    res = requests.get("https://httpbin.org/ip")
+    assert res.status_code == 200
+
+
+@mock_sqs
+def test_requests_to_amazon_subdomains_dont_work():
+    res = requests.get("https://fakeservice.amazonaws.com/foo/bar")
+    assert res.content == b"The method is not implemented"
+    assert res.status_code == 400

--- a/tests/test_core/test_request_mocking.py
+++ b/tests/test_core/test_request_mocking.py
@@ -2,7 +2,7 @@ import requests
 import sure  # noqa
 
 import boto3
-from moto import mock_sqs
+from moto import mock_sqs, settings
 
 
 @mock_sqs
@@ -14,8 +14,9 @@ def test_passthrough_requests():
     assert res.status_code == 200
 
 
-@mock_sqs
-def test_requests_to_amazon_subdomains_dont_work():
-    res = requests.get("https://fakeservice.amazonaws.com/foo/bar")
-    assert res.content == b"The method is not implemented"
-    assert res.status_code == 400
+if settings.TEST_SERVER_MODE:
+    @mock_sqs
+    def test_requests_to_amazon_subdomains_dont_work():
+        res = requests.get("https://fakeservice.amazonaws.com/foo/bar")
+        assert res.content == b"The method is not implemented"
+        assert res.status_code == 400

--- a/tests/test_core/test_request_mocking.py
+++ b/tests/test_core/test_request_mocking.py
@@ -14,7 +14,7 @@ def test_passthrough_requests():
     assert res.status_code == 200
 
 
-if settings.TEST_SERVER_MODE:
+if not settings.TEST_SERVER_MODE:
     @mock_sqs
     def test_requests_to_amazon_subdomains_dont_work():
         res = requests.get("https://fakeservice.amazonaws.com/foo/bar")


### PR DESCRIPTION
This unblocks requests to other websites with requests while Moto
is activated. It also adds a wildcard for AWS services to still
ensure no accidental requests are made for unmocked services