### PR TITLE
setup.py: remove unnecessary 'datetime' entry

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,6 @@ install_requires = [
     "boto3>=1.9.86",
     "botocore>=1.12.86",
     "cryptography>=2.3.0",
-    "datetime",
     "requests>=2.5",
     "xmltodict",
     "six>1.9",


### PR DESCRIPTION
This entry is added in [1]. New statements in [1] use the built-in datetime module, which is available since Python 2.3 [2]. On the other hand, when running `pip install moto`, pip installs Zope Datetime module [3], which is unnecessary.

[1] https://github.com/spulec/moto/commit/ed93821621af337b701319823f9cb022e49c7a6d
[2] https://docs.python.org/2.7/library/datetime.html
[3] https://pypi.org/project/DateTime/