### PR TITLE
Implement update_user_pool_domain

### DIFF
--- a/IMPLEMENTATION_COVERAGE.md
+++ b/IMPLEMENTATION_COVERAGE.md
@@ -928,6 +928,7 @@
 - [ ] update_user_attributes
 - [ ] update_user_pool
 - [X] update_user_pool_client
+- [X] update_user_pool_domain
 - [ ] verify_software_token
 - [ ] verify_user_attribute
 

--- a/moto/cognitoidp/responses.py
+++ b/moto/cognitoidp/responses.py
@@ -50,7 +50,13 @@ class CognitoIdpResponse(BaseResponse):
     def create_user_pool_domain(self):
         domain = self._get_param("Domain")
         user_pool_id = self._get_param("UserPoolId")
-        cognitoidp_backends[self.region].create_user_pool_domain(user_pool_id, domain)
+        custom_domain_config = self._get_param("CustomDomainConfig")
+        user_pool_domain = cognitoidp_backends[self.region].create_user_pool_domain(
+            user_pool_id, domain, custom_domain_config
+        )
+        domain_description = user_pool_domain.to_json(extended=False)
+        if domain_description:
+            return json.dumps(domain_description)
         return ""
 
     def describe_user_pool_domain(self):
@@ -67,6 +73,17 @@ class CognitoIdpResponse(BaseResponse):
     def delete_user_pool_domain(self):
         domain = self._get_param("Domain")
         cognitoidp_backends[self.region].delete_user_pool_domain(domain)
+        return ""
+
+    def update_user_pool_domain(self):
+        domain = self._get_param("Domain")
+        custom_domain_config = self._get_param("CustomDomainConfig")
+        user_pool_domain = cognitoidp_backends[self.region].update_user_pool_domain(
+            domain, custom_domain_config
+        )
+        domain_description = user_pool_domain.to_json(extended=False)
+        if domain_description:
+            return json.dumps(domain_description)
         return ""
 
     # User pool client

--- a/tests/test_cognitoidp/test_cognitoidp.py
+++ b/tests/test_cognitoidp/test_cognitoidp.py
@@ -134,6 +134,22 @@ def test_create_user_pool_domain():
 
 
 @mock_cognitoidp
+def test_create_user_pool_domain_custom_domain_config():
+    conn = boto3.client("cognito-idp", "us-west-2")
+
+    domain = str(uuid.uuid4())
+    custom_domain_config = {
+        "CertificateArn": "arn:aws:acm:us-east-1:123456789012:certificate/123456789012",
+    }
+    user_pool_id = conn.create_user_pool(PoolName=str(uuid.uuid4()))["UserPool"]["Id"]
+    result = conn.create_user_pool_domain(
+        UserPoolId=user_pool_id, Domain=domain, CustomDomainConfig=custom_domain_config
+    )
+    result["ResponseMetadata"]["HTTPStatusCode"].should.equal(200)
+    result["CloudFrontDomain"].should.equal("e2c343b3293ee505.cloudfront.net")
+
+
+@mock_cognitoidp
 def test_describe_user_pool_domain():
     conn = boto3.client("cognito-idp", "us-west-2")
 
@@ -160,6 +176,23 @@ def test_delete_user_pool_domain():
     # back with status 200 and a DomainDescription of {}
     result["ResponseMetadata"]["HTTPStatusCode"].should.equal(200)
     result["DomainDescription"].keys().should.have.length_of(0)
+
+
+@mock_cognitoidp
+def test_update_user_pool_domain():
+    conn = boto3.client("cognito-idp", "us-west-2")
+
+    domain = str(uuid.uuid4())
+    custom_domain_config = {
+        "CertificateArn": "arn:aws:acm:us-east-1:123456789012:certificate/123456789012",
+    }
+    user_pool_id = conn.create_user_pool(PoolName=str(uuid.uuid4()))["UserPool"]["Id"]
+    conn.create_user_pool_domain(UserPoolId=user_pool_id, Domain=domain)
+    result = conn.update_user_pool_domain(
+        UserPoolId=user_pool_id, Domain=domain, CustomDomainConfig=custom_domain_config
+    )
+    result["ResponseMetadata"]["HTTPStatusCode"].should.equal(200)
+    result["CloudFrontDomain"].should.equal("e2c343b3293ee505.cloudfront.net")
 
 
 @mock_cognitoidp


### PR DESCRIPTION
Introduce the CognitoIDP's UpdateUserPoolDomain to update configuration
options of the associated domain to a Cognito IDP (e.g. ACM certificate).

This implements feature #2308 