### PR TITLE
Handle change of ASG desired capacity on min and max size update

### DIFF
--- a/moto/autoscaling/models.py
+++ b/moto/autoscaling/models.py
@@ -279,6 +279,12 @@ class FakeAutoScalingGroup(BaseModel):
         if min_size is not None:
             self.min_size = min_size
 
+        if desired_capacity is None:
+            if min_size is not None and min_size > len(self.instance_states):
+                desired_capacity = min_size
+            if max_size is not None and max_size < len(self.instance_states):
+                desired_capacity = max_size
+
         if launch_config_name:
             self.launch_config = self.autoscaling_backend.launch_configurations[
                 launch_config_name]

--- a/tests/test_autoscaling/test_autoscaling.py
+++ b/tests/test_autoscaling/test_autoscaling.py
@@ -824,6 +824,62 @@ def test_update_autoscaling_group_boto3():
 
 
 @mock_autoscaling
+def test_update_autoscaling_group_min_size_desired_capacity_change():
+    mocked_networking = setup_networking()
+    client = boto3.client('autoscaling', region_name='us-east-1')
+
+    client.create_launch_configuration(
+        LaunchConfigurationName='test_launch_configuration'
+    )
+    client.create_auto_scaling_group(
+        AutoScalingGroupName='test_asg',
+        LaunchConfigurationName='test_launch_configuration',
+        MinSize=2,
+        MaxSize=20,
+        DesiredCapacity=3,
+        VPCZoneIdentifier=mocked_networking['subnet1'],
+    )
+    client.update_auto_scaling_group(
+        AutoScalingGroupName='test_asg',
+        MinSize=5,
+    )
+    response = client.describe_auto_scaling_groups(
+        AutoScalingGroupNames=['test_asg'])
+    group = response['AutoScalingGroups'][0]
+    group['DesiredCapacity'].should.equal(5)
+    group['MinSize'].should.equal(5)
+    group['Instances'].should.have.length_of(5)
+
+
+@mock_autoscaling
+def test_update_autoscaling_group_max_size_desired_capacity_change():
+    mocked_networking = setup_networking()
+    client = boto3.client('autoscaling', region_name='us-east-1')
+
+    client.create_launch_configuration(
+        LaunchConfigurationName='test_launch_configuration'
+    )
+    client.create_auto_scaling_group(
+        AutoScalingGroupName='test_asg',
+        LaunchConfigurationName='test_launch_configuration',
+        MinSize=2,
+        MaxSize=20,
+        DesiredCapacity=10,
+        VPCZoneIdentifier=mocked_networking['subnet1'],
+    )
+    client.update_auto_scaling_group(
+        AutoScalingGroupName='test_asg',
+        MaxSize=5,
+    )
+    response = client.describe_auto_scaling_groups(
+        AutoScalingGroupNames=['test_asg'])
+    group = response['AutoScalingGroups'][0]
+    group['DesiredCapacity'].should.equal(5)
+    group['MaxSize'].should.equal(5)
+    group['Instances'].should.have.length_of(5)
+
+
+@mock_autoscaling
 def test_autoscaling_taqs_update_boto3():
     mocked_networking = setup_networking()
     client = boto3.client('autoscaling', region_name='us-east-1')


### PR DESCRIPTION
A change in UpdateAutoScalingGroup:
* if a value for MinSize is specified without specifying a value for
DesiredCapacity, and the new MinSize is larger than the current size of
the group, set the group's DesiredCapacity to the new MinSize value
* if a value for MaxSize is specified without specifying a value for
DesiredCapacity, and the new MaxSize is smaller than the current size of
the group, set the group's DesiredCapacity to the new MaxSize value

Resolves: #2257