### PR TITLE
Fix 'MaxRecords' type issues by _get_param()

### DIFF
--- a/moto/autoscaling/responses.py
+++ b/moto/autoscaling/responses.py
@@ -48,7 +48,7 @@ class AutoScalingResponse(BaseResponse):
             start = all_names.index(marker) + 1
         else:
             start = 0
-        max_records = self._get_param('MaxRecords', 50)  # the default is 100, but using 50 to make testing easier
+        max_records = self._get_int_param('MaxRecords', 50)  # the default is 100, but using 50 to make testing easier
         launch_configurations_resp = all_launch_configurations[start:start + max_records]
         next_token = None
         if len(all_launch_configurations) > start + max_records:

--- a/moto/rds/responses.py
+++ b/moto/rds/responses.py
@@ -95,7 +95,7 @@ class RDSResponse(BaseResponse):
             start = all_ids.index(marker) + 1
         else:
             start = 0
-        page_size = self._get_param('MaxRecords', 50)  # the default is 100, but using 50 to make testing easier
+        page_size = self._get_int_param('MaxRecords', 50)  # the default is 100, but using 50 to make testing easier
         instances_resp = all_instances[start:start + page_size]
         next_marker = None
         if len(all_instances) > start + page_size:

--- a/moto/rds2/responses.py
+++ b/moto/rds2/responses.py
@@ -280,7 +280,7 @@ class RDS2Response(BaseResponse):
 
     def describe_option_groups(self):
         kwargs = self._get_option_group_kwargs()
-        kwargs['max_records'] = self._get_param('MaxRecords')
+        kwargs['max_records'] = self._get_int_param('MaxRecords')
         kwargs['marker'] = self._get_param('Marker')
         option_groups = self.backend.describe_option_groups(kwargs)
         template = self.response_template(DESCRIBE_OPTION_GROUP_TEMPLATE)
@@ -329,7 +329,7 @@ class RDS2Response(BaseResponse):
 
     def describe_db_parameter_groups(self):
         kwargs = self._get_db_parameter_group_kwargs()
-        kwargs['max_records'] = self._get_param('MaxRecords')
+        kwargs['max_records'] = self._get_int_param('MaxRecords')
         kwargs['marker'] = self._get_param('Marker')
         db_parameter_groups = self.backend.describe_db_parameter_groups(kwargs)
         template = self.response_template(


### PR DESCRIPTION
It fixes the **TypeError** described below by alternating `_get_param()` with `_get_int_param()` on parsing the parameter `MaxRecords` in below APIs:
* `autoscaling.describe_launch_configurations()`
* `rds.describe_db_instances()`
* `rds2.describe_option_groups()`
* `rds2.describe_db_parameter_groups()`

I checked `MaxRecords` should be `int` in the above APIs in Boto3 API documents.

# TypeError
I got an error when I set `MaxRecords` in `describe_launch_configurations()`:
```python
self = <moto.autoscaling.responses.AutoScalingResponse object at 0x1178d2518>

    def describe_launch_configurations(self):
        names = self._get_multi_param('LaunchConfigurationNames.member')
        all_launch_configurations = self.autoscaling_backend.describe_launch_configurations(names)
        marker = self._get_param('NextToken')
        all_names = [lc.name for lc in all_launch_configurations]
        if marker:
            start = all_names.index(marker) + 1
        else:
            start = 0
        max_records = self._get_param('MaxRecords', 50)  # the default is 100, but using 50 to make testing easier
        print("moto.autoscaling: max_records: " + str(max_records) + " " + str(type(max_records)))
>       launch_configurations_resp = all_launch_configurations[start:start + max_records]
E       TypeError: unsupported operand type(s) for +: 'int' and 'str'

../../../../../../envs/venv3/lib/python3.7/site-packages/moto/autoscaling/responses.py:53: TypeError
```

And found there was a [similar issue](https://github.com/spulec/moto/pull/1486) on `describe_auto_scaling_groups()`.
Also I could notice it resides in several APIs.
 ```sh
> grep -n -r -E "get_param.*MaxRecords" *
moto/rds2/responses.py:283:        kwargs['max_records'] = self._get_param('MaxRecords')
moto/rds2/responses.py:332:        kwargs['max_records'] = self._get_param('MaxRecords')
moto/autoscaling/responses.py:51:        max_records = self._get_param('MaxRecords', 50)  # the default is 100, but using 50 to make testing easier
moto/rds/responses.py:98:        page_size = self._get_param('MaxRecords', 50)  # the default is 100, but using 50 to make testing easier
```