### PR TITLE
Implemented creating Auto Scaling group from instance

### DIFF
--- a/moto/autoscaling/exceptions.py
+++ b/moto/autoscaling/exceptions.py
@@ -13,3 +13,12 @@ class ResourceContentionError(RESTError):
         super(ResourceContentionError, self).__init__(
             "ResourceContentionError",
             "You already have a pending update to an Auto Scaling resource (for example, a group, instance, or load balancer).")
+
+
+class InvalidInstanceError(AutoscalingClientError):
+
+    def __init__(self, instance_id):
+        super(InvalidInstanceError, self).__init__(
+            "ValidationError",
+            "Instance [{0}] is invalid."
+            .format(instance_id))

--- a/moto/autoscaling/models.py
+++ b/moto/autoscaling/models.py
@@ -430,13 +430,14 @@ class AutoScalingBackend(BaseBackend):
         self.launch_configurations.pop(launch_configuration_name, None)
 
     def create_auto_scaling_group(self, name, availability_zones,
-                                  desired_capacity, max_size, min_size,
-                                  instance_id, launch_config_name,
-                                  vpc_zone_identifier, default_cooldown,
-                                  health_check_period, health_check_type,
-                                  load_balancers, target_group_arns,
-                                  placement_group, termination_policies, tags,
-                                  new_instances_protected_from_scale_in=False):
+                                 desired_capacity, max_size, min_size,
+                                 launch_config_name, vpc_zone_identifier,
+                                 default_cooldown, health_check_period,
+                                 health_check_type, load_balancers,
+                                 target_group_arns, placement_group,
+                                 termination_policies, tags,
+                                 new_instances_protected_from_scale_in=False,
+                                  instance_id=None):
 
         def make_int(value):
             return int(value) if value is not None else value

--- a/moto/autoscaling/models.py
+++ b/moto/autoscaling/models.py
@@ -435,7 +435,7 @@ class AutoScalingBackend(BaseBackend):
                                   vpc_zone_identifier, default_cooldown,
                                   health_check_period, health_check_type,
                                   load_balancers, target_group_arns,
-                                  placement_group,termination_policies, tags,
+                                  placement_group, termination_policies, tags,
                                   new_instances_protected_from_scale_in=False):
 
         def make_int(value):

--- a/moto/autoscaling/responses.py
+++ b/moto/autoscaling/responses.py
@@ -74,6 +74,7 @@ class AutoScalingResponse(BaseResponse):
             desired_capacity=self._get_int_param('DesiredCapacity'),
             max_size=self._get_int_param('MaxSize'),
             min_size=self._get_int_param('MinSize'),
+            instance_id=self._get_param('InstanceId'),
             launch_config_name=self._get_param('LaunchConfigurationName'),
             vpc_zone_identifier=self._get_param('VPCZoneIdentifier'),
             default_cooldown=self._get_int_param('DefaultCooldown'),

--- a/moto/ec2/models.py
+++ b/moto/ec2/models.py
@@ -406,10 +406,10 @@ class Instance(TaggedEC2Resource, BotoInstance):
         self.ami_launch_index = kwargs.get("ami_launch_index", 0)
         self.disable_api_termination = kwargs.get("disable_api_termination", False)
         self._spot_fleet_id = kwargs.get("spot_fleet_id", None)
-        associate_public_ip = kwargs.get("associate_public_ip", False)
+        self.associate_public_ip = kwargs.get("associate_public_ip", False)
         if in_ec2_classic:
             # If we are in EC2-Classic, autoassign a public IP
-            associate_public_ip = True
+            self.associate_public_ip = True
 
         amis = self.ec2_backend.describe_images(filters={'image-id': image_id})
         ami = amis[0] if amis else None
@@ -440,9 +440,9 @@ class Instance(TaggedEC2Resource, BotoInstance):
             self.vpc_id = subnet.vpc_id
             self._placement.zone = subnet.availability_zone
 
-            if associate_public_ip is None:
+            if self.associate_public_ip is None:
                 # Mapping public ip hasnt been explicitly enabled or disabled
-                associate_public_ip = subnet.map_public_ip_on_launch == 'true'
+                self.associate_public_ip = subnet.map_public_ip_on_launch == 'true'
         elif placement:
             self._placement.zone = placement
         else:
@@ -454,7 +454,7 @@ class Instance(TaggedEC2Resource, BotoInstance):
         self.prep_nics(
             kwargs.get("nics", {}),
             private_ip=kwargs.get("private_ip"),
-            associate_public_ip=associate_public_ip
+            associate_public_ip=self.associate_public_ip
         )
 
     def __del__(self):

--- a/tests/test_autoscaling/utils.py
+++ b/tests/test_autoscaling/utils.py
@@ -31,3 +31,18 @@ def setup_networking_deprecated():
         "10.11.2.0/24",
         availability_zone='us-east-1b')
     return {'vpc': vpc.id, 'subnet1': subnet1.id, 'subnet2': subnet2.id}
+
+
+@mock_ec2
+def setup_instance_with_networking(image_id, instance_type):
+    mock_data = setup_networking()
+    ec2 = boto3.resource('ec2', region_name='us-east-1')
+    instances = ec2.create_instances(
+        ImageId=image_id,
+        InstanceType=instance_type,
+        MaxCount=1,
+        MinCount=1,
+        SubnetId=mock_data['subnet1']
+    )
+    mock_data['instance'] = instances[0].id
+    return mock_data


### PR DESCRIPTION
Implemented creating Auto Scaling group from instance and added tests for it.

Without this PR, when `CreateAutoScalingGroup` was called without a `LaunchConfigurationName` parameter, and the `InstanceId` was specified instead, moto returned an internal server error (500).