### PR TITLE
added support to UPSERT records that are not simple routing policy such as weighted records

### DIFF
--- a/moto/route53/models.py
+++ b/moto/route53/models.py
@@ -198,7 +198,7 @@ class FakeZone(BaseModel):
     def upsert_rrset(self, record_set):
         new_rrset = RecordSet(record_set)
         for i, rrset in enumerate(self.rrsets):
-            if rrset.name == new_rrset.name and rrset.type_ == new_rrset.type_:
+            if rrset.name == new_rrset.name and rrset.type_ == new_rrset.type_ and rrset.set_identifier == new_rrset.set_identifier:
                 self.rrsets[i] = new_rrset
                 break
         else:


### PR DESCRIPTION
Implemented UPSERT for `change_resource_records()` in Route 53 if the record is not a simple routing policy i.e. weighted or latency based.
Without this PR, moto only compares the record name and type and will always change the first record in the list. Now, upsert also looks at the `set_identifier` to change the correct record.