### PR TITLE
ELBv2 DescribeTargetHealth returns correct response for stopped instance

### DIFF
--- a/moto/elbv2/responses.py
+++ b/moto/elbv2/responses.py
@@ -1208,6 +1208,12 @@ DESCRIBE_TARGET_HEALTH_TEMPLATE = """<DescribeTargetHealthResponse xmlns="http:/
         <HealthCheckPort>{{ target_health.health_port }}</HealthCheckPort>
         <TargetHealth>
           <State>{{ target_health.status }}</State>
+          {% if target_health.reason %}
+            <Reason>{{ target_health.reason }}</Reason>
+          {% endif %}
+          {% if target_health.description %}
+            <Description>{{ target_health.description }}</Description>
+          {% endif %}
         </TargetHealth>
         <Target>
           <Port>{{ target_health.port }}</Port>


### PR DESCRIPTION
When an EC2 instance is registered as a target in an ELBv2 target group, and it is stopped, the following should be its health status:
```json
{
     "State": "unused",
     "Reason": "Target.InvalidState",
     "Description": "Target is in the stopped state"
}
```