### PR TITLE
tests: multipart: use REDUCED_PART_SIZE and variable part size

### DIFF
--- a/tests/test_s3/test_s3.py
+++ b/tests/test_s3/test_s3.py
@@ -1683,7 +1683,7 @@ def test_boto3_multipart_part_size():
     parts = []
     n_parts = 10
     for i in range(1, n_parts + 1):
-        part_size = 5 * 1024 * 1024
+        part_size = REDUCED_PART_SIZE + i
         body = b'1' * part_size
         part = s3.upload_part(
             Bucket='mybucket',
@@ -1704,7 +1704,7 @@ def test_boto3_multipart_part_size():
 
     for i in range(1, n_parts + 1):
         obj = s3.head_object(Bucket='mybucket', Key='the-key', PartNumber=i)
-        assert obj["ContentLength"] == part_size
+        assert obj["ContentLength"] == REDUCED_PART_SIZE + i
 
 
 @mock_s3


### PR DESCRIPTION
There is no reason to use 5M chunks, especially with the reduced_part_size
decorator. Also made part_size to be variable to add extra layer of
testing to make sure that moto is handling that scenario correctly.

Related to #2307

Signed-off-by: Ruslan Kuprieiev <ruslan@iterative.ai>