### PR TITLE
Use the same default Owner ID between EC2 models

### DIFF
--- a/moto/ec2/models.py
+++ b/moto/ec2/models.py
@@ -142,6 +142,8 @@ AMIS = json.load(
          __name__, 'resources/amis.json'), 'r')
 )
 
+OWNER_ID = "111122223333"
+
 
 def utc_date_and_time():
     return datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%S.000Z')
@@ -1087,7 +1089,7 @@ class TagBackend(object):
 
 class Ami(TaggedEC2Resource):
     def __init__(self, ec2_backend, ami_id, instance=None, source_ami=None,
-                 name=None, description=None, owner_id=111122223333,
+                 name=None, description=None, owner_id=OWNER_ID,
                  public=False, virtualization_type=None, architecture=None,
                  state='available', creation_date=None, platform=None,
                  image_type='machine', image_location=None, hypervisor=None,
@@ -1200,7 +1202,7 @@ class AmiBackend(object):
 
         ami = Ami(self, ami_id, instance=instance, source_ami=None,
                   name=name, description=description,
-                  owner_id=context.get_current_user() if context else '111122223333')
+                  owner_id=context.get_current_user() if context else OWNER_ID)
         self.amis[ami_id] = ami
         return ami
 
@@ -1468,7 +1470,7 @@ class SecurityGroup(TaggedEC2Resource):
         self.egress_rules = [SecurityRule(-1, None, None, ['0.0.0.0/0'], [])]
         self.enis = {}
         self.vpc_id = vpc_id
-        self.owner_id = "123456789012"
+        self.owner_id = OWNER_ID
 
     @classmethod
     def create_from_cloudformation_json(cls, resource_name, cloudformation_json, region_name):
@@ -1989,7 +1991,7 @@ class Volume(TaggedEC2Resource):
 
 
 class Snapshot(TaggedEC2Resource):
-    def __init__(self, ec2_backend, snapshot_id, volume, description, encrypted=False, owner_id='123456789012'):
+    def __init__(self, ec2_backend, snapshot_id, volume, description, encrypted=False, owner_id=OWNER_ID):
         self.id = snapshot_id
         self.volume = volume
         self.description = description
@@ -2491,7 +2493,7 @@ class VPCPeeringConnectionBackend(object):
 
 class Subnet(TaggedEC2Resource):
     def __init__(self, ec2_backend, subnet_id, vpc_id, cidr_block, availability_zone, default_for_az,
-                 map_public_ip_on_launch, owner_id=111122223333, assign_ipv6_address_on_creation=False):
+                 map_public_ip_on_launch, owner_id=OWNER_ID, assign_ipv6_address_on_creation=False):
         self.ec2_backend = ec2_backend
         self.id = subnet_id
         self.vpc_id = vpc_id
@@ -2657,7 +2659,7 @@ class SubnetBackend(object):
             raise InvalidAvailabilityZoneError(availability_zone, ", ".join([zone.name for zones in RegionsAndZonesBackend.zones.values() for zone in zones]))
         subnet = Subnet(self, subnet_id, vpc_id, cidr_block, availability_zone_data,
                         default_for_az, map_public_ip_on_launch,
-                        owner_id=context.get_current_user() if context else '111122223333', assign_ipv6_address_on_creation=False)
+                        owner_id=context.get_current_user() if context else OWNER_ID, assign_ipv6_address_on_creation=False)
 
         # AWS associates a new subnet with the default Network ACL
         self.associate_default_network_acl_with_subnet(subnet_id, vpc_id)

--- a/tests/test_ec2/test_elastic_block_store.py
+++ b/tests/test_ec2/test_elastic_block_store.py
@@ -12,6 +12,7 @@ from freezegun import freeze_time
 import sure  # noqa
 
 from moto import mock_ec2_deprecated, mock_ec2
+from moto.ec2.models import OWNER_ID
 
 
 @mock_ec2_deprecated
@@ -395,7 +396,7 @@ def test_snapshot_filters():
         ).should.equal({snapshot3.id})
 
     snapshots_by_owner_id = conn.get_all_snapshots(
-        filters={'owner-id': '123456789012'})
+        filters={'owner-id': OWNER_ID})
     set([snap.id for snap in snapshots_by_owner_id]
         ).should.equal({snapshot1.id, snapshot2.id, snapshot3.id})
 


### PR DESCRIPTION
When attempting to use Moto to do something similar to this:

``` python
@mock_ec2
def test_copy_image_example():
  conn = boto3.client("ec2")
  copy_resp = conn.copy_image(SourceImageId="one of the default ami ids from resources")
  describe_resp = conn.describe_images(Owners=["self"])
  describe_resp["Images"].should.have.length_of(1)
```

The test ended up failing, and `describe_images` responded with an empty list.

To me, the expected result would be that any image created with `copy_image` would be given the same OwnerId as images found when using `Owners=["self"]`.

The first commit does just that, by creating a common `OWNER_ID` used by all the ec2 models.

The second commit adds a test case for the above example code to ensure future changes don't accidentally result in `copy_image` using a different owner id than the one used for `self`.

There may be additional test cases that could be useful to ensure the owner ids are the same between calls using the same resource types, and I would be more than glad to write those tests, but I'm not sure if they'd be helpful, or even what would need to be tested.
