### PR TITLE
Add ecs list tags for resource

### DIFF
--- a/moto/ecs/exceptions.py
+++ b/moto/ecs/exceptions.py
@@ -1,5 +1,5 @@
 from __future__ import unicode_literals
-from moto.core.exceptions import RESTError
+from moto.core.exceptions import RESTError, JsonRESTError
 
 
 class ServiceNotFoundException(RESTError):
@@ -10,4 +10,14 @@ class ServiceNotFoundException(RESTError):
             error_type="ServiceNotFoundException",
             message="The service {0} does not exist".format(service_name),
             template='error_json',
+        )
+
+
+class TaskDefinitionNotFoundException(JsonRESTError):
+    code = 400
+
+    def __init__(self):
+        super(TaskDefinitionNotFoundException, self).__init__(
+            error_type="ClientException",
+            message="The specified task definition does not exist.",
         )

--- a/moto/ecs/responses.py
+++ b/moto/ecs/responses.py
@@ -62,8 +62,9 @@ class EC2ContainerServiceResponse(BaseResponse):
         family = self._get_param('family')
         container_definitions = self._get_param('containerDefinitions')
         volumes = self._get_param('volumes')
+        tags = self._get_param('tags')
         task_definition = self.ecs_backend.register_task_definition(
-            family, container_definitions, volumes)
+            family, container_definitions, volumes, tags)
         return json.dumps({
             'taskDefinition': task_definition.response_object
         })
@@ -313,3 +314,8 @@ class EC2ContainerServiceResponse(BaseResponse):
         results = self.ecs_backend.list_task_definition_families(family_prefix, status, max_results, next_token)
 
         return json.dumps({'families': list(results)})
+
+    def list_tags_for_resource(self):
+        resource_arn = self._get_param('resourceArn')
+        tags = self.ecs_backend.list_tags_for_resource(resource_arn)
+        return json.dumps({'tags': tags})

--- a/tests/test_ecs/test_ecs_boto3.py
+++ b/tests/test_ecs/test_ecs_boto3.py
@@ -94,6 +94,10 @@ def test_register_task_definition():
                 }],
                 'logConfiguration': {'logDriver': 'json-file'}
             }
+        ],
+        tags=[
+            {'key': 'createdBy', 'value': 'moto-unittest'},
+            {'key': 'foo', 'value': 'bar'},
         ]
     )
     type(response['taskDefinition']).should.be(dict)
@@ -2304,3 +2308,52 @@ def test_create_service_load_balancing():
     response['service']['status'].should.equal('ACTIVE')
     response['service']['taskDefinition'].should.equal(
         'arn:aws:ecs:us-east-1:012345678910:task-definition/test_ecs_task:1')
+
+
+@mock_ecs
+def test_list_tags_for_resource():
+    client = boto3.client('ecs', region_name='us-east-1')
+    response = client.register_task_definition(
+        family='test_ecs_task',
+        containerDefinitions=[
+            {
+                'name': 'hello_world',
+                'image': 'docker/hello-world:latest',
+                'cpu': 1024,
+                'memory': 400,
+                'essential': True,
+                'environment': [{
+                    'name': 'AWS_ACCESS_KEY_ID',
+                    'value': 'SOME_ACCESS_KEY'
+                }],
+                'logConfiguration': {'logDriver': 'json-file'}
+            }
+        ],
+        tags=[
+            {'key': 'createdBy', 'value': 'moto-unittest'},
+            {'key': 'foo', 'value': 'bar'},
+        ]
+    )
+    type(response['taskDefinition']).should.be(dict)
+    response['taskDefinition']['revision'].should.equal(1)
+    response['taskDefinition']['taskDefinitionArn'].should.equal(
+        'arn:aws:ecs:us-east-1:012345678910:task-definition/test_ecs_task:1')
+
+    task_definition_arn = response['taskDefinition']['taskDefinitionArn']
+    response = client.list_tags_for_resource(resourceArn=task_definition_arn)
+
+    type(response['tags']).should.be(list)
+    response['tags'].should.equal([
+        {'key': 'createdBy', 'value': 'moto-unittest'},
+        {'key': 'foo', 'value': 'bar'},
+    ])
+
+
+@mock_ecs
+def test_list_tags_for_resource_unknown():
+    client = boto3.client('ecs', region_name='us-east-1')
+    task_definition_arn = 'arn:aws:ecs:us-east-1:012345678910:task-definition/unknown:1'
+    try:
+        client.list_tags_for_resource(resourceArn=task_definition_arn)
+    except ClientError as err:
+        err.response['Error']['Code'].should.equal('ClientException')


### PR DESCRIPTION
This adds support for setting tags on task definitions and retrieving them via `list_tags_for_resource`

See https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/ecs.html#ECS.Client.list_tags_for_resource