### PR TITLE
Convert fields createdAt and updatedAt of ECS deployment to timestamp

### DIFF
--- a/moto/ecs/models.py
+++ b/moto/ecs/models.py
@@ -8,6 +8,7 @@ import boto3
 import pytz
 from moto.core.exceptions import JsonRESTError
 from moto.core import BaseBackend, BaseModel
+from moto.core.utils import unix_time
 from moto.ec2 import ec2_backends
 from copy import copy
 
@@ -231,9 +232,9 @@ class Service(BaseObject):
 
         for deployment in response_object['deployments']:
             if isinstance(deployment['createdAt'], datetime):
-                deployment['createdAt'] = deployment['createdAt'].isoformat()
+                deployment['createdAt'] = unix_time(deployment['createdAt'].replace(tzinfo=None))
             if isinstance(deployment['updatedAt'], datetime):
-                deployment['updatedAt'] = deployment['updatedAt'].isoformat()
+                deployment['updatedAt'] = unix_time(deployment['updatedAt'].replace(tzinfo=None))
 
         return response_object
 

--- a/tests/test_ecs/test_ecs_boto3.py
+++ b/tests/test_ecs/test_ecs_boto3.py
@@ -1,4 +1,5 @@
 from __future__ import unicode_literals
+from datetime import datetime
 
 from copy import deepcopy
 
@@ -477,6 +478,8 @@ def test_describe_services():
     response['services'][0]['deployments'][0]['pendingCount'].should.equal(2)
     response['services'][0]['deployments'][0]['runningCount'].should.equal(0)
     response['services'][0]['deployments'][0]['status'].should.equal('PRIMARY')
+    (datetime.now() - response['services'][0]['deployments'][0]["createdAt"].replace(tzinfo=None)).seconds.should.be.within(0, 10)
+    (datetime.now() - response['services'][0]['deployments'][0]["updatedAt"].replace(tzinfo=None)).seconds.should.be.within(0, 10)
 
 
 @mock_ecs


### PR DESCRIPTION
The AWS SDK for Go fails to parse the response of the `ecs.DescribeServices()` function because it expects the values of the fields [`createdAt`][1] and [`updatedAt`][2] to be timestamps, not ISO 8601.

This change converts the value of each field to a timestamp instead of ISO.

[1]: https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_Deployment.html#ECS-Type-Deployment-createdAt
[2]: https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_Deployment.html#ECS-Type-Deployment-updatedAt