### PR TITLE
Resolve invalid escape sequence

### DIFF
--- a/moto/dynamodb2/responses.py
+++ b/moto/dynamodb2/responses.py
@@ -600,7 +600,7 @@ class DynamoHandler(BaseResponse):
         # E.g. `a = b + c` -> `a=b+c`
         if update_expression:
             update_expression = re.sub(
-                '\s*([=\+-])\s*', '\\1', update_expression)
+                r'\s*([=\+-])\s*', '\\1', update_expression)
 
         try:
             item = self.dynamodb_backend.update_item(


### PR DESCRIPTION
When run not as a decorator dynamodb2 displays an invalid escape sequence error in 3.6/7

/moto/dynamodb2/responses.py:603: DeprecationWarning: invalid escape sequence \s
  '\s*([=\+-])\s*', '\\1', update_expression)