### PR TITLE
Existing user now raises a UsernameExistsException

### DIFF
--- a/moto/cognitoidp/exceptions.py
+++ b/moto/cognitoidp/exceptions.py
@@ -24,6 +24,16 @@ class UserNotFoundError(BadRequest):
         })
 
 
+class UsernameExistsException(BadRequest):
+
+    def __init__(self, message):
+        super(UsernameExistsException, self).__init__()
+        self.description = json.dumps({
+            "message": message,
+            '__type': 'UsernameExistsException',
+        })
+
+
 class GroupExistsException(BadRequest):
 
     def __init__(self, message):

--- a/moto/cognitoidp/models.py
+++ b/moto/cognitoidp/models.py
@@ -14,7 +14,8 @@ from jose import jws
 
 from moto.compat import OrderedDict
 from moto.core import BaseBackend, BaseModel
-from .exceptions import GroupExistsException, NotAuthorizedError, ResourceNotFoundError, UserNotFoundError
+from .exceptions import GroupExistsException, NotAuthorizedError, ResourceNotFoundError, UserNotFoundError, \
+    UsernameExistsException
 
 UserStatus = {
     "FORCE_CHANGE_PASSWORD": "FORCE_CHANGE_PASSWORD",
@@ -560,6 +561,9 @@ class CognitoIdpBackend(BaseBackend):
         user_pool = self.user_pools.get(user_pool_id)
         if not user_pool:
             raise ResourceNotFoundError(user_pool_id)
+
+        if username in user_pool.users:
+            raise UsernameExistsException(username)
 
         user = CognitoIdpUser(user_pool_id, username, temporary_password, UserStatus["FORCE_CHANGE_PASSWORD"], attributes)
         user_pool.users[user.username] = user

--- a/tests/test_cognitoidp/test_cognitoidp.py
+++ b/tests/test_cognitoidp/test_cognitoidp.py
@@ -887,6 +887,36 @@ def test_admin_create_user():
 
 
 @mock_cognitoidp
+def test_admin_create_existing_user():
+    conn = boto3.client("cognito-idp", "us-west-2")
+
+    username = str(uuid.uuid4())
+    value = str(uuid.uuid4())
+    user_pool_id = conn.create_user_pool(PoolName=str(uuid.uuid4()))["UserPool"]["Id"]
+    conn.admin_create_user(
+        UserPoolId=user_pool_id,
+        Username=username,
+        UserAttributes=[
+            {"Name": "thing", "Value": value}
+        ],
+    )
+
+    caught = False
+    try:
+        conn.admin_create_user(
+            UserPoolId=user_pool_id,
+            Username=username,
+            UserAttributes=[
+                {"Name": "thing", "Value": value}
+            ],
+        )
+    except conn.exceptions.UsernameExistsException:
+        caught = True
+
+    caught.should.be.true
+
+
+@mock_cognitoidp
 def test_admin_get_user():
     conn = boto3.client("cognito-idp", "us-west-2")
 


### PR DESCRIPTION
If a user is attempted to be added to a pool that already contains a user with that username, the UsernameExistsException is thrown, to match AWS behaviour.

resolves https://github.com/spulec/moto/issues/2356