### PR TITLE
[Resolves #2355] - create_organization(): add master account, default…

### DIFF
--- a/moto/organizations/utils.py
+++ b/moto/organizations/utils.py
@@ -4,7 +4,8 @@ import random
 import string
 
 MASTER_ACCOUNT_ID = '123456789012'
-MASTER_ACCOUNT_EMAIL = 'fakeorg@moto-example.com'
+MASTER_ACCOUNT_EMAIL = 'master@example.com'
+DEFAULT_POLICY_ID = 'p-FullAWSAccess'
 ORGANIZATION_ARN_FORMAT = 'arn:aws:organizations::{0}:organization/{1}'
 MASTER_ACCOUNT_ARN_FORMAT = 'arn:aws:organizations::{0}:account/{1}/{0}'
 ACCOUNT_ARN_FORMAT = 'arn:aws:organizations::{0}:account/{1}/{2}'
@@ -26,7 +27,7 @@ ROOT_ID_REGEX = r'r-[a-z0-9]{%s}' % ROOT_ID_SIZE
 OU_ID_REGEX = r'ou-[a-z0-9]{%s}-[a-z0-9]{%s}' % (ROOT_ID_SIZE, OU_ID_SUFFIX_SIZE)
 ACCOUNT_ID_REGEX = r'[0-9]{%s}' % ACCOUNT_ID_SIZE
 CREATE_ACCOUNT_STATUS_ID_REGEX = r'car-[a-z0-9]{%s}' % CREATE_ACCOUNT_STATUS_ID_SIZE
-SCP_ID_REGEX = r'p-[a-z0-9]{%s}' % SCP_ID_SIZE
+SCP_ID_REGEX = r'%s|p-[a-z0-9]{%s}' % (DEFAULT_POLICY_ID, SCP_ID_SIZE)
 
 
 def make_random_org_id():

--- a/tests/test_organizations/organizations_test_utils.py
+++ b/tests/test_organizations/organizations_test_utils.py
@@ -1,7 +1,6 @@
 from __future__ import unicode_literals
 
 import six
-import sure   # noqa
 import datetime
 from moto.organizations import utils
 

--- a/tests/test_organizations/test_organizations_boto3.py
+++ b/tests/test_organizations/test_organizations_boto3.py
@@ -3,7 +3,6 @@ from __future__ import unicode_literals
 import boto3
 import json
 import six
-import sure   # noqa
 from botocore.exceptions import ClientError
 from nose.tools import assert_raises
 
@@ -26,6 +25,25 @@ def test_create_organization():
     response = client.create_organization(FeatureSet='ALL')
     validate_organization(response)
     response['Organization']['FeatureSet'].should.equal('ALL')
+
+    response = client.list_accounts()
+    len(response['Accounts']).should.equal(1)
+    response['Accounts'][0]['Name'].should.equal('master')
+    response['Accounts'][0]['Id'].should.equal(utils.MASTER_ACCOUNT_ID)
+    response['Accounts'][0]['Email'].should.equal(utils.MASTER_ACCOUNT_EMAIL)
+
+    response = client.list_policies(Filter='SERVICE_CONTROL_POLICY')
+    len(response['Policies']).should.equal(1)
+    response['Policies'][0]['Name'].should.equal('FullAWSAccess')
+    response['Policies'][0]['Id'].should.equal(utils.DEFAULT_POLICY_ID)
+    response['Policies'][0]['AwsManaged'].should.equal(True)
+
+    response = client.list_targets_for_policy(PolicyId=utils.DEFAULT_POLICY_ID)
+    len(response['Targets']).should.equal(2)
+    root_ou = [t for t in response['Targets'] if t['Type'] == 'ROOT'][0]
+    root_ou['Name'].should.equal('Root')
+    master_account = [t for t in response['Targets'] if t['Type'] == 'ACCOUNT'][0]
+    master_account['Name'].should.equal('master')
 
 
 @mock_organizations
@@ -177,11 +195,11 @@ def test_list_accounts():
     response = client.list_accounts()
     response.should.have.key('Accounts')
     accounts = response['Accounts']
-    len(accounts).should.equal(5)
+    len(accounts).should.equal(6)
     for account in accounts:
         validate_account(org, account)
-    accounts[3]['Name'].should.equal(mockname + '3')
-    accounts[2]['Email'].should.equal(mockname + '2' + '@' + mockdomain)
+    accounts[4]['Name'].should.equal(mockname + '3')
+    accounts[3]['Email'].should.equal(mockname + '2' + '@' + mockdomain)
 
 
 @mock_organizations
@@ -291,8 +309,10 @@ def test_list_children():
     response02 = client.list_children(ParentId=root_id, ChildType='ORGANIZATIONAL_UNIT')
     response03 = client.list_children(ParentId=ou01_id, ChildType='ACCOUNT')
     response04 = client.list_children(ParentId=ou01_id, ChildType='ORGANIZATIONAL_UNIT')
-    response01['Children'][0]['Id'].should.equal(account01_id)
+    response01['Children'][0]['Id'].should.equal(utils.MASTER_ACCOUNT_ID)
     response01['Children'][0]['Type'].should.equal('ACCOUNT')
+    response01['Children'][1]['Id'].should.equal(account01_id)
+    response01['Children'][1]['Type'].should.equal('ACCOUNT')
     response02['Children'][0]['Id'].should.equal(ou01_id)
     response02['Children'][0]['Type'].should.equal('ORGANIZATIONAL_UNIT')
     response03['Children'][0]['Id'].should.equal(account02_id)
@@ -591,4 +611,3 @@ def test_list_targets_for_policy_exception():
     ex.operation_name.should.equal('ListTargetsForPolicy')
     ex.response['Error']['Code'].should.equal('400')
     ex.response['Error']['Message'].should.contain('InvalidInputException')
- 


### PR DESCRIPTION
… policy

Model: OrganizationsBackend
Method: create_organization

create_organization now creates master account, root ou, and a
default service control policy objects and adds them to the
OrganizationsBackend object.  the policy is attached to both
the master account and the root ou.  any subsiquently created
accounts or OU also have the default policy attached.