### PR TITLE
Add tag support to API Gateway keys

### DIFF
--- a/moto/apigateway/models.py
+++ b/moto/apigateway/models.py
@@ -298,7 +298,7 @@ class Stage(BaseModel, dict):
 class ApiKey(BaseModel, dict):
 
     def __init__(self, name=None, description=None, enabled=True,
-                 generateDistinctId=False, value=None, stageKeys=None, customerId=None):
+                 generateDistinctId=False, value=None, stageKeys=None, tags=None, customerId=None):
         super(ApiKey, self).__init__()
         self['id'] = create_id()
         self['value'] = value if value else ''.join(random.sample(string.ascii_letters + string.digits, 40))
@@ -308,6 +308,7 @@ class ApiKey(BaseModel, dict):
         self['enabled'] = enabled
         self['createdDate'] = self['lastUpdatedDate'] = int(time.time())
         self['stageKeys'] = stageKeys
+        self['tags'] = tags
 
     def update_operations(self, patch_operations):
         for op in patch_operations:

--- a/tests/test_apigateway/test_apigateway.py
+++ b/tests/test_apigateway/test_apigateway.py
@@ -981,11 +981,13 @@ def test_api_keys():
     apikey['value'].should.equal(apikey_value)
 
     apikey_name = 'TESTKEY2'
-    payload = {'name': apikey_name }
+    payload = {'name': apikey_name, 'tags': {'tag1': 'test_tag1', 'tag2': '1'}}
     response = client.create_api_key(**payload)
     apikey_id = response['id']
     apikey = client.get_api_key(apiKey=apikey_id)
     apikey['name'].should.equal(apikey_name)
+    apikey['tags']['tag1'].should.equal('test_tag1')
+    apikey['tags']['tag2'].should.equal('1')
     len(apikey['value']).should.equal(40)
 
     apikey_name = 'TESTKEY3'


### PR DESCRIPTION
This PR add support for API Gateway key tags. 

boto3 support tags since version 1.9.154.

