### PR TITLE
fix #2392 Add validation for device shadow version

### DIFF
--- a/moto/iotdata/exceptions.py
+++ b/moto/iotdata/exceptions.py
@@ -21,3 +21,11 @@ class InvalidRequestException(IoTDataPlaneClientError):
         super(InvalidRequestException, self).__init__(
             "InvalidRequestException", message
         )
+
+
+class ConflictException(IoTDataPlaneClientError):
+    def __init__(self, message):
+        self.code = 409
+        super(ConflictException, self).__init__(
+            "ConflictException", message
+        )

--- a/moto/iotdata/models.py
+++ b/moto/iotdata/models.py
@@ -6,6 +6,7 @@ import jsondiff
 from moto.core import BaseBackend, BaseModel
 from moto.iot import iot_backends
 from .exceptions import (
+    ConflictException,
     ResourceNotFoundException,
     InvalidRequestException
 )
@@ -161,6 +162,8 @@ class IoTDataPlaneBackend(BaseBackend):
         if any(_ for _ in payload['state'].keys() if _ not in ['desired', 'reported']):
             raise InvalidRequestException('State contains an invalid node')
 
+        if 'version' in payload and thing.thing_shadow.version != payload['version']:
+                raise ConflictException('Version conflict')
         new_shadow = FakeShadow.create_from_previous_version(thing.thing_shadow, payload)
         thing.thing_shadow = new_shadow
         return thing.thing_shadow

--- a/tests/test_iotdata/test_iotdata.py
+++ b/tests/test_iotdata/test_iotdata.py
@@ -86,6 +86,12 @@ def test_update():
     payload.should.have.key('version').which.should.equal(2)
     payload.should.have.key('timestamp')
 
+    raw_payload = b'{"state": {"desired": {"led": "on"}}, "version": 1}'
+    with assert_raises(ClientError) as ex:
+        client.update_thing_shadow(thingName=name, payload=raw_payload)
+    ex.exception.response['ResponseMetadata']['HTTPStatusCode'].should.equal(409)
+    ex.exception.response['Error']['Message'].should.equal('Version conflict')
+
 
 @mock_iotdata
 def test_publish():


### PR DESCRIPTION
This PR add validation for iot-data update_thing_shadow(),fixing #2392

