### PR TITLE
Allows leading // for mocked s3 paths (fix for #1637)

### DIFF
--- a/moto/s3/urls.py
+++ b/moto/s3/urls.py
@@ -15,4 +15,6 @@ url_paths = {
     '{0}/(?P<key_or_bucket_name>[^/]+)/?$': S3ResponseInstance.ambiguous_response,
     # path-based bucket + key
     '{0}/(?P<bucket_name_path>[^/]+)/(?P<key_name>.+)': S3ResponseInstance.key_response,
+    # subdomain bucket + key with empty first part of path
+    '{0}//(?P<key_name>.*)$': S3ResponseInstance.key_response,
 }

--- a/moto/server.py
+++ b/moto/server.py
@@ -174,10 +174,11 @@ def create_backend_app(service):
     backend_app.url_map.converters['regex'] = RegexConverter
     backend = list(BACKENDS[service].values())[0]
     for url_path, handler in backend.flask_paths.items():
+        view_func = convert_flask_to_httpretty_response(handler)
         if handler.__name__ == 'dispatch':
             endpoint = '{0}.dispatch'.format(handler.__self__.__name__)
         else:
-            endpoint = None
+            endpoint = view_func.__name__
 
         original_endpoint = endpoint
         index = 2
@@ -191,7 +192,7 @@ def create_backend_app(service):
             url_path,
             endpoint=endpoint,
             methods=HTTP_METHODS,
-            view_func=convert_flask_to_httpretty_response(handler),
+            view_func=view_func,
             strict_slashes=False,
         )
 


### PR DESCRIPTION
Allows request paths to start with multiple slashes for S3. This PR fixes #1637 for mocked requests.

Unfortunately, similar problem exists for server mode, but it's caused by an error in Werkzeug.
