### PR TITLE
Don't error out on route53.list_tags_for_resource when resource has no tags

### DIFF
--- a/moto/route53/models.py
+++ b/moto/route53/models.py
@@ -305,6 +305,7 @@ class Route53Backend(BaseBackend):
     def list_tags_for_resource(self, resource_id):
         if resource_id in self.resource_tags:
             return self.resource_tags[resource_id]
+        return {}
 
     def get_all_hosted_zones(self):
         return self.zones.values()

--- a/tests/test_route53/test_route53.py
+++ b/tests/test_route53/test_route53.py
@@ -404,6 +404,13 @@ def test_list_or_change_tags_for_resource_request():
     )
     healthcheck_id = health_check['HealthCheck']['Id']
 
+    # confirm this works for resources with zero tags
+    response = conn.list_tags_for_resource(
+        ResourceType="healthcheck", ResourceId=healthcheck_id)
+    response["ResourceTagSet"]["Tags"].should.be.empty
+
+    print(response)
+
     tag1 = {"Key": "Deploy", "Value": "True"}
     tag2 = {"Key": "Name", "Value": "UnitTest"}
 

--- a/tests/test_route53/test_route53.py
+++ b/tests/test_route53/test_route53.py
@@ -409,8 +409,6 @@ def test_list_or_change_tags_for_resource_request():
         ResourceType="healthcheck", ResourceId=healthcheck_id)
     response["ResourceTagSet"]["Tags"].should.be.empty
 
-    print(response)
-
     tag1 = {"Key": "Deploy", "Value": "True"}
     tag2 = {"Key": "Name", "Value": "UnitTest"}
 


### PR DESCRIPTION
Currently, when you call `boto3.client('route53').list_tags_for_resource()` on a resource without any tags, it results in a jinja templating error (because the backend returns `None` when the template expects a dict).

This fixes the backend to return an empty dict when no resources are found, so that the call works as expected.