### PR TITLE
Terminated EC2 instances are deregistered from ELBv2 target groups.

### DIFF
--- a/moto/ec2/responses/instances.py
+++ b/moto/ec2/responses/instances.py
@@ -6,6 +6,7 @@ from moto.core.responses import BaseResponse
 from moto.core.utils import camelcase_to_underscores
 from moto.ec2.utils import filters_from_querystring, \
     dict_from_querystring
+from moto.elbv2 import elbv2_backends
 
 
 class InstanceResponse(BaseResponse):
@@ -68,6 +69,7 @@ class InstanceResponse(BaseResponse):
         if self.is_not_dryrun('TerminateInstance'):
             instances = self.ec2_backend.terminate_instances(instance_ids)
             autoscaling_backends[self.region].notify_terminate_instances(instance_ids)
+            elbv2_backends[self.region].notify_terminate_instances(instance_ids)
             template = self.response_template(EC2_TERMINATE_INSTANCES)
             return template.render(instances=instances)
 

--- a/moto/elbv2/models.py
+++ b/moto/elbv2/models.py
@@ -110,6 +110,11 @@ class FakeTargetGroup(BaseModel):
             if not t:
                 raise InvalidTargetError()
 
+    def deregister_terminated_instances(self, instance_ids):
+        for target_id in list(self.targets.keys()):
+            if target_id in instance_ids:
+                del self.targets[target_id]
+
     def add_tag(self, key, value):
         if len(self.tags) >= 10 and key not in self.tags:
             raise TooManyTagsError()
@@ -935,6 +940,10 @@ class ELBv2Backend(BaseBackend):
                         if action.data.get('target_group_arn') == target_group_arn:
                             return True
         return False
+
+    def notify_terminate_instances(self, instance_ids):
+        for target_group in self.target_groups.values():
+            target_group.deregister_terminated_instances(instance_ids)
 
 
 elbv2_backends = {}

--- a/tests/test_elbv2/test_elbv2.py
+++ b/tests/test_elbv2/test_elbv2.py
@@ -754,6 +754,83 @@ def test_stopped_instance_target():
 
 @mock_ec2
 @mock_elbv2
+def test_terminated_instance_target():
+    target_group_port = 8080
+
+    conn = boto3.client('elbv2', region_name='us-east-1')
+    ec2 = boto3.resource('ec2', region_name='us-east-1')
+
+    security_group = ec2.create_security_group(
+        GroupName='a-security-group', Description='First One')
+    vpc = ec2.create_vpc(CidrBlock='172.28.7.0/24', InstanceTenancy='default')
+    subnet1 = ec2.create_subnet(
+        VpcId=vpc.id,
+        CidrBlock='172.28.7.192/26',
+        AvailabilityZone='us-east-1a')
+    subnet2 = ec2.create_subnet(
+        VpcId=vpc.id,
+        CidrBlock='172.28.7.0/26',
+        AvailabilityZone='us-east-1b')
+
+    conn.create_load_balancer(
+        Name='my-lb',
+        Subnets=[subnet1.id, subnet2.id],
+        SecurityGroups=[security_group.id],
+        Scheme='internal',
+        Tags=[{'Key': 'key_name', 'Value': 'a_value'}])
+
+    response = conn.create_target_group(
+        Name='a-target',
+        Protocol='HTTP',
+        Port=target_group_port,
+        VpcId=vpc.id,
+        HealthCheckProtocol='HTTP',
+        HealthCheckPath='/',
+        HealthCheckIntervalSeconds=5,
+        HealthCheckTimeoutSeconds=5,
+        HealthyThresholdCount=5,
+        UnhealthyThresholdCount=2,
+        Matcher={'HttpCode': '200'})
+    target_group = response.get('TargetGroups')[0]
+
+    # No targets registered yet
+    response = conn.describe_target_health(
+        TargetGroupArn=target_group.get('TargetGroupArn'))
+    response.get('TargetHealthDescriptions').should.have.length_of(0)
+
+    response = ec2.create_instances(
+        ImageId='ami-1234abcd', MinCount=1, MaxCount=1)
+    instance = response[0]
+
+    target_dict = {
+        'Id': instance.id,
+        'Port': 500
+    }
+
+    response = conn.register_targets(
+        TargetGroupArn=target_group.get('TargetGroupArn'),
+        Targets=[target_dict])
+
+    response = conn.describe_target_health(
+        TargetGroupArn=target_group.get('TargetGroupArn'))
+    response.get('TargetHealthDescriptions').should.have.length_of(1)
+    target_health_description = response.get('TargetHealthDescriptions')[0]
+
+    target_health_description['Target'].should.equal(target_dict)
+    target_health_description['HealthCheckPort'].should.equal(str(target_group_port))
+    target_health_description['TargetHealth'].should.equal({
+        'State': 'healthy'
+    })
+
+    instance.terminate()
+
+    response = conn.describe_target_health(
+        TargetGroupArn=target_group.get('TargetGroupArn'))
+    response.get('TargetHealthDescriptions').should.have.length_of(0)
+
+
+@mock_ec2
+@mock_elbv2
 def test_target_group_attributes():
     conn = boto3.client('elbv2', region_name='us-east-1')
     ec2 = boto3.resource('ec2', region_name='us-east-1')


### PR DESCRIPTION
Previously, when querying the target healths for an ELBv2 target group (DescribeTargetHealth), it showed terminated instance to be healthy. Now when an instance is terminated, it is also completely removed from any ELBv2 target group it has been registered with. 