### PR TITLE
add enhanced vpc routing option to redshift moto

### DIFF
--- a/moto/redshift/models.py
+++ b/moto/redshift/models.py
@@ -74,7 +74,7 @@ class Cluster(TaggableResourceMixin, BaseModel):
                  automated_snapshot_retention_period, port, cluster_version,
                  allow_version_upgrade, number_of_nodes, publicly_accessible,
                  encrypted, region_name, tags=None, iam_roles_arn=None,
-                 restored_from_snapshot=False):
+                 enhanced_vpc_routing=None, restored_from_snapshot=False):
         super(Cluster, self).__init__(region_name, tags)
         self.redshift_backend = redshift_backend
         self.cluster_identifier = cluster_identifier
@@ -85,6 +85,7 @@ class Cluster(TaggableResourceMixin, BaseModel):
         self.master_user_password = master_user_password
         self.db_name = db_name if db_name else "dev"
         self.vpc_security_group_ids = vpc_security_group_ids
+        self.enhanced_vpc_routing = enhanced_vpc_routing if enhanced_vpc_routing is not None else False
         self.cluster_subnet_group_name = cluster_subnet_group_name
         self.publicly_accessible = publicly_accessible
         self.encrypted = encrypted
@@ -154,6 +155,7 @@ class Cluster(TaggableResourceMixin, BaseModel):
             port=properties.get('Port'),
             cluster_version=properties.get('ClusterVersion'),
             allow_version_upgrade=properties.get('AllowVersionUpgrade'),
+            enhanced_vpc_routing=properties.get('EnhancedVpcRouting'),
             number_of_nodes=properties.get('NumberOfNodes'),
             publicly_accessible=properties.get("PubliclyAccessible"),
             encrypted=properties.get("Encrypted"),
@@ -241,6 +243,7 @@ class Cluster(TaggableResourceMixin, BaseModel):
             'ClusterCreateTime': self.create_time,
             "PendingModifiedValues": [],
             "Tags": self.tags,
+            "EnhancedVpcRouting": self.enhanced_vpc_routing,
             "IamRoles": [{
                 "ApplyStatus": "in-sync",
                 "IamRoleArn": iam_role_arn
@@ -427,6 +430,7 @@ class Snapshot(TaggableResourceMixin, BaseModel):
             'NumberOfNodes': self.cluster.number_of_nodes,
             'DBName': self.cluster.db_name,
             'Tags': self.tags,
+            'EnhancedVpcRouting': self.cluster.enhanced_vpc_routing,
             "IamRoles": [{
                 "ApplyStatus": "in-sync",
                 "IamRoleArn": iam_role_arn
@@ -678,7 +682,8 @@ class RedshiftBackend(BaseBackend):
             "number_of_nodes": snapshot.cluster.number_of_nodes,
             "encrypted": snapshot.cluster.encrypted,
             "tags": snapshot.cluster.tags,
-            "restored_from_snapshot": True
+            "restored_from_snapshot": True,
+            "enhanced_vpc_routing": snapshot.cluster.enhanced_vpc_routing
         }
         create_kwargs.update(kwargs)
         return self.create_cluster(**create_kwargs)

--- a/moto/redshift/responses.py
+++ b/moto/redshift/responses.py
@@ -135,6 +135,7 @@ class RedshiftResponse(BaseResponse):
             "region_name": self.region,
             "tags": self.unpack_complex_list_params('Tags.Tag', ('Key', 'Value')),
             "iam_roles_arn": self._get_iam_roles(),
+            "enhanced_vpc_routing": self._get_param('EnhancedVpcRouting'),
         }
         cluster = self.redshift_backend.create_cluster(**cluster_kwargs).to_json()
         cluster['ClusterStatus'] = 'creating'
@@ -150,6 +151,7 @@ class RedshiftResponse(BaseResponse):
         })
 
     def restore_from_cluster_snapshot(self):
+        enhanced_vpc_routing = self._get_bool_param('EnhancedVpcRouting')
         restore_kwargs = {
             "snapshot_identifier": self._get_param('SnapshotIdentifier'),
             "cluster_identifier": self._get_param('ClusterIdentifier'),
@@ -171,6 +173,8 @@ class RedshiftResponse(BaseResponse):
             "region_name": self.region,
             "iam_roles_arn": self._get_iam_roles(),
         }
+        if enhanced_vpc_routing is not None:
+            restore_kwargs['enhanced_vpc_routing'] = enhanced_vpc_routing
         cluster = self.redshift_backend.restore_from_cluster_snapshot(**restore_kwargs).to_json()
         cluster['ClusterStatus'] = 'creating'
         return self.get_response({
@@ -218,6 +222,7 @@ class RedshiftResponse(BaseResponse):
             "publicly_accessible": self._get_param("PubliclyAccessible"),
             "encrypted": self._get_param("Encrypted"),
             "iam_roles_arn": self._get_iam_roles(),
+            "enhanced_vpc_routing": self._get_param("EnhancedVpcRouting")
         }
         cluster_kwargs = {}
         # We only want parameters that were actually passed in, otherwise


### PR DESCRIPTION
Enhanced VPC Routing was added sometime ago and now add for unit testing.

Also EnhancedVpcRouting is only available when mock_redshift not mock_redshift_deprecated (boto3 not boto).