### PR TITLE
Store SQS RedrivePolicy maxReceiveCount value as int

### DIFF
--- a/moto/sqs/models.py
+++ b/moto/sqs/models.py
@@ -263,6 +263,9 @@ class Queue(BaseModel):
         if 'maxReceiveCount' not in self.redrive_policy:
             raise RESTError('InvalidParameterValue', 'Redrive policy does not contain maxReceiveCount')
 
+        # 'maxReceiveCount' is stored as int
+        self.redrive_policy['maxReceiveCount'] = int(self.redrive_policy['maxReceiveCount'])
+
         for queue in sqs_backends[self.region].queues.values():
             if queue.queue_arn == self.redrive_policy['deadLetterTargetArn']:
                 self.dead_letter_queue = queue


### PR DESCRIPTION
Fixes #2382

The `maxReceiveCount` value is stored as an int, reflects the behavior as in AWS.