### PR TITLE
Add mock for ElasticBeanstalk

### DIFF
--- a/moto/__init__.py
+++ b/moto/__init__.py
@@ -18,6 +18,7 @@ from .datapipeline import mock_datapipeline, mock_datapipeline_deprecated  # fla
 from .dynamodb import mock_dynamodb, mock_dynamodb_deprecated  # flake8: noqa
 from .dynamodb2 import mock_dynamodb2, mock_dynamodb2_deprecated  # flake8: noqa
 from .dynamodbstreams import mock_dynamodbstreams # flake8: noqa
+from .eb import mock_eb  # flake8: noqa
 from .ec2 import mock_ec2, mock_ec2_deprecated  # flake8: noqa
 from .ecr import mock_ecr, mock_ecr_deprecated  # flake8: noqa
 from .ecs import mock_ecs, mock_ecs_deprecated  # flake8: noqa

--- a/moto/core/utils.py
+++ b/moto/core/utils.py
@@ -299,15 +299,27 @@ def path_url(url):
     return path
 
 
-def tags_from_query_string(querystring_dict):
-    prefix = 'Tag'
-    suffix = 'Key'
+def tags_from_query_string(
+        querystring_dict,
+        prefix="Tag",
+        key_suffix="Key",
+        value_suffix="Value"
+):
     response_values = {}
     for key, value in querystring_dict.items():
-        if key.startswith(prefix) and key.endswith(suffix):
-            tag_index = key.replace(prefix + ".", "").replace("." + suffix, "")
-            tag_key = querystring_dict.get("Tag.{0}.Key".format(tag_index))[0]
-            tag_value_key = "Tag.{0}.Value".format(tag_index)
+        if key.startswith(prefix) and key.endswith(key_suffix):
+            tag_index = key.replace(prefix + ".", "").replace("." + key_suffix, "")
+            tag_key = querystring_dict.get(
+                "{prefix}.{index}.{key_suffix}".format(
+                    prefix=prefix,
+                    index=tag_index,
+                    key_suffix=key_suffix,
+                ))[0]
+            tag_value_key = "{prefix}.{index}.{value_suffix}".format(
+                prefix=prefix,
+                index=tag_index,
+                value_suffix=value_suffix,
+            )
             if tag_value_key in querystring_dict:
                 response_values[tag_key] = querystring_dict.get(tag_value_key)[
                     0]

--- a/moto/core/utils.py
+++ b/moto/core/utils.py
@@ -297,3 +297,20 @@ def path_url(url):
     if parsed_url.query:
         path = path + '?' + parsed_url.query
     return path
+
+
+def tags_from_query_string(querystring_dict):
+    prefix = 'Tag'
+    suffix = 'Key'
+    response_values = {}
+    for key, value in querystring_dict.items():
+        if key.startswith(prefix) and key.endswith(suffix):
+            tag_index = key.replace(prefix + ".", "").replace("." + suffix, "")
+            tag_key = querystring_dict.get("Tag.{0}.Key".format(tag_index))[0]
+            tag_value_key = "Tag.{0}.Value".format(tag_index)
+            if tag_value_key in querystring_dict:
+                response_values[tag_key] = querystring_dict.get(tag_value_key)[
+                    0]
+            else:
+                response_values[tag_key] = None
+    return response_values

--- a/moto/eb/__init__.py
+++ b/moto/eb/__init__.py
@@ -1,0 +1,4 @@
+from .models import eb_backends
+from moto.core.models import base_decorator
+
+mock_eb = base_decorator(eb_backends)

--- a/moto/eb/exceptions.py
+++ b/moto/eb/exceptions.py
@@ -5,3 +5,9 @@ class InvalidParameterValueError(RESTError):
     def __init__(self, message):
         super(InvalidParameterValueError, self).__init__(
             "InvalidParameterValue", message)
+
+
+class ResourceNotFoundException(RESTError):
+    def __init__(self, message):
+        super(ResourceNotFoundException, self).__init__(
+            "ResourceNotFoundException", message)

--- a/moto/eb/exceptions.py
+++ b/moto/eb/exceptions.py
@@ -1,0 +1,7 @@
+from moto.core.exceptions import RESTError
+
+
+class InvalidParameterValueError(RESTError):
+    def __init__(self, message):
+        super(InvalidParameterValueError, self).__init__(
+            "InvalidParameterValue", message)

--- a/moto/eb/models.py
+++ b/moto/eb/models.py
@@ -1,0 +1,37 @@
+import boto.beanstalk
+
+from moto.core import BaseBackend, BaseModel
+from .exceptions import InvalidParameterValueError
+
+
+class FakeApplication(BaseModel):
+    def __init__(self, application_name):
+        self.application_name = application_name
+
+
+class EBBackend(BaseBackend):
+    def __init__(self, region):
+        self.region = region
+        self.applications = dict()
+
+    def reset(self):
+        # preserve region
+        region = self.region
+        self._reset_model_refs()
+        self.__dict__ = {}
+        self.__init__(region)
+
+    def create_application(self, application_name):
+        if application_name in self.applications:
+            raise InvalidParameterValueError(
+                "Application {} already exists.".format(application_name)
+            )
+        new_app = FakeApplication(
+            application_name=application_name,
+        )
+        self.applications[application_name] = new_app
+        return new_app
+
+
+eb_backends = dict((region.name, EBBackend(region.name))
+                   for region in boto.beanstalk.regions())

--- a/moto/eb/models.py
+++ b/moto/eb/models.py
@@ -11,10 +11,12 @@ class FakeEnvironment(BaseModel):
             self,
             application,
             environment_name,
+            solution_stack_name,
             tags,
     ):
         self.application = weakref.proxy(application)  # weakref to break circular dependencies
         self.environment_name = environment_name
+        self.solution_stack_name = solution_stack_name
         self.tags = tags
 
     @property
@@ -36,10 +38,6 @@ class FakeEnvironment(BaseModel):
         return 'TODO'  # TODO
 
     @property
-    def solution_stack_name(self):
-        return 'TODO'  # TODO
-
-    @property
     def region(self):
         return self.application.region
 
@@ -53,6 +51,7 @@ class FakeApplication(BaseModel):
     def create_environment(
             self,
             environment_name,
+            solution_stack_name,
             tags,
     ):
         if environment_name in self.environments:
@@ -61,6 +60,7 @@ class FakeApplication(BaseModel):
         env = FakeEnvironment(
             application=self,
             environment_name=environment_name,
+            solution_stack_name=solution_stack_name,
             tags=tags,
         )
         self.environments[environment_name] = env

--- a/moto/eb/models.py
+++ b/moto/eb/models.py
@@ -26,12 +26,12 @@ class FakeEnvironment(BaseModel):
     @property
     def environment_arn(self):
         return 'arn:aws:elasticbeanstalk:{region}:{account_id}:' \
-               'environment/{application_name}/{environment_name}'.format(
-                    region=self.region,
-                    account_id='123456789012',
-                    application_name=self.application_name,
-                    environment_name=self.environment_name,
-                )
+            'environment/{application_name}/{environment_name}'.format(
+                region=self.region,
+                account_id='123456789012',
+                application_name=self.application_name,
+                environment_name=self.environment_name,
+            )
 
     @property
     def platform_arn(self):

--- a/moto/eb/responses.py
+++ b/moto/eb/responses.py
@@ -1,0 +1,92 @@
+from moto.core.responses import BaseResponse
+from .models import eb_backends
+
+EB_CREATE_APPLICATION = """
+<CreateApplicationResponse xmlns="http://elasticbeanstalk.amazonaws.com/docs/2010-12-01/">
+  <CreateApplicationResult>
+    <Application>
+      <ConfigurationTemplates/>
+      <DateCreated>2019-09-03T13:08:29.049Z</DateCreated>
+      <ResourceLifecycleConfig>
+        <VersionLifecycleConfig>
+          <MaxAgeRule>
+            <DeleteSourceFromS3>false</DeleteSourceFromS3>
+            <MaxAgeInDays>180</MaxAgeInDays>
+            <Enabled>false</Enabled>
+          </MaxAgeRule>
+          <MaxCountRule>
+            <DeleteSourceFromS3>false</DeleteSourceFromS3>
+            <MaxCount>200</MaxCount>
+            <Enabled>false</Enabled>
+          </MaxCountRule>
+        </VersionLifecycleConfig>
+      </ResourceLifecycleConfig>
+      <ApplicationArn>arn:aws:elasticbeanstalk:{{ region_name }}:111122223333:application/{{ application_name }}</ApplicationArn>
+      <ApplicationName>{{ application.application_name }}</ApplicationName>
+      <DateUpdated>2019-09-03T13:08:29.049Z</DateUpdated>
+    </Application>
+  </CreateApplicationResult>
+  <ResponseMetadata>
+    <RequestId>1b6173c8-13aa-4b0a-99e9-eb36a1fb2778</RequestId>
+  </ResponseMetadata>
+</CreateApplicationResponse>
+"""
+
+
+EB_DESCRIBE_APPLICATIONS = """
+<DescribeApplicationsResponse xmlns="http://elasticbeanstalk.amazonaws.com/docs/2010-12-01/">
+  <DescribeApplicationsResult>
+    <Applications>
+      {% for application in applications %}
+      <member>
+        <ConfigurationTemplates/>
+        <DateCreated>2019-09-03T13:08:29.049Z</DateCreated>
+        <ResourceLifecycleConfig>
+          <VersionLifecycleConfig>
+            <MaxAgeRule>
+              <MaxAgeInDays>180</MaxAgeInDays>
+              <DeleteSourceFromS3>false</DeleteSourceFromS3>
+              <Enabled>false</Enabled>
+            </MaxAgeRule>
+            <MaxCountRule>
+              <DeleteSourceFromS3>false</DeleteSourceFromS3>
+              <MaxCount>200</MaxCount>
+              <Enabled>false</Enabled>
+            </MaxCountRule>
+          </VersionLifecycleConfig>
+        </ResourceLifecycleConfig>
+        <ApplicationArn>arn:aws:elasticbeanstalk:{{ region_name }}:387323646340:application/{{ application.name }}</ApplicationArn>
+        <ApplicationName>{{ application.application_name }}</ApplicationName>
+        <DateUpdated>2019-09-03T13:08:29.049Z</DateUpdated>
+      </member>
+      {% endfor %}
+    </Applications>
+  </DescribeApplicationsResult>
+  <ResponseMetadata>
+    <RequestId>015a05eb-282e-4b76-bd18-663fdfaf42e4</RequestId>
+  </ResponseMetadata>
+</DescribeApplicationsResponse>
+"""
+
+
+class EBResponse(BaseResponse):
+    @property
+    def backend(self):
+        return eb_backends[self.region]
+
+    def create_application(self):
+        app = self.backend.create_application(
+            application_name=self._get_param('ApplicationName'),
+        )
+
+        template = self.response_template(EB_CREATE_APPLICATION)
+        return template.render(
+            region_name=self.backend.region,
+            application=app,
+        )
+
+    def describe_applications(self):
+        template = self.response_template(EB_DESCRIBE_APPLICATIONS)
+        return template.render(
+            applications=self.backend.applications.values(),
+        )

--- a/moto/eb/responses.py
+++ b/moto/eb/responses.py
@@ -31,7 +31,6 @@ class EBResponse(BaseResponse):
 
     def create_environment(self):
         application_name = self._get_param('ApplicationName')
-        environment_name = self._get_param('EnvironmentName')
         try:
             app = self.backend.applications[application_name]
         except KeyError:
@@ -41,7 +40,8 @@ class EBResponse(BaseResponse):
 
         tags = tags_from_query_string(self.querystring, prefix="Tags.member")
         env = app.create_environment(
-            environment_name=environment_name,
+            environment_name=self._get_param('EnvironmentName'),
+            solution_stack_name=self._get_param('SolutionStackName'),
             tags=tags,
         )
 

--- a/moto/eb/responses.py
+++ b/moto/eb/responses.py
@@ -1,6 +1,6 @@
 from moto.core.responses import BaseResponse
 from moto.core.utils import tags_from_query_string
-from .models import eb_backends, EBBackend
+from .models import eb_backends
 from .exceptions import InvalidParameterValueError, ResourceNotFoundException
 
 

--- a/moto/eb/urls.py
+++ b/moto/eb/urls.py
@@ -1,0 +1,11 @@
+from __future__ import unicode_literals
+
+from .responses import EBResponse
+
+url_bases = [
+    r"https?://elasticbeanstalk.(?P<region>[a-zA-Z0-9\-_]+).amazonaws.com",
+]
+
+url_paths = {
+    '{0}/$': EBResponse.dispatch,
+}

--- a/moto/ec2/responses/tags.py
+++ b/moto/ec2/responses/tags.py
@@ -2,7 +2,8 @@ from __future__ import unicode_literals
 
 from moto.core.responses import BaseResponse
 from moto.ec2.models import validate_resource_ids
-from moto.ec2.utils import tags_from_query_string, filters_from_querystring
+from moto.ec2.utils import filters_from_querystring
+from moto.core.utils import tags_from_query_string
 
 
 class TagResponse(BaseResponse):

--- a/moto/ec2/utils.py
+++ b/moto/ec2/utils.py
@@ -198,23 +198,6 @@ def split_route_id(route_id):
     return values[0], values[1]
 
 
-def tags_from_query_string(querystring_dict):
-    prefix = 'Tag'
-    suffix = 'Key'
-    response_values = {}
-    for key, value in querystring_dict.items():
-        if key.startswith(prefix) and key.endswith(suffix):
-            tag_index = key.replace(prefix + ".", "").replace("." + suffix, "")
-            tag_key = querystring_dict.get("Tag.{0}.Key".format(tag_index))[0]
-            tag_value_key = "Tag.{0}.Value".format(tag_index)
-            if tag_value_key in querystring_dict:
-                response_values[tag_key] = querystring_dict.get(tag_value_key)[
-                    0]
-            else:
-                response_values[tag_key] = None
-    return response_values
-
-
 def dhcp_configuration_from_querystring(querystring, option=u'DhcpConfiguration'):
     """
     turn:

--- a/tests/test_eb/test_eb.py
+++ b/tests/test_eb/test_eb.py
@@ -1,0 +1,15 @@
+import boto3
+from moto import mock_eb
+
+
+@mock_eb
+def test_application():
+    # Create Elastic Beanstalk Application
+    eb_client = boto3.client('elasticbeanstalk', region_name='us-east-1')
+
+    eb_client.create_application(
+        ApplicationName="myapp",
+    )
+
+    eb_apps = eb_client.describe_applications()
+    eb_apps['Applications'][0]['ApplicationName'].should.equal("myapp")

--- a/tests/test_eb/test_eb.py
+++ b/tests/test_eb/test_eb.py
@@ -37,3 +37,44 @@ def test_describe_applications():
     apps = conn.describe_applications()
     len(apps['Applications']).should.equal(1)
     apps['Applications'][0]['ApplicationName'].should.equal('myapp')
+
+
+@mock_eb
+def test_create_environment():
+    # Create Elastic Beanstalk Environment
+    conn = boto3.client('elasticbeanstalk', region_name='us-east-1')
+    app = conn.create_application(
+        ApplicationName="myapp",
+    )
+    env = conn.create_environment(
+        ApplicationName="myapp",
+        EnvironmentName="myenv",
+    )
+    env['EnvironmentName'].should.equal("myenv")
+
+
+@mock_eb
+def test_describe_environments():
+    # List Elastic Beanstalk Envs
+    conn = boto3.client('elasticbeanstalk', region_name='us-east-1')
+    conn.create_application(
+        ApplicationName="myapp",
+    )
+    conn.create_environment(
+        ApplicationName="myapp",
+        EnvironmentName="myenv",
+    )
+
+    envs = conn.describe_environments()
+    envs = envs['Environments']
+    len(envs).should.equal(1)
+    envs[0]['ApplicationName'].should.equal('myapp')
+    envs[0]['EnvironmentName'].should.equal('myenv')
+
+
+@mock_eb
+def test_list_available_solution_stacks():
+    conn = boto3.client('elasticbeanstalk', region_name='us-east-1')
+    stacks = conn.list_available_solution_stacks()
+    len(stacks['SolutionStacks']).should.be.greater_than(0)
+    len(stacks['SolutionStacks']).should.be.equal(len(stacks['SolutionStackDetails']))

--- a/tests/test_eb/test_eb.py
+++ b/tests/test_eb/test_eb.py
@@ -1,15 +1,39 @@
 import boto3
+import sure  # noqa
+from botocore.exceptions import ClientError
+
 from moto import mock_eb
 
 
 @mock_eb
-def test_application():
+def test_create_application():
     # Create Elastic Beanstalk Application
-    eb_client = boto3.client('elasticbeanstalk', region_name='us-east-1')
+    conn = boto3.client('elasticbeanstalk', region_name='us-east-1')
+    app = conn.create_application(
+        ApplicationName="myapp",
+    )
+    app['Application']['ApplicationName'].should.equal("myapp")
 
-    eb_client.create_application(
+
+@mock_eb
+def test_create_application_dup():
+    conn = boto3.client('elasticbeanstalk', region_name='us-east-1')
+    conn.create_application(
+        ApplicationName="myapp",
+    )
+    conn.create_application.when.called_with(
+        ApplicationName="myapp",
+    ).should.throw(ClientError)
+
+
+@mock_eb
+def test_describe_applications():
+    # Create Elastic Beanstalk Application
+    conn = boto3.client('elasticbeanstalk', region_name='us-east-1')
+    conn.create_application(
         ApplicationName="myapp",
     )
 
-    eb_apps = eb_client.describe_applications()
-    eb_apps['Applications'][0]['ApplicationName'].should.equal("myapp")
+    apps = conn.describe_applications()
+    len(apps['Applications']).should.equal(1)
+    apps['Applications'][0]['ApplicationName'].should.equal('myapp')


### PR DESCRIPTION
Related to issue #2405 

This PR (currently) adds failing tests for Elastic Beanstalk `create_application()`

Update: tests no longer fail because I've added a try to implement an absolute minimal mock for `create_application()` and `describe_application()`