### PR TITLE
sqs physical resource id is queue url in cfn list-stack-resources 

### DIFF
--- a/moto/cloudformation/responses.py
+++ b/moto/cloudformation/responses.py
@@ -226,9 +226,16 @@ class CloudFormationResponse(BaseResponse):
         stack_name_or_id = self._get_param('StackName')
         resources = self.cloudformation_backend.list_stack_resources(
             stack_name_or_id)
+        request_url = urlparse(self.uri)
+        resources_with_request_url = []
+        for resource in resources:
+            if hasattr(resource, 'with_request_url'):
+                resources_with_request_url.append(resource.with_request_url(request_url))
+            else:
+                resources_with_request_url.append(resource)
 
         template = self.response_template(LIST_STACKS_RESOURCES_RESPONSE)
-        return template.render(resources=resources)
+        return template.render(resources=resources_with_request_url)
 
     def get_template(self):
         name_or_stack_id = self.querystring.get('StackName')[0]

--- a/moto/core/models.py
+++ b/moto/core/models.py
@@ -7,6 +7,7 @@ import inspect
 import os
 import re
 import six
+from copy import copy 
 from io import BytesIO
 from collections import defaultdict
 from botocore.handlers import BUILTIN_HANDLERS
@@ -465,6 +466,22 @@ class BaseModel(object):
         instance = super(BaseModel, cls).__new__(cls)
         cls.instances.append(instance)
         return instance
+
+    @property
+    def request_url(self):
+        if hasattr(self, '_request_url'):
+            return self._request_url
+        else:
+            return None
+
+    @request_url.setter
+    def request_url(self, request_url):
+        self._request_url = request_url
+
+    def with_request_url(self, request_url):
+        new_model = copy(self)
+        new_model.request_url = request_url
+        return new_model
 
 
 class BaseBackend(object):

--- a/moto/core/models.py
+++ b/moto/core/models.py
@@ -7,7 +7,7 @@ import inspect
 import os
 import re
 import six
-from copy import copy 
+from copy import copy
 from io import BytesIO
 from collections import defaultdict
 from botocore.handlers import BUILTIN_HANDLERS

--- a/moto/sqs/models.py
+++ b/moto/sqs/models.py
@@ -321,7 +321,10 @@ class Queue(BaseModel):
 
     @property
     def physical_resource_id(self):
-        return self.name
+        if self.request_url != None:
+            return self.url(self.request_url)
+        else:
+            return self.name
 
     @property
     def attributes(self):

--- a/moto/sqs/models.py
+++ b/moto/sqs/models.py
@@ -321,7 +321,7 @@ class Queue(BaseModel):
 
     @property
     def physical_resource_id(self):
-        if self.request_url != None:
+        if self.request_url is not None:
             return self.url(self.request_url)
         else:
             return self.name

--- a/tests/test_cloudformation/test_cloudformation_stack_integration.py
+++ b/tests/test_cloudformation/test_cloudformation_stack_integration.py
@@ -117,7 +117,7 @@ def test_stack_list_resources():
     queue = resources[0]
     queue.resource_type.should.equal('AWS::SQS::Queue')
     queue.logical_resource_id.should.equal("QueueGroup")
-    queue.physical_resource_id.should.equal("my-queue")
+    queue.physical_resource_id.should.equal("https://cloudformation.us-west-1.amazonaws.com/123456789012/my-queue")
 
 
 @mock_cloudformation_deprecated()


### PR DESCRIPTION
The physical resource id of AWS::SQS::Queue should be the queue URL [according to the AWS CFN docs for SQS](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sqs-queues.html#aws-properties-sqs-queues-return-values-ref) but is currently the queue name in Moto.

This PR makes the necessary change for the `cloudformation:ListStackResources` action. It should be easy to extend the same approach in this PR to other CFN actions.

Fixes #2407  