### PR TITLE
Fix/tighten AWS Batch test_reregister_task_definition unit test

### DIFF
--- a/tests/test_batch/test_batch.py
+++ b/tests/test_batch/test_batch.py
@@ -563,6 +563,38 @@ def test_reregister_task_definition():
 
     resp2['jobDefinitionArn'].should_not.equal(resp1['jobDefinitionArn'])
 
+    resp3 = batch_client.register_job_definition(
+        jobDefinitionName='sleep10',
+        type='container',
+        containerProperties={
+            'image': 'busybox',
+            'vcpus': 1,
+            'memory': 42,
+            'command': ['sleep', '10']
+        }
+    )
+    resp3['revision'].should.equal(3)
+
+    resp3['jobDefinitionArn'].should_not.equal(resp1['jobDefinitionArn'])
+    resp3['jobDefinitionArn'].should_not.equal(resp2['jobDefinitionArn'])
+
+    resp4 = batch_client.register_job_definition(
+        jobDefinitionName='sleep10',
+        type='container',
+        containerProperties={
+            'image': 'busybox',
+            'vcpus': 1,
+            'memory': 41,
+            'command': ['sleep', '10']
+        }
+    )
+    resp4['revision'].should.equal(4)
+
+    resp4['jobDefinitionArn'].should_not.equal(resp1['jobDefinitionArn'])
+    resp4['jobDefinitionArn'].should_not.equal(resp2['jobDefinitionArn'])
+    resp4['jobDefinitionArn'].should_not.equal(resp3['jobDefinitionArn'])
+    
+
 
 @mock_ec2
 @mock_ecs


### PR DESCRIPTION
This PR strengthens the `tests/test_batch/test_batch.py` unit test.

**Expected behavior:**
When you register a job definition using the name of a pre-existing job, the revision number should increment.  E.g., using the AWS CLI:

```
williamharvey@fnord $ aws batch register-job-definition --job-definition-name='wjh-bippy-2019-09-10' --type='container' --container-properties='{"image": "busybox", "vcpus": 1, "memory": 128, "command": ["sleep", "10"]}'
arn:aws:batch:us-east-1:scrubbed:job-definition/wjh-bippy-2019-09-10:1    wjh-bippy-2019-09-10    1

williamharvey@fnord $ aws batch register-job-definition --job-definition-name='wjh-bippy-2019-09-10' --type='container' --container-properties='{"image": "busybox", "vcpus": 1, "memory": 127, "command": ["sleep", "10"]}'
arn:aws:batch:us-east-1:scrubbed:job-definition/wjh-bippy-2019-09-10:2    wjh-bippy-2019-09-10    2

williamharvey@fnord $ aws batch register-job-definition --job-definition-name='wjh-bippy-2019-09-10' --type='container' --container-properties='{"image": "busybox", "vcpus": 1, "memory": 126, "command": ["sleep", "10"]}'
arn:aws:batch:us-east-1:scrubbed:job-definition/wjh-bippy-2019-09-10:3    wjh-bippy-2019-09-10    3
```

The comment in the unit test, "Reregistering task with the same name bumps the revision number," reflects this desired behavior.  However, the unit test only checks to make sure that the first redefinition increases the revision number to 2.

**Erroneous Behavior**
It turns out that moto 1.3.13, and possibly earlier versions, have a bug related to this behavior: The revision number does not seem to increase beyond 2 regardless of how many times a job is redefined.

This bug seems to have disappeared in version 1.3.14.dev.

**Resolution**
This PR strengthens the unit test in question so that it (1) exposes the bug if run against moto 1.3.13, and (2) confirms that the bug is no longer present in moto 1.3.14.dev.