### PR TITLE
Fix multiple IAM Policy Statement creation with empty sid

### DIFF
--- a/moto/iam/policy_validation.py
+++ b/moto/iam/policy_validation.py
@@ -152,8 +152,10 @@ class IAMPolicyDocumentValidator:
         sids = []
         for statement in self._statements:
             if "Sid" in statement:
-                assert statement["Sid"] not in sids
-                sids.append(statement["Sid"])
+                statementId = statement["Sid"]
+                if statementId:
+                    assert statementId not in sids
+                    sids.append(statementId)
 
     def _validate_statements_syntax(self):
         assert "Statement" in self._policy_json

--- a/tests/test_iam/test_iam_policies.py
+++ b/tests/test_iam/test_iam_policies.py
@@ -1827,6 +1827,23 @@ valid_policy_documents = [
                 "Resource": ["*"]
             }
         ]
+    },
+    {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Sid": "",
+                "Effect": "Allow",
+                "Action": "rds:*",
+                "Resource": ["arn:aws:rds:region:*:*"]
+            },
+            {
+                "Sid": "",
+                "Effect": "Allow",
+                "Action": ["rds:Describe*"],
+                "Resource": ["*"]
+            }
+        ]
     }
 ]
 


### PR DESCRIPTION
When I executed terraform with multiple statements it generate an request with empty `Sid` attribute on each statement.
This problem was originally created in localstack ([Issue 1556](https://github.com/localstack/localstack/issues/1556)), but the related validation was applied by moto.
The same request were sent to AWS and were successful.