### PR TITLE
Elbv2 fixed response action

### DIFF
--- a/moto/elbv2/exceptions.py
+++ b/moto/elbv2/exceptions.py
@@ -190,3 +190,18 @@ class InvalidModifyRuleArgumentsError(ELBClientError):
             "ValidationError",
             "Either conditions or actions must be specified"
         )
+
+
+class InvalidStatusCodeActionTypeError(ELBClientError):
+    def __init__(self, msg):
+        super(InvalidStatusCodeActionTypeError, self).__init__(
+            "ValidationError", msg
+        )
+
+
+class InvalidLoadBalancerActionException(ELBClientError):
+
+    def __init__(self, msg):
+        super(InvalidLoadBalancerActionException, self).__init__(
+            "InvalidLoadBalancerAction", msg
+        )

--- a/tests/test_elbv2/test_elbv2.py
+++ b/tests/test_elbv2/test_elbv2.py
@@ -4,7 +4,7 @@ import json
 import os
 import boto3
 import botocore
-from botocore.exceptions import ClientError
+from botocore.exceptions import ClientError, ParamValidationError
 from nose.tools import assert_raises
 import sure  # noqa
 
@@ -2146,3 +2146,150 @@ def test_fixed_response_action_listener_rule_cloudformation():
             'StatusCode': '404',
         }
     },])
+
+
+@mock_elbv2
+@mock_ec2
+def test_fixed_response_action_listener_rule_validates_status_code():
+    conn = boto3.client('elbv2', region_name='us-east-1')
+    ec2 = boto3.resource('ec2', region_name='us-east-1')
+
+    security_group = ec2.create_security_group(
+        GroupName='a-security-group', Description='First One')
+    vpc = ec2.create_vpc(CidrBlock='172.28.7.0/24', InstanceTenancy='default')
+    subnet1 = ec2.create_subnet(
+        VpcId=vpc.id,
+        CidrBlock='172.28.7.192/26',
+        AvailabilityZone='us-east-1a')
+    subnet2 = ec2.create_subnet(
+        VpcId=vpc.id,
+        CidrBlock='172.28.7.128/26',
+        AvailabilityZone='us-east-1b')
+
+    response = conn.create_load_balancer(
+        Name='my-lb',
+        Subnets=[subnet1.id, subnet2.id],
+        SecurityGroups=[security_group.id],
+        Scheme='internal',
+        Tags=[{'Key': 'key_name', 'Value': 'a_value'}])
+    load_balancer_arn = response.get('LoadBalancers')[0].get('LoadBalancerArn')
+
+    missing_status_code_action = {
+        'Type': 'fixed-response',
+        'FixedResponseConfig': {
+             'ContentType': 'text/plain',
+             'MessageBody': 'This page does not exist',
+         }
+    }
+    with assert_raises(ParamValidationError):
+        conn.create_listener(LoadBalancerArn=load_balancer_arn,
+                                    Protocol='HTTP',
+                                    Port=80,
+                                    DefaultActions=[missing_status_code_action])
+
+    invalid_status_code_action = {
+        'Type': 'fixed-response',
+        'FixedResponseConfig': {
+            'ContentType': 'text/plain',
+            'MessageBody': 'This page does not exist',
+            'StatusCode': '100'
+        }
+    }
+
+    @mock_elbv2
+    @mock_ec2
+    def test_fixed_response_action_listener_rule_validates_status_code():
+        conn = boto3.client('elbv2', region_name='us-east-1')
+        ec2 = boto3.resource('ec2', region_name='us-east-1')
+
+        security_group = ec2.create_security_group(
+            GroupName='a-security-group', Description='First One')
+        vpc = ec2.create_vpc(CidrBlock='172.28.7.0/24', InstanceTenancy='default')
+        subnet1 = ec2.create_subnet(
+            VpcId=vpc.id,
+            CidrBlock='172.28.7.192/26',
+            AvailabilityZone='us-east-1a')
+        subnet2 = ec2.create_subnet(
+            VpcId=vpc.id,
+            CidrBlock='172.28.7.128/26',
+            AvailabilityZone='us-east-1b')
+
+        response = conn.create_load_balancer(
+            Name='my-lb',
+            Subnets=[subnet1.id, subnet2.id],
+            SecurityGroups=[security_group.id],
+            Scheme='internal',
+            Tags=[{'Key': 'key_name', 'Value': 'a_value'}])
+        load_balancer_arn = response.get('LoadBalancers')[0].get('LoadBalancerArn')
+
+        missing_status_code_action = {
+            'Type': 'fixed-response',
+            'FixedResponseConfig': {
+                'ContentType': 'text/plain',
+                'MessageBody': 'This page does not exist',
+            }
+        }
+        with assert_raises(ParamValidationError):
+            conn.create_listener(LoadBalancerArn=load_balancer_arn,
+                                 Protocol='HTTP',
+                                 Port=80,
+                                 DefaultActions=[missing_status_code_action])
+
+        invalid_status_code_action = {
+            'Type': 'fixed-response',
+            'FixedResponseConfig': {
+                'ContentType': 'text/plain',
+                'MessageBody': 'This page does not exist',
+                'StatusCode': '100'
+            }
+        }
+
+        with assert_raises(ClientError) as invalid_status_code_exception:
+            conn.create_listener(LoadBalancerArn=load_balancer_arn,
+                                 Protocol='HTTP',
+                                 Port=80,
+                                 DefaultActions=[invalid_status_code_action])
+
+        invalid_status_code_exception.exception.response['Error']['Code'].should.equal('ValidationError')
+
+
+@mock_elbv2
+@mock_ec2
+def test_fixed_response_action_listener_rule_validates_content_type():
+    conn = boto3.client('elbv2', region_name='us-east-1')
+    ec2 = boto3.resource('ec2', region_name='us-east-1')
+
+    security_group = ec2.create_security_group(
+        GroupName='a-security-group', Description='First One')
+    vpc = ec2.create_vpc(CidrBlock='172.28.7.0/24', InstanceTenancy='default')
+    subnet1 = ec2.create_subnet(
+        VpcId=vpc.id,
+        CidrBlock='172.28.7.192/26',
+        AvailabilityZone='us-east-1a')
+    subnet2 = ec2.create_subnet(
+        VpcId=vpc.id,
+        CidrBlock='172.28.7.128/26',
+        AvailabilityZone='us-east-1b')
+
+    response = conn.create_load_balancer(
+        Name='my-lb',
+        Subnets=[subnet1.id, subnet2.id],
+        SecurityGroups=[security_group.id],
+        Scheme='internal',
+        Tags=[{'Key': 'key_name', 'Value': 'a_value'}])
+    load_balancer_arn = response.get('LoadBalancers')[0].get('LoadBalancerArn')
+
+    invalid_content_type_action = {
+        'Type': 'fixed-response',
+        'FixedResponseConfig': {
+            'ContentType': 'Fake content type',
+            'MessageBody': 'This page does not exist',
+            'StatusCode': '200'
+        }
+    }
+    with assert_raises(ClientError) as invalid_content_type_exception:
+        conn.create_listener(LoadBalancerArn=load_balancer_arn,
+                             Protocol='HTTP',
+                             Port=80,
+                             DefaultActions=[invalid_content_type_action])
+    invalid_content_type_exception.exception.response['Error']['Code'].should.equal('InvalidLoadBalancerAction')


### PR DESCRIPTION
This PR adds support for the `fixed-response` action type.

Listener Action Cloudformation docs: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-elasticloadbalancingv2-listener-defaultactions.html

FixedResponseConfig Cloudformation docs:
https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-elasticloadbalancingv2-listener-fixedresponseconfig.html

I didn't see many other validation tests, let me know if you'd prefer a different format for those @spulec