### PR TITLE
Normalize KMS key ID validation

### DIFF
--- a/moto/kms/models.py
+++ b/moto/kms/models.py
@@ -1,12 +1,16 @@
 from __future__ import unicode_literals
 
 import os
-import boto.kms
-from moto.core import BaseBackend, BaseModel
-from moto.core.utils import iso_8601_datetime_without_milliseconds
-from .utils import decrypt, encrypt, generate_key_id, generate_master_key
+import re
 from collections import defaultdict
 from datetime import datetime, timedelta
+
+import boto.kms
+
+from moto.core import BaseBackend, BaseModel
+from moto.core.utils import iso_8601_datetime_without_milliseconds
+
+from .utils import decrypt, encrypt, generate_key_id, generate_master_key
 
 
 class Key(BaseModel):
@@ -18,7 +22,7 @@ class Key(BaseModel):
         self.description = description
         self.enabled = True
         self.region = region
-        self.account_id = "0123456789012"
+        self.account_id = "012345678912"
         self.key_rotation_status = False
         self.deletion_date = None
         self.tags = tags or {}
@@ -116,13 +120,21 @@ class KmsBackend(BaseBackend):
     def list_keys(self):
         return self.keys.values()
 
-    def get_key_id(self, key_id):
+    @staticmethod
+    def get_key_id(key_id):
         # Allow use of ARN as well as pure KeyId
-        return str(key_id).split(r":key/")[1] if r":key/" in str(key_id).lower() else key_id
+        if key_id.startswith("arn:") and ":key/" in key_id:
+            return key_id.split(":key/")[1]
 
-    def get_alias_name(self, alias_name):
+        return key_id
+
+    @staticmethod
+    def get_alias_name(alias_name):
         # Allow use of ARN as well as alias name
-        return str(alias_name).split(r":alias/")[1] if r":alias/" in str(alias_name).lower() else alias_name
+        if alias_name.startswith("arn:") and ":alias/" in alias_name:
+            return alias_name.split(":alias/")[1]
+
+        return alias_name
 
     def any_id_to_key_id(self, key_id):
         """Go from any valid key ID to the raw key ID.

--- a/moto/kms/models.py
+++ b/moto/kms/models.py
@@ -1,7 +1,6 @@
 from __future__ import unicode_literals
 
 import os
-import re
 from collections import defaultdict
 from datetime import datetime, timedelta
 

--- a/moto/kms/responses.py
+++ b/moto/kms/responses.py
@@ -475,11 +475,10 @@ class KmsResponse(BaseResponse):
 
         if number_of_bytes and (number_of_bytes > 1024 or number_of_bytes < 1):
             raise ValidationException((
-                    "1 validation error detected: Value '{number_of_bytes:d}' at 'numberOfBytes' failed "
-                    "to satisfy constraint: Member must have value less than or "
-                    "equal to 1024"
-                ).format(number_of_bytes=number_of_bytes)
-            )
+                "1 validation error detected: Value '{number_of_bytes:d}' at 'numberOfBytes' failed "
+                "to satisfy constraint: Member must have value less than or "
+                "equal to 1024"
+            ).format(number_of_bytes=number_of_bytes))
 
         entropy = os.urandom(number_of_bytes)
 

--- a/moto/kms/responses.py
+++ b/moto/kms/responses.py
@@ -152,13 +152,10 @@ class KmsResponse(BaseResponse):
 
         self._validate_key_id(key_id)
 
-        try:
-            key = self.kms_backend.describe_key(
-                self.kms_backend.get_key_id(key_id))
-        except KeyError:
-            headers = dict(self.headers)
-            headers['status'] = 404
-            return "{}", headers
+        key = self.kms_backend.describe_key(
+            self.kms_backend.get_key_id(key_id)
+        )
+
         return json.dumps(key.to_dict())
 
     def list_keys(self):

--- a/moto/kms/responses.py
+++ b/moto/kms/responses.py
@@ -11,6 +11,7 @@ from moto.core.responses import BaseResponse
 from .models import kms_backends
 from .exceptions import NotFoundException, ValidationException, AlreadyExistsException, NotAuthorizedException
 
+ACCOUNT_ID = "012345678912"
 reserved_aliases = [
     'alias/aws/ebs',
     'alias/aws/s3',
@@ -35,7 +36,74 @@ class KmsResponse(BaseResponse):
     def kms_backend(self):
         return kms_backends[self.region]
 
+    def _display_arn(self, key_id):
+        if key_id.startswith("arn:"):
+            return key_id
+
+        if key_id.startswith("alias/"):
+            id_type = ""
+        else:
+            id_type = "key/"
+
+        return "arn:aws:kms:{region}:{account}:{id_type}{key_id}".format(
+            region=self.region, account=ACCOUNT_ID, id_type=id_type, key_id=key_id
+        )
+
+    def _validate_cmk_id(self, key_id):
+        """Determine whether a CMK ID exists.
+
+        - raw key ID
+        - key ARN
+        """
+        is_arn = key_id.startswith("arn:") and ":key/" in key_id
+        is_raw_key_id = re.match(r"^[A-F0-9]{8}-[A-F0-9]{4}-[A-F0-9]{4}-[A-F0-9]{4}-[A-F0-9]{12}$", key_id, re.IGNORECASE)
+
+        if not is_arn and not is_raw_key_id:
+            raise NotFoundException("Invalid keyId {key_id}".format(key_id=key_id))
+
+        cmk_id = self.kms_backend.get_key_id(key_id)
+
+        if cmk_id not in self.kms_backend.keys:
+            raise NotFoundException("Key '{key_id}' does not exist".format(key_id=self._display_arn(key_id)))
+
+    def _validate_alias(self, key_id):
+        """Determine whether an alias exists.
+
+        - alias name
+        - alias ARN
+        """
+        error = NotFoundException("Alias {key_id} is not found.".format(key_id=self._display_arn(key_id)))
+
+        is_arn = key_id.startswith("arn:") and ":alias/" in key_id
+        is_name = key_id.startswith("alias/")
+
+        if not is_arn and not is_name:
+            raise error
+
+        alias_name = self.kms_backend.get_alias_name(key_id)
+        cmk_id = self.kms_backend.get_key_id_from_alias(alias_name)
+        if cmk_id is None:
+            raise error
+
+    def _validate_key_id(self, key_id):
+        """Determine whether or not a key ID exists.
+
+        - raw key ID
+        - key ARN
+        - alias name
+        - alias ARN
+        """
+        is_alias_arn = key_id.startswith("arn:") and ":alias/" in key_id
+        is_alias_name = key_id.startswith("alias/")
+
+        if is_alias_arn or is_alias_name:
+            self._validate_alias(key_id)
+            return
+
+        self._validate_cmk_id(key_id)
+
     def create_key(self):
+        """https://docs.aws.amazon.com/kms/latest/APIReference/API_CreateKey.html"""
         policy = self.parameters.get('Policy')
         key_usage = self.parameters.get('KeyUsage')
         description = self.parameters.get('Description')
@@ -46,20 +114,31 @@ class KmsResponse(BaseResponse):
         return json.dumps(key.to_dict())
 
     def update_key_description(self):
+        """https://docs.aws.amazon.com/kms/latest/APIReference/API_UpdateKeyDescription.html"""
         key_id = self.parameters.get('KeyId')
         description = self.parameters.get('Description')
+
+        self._validate_cmk_id(key_id)
 
         self.kms_backend.update_key_description(key_id, description)
         return json.dumps(None)
 
     def tag_resource(self):
+        """https://docs.aws.amazon.com/kms/latest/APIReference/API_TagResource.html"""
         key_id = self.parameters.get('KeyId')
         tags = self.parameters.get('Tags')
+
+        self._validate_cmk_id(key_id)
+
         self.kms_backend.tag_resource(key_id, tags)
         return json.dumps({})
 
     def list_resource_tags(self):
+        """https://docs.aws.amazon.com/kms/latest/APIReference/API_ListResourceTags.html"""
         key_id = self.parameters.get('KeyId')
+
+        self._validate_cmk_id(key_id)
+
         tags = self.kms_backend.list_resource_tags(key_id)
         return json.dumps({
             "Tags": tags,
@@ -68,7 +147,11 @@ class KmsResponse(BaseResponse):
         })
 
     def describe_key(self):
+        """https://docs.aws.amazon.com/kms/latest/APIReference/API_DescribeKey.html"""
         key_id = self.parameters.get('KeyId')
+
+        self._validate_key_id(key_id)
+
         try:
             key = self.kms_backend.describe_key(
                 self.kms_backend.get_key_id(key_id))
@@ -79,6 +162,7 @@ class KmsResponse(BaseResponse):
         return json.dumps(key.to_dict())
 
     def list_keys(self):
+        """https://docs.aws.amazon.com/kms/latest/APIReference/API_ListKeys.html"""
         keys = self.kms_backend.list_keys()
 
         return json.dumps({
@@ -93,6 +177,7 @@ class KmsResponse(BaseResponse):
         })
 
     def create_alias(self):
+        """https://docs.aws.amazon.com/kms/latest/APIReference/API_CreateAlias.html"""
         alias_name = self.parameters['AliasName']
         target_key_id = self.parameters['TargetKeyId']
 
@@ -118,26 +203,30 @@ class KmsResponse(BaseResponse):
             raise AlreadyExistsException('An alias with the name arn:aws:kms:{region}:012345678912:{alias_name} '
                                          'already exists'.format(region=self.region, alias_name=alias_name))
 
+        self._validate_cmk_id(target_key_id)
+
         self.kms_backend.add_alias(target_key_id, alias_name)
 
         return json.dumps(None)
 
     def delete_alias(self):
+        """https://docs.aws.amazon.com/kms/latest/APIReference/API_DeleteAlias.html"""
         alias_name = self.parameters['AliasName']
 
         if not alias_name.startswith('alias/'):
             raise ValidationException('Invalid identifier')
 
-        if not self.kms_backend.alias_exists(alias_name):
-            raise NotFoundException('Alias arn:aws:kms:{region}:012345678912:'
-                                    '{alias_name} is not found.'.format(region=self.region, alias_name=alias_name))
+        self._validate_alias(alias_name)
 
         self.kms_backend.delete_alias(alias_name)
 
         return json.dumps(None)
 
     def list_aliases(self):
+        """https://docs.aws.amazon.com/kms/latest/APIReference/API_ListAliases.html"""
         region = self.region
+
+        # TODO: The actual API can filter on KeyId.
 
         response_aliases = [
             {
@@ -163,78 +252,75 @@ class KmsResponse(BaseResponse):
         })
 
     def enable_key_rotation(self):
+        """https://docs.aws.amazon.com/kms/latest/APIReference/API_EnableKeyRotation.html"""
         key_id = self.parameters.get('KeyId')
-        _assert_valid_key_id(self.kms_backend.get_key_id(key_id))
-        try:
-            self.kms_backend.enable_key_rotation(key_id)
-        except KeyError:
-            raise NotFoundException("Key 'arn:aws:kms:{region}:012345678912:key/"
-                                    "{key_id}' does not exist".format(region=self.region, key_id=key_id))
+
+        self._validate_cmk_id(key_id)
+
+        self.kms_backend.enable_key_rotation(key_id)
 
         return json.dumps(None)
 
     def disable_key_rotation(self):
+        """https://docs.aws.amazon.com/kms/latest/APIReference/API_EnableKeyRotation.html"""
         key_id = self.parameters.get('KeyId')
-        _assert_valid_key_id(self.kms_backend.get_key_id(key_id))
-        try:
-            self.kms_backend.disable_key_rotation(key_id)
-        except KeyError:
-            raise NotFoundException("Key 'arn:aws:kms:{region}:012345678912:key/"
-                                    "{key_id}' does not exist".format(region=self.region, key_id=key_id))
+
+        self._validate_cmk_id(key_id)
+
+        self.kms_backend.disable_key_rotation(key_id)
+
         return json.dumps(None)
 
     def get_key_rotation_status(self):
+        """https://docs.aws.amazon.com/kms/latest/APIReference/API_GetKeyRotationStatus.html"""
         key_id = self.parameters.get('KeyId')
-        _assert_valid_key_id(self.kms_backend.get_key_id(key_id))
-        try:
-            rotation_enabled = self.kms_backend.get_key_rotation_status(key_id)
-        except KeyError:
-            raise NotFoundException("Key 'arn:aws:kms:{region}:012345678912:key/"
-                                    "{key_id}' does not exist".format(region=self.region, key_id=key_id))
+
+        self._validate_cmk_id(key_id)
+
+        rotation_enabled = self.kms_backend.get_key_rotation_status(key_id)
+
         return json.dumps({'KeyRotationEnabled': rotation_enabled})
 
     def put_key_policy(self):
+        """https://docs.aws.amazon.com/kms/latest/APIReference/API_PutKeyPolicy.html"""
         key_id = self.parameters.get('KeyId')
         policy_name = self.parameters.get('PolicyName')
         policy = self.parameters.get('Policy')
-        _assert_valid_key_id(self.kms_backend.get_key_id(key_id))
         _assert_default_policy(policy_name)
 
-        try:
-            self.kms_backend.put_key_policy(key_id, policy)
-        except KeyError:
-            raise NotFoundException("Key 'arn:aws:kms:{region}:012345678912:key/"
-                                    "{key_id}' does not exist".format(region=self.region, key_id=key_id))
+        self._validate_cmk_id(key_id)
+
+        self.kms_backend.put_key_policy(key_id, policy)
 
         return json.dumps(None)
 
     def get_key_policy(self):
+        """https://docs.aws.amazon.com/kms/latest/APIReference/API_GetKeyPolicy.html"""
         key_id = self.parameters.get('KeyId')
         policy_name = self.parameters.get('PolicyName')
-        _assert_valid_key_id(self.kms_backend.get_key_id(key_id))
         _assert_default_policy(policy_name)
 
-        try:
-            return json.dumps({'Policy': self.kms_backend.get_key_policy(key_id)})
-        except KeyError:
-            raise NotFoundException("Key 'arn:aws:kms:{region}:012345678912:key/"
-                                    "{key_id}' does not exist".format(region=self.region, key_id=key_id))
+        self._validate_cmk_id(key_id)
+
+        return json.dumps({'Policy': self.kms_backend.get_key_policy(key_id)})
 
     def list_key_policies(self):
+        """https://docs.aws.amazon.com/kms/latest/APIReference/API_ListKeyPolicies.html"""
         key_id = self.parameters.get('KeyId')
-        _assert_valid_key_id(self.kms_backend.get_key_id(key_id))
-        try:
-            self.kms_backend.describe_key(key_id)
-        except KeyError:
-            raise NotFoundException("Key 'arn:aws:kms:{region}:012345678912:key/"
-                                    "{key_id}' does not exist".format(region=self.region, key_id=key_id))
+
+        self._validate_cmk_id(key_id)
+
+        self.kms_backend.describe_key(key_id)
 
         return json.dumps({'Truncated': False, 'PolicyNames': ['default']})
 
     def encrypt(self):
+        """https://docs.aws.amazon.com/kms/latest/APIReference/API_Encrypt.html"""
         key_id = self.parameters.get("KeyId")
         encryption_context = self.parameters.get('EncryptionContext', {})
         plaintext = self.parameters.get("Plaintext")
+
+        self._validate_key_id(key_id)
 
         if isinstance(plaintext, six.text_type):
             plaintext = plaintext.encode('utf-8')
@@ -249,6 +335,7 @@ class KmsResponse(BaseResponse):
         return json.dumps({"CiphertextBlob": ciphertext_blob_response, "KeyId": arn})
 
     def decrypt(self):
+        """https://docs.aws.amazon.com/kms/latest/APIReference/API_Decrypt.html"""
         ciphertext_blob = self.parameters.get("CiphertextBlob")
         encryption_context = self.parameters.get('EncryptionContext', {})
 
@@ -262,10 +349,13 @@ class KmsResponse(BaseResponse):
         return json.dumps({"Plaintext": plaintext_response, 'KeyId': arn})
 
     def re_encrypt(self):
+        """https://docs.aws.amazon.com/kms/latest/APIReference/API_ReEncrypt.html"""
         ciphertext_blob = self.parameters.get("CiphertextBlob")
         source_encryption_context = self.parameters.get("SourceEncryptionContext", {})
         destination_key_id = self.parameters.get("DestinationKeyId")
         destination_encryption_context = self.parameters.get("DestinationEncryptionContext", {})
+
+        self._validate_cmk_id(destination_key_id)
 
         new_ciphertext_blob, decrypting_arn, encrypting_arn = self.kms_backend.re_encrypt(
             ciphertext_blob=ciphertext_blob,
@@ -281,52 +371,52 @@ class KmsResponse(BaseResponse):
         )
 
     def disable_key(self):
+        """https://docs.aws.amazon.com/kms/latest/APIReference/API_DisableKey.html"""
         key_id = self.parameters.get('KeyId')
-        _assert_valid_key_id(self.kms_backend.get_key_id(key_id))
-        try:
-            self.kms_backend.disable_key(key_id)
-        except KeyError:
-            raise NotFoundException("Key 'arn:aws:kms:{region}:012345678912:key/"
-                                    "{key_id}' does not exist".format(region=self.region, key_id=key_id))
+
+        self._validate_cmk_id(key_id)
+
+        self.kms_backend.disable_key(key_id)
+
         return json.dumps(None)
 
     def enable_key(self):
+        """https://docs.aws.amazon.com/kms/latest/APIReference/API_EnableKey.html"""
         key_id = self.parameters.get('KeyId')
-        _assert_valid_key_id(self.kms_backend.get_key_id(key_id))
-        try:
-            self.kms_backend.enable_key(key_id)
-        except KeyError:
-            raise NotFoundException("Key 'arn:aws:kms:{region}:012345678912:key/"
-                                    "{key_id}' does not exist".format(region=self.region, key_id=key_id))
+
+        self._validate_cmk_id(key_id)
+
+        self.kms_backend.enable_key(key_id)
+
         return json.dumps(None)
 
     def cancel_key_deletion(self):
+        """https://docs.aws.amazon.com/kms/latest/APIReference/API_CancelKeyDeletion.html"""
         key_id = self.parameters.get('KeyId')
-        _assert_valid_key_id(self.kms_backend.get_key_id(key_id))
-        try:
-            self.kms_backend.cancel_key_deletion(key_id)
-        except KeyError:
-            raise NotFoundException("Key 'arn:aws:kms:{region}:012345678912:key/"
-                                    "{key_id}' does not exist".format(region=self.region, key_id=key_id))
+
+        self._validate_cmk_id(key_id)
+
+        self.kms_backend.cancel_key_deletion(key_id)
+
         return json.dumps({'KeyId': key_id})
 
     def schedule_key_deletion(self):
+        """https://docs.aws.amazon.com/kms/latest/APIReference/API_ScheduleKeyDeletion.html"""
         key_id = self.parameters.get('KeyId')
         if self.parameters.get('PendingWindowInDays') is None:
             pending_window_in_days = 30
         else:
             pending_window_in_days = self.parameters.get('PendingWindowInDays')
-        _assert_valid_key_id(self.kms_backend.get_key_id(key_id))
-        try:
-            return json.dumps({
-                'KeyId': key_id,
-                'DeletionDate': self.kms_backend.schedule_key_deletion(key_id, pending_window_in_days)
-            })
-        except KeyError:
-            raise NotFoundException("Key 'arn:aws:kms:{region}:012345678912:key/"
-                                    "{key_id}' does not exist".format(region=self.region, key_id=key_id))
+
+        self._validate_cmk_id(key_id)
+
+        return json.dumps({
+            'KeyId': key_id,
+            'DeletionDate': self.kms_backend.schedule_key_deletion(key_id, pending_window_in_days)
+        })
 
     def generate_data_key(self):
+        """https://docs.aws.amazon.com/kms/latest/APIReference/API_GenerateDataKey.html"""
         key_id = self.parameters.get('KeyId')
         encryption_context = self.parameters.get('EncryptionContext', {})
         number_of_bytes = self.parameters.get('NumberOfBytes')
@@ -334,15 +424,9 @@ class KmsResponse(BaseResponse):
         grant_tokens = self.parameters.get('GrantTokens')
 
         # Param validation
-        if key_id.startswith('alias'):
-            if self.kms_backend.get_key_id_from_alias(key_id) is None:
-                raise NotFoundException('Alias arn:aws:kms:{region}:012345678912:{alias_name} is not found.'.format(
-                                        region=self.region, alias_name=key_id))
-        else:
-            if self.kms_backend.get_key_id(key_id) not in self.kms_backend.keys:
-                raise NotFoundException('Invalid keyId')
+        self._validate_key_id(key_id)
 
-        if number_of_bytes and (number_of_bytes > 1024 or number_of_bytes < 0):
+        if number_of_bytes and (number_of_bytes > 1024 or number_of_bytes < 1):
             raise ValidationException((
                 "1 validation error detected: Value '{number_of_bytes:d}' at 'numberOfBytes' failed "
                 "to satisfy constraint: Member must have value less than or "
@@ -357,6 +441,7 @@ class KmsResponse(BaseResponse):
             ).format(key_spec=key_spec))
         if not key_spec and not number_of_bytes:
             raise ValidationException("Please specify either number of bytes or key spec.")
+
         if key_spec and number_of_bytes:
             raise ValidationException("Please specify either number of bytes or key spec.")
 
@@ -378,24 +463,29 @@ class KmsResponse(BaseResponse):
         })
 
     def generate_data_key_without_plaintext(self):
+        """https://docs.aws.amazon.com/kms/latest/APIReference/API_GenerateDataKeyWithoutPlaintext.html"""
         result = json.loads(self.generate_data_key())
         del result['Plaintext']
 
         return json.dumps(result)
 
     def generate_random(self):
+        """https://docs.aws.amazon.com/kms/latest/APIReference/API_GenerateRandom.html"""
         number_of_bytes = self.parameters.get("NumberOfBytes")
+
+        if number_of_bytes and (number_of_bytes > 1024 or number_of_bytes < 1):
+            raise ValidationException((
+                    "1 validation error detected: Value '{number_of_bytes:d}' at 'numberOfBytes' failed "
+                    "to satisfy constraint: Member must have value less than or "
+                    "equal to 1024"
+                ).format(number_of_bytes=number_of_bytes)
+            )
 
         entropy = os.urandom(number_of_bytes)
 
         response_entropy = base64.b64encode(entropy).decode("utf-8")
 
         return json.dumps({"Plaintext": response_entropy})
-
-
-def _assert_valid_key_id(key_id):
-    if not re.match(r'^[A-F0-9]{8}-[A-F0-9]{4}-[A-F0-9]{4}-[A-F0-9]{4}-[A-F0-9]{12}$', key_id, re.IGNORECASE):
-        raise NotFoundException('Invalid keyId')
 
 
 def _assert_default_policy(policy_name):

--- a/tests/test_kms/test_kms.py
+++ b/tests/test_kms/test_kms.py
@@ -971,6 +971,21 @@ def test_generate_random(number_of_bytes):
     len(response["Plaintext"]).should.equal(number_of_bytes)
 
 
+@parameterized((
+        (2048, botocore.exceptions.ClientError),
+        (1025, botocore.exceptions.ClientError),
+        (0, botocore.exceptions.ParamValidationError),
+        (-1, botocore.exceptions.ParamValidationError),
+        (-1024, botocore.exceptions.ParamValidationError)
+))
+@mock_kms
+def test_generate_random_invalid_number_of_bytes(number_of_bytes, error_type):
+    client = boto3.client("kms", region_name="us-west-2")
+
+    with assert_raises(error_type):
+        client.generate_random(NumberOfBytes=number_of_bytes)
+
+
 @mock_kms
 def test_enable_key_rotation_key_not_found():
     client = boto3.client("kms", region_name="us-east-1")

--- a/tests/test_kms/test_kms.py
+++ b/tests/test_kms/test_kms.py
@@ -68,12 +68,11 @@ def test_describe_key_via_alias():
 
 @mock_kms_deprecated
 def test_describe_key_via_alias_not_found():
-    # TODO: Fix in next commit: bug. Should (and now does) throw NotFoundError
     conn = boto.kms.connect_to_region("us-west-2")
     key = conn.create_key(policy="my policy", description="my key", key_usage="ENCRYPT_DECRYPT")
     conn.create_alias(alias_name="alias/my-key-alias", target_key_id=key["KeyMetadata"]["KeyId"])
 
-    conn.describe_key.when.called_with("alias/not-found-alias").should.throw(JSONResponseError)
+    conn.describe_key.when.called_with("alias/not-found-alias").should.throw(NotFoundException)
 
 
 @mock_kms_deprecated
@@ -90,9 +89,8 @@ def test_describe_key_via_arn():
 
 @mock_kms_deprecated
 def test_describe_missing_key():
-    # TODO: Fix in next commit: bug. Should (and now does) throw NotFoundError
     conn = boto.kms.connect_to_region("us-west-2")
-    conn.describe_key.when.called_with("not-a-key").should.throw(JSONResponseError)
+    conn.describe_key.when.called_with("not-a-key").should.throw(NotFoundException)
 
 
 @mock_kms_deprecated

--- a/tests/test_kms/test_kms.py
+++ b/tests/test_kms/test_kms.py
@@ -75,6 +75,20 @@ def test_describe_key_via_alias_not_found():
     conn.describe_key.when.called_with("alias/not-found-alias").should.throw(NotFoundException)
 
 
+@parameterized((
+        ("alias/does-not-exist",),
+        ("arn:aws:kms:us-east-1:012345678912:alias/does-not-exist",),
+        ("invalid",),
+))
+@mock_kms
+def test_describe_key_via_alias_invalid_alias(key_id):
+    client = boto3.client("kms", region_name="us-east-1")
+    client.create_key(Description="key")
+
+    with assert_raises(client.exceptions.NotFoundException):
+        client.describe_key(KeyId=key_id)
+
+
 @mock_kms_deprecated
 def test_describe_key_via_arn():
     conn = boto.kms.connect_to_region("us-west-2")


### PR DESCRIPTION
Following up from #2397, this:
1. Normalizes how key IDs are validated for KMS calls.
2. Adds key ID validation to all KMS calls that were missing key ID validation.

I also made sure that each method accepts the same types of key IDs (ex: aliases or no aliases) as the actual KMS APIs.