### PR TITLE
Issue #2441 Add informations in SNS subscriptions `attributes`

### DIFF
--- a/moto/sns/models.py
+++ b/moto/sns/models.py
@@ -340,9 +340,9 @@ class SNSBackend(BaseBackend):
         topic = self.get_topic(topic_arn)
         subscription = Subscription(topic, endpoint, protocol)
         attributes = {
-            'PendingConfirmation' : 'false',
-            'Endpoint' : endpoint,
-            'TopicArn' : topic_arn,
+            'PendingConfirmation': 'false',
+            'Endpoint': endpoint,
+            'TopicArn': topic_arn,
             'Protocol': protocol,
             'SubscriptionArn': subscription.arn
         }

--- a/moto/sns/models.py
+++ b/moto/sns/models.py
@@ -339,6 +339,14 @@ class SNSBackend(BaseBackend):
             return old_subscription
         topic = self.get_topic(topic_arn)
         subscription = Subscription(topic, endpoint, protocol)
+        attributes = {
+            'PendingConfirmation' : 'false',
+            'Endpoint' : endpoint,
+            'TopicArn' : topic_arn,
+            'Protocol': protocol,
+            'SubscriptionArn': subscription.arn
+        }
+        subscription.attributes = attributes
         self.subscriptions[subscription.arn] = subscription
         return subscription
 

--- a/tests/test_sns/test_subscriptions_boto3.py
+++ b/tests/test_sns/test_subscriptions_boto3.py
@@ -181,6 +181,30 @@ def test_subscription_paging():
         int(DEFAULT_PAGE_SIZE / 3))
     topic1_subscriptions.shouldnt.have("NextToken")
 
+@mock_sns
+def test_subscribe_attributes():
+    client = boto3.client('sns', region_name='us-east-1')
+    client.create_topic(Name="some-topic")
+    resp = client.create_topic(Name="some-topic")
+    arn = resp['TopicArn']
+
+    resp = client.subscribe(
+        TopicArn=arn,
+        Protocol='http',
+        Endpoint='http://test.com'
+    )
+
+    attributes = client.get_subscription_attributes(
+        SubscriptionArn=resp['SubscriptionArn']
+    )
+
+    attributes.should.contain('Attributes')
+    attributes['Attributes'].should.contain('PendingConfirmation')
+    attributes['Attributes'].should.contain('Endpoint')
+    attributes['Attributes'].should.contain('TopicArn')
+    attributes['Attributes'].should.contain('Protocol')
+    attributes['Attributes'].should.contain('SubscriptionArn')
+
 
 @mock_sns
 def test_creating_subscription_with_attributes():

--- a/tests/test_sns/test_subscriptions_boto3.py
+++ b/tests/test_sns/test_subscriptions_boto3.py
@@ -200,10 +200,15 @@ def test_subscribe_attributes():
 
     attributes.should.contain('Attributes')
     attributes['Attributes'].should.contain('PendingConfirmation')
+    attributes['Attributes']['PendingConfirmation'].should.equal('false')
     attributes['Attributes'].should.contain('Endpoint')
+    attributes['Attributes']['Endpoint'].should.equal('http://test.com')
     attributes['Attributes'].should.contain('TopicArn')
+    attributes['Attributes']['TopicArn'].should.equal(arn)
     attributes['Attributes'].should.contain('Protocol')
+    attributes['Attributes']['Protocol'].should.equal('http')
     attributes['Attributes'].should.contain('SubscriptionArn')
+    attributes['Attributes']['SubscriptionArn'].should.equal(resp['SubscriptionArn'])
 
 
 @mock_sns


### PR DESCRIPTION
As I explained in the issue #2441 the field `attributes` of SNS subscription is empty when they are created with moto. 
This PR is only here to have mocked subscriptions that look a bit more like real subscriptions.