### PR TITLE
Adding support for querying AWS Config

### DIFF
--- a/CONFIG_README.md
+++ b/CONFIG_README.md
@@ -1,0 +1,107 @@
+# AWS Config Querying Support in Moto
+
+An experimental feature for AWS Config has been developed to provide AWS Config capabilities in your unit tests. 
+This feature is experimental as there are many services that are not yet supported and will require the community to add them in
+over time. This page details how the feature works and how you can use it.
+
+## What is this and why would I use this?
+
+AWS Config is an AWS service that describes your AWS resource types and can track their changes over time. At this time, moto does not
+have support for handling the configuration history changes, but it does have a few methods mocked out that can be immensely useful 
+for unit testing.
+
+If you are developing automation that needs to pull against AWS Config, then this will help you write tests that can simulate your
+code in production.
+
+## How does this work?
+
+The AWS Config capabilities in moto work by examining the state of resources that are created within moto, and then returning that data
+in the way that AWS Config would return it (sans history). This will work by querying all of the moto backends (regions) for a given
+resource type.
+
+However, this will only work on resource types that have this enabled.
+
+### Current enabled resource types:
+
+1. S3
+
+
+## Developer Guide
+
+There are several pieces to this for adding new capabilities to moto:
+
+1. Listing resources
+1. Describing resources
+
+For both, there are a number of pre-requisites:
+
+### Base Components
+
+In the `moto/core/models.py` file is a class named `ConfigQueryModel`. This is a base class that keeps track of all the 
+resource type backends.
+
+At a minimum, resource types that have this enabled will have:
+
+1. A `config.py` file that will import the resource type backends (from the `__init__.py`)
+1. In the resource's `config.py`, an implementation of the `ConfigQueryModel` class with logic unique to the resource type
+1. An instantiation of the `ConfigQueryModel`
+1. In the `moto/config/models.py` file, import the `ConfigQueryModel` instantiation, and update `RESOURCE_MAP` to have a mapping of the AWS Config resource type
+ to the instantiation on the previous step (just imported).
+   
+An example of the above is implemented for S3. You can see that by looking at:
+
+1. `moto/s3/config.py`
+1. `moto/config/models.py`
+
+As well as the corresponding unit tests in:
+
+1. `tests/s3/test_s3.py`
+1. `tests/config/test_config.py`
+
+Note for unit testing, you will want to add a test to ensure that you can query all the resources effectively. For testing this feature,
+the unit tests for the `ConfigQueryModel` will not make use of `boto` to create resources, such as S3 buckets. You will need to use the 
+backend model methods to provision the resources. This is to make tests compatible with the moto server. You should absolutely make tests
+in the resource type to test listing and object fetching.
+
+### Listing
+S3 is currently the model implementation, but it also odd in that S3 is a global resource type with regional resource residency.
+
+But for most resource types the following is true:
+
+1. There are regional backends with their own sets of data
+1. Config aggregation can pull data from any backend region -- we assume that everything lives in the same account
+
+Implementing the listing capability will be different for each resource type. At a minimum, you will need to return a `List` of `Dict`s
+that look like this:
+
+```python
+ [
+    {
+        'type': 'AWS::The AWS Config data type',
+        'name': 'The name of the resource',
+        'id': 'The ID of the resource',
+        'region': 'The region of the resource -- if global, then you may want to have the calling logic pass in the
+                   aggregator region in for the resource region -- or just us-east-1 :P'
+    }
+    , ...
+]
+```
+
+It's recommended to read the comment for the `ConfigQueryModel` [base class here](moto/core/models.py).
+
+^^ The AWS Config code will see this and format it correct for both aggregated and non-aggregated calls.
+
+#### General implementation tips
+The aggregation and non-aggregation querying can and should just use the same overall logic. The differences are:
+
+1. Non-aggregated listing will specify the region-name of the resource backend `backend_region`
+1. Aggregated listing will need to be able to list resource types across ALL backends and filter optionally by passing in `resource_region`.
+
+An example of a working implementation of this is [S3](moto/s3/config.py).
+
+Pagination should generally be able to pull out the resource across any region so should be sharded by `region-item-name` -- not done for S3
+because S3 has a globally unique name space.
+
+
+### Describing Resources
+TODO: Need to fill this in when it's implemented

--- a/README.md
+++ b/README.md
@@ -297,6 +297,9 @@ def test_describe_instances_allowed():
 
 See [the related test suite](https://github.com/spulec/moto/blob/master/tests/test_core/test_auth.py) for more examples.
 
+## Experimental: AWS Config Querying
+For details about the experimental AWS Config support please see the [AWS Config readme here](CONFIG_README.md).
+
 ## Very Important -- Recommended Usage
 There are some important caveats to be aware of when using moto:
 

--- a/moto/config/exceptions.py
+++ b/moto/config/exceptions.py
@@ -230,3 +230,27 @@ class TooManyTags(JsonRESTError):
         super(TooManyTags, self).__init__(
             'ValidationException', "1 validation error detected: Value '{}' at '{}' failed to satisfy "
                                    "constraint: Member must have length less than or equal to 50.".format(tags, param))
+
+
+class InvalidResourceParameters(JsonRESTError):
+    code = 400
+
+    def __init__(self):
+        super(InvalidResourceParameters, self).__init__('ValidationException', 'Both Resource ID and Resource Name '
+                                                                               'cannot be specified in the request')
+
+
+class InvalidLimit(JsonRESTError):
+    code = 400
+
+    def __init__(self, value):
+        super(InvalidLimit, self).__init__('ValidationException', 'Value \'{value}\' at \'limit\' failed to satisify constraint: Member'
+                                                                  ' must have value less than or equal to 100'.format(value=value))
+
+
+class TooManyResourceIds(JsonRESTError):
+    code = 400
+
+    def __init__(self):
+        super(TooManyResourceIds, self).__init__('ValidationException', "The specified list had more than 20 resource ID's. "
+                                                                        "It must have '20' or less items")

--- a/moto/config/responses.py
+++ b/moto/config/responses.py
@@ -84,3 +84,34 @@ class ConfigResponse(BaseResponse):
     def stop_configuration_recorder(self):
         self.config_backend.stop_configuration_recorder(self._get_param('ConfigurationRecorderName'))
         return ""
+
+    def list_discovered_resources(self):
+        schema = self.config_backend.list_discovered_resources(self._get_param('resourceType'),
+                                                               self.region,
+                                                               self._get_param('resourceIds'),
+                                                               self._get_param('resourceName'),
+                                                               self._get_param('limit'),
+                                                               self._get_param('nextToken'))
+        return json.dumps(schema)
+
+    def list_aggregate_discovered_resources(self):
+        schema = self.config_backend.list_aggregate_discovered_resources(self._get_param('ConfigurationAggregatorName'),
+                                                                         self._get_param('ResourceType'),
+                                                                         self._get_param('Filters'),
+                                                                         self._get_param('Limit'),
+                                                                         self._get_param('NextToken'))
+        return json.dumps(schema)
+
+    """
+    def batch_get_resource_config(self):
+        # TODO implement me!
+        return ""
+
+    def batch_get_aggregate_resource_config(self):
+        # TODO implement me!
+        return ""
+
+    def get_resource_config_history(self):
+        # TODO implement me!
+        return ""
+    """

--- a/moto/core/exceptions.py
+++ b/moto/core/exceptions.py
@@ -104,3 +104,11 @@ class AuthFailureError(RESTError):
         super(AuthFailureError, self).__init__(
             'AuthFailure',
             "AWS was not able to validate the provided access credentials")
+
+
+class InvalidNextTokenException(JsonRESTError):
+    """For AWS Config resource listing. This will be used by many different resource types, and so it is in moto.core."""
+    code = 400
+
+    def __init__(self):
+        super(InvalidNextTokenException, self).__init__('InvalidNextTokenException', 'The nextToken provided is invalid')

--- a/moto/core/models.py
+++ b/moto/core/models.py
@@ -538,6 +538,65 @@ class BaseBackend(object):
         else:
             return HttprettyMockAWS({'global': self})
 
+    # def list_config_service_resources(self, resource_ids, resource_name, limit, next_token):
+    #     """For AWS Config. This will list all of the resources of the given type and optional resource name and region"""
+    #     raise NotImplementedError()
+
+
+class ConfigQueryModel(object):
+
+    def __init__(self, backends):
+        """Inits based on the resource type's backends (1 for each region if applicable)"""
+        self.backends = backends
+
+    def list_config_service_resources(self, resource_ids, resource_name, limit, next_token, backend_region=None, resource_region=None):
+        """For AWS Config. This will list all of the resources of the given type and optional resource name and region.
+
+        This supports both aggregated and non-aggregated listing. The following notes the difference:
+
+        - Non Aggregated Listing -
+        This only lists resources within a region. The way that this is implemented in moto is based on the region
+        for the resource backend.
+
+        You must set the `backend_region` to the region that the API request arrived from. resource_region can be set to `None`.
+
+        - Aggregated Listing -
+        This lists resources from all potential regional backends. For non-global resource types, this should collect a full
+        list of resources from all the backends, and then be able to filter from the resource region. This is because an
+        aggregator can aggregate resources from multiple regions. In moto, aggregated regions will *assume full aggregation
+        from all resources in all regions for a given resource type*.
+
+        The `backend_region` should be set to `None` for these queries, and the `resource_region` should optionally be set to
+        the `Filters` region parameter to filter out resources that reside in a specific region.
+
+        For aggregated listings, pagination logic should be set such that the next page can properly span all the region backends.
+        As such, the proper way to implement is to first obtain a full list of results from all the region backends, and then filter
+        from there. It may be valuable to make this a concatenation of the region and resource name.
+
+        :param resource_region:
+        :param resource_ids:
+        :param resource_name:
+        :param limit:
+        :param next_token:
+        :param backend_region: The region for the backend to pull results from. Set to `None` if this is an aggregated query.
+        :return: This should return a list of Dicts that have the following fields:
+            [
+                {
+                    'type': 'AWS::The AWS Config data type',
+                    'name': 'The name of the resource',
+                    'id': 'The ID of the resource',
+                    'region': 'The region of the resource -- if global, then you may want to have the calling logic pass in the
+                               aggregator region in for the resource region -- or just us-east-1 :P'
+                }
+                , ...
+            ]
+        """
+        raise NotImplementedError()
+
+    def get_config_resource(self):
+        """TODO implement me."""
+        raise NotImplementedError()
+
 
 class base_decorator(object):
     mock_backend = MockAWS

--- a/moto/s3/config.py
+++ b/moto/s3/config.py
@@ -1,0 +1,70 @@
+from moto.core.exceptions import InvalidNextTokenException
+from moto.core.models import ConfigQueryModel
+from moto.s3 import s3_backends
+
+
+class S3ConfigQuery(ConfigQueryModel):
+
+    def list_config_service_resources(self, resource_ids, resource_name, limit, next_token, backend_region=None, resource_region=None):
+        # S3 need not care about "backend_region" as S3 is global. The resource_region only matters for aggregated queries as you can
+        # filter on bucket regions for them. For other resource types, you would need to iterate appropriately for the backend_region.
+
+        # Resource IDs are the same as S3 bucket names
+        # For aggregation -- did we get both a resource ID and a resource name?
+        if resource_ids and resource_name:
+            # If the values are different, then return an empty list:
+            if resource_name not in resource_ids:
+                return [], None
+
+        # If no filter was passed in for resource names/ids then return them all:
+        if not resource_ids and not resource_name:
+            bucket_list = list(self.backends['global'].buckets.keys())
+
+        else:
+            # Match the resource name / ID:
+            bucket_list = []
+            filter_buckets = [resource_name] if resource_name else resource_ids
+
+            for bucket in self.backends['global'].buckets.keys():
+                if bucket in filter_buckets:
+                    bucket_list.append(bucket)
+
+        # If a resource_region was supplied (aggregated only), then filter on bucket region too:
+        if resource_region:
+            region_buckets = []
+
+            for bucket in bucket_list:
+                if self.backends['global'].buckets[bucket].region_name == resource_region:
+                    region_buckets.append(bucket)
+
+            bucket_list = region_buckets
+
+        if not bucket_list:
+            return [], None
+
+        # Pagination logic:
+        sorted_buckets = sorted(bucket_list)
+        new_token = None
+
+        # Get the start:
+        if not next_token:
+            start = 0
+        else:
+            # Tokens for this moto feature is just the bucket name:
+            # For OTHER non-global resource types, it's the region concatenated with the resource ID.
+            if next_token not in sorted_buckets:
+                raise InvalidNextTokenException()
+
+            start = sorted_buckets.index(next_token)
+
+        # Get the list of items to collect:
+        bucket_list = sorted_buckets[start:(start + limit)]
+
+        if len(sorted_buckets) > (start + limit):
+            new_token = sorted_buckets[start + limit]
+
+        return [{'type': 'AWS::S3::Bucket', 'id': bucket, 'name': bucket, 'region': self.backends['global'].buckets[bucket].region_name}
+                for bucket in bucket_list], new_token
+
+
+s3_config_query = S3ConfigQuery(s3_backends)


### PR DESCRIPTION
PR to add experimental support for listing and querying AWS Config for resource types that have the feature implemented.

The benefit of this PR is to develop unit tests against a data set that AWS Config would likely return based on the existing state in Moto.

At this time, I am developing the feature for S3 as I have an immediate need for it. This PR only contains the ability to list S3 buckets in AWS Config (both aggregated and non-aggregated). A follow-up PR will contain a feature to return the object from the Config API.
