### PR TITLE
Stepfunctions minor improvements

### DIFF
--- a/moto/stepfunctions/models.py
+++ b/moto/stepfunctions/models.py
@@ -143,7 +143,7 @@ class StepFunctionBackend(BaseBackend):
     def _validate_machine_arn(self, machine_arn):
         self._validate_arn(arn=machine_arn,
                            regex=self.accepted_mchn_arn_format,
-                           invalid_msg="Invalid Role Arn: '" + machine_arn + "'")
+                           invalid_msg="Invalid State Machine Arn: '" + machine_arn + "'")
 
     def _validate_execution_arn(self, execution_arn):
         self._validate_arn(arn=execution_arn,

--- a/moto/stepfunctions/models.py
+++ b/moto/stepfunctions/models.py
@@ -59,7 +59,7 @@ class StepFunctionBackend(BaseBackend):
                                  u'\u0090', u'\u0091', u'\u0092', u'\u0093', u'\u0094', u'\u0095',
                                  u'\u0096', u'\u0097', u'\u0098', u'\u0099',
                                  u'\u009A', u'\u009B', u'\u009C', u'\u009D', u'\u009E', u'\u009F']
-    accepted_role_arn_format = re.compile('arn:aws:iam:(?P<account_id>[0-9]{12}):role/.+')
+    accepted_role_arn_format = re.compile('arn:aws:iam::(?P<account_id>[0-9]{12}):role/.+')
     accepted_mchn_arn_format = re.compile('arn:aws:states:[-0-9a-zA-Z]+:(?P<account_id>[0-9]{12}):stateMachine:.+')
     accepted_exec_arn_format = re.compile('arn:aws:states:[-0-9a-zA-Z]+:(?P<account_id>[0-9]{12}):execution:.+')
 

--- a/moto/stepfunctions/models.py
+++ b/moto/stepfunctions/models.py
@@ -96,12 +96,12 @@ class StepFunctionBackend(BaseBackend):
         if sm:
             self.state_machines.remove(sm)
 
-    def start_execution(self, state_machine_arn):
+    def start_execution(self, state_machine_arn, name=None):
         state_machine_name = self.describe_state_machine(state_machine_arn).name
         execution = Execution(region_name=self.region_name,
                               account_id=self._get_account_id(),
                               state_machine_name=state_machine_name,
-                              execution_name=str(uuid4()),
+                              execution_name=name or str(uuid4()),
                               state_machine_arn=state_machine_arn)
         self.executions.append(execution)
         return execution

--- a/moto/stepfunctions/responses.py
+++ b/moto/stepfunctions/responses.py
@@ -86,7 +86,8 @@ class StepFunctionResponse(BaseResponse):
     @amzn_request_id
     def start_execution(self):
         arn = self._get_param('stateMachineArn')
-        execution = self.stepfunction_backend.start_execution(arn)
+        name = self._get_param('name')
+        execution = self.stepfunction_backend.start_execution(arn, name)
         response = {'executionArn': execution.execution_arn,
                     'startDate': execution.start_date}
         return 200, {}, json.dumps(response)

--- a/tests/test_stepfunctions/test_stepfunctions.py
+++ b/tests/test_stepfunctions/test_stepfunctions.py
@@ -243,8 +243,23 @@ def test_state_machine_start_execution():
     execution = client.start_execution(stateMachineArn=sm['stateMachineArn'])
     #
     execution['ResponseMetadata']['HTTPStatusCode'].should.equal(200)
-    expected_exec_name = 'arn:aws:states:' + region + ':' + _get_account_id() + ':execution:name:[a-zA-Z0-9-]+'
+    uuid_regex = '[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}'
+    expected_exec_name = 'arn:aws:states:' + region + ':' + _get_account_id() + ':execution:name:' + uuid_regex
     execution['executionArn'].should.match(expected_exec_name)
+    execution['startDate'].should.be.a(datetime)
+
+
+@mock_stepfunctions
+@mock_sts
+def test_state_machine_start_execution_with_custom_name():
+    client = boto3.client('stepfunctions', region_name=region)
+    #
+    sm = client.create_state_machine(name='name', definition=str(simple_definition), roleArn=_get_default_role())
+    execution = client.start_execution(stateMachineArn=sm['stateMachineArn'], name='execution_name')
+    #
+    execution['ResponseMetadata']['HTTPStatusCode'].should.equal(200)
+    expected_exec_name = 'arn:aws:states:' + region + ':' + _get_account_id() + ':execution:name:execution_name'
+    execution['executionArn'].should.equal(expected_exec_name)
     execution['startDate'].should.be.a(datetime)
 
 

--- a/tests/test_stepfunctions/test_stepfunctions.py
+++ b/tests/test_stepfunctions/test_stepfunctions.py
@@ -78,7 +78,7 @@ def test_state_machine_creation_requires_valid_role_arn():
     with assert_raises(ClientError) as exc:
         client.create_state_machine(name=name,
                                     definition=str(simple_definition),
-                                    roleArn='arn:aws:iam:1234:role/unknown_role')
+                                    roleArn='arn:aws:iam::1234:role/unknown_role')
 
 
 @mock_stepfunctions
@@ -375,4 +375,4 @@ def _get_account_id():
 
 
 def _get_default_role():
-    return 'arn:aws:iam:' + _get_account_id() + ':role/unknown_sf_role'
+    return 'arn:aws:iam::' + _get_account_id() + ':role/unknown_sf_role'


### PR DESCRIPTION
Some updates for the recently added stepfunctions utility.

* The ARN format for IAM seems to be wrong, there should be a double colon after ``iam``: ``arn:aws:iam::<account>...``
* I spotted a probable copy-paste mistake in an exception message, where it reported "Invalid Role ARN" where it meant "Invalid State Machine ARN"
* ``start_execution()`` can accept a ``name`` argument in which case stepfunctions will use that instead of a random UUID as the execution ID