### PR TITLE
Events and ecs multi region

### DIFF
--- a/moto/ecs/models.py
+++ b/moto/ecs/models.py
@@ -44,15 +44,17 @@ class BaseObject(BaseModel):
 
 class Cluster(BaseObject):
 
-    def __init__(self, cluster_name):
+    def __init__(self, cluster_name, region_name):
         self.active_services_count = 0
-        self.arn = 'arn:aws:ecs:us-east-1:012345678910:cluster/{0}'.format(
+        self.arn = 'arn:aws:ecs:{0}:012345678910:cluster/{1}'.format(
+            region_name,
             cluster_name)
         self.name = cluster_name
         self.pending_tasks_count = 0
         self.registered_container_instances_count = 0
         self.running_tasks_count = 0
         self.status = 'ACTIVE'
+        self.region_name = region_name
 
     @property
     def physical_resource_id(self):
@@ -108,11 +110,11 @@ class Cluster(BaseObject):
 
 class TaskDefinition(BaseObject):
 
-    def __init__(self, family, revision, container_definitions, volumes=None, tags=None):
+    def __init__(self, family, revision, container_definitions, region_name, volumes=None, tags=None):
         self.family = family
         self.revision = revision
-        self.arn = 'arn:aws:ecs:us-east-1:012345678910:task-definition/{0}:{1}'.format(
-            family, revision)
+        self.arn = 'arn:aws:ecs:{0}:012345678910:task-definition/{1}:{2}'.format(
+            region_name, family, revision)
         self.container_definitions = container_definitions
         self.tags = tags if tags is not None else []
         if volumes is None:
@@ -172,7 +174,8 @@ class Task(BaseObject):
     def __init__(self, cluster, task_definition, container_instance_arn,
                  resource_requirements, overrides={}, started_by=''):
         self.cluster_arn = cluster.arn
-        self.task_arn = 'arn:aws:ecs:us-east-1:012345678910:task/{0}'.format(
+        self.task_arn = 'arn:aws:ecs:{0}:012345678910:task/{1}'.format(
+            cluster.region_name,
             str(uuid.uuid4()))
         self.container_instance_arn = container_instance_arn
         self.last_status = 'RUNNING'
@@ -194,7 +197,8 @@ class Service(BaseObject):
 
     def __init__(self, cluster, service_name, task_definition, desired_count, load_balancers=None, scheduling_strategy=None):
         self.cluster_arn = cluster.arn
-        self.arn = 'arn:aws:ecs:us-east-1:012345678910:service/{0}'.format(
+        self.arn = 'arn:aws:ecs:{0}:012345678910:service/{1}'.format(
+            cluster.region_name,
             service_name)
         self.name = service_name
         self.status = 'ACTIVE'
@@ -273,7 +277,7 @@ class Service(BaseObject):
 
         ecs_backend = ecs_backends[region_name]
         service_name = original_resource.name
-        if original_resource.cluster_arn != Cluster(cluster_name).arn:
+        if original_resource.cluster_arn != Cluster(cluster_name, region_name).arn:
             # TODO: LoadBalancers
             # TODO: Role
             ecs_backend.delete_service(cluster_name, service_name)
@@ -320,7 +324,8 @@ class ContainerInstance(BaseObject):
              'name': 'PORTS_UDP',
              'stringSetValue': [],
              'type': 'STRINGSET'}]
-        self.container_instance_arn = "arn:aws:ecs:us-east-1:012345678910:container-instance/{0}".format(
+        self.container_instance_arn = "arn:aws:ecs:{0}:012345678910:container-instance/{1}".format(
+            region_name,
             str(uuid.uuid4()))
         self.pending_tasks_count = 0
         self.remaining_resources = [
@@ -378,9 +383,10 @@ class ContainerInstance(BaseObject):
 
 
 class ClusterFailure(BaseObject):
-    def __init__(self, reason, cluster_name):
+    def __init__(self, reason, cluster_name, region_name):
         self.reason = reason
-        self.arn = "arn:aws:ecs:us-east-1:012345678910:cluster/{0}".format(
+        self.arn = "arn:aws:ecs:{0}:012345678910:cluster/{1}".format(
+            region_name,
             cluster_name)
 
     @property
@@ -393,9 +399,10 @@ class ClusterFailure(BaseObject):
 
 class ContainerInstanceFailure(BaseObject):
 
-    def __init__(self, reason, container_instance_id):
+    def __init__(self, reason, container_instance_id, region_name):
         self.reason = reason
-        self.arn = "arn:aws:ecs:us-east-1:012345678910:container-instance/{0}".format(
+        self.arn = "arn:aws:ecs:{0}:012345678910:container-instance/{1}".format(
+            region_name,
             container_instance_id)
 
     @property
@@ -438,7 +445,7 @@ class EC2ContainerServiceBackend(BaseBackend):
                 "{0} is not a task_definition".format(task_definition_name))
 
     def create_cluster(self, cluster_name):
-        cluster = Cluster(cluster_name)
+        cluster = Cluster(cluster_name, self.region_name)
         self.clusters[cluster_name] = cluster
         return cluster
 
@@ -461,7 +468,7 @@ class EC2ContainerServiceBackend(BaseBackend):
                     list_clusters.append(
                         self.clusters[cluster_name].response_object)
                 else:
-                    failures.append(ClusterFailure('MISSING', cluster_name))
+                    failures.append(ClusterFailure('MISSING', cluster_name, self.region_name))
         return list_clusters, failures
 
     def delete_cluster(self, cluster_str):
@@ -479,7 +486,7 @@ class EC2ContainerServiceBackend(BaseBackend):
             self.task_definitions[family] = {}
             revision = 1
         task_definition = TaskDefinition(
-            family, revision, container_definitions, volumes, tags)
+            family, revision, container_definitions, self.region_name, volumes, tags)
         self.task_definitions[family][revision] = task_definition
 
         return task_definition
@@ -792,7 +799,7 @@ class EC2ContainerServiceBackend(BaseBackend):
                 container_instance_objects.append(container_instance)
             else:
                 failures.append(ContainerInstanceFailure(
-                    'MISSING', container_instance_id))
+                    'MISSING', container_instance_id, self.region_name))
 
         return container_instance_objects, failures
 
@@ -814,7 +821,7 @@ class EC2ContainerServiceBackend(BaseBackend):
                 container_instance.status = status
                 container_instance_objects.append(container_instance)
             else:
-                failures.append(ContainerInstanceFailure('MISSING', container_instance_id))
+                failures.append(ContainerInstanceFailure('MISSING', container_instance_id, self.region_name))
 
         return container_instance_objects, failures
 

--- a/moto/events/__init__.py
+++ b/moto/events/__init__.py
@@ -1,6 +1,7 @@
 from __future__ import unicode_literals
 
-from .models import events_backend
+from .models import events_backends
+from ..core.models import base_decorator
 
-events_backends = {"global": events_backend}
-mock_events = events_backend.decorator
+events_backend = events_backends['us-east-1']
+mock_events = base_decorator(events_backends)

--- a/moto/events/models.py
+++ b/moto/events/models.py
@@ -9,15 +9,16 @@ from moto.core import BaseBackend, BaseModel
 
 class Rule(BaseModel):
 
-    def _generate_arn(self, name, region_name):
+    def _generate_arn(self, name):
         return 'arn:aws:events:{region_name}:111111111111:rule/{name}'.format(
-            region_name=region_name,
+            region_name=self.region_name,
             name=name
         )
 
     def __init__(self, name, region_name, **kwargs):
         self.name = name
-        self.arn = kwargs.get('Arn') or self._generate_arn(name, region_name)
+        self.region_name = region_name
+        self.arn = kwargs.get('Arn') or self._generate_arn(name)
         self.event_pattern = kwargs.get('EventPattern')
         self.schedule_exp = kwargs.get('ScheduleExpression')
         self.state = kwargs.get('State') or 'ENABLED'

--- a/moto/events/models.py
+++ b/moto/events/models.py
@@ -1,6 +1,7 @@
 import os
 import re
 import json
+import boto3
 
 from moto.core.exceptions import JsonRESTError
 from moto.core import BaseBackend, BaseModel
@@ -8,12 +9,15 @@ from moto.core import BaseBackend, BaseModel
 
 class Rule(BaseModel):
 
-    def _generate_arn(self, name):
-        return 'arn:aws:events:us-west-2:111111111111:rule/' + name
+    def _generate_arn(self, name, region_name):
+        return 'arn:aws:events:{region_name}:111111111111:rule/{name}'.format(
+            region_name=region_name,
+            name=name
+        )
 
-    def __init__(self, name, **kwargs):
+    def __init__(self, name, region_name, **kwargs):
         self.name = name
-        self.arn = kwargs.get('Arn') or self._generate_arn(name)
+        self.arn = kwargs.get('Arn') or self._generate_arn(name, region_name)
         self.event_pattern = kwargs.get('EventPattern')
         self.schedule_exp = kwargs.get('ScheduleExpression')
         self.state = kwargs.get('State') or 'ENABLED'
@@ -55,14 +59,19 @@ class EventsBackend(BaseBackend):
     ACCOUNT_ID = re.compile(r'^(\d{1,12}|\*)$')
     STATEMENT_ID = re.compile(r'^[a-zA-Z0-9-_]{1,64}$')
 
-    def __init__(self):
+    def __init__(self, region_name):
         self.rules = {}
         # This array tracks the order in which the rules have been added, since
         # 2.6 doesn't have OrderedDicts.
         self.rules_order = []
         self.next_tokens = {}
-
+        self.region_name = region_name
         self.permissions = {}
+
+    def reset(self):
+        region_name = self.region_name
+        self.__dict__ = {}
+        self.__init__(region_name)
 
     def _get_rule_by_index(self, i):
         return self.rules.get(self.rules_order[i])
@@ -173,7 +182,7 @@ class EventsBackend(BaseBackend):
         return return_obj
 
     def put_rule(self, name, **kwargs):
-        rule = Rule(name, **kwargs)
+        rule = Rule(name, self.region_name, **kwargs)
         self.rules[rule.name] = rule
         self.rules_order.append(rule.name)
         return rule.arn
@@ -229,7 +238,7 @@ class EventsBackend(BaseBackend):
             raise JsonRESTError('ResourceNotFoundException', 'StatementId not found')
 
     def describe_event_bus(self):
-        arn = "arn:aws:events:us-east-1:000000000000:event-bus/default"
+        arn = "arn:aws:events:{0}:000000000000:event-bus/default".format(self.region_name)
         statements = []
         for statement_id, data in self.permissions.items():
             statements.append({
@@ -248,4 +257,5 @@ class EventsBackend(BaseBackend):
         }
 
 
-events_backend = EventsBackend()
+available_regions = boto3.session.Session().get_available_regions("events")
+events_backends = {region: EventsBackend(region) for region in available_regions}

--- a/tests/test_ecs/test_ecs_boto3.py
+++ b/tests/test_ecs/test_ecs_boto3.py
@@ -34,7 +34,7 @@ def test_create_cluster():
 
 @mock_ecs
 def test_list_clusters():
-    client = boto3.client('ecs', region_name='us-east-1')
+    client = boto3.client('ecs', region_name='us-east-2')
     _ = client.create_cluster(
         clusterName='test_cluster0'
     )
@@ -43,9 +43,9 @@ def test_list_clusters():
     )
     response = client.list_clusters()
     response['clusterArns'].should.contain(
-        'arn:aws:ecs:us-east-1:012345678910:cluster/test_cluster0')
+        'arn:aws:ecs:us-east-2:012345678910:cluster/test_cluster0')
     response['clusterArns'].should.contain(
-        'arn:aws:ecs:us-east-1:012345678910:cluster/test_cluster1')
+        'arn:aws:ecs:us-east-2:012345678910:cluster/test_cluster1')
 
 
 @mock_ecs

--- a/tests/test_events/test_events.py
+++ b/tests/test_events/test_events.py
@@ -87,7 +87,7 @@ def test_describe_rule():
 
     assert(response is not None)
     assert(response.get('Name') == rule_name)
-    assert(response.get('Arn') is not None)
+    assert(response.get('Arn') == 'arn:aws:events:us-west-2:111111111111:rule/{0}'.format(rule_name))
 
 
 @mock_events


### PR DESCRIPTION
This PR does two things:
1) Pass the `region_name` to ECS models to use when creating and describing resources. Previously `us-east-1` was hard coded in the ARNs
2) Add multi region support for Cloudwatch Events

Please let me know if there are any questions, thanks!