### PR TITLE
Add support for tagging and untagging ECS services

### DIFF
--- a/IMPLEMENTATION_COVERAGE.md
+++ b/IMPLEMENTATION_COVERAGE.md
@@ -2343,7 +2343,7 @@
 - [ ] upload_layer_part
 
 ## ecs
-63% implemented
+49% implemented
 - [X] create_cluster
 - [X] create_service
 - [ ] create_task_set
@@ -2381,8 +2381,8 @@
 - [ ] submit_attachment_state_changes
 - [ ] submit_container_state_change
 - [ ] submit_task_state_change
-- [ ] tag_resource
-- [ ] untag_resource
+- [x] tag_resource
+- [x] untag_resource
 - [ ] update_container_agent
 - [X] update_container_instances_state
 - [X] update_service

--- a/moto/ecs/responses.py
+++ b/moto/ecs/responses.py
@@ -320,3 +320,15 @@ class EC2ContainerServiceResponse(BaseResponse):
         resource_arn = self._get_param('resourceArn')
         tags = self.ecs_backend.list_tags_for_resource(resource_arn)
         return json.dumps({'tags': tags})
+
+    def tag_resource(self):
+        resource_arn = self._get_param('resourceArn')
+        tags = self._get_param('tags')
+        results = self.ecs_backend.tag_resource(resource_arn, tags)
+        return json.dumps(results)
+
+    def untag_resource(self):
+        resource_arn = self._get_param('resourceArn')
+        tag_keys = self._get_param('tagKeys')
+        results = self.ecs_backend.untag_resource(resource_arn, tag_keys)
+        return json.dumps(results)

--- a/moto/ecs/responses.py
+++ b/moto/ecs/responses.py
@@ -156,8 +156,9 @@ class EC2ContainerServiceResponse(BaseResponse):
         desired_count = self._get_int_param('desiredCount')
         load_balancers = self._get_param('loadBalancers')
         scheduling_strategy = self._get_param('schedulingStrategy')
+        tags = self._get_param('tags')
         service = self.ecs_backend.create_service(
-            cluster_str, service_name, task_definition_str, desired_count, load_balancers, scheduling_strategy)
+            cluster_str, service_name, task_definition_str, desired_count, load_balancers, scheduling_strategy, tags)
         return json.dumps({
             'service': service.response_object
         })

--- a/tests/test_ecs/test_ecs_boto3.py
+++ b/tests/test_ecs/test_ecs_boto3.py
@@ -2360,3 +2360,54 @@ def test_list_tags_for_resource_unknown():
         client.list_tags_for_resource(resourceArn=task_definition_arn)
     except ClientError as err:
         err.response['Error']['Code'].should.equal('ClientException')
+
+
+@mock_ecs
+def test_list_tags_for_resource_ecs_service():
+    client = boto3.client('ecs', region_name='us-east-1')
+    _ = client.create_cluster(
+        clusterName='test_ecs_cluster'
+    )
+    _ = client.register_task_definition(
+        family='test_ecs_task',
+        containerDefinitions=[
+            {
+                'name': 'hello_world',
+                'image': 'docker/hello-world:latest',
+                'cpu': 1024,
+                'memory': 400,
+                'essential': True,
+                'environment': [{
+                    'name': 'AWS_ACCESS_KEY_ID',
+                    'value': 'SOME_ACCESS_KEY'
+                }],
+                'logConfiguration': {'logDriver': 'json-file'}
+            }
+        ]
+    )
+    response = client.create_service(
+        cluster='test_ecs_cluster',
+        serviceName='test_ecs_service',
+        taskDefinition='test_ecs_task',
+        desiredCount=2,
+        tags=[
+            {'key': 'createdBy', 'value': 'moto-unittest'},
+            {'key': 'foo', 'value': 'bar'},
+        ]
+    )
+    response = client.list_tags_for_resource(resourceArn=response['service']['serviceArn'])
+    type(response['tags']).should.be(list)
+    response['tags'].should.equal([
+        {'key': 'createdBy', 'value': 'moto-unittest'},
+        {'key': 'foo', 'value': 'bar'},
+    ])
+
+
+@mock_ecs
+def test_list_tags_for_resource_unknown_service():
+    client = boto3.client('ecs', region_name='us-east-1')
+    service_arn = 'arn:aws:ecs:us-east-1:012345678910:service/unknown:1'
+    try:
+        client.list_tags_for_resource(resourceArn=service_arn)
+    except ClientError as err:
+        err.response['Error']['Code'].should.equal('ServiceNotFoundException')

--- a/tests/test_ecs/test_ecs_boto3.py
+++ b/tests/test_ecs/test_ecs_boto3.py
@@ -2411,3 +2411,178 @@ def test_list_tags_for_resource_unknown_service():
         client.list_tags_for_resource(resourceArn=service_arn)
     except ClientError as err:
         err.response['Error']['Code'].should.equal('ServiceNotFoundException')
+
+
+@mock_ecs
+def test_ecs_service_tag_resource():
+    client = boto3.client('ecs', region_name='us-east-1')
+    _ = client.create_cluster(
+        clusterName='test_ecs_cluster'
+    )
+    _ = client.register_task_definition(
+        family='test_ecs_task',
+        containerDefinitions=[
+            {
+                'name': 'hello_world',
+                'image': 'docker/hello-world:latest',
+                'cpu': 1024,
+                'memory': 400,
+                'essential': True,
+                'environment': [{
+                    'name': 'AWS_ACCESS_KEY_ID',
+                    'value': 'SOME_ACCESS_KEY'
+                }],
+                'logConfiguration': {'logDriver': 'json-file'}
+            }
+        ]
+    )
+    response = client.create_service(
+        cluster='test_ecs_cluster',
+        serviceName='test_ecs_service',
+        taskDefinition='test_ecs_task',
+        desiredCount=2
+    )
+    client.tag_resource(
+        resourceArn=response['service']['serviceArn'],
+        tags=[
+            {'key': 'createdBy', 'value': 'moto-unittest'},
+            {'key': 'foo', 'value': 'bar'},
+        ]
+    )
+    response = client.list_tags_for_resource(resourceArn=response['service']['serviceArn'])
+    type(response['tags']).should.be(list)
+    response['tags'].should.equal([
+        {'key': 'createdBy', 'value': 'moto-unittest'},
+        {'key': 'foo', 'value': 'bar'},
+    ])
+
+
+@mock_ecs
+def test_ecs_service_tag_resource_overwrites_tag():
+    client = boto3.client('ecs', region_name='us-east-1')
+    _ = client.create_cluster(
+        clusterName='test_ecs_cluster'
+    )
+    _ = client.register_task_definition(
+        family='test_ecs_task',
+        containerDefinitions=[
+            {
+                'name': 'hello_world',
+                'image': 'docker/hello-world:latest',
+                'cpu': 1024,
+                'memory': 400,
+                'essential': True,
+                'environment': [{
+                    'name': 'AWS_ACCESS_KEY_ID',
+                    'value': 'SOME_ACCESS_KEY'
+                }],
+                'logConfiguration': {'logDriver': 'json-file'}
+            }
+        ]
+    )
+    response = client.create_service(
+        cluster='test_ecs_cluster',
+        serviceName='test_ecs_service',
+        taskDefinition='test_ecs_task',
+        desiredCount=2,
+        tags=[
+            {'key': 'foo', 'value': 'bar'},
+        ]
+    )
+    client.tag_resource(
+        resourceArn=response['service']['serviceArn'],
+        tags=[
+            {'key': 'createdBy', 'value': 'moto-unittest'},
+            {'key': 'foo', 'value': 'hello world'},
+        ]
+    )
+    response = client.list_tags_for_resource(resourceArn=response['service']['serviceArn'])
+    type(response['tags']).should.be(list)
+    response['tags'].should.equal([
+        {'key': 'createdBy', 'value': 'moto-unittest'},
+        {'key': 'foo', 'value': 'hello world'},
+    ])
+
+
+@mock_ecs
+def test_ecs_service_untag_resource():
+    client = boto3.client('ecs', region_name='us-east-1')
+    _ = client.create_cluster(
+        clusterName='test_ecs_cluster'
+    )
+    _ = client.register_task_definition(
+        family='test_ecs_task',
+        containerDefinitions=[
+            {
+                'name': 'hello_world',
+                'image': 'docker/hello-world:latest',
+                'cpu': 1024,
+                'memory': 400,
+                'essential': True,
+                'environment': [{
+                    'name': 'AWS_ACCESS_KEY_ID',
+                    'value': 'SOME_ACCESS_KEY'
+                }],
+                'logConfiguration': {'logDriver': 'json-file'}
+            }
+        ]
+    )
+    response = client.create_service(
+        cluster='test_ecs_cluster',
+        serviceName='test_ecs_service',
+        taskDefinition='test_ecs_task',
+        desiredCount=2,
+        tags=[
+            {'key': 'foo', 'value': 'bar'},
+        ]
+    )
+    client.untag_resource(
+        resourceArn=response['service']['serviceArn'],
+        tagKeys=['foo']
+    )
+    response = client.list_tags_for_resource(resourceArn=response['service']['serviceArn'])
+    response['tags'].should.equal([])
+
+
+@mock_ecs
+def test_ecs_service_untag_resource_multiple_tags():
+    client = boto3.client('ecs', region_name='us-east-1')
+    _ = client.create_cluster(
+        clusterName='test_ecs_cluster'
+    )
+    _ = client.register_task_definition(
+        family='test_ecs_task',
+        containerDefinitions=[
+            {
+                'name': 'hello_world',
+                'image': 'docker/hello-world:latest',
+                'cpu': 1024,
+                'memory': 400,
+                'essential': True,
+                'environment': [{
+                    'name': 'AWS_ACCESS_KEY_ID',
+                    'value': 'SOME_ACCESS_KEY'
+                }],
+                'logConfiguration': {'logDriver': 'json-file'}
+            }
+        ]
+    )
+    response = client.create_service(
+        cluster='test_ecs_cluster',
+        serviceName='test_ecs_service',
+        taskDefinition='test_ecs_task',
+        desiredCount=2,
+        tags=[
+            {'key': 'foo', 'value': 'bar'},
+            {'key': 'createdBy', 'value': 'moto-unittest'},
+            {'key': 'hello', 'value': 'world'},
+        ]
+    )
+    client.untag_resource(
+        resourceArn=response['service']['serviceArn'],
+        tagKeys=['foo', 'createdBy']
+    )
+    response = client.list_tags_for_resource(resourceArn=response['service']['serviceArn'])
+    response['tags'].should.equal([
+        {'key': 'hello', 'value': 'world'},
+    ])


### PR DESCRIPTION
Adds support for:
* Passing `tags` to `create_service`
* Getting tags for an ECS service from `list_tags_for_resource`
* Tagging an ECS service with `tag_resource`
* Untagging an ECS service with `untag_resource`