### PR TITLE
Feature: Add option for DynamoDB stream to kick off lambda

### DIFF
--- a/moto/dynamodb2/models.py
+++ b/moto/dynamodb2/models.py
@@ -409,6 +409,15 @@ class StreamShard(BaseModel):
         seq = len(self.items) + self.starting_sequence_number
         self.items.append(
             StreamRecord(self.table, t, event_name, old, new, seq))
+        result = None
+        from moto.awslambda import lambda_backends
+        for arn, esm in self.table.lambda_event_source_mappings.items():
+            region = arn[len('arn:aws:lambda:'):arn.index(':', len('arn:aws:lambda:'))]
+
+            result = lambda_backends[region].send_dynamodb_items(arn, self.items, esm.event_source_arn)
+
+        if result:
+            self.items = []
 
     def get(self, start, quantity):
         start -= self.starting_sequence_number
@@ -451,6 +460,7 @@ class Table(BaseModel):
             # 'AttributeName': 'string'  # Can contain this
         }
         self.set_stream_specification(streams)
+        self.lambda_event_source_mappings = {}
 
     @classmethod
     def create_from_cloudformation_json(cls, resource_name, cloudformation_json, region_name):

--- a/tests/test_awslambda/test_lambda.py
+++ b/tests/test_awslambda/test_lambda.py
@@ -12,7 +12,7 @@ import zipfile
 import sure  # noqa
 
 from freezegun import freeze_time
-from moto import mock_lambda, mock_s3, mock_ec2, mock_sns, mock_logs, settings, mock_sqs
+from moto import mock_dynamodb2, mock_lambda, mock_s3, mock_ec2, mock_sns, mock_logs, settings, mock_sqs
 from nose.tools import assert_raises
 from botocore.exceptions import ClientError
 
@@ -1009,6 +1009,54 @@ def test_invoke_function_from_sqs():
 
     sqs_client = boto3.client('sqs')
     sqs_client.send_message(QueueUrl=queue.url, MessageBody='test')
+    start = time.time()
+    while (time.time() - start) < 30:
+        result = logs_conn.describe_log_streams(logGroupName='/aws/lambda/testFunction')
+        log_streams = result.get('logStreams')
+        if not log_streams:
+            time.sleep(1)
+            continue
+
+        assert len(log_streams) == 1
+        result = logs_conn.get_log_events(logGroupName='/aws/lambda/testFunction', logStreamName=log_streams[0]['logStreamName'])
+        for event in result.get('events'):
+            if event['message'] == 'get_test_zip_file3 success':
+                return
+        time.sleep(1)
+
+    assert False, "Test Failed"
+
+
+@mock_logs
+@mock_lambda
+@mock_dynamodb2
+def test_invoke_function_from_dynamodb():
+    logs_conn = boto3.client("logs")
+    dynamodb = boto3.client('dynamodb')
+    table_name = 'table_with_stream'
+    table = dynamodb.create_table(TableName=table_name,
+                                  KeySchema=[{'AttributeName':'id','KeyType':'HASH'}],
+                                  AttributeDefinitions=[{'AttributeName':'id','AttributeType':'S'}],
+                                  StreamSpecification={'StreamEnabled': True,
+                                                       'StreamViewType': 'NEW_AND_OLD_IMAGES'})
+
+    conn = boto3.client('lambda')
+    func = conn.create_function(FunctionName='testFunction', Runtime='python2.7',
+                                Role='test-iam-role',
+                                Handler='lambda_function.lambda_handler',
+                                Code={'ZipFile': get_test_zip_file3()},
+                                Description='test lambda function executed after a DynamoDB table is updated',
+                                Timeout=3, MemorySize=128, Publish=True)
+
+    response = conn.create_event_source_mapping(
+        EventSourceArn=table['TableDescription']['LatestStreamArn'],
+        FunctionName=func['FunctionArn']
+    )
+
+    assert response['EventSourceArn'] == table['TableDescription']['LatestStreamArn']
+    assert response['State'] == 'Enabled'
+
+    dynamodb.put_item(TableName=table_name, Item={'id': { 'S': 'item 1' }})
     start = time.time()
     while (time.time() - start) < 30:
         result = logs_conn.describe_log_streams(logGroupName='/aws/lambda/testFunction')


### PR DESCRIPTION
Currently, only option for EventSourceMappings is to kick off a Lambda function after receiving an SQS message
This PR adds the option to kick off a Lambda function after updating a DynamoDB table