### PR TITLE
Add tags parameter to sqs.create_queue

### DIFF
--- a/moto/sqs/models.py
+++ b/moto/sqs/models.py
@@ -415,7 +415,7 @@ class SQSBackend(BaseBackend):
         self.__dict__ = {}
         self.__init__(region_name)
 
-    def create_queue(self, name, **kwargs):
+    def create_queue(self, name, tags, **kwargs):
         queue = self.queues.get(name)
         if queue:
             try:
@@ -454,6 +454,8 @@ class SQSBackend(BaseBackend):
                 pass
             queue = Queue(name, region=self.region_name, **kwargs)
             self.queues[name] = queue
+
+        queue.tags = tags
         return queue
 
     def list_queues(self, queue_name_prefix):
@@ -654,6 +656,10 @@ class SQSBackend(BaseBackend):
 
     def untag_queue(self, queue_name, tag_keys):
         queue = self.get_queue(queue_name)
+
+        if len(tag_keys) == 0:
+            raise RESTError('InvalidParameterValue', 'Tag keys must be between 1 and 128 characters in length.')
+
         for key in tag_keys:
             try:
                 del queue.tags[key]

--- a/moto/sqs/models.py
+++ b/moto/sqs/models.py
@@ -415,7 +415,7 @@ class SQSBackend(BaseBackend):
         self.__dict__ = {}
         self.__init__(region_name)
 
-    def create_queue(self, name, tags, **kwargs):
+    def create_queue(self, name, tags=None, **kwargs):
         queue = self.queues.get(name)
         if queue:
             try:
@@ -455,7 +455,9 @@ class SQSBackend(BaseBackend):
             queue = Queue(name, region=self.region_name, **kwargs)
             self.queues[name] = queue
 
-        queue.tags = tags
+        if tags:
+            queue.tags = tags
+
         return queue
 
     def list_queues(self, queue_name_prefix):

--- a/moto/sqs/responses.py
+++ b/moto/sqs/responses.py
@@ -406,7 +406,11 @@ class SQSResponse(BaseResponse):
         queue_name = self._get_queue_name()
         tag_keys = self._get_multi_param('TagKey')
 
-        self.sqs_backend.untag_queue(queue_name, tag_keys)
+        try:
+            self.sqs_backend.untag_queue(queue_name, tag_keys)
+        except QueueDoesNotExist as e:
+            return self._error('AWS.SimpleQueueService.NonExistentQueue',
+                               e.description)
 
         template = self.response_template(UNTAG_QUEUE_RESPONSE)
         return template.render()

--- a/moto/sqs/responses.py
+++ b/moto/sqs/responses.py
@@ -33,6 +33,12 @@ class SQSResponse(BaseResponse):
             self._attribute = self._get_map_prefix('Attribute', key_end='.Name', value_end='.Value')
         return self._attribute
 
+    @property
+    def tags(self):
+        if not hasattr(self, '_tags'):
+            self._tags = self._get_map_prefix('Tag', key_end='.Key', value_end='.Value')
+        return self._tags
+
     def _get_queue_name(self):
         try:
             queue_name = self.querystring.get('QueueUrl')[0].split("/")[-1]
@@ -73,12 +79,12 @@ class SQSResponse(BaseResponse):
         queue_name = self._get_param("QueueName")
 
         try:
-            queue = self.sqs_backend.create_queue(queue_name, **self.attribute)
+            queue = self.sqs_backend.create_queue(queue_name, self.tags, **self.attribute)
         except MessageAttributesInvalid as e:
             return self._error('InvalidParameterValue', e.description)
 
         template = self.response_template(CREATE_QUEUE_RESPONSE)
-        return template.render(queue=queue, request_url=request_url)
+        return template.render(queue_url=queue.url(request_url))
 
     def get_queue_url(self):
         request_url = urlparse(self.uri)
@@ -416,8 +422,7 @@ class SQSResponse(BaseResponse):
 
 CREATE_QUEUE_RESPONSE = """<CreateQueueResponse>
     <CreateQueueResult>
-        <QueueUrl>{{ queue.url(request_url) }}</QueueUrl>
-        <VisibilityTimeout>{{ queue.visibility_timeout }}</VisibilityTimeout>
+        <QueueUrl>{{ queue_url }}</QueueUrl>
     </CreateQueueResult>
     <ResponseMetadata>
         <RequestId></RequestId>

--- a/tests/test_sqs/test_sqs.py
+++ b/tests/test_sqs/test_sqs.py
@@ -17,7 +17,6 @@ import time
 import uuid
 
 from moto import settings, mock_sqs, mock_sqs_deprecated
-from moto.sqs.exceptions import QueueDoesNotExist
 from tests.helpers import requires_boto_gte
 import tests.backport_assert_raises  # noqa
 from nose.tools import assert_raises
@@ -1006,7 +1005,8 @@ def test_untag_queue_errors():
             'tag_key_1'
         ]
     ).should.throw(
-        QueueDoesNotExist
+        ClientError,
+        "The specified queue does not exist for this wsdl version."
     )
 
     client.untag_queue.when.called_with(


### PR DESCRIPTION
Also fixes #1686

Also adjusted the `CREATE_QUEUE_RESPONSE` to align with the current API response. See https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_CreateQueue.html#API_CreateQueue_ResponseElements