### PR TITLE
Fix getsecretmananger error

### DIFF
--- a/moto/secretsmanager/exceptions.py
+++ b/moto/secretsmanager/exceptions.py
@@ -15,6 +15,15 @@ class ResourceNotFoundException(SecretsManagerClientError):
         )
 
 
+class SecretNotFoundException(SecretsManagerClientError):
+    def __init__(self):
+        self.code = 404
+        super(SecretNotFoundException, self).__init__(
+            "ResourceNotFoundException",
+            message=u"Secrets Manager can\u2019t find the specified secret."
+        )
+
+
 class ClientError(SecretsManagerClientError):
     def __init__(self, message):
         super(ClientError, self).__init__(

--- a/moto/secretsmanager/exceptions.py
+++ b/moto/secretsmanager/exceptions.py
@@ -7,11 +7,11 @@ class SecretsManagerClientError(JsonRESTError):
 
 
 class ResourceNotFoundException(SecretsManagerClientError):
-    def __init__(self):
+    def __init__(self, message):
         self.code = 404
         super(ResourceNotFoundException, self).__init__(
             "ResourceNotFoundException",
-            "Secrets Manager can't find the specified secret"
+            message,
         )
 
 

--- a/moto/secretsmanager/exceptions.py
+++ b/moto/secretsmanager/exceptions.py
@@ -15,12 +15,24 @@ class ResourceNotFoundException(SecretsManagerClientError):
         )
 
 
+# Using specialised exception due to the use of a non-ASCII character
 class SecretNotFoundException(SecretsManagerClientError):
     def __init__(self):
         self.code = 404
         super(SecretNotFoundException, self).__init__(
             "ResourceNotFoundException",
             message=u"Secrets Manager can\u2019t find the specified secret."
+        )
+
+
+# Using specialised exception due to the use of a non-ASCII character
+class SecretHasNoValueException(SecretsManagerClientError):
+    def __init__(self, version_stage):
+        self.code = 404
+        super(SecretHasNoValueException, self).__init__(
+            "ResourceNotFoundException",
+            message=u"Secrets Manager can\u2019t find the specified secret "
+                    u"value for staging label: {}".format(version_stage)
         )
 
 

--- a/moto/secretsmanager/models.py
+++ b/moto/secretsmanager/models.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
 import time

--- a/moto/secretsmanager/models.py
+++ b/moto/secretsmanager/models.py
@@ -88,7 +88,7 @@ class SecretsManagerBackend(BaseBackend):
 
         if 'secret_string' not in secret_version and 'secret_binary' not in secret_version:
             raise ResourceNotFoundException(
-                u"Secrets Manager can’t find the specified secret value for staging label: %s" %
+                u"Secrets Manager can\u2019t find the specified secret value for staging label: %s" %
                 (version_stage or u"AWSCURRENT")
             )
 

--- a/moto/secretsmanager/models.py
+++ b/moto/secretsmanager/models.py
@@ -11,6 +11,7 @@ import boto3
 from moto.core import BaseBackend, BaseModel
 from .exceptions import (
     ResourceNotFoundException,
+    SecretNotFoundException,
     InvalidParameterException,
     ResourceExistsException,
     InvalidRequestException,
@@ -47,7 +48,7 @@ class SecretsManagerBackend(BaseBackend):
     def get_secret_value(self, secret_id, version_id, version_stage):
 
         if not self._is_valid_identifier(secret_id):
-            raise ResourceNotFoundException(u"Secrets Manager can’t find the specified secret.")
+            raise SecretNotFoundException()
 
         if not version_id and version_stage:
             # set version_id to match version_stage
@@ -57,7 +58,7 @@ class SecretsManagerBackend(BaseBackend):
                     version_id = ver_id
                     break
             if not version_id:
-                raise ResourceNotFoundException(u"Secrets Manager can’t find the specified secret.")
+                raise SecretNotFoundException()
 
         # TODO check this part
         if 'deleted_date' in self.secrets[secret_id]:
@@ -176,7 +177,7 @@ class SecretsManagerBackend(BaseBackend):
 
     def describe_secret(self, secret_id):
         if not self._is_valid_identifier(secret_id):
-            raise ResourceNotFoundException(u"Secrets Manager can’t find the specified secret.")
+            raise SecretNotFoundException()
 
         secret = self.secrets[secret_id]
 
@@ -205,7 +206,7 @@ class SecretsManagerBackend(BaseBackend):
         rotation_days = 'AutomaticallyAfterDays'
 
         if not self._is_valid_identifier(secret_id):
-            raise ResourceNotFoundException(u"Secrets Manager can’t find the specified secret.")
+            raise SecretNotFoundException()
 
         if 'deleted_date' in self.secrets[secret_id]:
             raise InvalidRequestException(
@@ -347,7 +348,7 @@ class SecretsManagerBackend(BaseBackend):
     def delete_secret(self, secret_id, recovery_window_in_days, force_delete_without_recovery):
 
         if not self._is_valid_identifier(secret_id):
-            raise ResourceNotFoundException(u"Secrets Manager can’t find the specified secret.")
+            raise SecretNotFoundException()
 
         if 'deleted_date' in self.secrets[secret_id]:
             raise InvalidRequestException(
@@ -377,7 +378,7 @@ class SecretsManagerBackend(BaseBackend):
             secret = self.secrets.get(secret_id, None)
 
         if not secret:
-            raise ResourceNotFoundException(u"Secrets Manager can’t find the specified secret.")
+            raise SecretNotFoundException()
 
         arn = secret_arn(self.region, secret['secret_id'])
         name = secret['name']
@@ -387,7 +388,7 @@ class SecretsManagerBackend(BaseBackend):
     def restore_secret(self, secret_id):
 
         if not self._is_valid_identifier(secret_id):
-            raise ResourceNotFoundException(u"Secrets Manager can’t find the specified secret.")
+            raise SecretNotFoundException()
 
         self.secrets[secret_id].pop('deleted_date', None)
 

--- a/moto/secretsmanager/models.py
+++ b/moto/secretsmanager/models.py
@@ -46,7 +46,7 @@ class SecretsManagerBackend(BaseBackend):
     def get_secret_value(self, secret_id, version_id, version_stage):
 
         if not self._is_valid_identifier(secret_id):
-            raise ResourceNotFoundException()
+            raise ResourceNotFoundException("Secrets Manager can't find the specified secret")
 
         if not version_id and version_stage:
             # set version_id to match version_stage
@@ -56,7 +56,7 @@ class SecretsManagerBackend(BaseBackend):
                     version_id = ver_id
                     break
             if not version_id:
-                raise ResourceNotFoundException()
+                raise ResourceNotFoundException("Secrets Manager can't find the specified secret")
 
         # TODO check this part
         if 'deleted_date' in self.secrets[secret_id]:
@@ -83,6 +83,12 @@ class SecretsManagerBackend(BaseBackend):
 
         if 'secret_binary' in secret_version:
             response_data["SecretBinary"] = secret_version['secret_binary']
+
+        if 'secret_string' not in secret_version and 'secret_binary' not in secret_version:
+            raise ResourceNotFoundException(
+                "Secrets Manager can’t find the specified secret value for staging label: %s" %
+                (version_stage or "AWSCURRENT")
+            )
 
         response = json.dumps(response_data)
 
@@ -169,7 +175,7 @@ class SecretsManagerBackend(BaseBackend):
 
     def describe_secret(self, secret_id):
         if not self._is_valid_identifier(secret_id):
-            raise ResourceNotFoundException
+            raise ResourceNotFoundException("Secrets Manager can't find the specified secret")
 
         secret = self.secrets[secret_id]
 
@@ -198,7 +204,7 @@ class SecretsManagerBackend(BaseBackend):
         rotation_days = 'AutomaticallyAfterDays'
 
         if not self._is_valid_identifier(secret_id):
-            raise ResourceNotFoundException
+            raise ResourceNotFoundException("Secrets Manager can't find the specified secret")
 
         if 'deleted_date' in self.secrets[secret_id]:
             raise InvalidRequestException(
@@ -340,7 +346,7 @@ class SecretsManagerBackend(BaseBackend):
     def delete_secret(self, secret_id, recovery_window_in_days, force_delete_without_recovery):
 
         if not self._is_valid_identifier(secret_id):
-            raise ResourceNotFoundException
+            raise ResourceNotFoundException("Secrets Manager can't find the specified secret")
 
         if 'deleted_date' in self.secrets[secret_id]:
             raise InvalidRequestException(
@@ -370,7 +376,7 @@ class SecretsManagerBackend(BaseBackend):
             secret = self.secrets.get(secret_id, None)
 
         if not secret:
-            raise ResourceNotFoundException
+            raise ResourceNotFoundException("Secrets Manager can't find the specified secret")
 
         arn = secret_arn(self.region, secret['secret_id'])
         name = secret['name']
@@ -380,7 +386,7 @@ class SecretsManagerBackend(BaseBackend):
     def restore_secret(self, secret_id):
 
         if not self._is_valid_identifier(secret_id):
-            raise ResourceNotFoundException
+            raise ResourceNotFoundException("Secrets Manager can't find the specified secret")
 
         self.secrets[secret_id].pop('deleted_date', None)
 

--- a/moto/secretsmanager/models.py
+++ b/moto/secretsmanager/models.py
@@ -46,7 +46,7 @@ class SecretsManagerBackend(BaseBackend):
     def get_secret_value(self, secret_id, version_id, version_stage):
 
         if not self._is_valid_identifier(secret_id):
-            raise ResourceNotFoundException("Secrets Manager can't find the specified secret")
+            raise ResourceNotFoundException("Secrets Manager can’t find the specified secret.")
 
         if not version_id and version_stage:
             # set version_id to match version_stage
@@ -56,7 +56,7 @@ class SecretsManagerBackend(BaseBackend):
                     version_id = ver_id
                     break
             if not version_id:
-                raise ResourceNotFoundException("Secrets Manager can't find the specified secret")
+                raise ResourceNotFoundException("Secrets Manager can’t find the specified secret.")
 
         # TODO check this part
         if 'deleted_date' in self.secrets[secret_id]:
@@ -175,7 +175,7 @@ class SecretsManagerBackend(BaseBackend):
 
     def describe_secret(self, secret_id):
         if not self._is_valid_identifier(secret_id):
-            raise ResourceNotFoundException("Secrets Manager can't find the specified secret")
+            raise ResourceNotFoundException("Secrets Manager can’t find the specified secret.")
 
         secret = self.secrets[secret_id]
 
@@ -204,7 +204,7 @@ class SecretsManagerBackend(BaseBackend):
         rotation_days = 'AutomaticallyAfterDays'
 
         if not self._is_valid_identifier(secret_id):
-            raise ResourceNotFoundException("Secrets Manager can't find the specified secret")
+            raise ResourceNotFoundException("Secrets Manager can’t find the specified secret.")
 
         if 'deleted_date' in self.secrets[secret_id]:
             raise InvalidRequestException(
@@ -346,7 +346,7 @@ class SecretsManagerBackend(BaseBackend):
     def delete_secret(self, secret_id, recovery_window_in_days, force_delete_without_recovery):
 
         if not self._is_valid_identifier(secret_id):
-            raise ResourceNotFoundException("Secrets Manager can't find the specified secret")
+            raise ResourceNotFoundException("Secrets Manager can’t find the specified secret.")
 
         if 'deleted_date' in self.secrets[secret_id]:
             raise InvalidRequestException(
@@ -376,7 +376,7 @@ class SecretsManagerBackend(BaseBackend):
             secret = self.secrets.get(secret_id, None)
 
         if not secret:
-            raise ResourceNotFoundException("Secrets Manager can't find the specified secret")
+            raise ResourceNotFoundException("Secrets Manager can’t find the specified secret.")
 
         arn = secret_arn(self.region, secret['secret_id'])
         name = secret['name']
@@ -386,7 +386,7 @@ class SecretsManagerBackend(BaseBackend):
     def restore_secret(self, secret_id):
 
         if not self._is_valid_identifier(secret_id):
-            raise ResourceNotFoundException("Secrets Manager can't find the specified secret")
+            raise ResourceNotFoundException("Secrets Manager can’t find the specified secret.")
 
         self.secrets[secret_id].pop('deleted_date', None)
 

--- a/moto/secretsmanager/models.py
+++ b/moto/secretsmanager/models.py
@@ -10,8 +10,8 @@ import boto3
 
 from moto.core import BaseBackend, BaseModel
 from .exceptions import (
-    ResourceNotFoundException,
     SecretNotFoundException,
+    SecretHasNoValueException,
     InvalidParameterException,
     ResourceExistsException,
     InvalidRequestException,
@@ -87,10 +87,7 @@ class SecretsManagerBackend(BaseBackend):
             response_data["SecretBinary"] = secret_version['secret_binary']
 
         if 'secret_string' not in secret_version and 'secret_binary' not in secret_version:
-            raise ResourceNotFoundException(
-                u"Secrets Manager can\u2019t find the specified secret value for staging label: %s" %
-                (version_stage or u"AWSCURRENT")
-            )
+            raise SecretHasNoValueException(version_stage or u"AWSCURRENT")
 
         response = json.dumps(response_data)
 

--- a/moto/secretsmanager/models.py
+++ b/moto/secretsmanager/models.py
@@ -47,7 +47,7 @@ class SecretsManagerBackend(BaseBackend):
     def get_secret_value(self, secret_id, version_id, version_stage):
 
         if not self._is_valid_identifier(secret_id):
-            raise ResourceNotFoundException("Secrets Manager can’t find the specified secret.")
+            raise ResourceNotFoundException(u"Secrets Manager can’t find the specified secret.")
 
         if not version_id and version_stage:
             # set version_id to match version_stage
@@ -57,7 +57,7 @@ class SecretsManagerBackend(BaseBackend):
                     version_id = ver_id
                     break
             if not version_id:
-                raise ResourceNotFoundException("Secrets Manager can’t find the specified secret.")
+                raise ResourceNotFoundException(u"Secrets Manager can’t find the specified secret.")
 
         # TODO check this part
         if 'deleted_date' in self.secrets[secret_id]:
@@ -87,8 +87,8 @@ class SecretsManagerBackend(BaseBackend):
 
         if 'secret_string' not in secret_version and 'secret_binary' not in secret_version:
             raise ResourceNotFoundException(
-                "Secrets Manager can’t find the specified secret value for staging label: %s" %
-                (version_stage or "AWSCURRENT")
+                u"Secrets Manager can’t find the specified secret value for staging label: %s" %
+                (version_stage or u"AWSCURRENT")
             )
 
         response = json.dumps(response_data)
@@ -176,7 +176,7 @@ class SecretsManagerBackend(BaseBackend):
 
     def describe_secret(self, secret_id):
         if not self._is_valid_identifier(secret_id):
-            raise ResourceNotFoundException("Secrets Manager can’t find the specified secret.")
+            raise ResourceNotFoundException(u"Secrets Manager can’t find the specified secret.")
 
         secret = self.secrets[secret_id]
 
@@ -205,7 +205,7 @@ class SecretsManagerBackend(BaseBackend):
         rotation_days = 'AutomaticallyAfterDays'
 
         if not self._is_valid_identifier(secret_id):
-            raise ResourceNotFoundException("Secrets Manager can’t find the specified secret.")
+            raise ResourceNotFoundException(u"Secrets Manager can’t find the specified secret.")
 
         if 'deleted_date' in self.secrets[secret_id]:
             raise InvalidRequestException(
@@ -347,7 +347,7 @@ class SecretsManagerBackend(BaseBackend):
     def delete_secret(self, secret_id, recovery_window_in_days, force_delete_without_recovery):
 
         if not self._is_valid_identifier(secret_id):
-            raise ResourceNotFoundException("Secrets Manager can’t find the specified secret.")
+            raise ResourceNotFoundException(u"Secrets Manager can’t find the specified secret.")
 
         if 'deleted_date' in self.secrets[secret_id]:
             raise InvalidRequestException(
@@ -377,7 +377,7 @@ class SecretsManagerBackend(BaseBackend):
             secret = self.secrets.get(secret_id, None)
 
         if not secret:
-            raise ResourceNotFoundException("Secrets Manager can’t find the specified secret.")
+            raise ResourceNotFoundException(u"Secrets Manager can’t find the specified secret.")
 
         arn = secret_arn(self.region, secret['secret_id'])
         name = secret['name']
@@ -387,7 +387,7 @@ class SecretsManagerBackend(BaseBackend):
     def restore_secret(self, secret_id):
 
         if not self._is_valid_identifier(secret_id):
-            raise ResourceNotFoundException("Secrets Manager can’t find the specified secret.")
+            raise ResourceNotFoundException(u"Secrets Manager can’t find the specified secret.")
 
         self.secrets[secret_id].pop('deleted_date', None)
 

--- a/tests/test_secretsmanager/test_secretsmanager.py
+++ b/tests/test_secretsmanager/test_secretsmanager.py
@@ -8,7 +8,7 @@ import string
 import pytz
 from datetime import datetime
 import sure  # noqa
-from nose.tools import assert_raises
+from nose.tools import assert_raises, assert_raises_regexp
 from six import b
 
 DEFAULT_SECRET_NAME = 'test-secret'
@@ -63,6 +63,21 @@ def test_get_secret_value_that_is_marked_deleted():
 
     with assert_raises(ClientError):
         result = conn.get_secret_value(SecretId='test-secret')
+
+
+@mock_secretsmanager
+def test_get_secret_that_has_no_value():
+    conn = boto3.client('secretsmanager', region_name='us-west-2')
+
+    create_secret = conn.create_secret(Name="java-util-test-password")
+
+    with assert_raises_regexp(
+            ClientError,
+            r"An error occurred \(ResourceNotFoundException\) when calling the GetSecretValue "
+            r"operation: Secrets Manager can’t find the specified secret value for staging label: "
+            r"AWSCURRENT"
+    ):
+        result = conn.get_secret_value(SecretId='java-util-test-password')
 
 
 @mock_secretsmanager

--- a/tests/test_secretsmanager/test_secretsmanager.py
+++ b/tests/test_secretsmanager/test_secretsmanager.py
@@ -38,7 +38,11 @@ def test_get_secret_value_binary():
 def test_get_secret_that_does_not_exist():
     conn = boto3.client('secretsmanager', region_name='us-west-2')
 
-    with assert_raises(ClientError):
+    with assert_raises_regexp(
+            ClientError,
+            r"An error occurred \(ResourceNotFoundException\) when calling the GetSecretValue "
+            r"operation: Secrets Manager can’t find the specified secret."
+    ):
         result = conn.get_secret_value(SecretId='i-dont-exist')
 
 
@@ -48,7 +52,11 @@ def test_get_secret_that_does_not_match():
     create_secret = conn.create_secret(Name='java-util-test-password',
                                        SecretString="foosecret")
 
-    with assert_raises(ClientError):
+    with assert_raises_regexp(
+            ClientError,
+            r"An error occurred \(ResourceNotFoundException\) when calling the GetSecretValue "
+            r"operation: Secrets Manager can’t find the specified secret."
+    ):
         result = conn.get_secret_value(SecretId='i-dont-match')
 
 

--- a/tests/test_secretsmanager/test_secretsmanager.py
+++ b/tests/test_secretsmanager/test_secretsmanager.py
@@ -43,7 +43,7 @@ def test_get_secret_that_does_not_exist():
         result = conn.get_secret_value(SecretId='i-dont-exist')
 
     assert_equal(
-        u"Secrets Manager can’t find the specified secret.",
+        u"Secrets Manager can\u2019t find the specified secret.",
         cm.exception.response['Error']['Message']
     )
 
@@ -58,9 +58,10 @@ def test_get_secret_that_does_not_match():
         result = conn.get_secret_value(SecretId='i-dont-match')
 
     assert_equal(
-        u"Secrets Manager can’t find the specified secret.",
+        u"Secrets Manager can\u2019t find the specified secret.",
         cm.exception.response['Error']['Message']
     )
+
 
 @mock_secretsmanager
 def test_get_secret_value_that_is_marked_deleted():
@@ -85,7 +86,7 @@ def test_get_secret_that_has_no_value():
         result = conn.get_secret_value(SecretId='java-util-test-password')
 
     assert_equal(
-        u"Secrets Manager can’t find the specified secret value for staging label: AWSCURRENT",
+        u"Secrets Manager can\u2019t find the specified secret value for staging label: AWSCURRENT",
         cm.exception.response['Error']['Message']
     )
 

--- a/tests/test_secretsmanager/test_secretsmanager.py
+++ b/tests/test_secretsmanager/test_secretsmanager.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
 import boto3

--- a/tests/test_secretsmanager/test_server.py
+++ b/tests/test_secretsmanager/test_server.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
 import json

--- a/tests/test_secretsmanager/test_server.py
+++ b/tests/test_secretsmanager/test_server.py
@@ -50,7 +50,7 @@ def test_get_secret_that_does_not_exist():
                                "X-Amz-Target": "secretsmanager.GetSecretValue"},
                            )
     json_data = json.loads(get_secret.data.decode("utf-8"))
-    assert json_data['message'] == u"Secrets Manager can’t find the specified secret."
+    assert json_data['message'] == u"Secrets Manager can\u2019t find the specified secret."
     assert json_data['__type'] == 'ResourceNotFoundException'
 
 @mock_secretsmanager
@@ -71,7 +71,7 @@ def test_get_secret_that_does_not_match():
                                "X-Amz-Target": "secretsmanager.GetSecretValue"},
                            )
     json_data = json.loads(get_secret.data.decode("utf-8"))
-    assert json_data['message'] == u"Secrets Manager can’t find the specified secret."
+    assert json_data['message'] == u"Secrets Manager can\u2019t find the specified secret."
     assert json_data['__type'] == 'ResourceNotFoundException'
 
 @mock_secretsmanager
@@ -91,7 +91,7 @@ def test_get_secret_that_has_no_value():
                            )
 
     json_data = json.loads(get_secret.data.decode("utf-8"))
-    assert json_data['message'] == u"Secrets Manager can’t find the specified secret value for staging label: AWSCURRENT"
+    assert json_data['message'] == u"Secrets Manager can\u2019t find the specified secret value for staging label: AWSCURRENT"
     assert json_data['__type'] == 'ResourceNotFoundException'
 
 @mock_secretsmanager
@@ -179,7 +179,7 @@ def test_describe_secret_that_does_not_exist():
                     )
 
     json_data = json.loads(describe_secret.data.decode("utf-8"))
-    assert json_data['message'] == u"Secrets Manager can’t find the specified secret."
+    assert json_data['message'] == u"Secrets Manager can\u2019t find the specified secret."
     assert json_data['__type'] == 'ResourceNotFoundException'
 
 @mock_secretsmanager
@@ -203,7 +203,7 @@ def test_describe_secret_that_does_not_match():
                     )
 
     json_data = json.loads(describe_secret.data.decode("utf-8"))
-    assert json_data['message'] == u"Secrets Manager can’t find the specified secret."
+    assert json_data['message'] == u"Secrets Manager can\u2019t find the specified secret."
     assert json_data['__type'] == 'ResourceNotFoundException'
 
 @mock_secretsmanager
@@ -304,7 +304,7 @@ def test_rotate_secret_that_does_not_exist():
                     )
 
     json_data = json.loads(rotate_secret.data.decode("utf-8"))
-    assert json_data['message'] == u"Secrets Manager can’t find the specified secret."
+    assert json_data['message'] == u"Secrets Manager can\u2019t find the specified secret."
     assert json_data['__type'] == 'ResourceNotFoundException'
 
 @mock_secretsmanager
@@ -328,7 +328,7 @@ def test_rotate_secret_that_does_not_match():
                     )
 
     json_data = json.loads(rotate_secret.data.decode("utf-8"))
-    assert json_data['message'] == u"Secrets Manager can’t find the specified secret."
+    assert json_data['message'] == u"Secrets Manager can\u2019t find the specified secret."
     assert json_data['__type'] == 'ResourceNotFoundException'
 
 @mock_secretsmanager

--- a/tests/test_secretsmanager/test_server.py
+++ b/tests/test_secretsmanager/test_server.py
@@ -49,7 +49,7 @@ def test_get_secret_that_does_not_exist():
                                "X-Amz-Target": "secretsmanager.GetSecretValue"},
                            )
     json_data = json.loads(get_secret.data.decode("utf-8"))
-    assert json_data['message'] == "Secrets Manager can't find the specified secret"
+    assert json_data['message'] == "Secrets Manager can’t find the specified secret."
     assert json_data['__type'] == 'ResourceNotFoundException'
 
 @mock_secretsmanager
@@ -70,7 +70,7 @@ def test_get_secret_that_does_not_match():
                                "X-Amz-Target": "secretsmanager.GetSecretValue"},
                            )
     json_data = json.loads(get_secret.data.decode("utf-8"))
-    assert json_data['message'] == "Secrets Manager can't find the specified secret"
+    assert json_data['message'] == "Secrets Manager can’t find the specified secret."
     assert json_data['__type'] == 'ResourceNotFoundException'
 
 @mock_secretsmanager
@@ -178,7 +178,7 @@ def test_describe_secret_that_does_not_exist():
                     )
 
     json_data = json.loads(describe_secret.data.decode("utf-8"))
-    assert json_data['message'] == "Secrets Manager can't find the specified secret"
+    assert json_data['message'] == "Secrets Manager can’t find the specified secret."
     assert json_data['__type'] == 'ResourceNotFoundException'
 
 @mock_secretsmanager
@@ -202,7 +202,7 @@ def test_describe_secret_that_does_not_match():
                     )
 
     json_data = json.loads(describe_secret.data.decode("utf-8"))
-    assert json_data['message'] == "Secrets Manager can't find the specified secret"
+    assert json_data['message'] == "Secrets Manager can’t find the specified secret."
     assert json_data['__type'] == 'ResourceNotFoundException'
 
 @mock_secretsmanager
@@ -303,7 +303,7 @@ def test_rotate_secret_that_does_not_exist():
                     )
 
     json_data = json.loads(rotate_secret.data.decode("utf-8"))
-    assert json_data['message'] == "Secrets Manager can't find the specified secret"
+    assert json_data['message'] == "Secrets Manager can’t find the specified secret."
     assert json_data['__type'] == 'ResourceNotFoundException'
 
 @mock_secretsmanager
@@ -327,7 +327,7 @@ def test_rotate_secret_that_does_not_match():
                     )
 
     json_data = json.loads(rotate_secret.data.decode("utf-8"))
-    assert json_data['message'] == "Secrets Manager can't find the specified secret"
+    assert json_data['message'] == "Secrets Manager can’t find the specified secret."
     assert json_data['__type'] == 'ResourceNotFoundException'
 
 @mock_secretsmanager

--- a/tests/test_secretsmanager/test_server.py
+++ b/tests/test_secretsmanager/test_server.py
@@ -50,7 +50,7 @@ def test_get_secret_that_does_not_exist():
                                "X-Amz-Target": "secretsmanager.GetSecretValue"},
                            )
     json_data = json.loads(get_secret.data.decode("utf-8"))
-    assert json_data['message'] == "Secrets Manager can’t find the specified secret."
+    assert json_data['message'] == u"Secrets Manager can’t find the specified secret."
     assert json_data['__type'] == 'ResourceNotFoundException'
 
 @mock_secretsmanager
@@ -71,7 +71,7 @@ def test_get_secret_that_does_not_match():
                                "X-Amz-Target": "secretsmanager.GetSecretValue"},
                            )
     json_data = json.loads(get_secret.data.decode("utf-8"))
-    assert json_data['message'] == "Secrets Manager can’t find the specified secret."
+    assert json_data['message'] == u"Secrets Manager can’t find the specified secret."
     assert json_data['__type'] == 'ResourceNotFoundException'
 
 @mock_secretsmanager
@@ -91,7 +91,7 @@ def test_get_secret_that_has_no_value():
                            )
 
     json_data = json.loads(get_secret.data.decode("utf-8"))
-    assert json_data['message'] == "Secrets Manager can’t find the specified secret value for staging label: AWSCURRENT"
+    assert json_data['message'] == u"Secrets Manager can’t find the specified secret value for staging label: AWSCURRENT"
     assert json_data['__type'] == 'ResourceNotFoundException'
 
 @mock_secretsmanager
@@ -179,7 +179,7 @@ def test_describe_secret_that_does_not_exist():
                     )
 
     json_data = json.loads(describe_secret.data.decode("utf-8"))
-    assert json_data['message'] == "Secrets Manager can’t find the specified secret."
+    assert json_data['message'] == u"Secrets Manager can’t find the specified secret."
     assert json_data['__type'] == 'ResourceNotFoundException'
 
 @mock_secretsmanager
@@ -203,7 +203,7 @@ def test_describe_secret_that_does_not_match():
                     )
 
     json_data = json.loads(describe_secret.data.decode("utf-8"))
-    assert json_data['message'] == "Secrets Manager can’t find the specified secret."
+    assert json_data['message'] == u"Secrets Manager can’t find the specified secret."
     assert json_data['__type'] == 'ResourceNotFoundException'
 
 @mock_secretsmanager
@@ -304,7 +304,7 @@ def test_rotate_secret_that_does_not_exist():
                     )
 
     json_data = json.loads(rotate_secret.data.decode("utf-8"))
-    assert json_data['message'] == "Secrets Manager can’t find the specified secret."
+    assert json_data['message'] == u"Secrets Manager can’t find the specified secret."
     assert json_data['__type'] == 'ResourceNotFoundException'
 
 @mock_secretsmanager
@@ -328,7 +328,7 @@ def test_rotate_secret_that_does_not_match():
                     )
 
     json_data = json.loads(rotate_secret.data.decode("utf-8"))
-    assert json_data['message'] == "Secrets Manager can’t find the specified secret."
+    assert json_data['message'] == u"Secrets Manager can’t find the specified secret."
     assert json_data['__type'] == 'ResourceNotFoundException'
 
 @mock_secretsmanager

--- a/tests/test_secretsmanager/test_server.py
+++ b/tests/test_secretsmanager/test_server.py
@@ -74,6 +74,26 @@ def test_get_secret_that_does_not_match():
     assert json_data['__type'] == 'ResourceNotFoundException'
 
 @mock_secretsmanager
+def test_get_secret_that_has_no_value():
+    backend = server.create_backend_app('secretsmanager')
+    test_client = backend.test_client()
+
+    create_secret = test_client.post('/',
+                           data={"Name": DEFAULT_SECRET_NAME},
+                           headers={
+                               "X-Amz-Target": "secretsmanager.CreateSecret"},
+                           )
+    get_secret = test_client.post('/',
+                           data={"SecretId": DEFAULT_SECRET_NAME},
+                           headers={
+                               "X-Amz-Target": "secretsmanager.GetSecretValue"},
+                           )
+
+    json_data = json.loads(get_secret.data.decode("utf-8"))
+    assert json_data['message'] == "Secrets Manager can’t find the specified secret value for staging label: AWSCURRENT"
+    assert json_data['__type'] == 'ResourceNotFoundException'
+
+@mock_secretsmanager
 def test_create_secret():
 
     backend = server.create_backend_app("secretsmanager")


### PR DESCRIPTION
Secretsmanager will raise a ResourceNotFoundException with a slightly different message when a secret exists but has not SecretString or SecretBinary. Current behaviour of moto is to successfully return a response dictionary with no SecretString or SecretBinary, which does not happen with boto3.

Existing uses of ResourceNotFoundException will still give the same message, and the newly added one will give the observed, different message. A slight punctuation mistake was fixed in the original message.