### PR TITLE
Avoid exception occur in `moto.s3.models.S3Backend.get_key`

### DIFF
--- a/moto/s3/models.py
+++ b/moto/s3/models.py
@@ -1107,7 +1107,7 @@ class S3Backend(BaseBackend):
                         key = key_version
                         break
 
-            if part_number and key.multipart:
+            if part_number and key and key.multipart:
                 key = key.multipart.parts[part_number]
 
         if isinstance(key, FakeKey):

--- a/tests/test_s3/test_s3.py
+++ b/tests/test_s3/test_s3.py
@@ -1535,6 +1535,18 @@ def test_boto3_get_object():
 
 
 @mock_s3
+def test_boto3_get_missing_object_with_part_number():
+    s3 = boto3.resource('s3', region_name='us-east-1')
+    s3.create_bucket(Bucket="blah")
+
+    with assert_raises(ClientError) as e:
+        s3.Object('blah', 'hello.txt').meta.client.head_object(
+            Bucket='blah', Key='hello.txt', PartNumber=123)
+
+    e.exception.response['Error']['Code'].should.equal('404')
+
+
+@mock_s3
 def test_boto3_head_object_with_versioning():
     s3 = boto3.resource('s3', region_name='us-east-1')
     bucket = s3.create_bucket(Bucket='blah')


### PR DESCRIPTION
The variable `key` may `None`.
But, its attribute `multipart` will be accessed even though `key` is `None`.

https://github.com/spulec/moto/blob/4da9ec134693afbbcf05d8ae284a140d103ba422/moto/s3/models.py#L1110-L1111

#2307