### PR TITLE
Use ==/!= to compare str, bytes, and int literals

### DIFF
--- a/tests/test_awslambda/test_lambda.py
+++ b/tests/test_awslambda/test_lambda.py
@@ -1134,7 +1134,7 @@ def test_invoke_function_from_sqs_exception():
             if 'I failed!' in event['message']:
                 messages = queue.receive_messages(MaxNumberOfMessages=10)
                 # Verify messages are still visible and unprocessed
-                assert len(messages) is 3
+                assert len(messages) == 3
                 return
         time.sleep(1)
 


### PR DESCRIPTION
Python 3.8 will probably [raise SyntaxWarnings](https://docs.python.org/3/whatsnew/3.8.html#changes-in-python-behavior) on the flake8 F632 issue raised below.

[flake8](http://flake8.pycqa.org) testing of https://github.com/spulec/moto on Python 3.7.1

$ __flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics__
```
./tests/test_awslambda/test_lambda.py:1137:24: F632 use ==/!= to compare str, bytes, and int literals
                assert len(messages) is 3
                       ^
1     F632 use ==/!= to compare str, bytes, and int literals
1
```