### PR TITLE
Add Documentation URL

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -94,4 +94,7 @@ setup(
         "License :: OSI Approved :: Apache Software License",
         "Topic :: Software Development :: Testing",
     ],
+    project_urls={
+        "Documentation": "http://docs.getmoto.org/en/latest/",
+    },
 )


### PR DESCRIPTION
This adds a [Documentation URL](https://packaging.python.org/guides/distributing-packages-using-setuptools/#project-urls), which will display in the left-hand nav of the projects PyPI page, allowing users arriving there to get to the documentation slightly faster.