### PR TITLE
Feature - Lambda Delete by arn

### DIFF
--- a/moto/awslambda/models.py
+++ b/moto/awslambda/models.py
@@ -645,8 +645,10 @@ class LambdaStorage(object):
         self._arns[fn.function_arn] = fn
         return fn
 
-    def del_function(self, name, qualifier=None):
-        if name in self._functions:
+    def del_function(self, name_or_arn, qualifier=None):
+        function = self.get_function_by_name_or_arn(name_or_arn)
+        if function:
+            name = function.function_name
             if not qualifier:
                 # Something is still reffing this so delete all arns
                 latest = self._functions[name]['latest'].function_arn

--- a/moto/awslambda/responses.py
+++ b/moto/awslambda/responses.py
@@ -266,7 +266,7 @@ class LambdaResponse(BaseResponse):
             return 404, {}, "{}"
 
     def _delete_function(self, request, full_url, headers):
-        function_name = self.path.rsplit('/', 1)[-1]
+        function_name = unquote(self.path.rsplit('/', 1)[-1])
         qualifier = self._get_param('Qualifier', None)
 
         if self.lambda_backend.delete_function(function_name, qualifier):

--- a/moto/awslambda/urls.py
+++ b/moto/awslambda/urls.py
@@ -9,7 +9,7 @@ response = LambdaResponse()
 
 url_paths = {
     '{0}/(?P<api_version>[^/]+)/functions/?$': response.root,
-    r'{0}/(?P<api_version>[^/]+)/functions/(?P<function_name>[\w_-]+)/?$': response.function,
+    r'{0}/(?P<api_version>[^/]+)/functions/(?P<function_name>[\w_:%-]+)/?$': response.function,
     r'{0}/(?P<api_version>[^/]+)/functions/(?P<function_name>[\w_-]+)/versions/?$': response.versions,
     r'{0}/(?P<api_version>[^/]+)/event-source-mappings/?$': response.event_source_mappings,
     r'{0}/(?P<api_version>[^/]+)/event-source-mappings/(?P<UUID>[\w_-]+)/?$': response.event_source_mapping,


### PR DESCRIPTION
Existing tests only tested whether Lambdas could be deleted when passing in a name.
According to the docs, Lambdas can also be deleted by passing in an ARN: https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/lambda.html#Lambda.Client.delete_function

The list of mock-URLs had to be adjusted to account for the fact we're passing a HTML-safe ARN in the URL, which can contain ampersands