### PR TITLE
Fix sns.add_permission & remove_permission

### DIFF
--- a/IMPLEMENTATION_COVERAGE.md
+++ b/IMPLEMENTATION_COVERAGE.md
@@ -700,6 +700,7 @@
 0% implemented
 - [ ] associate_phone_number_with_user
 - [ ] associate_phone_numbers_with_voice_connector
+- [ ] associate_phone_numbers_with_voice_connector_group
 - [ ] batch_delete_phone_number
 - [ ] batch_suspend_user
 - [ ] batch_unsuspend_user
@@ -709,15 +710,19 @@
 - [ ] create_bot
 - [ ] create_phone_number_order
 - [ ] create_voice_connector
+- [ ] create_voice_connector_group
 - [ ] delete_account
 - [ ] delete_events_configuration
 - [ ] delete_phone_number
 - [ ] delete_voice_connector
+- [ ] delete_voice_connector_group
 - [ ] delete_voice_connector_origination
+- [ ] delete_voice_connector_streaming_configuration
 - [ ] delete_voice_connector_termination
 - [ ] delete_voice_connector_termination_credentials
 - [ ] disassociate_phone_number_from_user
 - [ ] disassociate_phone_numbers_from_voice_connector
+- [ ] disassociate_phone_numbers_from_voice_connector_group
 - [ ] get_account
 - [ ] get_account_settings
 - [ ] get_bot
@@ -725,10 +730,14 @@
 - [ ] get_global_settings
 - [ ] get_phone_number
 - [ ] get_phone_number_order
+- [ ] get_phone_number_settings
 - [ ] get_user
 - [ ] get_user_settings
 - [ ] get_voice_connector
+- [ ] get_voice_connector_group
+- [ ] get_voice_connector_logging_configuration
 - [ ] get_voice_connector_origination
+- [ ] get_voice_connector_streaming_configuration
 - [ ] get_voice_connector_termination
 - [ ] get_voice_connector_termination_health
 - [ ] invite_users
@@ -737,11 +746,14 @@
 - [ ] list_phone_number_orders
 - [ ] list_phone_numbers
 - [ ] list_users
+- [ ] list_voice_connector_groups
 - [ ] list_voice_connector_termination_credentials
 - [ ] list_voice_connectors
 - [ ] logout_user
 - [ ] put_events_configuration
+- [ ] put_voice_connector_logging_configuration
 - [ ] put_voice_connector_origination
+- [ ] put_voice_connector_streaming_configuration
 - [ ] put_voice_connector_termination
 - [ ] put_voice_connector_termination_credentials
 - [ ] regenerate_security_token
@@ -753,9 +765,11 @@
 - [ ] update_bot
 - [ ] update_global_settings
 - [ ] update_phone_number
+- [ ] update_phone_number_settings
 - [ ] update_user
 - [ ] update_user_settings
 - [ ] update_voice_connector
+- [ ] update_voice_connector_group
 
 ## cloud9
 0% implemented
@@ -1525,6 +1539,10 @@
 - [ ] get_current_metric_data
 - [ ] get_federation_token
 - [ ] get_metric_data
+- [ ] list_contact_flows
+- [ ] list_hours_of_operations
+- [ ] list_phone_numbers
+- [ ] list_queues
 - [ ] list_routing_profiles
 - [ ] list_security_profiles
 - [ ] list_user_hierarchy_groups
@@ -3244,7 +3262,7 @@
 - [ ] describe_events
 
 ## iam
-61% implemented
+60% implemented
 - [ ] add_client_id_to_open_id_connect_provider
 - [X] add_role_to_instance_profile
 - [X] add_user_to_group
@@ -6029,8 +6047,8 @@
 - [ ] update_job
 
 ## sns
-57% implemented
-- [ ] add_permission
+63% implemented
+- [X] add_permission
 - [ ] check_if_phone_number_is_opted_out
 - [ ] confirm_subscription
 - [X] create_platform_application
@@ -6053,7 +6071,7 @@
 - [X] list_topics
 - [ ] opt_in_phone_number
 - [X] publish
-- [ ] remove_permission
+- [X] remove_permission
 - [X] set_endpoint_attributes
 - [ ] set_platform_application_attributes
 - [ ] set_sms_attributes

--- a/moto/sns/responses.py
+++ b/moto/sns/responses.py
@@ -639,34 +639,21 @@ class SNSResponse(BaseResponse):
         return template.render()
 
     def add_permission(self):
-        arn = self._get_param('TopicArn')
+        topic_arn = self._get_param('TopicArn')
         label = self._get_param('Label')
-        accounts = self._get_multi_param('AWSAccountId.member.')
-        action = self._get_multi_param('ActionName.member.')
+        aws_account_ids = self._get_multi_param('AWSAccountId.member.')
+        action_names = self._get_multi_param('ActionName.member.')
 
-        if arn not in self.backend.topics:
-            error_response = self._error('NotFound', 'Topic does not exist')
-            return error_response, dict(status=404)
-
-        key = (arn, label)
-        self.backend.permissions[key] = {'accounts': accounts, 'action': action}
+        self.backend.add_permission(topic_arn, label, aws_account_ids, action_names)
 
         template = self.response_template(ADD_PERMISSION_TEMPLATE)
         return template.render()
 
     def remove_permission(self):
-        arn = self._get_param('TopicArn')
+        topic_arn = self._get_param('TopicArn')
         label = self._get_param('Label')
 
-        if arn not in self.backend.topics:
-            error_response = self._error('NotFound', 'Topic does not exist')
-            return error_response, dict(status=404)
-
-        try:
-            key = (arn, label)
-            del self.backend.permissions[key]
-        except KeyError:
-            pass
+        self.backend.remove_permission(topic_arn, label)
 
         template = self.response_template(DEL_PERMISSION_TEMPLATE)
         return template.render()


### PR DESCRIPTION
The whole permission handling was wrongly implemented. If you add or remove a permission it changes the access policy of the topic. I also changed the default policy to the correct one and create it with the correct region and account id. Additionally I added more tests and some extra error handling.