### PR TITLE
Remove newlines from XML responses

### DIFF
--- a/moto/core/responses.py
+++ b/moto/core/responses.py
@@ -83,6 +83,8 @@ class DynamicDictLoader(DictLoader):
 
 
 class _TemplateEnvironmentMixin(object):
+    LEFT_PATTERN = re.compile(r"[\s\n]+<")
+    RIGHT_PATTERN = re.compile(r">[\s\n]+")
 
     def __init__(self):
         super(_TemplateEnvironmentMixin, self).__init__()
@@ -101,7 +103,12 @@ class _TemplateEnvironmentMixin(object):
     def response_template(self, source):
         template_id = id(source)
         if not self.contains_template(template_id):
-            self.loader.update({template_id: source})
+            collapsed = re.sub(
+                self.RIGHT_PATTERN,
+                ">",
+                re.sub(self.LEFT_PATTERN, "<", source)
+            )
+            self.loader.update({template_id: collapsed})
             self.environment = Environment(loader=self.loader, autoescape=self.should_autoescape, trim_blocks=True,
                                            lstrip_blocks=True)
         return self.environment.get_template(template_id)


### PR DESCRIPTION
This is a fix for [#1870].

This is a second attempt at resolving the issues with producing an XML consistent with what is produced from AWS (i.e., no spaces/new lines between tags). Another attempt (https://github.com/spulec/moto/pull/2205) is currently failing in tests.

This attempt uses precompiled regex patterns as class attributes of the `_TemplateEnvironmentMixin` to remove trailing spaces and newlines after a `">"`, and preceding newlines/spaces before a `"<"`. This *explicitly* wasn't done with a single regex to ensure that even things like `"...<ID>\n      12345\n    </ID>"` are properly collapsed.