### PR TITLE
Fix deprecations in travis.yaml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 dist: xenial
 language: python
-sudo: false
 services:
 - docker
 python:
@@ -54,7 +53,7 @@ deploy:
     on:
       branch:
       - master
-    skip_cleanup: true
+    cleanup: false
     skip_existing: true
   # - provider: pypi
   #   distributions: sdist bdist_wheel


### PR DESCRIPTION
https://docs.travis-ci.com/user/reference/overview/#deprecated-virtualization-environments
https://blog.travis-ci.com/2019-08-27-deployment-tooling-dpl-v2-preview-release

> skip_cleanup is now deprecated, and cleanup is false by default. The default used to be true, so you had to opt out using skip_cleanup … and has been used a lot. Cleaning up the working directory from any left over build artifacts only made sense for few providers, so we have changed this default.


<img width="700" alt="Screenshot 2019-11-03 20 12 43" src="https://user-images.githubusercontent.com/1268088/68099331-c9fe6800-fe76-11e9-825a-66b792da9639.png">
