### PR TITLE
Add ssm `get_parameter_history` support

### DIFF
--- a/moto/ssm/models.py
+++ b/moto/ssm/models.py
@@ -527,7 +527,10 @@ class SimpleSystemManagerBackend(BaseBackend):
 
         return result
 
-        return result
+    def get_parameter_history(self, name, with_decryption):
+        if name in self._parameters:
+            return self._parameters[name]
+        return None
 
     def _match_filters(self, parameter, filters=None):
         """Return True if the given parameter matches all the filters"""

--- a/moto/ssm/models.py
+++ b/moto/ssm/models.py
@@ -521,7 +521,9 @@ class SimpleSystemManagerBackend(BaseBackend):
                 continue
             if "/" in param_name[len(path) + 1 :] and not recursive:
                 continue
-            if not self._match_filters(self.get_parameter(param_name, with_decryption), filters):
+            if not self._match_filters(
+                self.get_parameter(param_name, with_decryption), filters
+            ):
                 continue
             result.append(self.get_parameter(param_name, with_decryption))
 
@@ -605,16 +607,18 @@ class SimpleSystemManagerBackend(BaseBackend):
                 return
 
         last_modified_date = time.time()
-        self._parameters[name].append(Parameter(
-            name,
-            value,
-            type,
-            description,
-            allowed_pattern,
-            keyid,
-            last_modified_date,
-            version,
-        ))
+        self._parameters[name].append(
+            Parameter(
+                name,
+                value,
+                type,
+                description,
+                allowed_pattern,
+                keyid,
+                last_modified_date,
+                version,
+            )
+        )
         return version
 
     def add_tags_to_resource(self, resource_type, resource_id, tags):

--- a/moto/ssm/responses.py
+++ b/moto/ssm/responses.py
@@ -145,6 +145,13 @@ class SimpleSystemManagerResponse(BaseResponse):
 
         result = self.ssm_backend.get_parameter_history(name, with_decryption)
 
+        if result is None:
+            error = {
+                "__type": "ParameterNotFound",
+                "message": "Parameter {0} not found.".format(name),
+            }
+            return json.dumps(error), dict(status=400)
+
         response = {"Parameters": []}
         for parameter_version in result:
             param_data = parameter_version.describe_response_object(

--- a/moto/ssm/responses.py
+++ b/moto/ssm/responses.py
@@ -139,6 +139,19 @@ class SimpleSystemManagerResponse(BaseResponse):
         response = {"Version": result}
         return json.dumps(response)
 
+    def get_parameter_history(self):
+        name = self._get_param('Name')
+        with_decryption = self._get_param("WithDecryption")
+
+        result = self.ssm_backend.get_parameter_history(name, with_decryption)
+
+        response = {"Parameters": []}
+        for parameter_version in result:
+            param_data = parameter_version.describe_response_object(decrypt=with_decryption)
+            response['Parameters'].append(param_data)
+
+        return json.dumps(response)
+
     def add_tags_to_resource(self):
         resource_id = self._get_param("ResourceId")
         resource_type = self._get_param("ResourceType")

--- a/moto/ssm/responses.py
+++ b/moto/ssm/responses.py
@@ -140,15 +140,17 @@ class SimpleSystemManagerResponse(BaseResponse):
         return json.dumps(response)
 
     def get_parameter_history(self):
-        name = self._get_param('Name')
+        name = self._get_param("Name")
         with_decryption = self._get_param("WithDecryption")
 
         result = self.ssm_backend.get_parameter_history(name, with_decryption)
 
         response = {"Parameters": []}
         for parameter_version in result:
-            param_data = parameter_version.describe_response_object(decrypt=with_decryption)
-            response['Parameters'].append(param_data)
+            param_data = parameter_version.describe_response_object(
+                decrypt=with_decryption
+            )
+            response["Parameters"].append(param_data)
 
         return json.dumps(response)
 

--- a/tests/test_ssm/test_ssm_boto3.py
+++ b/tests/test_ssm/test_ssm_boto3.py
@@ -813,6 +813,7 @@ def test_put_parameter_secure_custom_kms():
     response["Parameters"][0]["Value"].should.equal("value")
     response["Parameters"][0]["Type"].should.equal("SecureString")
 
+
 @mock_ssm
 def test_get_parameter_history():
     client = boto3.client("ssm", region_name="us-east-1")
@@ -821,21 +822,25 @@ def test_get_parameter_history():
 
     for i in range(3):
         client.put_parameter(
-            Name=test_parameter_name, Description="A test parameter version %d" % i, Value="value-%d" % i, Type="String",
-            Overwrite=True
+            Name=test_parameter_name,
+            Description="A test parameter version %d" % i,
+            Value="value-%d" % i,
+            Type="String",
+            Overwrite=True,
         )
 
     response = client.get_parameter_history(Name=test_parameter_name)
-    parameters_response = response['Parameters']
+    parameters_response = response["Parameters"]
 
     for index, param in enumerate(parameters_response):
-        param['Name'].should.equal(test_parameter_name)
-        param['Type'].should.equal('String')
-        param['Value'].should.equal('value-%d' % index)
-        param['Version'].should.equal(index + 1)
-        param['Description'].should.equal("A test parameter version %d" % index)
+        param["Name"].should.equal(test_parameter_name)
+        param["Type"].should.equal("String")
+        param["Value"].should.equal("value-%d" % index)
+        param["Version"].should.equal(index + 1)
+        param["Description"].should.equal("A test parameter version %d" % index)
 
     len(parameters_response).should.equal(3)
+
 
 @mock_ssm
 def test_get_parameter_history_with_secure_string():
@@ -845,27 +850,33 @@ def test_get_parameter_history_with_secure_string():
 
     for i in range(3):
         client.put_parameter(
-            Name=test_parameter_name, Description="A test parameter version %d" % i, Value="value-%d" % i, Type="SecureString",
-            Overwrite=True
+            Name=test_parameter_name,
+            Description="A test parameter version %d" % i,
+            Value="value-%d" % i,
+            Type="SecureString",
+            Overwrite=True,
         )
 
     for with_decryption in [True, False]:
-        response = client.get_parameter_history(Name=test_parameter_name, WithDecryption=with_decryption)
-        parameters_response = response['Parameters']
+        response = client.get_parameter_history(
+            Name=test_parameter_name, WithDecryption=with_decryption
+        )
+        parameters_response = response["Parameters"]
 
         for index, param in enumerate(parameters_response):
-            param['Name'].should.equal(test_parameter_name)
-            param['Type'].should.equal('SecureString')
-            expected_plaintext_value = 'value-%d' % index
+            param["Name"].should.equal(test_parameter_name)
+            param["Type"].should.equal("SecureString")
+            expected_plaintext_value = "value-%d" % index
             if with_decryption:
-                param['Value'].should.equal(expected_plaintext_value)
+                param["Value"].should.equal(expected_plaintext_value)
             else:
-                param['Value'].should.equal('kms:alias/aws/ssm:%s' % expected_plaintext_value)
-            param['Version'].should.equal(index + 1)
-            param['Description'].should.equal("A test parameter version %d" % index)
+                param["Value"].should.equal(
+                    "kms:alias/aws/ssm:%s" % expected_plaintext_value
+                )
+            param["Version"].should.equal(index + 1)
+            param["Description"].should.equal("A test parameter version %d" % index)
 
         len(parameters_response).should.equal(3)
-
 
 
 @mock_ssm

--- a/tests/test_ssm/test_ssm_boto3.py
+++ b/tests/test_ssm/test_ssm_boto3.py
@@ -813,6 +813,60 @@ def test_put_parameter_secure_custom_kms():
     response["Parameters"][0]["Value"].should.equal("value")
     response["Parameters"][0]["Type"].should.equal("SecureString")
 
+@mock_ssm
+def test_get_parameter_history():
+    client = boto3.client("ssm", region_name="us-east-1")
+
+    test_parameter_name = "test"
+
+    for i in range(3):
+        client.put_parameter(
+            Name=test_parameter_name, Description="A test parameter version %d" % i, Value="value-%d" % i, Type="String",
+            Overwrite=True
+        )
+
+    response = client.get_parameter_history(Name=test_parameter_name)
+    parameters_response = response['Parameters']
+
+    for index, param in enumerate(parameters_response):
+        param['Name'].should.equal(test_parameter_name)
+        param['Type'].should.equal('String')
+        param['Value'].should.equal('value-%d' % index)
+        param['Version'].should.equal(index + 1)
+        param['Description'].should.equal("A test parameter version %d" % index)
+
+    len(parameters_response).should.equal(3)
+
+@mock_ssm
+def test_get_parameter_history_with_secure_string():
+    client = boto3.client("ssm", region_name="us-east-1")
+
+    test_parameter_name = "test"
+
+    for i in range(3):
+        client.put_parameter(
+            Name=test_parameter_name, Description="A test parameter version %d" % i, Value="value-%d" % i, Type="SecureString",
+            Overwrite=True
+        )
+
+    for with_decryption in [True, False]:
+        response = client.get_parameter_history(Name=test_parameter_name, WithDecryption=with_decryption)
+        parameters_response = response['Parameters']
+
+        for index, param in enumerate(parameters_response):
+            param['Name'].should.equal(test_parameter_name)
+            param['Type'].should.equal('SecureString')
+            expected_plaintext_value = 'value-%d' % index
+            if with_decryption:
+                param['Value'].should.equal(expected_plaintext_value)
+            else:
+                param['Value'].should.equal('kms:alias/aws/ssm:%s' % expected_plaintext_value)
+            param['Version'].should.equal(index + 1)
+            param['Description'].should.equal("A test parameter version %d" % index)
+
+        len(parameters_response).should.equal(3)
+
+
 
 @mock_ssm
 def test_add_remove_list_tags_for_resource():

--- a/tests/test_ssm/test_ssm_boto3.py
+++ b/tests/test_ssm/test_ssm_boto3.py
@@ -880,6 +880,20 @@ def test_get_parameter_history_with_secure_string():
 
 
 @mock_ssm
+def test_get_parameter_history_missing_parameter():
+    client = boto3.client("ssm", region_name="us-east-1")
+
+    try:
+        client.get_parameter_history(Name="test_noexist")
+        raise RuntimeError("Should have failed")
+    except botocore.exceptions.ClientError as err:
+        err.operation_name.should.equal("GetParameterHistory")
+        err.response["Error"]["Message"].should.equal(
+            "Parameter test_noexist not found."
+        )
+
+
+@mock_ssm
 def test_add_remove_list_tags_for_resource():
     client = boto3.client("ssm", region_name="us-east-1")
 


### PR DESCRIPTION
Basically, this PR changes how SSM parameters are stored in the backend to keep all previous versions, and then allow access to those versions via a `get_parameter_history` request.  All other endpoints should work exactly the same, grabbing the latest version of the parameter.