### PR TITLE
Add events event bus

### DIFF
--- a/IMPLEMENTATION_COVERAGE.md
+++ b/IMPLEMENTATION_COVERAGE.md
@@ -2713,9 +2713,9 @@
 - [ ] upgrade_elasticsearch_domain
 
 ## events
-48% implemented
+51% implemented
 - [ ] activate_event_source
-- [ ] create_event_bus
+- [X] create_event_bus
 - [ ] create_partner_event_source
 - [ ] deactivate_event_source
 - [ ] delete_event_bus

--- a/IMPLEMENTATION_COVERAGE.md
+++ b/IMPLEMENTATION_COVERAGE.md
@@ -2713,7 +2713,7 @@
 - [ ] upgrade_elasticsearch_domain
 
 ## events
-51% implemented
+54% implemented
 - [ ] activate_event_source
 - [X] create_event_bus
 - [ ] create_partner_event_source
@@ -2727,7 +2727,7 @@
 - [X] describe_rule
 - [X] disable_rule
 - [X] enable_rule
-- [ ] list_event_buses
+- [X] list_event_buses
 - [ ] list_event_sources
 - [ ] list_partner_event_source_accounts
 - [ ] list_partner_event_sources

--- a/IMPLEMENTATION_COVERAGE.md
+++ b/IMPLEMENTATION_COVERAGE.md
@@ -2713,12 +2713,12 @@
 - [ ] upgrade_elasticsearch_domain
 
 ## events
-54% implemented
+58% implemented
 - [ ] activate_event_source
 - [X] create_event_bus
 - [ ] create_partner_event_source
 - [ ] deactivate_event_source
-- [ ] delete_event_bus
+- [X] delete_event_bus
 - [ ] delete_partner_event_source
 - [X] delete_rule
 - [X] describe_event_bus

--- a/moto/events/models.py
+++ b/moto/events/models.py
@@ -354,6 +354,14 @@ class EventsBackend(BaseBackend):
 
         return list(self.event_buses.values())
 
+    def delete_event_bus(self, name):
+        if name == "default":
+            raise JsonRESTError(
+                "ValidationException", "Cannot delete event bus default."
+            )
+
+        self.event_buses.pop(name, None)
+
 
 available_regions = boto3.session.Session().get_available_regions("events")
 events_backends = {region: EventsBackend(region) for region in available_regions}

--- a/moto/events/models.py
+++ b/moto/events/models.py
@@ -344,6 +344,16 @@ class EventsBackend(BaseBackend):
 
         return self.event_buses[name]
 
+    def list_event_buses(self, name_prefix):
+        if name_prefix:
+            return [
+                event_bus
+                for event_bus in self.event_buses.values()
+                if event_bus.name.startswith(name_prefix)
+            ]
+
+        return list(self.event_buses.values())
+
 
 available_regions = boto3.session.Session().get_available_regions("events")
 events_backends = {region: EventsBackend(region) for region in available_regions}

--- a/moto/events/models.py
+++ b/moto/events/models.py
@@ -60,11 +60,35 @@ class EventBus(BaseModel):
         self.region = region_name
         self.name = name
 
+        self._permissions = {}
+
     @property
     def arn(self):
         return "arn:aws:events:{region}:{account_id}:event-bus/{name}".format(
             region=self.region, account_id=ACCOUNT_ID, name=self.name
         )
+
+    @property
+    def policy(self):
+        if not len(self._permissions):
+            return None
+
+        policy = {"Version": "2012-10-17", "Statement": []}
+
+        for sid, permission in self._permissions.items():
+            policy["Statement"].append(
+                {
+                    "Sid": sid,
+                    "Effect": "Allow",
+                    "Principal": {
+                        "AWS": "arn:aws:iam::{}:root".format(permission["Principal"])
+                    },
+                    "Action": permission["Action"],
+                    "Resource": self.arn,
+                }
+            )
+
+        return json.dumps(policy)
 
 
 class EventsBackend(BaseBackend):
@@ -78,7 +102,6 @@ class EventsBackend(BaseBackend):
         self.rules_order = []
         self.next_tokens = {}
         self.region_name = region_name
-        self.permissions = {}
         self.event_buses = {}
         self.event_sources = {}
 
@@ -241,9 +264,17 @@ class EventsBackend(BaseBackend):
     def test_event_pattern(self):
         raise NotImplementedError()
 
-    def put_permission(self, action, principal, statement_id):
+    def put_permission(self, event_bus_name, action, principal, statement_id):
+        if not event_bus_name:
+            event_bus_name = "default"
+
+        event_bus = self.describe_event_bus(event_bus_name)
+
         if action is None or action != "events:PutEvents":
-            raise JsonRESTError("InvalidParameterValue", "Action must be PutEvents")
+            raise JsonRESTError(
+                "ValidationException",
+                "Provided value in parameter 'action' is not supported.",
+            )
 
         if principal is None or self.ACCOUNT_ID.match(principal) is None:
             raise JsonRESTError(
@@ -255,34 +286,41 @@ class EventsBackend(BaseBackend):
                 "InvalidParameterValue", "StatementId must match ^[a-zA-Z0-9-_]{1,64}$"
             )
 
-        self.permissions[statement_id] = {"action": action, "principal": principal}
+        event_bus._permissions[statement_id] = {
+            "Action": action,
+            "Principal": principal,
+        }
 
-    def remove_permission(self, statement_id):
-        try:
-            del self.permissions[statement_id]
-        except KeyError:
-            raise JsonRESTError("ResourceNotFoundException", "StatementId not found")
+    def remove_permission(self, event_bus_name, statement_id):
+        if not event_bus_name:
+            event_bus_name = "default"
 
-    def describe_event_bus(self):
-        arn = "arn:aws:events:{0}:000000000000:event-bus/default".format(
-            self.region_name
-        )
-        statements = []
-        for statement_id, data in self.permissions.items():
-            statements.append(
-                {
-                    "Sid": statement_id,
-                    "Effect": "Allow",
-                    "Principal": {
-                        "AWS": "arn:aws:iam::{0}:root".format(data["principal"])
-                    },
-                    "Action": data["action"],
-                    "Resource": arn,
-                }
+        event_bus = self.describe_event_bus(event_bus_name)
+
+        if not len(event_bus._permissions):
+            raise JsonRESTError(
+                "ResourceNotFoundException", "EventBus does not have a policy."
             )
-        policy = {"Version": "2012-10-17", "Statement": statements}
-        policy_json = json.dumps(policy)
-        return {"Policy": policy_json, "Name": "default", "Arn": arn}
+
+        if not event_bus._permissions.pop(statement_id, None):
+            raise JsonRESTError(
+                "ResourceNotFoundException",
+                "Statement with the provided id does not exist.",
+            )
+
+    def describe_event_bus(self, name):
+        if not name:
+            name = "default"
+
+        event_bus = self.event_buses.get(name)
+
+        if not event_bus:
+            raise JsonRESTError(
+                "ResourceNotFoundException",
+                "Event bus {} does not exist.".format(name),
+            )
+
+        return event_bus
 
     def create_event_bus(self, name, event_source_name):
         if name in self.event_buses:

--- a/moto/events/responses.py
+++ b/moto/events/responses.py
@@ -255,3 +255,11 @@ class EventsHandler(BaseResponse):
 
     def describe_event_bus(self):
         return json.dumps(self.events_backend.describe_event_bus())
+
+    def create_event_bus(self):
+        name = self._get_param("Name")
+        event_source_name = self._get_param("EventSourceName")
+
+        event_bus = self.events_backend.create_event_bus(name, event_source_name)
+
+        return json.dumps({"EventBusArn": event_bus.arn}), self.response_headers

--- a/moto/events/responses.py
+++ b/moto/events/responses.py
@@ -296,3 +296,10 @@ class EventsHandler(BaseResponse):
             response.append(event_bus_response)
 
         return json.dumps({"EventBuses": response}), self.response_headers
+
+    def delete_event_bus(self):
+        name = self._get_param("Name")
+
+        self.events_backend.delete_event_bus(name)
+
+        return "", self.response_headers

--- a/moto/events/responses.py
+++ b/moto/events/responses.py
@@ -278,3 +278,21 @@ class EventsHandler(BaseResponse):
         event_bus = self.events_backend.create_event_bus(name, event_source_name)
 
         return json.dumps({"EventBusArn": event_bus.arn}), self.response_headers
+
+    def list_event_buses(self):
+        name_prefix = self._get_param("NamePrefix")
+        # ToDo: add 'NextToken' & 'Limit' parameters
+
+        response = []
+        for event_bus in self.events_backend.list_event_buses(name_prefix):
+            event_bus_response = {
+                "Name": event_bus.name,
+                "Arn": event_bus.arn,
+            }
+
+            if event_bus.policy:
+                event_bus_response["Policy"] = event_bus.policy
+
+            response.append(event_bus_response)
+
+        return json.dumps({"EventBuses": response}), self.response_headers

--- a/moto/events/responses.py
+++ b/moto/events/responses.py
@@ -238,23 +238,38 @@ class EventsHandler(BaseResponse):
         pass
 
     def put_permission(self):
+        event_bus_name = self._get_param("EventBusName")
         action = self._get_param("Action")
         principal = self._get_param("Principal")
         statement_id = self._get_param("StatementId")
 
-        self.events_backend.put_permission(action, principal, statement_id)
+        self.events_backend.put_permission(
+            event_bus_name, action, principal, statement_id
+        )
 
         return ""
 
     def remove_permission(self):
+        event_bus_name = self._get_param("EventBusName")
         statement_id = self._get_param("StatementId")
 
-        self.events_backend.remove_permission(statement_id)
+        self.events_backend.remove_permission(event_bus_name, statement_id)
 
         return ""
 
     def describe_event_bus(self):
-        return json.dumps(self.events_backend.describe_event_bus())
+        name = self._get_param("Name")
+
+        event_bus = self.events_backend.describe_event_bus(name)
+        response = {
+            "Name": event_bus.name,
+            "Arn": event_bus.arn,
+        }
+
+        if event_bus.policy:
+            response["Policy"] = event_bus.policy
+
+        return json.dumps(response), self.response_headers
 
     def create_event_bus(self):
         name = self._get_param("Name")

--- a/tests/test_events/test_events.py
+++ b/tests/test_events/test_events.py
@@ -361,12 +361,6 @@ def test_describe_event_bus_errors():
 def test_list_event_buses():
     client = boto3.client("events", "us-east-1")
     client.create_event_bus(Name="test-bus-1")
-    client.put_permission(
-        EventBusName="test-bus-1",
-        Action="events:PutEvents",
-        Principal="111111111111",
-        StatementId="test",
-    )
     client.create_event_bus(Name="test-bus-2")
     client.create_event_bus(Name="other-bus-1")
     client.create_event_bus(Name="other-bus-2")
@@ -391,7 +385,6 @@ def test_list_event_buses():
             {
                 "Name": "test-bus-1",
                 "Arn": "arn:aws:events:us-east-1:123456789012:event-bus/test-bus-1",
-                "Policy": '{"Version": "2012-10-17", "Statement": [{"Sid": "test", "Effect": "Allow", "Principal": {"AWS": "arn:aws:iam::111111111111:root"}, "Action": "events:PutEvents", "Resource": "arn:aws:events:us-east-1:123456789012:event-bus/test-bus-1"}]}',
             },
             {
                 "Name": "test-bus-2",
@@ -403,7 +396,7 @@ def test_list_event_buses():
     response = client.list_event_buses(NamePrefix="other-bus")
 
     response["EventBuses"].should.have.length_of(2)
-    response["EventBuses"].should.equal(
+    sorted(response["EventBuses"], key=lambda i: i["Name"]).should.equal(
         [
             {
                 "Name": "other-bus-1",


### PR DESCRIPTION
I had to redo the whole permissions handling in events to support Event Buses. I left out the implementation of `NextToken` & `Limit` in `list_event_buses()`, because the PR is already big enough and it doesn't add up any meaningful functionality at the moment.

Adds support for custom event buses, but not for partner ones, because per default an AWS account doesn't have any partner event buses available for usage. Any advice or idea on how to support partner event buses? Add a new decorator `@mock_event_bus(partner="datadog")` or extend existing one `@mock_events(partner_event_bus="datadog")`?

Partially solves #2322