### PR TITLE
IAM - Validate duplicate role names

### DIFF
--- a/moto/iam/models.py
+++ b/moto/iam/models.py
@@ -898,6 +898,10 @@ class IAMBackend(BaseBackend):
                     permissions_boundary
                 ),
             )
+        if [role for role in self.get_roles() if role.name == role_name]:
+            raise EntityAlreadyExists(
+                "Role with name {0} already exists.".format(role_name)
+            )
 
         clean_tags = self._tag_verification(tags)
         role = Role(

--- a/moto/iam/models.py
+++ b/moto/iam/models.py
@@ -820,7 +820,7 @@ class IAMBackend(BaseBackend):
         )
         if policy.arn in self.managed_policies:
             raise EntityAlreadyExists(
-                "A policy called {} already exists. Duplicate names are not allowed.".format(
+                "A policy called {0} already exists. Duplicate names are not allowed.".format(
                     policy_name
                 )
             )

--- a/tests/test_core/test_auth.py
+++ b/tests/test_core/test_auth.py
@@ -11,6 +11,7 @@ from nose.tools import assert_raises
 from moto import mock_iam, mock_ec2, mock_s3, mock_sts, mock_elbv2, mock_rds2
 from moto.core import set_initial_no_auth_action_count
 from moto.iam.models import ACCOUNT_ID
+from uuid import uuid4
 
 
 @mock_iam
@@ -71,8 +72,10 @@ def create_user_with_access_key_and_multiple_policies(
 
 
 def create_group_with_attached_policy_and_add_user(
-    user_name, policy_document, group_name="test-group", policy_name="policy1"
+    user_name, policy_document, group_name="test-group", policy_name=None
 ):
+    if not policy_name:
+        policy_name = str(uuid4())
     client = boto3.client("iam", region_name="us-east-1")
     client.create_group(GroupName=group_name)
     policy_arn = client.create_policy(
@@ -101,8 +104,10 @@ def create_group_with_multiple_policies_and_add_user(
     attached_policy_document,
     group_name="test-group",
     inline_policy_name="policy1",
-    attached_policy_name="policy1",
+    attached_policy_name=None,
 ):
+    if not attached_policy_name:
+        attached_policy_name = str(uuid4())
     client = boto3.client("iam", region_name="us-east-1")
     client.create_group(GroupName=group_name)
     client.put_group_policy(

--- a/tests/test_iam/test_iam.py
+++ b/tests/test_iam/test_iam.py
@@ -2072,6 +2072,22 @@ def test_create_role_with_same_name_should_fail():
 
 
 @mock_iam
+def test_create_policy_with_same_name_should_fail():
+    iam = boto3.client("iam", region_name="us-east-1")
+    test_policy_name = str(uuid4())
+    policy = iam.create_policy(PolicyName=test_policy_name, PolicyDocument=MOCK_POLICY)
+    # Create the role again, and verify that it fails
+    with assert_raises(ClientError) as err:
+        iam.create_policy(PolicyName=test_policy_name, PolicyDocument=MOCK_POLICY)
+    err.exception.response["Error"]["Code"].should.equal("EntityAlreadyExists")
+    err.exception.response["Error"]["Message"].should.equal(
+        "A policy called {0} already exists. Duplicate names are not allowed.".format(
+            test_policy_name
+        )
+    )
+
+
+@mock_iam
 def test_create_open_id_connect_provider():
     client = boto3.client("iam", region_name="us-east-1")
     response = client.create_open_id_connect_provider(

--- a/tests/test_iam/test_iam.py
+++ b/tests/test_iam/test_iam.py
@@ -18,6 +18,7 @@ from nose.tools import raises
 
 from datetime import datetime
 from tests.helpers import requires_boto_gte
+from uuid import uuid4
 
 
 MOCK_CERT = """-----BEGIN CERTIFICATE-----
@@ -2048,6 +2049,26 @@ def test_create_role_with_permissions_boundary():
 
     # Ensure the PermissionsBoundary is included in role listing as well
     conn.list_roles().get("Roles")[0].get("PermissionsBoundary").should.equal(expected)
+
+
+@mock_iam
+def test_create_role_with_same_name_should_fail():
+    iam = boto3.client("iam", region_name="us-east-1")
+    test_role_name = str(uuid4())
+    iam.create_role(
+        RoleName=test_role_name, AssumeRolePolicyDocument="policy", Description="test"
+    )
+    # Create the role again, and verify that it fails
+    with assert_raises(ClientError) as err:
+        iam.create_role(
+            RoleName=test_role_name,
+            AssumeRolePolicyDocument="policy",
+            Description="test",
+        )
+    err.exception.response["Error"]["Code"].should.equal("EntityAlreadyExists")
+    err.exception.response["Error"]["Message"].should.equal(
+        "Role with name {0} already exists.".format(test_role_name)
+    )
 
 
 @mock_iam


### PR DESCRIPTION
Adds a check when creating a role, to make sure a role with that name doesn't already exist.

Now matches AWS behaviour.

Edit: Added the same validation when creating an IAM policy