### PR TITLE
Match AWS's change from smart-quote to ASCII quote

### DIFF
--- a/moto/secretsmanager/exceptions.py
+++ b/moto/secretsmanager/exceptions.py
@@ -14,23 +14,21 @@ class ResourceNotFoundException(SecretsManagerClientError):
         )
 
 
-# Using specialised exception due to the use of a non-ASCII character
 class SecretNotFoundException(SecretsManagerClientError):
     def __init__(self):
         self.code = 404
         super(SecretNotFoundException, self).__init__(
             "ResourceNotFoundException",
-            message="Secrets Manager can\u2019t find the specified secret.",
+            message="Secrets Manager can't find the specified secret.",
         )
 
 
-# Using specialised exception due to the use of a non-ASCII character
 class SecretHasNoValueException(SecretsManagerClientError):
     def __init__(self, version_stage):
         self.code = 404
         super(SecretHasNoValueException, self).__init__(
             "ResourceNotFoundException",
-            message="Secrets Manager can\u2019t find the specified secret "
+            message="Secrets Manager can't find the specified secret "
             "value for staging label: {}".format(version_stage),
         )
 

--- a/tests/test_secretsmanager/test_secretsmanager.py
+++ b/tests/test_secretsmanager/test_secretsmanager.py
@@ -45,7 +45,7 @@ def test_get_secret_that_does_not_exist():
         result = conn.get_secret_value(SecretId="i-dont-exist")
 
     assert_equal(
-        "Secrets Manager can\u2019t find the specified secret.",
+        "Secrets Manager can't find the specified secret.",
         cm.exception.response["Error"]["Message"],
     )
 
@@ -61,7 +61,7 @@ def test_get_secret_that_does_not_match():
         result = conn.get_secret_value(SecretId="i-dont-match")
 
     assert_equal(
-        "Secrets Manager can\u2019t find the specified secret.",
+        "Secrets Manager can't find the specified secret.",
         cm.exception.response["Error"]["Message"],
     )
 
@@ -88,7 +88,7 @@ def test_get_secret_that_has_no_value():
         result = conn.get_secret_value(SecretId="java-util-test-password")
 
     assert_equal(
-        "Secrets Manager can\u2019t find the specified secret value for staging label: AWSCURRENT",
+        "Secrets Manager can't find the specified secret value for staging label: AWSCURRENT",
         cm.exception.response["Error"]["Message"],
     )
 

--- a/tests/test_secretsmanager/test_server.py
+++ b/tests/test_secretsmanager/test_server.py
@@ -48,9 +48,7 @@ def test_get_secret_that_does_not_exist():
         headers={"X-Amz-Target": "secretsmanager.GetSecretValue"},
     )
     json_data = json.loads(get_secret.data.decode("utf-8"))
-    assert (
-        json_data["message"] == "Secrets Manager can\u2019t find the specified secret."
-    )
+    assert json_data["message"] == "Secrets Manager can't find the specified secret."
     assert json_data["__type"] == "ResourceNotFoundException"
 
 
@@ -70,9 +68,7 @@ def test_get_secret_that_does_not_match():
         headers={"X-Amz-Target": "secretsmanager.GetSecretValue"},
     )
     json_data = json.loads(get_secret.data.decode("utf-8"))
-    assert (
-        json_data["message"] == "Secrets Manager can\u2019t find the specified secret."
-    )
+    assert json_data["message"] == "Secrets Manager can't find the specified secret."
     assert json_data["__type"] == "ResourceNotFoundException"
 
 
@@ -95,7 +91,7 @@ def test_get_secret_that_has_no_value():
     json_data = json.loads(get_secret.data.decode("utf-8"))
     assert (
         json_data["message"]
-        == "Secrets Manager can\u2019t find the specified secret value for staging label: AWSCURRENT"
+        == "Secrets Manager can't find the specified secret value for staging label: AWSCURRENT"
     )
     assert json_data["__type"] == "ResourceNotFoundException"
 
@@ -178,9 +174,7 @@ def test_describe_secret_that_does_not_exist():
     )
 
     json_data = json.loads(describe_secret.data.decode("utf-8"))
-    assert (
-        json_data["message"] == "Secrets Manager can\u2019t find the specified secret."
-    )
+    assert json_data["message"] == "Secrets Manager can't find the specified secret."
     assert json_data["__type"] == "ResourceNotFoundException"
 
 
@@ -202,9 +196,7 @@ def test_describe_secret_that_does_not_match():
     )
 
     json_data = json.loads(describe_secret.data.decode("utf-8"))
-    assert (
-        json_data["message"] == "Secrets Manager can\u2019t find the specified secret."
-    )
+    assert json_data["message"] == "Secrets Manager can't find the specified secret."
     assert json_data["__type"] == "ResourceNotFoundException"
 
 
@@ -306,9 +298,7 @@ def test_rotate_secret_that_does_not_exist():
     )
 
     json_data = json.loads(rotate_secret.data.decode("utf-8"))
-    assert (
-        json_data["message"] == "Secrets Manager can\u2019t find the specified secret."
-    )
+    assert json_data["message"] == "Secrets Manager can't find the specified secret."
     assert json_data["__type"] == "ResourceNotFoundException"
 
 
@@ -330,9 +320,7 @@ def test_rotate_secret_that_does_not_match():
     )
 
     json_data = json.loads(rotate_secret.data.decode("utf-8"))
-    assert (
-        json_data["message"] == "Secrets Manager can\u2019t find the specified secret."
-    )
+    assert json_data["message"] == "Secrets Manager can't find the specified secret."
     assert json_data["__type"] == "ResourceNotFoundException"
 
 


### PR DESCRIPTION
Sometime since I made the PR to represent the smart-quotes in the error messages sent by AWS secretsmanager AWS appear to have changed them to regular old quotes. This PR matches that change in order to make moto representative of actual behaviour once again.