### PR TITLE
 #2562 - DynamoDB - allow updates to be of a different type

### DIFF
--- a/moto/dynamodb2/models.py
+++ b/moto/dynamodb2/models.py
@@ -77,6 +77,7 @@ class DynamoType(object):
             attr, list_index = attribute_is_list(attr)
             if not key:
                 # {'S': value} ==> {'S': new_value}
+                self.type = new_value.type
                 self.value = new_value.value
             else:
                 if attr not in self.value:  # nonexistingattribute


### PR DESCRIPTION
Fixes #2562 

DynamoDB allows item attributes to gain a different type. All scenarios have been verified against AWS