### PR TITLE
Add/improve Lambda coverage - no functionality changes

### DIFF
--- a/IMPLEMENTATION_COVERAGE.md
+++ b/IMPLEMENTATION_COVERAGE.md
@@ -3977,46 +3977,46 @@
 - [ ] update_resource
 
 ## lambda
-0% implemented
+41% implemented
 - [ ] add_layer_version_permission
 - [ ] add_permission
 - [ ] create_alias
-- [ ] create_event_source_mapping
-- [ ] create_function
+- [X] create_event_source_mapping
+- [X] create_function
 - [ ] delete_alias
-- [ ] delete_event_source_mapping
-- [ ] delete_function
+- [X] delete_event_source_mapping
+- [X] delete_function
 - [ ] delete_function_concurrency
 - [ ] delete_layer_version
 - [ ] get_account_settings
 - [ ] get_alias
-- [ ] get_event_source_mapping
-- [ ] get_function
+- [X] get_event_source_mapping
+- [X] get_function
 - [ ] get_function_configuration
 - [ ] get_layer_version
 - [ ] get_layer_version_by_arn
 - [ ] get_layer_version_policy
 - [ ] get_policy
-- [ ] invoke
+- [X] invoke
 - [ ] invoke_async
 - [ ] list_aliases
-- [ ] list_event_source_mappings
-- [ ] list_functions
+- [X] list_event_source_mappings
+- [X] list_functions
 - [ ] list_layer_versions
 - [ ] list_layers
-- [ ] list_tags
-- [ ] list_versions_by_function
+- [X] list_tags
+- [X] list_versions_by_function
 - [ ] publish_layer_version
 - [ ] publish_version
 - [ ] put_function_concurrency
 - [ ] remove_layer_version_permission
 - [ ] remove_permission
-- [ ] tag_resource
-- [ ] untag_resource
+- [X] tag_resource
+- [X] untag_resource
 - [ ] update_alias
-- [ ] update_event_source_mapping
-- [ ] update_function_code
-- [ ] update_function_configuration
+- [X] update_event_source_mapping
+- [X] update_function_code
+- [X] update_function_configuration
 
 ## lex-models
 0% implemented

--- a/moto/awslambda/models.py
+++ b/moto/awslambda/models.py
@@ -979,6 +979,32 @@ class LambdaBackend(BaseBackend):
     def add_policy(self, function_name, policy):
         self.get_function(function_name).policy = policy
 
+    def update_function_code(self, function_name, qualifier, body):
+        fn = self.get_function(function_name, qualifier)
+
+        if fn:
+            if body.get("Publish", False):
+                fn = self.publish_function(function_name)
+
+            config = fn.update_function_code(body)
+            return config
+        else:
+            return None
+
+    def update_function_configuration(self, function_name, qualifier, body):
+        fn = self.get_function(function_name, qualifier)
+
+        return fn.update_configuration(body) if fn else None
+
+    def invoke(self, function_name, qualifier, body, headers, response_headers):
+        fn = self.get_function(function_name, qualifier)
+        if fn:
+            payload = fn.invoke(body, headers, response_headers)
+            response_headers["Content-Length"] = str(len(payload))
+            return response_headers, payload
+        else:
+            return response_headers, None
+
 
 def do_validate_s3():
     return os.environ.get("VALIDATE_LAMBDA_S3", "") in ["", "1", "true"]

--- a/scripts/implementation_coverage.py
+++ b/scripts/implementation_coverage.py
@@ -7,16 +7,18 @@ import boto3
 
 
 script_dir = os.path.dirname(os.path.abspath(__file__))
+alternative_service_names = {'lambda': 'awslambda'}
 
 
 def get_moto_implementation(service_name):
-    service_name_standardized = service_name.replace("-", "") if "-" in service_name else service_name
-    if not hasattr(moto, service_name_standardized):
+    service_name = service_name.replace("-", "") if "-" in service_name else service_name
+    alt_service_name = alternative_service_names[service_name] if service_name in alternative_service_names else service_name
+    if not hasattr(moto, alt_service_name):
         return None
-    module = getattr(moto, service_name_standardized)
+    module = getattr(moto, alt_service_name)
     if module is None:
         return None
-    mock = getattr(module, "mock_{}".format(service_name_standardized))
+    mock = getattr(module, "mock_{}".format(service_name))
     if mock is None:
         return None
     backends = list(mock().backends.values())


### PR DESCRIPTION
Two changes:

 - Make sure implementation_coverage.py knows that the boto-service 'lambda' maps to folder 'awslambda'
 - Move logic from responses.py to models.py, ensuring that implementation_coverage can find all implemented functions in models.py