### PR TITLE
Cap python-dateutil to 2.8.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ install_requires = [
     "werkzeug",
     "PyYAML>=5.1",
     "pytz",
-    "python-dateutil<3.0.0,>=2.1",
+    "python-dateutil<2.8.1,>=2.1",
     "python-jose<4.0.0",
     "mock",
     "docker>=2.5.1",


### PR DESCRIPTION
Due to changes by boto/botocore@e87e7a7 the `python-dateutil` dependency was capped to version 2.8.0.

When issue boto/botocore#1872 is fixed the cap can be reverted to the old one.

Also fixes #2540 and fixes #2568