### PR TITLE
Add the ssh_public_key methods that were missing from IAM

### DIFF
--- a/moto/iam/models.py
+++ b/moto/iam/models.py
@@ -489,13 +489,6 @@ class SshPublicKey(BaseModel):
     def uploaded_iso_8601(self):
         return iso_8601_datetime_without_milliseconds(self.upload_date)
 
-    def get_cfn_attribute(self, attribute_name):
-        from moto.cloudformation.exceptions import UnformattedGetAttTemplateException
-
-        if attribute_name == "PublicKeyBody":
-            return self.public_key_body
-        raise UnformattedGetAttTemplateException()
-
 
 class Group(BaseModel):
     def __init__(self, name, path="/"):

--- a/moto/iam/responses.py
+++ b/moto/iam/responses.py
@@ -590,6 +590,46 @@ class IamResponse(BaseResponse):
         template = self.response_template(GENERIC_EMPTY_TEMPLATE)
         return template.render(name="DeleteAccessKey")
 
+    def upload_ssh_public_key(self):
+        user_name = self._get_param("UserName")
+        ssh_public_key_body = self._get_param("SSHPublicKeyBody")
+
+        key = iam_backend.upload_ssh_public_key(user_name, ssh_public_key_body)
+        template = self.response_template(UPLOAD_SSH_PUBLIC_KEY_TEMPLATE)
+        return template.render(key=key)
+
+    def get_ssh_public_key(self):
+        user_name = self._get_param("UserName")
+        ssh_public_key_id = self._get_param("SSHPublicKeyId")
+
+        key = iam_backend.get_ssh_public_key(user_name, ssh_public_key_id)
+        template = self.response_template(GET_SSH_PUBLIC_KEY_TEMPLATE)
+        return template.render(key=key)
+
+    def list_ssh_public_keys(self):
+        user_name = self._get_param("UserName")
+
+        keys = iam_backend.get_all_ssh_public_keys(user_name)
+        template = self.response_template(LIST_SSH_PUBLIC_KEYS_TEMPLATE)
+        return template.render(keys=keys)
+
+    def update_ssh_public_key(self):
+        user_name = self._get_param("UserName")
+        ssh_public_key_id = self._get_param("SSHPublicKeyId")
+        status = self._get_param("Status")
+
+        iam_backend.update_ssh_public_key(user_name, ssh_public_key_id, status)
+        template = self.response_template(UPDATE_SSH_PUBLIC_KEY_TEMPLATE)
+        return template.render()
+
+    def delete_ssh_public_key(self):
+        user_name = self._get_param("UserName")
+        ssh_public_key_id = self._get_param("SSHPublicKeyId")
+
+        iam_backend.delete_ssh_public_key(user_name, ssh_public_key_id)
+        template = self.response_template(DELETE_SSH_PUBLIC_KEY_TEMPLATE)
+        return template.render()
+
     def deactivate_mfa_device(self):
         user_name = self._get_param("UserName")
         serial_number = self._get_param("SerialNumber")
@@ -1695,6 +1735,73 @@ GET_ACCESS_KEY_LAST_USED_TEMPLATE = """
     </GetAccessKeyLastUsedResult>
 </GetAccessKeyLastUsedResponse>
 """
+
+UPLOAD_SSH_PUBLIC_KEY_TEMPLATE = """<UploadSSHPublicKeyResponse>
+   <UploadSSHPublicKeyResult>
+     <SSHPublicKey>
+         <UserName>{{ key.user_name }}</UserName>
+         <SSHPublicKeyBody>{{ key.ssh_public_key_body }}</SSHPublicKeyBody>
+         <SSHPublicKeyId>{{ key.ssh_public_key_id }}</SSHPublicKeyId>
+         <Fingerprint>{{ key.fingerprint }}</Fingerprint>
+         <Status>{{ key.status }}</Status>
+         <UploadDate>{{ key.uploaded_iso_8601 }}</UploadDate>
+      </SSHPublicKey>
+   </UploadSSHPublicKeyResult>
+   <ResponseMetadata>
+      <RequestId>7a62c49f-347e-4fc4-9331-6e8eEXAMPLE</RequestId>
+   </ResponseMetadata>
+</UploadSSHPublicKeyResponse>"""
+
+GET_SSH_PUBLIC_KEY_TEMPLATE = """<GetSSHPublicKeyResponse>
+   <GetSSHPublicKeyResult>
+     <SSHPublicKey>
+         <UserName>{{ key.user_name }}</UserName>
+         <SSHPublicKeyBody>{{ key.ssh_public_key_body }}</SSHPublicKeyBody>
+         <SSHPublicKeyId>{{ key.ssh_public_key_id }}</SSHPublicKeyId>
+         <Fingerprint>{{ key.fingerprint }}</Fingerprint>
+         <Status>{{ key.status }}</Status>
+         <UploadDate>{{ key.uploaded_iso_8601 }}</UploadDate>
+      </SSHPublicKey>
+   </GetSSHPublicKeyResult>
+   <ResponseMetadata>
+      <RequestId>7a62c49f-347e-4fc4-9331-6e8eEXAMPLE</RequestId>
+   </ResponseMetadata>
+</GetSSHPublicKeyResponse>"""
+
+LIST_SSH_PUBLIC_KEYS_TEMPLATE = """<ListSSHPublicKeysResponse>
+   <ListSSHPublicKeysResult>
+      <SSHPublicKeys>
+        {% for key in keys %}
+            <member>
+                <UserName>{{ key.user_name }}</UserName>
+                <SSHPublicKeyId>{{ key.ssh_public_key_id }}</SSHPublicKeyId>
+                <Status>{{ key.status }}</Status>
+                <UploadDate>{{ key.uploaded_iso_8601 }}</UploadDate>
+            </member>
+        {% endfor %}
+      </SSHPublicKeys>
+      <IsTruncated>false</IsTruncated>
+   </ListSSHPublicKeysResult>
+   <ResponseMetadata>
+      <RequestId>7a62c49f-347e-4fc4-9331-6e8eEXAMPLE</RequestId>
+   </ResponseMetadata>
+</ListSSHPublicKeysResponse>"""
+
+UPDATE_SSH_PUBLIC_KEY_TEMPLATE = """<UpdateSSHPublicKeyResponse>
+   <UpdateSSHPublicKeyResult>
+   </UpdateSSHPublicKeyResult>
+   <ResponseMetadata>
+      <RequestId>7a62c49f-347e-4fc4-9331-6e8eEXAMPLE</RequestId>
+   </ResponseMetadata>
+</UpdateSSHPublicKeyResponse>"""
+
+DELETE_SSH_PUBLIC_KEY_TEMPLATE = """<DeleteSSHPublicKeyResponse>
+   <DeleteSSHPublicKeyResult>
+   </DeleteSSHPublicKeyResult>
+   <ResponseMetadata>
+      <RequestId>7a62c49f-347e-4fc4-9331-6e8eEXAMPLE</RequestId>
+   </ResponseMetadata>
+</DeleteSSHPublicKeyResponse>"""
 
 CREDENTIAL_REPORT_GENERATING = """
 <GenerateCredentialReportResponse>


### PR DESCRIPTION
Needed these for some testing that I was doing, so just tried to follow the patterns that were there for the similar access_key capabilities.

I didn't do any validation of keys, or conversion (PEM vs SSH encoded) for the get method as I'd probably have to pull in some crypto lib to do so, and wasn't sure what the preference would be there