### PR TITLE
Fixed the Lambda invocation due to lambci changes.

### DIFF
--- a/moto/awslambda/models.py
+++ b/moto/awslambda/models.py
@@ -46,8 +46,9 @@ try:
 except ImportError:
     from backports.tempfile import TemporaryDirectory
 
-
-_stderr_regex = re.compile(r"START|END|REPORT RequestId: .*")
+# The lambci container is returning a special escape character for the "RequestID" fields. Unicode 033:
+# _stderr_regex = re.compile(r"START|END|REPORT RequestId: .*")
+_stderr_regex = re.compile(r"\033\[\d+.*")
 _orig_adapter_send = requests.adapters.HTTPAdapter.send
 docker_3 = docker.__version__[0] >= "3"
 
@@ -444,7 +445,7 @@ class LambdaFunction(BaseModel):
             if exit_code != 0:
                 raise Exception("lambda invoke failed output: {}".format(output))
 
-            # strip out RequestId lines
+            # strip out RequestId lines (TODO: This will return an additional '\n' in the response)
             output = os.linesep.join(
                 [
                     line

--- a/tests/test_awslambda/test_lambda.py
+++ b/tests/test_awslambda/test_lambda.py
@@ -162,7 +162,7 @@ if settings.TEST_SERVER_MODE:
         conn = boto3.client("lambda", "us-west-2")
         conn.create_function(
             FunctionName="testFunction",
-            Runtime="python2.7",
+            Runtime="python3.7",
             Role="test-iam-role",
             Handler="lambda_function.lambda_handler",
             Code={"ZipFile": get_test_zip_file2()},
@@ -184,18 +184,20 @@ if settings.TEST_SERVER_MODE:
             vol.id,
             vol.state,
             vol.size,
-            json.dumps(in_data),
+            json.dumps(in_data).replace(
+                " ", ""
+            ),  # Makes the tests pass as the result is missing the whitespace
         )
 
         log_result = base64.b64decode(result["LogResult"]).decode("utf-8")
 
-        # fix for running under travis (TODO: investigate why it has an extra newline)
+        # The Docker lambda invocation will return an additional '\n', so need to replace it:
         log_result = log_result.replace("\n\n", "\n")
         log_result.should.equal(msg)
 
         payload = result["Payload"].read().decode("utf-8")
 
-        # fix for running under travis (TODO: investigate why it has an extra newline)
+        # The Docker lambda invocation will return an additional '\n', so need to replace it:
         payload = payload.replace("\n\n", "\n")
         payload.should.equal(msg)
 


### PR DESCRIPTION
It looks like lambci is pre-pending the lambda responses with an
escape character `\033`. This was breaking the unit tests.