### PR TITLE
Improve parsing DynamoDB begins_with expression

### DIFF
--- a/moto/dynamodb2/responses.py
+++ b/moto/dynamodb2/responses.py
@@ -481,7 +481,7 @@ class DynamoHandler(BaseResponse):
                     ]
                 elif "begins_with" in range_key_expression:
                     range_comparison = "BEGINS_WITH"
-                    range_values = [value_alias_map[range_key_expression_components[1]]]
+                    range_values = [value_alias_map[range_key_expression_components[-1]]]
                 else:
                     range_values = [value_alias_map[range_key_expression_components[2]]]
             else:

--- a/moto/dynamodb2/responses.py
+++ b/moto/dynamodb2/responses.py
@@ -438,9 +438,12 @@ class DynamoHandler(BaseResponse):
                 all_indexes = (table.global_indexes or []) + (table.indexes or [])
                 indexes_by_name = dict((i["IndexName"], i) for i in all_indexes)
                 if index_name not in indexes_by_name:
-                    raise ValueError(
-                        "Invalid index: %s for table: %s. Available indexes are: %s"
-                        % (index_name, name, ", ".join(indexes_by_name.keys()))
+                    er = "com.amazonaws.dynamodb.v20120810#ResourceNotFoundException"
+                    return self.error(
+                        er,
+                        "Invalid index: {} for table: {}. Available indexes are: {}".format(
+                            index_name, name, ", ".join(indexes_by_name.keys())
+                        ),
                     )
 
                 index = indexes_by_name[index_name]["KeySchema"]

--- a/moto/dynamodb2/responses.py
+++ b/moto/dynamodb2/responses.py
@@ -481,7 +481,9 @@ class DynamoHandler(BaseResponse):
                     ]
                 elif "begins_with" in range_key_expression:
                     range_comparison = "BEGINS_WITH"
-                    range_values = [value_alias_map[range_key_expression_components[-1]]]
+                    range_values = [
+                        value_alias_map[range_key_expression_components[-1]]
+                    ]
                 else:
                     range_values = [value_alias_map[range_key_expression_components[2]]]
             else:

--- a/tests/test_dynamodb2/test_dynamodb.py
+++ b/tests/test_dynamodb2/test_dynamodb.py
@@ -2655,14 +2655,15 @@ def test_query_by_non_exists_index():
         ],
     )
 
-    with assert_raises(ValueError) as ex:
+    with assert_raises(ClientError) as ex:
         dynamodb.query(
             TableName="test",
             IndexName="non_exists_index",
             KeyConditionExpression="CarModel=M",
         )
 
-    str(ex.exception).should.equal(
+    ex.exception.response["Error"]["Code"].should.equal("ResourceNotFoundException")
+    ex.exception.response["Error"]["Message"].should.equal(
         "Invalid index: non_exists_index for table: test. Available indexes are: test_gsi"
     )
 


### PR DESCRIPTION
A query fails if it has a space between `begins_with` and `(`,
for example: ```begins_with (#1, :1)```

Fix #1996