### PR TITLE
Add MaxSessionDuration field to IAM Role, Remove Description field from response if empty

### DIFF
--- a/moto/iam/models.py
+++ b/moto/iam/models.py
@@ -340,6 +340,7 @@ class Role(BaseModel):
             permissions_boundary=properties.get("PermissionsBoundary", ""),
             description=properties.get("Description", ""),
             tags=properties.get("Tags", {}),
+            max_session_duration=properties.get("MaxSessionDuration", 3600)
         )
 
         policies = properties.get("Policies", [])

--- a/moto/iam/models.py
+++ b/moto/iam/models.py
@@ -340,7 +340,7 @@ class Role(BaseModel):
             permissions_boundary=properties.get("PermissionsBoundary", ""),
             description=properties.get("Description", ""),
             tags=properties.get("Tags", {}),
-            max_session_duration=properties.get("MaxSessionDuration", 3600)
+            max_session_duration=properties.get("MaxSessionDuration", 3600),
         )
 
         policies = properties.get("Policies", [])

--- a/moto/iam/models.py
+++ b/moto/iam/models.py
@@ -309,6 +309,7 @@ class Role(BaseModel):
         permissions_boundary,
         description,
         tags,
+        max_session_duration,
     ):
         self.id = role_id
         self.name = name
@@ -320,6 +321,7 @@ class Role(BaseModel):
         self.tags = tags
         self.description = description
         self.permissions_boundary = permissions_boundary
+        self.max_session_duration = max_session_duration
 
     @property
     def created_iso_8601(self):
@@ -938,9 +940,10 @@ class IAMBackend(BaseBackend):
         role.description = role_description
         return role
 
-    def update_role(self, role_name, role_description):
+    def update_role(self, role_name, role_description, max_session_duration):
         role = self.get_role(role_name)
         role.description = role_description
+        role.max_session_duration = max_session_duration
         return role
 
     def detach_role_policy(self, policy_arn, role_name):
@@ -1059,6 +1062,7 @@ class IAMBackend(BaseBackend):
         permissions_boundary,
         description,
         tags,
+        max_session_duration,
     ):
         role_id = random_resource_id()
         if permissions_boundary and not self.policy_arn_regex.match(
@@ -1084,6 +1088,7 @@ class IAMBackend(BaseBackend):
             permissions_boundary,
             description,
             clean_tags,
+            max_session_duration,
         )
         self.roles[role_id] = role
         return role

--- a/moto/iam/responses.py
+++ b/moto/iam/responses.py
@@ -182,6 +182,7 @@ class IamResponse(BaseResponse):
         permissions_boundary = self._get_param("PermissionsBoundary")
         description = self._get_param("Description")
         tags = self._get_multi_param("Tags.member")
+        max_session_duration = self._get_param("MaxSessionDuration", 3600)
 
         role = iam_backend.create_role(
             role_name,
@@ -190,6 +191,7 @@ class IamResponse(BaseResponse):
             permissions_boundary,
             description,
             tags,
+            max_session_duration,
         )
         template = self.response_template(CREATE_ROLE_TEMPLATE)
         return template.render(role=role)
@@ -258,7 +260,8 @@ class IamResponse(BaseResponse):
     def update_role(self):
         role_name = self._get_param("RoleName")
         description = self._get_param("Description")
-        role = iam_backend.update_role(role_name, description)
+        max_session_duration = self._get_param("MaxSessionDuration", 3600)
+        role = iam_backend.update_role(role_name, description, max_session_duration)
         template = self.response_template(UPDATE_ROLE_TEMPLATE)
         return template.render(role=role)
 
@@ -1189,9 +1192,12 @@ CREATE_ROLE_TEMPLATE = """<CreateRoleResponse xmlns="https://iam.amazonaws.com/d
       <Arn>{{ role.arn }}</Arn>
       <RoleName>{{ role.name }}</RoleName>
       <AssumeRolePolicyDocument>{{ role.assume_role_policy_document }}</AssumeRolePolicyDocument>
+      {% if role.description %}
       <Description>{{role.description}}</Description>
+      {% endif %}
       <CreateDate>{{ role.created_iso_8601 }}</CreateDate>
       <RoleId>{{ role.id }}</RoleId>
+      <MaxSessionDuration>{{ role.max_session_duration }}</MaxSessionDuration>
       {% if role.permissions_boundary %}
       <PermissionsBoundary>
           <PermissionsBoundaryType>PermissionsBoundaryPolicy</PermissionsBoundaryType>
@@ -1244,6 +1250,7 @@ UPDATE_ROLE_DESCRIPTION_TEMPLATE = """<UpdateRoleDescriptionResponse xmlns="http
       <Description>{{role.description}}</Description>
       <CreateDate>{{ role.created_iso_8601 }}</CreateDate>
       <RoleId>{{ role.id }}</RoleId>
+      <MaxSessionDuration>{{ role.max_session_duration }}</MaxSessionDuration>
       {% if role.tags %}
       <Tags>
         {% for tag in role.get_tags() %}
@@ -1268,9 +1275,12 @@ GET_ROLE_TEMPLATE = """<GetRoleResponse xmlns="https://iam.amazonaws.com/doc/201
       <Arn>{{ role.arn }}</Arn>
       <RoleName>{{ role.name }}</RoleName>
       <AssumeRolePolicyDocument>{{ role.assume_role_policy_document }}</AssumeRolePolicyDocument>
+      {% if role.description %}
       <Description>{{role.description}}</Description>
+      {% endif %}
       <CreateDate>{{ role.created_iso_8601 }}</CreateDate>
       <RoleId>{{ role.id }}</RoleId>
+      <MaxSessionDuration>{{ role.max_session_duration }}</MaxSessionDuration>
       {% if role.tags %}
       <Tags>
         {% for tag in role.get_tags() %}

--- a/tests/test_iam/test_iam.py
+++ b/tests/test_iam/test_iam.py
@@ -1703,6 +1703,21 @@ def test_delete_saml_provider():
 
 
 @mock_iam()
+def test_create_role_defaults():
+    """Tests default values"""
+    conn = boto3.client("iam", region_name="us-east-1")
+    conn.create_role(
+        RoleName="my-role", AssumeRolePolicyDocument="{}",
+    )
+
+    # Get role:
+    role = conn.get_role(RoleName="my-role")["Role"]
+
+    assert role["MaxSessionDuration"] == 3600
+    assert role.get("Description") is None
+
+
+@mock_iam()
 def test_create_role_with_tags():
     """Tests both the tag_role and get_role_tags capability"""
     conn = boto3.client("iam", region_name="us-east-1")
@@ -2042,6 +2057,28 @@ def test_update_role():
     )
     response = conn.update_role(RoleName="my-role", Description="test")
     assert len(response.keys()) == 1
+
+
+@mock_iam()
+def test_update_role_defaults():
+    conn = boto3.client("iam", region_name="us-east-1")
+
+    with assert_raises(ClientError):
+        conn.delete_role(RoleName="my-role")
+
+    conn.create_role(
+        RoleName="my-role",
+        AssumeRolePolicyDocument="some policy",
+        Description="test",
+        Path="/my-path/",
+    )
+    response = conn.update_role(RoleName="my-role")
+    assert len(response.keys()) == 1
+
+    role = conn.get_role(RoleName="my-role")["Role"]
+
+    assert role["MaxSessionDuration"] == 3600
+    assert role.get("Description") is None
 
 
 @mock_iam()


### PR DESCRIPTION
Had this issue when I was using localstack (which uses moto underneath) with terraform. 

Was causing continual redeploys due to not storing the MaxSessionDuration field and description not being optional.