### PR TITLE
Add missing attributes to SNS subscription

### DIFF
--- a/moto/sns/models.py
+++ b/moto/sns/models.py
@@ -432,11 +432,18 @@ class SNSBackend(BaseBackend):
         subscription = Subscription(topic, endpoint, protocol)
         attributes = {
             "PendingConfirmation": "false",
+            "ConfirmationWasAuthenticated": "true",
             "Endpoint": endpoint,
             "TopicArn": topic_arn,
             "Protocol": protocol,
             "SubscriptionArn": subscription.arn,
+            "Owner": DEFAULT_ACCOUNT_ID,
+            "RawMessageDelivery": "false",
         }
+
+        if protocol in ["http", "https"]:
+            attributes["EffectiveDeliveryPolicy"] = topic.effective_delivery_policy
+
         subscription.attributes = attributes
         self.subscriptions[subscription.arn] = subscription
         return subscription
@@ -696,18 +703,18 @@ for region in Session().get_available_regions("sns"):
 
 
 DEFAULT_EFFECTIVE_DELIVERY_POLICY = {
-    "http": {
-        "disableSubscriptionOverrides": False,
-        "defaultHealthyRetryPolicy": {
-            "numNoDelayRetries": 0,
-            "numMinDelayRetries": 0,
-            "minDelayTarget": 20,
-            "maxDelayTarget": 20,
-            "numMaxDelayRetries": 0,
-            "numRetries": 3,
-            "backoffFunction": "linear",
-        },
-    }
+    "defaultHealthyRetryPolicy": {
+        "numNoDelayRetries": 0,
+        "numMinDelayRetries": 0,
+        "minDelayTarget": 20,
+        "maxDelayTarget": 20,
+        "numMaxDelayRetries": 0,
+        "numRetries": 3,
+        "backoffFunction": "linear",
+    },
+    "sicklyRetryPolicy": None,
+    "throttlePolicy": None,
+    "guaranteed": False,
 }
 
 

--- a/tests/test_sns/test_subscriptions_boto3.py
+++ b/tests/test_sns/test_subscriptions_boto3.py
@@ -8,7 +8,11 @@ from botocore.exceptions import ClientError
 from nose.tools import assert_raises
 
 from moto import mock_sns
-from moto.sns.models import DEFAULT_PAGE_SIZE
+from moto.sns.models import (
+    DEFAULT_PAGE_SIZE,
+    DEFAULT_EFFECTIVE_DELIVERY_POLICY,
+    DEFAULT_ACCOUNT_ID,
+)
 
 
 @mock_sns
@@ -195,21 +199,23 @@ def test_subscribe_attributes():
 
     resp = client.subscribe(TopicArn=arn, Protocol="http", Endpoint="http://test.com")
 
-    attributes = client.get_subscription_attributes(
+    response = client.get_subscription_attributes(
         SubscriptionArn=resp["SubscriptionArn"]
     )
 
-    attributes.should.contain("Attributes")
-    attributes["Attributes"].should.contain("PendingConfirmation")
-    attributes["Attributes"]["PendingConfirmation"].should.equal("false")
-    attributes["Attributes"].should.contain("Endpoint")
-    attributes["Attributes"]["Endpoint"].should.equal("http://test.com")
-    attributes["Attributes"].should.contain("TopicArn")
-    attributes["Attributes"]["TopicArn"].should.equal(arn)
-    attributes["Attributes"].should.contain("Protocol")
-    attributes["Attributes"]["Protocol"].should.equal("http")
-    attributes["Attributes"].should.contain("SubscriptionArn")
-    attributes["Attributes"]["SubscriptionArn"].should.equal(resp["SubscriptionArn"])
+    response.should.contain("Attributes")
+    attributes = response["Attributes"]
+    attributes["PendingConfirmation"].should.equal("false")
+    attributes["ConfirmationWasAuthenticated"].should.equal("true")
+    attributes["Endpoint"].should.equal("http://test.com")
+    attributes["TopicArn"].should.equal(arn)
+    attributes["Protocol"].should.equal("http")
+    attributes["SubscriptionArn"].should.equal(resp["SubscriptionArn"])
+    attributes["Owner"].should.equal(str(DEFAULT_ACCOUNT_ID))
+    attributes["RawMessageDelivery"].should.equal("false")
+    json.loads(attributes["EffectiveDeliveryPolicy"]).should.equal(
+        DEFAULT_EFFECTIVE_DELIVERY_POLICY
+    )
 
 
 @mock_sns


### PR DESCRIPTION
Adds missing attributes to the subscription and I also updated the default EffectiveDeliveryPolicy.

I got one question regarding the code in [moto/sns/response.py](https://github.com/spulec/moto/blob/3d5d477/moto/sns/responses.py#L101). Most of the methods have the part `if self.request_json:` in it. Is it some kind of legacy code or what is it used for?

Fixes #2441