### PR TITLE
Add missing information in SSM parameters

### DIFF
--- a/moto/ssm/models.py
+++ b/moto/ssm/models.py
@@ -13,6 +13,7 @@ import time
 import uuid
 import itertools
 
+from .utils import parameter_arn
 from .exceptions import (
     ValidationException,
     InvalidFilterValue,
@@ -60,19 +61,23 @@ class Parameter(BaseModel):
         if value.startswith(prefix):
             return value[len(prefix) :]
 
-    def response_object(self, decrypt=False):
+    def response_object(self, decrypt=False, region=None):
         r = {
             "Name": self.name,
             "Type": self.type,
             "Value": self.decrypt(self.value) if decrypt else self.value,
             "Version": self.version,
+            "LastModifiedDate": round(self.last_modified_date, 3),
         }
+
+        if region:
+            r["ARN"] = parameter_arn(region, self.name)
 
         return r
 
     def describe_response_object(self, decrypt=False):
         r = self.response_object(decrypt)
-        r["LastModifiedDate"] = int(self.last_modified_date)
+        r["LastModifiedDate"] = round(self.last_modified_date, 3)
         r["LastModifiedUser"] = "N/A"
 
         if self.description:

--- a/moto/ssm/responses.py
+++ b/moto/ssm/responses.py
@@ -51,7 +51,7 @@ class SimpleSystemManagerResponse(BaseResponse):
             }
             return json.dumps(error), dict(status=400)
 
-        response = {"Parameter": result.response_object(with_decryption)}
+        response = {"Parameter": result.response_object(with_decryption, self.region)}
         return json.dumps(response)
 
     def get_parameters(self):
@@ -63,7 +63,7 @@ class SimpleSystemManagerResponse(BaseResponse):
         response = {"Parameters": [], "InvalidParameters": []}
 
         for parameter in result:
-            param_data = parameter.response_object(with_decryption)
+            param_data = parameter.response_object(with_decryption, self.region)
             response["Parameters"].append(param_data)
 
         param_names = [param.name for param in result]
@@ -85,7 +85,7 @@ class SimpleSystemManagerResponse(BaseResponse):
         response = {"Parameters": []}
 
         for parameter in result:
-            param_data = parameter.response_object(with_decryption)
+            param_data = parameter.response_object(with_decryption, self.region)
             response["Parameters"].append(param_data)
 
         return json.dumps(response)

--- a/moto/ssm/utils.py
+++ b/moto/ssm/utils.py
@@ -1,0 +1,4 @@
+def parameter_arn(region, parameter_name):
+    if parameter_name[0] == "/":
+        parameter_name = parameter_name[1:]
+    return "arn:aws:ssm:{0}:1234567890:parameter/{1}".format(region, parameter_name)

--- a/moto/ssm/utils.py
+++ b/moto/ssm/utils.py
@@ -1,4 +1,9 @@
+ACCOUNT_ID = "1234567890"
+
+
 def parameter_arn(region, parameter_name):
     if parameter_name[0] == "/":
         parameter_name = parameter_name[1:]
-    return "arn:aws:ssm:{0}:1234567890:parameter/{1}".format(region, parameter_name)
+    return "arn:aws:ssm:{0}:{1}:parameter/{2}".format(
+        region, ACCOUNT_ID, parameter_name
+    )

--- a/tests/test_ssm/test_ssm_boto3.py
+++ b/tests/test_ssm/test_ssm_boto3.py
@@ -102,6 +102,18 @@ def test_get_parameters_by_path():
     response = client.get_parameters_by_path(Path="/", Recursive=False)
     len(response["Parameters"]).should.equal(2)
     {p["Value"] for p in response["Parameters"]}.should.equal(set(["bar", "qux"]))
+    {p["ARN"] for p in response["Parameters"]}.should.equal(
+        set(
+            [
+                "arn:aws:ssm:us-east-1:1234567890:parameter/foo",
+                "arn:aws:ssm:us-east-1:1234567890:parameter/baz",
+            ]
+        )
+    )
+    {
+        p["LastModifiedDate"].should.be.a(datetime.datetime)
+        for p in response["Parameters"]
+    }
 
     response = client.get_parameters_by_path(Path="/", Recursive=True)
     len(response["Parameters"]).should.equal(9)
@@ -176,6 +188,11 @@ def test_put_parameter():
     response["Parameters"][0]["Value"].should.equal("value")
     response["Parameters"][0]["Type"].should.equal("String")
     response["Parameters"][0]["Version"].should.equal(1)
+    response["Parameters"][0]["LastModifiedDate"].should.be.a(datetime.datetime)
+    response["Parameters"][0]["ARN"].should.equal(
+        "arn:aws:ssm:us-east-1:1234567890:parameter/test"
+    )
+    initial_modification_date = response["Parameters"][0]["LastModifiedDate"]
 
     try:
         client.put_parameter(
@@ -194,6 +211,12 @@ def test_put_parameter():
     response["Parameters"][0]["Value"].should.equal("value")
     response["Parameters"][0]["Type"].should.equal("String")
     response["Parameters"][0]["Version"].should.equal(1)
+    response["Parameters"][0]["LastModifiedDate"].should.equal(
+        initial_modification_date
+    )
+    response["Parameters"][0]["ARN"].should.equal(
+        "arn:aws:ssm:us-east-1:1234567890:parameter/test"
+    )
 
     response = client.put_parameter(
         Name="test",
@@ -213,6 +236,12 @@ def test_put_parameter():
     response["Parameters"][0]["Value"].should.equal("value 3")
     response["Parameters"][0]["Type"].should.equal("String")
     response["Parameters"][0]["Version"].should.equal(2)
+    response["Parameters"][0]["LastModifiedDate"].should_not.equal(
+        initial_modification_date
+    )
+    response["Parameters"][0]["ARN"].should.equal(
+        "arn:aws:ssm:us-east-1:1234567890:parameter/test"
+    )
 
 
 @mock_ssm
@@ -239,6 +268,10 @@ def test_get_parameter():
     response["Parameter"]["Name"].should.equal("test")
     response["Parameter"]["Value"].should.equal("value")
     response["Parameter"]["Type"].should.equal("String")
+    response["Parameter"]["LastModifiedDate"].should.be.a(datetime.datetime)
+    response["Parameter"]["ARN"].should.equal(
+        "arn:aws:ssm:us-east-1:1234567890:parameter/test"
+    )
 
 
 @mock_ssm


### PR DESCRIPTION
We were missing some new information returned by SSM.
A typical message now looks like:
```
{
    "Parameter": {
        "Name": "test",
        "Type": "String",
        "Value": "test",
        "Version": 1,
        "LastModifiedDate": 1575156149.591,
        "ARN": "arn:aws:ssm:us-east-1:1234567890:parameter/test"
    }
}
```