### PR TITLE
Import ABC from collections.abc for Python 3.9 compatibility.

### DIFF
--- a/moto/cloudformation/parsing.py
+++ b/moto/cloudformation/parsing.py
@@ -1,5 +1,4 @@
 from __future__ import unicode_literals
-import collections
 import functools
 import logging
 import copy

--- a/moto/cloudformation/parsing.py
+++ b/moto/cloudformation/parsing.py
@@ -11,6 +11,7 @@ from moto.awslambda import models as lambda_models
 from moto.batch import models as batch_models
 from moto.cloudwatch import models as cloudwatch_models
 from moto.cognitoidentity import models as cognitoidentity_models
+from moto.compat import collections_abc
 from moto.datapipeline import models as datapipeline_models
 from moto.dynamodb2 import models as dynamodb2_models
 from moto.ec2 import models as ec2_models
@@ -404,7 +405,7 @@ def parse_output(output_logical_id, output_json, resources_map):
     return output
 
 
-class ResourceMap(collections.Mapping):
+class ResourceMap(collections_abc.Mapping):
     """
     This is a lazy loading map for resources. This allows us to create resources
     without needing to create a full dependency tree. Upon creation, each
@@ -633,7 +634,7 @@ class ResourceMap(collections.Mapping):
             raise last_exception
 
 
-class OutputMap(collections.Mapping):
+class OutputMap(collections_abc.Mapping):
     def __init__(self, resources, template, stack_id):
         self._template = template
         self._stack_id = stack_id

--- a/moto/compat.py
+++ b/moto/compat.py
@@ -5,6 +5,6 @@ except ImportError:
     from ordereddict import OrderedDict  # noqa
 
 try:
-    import collections.abc as collections_abc
+    import collections.abc as collections_abc  # noqa
 except ImportError:
-    import collections as collections_abc
+    import collections as collections_abc  # noqa

--- a/moto/compat.py
+++ b/moto/compat.py
@@ -3,3 +3,8 @@ try:
 except ImportError:
     # python 2.6 or earlier, use backport
     from ordereddict import OrderedDict  # noqa
+
+try:
+    import collections.abc as collections_abc
+except ImportError:
+    import collections as collections_abc

--- a/moto/datapipeline/utils.py
+++ b/moto/datapipeline/utils.py
@@ -1,5 +1,5 @@
-import collections
 import six
+from moto.compat import collections_abc
 from moto.core.utils import get_random_hex
 
 
@@ -8,13 +8,13 @@ def get_random_pipeline_id():
 
 
 def remove_capitalization_of_dict_keys(obj):
-    if isinstance(obj, collections.Mapping):
+    if isinstance(obj, collections_abc.Mapping):
         result = obj.__class__()
         for key, value in obj.items():
             normalized_key = key[:1].lower() + key[1:]
             result[normalized_key] = remove_capitalization_of_dict_keys(value)
         return result
-    elif isinstance(obj, collections.Iterable) and not isinstance(
+    elif isinstance(obj, collections_abc.Iterable) and not isinstance(
         obj, six.string_types
     ):
         result = obj.__class__()


### PR DESCRIPTION
Importing ABC from collections module has been deprecated since Python 3.4 and removed in Python 3.9. I have made the import fix in compat.py to reuse it across other modules . Reference : https://github.com/python/cpython/pull/10596