### PR TITLE
Batch: computeResources.instanceRole is an instance profile

### DIFF
--- a/moto/batch/models.py
+++ b/moto/batch/models.py
@@ -815,8 +815,10 @@ class BatchBackend(BaseBackend):
                 raise InvalidParameterValueException(
                     "computeResources must contain {0}".format(param)
                 )
-
-        if self.iam_backend.get_role_by_arn(cr["instanceRole"]) is None:
+        for profile in self.iam_backend.get_instance_profiles():
+            if profile.arn == cr["instanceRole"]:
+                break
+        else:
             raise InvalidParameterValueException(
                 "could not find instanceRole {0}".format(cr["instanceRole"])
             )

--- a/tests/test_batch/test_batch.py
+++ b/tests/test_batch/test_batch.py
@@ -55,6 +55,10 @@ def _setup(ec2_client, iam_client):
         RoleName="TestRole", AssumeRolePolicyDocument="some_policy"
     )
     iam_arn = resp["Role"]["Arn"]
+    iam_client.create_instance_profile(InstanceProfileName="TestRole")
+    iam_client.add_role_to_instance_profile(
+        InstanceProfileName="TestRole", RoleName="TestRole"
+    )
 
     return vpc_id, subnet_id, sg_id, iam_arn
 
@@ -83,7 +87,7 @@ def test_create_managed_compute_environment():
             "subnets": [subnet_id],
             "securityGroupIds": [sg_id],
             "ec2KeyPair": "string",
-            "instanceRole": iam_arn,
+            "instanceRole": iam_arn.replace("role", "instance-profile"),
             "tags": {"string": "string"},
             "bidPercentage": 123,
             "spotIamFleetRole": "string",
@@ -209,7 +213,7 @@ def test_delete_managed_compute_environment():
             "subnets": [subnet_id],
             "securityGroupIds": [sg_id],
             "ec2KeyPair": "string",
-            "instanceRole": iam_arn,
+            "instanceRole": iam_arn.replace("role", "instance-profile"),
             "tags": {"string": "string"},
             "bidPercentage": 123,
             "spotIamFleetRole": "string",

--- a/tests/test_batch/test_cloudformation.py
+++ b/tests/test_batch/test_cloudformation.py
@@ -51,6 +51,10 @@ def _setup(ec2_client, iam_client):
         RoleName="TestRole", AssumeRolePolicyDocument="some_policy"
     )
     iam_arn = resp["Role"]["Arn"]
+    iam_client.create_instance_profile(InstanceProfileName="TestRole")
+    iam_client.add_role_to_instance_profile(
+        InstanceProfileName="TestRole", RoleName="TestRole"
+    )
 
     return vpc_id, subnet_id, sg_id, iam_arn
 
@@ -78,7 +82,7 @@ def test_create_env_cf():
                         "InstanceTypes": ["optimal"],
                         "Subnets": [subnet_id],
                         "SecurityGroupIds": [sg_id],
-                        "InstanceRole": iam_arn,
+                        "InstanceRole": iam_arn.replace("role", "instance-profile"),
                     },
                     "ServiceRole": iam_arn,
                 },
@@ -129,7 +133,7 @@ def test_create_job_queue_cf():
                         "InstanceTypes": ["optimal"],
                         "Subnets": [subnet_id],
                         "SecurityGroupIds": [sg_id],
-                        "InstanceRole": iam_arn,
+                        "InstanceRole": iam_arn.replace("role", "instance-profile"),
                     },
                     "ServiceRole": iam_arn,
                 },
@@ -195,7 +199,7 @@ def test_create_job_def_cf():
                         "InstanceTypes": ["optimal"],
                         "Subnets": [subnet_id],
                         "SecurityGroupIds": [sg_id],
-                        "InstanceRole": iam_arn,
+                        "InstanceRole": iam_arn.replace("role", "instance-profile"),
                     },
                     "ServiceRole": iam_arn,
                 },


### PR DESCRIPTION
It's not an IAM role (the API parameter name in Batch is a misnomer).

Validation by matching against known role ARNs will always fail.
Scan the known instance profile ARNs instead.

Relevant part of Batch docs:

> instanceRole (string) -- [REQUIRED]
> The Amazon ECS instance profile applied to Amazon EC2 instances in a compute environment. You can specify the short name or full Amazon Resource Name (ARN) of an instance profile. For example, `` ecsInstanceRole `` or ``arn:aws:iam::<aws_account_id> :instance-profile/ecsInstanceRole `` . For more information, see Amazon ECS Instance Role in the AWS Batch User Guide .