### PR TITLE
Batch: job definitions default to ACTIVE

### DIFF
--- a/moto/batch/models.py
+++ b/moto/batch/models.py
@@ -182,7 +182,7 @@ class JobDefinition(BaseModel):
         self._region = region_name
         self.container_properties = container_properties
         self.arn = None
-        self.status = "INACTIVE"
+        self.status = "ACTIVE"
 
         if parameters is None:
             parameters = {}

--- a/tests/test_batch/test_batch.py
+++ b/tests/test_batch/test_batch.py
@@ -608,6 +608,9 @@ def test_describe_task_definition():
     resp = batch_client.describe_job_definitions(jobDefinitions=["sleep10", "test1"])
     len(resp["jobDefinitions"]).should.equal(3)
 
+    for job_definition in resp["jobDefinitions"]:
+        job_definition["status"].should.equal("ACTIVE")
+
 
 @mock_logs
 @mock_ec2


### PR DESCRIPTION
```
>aws batch register-job-definition  --job-definition-name test --type container --container-properties "$(cat batch_job_container_properties.json)"
```
```
{
    "jobDefinitionName": "test",
    "jobDefinitionArn": "arn:aws:batch:us-west-2:123456789012:job-definition/test:1",
    "revision": 1
}
```
```
>aws batch describe-job-definitions --job-definition-name test
```
```
{
    "jobDefinitions": [
        {
            "jobDefinitionName": "test",
            "jobDefinitionArn": "arn:aws:batch:us-west-2:123456789012:job-definition/test:1",
            "revision": 1,
            "status": "ACTIVE",
            "type": "container",
            "parameters": {},
            "containerProperties": {
              ...
            }
        }
    ]
}
```