### PR TITLE
Batch: Relax instance type check

### DIFF
--- a/moto/batch/models.py
+++ b/moto/batch/models.py
@@ -837,7 +837,7 @@ class BatchBackend(BaseBackend):
         for instance_type in cr["instanceTypes"]:
             if instance_type == "optimal":
                 pass  # Optimal should pick from latest of current gen
-            elif instance_type not in EC2_INSTANCE_TYPES:
+            elif "." in instance_type and instance_type not in EC2_INSTANCE_TYPES:
                 raise InvalidParameterValueException(
                     "Instance type {0} does not exist".format(instance_type)
                 )


### PR DESCRIPTION
This check should conform to the following passage from the AWS Batch documentation:

> The instance types that may be launched. You can specify instance families to launch any instance type within those families (for example, c5, c5n, or p3), or you can specify specific sizes within a family (such as c5.8xlarge). Note that metal instance types are not in the instance families (for example c5 does not include c5.metal.) You can also choose optimal to pick instance types (from the C, M, and R instance families) on the fly that match the demand of your job queues.

Unfortunately, EC2_INSTANCE_TYPES is out-of-date and does not include all instance type families found at https://ec2instances.info/, so this check is hard to implement for instance type families.