### PR TITLE
Added references to moto.iam.models.ACCOUNT_ID instead of hardcoded id

### DIFF
--- a/moto/acm/models.py
+++ b/moto/acm/models.py
@@ -13,7 +13,7 @@ import cryptography.hazmat.primitives.asymmetric.rsa
 from cryptography.hazmat.primitives import serialization, hashes
 from cryptography.hazmat.backends import default_backend
 
-from moto.iam.models import ACCOUNT_ID as DEFAULT_ACCOUNT_ID
+from moto.core import ACCOUNT_ID as DEFAULT_ACCOUNT_ID
 
 
 GOOGLE_ROOT_CA = b"""-----BEGIN CERTIFICATE-----

--- a/moto/acm/models.py
+++ b/moto/acm/models.py
@@ -13,8 +13,9 @@ import cryptography.hazmat.primitives.asymmetric.rsa
 from cryptography.hazmat.primitives import serialization, hashes
 from cryptography.hazmat.backends import default_backend
 
+from moto.iam.models import ACCOUNT_ID as DEFAULT_ACCOUNT_ID
 
-DEFAULT_ACCOUNT_ID = 123456789012
+
 GOOGLE_ROOT_CA = b"""-----BEGIN CERTIFICATE-----
 MIIEKDCCAxCgAwIBAgIQAQAhJYiw+lmnd+8Fe2Yn3zANBgkqhkiG9w0BAQsFADBC
 MQswCQYDVQQGEwJVUzEWMBQGA1UEChMNR2VvVHJ1c3QgSW5jLjEbMBkGA1UEAxMS

--- a/moto/athena/models.py
+++ b/moto/athena/models.py
@@ -4,7 +4,7 @@ import time
 import boto3
 from moto.core import BaseBackend, BaseModel
 
-ACCOUNT_ID = 123456789012
+from moto.iam.models import ACCOUNT_ID
 
 
 class TaggableResourceMixin(object):

--- a/moto/athena/models.py
+++ b/moto/athena/models.py
@@ -4,7 +4,7 @@ import time
 import boto3
 from moto.core import BaseBackend, BaseModel
 
-from moto.iam.models import ACCOUNT_ID
+from moto.core import ACCOUNT_ID
 
 
 class TaggableResourceMixin(object):

--- a/moto/awslambda/models.py
+++ b/moto/awslambda/models.py
@@ -42,7 +42,7 @@ from .utils import make_function_arn, make_function_ver_arn
 from moto.sqs import sqs_backends
 from moto.dynamodb2 import dynamodb_backends2
 from moto.dynamodbstreams import dynamodbstreams_backends
-from moto.iam.models import ACCOUNT_ID
+from moto.core import ACCOUNT_ID
 
 logger = logging.getLogger(__name__)
 

--- a/moto/awslambda/models.py
+++ b/moto/awslambda/models.py
@@ -45,7 +45,7 @@ from moto.dynamodbstreams import dynamodbstreams_backends
 
 logger = logging.getLogger(__name__)
 
-ACCOUNT_ID = "123456789012"
+from moto.iam.models import ACCOUNT_ID
 
 
 try:

--- a/moto/awslambda/models.py
+++ b/moto/awslambda/models.py
@@ -42,10 +42,9 @@ from .utils import make_function_arn, make_function_ver_arn
 from moto.sqs import sqs_backends
 from moto.dynamodb2 import dynamodb_backends2
 from moto.dynamodbstreams import dynamodbstreams_backends
+from moto.iam.models import ACCOUNT_ID
 
 logger = logging.getLogger(__name__)
-
-from moto.iam.models import ACCOUNT_ID
 
 
 try:

--- a/moto/batch/models.py
+++ b/moto/batch/models.py
@@ -28,7 +28,7 @@ from .utils import (
 from moto.ec2.exceptions import InvalidSubnetIdError
 from moto.ec2.models import INSTANCE_TYPES as EC2_INSTANCE_TYPES
 from moto.iam.exceptions import IAMNotFoundException
-from moto.iam.models import ACCOUNT_ID as DEFAULT_ACCOUNT_ID
+from moto.core import ACCOUNT_ID as DEFAULT_ACCOUNT_ID
 
 _orig_adapter_send = requests.adapters.HTTPAdapter.send
 logger = logging.getLogger(__name__)

--- a/moto/batch/models.py
+++ b/moto/batch/models.py
@@ -28,11 +28,10 @@ from .utils import (
 from moto.ec2.exceptions import InvalidSubnetIdError
 from moto.ec2.models import INSTANCE_TYPES as EC2_INSTANCE_TYPES
 from moto.iam.exceptions import IAMNotFoundException
-
+from moto.iam.models import ACCOUNT_ID as DEFAULT_ACCOUNT_ID
 
 _orig_adapter_send = requests.adapters.HTTPAdapter.send
 logger = logging.getLogger(__name__)
-DEFAULT_ACCOUNT_ID = 123456789012
 COMPUTE_ENVIRONMENT_NAME_REGEX = re.compile(
     r"^[A-Za-z0-9][A-Za-z0-9_-]{1,126}[A-Za-z0-9]$"
 )

--- a/moto/cloudformation/parsing.py
+++ b/moto/cloudformation/parsing.py
@@ -27,6 +27,7 @@ from moto.route53 import models as route53_models
 from moto.s3 import models as s3_models
 from moto.sns import models as sns_models
 from moto.sqs import models as sqs_models
+from moto.iam.models import ACCOUNT_ID
 from .utils import random_suffix
 from .exceptions import (
     ExportNotFound,
@@ -431,7 +432,7 @@ class ResourceMap(collections.Mapping):
 
         # Create the default resources
         self._parsed_resources = {
-            "AWS::AccountId": "123456789012",
+            "AWS::AccountId": ACCOUNT_ID,
             "AWS::Region": self._region_name,
             "AWS::StackId": stack_id,
             "AWS::StackName": stack_name,

--- a/moto/cloudformation/parsing.py
+++ b/moto/cloudformation/parsing.py
@@ -27,7 +27,7 @@ from moto.route53 import models as route53_models
 from moto.s3 import models as s3_models
 from moto.sns import models as sns_models
 from moto.sqs import models as sqs_models
-from moto.iam.models import ACCOUNT_ID
+from moto.core import ACCOUNT_ID
 from .utils import random_suffix
 from .exceptions import (
     ExportNotFound,

--- a/moto/cloudformation/responses.py
+++ b/moto/cloudformation/responses.py
@@ -426,7 +426,9 @@ class CloudFormationResponse(BaseResponse):
         stackset = self.cloudformation_backend.get_stack_set(stackset_name)
 
         if not stackset.admin_role:
-            stackset.admin_role = "arn:aws:iam::{AccountId}:role/AWSCloudFormationStackSetAdministrationRole".format(AccountId=ACCOUNT_ID)
+            stackset.admin_role = "arn:aws:iam::{AccountId}:role/AWSCloudFormationStackSetAdministrationRole".format(
+                AccountId=ACCOUNT_ID
+            )
         if not stackset.execution_role:
             stackset.execution_role = "AWSCloudFormationStackSetExecutionRole"
 
@@ -1052,11 +1054,14 @@ STOP_STACK_SET_OPERATION_RESPONSE_TEMPLATE = """<StopStackSetOperationResponse x
   </ResponseMetadata>                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     </StopStackSetOperationResponse>
 """
 
-DESCRIBE_STACKSET_OPERATION_RESPONSE_TEMPLATE = """<DescribeStackSetOperationResponse xmlns="http://internal.amazon.com/coral/com.amazonaws.maestro.service.v20160713/">
+DESCRIBE_STACKSET_OPERATION_RESPONSE_TEMPLATE = (
+    """<DescribeStackSetOperationResponse xmlns="http://internal.amazon.com/coral/com.amazonaws.maestro.service.v20160713/">
   <DescribeStackSetOperationResult>
     <StackSetOperation>
       <ExecutionRoleName>{{ stackset.execution_role }}</ExecutionRoleName>
-      <AdministrationRoleARN>arn:aws:iam::""" + ACCOUNT_ID + """:role/{{ stackset.admin_role }}</AdministrationRoleARN>
+      <AdministrationRoleARN>arn:aws:iam::"""
+    + ACCOUNT_ID
+    + """:role/{{ stackset.admin_role }}</AdministrationRoleARN>
       <StackSetId>{{ stackset.id }}</StackSetId>
       <CreationTimestamp>{{ operation.CreationTimestamp }}</CreationTimestamp>
       <OperationId>{{ operation.OperationId }}</OperationId>
@@ -1073,15 +1078,19 @@ DESCRIBE_STACKSET_OPERATION_RESPONSE_TEMPLATE = """<DescribeStackSetOperationRes
   </ResponseMetadata>
 </DescribeStackSetOperationResponse>
 """
+)
 
-LIST_STACK_SET_OPERATION_RESULTS_RESPONSE_TEMPLATE = """<ListStackSetOperationResultsResponse xmlns="http://internal.amazon.com/coral/com.amazonaws.maestro.service.v20160713/">
+LIST_STACK_SET_OPERATION_RESULTS_RESPONSE_TEMPLATE = (
+    """<ListStackSetOperationResultsResponse xmlns="http://internal.amazon.com/coral/com.amazonaws.maestro.service.v20160713/">
   <ListStackSetOperationResultsResult>
     <Summaries>
     {% for instance in operation.Instances %}
     {% for account, region in instance.items() %}
       <member>
         <AccountGateResult>
-          <StatusReason>Function not found: arn:aws:lambda:us-west-2:""" + ACCOUNT_ID + """:function:AWSCloudFormationStackSetAccountGate</StatusReason>
+          <StatusReason>Function not found: arn:aws:lambda:us-west-2:"""
+    + ACCOUNT_ID
+    + """:function:AWSCloudFormationStackSetAccountGate</StatusReason>
           <Status>SKIPPED</Status>
         </AccountGateResult>
         <Region>{{ region }}</Region>
@@ -1097,3 +1106,4 @@ LIST_STACK_SET_OPERATION_RESULTS_RESPONSE_TEMPLATE = """<ListStackSetOperationRe
   </ResponseMetadata>
 </ListStackSetOperationResultsResponse>
 """
+)

--- a/moto/cloudformation/responses.py
+++ b/moto/cloudformation/responses.py
@@ -7,6 +7,7 @@ from six.moves.urllib.parse import urlparse
 from moto.core.responses import BaseResponse
 from moto.core.utils import amzn_request_id
 from moto.s3 import s3_backend
+from moto.iam.models import ACCOUNT_ID
 from .models import cloudformation_backends
 from .exceptions import ValidationError
 
@@ -425,7 +426,7 @@ class CloudFormationResponse(BaseResponse):
         stackset = self.cloudformation_backend.get_stack_set(stackset_name)
 
         if not stackset.admin_role:
-            stackset.admin_role = "arn:aws:iam::123456789012:role/AWSCloudFormationStackSetAdministrationRole"
+            stackset.admin_role = "arn:aws:iam::{AccountId}:role/AWSCloudFormationStackSetAdministrationRole".format(AccountId=ACCOUNT_ID)
         if not stackset.execution_role:
             stackset.execution_role = "AWSCloudFormationStackSetExecutionRole"
 
@@ -1055,7 +1056,7 @@ DESCRIBE_STACKSET_OPERATION_RESPONSE_TEMPLATE = """<DescribeStackSetOperationRes
   <DescribeStackSetOperationResult>
     <StackSetOperation>
       <ExecutionRoleName>{{ stackset.execution_role }}</ExecutionRoleName>
-      <AdministrationRoleARN>arn:aws:iam::123456789012:role/{{ stackset.admin_role }}</AdministrationRoleARN>
+      <AdministrationRoleARN>arn:aws:iam::"""+ACCOUNT_ID+""":role/{{ stackset.admin_role }}</AdministrationRoleARN>
       <StackSetId>{{ stackset.id }}</StackSetId>
       <CreationTimestamp>{{ operation.CreationTimestamp }}</CreationTimestamp>
       <OperationId>{{ operation.OperationId }}</OperationId>
@@ -1080,7 +1081,7 @@ LIST_STACK_SET_OPERATION_RESULTS_RESPONSE_TEMPLATE = """<ListStackSetOperationRe
     {% for account, region in instance.items() %}
       <member>
         <AccountGateResult>
-          <StatusReason>Function not found: arn:aws:lambda:us-west-2:123456789012:function:AWSCloudFormationStackSetAccountGate</StatusReason>
+          <StatusReason>Function not found: arn:aws:lambda:us-west-2:"""+ACCOUNT_ID+""":function:AWSCloudFormationStackSetAccountGate</StatusReason>
           <Status>SKIPPED</Status>
         </AccountGateResult>
         <Region>{{ region }}</Region>

--- a/moto/cloudformation/responses.py
+++ b/moto/cloudformation/responses.py
@@ -1056,7 +1056,7 @@ DESCRIBE_STACKSET_OPERATION_RESPONSE_TEMPLATE = """<DescribeStackSetOperationRes
   <DescribeStackSetOperationResult>
     <StackSetOperation>
       <ExecutionRoleName>{{ stackset.execution_role }}</ExecutionRoleName>
-      <AdministrationRoleARN>arn:aws:iam::"""+ACCOUNT_ID+""":role/{{ stackset.admin_role }}</AdministrationRoleARN>
+      <AdministrationRoleARN>arn:aws:iam::""" + ACCOUNT_ID + """:role/{{ stackset.admin_role }}</AdministrationRoleARN>
       <StackSetId>{{ stackset.id }}</StackSetId>
       <CreationTimestamp>{{ operation.CreationTimestamp }}</CreationTimestamp>
       <OperationId>{{ operation.OperationId }}</OperationId>
@@ -1081,7 +1081,7 @@ LIST_STACK_SET_OPERATION_RESULTS_RESPONSE_TEMPLATE = """<ListStackSetOperationRe
     {% for account, region in instance.items() %}
       <member>
         <AccountGateResult>
-          <StatusReason>Function not found: arn:aws:lambda:us-west-2:"""+ACCOUNT_ID+""":function:AWSCloudFormationStackSetAccountGate</StatusReason>
+          <StatusReason>Function not found: arn:aws:lambda:us-west-2:""" + ACCOUNT_ID + """:function:AWSCloudFormationStackSetAccountGate</StatusReason>
           <Status>SKIPPED</Status>
         </AccountGateResult>
         <Region>{{ region }}</Region>

--- a/moto/cloudformation/responses.py
+++ b/moto/cloudformation/responses.py
@@ -7,7 +7,7 @@ from six.moves.urllib.parse import urlparse
 from moto.core.responses import BaseResponse
 from moto.core.utils import amzn_request_id
 from moto.s3 import s3_backend
-from moto.iam.models import ACCOUNT_ID
+from moto.core import ACCOUNT_ID
 from .models import cloudformation_backends
 from .exceptions import ValidationError
 

--- a/moto/cloudformation/utils.py
+++ b/moto/cloudformation/utils.py
@@ -9,6 +9,7 @@ import string
 from cfnlint import decode, core
 from moto.core import ACCOUNT_ID
 
+
 def generate_stack_id(stack_name, region="us-east-1", account="123456789"):
     random_id = uuid.uuid4()
     return "arn:aws:cloudformation:{}:{}:stack/{}/{}".format(

--- a/moto/cloudformation/utils.py
+++ b/moto/cloudformation/utils.py
@@ -7,7 +7,7 @@ import os
 import string
 
 from cfnlint import decode, core
-
+from moto.iam.models import ACCOUNT_ID
 
 def generate_stack_id(stack_name, region="us-east-1", account="123456789"):
     random_id = uuid.uuid4()
@@ -29,8 +29,8 @@ def generate_stackset_id(stackset_name):
 
 
 def generate_stackset_arn(stackset_id, region_name):
-    return "arn:aws:cloudformation:{}:123456789012:stackset/{}".format(
-        region_name, stackset_id
+    return "arn:aws:cloudformation:{}:{}:stackset/{}".format(
+        region_name, ACCOUNT_ID, stackset_id
     )
 
 

--- a/moto/cloudformation/utils.py
+++ b/moto/cloudformation/utils.py
@@ -7,7 +7,7 @@ import os
 import string
 
 from cfnlint import decode, core
-from moto.iam.models import ACCOUNT_ID
+from moto.core import ACCOUNT_ID
 
 def generate_stack_id(stack_name, region="us-east-1", account="123456789"):
     random_id = uuid.uuid4()

--- a/moto/cloudwatch/models.py
+++ b/moto/cloudwatch/models.py
@@ -8,7 +8,7 @@ from dateutil.tz import tzutc
 from uuid import uuid4
 from .utils import make_arn_for_dashboard
 
-from moto.iam.models import ACCOUNT_ID as DEFAULT_ACCOUNT_ID
+from moto.core import ACCOUNT_ID as DEFAULT_ACCOUNT_ID
 
 _EMPTY_LIST = tuple()
 

--- a/moto/cloudwatch/models.py
+++ b/moto/cloudwatch/models.py
@@ -8,7 +8,7 @@ from dateutil.tz import tzutc
 from uuid import uuid4
 from .utils import make_arn_for_dashboard
 
-DEFAULT_ACCOUNT_ID = 123456789012
+from moto.iam.models import ACCOUNT_ID as DEFAULT_ACCOUNT_ID
 
 _EMPTY_LIST = tuple()
 

--- a/moto/config/models.py
+++ b/moto/config/models.py
@@ -46,6 +46,7 @@ from moto.core import BaseBackend, BaseModel
 from moto.s3.config import s3_config_query
 
 from moto.core import ACCOUNT_ID as DEFAULT_ACCOUNT_ID
+
 POP_STRINGS = [
     "capitalizeStart",
     "CapitalizeStart",

--- a/moto/config/models.py
+++ b/moto/config/models.py
@@ -45,7 +45,7 @@ from moto.config.exceptions import (
 from moto.core import BaseBackend, BaseModel
 from moto.s3.config import s3_config_query
 
-from moto.iam.models import ACCOUNT_ID as DEFAULT_ACCOUNT_ID
+from moto.core import ACCOUNT_ID as DEFAULT_ACCOUNT_ID
 POP_STRINGS = [
     "capitalizeStart",
     "CapitalizeStart",

--- a/moto/config/models.py
+++ b/moto/config/models.py
@@ -45,7 +45,7 @@ from moto.config.exceptions import (
 from moto.core import BaseBackend, BaseModel
 from moto.s3.config import s3_config_query
 
-DEFAULT_ACCOUNT_ID = "123456789012"
+from moto.iam.models import ACCOUNT_ID as DEFAULT_ACCOUNT_ID
 POP_STRINGS = [
     "capitalizeStart",
     "CapitalizeStart",

--- a/moto/core/__init__.py
+++ b/moto/core/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import unicode_literals
 
-from .models import BaseModel, BaseBackend, moto_api_backend  # noqa
+from .models import BaseModel, BaseBackend, moto_api_backend, ACCOUNT_ID  # noqa
 from .responses import ActionAuthenticatorMixin
 
 moto_api_backends = {"global": moto_api_backend}

--- a/moto/core/access_control.py
+++ b/moto/core/access_control.py
@@ -24,7 +24,7 @@ from botocore.awsrequest import AWSRequest
 from botocore.credentials import Credentials
 from six import string_types
 
-from moto.core import ACCOUNT_ID 
+from moto.core import ACCOUNT_ID
 from moto.iam.models import Policy
 from moto.iam import iam_backend
 from moto.core.exceptions import (

--- a/moto/core/access_control.py
+++ b/moto/core/access_control.py
@@ -24,7 +24,8 @@ from botocore.awsrequest import AWSRequest
 from botocore.credentials import Credentials
 from six import string_types
 
-from moto.iam.models import ACCOUNT_ID, Policy
+from moto.core import ACCOUNT_ID 
+from moto.iam.models import Policy
 from moto.iam import iam_backend
 from moto.core.exceptions import (
     SignatureDoesNotMatchError,

--- a/moto/core/models.py
+++ b/moto/core/models.py
@@ -23,6 +23,9 @@ from .utils import (
 )
 
 
+ACCOUNT_ID = os.environ.get('MOTO_ACCOUNT_ID','123456789012')
+    
+
 class BaseMockAWS(object):
     nested_count = 0
 

--- a/moto/core/models.py
+++ b/moto/core/models.py
@@ -23,8 +23,8 @@ from .utils import (
 )
 
 
-ACCOUNT_ID = os.environ.get('MOTO_ACCOUNT_ID','123456789012')
-    
+ACCOUNT_ID = os.environ.get("MOTO_ACCOUNT_ID", "123456789012")
+
 
 class BaseMockAWS(object):
     nested_count = 0

--- a/moto/dynamodb/models.py
+++ b/moto/dynamodb/models.py
@@ -6,6 +6,7 @@ import json
 from moto.compat import OrderedDict
 from moto.core import BaseBackend, BaseModel
 from moto.core.utils import unix_time
+from moto.iam.models import ACCOUNT_ID
 from .comparisons import get_comparison_func
 
 
@@ -277,8 +278,8 @@ class Table(BaseModel):
         if attribute_name == "StreamArn":
             region = "us-east-1"
             time = "2000-01-01T00:00:00.000"
-            return "arn:aws:dynamodb:{0}:123456789012:table/{1}/stream/{2}".format(
-                region, self.name, time
+            return "arn:aws:dynamodb:{0}:{1}:table/{2}/stream/{3}".format(
+                region, ACCOUNT_ID, self.name, time
             )
         raise UnformattedGetAttTemplateException()
 

--- a/moto/dynamodb/models.py
+++ b/moto/dynamodb/models.py
@@ -6,7 +6,7 @@ import json
 from moto.compat import OrderedDict
 from moto.core import BaseBackend, BaseModel
 from moto.core.utils import unix_time
-from moto.iam.models import ACCOUNT_ID
+from moto.core import ACCOUNT_ID
 from .comparisons import get_comparison_func
 
 

--- a/moto/ec2/responses/instances.py
+++ b/moto/ec2/responses/instances.py
@@ -8,6 +8,7 @@ from moto.ec2.utils import filters_from_querystring, dict_from_querystring
 from moto.elbv2 import elbv2_backends
 from moto.core import ACCOUNT_ID
 
+
 class InstanceResponse(BaseResponse):
     def describe_instances(self):
         filter_dict = filters_from_querystring(self.querystring)
@@ -246,10 +247,13 @@ class InstanceResponse(BaseResponse):
             return EC2_MODIFY_INSTANCE_ATTRIBUTE
 
 
-EC2_RUN_INSTANCES = """<RunInstancesResponse xmlns="http://ec2.amazonaws.com/doc/2013-10-15/">
+EC2_RUN_INSTANCES = (
+    """<RunInstancesResponse xmlns="http://ec2.amazonaws.com/doc/2013-10-15/">
   <requestId>59dbff89-35bd-4eac-99ed-be587EXAMPLE</requestId>
   <reservationId>{{ reservation.id }}</reservationId>
-  <ownerId>""" + ACCOUNT_ID + """</ownerId>
+  <ownerId>"""
+    + ACCOUNT_ID
+    + """</ownerId>
   <groupSet>
     <item>
       <groupId>sg-245f6a01</groupId>
@@ -331,7 +335,9 @@ EC2_RUN_INSTANCES = """<RunInstancesResponse xmlns="http://ec2.amazonaws.com/doc
                   <vpcId>{{ nic.subnet.vpc_id }}</vpcId>
                 {% endif %}
                 <description>Primary network interface</description>
-                <ownerId>""" + ACCOUNT_ID + """</ownerId>
+                <ownerId>"""
+    + ACCOUNT_ID
+    + """</ownerId>
                 <status>in-use</status>
                 <macAddress>1b:2b:3c:4d:5e:6f</macAddress>
                 <privateIpAddress>{{ nic.private_ip_address }}</privateIpAddress>
@@ -354,7 +360,9 @@ EC2_RUN_INSTANCES = """<RunInstancesResponse xmlns="http://ec2.amazonaws.com/doc
                 {% if nic.public_ip %}
                   <association>
                     <publicIp>{{ nic.public_ip }}</publicIp>
-                    <ipOwnerId>""" + ACCOUNT_ID + """</ipOwnerId>
+                    <ipOwnerId>"""
+    + ACCOUNT_ID
+    + """</ipOwnerId>
                   </association>
                 {% endif %}
                 <privateIpAddressesSet>
@@ -364,7 +372,9 @@ EC2_RUN_INSTANCES = """<RunInstancesResponse xmlns="http://ec2.amazonaws.com/doc
                     {% if nic.public_ip %}
                       <association>
                         <publicIp>{{ nic.public_ip }}</publicIp>
-                        <ipOwnerId>""" + ACCOUNT_ID + """</ipOwnerId>
+                        <ipOwnerId>"""
+    + ACCOUNT_ID
+    + """</ipOwnerId>
                       </association>
                     {% endif %}
                   </item>
@@ -376,14 +386,18 @@ EC2_RUN_INSTANCES = """<RunInstancesResponse xmlns="http://ec2.amazonaws.com/doc
     {% endfor %}
   </instancesSet>
   </RunInstancesResponse>"""
+)
 
-EC2_DESCRIBE_INSTANCES = """<DescribeInstancesResponse xmlns="http://ec2.amazonaws.com/doc/2013-10-15/">
+EC2_DESCRIBE_INSTANCES = (
+    """<DescribeInstancesResponse xmlns="http://ec2.amazonaws.com/doc/2013-10-15/">
   <requestId>fdcdcab1-ae5c-489e-9c33-4637c5dda355</requestId>
       <reservationSet>
         {% for reservation in reservations %}
           <item>
             <reservationId>{{ reservation.id }}</reservationId>
-            <ownerId>""" + ACCOUNT_ID + """</ownerId>
+            <ownerId>"""
+    + ACCOUNT_ID
+    + """</ownerId>
             <groupSet>
               {% for group in reservation.dynamic_group_list %}
               <item>
@@ -476,7 +490,9 @@ EC2_DESCRIBE_INSTANCES = """<DescribeInstancesResponse xmlns="http://ec2.amazona
                      {% endfor %}
                     </blockDeviceMapping>
                     <virtualizationType>{{ instance.virtualization_type }}</virtualizationType>
-                    <clientToken>ABCDE""" + ACCOUNT_ID + """3</clientToken>
+                    <clientToken>ABCDE"""
+    + ACCOUNT_ID
+    + """3</clientToken>
                     {% if instance.get_tags() %}
                     <tagSet>
                       {% for tag in instance.get_tags() %}
@@ -499,7 +515,9 @@ EC2_DESCRIBE_INSTANCES = """<DescribeInstancesResponse xmlns="http://ec2.amazona
                             <vpcId>{{ nic.subnet.vpc_id }}</vpcId>
                           {% endif %}
                           <description>Primary network interface</description>
-                          <ownerId>""" + ACCOUNT_ID + """</ownerId>
+                          <ownerId>"""
+    + ACCOUNT_ID
+    + """</ownerId>
                           <status>in-use</status>
                           <macAddress>1b:2b:3c:4d:5e:6f</macAddress>
                           <privateIpAddress>{{ nic.private_ip_address }}</privateIpAddress>
@@ -526,7 +544,9 @@ EC2_DESCRIBE_INSTANCES = """<DescribeInstancesResponse xmlns="http://ec2.amazona
                           {% if nic.public_ip %}
                             <association>
                               <publicIp>{{ nic.public_ip }}</publicIp>
-                              <ipOwnerId>""" + ACCOUNT_ID + """</ipOwnerId>
+                              <ipOwnerId>"""
+    + ACCOUNT_ID
+    + """</ipOwnerId>
                             </association>
                           {% endif %}
                           <privateIpAddressesSet>
@@ -536,7 +556,9 @@ EC2_DESCRIBE_INSTANCES = """<DescribeInstancesResponse xmlns="http://ec2.amazona
                               {% if nic.public_ip %}
                                 <association>
                                   <publicIp>{{ nic.public_ip }}</publicIp>
-                                  <ipOwnerId>""" + ACCOUNT_ID + """</ipOwnerId>
+                                  <ipOwnerId>"""
+    + ACCOUNT_ID
+    + """</ipOwnerId>
                                 </association>
                               {% endif %}
                             </item>
@@ -554,6 +576,7 @@ EC2_DESCRIBE_INSTANCES = """<DescribeInstancesResponse xmlns="http://ec2.amazona
       <nextToken>{{ next_token }}</nextToken>
       {% endif %}
 </DescribeInstancesResponse>"""
+)
 
 EC2_TERMINATE_INSTANCES = """
 <TerminateInstancesResponse xmlns="http://ec2.amazonaws.com/doc/2013-10-15/">

--- a/moto/ec2/responses/instances.py
+++ b/moto/ec2/responses/instances.py
@@ -6,7 +6,7 @@ from moto.core.responses import BaseResponse
 from moto.core.utils import camelcase_to_underscores
 from moto.ec2.utils import filters_from_querystring, dict_from_querystring
 from moto.elbv2 import elbv2_backends
-from moto.iam.models import ACCOUNT_ID
+from moto.core import ACCOUNT_ID
 
 class InstanceResponse(BaseResponse):
     def describe_instances(self):

--- a/moto/ec2/responses/instances.py
+++ b/moto/ec2/responses/instances.py
@@ -6,7 +6,7 @@ from moto.core.responses import BaseResponse
 from moto.core.utils import camelcase_to_underscores
 from moto.ec2.utils import filters_from_querystring, dict_from_querystring
 from moto.elbv2 import elbv2_backends
-
+from moto.iam.models import ACCOUNT_ID
 
 class InstanceResponse(BaseResponse):
     def describe_instances(self):
@@ -249,7 +249,7 @@ class InstanceResponse(BaseResponse):
 EC2_RUN_INSTANCES = """<RunInstancesResponse xmlns="http://ec2.amazonaws.com/doc/2013-10-15/">
   <requestId>59dbff89-35bd-4eac-99ed-be587EXAMPLE</requestId>
   <reservationId>{{ reservation.id }}</reservationId>
-  <ownerId>123456789012</ownerId>
+  <ownerId>"""+ACCOUNT_ID+"""</ownerId>
   <groupSet>
     <item>
       <groupId>sg-245f6a01</groupId>
@@ -331,7 +331,7 @@ EC2_RUN_INSTANCES = """<RunInstancesResponse xmlns="http://ec2.amazonaws.com/doc
                   <vpcId>{{ nic.subnet.vpc_id }}</vpcId>
                 {% endif %}
                 <description>Primary network interface</description>
-                <ownerId>123456789012</ownerId>
+                <ownerId>"""+ACCOUNT_ID+"""</ownerId>
                 <status>in-use</status>
                 <macAddress>1b:2b:3c:4d:5e:6f</macAddress>
                 <privateIpAddress>{{ nic.private_ip_address }}</privateIpAddress>
@@ -354,7 +354,7 @@ EC2_RUN_INSTANCES = """<RunInstancesResponse xmlns="http://ec2.amazonaws.com/doc
                 {% if nic.public_ip %}
                   <association>
                     <publicIp>{{ nic.public_ip }}</publicIp>
-                    <ipOwnerId>123456789012</ipOwnerId>
+                    <ipOwnerId>"""+ACCOUNT_ID+"""</ipOwnerId>
                   </association>
                 {% endif %}
                 <privateIpAddressesSet>
@@ -364,7 +364,7 @@ EC2_RUN_INSTANCES = """<RunInstancesResponse xmlns="http://ec2.amazonaws.com/doc
                     {% if nic.public_ip %}
                       <association>
                         <publicIp>{{ nic.public_ip }}</publicIp>
-                        <ipOwnerId>123456789012</ipOwnerId>
+                        <ipOwnerId>"""+ACCOUNT_ID+"""</ipOwnerId>
                       </association>
                     {% endif %}
                   </item>
@@ -383,7 +383,7 @@ EC2_DESCRIBE_INSTANCES = """<DescribeInstancesResponse xmlns="http://ec2.amazona
         {% for reservation in reservations %}
           <item>
             <reservationId>{{ reservation.id }}</reservationId>
-            <ownerId>123456789012</ownerId>
+            <ownerId>"""+ACCOUNT_ID+"""</ownerId>
             <groupSet>
               {% for group in reservation.dynamic_group_list %}
               <item>
@@ -476,7 +476,7 @@ EC2_DESCRIBE_INSTANCES = """<DescribeInstancesResponse xmlns="http://ec2.amazona
                      {% endfor %}
                     </blockDeviceMapping>
                     <virtualizationType>{{ instance.virtualization_type }}</virtualizationType>
-                    <clientToken>ABCDE1234567890123</clientToken>
+                    <clientToken>ABCDE"""+ACCOUNT_ID+"""3</clientToken>
                     {% if instance.get_tags() %}
                     <tagSet>
                       {% for tag in instance.get_tags() %}
@@ -499,7 +499,7 @@ EC2_DESCRIBE_INSTANCES = """<DescribeInstancesResponse xmlns="http://ec2.amazona
                             <vpcId>{{ nic.subnet.vpc_id }}</vpcId>
                           {% endif %}
                           <description>Primary network interface</description>
-                          <ownerId>123456789012</ownerId>
+                          <ownerId>"""+ACCOUNT_ID+"""</ownerId>
                           <status>in-use</status>
                           <macAddress>1b:2b:3c:4d:5e:6f</macAddress>
                           <privateIpAddress>{{ nic.private_ip_address }}</privateIpAddress>
@@ -526,7 +526,7 @@ EC2_DESCRIBE_INSTANCES = """<DescribeInstancesResponse xmlns="http://ec2.amazona
                           {% if nic.public_ip %}
                             <association>
                               <publicIp>{{ nic.public_ip }}</publicIp>
-                              <ipOwnerId>123456789012</ipOwnerId>
+                              <ipOwnerId>"""+ACCOUNT_ID+"""</ipOwnerId>
                             </association>
                           {% endif %}
                           <privateIpAddressesSet>
@@ -536,7 +536,7 @@ EC2_DESCRIBE_INSTANCES = """<DescribeInstancesResponse xmlns="http://ec2.amazona
                               {% if nic.public_ip %}
                                 <association>
                                   <publicIp>{{ nic.public_ip }}</publicIp>
-                                  <ipOwnerId>123456789012</ipOwnerId>
+                                  <ipOwnerId>"""+ACCOUNT_ID+"""</ipOwnerId>
                                 </association>
                               {% endif %}
                             </item>

--- a/moto/ec2/responses/instances.py
+++ b/moto/ec2/responses/instances.py
@@ -249,7 +249,7 @@ class InstanceResponse(BaseResponse):
 EC2_RUN_INSTANCES = """<RunInstancesResponse xmlns="http://ec2.amazonaws.com/doc/2013-10-15/">
   <requestId>59dbff89-35bd-4eac-99ed-be587EXAMPLE</requestId>
   <reservationId>{{ reservation.id }}</reservationId>
-  <ownerId>"""+ACCOUNT_ID+"""</ownerId>
+  <ownerId>""" + ACCOUNT_ID + """</ownerId>
   <groupSet>
     <item>
       <groupId>sg-245f6a01</groupId>
@@ -331,7 +331,7 @@ EC2_RUN_INSTANCES = """<RunInstancesResponse xmlns="http://ec2.amazonaws.com/doc
                   <vpcId>{{ nic.subnet.vpc_id }}</vpcId>
                 {% endif %}
                 <description>Primary network interface</description>
-                <ownerId>"""+ACCOUNT_ID+"""</ownerId>
+                <ownerId>""" + ACCOUNT_ID + """</ownerId>
                 <status>in-use</status>
                 <macAddress>1b:2b:3c:4d:5e:6f</macAddress>
                 <privateIpAddress>{{ nic.private_ip_address }}</privateIpAddress>
@@ -354,7 +354,7 @@ EC2_RUN_INSTANCES = """<RunInstancesResponse xmlns="http://ec2.amazonaws.com/doc
                 {% if nic.public_ip %}
                   <association>
                     <publicIp>{{ nic.public_ip }}</publicIp>
-                    <ipOwnerId>"""+ACCOUNT_ID+"""</ipOwnerId>
+                    <ipOwnerId>""" + ACCOUNT_ID + """</ipOwnerId>
                   </association>
                 {% endif %}
                 <privateIpAddressesSet>
@@ -364,7 +364,7 @@ EC2_RUN_INSTANCES = """<RunInstancesResponse xmlns="http://ec2.amazonaws.com/doc
                     {% if nic.public_ip %}
                       <association>
                         <publicIp>{{ nic.public_ip }}</publicIp>
-                        <ipOwnerId>"""+ACCOUNT_ID+"""</ipOwnerId>
+                        <ipOwnerId>""" + ACCOUNT_ID + """</ipOwnerId>
                       </association>
                     {% endif %}
                   </item>
@@ -383,7 +383,7 @@ EC2_DESCRIBE_INSTANCES = """<DescribeInstancesResponse xmlns="http://ec2.amazona
         {% for reservation in reservations %}
           <item>
             <reservationId>{{ reservation.id }}</reservationId>
-            <ownerId>"""+ACCOUNT_ID+"""</ownerId>
+            <ownerId>""" + ACCOUNT_ID + """</ownerId>
             <groupSet>
               {% for group in reservation.dynamic_group_list %}
               <item>
@@ -476,7 +476,7 @@ EC2_DESCRIBE_INSTANCES = """<DescribeInstancesResponse xmlns="http://ec2.amazona
                      {% endfor %}
                     </blockDeviceMapping>
                     <virtualizationType>{{ instance.virtualization_type }}</virtualizationType>
-                    <clientToken>ABCDE"""+ACCOUNT_ID+"""3</clientToken>
+                    <clientToken>ABCDE""" + ACCOUNT_ID + """3</clientToken>
                     {% if instance.get_tags() %}
                     <tagSet>
                       {% for tag in instance.get_tags() %}
@@ -499,7 +499,7 @@ EC2_DESCRIBE_INSTANCES = """<DescribeInstancesResponse xmlns="http://ec2.amazona
                             <vpcId>{{ nic.subnet.vpc_id }}</vpcId>
                           {% endif %}
                           <description>Primary network interface</description>
-                          <ownerId>"""+ACCOUNT_ID+"""</ownerId>
+                          <ownerId>""" + ACCOUNT_ID + """</ownerId>
                           <status>in-use</status>
                           <macAddress>1b:2b:3c:4d:5e:6f</macAddress>
                           <privateIpAddress>{{ nic.private_ip_address }}</privateIpAddress>
@@ -526,7 +526,7 @@ EC2_DESCRIBE_INSTANCES = """<DescribeInstancesResponse xmlns="http://ec2.amazona
                           {% if nic.public_ip %}
                             <association>
                               <publicIp>{{ nic.public_ip }}</publicIp>
-                              <ipOwnerId>"""+ACCOUNT_ID+"""</ipOwnerId>
+                              <ipOwnerId>""" + ACCOUNT_ID + """</ipOwnerId>
                             </association>
                           {% endif %}
                           <privateIpAddressesSet>
@@ -536,7 +536,7 @@ EC2_DESCRIBE_INSTANCES = """<DescribeInstancesResponse xmlns="http://ec2.amazona
                               {% if nic.public_ip %}
                                 <association>
                                   <publicIp>{{ nic.public_ip }}</publicIp>
-                                  <ipOwnerId>"""+ACCOUNT_ID+"""</ipOwnerId>
+                                  <ipOwnerId>""" + ACCOUNT_ID + """</ipOwnerId>
                                 </association>
                               {% endif %}
                             </item>

--- a/moto/ec2/responses/security_groups.py
+++ b/moto/ec2/responses/security_groups.py
@@ -177,7 +177,7 @@ DESCRIBE_SECURITY_GROUPS_RESPONSE = """<DescribeSecurityGroupsResponse xmlns="ht
    <securityGroupInfo>
       {% for group in groups %}
           <item>
-             <ownerId>"""+ACCOUNT_ID+"""</ownerId>
+             <ownerId>""" + ACCOUNT_ID + """</ownerId>
              <groupId>{{ group.id }}</groupId>
              <groupName>{{ group.name }}</groupName>
              <groupDescription>{{ group.description }}</groupDescription>
@@ -197,7 +197,7 @@ DESCRIBE_SECURITY_GROUPS_RESPONSE = """<DescribeSecurityGroupsResponse xmlns="ht
                        <groups>
                           {% for source_group in rule.source_groups %}
                               <item>
-                                 <userId>"""+ACCOUNT_ID+"""</userId>
+                                 <userId>""" + ACCOUNT_ID + """</userId>
                                  <groupId>{{ source_group.id }}</groupId>
                                  <groupName>{{ source_group.name }}</groupName>
                               </item>
@@ -226,7 +226,7 @@ DESCRIBE_SECURITY_GROUPS_RESPONSE = """<DescribeSecurityGroupsResponse xmlns="ht
                        <groups>
                           {% for source_group in rule.source_groups %}
                               <item>
-                                 <userId>"""+ACCOUNT_ID+"""</userId>
+                                 <userId>""" + ACCOUNT_ID + """</userId>
                                  <groupId>{{ source_group.id }}</groupId>
                                  <groupName>{{ source_group.name }}</groupName>
                               </item>

--- a/moto/ec2/responses/security_groups.py
+++ b/moto/ec2/responses/security_groups.py
@@ -2,6 +2,7 @@ from __future__ import unicode_literals
 
 from moto.core.responses import BaseResponse
 from moto.ec2.utils import filters_from_querystring
+from moto.iam.models import ACCOUNT_ID
 
 
 def try_parse_int(value, default=None):
@@ -176,7 +177,7 @@ DESCRIBE_SECURITY_GROUPS_RESPONSE = """<DescribeSecurityGroupsResponse xmlns="ht
    <securityGroupInfo>
       {% for group in groups %}
           <item>
-             <ownerId>123456789012</ownerId>
+             <ownerId>"""+ACCOUNT_ID+"""</ownerId>
              <groupId>{{ group.id }}</groupId>
              <groupName>{{ group.name }}</groupName>
              <groupDescription>{{ group.description }}</groupDescription>
@@ -196,7 +197,7 @@ DESCRIBE_SECURITY_GROUPS_RESPONSE = """<DescribeSecurityGroupsResponse xmlns="ht
                        <groups>
                           {% for source_group in rule.source_groups %}
                               <item>
-                                 <userId>123456789012</userId>
+                                 <userId>"""+ACCOUNT_ID+"""</userId>
                                  <groupId>{{ source_group.id }}</groupId>
                                  <groupName>{{ source_group.name }}</groupName>
                               </item>
@@ -225,7 +226,7 @@ DESCRIBE_SECURITY_GROUPS_RESPONSE = """<DescribeSecurityGroupsResponse xmlns="ht
                        <groups>
                           {% for source_group in rule.source_groups %}
                               <item>
-                                 <userId>123456789012</userId>
+                                 <userId>"""+ACCOUNT_ID+"""</userId>
                                  <groupId>{{ source_group.id }}</groupId>
                                  <groupName>{{ source_group.name }}</groupName>
                               </item>

--- a/moto/ec2/responses/security_groups.py
+++ b/moto/ec2/responses/security_groups.py
@@ -2,7 +2,7 @@ from __future__ import unicode_literals
 
 from moto.core.responses import BaseResponse
 from moto.ec2.utils import filters_from_querystring
-from moto.iam.models import ACCOUNT_ID
+from moto.core import ACCOUNT_ID
 
 
 def try_parse_int(value, default=None):

--- a/moto/ec2/responses/security_groups.py
+++ b/moto/ec2/responses/security_groups.py
@@ -172,12 +172,15 @@ DELETE_GROUP_RESPONSE = """<DeleteSecurityGroupResponse xmlns="http://ec2.amazon
   <return>true</return>
 </DeleteSecurityGroupResponse>"""
 
-DESCRIBE_SECURITY_GROUPS_RESPONSE = """<DescribeSecurityGroupsResponse xmlns="http://ec2.amazonaws.com/doc/2013-10-15/">
+DESCRIBE_SECURITY_GROUPS_RESPONSE = (
+    """<DescribeSecurityGroupsResponse xmlns="http://ec2.amazonaws.com/doc/2013-10-15/">
    <requestId>59dbff89-35bd-4eac-99ed-be587EXAMPLE</requestId>
    <securityGroupInfo>
       {% for group in groups %}
           <item>
-             <ownerId>""" + ACCOUNT_ID + """</ownerId>
+             <ownerId>"""
+    + ACCOUNT_ID
+    + """</ownerId>
              <groupId>{{ group.id }}</groupId>
              <groupName>{{ group.name }}</groupName>
              <groupDescription>{{ group.description }}</groupDescription>
@@ -197,7 +200,9 @@ DESCRIBE_SECURITY_GROUPS_RESPONSE = """<DescribeSecurityGroupsResponse xmlns="ht
                        <groups>
                           {% for source_group in rule.source_groups %}
                               <item>
-                                 <userId>""" + ACCOUNT_ID + """</userId>
+                                 <userId>"""
+    + ACCOUNT_ID
+    + """</userId>
                                  <groupId>{{ source_group.id }}</groupId>
                                  <groupName>{{ source_group.name }}</groupName>
                               </item>
@@ -226,7 +231,9 @@ DESCRIBE_SECURITY_GROUPS_RESPONSE = """<DescribeSecurityGroupsResponse xmlns="ht
                        <groups>
                           {% for source_group in rule.source_groups %}
                               <item>
-                                 <userId>""" + ACCOUNT_ID + """</userId>
+                                 <userId>"""
+    + ACCOUNT_ID
+    + """</userId>
                                  <groupId>{{ source_group.id }}</groupId>
                                  <groupName>{{ source_group.name }}</groupName>
                               </item>
@@ -256,6 +263,7 @@ DESCRIBE_SECURITY_GROUPS_RESPONSE = """<DescribeSecurityGroupsResponse xmlns="ht
       {% endfor %}
    </securityGroupInfo>
 </DescribeSecurityGroupsResponse>"""
+)
 
 AUTHORIZE_SECURITY_GROUP_INGRESS_REPONSE = """<AuthorizeSecurityGroupIngressResponse xmlns="http://ec2.amazonaws.com/doc/2013-10-15/">
   <requestId>59dbff89-35bd-4eac-99ed-be587EXAMPLE</requestId>

--- a/moto/ec2/responses/vpc_peering_connections.py
+++ b/moto/ec2/responses/vpc_peering_connections.py
@@ -2,6 +2,7 @@ from __future__ import unicode_literals
 from moto.core.responses import BaseResponse
 from moto.iam.models import ACCOUNT_ID
 
+
 class VPCPeeringConnections(BaseResponse):
     def create_vpc_peering_connection(self):
         peer_region = self._get_param("PeerRegion")
@@ -56,7 +57,7 @@ CREATE_VPC_PEERING_CONNECTION_RESPONSE = """
      </peeringOptions>
     </requesterVpcInfo>
     <accepterVpcInfo>
-      <ownerId>"""+ACCOUNT_ID+"""</ownerId>
+      <ownerId>""" + ACCOUNT_ID + """</ownerId>
       <vpcId>{{ vpc_pcx.peer_vpc.id }}</vpcId>
     </accepterVpcInfo>
     <status>
@@ -82,7 +83,7 @@ DESCRIBE_VPC_PEERING_CONNECTIONS_RESPONSE = """
      <cidrBlock>{{ vpc_pcx.vpc.cidr_block }}</cidrBlock>
     </requesterVpcInfo>
     <accepterVpcInfo>
-     <ownerId>"""+ACCOUNT_ID+"""</ownerId>
+     <ownerId>""" + ACCOUNT_ID + """</ownerId>
      <vpcId>{{ vpc_pcx.peer_vpc.id }}</vpcId>
      <cidrBlock>{{ vpc_pcx.peer_vpc.cidr_block }}</cidrBlock>
      <peeringOptions>
@@ -120,7 +121,7 @@ ACCEPT_VPC_PEERING_CONNECTION_RESPONSE = """
       <cidrBlock>{{ vpc_pcx.vpc.cidr_block }}</cidrBlock>
     </requesterVpcInfo>
     <accepterVpcInfo>
-      <ownerId>"""+ACCOUNT_ID+"""</ownerId>
+      <ownerId>""" + ACCOUNT_ID + """</ownerId>
       <vpcId>{{ vpc_pcx.peer_vpc.id }}</vpcId>
       <cidrBlock>{{ vpc_pcx.peer_vpc.cidr_block }}</cidrBlock>
       <peeringOptions>

--- a/moto/ec2/responses/vpc_peering_connections.py
+++ b/moto/ec2/responses/vpc_peering_connections.py
@@ -1,6 +1,6 @@
 from __future__ import unicode_literals
 from moto.core.responses import BaseResponse
-
+from moto.iam.models import ACCOUNT_ID
 
 class VPCPeeringConnections(BaseResponse):
     def create_vpc_peering_connection(self):
@@ -56,7 +56,7 @@ CREATE_VPC_PEERING_CONNECTION_RESPONSE = """
      </peeringOptions>
     </requesterVpcInfo>
     <accepterVpcInfo>
-      <ownerId>123456789012</ownerId>
+      <ownerId>"""+ACCOUNT_ID+"""</ownerId>
       <vpcId>{{ vpc_pcx.peer_vpc.id }}</vpcId>
     </accepterVpcInfo>
     <status>
@@ -82,7 +82,7 @@ DESCRIBE_VPC_PEERING_CONNECTIONS_RESPONSE = """
      <cidrBlock>{{ vpc_pcx.vpc.cidr_block }}</cidrBlock>
     </requesterVpcInfo>
     <accepterVpcInfo>
-     <ownerId>123456789012</ownerId>
+     <ownerId>"""+ACCOUNT_ID+"""</ownerId>
      <vpcId>{{ vpc_pcx.peer_vpc.id }}</vpcId>
      <cidrBlock>{{ vpc_pcx.peer_vpc.cidr_block }}</cidrBlock>
      <peeringOptions>
@@ -120,7 +120,7 @@ ACCEPT_VPC_PEERING_CONNECTION_RESPONSE = """
       <cidrBlock>{{ vpc_pcx.vpc.cidr_block }}</cidrBlock>
     </requesterVpcInfo>
     <accepterVpcInfo>
-      <ownerId>123456789012</ownerId>
+      <ownerId>"""+ACCOUNT_ID+"""</ownerId>
       <vpcId>{{ vpc_pcx.peer_vpc.id }}</vpcId>
       <cidrBlock>{{ vpc_pcx.peer_vpc.cidr_block }}</cidrBlock>
       <peeringOptions>

--- a/moto/ec2/responses/vpc_peering_connections.py
+++ b/moto/ec2/responses/vpc_peering_connections.py
@@ -41,7 +41,8 @@ class VPCPeeringConnections(BaseResponse):
         return template.render()
 
 
-CREATE_VPC_PEERING_CONNECTION_RESPONSE = """
+CREATE_VPC_PEERING_CONNECTION_RESPONSE = (
+    """
 <CreateVpcPeeringConnectionResponse xmlns="http://ec2.amazonaws.com/doc/2016-11-15/">
  <requestId>7a62c49f-347e-4fc4-9331-6e8eEXAMPLE</requestId>
  <vpcPeeringConnection>
@@ -57,7 +58,9 @@ CREATE_VPC_PEERING_CONNECTION_RESPONSE = """
      </peeringOptions>
     </requesterVpcInfo>
     <accepterVpcInfo>
-      <ownerId>""" + ACCOUNT_ID + """</ownerId>
+      <ownerId>"""
+    + ACCOUNT_ID
+    + """</ownerId>
       <vpcId>{{ vpc_pcx.peer_vpc.id }}</vpcId>
     </accepterVpcInfo>
     <status>
@@ -69,8 +72,10 @@ CREATE_VPC_PEERING_CONNECTION_RESPONSE = """
  </vpcPeeringConnection>
 </CreateVpcPeeringConnectionResponse>
 """
+)
 
-DESCRIBE_VPC_PEERING_CONNECTIONS_RESPONSE = """
+DESCRIBE_VPC_PEERING_CONNECTIONS_RESPONSE = (
+    """
 <DescribeVpcPeeringConnectionsResponse xmlns="http://ec2.amazonaws.com/doc/2016-11-15/">
 <requestId>7a62c49f-347e-4fc4-9331-6e8eEXAMPLE</requestId>
  <vpcPeeringConnectionSet>
@@ -83,7 +88,9 @@ DESCRIBE_VPC_PEERING_CONNECTIONS_RESPONSE = """
      <cidrBlock>{{ vpc_pcx.vpc.cidr_block }}</cidrBlock>
     </requesterVpcInfo>
     <accepterVpcInfo>
-     <ownerId>""" + ACCOUNT_ID + """</ownerId>
+     <ownerId>"""
+    + ACCOUNT_ID
+    + """</ownerId>
      <vpcId>{{ vpc_pcx.peer_vpc.id }}</vpcId>
      <cidrBlock>{{ vpc_pcx.peer_vpc.cidr_block }}</cidrBlock>
      <peeringOptions>
@@ -102,6 +109,7 @@ DESCRIBE_VPC_PEERING_CONNECTIONS_RESPONSE = """
  </vpcPeeringConnectionSet>
 </DescribeVpcPeeringConnectionsResponse>
 """
+)
 
 DELETE_VPC_PEERING_CONNECTION_RESPONSE = """
 <DeleteVpcPeeringConnectionResponse xmlns="http://ec2.amazonaws.com/doc/2013-10-15/">
@@ -110,7 +118,8 @@ DELETE_VPC_PEERING_CONNECTION_RESPONSE = """
 </DeleteVpcPeeringConnectionResponse>
 """
 
-ACCEPT_VPC_PEERING_CONNECTION_RESPONSE = """
+ACCEPT_VPC_PEERING_CONNECTION_RESPONSE = (
+    """
 <AcceptVpcPeeringConnectionResponse xmlns="http://ec2.amazonaws.com/doc/2016-11-15/">
   <requestId>7a62c49f-347e-4fc4-9331-6e8eEXAMPLE</requestId>
   <vpcPeeringConnection>
@@ -121,7 +130,9 @@ ACCEPT_VPC_PEERING_CONNECTION_RESPONSE = """
       <cidrBlock>{{ vpc_pcx.vpc.cidr_block }}</cidrBlock>
     </requesterVpcInfo>
     <accepterVpcInfo>
-      <ownerId>""" + ACCOUNT_ID + """</ownerId>
+      <ownerId>"""
+    + ACCOUNT_ID
+    + """</ownerId>
       <vpcId>{{ vpc_pcx.peer_vpc.id }}</vpcId>
       <cidrBlock>{{ vpc_pcx.peer_vpc.cidr_block }}</cidrBlock>
       <peeringOptions>
@@ -138,6 +149,7 @@ ACCEPT_VPC_PEERING_CONNECTION_RESPONSE = """
   </vpcPeeringConnection>
 </AcceptVpcPeeringConnectionResponse>
 """
+)
 
 REJECT_VPC_PEERING_CONNECTION_RESPONSE = """
 <RejectVpcPeeringConnectionResponse xmlns="http://ec2.amazonaws.com/doc/2013-10-15/">

--- a/moto/ec2/responses/vpc_peering_connections.py
+++ b/moto/ec2/responses/vpc_peering_connections.py
@@ -1,6 +1,6 @@
 from __future__ import unicode_literals
 from moto.core.responses import BaseResponse
-from moto.iam.models import ACCOUNT_ID
+from moto.core import ACCOUNT_ID
 
 
 class VPCPeeringConnections(BaseResponse):

--- a/moto/iam/models.py
+++ b/moto/iam/models.py
@@ -45,7 +45,7 @@ from .utils import (
     random_policy_id,
 )
 
-ACCOUNT_ID = '123456789012' #make sure this is a str and not an int
+ACCOUNT_ID = '123456789012'
 
 
 class MFADevice(object):

--- a/moto/iam/models.py
+++ b/moto/iam/models.py
@@ -14,7 +14,7 @@ from cryptography.hazmat.backends import default_backend
 from six.moves.urllib.parse import urlparse
 
 from moto.core.exceptions import RESTError
-from moto.core import BaseBackend, BaseModel
+from moto.core import BaseBackend, BaseModel, ACCOUNT_ID
 from moto.core.utils import (
     iso_8601_datetime_without_milliseconds,
     iso_8601_datetime_with_milliseconds,
@@ -44,8 +44,6 @@ from .utils import (
     random_resource_id,
     random_policy_id,
 )
-
-ACCOUNT_ID = '123456789012'
 
 
 class MFADevice(object):

--- a/moto/iam/models.py
+++ b/moto/iam/models.py
@@ -45,7 +45,7 @@ from .utils import (
     random_policy_id,
 )
 
-ACCOUNT_ID = 123456789012
+ACCOUNT_ID = '123456789012' #make sure this is a str and not an int
 
 
 class MFADevice(object):

--- a/moto/kinesis/exceptions.py
+++ b/moto/kinesis/exceptions.py
@@ -2,6 +2,7 @@ from __future__ import unicode_literals
 
 import json
 from werkzeug.exceptions import BadRequest
+from moto.iam.models import ACCOUNT_ID
 
 
 class ResourceNotFoundError(BadRequest):
@@ -23,14 +24,14 @@ class ResourceInUseError(BadRequest):
 class StreamNotFoundError(ResourceNotFoundError):
     def __init__(self, stream_name):
         super(StreamNotFoundError, self).__init__(
-            "Stream {0} under account 123456789012 not found.".format(stream_name)
+            "Stream {0} under account {1} not found.".format(stream_name, ACCOUNT_ID)
         )
 
 
 class ShardNotFoundError(ResourceNotFoundError):
     def __init__(self, shard_id):
         super(ShardNotFoundError, self).__init__(
-            "Shard {0} under account 123456789012 not found.".format(shard_id)
+            "Shard {0} under account {1} not found.".format(shard_id, ACCOUNT_ID)
         )
 
 

--- a/moto/kinesis/exceptions.py
+++ b/moto/kinesis/exceptions.py
@@ -2,7 +2,7 @@ from __future__ import unicode_literals
 
 import json
 from werkzeug.exceptions import BadRequest
-from moto.iam.models import ACCOUNT_ID
+from moto.core import ACCOUNT_ID
 
 
 class ResourceNotFoundError(BadRequest):

--- a/moto/kinesis/models.py
+++ b/moto/kinesis/models.py
@@ -13,7 +13,7 @@ from hashlib import md5
 from moto.compat import OrderedDict
 from moto.core import BaseBackend, BaseModel
 from moto.core.utils import unix_time
-from moto.iam.models import ACCOUNT_ID
+from moto.core import ACCOUNT_ID
 from .exceptions import (
     StreamNotFoundError,
     ShardNotFoundError,

--- a/moto/kinesis/models.py
+++ b/moto/kinesis/models.py
@@ -13,6 +13,7 @@ from hashlib import md5
 from moto.compat import OrderedDict
 from moto.core import BaseBackend, BaseModel
 from moto.core.utils import unix_time
+from moto.iam.models import ACCOUNT_ID
 from .exceptions import (
     StreamNotFoundError,
     ShardNotFoundError,
@@ -133,7 +134,7 @@ class Stream(BaseModel):
         self.shard_count = shard_count
         self.creation_datetime = datetime.datetime.now()
         self.region = region
-        self.account_number = "123456789012"
+        self.account_number = ACCOUNT_ID
         self.shards = {}
         self.tags = {}
         self.status = "ACTIVE"
@@ -259,8 +260,8 @@ class DeliveryStream(BaseModel):
 
     @property
     def arn(self):
-        return "arn:aws:firehose:us-east-1:123456789012:deliverystream/{0}".format(
-            self.name
+        return "arn:aws:firehose:us-east-1:{1}:deliverystream/{0}".format(
+            self.name, ACCOUNT_ID
         )
 
     def destinations_to_dict(self):

--- a/moto/opsworks/models.py
+++ b/moto/opsworks/models.py
@@ -1,6 +1,7 @@
 from __future__ import unicode_literals
 from moto.core import BaseBackend, BaseModel
 from moto.ec2 import ec2_backends
+from moto.iam.models import ACCOUNT_ID
 import uuid
 import datetime
 from random import choice
@@ -367,7 +368,7 @@ class Stack(BaseModel):
         self.id = "{0}".format(uuid.uuid4())
         self.layers = []
         self.apps = []
-        self.account_number = "123456789012"
+        self.account_number = ACCOUNT_ID
         self.created_at = datetime.datetime.utcnow()
 
     def __eq__(self, other):

--- a/moto/opsworks/models.py
+++ b/moto/opsworks/models.py
@@ -1,7 +1,7 @@
 from __future__ import unicode_literals
 from moto.core import BaseBackend, BaseModel
 from moto.ec2 import ec2_backends
-from moto.iam.models import ACCOUNT_ID
+from moto.core import ACCOUNT_ID
 import uuid
 import datetime
 from random import choice

--- a/moto/organizations/utils.py
+++ b/moto/organizations/utils.py
@@ -2,7 +2,7 @@ from __future__ import unicode_literals
 
 import random
 import string
-from moto.iam.models import ACCOUNT_ID
+from moto.core import ACCOUNT_ID
 
 
 MASTER_ACCOUNT_ID = ACCOUNT_ID

--- a/moto/organizations/utils.py
+++ b/moto/organizations/utils.py
@@ -3,7 +3,7 @@ from __future__ import unicode_literals
 import random
 import string
 
-MASTER_ACCOUNT_ID = "123456789012"
+from moto.iam.models import ACCOUNT_ID as MASTER_ACCOUNT_ID
 MASTER_ACCOUNT_EMAIL = "master@example.com"
 DEFAULT_POLICY_ID = "p-FullAWSAccess"
 ORGANIZATION_ARN_FORMAT = "arn:aws:organizations::{0}:organization/{1}"

--- a/moto/organizations/utils.py
+++ b/moto/organizations/utils.py
@@ -2,8 +2,10 @@ from __future__ import unicode_literals
 
 import random
 import string
+from moto.iam.models import ACCOUNT_ID
 
-from moto.iam.models import ACCOUNT_ID as MASTER_ACCOUNT_ID
+
+MASTER_ACCOUNT_ID = ACCOUNT_ID
 MASTER_ACCOUNT_EMAIL = "master@example.com"
 DEFAULT_POLICY_ID = "p-FullAWSAccess"
 ORGANIZATION_ARN_FORMAT = "arn:aws:organizations::{0}:organization/{1}"

--- a/moto/polly/models.py
+++ b/moto/polly/models.py
@@ -8,7 +8,7 @@ from moto.core import BaseBackend, BaseModel
 from .resources import VOICE_DATA
 from .utils import make_arn_for_lexicon
 
-from moto.iam.models import ACCOUNT_ID as DEFAULT_ACCOUNT_ID
+from moto.core import ACCOUNT_ID as DEFAULT_ACCOUNT_ID
 
 
 class Lexicon(BaseModel):

--- a/moto/polly/models.py
+++ b/moto/polly/models.py
@@ -8,7 +8,7 @@ from moto.core import BaseBackend, BaseModel
 from .resources import VOICE_DATA
 from .utils import make_arn_for_lexicon
 
-DEFAULT_ACCOUNT_ID = 123456789012
+from moto.iam.models import ACCOUNT_ID as DEFAULT_ACCOUNT_ID
 
 
 class Lexicon(BaseModel):

--- a/moto/redshift/models.py
+++ b/moto/redshift/models.py
@@ -27,7 +27,7 @@ from .exceptions import (
 )
 
 
-ACCOUNT_ID = 123456789012
+from moto.iam.models import ACCOUNT_ID
 
 
 class TaggableResourceMixin(object):

--- a/moto/redshift/models.py
+++ b/moto/redshift/models.py
@@ -27,7 +27,7 @@ from .exceptions import (
 )
 
 
-from moto.iam.models import ACCOUNT_ID
+from moto.core import ACCOUNT_ID
 
 
 class TaggableResourceMixin(object):

--- a/moto/resourcegroups/models.py
+++ b/moto/resourcegroups/models.py
@@ -6,6 +6,7 @@ import json
 import re
 
 from moto.core import BaseBackend, BaseModel
+from moto.iam.models import ACCOUNT_ID
 from .exceptions import BadRequestException
 
 
@@ -23,8 +24,8 @@ class FakeResourceGroup(BaseModel):
         if self._validate_tags(value=tags):
             self._tags = tags
         self._raise_errors()
-        self.arn = "arn:aws:resource-groups:us-west-1:123456789012:{name}".format(
-            name=name
+        self.arn = "arn:aws:resource-groups:us-west-1:{AccountId}:{name}".format(
+            name=name, AccountId=ACCOUNT_ID
         )
 
     @staticmethod

--- a/moto/resourcegroups/models.py
+++ b/moto/resourcegroups/models.py
@@ -6,7 +6,7 @@ import json
 import re
 
 from moto.core import BaseBackend, BaseModel
-from moto.iam.models import ACCOUNT_ID
+from moto.core import ACCOUNT_ID
 from .exceptions import BadRequestException
 
 

--- a/moto/s3/responses.py
+++ b/moto/s3/responses.py
@@ -13,6 +13,7 @@ import xmltodict
 from moto.packages.httpretty.core import HTTPrettyRequest
 from moto.core.responses import _TemplateEnvironmentMixin, ActionAuthenticatorMixin
 from moto.core.utils import path_url
+from moto.iam.models import ACCOUNT_ID
 
 from moto.s3bucket_path.utils import (
     bucket_name_from_url as bucketpath_bucket_name_from_url,
@@ -1898,7 +1899,7 @@ S3_ALL_MULTIPARTS = """<?xml version="1.0" encoding="UTF-8"?>
     <Key>{{ upload.key_name }}</Key>
     <UploadId>{{ upload.id }}</UploadId>
     <Initiator>
-      <ID>arn:aws:iam::123456789012:user/user1-11111a31-17b5-4fb7-9df5-b111111f13de</ID>
+      <ID>arn:aws:iam::"""+ACCOUNT_ID+""":user/user1-11111a31-17b5-4fb7-9df5-b111111f13de</ID>
       <DisplayName>user1-11111a31-17b5-4fb7-9df5-b111111f13de</DisplayName>
     </Initiator>
     <Owner>

--- a/moto/s3/responses.py
+++ b/moto/s3/responses.py
@@ -1899,7 +1899,7 @@ S3_ALL_MULTIPARTS = """<?xml version="1.0" encoding="UTF-8"?>
     <Key>{{ upload.key_name }}</Key>
     <UploadId>{{ upload.id }}</UploadId>
     <Initiator>
-      <ID>arn:aws:iam::"""+ACCOUNT_ID+""":user/user1-11111a31-17b5-4fb7-9df5-b111111f13de</ID>
+      <ID>arn:aws:iam::""" + ACCOUNT_ID + """:user/user1-11111a31-17b5-4fb7-9df5-b111111f13de</ID>
       <DisplayName>user1-11111a31-17b5-4fb7-9df5-b111111f13de</DisplayName>
     </Initiator>
     <Owner>

--- a/moto/s3/responses.py
+++ b/moto/s3/responses.py
@@ -1887,7 +1887,8 @@ S3_MULTIPART_COMPLETE_RESPONSE = """<?xml version="1.0" encoding="UTF-8"?>
 </CompleteMultipartUploadResult>
 """
 
-S3_ALL_MULTIPARTS = """<?xml version="1.0" encoding="UTF-8"?>
+S3_ALL_MULTIPARTS = (
+    """<?xml version="1.0" encoding="UTF-8"?>
 <ListMultipartUploadsResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
   <Bucket>{{ bucket_name }}</Bucket>
   <KeyMarker></KeyMarker>
@@ -1899,7 +1900,9 @@ S3_ALL_MULTIPARTS = """<?xml version="1.0" encoding="UTF-8"?>
     <Key>{{ upload.key_name }}</Key>
     <UploadId>{{ upload.id }}</UploadId>
     <Initiator>
-      <ID>arn:aws:iam::""" + ACCOUNT_ID + """:user/user1-11111a31-17b5-4fb7-9df5-b111111f13de</ID>
+      <ID>arn:aws:iam::"""
+    + ACCOUNT_ID
+    + """:user/user1-11111a31-17b5-4fb7-9df5-b111111f13de</ID>
       <DisplayName>user1-11111a31-17b5-4fb7-9df5-b111111f13de</DisplayName>
     </Initiator>
     <Owner>
@@ -1912,6 +1915,7 @@ S3_ALL_MULTIPARTS = """<?xml version="1.0" encoding="UTF-8"?>
   {% endfor %}
 </ListMultipartUploadsResult>
 """
+)
 
 S3_NO_POLICY = """<?xml version="1.0" encoding="UTF-8"?>
 <Error>

--- a/moto/s3/responses.py
+++ b/moto/s3/responses.py
@@ -13,7 +13,7 @@ import xmltodict
 from moto.packages.httpretty.core import HTTPrettyRequest
 from moto.core.responses import _TemplateEnvironmentMixin, ActionAuthenticatorMixin
 from moto.core.utils import path_url
-from moto.iam.models import ACCOUNT_ID
+from moto.core import ACCOUNT_ID
 
 from moto.s3bucket_path.utils import (
     bucket_name_from_url as bucketpath_bucket_name_from_url,

--- a/moto/ses/feedback.py
+++ b/moto/ses/feedback.py
@@ -1,3 +1,4 @@
+from moto.iam.models import ACCOUNT_ID
 """
 SES Feedback messages
 Extracted from https://docs.aws.amazon.com/ses/latest/DeveloperGuide/notification-contents.html
@@ -10,7 +11,7 @@ COMMON_MAIL = {
         "source": "sender@example.com",
         "sourceArn": "arn:aws:ses:us-west-2:888888888888:identity/example.com",
         "sourceIp": "127.0.3.0",
-        "sendingAccountId": "123456789012",
+        "sendingAccountId": ACCOUNT_ID,
         "destination": ["recipient@example.com"],
         "headersTruncated": False,
         "headers": [

--- a/moto/ses/feedback.py
+++ b/moto/ses/feedback.py
@@ -1,4 +1,5 @@
 from moto.core import ACCOUNT_ID
+
 """
 SES Feedback messages
 Extracted from https://docs.aws.amazon.com/ses/latest/DeveloperGuide/notification-contents.html

--- a/moto/ses/feedback.py
+++ b/moto/ses/feedback.py
@@ -1,4 +1,4 @@
-from moto.iam.models import ACCOUNT_ID
+from moto.core import ACCOUNT_ID
 """
 SES Feedback messages
 Extracted from https://docs.aws.amazon.com/ses/latest/DeveloperGuide/notification-contents.html

--- a/moto/sns/models.py
+++ b/moto/sns/models.py
@@ -12,6 +12,7 @@ from boto3 import Session
 
 from moto.compat import OrderedDict
 from moto.core import BaseBackend, BaseModel
+from moto.iam.models import ACCOUNT_ID
 from moto.core.utils import (
     iso_8601_datetime_with_milliseconds,
     camelcase_to_underscores,
@@ -31,7 +32,7 @@ from .exceptions import (
 )
 from .utils import make_arn_for_topic, make_arn_for_subscription, is_e164
 
-DEFAULT_ACCOUNT_ID = 123456789012
+from moto.iam.models import ACCOUNT_ID as DEFAULT_ACCOUNT_ID
 DEFAULT_PAGE_SIZE = 100
 MAXIMUM_MESSAGE_LENGTH = 262144  # 256 KiB
 
@@ -259,7 +260,7 @@ class Subscription(BaseModel):
             "SignatureVersion": "1",
             "Signature": "EXAMPLElDMXvB8r9R83tGoNn0ecwd5UjllzsvSvbItzfaMpN2nk5HVSw7XnOn/49IkxDKz8YrlH2qJXj2iZB0Zo2O71c4qQk1fMUDi3LGpij7RCW7AW9vYYsSqIKRnFS94ilu7NFhUzLiieYr4BKHpdTmdD6c0esKEYBpabxDSc=",
             "SigningCertURL": "https://sns.us-east-1.amazonaws.com/SimpleNotificationService-f3ecfb7224c7233fe7bb5f59f96de52f.pem",
-            "UnsubscribeURL": "https://sns.us-east-1.amazonaws.com/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:us-east-1:123456789012:some-topic:2bcfbf39-05c3-41de-beaa-fcfcc21c8f55",
+            "UnsubscribeURL": "https://sns.us-east-1.amazonaws.com/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:us-east-1:{}:some-topic:2bcfbf39-05c3-41de-beaa-fcfcc21c8f55".format(ACCOUNT_ID),
         }
         if message_attributes:
             post_data["MessageAttributes"] = message_attributes
@@ -275,8 +276,8 @@ class PlatformApplication(BaseModel):
 
     @property
     def arn(self):
-        return "arn:aws:sns:{region}:123456789012:app/{platform}/{name}".format(
-            region=self.region, platform=self.platform, name=self.name
+        return "arn:aws:sns:{region}:{AccountId}:app/{platform}/{name}".format(
+            region=self.region, platform=self.platform, name=self.name, AccountId=ACCOUNT_ID
         )
 
 
@@ -305,8 +306,9 @@ class PlatformEndpoint(BaseModel):
 
     @property
     def arn(self):
-        return "arn:aws:sns:{region}:123456789012:endpoint/{platform}/{name}/{id}".format(
+        return "arn:aws:sns:{region}:{AccountId}:endpoint/{platform}/{name}/{id}".format(
             region=self.region,
+            AccountId=ACCOUNT_ID,
             platform=self.application.platform,
             name=self.application.name,
             id=self.id,

--- a/moto/sns/models.py
+++ b/moto/sns/models.py
@@ -12,7 +12,6 @@ from boto3 import Session
 
 from moto.compat import OrderedDict
 from moto.core import BaseBackend, BaseModel
-from moto.iam.models import ACCOUNT_ID
 from moto.core.utils import (
     iso_8601_datetime_with_milliseconds,
     camelcase_to_underscores,
@@ -32,7 +31,7 @@ from .exceptions import (
 )
 from .utils import make_arn_for_topic, make_arn_for_subscription, is_e164
 
-from moto.iam.models import ACCOUNT_ID as DEFAULT_ACCOUNT_ID
+from moto.core import ACCOUNT_ID as DEFAULT_ACCOUNT_ID
 DEFAULT_PAGE_SIZE = 100
 MAXIMUM_MESSAGE_LENGTH = 262144  # 256 KiB
 
@@ -260,7 +259,7 @@ class Subscription(BaseModel):
             "SignatureVersion": "1",
             "Signature": "EXAMPLElDMXvB8r9R83tGoNn0ecwd5UjllzsvSvbItzfaMpN2nk5HVSw7XnOn/49IkxDKz8YrlH2qJXj2iZB0Zo2O71c4qQk1fMUDi3LGpij7RCW7AW9vYYsSqIKRnFS94ilu7NFhUzLiieYr4BKHpdTmdD6c0esKEYBpabxDSc=",
             "SigningCertURL": "https://sns.us-east-1.amazonaws.com/SimpleNotificationService-f3ecfb7224c7233fe7bb5f59f96de52f.pem",
-            "UnsubscribeURL": "https://sns.us-east-1.amazonaws.com/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:us-east-1:{}:some-topic:2bcfbf39-05c3-41de-beaa-fcfcc21c8f55".format(ACCOUNT_ID),
+            "UnsubscribeURL": "https://sns.us-east-1.amazonaws.com/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:us-east-1:{}:some-topic:2bcfbf39-05c3-41de-beaa-fcfcc21c8f55".format(DEFAULT_ACCOUNT_ID),
         }
         if message_attributes:
             post_data["MessageAttributes"] = message_attributes
@@ -277,7 +276,7 @@ class PlatformApplication(BaseModel):
     @property
     def arn(self):
         return "arn:aws:sns:{region}:{AccountId}:app/{platform}/{name}".format(
-            region=self.region, platform=self.platform, name=self.name, AccountId=ACCOUNT_ID
+            region=self.region, platform=self.platform, name=self.name, AccountId=DEFAULT_ACCOUNT_ID
         )
 
 
@@ -308,7 +307,7 @@ class PlatformEndpoint(BaseModel):
     def arn(self):
         return "arn:aws:sns:{region}:{AccountId}:endpoint/{platform}/{name}/{id}".format(
             region=self.region,
-            AccountId=ACCOUNT_ID,
+            AccountId=DEFAULT_ACCOUNT_ID,
             platform=self.application.platform,
             name=self.application.name,
             id=self.id,

--- a/moto/sns/models.py
+++ b/moto/sns/models.py
@@ -32,6 +32,7 @@ from .exceptions import (
 from .utils import make_arn_for_topic, make_arn_for_subscription, is_e164
 
 from moto.core import ACCOUNT_ID as DEFAULT_ACCOUNT_ID
+
 DEFAULT_PAGE_SIZE = 100
 MAXIMUM_MESSAGE_LENGTH = 262144  # 256 KiB
 
@@ -259,7 +260,9 @@ class Subscription(BaseModel):
             "SignatureVersion": "1",
             "Signature": "EXAMPLElDMXvB8r9R83tGoNn0ecwd5UjllzsvSvbItzfaMpN2nk5HVSw7XnOn/49IkxDKz8YrlH2qJXj2iZB0Zo2O71c4qQk1fMUDi3LGpij7RCW7AW9vYYsSqIKRnFS94ilu7NFhUzLiieYr4BKHpdTmdD6c0esKEYBpabxDSc=",
             "SigningCertURL": "https://sns.us-east-1.amazonaws.com/SimpleNotificationService-f3ecfb7224c7233fe7bb5f59f96de52f.pem",
-            "UnsubscribeURL": "https://sns.us-east-1.amazonaws.com/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:us-east-1:{}:some-topic:2bcfbf39-05c3-41de-beaa-fcfcc21c8f55".format(DEFAULT_ACCOUNT_ID),
+            "UnsubscribeURL": "https://sns.us-east-1.amazonaws.com/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:us-east-1:{}:some-topic:2bcfbf39-05c3-41de-beaa-fcfcc21c8f55".format(
+                DEFAULT_ACCOUNT_ID
+            ),
         }
         if message_attributes:
             post_data["MessageAttributes"] = message_attributes
@@ -276,7 +279,10 @@ class PlatformApplication(BaseModel):
     @property
     def arn(self):
         return "arn:aws:sns:{region}:{AccountId}:app/{platform}/{name}".format(
-            region=self.region, platform=self.platform, name=self.name, AccountId=DEFAULT_ACCOUNT_ID
+            region=self.region,
+            platform=self.platform,
+            name=self.name,
+            AccountId=DEFAULT_ACCOUNT_ID,
         )
 
 

--- a/moto/sqs/models.py
+++ b/moto/sqs/models.py
@@ -12,7 +12,6 @@ import boto.sqs
 
 from moto.core.exceptions import RESTError
 from moto.core import BaseBackend, BaseModel
-from moto.iam.models import ACCOUNT_ID
 from moto.core.utils import (
     camelcase_to_underscores,
     get_random_message_id,
@@ -33,7 +32,7 @@ from .exceptions import (
     InvalidAttributeName,
 )
 
-from moto.iam.models import ACCOUNT_ID as DEFAULT_ACCOUNT_ID
+from moto.core import ACCOUNT_ID as DEFAULT_ACCOUNT_ID
 DEFAULT_SENDER_ID = "AIDAIT2UOQQY3AUEKVGXU"
 
 MAXIMUM_MESSAGE_LENGTH = 262144  # 256 KiB
@@ -419,7 +418,7 @@ class Queue(BaseModel):
 
     def url(self, request_url):
         return "{0}://{1}/{2}/{3}".format(
-            request_url.scheme, request_url.netloc, ACCOUNT_ID, self.name
+            request_url.scheme, request_url.netloc, DEFAULT_ACCOUNT_ID, self.name
         )
 
     @property

--- a/moto/sqs/models.py
+++ b/moto/sqs/models.py
@@ -33,6 +33,7 @@ from .exceptions import (
 )
 
 from moto.core import ACCOUNT_ID as DEFAULT_ACCOUNT_ID
+
 DEFAULT_SENDER_ID = "AIDAIT2UOQQY3AUEKVGXU"
 
 MAXIMUM_MESSAGE_LENGTH = 262144  # 256 KiB

--- a/moto/sqs/models.py
+++ b/moto/sqs/models.py
@@ -12,6 +12,7 @@ import boto.sqs
 
 from moto.core.exceptions import RESTError
 from moto.core import BaseBackend, BaseModel
+from moto.iam.models import ACCOUNT_ID
 from moto.core.utils import (
     camelcase_to_underscores,
     get_random_message_id,
@@ -32,7 +33,7 @@ from .exceptions import (
     InvalidAttributeName,
 )
 
-DEFAULT_ACCOUNT_ID = 123456789012
+from moto.iam.models import ACCOUNT_ID as DEFAULT_ACCOUNT_ID
 DEFAULT_SENDER_ID = "AIDAIT2UOQQY3AUEKVGXU"
 
 MAXIMUM_MESSAGE_LENGTH = 262144  # 256 KiB
@@ -417,8 +418,8 @@ class Queue(BaseModel):
         return result
 
     def url(self, request_url):
-        return "{0}://{1}/123456789012/{2}".format(
-            request_url.scheme, request_url.netloc, self.name
+        return "{0}://{1}/{2}/{3}".format(
+            request_url.scheme, request_url.netloc, ACCOUNT_ID, self.name
         )
 
     @property

--- a/moto/sts/models.py
+++ b/moto/sts/models.py
@@ -2,7 +2,7 @@ from __future__ import unicode_literals
 import datetime
 from moto.core import BaseBackend, BaseModel
 from moto.core.utils import iso_8601_datetime_with_milliseconds
-from moto.iam.models import ACCOUNT_ID
+from moto.core import ACCOUNT_ID
 from moto.sts.utils import (
     random_access_key_id,
     random_secret_access_key,

--- a/moto/sts/responses.py
+++ b/moto/sts/responses.py
@@ -1,7 +1,7 @@
 from __future__ import unicode_literals
 
 from moto.core.responses import BaseResponse
-from moto.iam.models import ACCOUNT_ID
+from moto.core import ACCOUNT_ID
 from moto.iam import iam_backend
 from .exceptions import STSValidationError
 from .models import sts_backend

--- a/tests/test_acm/test_acm.py
+++ b/tests/test_acm/test_acm.py
@@ -20,7 +20,9 @@ SERVER_CRT = _GET_RESOURCE("star_moto_com.pem")
 SERVER_COMMON_NAME = "*.moto.com"
 SERVER_CRT_BAD = _GET_RESOURCE("star_moto_com-bad.pem")
 SERVER_KEY = _GET_RESOURCE("star_moto_com.key")
-BAD_ARN = "arn:aws:acm:us-east-2:{}:certificate/_0000000-0000-0000-0000-000000000000".format(ACCOUNT_ID)
+BAD_ARN = "arn:aws:acm:us-east-2:{}:certificate/_0000000-0000-0000-0000-000000000000".format(
+    ACCOUNT_ID
+)
 
 
 def _import_cert(client):

--- a/tests/test_acm/test_acm.py
+++ b/tests/test_acm/test_acm.py
@@ -9,7 +9,7 @@ import uuid
 from botocore.exceptions import ClientError
 
 from moto import mock_acm
-from moto.iam.models import ACCOUNT_ID
+from moto.core import ACCOUNT_ID
 
 
 RESOURCE_FOLDER = os.path.join(os.path.dirname(__file__), "resources")

--- a/tests/test_acm/test_acm.py
+++ b/tests/test_acm/test_acm.py
@@ -9,6 +9,7 @@ import uuid
 from botocore.exceptions import ClientError
 
 from moto import mock_acm
+from moto.iam.models import ACCOUNT_ID
 
 
 RESOURCE_FOLDER = os.path.join(os.path.dirname(__file__), "resources")
@@ -19,7 +20,7 @@ SERVER_CRT = _GET_RESOURCE("star_moto_com.pem")
 SERVER_COMMON_NAME = "*.moto.com"
 SERVER_CRT_BAD = _GET_RESOURCE("star_moto_com-bad.pem")
 SERVER_KEY = _GET_RESOURCE("star_moto_com.key")
-BAD_ARN = "arn:aws:acm:us-east-2:123456789012:certificate/_0000000-0000-0000-0000-000000000000"
+BAD_ARN = "arn:aws:acm:us-east-2:{}:certificate/_0000000-0000-0000-0000-000000000000".format(ACCOUNT_ID)
 
 
 def _import_cert(client):

--- a/tests/test_apigateway/test_apigateway.py
+++ b/tests/test_apigateway/test_apigateway.py
@@ -9,7 +9,7 @@ from botocore.exceptions import ClientError
 
 import responses
 from moto import mock_apigateway, settings
-from moto.iam.models import ACCOUNT_ID
+from moto.core import ACCOUNT_ID
 from nose.tools import assert_raises
 
 

--- a/tests/test_apigateway/test_apigateway.py
+++ b/tests/test_apigateway/test_apigateway.py
@@ -882,7 +882,9 @@ def test_put_integration_validation():
         client.put_integration(
             restApiId=api_id,
             resourceId=root_id,
-            credentials="arn:aws:iam::{}:role/service-role/testfunction-role-oe783psq".format(ACCOUNT_ID),
+            credentials="arn:aws:iam::{}:role/service-role/testfunction-role-oe783psq".format(
+                ACCOUNT_ID
+            ),
             httpMethod="GET",
             type=type,
             uri="arn:aws:apigateway:us-west-2:s3:path/b/k",
@@ -904,7 +906,9 @@ def test_put_integration_validation():
             client.put_integration(
                 restApiId=api_id,
                 resourceId=root_id,
-                credentials="arn:aws:iam::{}:role/service-role/testfunction-role-oe783psq".format(ACCOUNT_ID),
+                credentials="arn:aws:iam::{}:role/service-role/testfunction-role-oe783psq".format(
+                    ACCOUNT_ID
+                ),
                 httpMethod="GET",
                 type=type,
                 uri="arn:aws:apigateway:us-west-2:s3:path/b/k",

--- a/tests/test_apigateway/test_apigateway.py
+++ b/tests/test_apigateway/test_apigateway.py
@@ -9,6 +9,7 @@ from botocore.exceptions import ClientError
 
 import responses
 from moto import mock_apigateway, settings
+from moto.iam.models import ACCOUNT_ID
 from nose.tools import assert_raises
 
 
@@ -881,7 +882,7 @@ def test_put_integration_validation():
         client.put_integration(
             restApiId=api_id,
             resourceId=root_id,
-            credentials="arn:aws:iam::123456789012:role/service-role/testfunction-role-oe783psq",
+            credentials="arn:aws:iam::{}:role/service-role/testfunction-role-oe783psq".format(ACCOUNT_ID),
             httpMethod="GET",
             type=type,
             uri="arn:aws:apigateway:us-west-2:s3:path/b/k",
@@ -903,7 +904,7 @@ def test_put_integration_validation():
             client.put_integration(
                 restApiId=api_id,
                 resourceId=root_id,
-                credentials="arn:aws:iam::123456789012:role/service-role/testfunction-role-oe783psq",
+                credentials="arn:aws:iam::{}:role/service-role/testfunction-role-oe783psq".format(ACCOUNT_ID),
                 httpMethod="GET",
                 type=type,
                 uri="arn:aws:apigateway:us-west-2:s3:path/b/k",

--- a/tests/test_autoscaling/test_launch_configurations.py
+++ b/tests/test_autoscaling/test_launch_configurations.py
@@ -8,7 +8,7 @@ import sure  # noqa
 
 from moto import mock_autoscaling_deprecated
 from moto import mock_autoscaling
-from moto.iam.models import ACCOUNT_ID
+from moto.core import ACCOUNT_ID
 from tests.helpers import requires_boto_gte
 
 

--- a/tests/test_autoscaling/test_launch_configurations.py
+++ b/tests/test_autoscaling/test_launch_configurations.py
@@ -23,7 +23,9 @@ def test_create_launch_configuration():
         security_groups=["default", "default2"],
         user_data=b"This is some user_data",
         instance_monitoring=True,
-        instance_profile_name="arn:aws:iam::{}:instance-profile/testing".format(ACCOUNT_ID),
+        instance_profile_name="arn:aws:iam::{}:instance-profile/testing".format(
+            ACCOUNT_ID
+        ),
         spot_price=0.1,
     )
     conn.create_launch_configuration(config)
@@ -72,7 +74,9 @@ def test_create_launch_configuration_with_block_device_mappings():
         security_groups=["default", "default2"],
         user_data=b"This is some user_data",
         instance_monitoring=True,
-        instance_profile_name="arn:aws:iam::{}:instance-profile/testing".format(ACCOUNT_ID),
+        instance_profile_name="arn:aws:iam::{}:instance-profile/testing".format(
+            ACCOUNT_ID
+        ),
         spot_price=0.1,
         block_device_mappings=[block_device_mapping],
     )

--- a/tests/test_autoscaling/test_launch_configurations.py
+++ b/tests/test_autoscaling/test_launch_configurations.py
@@ -8,6 +8,7 @@ import sure  # noqa
 
 from moto import mock_autoscaling_deprecated
 from moto import mock_autoscaling
+from moto.iam.models import ACCOUNT_ID
 from tests.helpers import requires_boto_gte
 
 
@@ -22,7 +23,7 @@ def test_create_launch_configuration():
         security_groups=["default", "default2"],
         user_data=b"This is some user_data",
         instance_monitoring=True,
-        instance_profile_name="arn:aws:iam::123456789012:instance-profile/testing",
+        instance_profile_name="arn:aws:iam::{}:instance-profile/testing".format(ACCOUNT_ID),
         spot_price=0.1,
     )
     conn.create_launch_configuration(config)
@@ -36,7 +37,7 @@ def test_create_launch_configuration():
     launch_config.user_data.should.equal(b"This is some user_data")
     launch_config.instance_monitoring.enabled.should.equal("true")
     launch_config.instance_profile_name.should.equal(
-        "arn:aws:iam::123456789012:instance-profile/testing"
+        "arn:aws:iam::{}:instance-profile/testing".format(ACCOUNT_ID)
     )
     launch_config.spot_price.should.equal(0.1)
 
@@ -71,7 +72,7 @@ def test_create_launch_configuration_with_block_device_mappings():
         security_groups=["default", "default2"],
         user_data=b"This is some user_data",
         instance_monitoring=True,
-        instance_profile_name="arn:aws:iam::123456789012:instance-profile/testing",
+        instance_profile_name="arn:aws:iam::{}:instance-profile/testing".format(ACCOUNT_ID),
         spot_price=0.1,
         block_device_mappings=[block_device_mapping],
     )
@@ -86,7 +87,7 @@ def test_create_launch_configuration_with_block_device_mappings():
     launch_config.user_data.should.equal(b"This is some user_data")
     launch_config.instance_monitoring.enabled.should.equal("true")
     launch_config.instance_profile_name.should.equal(
-        "arn:aws:iam::123456789012:instance-profile/testing"
+        "arn:aws:iam::{}:instance-profile/testing".format(ACCOUNT_ID)
     )
     launch_config.spot_price.should.equal(0.1)
     len(launch_config.block_device_mappings).should.equal(3)

--- a/tests/test_awslambda/test_lambda.py
+++ b/tests/test_awslambda/test_lambda.py
@@ -306,8 +306,8 @@ def test_create_function_from_aws_bucket():
     result.should.equal(
         {
             "FunctionName": "testFunction",
-            "FunctionArn": "arn:aws:lambda:{}:123456789012:function:testFunction".format(
-                _lambda_region
+            "FunctionArn": "arn:aws:lambda:{}:{}:function:testFunction".format(
+                _lambda_region, ACCOUNT_ID
             ),
             "Runtime": "python2.7",
             "Role": result["Role"],
@@ -353,8 +353,8 @@ def test_create_function_from_zipfile():
     result.should.equal(
         {
             "FunctionName": "testFunction",
-            "FunctionArn": "arn:aws:lambda:{}:123456789012:function:testFunction".format(
-                _lambda_region
+            "FunctionArn": "arn:aws:lambda:{}:{}:function:testFunction".format(
+                _lambda_region, ACCOUNT_ID
             ),
             "Runtime": "python2.7",
             "Role": result["Role"],
@@ -431,7 +431,7 @@ def test_get_function():
     result = conn.get_function(FunctionName="testFunction", Qualifier="$LATEST")
     result["Configuration"]["Version"].should.equal("$LATEST")
     result["Configuration"]["FunctionArn"].should.equal(
-        "arn:aws:lambda:us-west-2:123456789012:function:testFunction:$LATEST"
+        "arn:aws:lambda:us-west-2:{}:function:testFunction:$LATEST".format(ACCOUNT_ID)
     )
 
     # Test get function when can't find function name
@@ -620,8 +620,8 @@ def test_list_create_list_get_delete_list():
             "CodeSha256": hashlib.sha256(zip_content).hexdigest(),
             "CodeSize": len(zip_content),
             "Description": "test lambda function",
-            "FunctionArn": "arn:aws:lambda:{}:123456789012:function:testFunction".format(
-                _lambda_region
+            "FunctionArn": "arn:aws:lambda:{}:{}:function:testFunction".format(
+                _lambda_region, ACCOUNT_ID
             ),
             "FunctionName": "testFunction",
             "Handler": "lambda_function.lambda_handler",
@@ -749,16 +749,16 @@ def test_tags_not_found():
     """
     conn = boto3.client("lambda", "us-west-2")
     conn.list_tags.when.called_with(
-        Resource="arn:aws:lambda:123456789012:function:not-found"
+        Resource="arn:aws:lambda:{}:function:not-found".format(ACCOUNT_ID)
     ).should.throw(botocore.client.ClientError)
 
     conn.tag_resource.when.called_with(
-        Resource="arn:aws:lambda:123456789012:function:not-found",
+        Resource="arn:aws:lambda:{}:function:not-found".format(ACCOUNT_ID),
         Tags=dict(spam="eggs"),
     ).should.throw(botocore.client.ClientError)
 
     conn.untag_resource.when.called_with(
-        Resource="arn:aws:lambda:123456789012:function:not-found", TagKeys=["spam"]
+        Resource="arn:aws:lambda:{}:function:not-found".format(ACCOUNT_ID), TagKeys=["spam"]
     ).should.throw(botocore.client.ClientError)
 
 
@@ -815,8 +815,8 @@ def test_get_function_created_with_zipfile():
             "CodeSha256": hashlib.sha256(zip_content).hexdigest(),
             "CodeSize": len(zip_content),
             "Description": "test lambda function",
-            "FunctionArn": "arn:aws:lambda:{}:123456789012:function:testFunction".format(
-                _lambda_region
+            "FunctionArn": "arn:aws:lambda:{}:{}:function:testFunction".format(
+                _lambda_region, ACCOUNT_ID
             ),
             "FunctionName": "testFunction",
             "Handler": "lambda_function.handler",
@@ -923,15 +923,15 @@ def test_list_versions_by_function():
     assert len(versions["Versions"]) == 3
     assert (
         versions["Versions"][0]["FunctionArn"]
-        == "arn:aws:lambda:us-west-2:123456789012:function:testFunction:$LATEST"
+        == "arn:aws:lambda:us-west-2:{}:function:testFunction:$LATEST".format(ACCOUNT_ID)
     )
     assert (
         versions["Versions"][1]["FunctionArn"]
-        == "arn:aws:lambda:us-west-2:123456789012:function:testFunction:1"
+        == "arn:aws:lambda:us-west-2:{}:function:testFunction:1".format(ACCOUNT_ID)
     )
     assert (
         versions["Versions"][2]["FunctionArn"]
-        == "arn:aws:lambda:us-west-2:123456789012:function:testFunction:2"
+        == "arn:aws:lambda:us-west-2:{}:function:testFunction:2".format(ACCOUNT_ID)
     )
 
     conn.create_function(
@@ -949,7 +949,7 @@ def test_list_versions_by_function():
     assert len(versions["Versions"]) == 1
     assert (
         versions["Versions"][0]["FunctionArn"]
-        == "arn:aws:lambda:us-west-2:123456789012:function:testFunction_2:$LATEST"
+        == "arn:aws:lambda:us-west-2:{}:function:testFunction_2:$LATEST".format(ACCOUNT_ID)
     )
 
 
@@ -1426,8 +1426,8 @@ def test_update_function_zip():
             "CodeSha256": hashlib.sha256(zip_content_two).hexdigest(),
             "CodeSize": len(zip_content_two),
             "Description": "test lambda function",
-            "FunctionArn": "arn:aws:lambda:{}:123456789012:function:testFunctionZip:2".format(
-                _lambda_region
+            "FunctionArn": "arn:aws:lambda:{}:{}:function:testFunctionZip:2".format(
+                _lambda_region, ACCOUNT_ID
             ),
             "FunctionName": "testFunctionZip",
             "Handler": "lambda_function.lambda_handler",
@@ -1488,8 +1488,8 @@ def test_update_function_s3():
             "CodeSha256": hashlib.sha256(zip_content_two).hexdigest(),
             "CodeSize": len(zip_content_two),
             "Description": "test lambda function",
-            "FunctionArn": "arn:aws:lambda:{}:123456789012:function:testFunctionS3:2".format(
-                _lambda_region
+            "FunctionArn": "arn:aws:lambda:{}:{}:function:testFunctionS3:2".format(
+                _lambda_region, ACCOUNT_ID
             ),
             "FunctionName": "testFunctionS3",
             "Handler": "lambda_function.lambda_handler",

--- a/tests/test_awslambda/test_lambda.py
+++ b/tests/test_awslambda/test_lambda.py
@@ -758,7 +758,8 @@ def test_tags_not_found():
     ).should.throw(botocore.client.ClientError)
 
     conn.untag_resource.when.called_with(
-        Resource="arn:aws:lambda:{}:function:not-found".format(ACCOUNT_ID), TagKeys=["spam"]
+        Resource="arn:aws:lambda:{}:function:not-found".format(ACCOUNT_ID),
+        TagKeys=["spam"],
     ).should.throw(botocore.client.ClientError)
 
 
@@ -921,18 +922,15 @@ def test_list_versions_by_function():
     assert res["ResponseMetadata"]["HTTPStatusCode"] == 201
     versions = conn.list_versions_by_function(FunctionName="testFunction")
     assert len(versions["Versions"]) == 3
-    assert (
-        versions["Versions"][0]["FunctionArn"]
-        == "arn:aws:lambda:us-west-2:{}:function:testFunction:$LATEST".format(ACCOUNT_ID)
-    )
-    assert (
-        versions["Versions"][1]["FunctionArn"]
-        == "arn:aws:lambda:us-west-2:{}:function:testFunction:1".format(ACCOUNT_ID)
-    )
-    assert (
-        versions["Versions"][2]["FunctionArn"]
-        == "arn:aws:lambda:us-west-2:{}:function:testFunction:2".format(ACCOUNT_ID)
-    )
+    assert versions["Versions"][0][
+        "FunctionArn"
+    ] == "arn:aws:lambda:us-west-2:{}:function:testFunction:$LATEST".format(ACCOUNT_ID)
+    assert versions["Versions"][1][
+        "FunctionArn"
+    ] == "arn:aws:lambda:us-west-2:{}:function:testFunction:1".format(ACCOUNT_ID)
+    assert versions["Versions"][2][
+        "FunctionArn"
+    ] == "arn:aws:lambda:us-west-2:{}:function:testFunction:2".format(ACCOUNT_ID)
 
     conn.create_function(
         FunctionName="testFunction_2",
@@ -947,9 +945,10 @@ def test_list_versions_by_function():
     )
     versions = conn.list_versions_by_function(FunctionName="testFunction_2")
     assert len(versions["Versions"]) == 1
-    assert (
-        versions["Versions"][0]["FunctionArn"]
-        == "arn:aws:lambda:us-west-2:{}:function:testFunction_2:$LATEST".format(ACCOUNT_ID)
+    assert versions["Versions"][0][
+        "FunctionArn"
+    ] == "arn:aws:lambda:us-west-2:{}:function:testFunction_2:$LATEST".format(
+        ACCOUNT_ID
     )
 
 

--- a/tests/test_cloudformation/test_cloudformation_stack_crud.py
+++ b/tests/test_cloudformation/test_cloudformation_stack_crud.py
@@ -14,7 +14,7 @@ import sure  # noqa
 # Ensure 'assert_raises' context manager support for Python 2.6
 import tests.backport_assert_raises  # noqa
 from nose.tools import assert_raises
-from moto.iam.models import ACCOUNT_ID
+from moto.core import ACCOUNT_ID
 
 from moto import (
     mock_cloudformation_deprecated,

--- a/tests/test_cloudformation/test_cloudformation_stack_crud.py
+++ b/tests/test_cloudformation/test_cloudformation_stack_crud.py
@@ -14,6 +14,7 @@ import sure  # noqa
 # Ensure 'assert_raises' context manager support for Python 2.6
 import tests.backport_assert_raises  # noqa
 from nose.tools import assert_raises
+from moto.iam.models import ACCOUNT_ID
 
 from moto import (
     mock_cloudformation_deprecated,
@@ -129,12 +130,12 @@ def test_create_stack_with_notification_arn():
     conn.create_stack(
         "test_stack_with_notifications",
         template_body=dummy_template_json,
-        notification_arns="arn:aws:sns:us-east-1:123456789012:fake-queue",
+        notification_arns="arn:aws:sns:us-east-1:{}:fake-queue".format(ACCOUNT_ID),
     )
 
     stack = conn.describe_stacks()[0]
     [n.value for n in stack.notification_arns].should.contain(
-        "arn:aws:sns:us-east-1:123456789012:fake-queue"
+        "arn:aws:sns:us-east-1:{}:fake-queue".format(ACCOUNT_ID)
     )
 
 

--- a/tests/test_cloudformation/test_cloudformation_stack_crud_boto3.py
+++ b/tests/test_cloudformation/test_cloudformation_stack_crud_boto3.py
@@ -11,7 +11,7 @@ import sure  # noqa
 from nose.tools import assert_raises
 
 from moto import mock_cloudformation, mock_s3, mock_sqs, mock_ec2
-from moto.iam.models import ACCOUNT_ID
+from moto.core import ACCOUNT_ID
 
 dummy_template = {
     "AWSTemplateFormatVersion": "2010-09-09",

--- a/tests/test_cloudformation/test_cloudformation_stack_crud_boto3.py
+++ b/tests/test_cloudformation/test_cloudformation_stack_crud_boto3.py
@@ -298,9 +298,7 @@ def test_boto3_list_stack_set_operation_results():
     )
 
     response["Summaries"].should.have.length_of(3)
-    response["Summaries"][0].should.have.key("Account").which.should.equal(
-        ACCOUNT_ID
-    )
+    response["Summaries"][0].should.have.key("Account").which.should.equal(ACCOUNT_ID)
     response["Summaries"][1].should.have.key("Status").which.should.equal("STOPPED")
 
 

--- a/tests/test_cloudformation/test_cloudformation_stack_crud_boto3.py
+++ b/tests/test_cloudformation/test_cloudformation_stack_crud_boto3.py
@@ -11,6 +11,7 @@ import sure  # noqa
 from nose.tools import assert_raises
 
 from moto import mock_cloudformation, mock_s3, mock_sqs, mock_ec2
+from moto.iam.models import ACCOUNT_ID
 
 dummy_template = {
     "AWSTemplateFormatVersion": "2010-09-09",
@@ -174,17 +175,17 @@ def test_boto3_describe_stack_instances():
     )
     cf_conn.create_stack_instances(
         StackSetName="test_stack_set",
-        Accounts=["123456789012"],
+        Accounts=[ACCOUNT_ID],
         Regions=["us-east-1", "us-west-2"],
     )
     usw2_instance = cf_conn.describe_stack_instance(
         StackSetName="test_stack_set",
-        StackInstanceAccount="123456789012",
+        StackInstanceAccount=ACCOUNT_ID,
         StackInstanceRegion="us-west-2",
     )
     use1_instance = cf_conn.describe_stack_instance(
         StackSetName="test_stack_set",
-        StackInstanceAccount="123456789012",
+        StackInstanceAccount=ACCOUNT_ID,
         StackInstanceRegion="us-east-1",
     )
 
@@ -192,13 +193,13 @@ def test_boto3_describe_stack_instances():
         "us-west-2"
     )
     usw2_instance["StackInstance"].should.have.key("Account").which.should.equal(
-        "123456789012"
+        ACCOUNT_ID
     )
     use1_instance["StackInstance"].should.have.key("Region").which.should.equal(
         "us-east-1"
     )
     use1_instance["StackInstance"].should.have.key("Account").which.should.equal(
-        "123456789012"
+        ACCOUNT_ID
     )
 
 
@@ -236,7 +237,7 @@ def test_boto3_stop_stack_set_operation():
     )
     cf_conn.create_stack_instances(
         StackSetName="test_stack_set",
-        Accounts=["123456789012"],
+        Accounts=[ACCOUNT_ID],
         Regions=["us-east-1", "us-west-1", "us-west-2"],
     )
     operation_id = cf_conn.list_stack_set_operations(StackSetName="test_stack_set")[
@@ -257,7 +258,7 @@ def test_boto3_describe_stack_set_operation():
     )
     cf_conn.create_stack_instances(
         StackSetName="test_stack_set",
-        Accounts=["123456789012"],
+        Accounts=[ACCOUNT_ID],
         Regions=["us-east-1", "us-west-1", "us-west-2"],
     )
     operation_id = cf_conn.list_stack_set_operations(StackSetName="test_stack_set")[
@@ -282,7 +283,7 @@ def test_boto3_list_stack_set_operation_results():
     )
     cf_conn.create_stack_instances(
         StackSetName="test_stack_set",
-        Accounts=["123456789012"],
+        Accounts=[ACCOUNT_ID],
         Regions=["us-east-1", "us-west-1", "us-west-2"],
     )
     operation_id = cf_conn.list_stack_set_operations(StackSetName="test_stack_set")[
@@ -298,7 +299,7 @@ def test_boto3_list_stack_set_operation_results():
 
     response["Summaries"].should.have.length_of(3)
     response["Summaries"][0].should.have.key("Account").which.should.equal(
-        "123456789012"
+        ACCOUNT_ID
     )
     response["Summaries"][1].should.have.key("Status").which.should.equal("STOPPED")
 
@@ -321,28 +322,28 @@ def test_boto3_update_stack_instances():
     )
     cf_conn.create_stack_instances(
         StackSetName="test_stack_set",
-        Accounts=["123456789012"],
+        Accounts=[ACCOUNT_ID],
         Regions=["us-east-1", "us-west-1", "us-west-2"],
     )
     cf_conn.update_stack_instances(
         StackSetName="test_stack_set",
-        Accounts=["123456789012"],
+        Accounts=[ACCOUNT_ID],
         Regions=["us-west-1", "us-west-2"],
         ParameterOverrides=param_overrides,
     )
     usw2_instance = cf_conn.describe_stack_instance(
         StackSetName="test_stack_set",
-        StackInstanceAccount="123456789012",
+        StackInstanceAccount=ACCOUNT_ID,
         StackInstanceRegion="us-west-2",
     )
     usw1_instance = cf_conn.describe_stack_instance(
         StackSetName="test_stack_set",
-        StackInstanceAccount="123456789012",
+        StackInstanceAccount=ACCOUNT_ID,
         StackInstanceRegion="us-west-1",
     )
     use1_instance = cf_conn.describe_stack_instance(
         StackSetName="test_stack_set",
-        StackInstanceAccount="123456789012",
+        StackInstanceAccount=ACCOUNT_ID,
         StackInstanceRegion="us-east-1",
     )
 
@@ -383,13 +384,13 @@ def test_boto3_delete_stack_instances():
     )
     cf_conn.create_stack_instances(
         StackSetName="test_stack_set",
-        Accounts=["123456789012"],
+        Accounts=[ACCOUNT_ID],
         Regions=["us-east-1", "us-west-2"],
     )
 
     cf_conn.delete_stack_instances(
         StackSetName="test_stack_set",
-        Accounts=["123456789012"],
+        Accounts=[ACCOUNT_ID],
         Regions=["us-east-1"],
         RetainStacks=False,
     )
@@ -410,7 +411,7 @@ def test_boto3_create_stack_instances():
     )
     cf_conn.create_stack_instances(
         StackSetName="test_stack_set",
-        Accounts=["123456789012"],
+        Accounts=[ACCOUNT_ID],
         Regions=["us-east-1", "us-west-2"],
     )
 
@@ -419,7 +420,7 @@ def test_boto3_create_stack_instances():
     ].should.have.length_of(2)
     cf_conn.list_stack_instances(StackSetName="test_stack_set")["Summaries"][0][
         "Account"
-    ].should.equal("123456789012")
+    ].should.equal(ACCOUNT_ID)
 
 
 @mock_cloudformation
@@ -440,13 +441,13 @@ def test_boto3_create_stack_instances_with_param_overrides():
     )
     cf_conn.create_stack_instances(
         StackSetName="test_stack_set",
-        Accounts=["123456789012"],
+        Accounts=[ACCOUNT_ID],
         Regions=["us-east-1", "us-west-2"],
         ParameterOverrides=param_overrides,
     )
     usw2_instance = cf_conn.describe_stack_instance(
         StackSetName="test_stack_set",
-        StackInstanceAccount="123456789012",
+        StackInstanceAccount=ACCOUNT_ID,
         StackInstanceRegion="us-west-2",
     )
 
@@ -509,12 +510,12 @@ def test_boto3_list_stack_set_operations():
     )
     cf_conn.create_stack_instances(
         StackSetName="test_stack_set",
-        Accounts=["123456789012"],
+        Accounts=[ACCOUNT_ID],
         Regions=["us-east-1", "us-west-2"],
     )
     cf_conn.update_stack_instances(
         StackSetName="test_stack_set",
-        Accounts=["123456789012"],
+        Accounts=[ACCOUNT_ID],
         Regions=["us-east-1", "us-west-2"],
     )
 
@@ -682,12 +683,12 @@ def test_create_stack_with_notification_arn():
     cf.create_stack(
         StackName="test_stack_with_notifications",
         TemplateBody=dummy_template_json,
-        NotificationARNs=["arn:aws:sns:us-east-1:123456789012:fake-queue"],
+        NotificationARNs=["arn:aws:sns:us-east-1:{}:fake-queue".format(ACCOUNT_ID)],
     )
 
     stack = list(cf.stacks.all())[0]
     stack.notification_arns.should.contain(
-        "arn:aws:sns:us-east-1:123456789012:fake-queue"
+        "arn:aws:sns:us-east-1:{}:fake-queue".format(ACCOUNT_ID)
     )
 
 
@@ -697,10 +698,10 @@ def test_create_stack_with_role_arn():
     cf.create_stack(
         StackName="test_stack_with_notifications",
         TemplateBody=dummy_template_json,
-        RoleARN="arn:aws:iam::123456789012:role/moto",
+        RoleARN="arn:aws:iam::{}:role/moto".format(ACCOUNT_ID),
     )
     stack = list(cf.stacks.all())[0]
-    stack.role_arn.should.equal("arn:aws:iam::123456789012:role/moto")
+    stack.role_arn.should.equal("arn:aws:iam::{}:role/moto".format(ACCOUNT_ID))
 
 
 @mock_cloudformation
@@ -1019,7 +1020,7 @@ def test_describe_updated_stack():
 
     cf_conn.update_stack(
         StackName="test_stack",
-        RoleARN="arn:aws:iam::123456789012:role/moto",
+        RoleARN="arn:aws:iam::{}:role/moto".format(ACCOUNT_ID),
         TemplateBody=dummy_update_template_json,
         Tags=[{"Key": "foo", "Value": "baz"}],
     )
@@ -1030,7 +1031,7 @@ def test_describe_updated_stack():
     stack_by_id["StackId"].should.equal(stack["StackId"])
     stack_by_id["StackName"].should.equal("test_stack")
     stack_by_id["StackStatus"].should.equal("UPDATE_COMPLETE")
-    stack_by_id["RoleARN"].should.equal("arn:aws:iam::123456789012:role/moto")
+    stack_by_id["RoleARN"].should.equal("arn:aws:iam::{}:role/moto".format(ACCOUNT_ID))
     stack_by_id["Tags"].should.equal([{"Key": "foo", "Value": "baz"}])
 
 

--- a/tests/test_cloudformation/test_cloudformation_stack_integration.py
+++ b/tests/test_cloudformation/test_cloudformation_stack_integration.py
@@ -43,7 +43,7 @@ from moto import (
     mock_sqs_deprecated,
     mock_elbv2,
 )
-from moto.iam.models import ACCOUNT_ID
+from moto.core import ACCOUNT_ID
 from moto.dynamodb2.models import Table
 
 from .fixtures import (

--- a/tests/test_cloudformation/test_cloudformation_stack_integration.py
+++ b/tests/test_cloudformation/test_cloudformation_stack_integration.py
@@ -43,6 +43,7 @@ from moto import (
     mock_sqs_deprecated,
     mock_elbv2,
 )
+from moto.iam.models import ACCOUNT_ID
 from moto.dynamodb2.models import Table
 
 from .fixtures import (
@@ -1912,7 +1913,7 @@ def test_stack_spot_fleet():
                 "Type": "AWS::EC2::SpotFleet",
                 "Properties": {
                     "SpotFleetRequestConfigData": {
-                        "IamFleetRole": "arn:aws:iam::123456789012:role/fleet",
+                        "IamFleetRole": "arn:aws:iam::{}:role/fleet".format(ACCOUNT_ID),
                         "SpotPrice": "0.12",
                         "TargetCapacity": 6,
                         "AllocationStrategy": "diversified",
@@ -1933,7 +1934,7 @@ def test_stack_spot_fleet():
                                 "SecurityGroups": [{"GroupId": "sg-123"}],
                                 "SubnetId": subnet_id,
                                 "IamInstanceProfile": {
-                                    "Arn": "arn:aws:iam::123456789012:role/fleet"
+                                    "Arn": "arn:aws:iam::{}:role/fleet".format(ACCOUNT_ID)
                                 },
                                 "WeightedCapacity": "4",
                                 "SpotPrice": "10.00",
@@ -1966,7 +1967,7 @@ def test_stack_spot_fleet():
     spot_fleet_config["SpotPrice"].should.equal("0.12")
     spot_fleet_config["TargetCapacity"].should.equal(6)
     spot_fleet_config["IamFleetRole"].should.equal(
-        "arn:aws:iam::123456789012:role/fleet"
+        "arn:aws:iam::{}:role/fleet".format(ACCOUNT_ID)
     )
     spot_fleet_config["AllocationStrategy"].should.equal("diversified")
     spot_fleet_config["FulfilledCapacity"].should.equal(6.0)
@@ -1999,7 +2000,7 @@ def test_stack_spot_fleet_should_figure_out_default_price():
                 "Type": "AWS::EC2::SpotFleet",
                 "Properties": {
                     "SpotFleetRequestConfigData": {
-                        "IamFleetRole": "arn:aws:iam::123456789012:role/fleet",
+                        "IamFleetRole": "arn:aws:iam::{}:role/fleet".format(ACCOUNT_ID),
                         "TargetCapacity": 6,
                         "AllocationStrategy": "diversified",
                         "LaunchSpecifications": [
@@ -2018,7 +2019,7 @@ def test_stack_spot_fleet_should_figure_out_default_price():
                                 "SecurityGroups": [{"GroupId": "sg-123"}],
                                 "SubnetId": subnet_id,
                                 "IamInstanceProfile": {
-                                    "Arn": "arn:aws:iam::123456789012:role/fleet"
+                                    "Arn": "arn:aws:iam::{}:role/fleet".format(ACCOUNT_ID)
                                 },
                                 "WeightedCapacity": "4",
                             },

--- a/tests/test_cloudformation/test_cloudformation_stack_integration.py
+++ b/tests/test_cloudformation/test_cloudformation_stack_integration.py
@@ -1934,7 +1934,9 @@ def test_stack_spot_fleet():
                                 "SecurityGroups": [{"GroupId": "sg-123"}],
                                 "SubnetId": subnet_id,
                                 "IamInstanceProfile": {
-                                    "Arn": "arn:aws:iam::{}:role/fleet".format(ACCOUNT_ID)
+                                    "Arn": "arn:aws:iam::{}:role/fleet".format(
+                                        ACCOUNT_ID
+                                    )
                                 },
                                 "WeightedCapacity": "4",
                                 "SpotPrice": "10.00",
@@ -2019,7 +2021,9 @@ def test_stack_spot_fleet_should_figure_out_default_price():
                                 "SecurityGroups": [{"GroupId": "sg-123"}],
                                 "SubnetId": subnet_id,
                                 "IamInstanceProfile": {
-                                    "Arn": "arn:aws:iam::{}:role/fleet".format(ACCOUNT_ID)
+                                    "Arn": "arn:aws:iam::{}:role/fleet".format(
+                                        ACCOUNT_ID
+                                    )
                                 },
                                 "WeightedCapacity": "4",
                             },

--- a/tests/test_cognitoidentity/test_cognitoidentity.py
+++ b/tests/test_cognitoidentity/test_cognitoidentity.py
@@ -6,7 +6,7 @@ from nose.tools import assert_raises
 
 from moto import mock_cognitoidentity
 from moto.cognitoidentity.utils import get_random_identity_id
-
+from moto.iam.models import ACCOUNT_ID
 
 @mock_cognitoidentity
 def test_create_identity_pool():
@@ -17,7 +17,7 @@ def test_create_identity_pool():
         AllowUnauthenticatedIdentities=False,
         SupportedLoginProviders={"graph.facebook.com": "123456789012345"},
         DeveloperProviderName="devname",
-        OpenIdConnectProviderARNs=["arn:aws:rds:eu-west-2:123456789012:db:mysql-db"],
+        OpenIdConnectProviderARNs=["arn:aws:rds:eu-west-2:{}:db:mysql-db".format(ACCOUNT_ID)],
         CognitoIdentityProviders=[
             {
                 "ProviderName": "testprovider",
@@ -25,7 +25,7 @@ def test_create_identity_pool():
                 "ServerSideTokenCheck": True,
             }
         ],
-        SamlProviderARNs=["arn:aws:rds:eu-west-2:123456789012:db:mysql-db"],
+        SamlProviderARNs=["arn:aws:rds:eu-west-2:{}:db:mysql-db".format(ACCOUNT_ID)],
     )
     assert result["IdentityPoolId"] != ""
 
@@ -39,7 +39,7 @@ def test_describe_identity_pool():
         AllowUnauthenticatedIdentities=False,
         SupportedLoginProviders={"graph.facebook.com": "123456789012345"},
         DeveloperProviderName="devname",
-        OpenIdConnectProviderARNs=["arn:aws:rds:eu-west-2:123456789012:db:mysql-db"],
+        OpenIdConnectProviderARNs=["arn:aws:rds:eu-west-2:{}:db:mysql-db".format(ACCOUNT_ID)],
         CognitoIdentityProviders=[
             {
                 "ProviderName": "testprovider",
@@ -47,7 +47,7 @@ def test_describe_identity_pool():
                 "ServerSideTokenCheck": True,
             }
         ],
-        SamlProviderARNs=["arn:aws:rds:eu-west-2:123456789012:db:mysql-db"],
+        SamlProviderARNs=["arn:aws:rds:eu-west-2:{}:db:mysql-db".format(ACCOUNT_ID)],
     )
 
     result = conn.describe_identity_pool(IdentityPoolId=res["IdentityPoolId"])

--- a/tests/test_cognitoidentity/test_cognitoidentity.py
+++ b/tests/test_cognitoidentity/test_cognitoidentity.py
@@ -8,6 +8,7 @@ from moto import mock_cognitoidentity
 from moto.cognitoidentity.utils import get_random_identity_id
 from moto.core import ACCOUNT_ID
 
+
 @mock_cognitoidentity
 def test_create_identity_pool():
     conn = boto3.client("cognito-identity", "us-west-2")
@@ -17,7 +18,9 @@ def test_create_identity_pool():
         AllowUnauthenticatedIdentities=False,
         SupportedLoginProviders={"graph.facebook.com": "123456789012345"},
         DeveloperProviderName="devname",
-        OpenIdConnectProviderARNs=["arn:aws:rds:eu-west-2:{}:db:mysql-db".format(ACCOUNT_ID)],
+        OpenIdConnectProviderARNs=[
+            "arn:aws:rds:eu-west-2:{}:db:mysql-db".format(ACCOUNT_ID)
+        ],
         CognitoIdentityProviders=[
             {
                 "ProviderName": "testprovider",
@@ -39,7 +42,9 @@ def test_describe_identity_pool():
         AllowUnauthenticatedIdentities=False,
         SupportedLoginProviders={"graph.facebook.com": "123456789012345"},
         DeveloperProviderName="devname",
-        OpenIdConnectProviderARNs=["arn:aws:rds:eu-west-2:{}:db:mysql-db".format(ACCOUNT_ID)],
+        OpenIdConnectProviderARNs=[
+            "arn:aws:rds:eu-west-2:{}:db:mysql-db".format(ACCOUNT_ID)
+        ],
         CognitoIdentityProviders=[
             {
                 "ProviderName": "testprovider",

--- a/tests/test_cognitoidentity/test_cognitoidentity.py
+++ b/tests/test_cognitoidentity/test_cognitoidentity.py
@@ -6,7 +6,7 @@ from nose.tools import assert_raises
 
 from moto import mock_cognitoidentity
 from moto.cognitoidentity.utils import get_random_identity_id
-from moto.iam.models import ACCOUNT_ID
+from moto.core import ACCOUNT_ID
 
 @mock_cognitoidentity
 def test_create_identity_pool():

--- a/tests/test_cognitoidp/test_cognitoidp.py
+++ b/tests/test_cognitoidp/test_cognitoidp.py
@@ -14,7 +14,7 @@ from jose import jws
 from nose.tools import assert_raises
 
 from moto import mock_cognitoidp
-from moto.iam.models import ACCOUNT_ID
+from moto.core import ACCOUNT_ID
 
 
 @mock_cognitoidp

--- a/tests/test_cognitoidp/test_cognitoidp.py
+++ b/tests/test_cognitoidp/test_cognitoidp.py
@@ -14,6 +14,7 @@ from jose import jws
 from nose.tools import assert_raises
 
 from moto import mock_cognitoidp
+from moto.iam.models import ACCOUNT_ID
 
 
 @mock_cognitoidp
@@ -132,7 +133,7 @@ def test_create_user_pool_domain_custom_domain_config():
 
     domain = str(uuid.uuid4())
     custom_domain_config = {
-        "CertificateArn": "arn:aws:acm:us-east-1:123456789012:certificate/123456789012"
+        "CertificateArn": "arn:aws:acm:us-east-1:{}:certificate/123456789012".format(ACCOUNT_ID)
     }
     user_pool_id = conn.create_user_pool(PoolName=str(uuid.uuid4()))["UserPool"]["Id"]
     result = conn.create_user_pool_domain(
@@ -177,7 +178,7 @@ def test_update_user_pool_domain():
 
     domain = str(uuid.uuid4())
     custom_domain_config = {
-        "CertificateArn": "arn:aws:acm:us-east-1:123456789012:certificate/123456789012"
+        "CertificateArn": "arn:aws:acm:us-east-1:{}:certificate/123456789012".format(ACCOUNT_ID)
     }
     user_pool_id = conn.create_user_pool(PoolName=str(uuid.uuid4()))["UserPool"]["Id"]
     conn.create_user_pool_domain(UserPoolId=user_pool_id, Domain=domain)

--- a/tests/test_cognitoidp/test_cognitoidp.py
+++ b/tests/test_cognitoidp/test_cognitoidp.py
@@ -133,7 +133,9 @@ def test_create_user_pool_domain_custom_domain_config():
 
     domain = str(uuid.uuid4())
     custom_domain_config = {
-        "CertificateArn": "arn:aws:acm:us-east-1:{}:certificate/123456789012".format(ACCOUNT_ID)
+        "CertificateArn": "arn:aws:acm:us-east-1:{}:certificate/123456789012".format(
+            ACCOUNT_ID
+        )
     }
     user_pool_id = conn.create_user_pool(PoolName=str(uuid.uuid4()))["UserPool"]["Id"]
     result = conn.create_user_pool_domain(
@@ -178,7 +180,9 @@ def test_update_user_pool_domain():
 
     domain = str(uuid.uuid4())
     custom_domain_config = {
-        "CertificateArn": "arn:aws:acm:us-east-1:{}:certificate/123456789012".format(ACCOUNT_ID)
+        "CertificateArn": "arn:aws:acm:us-east-1:{}:certificate/123456789012".format(
+            ACCOUNT_ID
+        )
     }
     user_pool_id = conn.create_user_pool(PoolName=str(uuid.uuid4()))["UserPool"]["Id"]
     conn.create_user_pool_domain(UserPoolId=user_pool_id, Domain=domain)

--- a/tests/test_config/test_config.py
+++ b/tests/test_config/test_config.py
@@ -9,6 +9,7 @@ from moto import mock_s3
 from moto.config import mock_config
 from moto.core import ACCOUNT_ID
 
+
 @mock_config
 def test_put_configuration_recorder():
     client = boto3.client("config", region_name="us-west-2")
@@ -397,7 +398,9 @@ def test_put_configuration_aggregator():
         account_aggregation_source
     ]
     assert (
-        "arn:aws:config:us-west-2:{}:config-aggregator/config-aggregator-".format(ACCOUNT_ID)
+        "arn:aws:config:us-west-2:{}:config-aggregator/config-aggregator-".format(
+            ACCOUNT_ID
+        )
         in result["ConfigurationAggregator"]["ConfigurationAggregatorArn"]
     )
     assert (
@@ -626,9 +629,10 @@ def test_put_aggregation_authorization():
         Tags=[{"Key": "tag", "Value": "a"}],
     )
 
-    assert (
-        result["AggregationAuthorization"]["AggregationAuthorizationArn"]
-        == "arn:aws:config:us-west-2:{}:aggregation-authorization/012345678910/us-east-1".format(ACCOUNT_ID)
+    assert result["AggregationAuthorization"][
+        "AggregationAuthorizationArn"
+    ] == "arn:aws:config:us-west-2:{}:aggregation-authorization/012345678910/us-east-1".format(
+        ACCOUNT_ID
     )
     assert result["AggregationAuthorization"]["AuthorizedAccountId"] == "012345678910"
     assert result["AggregationAuthorization"]["AuthorizedAwsRegion"] == "us-east-1"
@@ -640,9 +644,10 @@ def test_put_aggregation_authorization():
     result = client.put_aggregation_authorization(
         AuthorizedAccountId="012345678910", AuthorizedAwsRegion="us-east-1"
     )
-    assert (
-        result["AggregationAuthorization"]["AggregationAuthorizationArn"]
-        == "arn:aws:config:us-west-2:{}:aggregation-authorization/012345678910/us-east-1".format(ACCOUNT_ID)
+    assert result["AggregationAuthorization"][
+        "AggregationAuthorizationArn"
+    ] == "arn:aws:config:us-west-2:{}:aggregation-authorization/012345678910/us-east-1".format(
+        ACCOUNT_ID
     )
     assert result["AggregationAuthorization"]["AuthorizedAccountId"] == "012345678910"
     assert result["AggregationAuthorization"]["AuthorizedAwsRegion"] == "us-east-1"

--- a/tests/test_config/test_config.py
+++ b/tests/test_config/test_config.py
@@ -7,7 +7,7 @@ from nose.tools import assert_raises
 
 from moto import mock_s3
 from moto.config import mock_config
-
+from moto.iam.models import ACCOUNT_ID
 
 @mock_config
 def test_put_configuration_recorder():
@@ -397,7 +397,7 @@ def test_put_configuration_aggregator():
         account_aggregation_source
     ]
     assert (
-        "arn:aws:config:us-west-2:123456789012:config-aggregator/config-aggregator-"
+        "arn:aws:config:us-west-2:{}:config-aggregator/config-aggregator-".format(ACCOUNT_ID)
         in result["ConfigurationAggregator"]["ConfigurationAggregatorArn"]
     )
     assert (
@@ -628,8 +628,7 @@ def test_put_aggregation_authorization():
 
     assert (
         result["AggregationAuthorization"]["AggregationAuthorizationArn"]
-        == "arn:aws:config:us-west-2:123456789012:"
-        "aggregation-authorization/012345678910/us-east-1"
+        == "arn:aws:config:us-west-2:{}:aggregation-authorization/012345678910/us-east-1".format(ACCOUNT_ID)
     )
     assert result["AggregationAuthorization"]["AuthorizedAccountId"] == "012345678910"
     assert result["AggregationAuthorization"]["AuthorizedAwsRegion"] == "us-east-1"
@@ -643,8 +642,7 @@ def test_put_aggregation_authorization():
     )
     assert (
         result["AggregationAuthorization"]["AggregationAuthorizationArn"]
-        == "arn:aws:config:us-west-2:123456789012:"
-        "aggregation-authorization/012345678910/us-east-1"
+        == "arn:aws:config:us-west-2:{}:aggregation-authorization/012345678910/us-east-1".format(ACCOUNT_ID)
     )
     assert result["AggregationAuthorization"]["AuthorizedAccountId"] == "012345678910"
     assert result["AggregationAuthorization"]["AuthorizedAwsRegion"] == "us-east-1"
@@ -1416,7 +1414,7 @@ def test_list_aggregate_discovered_resource():
     assert len(result["ResourceIdentifiers"]) == 12
     for x in range(0, 10):
         assert result["ResourceIdentifiers"][x] == {
-            "SourceAccountId": "123456789012",
+            "SourceAccountId": ACCOUNT_ID,
             "ResourceType": "AWS::S3::Bucket",
             "ResourceId": "bucket{}".format(x),
             "ResourceName": "bucket{}".format(x),
@@ -1424,7 +1422,7 @@ def test_list_aggregate_discovered_resource():
         }
     for x in range(11, 12):
         assert result["ResourceIdentifiers"][x] == {
-            "SourceAccountId": "123456789012",
+            "SourceAccountId": ACCOUNT_ID,
             "ResourceType": "AWS::S3::Bucket",
             "ResourceId": "eu-bucket{}".format(x),
             "ResourceName": "eu-bucket{}".format(x),

--- a/tests/test_config/test_config.py
+++ b/tests/test_config/test_config.py
@@ -7,7 +7,7 @@ from nose.tools import assert_raises
 
 from moto import mock_s3
 from moto.config import mock_config
-from moto.iam.models import ACCOUNT_ID
+from moto.core import ACCOUNT_ID
 
 @mock_config
 def test_put_configuration_recorder():

--- a/tests/test_core/test_auth.py
+++ b/tests/test_core/test_auth.py
@@ -10,7 +10,7 @@ from nose.tools import assert_raises
 
 from moto import mock_iam, mock_ec2, mock_s3, mock_sts, mock_elbv2, mock_rds2
 from moto.core import set_initial_no_auth_action_count
-from moto.iam.models import ACCOUNT_ID
+from moto.core import ACCOUNT_ID
 from uuid import uuid4
 
 

--- a/tests/test_ec2/test_spot_fleet.py
+++ b/tests/test_ec2/test_spot_fleet.py
@@ -4,6 +4,7 @@ import boto3
 import sure  # noqa
 
 from moto import mock_ec2
+from moto.iam.models import ACCOUNT_ID
 
 
 def get_subnet_id(conn):
@@ -20,7 +21,7 @@ def spot_config(subnet_id, allocation_strategy="lowestPrice"):
         "ClientToken": "string",
         "SpotPrice": "0.12",
         "TargetCapacity": 6,
-        "IamFleetRole": "arn:aws:iam::123456789012:role/fleet",
+        "IamFleetRole": "arn:aws:iam::{}:role/fleet".format(ACCOUNT_ID),
         "LaunchSpecifications": [
             {
                 "ImageId": "ami-123",
@@ -45,7 +46,7 @@ def spot_config(subnet_id, allocation_strategy="lowestPrice"):
                 ],
                 "Monitoring": {"Enabled": True},
                 "SubnetId": subnet_id,
-                "IamInstanceProfile": {"Arn": "arn:aws:iam::123456789012:role/fleet"},
+                "IamInstanceProfile": {"Arn": "arn:aws:iam::{}:role/fleet".format(ACCOUNT_ID)},
                 "EbsOptimized": False,
                 "WeightedCapacity": 2.0,
                 "SpotPrice": "0.13",
@@ -58,7 +59,7 @@ def spot_config(subnet_id, allocation_strategy="lowestPrice"):
                 "InstanceType": "t2.large",
                 "Monitoring": {"Enabled": True},
                 "SubnetId": subnet_id,
-                "IamInstanceProfile": {"Arn": "arn:aws:iam::123456789012:role/fleet"},
+                "IamInstanceProfile": {"Arn": "arn:aws:iam::{}:role/fleet".format(ACCOUNT_ID)},
                 "EbsOptimized": False,
                 "WeightedCapacity": 4.0,
                 "SpotPrice": "10.00",
@@ -90,7 +91,7 @@ def test_create_spot_fleet_with_lowest_price():
     spot_fleet_config["SpotPrice"].should.equal("0.12")
     spot_fleet_config["TargetCapacity"].should.equal(6)
     spot_fleet_config["IamFleetRole"].should.equal(
-        "arn:aws:iam::123456789012:role/fleet"
+        "arn:aws:iam::{}:role/fleet".format(ACCOUNT_ID)
     )
     spot_fleet_config["AllocationStrategy"].should.equal("lowestPrice")
     spot_fleet_config["FulfilledCapacity"].should.equal(6.0)
@@ -101,7 +102,7 @@ def test_create_spot_fleet_with_lowest_price():
     launch_spec["EbsOptimized"].should.equal(False)
     launch_spec["SecurityGroups"].should.equal([{"GroupId": "sg-123"}])
     launch_spec["IamInstanceProfile"].should.equal(
-        {"Arn": "arn:aws:iam::123456789012:role/fleet"}
+        {"Arn": "arn:aws:iam::{}:role/fleet".format(ACCOUNT_ID)}
     )
     launch_spec["ImageId"].should.equal("ami-123")
     launch_spec["InstanceType"].should.equal("t2.small")

--- a/tests/test_ec2/test_spot_fleet.py
+++ b/tests/test_ec2/test_spot_fleet.py
@@ -46,7 +46,9 @@ def spot_config(subnet_id, allocation_strategy="lowestPrice"):
                 ],
                 "Monitoring": {"Enabled": True},
                 "SubnetId": subnet_id,
-                "IamInstanceProfile": {"Arn": "arn:aws:iam::{}:role/fleet".format(ACCOUNT_ID)},
+                "IamInstanceProfile": {
+                    "Arn": "arn:aws:iam::{}:role/fleet".format(ACCOUNT_ID)
+                },
                 "EbsOptimized": False,
                 "WeightedCapacity": 2.0,
                 "SpotPrice": "0.13",
@@ -59,7 +61,9 @@ def spot_config(subnet_id, allocation_strategy="lowestPrice"):
                 "InstanceType": "t2.large",
                 "Monitoring": {"Enabled": True},
                 "SubnetId": subnet_id,
-                "IamInstanceProfile": {"Arn": "arn:aws:iam::{}:role/fleet".format(ACCOUNT_ID)},
+                "IamInstanceProfile": {
+                    "Arn": "arn:aws:iam::{}:role/fleet".format(ACCOUNT_ID)
+                },
                 "EbsOptimized": False,
                 "WeightedCapacity": 4.0,
                 "SpotPrice": "10.00",

--- a/tests/test_ec2/test_spot_fleet.py
+++ b/tests/test_ec2/test_spot_fleet.py
@@ -4,7 +4,7 @@ import boto3
 import sure  # noqa
 
 from moto import mock_ec2
-from moto.iam.models import ACCOUNT_ID
+from moto.core import ACCOUNT_ID
 
 
 def get_subnet_id(conn):

--- a/tests/test_elb/test_elb.py
+++ b/tests/test_elb/test_elb.py
@@ -15,6 +15,7 @@ from nose.tools import assert_raises
 import sure  # noqa
 
 from moto import mock_elb, mock_ec2, mock_elb_deprecated, mock_ec2_deprecated
+from moto.iam.models import ACCOUNT_ID
 
 
 @mock_elb_deprecated
@@ -76,7 +77,7 @@ def test_create_load_balancer_with_certificate():
 
     zones = ["us-east-1a"]
     ports = [
-        (443, 8443, "https", "arn:aws:iam:123456789012:server-certificate/test-cert")
+        (443, 8443, "https", "arn:aws:iam:{}:server-certificate/test-cert".format(ACCOUNT_ID))
     ]
     conn.create_load_balancer("my-lb", zones, ports)
 
@@ -90,7 +91,7 @@ def test_create_load_balancer_with_certificate():
     listener.instance_port.should.equal(8443)
     listener.protocol.should.equal("HTTPS")
     listener.ssl_certificate_id.should.equal(
-        "arn:aws:iam:123456789012:server-certificate/test-cert"
+        "arn:aws:iam:{}:server-certificate/test-cert".format(ACCOUNT_ID)
     )
 
 

--- a/tests/test_elb/test_elb.py
+++ b/tests/test_elb/test_elb.py
@@ -77,7 +77,12 @@ def test_create_load_balancer_with_certificate():
 
     zones = ["us-east-1a"]
     ports = [
-        (443, 8443, "https", "arn:aws:iam:{}:server-certificate/test-cert".format(ACCOUNT_ID))
+        (
+            443,
+            8443,
+            "https",
+            "arn:aws:iam:{}:server-certificate/test-cert".format(ACCOUNT_ID),
+        )
     ]
     conn.create_load_balancer("my-lb", zones, ports)
 

--- a/tests/test_elb/test_elb.py
+++ b/tests/test_elb/test_elb.py
@@ -15,7 +15,7 @@ from nose.tools import assert_raises
 import sure  # noqa
 
 from moto import mock_elb, mock_ec2, mock_elb_deprecated, mock_ec2_deprecated
-from moto.iam.models import ACCOUNT_ID
+from moto.core import ACCOUNT_ID
 
 
 @mock_elb_deprecated

--- a/tests/test_elbv2/test_elbv2.py
+++ b/tests/test_elbv2/test_elbv2.py
@@ -10,6 +10,7 @@ import sure  # noqa
 
 from moto import mock_elbv2, mock_ec2, mock_acm, mock_cloudformation
 from moto.elbv2 import elbv2_backends
+from moto.iam.models import ACCOUNT_ID
 
 
 @mock_elbv2
@@ -346,7 +347,7 @@ def test_create_target_group_and_listeners():
         Protocol="HTTPS",
         Port=443,
         Certificates=[
-            {"CertificateArn": "arn:aws:iam:123456789012:server-certificate/test-cert"}
+            {"CertificateArn": "arn:aws:iam:{}:server-certificate/test-cert".format(ACCOUNT_ID)}
         ],
         DefaultActions=[
             {"Type": "forward", "TargetGroupArn": target_group.get("TargetGroupArn")}
@@ -356,7 +357,7 @@ def test_create_target_group_and_listeners():
     listener.get("Port").should.equal(443)
     listener.get("Protocol").should.equal("HTTPS")
     listener.get("Certificates").should.equal(
-        [{"CertificateArn": "arn:aws:iam:123456789012:server-certificate/test-cert"}]
+        [{"CertificateArn": "arn:aws:iam:{}:server-certificate/test-cert".format(ACCOUNT_ID)}]
     )
     listener.get("DefaultActions").should.equal(
         [{"TargetGroupArn": target_group.get("TargetGroupArn"), "Type": "forward"}]
@@ -1902,7 +1903,7 @@ def test_cognito_action_listener_rule():
     action = {
         "Type": "authenticate-cognito",
         "AuthenticateCognitoConfig": {
-            "UserPoolArn": "arn:aws:cognito-idp:us-east-1:123456789012:userpool/us-east-1_ABCD1234",
+            "UserPoolArn": "arn:aws:cognito-idp:us-east-1:{}:userpool/us-east-1_ABCD1234".format(ACCOUNT_ID),
             "UserPoolClientId": "abcd1234abcd",
             "UserPoolDomain": "testpool",
         },
@@ -1977,7 +1978,7 @@ def test_cognito_action_listener_rule_cloudformation():
                         {
                             "Type": "authenticate-cognito",
                             "AuthenticateCognitoConfig": {
-                                "UserPoolArn": "arn:aws:cognito-idp:us-east-1:123456789012:userpool/us-east-1_ABCD1234",
+                                "UserPoolArn": "arn:aws:cognito-idp:us-east-1:{}:userpool/us-east-1_ABCD1234".format(ACCOUNT_ID),
                                 "UserPoolClientId": "abcd1234abcd",
                                 "UserPoolDomain": "testpool",
                             },
@@ -2006,7 +2007,7 @@ def test_cognito_action_listener_rule_cloudformation():
             {
                 "Type": "authenticate-cognito",
                 "AuthenticateCognitoConfig": {
-                    "UserPoolArn": "arn:aws:cognito-idp:us-east-1:123456789012:userpool/us-east-1_ABCD1234",
+                    "UserPoolArn": "arn:aws:cognito-idp:us-east-1:{}:userpool/us-east-1_ABCD1234".format(ACCOUNT_ID),
                     "UserPoolClientId": "abcd1234abcd",
                     "UserPoolDomain": "testpool",
                 },

--- a/tests/test_elbv2/test_elbv2.py
+++ b/tests/test_elbv2/test_elbv2.py
@@ -347,7 +347,11 @@ def test_create_target_group_and_listeners():
         Protocol="HTTPS",
         Port=443,
         Certificates=[
-            {"CertificateArn": "arn:aws:iam:{}:server-certificate/test-cert".format(ACCOUNT_ID)}
+            {
+                "CertificateArn": "arn:aws:iam:{}:server-certificate/test-cert".format(
+                    ACCOUNT_ID
+                )
+            }
         ],
         DefaultActions=[
             {"Type": "forward", "TargetGroupArn": target_group.get("TargetGroupArn")}
@@ -357,7 +361,13 @@ def test_create_target_group_and_listeners():
     listener.get("Port").should.equal(443)
     listener.get("Protocol").should.equal("HTTPS")
     listener.get("Certificates").should.equal(
-        [{"CertificateArn": "arn:aws:iam:{}:server-certificate/test-cert".format(ACCOUNT_ID)}]
+        [
+            {
+                "CertificateArn": "arn:aws:iam:{}:server-certificate/test-cert".format(
+                    ACCOUNT_ID
+                )
+            }
+        ]
     )
     listener.get("DefaultActions").should.equal(
         [{"TargetGroupArn": target_group.get("TargetGroupArn"), "Type": "forward"}]
@@ -1903,7 +1913,9 @@ def test_cognito_action_listener_rule():
     action = {
         "Type": "authenticate-cognito",
         "AuthenticateCognitoConfig": {
-            "UserPoolArn": "arn:aws:cognito-idp:us-east-1:{}:userpool/us-east-1_ABCD1234".format(ACCOUNT_ID),
+            "UserPoolArn": "arn:aws:cognito-idp:us-east-1:{}:userpool/us-east-1_ABCD1234".format(
+                ACCOUNT_ID
+            ),
             "UserPoolClientId": "abcd1234abcd",
             "UserPoolDomain": "testpool",
         },
@@ -1978,7 +1990,9 @@ def test_cognito_action_listener_rule_cloudformation():
                         {
                             "Type": "authenticate-cognito",
                             "AuthenticateCognitoConfig": {
-                                "UserPoolArn": "arn:aws:cognito-idp:us-east-1:{}:userpool/us-east-1_ABCD1234".format(ACCOUNT_ID),
+                                "UserPoolArn": "arn:aws:cognito-idp:us-east-1:{}:userpool/us-east-1_ABCD1234".format(
+                                    ACCOUNT_ID
+                                ),
                                 "UserPoolClientId": "abcd1234abcd",
                                 "UserPoolDomain": "testpool",
                             },
@@ -2007,7 +2021,9 @@ def test_cognito_action_listener_rule_cloudformation():
             {
                 "Type": "authenticate-cognito",
                 "AuthenticateCognitoConfig": {
-                    "UserPoolArn": "arn:aws:cognito-idp:us-east-1:{}:userpool/us-east-1_ABCD1234".format(ACCOUNT_ID),
+                    "UserPoolArn": "arn:aws:cognito-idp:us-east-1:{}:userpool/us-east-1_ABCD1234".format(
+                        ACCOUNT_ID
+                    ),
                     "UserPoolClientId": "abcd1234abcd",
                     "UserPoolDomain": "testpool",
                 },

--- a/tests/test_elbv2/test_elbv2.py
+++ b/tests/test_elbv2/test_elbv2.py
@@ -10,7 +10,7 @@ import sure  # noqa
 
 from moto import mock_elbv2, mock_ec2, mock_acm, mock_cloudformation
 from moto.elbv2 import elbv2_backends
-from moto.iam.models import ACCOUNT_ID
+from moto.core import ACCOUNT_ID
 
 
 @mock_elbv2

--- a/tests/test_events/test_events.py
+++ b/tests/test_events/test_events.py
@@ -6,6 +6,7 @@ import sure  # noqa
 from moto.events import mock_events
 from botocore.exceptions import ClientError
 from nose.tools import assert_raises
+from moto.iam.models import ACCOUNT_ID
 
 RULES = [
     {"Name": "test1", "ScheduleExpression": "rate(5 minutes)"},
@@ -276,7 +277,7 @@ def test_create_event_bus():
     response = client.create_event_bus(Name="test-bus")
 
     response["EventBusArn"].should.equal(
-        "arn:aws:events:us-east-1:123456789012:event-bus/test-bus"
+        "arn:aws:events:us-east-1:{}:event-bus/test-bus".format(ACCOUNT_ID)
     )
 
 
@@ -314,7 +315,7 @@ def test_describe_event_bus():
 
     response["Name"].should.equal("default")
     response["Arn"].should.equal(
-        "arn:aws:events:us-east-1:123456789012:event-bus/default"
+        "arn:aws:events:us-east-1:{}:event-bus/default".format(ACCOUNT_ID)
     )
     response.should_not.have.key("Policy")
 
@@ -330,7 +331,7 @@ def test_describe_event_bus():
 
     response["Name"].should.equal("test-bus")
     response["Arn"].should.equal(
-        "arn:aws:events:us-east-1:123456789012:event-bus/test-bus"
+        "arn:aws:events:us-east-1:{}:event-bus/test-bus".format(ACCOUNT_ID)
     )
     json.loads(response["Policy"]).should.equal(
         {
@@ -341,7 +342,7 @@ def test_describe_event_bus():
                     "Effect": "Allow",
                     "Principal": {"AWS": "arn:aws:iam::111111111111:root"},
                     "Action": "events:PutEvents",
-                    "Resource": "arn:aws:events:us-east-1:123456789012:event-bus/test-bus",
+                    "Resource": "arn:aws:events:us-east-1:{}:event-bus/test-bus".format(ACCOUNT_ID),
                 }
             ],
         }
@@ -372,23 +373,23 @@ def test_list_event_buses():
         [
             {
                 "Name": "default",
-                "Arn": "arn:aws:events:us-east-1:123456789012:event-bus/default",
+                "Arn": "arn:aws:events:us-east-1:{}:event-bus/default".format(ACCOUNT_ID),
             },
             {
                 "Name": "other-bus-1",
-                "Arn": "arn:aws:events:us-east-1:123456789012:event-bus/other-bus-1",
+                "Arn": "arn:aws:events:us-east-1:{}:event-bus/other-bus-1".format(ACCOUNT_ID),
             },
             {
                 "Name": "other-bus-2",
-                "Arn": "arn:aws:events:us-east-1:123456789012:event-bus/other-bus-2",
+                "Arn": "arn:aws:events:us-east-1:{}:event-bus/other-bus-2".format(ACCOUNT_ID),
             },
             {
                 "Name": "test-bus-1",
-                "Arn": "arn:aws:events:us-east-1:123456789012:event-bus/test-bus-1",
+                "Arn": "arn:aws:events:us-east-1:{}:event-bus/test-bus-1".format(ACCOUNT_ID),
             },
             {
                 "Name": "test-bus-2",
-                "Arn": "arn:aws:events:us-east-1:123456789012:event-bus/test-bus-2",
+                "Arn": "arn:aws:events:us-east-1:{}:event-bus/test-bus-2".format(ACCOUNT_ID),
             },
         ]
     )
@@ -400,11 +401,11 @@ def test_list_event_buses():
         [
             {
                 "Name": "other-bus-1",
-                "Arn": "arn:aws:events:us-east-1:123456789012:event-bus/other-bus-1",
+                "Arn": "arn:aws:events:us-east-1:{}:event-bus/other-bus-1".format(ACCOUNT_ID),
             },
             {
                 "Name": "other-bus-2",
-                "Arn": "arn:aws:events:us-east-1:123456789012:event-bus/other-bus-2",
+                "Arn": "arn:aws:events:us-east-1:{}:event-bus/other-bus-2".format(ACCOUNT_ID),
             },
         ]
     )
@@ -426,7 +427,7 @@ def test_delete_event_bus():
         [
             {
                 "Name": "default",
-                "Arn": "arn:aws:events:us-east-1:123456789012:event-bus/default",
+                "Arn": "arn:aws:events:us-east-1:{}:event-bus/default".format(ACCOUNT_ID),
             }
         ]
     )

--- a/tests/test_events/test_events.py
+++ b/tests/test_events/test_events.py
@@ -6,7 +6,7 @@ import sure  # noqa
 from moto.events import mock_events
 from botocore.exceptions import ClientError
 from nose.tools import assert_raises
-from moto.iam.models import ACCOUNT_ID
+from moto.core import ACCOUNT_ID
 
 RULES = [
     {"Name": "test1", "ScheduleExpression": "rate(5 minutes)"},

--- a/tests/test_events/test_events.py
+++ b/tests/test_events/test_events.py
@@ -342,7 +342,9 @@ def test_describe_event_bus():
                     "Effect": "Allow",
                     "Principal": {"AWS": "arn:aws:iam::111111111111:root"},
                     "Action": "events:PutEvents",
-                    "Resource": "arn:aws:events:us-east-1:{}:event-bus/test-bus".format(ACCOUNT_ID),
+                    "Resource": "arn:aws:events:us-east-1:{}:event-bus/test-bus".format(
+                        ACCOUNT_ID
+                    ),
                 }
             ],
         }
@@ -373,23 +375,33 @@ def test_list_event_buses():
         [
             {
                 "Name": "default",
-                "Arn": "arn:aws:events:us-east-1:{}:event-bus/default".format(ACCOUNT_ID),
+                "Arn": "arn:aws:events:us-east-1:{}:event-bus/default".format(
+                    ACCOUNT_ID
+                ),
             },
             {
                 "Name": "other-bus-1",
-                "Arn": "arn:aws:events:us-east-1:{}:event-bus/other-bus-1".format(ACCOUNT_ID),
+                "Arn": "arn:aws:events:us-east-1:{}:event-bus/other-bus-1".format(
+                    ACCOUNT_ID
+                ),
             },
             {
                 "Name": "other-bus-2",
-                "Arn": "arn:aws:events:us-east-1:{}:event-bus/other-bus-2".format(ACCOUNT_ID),
+                "Arn": "arn:aws:events:us-east-1:{}:event-bus/other-bus-2".format(
+                    ACCOUNT_ID
+                ),
             },
             {
                 "Name": "test-bus-1",
-                "Arn": "arn:aws:events:us-east-1:{}:event-bus/test-bus-1".format(ACCOUNT_ID),
+                "Arn": "arn:aws:events:us-east-1:{}:event-bus/test-bus-1".format(
+                    ACCOUNT_ID
+                ),
             },
             {
                 "Name": "test-bus-2",
-                "Arn": "arn:aws:events:us-east-1:{}:event-bus/test-bus-2".format(ACCOUNT_ID),
+                "Arn": "arn:aws:events:us-east-1:{}:event-bus/test-bus-2".format(
+                    ACCOUNT_ID
+                ),
             },
         ]
     )
@@ -401,11 +413,15 @@ def test_list_event_buses():
         [
             {
                 "Name": "other-bus-1",
-                "Arn": "arn:aws:events:us-east-1:{}:event-bus/other-bus-1".format(ACCOUNT_ID),
+                "Arn": "arn:aws:events:us-east-1:{}:event-bus/other-bus-1".format(
+                    ACCOUNT_ID
+                ),
             },
             {
                 "Name": "other-bus-2",
-                "Arn": "arn:aws:events:us-east-1:{}:event-bus/other-bus-2".format(ACCOUNT_ID),
+                "Arn": "arn:aws:events:us-east-1:{}:event-bus/other-bus-2".format(
+                    ACCOUNT_ID
+                ),
             },
         ]
     )
@@ -427,7 +443,9 @@ def test_delete_event_bus():
         [
             {
                 "Name": "default",
-                "Arn": "arn:aws:events:us-east-1:{}:event-bus/default".format(ACCOUNT_ID),
+                "Arn": "arn:aws:events:us-east-1:{}:event-bus/default".format(
+                    ACCOUNT_ID
+                ),
             }
         ]
     )

--- a/tests/test_iam/test_iam.py
+++ b/tests/test_iam/test_iam.py
@@ -13,6 +13,7 @@ from dateutil.tz import tzutc
 
 from moto import mock_iam, mock_iam_deprecated
 from moto.iam.models import aws_managed_policies
+from moto.iam.models import ACCOUNT_ID
 from nose.tools import assert_raises, assert_equals
 from nose.tools import raises
 
@@ -83,7 +84,7 @@ def test_get_all_server_certs():
     certs.should.have.length_of(1)
     cert1 = certs[0]
     cert1.server_certificate_name.should.equal("certname")
-    cert1.arn.should.equal("arn:aws:iam::123456789012:server-certificate/certname")
+    cert1.arn.should.equal("arn:aws:iam::{}:server-certificate/certname".format(ACCOUNT_ID))
 
 
 @mock_iam_deprecated()
@@ -101,7 +102,7 @@ def test_get_server_cert():
     conn.upload_server_cert("certname", "certbody", "privatekey")
     cert = conn.get_server_certificate("certname")
     cert.server_certificate_name.should.equal("certname")
-    cert.arn.should.equal("arn:aws:iam::123456789012:server-certificate/certname")
+    cert.arn.should.equal("arn:aws:iam::{}:server-certificate/certname".format(ACCOUNT_ID))
 
 
 @mock_iam_deprecated()
@@ -111,7 +112,7 @@ def test_upload_server_cert():
     conn.upload_server_cert("certname", "certbody", "privatekey")
     cert = conn.get_server_certificate("certname")
     cert.server_certificate_name.should.equal("certname")
-    cert.arn.should.equal("arn:aws:iam::123456789012:server-certificate/certname")
+    cert.arn.should.equal("arn:aws:iam::{}:server-certificate/certname".format(ACCOUNT_ID))
 
 
 @mock_iam_deprecated()
@@ -405,7 +406,7 @@ def test_create_policy():
         PolicyName="TestCreatePolicy", PolicyDocument=MOCK_POLICY
     )
     response["Policy"]["Arn"].should.equal(
-        "arn:aws:iam::123456789012:policy/TestCreatePolicy"
+        "arn:aws:iam::{}:policy/TestCreatePolicy".format(ACCOUNT_ID)
     )
 
 
@@ -442,12 +443,12 @@ def test_create_policy_versions():
     conn = boto3.client("iam", region_name="us-east-1")
     with assert_raises(ClientError):
         conn.create_policy_version(
-            PolicyArn="arn:aws:iam::123456789012:policy/TestCreatePolicyVersion",
+            PolicyArn="arn:aws:iam::{}:policy/TestCreatePolicyVersion".format(ACCOUNT_ID),
             PolicyDocument='{"some":"policy"}',
         )
     conn.create_policy(PolicyName="TestCreatePolicyVersion", PolicyDocument=MOCK_POLICY)
     version = conn.create_policy_version(
-        PolicyArn="arn:aws:iam::123456789012:policy/TestCreatePolicyVersion",
+        PolicyArn="arn:aws:iam::{}:policy/TestCreatePolicyVersion".format(ACCOUNT_ID),
         PolicyDocument=MOCK_POLICY,
         SetAsDefault=True,
     )
@@ -455,11 +456,11 @@ def test_create_policy_versions():
     version.get("PolicyVersion").get("VersionId").should.equal("v2")
     version.get("PolicyVersion").get("IsDefaultVersion").should.be.ok
     conn.delete_policy_version(
-        PolicyArn="arn:aws:iam::123456789012:policy/TestCreatePolicyVersion",
+        PolicyArn="arn:aws:iam::{}:policy/TestCreatePolicyVersion".format(ACCOUNT_ID),
         VersionId="v1",
     )
     version = conn.create_policy_version(
-        PolicyArn="arn:aws:iam::123456789012:policy/TestCreatePolicyVersion",
+        PolicyArn="arn:aws:iam::{}:policy/TestCreatePolicyVersion".format(ACCOUNT_ID),
         PolicyDocument=MOCK_POLICY,
     )
     version.get("PolicyVersion").get("VersionId").should.equal("v3")
@@ -474,12 +475,12 @@ def test_create_many_policy_versions():
     )
     for _ in range(0, 4):
         conn.create_policy_version(
-            PolicyArn="arn:aws:iam::123456789012:policy/TestCreateManyPolicyVersions",
+            PolicyArn="arn:aws:iam::{}:policy/TestCreateManyPolicyVersions".format(ACCOUNT_ID),
             PolicyDocument=MOCK_POLICY,
         )
     with assert_raises(ClientError):
         conn.create_policy_version(
-            PolicyArn="arn:aws:iam::123456789012:policy/TestCreateManyPolicyVersions",
+            PolicyArn="arn:aws:iam::{}:policy/TestCreateManyPolicyVersions".format(ACCOUNT_ID),
             PolicyDocument=MOCK_POLICY,
         )
 
@@ -491,17 +492,17 @@ def test_set_default_policy_version():
         PolicyName="TestSetDefaultPolicyVersion", PolicyDocument=MOCK_POLICY
     )
     conn.create_policy_version(
-        PolicyArn="arn:aws:iam::123456789012:policy/TestSetDefaultPolicyVersion",
+        PolicyArn="arn:aws:iam::{}:policy/TestSetDefaultPolicyVersion".format(ACCOUNT_ID),
         PolicyDocument=MOCK_POLICY_2,
         SetAsDefault=True,
     )
     conn.create_policy_version(
-        PolicyArn="arn:aws:iam::123456789012:policy/TestSetDefaultPolicyVersion",
+        PolicyArn="arn:aws:iam::{}:policy/TestSetDefaultPolicyVersion".format(ACCOUNT_ID),
         PolicyDocument=MOCK_POLICY_3,
         SetAsDefault=True,
     )
     versions = conn.list_policy_versions(
-        PolicyArn="arn:aws:iam::123456789012:policy/TestSetDefaultPolicyVersion"
+        PolicyArn="arn:aws:iam::{}:policy/TestSetDefaultPolicyVersion".format(ACCOUNT_ID)
     )
     versions.get("Versions")[0].get("Document").should.equal(json.loads(MOCK_POLICY))
     versions.get("Versions")[0].get("IsDefaultVersion").shouldnt.be.ok
@@ -517,9 +518,9 @@ def test_get_policy():
     response = conn.create_policy(
         PolicyName="TestGetPolicy", PolicyDocument=MOCK_POLICY
     )
-    policy = conn.get_policy(PolicyArn="arn:aws:iam::123456789012:policy/TestGetPolicy")
+    policy = conn.get_policy(PolicyArn="arn:aws:iam::{}:policy/TestGetPolicy".format(ACCOUNT_ID))
     policy["Policy"]["Arn"].should.equal(
-        "arn:aws:iam::123456789012:policy/TestGetPolicy"
+        "arn:aws:iam::{}:policy/TestGetPolicy".format(ACCOUNT_ID)
     )
 
 
@@ -542,16 +543,16 @@ def test_get_policy_version():
     conn = boto3.client("iam", region_name="us-east-1")
     conn.create_policy(PolicyName="TestGetPolicyVersion", PolicyDocument=MOCK_POLICY)
     version = conn.create_policy_version(
-        PolicyArn="arn:aws:iam::123456789012:policy/TestGetPolicyVersion",
+        PolicyArn="arn:aws:iam::{}:policy/TestGetPolicyVersion".format(ACCOUNT_ID),
         PolicyDocument=MOCK_POLICY,
     )
     with assert_raises(ClientError):
         conn.get_policy_version(
-            PolicyArn="arn:aws:iam::123456789012:policy/TestGetPolicyVersion",
+            PolicyArn="arn:aws:iam::{}:policy/TestGetPolicyVersion".format(ACCOUNT_ID),
             VersionId="v2-does-not-exist",
         )
     retrieved = conn.get_policy_version(
-        PolicyArn="arn:aws:iam::123456789012:policy/TestGetPolicyVersion",
+        PolicyArn="arn:aws:iam::{}:policy/TestGetPolicyVersion".format(ACCOUNT_ID),
         VersionId=version.get("PolicyVersion").get("VersionId"),
     )
     retrieved.get("PolicyVersion").get("Document").should.equal(json.loads(MOCK_POLICY))
@@ -601,25 +602,25 @@ def test_list_policy_versions():
     conn = boto3.client("iam", region_name="us-east-1")
     with assert_raises(ClientError):
         versions = conn.list_policy_versions(
-            PolicyArn="arn:aws:iam::123456789012:policy/TestListPolicyVersions"
+            PolicyArn="arn:aws:iam::{}:policy/TestListPolicyVersions".format(ACCOUNT_ID)
         )
     conn.create_policy(PolicyName="TestListPolicyVersions", PolicyDocument=MOCK_POLICY)
     versions = conn.list_policy_versions(
-        PolicyArn="arn:aws:iam::123456789012:policy/TestListPolicyVersions"
+        PolicyArn="arn:aws:iam::{}:policy/TestListPolicyVersions".format(ACCOUNT_ID)
     )
     versions.get("Versions")[0].get("VersionId").should.equal("v1")
     versions.get("Versions")[0].get("IsDefaultVersion").should.be.ok
 
     conn.create_policy_version(
-        PolicyArn="arn:aws:iam::123456789012:policy/TestListPolicyVersions",
+        PolicyArn="arn:aws:iam::{}:policy/TestListPolicyVersions".format(ACCOUNT_ID),
         PolicyDocument=MOCK_POLICY_2,
     )
     conn.create_policy_version(
-        PolicyArn="arn:aws:iam::123456789012:policy/TestListPolicyVersions",
+        PolicyArn="arn:aws:iam::{}:policy/TestListPolicyVersions".format(ACCOUNT_ID),
         PolicyDocument=MOCK_POLICY_3,
     )
     versions = conn.list_policy_versions(
-        PolicyArn="arn:aws:iam::123456789012:policy/TestListPolicyVersions"
+        PolicyArn="arn:aws:iam::{}:policy/TestListPolicyVersions".format(ACCOUNT_ID)
     )
     versions.get("Versions")[1].get("Document").should.equal(json.loads(MOCK_POLICY_2))
     versions.get("Versions")[1].get("IsDefaultVersion").shouldnt.be.ok
@@ -632,20 +633,20 @@ def test_delete_policy_version():
     conn = boto3.client("iam", region_name="us-east-1")
     conn.create_policy(PolicyName="TestDeletePolicyVersion", PolicyDocument=MOCK_POLICY)
     conn.create_policy_version(
-        PolicyArn="arn:aws:iam::123456789012:policy/TestDeletePolicyVersion",
+        PolicyArn="arn:aws:iam::{}:policy/TestDeletePolicyVersion".format(ACCOUNT_ID),
         PolicyDocument=MOCK_POLICY,
     )
     with assert_raises(ClientError):
         conn.delete_policy_version(
-            PolicyArn="arn:aws:iam::123456789012:policy/TestDeletePolicyVersion",
+            PolicyArn="arn:aws:iam::{}:policy/TestDeletePolicyVersion".format(ACCOUNT_ID),
             VersionId="v2-nope-this-does-not-exist",
         )
     conn.delete_policy_version(
-        PolicyArn="arn:aws:iam::123456789012:policy/TestDeletePolicyVersion",
+        PolicyArn="arn:aws:iam::{}:policy/TestDeletePolicyVersion".format(ACCOUNT_ID),
         VersionId="v2",
     )
     versions = conn.list_policy_versions(
-        PolicyArn="arn:aws:iam::123456789012:policy/TestDeletePolicyVersion"
+        PolicyArn="arn:aws:iam::{}:policy/TestDeletePolicyVersion".format(ACCOUNT_ID)
     )
     len(versions.get("Versions")).should.equal(1)
 
@@ -655,12 +656,12 @@ def test_delete_default_policy_version():
     conn = boto3.client("iam", region_name="us-east-1")
     conn.create_policy(PolicyName="TestDeletePolicyVersion", PolicyDocument=MOCK_POLICY)
     conn.create_policy_version(
-        PolicyArn="arn:aws:iam::123456789012:policy/TestDeletePolicyVersion",
+        PolicyArn="arn:aws:iam::{}:policy/TestDeletePolicyVersion".format(ACCOUNT_ID),
         PolicyDocument=MOCK_POLICY_2,
     )
     with assert_raises(ClientError):
         conn.delete_policy_version(
-            PolicyArn="arn:aws:iam::123456789012:policy/TestDeletePolicyVersion",
+            PolicyArn="arn:aws:iam::{}:policy/TestDeletePolicyVersion".format(ACCOUNT_ID),
             VersionId="v1",
         )
 
@@ -713,7 +714,7 @@ def test_list_users():
     user = response["Users"][0]
     user["UserName"].should.equal("my-user")
     user["Path"].should.equal("/")
-    user["Arn"].should.equal("arn:aws:iam::123456789012:user/my-user")
+    user["Arn"].should.equal("arn:aws:iam::{}:user/my-user".format(ACCOUNT_ID))
 
 
 @mock_iam()
@@ -839,7 +840,7 @@ def test_create_virtual_mfa_device():
     response = client.create_virtual_mfa_device(VirtualMFADeviceName="test-device")
     device = response["VirtualMFADevice"]
 
-    device["SerialNumber"].should.equal("arn:aws:iam::123456789012:mfa/test-device")
+    device["SerialNumber"].should.equal("arn:aws:iam::{}:mfa/test-device".format(ACCOUNT_ID))
     device["Base32StringSeed"].decode("ascii").should.match("[A-Z234567]")
     device["QRCodePNG"].should_not.be.empty
 
@@ -848,7 +849,7 @@ def test_create_virtual_mfa_device():
     )
     device = response["VirtualMFADevice"]
 
-    device["SerialNumber"].should.equal("arn:aws:iam::123456789012:mfa/test-device-2")
+    device["SerialNumber"].should.equal("arn:aws:iam::{}:mfa/test-device-2".format(ACCOUNT_ID))
     device["Base32StringSeed"].decode("ascii").should.match("[A-Z234567]")
     device["QRCodePNG"].should_not.be.empty
 
@@ -858,7 +859,7 @@ def test_create_virtual_mfa_device():
     device = response["VirtualMFADevice"]
 
     device["SerialNumber"].should.equal(
-        "arn:aws:iam::123456789012:mfa/test/test-device"
+        "arn:aws:iam::{}:mfa/test/test-device".format(ACCOUNT_ID)
     )
     device["Base32StringSeed"].decode("ascii").should.match("[A-Z234567]")
     device["QRCodePNG"].should_not.be.empty
@@ -920,7 +921,7 @@ def test_delete_virtual_mfa_device():
 def test_delete_virtual_mfa_device_errors():
     client = boto3.client("iam", region_name="us-east-1")
 
-    serial_number = "arn:aws:iam::123456789012:mfa/not-existing"
+    serial_number = "arn:aws:iam::{}:mfa/not-existing".format(ACCOUNT_ID)
     client.delete_virtual_mfa_device.when.called_with(
         SerialNumber=serial_number
     ).should.throw(
@@ -1009,7 +1010,7 @@ def test_enable_virtual_mfa_device():
     device["User"]["Path"].should.equal("/")
     device["User"]["UserName"].should.equal("test-user")
     device["User"]["UserId"].should_not.be.empty
-    device["User"]["Arn"].should.equal("arn:aws:iam::123456789012:user/test-user")
+    device["User"]["Arn"].should.equal("arn:aws:iam::{}:user/test-user".format(ACCOUNT_ID))
     device["User"]["CreateDate"].should.be.a(datetime)
     device["EnableDate"].should.be.a(datetime)
     response["IsTruncated"].should_not.be.ok
@@ -1444,7 +1445,7 @@ def test_get_account_authorization_details():
     )
 
     conn = boto3.client("iam", region_name="us-east-1")
-    boundary = "arn:aws:iam::123456789012:policy/boundary"
+    boundary = "arn:aws:iam::{}:policy/boundary".format(ACCOUNT_ID)
     conn.create_role(
         RoleName="my-role",
         AssumeRolePolicyDocument="some policy",
@@ -1470,10 +1471,10 @@ def test_get_account_authorization_details():
     )
 
     conn.attach_user_policy(
-        UserName="testUser", PolicyArn="arn:aws:iam::123456789012:policy/testPolicy"
+        UserName="testUser", PolicyArn="arn:aws:iam::{}:policy/testPolicy".format(ACCOUNT_ID)
     )
     conn.attach_group_policy(
-        GroupName="testGroup", PolicyArn="arn:aws:iam::123456789012:policy/testPolicy"
+        GroupName="testGroup", PolicyArn="arn:aws:iam::{}:policy/testPolicy".format(ACCOUNT_ID)
     )
 
     conn.add_user_to_group(UserName="testUser", GroupName="testGroup")
@@ -1492,7 +1493,7 @@ def test_get_account_authorization_details():
         RoleName="my-role", PolicyName="test-policy", PolicyDocument=test_policy
     )
     conn.attach_role_policy(
-        RoleName="my-role", PolicyArn="arn:aws:iam::123456789012:policy/testPolicy"
+        RoleName="my-role", PolicyArn="arn:aws:iam::{}:policy/testPolicy".format(ACCOUNT_ID)
     )
 
     result = conn.get_account_authorization_details(Filter=["Role"])
@@ -1509,7 +1510,7 @@ def test_get_account_authorization_details():
         "PermissionsBoundary"
     ] == {
         "PermissionsBoundaryType": "PermissionsBoundaryPolicy",
-        "PermissionsBoundaryArn": "arn:aws:iam::123456789012:policy/boundary",
+        "PermissionsBoundaryArn": "arn:aws:iam::{}:policy/boundary".format(ACCOUNT_ID),
     }
     assert len(result["RoleDetailList"][0]["Tags"]) == 2
     assert len(result["RoleDetailList"][0]["RolePolicyList"]) == 1
@@ -1520,7 +1521,7 @@ def test_get_account_authorization_details():
     )
     assert (
         result["RoleDetailList"][0]["AttachedManagedPolicies"][0]["PolicyArn"]
-        == "arn:aws:iam::123456789012:policy/testPolicy"
+        == "arn:aws:iam::{}:policy/testPolicy".format(ACCOUNT_ID)
     )
 
     result = conn.get_account_authorization_details(Filter=["User"])
@@ -1536,7 +1537,7 @@ def test_get_account_authorization_details():
     )
     assert (
         result["UserDetailList"][0]["AttachedManagedPolicies"][0]["PolicyArn"]
-        == "arn:aws:iam::123456789012:policy/testPolicy"
+        == "arn:aws:iam::{}:policy/testPolicy".format(ACCOUNT_ID)
     )
 
     result = conn.get_account_authorization_details(Filter=["Group"])
@@ -1552,7 +1553,7 @@ def test_get_account_authorization_details():
     )
     assert (
         result["GroupDetailList"][0]["AttachedManagedPolicies"][0]["PolicyArn"]
-        == "arn:aws:iam::123456789012:policy/testPolicy"
+        == "arn:aws:iam::{}:policy/testPolicy".format(ACCOUNT_ID)
     )
 
     result = conn.get_account_authorization_details(Filter=["LocalManagedPolicy"])
@@ -1650,7 +1651,7 @@ def test_create_saml_provider():
         Name="TestSAMLProvider", SAMLMetadataDocument="a" * 1024
     )
     response["SAMLProviderArn"].should.equal(
-        "arn:aws:iam::123456789012:saml-provider/TestSAMLProvider"
+        "arn:aws:iam::{}:saml-provider/TestSAMLProvider".format(ACCOUNT_ID)
     )
 
 
@@ -1672,7 +1673,7 @@ def test_list_saml_providers():
     conn.create_saml_provider(Name="TestSAMLProvider", SAMLMetadataDocument="a" * 1024)
     response = conn.list_saml_providers()
     response["SAMLProviderList"][0]["Arn"].should.equal(
-        "arn:aws:iam::123456789012:saml-provider/TestSAMLProvider"
+        "arn:aws:iam::{}:saml-provider/TestSAMLProvider".format(ACCOUNT_ID)
     )
 
 
@@ -2114,10 +2115,10 @@ def test_list_entities_for_policy():
     )
 
     conn.attach_user_policy(
-        UserName="testUser", PolicyArn="arn:aws:iam::123456789012:policy/testPolicy"
+        UserName="testUser", PolicyArn="arn:aws:iam::{}:policy/testPolicy".format(ACCOUNT_ID)
     )
     conn.attach_group_policy(
-        GroupName="testGroup", PolicyArn="arn:aws:iam::123456789012:policy/testPolicy"
+        GroupName="testGroup", PolicyArn="arn:aws:iam::{}:policy/testPolicy".format(ACCOUNT_ID)
     )
 
     conn.add_user_to_group(UserName="testUser", GroupName="testGroup")
@@ -2136,26 +2137,26 @@ def test_list_entities_for_policy():
         RoleName="my-role", PolicyName="test-policy", PolicyDocument=test_policy
     )
     conn.attach_role_policy(
-        RoleName="my-role", PolicyArn="arn:aws:iam::123456789012:policy/testPolicy"
+        RoleName="my-role", PolicyArn="arn:aws:iam::{}:policy/testPolicy".format(ACCOUNT_ID)
     )
 
     response = conn.list_entities_for_policy(
-        PolicyArn="arn:aws:iam::123456789012:policy/testPolicy", EntityFilter="Role"
+        PolicyArn="arn:aws:iam::{}:policy/testPolicy".format(ACCOUNT_ID), EntityFilter="Role"
     )
     assert response["PolicyRoles"] == [{"RoleName": "my-role"}]
 
     response = conn.list_entities_for_policy(
-        PolicyArn="arn:aws:iam::123456789012:policy/testPolicy", EntityFilter="User"
+        PolicyArn="arn:aws:iam::{}:policy/testPolicy".format(ACCOUNT_ID), EntityFilter="User"
     )
     assert response["PolicyUsers"] == [{"UserName": "testUser"}]
 
     response = conn.list_entities_for_policy(
-        PolicyArn="arn:aws:iam::123456789012:policy/testPolicy", EntityFilter="Group"
+        PolicyArn="arn:aws:iam::{}:policy/testPolicy".format(ACCOUNT_ID), EntityFilter="Group"
     )
     assert response["PolicyGroups"] == [{"GroupName": "testGroup"}]
 
     response = conn.list_entities_for_policy(
-        PolicyArn="arn:aws:iam::123456789012:policy/testPolicy",
+        PolicyArn="arn:aws:iam::{}:policy/testPolicy".format(ACCOUNT_ID),
         EntityFilter="LocalManagedPolicy",
     )
     assert response["PolicyGroups"] == [{"GroupName": "testGroup"}]
@@ -2169,7 +2170,7 @@ def test_create_role_no_path():
     resp = conn.create_role(
         RoleName="my-role", AssumeRolePolicyDocument="some policy", Description="test"
     )
-    resp.get("Role").get("Arn").should.equal("arn:aws:iam::123456789012:role/my-role")
+    resp.get("Role").get("Arn").should.equal("arn:aws:iam::{}:role/my-role".format(ACCOUNT_ID))
     resp.get("Role").should_not.have.key("PermissionsBoundary")
     resp.get("Role").get("Description").should.equal("test")
 
@@ -2177,7 +2178,7 @@ def test_create_role_no_path():
 @mock_iam()
 def test_create_role_with_permissions_boundary():
     conn = boto3.client("iam", region_name="us-east-1")
-    boundary = "arn:aws:iam::123456789012:policy/boundary"
+    boundary = "arn:aws:iam::{}:policy/boundary".format(ACCOUNT_ID)
     resp = conn.create_role(
         RoleName="my-role",
         AssumeRolePolicyDocument="some policy",
@@ -2249,7 +2250,7 @@ def test_create_open_id_connect_provider():
     )
 
     response["OpenIDConnectProviderArn"].should.equal(
-        "arn:aws:iam::123456789012:oidc-provider/example.com"
+        "arn:aws:iam::{}:oidc-provider/example.com".format(ACCOUNT_ID)
     )
 
     response = client.create_open_id_connect_provider(
@@ -2257,7 +2258,7 @@ def test_create_open_id_connect_provider():
     )
 
     response["OpenIDConnectProviderArn"].should.equal(
-        "arn:aws:iam::123456789012:oidc-provider/example.org"
+        "arn:aws:iam::{}:oidc-provider/example.org".format(ACCOUNT_ID)
     )
 
     response = client.create_open_id_connect_provider(
@@ -2265,7 +2266,7 @@ def test_create_open_id_connect_provider():
     )
 
     response["OpenIDConnectProviderArn"].should.equal(
-        "arn:aws:iam::123456789012:oidc-provider/example.org/oidc"
+        "arn:aws:iam::{}:oidc-provider/example.org/oidc".format(ACCOUNT_ID)
     )
 
     response = client.create_open_id_connect_provider(
@@ -2273,7 +2274,7 @@ def test_create_open_id_connect_provider():
     )
 
     response["OpenIDConnectProviderArn"].should.equal(
-        "arn:aws:iam::123456789012:oidc-provider/example.org/oidc-query"
+        "arn:aws:iam::{}:oidc-provider/example.org/oidc-query".format(ACCOUNT_ID)
     )
 
 
@@ -2487,7 +2488,7 @@ def test_get_account_password_policy_errors():
 
     client.get_account_password_policy.when.called_with().should.throw(
         ClientError,
-        "The Password Policy with domain name 123456789012 cannot be found.",
+        "The Password Policy with domain name {} cannot be found.".format(ACCOUNT_ID),
     )
 
 
@@ -2504,7 +2505,7 @@ def test_delete_account_password_policy():
 
     client.get_account_password_policy.when.called_with().should.throw(
         ClientError,
-        "The Password Policy with domain name 123456789012 cannot be found.",
+        "The Password Policy with domain name {} cannot be found.".format(ACCOUNT_ID),
     )
 
 

--- a/tests/test_iam/test_iam.py
+++ b/tests/test_iam/test_iam.py
@@ -13,7 +13,7 @@ from dateutil.tz import tzutc
 
 from moto import mock_iam, mock_iam_deprecated
 from moto.iam.models import aws_managed_policies
-from moto.iam.models import ACCOUNT_ID
+from moto.core import ACCOUNT_ID
 from nose.tools import assert_raises, assert_equals
 from nose.tools import raises
 

--- a/tests/test_iam/test_iam.py
+++ b/tests/test_iam/test_iam.py
@@ -84,7 +84,9 @@ def test_get_all_server_certs():
     certs.should.have.length_of(1)
     cert1 = certs[0]
     cert1.server_certificate_name.should.equal("certname")
-    cert1.arn.should.equal("arn:aws:iam::{}:server-certificate/certname".format(ACCOUNT_ID))
+    cert1.arn.should.equal(
+        "arn:aws:iam::{}:server-certificate/certname".format(ACCOUNT_ID)
+    )
 
 
 @mock_iam_deprecated()
@@ -102,7 +104,9 @@ def test_get_server_cert():
     conn.upload_server_cert("certname", "certbody", "privatekey")
     cert = conn.get_server_certificate("certname")
     cert.server_certificate_name.should.equal("certname")
-    cert.arn.should.equal("arn:aws:iam::{}:server-certificate/certname".format(ACCOUNT_ID))
+    cert.arn.should.equal(
+        "arn:aws:iam::{}:server-certificate/certname".format(ACCOUNT_ID)
+    )
 
 
 @mock_iam_deprecated()
@@ -112,7 +116,9 @@ def test_upload_server_cert():
     conn.upload_server_cert("certname", "certbody", "privatekey")
     cert = conn.get_server_certificate("certname")
     cert.server_certificate_name.should.equal("certname")
-    cert.arn.should.equal("arn:aws:iam::{}:server-certificate/certname".format(ACCOUNT_ID))
+    cert.arn.should.equal(
+        "arn:aws:iam::{}:server-certificate/certname".format(ACCOUNT_ID)
+    )
 
 
 @mock_iam_deprecated()
@@ -443,7 +449,9 @@ def test_create_policy_versions():
     conn = boto3.client("iam", region_name="us-east-1")
     with assert_raises(ClientError):
         conn.create_policy_version(
-            PolicyArn="arn:aws:iam::{}:policy/TestCreatePolicyVersion".format(ACCOUNT_ID),
+            PolicyArn="arn:aws:iam::{}:policy/TestCreatePolicyVersion".format(
+                ACCOUNT_ID
+            ),
             PolicyDocument='{"some":"policy"}',
         )
     conn.create_policy(PolicyName="TestCreatePolicyVersion", PolicyDocument=MOCK_POLICY)
@@ -475,12 +483,16 @@ def test_create_many_policy_versions():
     )
     for _ in range(0, 4):
         conn.create_policy_version(
-            PolicyArn="arn:aws:iam::{}:policy/TestCreateManyPolicyVersions".format(ACCOUNT_ID),
+            PolicyArn="arn:aws:iam::{}:policy/TestCreateManyPolicyVersions".format(
+                ACCOUNT_ID
+            ),
             PolicyDocument=MOCK_POLICY,
         )
     with assert_raises(ClientError):
         conn.create_policy_version(
-            PolicyArn="arn:aws:iam::{}:policy/TestCreateManyPolicyVersions".format(ACCOUNT_ID),
+            PolicyArn="arn:aws:iam::{}:policy/TestCreateManyPolicyVersions".format(
+                ACCOUNT_ID
+            ),
             PolicyDocument=MOCK_POLICY,
         )
 
@@ -492,17 +504,23 @@ def test_set_default_policy_version():
         PolicyName="TestSetDefaultPolicyVersion", PolicyDocument=MOCK_POLICY
     )
     conn.create_policy_version(
-        PolicyArn="arn:aws:iam::{}:policy/TestSetDefaultPolicyVersion".format(ACCOUNT_ID),
+        PolicyArn="arn:aws:iam::{}:policy/TestSetDefaultPolicyVersion".format(
+            ACCOUNT_ID
+        ),
         PolicyDocument=MOCK_POLICY_2,
         SetAsDefault=True,
     )
     conn.create_policy_version(
-        PolicyArn="arn:aws:iam::{}:policy/TestSetDefaultPolicyVersion".format(ACCOUNT_ID),
+        PolicyArn="arn:aws:iam::{}:policy/TestSetDefaultPolicyVersion".format(
+            ACCOUNT_ID
+        ),
         PolicyDocument=MOCK_POLICY_3,
         SetAsDefault=True,
     )
     versions = conn.list_policy_versions(
-        PolicyArn="arn:aws:iam::{}:policy/TestSetDefaultPolicyVersion".format(ACCOUNT_ID)
+        PolicyArn="arn:aws:iam::{}:policy/TestSetDefaultPolicyVersion".format(
+            ACCOUNT_ID
+        )
     )
     versions.get("Versions")[0].get("Document").should.equal(json.loads(MOCK_POLICY))
     versions.get("Versions")[0].get("IsDefaultVersion").shouldnt.be.ok
@@ -518,7 +536,9 @@ def test_get_policy():
     response = conn.create_policy(
         PolicyName="TestGetPolicy", PolicyDocument=MOCK_POLICY
     )
-    policy = conn.get_policy(PolicyArn="arn:aws:iam::{}:policy/TestGetPolicy".format(ACCOUNT_ID))
+    policy = conn.get_policy(
+        PolicyArn="arn:aws:iam::{}:policy/TestGetPolicy".format(ACCOUNT_ID)
+    )
     policy["Policy"]["Arn"].should.equal(
         "arn:aws:iam::{}:policy/TestGetPolicy".format(ACCOUNT_ID)
     )
@@ -638,7 +658,9 @@ def test_delete_policy_version():
     )
     with assert_raises(ClientError):
         conn.delete_policy_version(
-            PolicyArn="arn:aws:iam::{}:policy/TestDeletePolicyVersion".format(ACCOUNT_ID),
+            PolicyArn="arn:aws:iam::{}:policy/TestDeletePolicyVersion".format(
+                ACCOUNT_ID
+            ),
             VersionId="v2-nope-this-does-not-exist",
         )
     conn.delete_policy_version(
@@ -661,7 +683,9 @@ def test_delete_default_policy_version():
     )
     with assert_raises(ClientError):
         conn.delete_policy_version(
-            PolicyArn="arn:aws:iam::{}:policy/TestDeletePolicyVersion".format(ACCOUNT_ID),
+            PolicyArn="arn:aws:iam::{}:policy/TestDeletePolicyVersion".format(
+                ACCOUNT_ID
+            ),
             VersionId="v1",
         )
 
@@ -840,7 +864,9 @@ def test_create_virtual_mfa_device():
     response = client.create_virtual_mfa_device(VirtualMFADeviceName="test-device")
     device = response["VirtualMFADevice"]
 
-    device["SerialNumber"].should.equal("arn:aws:iam::{}:mfa/test-device".format(ACCOUNT_ID))
+    device["SerialNumber"].should.equal(
+        "arn:aws:iam::{}:mfa/test-device".format(ACCOUNT_ID)
+    )
     device["Base32StringSeed"].decode("ascii").should.match("[A-Z234567]")
     device["QRCodePNG"].should_not.be.empty
 
@@ -849,7 +875,9 @@ def test_create_virtual_mfa_device():
     )
     device = response["VirtualMFADevice"]
 
-    device["SerialNumber"].should.equal("arn:aws:iam::{}:mfa/test-device-2".format(ACCOUNT_ID))
+    device["SerialNumber"].should.equal(
+        "arn:aws:iam::{}:mfa/test-device-2".format(ACCOUNT_ID)
+    )
     device["Base32StringSeed"].decode("ascii").should.match("[A-Z234567]")
     device["QRCodePNG"].should_not.be.empty
 
@@ -1010,7 +1038,9 @@ def test_enable_virtual_mfa_device():
     device["User"]["Path"].should.equal("/")
     device["User"]["UserName"].should.equal("test-user")
     device["User"]["UserId"].should_not.be.empty
-    device["User"]["Arn"].should.equal("arn:aws:iam::{}:user/test-user".format(ACCOUNT_ID))
+    device["User"]["Arn"].should.equal(
+        "arn:aws:iam::{}:user/test-user".format(ACCOUNT_ID)
+    )
     device["User"]["CreateDate"].should.be.a(datetime)
     device["EnableDate"].should.be.a(datetime)
     response["IsTruncated"].should_not.be.ok
@@ -1471,10 +1501,12 @@ def test_get_account_authorization_details():
     )
 
     conn.attach_user_policy(
-        UserName="testUser", PolicyArn="arn:aws:iam::{}:policy/testPolicy".format(ACCOUNT_ID)
+        UserName="testUser",
+        PolicyArn="arn:aws:iam::{}:policy/testPolicy".format(ACCOUNT_ID),
     )
     conn.attach_group_policy(
-        GroupName="testGroup", PolicyArn="arn:aws:iam::{}:policy/testPolicy".format(ACCOUNT_ID)
+        GroupName="testGroup",
+        PolicyArn="arn:aws:iam::{}:policy/testPolicy".format(ACCOUNT_ID),
     )
 
     conn.add_user_to_group(UserName="testUser", GroupName="testGroup")
@@ -1493,7 +1525,8 @@ def test_get_account_authorization_details():
         RoleName="my-role", PolicyName="test-policy", PolicyDocument=test_policy
     )
     conn.attach_role_policy(
-        RoleName="my-role", PolicyArn="arn:aws:iam::{}:policy/testPolicy".format(ACCOUNT_ID)
+        RoleName="my-role",
+        PolicyArn="arn:aws:iam::{}:policy/testPolicy".format(ACCOUNT_ID),
     )
 
     result = conn.get_account_authorization_details(Filter=["Role"])
@@ -1519,10 +1552,9 @@ def test_get_account_authorization_details():
         result["RoleDetailList"][0]["AttachedManagedPolicies"][0]["PolicyName"]
         == "testPolicy"
     )
-    assert (
-        result["RoleDetailList"][0]["AttachedManagedPolicies"][0]["PolicyArn"]
-        == "arn:aws:iam::{}:policy/testPolicy".format(ACCOUNT_ID)
-    )
+    assert result["RoleDetailList"][0]["AttachedManagedPolicies"][0][
+        "PolicyArn"
+    ] == "arn:aws:iam::{}:policy/testPolicy".format(ACCOUNT_ID)
 
     result = conn.get_account_authorization_details(Filter=["User"])
     assert len(result["RoleDetailList"]) == 0
@@ -1535,10 +1567,9 @@ def test_get_account_authorization_details():
         result["UserDetailList"][0]["AttachedManagedPolicies"][0]["PolicyName"]
         == "testPolicy"
     )
-    assert (
-        result["UserDetailList"][0]["AttachedManagedPolicies"][0]["PolicyArn"]
-        == "arn:aws:iam::{}:policy/testPolicy".format(ACCOUNT_ID)
-    )
+    assert result["UserDetailList"][0]["AttachedManagedPolicies"][0][
+        "PolicyArn"
+    ] == "arn:aws:iam::{}:policy/testPolicy".format(ACCOUNT_ID)
 
     result = conn.get_account_authorization_details(Filter=["Group"])
     assert len(result["RoleDetailList"]) == 0
@@ -1551,10 +1582,9 @@ def test_get_account_authorization_details():
         result["GroupDetailList"][0]["AttachedManagedPolicies"][0]["PolicyName"]
         == "testPolicy"
     )
-    assert (
-        result["GroupDetailList"][0]["AttachedManagedPolicies"][0]["PolicyArn"]
-        == "arn:aws:iam::{}:policy/testPolicy".format(ACCOUNT_ID)
-    )
+    assert result["GroupDetailList"][0]["AttachedManagedPolicies"][0][
+        "PolicyArn"
+    ] == "arn:aws:iam::{}:policy/testPolicy".format(ACCOUNT_ID)
 
     result = conn.get_account_authorization_details(Filter=["LocalManagedPolicy"])
     assert len(result["RoleDetailList"]) == 0
@@ -2115,10 +2145,12 @@ def test_list_entities_for_policy():
     )
 
     conn.attach_user_policy(
-        UserName="testUser", PolicyArn="arn:aws:iam::{}:policy/testPolicy".format(ACCOUNT_ID)
+        UserName="testUser",
+        PolicyArn="arn:aws:iam::{}:policy/testPolicy".format(ACCOUNT_ID),
     )
     conn.attach_group_policy(
-        GroupName="testGroup", PolicyArn="arn:aws:iam::{}:policy/testPolicy".format(ACCOUNT_ID)
+        GroupName="testGroup",
+        PolicyArn="arn:aws:iam::{}:policy/testPolicy".format(ACCOUNT_ID),
     )
 
     conn.add_user_to_group(UserName="testUser", GroupName="testGroup")
@@ -2137,21 +2169,25 @@ def test_list_entities_for_policy():
         RoleName="my-role", PolicyName="test-policy", PolicyDocument=test_policy
     )
     conn.attach_role_policy(
-        RoleName="my-role", PolicyArn="arn:aws:iam::{}:policy/testPolicy".format(ACCOUNT_ID)
+        RoleName="my-role",
+        PolicyArn="arn:aws:iam::{}:policy/testPolicy".format(ACCOUNT_ID),
     )
 
     response = conn.list_entities_for_policy(
-        PolicyArn="arn:aws:iam::{}:policy/testPolicy".format(ACCOUNT_ID), EntityFilter="Role"
+        PolicyArn="arn:aws:iam::{}:policy/testPolicy".format(ACCOUNT_ID),
+        EntityFilter="Role",
     )
     assert response["PolicyRoles"] == [{"RoleName": "my-role"}]
 
     response = conn.list_entities_for_policy(
-        PolicyArn="arn:aws:iam::{}:policy/testPolicy".format(ACCOUNT_ID), EntityFilter="User"
+        PolicyArn="arn:aws:iam::{}:policy/testPolicy".format(ACCOUNT_ID),
+        EntityFilter="User",
     )
     assert response["PolicyUsers"] == [{"UserName": "testUser"}]
 
     response = conn.list_entities_for_policy(
-        PolicyArn="arn:aws:iam::{}:policy/testPolicy".format(ACCOUNT_ID), EntityFilter="Group"
+        PolicyArn="arn:aws:iam::{}:policy/testPolicy".format(ACCOUNT_ID),
+        EntityFilter="Group",
     )
     assert response["PolicyGroups"] == [{"GroupName": "testGroup"}]
 
@@ -2170,7 +2206,9 @@ def test_create_role_no_path():
     resp = conn.create_role(
         RoleName="my-role", AssumeRolePolicyDocument="some policy", Description="test"
     )
-    resp.get("Role").get("Arn").should.equal("arn:aws:iam::{}:role/my-role".format(ACCOUNT_ID))
+    resp.get("Role").get("Arn").should.equal(
+        "arn:aws:iam::{}:role/my-role".format(ACCOUNT_ID)
+    )
     resp.get("Role").should_not.have.key("PermissionsBoundary")
     resp.get("Role").get("Description").should.equal("test")
 

--- a/tests/test_iam/test_iam_groups.py
+++ b/tests/test_iam/test_iam_groups.py
@@ -10,7 +10,7 @@ from nose.tools import assert_raises
 from boto.exception import BotoServerError
 from botocore.exceptions import ClientError
 from moto import mock_iam, mock_iam_deprecated
-from moto.iam.models import ACCOUNT_ID
+from moto.core import ACCOUNT_ID
 
 MOCK_POLICY = """
 {

--- a/tests/test_iam/test_iam_groups.py
+++ b/tests/test_iam/test_iam_groups.py
@@ -58,10 +58,9 @@ def test_get_group_current():
     # Make a group with a different path:
     other_group = conn.create_group(GroupName="my-other-group", Path="some/location")
     assert other_group["Group"]["Path"] == "some/location"
-    assert (
-        other_group["Group"]["Arn"]
-        == "arn:aws:iam::{}:group/some/location/my-other-group".format(ACCOUNT_ID)
-    )
+    assert other_group["Group"][
+        "Arn"
+    ] == "arn:aws:iam::{}:group/some/location/my-other-group".format(ACCOUNT_ID)
 
 
 @mock_iam_deprecated()

--- a/tests/test_iam/test_iam_groups.py
+++ b/tests/test_iam/test_iam_groups.py
@@ -10,6 +10,7 @@ from nose.tools import assert_raises
 from boto.exception import BotoServerError
 from botocore.exceptions import ClientError
 from moto import mock_iam, mock_iam_deprecated
+from moto.iam.models import ACCOUNT_ID
 
 MOCK_POLICY = """
 {
@@ -51,7 +52,7 @@ def test_get_group_current():
     assert result["Group"]["GroupName"] == "my-group"
     assert isinstance(result["Group"]["CreateDate"], datetime)
     assert result["Group"]["GroupId"]
-    assert result["Group"]["Arn"] == "arn:aws:iam::123456789012:group/my-group"
+    assert result["Group"]["Arn"] == "arn:aws:iam::{}:group/my-group".format(ACCOUNT_ID)
     assert not result["Users"]
 
     # Make a group with a different path:
@@ -59,7 +60,7 @@ def test_get_group_current():
     assert other_group["Group"]["Path"] == "some/location"
     assert (
         other_group["Group"]["Arn"]
-        == "arn:aws:iam::123456789012:group/some/location/my-other-group"
+        == "arn:aws:iam::{}:group/some/location/my-other-group".format(ACCOUNT_ID)
     )
 
 

--- a/tests/test_kinesis/test_firehose.py
+++ b/tests/test_kinesis/test_firehose.py
@@ -7,7 +7,7 @@ import boto3
 import sure  # noqa
 
 from moto import mock_kinesis
-from moto.iam.models import ACCOUNT_ID
+from moto.core import ACCOUNT_ID
 
 
 def create_s3_delivery_stream(client, stream_name):

--- a/tests/test_kinesis/test_firehose.py
+++ b/tests/test_kinesis/test_firehose.py
@@ -7,6 +7,7 @@ import boto3
 import sure  # noqa
 
 from moto import mock_kinesis
+from moto.iam.models import ACCOUNT_ID
 
 
 def create_s3_delivery_stream(client, stream_name):
@@ -14,7 +15,7 @@ def create_s3_delivery_stream(client, stream_name):
         DeliveryStreamName=stream_name,
         DeliveryStreamType="DirectPut",
         ExtendedS3DestinationConfiguration={
-            "RoleARN": "arn:aws:iam::123456789012:role/firehose_delivery_role",
+            "RoleARN": "arn:aws:iam::{}:role/firehose_delivery_role".format(ACCOUNT_ID),
             "BucketARN": "arn:aws:s3:::kinesis-test",
             "Prefix": "myFolder/",
             "CompressionFormat": "UNCOMPRESSED",
@@ -26,7 +27,7 @@ def create_s3_delivery_stream(client, stream_name):
                 },
                 "SchemaConfiguration": {
                     "DatabaseName": stream_name,
-                    "RoleARN": "arn:aws:iam::123456789012:role/firehose_delivery_role",
+                    "RoleARN": "arn:aws:iam::{}:role/firehose_delivery_role".format(ACCOUNT_ID),
                     "TableName": "outputTable",
                 },
             },
@@ -38,7 +39,7 @@ def create_redshift_delivery_stream(client, stream_name):
     return client.create_delivery_stream(
         DeliveryStreamName=stream_name,
         RedshiftDestinationConfiguration={
-            "RoleARN": "arn:aws:iam::123456789012:role/firehose_delivery_role",
+            "RoleARN": "arn:aws:iam::{}:role/firehose_delivery_role".format(ACCOUNT_ID),
             "ClusterJDBCURL": "jdbc:redshift://host.amazonaws.com:5439/database",
             "CopyCommand": {
                 "DataTableName": "outputTable",
@@ -47,7 +48,7 @@ def create_redshift_delivery_stream(client, stream_name):
             "Username": "username",
             "Password": "password",
             "S3Configuration": {
-                "RoleARN": "arn:aws:iam::123456789012:role/firehose_delivery_role",
+                "RoleARN": "arn:aws:iam::{}:role/firehose_delivery_role".format(ACCOUNT_ID),
                 "BucketARN": "arn:aws:s3:::kinesis-test",
                 "Prefix": "myFolder/",
                 "BufferingHints": {"SizeInMBs": 123, "IntervalInSeconds": 124},
@@ -81,7 +82,7 @@ def test_create_redshift_delivery_stream():
                 {
                     "DestinationId": "string",
                     "RedshiftDestinationDescription": {
-                        "RoleARN": "arn:aws:iam::123456789012:role/firehose_delivery_role",
+                        "RoleARN": "arn:aws:iam::{}:role/firehose_delivery_role".format(ACCOUNT_ID),
                         "ClusterJDBCURL": "jdbc:redshift://host.amazonaws.com:5439/database",
                         "CopyCommand": {
                             "DataTableName": "outputTable",
@@ -89,7 +90,7 @@ def test_create_redshift_delivery_stream():
                         },
                         "Username": "username",
                         "S3DestinationDescription": {
-                            "RoleARN": "arn:aws:iam::123456789012:role/firehose_delivery_role",
+                            "RoleARN": "arn:aws:iam::{}:role/firehose_delivery_role".format(ACCOUNT_ID),
                             "BucketARN": "arn:aws:s3:::kinesis-test",
                             "Prefix": "myFolder/",
                             "BufferingHints": {
@@ -130,7 +131,7 @@ def test_create_s3_delivery_stream():
                 {
                     "DestinationId": "string",
                     "ExtendedS3DestinationDescription": {
-                        "RoleARN": "arn:aws:iam::123456789012:role/firehose_delivery_role",
+                        "RoleARN": "arn:aws:iam::{}:role/firehose_delivery_role".format(ACCOUNT_ID),
                         "BucketARN": "arn:aws:s3:::kinesis-test",
                         "Prefix": "myFolder/",
                         "CompressionFormat": "UNCOMPRESSED",
@@ -146,7 +147,7 @@ def test_create_s3_delivery_stream():
                             },
                             "SchemaConfiguration": {
                                 "DatabaseName": "stream1",
-                                "RoleARN": "arn:aws:iam::123456789012:role/firehose_delivery_role",
+                                "RoleARN": "arn:aws:iam::{}:role/firehose_delivery_role".format(ACCOUNT_ID),
                                 "TableName": "outputTable",
                             },
                         },
@@ -165,7 +166,7 @@ def test_create_stream_without_redshift():
     response = client.create_delivery_stream(
         DeliveryStreamName="stream1",
         S3DestinationConfiguration={
-            "RoleARN": "arn:aws:iam::123456789012:role/firehose_delivery_role",
+            "RoleARN": "arn:aws:iam::{}:role/firehose_delivery_role".format(ACCOUNT_ID),
             "BucketARN": "arn:aws:s3:::kinesis-test",
             "Prefix": "myFolder/",
             "BufferingHints": {"SizeInMBs": 123, "IntervalInSeconds": 124},
@@ -191,8 +192,8 @@ def test_create_stream_without_redshift():
                 {
                     "DestinationId": "string",
                     "S3DestinationDescription": {
-                        "RoleARN": "arn:aws:iam::123456789012:role/firehose_delivery_role",
-                        "RoleARN": "arn:aws:iam::123456789012:role/firehose_delivery_role",
+                        "RoleARN": "arn:aws:iam::{}:role/firehose_delivery_role".format(ACCOUNT_ID),
+                        "RoleARN": "arn:aws:iam::{}:role/firehose_delivery_role".format(ACCOUNT_ID),
                         "BucketARN": "arn:aws:s3:::kinesis-test",
                         "Prefix": "myFolder/",
                         "BufferingHints": {"SizeInMBs": 123, "IntervalInSeconds": 124},

--- a/tests/test_kinesis/test_firehose.py
+++ b/tests/test_kinesis/test_firehose.py
@@ -27,7 +27,9 @@ def create_s3_delivery_stream(client, stream_name):
                 },
                 "SchemaConfiguration": {
                     "DatabaseName": stream_name,
-                    "RoleARN": "arn:aws:iam::{}:role/firehose_delivery_role".format(ACCOUNT_ID),
+                    "RoleARN": "arn:aws:iam::{}:role/firehose_delivery_role".format(
+                        ACCOUNT_ID
+                    ),
                     "TableName": "outputTable",
                 },
             },
@@ -48,7 +50,9 @@ def create_redshift_delivery_stream(client, stream_name):
             "Username": "username",
             "Password": "password",
             "S3Configuration": {
-                "RoleARN": "arn:aws:iam::{}:role/firehose_delivery_role".format(ACCOUNT_ID),
+                "RoleARN": "arn:aws:iam::{}:role/firehose_delivery_role".format(
+                    ACCOUNT_ID
+                ),
                 "BucketARN": "arn:aws:s3:::kinesis-test",
                 "Prefix": "myFolder/",
                 "BufferingHints": {"SizeInMBs": 123, "IntervalInSeconds": 124},
@@ -82,7 +86,9 @@ def test_create_redshift_delivery_stream():
                 {
                     "DestinationId": "string",
                     "RedshiftDestinationDescription": {
-                        "RoleARN": "arn:aws:iam::{}:role/firehose_delivery_role".format(ACCOUNT_ID),
+                        "RoleARN": "arn:aws:iam::{}:role/firehose_delivery_role".format(
+                            ACCOUNT_ID
+                        ),
                         "ClusterJDBCURL": "jdbc:redshift://host.amazonaws.com:5439/database",
                         "CopyCommand": {
                             "DataTableName": "outputTable",
@@ -90,7 +96,9 @@ def test_create_redshift_delivery_stream():
                         },
                         "Username": "username",
                         "S3DestinationDescription": {
-                            "RoleARN": "arn:aws:iam::{}:role/firehose_delivery_role".format(ACCOUNT_ID),
+                            "RoleARN": "arn:aws:iam::{}:role/firehose_delivery_role".format(
+                                ACCOUNT_ID
+                            ),
                             "BucketARN": "arn:aws:s3:::kinesis-test",
                             "Prefix": "myFolder/",
                             "BufferingHints": {
@@ -131,7 +139,9 @@ def test_create_s3_delivery_stream():
                 {
                     "DestinationId": "string",
                     "ExtendedS3DestinationDescription": {
-                        "RoleARN": "arn:aws:iam::{}:role/firehose_delivery_role".format(ACCOUNT_ID),
+                        "RoleARN": "arn:aws:iam::{}:role/firehose_delivery_role".format(
+                            ACCOUNT_ID
+                        ),
                         "BucketARN": "arn:aws:s3:::kinesis-test",
                         "Prefix": "myFolder/",
                         "CompressionFormat": "UNCOMPRESSED",
@@ -147,7 +157,9 @@ def test_create_s3_delivery_stream():
                             },
                             "SchemaConfiguration": {
                                 "DatabaseName": "stream1",
-                                "RoleARN": "arn:aws:iam::{}:role/firehose_delivery_role".format(ACCOUNT_ID),
+                                "RoleARN": "arn:aws:iam::{}:role/firehose_delivery_role".format(
+                                    ACCOUNT_ID
+                                ),
                                 "TableName": "outputTable",
                             },
                         },
@@ -192,8 +204,12 @@ def test_create_stream_without_redshift():
                 {
                     "DestinationId": "string",
                     "S3DestinationDescription": {
-                        "RoleARN": "arn:aws:iam::{}:role/firehose_delivery_role".format(ACCOUNT_ID),
-                        "RoleARN": "arn:aws:iam::{}:role/firehose_delivery_role".format(ACCOUNT_ID),
+                        "RoleARN": "arn:aws:iam::{}:role/firehose_delivery_role".format(
+                            ACCOUNT_ID
+                        ),
+                        "RoleARN": "arn:aws:iam::{}:role/firehose_delivery_role".format(
+                            ACCOUNT_ID
+                        ),
                         "BucketARN": "arn:aws:s3:::kinesis-test",
                         "Prefix": "myFolder/",
                         "BufferingHints": {"SizeInMBs": 123, "IntervalInSeconds": 124},

--- a/tests/test_kinesis/test_kinesis.py
+++ b/tests/test_kinesis/test_kinesis.py
@@ -22,7 +22,9 @@ def test_create_cluster():
     stream = stream_response["StreamDescription"]
     stream["StreamName"].should.equal("my_stream")
     stream["HasMoreShards"].should.equal(False)
-    stream["StreamARN"].should.equal("arn:aws:kinesis:us-west-2:{}:my_stream".format(ACCOUNT_ID))
+    stream["StreamARN"].should.equal(
+        "arn:aws:kinesis:us-west-2:{}:my_stream".format(ACCOUNT_ID)
+    )
     stream["StreamStatus"].should.equal("ACTIVE")
 
     shards = stream["Shards"]

--- a/tests/test_kinesis/test_kinesis.py
+++ b/tests/test_kinesis/test_kinesis.py
@@ -8,7 +8,7 @@ import boto3
 from boto.kinesis.exceptions import ResourceNotFoundException, InvalidArgumentException
 
 from moto import mock_kinesis, mock_kinesis_deprecated
-from moto.iam.models import ACCOUNT_ID
+from moto.core import ACCOUNT_ID
 
 
 @mock_kinesis_deprecated

--- a/tests/test_kinesis/test_kinesis.py
+++ b/tests/test_kinesis/test_kinesis.py
@@ -8,6 +8,7 @@ import boto3
 from boto.kinesis.exceptions import ResourceNotFoundException, InvalidArgumentException
 
 from moto import mock_kinesis, mock_kinesis_deprecated
+from moto.iam.models import ACCOUNT_ID
 
 
 @mock_kinesis_deprecated
@@ -21,7 +22,7 @@ def test_create_cluster():
     stream = stream_response["StreamDescription"]
     stream["StreamName"].should.equal("my_stream")
     stream["HasMoreShards"].should.equal(False)
-    stream["StreamARN"].should.equal("arn:aws:kinesis:us-west-2:123456789012:my_stream")
+    stream["StreamARN"].should.equal("arn:aws:kinesis:us-west-2:{}:my_stream".format(ACCOUNT_ID))
     stream["StreamStatus"].should.equal("ACTIVE")
 
     shards = stream["Shards"]
@@ -87,7 +88,7 @@ def test_describe_stream_summary():
     stream["StreamName"].should.equal(stream_name)
     stream["OpenShardCount"].should.equal(shard_count)
     stream["StreamARN"].should.equal(
-        "arn:aws:kinesis:us-west-2:123456789012:{}".format(stream_name)
+        "arn:aws:kinesis:us-west-2:{}:{}".format(ACCOUNT_ID, stream_name)
     )
     stream["StreamStatus"].should.equal("ACTIVE")
 

--- a/tests/test_redshift/test_redshift.py
+++ b/tests/test_redshift/test_redshift.py
@@ -18,7 +18,7 @@ from moto import mock_ec2
 from moto import mock_ec2_deprecated
 from moto import mock_redshift
 from moto import mock_redshift_deprecated
-
+from moto.iam.models import ACCOUNT_ID
 
 @mock_redshift
 def test_create_cluster_boto3():
@@ -998,12 +998,12 @@ def test_create_cluster_status_update():
 def test_describe_tags_with_resource_type():
     client = boto3.client("redshift", region_name="us-east-1")
     cluster_identifier = "my_cluster"
-    cluster_arn = "arn:aws:redshift:us-east-1:123456789012:" "cluster:{}".format(
-        cluster_identifier
+    cluster_arn = "arn:aws:redshift:us-east-1:{}:" "cluster:{}".format(
+        ACCOUNT_ID, cluster_identifier
     )
     snapshot_identifier = "my_snapshot"
-    snapshot_arn = "arn:aws:redshift:us-east-1:123456789012:" "snapshot:{}/{}".format(
-        cluster_identifier, snapshot_identifier
+    snapshot_arn = "arn:aws:redshift:us-east-1:{}:" "snapshot:{}/{}".format(
+        ACCOUNT_ID, cluster_identifier, snapshot_identifier
     )
     tag_key = "test-tag-key"
     tag_value = "test-tag-value"
@@ -1044,7 +1044,7 @@ def test_describe_tags_with_resource_type():
 @mock_redshift
 def test_describe_tags_cannot_specify_resource_type_and_resource_name():
     client = boto3.client("redshift", region_name="us-east-1")
-    resource_name = "arn:aws:redshift:us-east-1:123456789012:cluster:cluster-id"
+    resource_name = "arn:aws:redshift:us-east-1:{}:cluster:cluster-id".format(ACCOUNT_ID)
     resource_type = "cluster"
     client.describe_tags.when.called_with(
         ResourceName=resource_name, ResourceType=resource_type
@@ -1055,12 +1055,12 @@ def test_describe_tags_cannot_specify_resource_type_and_resource_name():
 def test_describe_tags_with_resource_name():
     client = boto3.client("redshift", region_name="us-east-1")
     cluster_identifier = "cluster-id"
-    cluster_arn = "arn:aws:redshift:us-east-1:123456789012:" "cluster:{}".format(
-        cluster_identifier
+    cluster_arn = "arn:aws:redshift:us-east-1:{}:" "cluster:{}".format(
+        ACCOUNT_ID, cluster_identifier
     )
     snapshot_identifier = "snapshot-id"
-    snapshot_arn = "arn:aws:redshift:us-east-1:123456789012:" "snapshot:{}/{}".format(
-        cluster_identifier, snapshot_identifier
+    snapshot_arn = "arn:aws:redshift:us-east-1:{}:" "snapshot:{}/{}".format(
+        ACCOUNT_ID, cluster_identifier, snapshot_identifier
     )
     tag_key = "test-tag-key"
     tag_value = "test-tag-value"
@@ -1102,8 +1102,8 @@ def test_describe_tags_with_resource_name():
 def test_create_tags():
     client = boto3.client("redshift", region_name="us-east-1")
     cluster_identifier = "cluster-id"
-    cluster_arn = "arn:aws:redshift:us-east-1:123456789012:" "cluster:{}".format(
-        cluster_identifier
+    cluster_arn = "arn:aws:redshift:us-east-1:{}:" "cluster:{}".format(
+        ACCOUNT_ID, cluster_identifier
     )
     tag_key = "test-tag-key"
     tag_value = "test-tag-value"
@@ -1133,8 +1133,8 @@ def test_create_tags():
 def test_delete_tags():
     client = boto3.client("redshift", region_name="us-east-1")
     cluster_identifier = "cluster-id"
-    cluster_arn = "arn:aws:redshift:us-east-1:123456789012:" "cluster:{}".format(
-        cluster_identifier
+    cluster_arn = "arn:aws:redshift:us-east-1:{}:" "cluster:{}".format(
+        ACCOUNT_ID, cluster_identifier
     )
     tag_key = "test-tag-key"
     tag_value = "test-tag-value"

--- a/tests/test_redshift/test_redshift.py
+++ b/tests/test_redshift/test_redshift.py
@@ -20,6 +20,7 @@ from moto import mock_redshift
 from moto import mock_redshift_deprecated
 from moto.core import ACCOUNT_ID
 
+
 @mock_redshift
 def test_create_cluster_boto3():
     client = boto3.client("redshift", region_name="us-east-1")
@@ -1044,7 +1045,9 @@ def test_describe_tags_with_resource_type():
 @mock_redshift
 def test_describe_tags_cannot_specify_resource_type_and_resource_name():
     client = boto3.client("redshift", region_name="us-east-1")
-    resource_name = "arn:aws:redshift:us-east-1:{}:cluster:cluster-id".format(ACCOUNT_ID)
+    resource_name = "arn:aws:redshift:us-east-1:{}:cluster:cluster-id".format(
+        ACCOUNT_ID
+    )
     resource_type = "cluster"
     client.describe_tags.when.called_with(
         ResourceName=resource_name, ResourceType=resource_type

--- a/tests/test_redshift/test_redshift.py
+++ b/tests/test_redshift/test_redshift.py
@@ -18,7 +18,7 @@ from moto import mock_ec2
 from moto import mock_ec2_deprecated
 from moto import mock_redshift
 from moto import mock_redshift_deprecated
-from moto.iam.models import ACCOUNT_ID
+from moto.core import ACCOUNT_ID
 
 @mock_redshift
 def test_create_cluster_boto3():

--- a/tests/test_ses/test_ses_sns_boto3.py
+++ b/tests/test_ses/test_ses_sns_boto3.py
@@ -10,6 +10,7 @@ import sure  # noqa
 from nose import tools
 from moto import mock_ses, mock_sns, mock_sqs
 from moto.ses.models import SESFeedback
+from moto.iam.models import ACCOUNT_ID
 
 
 @mock_ses
@@ -35,7 +36,7 @@ def __setup_feedback_env__(
     sns_conn.subscribe(
         TopicArn=topic_arn,
         Protocol="sqs",
-        Endpoint="arn:aws:sqs:%s:123456789012:%s" % (region, queue),
+        Endpoint="arn:aws:sqs:%s:%s:%s" % (region, ACCOUNT_ID, queue),
     )
     # Verify SES domain
     ses_conn.verify_domain_identity(Domain=domain)

--- a/tests/test_ses/test_ses_sns_boto3.py
+++ b/tests/test_ses/test_ses_sns_boto3.py
@@ -10,7 +10,7 @@ import sure  # noqa
 from nose import tools
 from moto import mock_ses, mock_sns, mock_sqs
 from moto.ses.models import SESFeedback
-from moto.iam.models import ACCOUNT_ID
+from moto.core import ACCOUNT_ID
 
 
 @mock_ses

--- a/tests/test_sns/test_application.py
+++ b/tests/test_sns/test_application.py
@@ -3,6 +3,7 @@ from __future__ import unicode_literals
 import boto
 from boto.exception import BotoServerError
 from moto import mock_sns_deprecated
+from moto.iam.models import ACCOUNT_ID
 import sure  # noqa
 
 
@@ -21,7 +22,7 @@ def test_create_platform_application():
         "CreatePlatformApplicationResult"
     ]["PlatformApplicationArn"]
     application_arn.should.equal(
-        "arn:aws:sns:us-east-1:123456789012:app/APNS/my-application"
+        "arn:aws:sns:us-east-1:{}:app/APNS/my-application".format(ACCOUNT_ID)
     )
 
 
@@ -137,7 +138,7 @@ def test_create_platform_endpoint():
         "CreatePlatformEndpointResult"
     ]["EndpointArn"]
     endpoint_arn.should.contain(
-        "arn:aws:sns:us-east-1:123456789012:endpoint/APNS/my-application/"
+        "arn:aws:sns:us-east-1:{}:endpoint/APNS/my-application/".format(ACCOUNT_ID)
     )
 
 

--- a/tests/test_sns/test_application.py
+++ b/tests/test_sns/test_application.py
@@ -3,7 +3,7 @@ from __future__ import unicode_literals
 import boto
 from boto.exception import BotoServerError
 from moto import mock_sns_deprecated
-from moto.iam.models import ACCOUNT_ID
+from moto.core import ACCOUNT_ID
 import sure  # noqa
 
 

--- a/tests/test_sns/test_application_boto3.py
+++ b/tests/test_sns/test_application_boto3.py
@@ -4,7 +4,7 @@ import boto3
 from botocore.exceptions import ClientError
 from moto import mock_sns
 import sure  # noqa
-from moto.iam.models import ACCOUNT_ID
+from moto.core import ACCOUNT_ID
 
 
 @mock_sns

--- a/tests/test_sns/test_application_boto3.py
+++ b/tests/test_sns/test_application_boto3.py
@@ -4,6 +4,7 @@ import boto3
 from botocore.exceptions import ClientError
 from moto import mock_sns
 import sure  # noqa
+from moto.iam.models import ACCOUNT_ID
 
 
 @mock_sns
@@ -19,7 +20,7 @@ def test_create_platform_application():
     )
     application_arn = response["PlatformApplicationArn"]
     application_arn.should.equal(
-        "arn:aws:sns:us-east-1:123456789012:app/APNS/my-application"
+        "arn:aws:sns:us-east-1:{}:app/APNS/my-application".format(ACCOUNT_ID)
     )
 
 
@@ -131,7 +132,7 @@ def test_create_platform_endpoint():
 
     endpoint_arn = endpoint["EndpointArn"]
     endpoint_arn.should.contain(
-        "arn:aws:sns:us-east-1:123456789012:endpoint/APNS/my-application/"
+        "arn:aws:sns:us-east-1:{}:endpoint/APNS/my-application/".format(ACCOUNT_ID)
     )
 
 

--- a/tests/test_sns/test_publishing.py
+++ b/tests/test_sns/test_publishing.py
@@ -7,7 +7,7 @@ from freezegun import freeze_time
 import sure  # noqa
 
 from moto import mock_sns_deprecated, mock_sqs_deprecated
-from moto.iam.models import ACCOUNT_ID
+from moto.core import ACCOUNT_ID
 
 MESSAGE_FROM_SQS_TEMPLATE = '{\n  "Message": "%s",\n  "MessageId": "%s",\n  "Signature": "EXAMPLElDMXvB8r9R83tGoNn0ecwd5UjllzsvSvbItzfaMpN2nk5HVSw7XnOn/49IkxDKz8YrlH2qJXj2iZB0Zo2O71c4qQk1fMUDi3LGpij7RCW7AW9vYYsSqIKRnFS94ilu7NFhUzLiieYr4BKHpdTmdD6c0esKEYBpabxDSc=",\n  "SignatureVersion": "1",\n  "SigningCertURL": "https://sns.us-east-1.amazonaws.com/SimpleNotificationService-f3ecfb7224c7233fe7bb5f59f96de52f.pem",\n  "Subject": "%s",\n  "Timestamp": "2015-01-01T12:00:00.000Z",\n  "TopicArn": "arn:aws:sns:%s:'+ACCOUNT_ID+':some-topic",\n  "Type": "Notification",\n  "UnsubscribeURL": "https://sns.us-east-1.amazonaws.com/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:us-east-1:'+ACCOUNT_ID+':some-topic:2bcfbf39-05c3-41de-beaa-fcfcc21c8f55"\n}'
 

--- a/tests/test_sns/test_publishing.py
+++ b/tests/test_sns/test_publishing.py
@@ -7,9 +7,9 @@ from freezegun import freeze_time
 import sure  # noqa
 
 from moto import mock_sns_deprecated, mock_sqs_deprecated
+from moto.iam.models import ACCOUNT_ID
 
-
-MESSAGE_FROM_SQS_TEMPLATE = '{\n  "Message": "%s",\n  "MessageId": "%s",\n  "Signature": "EXAMPLElDMXvB8r9R83tGoNn0ecwd5UjllzsvSvbItzfaMpN2nk5HVSw7XnOn/49IkxDKz8YrlH2qJXj2iZB0Zo2O71c4qQk1fMUDi3LGpij7RCW7AW9vYYsSqIKRnFS94ilu7NFhUzLiieYr4BKHpdTmdD6c0esKEYBpabxDSc=",\n  "SignatureVersion": "1",\n  "SigningCertURL": "https://sns.us-east-1.amazonaws.com/SimpleNotificationService-f3ecfb7224c7233fe7bb5f59f96de52f.pem",\n  "Subject": "%s",\n  "Timestamp": "2015-01-01T12:00:00.000Z",\n  "TopicArn": "arn:aws:sns:%s:123456789012:some-topic",\n  "Type": "Notification",\n  "UnsubscribeURL": "https://sns.us-east-1.amazonaws.com/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:us-east-1:123456789012:some-topic:2bcfbf39-05c3-41de-beaa-fcfcc21c8f55"\n}'
+MESSAGE_FROM_SQS_TEMPLATE = '{\n  "Message": "%s",\n  "MessageId": "%s",\n  "Signature": "EXAMPLElDMXvB8r9R83tGoNn0ecwd5UjllzsvSvbItzfaMpN2nk5HVSw7XnOn/49IkxDKz8YrlH2qJXj2iZB0Zo2O71c4qQk1fMUDi3LGpij7RCW7AW9vYYsSqIKRnFS94ilu7NFhUzLiieYr4BKHpdTmdD6c0esKEYBpabxDSc=",\n  "SignatureVersion": "1",\n  "SigningCertURL": "https://sns.us-east-1.amazonaws.com/SimpleNotificationService-f3ecfb7224c7233fe7bb5f59f96de52f.pem",\n  "Subject": "%s",\n  "Timestamp": "2015-01-01T12:00:00.000Z",\n  "TopicArn": "arn:aws:sns:%s:'+ACCOUNT_ID+':some-topic",\n  "Type": "Notification",\n  "UnsubscribeURL": "https://sns.us-east-1.amazonaws.com/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:us-east-1:'+ACCOUNT_ID+':some-topic:2bcfbf39-05c3-41de-beaa-fcfcc21c8f55"\n}'
 
 
 @mock_sqs_deprecated
@@ -25,7 +25,7 @@ def test_publish_to_sqs():
     sqs_conn = boto.connect_sqs()
     sqs_conn.create_queue("test-queue")
 
-    conn.subscribe(topic_arn, "sqs", "arn:aws:sqs:us-east-1:123456789012:test-queue")
+    conn.subscribe(topic_arn, "sqs", "arn:aws:sqs:us-east-1:{}:test-queue".format(ACCOUNT_ID))
 
     message_to_publish = "my message"
     subject_to_publish = "test subject"
@@ -66,7 +66,7 @@ def test_publish_to_sqs_in_different_region():
     sqs_conn = boto.sqs.connect_to_region("us-west-2")
     sqs_conn.create_queue("test-queue")
 
-    conn.subscribe(topic_arn, "sqs", "arn:aws:sqs:us-west-2:123456789012:test-queue")
+    conn.subscribe(topic_arn, "sqs", "arn:aws:sqs:us-west-2:{}:test-queue".format(ACCOUNT_ID))
 
     message_to_publish = "my message"
     subject_to_publish = "test subject"

--- a/tests/test_sns/test_publishing.py
+++ b/tests/test_sns/test_publishing.py
@@ -9,7 +9,13 @@ import sure  # noqa
 from moto import mock_sns_deprecated, mock_sqs_deprecated
 from moto.core import ACCOUNT_ID
 
-MESSAGE_FROM_SQS_TEMPLATE = '{\n  "Message": "%s",\n  "MessageId": "%s",\n  "Signature": "EXAMPLElDMXvB8r9R83tGoNn0ecwd5UjllzsvSvbItzfaMpN2nk5HVSw7XnOn/49IkxDKz8YrlH2qJXj2iZB0Zo2O71c4qQk1fMUDi3LGpij7RCW7AW9vYYsSqIKRnFS94ilu7NFhUzLiieYr4BKHpdTmdD6c0esKEYBpabxDSc=",\n  "SignatureVersion": "1",\n  "SigningCertURL": "https://sns.us-east-1.amazonaws.com/SimpleNotificationService-f3ecfb7224c7233fe7bb5f59f96de52f.pem",\n  "Subject": "%s",\n  "Timestamp": "2015-01-01T12:00:00.000Z",\n  "TopicArn": "arn:aws:sns:%s:'+ACCOUNT_ID+':some-topic",\n  "Type": "Notification",\n  "UnsubscribeURL": "https://sns.us-east-1.amazonaws.com/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:us-east-1:'+ACCOUNT_ID+':some-topic:2bcfbf39-05c3-41de-beaa-fcfcc21c8f55"\n}'
+MESSAGE_FROM_SQS_TEMPLATE = (
+    '{\n  "Message": "%s",\n  "MessageId": "%s",\n  "Signature": "EXAMPLElDMXvB8r9R83tGoNn0ecwd5UjllzsvSvbItzfaMpN2nk5HVSw7XnOn/49IkxDKz8YrlH2qJXj2iZB0Zo2O71c4qQk1fMUDi3LGpij7RCW7AW9vYYsSqIKRnFS94ilu7NFhUzLiieYr4BKHpdTmdD6c0esKEYBpabxDSc=",\n  "SignatureVersion": "1",\n  "SigningCertURL": "https://sns.us-east-1.amazonaws.com/SimpleNotificationService-f3ecfb7224c7233fe7bb5f59f96de52f.pem",\n  "Subject": "%s",\n  "Timestamp": "2015-01-01T12:00:00.000Z",\n  "TopicArn": "arn:aws:sns:%s:'
+    + ACCOUNT_ID
+    + ':some-topic",\n  "Type": "Notification",\n  "UnsubscribeURL": "https://sns.us-east-1.amazonaws.com/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:us-east-1:'
+    + ACCOUNT_ID
+    + ':some-topic:2bcfbf39-05c3-41de-beaa-fcfcc21c8f55"\n}'
+)
 
 
 @mock_sqs_deprecated
@@ -25,7 +31,9 @@ def test_publish_to_sqs():
     sqs_conn = boto.connect_sqs()
     sqs_conn.create_queue("test-queue")
 
-    conn.subscribe(topic_arn, "sqs", "arn:aws:sqs:us-east-1:{}:test-queue".format(ACCOUNT_ID))
+    conn.subscribe(
+        topic_arn, "sqs", "arn:aws:sqs:us-east-1:{}:test-queue".format(ACCOUNT_ID)
+    )
 
     message_to_publish = "my message"
     subject_to_publish = "test subject"
@@ -66,7 +74,9 @@ def test_publish_to_sqs_in_different_region():
     sqs_conn = boto.sqs.connect_to_region("us-west-2")
     sqs_conn.create_queue("test-queue")
 
-    conn.subscribe(topic_arn, "sqs", "arn:aws:sqs:us-west-2:{}:test-queue".format(ACCOUNT_ID))
+    conn.subscribe(
+        topic_arn, "sqs", "arn:aws:sqs:us-west-2:{}:test-queue".format(ACCOUNT_ID)
+    )
 
     message_to_publish = "my message"
     subject_to_publish = "test subject"

--- a/tests/test_sns/test_publishing_boto3.py
+++ b/tests/test_sns/test_publishing_boto3.py
@@ -14,7 +14,13 @@ from nose.tools import assert_raises
 from moto import mock_sns, mock_sqs
 from moto.core import ACCOUNT_ID
 
-MESSAGE_FROM_SQS_TEMPLATE = '{\n  "Message": "%s",\n  "MessageId": "%s",\n  "Signature": "EXAMPLElDMXvB8r9R83tGoNn0ecwd5UjllzsvSvbItzfaMpN2nk5HVSw7XnOn/49IkxDKz8YrlH2qJXj2iZB0Zo2O71c4qQk1fMUDi3LGpij7RCW7AW9vYYsSqIKRnFS94ilu7NFhUzLiieYr4BKHpdTmdD6c0esKEYBpabxDSc=",\n  "SignatureVersion": "1",\n  "SigningCertURL": "https://sns.us-east-1.amazonaws.com/SimpleNotificationService-f3ecfb7224c7233fe7bb5f59f96de52f.pem",\n  "Subject": "my subject",\n  "Timestamp": "2015-01-01T12:00:00.000Z",\n  "TopicArn": "arn:aws:sns:%s:'+ACCOUNT_ID+':some-topic",\n  "Type": "Notification",\n  "UnsubscribeURL": "https://sns.us-east-1.amazonaws.com/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:us-east-1:'+ACCOUNT_ID+':some-topic:2bcfbf39-05c3-41de-beaa-fcfcc21c8f55"\n}'
+MESSAGE_FROM_SQS_TEMPLATE = (
+    '{\n  "Message": "%s",\n  "MessageId": "%s",\n  "Signature": "EXAMPLElDMXvB8r9R83tGoNn0ecwd5UjllzsvSvbItzfaMpN2nk5HVSw7XnOn/49IkxDKz8YrlH2qJXj2iZB0Zo2O71c4qQk1fMUDi3LGpij7RCW7AW9vYYsSqIKRnFS94ilu7NFhUzLiieYr4BKHpdTmdD6c0esKEYBpabxDSc=",\n  "SignatureVersion": "1",\n  "SigningCertURL": "https://sns.us-east-1.amazonaws.com/SimpleNotificationService-f3ecfb7224c7233fe7bb5f59f96de52f.pem",\n  "Subject": "my subject",\n  "Timestamp": "2015-01-01T12:00:00.000Z",\n  "TopicArn": "arn:aws:sns:%s:'
+    + ACCOUNT_ID
+    + ':some-topic",\n  "Type": "Notification",\n  "UnsubscribeURL": "https://sns.us-east-1.amazonaws.com/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:us-east-1:'
+    + ACCOUNT_ID
+    + ':some-topic:2bcfbf39-05c3-41de-beaa-fcfcc21c8f55"\n}'
+)
 
 
 @mock_sqs

--- a/tests/test_sns/test_publishing_boto3.py
+++ b/tests/test_sns/test_publishing_boto3.py
@@ -12,9 +12,9 @@ import responses
 from botocore.exceptions import ClientError
 from nose.tools import assert_raises
 from moto import mock_sns, mock_sqs
+from moto.iam.models import ACCOUNT_ID
 
-
-MESSAGE_FROM_SQS_TEMPLATE = '{\n  "Message": "%s",\n  "MessageId": "%s",\n  "Signature": "EXAMPLElDMXvB8r9R83tGoNn0ecwd5UjllzsvSvbItzfaMpN2nk5HVSw7XnOn/49IkxDKz8YrlH2qJXj2iZB0Zo2O71c4qQk1fMUDi3LGpij7RCW7AW9vYYsSqIKRnFS94ilu7NFhUzLiieYr4BKHpdTmdD6c0esKEYBpabxDSc=",\n  "SignatureVersion": "1",\n  "SigningCertURL": "https://sns.us-east-1.amazonaws.com/SimpleNotificationService-f3ecfb7224c7233fe7bb5f59f96de52f.pem",\n  "Subject": "my subject",\n  "Timestamp": "2015-01-01T12:00:00.000Z",\n  "TopicArn": "arn:aws:sns:%s:123456789012:some-topic",\n  "Type": "Notification",\n  "UnsubscribeURL": "https://sns.us-east-1.amazonaws.com/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:us-east-1:123456789012:some-topic:2bcfbf39-05c3-41de-beaa-fcfcc21c8f55"\n}'
+MESSAGE_FROM_SQS_TEMPLATE = '{\n  "Message": "%s",\n  "MessageId": "%s",\n  "Signature": "EXAMPLElDMXvB8r9R83tGoNn0ecwd5UjllzsvSvbItzfaMpN2nk5HVSw7XnOn/49IkxDKz8YrlH2qJXj2iZB0Zo2O71c4qQk1fMUDi3LGpij7RCW7AW9vYYsSqIKRnFS94ilu7NFhUzLiieYr4BKHpdTmdD6c0esKEYBpabxDSc=",\n  "SignatureVersion": "1",\n  "SigningCertURL": "https://sns.us-east-1.amazonaws.com/SimpleNotificationService-f3ecfb7224c7233fe7bb5f59f96de52f.pem",\n  "Subject": "my subject",\n  "Timestamp": "2015-01-01T12:00:00.000Z",\n  "TopicArn": "arn:aws:sns:%s:'+ACCOUNT_ID+':some-topic",\n  "Type": "Notification",\n  "UnsubscribeURL": "https://sns.us-east-1.amazonaws.com/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:us-east-1:'+ACCOUNT_ID+':some-topic:2bcfbf39-05c3-41de-beaa-fcfcc21c8f55"\n}'
 
 
 @mock_sqs
@@ -31,7 +31,7 @@ def test_publish_to_sqs():
     conn.subscribe(
         TopicArn=topic_arn,
         Protocol="sqs",
-        Endpoint="arn:aws:sqs:us-east-1:123456789012:test-queue",
+        Endpoint="arn:aws:sqs:us-east-1:{}:test-queue".format(ACCOUNT_ID),
     )
     message = "my message"
     with freeze_time("2015-01-01 12:00:00"):
@@ -88,7 +88,7 @@ def test_publish_to_sqs_bad():
     conn.subscribe(
         TopicArn=topic_arn,
         Protocol="sqs",
-        Endpoint="arn:aws:sqs:us-east-1:123456789012:test-queue",
+        Endpoint="arn:aws:sqs:us-east-1:{}:test-queue".format(ACCOUNT_ID),
     )
     message = "my message"
     try:
@@ -149,7 +149,7 @@ def test_publish_to_sqs_msg_attr_byte_value():
     conn.subscribe(
         TopicArn=topic_arn,
         Protocol="sqs",
-        Endpoint="arn:aws:sqs:us-east-1:123456789012:test-queue",
+        Endpoint="arn:aws:sqs:us-east-1:{}:test-queue".format(ACCOUNT_ID),
     )
     message = "my message"
     conn.publish(
@@ -243,7 +243,7 @@ def test_publish_to_sqs_dump_json():
     conn.subscribe(
         TopicArn=topic_arn,
         Protocol="sqs",
-        Endpoint="arn:aws:sqs:us-east-1:123456789012:test-queue",
+        Endpoint="arn:aws:sqs:us-east-1:{}:test-queue".format(ACCOUNT_ID),
     )
 
     message = json.dumps(
@@ -289,7 +289,7 @@ def test_publish_to_sqs_in_different_region():
     conn.subscribe(
         TopicArn=topic_arn,
         Protocol="sqs",
-        Endpoint="arn:aws:sqs:us-west-2:123456789012:test-queue",
+        Endpoint="arn:aws:sqs:us-west-2:{}:test-queue".format(ACCOUNT_ID),
     )
 
     message = "my message"
@@ -348,7 +348,7 @@ def test_publish_subject():
     conn.subscribe(
         TopicArn=topic_arn,
         Protocol="sqs",
-        Endpoint="arn:aws:sqs:us-east-1:123456789012:test-queue",
+        Endpoint="arn:aws:sqs:us-east-1:{}:test-queue".format(ACCOUNT_ID),
     )
     message = "my message"
     subject1 = "test subject"

--- a/tests/test_sns/test_publishing_boto3.py
+++ b/tests/test_sns/test_publishing_boto3.py
@@ -12,7 +12,7 @@ import responses
 from botocore.exceptions import ClientError
 from nose.tools import assert_raises
 from moto import mock_sns, mock_sqs
-from moto.iam.models import ACCOUNT_ID
+from moto.core import ACCOUNT_ID
 
 MESSAGE_FROM_SQS_TEMPLATE = '{\n  "Message": "%s",\n  "MessageId": "%s",\n  "Signature": "EXAMPLElDMXvB8r9R83tGoNn0ecwd5UjllzsvSvbItzfaMpN2nk5HVSw7XnOn/49IkxDKz8YrlH2qJXj2iZB0Zo2O71c4qQk1fMUDi3LGpij7RCW7AW9vYYsSqIKRnFS94ilu7NFhUzLiieYr4BKHpdTmdD6c0esKEYBpabxDSc=",\n  "SignatureVersion": "1",\n  "SigningCertURL": "https://sns.us-east-1.amazonaws.com/SimpleNotificationService-f3ecfb7224c7233fe7bb5f59f96de52f.pem",\n  "Subject": "my subject",\n  "Timestamp": "2015-01-01T12:00:00.000Z",\n  "TopicArn": "arn:aws:sns:%s:'+ACCOUNT_ID+':some-topic",\n  "Type": "Notification",\n  "UnsubscribeURL": "https://sns.us-east-1.amazonaws.com/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:us-east-1:'+ACCOUNT_ID+':some-topic:2bcfbf39-05c3-41de-beaa-fcfcc21c8f55"\n}'
 

--- a/tests/test_sns/test_server.py
+++ b/tests/test_sns/test_server.py
@@ -1,4 +1,5 @@
 from __future__ import unicode_literals
+from moto.iam.models import ACCOUNT_ID
 
 import sure  # noqa
 
@@ -16,11 +17,11 @@ def test_sns_server_get():
     topic_data = test_client.action_data("CreateTopic", Name="testtopic")
     topic_data.should.contain("CreateTopicResult")
     topic_data.should.contain(
-        "<TopicArn>arn:aws:sns:us-east-1:123456789012:testtopic</TopicArn>"
+        "<TopicArn>arn:aws:sns:us-east-1:{}:testtopic</TopicArn>".format(ACCOUNT_ID)
     )
 
     topics_data = test_client.action_data("ListTopics")
     topics_data.should.contain("ListTopicsResult")
     topic_data.should.contain(
-        "<TopicArn>arn:aws:sns:us-east-1:123456789012:testtopic</TopicArn>"
+        "<TopicArn>arn:aws:sns:us-east-1:{}:testtopic</TopicArn>".format(ACCOUNT_ID)
     )

--- a/tests/test_sns/test_server.py
+++ b/tests/test_sns/test_server.py
@@ -1,5 +1,5 @@
 from __future__ import unicode_literals
-from moto.iam.models import ACCOUNT_ID
+from moto.core import ACCOUNT_ID
 
 import sure  # noqa
 

--- a/tests/test_sns/test_topics.py
+++ b/tests/test_sns/test_topics.py
@@ -59,7 +59,9 @@ def test_topic_corresponds_to_region():
         topic_arn = topics_json["ListTopicsResponse"]["ListTopicsResult"]["Topics"][0][
             "TopicArn"
         ]
-        topic_arn.should.equal("arn:aws:sns:{0}:{1}:some-topic".format(region, ACCOUNT_ID))
+        topic_arn.should.equal(
+            "arn:aws:sns:{0}:{1}:some-topic".format(region, ACCOUNT_ID)
+        )
 
 
 @mock_sns_deprecated
@@ -99,7 +101,9 @@ def test_topic_attributes():
                         "SNS:Publish",
                         "SNS:Receive",
                     ],
-                    "Resource": "arn:aws:sns:us-east-1:{}:some-topic".format(ACCOUNT_ID),
+                    "Resource": "arn:aws:sns:us-east-1:{}:some-topic".format(
+                        ACCOUNT_ID
+                    ),
                     "Condition": {"StringEquals": {"AWS:SourceOwner": ACCOUNT_ID}},
                 }
             ],

--- a/tests/test_sns/test_topics.py
+++ b/tests/test_sns/test_topics.py
@@ -8,6 +8,7 @@ import sure  # noqa
 from boto.exception import BotoServerError
 from moto import mock_sns_deprecated
 from moto.sns.models import DEFAULT_EFFECTIVE_DELIVERY_POLICY, DEFAULT_PAGE_SIZE
+from moto.iam.models import ACCOUNT_ID
 
 
 @mock_sns_deprecated
@@ -19,7 +20,7 @@ def test_create_and_delete_topic():
     topics = topics_json["ListTopicsResponse"]["ListTopicsResult"]["Topics"]
     topics.should.have.length_of(1)
     topics[0]["TopicArn"].should.equal(
-        "arn:aws:sns:{0}:123456789012:some-topic".format(conn.region.name)
+        "arn:aws:sns:{0}:{1}:some-topic".format(conn.region.name, ACCOUNT_ID)
     )
 
     # Delete the topic
@@ -58,7 +59,7 @@ def test_topic_corresponds_to_region():
         topic_arn = topics_json["ListTopicsResponse"]["ListTopicsResult"]["Topics"][0][
             "TopicArn"
         ]
-        topic_arn.should.equal("arn:aws:sns:{0}:123456789012:some-topic".format(region))
+        topic_arn.should.equal("arn:aws:sns:{0}:{1}:some-topic".format(region, ACCOUNT_ID))
 
 
 @mock_sns_deprecated
@@ -75,9 +76,9 @@ def test_topic_attributes():
         "GetTopicAttributesResult"
     ]["Attributes"]
     attributes["TopicArn"].should.equal(
-        "arn:aws:sns:{0}:123456789012:some-topic".format(conn.region.name)
+        "arn:aws:sns:{0}:{1}:some-topic".format(conn.region.name, ACCOUNT_ID)
     )
-    attributes["Owner"].should.equal(123456789012)
+    attributes["Owner"].should.equal(ACCOUNT_ID)
     json.loads(attributes["Policy"]).should.equal(
         {
             "Version": "2008-10-17",
@@ -98,8 +99,8 @@ def test_topic_attributes():
                         "SNS:Publish",
                         "SNS:Receive",
                     ],
-                    "Resource": "arn:aws:sns:us-east-1:123456789012:some-topic",
-                    "Condition": {"StringEquals": {"AWS:SourceOwner": "123456789012"}},
+                    "Resource": "arn:aws:sns:us-east-1:{}:some-topic".format(ACCOUNT_ID),
+                    "Condition": {"StringEquals": {"AWS:SourceOwner": ACCOUNT_ID}},
                 }
             ],
         }

--- a/tests/test_sns/test_topics.py
+++ b/tests/test_sns/test_topics.py
@@ -8,7 +8,7 @@ import sure  # noqa
 from boto.exception import BotoServerError
 from moto import mock_sns_deprecated
 from moto.sns.models import DEFAULT_EFFECTIVE_DELIVERY_POLICY, DEFAULT_PAGE_SIZE
-from moto.iam.models import ACCOUNT_ID
+from moto.core import ACCOUNT_ID
 
 
 @mock_sns_deprecated

--- a/tests/test_sns/test_topics_boto3.py
+++ b/tests/test_sns/test_topics_boto3.py
@@ -10,6 +10,7 @@ from moto import mock_sns
 from moto.sns.models import DEFAULT_EFFECTIVE_DELIVERY_POLICY, DEFAULT_PAGE_SIZE
 from moto.core import ACCOUNT_ID
 
+
 @mock_sns
 def test_create_and_delete_topic():
     conn = boto3.client("sns", region_name="us-east-1")
@@ -132,7 +133,9 @@ def test_topic_corresponds_to_region():
         conn.create_topic(Name="some-topic")
         topics_json = conn.list_topics()
         topic_arn = topics_json["Topics"][0]["TopicArn"]
-        topic_arn.should.equal("arn:aws:sns:{0}:{1}:some-topic".format(region, ACCOUNT_ID))
+        topic_arn.should.equal(
+            "arn:aws:sns:{0}:{1}:some-topic".format(region, ACCOUNT_ID)
+        )
 
 
 @mock_sns
@@ -170,7 +173,9 @@ def test_topic_attributes():
                         "SNS:Publish",
                         "SNS:Receive",
                     ],
-                    "Resource": "arn:aws:sns:us-east-1:{}:some-topic".format(ACCOUNT_ID),
+                    "Resource": "arn:aws:sns:us-east-1:{}:some-topic".format(
+                        ACCOUNT_ID
+                    ),
                     "Condition": {"StringEquals": {"AWS:SourceOwner": ACCOUNT_ID}},
                 }
             ],
@@ -271,7 +276,9 @@ def test_add_remove_permissions():
                         "SNS:Publish",
                         "SNS:Receive",
                     ],
-                    "Resource": "arn:aws:sns:us-east-1:{}:test-permissions".format(ACCOUNT_ID),
+                    "Resource": "arn:aws:sns:us-east-1:{}:test-permissions".format(
+                        ACCOUNT_ID
+                    ),
                     "Condition": {"StringEquals": {"AWS:SourceOwner": ACCOUNT_ID}},
                 },
                 {
@@ -279,7 +286,9 @@ def test_add_remove_permissions():
                     "Effect": "Allow",
                     "Principal": {"AWS": "arn:aws:iam::999999999999:root"},
                     "Action": "SNS:Publish",
-                    "Resource": "arn:aws:sns:us-east-1:{}:test-permissions".format(ACCOUNT_ID),
+                    "Resource": "arn:aws:sns:us-east-1:{}:test-permissions".format(
+                        ACCOUNT_ID
+                    ),
                 },
             ],
         }
@@ -308,7 +317,9 @@ def test_add_remove_permissions():
                         "SNS:Publish",
                         "SNS:Receive",
                     ],
-                    "Resource": "arn:aws:sns:us-east-1:{}:test-permissions".format(ACCOUNT_ID),
+                    "Resource": "arn:aws:sns:us-east-1:{}:test-permissions".format(
+                        ACCOUNT_ID
+                    ),
                     "Condition": {"StringEquals": {"AWS:SourceOwner": ACCOUNT_ID}},
                 }
             ],

--- a/tests/test_sns/test_topics_boto3.py
+++ b/tests/test_sns/test_topics_boto3.py
@@ -8,7 +8,7 @@ import sure  # noqa
 from botocore.exceptions import ClientError
 from moto import mock_sns
 from moto.sns.models import DEFAULT_EFFECTIVE_DELIVERY_POLICY, DEFAULT_PAGE_SIZE
-
+from moto.iam.models import ACCOUNT_ID
 
 @mock_sns
 def test_create_and_delete_topic():
@@ -20,8 +20,8 @@ def test_create_and_delete_topic():
         topics = topics_json["Topics"]
         topics.should.have.length_of(1)
         topics[0]["TopicArn"].should.equal(
-            "arn:aws:sns:{0}:123456789012:{1}".format(
-                conn._client_config.region_name, topic_name
+            "arn:aws:sns:{0}:{1}:{2}".format(
+                conn._client_config.region_name, ACCOUNT_ID, topic_name
             )
         )
 
@@ -132,7 +132,7 @@ def test_topic_corresponds_to_region():
         conn.create_topic(Name="some-topic")
         topics_json = conn.list_topics()
         topic_arn = topics_json["Topics"][0]["TopicArn"]
-        topic_arn.should.equal("arn:aws:sns:{0}:123456789012:some-topic".format(region))
+        topic_arn.should.equal("arn:aws:sns:{0}:{1}:some-topic".format(region, ACCOUNT_ID))
 
 
 @mock_sns
@@ -145,11 +145,11 @@ def test_topic_attributes():
 
     attributes = conn.get_topic_attributes(TopicArn=topic_arn)["Attributes"]
     attributes["TopicArn"].should.equal(
-        "arn:aws:sns:{0}:123456789012:some-topic".format(
-            conn._client_config.region_name
+        "arn:aws:sns:{0}:{1}:some-topic".format(
+            conn._client_config.region_name, ACCOUNT_ID
         )
     )
-    attributes["Owner"].should.equal("123456789012")
+    attributes["Owner"].should.equal(ACCOUNT_ID)
     json.loads(attributes["Policy"]).should.equal(
         {
             "Version": "2008-10-17",
@@ -170,8 +170,8 @@ def test_topic_attributes():
                         "SNS:Publish",
                         "SNS:Receive",
                     ],
-                    "Resource": "arn:aws:sns:us-east-1:123456789012:some-topic",
-                    "Condition": {"StringEquals": {"AWS:SourceOwner": "123456789012"}},
+                    "Resource": "arn:aws:sns:us-east-1:{}:some-topic".format(ACCOUNT_ID),
+                    "Condition": {"StringEquals": {"AWS:SourceOwner": ACCOUNT_ID}},
                 }
             ],
         }
@@ -271,15 +271,15 @@ def test_add_remove_permissions():
                         "SNS:Publish",
                         "SNS:Receive",
                     ],
-                    "Resource": "arn:aws:sns:us-east-1:123456789012:test-permissions",
-                    "Condition": {"StringEquals": {"AWS:SourceOwner": "123456789012"}},
+                    "Resource": "arn:aws:sns:us-east-1:{}:test-permissions".format(ACCOUNT_ID),
+                    "Condition": {"StringEquals": {"AWS:SourceOwner": ACCOUNT_ID}},
                 },
                 {
                     "Sid": "test",
                     "Effect": "Allow",
                     "Principal": {"AWS": "arn:aws:iam::999999999999:root"},
                     "Action": "SNS:Publish",
-                    "Resource": "arn:aws:sns:us-east-1:123456789012:test-permissions",
+                    "Resource": "arn:aws:sns:us-east-1:{}:test-permissions".format(ACCOUNT_ID),
                 },
             ],
         }
@@ -308,8 +308,8 @@ def test_add_remove_permissions():
                         "SNS:Publish",
                         "SNS:Receive",
                     ],
-                    "Resource": "arn:aws:sns:us-east-1:123456789012:test-permissions",
-                    "Condition": {"StringEquals": {"AWS:SourceOwner": "123456789012"}},
+                    "Resource": "arn:aws:sns:us-east-1:{}:test-permissions".format(ACCOUNT_ID),
+                    "Condition": {"StringEquals": {"AWS:SourceOwner": ACCOUNT_ID}},
                 }
             ],
         }
@@ -334,7 +334,7 @@ def test_add_remove_permissions():
                 ]
             },
             "Action": ["SNS:Publish", "SNS:Subscribe"],
-            "Resource": "arn:aws:sns:us-east-1:123456789012:test-permissions",
+            "Resource": "arn:aws:sns:us-east-1:{}:test-permissions".format(ACCOUNT_ID),
         }
     )
 

--- a/tests/test_sns/test_topics_boto3.py
+++ b/tests/test_sns/test_topics_boto3.py
@@ -8,7 +8,7 @@ import sure  # noqa
 from botocore.exceptions import ClientError
 from moto import mock_sns
 from moto.sns.models import DEFAULT_EFFECTIVE_DELIVERY_POLICY, DEFAULT_PAGE_SIZE
-from moto.iam.models import ACCOUNT_ID
+from moto.core import ACCOUNT_ID
 
 @mock_sns
 def test_create_and_delete_topic():

--- a/tests/test_sqs/test_sqs.py
+++ b/tests/test_sqs/test_sqs.py
@@ -283,7 +283,7 @@ def test_create_queues_in_multiple_region():
         base_url = "https://us-west-1.queue.amazonaws.com"
 
     west1_conn.list_queues()["QueueUrls"][0].should.equal(
-        "{base_url}/{AccountId}/blah".format(base_url=base_url,AccountId=ACCCOUNT_ID)
+        "{base_url}/{AccountId}/blah".format(base_url=base_url,AccountId=ACCOUNT_ID)
     )
 
 

--- a/tests/test_sqs/test_sqs.py
+++ b/tests/test_sqs/test_sqs.py
@@ -23,6 +23,7 @@ from nose.tools import assert_raises
 from tests.helpers import requires_boto_gte
 from moto.core import ACCOUNT_ID
 
+
 @mock_sqs
 def test_create_fifo_queue_fail():
     sqs = boto3.client("sqs", region_name="us-east-1")
@@ -283,7 +284,7 @@ def test_create_queues_in_multiple_region():
         base_url = "https://us-west-1.queue.amazonaws.com"
 
     west1_conn.list_queues()["QueueUrls"][0].should.equal(
-        "{base_url}/{AccountId}/blah".format(base_url=base_url,AccountId=ACCOUNT_ID)
+        "{base_url}/{AccountId}/blah".format(base_url=base_url, AccountId=ACCOUNT_ID)
     )
 
 
@@ -305,7 +306,9 @@ def test_get_queue_with_prefix():
         base_url = "https://us-west-1.queue.amazonaws.com"
 
     queue[0].should.equal(
-        "{base_url}/{AccountId}/test-queue".format(base_url=base_url, AccountId=ACCOUNT_ID)
+        "{base_url}/{AccountId}/test-queue".format(
+            base_url=base_url, AccountId=ACCOUNT_ID
+        )
     )
 
 
@@ -851,7 +854,9 @@ def test_queue_attributes():
     attributes = queue.get_attributes()
 
     attributes["QueueArn"].should.look_like(
-        "arn:aws:sqs:us-east-1:{AccountId}:{name}".format(AccountId=ACCOUNT_ID,name=queue_name)
+        "arn:aws:sqs:us-east-1:{AccountId}:{name}".format(
+            AccountId=ACCOUNT_ID, name=queue_name
+        )
     )
 
     attributes["VisibilityTimeout"].should.look_like(str(visibility_timeout))

--- a/tests/test_sqs/test_sqs.py
+++ b/tests/test_sqs/test_sqs.py
@@ -21,7 +21,7 @@ from moto import mock_sqs, mock_sqs_deprecated, settings
 from nose import SkipTest
 from nose.tools import assert_raises
 from tests.helpers import requires_boto_gte
-from moto.iam.models import ACCOUNT_ID
+from moto.core import ACCOUNT_ID
 
 @mock_sqs
 def test_create_fifo_queue_fail():

--- a/tests/test_sqs/test_sqs.py
+++ b/tests/test_sqs/test_sqs.py
@@ -21,7 +21,7 @@ from moto import mock_sqs, mock_sqs_deprecated, settings
 from nose import SkipTest
 from nose.tools import assert_raises
 from tests.helpers import requires_boto_gte
-
+from moto.iam.models import ACCOUNT_ID
 
 @mock_sqs
 def test_create_fifo_queue_fail():
@@ -283,7 +283,7 @@ def test_create_queues_in_multiple_region():
         base_url = "https://us-west-1.queue.amazonaws.com"
 
     west1_conn.list_queues()["QueueUrls"][0].should.equal(
-        "{base_url}/123456789012/blah".format(base_url=base_url)
+        "{base_url}/{AccountId}/blah".format(base_url=base_url,AccountId=ACCCOUNT_ID)
     )
 
 
@@ -305,7 +305,7 @@ def test_get_queue_with_prefix():
         base_url = "https://us-west-1.queue.amazonaws.com"
 
     queue[0].should.equal(
-        "{base_url}/123456789012/test-queue".format(base_url=base_url)
+        "{base_url}/{AccountId}/test-queue".format(base_url=base_url, AccountId=ACCOUNT_ID)
     )
 
 
@@ -342,7 +342,7 @@ def test_get_queue_attributes():
     response["Attributes"]["MaximumMessageSize"].should.equal("65536")
     response["Attributes"]["MessageRetentionPeriod"].should.equal("345600")
     response["Attributes"]["QueueArn"].should.equal(
-        "arn:aws:sqs:us-east-1:123456789012:test-queue"
+        "arn:aws:sqs:us-east-1:{}:test-queue".format(ACCOUNT_ID)
     )
     response["Attributes"]["ReceiveMessageWaitTimeSeconds"].should.equal("0")
     response["Attributes"]["VisibilityTimeout"].should.equal("30")
@@ -361,7 +361,7 @@ def test_get_queue_attributes():
         {
             "ApproximateNumberOfMessages": "0",
             "MaximumMessageSize": "65536",
-            "QueueArn": "arn:aws:sqs:us-east-1:123456789012:test-queue",
+            "QueueArn": "arn:aws:sqs:us-east-1:{}:test-queue".format(ACCOUNT_ID),
             "VisibilityTimeout": "30",
         }
     )
@@ -851,7 +851,7 @@ def test_queue_attributes():
     attributes = queue.get_attributes()
 
     attributes["QueueArn"].should.look_like(
-        "arn:aws:sqs:us-east-1:123456789012:%s" % queue_name
+        "arn:aws:sqs:us-east-1:{AccountId}:{name}".format(AccountId=ACCOUNT_ID,name=queue_name)
     )
 
     attributes["VisibilityTimeout"].should.look_like(str(visibility_timeout))
@@ -1402,7 +1402,7 @@ def test_redrive_policy_available():
 def test_redrive_policy_non_existent_queue():
     sqs = boto3.client("sqs", region_name="us-east-1")
     redrive_policy = {
-        "deadLetterTargetArn": "arn:aws:sqs:us-east-1:123456789012:no-queue",
+        "deadLetterTargetArn": "arn:aws:sqs:us-east-1:{}:no-queue".format(ACCOUNT_ID),
         "maxReceiveCount": 1,
     }
 

--- a/tests/test_stepfunctions/test_stepfunctions.py
+++ b/tests/test_stepfunctions/test_stepfunctions.py
@@ -34,7 +34,7 @@ def test_state_machine_creation_succeeds():
     response["ResponseMetadata"]["HTTPStatusCode"].should.equal(200)
     response["creationDate"].should.be.a(datetime)
     response["stateMachineArn"].should.equal(
-        "arn:aws:states:" + region + ":"+ACCOUNT_ID+":stateMachine:" + name
+        "arn:aws:states:" + region + ":" + ACCOUNT_ID + ":stateMachine:" + name
     )
 
 
@@ -286,7 +286,7 @@ def test_state_machine_can_deleted_nonexisting_machine():
     client = boto3.client("stepfunctions", region_name=region)
     #
     unknown_state_machine = (
-        "arn:aws:states:" + region + ":"+ACCOUNT_ID+":stateMachine:unknown"
+        "arn:aws:states:" + region + ":" + ACCOUNT_ID + ":stateMachine:unknown"
     )
     response = client.delete_state_machine(stateMachineArn=unknown_state_machine)
     response["ResponseMetadata"]["HTTPStatusCode"].should.equal(200)

--- a/tests/test_stepfunctions/test_stepfunctions.py
+++ b/tests/test_stepfunctions/test_stepfunctions.py
@@ -9,7 +9,7 @@ from botocore.exceptions import ClientError
 from nose.tools import assert_raises
 
 from moto import mock_sts, mock_stepfunctions
-
+from moto.iam.models import ACCOUNT_ID
 
 region = "us-east-1"
 simple_definition = (
@@ -34,7 +34,7 @@ def test_state_machine_creation_succeeds():
     response["ResponseMetadata"]["HTTPStatusCode"].should.equal(200)
     response["creationDate"].should.be.a(datetime)
     response["stateMachineArn"].should.equal(
-        "arn:aws:states:" + region + ":123456789012:stateMachine:" + name
+        "arn:aws:states:" + region + ":"+ACCOUNT_ID+":stateMachine:" + name
     )
 
 
@@ -286,7 +286,7 @@ def test_state_machine_can_deleted_nonexisting_machine():
     client = boto3.client("stepfunctions", region_name=region)
     #
     unknown_state_machine = (
-        "arn:aws:states:" + region + ":123456789012:stateMachine:unknown"
+        "arn:aws:states:" + region + ":"+ACCOUNT_ID+":stateMachine:unknown"
     )
     response = client.delete_state_machine(stateMachineArn=unknown_state_machine)
     response["ResponseMetadata"]["HTTPStatusCode"].should.equal(200)

--- a/tests/test_stepfunctions/test_stepfunctions.py
+++ b/tests/test_stepfunctions/test_stepfunctions.py
@@ -9,7 +9,7 @@ from botocore.exceptions import ClientError
 from nose.tools import assert_raises
 
 from moto import mock_sts, mock_stepfunctions
-from moto.iam.models import ACCOUNT_ID
+from moto.core import ACCOUNT_ID
 
 region = "us-east-1"
 simple_definition = (

--- a/tests/test_sts/test_sts.py
+++ b/tests/test_sts/test_sts.py
@@ -10,7 +10,7 @@ import sure  # noqa
 
 
 from moto import mock_sts, mock_sts_deprecated, mock_iam, settings
-from moto.iam.models import ACCOUNT_ID
+from moto.core import ACCOUNT_ID
 from moto.sts.responses import MAX_FEDERATION_TOKEN_POLICY_LENGTH
 
 


### PR DESCRIPTION
This adds support to mocking the AccountID by replacing all hardcoded '123456789012' that referenced account ids with imports from moto.iam.models.

Related issue #2545