### PR TITLE
Security Groups - Create a second default egress rule for IPv6

### DIFF
--- a/moto/ec2/models.py
+++ b/moto/ec2/models.py
@@ -1722,6 +1722,12 @@ class SecurityGroup(TaggedEC2Resource):
         self.vpc_id = vpc_id
         self.owner_id = OWNER_ID
 
+        # Append default IPv6 egress rule for VPCs with IPv6 support
+        if vpc_id:
+            vpc = self.ec2_backend.vpcs.get(vpc_id)
+            if vpc and len(vpc.get_cidr_block_association_set(ipv6=True)) > 0:
+                self.egress_rules.append(SecurityRule("-1", None, None, [], []))
+
     @classmethod
     def create_from_cloudformation_json(
         cls, resource_name, cloudformation_json, region_name

--- a/tests/test_ec2/test_security_groups.py
+++ b/tests/test_ec2/test_security_groups.py
@@ -123,6 +123,18 @@ def test_create_two_security_groups_with_same_name_in_different_vpc():
     set(group_names).should.equal(set(["default", "test security group"]))
 
 
+@mock_ec2
+def test_create_two_security_groups_in_vpc_with_ipv6_enabled():
+    ec2 = boto3.resource("ec2", region_name="us-west-1")
+    vpc = ec2.create_vpc(CidrBlock="10.0.0.0/16", AmazonProvidedIpv6CidrBlock=True)
+
+    security_group = ec2.create_security_group(
+        GroupName="sg01", Description="Test security group sg01", VpcId=vpc.id
+    )
+
+    security_group.ip_permissions_egress.should.have.length_of(2)
+
+
 @mock_ec2_deprecated
 def test_deleting_security_groups():
     conn = boto.connect_ec2("the_key", "the_secret")

--- a/tests/test_ec2/test_security_groups.py
+++ b/tests/test_ec2/test_security_groups.py
@@ -132,6 +132,7 @@ def test_create_two_security_groups_in_vpc_with_ipv6_enabled():
         GroupName="sg01", Description="Test security group sg01", VpcId=vpc.id
     )
 
+    # The security group must have two defaul egress rules (one for ipv4 and aonther for ipv6)
     security_group.ip_permissions_egress.should.have.length_of(2)
 
 


### PR DESCRIPTION
This PR fixes issue #2646. I'm not sure if my approach is correct, however, I can confirm that this patch actually causes Terraform to succeed in creating the security group. For some reason,  Terraform was expecting the IPv6 range to be an empty array. I have not yet confirmed if this indeed how AWS behaves.