### PR TITLE
Fix issue when working with dyanmodb stream and complex types.

### DIFF
--- a/moto/dynamodb2/models.py
+++ b/moto/dynamodb2/models.py
@@ -586,7 +586,9 @@ class StreamRecord(BaseModel):
             self.record["dynamodb"]["OldImage"] = old_a
 
         # This is a substantial overestimate but it's the easiest to do now
-        self.record["dynamodb"]["SizeBytes"] = len(dynamo_json_dump(self.record["dynamodb"]))
+        self.record["dynamodb"]["SizeBytes"] = len(
+            dynamo_json_dump(self.record["dynamodb"])
+        )
 
     def to_json(self):
         return self.record

--- a/moto/dynamodb2/models.py
+++ b/moto/dynamodb2/models.py
@@ -586,7 +586,7 @@ class StreamRecord(BaseModel):
             self.record["dynamodb"]["OldImage"] = old_a
 
         # This is a substantial overestimate but it's the easiest to do now
-        self.record["dynamodb"]["SizeBytes"] = len(json.dumps(self.record["dynamodb"]))
+        self.record["dynamodb"]["SizeBytes"] = len(dynamo_json_dump(self.record["dynamodb"]))
 
     def to_json(self):
         return self.record

--- a/tests/test_dynamodb2/test_dynamodb.py
+++ b/tests/test_dynamodb2/test_dynamodb.py
@@ -394,9 +394,12 @@ def test_put_item_with_streams():
             "Data": {"M": {"Key1": {"S": "Value1"}, "Key2": {"S": "Value2"}}},
         }
     )
-    stream_shard = dynamodb_backends2["us-west-2"].get_table(name).stream_shard
-    len(stream_shard.items).should.be.equal(1)
-    stream_record = stream_shard.items[0].record
+    table = dynamodb_backends2["us-west-2"].get_table(name)
+    if not table:
+        # There is no way to access stream data over the API, so this part can't run in server-tests mode.
+        return
+    len(table.stream_shard.items).should.be.equal(1)
+    stream_record = table.stream_shard.items[0].record
     stream_record["eventName"].should.be.equal("INSERT")
     stream_record["dynamodb"]["SizeBytes"].should.be.equal(447)
 

--- a/tests/test_dynamodb2/test_dynamodb.py
+++ b/tests/test_dynamodb2/test_dynamodb.py
@@ -348,6 +348,35 @@ def test_put_item_with_special_chars():
             '"': {"S": "foo"},
         },
     )
+@requires_boto_gte("2.9")
+@mock_dynamodb2
+def test_put_item_with_streams():
+    name = "TestTable"
+    conn = boto3.client(
+        "dynamodb",
+        region_name="us-west-2",
+        aws_access_key_id="ak",
+        aws_secret_access_key="sk",
+    )
+
+    conn.create_table(
+        TableName=name,
+        KeySchema=[{"AttributeName": "forum_name", "KeyType": "HASH"}],
+        AttributeDefinitions=[{"AttributeName": "forum_name", "AttributeType": "S"}],
+        StreamSpecification={'StreamEnabled': True, 'StreamViewType': 'NEW_AND_OLD_IMAGES'},
+        ProvisionedThroughput={"ReadCapacityUnits": 5, "WriteCapacityUnits": 5},
+    )
+
+    conn.put_item(
+        TableName=name,
+        Item={
+            "forum_name": {"S": "LOLCat Forum"},
+            "subject": {"S": "Check this out!"},
+            "Body": {"S": "http://url_to_lolcat.gif"},
+            "SentBy": {"S": "test"},
+            "Data": {"M": {"Key1": {"S": "Value1"}, "Key2": {"S": "Value2"}}}
+        },
+    )
 
 
 @requires_boto_gte("2.9")

--- a/tests/test_dynamodb2/test_dynamodb.py
+++ b/tests/test_dynamodb2/test_dynamodb.py
@@ -348,6 +348,8 @@ def test_put_item_with_special_chars():
             '"': {"S": "foo"},
         },
     )
+
+
 @requires_boto_gte("2.9")
 @mock_dynamodb2
 def test_put_item_with_streams():
@@ -363,7 +365,10 @@ def test_put_item_with_streams():
         TableName=name,
         KeySchema=[{"AttributeName": "forum_name", "KeyType": "HASH"}],
         AttributeDefinitions=[{"AttributeName": "forum_name", "AttributeType": "S"}],
-        StreamSpecification={'StreamEnabled': True, 'StreamViewType': 'NEW_AND_OLD_IMAGES'},
+        StreamSpecification={
+            "StreamEnabled": True,
+            "StreamViewType": "NEW_AND_OLD_IMAGES",
+        },
         ProvisionedThroughput={"ReadCapacityUnits": 5, "WriteCapacityUnits": 5},
     )
 
@@ -374,7 +379,7 @@ def test_put_item_with_streams():
             "subject": {"S": "Check this out!"},
             "Body": {"S": "http://url_to_lolcat.gif"},
             "SentBy": {"S": "test"},
-            "Data": {"M": {"Key1": {"S": "Value1"}, "Key2": {"S": "Value2"}}}
+            "Data": {"M": {"Key1": {"S": "Value1"}, "Key2": {"S": "Value2"}}},
         },
     )
 


### PR DESCRIPTION
I think this was introduced in https://github.com/spulec/moto/pull/2605 (not a 100% sure thought).
I know this logic works properly in the v1.3.13 and it is busted in v1.3.14.

I have written a test to repo the issue, here is the relevant part of the call stack from the test failure.
```
File "/Users/asher/projects/moto/moto/dynamodb2/models.py", line 620, in add
  self.items.append(StreamRecord(self.table, t, event_name, old, new, seq))
File "/Users/asher/projects/moto/moto/dynamodb2/models.py", line 589, in __init__
  self.record["dynamodb"]["SizeBytes"] = len(json.dumps(self.record["dynamodb"]))
File "/usr/local/Cellar/python/3.7.4_1/Frameworks/Python.framework/Versions/3.7/lib/python3.7/json/__init__.py", line 231, in dumps
  return _default_encoder.encode(obj)
File "/usr/local/Cellar/python/3.7.4_1/Frameworks/Python.framework/Versions/3.7/lib/python3.7/json/encoder.py", line 199, in encode
  chunks = self.iterencode(o, _one_shot=True)
File "/usr/local/Cellar/python/3.7.4_1/Frameworks/Python.framework/Versions/3.7/lib/python3.7/json/encoder.py", line 257, in iterencode
  return _iterencode(o, 0)
File "/usr/local/Cellar/python/3.7.4_1/Frameworks/Python.framework/Versions/3.7/lib/python3.7/json/encoder.py", line 179, in default
  raise TypeError(f'Object of type {o.__class__.__name__} '
TypeError: Object of type DynamoType is not JSON serializable
```