### PR TITLE
Avoid rendering "None" as S3 Prefix value

### DIFF
--- a/moto/s3/responses.py
+++ b/moto/s3/responses.py
@@ -1491,7 +1491,9 @@ S3_ALL_BUCKETS = """<ListAllMyBucketsResult xmlns="http://s3.amazonaws.com/doc/2
 S3_BUCKET_GET_RESPONSE = """<?xml version="1.0" encoding="UTF-8"?>
 <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
   <Name>{{ bucket.name }}</Name>
+  {% if prefix != None %}
   <Prefix>{{ prefix }}</Prefix>
+  {% endif %}
   <MaxKeys>{{ max_keys }}</MaxKeys>
   <Delimiter>{{ delimiter }}</Delimiter>
   <IsTruncated>{{ is_truncated }}</IsTruncated>
@@ -1523,7 +1525,9 @@ S3_BUCKET_GET_RESPONSE = """<?xml version="1.0" encoding="UTF-8"?>
 S3_BUCKET_GET_RESPONSE_V2 = """<?xml version="1.0" encoding="UTF-8"?>
 <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
   <Name>{{ bucket.name }}</Name>
+{% if prefix != None %}
   <Prefix>{{ prefix }}</Prefix>
+{% endif %}
   <MaxKeys>{{ max_keys }}</MaxKeys>
   <KeyCount>{{ key_count }}</KeyCount>
 {% if delimiter %}
@@ -1684,7 +1688,9 @@ S3_BUCKET_GET_VERSIONING = """<?xml version="1.0" encoding="UTF-8"?>
 S3_BUCKET_GET_VERSIONS = """<?xml version="1.0" encoding="UTF-8"?>
 <ListVersionsResult xmlns="http://s3.amazonaws.com/doc/2006-03-01">
     <Name>{{ bucket.name }}</Name>
+    {% if prefix != None %}
     <Prefix>{{ prefix }}</Prefix>
+    {% endif %}
     <KeyMarker>{{ key_marker }}</KeyMarker>
     <MaxKeys>{{ max_keys }}</MaxKeys>
     <IsTruncated>{{ is_truncated }}</IsTruncated>

--- a/tests/test_s3/test_s3.py
+++ b/tests/test_s3/test_s3.py
@@ -1261,7 +1261,7 @@ def test_boto3_list_objects_truncated_response():
     assert listed_object["Key"] == "one"
     assert resp["MaxKeys"] == 1
     assert resp["IsTruncated"] == True
-    assert resp["Prefix"] == "None"
+    assert resp.get("Prefix") is None
     assert resp["Delimiter"] == "None"
     assert "NextMarker" in resp
 
@@ -1274,7 +1274,7 @@ def test_boto3_list_objects_truncated_response():
     assert listed_object["Key"] == "three"
     assert resp["MaxKeys"] == 1
     assert resp["IsTruncated"] == True
-    assert resp["Prefix"] == "None"
+    assert resp.get("Prefix") is None
     assert resp["Delimiter"] == "None"
     assert "NextMarker" in resp
 
@@ -1287,7 +1287,7 @@ def test_boto3_list_objects_truncated_response():
     assert listed_object["Key"] == "two"
     assert resp["MaxKeys"] == 1
     assert resp["IsTruncated"] == False
-    assert resp["Prefix"] == "None"
+    assert resp.get("Prefix") is None
     assert resp["Delimiter"] == "None"
     assert "NextMarker" not in resp
 


### PR DESCRIPTION
This is a small change to avoid rendering "None" as the value for `Prefix` in S3 response templates.

Currently, we're sometimes receiving `<Prefix>None</Prefix>` in S3 responses, which leads to issues with paginated requests, e.g., when using `listNextBatchOfObjects(..)` from the Java SDK.

Cheers