### PR TITLE
Add IsTruncated to Route53.list_resource_record_sets

### DIFF
--- a/moto/route53/responses.py
+++ b/moto/route53/responses.py
@@ -271,6 +271,7 @@ LIST_RRSET_RESPONSE = """<ListResourceRecordSetsResponse xmlns="https://route53.
       {{ record_set.to_xml() }}
    {% endfor %}
    </ResourceRecordSets>
+   <IsTruncated>false</IsTruncated>
 </ListResourceRecordSetsResponse>"""
 
 CHANGE_RRSET_RESPONSE = """<ChangeResourceRecordSetsResponse xmlns="https://route53.amazonaws.com/doc/2012-12-12/">

--- a/tests/test_route53/test_route53.py
+++ b/tests/test_route53/test_route53.py
@@ -862,6 +862,8 @@ def test_list_resource_record_sets_name_type_filters():
         StartRecordName=all_records[start_with][1],
     )
 
+    response["IsTruncated"].should.equal(False)
+
     returned_records = [
         (record["Type"], record["Name"]) for record in response["ResourceRecordSets"]
     ]


### PR DESCRIPTION
We should return `IsTruncated: False`  on `list_resource_record_sets`.

I've tested this, and code relying on this flag works as expected with this PR.

Fixes #2660 