### PR TITLE
Fix #1728 by introducing per-service extras_require

### DIFF
--- a/moto/rds/models.py
+++ b/moto/rds/models.py
@@ -3,7 +3,6 @@ from __future__ import unicode_literals
 import boto.rds
 from jinja2 import Template
 
-from moto.cloudformation.exceptions import UnformattedGetAttTemplateException
 from moto.core import BaseBackend, BaseModel
 from moto.core.utils import get_random_hex
 from moto.ec2.models import ec2_backends
@@ -16,6 +15,10 @@ class Database(BaseModel):
             return self.address
         elif attribute_name == "Endpoint.Port":
             return self.port
+
+        # Local import to avoid circular dependency with cloudformation.parsing
+        from moto.cloudformation.exceptions import UnformattedGetAttTemplateException
+
         raise UnformattedGetAttTemplateException()
 
     @classmethod

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 #  Please add requirements to setup.py
--e .
+-e .[all]

--- a/setup.py
+++ b/setup.py
@@ -33,21 +33,13 @@ install_requires = [
     "boto>=2.36.0",
     "boto3>=1.9.201",
     "botocore>=1.12.201",
-    "cryptography>=2.3.0",
     "requests>=2.5",
     "xmltodict",
     "six>1.9",
     "werkzeug",
-    "PyYAML>=5.1",
     "pytz",
     "python-dateutil<3.0.0,>=2.1",
-    "python-jose<4.0.0",
-    "docker>=2.5.1",
-    "jsondiff>=1.1.2",
-    "aws-xray-sdk!=0.96,>=0.93",
     "responses>=0.9.0",
-    "idna<3,>=2.5",
-    "cfn-lint>=0.4.0",
     "MarkupSafe<2.0",  # This is a Jinja2 dependency, 2.0.0a1 currently seems broken
 ]
 
@@ -71,7 +63,6 @@ if PY2:
         "mock<=3.0.5",
         "more-itertools==5.0.0",
         "setuptools==44.0.0",
-        "sshpubkeys>=3.1.0,<4.0",
         "zipp==0.6.0",
     ]
 else:
@@ -80,13 +71,54 @@ else:
         "mock",
         "more-itertools",
         "setuptools",
-        "sshpubkeys>=3.1.0",
         "zipp",
     ]
 
+_dep_cryptography = "cryptography>=2.3.0"
+_dep_PyYAML = "PyYAML>=5.1"
+_dep_python_jose = "python-jose<4.0.0"
+_dep_docker = "docker>=2.5.1"
+_dep_jsondiff = "jsondiff>=1.1.2"
+_dep_aws_xray_sdk = "aws-xray-sdk!=0.96,>=0.93"
+_dep_idna = "idna<3,>=2.5"
+_dep_cfn_lint = "cfn-lint>=0.4.0"
+_dep_sshpubkeys_py2 = "sshpubkeys>=3.1.0,<4.0; python_version<'3'"
+_dep_sshpubkeys_py3 = "sshpubkeys>=3.1.0; python_version>'3'"
+
+all_extra_deps = [
+    _dep_cryptography,
+    _dep_PyYAML,
+    _dep_python_jose,
+    _dep_docker,
+    _dep_jsondiff,
+    _dep_aws_xray_sdk,
+    _dep_idna,
+    _dep_cfn_lint,
+    _dep_sshpubkeys_py2,
+    _dep_sshpubkeys_py3,
+]
+
+# TODO: do we want to add ALL services here?
+# i.e. even those without extra dependencies.
+# Would be good for future-compatibility, I guess.
+extras_per_service = {
+    "ec2": [_dep_cryptography, _dep_sshpubkeys_py2, _dep_sshpubkeys_py3],
+    'acm': [_dep_cryptography],
+    'iam': [_dep_cryptography],
+    'cloudformation': [_dep_PyYAML, _dep_cfn_lint],
+    'cognitoidp': [_dep_python_jose],
+    'awslambda': [_dep_docker],
+    'batch': [_dep_docker],
+    'iotdata': [_dep_jsondiff],
+    'xray': [_dep_aws_xray_sdk],
+}
+
 extras_require = {
+    'all': all_extra_deps,
     'server': ['flask'],
 }
+
+extras_require.update(extras_per_service)
 
 # https://hynek.me/articles/conditional-python-dependencies/
 if int(setuptools.__version__.split(".", 1)[0]) < 18:

--- a/travis_moto_server.sh
+++ b/travis_moto_server.sh
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
 set -e
-pip install flask
-pip install /moto/dist/moto*.gz
+pip install $(ls /moto/dist/moto*.gz)[server,all]
 moto_server -H 0.0.0.0 -p 5000


### PR DESCRIPTION
This is the initial approach of fixing #1728 i.e. resolve the dependencies overhead and allow for installing minimal set of dependencies for a given service (e.g. when using only `s3` backend, install dependencies used by `moto.s3` module only).

Things to discuss/decide:
- [ ] is this approach even feasible for @spulec 
- [ ] do we still need `botocore.awsrequest` and `ConnectionCls` fix in `moto/__init__.py` (why do we need it anyway)?
- [ ] do we want to include ALL services in `extras_require` (in `setup.py`) i.e. even those that don't need any additional requirements (future-proof)?
- [ ] can we trim down more dependencies (i.e. remove any from `install_requires` still, e.g. werkzeug or Jinja2)?
