### PR TITLE
setup.py: Unlock use with jsondiff >1.1.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ install_requires = [
     "python-jose<4.0.0",
     "mock",
     "docker>=2.5.1",
-    "jsondiff==1.1.2",
+    "jsondiff>=1.1.2",
     "aws-xray-sdk!=0.96,>=0.93",
     "responses>=0.9.0",
     "idna<2.9,>=2.5",


### PR DESCRIPTION
Hi!

This line in `setup.py` prevents me from updating jsondiff to the latest release:
https://github.com/spulec/moto/blob/d596560971ae289f102b9aecb9939b3c49a56ac5/setup.py#L46

Dependency jsondiff was introduced with `==1.1.1` in 0de2e55b1379f3de040485cedbf5c6fdc5a61a2d without any documentation about why `==` rather than `>=` would be needed.  It was then bumped from 1.1.1 to 1.1.2 in 5ca68fbf06adecb0c0478f102a9cc7d331aa36c4, keeping the `==` untouched. So far no signs why 1.1.2 and only 1.1.2 would need to be used. Did I miss any?

It would be great if we could lift `==` to `>=` to play nice with other Python packages in the same virtualenv and allow users to use recent jsondiff. Tests seem to still pass after the change.  Does it take anything more to make this work, from your point of view?

Many thanks, Sebastian