### PR TITLE
DynamoDB - Update Item doesnt handle LT/GT properly

### DIFF
--- a/moto/dynamodb2/comparisons.py
+++ b/moto/dynamodb2/comparisons.py
@@ -979,8 +979,6 @@ class OpLessThan(Op):
         # In python3 None is not a valid comparator when using < or > so must be handled specially
         if lhs and rhs:
             return lhs < rhs
-        elif lhs is None and rhs:
-            return True
         else:
             return False
 
@@ -994,8 +992,6 @@ class OpGreaterThan(Op):
         # In python3 None is not a valid comparator when using < or > so must be handled specially
         if lhs and rhs:
             return lhs > rhs
-        elif lhs and rhs is None:
-            return True
         else:
             return False
 
@@ -1027,8 +1023,6 @@ class OpLessThanOrEqual(Op):
         # In python3 None is not a valid comparator when using < or > so must be handled specially
         if lhs and rhs:
             return lhs <= rhs
-        elif lhs is None and rhs or lhs is None and rhs is None:
-            return True
         else:
             return False
 
@@ -1042,8 +1036,6 @@ class OpGreaterThanOrEqual(Op):
         # In python3 None is not a valid comparator when using < or > so must be handled specially
         if lhs and rhs:
             return lhs >= rhs
-        elif lhs and rhs is None or lhs is None and rhs is None:
-            return True
         else:
             return False
 

--- a/moto/dynamodb2/comparisons.py
+++ b/moto/dynamodb2/comparisons.py
@@ -977,7 +977,7 @@ class OpLessThan(Op):
         lhs = self.lhs.expr(item)
         rhs = self.rhs.expr(item)
         # In python3 None is not a valid comparator when using < or > so must be handled specially
-        if lhs and rhs:
+        if lhs is not None and rhs is not None:
             return lhs < rhs
         else:
             return False
@@ -990,7 +990,7 @@ class OpGreaterThan(Op):
         lhs = self.lhs.expr(item)
         rhs = self.rhs.expr(item)
         # In python3 None is not a valid comparator when using < or > so must be handled specially
-        if lhs and rhs:
+        if lhs is not None and rhs is not None:
             return lhs > rhs
         else:
             return False
@@ -1021,7 +1021,7 @@ class OpLessThanOrEqual(Op):
         lhs = self.lhs.expr(item)
         rhs = self.rhs.expr(item)
         # In python3 None is not a valid comparator when using < or > so must be handled specially
-        if lhs and rhs:
+        if lhs is not None and rhs is not None:
             return lhs <= rhs
         else:
             return False
@@ -1034,7 +1034,7 @@ class OpGreaterThanOrEqual(Op):
         lhs = self.lhs.expr(item)
         rhs = self.rhs.expr(item)
         # In python3 None is not a valid comparator when using < or > so must be handled specially
-        if lhs and rhs:
+        if lhs is not None and rhs is not None:
             return lhs >= rhs
         else:
             return False

--- a/tests/test_dynamodb2/test_dynamodb.py
+++ b/tests/test_dynamodb2/test_dynamodb.py
@@ -1724,7 +1724,7 @@ def test_scan_filter_should_not_return_non_existing_attributes():
     table_name = "my-table"
     item = {"partitionKey": "pk-2", "my-attr": 42}
     # Create table
-    res = boto3.resource("dynamodb")
+    res = boto3.resource("dynamodb", region_name="us-east-1")
     res.create_table(
         TableName=table_name,
         KeySchema=[{"AttributeName": "partitionKey", "KeyType": "HASH"}],

--- a/tests/test_dynamodb2/test_dynamodb.py
+++ b/tests/test_dynamodb2/test_dynamodb.py
@@ -2533,7 +2533,7 @@ def test_condition_expressions():
 
 @mock_dynamodb2
 def test_condition_expression_numerical_attribute():
-    dynamodb = boto3.resource("dynamodb")
+    dynamodb = boto3.resource("dynamodb", region_name="us-east-1")
     dynamodb.create_table(
         TableName="my-table",
         KeySchema=[{"AttributeName": "partitionKey", "KeyType": "HASH"}],


### PR DESCRIPTION
Fixes #2626 

LT/GT expressions in FilterExpression should evaluate to false if one of the attributes is None, following the official behaviour

Fixes #2627 
Comparison for LT/GT treated numerical 0 as a None-value, and so would always evaluate to False if one of the attributes is 0