### PR TITLE
awslambda: return actual result in sync invoke

### DIFF
--- a/moto/awslambda/models.py
+++ b/moto/awslambda/models.py
@@ -472,7 +472,7 @@ class LambdaFunction(BaseModel):
             payload["result"] = response_headers["x-amz-log-result"]
             result = res.encode("utf-8")
         else:
-            result = json.dumps(payload)
+            result = res
         if errored:
             response_headers["x-amz-function-error"] = "Handled"
 

--- a/tests/test_awslambda/test_lambda.py
+++ b/tests/test_awslambda/test_lambda.py
@@ -148,7 +148,7 @@ def test_invoke_event_function():
         FunctionName="testFunction", InvocationType="Event", Payload=json.dumps(in_data)
     )
     success_result["StatusCode"].should.equal(202)
-    json.loads(success_result["Payload"].read().decode("utf-8")).should.equal({})
+    json.loads(success_result["Payload"].read().decode("utf-8")).should.equal(in_data)
 
 
 if settings.TEST_SERVER_MODE:


### PR DESCRIPTION
Return actual output of the Lambda instead of echoing the input.