### PR TITLE
Fixes awslambda policy management

### DIFF
--- a/moto/awslambda/exceptions.py
+++ b/moto/awslambda/exceptions.py
@@ -1,4 +1,5 @@
 from botocore.client import ClientError
+from moto.core.exceptions import JsonRESTError
 
 
 class LambdaClientError(ClientError):
@@ -29,3 +30,12 @@ class InvalidRoleFormat(LambdaClientError):
             role, InvalidRoleFormat.pattern
         )
         super(InvalidRoleFormat, self).__init__("ValidationException", message)
+
+
+class PreconditionFailedException(JsonRESTError):
+    code = 412
+
+    def __init__(self, message):
+        super(PreconditionFailedException, self).__init__(
+            "PreconditionFailedException", message
+        )

--- a/moto/awslambda/policy.py
+++ b/moto/awslambda/policy.py
@@ -1,0 +1,145 @@
+from __future__ import unicode_literals
+
+import json
+import uuid
+
+from six import string_types
+
+from moto.awslambda.exceptions import PreconditionFailedException
+
+
+class Policy:
+    def __init__(self, parent):
+        self.revision = str(uuid.uuid4())
+        self.statements = []
+        self.parent = parent
+
+    def __repr__(self):
+        return json.dumps(self.get_policy())
+
+    def wire_format(self):
+        return json.dumps(
+            {
+                "Policy": json.dumps(
+                    {
+                        "Version": "2012-10-17",
+                        "Id": "default",
+                        "Statement": self.statements,
+                    }
+                ),
+                "RevisionId": self.revision,
+            }
+        )
+
+    def get_policy(self):
+        return {
+            "Policy": {
+                "Version": "2012-10-17",
+                "Id": "default",
+                "Statement": self.statements,
+            },
+            "RevisionId": self.revision,
+        }
+
+    # adds the raw JSON statement to the policy
+    def add_statement(self, raw):
+        policy = json.loads(raw, object_hook=self.decode_policy)
+        if len(policy.revision) > 0 and self.revision != policy.revision:
+            raise PreconditionFailedException(
+                "The RevisionId provided does not match the latest RevisionId"
+                " for the Lambda function or alias. Call the GetFunction or the GetAlias API to retrieve"
+                " the latest RevisionId for your resource."
+            )
+        self.statements.append(policy.statements[0])
+        self.revision = str(uuid.uuid4())
+
+    # removes the statement that matches 'sid' from the policy
+    def del_statement(self, sid, revision=""):
+        if len(revision) > 0 and self.revision != revision:
+            raise PreconditionFailedException(
+                "The RevisionId provided does not match the latest RevisionId"
+                " for the Lambda function or alias. Call the GetFunction or the GetAlias API to retrieve"
+                " the latest RevisionId for your resource."
+            )
+        for statement in self.statements:
+            if "Sid" in statement and statement["Sid"] == sid:
+                self.statements.remove(statement)
+
+    # converts AddPermission request to PolicyStatement
+    # https://docs.aws.amazon.com/lambda/latest/dg/API_AddPermission.html
+    def decode_policy(self, obj):
+        # import pydevd
+        # pydevd.settrace("localhost", port=5678)
+        policy = Policy(self.parent)
+        policy.revision = obj.get("RevisionId", "")
+
+        # set some default values if these keys are not set
+        self.ensure_set(obj, "Effect", "Allow")
+        self.ensure_set(obj, "Resource", self.parent.function_arn + ":$LATEST")
+        self.ensure_set(obj, "StatementId", str(uuid.uuid4()))
+
+        # transform field names and values
+        self.transform_property(obj, "StatementId", "Sid", self.nop_formatter)
+        self.transform_property(obj, "Principal", "Principal", self.principal_formatter)
+        self.transform_property(
+            obj, "SourceArn", "SourceArn", self.source_arn_formatter
+        )
+        self.transform_property(
+            obj, "SourceAccount", "SourceAccount", self.source_account_formatter
+        )
+
+        # remove RevisionId and EventSourceToken if they are set
+        self.remove_if_set(obj, ["RevisionId", "EventSourceToken"])
+
+        # merge conditional statements into a single map under the Condition key
+        self.condition_merge(obj)
+
+        # append resulting statement to policy.statements
+        policy.statements.append(obj)
+
+        return policy
+
+    def nop_formatter(self, obj):
+        return obj
+
+    def ensure_set(self, obj, key, value):
+        if key not in obj:
+            obj[key] = value
+
+    def principal_formatter(self, obj):
+        if isinstance(obj, string_types):
+            if obj.endswith(".amazonaws.com"):
+                return {"Service": obj}
+            if obj.endswith(":root"):
+                return {"AWS": obj}
+        return obj
+
+    def source_account_formatter(self, obj):
+        return {"StringEquals": {"AWS:SourceAccount": obj}}
+
+    def source_arn_formatter(self, obj):
+        return {"ArnLike": {"AWS:SourceArn": obj}}
+
+    def transform_property(self, obj, old_name, new_name, formatter):
+        if old_name in obj:
+            obj[new_name] = formatter(obj[old_name])
+            if new_name != old_name:
+                del obj[old_name]
+
+    def remove_if_set(self, obj, keys):
+        for key in keys:
+            if key in obj:
+                del obj[key]
+
+    def condition_merge(self, obj):
+        if "SourceArn" in obj:
+            if "Condition" not in obj:
+                obj["Condition"] = {}
+            obj["Condition"].update(obj["SourceArn"])
+            del obj["SourceArn"]
+
+        if "SourceAccount" in obj:
+            if "Condition" not in obj:
+                obj["Condition"] = {}
+            obj["Condition"].update(obj["SourceAccount"])
+            del obj["SourceAccount"]

--- a/moto/awslambda/policy.py
+++ b/moto/awslambda/policy.py
@@ -14,22 +14,10 @@ class Policy:
         self.statements = []
         self.parent = parent
 
-    def __repr__(self):
-        return json.dumps(self.get_policy())
-
     def wire_format(self):
-        return json.dumps(
-            {
-                "Policy": json.dumps(
-                    {
-                        "Version": "2012-10-17",
-                        "Id": "default",
-                        "Statement": self.statements,
-                    }
-                ),
-                "RevisionId": self.revision,
-            }
-        )
+        p = self.get_policy()
+        p["Policy"] = json.dumps(p["Policy"])
+        return json.dumps(p)
 
     def get_policy(self):
         return {
@@ -81,6 +69,7 @@ class Policy:
         # transform field names and values
         self.transform_property(obj, "StatementId", "Sid", self.nop_formatter)
         self.transform_property(obj, "Principal", "Principal", self.principal_formatter)
+
         self.transform_property(
             obj, "SourceArn", "SourceArn", self.source_arn_formatter
         )

--- a/moto/awslambda/urls.py
+++ b/moto/awslambda/urls.py
@@ -6,7 +6,7 @@ url_bases = ["https?://lambda.(.+).amazonaws.com"]
 response = LambdaResponse()
 
 url_paths = {
-    "{0}/(?P<api_version>[^/]+)/functions/?$": response.root,
+    r"{0}/(?P<api_version>[^/]+)/functions/?$": response.root,
     r"{0}/(?P<api_version>[^/]+)/functions/(?P<function_name>[\w_:%-]+)/?$": response.function,
     r"{0}/(?P<api_version>[^/]+)/functions/(?P<function_name>[\w_-]+)/versions/?$": response.versions,
     r"{0}/(?P<api_version>[^/]+)/event-source-mappings/?$": response.event_source_mappings,
@@ -14,6 +14,7 @@ url_paths = {
     r"{0}/(?P<api_version>[^/]+)/functions/(?P<function_name>[\w_-]+)/invocations/?$": response.invoke,
     r"{0}/(?P<api_version>[^/]+)/functions/(?P<function_name>[\w_-]+)/invoke-async/?$": response.invoke_async,
     r"{0}/(?P<api_version>[^/]+)/tags/(?P<resource_arn>.+)": response.tag,
+    r"{0}/(?P<api_version>[^/]+)/functions/(?P<function_name>[\w_-]+)/policy/(?P<statement_id>[\w_-]+)$": response.policy,
     r"{0}/(?P<api_version>[^/]+)/functions/(?P<function_name>[\w_-]+)/policy/?$": response.policy,
     r"{0}/(?P<api_version>[^/]+)/functions/(?P<function_name>[\w_-]+)/configuration/?$": response.configuration,
     r"{0}/(?P<api_version>[^/]+)/functions/(?P<function_name>[\w_-]+)/code/?$": response.code,

--- a/tests/test_awslambda/test_lambda.py
+++ b/tests/test_awslambda/test_lambda.py
@@ -324,6 +324,7 @@ def test_create_function_from_aws_bucket():
                 "VpcId": "vpc-123abc",
             },
             "ResponseMetadata": {"HTTPStatusCode": 201},
+            "State": "Active",
         }
     )
 
@@ -367,6 +368,7 @@ def test_create_function_from_zipfile():
             "Version": "1",
             "VpcConfig": {"SecurityGroupIds": [], "SubnetIds": []},
             "ResponseMetadata": {"HTTPStatusCode": 201},
+            "State": "Active",
         }
     )
 
@@ -631,6 +633,7 @@ def test_list_create_list_get_delete_list():
             "Timeout": 3,
             "Version": "$LATEST",
             "VpcConfig": {"SecurityGroupIds": [], "SubnetIds": []},
+            "State": "Active",
         },
         "ResponseMetadata": {"HTTPStatusCode": 200},
     }
@@ -827,6 +830,7 @@ def test_get_function_created_with_zipfile():
             "Timeout": 3,
             "Version": "$LATEST",
             "VpcConfig": {"SecurityGroupIds": [], "SubnetIds": []},
+            "State": "Active",
         }
     )
 
@@ -1436,6 +1440,7 @@ def test_update_function_zip():
             "Timeout": 3,
             "Version": "2",
             "VpcConfig": {"SecurityGroupIds": [], "SubnetIds": []},
+            "State": "Active",
         }
     )
 
@@ -1498,6 +1503,7 @@ def test_update_function_s3():
             "Timeout": 3,
             "Version": "2",
             "VpcConfig": {"SecurityGroupIds": [], "SubnetIds": []},
+            "State": "Active",
         }
     )
 

--- a/tests/test_awslambda/test_policy.py
+++ b/tests/test_awslambda/test_policy.py
@@ -1,0 +1,104 @@
+from __future__ import unicode_literals
+
+import unittest
+import json
+
+from moto.awslambda.policy import Policy
+
+
+class MockLambdaFunction:
+    def __init__(self, arn):
+        self.function_arn = arn
+        self.policy = None
+
+
+class TC:
+    def __init__(self, lambda_arn, statement, expected):
+        self.statement = statement
+        self.expected = expected
+        self.fn = MockLambdaFunction(lambda_arn)
+        self.policy = Policy(self.fn)
+
+    def Run(self, parent):
+        self.policy.add_statement(json.dumps(self.statement))
+        parent.assertDictEqual(self.expected, self.policy.statements[0])
+
+        sid = self.statement.get("StatementId", None)
+        if sid == None:
+            raise "TestCase.statement does not contain StatementId"
+
+        self.policy.del_statement(sid)
+        parent.assertEqual([], self.policy.statements)
+
+
+class TestPolicy(unittest.TestCase):
+    def test(self):
+        tt = [
+            TC(
+                # lambda_arn
+                "arn",
+                {  # statement
+                    "StatementId": "statement0",
+                    "Action": "lambda:InvokeFunction",
+                    "FunctionName": "function_name",
+                    "Principal": "events.amazonaws.com",
+                },
+                {  # expected
+                    "Action": "lambda:InvokeFunction",
+                    "FunctionName": "function_name",
+                    "Principal": {"Service": "events.amazonaws.com"},
+                    "Effect": "Allow",
+                    "Resource": "arn:$LATEST",
+                    "Sid": "statement0",
+                },
+            ),
+            TC(
+                # lambda_arn
+                "arn",
+                {  # statement
+                    "StatementId": "statement1",
+                    "Action": "lambda:InvokeFunction",
+                    "FunctionName": "function_name",
+                    "Principal": "events.amazonaws.com",
+                    "SourceArn": "arn:aws:events:us-east-1:111111111111:rule/rule_name",
+                },
+                {
+                    "Action": "lambda:InvokeFunction",
+                    "FunctionName": "function_name",
+                    "Principal": {"Service": "events.amazonaws.com"},
+                    "Effect": "Allow",
+                    "Resource": "arn:$LATEST",
+                    "Sid": "statement1",
+                    "Condition": {
+                        "ArnLike": {
+                            "AWS:SourceArn": "arn:aws:events:us-east-1:111111111111:rule/rule_name"
+                        }
+                    },
+                },
+            ),
+            TC(
+                # lambda_arn
+                "arn",
+                {  # statement
+                    "StatementId": "statement2",
+                    "Action": "lambda:InvokeFunction",
+                    "FunctionName": "function_name",
+                    "Principal": "events.amazonaws.com",
+                    "SourceAccount": "111111111111",
+                },
+                {  # expected
+                    "Action": "lambda:InvokeFunction",
+                    "FunctionName": "function_name",
+                    "Principal": {"Service": "events.amazonaws.com"},
+                    "Effect": "Allow",
+                    "Resource": "arn:$LATEST",
+                    "Sid": "statement2",
+                    "Condition": {
+                        "StringEquals": {"AWS:SourceAccount": "111111111111"}
+                    },
+                },
+            ),
+        ]
+
+        for tc in tt:
+            tc.Run(self)

--- a/tests/test_awslambda/test_policy.py
+++ b/tests/test_awslambda/test_policy.py
@@ -1,7 +1,7 @@
 from __future__ import unicode_literals
 
-import unittest
 import json
+import sure
 
 from moto.awslambda.policy import Policy
 
@@ -12,39 +12,38 @@ class MockLambdaFunction:
         self.policy = None
 
 
-class TestPolicy(unittest.TestCase):
-    def test_policy(self):
-        policy = Policy(MockLambdaFunction("arn"))
-        statement = {
-            "StatementId": "statement0",
-            "Action": "lambda:InvokeFunction",
-            "FunctionName": "function_name",
-            "Principal": "events.amazonaws.com",
-            "SourceArn": "arn:aws:events:us-east-1:111111111111:rule/rule_name",
-            "SourceAccount": "111111111111",
-        }
+def test_policy():
+    policy = Policy(MockLambdaFunction("arn"))
+    statement = {
+        "StatementId": "statement0",
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": "function_name",
+        "Principal": "events.amazonaws.com",
+        "SourceArn": "arn:aws:events:us-east-1:111111111111:rule/rule_name",
+        "SourceAccount": "111111111111",
+    }
 
-        expected = {
-            "Action": "lambda:InvokeFunction",
-            "FunctionName": "function_name",
-            "Principal": {"Service": "events.amazonaws.com"},
-            "Effect": "Allow",
-            "Resource": "arn:$LATEST",
-            "Sid": "statement0",
-            "Condition": {
-                "ArnLike": {
-                    "AWS:SourceArn": "arn:aws:events:us-east-1:111111111111:rule/rule_name",
-                },
-                "StringEquals": {"AWS:SourceAccount": "111111111111"},
+    expected = {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": "function_name",
+        "Principal": {"Service": "events.amazonaws.com"},
+        "Effect": "Allow",
+        "Resource": "arn:$LATEST",
+        "Sid": "statement0",
+        "Condition": {
+            "ArnLike": {
+                "AWS:SourceArn": "arn:aws:events:us-east-1:111111111111:rule/rule_name",
             },
-        }
+            "StringEquals": {"AWS:SourceAccount": "111111111111"},
+        },
+    }
 
-        policy.add_statement(json.dumps(statement))
-        self.assertDictEqual(expected, policy.statements[0])
+    policy.add_statement(json.dumps(statement))
+    expected.should.be.equal(policy.statements[0])
 
-        sid = statement.get("StatementId", None)
-        if sid == None:
-            raise "TestCase.statement does not contain StatementId"
+    sid = statement.get("StatementId", None)
+    if sid == None:
+        raise "TestCase.statement does not contain StatementId"
 
-        policy.del_statement(sid)
-        self.assertEqual([], policy.statements)
+    policy.del_statement(sid)
+    [].should.be.equal(policy.statements)


### PR DESCRIPTION
- adds support for multiple policy statements
- adds support for RevisionId parameter
- adds support for lambda/RemovePermission
- adds State parameter to lambda/GetFunctionConfiguration (always returns Active)

Most of these changes were required in order to more closely mimic the AWS API and resolve issues when using moto[server] with terraform.