### PR TITLE
Botocore no longer needs an older version of python-dateutil.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ install_requires = [
     "werkzeug",
     "PyYAML>=5.1",
     "pytz",
-    "python-dateutil<2.8.1,>=2.1",
+    "python-dateutil<3.0.0,>=2.1",
     "python-jose<4.0.0",
     "mock",
     "docker>=2.5.1",


### PR DESCRIPTION
https://github.com/boto/botocore/pull/1910
https://github.com/boto/botocore/issues/1872
https://github.com/spulec/moto/pull/2570