### PR TITLE
RDS Feature: Add EnableIAMDatabaseAuthentication

### DIFF
--- a/moto/rds2/models.py
+++ b/moto/rds2/models.py
@@ -544,7 +544,7 @@ class Snapshot(BaseModel):
               <KmsKeyId>{{ database.kms_key_id }}</KmsKeyId>
               <DBSnapshotArn>{{ snapshot.snapshot_arn }}</DBSnapshotArn>
               <Timezone></Timezone>
-              <IAMDatabaseAuthenticationEnabled>false</IAMDatabaseAuthenticationEnabled>
+              <IAMDatabaseAuthenticationEnabled>{{ database.enable_iam_database_authentication|lower }}</IAMDatabaseAuthenticationEnabled>
             </DBSnapshot>"""
         )
         return template.render(snapshot=self, database=self.database)

--- a/moto/rds2/models.py
+++ b/moto/rds2/models.py
@@ -130,7 +130,9 @@ class Database(BaseModel):
         if not self.option_group_name and self.engine in self.default_option_groups:
             self.option_group_name = self.default_option_groups[self.engine]
         self.character_set_name = kwargs.get("character_set_name", None)
-        self.iam_database_authentication_enabled = False
+        self.enable_iam_database_authentication = kwargs.get(
+            "enable_iam_database_authentication", False
+        )
         self.dbi_resource_id = "db-M5ENSHXFPU6XHZ4G4ZEI5QIO2U"
         self.tags = kwargs.get("tags", [])
 

--- a/moto/rds2/models.py
+++ b/moto/rds2/models.py
@@ -216,7 +216,7 @@ class Database(BaseModel):
               <ReadReplicaSourceDBInstanceIdentifier>{{ database.source_db_identifier }}</ReadReplicaSourceDBInstanceIdentifier>
               {% endif %}
               <Engine>{{ database.engine }}</Engine>
-              <IAMDatabaseAuthenticationEnabled>{{database.iam_database_authentication_enabled }}</IAMDatabaseAuthenticationEnabled>
+              <IAMDatabaseAuthenticationEnabled>{{database.enable_iam_database_authentication|lower }}</IAMDatabaseAuthenticationEnabled>
               <LicenseModel>{{ database.license_model }}</LicenseModel>
               <EngineVersion>{{ database.engine_version }}</EngineVersion>
               <OptionGroupMemberships>

--- a/moto/rds2/responses.py
+++ b/moto/rds2/responses.py
@@ -27,6 +27,7 @@ class RDS2Response(BaseResponse):
             "db_subnet_group_name": self._get_param("DBSubnetGroupName"),
             "engine": self._get_param("Engine"),
             "engine_version": self._get_param("EngineVersion"),
+            "enable_iam_database_authentication": self._get_bool_param("EnableIAMDatabaseAuthentication"),
             "license_model": self._get_param("LicenseModel"),
             "iops": self._get_int_param("Iops"),
             "kms_key_id": self._get_param("KmsKeyId"),

--- a/moto/rds2/responses.py
+++ b/moto/rds2/responses.py
@@ -27,7 +27,9 @@ class RDS2Response(BaseResponse):
             "db_subnet_group_name": self._get_param("DBSubnetGroupName"),
             "engine": self._get_param("Engine"),
             "engine_version": self._get_param("EngineVersion"),
-            "enable_iam_database_authentication": self._get_bool_param("EnableIAMDatabaseAuthentication"),
+            "enable_iam_database_authentication": self._get_bool_param(
+                "EnableIAMDatabaseAuthentication"
+            ),
             "license_model": self._get_param("LicenseModel"),
             "iops": self._get_int_param("Iops"),
             "kms_key_id": self._get_param("KmsKeyId"),

--- a/tests/test_rds2/test_rds2.py
+++ b/tests/test_rds2/test_rds2.py
@@ -1692,7 +1692,7 @@ def test_create_parameter_group_with_tags():
 
 
 @mock_rds2
-def test_create_database_with_iam_authentication():
+def test_create_db_with_iam_authentication():
     conn = boto3.client("rds", region_name="us-west-2")
 
     database = conn.create_db_instance(

--- a/tests/test_rds2/test_rds2.py
+++ b/tests/test_rds2/test_rds2.py
@@ -1704,3 +1704,21 @@ def test_create_database_with_iam_authentication():
 
     db_instance = database["DBInstance"]
     db_instance["IAMDatabaseAuthenticationEnabled"].should.equal(True)
+
+
+@mock_rds2
+def test_create_db_snapshot_with_iam_authentication():
+    conn = boto3.client("rds", region_name="us-west-2")
+
+    conn.create_db_instance(
+        DBInstanceIdentifier="rds",
+        DBInstanceClass="db.t1.micro",
+        Engine="postgres",
+        EnableIAMDatabaseAuthentication=True,
+    )
+
+    snapshot = conn.create_db_snapshot(
+        DBInstanceIdentifier="rds", DBSnapshotIdentifier="snapshot"
+    ).get("DBSnapshot")
+
+    snapshot.get("IAMDatabaseAuthenticationEnabled").should.equal(True)

--- a/tests/test_rds2/test_rds2.py
+++ b/tests/test_rds2/test_rds2.py
@@ -1689,3 +1689,18 @@ def test_create_parameter_group_with_tags():
         ResourceName="arn:aws:rds:us-west-2:1234567890:pg:test"
     )
     result["TagList"].should.equal([{"Value": "bar", "Key": "foo"}])
+
+
+@mock_rds2
+def test_create_database_with_iam_authentication():
+    conn = boto3.client("rds", region_name="us-west-2")
+
+    database = conn.create_db_instance(
+        DBInstanceIdentifier="rds",
+        DBInstanceClass="db.t1.micro",
+        Engine="postgres",
+        EnableIAMDatabaseAuthentication=True,
+    )
+
+    db_instance = database["DBInstance"]
+    db_instance["IAMDatabaseAuthenticationEnabled"].should.equal(True)


### PR DESCRIPTION
#2690 . This PR adds `EnableIAMDatabaseAuthentication` parameter into rds's `create_db_instance`. Also a small patch to fix snapshot creation with this new option.

First contribution here, hope it helps :-).