### PR TITLE
Remove ResourceWarnings when loading AMIS and INSTANCE_TYPES

### DIFF
--- a/moto/ec2/models.py
+++ b/moto/ec2/models.py
@@ -139,16 +139,21 @@ from .utils import (
     rsa_public_key_fingerprint,
 )
 
-INSTANCE_TYPES = json.load(
-    open(resource_filename(__name__, "resources/instance_types.json"), "r")
+
+def _load_resource(filename):
+    with open(filename, "r") as f:
+        return json.load(f)
+
+
+INSTANCE_TYPES = _load_resource(
+    resource_filename(__name__, "resources/instance_types.json")
 )
-AMIS = json.load(
-    open(
-        os.environ.get("MOTO_AMIS_PATH")
-        or resource_filename(__name__, "resources/amis.json"),
-        "r",
-    )
+
+AMIS = _load_resource(
+    os.environ.get("MOTO_AMIS_PATH")
+    or resource_filename(__name__, "resources/amis.json"),
 )
+
 
 OWNER_ID = "111122223333"
 


### PR DESCRIPTION
When loading AMIS and INSTANCE_TYPES in moto.ec2.models a file handle is
potentially leaked when loading the JSON.  This results in a
ResourceWarning which is a bit of unnecessary noise.

Rather than pass a call to open() to json.load() this instead uses a
context-manager in a small private helper function.

This fixes https://github.com/spulec/moto/issues/2620