### PR TITLE
Handle map or list parameters in sns processing

### DIFF
--- a/moto/ses/models.py
+++ b/moto/ses/models.py
@@ -148,11 +148,15 @@ class SESBackend(BaseBackend):
     def __type_of_message__(self, destinations):
         """Checks the destination for any special address that could indicate delivery,
         complaint or bounce like in SES simulator"""
-        alladdress = (
-            destinations.get("ToAddresses", [])
-            + destinations.get("CcAddresses", [])
-            + destinations.get("BccAddresses", [])
-        )
+        if isinstance(destinations, list):
+            alladdress = destinations
+        else:
+            alladdress = (
+                destinations.get("ToAddresses", [])
+                + destinations.get("CcAddresses", [])
+                + destinations.get("BccAddresses", [])
+            )
+
         for addr in alladdress:
             if SESFeedback.SUCCESS_ADDR in addr:
                 return SESFeedback.DELIVERY


### PR DESCRIPTION
When utilizing sns the `__type_of_message__` can receive either a list or a map.

map:
- https://github.com/spulec/moto/blob/master/moto/ses/responses.py#L58
- https://github.com/spulec/moto/blob/master/moto/ses/responses.py#L79

list:
- https://github.com/spulec/moto/blob/master/moto/ses/responses.py#L104