### PR TITLE
Added 'x-amzn-ErrorType' in the return header for missing lambda function

### DIFF
--- a/moto/awslambda/responses.py
+++ b/moto/awslambda/responses.py
@@ -295,7 +295,7 @@ class LambdaResponse(BaseResponse):
                 code["Configuration"]["FunctionArn"] += ":$LATEST"
             return 200, {}, json.dumps(code)
         else:
-            return 404, {}, "{}"
+            return 404, {"x-amzn-ErrorType": "ResourceNotFoundException"}, "{}"
 
     def _get_aws_region(self, full_url):
         region = self.region_regex.search(full_url)

--- a/tests/test_awslambda/test_lambda.py
+++ b/tests/test_awslambda/test_lambda.py
@@ -78,7 +78,7 @@ def lambda_handler(event, context):
 
 def get_test_zip_file4():
     pfunc = """
-def lambda_handler(event, context):    
+def lambda_handler(event, context):
     raise Exception('I failed!')
 """
     return _process_lambda(pfunc)
@@ -455,7 +455,7 @@ def test_get_function():
     )
 
     # Test get function when can't find function name
-    with assert_raises(ClientError):
+    with assert_raises(conn.exceptions.ResourceNotFoundException):
         conn.get_function(FunctionName="junk", Qualifier="$LATEST")
 
 

--- a/tests/test_awslambda/test_lambda_cloudformation.py
+++ b/tests/test_awslambda/test_lambda_cloudformation.py
@@ -94,7 +94,7 @@ def test_lambda_can_be_deleted_by_cloudformation():
     # Verify function was deleted
     with assert_raises(ClientError) as e:
         lmbda.get_function(FunctionName=created_fn_name)
-    e.exception.response["Error"]["Code"].should.equal("404")
+    e.exception.response["Error"]["Code"].should.equal("ResourceNotFoundException")
 
 
 def create_stack(cf, s3):


### PR DESCRIPTION
This is so that lambda client get_function() method will raise the same exception that AWS does for a non-existent function.

