### PR TITLE
Limit SQS list_queues response to 1000 queues

### DIFF
--- a/moto/sqs/models.py
+++ b/moto/sqs/models.py
@@ -567,7 +567,7 @@ class SQSBackend(BaseBackend):
         for name, q in self.queues.items():
             if prefix_re.search(name):
                 qs.append(q)
-        return qs
+        return qs[:1000]
 
     def get_queue(self, queue_name):
         queue = self.queues.get(queue_name)

--- a/tests/test_sqs/test_sqs.py
+++ b/tests/test_sqs/test_sqs.py
@@ -1759,3 +1759,23 @@ def test_receive_message_for_queue_with_receive_message_wait_time_seconds_set():
     )
 
     queue.receive_messages()
+
+
+@mock_sqs
+def test_list_queues_limits_to_1000_queues():
+    client = boto3.client("sqs", region_name="us-east-1")
+
+    for i in range(1001):
+        client.create_queue(QueueName="test-queue-{0}".format(i))
+
+    client.list_queues()["QueueUrls"].should.have.length_of(1000)
+    client.list_queues(QueueNamePrefix="test-queue")["QueueUrls"].should.have.length_of(
+        1000
+    )
+
+    resource = boto3.resource("sqs", region_name="us-east-1")
+
+    list(resource.queues.all()).should.have.length_of(1000)
+    list(resource.queues.filter(QueueNamePrefix="test-queue")).should.have.length_of(
+        1000
+    )


### PR DESCRIPTION
The maximum number of queues that the ListQueues API can return is 1000:

https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_ListQueues.html

I had a couple of tests on another project that were incorrectly passing becuase Moto wasn't mimicking the same behavior as the AWS API.