### PR TITLE
Include closed execution extra info

### DIFF
--- a/moto/swf/models/workflow_execution.py
+++ b/moto/swf/models/workflow_execution.py
@@ -127,6 +127,10 @@ class WorkflowExecution(BaseModel):
             "executionInfo": self.to_medium_dict(),
             "executionConfiguration": {"taskList": {"name": self.task_list}},
         }
+        # info
+        if self.execution_status == "CLOSED":
+            hsh["executionInfo"]["closeStatus"] = self.close_status
+            hsh["executionInfo"]["closeTimestamp"] = self.close_timestamp
         # configuration
         for key in self._configuration_keys:
             attr = camelcase_to_underscores(key)

--- a/tests/test_swf/models/test_workflow_execution.py
+++ b/tests/test_swf/models/test_workflow_execution.py
@@ -148,6 +148,39 @@ def test_workflow_execution_full_dict_representation():
     )
 
 
+def test_closed_workflow_execution_full_dict_representation():
+    domain = get_basic_domain()
+    wf_type = WorkflowType(
+        "test-workflow",
+        "v1.0",
+        task_list="queue",
+        default_child_policy="ABANDON",
+        default_execution_start_to_close_timeout="300",
+        default_task_start_to_close_timeout="300",
+    )
+    wfe = WorkflowExecution(domain, wf_type, "ab1234")
+    wfe.execution_status = "CLOSED"
+    wfe.close_status = "CANCELED"
+    wfe.close_timestamp = 1420066801.123
+
+    fd = wfe.to_full_dict()
+    medium_dict = wfe.to_medium_dict()
+    medium_dict["closeStatus"] = "CANCELED"
+    medium_dict["closeTimestamp"] = 1420066801.123
+    fd["executionInfo"].should.equal(medium_dict)
+    fd["openCounts"]["openTimers"].should.equal(0)
+    fd["openCounts"]["openDecisionTasks"].should.equal(0)
+    fd["openCounts"]["openActivityTasks"].should.equal(0)
+    fd["executionConfiguration"].should.equal(
+        {
+            "childPolicy": "ABANDON",
+            "executionStartToCloseTimeout": "300",
+            "taskList": {"name": "queue"},
+            "taskStartToCloseTimeout": "300",
+        }
+    )
+
+
 def test_workflow_execution_list_dict_representation():
     domain = get_basic_domain()
     wf_type = WorkflowType(


### PR DESCRIPTION
[`describe_workflow_execution`](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/swf.html#SWF.Client.describe_workflow_execution) includes extra fields "closeStatus" and "closeTimestamp" in its output if the workflow is closed.