### PR TITLE
Support default task-priority and Lambda-role in SWF workflow registration

### DIFF
--- a/moto/swf/models/workflow_type.py
+++ b/moto/swf/models/workflow_type.py
@@ -8,6 +8,8 @@ class WorkflowType(GenericType):
             "defaultChildPolicy",
             "defaultExecutionStartToCloseTimeout",
             "defaultTaskStartToCloseTimeout",
+            "defaultTaskPriority",
+            "defaultLambdaRole",
         ]
 
     @property

--- a/moto/swf/responses.py
+++ b/moto/swf/responses.py
@@ -300,6 +300,12 @@ class SWFResponse(BaseResponse):
         default_execution_start_to_close_timeout = self._params.get(
             "defaultExecutionStartToCloseTimeout"
         )
+        default_task_priority = self._params.get(
+            "defaultTaskPriority"
+        )
+        default_lambda_role = self._params.get(
+            "defaultLambdaRole"
+        )
         description = self._params.get("description")
 
         self._check_string(domain)
@@ -309,10 +315,10 @@ class SWFResponse(BaseResponse):
         self._check_none_or_string(default_child_policy)
         self._check_none_or_string(default_task_start_to_close_timeout)
         self._check_none_or_string(default_execution_start_to_close_timeout)
+        self._check_none_or_string(default_task_priority)
+        self._check_none_or_string(default_lambda_role)
         self._check_none_or_string(description)
 
-        # TODO: add defaultTaskPriority when boto gets to support it
-        # TODO: add defaultLambdaRole when boto gets to support it
         self.swf_backend.register_type(
             "workflow",
             domain,
@@ -322,6 +328,8 @@ class SWFResponse(BaseResponse):
             default_child_policy=default_child_policy,
             default_task_start_to_close_timeout=default_task_start_to_close_timeout,
             default_execution_start_to_close_timeout=default_execution_start_to_close_timeout,
+            default_task_priority=default_task_priority,
+            default_lambda_role=default_lambda_role,
             description=description,
         )
         return ""

--- a/moto/swf/responses.py
+++ b/moto/swf/responses.py
@@ -300,12 +300,8 @@ class SWFResponse(BaseResponse):
         default_execution_start_to_close_timeout = self._params.get(
             "defaultExecutionStartToCloseTimeout"
         )
-        default_task_priority = self._params.get(
-            "defaultTaskPriority"
-        )
-        default_lambda_role = self._params.get(
-            "defaultLambdaRole"
-        )
+        default_task_priority = self._params.get("defaultTaskPriority")
+        default_lambda_role = self._params.get("defaultLambdaRole")
         description = self._params.get("description")
 
         self._check_string(domain)


### PR DESCRIPTION
SWF workflow type now keeps track of the default task-priority and default AWS Lambda role, set at workflow registration.

This requires the test to use `boto3` and `mock_swf` (instead of the existing import of `boto` and `mock_swf_deprecated`), as `boto` doesn't support these parameters in workflow registration.

A future PR will be needed to support decision task priority.