### PR TITLE
EMR - Return start time of first step

### DIFF
--- a/moto/emr/models.py
+++ b/moto/emr/models.py
@@ -86,6 +86,9 @@ class FakeStep(BaseModel):
         self.start_datetime = None
         self.state = state
 
+    def start(self):
+        self.start_datetime = datetime.now(pytz.utc)
+
 
 class FakeCluster(BaseModel):
     def __init__(
@@ -204,6 +207,8 @@ class FakeCluster(BaseModel):
 
         self.start_cluster()
         self.run_bootstrap_actions()
+        if self.steps:
+            self.steps[0].start()
 
     @property
     def instance_groups(self):

--- a/moto/emr/responses.py
+++ b/moto/emr/responses.py
@@ -835,7 +835,7 @@ LIST_STEPS_TEMPLATE = """<ListStepsResponse xmlns="http://elasticmapreduce.amazo
             {% if step.end_datetime is not none %}
             <EndDateTime>{{ step.end_datetime.isoformat() }}</EndDateTime>
             {% endif %}
-            {% if step.ready_datetime is not none %}
+            {% if step.start_datetime is not none %}
             <StartDateTime>{{ step.start_datetime.isoformat() }}</StartDateTime>
             {% endif %}
           </Timeline>

--- a/tests/test_emr/test_emr_boto3.py
+++ b/tests/test_emr/test_emr_boto3.py
@@ -752,7 +752,9 @@ def test_steps():
         # StateChangeReason
         x["Status"]["Timeline"]["CreationDateTime"].should.be.a("datetime.datetime")
         # x['Status']['Timeline']['EndDateTime'].should.be.a('datetime.datetime')
-        # x['Status']['Timeline']['StartDateTime'].should.be.a('datetime.datetime')
+        # Only the first step will have started - we don't know anything about when it finishes, so the second step never starts
+        if x["Name"] == "My wordcount example":
+            x["Status"]["Timeline"]["StartDateTime"].should.be.a("datetime.datetime")
 
         x = client.describe_step(ClusterId=cluster_id, StepId=x["Id"])["Step"]
         x["ActionOnFailure"].should.equal("TERMINATE_CLUSTER")


### PR DESCRIPTION
Fixes #1427 

'Starts' the first step of a cluster, and sets the start time of that step.
