### PR TITLE
Keep track of previous started event ID in SWF executions

### DIFF
--- a/moto/swf/models/decision_task.py
+++ b/moto/swf/models/decision_task.py
@@ -15,7 +15,7 @@ class DecisionTask(BaseModel):
         self.workflow_type = workflow_execution.workflow_type
         self.task_token = str(uuid.uuid4())
         self.scheduled_event_id = scheduled_event_id
-        self.previous_started_event_id = 0
+        self.previous_started_event_id = None
         self.started_event_id = None
         self.started_timestamp = None
         self.start_to_close_timeout = (
@@ -40,10 +40,11 @@ class DecisionTask(BaseModel):
         hsh = {
             "events": [evt.to_dict() for evt in events],
             "taskToken": self.task_token,
-            "previousStartedEventId": self.previous_started_event_id,
             "workflowExecution": self.workflow_execution.to_short_dict(),
             "workflowType": self.workflow_type.to_short_dict(),
         }
+        if self.previous_started_event_id is not None:
+            hsh["previousStartedEventId"] = self.previous_started_event_id
         if self.started_event_id:
             hsh["startedEventId"] = self.started_event_id
         return hsh

--- a/moto/swf/models/decision_task.py
+++ b/moto/swf/models/decision_task.py
@@ -49,10 +49,11 @@ class DecisionTask(BaseModel):
             hsh["startedEventId"] = self.started_event_id
         return hsh
 
-    def start(self, started_event_id):
+    def start(self, started_event_id, previous_started_event_id=None):
         self.state = "STARTED"
         self.started_timestamp = unix_time()
         self.started_event_id = started_event_id
+        self.previous_started_event_id = previous_started_event_id
 
     def complete(self):
         self._check_workflow_execution_open()

--- a/moto/swf/models/workflow_execution.py
+++ b/moto/swf/models/workflow_execution.py
@@ -82,6 +82,7 @@ class WorkflowExecution(BaseModel):
         self._events = []
         # child workflows
         self.child_workflow_executions = []
+        self._previous_started_event_id = None
 
     def __repr__(self):
         return "WorkflowExecution(run_id: {0})".format(self.run_id)
@@ -295,7 +296,8 @@ class WorkflowExecution(BaseModel):
             scheduled_event_id=dt.scheduled_event_id,
             identity=identity,
         )
-        dt.start(evt.event_id)
+        dt.start(evt.event_id, self._previous_started_event_id)
+        self._previous_started_event_id = evt.event_id
 
     def complete_decision_task(
         self, task_token, decisions=None, execution_context=None

--- a/tests/test_swf/models/test_decision_task.py
+++ b/tests/test_swf/models/test_decision_task.py
@@ -24,7 +24,7 @@ def test_decision_task_full_dict_representation():
 
     fd = dt.to_full_dict()
     fd["events"].should.be.a("list")
-    fd["previousStartedEventId"].should.equal(0)
+    fd.should_not.contain("previousStartedEventId")
     fd.should_not.contain("startedEventId")
     fd.should.contain("taskToken")
     fd["workflowExecution"].should.equal(wfe.to_short_dict())

--- a/tests/test_swf/models/test_decision_task.py
+++ b/tests/test_swf/models/test_decision_task.py
@@ -30,9 +30,10 @@ def test_decision_task_full_dict_representation():
     fd["workflowExecution"].should.equal(wfe.to_short_dict())
     fd["workflowType"].should.equal(wft.to_short_dict())
 
-    dt.start(1234)
+    dt.start(1234, 1230)
     fd = dt.to_full_dict()
     fd["startedEventId"].should.equal(1234)
+    fd["previousStartedEventId"].should.equal(1230)
 
 
 def test_decision_task_first_timeout():


### PR DESCRIPTION
Have the workflow execution keep track of the previous started event ID, to correctly include in decision tasks so deciders only have to process new events.

Closes #2107 