### PR TITLE
Return empty task-token on no-task

### DIFF
--- a/moto/swf/responses.py
+++ b/moto/swf/responses.py
@@ -423,7 +423,9 @@ class SWFResponse(BaseResponse):
         if decision:
             return json.dumps(decision.to_full_dict(reverse_order=reverse_order))
         else:
-            return json.dumps({"previousStartedEventId": 0, "startedEventId": 0})
+            return json.dumps(
+                {"previousStartedEventId": 0, "startedEventId": 0, "taskToken": ""}
+            )
 
     def count_pending_decision_tasks(self):
         domain_name = self._params["domain"]
@@ -457,7 +459,7 @@ class SWFResponse(BaseResponse):
         if activity_task:
             return json.dumps(activity_task.to_full_dict())
         else:
-            return json.dumps({"startedEventId": 0})
+            return json.dumps({"startedEventId": 0, "taskToken": ""})
 
     def count_pending_activity_tasks(self):
         domain_name = self._params["domain"]

--- a/tests/test_swf/responses/test_activity_tasks.py
+++ b/tests/test_swf/responses/test_activity_tasks.py
@@ -35,14 +35,14 @@ def test_poll_for_activity_task_when_one():
 def test_poll_for_activity_task_when_none():
     conn = setup_workflow()
     resp = conn.poll_for_activity_task("test-domain", "activity-task-list")
-    resp.should.equal({"startedEventId": 0})
+    resp.should.equal({"startedEventId": 0, "taskToken": ""})
 
 
 @mock_swf_deprecated
 def test_poll_for_activity_task_on_non_existent_queue():
     conn = setup_workflow()
     resp = conn.poll_for_activity_task("test-domain", "non-existent-queue")
-    resp.should.equal({"startedEventId": 0})
+    resp.should.equal({"startedEventId": 0, "taskToken": ""})
 
 
 # CountPendingActivityTasks endpoint

--- a/tests/test_swf/responses/test_decision_tasks.py
+++ b/tests/test_swf/responses/test_decision_tasks.py
@@ -38,14 +38,18 @@ def test_poll_for_decision_task_when_none():
     resp = conn.poll_for_decision_task("test-domain", "queue")
     # this is the DecisionTask representation you get from the real SWF
     # after waiting 60s when there's no decision to be taken
-    resp.should.equal({"previousStartedEventId": 0, "startedEventId": 0})
+    resp.should.equal(
+        {"previousStartedEventId": 0, "startedEventId": 0, "taskToken": ""}
+    )
 
 
 @mock_swf_deprecated
 def test_poll_for_decision_task_on_non_existent_queue():
     conn = setup_workflow()
     resp = conn.poll_for_decision_task("test-domain", "non-existent-queue")
-    resp.should.equal({"previousStartedEventId": 0, "startedEventId": 0})
+    resp.should.equal(
+        {"previousStartedEventId": 0, "startedEventId": 0, "taskToken": ""}
+    )
 
 
 @mock_swf_deprecated


### PR DESCRIPTION
To match the [SWF documentation](https://docs.aws.amazon.com/amazonswf/latest/apireference/API_PollForActivityTask.html), an empty task is one where the task-token is the empty string, rather than being a non-existent key