### PR TITLE
Changes behavior of delete_parameter when parameter doesn't exist

### DIFF
--- a/moto/ssm/models.py
+++ b/moto/ssm/models.py
@@ -278,10 +278,7 @@ class SimpleSystemManagerBackend(BaseBackend):
                 self._region = region
 
     def delete_parameter(self, name):
-        try:
-            del self._parameters[name]
-        except KeyError:
-            pass
+        return self._parameters.pop(name, None)
 
     def delete_parameters(self, names):
         result = []

--- a/moto/ssm/responses.py
+++ b/moto/ssm/responses.py
@@ -22,7 +22,13 @@ class SimpleSystemManagerResponse(BaseResponse):
 
     def delete_parameter(self):
         name = self._get_param("Name")
-        self.ssm_backend.delete_parameter(name)
+        result = self.ssm_backend.delete_parameter(name)
+        if result is None:
+            error = {
+                "__type": "ParameterNotFound",
+                "message": "Parameter {0} not found.".format(name),
+            }
+            return json.dumps(error), dict(status=400)
         return json.dumps({})
 
     def delete_parameters(self):

--- a/tests/test_ssm/test_ssm_boto3.py
+++ b/tests/test_ssm/test_ssm_boto3.py
@@ -34,14 +34,12 @@ def test_delete_parameter():
 def test_delete_nonexistent_parameter():
     client = boto3.client("ssm", region_name="us-east-1")
 
-    try:
+    with assert_raises(ClientError) as ex:
         client.delete_parameter(Name="test_noexist")
-        raise RuntimeError("Should of failed")
-    except botocore.exceptions.ClientError as err:
-        err.operation_name.should.equal("DeleteParameter")
-        err.response["Error"]["Message"].should.equal(
-            "Parameter test_noexist not found."
-        )
+    ex.exception.response["Error"]["Code"].should.equal("ParameterNotFound")
+    ex.exception.response["Error"]["Message"].should.equal(
+        "Parameter test_noexist not found."
+    )
 
 
 @mock_ssm

--- a/tests/test_ssm/test_ssm_boto3.py
+++ b/tests/test_ssm/test_ssm_boto3.py
@@ -31,6 +31,20 @@ def test_delete_parameter():
 
 
 @mock_ssm
+def test_delete_nonexistent_parameter():
+    client = boto3.client("ssm", region_name="us-east-1")
+
+    try:
+        client.delete_parameter(Name="test_noexist")
+        raise RuntimeError("Should of failed")
+    except botocore.exceptions.ClientError as err:
+        err.operation_name.should.equal("DeleteParameter")
+        err.response["Error"]["Message"].should.equal(
+            "Parameter test_noexist not found."
+        )
+
+
+@mock_ssm
 def test_delete_parameters():
     client = boto3.client("ssm", region_name="us-east-1")
 


### PR DESCRIPTION
**Reference Issues/PRs**
N/A

**What does this implement/fix? Explain your changes.**
Currently, the `delete_parameter` function for the ssm client will respond with a `dict` containing a key of` InvalidParameter` which has a value of a list containing the parameter name that was requested to be deleted when a parameter with said name doesn't exist which doesn't match the behavior of `boto3`. 

With this merge request, `delete_parameter` not responds with a 400 error and ParameterNotFound exception is raised. 

**Any other comments?**
N/A