### PR TITLE
fixing error when _get_default return value that already exists, on _get_appended_list

### DIFF
--- a/moto/dynamodb2/models.py
+++ b/moto/dynamodb2/models.py
@@ -450,9 +450,7 @@ class Item(BaseModel):
                 old_list_key = list_append_re.group(1)
                 # old_key could be a function itself (if_not_exists)
                 if old_list_key.startswith("if_not_exists"):
-                    old_list = DynamoType(
-                        expression_attribute_values[self._get_default(old_list_key)]
-                    )
+                    old_list = DynamoType(self._get_default(old_list_key))
                 else:
                     old_list = self.attrs[old_list_key.split(".")[0]]
                     if "." in old_list_key:

--- a/moto/dynamodb2/models.py
+++ b/moto/dynamodb2/models.py
@@ -452,9 +452,7 @@ class Item(BaseModel):
                 if old_list_key.startswith("if_not_exists"):
                     old_list = self._get_default(old_list_key)
                     if not isinstance(old_list, DynamoType):
-                        old_list = DynamoType(
-                            expression_attribute_values[old_list]
-                        )
+                        old_list = DynamoType(expression_attribute_values[old_list])
                 else:
                     old_list = self.attrs[old_list_key.split(".")[0]]
                     if "." in old_list_key:

--- a/moto/dynamodb2/models.py
+++ b/moto/dynamodb2/models.py
@@ -450,7 +450,11 @@ class Item(BaseModel):
                 old_list_key = list_append_re.group(1)
                 # old_key could be a function itself (if_not_exists)
                 if old_list_key.startswith("if_not_exists"):
-                    old_list = DynamoType(self._get_default(old_list_key))
+                    old_list = self._get_default(old_list_key)
+                    if not isinstance(old_list, DynamoType):
+                        old_list = DynamoType(
+                            expression_attribute_values[old_list]
+                        )
                 else:
                     old_list = self.attrs[old_list_key.split(".")[0]]
                     if "." in old_list_key:

--- a/tests/test_dynamodb2/test_dynamodb.py
+++ b/tests/test_dynamodb2/test_dynamodb.py
@@ -3635,6 +3635,31 @@ def test_update_supports_list_append_with_nested_if_not_exists_operation():
 
 
 @mock_dynamodb2
+def test_update_supports_list_append_with_nested_if_not_exists_operation_and_property_already_exists():
+    dynamo = boto3.resource("dynamodb", region_name="us-west-1")
+    table_name = "test"
+
+    dynamo.create_table(
+        TableName=table_name,
+        AttributeDefinitions=[{"AttributeName": "Id", "AttributeType": "S"}],
+        KeySchema=[{"AttributeName": "Id", "KeyType": "HASH"}],
+        ProvisionedThroughput={"ReadCapacityUnits": 20, "WriteCapacityUnits": 20},
+    )
+
+    table = dynamo.Table(table_name)
+
+    table.put_item(Item={"Id": "item-id", "event_history":["other_value"]})
+    table.update_item(
+        Key={"Id": "item-id"},
+        UpdateExpression="SET event_history = list_append(if_not_exists(event_history, :empty_list), :new_value)",
+        ExpressionAttributeValues={":empty_list": [], ":new_value": ["some_value"]},
+    )
+    table.get_item(Key={"Id": "item-id"})["Item"].should.equal(
+        {"Id": "item-id", "event_history": ["other_value", "some_value"]}
+    )
+
+
+@mock_dynamodb2
 def test_update_catches_invalid_list_append_operation():
     client = boto3.client("dynamodb", region_name="us-east-1")
 

--- a/tests/test_dynamodb2/test_dynamodb.py
+++ b/tests/test_dynamodb2/test_dynamodb.py
@@ -3648,7 +3648,7 @@ def test_update_supports_list_append_with_nested_if_not_exists_operation_and_pro
 
     table = dynamo.Table(table_name)
 
-    table.put_item(Item={"Id": "item-id", "event_history":["other_value"]})
+    table.put_item(Item={"Id": "item-id", "event_history": ["other_value"]})
     table.update_item(
         Key={"Id": "item-id"},
         UpdateExpression="SET event_history = list_append(if_not_exists(event_history, :empty_list), :new_value)",


### PR DESCRIPTION
Hello,

I found a error on use **if_not_exists** combined with **list_append**.
I know in merge https://github.com/spulec/moto/pull/2740 they tried to correct it.

But now raise a new error, is `Validation Exception` because in this line 454.
If the function **_get_default** dont return the default value will crash on `expression_attribute_values[key]`

This error occurs because if the data in db has the key.
The **_get_default** will not return an key of `expression_attribute_values`. 
In this case the **_get_default** return an `DynamoType` with data value in the db.