### PR TITLE
Add SWF domain and type undeprecation

### DIFF
--- a/IMPLEMENTATION_COVERAGE.md
+++ b/IMPLEMENTATION_COVERAGE.md
@@ -7272,9 +7272,9 @@
 - [X] start_workflow_execution
 - [ ] tag_resource
 - [X] terminate_workflow_execution
-- [ ] undeprecate_activity_type
-- [ ] undeprecate_domain
-- [ ] undeprecate_workflow_type
+- [X] undeprecate_activity_type
+- [X] undeprecate_domain
+- [X] undeprecate_workflow_type
 - [ ] untag_resource
 
 ## textract

--- a/moto/swf/models/__init__.py
+++ b/moto/swf/models/__init__.py
@@ -121,6 +121,12 @@ class SWFBackend(BaseBackend):
             raise SWFDomainDeprecatedFault(name)
         domain.status = "DEPRECATED"
 
+    def undeprecate_domain(self, name):
+        domain = self._get_domain(name)
+        if domain.status == "REGISTERED":
+            raise SWFDomainAlreadyExistsFault(name)
+        domain.status = "REGISTERED"
+
     def describe_domain(self, name):
         return self._get_domain(name)
 
@@ -147,6 +153,13 @@ class SWFBackend(BaseBackend):
         if _type.status == "DEPRECATED":
             raise SWFTypeDeprecatedFault(_type)
         _type.status = "DEPRECATED"
+
+    def undeprecate_type(self, kind, domain_name, name, version):
+        domain = self._get_domain(domain_name)
+        _type = domain.get_type(kind, name, version)
+        if _type.status == "REGISTERED":
+            raise SWFTypeAlreadyExistsFault(_type)
+        _type.status = "REGISTERED"
 
     def describe_type(self, kind, domain_name, name, version):
         domain = self._get_domain(domain_name)

--- a/moto/swf/responses.py
+++ b/moto/swf/responses.py
@@ -92,6 +92,17 @@ class SWFResponse(BaseResponse):
         self.swf_backend.deprecate_type(kind, domain, name, version)
         return ""
 
+    def _undeprecate_type(self, kind):
+        domain = self._params["domain"]
+        _type_args = self._params["{0}Type".format(kind)]
+        name = _type_args["name"]
+        version = _type_args["version"]
+        self._check_string(domain)
+        self._check_string(name)
+        self._check_string(version)
+        self.swf_backend.undeprecate_type(kind, domain, name, version)
+        return ""
+
     # TODO: implement pagination
     def list_domains(self):
         status = self._params["registrationStatus"]
@@ -219,6 +230,12 @@ class SWFResponse(BaseResponse):
         self.swf_backend.deprecate_domain(name)
         return ""
 
+    def undeprecate_domain(self):
+        name = self._params["name"]
+        self._check_string(name)
+        self.swf_backend.undeprecate_domain(name)
+        return ""
+
     def describe_domain(self):
         name = self._params["name"]
         self._check_string(name)
@@ -278,6 +295,9 @@ class SWFResponse(BaseResponse):
     def deprecate_activity_type(self):
         return self._deprecate_type("activity")
 
+    def undeprecate_activity_type(self):
+        return self._undeprecate_type("activity")
+
     def describe_activity_type(self):
         return self._describe_type("activity")
 
@@ -332,6 +352,9 @@ class SWFResponse(BaseResponse):
 
     def deprecate_workflow_type(self):
         return self._deprecate_type("workflow")
+
+    def undeprecate_workflow_type(self):
+        return self._undeprecate_type("workflow")
 
     def describe_workflow_type(self):
         return self._describe_type("workflow")


### PR DESCRIPTION
SWF API docs:
* [UndeprecateDomain](https://docs.aws.amazon.com/amazonswf/latest/apireference/API_UndeprecateDomain.html)
* [UndeprecateActivityType](https://docs.aws.amazon.com/amazonswf/latest/apireference/API_UndeprecateActivityType.html)
* [UndeprecateWorkflowType](https://docs.aws.amazon.com/amazonswf/latest/apireference/API_UndeprecateWorkflowType.html)

Note tests required `boto3` and `mock_swf` as `boto` doesn't support those endpoints