### PR TITLE
Change RESTError to JsonRESTError for ImageNotFoundException

### DIFF
--- a/moto/ecr/exceptions.py
+++ b/moto/ecr/exceptions.py
@@ -1,5 +1,5 @@
 from __future__ import unicode_literals
-from moto.core.exceptions import RESTError
+from moto.core.exceptions import RESTError, JsonRESTError
 
 
 class RepositoryNotFoundException(RESTError):
@@ -13,7 +13,7 @@ class RepositoryNotFoundException(RESTError):
         )
 
 
-class ImageNotFoundException(RESTError):
+class ImageNotFoundException(JsonRESTError):
     code = 400
 
     def __init__(self, image_id, repository_name, registry_id):

--- a/tests/test_ecr/test_ecr_boto3.py
+++ b/tests/test_ecr/test_ecr_boto3.py
@@ -538,7 +538,7 @@ def test_describe_image_that_doesnt_exist():
         repositoryName="test_repository",
         imageIds=[{"imageTag": "testtag"}],
         registryId="123",
-    ).should.throw(ClientError, error_msg1)
+    ).should.throw(client.exceptions.ImageNotFoundException, error_msg1)
 
     error_msg2 = re.compile(
         r".*The repository with name 'repo-that-doesnt-exist' does not exist in the registry with id '123'.*",


### PR DESCRIPTION
Change `RESTError` to `JsonRESTError` for `ImageNotFoundException`

When using `RESTError` boto3 falls back to a generic `ClientException` instead of `ImageNotFoundException`. 

I've updated the `test_describe_image_that_doesnt_exist` test to expect `ImageNotFoundException` instead.