### PR TITLE
Add test case in case botocore breaks again

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -10,7 +10,7 @@ freezegun
 flask
 boto>=2.45.0
 boto3>=1.4.4
-botocore>=1.12.13
+botocore>=1.15.13
 six>=1.9
 parameterized>=0.7.0
 prompt-toolkit==1.0.14


### PR DESCRIPTION
Fixes #2774 

Botocore versions between 1.15.8 and 1.15.12 (inclusive) have the bug in place, so 1.15.13 and up works fine