### PR TITLE
EC2 - Allow filtering by multiple tags

### DIFF
--- a/moto/ec2/utils.py
+++ b/moto/ec2/utils.py
@@ -252,6 +252,7 @@ def dhcp_configuration_from_querystring(querystring, option="DhcpConfiguration")
 
 def filters_from_querystring(querystring_dict):
     response_values = {}
+    last_tag_key = None
     for key, value in querystring_dict.items():
         match = re.search(r"Filter.(\d).Name", key)
         if match:
@@ -262,6 +263,10 @@ def filters_from_querystring(querystring_dict):
                 for filter_key, filter_value in querystring_dict.items()
                 if filter_key.startswith(value_prefix)
             ]
+            if value[0] == "tag-key":
+                last_tag_key = "tag:" + filter_values[0]
+            elif last_tag_key and value[0] == "tag-value":
+                response_values[last_tag_key] = filter_values
             response_values[value[0]] = filter_values
     return response_values
 
@@ -328,6 +333,8 @@ def tag_filter_matches(obj, filter_name, filter_values):
     if filter_name == "tag-key":
         tag_values = get_obj_tag_names(obj)
     elif filter_name == "tag-value":
+        tag_values = get_obj_tag_values(obj)
+    elif filter_name.startswith("tag:"):
         tag_values = get_obj_tag_values(obj)
     else:
         tag_values = [get_obj_tag(obj, filter_name) or ""]

--- a/moto/ec2/utils.py
+++ b/moto/ec2/utils.py
@@ -253,7 +253,7 @@ def dhcp_configuration_from_querystring(querystring, option="DhcpConfiguration")
 def filters_from_querystring(querystring_dict):
     response_values = {}
     last_tag_key = None
-    for key, value in querystring_dict.items():
+    for key, value in sorted(querystring_dict.items()):
         match = re.search(r"Filter.(\d).Name", key)
         if match:
             filter_index = match.groups()[0]

--- a/tests/test_ec2/test_tags.py
+++ b/tests/test_ec2/test_tags.py
@@ -468,3 +468,36 @@ def test_delete_tag_empty_resource():
     ex.exception.response["Error"]["Message"].should.equal(
         "The request must contain the parameter resourceIdSet"
     )
+
+
+@mock_ec2
+def test_retrieve_resource_with_multiple_tags():
+    ec2 = boto3.resource("ec2")
+    blue, green = ec2.create_instances(ImageId="ANY_ID", MinCount=2, MaxCount=2)
+    ec2.create_tags(
+        Resources=[blue.instance_id],
+        Tags=[
+            {"Key": "environment", "Value": "blue"},
+            {"Key": "application", "Value": "api"},
+        ],
+    )
+    ec2.create_tags(
+        Resources=[green.instance_id],
+        Tags=[
+            {"Key": "environment", "Value": "green"},
+            {"Key": "application", "Value": "api"},
+        ],
+    )
+    green_instances = list(ec2.instances.filter(Filters=(get_filter("green"))))
+    green_instances.should.equal([green])
+    blue_instances = list(ec2.instances.filter(Filters=(get_filter("blue"))))
+    blue_instances.should.equal([blue])
+
+
+def get_filter(color):
+    return [
+        {"Name": "tag-key", "Values": ["application"]},
+        {"Name": "tag-value", "Values": ["api"]},
+        {"Name": "tag-key", "Values": ["environment"]},
+        {"Name": "tag-value", "Values": [color]},
+    ]


### PR DESCRIPTION
Fixes #718

Before, the filter_from_querystring method would use this dict:
```{'tag-key': key, 'tag-value': value}```

This way, only a single tag (the last one) could be returned. This explains the unpredictable results.

Fix: Store all tags in the query under their own name, prefix them with 'tag:' and filter appropriately
```{'tag:key': name}```