### PR TITLE
support mock versions < 3.0.5

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 -r requirements.txt
-mock==3.0.5   # Last version compatible with Python 2.7
+mock<=3.0.5   # Last version compatible with Python 2.7
 nose
 black; python_version >= '3.6'
 regex==2019.11.1; python_version >= '3.6'   # Needed for black

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ install_requires = [
     "pytz",
     "python-dateutil<3.0.0,>=2.1",
     "python-jose<4.0.0",
-    "mock==3.0.5",
+    "mock<=3.0.5",
     "docker>=2.5.1",
     "jsondiff>=1.1.2",
     "aws-xray-sdk!=0.96,>=0.93",


### PR DESCRIPTION
https://github.com/spulec/moto/pull/2776 pinned the `mock` version, but unfortunately there are other packages that are more strict. Specifically, I cannot install moto + [azure-cli](https://github.com/Azure/azure-cli/blob/1174a3350fad3f308688fd37c9dacf12b7afa044/src/azure-cli/setup.py#L134).