### PR TITLE
Fix UPDATED_NEW return values differences

### DIFF
--- a/moto/dynamodb2/models.py
+++ b/moto/dynamodb2/models.py
@@ -146,6 +146,9 @@ class DynamoType(object):
     def __eq__(self, other):
         return self.type == other.type and self.value == other.value
 
+    def __ne__(self, other):
+        return self.type != other.type or self.value != other.value
+
     def __lt__(self, other):
         return self.cast_value < other.cast_value
 

--- a/moto/dynamodb2/responses.py
+++ b/moto/dynamodb2/responses.py
@@ -823,7 +823,9 @@ class DynamoHandler(BaseResponse):
                     return changed
                 else:
                     return [
-                        self._build_updated_new_attributes(original[index], changed[index])
+                        self._build_updated_new_attributes(
+                            original[index], changed[index]
+                        )
                         for index in range(len(changed))
                     ]
             elif changed != original:

--- a/tests/test_dynamodb2/test_dynamodb.py
+++ b/tests/test_dynamodb2/test_dynamodb.py
@@ -3412,13 +3412,18 @@ def test_update_supports_list_append():
     )
 
     # Update item using list_append expression
-    client.update_item(
+    updated_item = client.update_item(
         TableName="TestTable",
         Key={"SHA256": {"S": "sha-of-file"}},
         UpdateExpression="SET crontab = list_append(crontab, :i)",
         ExpressionAttributeValues={":i": {"L": [{"S": "bar2"}]}},
+        ReturnValues="UPDATED_NEW",
     )
 
+    # Verify updated item is correct
+    updated_item["Attributes"].should.equal(
+        {"crontab": {"L": [{"S": "bar1"}, {"S": "bar2"}]}}
+    )
     # Verify item is appended to the existing list
     result = client.get_item(
         TableName="TestTable", Key={"SHA256": {"S": "sha-of-file"}}
@@ -3451,15 +3456,19 @@ def test_update_supports_nested_list_append():
     )
 
     # Update item using list_append expression
-    client.update_item(
+    updated_item = client.update_item(
         TableName="TestTable",
         Key={"id": {"S": "nested_list_append"}},
         UpdateExpression="SET a.#b = list_append(a.#b, :i)",
         ExpressionAttributeValues={":i": {"L": [{"S": "bar2"}]}},
         ExpressionAttributeNames={"#b": "b"},
+        ReturnValues="UPDATED_NEW",
     )
 
-    # Verify item is appended to the existing list
+    # Verify updated item is correct
+    updated_item["Attributes"].should.equal(
+        {"a": {"M": {"b": {"L": [{"S": "bar1"}, {"S": "bar2"}]}}}}
+    )
     result = client.get_item(
         TableName="TestTable", Key={"id": {"S": "nested_list_append"}}
     )["Item"]
@@ -3491,14 +3500,19 @@ def test_update_supports_multiple_levels_nested_list_append():
     )
 
     # Update item using list_append expression
-    client.update_item(
+    updated_item = client.update_item(
         TableName="TestTable",
         Key={"id": {"S": "nested_list_append"}},
         UpdateExpression="SET a.#b.c = list_append(a.#b.#c, :i)",
         ExpressionAttributeValues={":i": {"L": [{"S": "bar2"}]}},
         ExpressionAttributeNames={"#b": "b", "#c": "c"},
+        ReturnValues="UPDATED_NEW",
     )
 
+    # Verify updated item is correct
+    updated_item["Attributes"].should.equal(
+        {"a": {"M": {"b": {"M": {"c": {"L": [{"S": "bar1"}, {"S": "bar2"}]}}}}}}
+    )
     # Verify item is appended to the existing list
     result = client.get_item(
         TableName="TestTable", Key={"id": {"S": "nested_list_append"}}
@@ -3532,14 +3546,19 @@ def test_update_supports_nested_list_append_onto_another_list():
     )
 
     # Update item using list_append expression
-    client.update_item(
+    updated_item = client.update_item(
         TableName="TestTable",
         Key={"id": {"S": "list_append_another"}},
         UpdateExpression="SET a.#c = list_append(a.#b, :i)",
         ExpressionAttributeValues={":i": {"L": [{"S": "bar2"}]}},
         ExpressionAttributeNames={"#b": "b", "#c": "c"},
+        ReturnValues="UPDATED_NEW",
     )
 
+    # Verify updated item is correct
+    updated_item["Attributes"].should.equal(
+        {"a": {"M": {"c": {"L": [{"S": "bar1"}, {"S": "bar2"}]}}}}
+    )
     # Verify item is appended to the existing list
     result = client.get_item(
         TableName="TestTable", Key={"id": {"S": "list_append_another"}}
@@ -3582,13 +3601,18 @@ def test_update_supports_list_append_maps():
     )
 
     # Update item using list_append expression
-    client.update_item(
+    updated_item = client.update_item(
         TableName="TestTable",
         Key={"id": {"S": "nested_list_append"}, "rid": {"S": "range_key"}},
         UpdateExpression="SET a = list_append(a, :i)",
         ExpressionAttributeValues={":i": {"L": [{"M": {"b": {"S": "bar2"}}}]}},
+        ReturnValues="UPDATED_NEW",
     )
 
+    # Verify updated item is correct
+    updated_item["Attributes"].should.equal(
+        {"a": {"L": [{"M": {"b": {"S": "bar1"}}}, {"M": {"b": {"S": "bar2"}}}]}}
+    )
     # Verify item is appended to the existing list
     result = client.query(
         TableName="TestTable",


### PR DESCRIPTION
This should fix #2798
The general idea was to play all the UpdateItem queries on a real DynamoDb and dump the value in the tests.
I then added a method that recursively checks for changes in the new item. It works but as stated in the issue I may miss some corner cases.

I don't do a lot of python so this may not be the cleanest code you've reviewed, i'll be glad to improve it following advices 😉 