### PR TITLE
Cloudwatch - Fix timestamp format

### DIFF
--- a/moto/cloudwatch/models.py
+++ b/moto/cloudwatch/models.py
@@ -2,13 +2,14 @@ import json
 
 from boto3 import Session
 
-from moto.core.utils import iso_8601_datetime_with_milliseconds
+from moto.core.utils import iso_8601_datetime_without_milliseconds
 from moto.core import BaseBackend, BaseModel
 from moto.core.exceptions import RESTError
 from datetime import datetime, timedelta
 from dateutil.tz import tzutc
 from uuid import uuid4
 from .utils import make_arn_for_dashboard
+from dateutil import parser
 
 from moto.core import ACCOUNT_ID as DEFAULT_ACCOUNT_ID
 
@@ -146,7 +147,7 @@ class Dashboard(BaseModel):
 
 class Statistics:
     def __init__(self, stats, dt):
-        self.timestamp = iso_8601_datetime_with_milliseconds(dt)
+        self.timestamp = iso_8601_datetime_without_milliseconds(dt)
         self.values = []
         self.stats = stats
 
@@ -278,8 +279,7 @@ class CloudWatchBackend(BaseBackend):
             # Preserve "datetime" for get_metric_statistics comparisons
             timestamp = metric_member.get("Timestamp")
             if timestamp is not None and type(timestamp) != datetime:
-                timestamp = datetime.strptime(timestamp, "%Y-%m-%dT%H:%M:%S.%fZ")
-                timestamp = timestamp.replace(tzinfo=tzutc())
+                timestamp = parser.parse(timestamp)
             self.metric_data.append(
                 MetricDatum(
                     namespace,

--- a/tests/test_cloudwatch/test_cloudwatch.py
+++ b/tests/test_cloudwatch/test_cloudwatch.py
@@ -125,24 +125,24 @@ def test_get_metric_statistics():
     metric_timestamp = datetime(2018, 4, 9, 13, 0, 0, 0)
 
     conn.put_metric_data(
-        namespace='tester',
-        name='metric',
+        namespace="tester",
+        name="metric",
         value=1.5,
-        dimensions={'InstanceId': ['i-0123456,i-0123457']},
-        timestamp=metric_timestamp
+        dimensions={"InstanceId": ["i-0123456,i-0123457"]},
+        timestamp=metric_timestamp,
     )
 
     metric_kwargs = dict(
-        namespace='tester',
-        metric_name='metric',
+        namespace="tester",
+        metric_name="metric",
         start_time=metric_timestamp,
         end_time=datetime.now(),
         period=3600,
-        statistics=['Minimum']
+        statistics=["Minimum"],
     )
 
     datapoints = conn.get_metric_statistics(**metric_kwargs)
     datapoints.should.have.length_of(1)
     datapoint = datapoints[0]
-    datapoint.should.have.key('Minimum').which.should.equal(1.5)
-    datapoint.should.have.key('Timestamp').which.should.equal(metric_timestamp)
+    datapoint.should.have.key("Minimum").which.should.equal(1.5)
+    datapoint.should.have.key("Timestamp").which.should.equal(metric_timestamp)


### PR DESCRIPTION
Work done  by @syunwei and supercedes his PR at #1558

Changes the CW metrics model so it doesn't expect microseconds

Not sure why GitHub thinks the entire test file is new - there's only one new test, test_get_metric_statistics

Fixes #2743 #2614 #2581 