### PR TITLE
Cloudformation - Set IAM role name

### DIFF
--- a/moto/iam/models.py
+++ b/moto/iam/models.py
@@ -331,7 +331,9 @@ class Role(BaseModel):
         cls, resource_name, cloudformation_json, region_name
     ):
         properties = cloudformation_json["Properties"]
-        role_name = properties['RoleName'] if 'RoleName' in properties else str(uuid4())[0:5]
+        role_name = (
+            properties["RoleName"] if "RoleName" in properties else str(uuid4())[0:5]
+        )
 
         role = iam_backend.create_role(
             role_name=role_name,

--- a/moto/iam/models.py
+++ b/moto/iam/models.py
@@ -12,6 +12,7 @@ import re
 from cryptography import x509
 from cryptography.hazmat.backends import default_backend
 from six.moves.urllib.parse import urlparse
+from uuid import uuid4
 
 from moto.core.exceptions import RESTError
 from moto.core import BaseBackend, BaseModel, ACCOUNT_ID
@@ -330,9 +331,10 @@ class Role(BaseModel):
         cls, resource_name, cloudformation_json, region_name
     ):
         properties = cloudformation_json["Properties"]
+        role_name = properties['RoleName'] if 'RoleName' in properties else str(uuid4())[0:5]
 
         role = iam_backend.create_role(
-            role_name=resource_name,
+            role_name=role_name,
             assume_role_policy_document=properties["AssumeRolePolicyDocument"],
             path=properties.get("Path", "/"),
             permissions_boundary=properties.get("PermissionsBoundary", ""),

--- a/tests/test_cloudformation/test_cloudformation_stack_integration.py
+++ b/tests/test_cloudformation/test_cloudformation_stack_integration.py
@@ -909,6 +909,7 @@ def test_iam_roles():
             },
             "my-role-no-path": {
                 "Properties": {
+                    "RoleName": "my-role-no-path-name",
                     "AssumeRolePolicyDocument": {
                         "Statement": [
                             {
@@ -936,13 +937,13 @@ def test_iam_roles():
     role_name_to_id = {}
     for role_result in role_results:
         role = iam_conn.get_role(role_result.role_name)
-        role.role_name.should.contain("my-role")
-        if "with-path" in role.role_name:
+        if "my-role" not in role.role_name:
             role_name_to_id["with-path"] = role.role_id
             role.path.should.equal("my-path")
+            len(role.role_name).should.equal(5)  # Role name is not specified, so randomly generated - can't check exact name
         else:
             role_name_to_id["no-path"] = role.role_id
-            role.role_name.should.contain("no-path")
+            role.role_name.should.equal("my-role-no-path-name")
             role.path.should.equal("/")
 
     instance_profile_responses = iam_conn.list_instance_profiles()[

--- a/tests/test_cloudformation/test_cloudformation_stack_integration.py
+++ b/tests/test_cloudformation/test_cloudformation_stack_integration.py
@@ -918,7 +918,7 @@ def test_iam_roles():
                                 "Principal": {"Service": ["ec2.amazonaws.com"]},
                             }
                         ]
-                    }
+                    },
                 },
                 "Type": "AWS::IAM::Role",
             },
@@ -940,7 +940,9 @@ def test_iam_roles():
         if "my-role" not in role.role_name:
             role_name_to_id["with-path"] = role.role_id
             role.path.should.equal("my-path")
-            len(role.role_name).should.equal(5)  # Role name is not specified, so randomly generated - can't check exact name
+            len(role.role_name).should.equal(
+                5
+            )  # Role name is not specified, so randomly generated - can't check exact name
         else:
             role_name_to_id["no-path"] = role.role_id
             role.role_name.should.equal("my-role-no-path-name")


### PR DESCRIPTION
Sets the IAM rolename if specified, otherwise randomly generates one
Docs: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-role.html

Supercedes #1932 
Fixes #2746 