### PR TITLE
Fix a misleading error message

### DIFF
--- a/moto/events/responses.py
+++ b/moto/events/responses.py
@@ -62,7 +62,9 @@ class EventsHandler(BaseResponse):
         rule = self.events_backend.describe_rule(name)
 
         if not rule:
-            return self.error("ResourceNotFoundException", "Rule test does not exist.")
+            return self.error(
+                "ResourceNotFoundException", "Rule " + name + " does not exist."
+            )
 
         rule_dict = self._generate_rule_dict(rule)
         return json.dumps(rule_dict), self.response_headers


### PR DESCRIPTION
AWSEvents.DescribeRule throws an error that references a rule named "test" rather than the specified rule name when a rule with the specified name does not exist. It has been fixed to reference the specified rule name.