### PR TITLE
Fix some 'DeprecationWarning: invalid escape sequence' warnings and use str.format for string interpolation.

### DIFF
--- a/moto/cloudformation/parsing.py
+++ b/moto/cloudformation/parsing.py
@@ -196,13 +196,13 @@ def clean_json(resource_json, resources_map):
                 )
             else:
                 fn_sub_value = clean_json(resource_json["Fn::Sub"], resources_map)
-                to_sub = re.findall('(?=\${)[^!^"]*?}', fn_sub_value)
-                literals = re.findall('(?=\${!)[^"]*?}', fn_sub_value)
+                to_sub = re.findall(r'(?=\${)[^!^"]*?}', fn_sub_value)
+                literals = re.findall(r'(?=\${!)[^"]*?}', fn_sub_value)
                 for sub in to_sub:
                     if "." in sub:
                         cleaned_ref = clean_json(
                             {
-                                "Fn::GetAtt": re.findall('(?<=\${)[^"]*?(?=})', sub)[
+                                "Fn::GetAtt": re.findall(r'(?<=\${)[^"]*?(?=})', sub)[
                                     0
                                 ].split(".")
                             },
@@ -210,7 +210,7 @@ def clean_json(resource_json, resources_map):
                         )
                     else:
                         cleaned_ref = clean_json(
-                            {"Ref": re.findall('(?<=\${)[^"]*?(?=})', sub)[0]},
+                            {"Ref": re.findall(r'(?<=\${)[^"]*?(?=})', sub)[0]},
                             resources_map,
                         )
                     fn_sub_value = fn_sub_value.replace(sub, cleaned_ref)

--- a/moto/core/models.py
+++ b/moto/core/models.py
@@ -347,7 +347,7 @@ class BotocoreEventMockAWS(BaseMockAWS):
             responses_mock.add(
                 CallbackResponse(
                     method=method,
-                    url=re.compile("https?://.+.amazonaws.com/.*"),
+                    url=re.compile(r"https?://.+.amazonaws.com/.*"),
                     callback=not_implemented_callback,
                     stream=True,
                     match_querystring=False,
@@ -356,7 +356,7 @@ class BotocoreEventMockAWS(BaseMockAWS):
             botocore_mock.add(
                 CallbackResponse(
                     method=method,
-                    url=re.compile("https?://.+.amazonaws.com/.*"),
+                    url=re.compile(r"https?://.+.amazonaws.com/.*"),
                     callback=not_implemented_callback,
                     stream=True,
                     match_querystring=False,

--- a/moto/core/utils.py
+++ b/moto/core/utils.py
@@ -95,7 +95,7 @@ def convert_regex_to_flask_path(url_path):
         match_name, match_pattern = reg.groups()
         return '<regex("{0}"):{1}>'.format(match_pattern, match_name)
 
-    url_path = re.sub("\(\?P<(.*?)>(.*?)\)", caller, url_path)
+    url_path = re.sub(r"\(\?P<(.*?)>(.*?)\)", caller, url_path)
 
     if url_path.endswith("/?"):
         # Flask does own handling of trailing slashes

--- a/moto/dynamodb2/comparisons.py
+++ b/moto/dynamodb2/comparisons.py
@@ -251,9 +251,9 @@ class ConditionExpressionParser:
 
     def _lex_one_node(self, remaining_expression):
         # TODO: Handle indexing like [1]
-        attribute_regex = "(:|#)?[A-z0-9\-_]+"
+        attribute_regex = r"(:|#)?[A-z0-9\-_]+"
         patterns = [
-            (self.Nonterminal.WHITESPACE, re.compile("^ +")),
+            (self.Nonterminal.WHITESPACE, re.compile(r"^ +")),
             (
                 self.Nonterminal.COMPARATOR,
                 re.compile(
@@ -270,12 +270,14 @@ class ConditionExpressionParser:
             (
                 self.Nonterminal.OPERAND,
                 re.compile(
-                    "^" + attribute_regex + "(\." + attribute_regex + "|\[[0-9]\])*"
+                    r"^{attribute_regex}(\.{attribute_regex}|\[[0-9]\])*".format(
+                        attribute_regex=attribute_regex
+                    )
                 ),
             ),
-            (self.Nonterminal.COMMA, re.compile("^,")),
-            (self.Nonterminal.LEFT_PAREN, re.compile("^\(")),
-            (self.Nonterminal.RIGHT_PAREN, re.compile("^\)")),
+            (self.Nonterminal.COMMA, re.compile(r"^,")),
+            (self.Nonterminal.LEFT_PAREN, re.compile(r"^\(")),
+            (self.Nonterminal.RIGHT_PAREN, re.compile(r"^\)")),
         ]
 
         for nonterminal, pattern in patterns:
@@ -285,7 +287,7 @@ class ConditionExpressionParser:
                 break
         else:  # pragma: no cover
             raise ValueError(
-                "Cannot parse condition starting at: " + remaining_expression
+                "Cannot parse condition starting at:{}".format(remaining_expression)
             )
 
         node = self.Node(
@@ -318,7 +320,7 @@ class ConditionExpressionParser:
                     for child in children:
                         self._assert(
                             child.nonterminal == self.Nonterminal.IDENTIFIER,
-                            "Cannot use %s in path" % child.text,
+                            "Cannot use {} in path".format(child.text),
                             [node],
                         )
                 output.append(
@@ -392,7 +394,7 @@ class ConditionExpressionParser:
         elif name.startswith("["):
             # e.g. [123]
             if not name.endswith("]"):  # pragma: no cover
-                raise ValueError("Bad path element %s" % name)
+                raise ValueError("Bad path element {}".format(name))
             return self.Node(
                 nonterminal=self.Nonterminal.IDENTIFIER,
                 kind=self.Kind.LITERAL,

--- a/moto/ecr/models.py
+++ b/moto/ecr/models.py
@@ -403,7 +403,7 @@ class ECRBackend(BaseBackend):
 
             # If we have a digest, is it valid?
             if "imageDigest" in image_id:
-                pattern = re.compile("^[0-9a-zA-Z_+\.-]+:[0-9a-fA-F]{64}")
+                pattern = re.compile(r"^[0-9a-zA-Z_+\.-]+:[0-9a-fA-F]{64}")
                 if not pattern.match(image_id.get("imageDigest")):
                     response["failures"].append(
                         {

--- a/moto/s3/utils.py
+++ b/moto/s3/utils.py
@@ -52,7 +52,7 @@ def parse_region_from_url(url):
 
 def metadata_from_headers(headers):
     metadata = {}
-    meta_regex = re.compile("^x-amz-meta-([a-zA-Z0-9\-_]+)$", flags=re.IGNORECASE)
+    meta_regex = re.compile(r"^x-amz-meta-([a-zA-Z0-9\-_]+)$", flags=re.IGNORECASE)
     for header, value in headers.items():
         if isinstance(header, six.string_types):
             result = meta_regex.match(header)


### PR DESCRIPTION
I am seeing a lot of deperecation warnings when I use moto for my tests (running under pytest), so I figured I'll clean up some of them.