### PR TITLE
set value for actions enabled on describe-alarms

### DIFF
--- a/moto/cloudwatch/models.py
+++ b/moto/cloudwatch/models.py
@@ -67,6 +67,7 @@ class FakeAlarm(BaseModel):
         ok_actions,
         insufficient_data_actions,
         unit,
+        actions_enabled,
     ):
         self.name = name
         self.namespace = namespace
@@ -80,6 +81,7 @@ class FakeAlarm(BaseModel):
         self.dimensions = [
             Dimension(dimension["name"], dimension["value"]) for dimension in dimensions
         ]
+        self.actions_enabled = actions_enabled
         self.alarm_actions = alarm_actions
         self.ok_actions = ok_actions
         self.insufficient_data_actions = insufficient_data_actions
@@ -215,6 +217,7 @@ class CloudWatchBackend(BaseBackend):
         ok_actions,
         insufficient_data_actions,
         unit,
+        actions_enabled,
     ):
         alarm = FakeAlarm(
             name,
@@ -231,6 +234,7 @@ class CloudWatchBackend(BaseBackend):
             ok_actions,
             insufficient_data_actions,
             unit,
+            actions_enabled,
         )
         self.alarms[name] = alarm
         return alarm

--- a/moto/cloudwatch/responses.py
+++ b/moto/cloudwatch/responses.py
@@ -28,7 +28,7 @@ class CloudWatchResponse(BaseResponse):
         dimensions = self._get_list_prefix("Dimensions.member")
         alarm_actions = self._get_multi_param("AlarmActions.member")
         ok_actions = self._get_multi_param("OKActions.member")
-        actions_enabled = self._get_multi_param("ActionsEnabled")
+        actions_enabled = self._get_param("ActionsEnabled")
         insufficient_data_actions = self._get_multi_param(
             "InsufficientDataActions.member"
         )

--- a/moto/cloudwatch/responses.py
+++ b/moto/cloudwatch/responses.py
@@ -28,6 +28,7 @@ class CloudWatchResponse(BaseResponse):
         dimensions = self._get_list_prefix("Dimensions.member")
         alarm_actions = self._get_multi_param("AlarmActions.member")
         ok_actions = self._get_multi_param("OKActions.member")
+        actions_enabled = self._get_multi_param("ActionsEnabled")
         insufficient_data_actions = self._get_multi_param(
             "InsufficientDataActions.member"
         )
@@ -47,6 +48,7 @@ class CloudWatchResponse(BaseResponse):
             ok_actions,
             insufficient_data_actions,
             unit,
+            actions_enabled,
         )
         template = self.response_template(PUT_METRIC_ALARM_TEMPLATE)
         return template.render(alarm=alarm)

--- a/tests/test_cloudwatch/test_cloudwatch.py
+++ b/tests/test_cloudwatch/test_cloudwatch.py
@@ -101,11 +101,11 @@ def test_describe_alarms():
     conn.create_alarm(alarm_fixture(name="nfoobaz", action="afoobaz"))
     conn.create_alarm(alarm_fixture(name="nbarfoo", action="abarfoo"))
     conn.create_alarm(alarm_fixture(name="nbazfoo", action="abazfoo"))
-    
+
     enabled = alarm_fixture(name="enabled1", action=["abarfoo"])
     enabled.add_alarm_action("arn:alarm")
     conn.create_alarm(enabled)
-    
+
     alarms = conn.describe_alarms()
     alarms.should.have.length_of(5)
     alarms = conn.describe_alarms(alarm_name_prefix="nfoo")
@@ -123,6 +123,7 @@ def test_describe_alarms():
 
     alarms = conn.describe_alarms()
     alarms.should.have.length_of(0)
+
 
 @mock_cloudwatch_deprecated
 def test_get_metric_statistics():

--- a/tests/test_cloudwatch/test_cloudwatch.py
+++ b/tests/test_cloudwatch/test_cloudwatch.py
@@ -101,22 +101,28 @@ def test_describe_alarms():
     conn.create_alarm(alarm_fixture(name="nfoobaz", action="afoobaz"))
     conn.create_alarm(alarm_fixture(name="nbarfoo", action="abarfoo"))
     conn.create_alarm(alarm_fixture(name="nbazfoo", action="abazfoo"))
-
+    
+    enabled = alarm_fixture(name="enabled1", action=["abarfoo"])
+    enabled.add_alarm_action("arn:alarm")
+    conn.create_alarm(enabled)
+    
     alarms = conn.describe_alarms()
-    alarms.should.have.length_of(4)
+    alarms.should.have.length_of(5)
     alarms = conn.describe_alarms(alarm_name_prefix="nfoo")
     alarms.should.have.length_of(2)
     alarms = conn.describe_alarms(alarm_names=["nfoobar", "nbarfoo", "nbazfoo"])
     alarms.should.have.length_of(3)
     alarms = conn.describe_alarms(action_prefix="afoo")
     alarms.should.have.length_of(2)
+    alarms = conn.describe_alarms(alarm_name_prefix="enabled")
+    alarms.should.have.length_of(1)
+    alarms[0].actions_enabled.should.equal("true")
 
     for alarm in conn.describe_alarms():
         alarm.delete()
 
     alarms = conn.describe_alarms()
     alarms.should.have.length_of(0)
-
 
 @mock_cloudwatch_deprecated
 def test_get_metric_statistics():

--- a/tests/test_cloudwatch/test_cloudwatch_boto3.py
+++ b/tests/test_cloudwatch/test_cloudwatch_boto3.py
@@ -128,11 +128,13 @@ def test_alarm_state():
     len(resp["MetricAlarms"]).should.equal(1)
     resp["MetricAlarms"][0]["AlarmName"].should.equal("testalarm1")
     resp["MetricAlarms"][0]["StateValue"].should.equal("ALARM")
+    resp["MetricAlarms"][0]["ActionsEnabled"].should.equal("True")
 
     resp = client.describe_alarms(StateValue="OK")
     len(resp["MetricAlarms"]).should.equal(1)
     resp["MetricAlarms"][0]["AlarmName"].should.equal("testalarm2")
     resp["MetricAlarms"][0]["StateValue"].should.equal("OK")
+    resp["MetricAlarms"][0]["ActionsEnabled"].should.equal("True")
 
     # Just for sanity
     resp = client.describe_alarms()

--- a/tests/test_cloudwatch/test_cloudwatch_boto3.py
+++ b/tests/test_cloudwatch/test_cloudwatch_boto3.py
@@ -141,6 +141,7 @@ def test_alarm_state():
     resp = client.describe_alarms()
     len(resp["MetricAlarms"]).should.equal(2)
 
+
 @mock_cloudwatch
 def test_put_metric_data_no_dimensions():
     conn = boto3.client("cloudwatch", region_name="us-east-1")

--- a/tests/test_cloudwatch/test_cloudwatch_boto3.py
+++ b/tests/test_cloudwatch/test_cloudwatch_boto3.py
@@ -104,6 +104,7 @@ def test_alarm_state():
         Statistic="Average",
         Threshold=2,
         ComparisonOperator="GreaterThanThreshold",
+        ActionsEnabled=True,
     )
     client.put_metric_alarm(
         AlarmName="testalarm2",
@@ -128,18 +129,17 @@ def test_alarm_state():
     len(resp["MetricAlarms"]).should.equal(1)
     resp["MetricAlarms"][0]["AlarmName"].should.equal("testalarm1")
     resp["MetricAlarms"][0]["StateValue"].should.equal("ALARM")
-    resp["MetricAlarms"][0]["ActionsEnabled"].should.equal("True")
+    resp["MetricAlarms"][0]["ActionsEnabled"].should.equal(True)
 
     resp = client.describe_alarms(StateValue="OK")
     len(resp["MetricAlarms"]).should.equal(1)
     resp["MetricAlarms"][0]["AlarmName"].should.equal("testalarm2")
     resp["MetricAlarms"][0]["StateValue"].should.equal("OK")
-    resp["MetricAlarms"][0]["ActionsEnabled"].should.equal("True")
+    resp["MetricAlarms"][0]["ActionsEnabled"].should.equal(False)
 
     # Just for sanity
     resp = client.describe_alarms()
     len(resp["MetricAlarms"]).should.equal(2)
-
 
 @mock_cloudwatch
 def test_put_metric_data_no_dimensions():


### PR DESCRIPTION
this is to avoid errors with terraform when creating metric alarms 
relates to https://github.com/localstack/localstack/issues/2161

I saw that enable and disable of metric alarms is currently not implemented. I'm happy to implement it in a follow up Pull Request to first fix issues with Terraform and Localstack.

_Edit:_ Btw shouldn't https://github.com/spulec/moto/blob/master/IMPLEMENTATION_COVERAGE.md#cloudwatch `describe-images` be marked as included? 