### PR TITLE
Cloudwatch  - Add default metrics for other services

### DIFF
--- a/moto/cloudwatch/responses.py
+++ b/moto/cloudwatch/responses.py
@@ -124,9 +124,10 @@ class CloudWatchResponse(BaseResponse):
     def list_metrics(self):
         namespace = self._get_param("Namespace")
         metric_name = self._get_param("MetricName")
+        dimensions = self._get_multi_param("Dimensions.member")
         next_token = self._get_param("NextToken")
         next_token, metrics = self.cloudwatch_backend.list_metrics(
-            next_token, namespace, metric_name
+            next_token, namespace, metric_name, dimensions
         )
         template = self.response_template(LIST_METRICS_TEMPLATE)
         return template.render(metrics=metrics, next_token=next_token)
@@ -342,7 +343,7 @@ LIST_METRICS_TEMPLATE = """<ListMetricsResponse xmlns="http://monitoring.amazona
                     </member>
                     {% endfor %}
                 </Dimensions>
-                <MetricName>{{ metric.name }}</MetricName>
+                <MetricName>Metric:{{ metric.name }}</MetricName>
                 <Namespace>{{ metric.namespace }}</Namespace>
             </member>
             {% endfor %}

--- a/moto/s3/utils.py
+++ b/moto/s3/utils.py
@@ -146,6 +146,12 @@ class _VersionedKeyStore(dict):
         for key in self:
             yield key, self.getlist(key)
 
+    def item_size(self):
+        size = 0
+        for val in self.values():
+            size += sys.getsizeof(val)
+        return size
+
     items = iteritems = _iteritems
     lists = iterlists = _iterlists
     values = itervalues = _itervalues

--- a/tests/test_cloudwatch/test_cloudwatch.py
+++ b/tests/test_cloudwatch/test_cloudwatch.py
@@ -1,9 +1,10 @@
 import boto
 from boto.ec2.cloudwatch.alarm import MetricAlarm
+from boto.s3.key import Key
 from datetime import datetime
 import sure  # noqa
 
-from moto import mock_cloudwatch_deprecated
+from moto import mock_cloudwatch_deprecated, mock_s3_deprecated
 
 
 def alarm_fixture(name="tester", action=None):
@@ -83,10 +84,11 @@ def test_put_metric_data():
     )
 
     metrics = conn.list_metrics()
-    metrics.should.have.length_of(1)
+    metric_names = [m for m in metrics if m.name == "metric"]
+    metric_names.should.have(1)
     metric = metrics[0]
     metric.namespace.should.equal("tester")
-    metric.name.should.equal("metric")
+    metric.name.should.equal("Metric:metric")
     dict(metric.dimensions).should.equal({"InstanceId": ["i-0123456,i-0123457"]})
 
 
@@ -153,3 +155,35 @@ def test_get_metric_statistics():
     datapoint = datapoints[0]
     datapoint.should.have.key("Minimum").which.should.equal(1.5)
     datapoint.should.have.key("Timestamp").which.should.equal(metric_timestamp)
+
+
+@mock_s3_deprecated
+@mock_cloudwatch_deprecated
+def test_cloudwatch_return_s3_metrics():
+
+    region = "us-east-1"
+
+    cw = boto.ec2.cloudwatch.connect_to_region(region)
+    s3 = boto.s3.connect_to_region(region)
+
+    bucket_name_1 = "test-bucket-1"
+    bucket_name_2 = "test-bucket-2"
+
+    bucket1 = s3.create_bucket(bucket_name=bucket_name_1)
+    key = Key(bucket1)
+    key.key = "the-key"
+    key.set_contents_from_string("foobar" * 4)
+    s3.create_bucket(bucket_name=bucket_name_2)
+
+    metrics_s3_bucket_1 = cw.list_metrics(dimensions={"BucketName": bucket_name_1})
+    # Verify that the OOTB S3 metrics are available for the created buckets
+    len(metrics_s3_bucket_1).should.be(2)
+    metric_names = [m.name for m in metrics_s3_bucket_1]
+    sorted(metric_names).should.equal(
+        ["Metric:BucketSizeBytes", "Metric:NumberOfObjects"]
+    )
+
+    # Explicit clean up - the metrics for these buckets are messing with subsequent tests
+    key.delete()
+    s3.delete_bucket(bucket_name_1)
+    s3.delete_bucket(bucket_name_2)

--- a/tests/test_cloudwatch/test_cloudwatch_boto3.py
+++ b/tests/test_cloudwatch/test_cloudwatch_boto3.py
@@ -154,7 +154,7 @@ def test_put_metric_data_no_dimensions():
     metrics.should.have.length_of(1)
     metric = metrics[0]
     metric["Namespace"].should.equal("tester")
-    metric["MetricName"].should.equal("metric")
+    metric["MetricName"].should.equal("Metric:metric")
 
 
 @mock_cloudwatch
@@ -182,7 +182,7 @@ def test_put_metric_data_with_statistics():
     metrics.should.have.length_of(1)
     metric = metrics[0]
     metric["Namespace"].should.equal("tester")
-    metric["MetricName"].should.equal("statmetric")
+    metric["MetricName"].should.equal("Metric:statmetric")
     # TODO: test statistics - https://github.com/spulec/moto/issues/1615
 
 
@@ -233,8 +233,16 @@ def test_list_metrics():
     # Verify format
     res.should.equal(
         [
-            {u"Namespace": "list_test_1/", u"Dimensions": [], u"MetricName": "metric1"},
-            {u"Namespace": "list_test_1/", u"Dimensions": [], u"MetricName": "metric1"},
+            {
+                u"Namespace": "list_test_1/",
+                u"Dimensions": [],
+                u"MetricName": "Metric:metric1",
+            },
+            {
+                u"Namespace": "list_test_1/",
+                u"Dimensions": [],
+                u"MetricName": "Metric:metric1",
+            },
         ]
     )
     # Verify unknown namespace still has no results


### PR DESCRIPTION
Fixes #2711 

Adds a framework for services to register AWS OOTB metrics in CloudWatch.
Currently only implemented for S3, which registers ```BucketSizeBytes``` and ```NumberOfObjects``` per bucket.

Can be fairly easily extended for EC2 for instance, if we want to return e.g. ```CPUUtilization```

Also adds the missing feature of being able to filter metrics by dimension - before you could only filter by name or namespace.