### PR TITLE
CloudFormation - CreateChangeSet should not create resources

### DIFF
--- a/moto/cloudformation/parsing.py
+++ b/moto/cloudformation/parsing.py
@@ -529,14 +529,16 @@ class ResourceMap(collections_abc.Mapping):
         for condition_name in self.lazy_condition_map:
             self.lazy_condition_map[condition_name]
 
-    def create(self):
+    def load(self):
         self.load_mapping()
         self.transform_mapping()
         self.load_parameters()
         self.load_conditions()
 
+    def create(self):
         # Since this is a lazy map, to create every object we just need to
         # iterate through self.
+        # Assumes that self.load() has been called before
         self.tags.update(
             {
                 "aws:cloudformation:stack-name": self.get("AWS::StackName"),


### PR DESCRIPTION
Fixes #2388 

Before, creating a ChangeSet would automatically create the underlying resources
Now, creating a changeset allows you to review the changes first.
Only after calling ```execute_change_set``` are the resources created

Relevant docs: https://docs.aws.amazon.com/cli/latest/reference/cloudformation/create-change-set.html
