### PR TITLE
fix: stepfunction stop_execution

### DIFF
--- a/moto/stepfunctions/models.py
+++ b/moto/stepfunctions/models.py
@@ -46,7 +46,7 @@ class Execution:
         self.stop_date = None
 
     def stop(self):
-        self.status = "SUCCEEDED"
+        self.status = "ABORTED"
         self.stop_date = iso_8601_datetime_without_milliseconds(datetime.now())
 
 

--- a/tests/test_stepfunctions/test_stepfunctions.py
+++ b/tests/test_stepfunctions/test_stepfunctions.py
@@ -516,7 +516,7 @@ def test_state_machine_describe_execution_after_stoppage():
     description = client.describe_execution(executionArn=execution["executionArn"])
     #
     description["ResponseMetadata"]["HTTPStatusCode"].should.equal(200)
-    description["status"].should.equal("SUCCEEDED")
+    description["status"].should.equal("ABORTED")
     description["stopDate"].should.be.a(datetime)
 
 


### PR DESCRIPTION
Fixes #2846

Calling stop_execution on a stepfunction should set the status to `ABORTED` not `SUCCEEDED`.