### PR TITLE
DynamoDB - fix put_item ValidationException

### DIFF
--- a/moto/dynamodb2/models.py
+++ b/moto/dynamodb2/models.py
@@ -800,13 +800,19 @@ class Table(BaseModel):
         overwrite=False,
     ):
         if self.hash_key_attr not in item_attrs.keys():
-            raise ValueError(
+            raise KeyError(
                 "One or more parameter values were invalid: Missing the key "
                 + self.hash_key_attr
                 + " in the item"
             )
         hash_value = DynamoType(item_attrs.get(self.hash_key_attr))
         if self.has_range_key:
+            if self.range_key_attr not in item_attrs.keys():
+                raise KeyError(
+                    "One or more parameter values were invalid: Missing the key "
+                    + self.range_key_attr
+                    + " in the item"
+                )
             range_value = DynamoType(item_attrs.get(self.range_key_attr))
         else:
             range_value = None

--- a/moto/dynamodb2/responses.py
+++ b/moto/dynamodb2/responses.py
@@ -299,6 +299,9 @@ class DynamoHandler(BaseResponse):
         except ItemSizeTooLarge:
             er = "com.amazonaws.dynamodb.v20111205#ValidationException"
             return self.error(er, ItemSizeTooLarge.message)
+        except KeyError as ke:
+            er = "com.amazonaws.dynamodb.v20111205#ValidationException"
+            return self.error(er, ke.args[0])
         except ValueError as ve:
             er = "com.amazonaws.dynamodb.v20111205#ConditionalCheckFailedException"
             return self.error(er, str(ve))


### PR DESCRIPTION
Fixes #2849

Changes made:
* Added additional check in `put_item` to make sure that passed item has range attribute key in it when table in which we are inserting has range key set.
* Changed the type of exception to `KeyError` to not break existing `ConditionalCheckFailedException` behavior.
* Added `ValidationException` in responses when `KeyError` is raised in `put_item`.
* Fixed existing `test_put_item_nonexisting_hash_key` test to check for error code and not just message.
* Added `test_put_empty_item` and `test_put_item_nonexisting_range_key` tests.