### PR TITLE
[WIP] Feature: S3 - Set metadata embedded in presigned url

### DIFF
--- a/moto/s3/responses.py
+++ b/moto/s3/responses.py
@@ -1224,6 +1224,7 @@ class ResponseObject(_TemplateEnvironmentMixin, ActionAuthenticatorMixin):
             )
             request.streaming = True
             metadata = metadata_from_headers(request.headers)
+            metadata.update(metadata_from_headers(query))
             new_key.set_metadata(metadata)
             new_key.set_acl(acl)
             new_key.website_redirect_location = request.headers.get(
@@ -1965,6 +1966,7 @@ S3_OBJECT_COPY_RESPONSE = """\
     <ETag>{{ key.etag }}</ETag>
     <LastModified>{{ key.last_modified_ISO8601 }}</LastModified>
 </CopyObjectResult>"""
+
 
 S3_MULTIPART_INITIATE_RESPONSE = """<?xml version="1.0" encoding="UTF-8"?>
 <InitiateMultipartUploadResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">

--- a/moto/s3/utils.py
+++ b/moto/s3/utils.py
@@ -75,7 +75,11 @@ def metadata_from_headers(headers):
                 # Check for special metadata that doesn't start with x-amz-meta
                 meta_key = header
             if meta_key:
-                metadata[meta_key] = headers[header]
+                metadata[meta_key] = (
+                    headers[header][0]
+                    if type(headers[header]) == list
+                    else headers[header]
+                )
     return metadata
 
 


### PR DESCRIPTION
Fixes #2104 

The metadata is part of the querystring when using presigned URLs, so we can simply parse it the same way we parse headers

TODO: Extend the signature to include header-names, and verify that incoming request contains those headers. See comment below