### PR TITLE
Raise errors on tagging buckets with aws:*

### DIFF
--- a/moto/s3/exceptions.py
+++ b/moto/s3/exceptions.py
@@ -368,3 +368,12 @@ class WrongPublicAccessBlockAccountIdError(S3ClientError):
         super(WrongPublicAccessBlockAccountIdError, self).__init__(
             "AccessDenied", "Access Denied"
         )
+
+
+class NoSystemTags(S3ClientError):
+    code = 400
+
+    def __init__(self):
+        super(NoSystemTags, self).__init__(
+            "InvalidTag", "System tags cannot be added/updated by requester"
+        )

--- a/moto/s3/responses.py
+++ b/moto/s3/responses.py
@@ -34,6 +34,7 @@ from .exceptions import (
     InvalidNotificationARN,
     InvalidNotificationEvent,
     ObjectNotInActiveTierError,
+    NoSystemTags,
 )
 from .models import (
     s3_backend,
@@ -1398,6 +1399,11 @@ class ResponseObject(_TemplateEnvironmentMixin, ActionAuthenticatorMixin):
             else:
                 for tag in parsed_xml["Tagging"]["TagSet"]["Tag"]:
                     tags.append(FakeTag(tag["Key"], tag["Value"]))
+
+        # Verify that "aws:" is not in the tags. If so, then this is a problem:
+        for tag in tags:
+            if tag.key.startswith("aws:"):
+                raise NoSystemTags()
 
         tag_set = FakeTagSet(tags)
         tagging = FakeTagging(tag_set)

--- a/tests/test_s3/test_s3.py
+++ b/tests/test_s3/test_s3.py
@@ -2413,6 +2413,24 @@ def test_boto3_put_bucket_tagging():
         "Cannot provide multiple Tags with the same key"
     )
 
+    # Cannot put tags that are "system" tags - i.e. tags that start with "aws:"
+    with assert_raises(ClientError) as ce:
+        s3.put_bucket_tagging(
+            Bucket=bucket_name,
+            Tagging={"TagSet": [{"Key": "aws:sometag", "Value": "nope"}]},
+        )
+    e = ce.exception
+    e.response["Error"]["Code"].should.equal("InvalidTag")
+    e.response["Error"]["Message"].should.equal(
+        "System tags cannot be added/updated by requester"
+    )
+
+    # This is OK though:
+    s3.put_bucket_tagging(
+        Bucket=bucket_name,
+        Tagging={"TagSet": [{"Key": "something:aws:stuff", "Value": "this is fine"}]},
+    )
+
 
 @mock_s3
 def test_boto3_get_bucket_tagging():


### PR DESCRIPTION
Cannot tag S3 buckets with reserved tag key space `aws:`