### PR TITLE
PutObject and DeleteObject should produce no XML

### DIFF
--- a/moto/s3/responses.py
+++ b/moto/s3/responses.py
@@ -1232,9 +1232,8 @@ class ResponseObject(_TemplateEnvironmentMixin, ActionAuthenticatorMixin):
             )
             new_key.set_tagging(tagging)
 
-        template = self.response_template(S3_OBJECT_RESPONSE)
         response_headers.update(new_key.response_dict)
-        return 200, response_headers, template.render(key=new_key)
+        return 200, response_headers, ""
 
     def _key_response_head(self, bucket_name, query, key_name, headers):
         response_headers = {}
@@ -1552,8 +1551,7 @@ class ResponseObject(_TemplateEnvironmentMixin, ActionAuthenticatorMixin):
             return 204, {}, ""
         version_id = query.get("versionId", [None])[0]
         self.backend.delete_key(bucket_name, key_name, version_id=version_id)
-        template = self.response_template(S3_DELETE_OBJECT_SUCCESS)
-        return 204, {}, template.render()
+        return 204, {}, ""
 
     def _complete_multipart_body(self, body):
         ps = minidom.parseString(body).getElementsByTagName("Part")
@@ -1867,18 +1865,6 @@ S3_DELETE_KEYS_RESPONSE = """<?xml version="1.0" encoding="UTF-8"?>
 </Error>
 {% endfor %}
 </DeleteResult>"""
-
-S3_DELETE_OBJECT_SUCCESS = """<?xml version="1.0" encoding="UTF-8"?>
-<DeleteObjectResponse xmlns="http://s3.amazonaws.com/doc/2006-03-01">
-  <Code>200</Code>
-  <Description>OK</Description>
-</DeleteObjectResponse>"""
-
-S3_OBJECT_RESPONSE = """<?xml version="1.0" encoding="UTF-8"?>
-    <PutObjectResponse xmlns="http://s3.amazonaws.com/doc/2006-03-01">
-      <ETag>{{ key.etag }}</ETag>
-      <LastModified>{{ key.last_modified_ISO8601 }}</LastModified>
-    </PutObjectResponse>"""
 
 S3_OBJECT_ACL_RESPONSE = """<?xml version="1.0" encoding="UTF-8"?>
     <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/">


### PR DESCRIPTION
PutObject and DeleteObject are not expected to a response body, with any response metadata in HTTP headers only.

The presence of this XML payload seems to have [tripped-up at least one S3 client implementation](https://github.com/rusoto/rusoto/pull/1728).

Superseeds https://github.com/spulec/moto/pull/2866