### PR TITLE
Changed mock_ecs to support ecs.run_task calls with a default cluster

### DIFF
--- a/moto/ecs/models.py
+++ b/moto/ecs/models.py
@@ -604,7 +604,10 @@ class EC2ContainerServiceBackend(BaseBackend):
             raise Exception("{0} is not a task_definition".format(task_definition_name))
 
     def run_task(self, cluster_str, task_definition_str, count, overrides, started_by):
-        cluster_name = cluster_str.split("/")[-1]
+        if cluster_str:
+            cluster_name = cluster_str.split("/")[-1]
+        else:
+            cluster_name = "default"
         if cluster_name in self.clusters:
             cluster = self.clusters[cluster_name]
         else:


### PR DESCRIPTION
`ecs.run_task` allows the caller to omit the `cluster` parameter, in which case `run_task` assumes the `default` cluster. This PR changes `mock_ecs` to also support this behavior instead of raising an exception on an implicit `None` value for `cluster`.

For reference: Boto 3 `ECS.Client.run_task` [API documentation](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/ecs.html#ECS.Client.run_task)