### PR TITLE
EC2 - Ensure NCI always has a Subnet

### DIFF
--- a/moto/ec2/models.py
+++ b/moto/ec2/models.py
@@ -775,7 +775,14 @@ class Instance(TaggedEC2Resource, BotoInstance):
                 if "SubnetId" in nic:
                     subnet = self.ec2_backend.get_subnet(nic["SubnetId"])
                 else:
-                    subnet = None
+                    # Get default Subnet
+                    subnet = [
+                        subnet
+                        for subnet in self.ec2_backend.get_all_subnets(
+                            filters={"availabilityZone": self._placement.zone}
+                        )
+                        if subnet.default_for_az
+                    ][0]
 
                 group_id = nic.get("SecurityGroupId")
                 group_ids = [group_id] if group_id else []

--- a/tests/test_cloudformation/test_cloudformation_stack_integration.py
+++ b/tests/test_cloudformation/test_cloudformation_stack_integration.py
@@ -495,7 +495,7 @@ def test_autoscaling_group_with_elb():
             "my-as-group": {
                 "Type": "AWS::AutoScaling::AutoScalingGroup",
                 "Properties": {
-                    "AvailabilityZones": ["us-east1"],
+                    "AvailabilityZones": ["us-east-1a"],
                     "LaunchConfigurationName": {"Ref": "my-launch-config"},
                     "MinSize": "2",
                     "MaxSize": "2",
@@ -522,7 +522,7 @@ def test_autoscaling_group_with_elb():
             "my-elb": {
                 "Type": "AWS::ElasticLoadBalancing::LoadBalancer",
                 "Properties": {
-                    "AvailabilityZones": ["us-east1"],
+                    "AvailabilityZones": ["us-east-1a"],
                     "Listeners": [
                         {
                             "LoadBalancerPort": "80",
@@ -545,10 +545,10 @@ def test_autoscaling_group_with_elb():
 
     web_setup_template_json = json.dumps(web_setup_template)
 
-    conn = boto.cloudformation.connect_to_region("us-west-1")
+    conn = boto.cloudformation.connect_to_region("us-east-1")
     conn.create_stack("web_stack", template_body=web_setup_template_json)
 
-    autoscale_conn = boto.ec2.autoscale.connect_to_region("us-west-1")
+    autoscale_conn = boto.ec2.autoscale.connect_to_region("us-east-1")
     autoscale_group = autoscale_conn.get_all_groups()[0]
     autoscale_group.launch_config_name.should.contain("my-launch-config")
     autoscale_group.load_balancers[0].should.equal("my-elb")
@@ -557,7 +557,7 @@ def test_autoscaling_group_with_elb():
     autoscale_conn.get_all_launch_configurations().should.have.length_of(1)
 
     # Confirm the ELB was actually created
-    elb_conn = boto.ec2.elb.connect_to_region("us-west-1")
+    elb_conn = boto.ec2.elb.connect_to_region("us-east-1")
     elb_conn.get_all_load_balancers().should.have.length_of(1)
 
     stack = conn.describe_stacks()[0]
@@ -584,7 +584,7 @@ def test_autoscaling_group_with_elb():
     elb_resource.physical_resource_id.should.contain("my-elb")
 
     # confirm the instances were created with the right tags
-    ec2_conn = boto.ec2.connect_to_region("us-west-1")
+    ec2_conn = boto.ec2.connect_to_region("us-east-1")
     reservations = ec2_conn.get_all_reservations()
     len(reservations).should.equal(1)
     reservation = reservations[0]
@@ -604,7 +604,7 @@ def test_autoscaling_group_update():
             "my-as-group": {
                 "Type": "AWS::AutoScaling::AutoScalingGroup",
                 "Properties": {
-                    "AvailabilityZones": ["us-west-1"],
+                    "AvailabilityZones": ["us-west-1a"],
                     "LaunchConfigurationName": {"Ref": "my-launch-config"},
                     "MinSize": "2",
                     "MaxSize": "2",

--- a/tests/test_ec2/test_instances.py
+++ b/tests/test_ec2/test_instances.py
@@ -71,7 +71,7 @@ def test_instance_launch_and_terminate():
     instance.id.should.equal(instance.id)
     instance.state.should.equal("running")
     instance.launch_time.should.equal("2014-01-01T05:00:00.000Z")
-    instance.vpc_id.should.equal(None)
+    instance.vpc_id.shouldnt.equal(None)
     instance.placement.should.equal("us-east-1a")
 
     root_device_name = instance.root_device_name

--- a/tests/test_ec2/test_subnets.py
+++ b/tests/test_ec2/test_subnets.py
@@ -599,3 +599,50 @@ def validate_subnet_details_after_creating_eni(
     for eni in enis_created:
         client.delete_network_interface(NetworkInterfaceId=eni["NetworkInterfaceId"])
     client.delete_subnet(SubnetId=subnet["SubnetId"])
+
+
+@mock_ec2
+def test_run_instances_should_attach_to_default_subnet():
+    ec2 = boto3.resource("ec2", region_name="us-west-1")
+    client = boto3.client("ec2", region_name="us-west-1")
+    ec2.create_security_group(GroupName="sg01", Description="Test security group sg01")
+    # run_instances
+    instances = client.run_instances(
+        MinCount=1,
+        MaxCount=1,
+        SecurityGroups=["sg01"],
+        TagSpecifications=[
+            {
+                "ResourceType": "instance",
+                "Tags": [{"Key": "Name", "Value": "test-01"},],
+            }
+        ],
+    )
+    default_subnet_id = client.describe_subnets()["Subnets"][0]["SubnetId"]
+    instances["Instances"][0]["NetworkInterfaces"][0]["SubnetId"].should.equal(
+        default_subnet_id
+    )
+
+
+@mock_ec2
+def test_describe_subnets_where_network_interface_has_no_subnets_attached():
+    # https://github.com/spulec/moto/issues/2877
+    # create security groups
+    ec2 = boto3.resource("ec2", region_name="us-west-1")
+    client = boto3.client("ec2", region_name="us-west-1")
+    ec2.create_security_group(GroupName="sg01", Description="Test security group sg01")
+    # run_instances
+    client.run_instances(
+        MinCount=1,
+        MaxCount=1,
+        SecurityGroups=["sg01"],
+        TagSpecifications=[
+            {
+                "ResourceType": "instance",
+                "Tags": [{"Key": "Name", "Value": "test-01"},],
+            }
+        ],
+    )
+    # describe_subnets
+    subnets = client.describe_subnets()["Subnets"]
+    subnets[0]["AvailableIpAddressCount"].should.equal(4090)


### PR DESCRIPTION
Fixes #2877 

The bug appeared when describing subnets, specifically when trying to get the number available ip addresses: https://github.com/spulec/moto/blob/master/moto/ec2/models.py#L2998

This line assumed that an ENI would always have a subnet attached

The actual bug: an ENI only had a subnet attached if a subnet ID was supplied by the user

Fix: If not user-supplied, find the default subnet for that availability zone and attach it to the ENI (which is the AWS behaviour)