### PR TITLE
Adding missing Param zoneId in the ec2 describe-availability-zone

### DIFF
--- a/moto/ec2/responses/availability_zones_and_regions.py
+++ b/moto/ec2/responses/availability_zones_and_regions.py
@@ -35,6 +35,7 @@ DESCRIBE_ZONES_RESPONSE = """<DescribeAvailabilityZonesResponse xmlns="http://ec
           <zoneName>{{ zone.name }}</zoneName>
           <zoneState>available</zoneState>
           <regionName>{{ zone.region_name }}</regionName>
+          <zoneId>{{ zone.zone_id }}</zoneId>
           <messageSet/>
        </item>
    {% endfor %}

--- a/tests/test_ec2/test_availability_zones_and_regions.py
+++ b/tests/test_ec2/test_availability_zones_and_regions.py
@@ -52,3 +52,15 @@ def test_boto3_availability_zones():
         resp = conn.describe_availability_zones()
         for rec in resp["AvailabilityZones"]:
             rec["ZoneName"].should.contain(region)
+
+
+@mock_ec2
+def test_boto3_zoneId_in_availability_zones():
+    conn = boto3.client("ec2", "us-east-1")
+    resp = conn.describe_availability_zones()
+    for rec in resp["AvailabilityZones"]:
+        rec.get("ZoneId").should.contain("use1")
+    conn = boto3.client("ec2", "us-west-1")
+    resp = conn.describe_availability_zones()
+    for rec in resp["AvailabilityZones"]:
+        rec.get("ZoneId").should.contain("usw1")


### PR DESCRIPTION
Adding missing Param zoneId in the describe-availability-zone and added tests against the same
