### PR TITLE
Bugfix: Allow stop_db_instance for compatible engines (refs #2006)

### DIFF
--- a/moto/rds2/models.py
+++ b/moto/rds2/models.py
@@ -865,7 +865,10 @@ class RDS2Backend(BaseBackend):
     def stop_database(self, db_instance_identifier, db_snapshot_identifier=None):
         database = self.describe_databases(db_instance_identifier)[0]
         # todo: certain rds types not allowed to be stopped at this time.
-        if database.is_replica or database.multi_az:
+        # https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_StopInstance.html#USER_StopInstance.Limitations
+        if database.is_replica or (
+            database.multi_az and database.engine.lower().startswith("sqlserver")
+        ):
             # todo: more db types not supported by stop/start instance api
             raise InvalidDBClusterStateFaultError(db_instance_identifier)
         if database.status != "available":


### PR DESCRIPTION
From the [RDS documentation](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_StopInstance.html#USER_StopInstance.Limitations):
> You can stop and start a DB instance whether it is configured for a single Availability Zone or for Multi-AZ, for database engines that support Multi-AZ deployments. You can't stop an Amazon RDS for SQL Server DB instance in a Multi-AZ configuration.

---

Related to https://github.com/spulec/moto/issues/2006