### PR TITLE
Use ISO 8601 format for ELB DescribeLoadBalancers

### DIFF
--- a/moto/elb/models.py
+++ b/moto/elb/models.py
@@ -1,6 +1,9 @@
 from __future__ import unicode_literals
 
 import datetime
+
+import pytz
+
 from boto.ec2.elb.attributes import (
     LbAttributes,
     ConnectionSettingAttribute,
@@ -83,7 +86,7 @@ class FakeLoadBalancer(BaseModel):
         self.zones = zones
         self.listeners = []
         self.backends = []
-        self.created_time = datetime.datetime.now()
+        self.created_time = datetime.datetime.now(pytz.utc)
         self.scheme = scheme
         self.attributes = FakeLoadBalancer.get_default_attributes()
         self.policies = Policies()

--- a/moto/elb/responses.py
+++ b/moto/elb/responses.py
@@ -442,7 +442,7 @@ DESCRIBE_LOAD_BALANCERS_TEMPLATE = """<DescribeLoadBalancersResponse xmlns="http
             {% endfor %}
           </SecurityGroups>
           <LoadBalancerName>{{ load_balancer.name }}</LoadBalancerName>
-          <CreatedTime>{{ load_balancer.created_time }}</CreatedTime>
+          <CreatedTime>{{ load_balancer.created_time.isoformat() }}</CreatedTime>
           <HealthCheck>
             {% if load_balancer.health_check %}
               <Interval>{{ load_balancer.health_check.interval }}</Interval>


### PR DESCRIPTION
Similar issue to https://github.com/spulec/moto/issues/2665 - JodaTime as used in the Java AWS SDK throws an exception when receiving `DescribeLoadBalancers` results.

See https://github.com/rwhogg/aws-elb-test for a program that demonstrates the problem.

Based on a quick look at the code, I strongly suspect this issue affects ELB v2 as well, but I've only fixed it for v1 at the moment.