### PR TITLE
Fix deprecation warnings.

### DIFF
--- a/moto/ec2/urls.py
+++ b/moto/ec2/urls.py
@@ -2,6 +2,6 @@ from __future__ import unicode_literals
 from .responses import EC2Response
 
 
-url_bases = ["https?://ec2\.(.+)\.amazonaws\.com(|\.cn)"]
+url_bases = [r"https?://ec2\.(.+)\.amazonaws\.com(|\.cn)"]
 
 url_paths = {"{0}/": EC2Response.dispatch}

--- a/moto/ssm/models.py
+++ b/moto/ssm/models.py
@@ -651,7 +651,7 @@ class SimpleSystemManagerBackend(BaseBackend):
                 label.startswith("aws")
                 or label.startswith("ssm")
                 or label[:1].isdigit()
-                or not re.match("^[a-zA-z0-9_\.\-]*$", label)
+                or not re.match(r"^[a-zA-z0-9_\.\-]*$", label)
             ):
                 invalid_labels.append(label)
                 continue


### PR DESCRIPTION
I am seeing `DeprecationWarning: invalid escape sequence` when those lines get hit.
this should fix it.