### PR TITLE
S3 - Allow keys to start with leading slashes

### DIFF
--- a/moto/s3/responses.py
+++ b/moto/s3/responses.py
@@ -135,7 +135,7 @@ ACTION_MAP = {
 
 def parse_key_name(pth):
     # strip the first '/' left by urlparse
-    return pth[1:] if pth.startswith('/') else pth
+    return pth[1:] if pth.startswith("/") else pth
 
 
 def is_delete_keys(request, path, bucket_name):

--- a/moto/s3/responses.py
+++ b/moto/s3/responses.py
@@ -134,7 +134,8 @@ ACTION_MAP = {
 
 
 def parse_key_name(pth):
-    return pth.lstrip("/")
+    # strip the first '/' left by urlparse
+    return pth[1:] if pth.startswith('/') else pth
 
 
 def is_delete_keys(request, path, bucket_name):

--- a/moto/s3/urls.py
+++ b/moto/s3/urls.py
@@ -15,5 +15,5 @@ url_paths = {
     # path-based bucket + key
     "{0}/(?P<bucket_name_path>[^/]+)/(?P<key_name>.+)": S3ResponseInstance.key_or_control_response,
     # subdomain bucket + key with empty first part of path
-    "{0}//(?P<key_name>.*)$": S3ResponseInstance.key_or_control_response,
+    "{0}/(?P<key_name>/.*)$": S3ResponseInstance.key_or_control_response,
 }

--- a/tests/test_s3/test_s3.py
+++ b/tests/test_s3/test_s3.py
@@ -3744,6 +3744,28 @@ def test_root_dir_with_empty_name_works():
     store_and_read_back_a_key("/")
 
 
+@parameterized(['mybucket', 'my.bucket'])
+@mock_s3
+def test_leading_slashes_not_removed(bucket_name):
+    """Make sure that leading slashes are not removed internally."""
+    s3 = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
+    s3.create_bucket(Bucket=bucket_name)
+
+    uploaded_key = '/key'
+    invalid_key_1 = 'key'
+    invalid_key_2 = '//key'
+
+    s3.put_object(Bucket=bucket_name, Key=uploaded_key, Body=b'Some body')
+
+    with assert_raises(ClientError) as e:
+        s3.get_object(Bucket=bucket_name, Key=invalid_key_1)
+    e.exception.response["Error"]["Code"].should.equal("NoSuchKey")
+
+    with assert_raises(ClientError) as e:
+        s3.get_object(Bucket=bucket_name, Key=invalid_key_2)
+    e.exception.response["Error"]["Code"].should.equal("NoSuchKey")
+
+
 @parameterized(
     [("foo/bar/baz",), ("foo",), ("foo/run_dt%3D2019-01-01%252012%253A30%253A00",)]
 )

--- a/tests/test_s3/test_s3.py
+++ b/tests/test_s3/test_s3.py
@@ -3744,18 +3744,18 @@ def test_root_dir_with_empty_name_works():
     store_and_read_back_a_key("/")
 
 
-@parameterized(['mybucket', 'my.bucket'])
+@parameterized(["mybucket", "my.bucket"])
 @mock_s3
 def test_leading_slashes_not_removed(bucket_name):
     """Make sure that leading slashes are not removed internally."""
     s3 = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
     s3.create_bucket(Bucket=bucket_name)
 
-    uploaded_key = '/key'
-    invalid_key_1 = 'key'
-    invalid_key_2 = '//key'
+    uploaded_key = "/key"
+    invalid_key_1 = "key"
+    invalid_key_2 = "//key"
 
-    s3.put_object(Bucket=bucket_name, Key=uploaded_key, Body=b'Some body')
+    s3.put_object(Bucket=bucket_name, Key=uploaded_key, Body=b"Some body")
 
     with assert_raises(ClientError) as e:
         s3.get_object(Bucket=bucket_name, Key=invalid_key_1)


### PR DESCRIPTION
Fixes #2759 

S3 allows objects keys to start with slashes (`/`); all leading slashes were previously incorrectly removed from key in `parse_key_name` instead of only removing the first one.

`moto.s3.urls` was also updated to clearly include the leading slash in the `key_name` group.