### PR TITLE
Add get_databases method to glue and update IMPLEMENTATION_COVERAGE.md

### DIFF
--- a/IMPLEMENTATION_COVERAGE.md
+++ b/IMPLEMENTATION_COVERAGE.md
@@ -3351,11 +3351,11 @@
 - [ ] update_listener
 
 ## glue
-4% implemented
-- [ ] batch_create_partition
+14/123 = 11% implemented
+- [X] batch_create_partition
 - [ ] batch_delete_connection
-- [ ] batch_delete_partition
-- [ ] batch_delete_table
+- [X] batch_delete_partition
+- [X] batch_delete_table
 - [ ] batch_delete_table_version
 - [ ] batch_get_crawlers
 - [ ] batch_get_dev_endpoints
@@ -3372,7 +3372,7 @@
 - [ ] create_dev_endpoint
 - [ ] create_job
 - [ ] create_ml_transform
-- [ ] create_partition
+- [X] create_partition
 - [ ] create_script
 - [ ] create_security_configuration
 - [X] create_table
@@ -3404,7 +3404,7 @@
 - [ ] get_crawlers
 - [ ] get_data_catalog_encryption_settings
 - [X] get_database
-- [ ] get_databases
+- [X] get_databases
 - [ ] get_dataflow_graph
 - [ ] get_dev_endpoint
 - [ ] get_dev_endpoints
@@ -3418,7 +3418,7 @@
 - [ ] get_ml_task_runs
 - [ ] get_ml_transform
 - [ ] get_ml_transforms
-- [ ] get_partition
+- [X] get_partition
 - [ ] get_partitions
 - [ ] get_plan
 - [ ] get_resource_policy
@@ -3470,8 +3470,8 @@
 - [ ] update_dev_endpoint
 - [ ] update_job
 - [ ] update_ml_transform
-- [ ] update_partition
-- [ ] update_table
+- [X] update_partition
+- [X] update_table
 - [ ] update_trigger
 - [ ] update_user_defined_function
 - [ ] update_workflow

--- a/IMPLEMENTATION_COVERAGE.md
+++ b/IMPLEMENTATION_COVERAGE.md
@@ -3351,7 +3351,7 @@
 - [ ] update_listener
 
 ## glue
-14/123 = 11% implemented
+11% implemented
 - [X] batch_create_partition
 - [ ] batch_delete_connection
 - [X] batch_delete_partition

--- a/moto/glue/models.py
+++ b/moto/glue/models.py
@@ -34,6 +34,9 @@ class GlueBackend(BaseBackend):
         except KeyError:
             raise DatabaseNotFoundException(database_name)
 
+    def get_databases(self):
+        return [self.databases[key] for key in self.databases] if self.databases else []
+
     def create_table(self, database_name, table_name, table_input):
         database = self.get_database(database_name)
 

--- a/moto/glue/responses.py
+++ b/moto/glue/responses.py
@@ -30,6 +30,10 @@ class GlueResponse(BaseResponse):
         database = self.glue_backend.get_database(database_name)
         return json.dumps({"Database": {"Name": database.name}})
 
+    def get_databases(self):
+        database_list = self.glue_backend.get_databases()
+        return json.dumps({"DatabaseList": [{"Name": database.name} for database in database_list]})
+
     def create_table(self):
         database_name = self.parameters.get("DatabaseName")
         table_input = self.parameters.get("TableInput")

--- a/moto/glue/responses.py
+++ b/moto/glue/responses.py
@@ -32,7 +32,9 @@ class GlueResponse(BaseResponse):
 
     def get_databases(self):
         database_list = self.glue_backend.get_databases()
-        return json.dumps({"DatabaseList": [{"Name": database.name} for database in database_list]})
+        return json.dumps(
+            {"DatabaseList": [{"Name": database.name} for database in database_list]}
+        )
 
     def create_table(self):
         database_name = self.parameters.get("DatabaseName")

--- a/tests/test_glue/test_datacatalog.py
+++ b/tests/test_glue/test_datacatalog.py
@@ -53,6 +53,27 @@ def test_get_database_not_exits():
 
 
 @mock_glue
+def test_get_databases_empty():
+    client = boto3.client("glue", region_name="us-east-1")
+    response = client.get_databases()
+    response["DatabaseList"].should.have.length_of(0)
+
+
+@mock_glue
+def test_get_databases_several_items():
+    client = boto3.client("glue", region_name="us-east-1")
+    database_name_1, database_name_2 = "firstdatabase", "seconddatabase"
+
+    helpers.create_database(client, database_name_1)
+    helpers.create_database(client, database_name_2)
+
+    database_list = sorted(client.get_databases()["DatabaseList"], key=lambda x: x["Name"])
+    database_list.should.have.length_of(2)
+    database_list[0].should.equal({"Name": database_name_1})
+    database_list[1].should.equal({"Name": database_name_2})
+
+
+@mock_glue
 def test_create_table():
     client = boto3.client("glue", region_name="us-east-1")
     database_name = "myspecialdatabase"

--- a/tests/test_glue/test_datacatalog.py
+++ b/tests/test_glue/test_datacatalog.py
@@ -67,7 +67,9 @@ def test_get_databases_several_items():
     helpers.create_database(client, database_name_1)
     helpers.create_database(client, database_name_2)
 
-    database_list = sorted(client.get_databases()["DatabaseList"], key=lambda x: x["Name"])
+    database_list = sorted(
+        client.get_databases()["DatabaseList"], key=lambda x: x["Name"]
+    )
     database_list.should.have.length_of(2)
     database_list[0].should.equal({"Name": database_name_1})
     database_list[1].should.equal({"Name": database_name_2})


### PR DESCRIPTION
### Overview
- Add get_databases method to glue moto client
- Update IMPLEMENTATION_COVERAGE.md with methods that were implemented previously

It only adds the simplified functionality. As in the rest of the glue methods, this method assumes no optional parameters are provided (CatalogId, NextToken, MaxResults)

### Test
Test can be checked with:
`nosetests --tests tests/test_glue/test_datacatalog.py`