### PR TITLE
Make all CallbackResponse requests into a Werkzeug Request

### DIFF
--- a/moto/core/models.py
+++ b/moto/core/models.py
@@ -186,13 +186,15 @@ class CallbackResponse(responses.CallbackResponse):
             else:
                 body = six.BytesIO(request.body)
             req = Request.from_values(
-                path='?'.join([url.path, url.query]),
+                path="?".join([url.path, url.query]),
                 input_stream=body,
                 content_length=request.headers.get("Content-Length"),
                 content_type=request.headers.get("Content-Type"),
                 method=request.method,
-                base_url='{scheme}://{netloc}'.format(scheme=url.scheme, netloc=url.netloc),
-                headers=[(k, v) for k, v in six.iteritems(request.headers)]
+                base_url="{scheme}://{netloc}".format(
+                    scheme=url.scheme, netloc=url.netloc
+                ),
+                headers=[(k, v) for k, v in six.iteritems(request.headers)],
             )
             request = req
         headers = self.get_headers()

--- a/moto/s3/responses.py
+++ b/moto/s3/responses.py
@@ -5,7 +5,6 @@ import sys
 
 import six
 from botocore.awsrequest import AWSPreparedRequest
-from werkzeug.wrappers import Request
 
 from moto.core.utils import str_to_rfc_1123_datetime, py2_strip_unicode_keys
 from six.moves.urllib.parse import parse_qs, urlparse, unquote, parse_qsl
@@ -796,14 +795,6 @@ class ResponseObject(_TemplateEnvironmentMixin, ActionAuthenticatorMixin):
         # POST to bucket-url should create file from form
         if hasattr(request, "form"):
             # Not HTTPretty
-            form = request.form
-        elif request.headers.get("Content-Type").startswith("multipart/form-data"):
-            request = Request.from_values(
-                input_stream=six.BytesIO(request.body),
-                content_length=request.headers["Content-Length"],
-                content_type=request.headers["Content-Type"],
-                method="POST",
-            )
             form = request.form
         else:
             # HTTPretty, build new form object


### PR DESCRIPTION
The "request" object in CallbackResponse is the PreparedRequest send by
whatever client is used to contact the mocked moto service. This can end
up with unparsed bodies, as we added for processing presigned post
requests in #2155. This will make sure that all of the requests comming
in from mocked functions also get processed by werkzeug as if it was
running a live server.