### PR TITLE
Do not remove tags after secret update, handle description

### DIFF
--- a/moto/secretsmanager/models.py
+++ b/moto/secretsmanager/models.py
@@ -126,7 +126,11 @@ class SecretsManagerBackend(BaseBackend):
         description = secret["description"]
 
         version_id = self._add_secret(
-            secret_id, secret_string=secret_string, secret_binary=secret_binary, description=description, tags=tags
+            secret_id,
+            secret_string=secret_string,
+            secret_binary=secret_binary,
+            description=description,
+            tags=tags,
         )
 
         response = json.dumps(
@@ -140,7 +144,13 @@ class SecretsManagerBackend(BaseBackend):
         return response
 
     def create_secret(
-        self, name, secret_string=None, secret_binary=None, description=None, tags=[], **kwargs
+        self,
+        name,
+        secret_string=None,
+        secret_binary=None,
+        description=None,
+        tags=[],
+        **kwargs
     ):
 
         # error if secret exists
@@ -150,7 +160,11 @@ class SecretsManagerBackend(BaseBackend):
             )
 
         version_id = self._add_secret(
-            name, secret_string=secret_string, secret_binary=secret_binary, description=description, tags=tags
+            name,
+            secret_string=secret_string,
+            secret_binary=secret_binary,
+            description=description,
+            tags=tags,
         )
 
         response = json.dumps(
@@ -236,7 +250,12 @@ class SecretsManagerBackend(BaseBackend):
             description = ""
 
         version_id = self._add_secret(
-            secret_id, secret_string, secret_binary, description=description, tags=tags, version_stages=version_stages
+            secret_id,
+            secret_string,
+            secret_binary,
+            description=description,
+            tags=tags,
+            version_stages=version_stages,
         )
 
         response = json.dumps(

--- a/moto/secretsmanager/models.py
+++ b/moto/secretsmanager/models.py
@@ -121,8 +121,12 @@ class SecretsManagerBackend(BaseBackend):
                 "You can't perform this operation on the secret because it was marked for deletion."
             )
 
+        secret = self.secrets[secret_id]
+        tags = secret["tags"]
+        description = secret["description"]
+
         version_id = self._add_secret(
-            secret_id, secret_string=secret_string, secret_binary=secret_binary
+            secret_id, secret_string=secret_string, secret_binary=secret_binary, description=description, tags=tags
         )
 
         response = json.dumps(
@@ -136,7 +140,7 @@ class SecretsManagerBackend(BaseBackend):
         return response
 
     def create_secret(
-        self, name, secret_string=None, secret_binary=None, tags=[], **kwargs
+        self, name, secret_string=None, secret_binary=None, description=None, tags=[], **kwargs
     ):
 
         # error if secret exists
@@ -146,7 +150,7 @@ class SecretsManagerBackend(BaseBackend):
             )
 
         version_id = self._add_secret(
-            name, secret_string=secret_string, secret_binary=secret_binary, tags=tags
+            name, secret_string=secret_string, secret_binary=secret_binary, description=description, tags=tags
         )
 
         response = json.dumps(
@@ -164,6 +168,7 @@ class SecretsManagerBackend(BaseBackend):
         secret_id,
         secret_string=None,
         secret_binary=None,
+        description=None,
         tags=[],
         version_id=None,
         version_stages=None,
@@ -216,13 +221,18 @@ class SecretsManagerBackend(BaseBackend):
         secret["rotation_lambda_arn"] = ""
         secret["auto_rotate_after_days"] = 0
         secret["tags"] = tags
+        secret["description"] = description
 
         return version_id
 
     def put_secret_value(self, secret_id, secret_string, secret_binary, version_stages):
 
+        secret = self.secrets[secret_id]
+        tags = secret["tags"]
+        description = secret["description"]
+
         version_id = self._add_secret(
-            secret_id, secret_string, secret_binary, version_stages=version_stages
+            secret_id, secret_string, secret_binary, description=description, tags=tags, version_stages=version_stages
         )
 
         response = json.dumps(
@@ -310,6 +320,7 @@ class SecretsManagerBackend(BaseBackend):
         self._add_secret(
             secret_id,
             old_secret_version["secret_string"],
+            secret["description"],
             secret["tags"],
             version_id=new_version_id,
             version_stages=["AWSCURRENT"],
@@ -416,7 +427,7 @@ class SecretsManagerBackend(BaseBackend):
                 {
                     "ARN": secret_arn(self.region, secret["secret_id"]),
                     "DeletedDate": secret.get("deleted_date", None),
-                    "Description": "",
+                    "Description": secret.get["description"],
                     "KmsKeyId": "",
                     "LastAccessedDate": None,
                     "LastChangedDate": None,

--- a/moto/secretsmanager/models.py
+++ b/moto/secretsmanager/models.py
@@ -279,7 +279,7 @@ class SecretsManagerBackend(BaseBackend):
             {
                 "ARN": secret_arn(self.region, secret["secret_id"]),
                 "Name": secret["name"],
-                "Description": "",
+                "Description": secret.get("description", ""),
                 "KmsKeyId": "",
                 "RotationEnabled": secret["rotation_enabled"],
                 "RotationLambdaARN": secret["rotation_lambda_arn"],

--- a/moto/secretsmanager/models.py
+++ b/moto/secretsmanager/models.py
@@ -227,9 +227,13 @@ class SecretsManagerBackend(BaseBackend):
 
     def put_secret_value(self, secret_id, secret_string, secret_binary, version_stages):
 
-        secret = self.secrets[secret_id]
-        tags = secret["tags"]
-        description = secret["description"]
+        if secret_id in self.secrets.keys():
+            secret = self.secrets[secret_id]
+            tags = secret["tags"]
+            description = secret["description"]
+        else:
+            tags = []
+            description = ""
 
         version_id = self._add_secret(
             secret_id, secret_string, secret_binary, description=description, tags=tags, version_stages=version_stages
@@ -427,7 +431,7 @@ class SecretsManagerBackend(BaseBackend):
                 {
                     "ARN": secret_arn(self.region, secret["secret_id"]),
                     "DeletedDate": secret.get("deleted_date", None),
-                    "Description": secret.get["description"],
+                    "Description": secret.get("description", ""),
                     "KmsKeyId": "",
                     "LastAccessedDate": None,
                     "LastChangedDate": None,

--- a/moto/secretsmanager/responses.py
+++ b/moto/secretsmanager/responses.py
@@ -21,11 +21,13 @@ class SecretsManagerResponse(BaseResponse):
         name = self._get_param("Name")
         secret_string = self._get_param("SecretString")
         secret_binary = self._get_param("SecretBinary")
+        description = self._get_param("Description", if_none="")
         tags = self._get_param("Tags", if_none=[])
         return secretsmanager_backends[self.region].create_secret(
             name=name,
             secret_string=secret_string,
             secret_binary=secret_binary,
+            description=description,
             tags=tags,
         )
 

--- a/tests/test_secretsmanager/test_secretsmanager.py
+++ b/tests/test_secretsmanager/test_secretsmanager.py
@@ -138,6 +138,45 @@ def test_create_secret_with_tags():
 
 
 @mock_secretsmanager
+def test_create_secret_with_description():
+    conn = boto3.client("secretsmanager", region_name="us-east-1")
+    secret_name = "test-secret-with-tags"
+
+    result = conn.create_secret(
+        Name=secret_name, SecretString="foosecret", Description="desc"
+    )
+    assert result["ARN"]
+    assert result["Name"] == secret_name
+    secret_value = conn.get_secret_value(SecretId=secret_name)
+    assert secret_value["SecretString"] == "foosecret"
+    secret_details = conn.describe_secret(SecretId=secret_name)
+    assert secret_details["Description"] == "desc"
+
+
+@mock_secretsmanager
+def test_create_secret_with_tags_and_description():
+    conn = boto3.client("secretsmanager", region_name="us-east-1")
+    secret_name = "test-secret-with-tags"
+
+    result = conn.create_secret(
+        Name=secret_name,
+        SecretString="foosecret",
+        Description="desc",
+        Tags=[{"Key": "Foo", "Value": "Bar"}, {"Key": "Mykey", "Value": "Myvalue"}],
+    )
+    assert result["ARN"]
+    assert result["Name"] == secret_name
+    secret_value = conn.get_secret_value(SecretId=secret_name)
+    assert secret_value["SecretString"] == "foosecret"
+    secret_details = conn.describe_secret(SecretId=secret_name)
+    assert secret_details["Tags"] == [
+        {"Key": "Foo", "Value": "Bar"},
+        {"Key": "Mykey", "Value": "Myvalue"},
+    ]
+    assert secret_details["Description"] == "desc"
+
+
+@mock_secretsmanager
 def test_delete_secret():
     conn = boto3.client("secretsmanager", region_name="us-west-2")
 
@@ -691,6 +730,31 @@ def test_put_secret_value_versions_differ_if_same_secret_put_twice():
 
 
 @mock_secretsmanager
+def test_put_secret_value_maintains_description_and_tags():
+    conn = boto3.client("secretsmanager", region_name="us-west-2")
+
+    conn.create_secret(
+        Name=DEFAULT_SECRET_NAME,
+        SecretString="foosecret",
+        Description="desc",
+        Tags=[{"Key": "Foo", "Value": "Bar"}, {"Key": "Mykey", "Value": "Myvalue"}],
+    )
+
+    conn = boto3.client("secretsmanager", region_name="us-west-2")
+    conn.put_secret_value(
+        SecretId=DEFAULT_SECRET_NAME,
+        SecretString="dupe_secret",
+        VersionStages=["AWSCURRENT"],
+    )
+    secret_details = conn.describe_secret(SecretId=DEFAULT_SECRET_NAME)
+    assert secret_details["Tags"] == [
+        {"Key": "Foo", "Value": "Bar"},
+        {"Key": "Mykey", "Value": "Myvalue"},
+    ]
+    assert secret_details["Description"] == "desc"
+
+
+@mock_secretsmanager
 def test_can_list_secret_version_ids():
     conn = boto3.client("secretsmanager", region_name="us-west-2")
     put_secret_value_dict = conn.put_secret_value(
@@ -737,6 +801,43 @@ def test_update_secret():
     secret = conn.get_secret_value(SecretId="test-secret")
     assert secret["SecretString"] == "barsecret"
     assert created_secret["VersionId"] != updated_secret["VersionId"]
+
+
+@mock_secretsmanager
+def test_update_secret_with_tags_and_description():
+    conn = boto3.client("secretsmanager", region_name="us-west-2")
+
+    created_secret = conn.create_secret(
+        Name="test-secret",
+        SecretString="foosecret",
+        Description="desc",
+        Tags=[{"Key": "Foo", "Value": "Bar"}, {"Key": "Mykey", "Value": "Myvalue"}],
+    )
+
+    assert created_secret["ARN"]
+    assert created_secret["Name"] == "test-secret"
+    assert created_secret["VersionId"] != ""
+
+    secret = conn.get_secret_value(SecretId="test-secret")
+    assert secret["SecretString"] == "foosecret"
+
+    updated_secret = conn.update_secret(
+        SecretId="test-secret", SecretString="barsecret"
+    )
+
+    assert updated_secret["ARN"]
+    assert updated_secret["Name"] == "test-secret"
+    assert updated_secret["VersionId"] != ""
+
+    secret = conn.get_secret_value(SecretId="test-secret")
+    assert secret["SecretString"] == "barsecret"
+    assert created_secret["VersionId"] != updated_secret["VersionId"]
+    secret_details = conn.describe_secret(SecretId="test-secret")
+    assert secret_details["Tags"] == [
+        {"Key": "Foo", "Value": "Bar"},
+        {"Key": "Mykey", "Value": "Myvalue"},
+    ]
+    assert secret_details["Description"] == "desc"
 
 
 @mock_secretsmanager


### PR DESCRIPTION
This PR addresses two issues I've originally created in localstack project:
https://github.com/localstack/localstack/issues/2347
https://github.com/localstack/localstack/issues/2348

In short: it adds support for secret description, and fixes an issue, where tags would be cleared upon updating secret value.

Please note, that I'm not a python developer, so perhaps some changes could be introduced, however I've tested those changes locally and they seem to fix mentioned issues.