### PR TITLE
Support OptInStatus for EC2 describe_region calls

### DIFF
--- a/moto/ec2/models.py
+++ b/moto/ec2/models.py
@@ -1504,21 +1504,30 @@ class Zone(object):
 
 
 class RegionsAndZonesBackend(object):
-    regions_not_enabled_by_default = [
-        'ap-east-1',
-        'me-south-1'
-    ]
+    regions_not_enabled_by_default = ["ap-east-1", "me-south-1"]
 
     regions = []
     for region in Session().get_available_regions("ec2"):
         if region in regions_not_enabled_by_default:
-            regions.append(Region(region, "ec2.{}.amazonaws.com".format(region), "not-opted-in"))
+            regions.append(
+                Region(region, "ec2.{}.amazonaws.com".format(region), "not-opted-in")
+            )
         else:
-            regions.append(Region(region, "ec2.{}.amazonaws.com".format(region), "opt-in-not-required"))
+            regions.append(
+                Region(
+                    region, "ec2.{}.amazonaws.com".format(region), "opt-in-not-required"
+                )
+            )
     for region in Session().get_available_regions("ec2", partition_name="aws-us-gov"):
-        regions.append(Region(region, "ec2.{}.amazonaws.com".format(region), "opt-in-not-required"))
+        regions.append(
+            Region(region, "ec2.{}.amazonaws.com".format(region), "opt-in-not-required")
+        )
     for region in Session().get_available_regions("ec2", partition_name="aws-cn"):
-        regions.append(Region(region, "ec2.{}.amazonaws.com.cn".format(region), "opt-in-not-required"))
+        regions.append(
+            Region(
+                region, "ec2.{}.amazonaws.com.cn".format(region), "opt-in-not-required"
+            )
+        )
 
     zones = {
         "af-south-1": [

--- a/moto/ec2/models.py
+++ b/moto/ec2/models.py
@@ -1490,9 +1490,10 @@ class AmiBackend(object):
 
 
 class Region(object):
-    def __init__(self, name, endpoint):
+    def __init__(self, name, endpoint, opt_in_status):
         self.name = name
         self.endpoint = endpoint
+        self.opt_in_status = opt_in_status
 
 
 class Zone(object):
@@ -1503,13 +1504,21 @@ class Zone(object):
 
 
 class RegionsAndZonesBackend(object):
+    regions_not_enabled_by_default = [
+        'ap-east-1',
+        'me-south-1'
+    ]
+
     regions = []
     for region in Session().get_available_regions("ec2"):
-        regions.append(Region(region, "ec2.{}.amazonaws.com".format(region)))
+        if region in regions_not_enabled_by_default:
+            regions.append(Region(region, "ec2.{}.amazonaws.com".format(region), "not-opted-in"))
+        else:
+            regions.append(Region(region, "ec2.{}.amazonaws.com".format(region), "opt-in-not-required"))
     for region in Session().get_available_regions("ec2", partition_name="aws-us-gov"):
-        regions.append(Region(region, "ec2.{}.amazonaws.com".format(region)))
+        regions.append(Region(region, "ec2.{}.amazonaws.com".format(region), "opt-in-not-required"))
     for region in Session().get_available_regions("ec2", partition_name="aws-cn"):
-        regions.append(Region(region, "ec2.{}.amazonaws.com.cn".format(region)))
+        regions.append(Region(region, "ec2.{}.amazonaws.com.cn".format(region), "opt-in-not-required"))
 
     zones = {
         "af-south-1": [

--- a/moto/ec2/models.py
+++ b/moto/ec2/models.py
@@ -1504,19 +1504,38 @@ class Zone(object):
 
 
 class RegionsAndZonesBackend(object):
-    regions_not_enabled_by_default = ["ap-east-1", "me-south-1"]
+    regions_opt_in_not_required = [
+        "af-south-1",
+        "ap-northeast-1",
+        "ap-northeast-2",
+        "ap-northeast-3",
+        "ap-south-1",
+        "ap-southeast-1",
+        "ap-southeast-2",
+        "ca-central-1",
+        "eu-central-1",
+        "eu-north-1",
+        "eu-west-1",
+        "eu-west-2",
+        "eu-west-3",
+        "sa-east-1",
+        "us-east-1",
+        "us-east-2",
+        "us-west-1",
+        "us-west-2",
+    ]
 
     regions = []
     for region in Session().get_available_regions("ec2"):
-        if region in regions_not_enabled_by_default:
-            regions.append(
-                Region(region, "ec2.{}.amazonaws.com".format(region), "not-opted-in")
-            )
-        else:
+        if region in regions_opt_in_not_required:
             regions.append(
                 Region(
                     region, "ec2.{}.amazonaws.com".format(region), "opt-in-not-required"
                 )
+            )
+        else:
+            regions.append(
+                Region(region, "ec2.{}.amazonaws.com".format(region), "not-opted-in")
             )
     for region in Session().get_available_regions("ec2", partition_name="aws-us-gov"):
         regions.append(

--- a/moto/ec2/responses/availability_zones_and_regions.py
+++ b/moto/ec2/responses/availability_zones_and_regions.py
@@ -22,6 +22,7 @@ DESCRIBE_REGIONS_RESPONSE = """<DescribeRegionsResponse xmlns="http://ec2.amazon
           <item>
              <regionName>{{ region.name }}</regionName>
              <regionEndpoint>{{ region.endpoint }}</regionEndpoint>
+             <optInStatus>{{ region.opt_in_status }}</optInStatus>
           </item>
       {% endfor %}
    </regionInfo>

--- a/tests/test_ec2/test_availability_zones_and_regions.py
+++ b/tests/test_ec2/test_availability_zones_and_regions.py
@@ -40,7 +40,9 @@ def test_boto3_describe_regions():
     resp = ec2.describe_regions(RegionNames=[test_region])
     resp["Regions"].should.have.length_of(1)
     resp["Regions"][0].should.have.key("RegionName").which.should.equal(test_region)
-    resp["Regions"][0].should.have.key("OptInStatus").which.should.equal("opt-in-not-required")
+    resp["Regions"][0].should.have.key("OptInStatus").which.should.equal(
+        "opt-in-not-required"
+    )
 
     test_region = "ap-east-1"
     resp = ec2.describe_regions(RegionNames=[test_region])

--- a/tests/test_ec2/test_availability_zones_and_regions.py
+++ b/tests/test_ec2/test_availability_zones_and_regions.py
@@ -40,6 +40,13 @@ def test_boto3_describe_regions():
     resp = ec2.describe_regions(RegionNames=[test_region])
     resp["Regions"].should.have.length_of(1)
     resp["Regions"][0].should.have.key("RegionName").which.should.equal(test_region)
+    resp["Regions"][0].should.have.key("OptInStatus").which.should.equal("opt-in-not-required")
+
+    test_region = "ap-east-1"
+    resp = ec2.describe_regions(RegionNames=[test_region])
+    resp["Regions"].should.have.length_of(1)
+    resp["Regions"][0].should.have.key("RegionName").which.should.equal(test_region)
+    resp["Regions"][0].should.have.key("OptInStatus").which.should.equal("not-opted-in")
 
 
 @mock_ec2


### PR DESCRIPTION
The `describe_regions` call now includes an `OptInStatus` key in the return.

Examples:
- https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/ec2.html#EC2.Client.describe_regions
- https://docs.aws.amazon.com/cli/latest/reference/ec2/describe-regions.html

Added this capability given these constraints:
- Regions can have a status of `opt-in-not-required`, `not-opted-in`, or `opted-in`
- Regions introduced by AWS after 3/20/19 must be enabled (ie, status of `not-opted-in`, or `opted-in`)
   - Source: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html (under "Available Regions" section)
   - Far as I know, this should be `me-south-1` and `ap-east-1`
- Regions before 3/20/19 should have status of `opt-in-not-required`

I am not exactly sure what China or Gov regions should return, but I set it to `opt-in-not-required`. 