### PR TITLE
Add policy to API Gateway 

### DIFF
--- a/moto/apigateway/models.py
+++ b/moto/apigateway/models.py
@@ -461,6 +461,7 @@ class RestAPI(BaseModel):
         self.description = description
         self.create_date = int(time.time())
         self.api_key_source = kwargs.get("api_key_source") or "HEADER"
+        self.policy = kwargs.get("policy") or None
         self.endpoint_configuration = kwargs.get("endpoint_configuration") or {
             "types": ["EDGE"]
         }
@@ -485,6 +486,7 @@ class RestAPI(BaseModel):
             "apiKeySource": self.api_key_source,
             "endpointConfiguration": self.endpoint_configuration,
             "tags": self.tags,
+            "policy": self.policy,
         }
 
     def add_child(self, path, parent_id=None):
@@ -713,6 +715,7 @@ class APIGatewayBackend(BaseBackend):
         api_key_source=None,
         endpoint_configuration=None,
         tags=None,
+        policy=None,
     ):
         api_id = create_id()
         rest_api = RestAPI(
@@ -723,6 +726,7 @@ class APIGatewayBackend(BaseBackend):
             api_key_source=api_key_source,
             endpoint_configuration=endpoint_configuration,
             tags=tags,
+            policy=policy,
         )
         self.apis[api_id] = rest_api
         return rest_api

--- a/moto/apigateway/responses.py
+++ b/moto/apigateway/responses.py
@@ -59,6 +59,7 @@ class APIGatewayResponse(BaseResponse):
             api_key_source = self._get_param("apiKeySource")
             endpoint_configuration = self._get_param("endpointConfiguration")
             tags = self._get_param("tags")
+            policy = self._get_param("policy")
 
             # Param validation
             if api_key_source and api_key_source not in API_KEY_SOURCES:
@@ -94,6 +95,7 @@ class APIGatewayResponse(BaseResponse):
                 api_key_source=api_key_source,
                 endpoint_configuration=endpoint_configuration,
                 tags=tags,
+                policy=policy,
             )
             return 200, {}, json.dumps(rest_api.to_dict())
 

--- a/tests/test_apigateway/test_apigateway.py
+++ b/tests/test_apigateway/test_apigateway.py
@@ -73,11 +73,9 @@ def test_create_rest_api_with_tags():
 def test_create_rest_api_with_policy():
     client = boto3.client("apigateway", region_name="us-west-2")
 
-    policy = "{\"Version\": \"2012-10-17\",\"Statement\": []}"
+    policy = '{"Version": "2012-10-17","Statement": []}'
     response = client.create_rest_api(
-        name="my_api",
-        description="this is my api",
-        policy=policy
+        name="my_api", description="this is my api", policy=policy
     )
     api_id = response["id"]
 

--- a/tests/test_apigateway/test_apigateway.py
+++ b/tests/test_apigateway/test_apigateway.py
@@ -70,6 +70,24 @@ def test_create_rest_api_with_tags():
 
 
 @mock_apigateway
+def test_create_rest_api_with_policy():
+    client = boto3.client("apigateway", region_name="us-west-2")
+
+    policy = "{\"Version\": \"2012-10-17\",\"Statement\": []}"
+    response = client.create_rest_api(
+        name="my_api",
+        description="this is my api",
+        policy=policy
+    )
+    api_id = response["id"]
+
+    response = client.get_rest_api(restApiId=api_id)
+
+    assert "policy" in response
+    response["policy"].should.equal(policy)
+
+
+@mock_apigateway
 def test_create_rest_api_invalid_apikeysource():
     client = boto3.client("apigateway", region_name="us-west-2")
 


### PR DESCRIPTION
We needed to be able to unit test lambda code that checks the existence of policy, added policy to ApiGateway model and response.

Fixes #2721 