### PR TITLE
Improve DDB expressions support4: Execution using AST

### DIFF
--- a/moto/dynamodb2/exceptions.py
+++ b/moto/dynamodb2/exceptions.py
@@ -39,6 +39,17 @@ class AttributeDoesNotExist(MockValidationException):
         super(AttributeDoesNotExist, self).__init__(self.attr_does_not_exist_msg)
 
 
+class ProvidedKeyDoesNotExist(MockValidationException):
+    provided_key_does_not_exist_msg = (
+        "The provided key element does not match the schema"
+    )
+
+    def __init__(self):
+        super(ProvidedKeyDoesNotExist, self).__init__(
+            self.provided_key_does_not_exist_msg
+        )
+
+
 class ExpressionAttributeNameNotDefined(InvalidUpdateExpression):
     name_not_defined_msg = "An expression attribute name used in the document path is not defined; attribute name: {n}"
 
@@ -131,3 +142,10 @@ class IncorrectOperandType(InvalidUpdateExpression):
         super(IncorrectOperandType, self).__init__(
             self.inv_operand_msg.format(f=operator_or_function, t=operand_type)
         )
+
+
+class IncorrectDataType(MockValidationException):
+    inc_data_type_msg = "An operand in the update expression has an incorrect data type"
+
+    def __init__(self):
+        super(IncorrectDataType, self).__init__(self.inc_data_type_msg)

--- a/moto/dynamodb2/parsing/executors.py
+++ b/moto/dynamodb2/parsing/executors.py
@@ -1,0 +1,262 @@
+from abc import abstractmethod
+
+from moto.dynamodb2.exceptions import IncorrectOperandType, IncorrectDataType
+from moto.dynamodb2.models import DynamoType
+from moto.dynamodb2.models.dynamo_type import DDBTypeConversion, DDBType
+from moto.dynamodb2.parsing.ast_nodes import (
+    UpdateExpressionSetAction,
+    UpdateExpressionDeleteAction,
+    UpdateExpressionRemoveAction,
+    UpdateExpressionAddAction,
+    UpdateExpressionPath,
+    DDBTypedValue,
+    ExpressionAttribute,
+    ExpressionSelector,
+    ExpressionAttributeName,
+)
+from moto.dynamodb2.parsing.validators import ExpressionPathResolver
+
+
+class NodeExecutor(object):
+    def __init__(self, ast_node, expression_attribute_names):
+        self.node = ast_node
+        self.expression_attribute_names = expression_attribute_names
+
+    @abstractmethod
+    def execute(self, item):
+        pass
+
+    def get_item_part_for_path_nodes(self, item, path_nodes):
+        """
+        For a list of path nodes travers the item by following the path_nodes
+        Args:
+            item(Item):
+            path_nodes(list):
+
+        Returns:
+
+        """
+        if len(path_nodes) == 0:
+            return item.attrs
+        else:
+            return ExpressionPathResolver(
+                self.expression_attribute_names
+            ).resolve_expression_path_nodes_to_dynamo_type(item, path_nodes)
+
+    def get_item_before_end_of_path(self, item):
+        """
+        Get the part ot the item where the item will perform the action. For most actions this should be the parent. As
+        that element will need to be modified by the action.
+        Args:
+            item(Item):
+
+        Returns:
+            DynamoType or dict: The path to be set
+        """
+        return self.get_item_part_for_path_nodes(
+            item, self.get_path_expression_nodes()[:-1]
+        )
+
+    def get_item_at_end_of_path(self, item):
+        """
+        For a DELETE the path points at the stringset so we need to evaluate the full path.
+        Args:
+            item(Item):
+
+        Returns:
+            DynamoType or dict: The path to be set
+        """
+        return self.get_item_part_for_path_nodes(item, self.get_path_expression_nodes())
+
+    # Get the part ot the item where the item will perform the action. For most actions this should be the parent. As
+    # that element will need to be modified by the action.
+    get_item_part_in_which_to_perform_action = get_item_before_end_of_path
+
+    def get_path_expression_nodes(self):
+        update_expression_path = self.node.children[0]
+        assert isinstance(update_expression_path, UpdateExpressionPath)
+        return update_expression_path.children
+
+    def get_element_to_action(self):
+        return self.get_path_expression_nodes()[-1]
+
+    def get_action_value(self):
+        """
+
+        Returns:
+            DynamoType: The value to be set
+        """
+        ddb_typed_value = self.node.children[1]
+        assert isinstance(ddb_typed_value, DDBTypedValue)
+        dynamo_type_value = ddb_typed_value.children[0]
+        assert isinstance(dynamo_type_value, DynamoType)
+        return dynamo_type_value
+
+
+class SetExecutor(NodeExecutor):
+    def execute(self, item):
+        self.set(
+            item_part_to_modify_with_set=self.get_item_part_in_which_to_perform_action(
+                item
+            ),
+            element_to_set=self.get_element_to_action(),
+            value_to_set=self.get_action_value(),
+            expression_attribute_names=self.expression_attribute_names,
+        )
+
+    @classmethod
+    def set(
+        cls,
+        item_part_to_modify_with_set,
+        element_to_set,
+        value_to_set,
+        expression_attribute_names,
+    ):
+        if isinstance(element_to_set, ExpressionAttribute):
+            attribute_name = element_to_set.get_attribute_name()
+            item_part_to_modify_with_set[attribute_name] = value_to_set
+        elif isinstance(element_to_set, ExpressionSelector):
+            index = element_to_set.get_index()
+            item_part_to_modify_with_set[index] = value_to_set
+        elif isinstance(element_to_set, ExpressionAttributeName):
+            attribute_name = expression_attribute_names[
+                element_to_set.get_attribute_name_placeholder()
+            ]
+            item_part_to_modify_with_set[attribute_name] = value_to_set
+        else:
+            raise NotImplementedError(
+                "Moto does not support setting {t} yet".format(t=type(element_to_set))
+            )
+
+
+class DeleteExecutor(NodeExecutor):
+    operator = "operator: DELETE"
+
+    def execute(self, item):
+        string_set_to_remove = self.get_action_value()
+        assert isinstance(string_set_to_remove, DynamoType)
+        if not string_set_to_remove.is_set():
+            raise IncorrectOperandType(
+                self.operator,
+                DDBTypeConversion.get_human_type(string_set_to_remove.type),
+            )
+
+        string_set = self.get_item_at_end_of_path(item)
+        assert isinstance(string_set, DynamoType)
+        if string_set.type != string_set_to_remove.type:
+            raise IncorrectDataType()
+        # String set is currently implemented as a list
+        string_set_list = string_set.value
+
+        stringset_to_remove_list = string_set_to_remove.value
+
+        for value in stringset_to_remove_list:
+            try:
+                string_set_list.remove(value)
+            except (KeyError, ValueError):
+                # DynamoDB does not mind if value is not present
+                pass
+
+
+class RemoveExecutor(NodeExecutor):
+    def execute(self, item):
+        element_to_remove = self.get_element_to_action()
+        if isinstance(element_to_remove, ExpressionAttribute):
+            attribute_name = element_to_remove.get_attribute_name()
+            self.get_item_part_in_which_to_perform_action(item).pop(
+                attribute_name, None
+            )
+        elif isinstance(element_to_remove, ExpressionAttributeName):
+            attribute_name = self.expression_attribute_names[
+                element_to_remove.get_attribute_name_placeholder()
+            ]
+            self.get_item_part_in_which_to_perform_action(item).pop(
+                attribute_name, None
+            )
+        elif isinstance(element_to_remove, ExpressionSelector):
+            index = element_to_remove.get_index()
+            try:
+                self.get_item_part_in_which_to_perform_action(item).pop(index)
+            except IndexError:
+                # DynamoDB does not care that index is out of bounds, it will just do nothing.
+                pass
+        else:
+            raise NotImplementedError(
+                "Moto does not support setting {t} yet".format(
+                    t=type(element_to_remove)
+                )
+            )
+
+
+class AddExecutor(NodeExecutor):
+    def execute(self, item):
+        value_to_add = self.get_action_value()
+        if isinstance(value_to_add, DynamoType):
+            if value_to_add.is_set():
+                current_string_set = self.get_item_at_end_of_path(item)
+                assert isinstance(current_string_set, DynamoType)
+                if not current_string_set.type == value_to_add.type:
+                    raise IncorrectDataType()
+                # Sets are implemented as list
+                for value in value_to_add.value:
+                    if value in current_string_set.value:
+                        continue
+                    else:
+                        current_string_set.value.append(value)
+            elif value_to_add.type == DDBType.NUMBER:
+                existing_value = self.get_item_at_end_of_path(item)
+                assert isinstance(existing_value, DynamoType)
+                if not existing_value.type == DDBType.NUMBER:
+                    raise IncorrectDataType()
+                new_value = existing_value + value_to_add
+                SetExecutor.set(
+                    item_part_to_modify_with_set=self.get_item_before_end_of_path(item),
+                    element_to_set=self.get_element_to_action(),
+                    value_to_set=new_value,
+                    expression_attribute_names=self.expression_attribute_names,
+                )
+            else:
+                raise IncorrectDataType()
+
+
+class UpdateExpressionExecutor(object):
+    execution_map = {
+        UpdateExpressionSetAction: SetExecutor,
+        UpdateExpressionAddAction: AddExecutor,
+        UpdateExpressionRemoveAction: RemoveExecutor,
+        UpdateExpressionDeleteAction: DeleteExecutor,
+    }
+
+    def __init__(self, update_ast, item, expression_attribute_names):
+        self.update_ast = update_ast
+        self.item = item
+        self.expression_attribute_names = expression_attribute_names
+
+    def execute(self, node=None):
+        """
+        As explained in moto.dynamodb2.parsing.expressions.NestableExpressionParserMixin._create_node the order of nodes
+        in the AST can be translated of the order of statements in the expression. As such we can start at the root node
+        and process the nodes 1-by-1. If no specific execution for the node type is defined we can execute the children
+        in order since it will be a container node that is expandable and left child will be first in the statement.
+
+        Args:
+            node(Node):
+
+        Returns:
+            None
+        """
+        if node is None:
+            node = self.update_ast
+
+        node_executor = self.get_specific_execution(node)
+        if node_executor is None:
+            for node in node.children:
+                self.execute(node)
+        else:
+            node_executor(node, self.expression_attribute_names).execute(self.item)
+
+    def get_specific_execution(self, node):
+        for node_class in self.execution_map:
+            if isinstance(node, node_class):
+                return self.execution_map[node_class]
+        return None

--- a/tests/test_dynamodb2/test_dynamodb_executor.py
+++ b/tests/test_dynamodb2/test_dynamodb_executor.py
@@ -1,0 +1,446 @@
+from moto.dynamodb2.exceptions import IncorrectOperandType, IncorrectDataType
+from moto.dynamodb2.models import Item, DynamoType
+from moto.dynamodb2.parsing.executors import UpdateExpressionExecutor
+from moto.dynamodb2.parsing.expressions import UpdateExpressionParser
+from moto.dynamodb2.parsing.validators import UpdateExpressionValidator
+from parameterized import parameterized
+
+
+def test_execution_of_if_not_exists_not_existing_value():
+    update_expression = "SET a = if_not_exists(b, a)"
+    update_expression_ast = UpdateExpressionParser.make(update_expression)
+    item = Item(
+        hash_key=DynamoType({"S": "id"}),
+        hash_key_type="TYPE",
+        range_key=None,
+        range_key_type=None,
+        attrs={"id": {"S": "1"}, "a": {"S": "A"}},
+    )
+    validated_ast = UpdateExpressionValidator(
+        update_expression_ast,
+        expression_attribute_names=None,
+        expression_attribute_values=None,
+        item=item,
+    ).validate()
+    UpdateExpressionExecutor(validated_ast, item, None).execute()
+    expected_item = Item(
+        hash_key=DynamoType({"S": "id"}),
+        hash_key_type="TYPE",
+        range_key=None,
+        range_key_type=None,
+        attrs={"id": {"S": "1"}, "a": {"S": "A"}},
+    )
+    assert expected_item == item
+
+
+def test_execution_of_if_not_exists_with_existing_attribute_should_return_attribute():
+    update_expression = "SET a = if_not_exists(b, a)"
+    update_expression_ast = UpdateExpressionParser.make(update_expression)
+    item = Item(
+        hash_key=DynamoType({"S": "id"}),
+        hash_key_type="TYPE",
+        range_key=None,
+        range_key_type=None,
+        attrs={"id": {"S": "1"}, "a": {"S": "A"}, "b": {"S": "B"}},
+    )
+    validated_ast = UpdateExpressionValidator(
+        update_expression_ast,
+        expression_attribute_names=None,
+        expression_attribute_values=None,
+        item=item,
+    ).validate()
+    UpdateExpressionExecutor(validated_ast, item, None).execute()
+    expected_item = Item(
+        hash_key=DynamoType({"S": "id"}),
+        hash_key_type="TYPE",
+        range_key=None,
+        range_key_type=None,
+        attrs={"id": {"S": "1"}, "a": {"S": "B"}, "b": {"S": "B"}},
+    )
+    assert expected_item == item
+
+
+def test_execution_of_if_not_exists_with_existing_attribute_should_return_value():
+    update_expression = "SET a = if_not_exists(b, :val)"
+    update_expression_values = {":val": {"N": "4"}}
+    update_expression_ast = UpdateExpressionParser.make(update_expression)
+    item = Item(
+        hash_key=DynamoType({"S": "id"}),
+        hash_key_type="TYPE",
+        range_key=None,
+        range_key_type=None,
+        attrs={"id": {"S": "1"}, "b": {"N": "3"}},
+    )
+    validated_ast = UpdateExpressionValidator(
+        update_expression_ast,
+        expression_attribute_names=None,
+        expression_attribute_values=update_expression_values,
+        item=item,
+    ).validate()
+    UpdateExpressionExecutor(validated_ast, item, None).execute()
+    expected_item = Item(
+        hash_key=DynamoType({"S": "id"}),
+        hash_key_type="TYPE",
+        range_key=None,
+        range_key_type=None,
+        attrs={"id": {"S": "1"}, "b": {"N": "3"}, "a": {"N": "3"}},
+    )
+    assert expected_item == item
+
+
+def test_execution_of_if_not_exists_with_non_existing_attribute_should_return_value():
+    update_expression = "SET a = if_not_exists(b, :val)"
+    update_expression_values = {":val": {"N": "4"}}
+    update_expression_ast = UpdateExpressionParser.make(update_expression)
+    item = Item(
+        hash_key=DynamoType({"S": "id"}),
+        hash_key_type="TYPE",
+        range_key=None,
+        range_key_type=None,
+        attrs={"id": {"S": "1"}},
+    )
+    validated_ast = UpdateExpressionValidator(
+        update_expression_ast,
+        expression_attribute_names=None,
+        expression_attribute_values=update_expression_values,
+        item=item,
+    ).validate()
+    UpdateExpressionExecutor(validated_ast, item, None).execute()
+    expected_item = Item(
+        hash_key=DynamoType({"S": "id"}),
+        hash_key_type="TYPE",
+        range_key=None,
+        range_key_type=None,
+        attrs={"id": {"S": "1"}, "a": {"N": "4"}},
+    )
+    assert expected_item == item
+
+
+def test_execution_of_sum_operation():
+    update_expression = "SET a = a + b"
+    update_expression_ast = UpdateExpressionParser.make(update_expression)
+    item = Item(
+        hash_key=DynamoType({"S": "id"}),
+        hash_key_type="TYPE",
+        range_key=None,
+        range_key_type=None,
+        attrs={"id": {"S": "1"}, "a": {"N": "3"}, "b": {"N": "4"}},
+    )
+    validated_ast = UpdateExpressionValidator(
+        update_expression_ast,
+        expression_attribute_names=None,
+        expression_attribute_values=None,
+        item=item,
+    ).validate()
+    UpdateExpressionExecutor(validated_ast, item, None).execute()
+    expected_item = Item(
+        hash_key=DynamoType({"S": "id"}),
+        hash_key_type="TYPE",
+        range_key=None,
+        range_key_type=None,
+        attrs={"id": {"S": "1"}, "a": {"N": "7"}, "b": {"N": "4"}},
+    )
+    assert expected_item == item
+
+
+def test_execution_of_remove():
+    update_expression = "Remove a"
+    update_expression_ast = UpdateExpressionParser.make(update_expression)
+    item = Item(
+        hash_key=DynamoType({"S": "id"}),
+        hash_key_type="TYPE",
+        range_key=None,
+        range_key_type=None,
+        attrs={"id": {"S": "1"}, "a": {"N": "3"}, "b": {"N": "4"}},
+    )
+    validated_ast = UpdateExpressionValidator(
+        update_expression_ast,
+        expression_attribute_names=None,
+        expression_attribute_values=None,
+        item=item,
+    ).validate()
+    UpdateExpressionExecutor(validated_ast, item, None).execute()
+    expected_item = Item(
+        hash_key=DynamoType({"S": "id"}),
+        hash_key_type="TYPE",
+        range_key=None,
+        range_key_type=None,
+        attrs={"id": {"S": "1"}, "b": {"N": "4"}},
+    )
+    assert expected_item == item
+
+
+def test_execution_of_remove_in_map():
+    update_expression = "Remove itemmap.itemlist[1].foo11"
+    update_expression_ast = UpdateExpressionParser.make(update_expression)
+    item = Item(
+        hash_key=DynamoType({"S": "id"}),
+        hash_key_type="TYPE",
+        range_key=None,
+        range_key_type=None,
+        attrs={
+            "id": {"S": "foo2"},
+            "itemmap": {
+                "M": {
+                    "itemlist": {
+                        "L": [
+                            {"M": {"foo00": {"S": "bar1"}, "foo01": {"S": "bar2"}}},
+                            {"M": {"foo10": {"S": "bar1"}, "foo11": {"S": "bar2"}}},
+                        ]
+                    }
+                }
+            },
+        },
+    )
+    validated_ast = UpdateExpressionValidator(
+        update_expression_ast,
+        expression_attribute_names=None,
+        expression_attribute_values=None,
+        item=item,
+    ).validate()
+    UpdateExpressionExecutor(validated_ast, item, None).execute()
+    expected_item = Item(
+        hash_key=DynamoType({"S": "id"}),
+        hash_key_type="TYPE",
+        range_key=None,
+        range_key_type=None,
+        attrs={
+            "id": {"S": "foo2"},
+            "itemmap": {
+                "M": {
+                    "itemlist": {
+                        "L": [
+                            {"M": {"foo00": {"S": "bar1"}, "foo01": {"S": "bar2"}}},
+                            {"M": {"foo10": {"S": "bar1"},}},
+                        ]
+                    }
+                }
+            },
+        },
+    )
+    assert expected_item == item
+
+
+def test_execution_of_remove_in_list():
+    update_expression = "Remove itemmap.itemlist[1]"
+    update_expression_ast = UpdateExpressionParser.make(update_expression)
+    item = Item(
+        hash_key=DynamoType({"S": "id"}),
+        hash_key_type="TYPE",
+        range_key=None,
+        range_key_type=None,
+        attrs={
+            "id": {"S": "foo2"},
+            "itemmap": {
+                "M": {
+                    "itemlist": {
+                        "L": [
+                            {"M": {"foo00": {"S": "bar1"}, "foo01": {"S": "bar2"}}},
+                            {"M": {"foo10": {"S": "bar1"}, "foo11": {"S": "bar2"}}},
+                        ]
+                    }
+                }
+            },
+        },
+    )
+    validated_ast = UpdateExpressionValidator(
+        update_expression_ast,
+        expression_attribute_names=None,
+        expression_attribute_values=None,
+        item=item,
+    ).validate()
+    UpdateExpressionExecutor(validated_ast, item, None).execute()
+    expected_item = Item(
+        hash_key=DynamoType({"S": "id"}),
+        hash_key_type="TYPE",
+        range_key=None,
+        range_key_type=None,
+        attrs={
+            "id": {"S": "foo2"},
+            "itemmap": {
+                "M": {
+                    "itemlist": {
+                        "L": [{"M": {"foo00": {"S": "bar1"}, "foo01": {"S": "bar2"}}},]
+                    }
+                }
+            },
+        },
+    )
+    assert expected_item == item
+
+
+def test_execution_of_delete_element_from_set():
+    update_expression = "delete s :value"
+    update_expression_ast = UpdateExpressionParser.make(update_expression)
+    item = Item(
+        hash_key=DynamoType({"S": "id"}),
+        hash_key_type="TYPE",
+        range_key=None,
+        range_key_type=None,
+        attrs={"id": {"S": "foo2"}, "s": {"SS": ["value1", "value2", "value3"]},},
+    )
+    validated_ast = UpdateExpressionValidator(
+        update_expression_ast,
+        expression_attribute_names=None,
+        expression_attribute_values={":value": {"SS": ["value2", "value5"]}},
+        item=item,
+    ).validate()
+    UpdateExpressionExecutor(validated_ast, item, None).execute()
+    expected_item = Item(
+        hash_key=DynamoType({"S": "id"}),
+        hash_key_type="TYPE",
+        range_key=None,
+        range_key_type=None,
+        attrs={"id": {"S": "foo2"}, "s": {"SS": ["value1", "value3"]},},
+    )
+    assert expected_item == item
+
+
+def test_execution_of_add_number():
+    update_expression = "add s :value"
+    update_expression_ast = UpdateExpressionParser.make(update_expression)
+    item = Item(
+        hash_key=DynamoType({"S": "id"}),
+        hash_key_type="TYPE",
+        range_key=None,
+        range_key_type=None,
+        attrs={"id": {"S": "foo2"}, "s": {"N": "5"},},
+    )
+    validated_ast = UpdateExpressionValidator(
+        update_expression_ast,
+        expression_attribute_names=None,
+        expression_attribute_values={":value": {"N": "10"}},
+        item=item,
+    ).validate()
+    UpdateExpressionExecutor(validated_ast, item, None).execute()
+    expected_item = Item(
+        hash_key=DynamoType({"S": "id"}),
+        hash_key_type="TYPE",
+        range_key=None,
+        range_key_type=None,
+        attrs={"id": {"S": "foo2"}, "s": {"N": "15"}},
+    )
+    assert expected_item == item
+
+
+def test_execution_of_add_set_to_a_number():
+    update_expression = "add s :value"
+    update_expression_ast = UpdateExpressionParser.make(update_expression)
+    item = Item(
+        hash_key=DynamoType({"S": "id"}),
+        hash_key_type="TYPE",
+        range_key=None,
+        range_key_type=None,
+        attrs={"id": {"S": "foo2"}, "s": {"N": "5"},},
+    )
+    try:
+        validated_ast = UpdateExpressionValidator(
+            update_expression_ast,
+            expression_attribute_names=None,
+            expression_attribute_values={":value": {"SS": ["s1"]}},
+            item=item,
+        ).validate()
+        UpdateExpressionExecutor(validated_ast, item, None).execute()
+        expected_item = Item(
+            hash_key=DynamoType({"S": "id"}),
+            hash_key_type="TYPE",
+            range_key=None,
+            range_key_type=None,
+            attrs={"id": {"S": "foo2"}, "s": {"N": "15"}},
+        )
+        assert expected_item == item
+        assert False
+    except IncorrectDataType:
+        assert True
+
+
+def test_execution_of_add_to_a_set():
+    update_expression = "ADD s :value"
+    update_expression_ast = UpdateExpressionParser.make(update_expression)
+    item = Item(
+        hash_key=DynamoType({"S": "id"}),
+        hash_key_type="TYPE",
+        range_key=None,
+        range_key_type=None,
+        attrs={"id": {"S": "foo2"}, "s": {"SS": ["value1", "value2", "value3"]},},
+    )
+    validated_ast = UpdateExpressionValidator(
+        update_expression_ast,
+        expression_attribute_names=None,
+        expression_attribute_values={":value": {"SS": ["value2", "value5"]}},
+        item=item,
+    ).validate()
+    UpdateExpressionExecutor(validated_ast, item, None).execute()
+    expected_item = Item(
+        hash_key=DynamoType({"S": "id"}),
+        hash_key_type="TYPE",
+        range_key=None,
+        range_key_type=None,
+        attrs={
+            "id": {"S": "foo2"},
+            "s": {"SS": ["value1", "value2", "value3", "value5"]},
+        },
+    )
+    assert expected_item == item
+
+
+@parameterized(
+    [
+        ({":value": {"S": "10"}}, "STRING",),
+        ({":value": {"N": "10"}}, "NUMBER",),
+        ({":value": {"B": "10"}}, "BINARY",),
+        ({":value": {"BOOL": True}}, "BOOLEAN",),
+        ({":value": {"NULL": True}}, "NULL",),
+        ({":value": {"M": {"el0": {"S": "10"}}}}, "MAP",),
+        ({":value": {"L": []}}, "LIST",),
+    ]
+)
+def test_execution_of__delete_element_from_set_invalid_value(
+    expression_attribute_values, unexpected_data_type
+):
+    """A delete statement must use a value of type SS in order to delete elements from a set."""
+    update_expression = "delete s :value"
+    update_expression_ast = UpdateExpressionParser.make(update_expression)
+    item = Item(
+        hash_key=DynamoType({"S": "id"}),
+        hash_key_type="TYPE",
+        range_key=None,
+        range_key_type=None,
+        attrs={"id": {"S": "foo2"}, "s": {"SS": ["value1", "value2", "value3"]},},
+    )
+    try:
+        validated_ast = UpdateExpressionValidator(
+            update_expression_ast,
+            expression_attribute_names=None,
+            expression_attribute_values=expression_attribute_values,
+            item=item,
+        ).validate()
+        UpdateExpressionExecutor(validated_ast, item, None).execute()
+        assert False, "Must raise exception"
+    except IncorrectOperandType as e:
+        assert e.operator_or_function == "operator: DELETE"
+        assert e.operand_type == unexpected_data_type
+
+
+def test_execution_of_delete_element_from_a_string_attribute():
+    """A delete statement must use a value of type SS in order to delete elements from a set."""
+    update_expression = "delete s :value"
+    update_expression_ast = UpdateExpressionParser.make(update_expression)
+    item = Item(
+        hash_key=DynamoType({"S": "id"}),
+        hash_key_type="TYPE",
+        range_key=None,
+        range_key_type=None,
+        attrs={"id": {"S": "foo2"}, "s": {"S": "5"},},
+    )
+    try:
+        validated_ast = UpdateExpressionValidator(
+            update_expression_ast,
+            expression_attribute_names=None,
+            expression_attribute_values={":value": {"SS": ["value2"]}},
+            item=item,
+        ).validate()
+        UpdateExpressionExecutor(validated_ast, item, None).execute()
+        assert False, "Must raise exception"
+    except IncorrectDataType:
+        assert True


### PR DESCRIPTION
Part of structured approach for UpdateExpressions:
 1) Expression gets parsed into a tokenlist (tokenized)
 2) Tokenlist get transformed to expression tree (AST)
 3) The AST gets validated (full semantic correctness)
 4) AST gets processed to perform the update -> this commit

This commit uses the AST to execute the UpdateExpression.
All the existing tests pass. The only tests that have been
updated are in test_dynamodb_table_with_range_key.py because
they wrongly allow adding a set to a path that doesn't exist.
This has been alligend to correspond to the behavior of AWS
DynamoDB.

This commit will resolve https://github.com/spulec/moto/issues/2806
Multiple tests have been implemented that verify this.

This would have conflicts with https://github.com/spulec/moto/pull/2896 but this solution also implements the required functionality and thus the tests pass. I can copy over the tests from there or that pull request can be reduced to its test cases.  