### PR TITLE
Place reserved_keywords.txt not in root.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,5 +3,6 @@ include requirements.txt requirements-dev.txt tox.ini
 include moto/ec2/resources/instance_types.json
 include moto/ec2/resources/amis.json
 include moto/cognitoidp/resources/*.json
+include moto/dynamodb2/parsing/reserved_keywords.txt
 recursive-include moto/templates *
 recursive-include tests *

--- a/setup.py
+++ b/setup.py
@@ -101,5 +101,4 @@ setup(
     project_urls={
         "Documentation": "http://docs.getmoto.org/en/latest/",
     },
-    data_files=[('', ['moto/dynamodb2/parsing/reserved_keywords.txt'])],
 )


### PR DESCRIPTION
Do not place reserved_keywords.txt in the root
as this can give environment errors.

This was raised in: https://github.com/spulec/moto/pull/2885#discussion_r415150276

From testing in virtual_env it avoids placing the one in the root and there will only be one in the parsing module directory.

@kislyuk could you verify whether this works for your setup as well?