### PR TITLE
Api gateway api get_usage_plan and get_usage_plan_key revised to handle missing values

### DIFF
--- a/moto/apigateway/exceptions.py
+++ b/moto/apigateway/exceptions.py
@@ -112,6 +112,15 @@ class ApiKeyNotFoundException(RESTError):
         )
 
 
+class UsagePlanNotFoundException(RESTError):
+    code = 404
+
+    def __init__(self):
+        super(UsagePlanNotFoundException, self).__init__(
+            "NotFoundException", "Invalid Usage Plan ID specified"
+        )
+
+
 class ApiKeyAlreadyExists(RESTError):
     code = 409
 

--- a/moto/apigateway/responses.py
+++ b/moto/apigateway/responses.py
@@ -6,6 +6,7 @@ from moto.core.responses import BaseResponse
 from .models import apigateway_backends
 from .exceptions import (
     ApiKeyNotFoundException,
+    UsagePlanNotFoundException,
     BadRequestException,
     CrossAccountNotAllowed,
     AuthorizerNotFoundException,
@@ -490,7 +491,16 @@ class APIGatewayResponse(BaseResponse):
         usage_plan = url_path_parts[2]
 
         if self.method == "GET":
-            usage_plan_response = self.backend.get_usage_plan(usage_plan)
+            try:
+                usage_plan_response = self.backend.get_usage_plan(usage_plan)
+            except (UsagePlanNotFoundException) as error:
+                return (
+                    error.code,
+                    {},
+                    '{{"message":"{0}","code":"{1}"}}'.format(
+                        error.message, error.error_type
+                    ),
+                )
         elif self.method == "DELETE":
             usage_plan_response = self.backend.delete_usage_plan(usage_plan)
         return 200, {}, json.dumps(usage_plan_response)
@@ -529,7 +539,18 @@ class APIGatewayResponse(BaseResponse):
         key_id = url_path_parts[4]
 
         if self.method == "GET":
-            usage_plan_response = self.backend.get_usage_plan_key(usage_plan_id, key_id)
+            try:
+                usage_plan_response = self.backend.get_usage_plan_key(
+                    usage_plan_id, key_id
+                )
+            except (UsagePlanNotFoundException, ApiKeyNotFoundException) as error:
+                return (
+                    error.code,
+                    {},
+                    '{{"message":"{0}","code":"{1}"}}'.format(
+                        error.message, error.error_type
+                    ),
+                )
         elif self.method == "DELETE":
             usage_plan_response = self.backend.delete_usage_plan_key(
                 usage_plan_id, key_id

--- a/tests/test_apigateway/test_apigateway.py
+++ b/tests/test_apigateway/test_apigateway.py
@@ -1797,6 +1797,14 @@ def test_usage_plans():
     response = client.get_usage_plans()
     len(response["items"]).should.equal(0)
 
+    # # Try to get info about a non existing usage
+    with assert_raises(ClientError) as ex:
+        client.get_usage_plan(usagePlanId="not_existing")
+    ex.exception.response["Error"]["Code"].should.equal("NotFoundException")
+    ex.exception.response["Error"]["Message"].should.equal(
+        "Invalid Usage Plan ID specified"
+    )
+
     usage_plan_name = "TEST-PLAN"
     payload = {"name": usage_plan_name}
     response = client.create_usage_plan(**payload)
@@ -1878,6 +1886,30 @@ def test_usage_plan_keys():
     # Get current plan keys (expect none)
     response = client.get_usage_plan_keys(usagePlanId=usage_plan_id)
     len(response["items"]).should.equal(0)
+
+    # Try to get info about a non existing api key
+    with assert_raises(ClientError) as ex:
+        client.get_usage_plan_key(usagePlanId=usage_plan_id, keyId="not_existing_key")
+    ex.exception.response["Error"]["Code"].should.equal("NotFoundException")
+    ex.exception.response["Error"]["Message"].should.equal(
+        "Invalid API Key identifier specified"
+    )
+
+    # Try to get info about an existing api key that has not jet added to a valid usage plan
+    with assert_raises(ClientError) as ex:
+        client.get_usage_plan_key(usagePlanId=usage_plan_id, keyId=key_id)
+    ex.exception.response["Error"]["Code"].should.equal("NotFoundException")
+    ex.exception.response["Error"]["Message"].should.equal(
+        "Invalid Usage Plan ID specified"
+    )
+
+    # Try to get info about an existing api key that has not jet added to a valid usage plan
+    with assert_raises(ClientError) as ex:
+        client.get_usage_plan_key(usagePlanId="not_existing_plan_id", keyId=key_id)
+    ex.exception.response["Error"]["Code"].should.equal("NotFoundException")
+    ex.exception.response["Error"]["Message"].should.equal(
+        "Invalid Usage Plan ID specified"
+    )
 
 
 @mock_apigateway

--- a/tests/test_apigateway/test_server.py
+++ b/tests/test_apigateway/test_server.py
@@ -39,6 +39,10 @@ def test_usage_plans_apis():
     fetched_plan = json.loads(res.data)
     fetched_plan.should.equal(created_plan)
 
+    # Not existing usage plan
+    res = test_client.get("/usageplans/{0}".format("not_existing"))
+    res.status_code.should.equal(404)
+
     # Delete usage plan
     res = test_client.delete("/usageplans/{0}".format(created_plan["id"]))
     res.data.should.equal(b"{}")
@@ -60,6 +64,24 @@ def test_usage_plans_keys():
     # List usage plans keys (expect empty)
     res = test_client.get("/usageplans/{0}/keys".format(usage_plan_id))
     json.loads(res.data)["item"].should.have.length_of(0)
+
+    # Invalid api key (does not exists at all)
+    res = test_client.get(
+        "/usageplans/{0}/keys/{1}".format(usage_plan_id, "not_existing")
+    )
+    res.status_code.should.equal(404)
+
+    # not existing usage plan with existing api key
+    res = test_client.get(
+        "/usageplans/{0}/keys/{1}".format("not_existing", created_api_key["id"])
+    )
+    res.status_code.should.equal(404)
+
+    # not jet added api key
+    res = test_client.get(
+        "/usageplans/{0}/keys/{1}".format(usage_plan_id, created_api_key["id"])
+    )
+    res.status_code.should.equal(404)
 
     # Create usage plan key
     res = test_client.post(


### PR DESCRIPTION
On master get_usage_plan_key and  get_usage_plan does not honor the behavior of API gateway, it hangs and fails with an unexpected error.

## get_usage_plan
Hangs if invoked with a not existing usagePlanId, now returns NotFound and 404 status code

## get_usage_plan_key fixed behaviour
In the follwing use cases it raise an unexpected error due to a non existing item
| Api key exists | Api Key Subscribed | Usage Plan exists | Raised Exception | Status Code |
|:--------:|:----:|:-------:|-------------------|:--------------:|
|  :x: | |  :white_check_mark:  | ApiKeyNotFoundException | 404 |
|  :x: | | :x:  | ApiKeyNotFoundException | 404 |
|  :white_check_mark:  | :x: | :white_check_mark:  | UsagePlanNotFoundException | 404 |
|  :white_check_mark:  | |:x:  | UsagePlanNotFoundException | 404 |

