### PR TITLE
Always call update ELBs for ASGs

### DIFF
--- a/moto/autoscaling/models.py
+++ b/moto/autoscaling/models.py
@@ -419,11 +419,8 @@ class FakeAutoScalingGroup(BaseModel):
         curr_instance_count = len(self.active_instances())
 
         if self.desired_capacity == curr_instance_count:
-            self.autoscaling_backend.update_attached_elbs(self.name)
-            self.autoscaling_backend.update_attached_target_groups(self.name)
-            return
-
-        if self.desired_capacity > curr_instance_count:
+            pass  # Nothing to do here
+        elif self.desired_capacity > curr_instance_count:
             # Need more instances
             count_needed = int(self.desired_capacity) - int(curr_instance_count)
 
@@ -447,6 +444,7 @@ class FakeAutoScalingGroup(BaseModel):
                 self.instance_states = list(
                     set(self.instance_states) - set(instances_to_remove)
                 )
+        if self.name in self.autoscaling_backend.autoscaling_groups:
             self.autoscaling_backend.update_attached_elbs(self.name)
             self.autoscaling_backend.update_attached_target_groups(self.name)
 

--- a/tests/test_autoscaling/test_autoscaling.py
+++ b/tests/test_autoscaling/test_autoscaling.py
@@ -1338,6 +1338,14 @@ def test_standby_elb_update():
 
     response = elb_client.describe_load_balancers(LoadBalancerNames=["my-lb"])
     list(response["LoadBalancerDescriptions"][0]["Instances"]).should.have.length_of(2)
+    instance_to_standby.shouldnt.be.within(
+        [x["InstanceId"] for x in response["LoadBalancerDescriptions"][0]["Instances"]]
+    )
+
+    response = elb_client.describe_instance_health(
+        LoadBalancerName="my-lb", Instances=[{"InstanceId": instance_to_standby},]
+    )
+    response["InstanceStates"][0]["State"].should_not.equal("InService")
 
 
 @mock_autoscaling


### PR DESCRIPTION
Fixed a bug where the attached ELBs were not correctly updated when an ASG instance is put in standby.