### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,12 @@
-FROM alpine:3.6
-
-RUN apk add --no-cache --update \
-    gcc \
-    musl-dev \
-    python3-dev \
-    libffi-dev \
-    openssl-dev \
-    python3
+FROM python:3.7-slim
 
 ADD . /moto/
 ENV PYTHONUNBUFFERED 1
 
 WORKDIR /moto/
-RUN  python3 -m ensurepip && \
-     rm -r /usr/lib/python*/ensurepip && \
-     pip3 --no-cache-dir install --upgrade pip setuptools && \
+RUN  pip3 --no-cache-dir install --upgrade pip setuptools && \
      pip3 --no-cache-dir install ".[server]"
 
-ENTRYPOINT ["/usr/bin/moto_server", "-H", "0.0.0.0"]
+ENTRYPOINT ["/usr/local/bin/moto_server", "-H", "0.0.0.0"]
 
 EXPOSE 5000


### PR DESCRIPTION
use python:3.7-slim image to avoid packages building steps for alpine and have a smaller image size