### PR TITLE
Fix S3:DeleteObjects in GoLang

### DIFF
--- a/moto/s3/responses.py
+++ b/moto/s3/responses.py
@@ -137,8 +137,13 @@ def parse_key_name(pth):
 
 
 def is_delete_keys(request, path, bucket_name):
-    return path == "/?delete" or (
-        path == "/" and getattr(request, "query_string", "") == "delete"
+    # GOlang sends a request as url/?delete= (treating it as a normal key=value, even if the value is empty)
+    # Python sends a request as url/?delete (treating it as a flag)
+    # https://github.com/spulec/moto/issues/2937
+    return (
+        path == "/?delete"
+        or path == "/?delete="
+        or (path == "/" and getattr(request, "query_string", "") == "delete")
     )
 
 

--- a/tests/test_s3/test_s3.py
+++ b/tests/test_s3/test_s3.py
@@ -3765,7 +3765,7 @@ def test_paths_with_leading_slashes_work():
 
 @mock_s3
 def test_root_dir_with_empty_name_works():
-    if os.environ.get("TEST_SERVER_MODE", "false").lower() == "true":
+    if settings.TEST_SERVER_MODE:
         raise SkipTest("Does not work in server mode due to error in Workzeug")
     store_and_read_back_a_key("/")
 


### PR DESCRIPTION
Fixes #2937 

The [official API](https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteObjects.html) expects this request when deleting objects:
```POST /?delete HTTP/1.1```

However, GOlang apparently automatically encodes this to:
```POST /?delete= HTTP/1.1```

This change allows requests in both formats.

Further info:
Both styles are acceptable according to the RFC spec
Some spicy discussions on why GOlang does this:
https://github.com/golang/go/issues/20820

(The test change is unrelated, but it's nice to have a single source of truth for this setting, especially when testing stuff like this locally)