### PR TITLE
update SQS MaximumMessageSize from 64K to 256K

### DIFF
--- a/moto/sqs/models.py
+++ b/moto/sqs/models.py
@@ -230,7 +230,7 @@ class Queue(BaseModel):
             "FifoQueue": "false",
             "KmsDataKeyReusePeriodSeconds": 300,  # five minutes
             "KmsMasterKeyId": None,
-            "MaximumMessageSize": int(64 << 10),
+            "MaximumMessageSize": int(64 << 12),
             "MessageRetentionPeriod": 86400 * 4,  # four days
             "Policy": None,
             "ReceiveMessageWaitTimeSeconds": 0,

--- a/tests/test_sqs/test_sqs.py
+++ b/tests/test_sqs/test_sqs.py
@@ -384,7 +384,7 @@ def test_get_queue_attributes():
     response["Attributes"]["CreatedTimestamp"].should.be.a(six.string_types)
     response["Attributes"]["DelaySeconds"].should.equal("0")
     response["Attributes"]["LastModifiedTimestamp"].should.be.a(six.string_types)
-    response["Attributes"]["MaximumMessageSize"].should.equal("65536")
+    response["Attributes"]["MaximumMessageSize"].should.equal("262144")
     response["Attributes"]["MessageRetentionPeriod"].should.equal("345600")
     response["Attributes"]["QueueArn"].should.equal(
         "arn:aws:sqs:us-east-1:{}:test-queue".format(ACCOUNT_ID)
@@ -406,7 +406,7 @@ def test_get_queue_attributes():
     response["Attributes"].should.equal(
         {
             "ApproximateNumberOfMessages": "0",
-            "MaximumMessageSize": "65536",
+            "MaximumMessageSize": "262144",
             "QueueArn": "arn:aws:sqs:us-east-1:{}:test-queue".format(ACCOUNT_ID),
             "VisibilityTimeout": "30",
             "RedrivePolicy": json.dumps(


### PR DESCRIPTION
Amazon SQS updated MaximumMessageSize from 64K to 256K back in 2013:
https://aws.amazon.com/about-aws/whats-new/2013/06/18/amazon-sqs-announces-256KB-large-payloads/

Tested with Python 2.7 and 3.7. I updated the one test that failed (as expected, since it tested the value I changed). I also see 4 `test_cloudformation.test_cloudformation_stack_crud_boto3` tests with errors, but the errors also happened before I made any changes:
* `test_create_change_set_from_s3_url`
* `test_create_stack_from_s3_url`
* `test_create_stack_set_from_s3_url`
* `test_update_stack_from_s3_url`
