### PR TITLE
Fix the online status in OpsWorks

### DIFF
--- a/moto/opsworks/models.py
+++ b/moto/opsworks/models.py
@@ -125,6 +125,9 @@ class OpsworkInstance(BaseModel):
     def status(self):
         if self.instance is None:
             return "stopped"
+        # OpsWorks reports the "running" state as "online"
+        elif self.instance._state.name == "running":
+            return "online"
         return self.instance._state.name
 
     def to_dict(self):

--- a/tests/test_opsworks/test_instances.py
+++ b/tests/test_opsworks/test_instances.py
@@ -195,6 +195,10 @@ def test_ec2_integration():
     reservations = ec2.describe_instances()["Reservations"]
     assert reservations.should.be.empty
 
+    # Before starting the instance, its status should be "stopped"
+    opsworks_instance = opsworks.describe_instances(StackId=stack_id)["Instances"][0]
+    opsworks_instance["Status"].should.equal("stopped")
+
     # After starting the instance, it should be discoverable via ec2
     opsworks.start_instance(InstanceId=instance_id)
     reservations = ec2.describe_instances()["Reservations"]
@@ -204,3 +208,5 @@ def test_ec2_integration():
 
     instance["InstanceId"].should.equal(opsworks_instance["Ec2InstanceId"])
     instance["PrivateIpAddress"].should.equal(opsworks_instance["PrivateIp"])
+    # After starting the instance, its status should be "online"
+    opsworks_instance["Status"].should.equal("online")


### PR DESCRIPTION
When an instance is running, OpsWorks reports its status as "online" [1], while EC2 reports it as "running". Until now, moto copied the EC2 instance's status as is. This commit introduces the converts the running status to online when returned by OpsWorks.

[1]: https://docs.aws.amazon.com/cli/latest/reference/opsworks/describe-instances.html