### PR TITLE
Adding missing Thing Group ARN to FakeThingGroup

### DIFF
--- a/moto/iot/models.py
+++ b/moto/iot/models.py
@@ -118,6 +118,7 @@ class FakeThingGroup(BaseModel):
 
     def to_dict(self):
         return {
+            "thingGroupArn": self.arn,
             "thingGroupName": self.thing_group_name,
             "thingGroupId": self.thing_group_id,
             "version": self.version,


### PR DESCRIPTION
The `thingGroupArn` should be returned for Thing Groups, according to `boto3` [docs](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/iot.html#IoT.Client.create_thing_group).