### PR TITLE
SFN - fix InvalidARN exception on start_execution

### DIFF
--- a/moto/stepfunctions/responses.py
+++ b/moto/stepfunctions/responses.py
@@ -95,7 +95,10 @@ class StepFunctionResponse(BaseResponse):
     def start_execution(self):
         arn = self._get_param("stateMachineArn")
         name = self._get_param("name")
-        execution = self.stepfunction_backend.start_execution(arn, name)
+        try:
+            execution = self.stepfunction_backend.start_execution(arn, name)
+        except AWSError as err:
+            return err.response()
         response = {
             "executionArn": execution.execution_arn,
             "startDate": execution.start_date,

--- a/tests/test_stepfunctions/test_stepfunctions.py
+++ b/tests/test_stepfunctions/test_stepfunctions.py
@@ -255,6 +255,15 @@ def test_state_machine_throws_error_when_describing_unknown_machine():
 
 @mock_stepfunctions
 @mock_sts
+def test_state_machine_throws_error_when_describing_bad_arn():
+    client = boto3.client("stepfunctions", region_name=region)
+    #
+    with assert_raises(ClientError) as exc:
+        client.describe_state_machine(stateMachineArn="bad")
+
+
+@mock_stepfunctions
+@mock_sts
 def test_state_machine_throws_error_when_describing_machine_in_different_account():
     client = boto3.client("stepfunctions", region_name=region)
     #
@@ -364,6 +373,15 @@ def test_state_machine_start_execution():
 
 @mock_stepfunctions
 @mock_sts
+def test_state_machine_start_execution_bad_arn_raises_exception():
+    client = boto3.client("stepfunctions", region_name=region)
+    #
+    with assert_raises(ClientError) as exc:
+        client.start_execution(stateMachineArn="bad")
+
+
+@mock_stepfunctions
+@mock_sts
 def test_state_machine_start_execution_with_custom_name():
     client = boto3.client("stepfunctions", region_name=region)
     #
@@ -446,7 +464,7 @@ def test_state_machine_describe_execution():
 
 @mock_stepfunctions
 @mock_sts
-def test_state_machine_throws_error_when_describing_unknown_machine():
+def test_execution_throws_error_when_describing_unknown_execution():
     client = boto3.client("stepfunctions", region_name=region)
     #
     with assert_raises(ClientError) as exc:


### PR DESCRIPTION
This fixes #3005 .

I also fixed a duplicate test name, but I don't think that has any affect on anything.