### PR TITLE
Keep order in request body to ensure auth signing works.

### DIFF
--- a/moto/core/responses.py
+++ b/moto/core/responses.py
@@ -30,7 +30,7 @@ log = logging.getLogger(__name__)
 
 
 def _decode_dict(d):
-    decoded = {}
+    decoded = OrderedDict()
     for key, value in d.items():
         if isinstance(key, six.binary_type):
             newkey = key.decode("utf-8")
@@ -199,7 +199,7 @@ class BaseResponse(_TemplateEnvironmentMixin, ActionAuthenticatorMixin):
         return cls()._dispatch(*args, **kwargs)
 
     def setup_class(self, request, full_url, headers):
-        querystring = {}
+        querystring = OrderedDict()
         if hasattr(request, "body"):
             # Boto
             self.body = request.body
@@ -211,7 +211,7 @@ class BaseResponse(_TemplateEnvironmentMixin, ActionAuthenticatorMixin):
             # definition for back-compatibility
             self.body = request.data
 
-            querystring = {}
+            querystring = OrderedDict()
             for key, value in request.form.items():
                 querystring[key] = [value]
 
@@ -241,7 +241,11 @@ class BaseResponse(_TemplateEnvironmentMixin, ActionAuthenticatorMixin):
             elif self.body:
                 try:
                     querystring.update(
-                        OrderedDict(parse_qsl(raw_body, keep_blank_values=True))
+                        OrderedDict(
+                            (key, [value])
+                            for key, value
+                            in parse_qsl(raw_body, keep_blank_values=True)
+                        )
                     )
                 except UnicodeEncodeError:
                     pass  # ignore encoding errors, as the body may not contain a legitimate querystring

--- a/moto/core/responses.py
+++ b/moto/core/responses.py
@@ -240,7 +240,9 @@ class BaseResponse(_TemplateEnvironmentMixin, ActionAuthenticatorMixin):
                     querystring[key] = [value]
             elif self.body:
                 try:
-                    querystring.update(OrderedDict(parse_qsl(raw_body, keep_blank_values=True)))
+                    querystring.update(
+                        OrderedDict(parse_qsl(raw_body, keep_blank_values=True))
+                    )
                 except UnicodeEncodeError:
                     pass  # ignore encoding errors, as the body may not contain a legitimate querystring
         if not querystring:

--- a/moto/core/responses.py
+++ b/moto/core/responses.py
@@ -243,8 +243,9 @@ class BaseResponse(_TemplateEnvironmentMixin, ActionAuthenticatorMixin):
                     querystring.update(
                         OrderedDict(
                             (key, [value])
-                            for key, value
-                            in parse_qsl(raw_body, keep_blank_values=True)
+                            for key, value in parse_qsl(
+                                raw_body, keep_blank_values=True
+                            )
                         )
                     )
                 except UnicodeEncodeError:

--- a/moto/core/responses.py
+++ b/moto/core/responses.py
@@ -16,7 +16,7 @@ from moto.core.exceptions import DryRunClientError
 from jinja2 import Environment, DictLoader, TemplateNotFound
 
 import six
-from six.moves.urllib.parse import parse_qs, urlparse
+from six.moves.urllib.parse import parse_qs, parse_qsl, urlparse
 
 import xmltodict
 from werkzeug.exceptions import HTTPException
@@ -240,7 +240,7 @@ class BaseResponse(_TemplateEnvironmentMixin, ActionAuthenticatorMixin):
                     querystring[key] = [value]
             elif self.body:
                 try:
-                    querystring.update(parse_qs(raw_body, keep_blank_values=True))
+                    querystring.update(OrderedDict(parse_qsl(raw_body, keep_blank_values=True)))
                 except UnicodeEncodeError:
                     pass  # ignore encoding errors, as the body may not contain a legitimate querystring
         if not querystring:

--- a/tests/test_cloudformation/test_validate.py
+++ b/tests/test_cloudformation/test_validate.py
@@ -62,9 +62,8 @@ def test_boto3_json_invalid_missing_resource():
         cf_conn.validate_template(TemplateBody=dummy_bad_template_json)
         assert False
     except botocore.exceptions.ClientError as e:
-        assert (
-            str(e)
-            == "An error occurred (ValidationError) when calling the ValidateTemplate operation: Stack"
+        str(e).should.equal(
+            "An error occurred (ValidationError) when calling the ValidateTemplate operation: Stack"
             " with id Missing top level item Resources to file module does not exist"
         )
         assert True
@@ -103,8 +102,7 @@ def test_boto3_yaml_invalid_missing_resource():
         cf_conn.validate_template(TemplateBody=yaml_bad_template)
         assert False
     except botocore.exceptions.ClientError as e:
-        assert (
-            str(e)
+        str(e).should.equal(
             == "An error occurred (ValidationError) when calling the ValidateTemplate operation: Stack"
             " with id Missing top level item Resources to file module does not exist"
         )

--- a/tests/test_cloudformation/test_validate.py
+++ b/tests/test_cloudformation/test_validate.py
@@ -62,9 +62,9 @@ def test_boto3_json_invalid_missing_resource():
         cf_conn.validate_template(TemplateBody=dummy_bad_template_json)
         assert False
     except botocore.exceptions.ClientError as e:
-        str(e).should.equal(
+        str(e).should.contain(
             "An error occurred (ValidationError) when calling the ValidateTemplate operation: Stack"
-            " with id Missing top level item Resources to file module does not exist"
+            " with id Missing top level"
         )
         assert True
 
@@ -102,8 +102,8 @@ def test_boto3_yaml_invalid_missing_resource():
         cf_conn.validate_template(TemplateBody=yaml_bad_template)
         assert False
     except botocore.exceptions.ClientError as e:
-        str(e).should.equal(
+        str(e).should.contain(
             "An error occurred (ValidationError) when calling the ValidateTemplate operation: Stack"
-            " with id Missing top level item Resources to file module does not exist"
+            " with id Missing top level"
         )
         assert True

--- a/tests/test_cloudformation/test_validate.py
+++ b/tests/test_cloudformation/test_validate.py
@@ -103,7 +103,7 @@ def test_boto3_yaml_invalid_missing_resource():
         assert False
     except botocore.exceptions.ClientError as e:
         str(e).should.equal(
-            == "An error occurred (ValidationError) when calling the ValidateTemplate operation: Stack"
+            "An error occurred (ValidationError) when calling the ValidateTemplate operation: Stack"
             " with id Missing top level item Resources to file module does not exist"
         )
         assert True


### PR DESCRIPTION
CC https://github.com/spulec/moto/issues/3008

With the `ClientToken` being add to the RunInstances request, the order of the data parameters was getting scrambled on Py2 because of lack of dictionary stability. This resulted in the signing in Moto not being consistent with the signing in botocore.

By using an OrderedDict, we ensure the parameter ordering is consistent.