### PR TITLE
SQS: fix message group behaviour

### DIFF
--- a/moto/sqs/responses.py
+++ b/moto/sqs/responses.py
@@ -232,6 +232,14 @@ class SQSResponse(BaseResponse):
 
         queue_name = self._get_queue_name()
 
+        if not message_group_id:
+            queue = self.sqs_backend.get_queue(queue_name)
+            if queue.attributes.get("FifoQueue", False):
+                return self._error(
+                    "MissingParameter",
+                    "The request must contain the parameter MessageGroupId.",
+                )
+
         message = self.sqs_backend.send_message(
             queue_name,
             message,


### PR DESCRIPTION
Fixes #2433 
Fixes #3006 

Changes the behaviour for message groups. A single call to `receive_messages` will receive all messages in the same group, but a subsequent call will now skip messages in that group if they haven't processed yet.
Before, the first request would only receive a single message per group.