### PR TITLE
Cfn change set fix outputs

### DIFF
--- a/moto/cloudformation/models.py
+++ b/moto/cloudformation/models.py
@@ -240,7 +240,8 @@ class FakeStack(BaseModel):
         self.resource_map = self._create_resource_map()
         self.output_map = self._create_output_map()
         if create_change_set:
-            self.status = "REVIEW_IN_PROGRESS"
+            self.status = "CREATE_COMPLETE"
+            self.execution_status = "AVAILABLE"
         else:
             self.create_resources()
             self._add_stack_event("CREATE_COMPLETE")
@@ -397,6 +398,7 @@ class FakeChangeSet(FakeStack):
         self.change_set_id = change_set_id
         self.change_set_name = change_set_name
         self.changes = self.diff(template=template, parameters=parameters)
+        self.creation_time = datetime.utcnow()
 
     def diff(self, template, parameters=None):
         self.template = template
@@ -587,7 +589,7 @@ class CloudFormationBackend(BaseBackend):
             if stack is None:
                 raise ValidationError(stack_name)
         else:
-            stack_id = generate_stack_id(stack_name)
+            stack_id = generate_stack_id(stack_name, region_name)
             stack_template = template
 
         change_set_id = generate_changeset_id(change_set_name, region_name)

--- a/moto/cloudformation/responses.py
+++ b/moto/cloudformation/responses.py
@@ -609,7 +609,7 @@ DESCRIBE_CHANGE_SET_RESPONSE_TEMPLATE = """<DescribeChangeSetResponse>
         </member>
       {% endfor %}
     </Parameters>
-    <CreationTime>2011-05-23T15:47:44Z</CreationTime>
+    <CreationTime>{{ change_set.creation_time_iso_8601 }}</CreationTime>
     <ExecutionStatus>{{ change_set.execution_status }}</ExecutionStatus>
     <Status>{{ change_set.status }}</Status>
     <StatusReason>{{ change_set.status_reason }}</StatusReason>

--- a/tests/test_cloudformation/test_cloudformation_stack_crud_boto3.py
+++ b/tests/test_cloudformation/test_cloudformation_stack_crud_boto3.py
@@ -819,7 +819,7 @@ def test_create_change_set_from_s3_url():
         in response["Id"]
     )
     assert (
-        "arn:aws:cloudformation:us-east-1:123456789:stack/NewStack"
+        "arn:aws:cloudformation:us-west-1:123456789:stack/NewStack"
         in response["StackId"]
     )
 
@@ -838,7 +838,12 @@ def test_describe_change_set():
 
     stack["ChangeSetName"].should.equal("NewChangeSet")
     stack["StackName"].should.equal("NewStack")
-    stack["Status"].should.equal("REVIEW_IN_PROGRESS")
+    stack["Status"].should.equal("CREATE_COMPLETE")
+    stack["ExecutionStatus"].should.equal("AVAILABLE")
+    two_secs_ago = datetime.now(tz=pytz.UTC) - timedelta(seconds=2)
+    assert (
+        two_secs_ago < stack["CreationTime"] < datetime.now(tz=pytz.UTC)
+    ), "Change set should have been created recently"
 
     cf_conn.create_change_set(
         StackName="NewStack",
@@ -868,7 +873,7 @@ def test_execute_change_set_w_arn():
     )
     ec2.describe_instances()["Reservations"].should.have.length_of(0)
     cf_conn.describe_change_set(ChangeSetName="NewChangeSet")["Status"].should.equal(
-        "REVIEW_IN_PROGRESS"
+        "CREATE_COMPLETE"
     )
     # Execute change set
     cf_conn.execute_change_set(ChangeSetName=change_set["Id"])


### PR DESCRIPTION
Fix #3032 :
- Status of change set should be 'CREATE_COMPLETE'
- Execution status of change set should be 'AVAILABLE'
- Creation time of change set should be set to the datetime.utcnow()
- Stack Id of change set should contain the same region in its name as the change set itself