### PR TITLE
Fix incorrect response for put-targets action

### DIFF
--- a/moto/events/responses.py
+++ b/moto/events/responses.py
@@ -217,7 +217,10 @@ class EventsHandler(BaseResponse):
                 "ResourceNotFoundException", "Rule " + rule_name + " does not exist."
             )
 
-        return "", self.response_headers
+        return (
+            json.dumps({"FailedEntryCount": 0, "FailedEntries": []}),
+            self.response_headers,
+        )
 
     def remove_targets(self):
         rule_name = self._get_param("Rule")


### PR DESCRIPTION
Hi,

In the AWS documentation, events put-targets action should return something like this:

```
[
    'FailedEntries' => [
        [
            'ErrorCode' => '<string>',
            'ErrorMessage' => '<string>',
            'TargetId' => '<string>',
        ],
        // ...
    ],
    'FailedEntryCount' => <integer>,
]
```
https://docs.aws.amazon.com/cli/latest/reference/events/put-targets.html#output
https://docs.aws.amazon.com/aws-sdk-php/v3/api/api-events-2015-10-07.html#puttargets