### PR TITLE
Add missing changes when creating a change set

### DIFF
--- a/moto/cloudformation/parsing.py
+++ b/moto/cloudformation/parsing.py
@@ -456,7 +456,7 @@ class ResourceMap(collections_abc.Mapping):
         cross_stack_resources,
     ):
         self._template = template
-        self._resource_json_map = template["Resources"]
+        self._resource_json_map = template["Resources"] if template != {} else {}
         self._region_name = region_name
         self.input_parameters = parameters
         self.tags = copy.deepcopy(tags)
@@ -592,10 +592,12 @@ class ResourceMap(collections_abc.Mapping):
         self.load_parameters()
         self.load_conditions()
 
-    def create(self):
+    def create(self, template):
         # Since this is a lazy map, to create every object we just need to
         # iterate through self.
         # Assumes that self.load() has been called before
+        self._template = template
+        self._resource_json_map = template["Resources"]
         self.tags.update(
             {
                 "aws:cloudformation:stack-name": self.get("AWS::StackName"),

--- a/moto/cloudformation/responses.py
+++ b/moto/cloudformation/responses.py
@@ -662,6 +662,10 @@ DESCRIBE_STACKS_TEMPLATE = """<DescribeStacksResponse>
       <member>
         <StackName>{{ stack.name }}</StackName>
         <StackId>{{ stack.stack_id }}</StackId>
+        {% if stack.change_set_id %}
+        <ChangeSetId>{{ stack.change_set_id }}</ChangeSetId>
+        {% endif %}
+        <Description>{{ stack.description }}</Description>
         <CreationTime>{{ stack.creation_time_iso_8601 }}</CreationTime>
         <StackStatus>{{ stack.status }}</StackStatus>
         {% if stack.notification_arns %}

--- a/tests/test_cloudformation/test_cloudformation_stack_crud_boto3.py
+++ b/tests/test_cloudformation/test_cloudformation_stack_crud_boto3.py
@@ -844,6 +844,13 @@ def test_describe_change_set():
     assert (
         two_secs_ago < stack["CreationTime"] < datetime.now(tz=pytz.UTC)
     ), "Change set should have been created recently"
+    stack["Changes"].should.have.length_of(1)
+    stack["Changes"][0].should.equal(dict({'Type': 'Resource', 'ResourceChange': {'Action': 'Add', 'LogicalResourceId': 'EC2Instance1', 'ResourceType': 'AWS::EC2::Instance'}}))
+
+    # Execute change set
+    cf_conn.execute_change_set(ChangeSetName="NewChangeSet")
+    # Verify that the changes have been applied
+    cf_conn.describe_change_set(ChangeSetName="NewChangeSet")["Changes"].should.have.length_of(1)
 
     cf_conn.create_change_set(
         StackName="NewStack",

--- a/tests/test_cloudformation/test_cloudformation_stack_integration.py
+++ b/tests/test_cloudformation/test_cloudformation_stack_integration.py
@@ -1,7 +1,6 @@
 from __future__ import unicode_literals
 import json
 
-import base64
 from decimal import Decimal
 
 import boto
@@ -28,7 +27,6 @@ from moto import (
     mock_dynamodb2,
     mock_ec2,
     mock_ec2_deprecated,
-    mock_elb,
     mock_elb_deprecated,
     mock_events,
     mock_iam_deprecated,
@@ -37,18 +35,14 @@ from moto import (
     mock_logs,
     mock_rds_deprecated,
     mock_rds2,
-    mock_rds2_deprecated,
-    mock_redshift,
     mock_redshift_deprecated,
     mock_route53_deprecated,
     mock_s3,
     mock_sns_deprecated,
-    mock_sqs,
     mock_sqs_deprecated,
     mock_elbv2,
 )
 from moto.core import ACCOUNT_ID
-from moto.dynamodb2.models import Table
 
 from tests.test_cloudformation.fixtures import (
     ec2_classic_eip,


### PR DESCRIPTION
Hi,

This PR fixes issue #3038 by adding the changes property when describing a change set.
Example:
```
{
    "Changes": [
        {
            "Type": "Resource",
            "ResourceChange": {
                "Action": "Add",
                "LogicalResourceId": "BucketResource",
                "ResourceType": "AWS::S3::Bucket",
                "Scope": [],
                "Details": []
            }
        }
    ],
...
}
```

When creating a change set, ``stack_template`` variable has to be initialized withan empty dict instead of ``template`` variable because the stack is not created at this time. If we don't do that, the call to ``diff`` function gives nothing (e.g. no change) because it compares the stack_template to itself.