### PR TITLE
Make sure the UTC tz is included in the bucket creation timestamp

### DIFF
--- a/moto/s3/models.py
+++ b/moto/s3/models.py
@@ -5,6 +5,7 @@ import json
 import os
 import base64
 import datetime
+import pytz
 import hashlib
 import copy
 import itertools
@@ -776,7 +777,7 @@ class FakeBucket(BaseModel):
         self.notification_configuration = None
         self.accelerate_configuration = None
         self.payer = "BucketOwner"
-        self.creation_date = datetime.datetime.utcnow()
+        self.creation_date = datetime.datetime.now(tz=pytz.utc)
         self.public_access_block = None
         self.encryption = None
 


### PR DESCRIPTION
Fix for the TZ in `CreationDate` of s3 buckets, fixes #2665 (similar to the fix for #2904 )

`bucket.creation_date.isoformat()` doesn't include timezone info if it's utc. The AWS Java SDK fails on this missing field:

```
com.amazonaws.util.DateUtils.parseISO8601Date("2020-06-02T08:43:57.470630")
// java.lang.IllegalArgumentException: Invalid format: "2020-06-02T08:43:57.470630" is too short
```