### PR TITLE
chore: refine python-jose dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ install_requires = [
     "PyYAML>=5.1",
     "pytz",
     "python-dateutil<3.0.0,>=2.1",
-    "python-jose<4.0.0",
+    "python-jose[cryptography]>=3.1.0,<4.0.0",
     "docker>=2.5.1",
     "jsondiff>=1.1.2",
     "aws-xray-sdk!=0.96,>=0.93",


### PR DESCRIPTION
Starting in 3.1.0[1], `python-jose` isolated all cryptographic operations into independent backends[2]. The unused dependencies cannot be easily removed, but selecting the `[cryptography]` extra installs the dependencies for the `pyca/cryptography` backend and forces all cryptographic operations onto that backend.

[1] https://github.com/mpdavis/python-jose/blob/master/CHANGELOG.md#310----2019-12-10
[2] https://github.com/mpdavis/python-jose#cryptographic-backends