### PR TITLE
CloudFormation - Support DynamoDB Streams

### DIFF
--- a/moto/dynamodb2/models/__init__.py
+++ b/moto/dynamodb2/models/__init__.py
@@ -342,6 +342,8 @@ class Table(BaseModel):
             params["throughput"] = properties["ProvisionedThroughput"]
         if "LocalSecondaryIndexes" in properties:
             params["indexes"] = properties["LocalSecondaryIndexes"]
+        if "StreamSpecification" in properties:
+            params["streams"] = properties["StreamSpecification"]
 
         table = dynamodb_backends[region_name].create_table(
             name=properties["TableName"], **params

--- a/tests/test_cloudformation/test_cloudformation_stack_integration.py
+++ b/tests/test_cloudformation/test_cloudformation_stack_integration.py
@@ -2307,6 +2307,7 @@ def test_stack_dynamodb_resources_integration():
                             },
                         }
                     ],
+                    "StreamSpecification": {"StreamViewType": "KEYS_ONLY"},
                 },
             }
         },
@@ -2317,6 +2318,12 @@ def test_stack_dynamodb_resources_integration():
     cfn_conn = boto3.client("cloudformation", "us-east-1")
     cfn_conn.create_stack(
         StackName="dynamodb_stack", TemplateBody=dynamodb_template_json
+    )
+
+    dynamodb_client = boto3.client("dynamodb", region_name="us-east-1")
+    table_desc = dynamodb_client.describe_table(TableName="myTableName")["Table"]
+    table_desc["StreamSpecification"].should.equal(
+        {"StreamEnabled": True, "StreamViewType": "KEYS_ONLY",}
     )
 
     dynamodb_conn = boto3.resource("dynamodb", region_name="us-east-1")


### PR DESCRIPTION
ATM it's not possible to create a DynamoDB stream via CloudFormation.
This PR fixes that.
