### PR TITLE
Fix: Support streaming upload from requests.

### DIFF
--- a/moto/core/models.py
+++ b/moto/core/models.py
@@ -184,6 +184,8 @@ class CallbackResponse(responses.CallbackResponse):
                 body = None
             elif isinstance(request.body, six.text_type):
                 body = six.BytesIO(six.b(request.body))
+            elif hasattr(request.body, 'read'):
+                body = six.BytesIO(request.body.read())
             else:
                 body = six.BytesIO(request.body)
             req = Request.from_values(

--- a/moto/core/models.py
+++ b/moto/core/models.py
@@ -184,7 +184,7 @@ class CallbackResponse(responses.CallbackResponse):
                 body = None
             elif isinstance(request.body, six.text_type):
                 body = six.BytesIO(six.b(request.body))
-            elif hasattr(request.body, 'read'):
+            elif hasattr(request.body, "read"):
                 body = six.BytesIO(request.body.read())
             else:
                 body = six.BytesIO(request.body)

--- a/tests/test_s3/test_s3.py
+++ b/tests/test_s3/test_s3.py
@@ -1051,7 +1051,7 @@ def test_streaming_upload_from_file_to_presigned_url():
     presigned_url = boto3.client("s3").generate_presigned_url(
         "put_object", params, ExpiresIn=900
     )
-    with open(__file__, 'rb') as f:
+    with open(__file__, "rb") as f:
         response = requests.get(presigned_url, data=f)
     assert response.status_code == 200
 

--- a/tests/test_s3/test_s3.py
+++ b/tests/test_s3/test_s3.py
@@ -1041,6 +1041,22 @@ def test_s3_object_in_public_bucket_using_multiple_presigned_urls():
 
 
 @mock_s3
+def test_streaming_upload_from_file_to_presigned_url():
+    s3 = boto3.resource("s3")
+    bucket = s3.Bucket("test-bucket")
+    bucket.create()
+    bucket.put_object(Body=b"ABCD", Key="file.txt")
+
+    params = {"Bucket": "test-bucket", "Key": "file.txt"}
+    presigned_url = boto3.client("s3").generate_presigned_url(
+        "put_object", params, ExpiresIn=900
+    )
+    with open(__file__, 'rb') as f:
+        response = requests.get(presigned_url, data=f)
+    assert response.status_code == 200
+
+
+@mock_s3
 def test_s3_object_in_private_bucket():
     s3 = boto3.resource("s3")
     bucket = s3.Bucket("test-bucket")


### PR DESCRIPTION
Resolves a bug where streaming uploads made via requests to a presigned s3 url were failing because their request bodies are file-like objects.

See https://2.python-requests.org/en/master/user/advanced/#streaming-uploads for details of this feature in `requests`.