### PR TITLE
Instance object never sets iam_instance_profile

### DIFF
--- a/tests/test_ec2/test_instances.py
+++ b/tests/test_ec2/test_instances.py
@@ -211,7 +211,6 @@ def test_instance_iam_instance_profile():
         MinCount=1,
         MaxCount=1,
         IamInstanceProfile={
-            "Name": "fake-instance-profile",
             "Arn": instance_profile_arn,
         },
     )

--- a/tests/test_ec2/test_instances.py
+++ b/tests/test_ec2/test_instances.py
@@ -199,6 +199,28 @@ def test_instance_detach_volume_wrong_path():
         )
 
 
+@mock_ec2
+def test_instance_iam_instance_profile():
+    ec2_resource = boto3.resource("ec2", "us-west-1")
+
+    instance_profile_arn = "arn:aws:iam::\
+                123456789012:instance-profile/not-a-real-profile"
+
+    result = ec2_resource.create_instances(
+        ImageId="ami-d3adb33f",
+        MinCount=1,
+        MaxCount=1,
+        IamInstanceProfile={
+            "Name": "fake-instance-profile",
+            "Arn": instance_profile_arn,
+        },
+    )
+    instance = result[0]
+    assert instance_profile_arn == instance.iam_instance_profile["Arn"]
+    instance.terminate()
+    instance.wait_until_terminated()
+
+
 @mock_ec2_deprecated
 def test_terminate_empty_instances():
     conn = boto.connect_ec2("the_key", "the_secret")


### PR DESCRIPTION
Hi!

I was trying to set up some tests that makes sure an instance profile is attached to an ec2 instance on creation but ran into the issue that the test object was missing the iam_instance_profile attribute.

I added a small test to show what's fails with the following TraceBack:

```
Traceback (most recent call last):
  File "/home/avass/git/github/albinvass/moto/.tox/py37/lib/python3.7/site-packages/nose/case.py", line 198, in runTest
    self.test(*self.arg)
  File "/home/avass/git/github/albinvass/moto/moto/core/models.py", line 98, in wrapper
    result = func(*args, **kwargs)
  File "/home/avass/git/github/albinvass/moto/tests/test_ec2/test_instances.py", line 219, in test_instance_iam_instance_profile
    assert instance_profile_arn == instance.iam_instance_profile["Arn"]
TypeError: 'NoneType' object is not subscriptable
```