### PR TITLE
Correct group inline policy rendering

### DIFF
--- a/moto/iam/responses.py
+++ b/moto/iam/responses.py
@@ -2106,7 +2106,7 @@ GET_ACCOUNT_AUTHORIZATION_DETAILS_TEMPLATE = """<GetAccountAuthorizationDetailsR
         {% for policy in group.policies %}
             <member>
                 <PolicyName>{{ policy }}</PolicyName>
-                <PolicyDocument>{{ group.get_policy(policy) }}</PolicyDocument>
+                <PolicyDocument>{{ group.policies[policy] }}</PolicyDocument>
             </member>
         {% endfor %}
         </GroupPolicyList>

--- a/moto/iam/responses.py
+++ b/moto/iam/responses.py
@@ -2083,6 +2083,16 @@ GET_ACCOUNT_AUTHORIZATION_DETAILS_TEMPLATE = """<GetAccountAuthorizationDetailsR
         <UserName>{{ user.name }}</UserName>
         <Arn>{{ user.arn }}</Arn>
         <CreateDate>{{ user.created_iso_8601 }}</CreateDate>
+        {% if user.policies %}
+        <UserPolicyList>
+        {% for policy in user.policies %}
+            <member>
+                <PolicyName>{{ policy }}</PolicyName>
+                <PolicyDocument>{{ user.policies[policy] }}</PolicyDocument>
+            </member>
+        {% endfor %}
+        </UserPolicyList>
+        {% endif %}
       </member>
     {% endfor %}
     </UserDetailList>

--- a/tests/test_iam/test_iam.py
+++ b/tests/test_iam/test_iam.py
@@ -1690,11 +1690,16 @@ def test_get_account_authorization_details():
     assert result["RoleDetailList"][0]["AttachedManagedPolicies"][0][
         "PolicyArn"
     ] == "arn:aws:iam::{}:policy/testPolicy".format(ACCOUNT_ID)
+    print(result["RoleDetailList"][0]["RolePolicyList"][0]["PolicyDocument"])
+    assert result["RoleDetailList"][0]["RolePolicyList"][0][
+        "PolicyDocument"
+    ] == json.loads(test_policy)
 
     result = conn.get_account_authorization_details(Filter=["User"])
     assert len(result["RoleDetailList"]) == 0
     assert len(result["UserDetailList"]) == 1
     assert len(result["UserDetailList"][0]["GroupList"]) == 1
+    assert len(result["UserDetailList"][0]["UserPolicyList"]) == 1
     assert len(result["UserDetailList"][0]["AttachedManagedPolicies"]) == 1
     assert len(result["GroupDetailList"]) == 0
     assert len(result["Policies"]) == 0
@@ -1705,6 +1710,9 @@ def test_get_account_authorization_details():
     assert result["UserDetailList"][0]["AttachedManagedPolicies"][0][
         "PolicyArn"
     ] == "arn:aws:iam::{}:policy/testPolicy".format(ACCOUNT_ID)
+    assert result["UserDetailList"][0]["UserPolicyList"][0][
+        "PolicyDocument"
+    ] == json.loads(test_policy)
 
     result = conn.get_account_authorization_details(Filter=["Group"])
     assert len(result["RoleDetailList"]) == 0
@@ -1720,6 +1728,10 @@ def test_get_account_authorization_details():
     assert result["GroupDetailList"][0]["AttachedManagedPolicies"][0][
         "PolicyArn"
     ] == "arn:aws:iam::{}:policy/testPolicy".format(ACCOUNT_ID)
+    print(result["GroupDetailList"][0]["GroupPolicyList"][0]["PolicyDocument"])
+    assert result["GroupDetailList"][0]["GroupPolicyList"][0][
+        "PolicyDocument"
+    ] == json.loads(test_policy)
 
     result = conn.get_account_authorization_details(Filter=["LocalManagedPolicy"])
     assert len(result["RoleDetailList"]) == 0

--- a/tests/test_iam/test_iam.py
+++ b/tests/test_iam/test_iam.py
@@ -1690,7 +1690,6 @@ def test_get_account_authorization_details():
     assert result["RoleDetailList"][0]["AttachedManagedPolicies"][0][
         "PolicyArn"
     ] == "arn:aws:iam::{}:policy/testPolicy".format(ACCOUNT_ID)
-    print(result["RoleDetailList"][0]["RolePolicyList"][0]["PolicyDocument"])
     assert result["RoleDetailList"][0]["RolePolicyList"][0][
         "PolicyDocument"
     ] == json.loads(test_policy)
@@ -1728,7 +1727,6 @@ def test_get_account_authorization_details():
     assert result["GroupDetailList"][0]["AttachedManagedPolicies"][0][
         "PolicyArn"
     ] == "arn:aws:iam::{}:policy/testPolicy".format(ACCOUNT_ID)
-    print(result["GroupDetailList"][0]["GroupPolicyList"][0]["PolicyDocument"])
     assert result["GroupDetailList"][0]["GroupPolicyList"][0][
         "PolicyDocument"
     ] == json.loads(test_policy)


### PR DESCRIPTION
GetAccountAuthorizationDetails returns an invalid response in group inline policies.
`PolicyDocument` should be an IAM policy document JSON, however the current implementation returns a Python dict expression.

Similar implementation can be found just below the code, in role inline policies, which seems correct.
https://github.com/spulec/moto/blob/cb600377b48ca676fc6a29a6690aeb51e702da43/moto/iam/responses.py#L2123
This PR fixes group inline policy rendering just like role inline policy.

## How to ensure issue

The small code below is a PoC with a group and a policy.
Backend data are correct: you can see a normal JSON.


```python
#!/usr/bin/env python

from moto import mock_iam
from moto.iam.models import iam_backend
import boto3

@mock_iam
def t():
    policy_document = """
{
  "Version": "2012-10-17",
  "Statement":
    {
      "Effect": "Allow",
      "Action": "s3:ListBucket",
      "Resource": "arn:aws:s3:::example_bucket"
    }
}
"""

    iam = boto3.client("iam")
    iam.create_group(GroupName="test-role")
    iam.put_group_policy(
        GroupName="test-role",
        PolicyName="s3",
        PolicyDocument=policy_document,
    )
    ret = iam.get_group_policy(GroupName="test-role", PolicyName="s3")
    d = iam_backend.get_account_authorization_details(["Group"])
    for group in d["groups"]:
        # like in template
        print(f"Group: {group.name}")
        for policy in group.policies:
            print(f"  p: {policy}")
            print(f"  d: {group.get_policy(policy)}")
        # backend data
        print(group.policies["s3"])

t()
```

Output

```
Group: test-role
  p: s3
  d: {'policy_name': 's3', 'policy_document': '\n{\n  "Version": "2012-10-17",\n  "Statement":\n    {\n      "Effect": "Allow",\n      "Action": "s3:ListBucket",\n      "Resource": "arn:aws:s3:::example_bucket"\n    }\n}\n', 'group_name': 'test-role'}

{
  "Version": "2012-10-17",
  "Statement":
    {
      "Effect": "Allow",
      "Action": "s3:ListBucket",
      "Resource": "arn:aws:s3:::example_bucket"
    }
}
```