### PR TITLE
Support for autoscaling policies in run_jobflow, add_instance_group a…

### DIFF
--- a/moto/core/responses.py
+++ b/moto/core/responses.py
@@ -99,19 +99,29 @@ class _TemplateEnvironmentMixin(object):
     def contains_template(self, template_id):
         return self.loader.contains(template_id)
 
-    def response_template(self, source):
+    def response_template(self, source, includes={}):
         template_id = id(source)
         if not self.contains_template(template_id):
             collapsed = re.sub(
                 self.RIGHT_PATTERN, ">", re.sub(self.LEFT_PATTERN, "<", source)
             )
             self.loader.update({template_id: collapsed})
-            self.environment = Environment(
-                loader=self.loader,
-                autoescape=self.should_autoescape,
-                trim_blocks=True,
-                lstrip_blocks=True,
-            )
+
+        for include_name in includes:
+            if not self.contains_template(include_name):
+                collapsed = re.sub(
+                    self.RIGHT_PATTERN,
+                    ">",
+                    re.sub(self.LEFT_PATTERN, "<", includes[include_name]),
+                )
+                self.loader.update({include_name: collapsed})
+
+        self.environment = Environment(
+            loader=self.loader,
+            autoescape=self.should_autoescape,
+            trim_blocks=True,
+            lstrip_blocks=True,
+        )
         return self.environment.get_template(template_id)
 
 

--- a/moto/emr/utils.py
+++ b/moto/emr/utils.py
@@ -1,6 +1,7 @@
 from __future__ import unicode_literals
 import random
 import string
+from moto.core.utils import camelcase_to_underscores
 
 import six
 
@@ -37,3 +38,109 @@ def steps_from_query_string(querystring_dict):
             idx += 1
         steps.append(step)
     return steps
+
+
+class Unflattener:
+    @staticmethod
+    def unflatten_complex_params(input_dict, param_name):
+        """ Function to unflatten (portions of) dicts with complex keys.  The moto request parser flattens the incoming
+        request bodies, which is generally helpful, but for nested dicts/lists can result in a hard-to-manage
+        parameter exposion.  This function allows one to selectively unflatten a set of dict keys, replacing them
+        with a deep dist/list structure named identically to the root component in the complex name.
+
+        Complex keys are composed of multiple components
+        separated by periods. Components may be prefixed with _, which is stripped.  Lists indexes are represented
+        with two components, 'member' and the index number. """
+        items_to_process = {}
+        for k in input_dict.keys():
+            if k.startswith(param_name):
+                items_to_process[k] = input_dict[k]
+        if len(items_to_process) == 0:
+            return
+
+        for k in items_to_process.keys():
+            del input_dict[k]
+
+        for k in items_to_process.keys():
+            Unflattener._set_deep(k, input_dict, items_to_process[k])
+
+    @staticmethod
+    def _set_deep(complex_key, container, value):
+        keys = complex_key.split(".")
+        keys.reverse()
+
+        while len(keys) > 0:
+            if len(keys) == 1:
+                key = keys.pop().strip("_")
+                Unflattener._add_to_container(container, key, value)
+            else:
+                key = keys.pop().strip("_")
+                if keys[-1] == "member":
+                    keys.pop()
+                    if not Unflattener._key_in_container(container, key):
+                        container = Unflattener._add_to_container(container, key, [])
+                    else:
+                        container = Unflattener._get_child(container, key)
+                else:
+                    if not Unflattener._key_in_container(container, key):
+                        container = Unflattener._add_to_container(container, key, {})
+                    else:
+                        container = Unflattener._get_child(container, key)
+
+    @staticmethod
+    def _add_to_container(container, key, value):
+        if type(container) is dict:
+            container[key] = value
+        elif type(container) is list:
+            i = int(key)
+            while len(container) < i:
+                container.append(None)
+            container[i - 1] = value
+        return value
+
+    @staticmethod
+    def _get_child(container, key):
+        if type(container) is dict:
+            return container[key]
+        elif type(container) is list:
+            i = int(key)
+            return container[i - 1]
+
+    @staticmethod
+    def _key_in_container(container, key):
+        if type(container) is dict:
+            return key in container
+        elif type(container) is list:
+            i = int(key)
+            return len(container) >= i
+
+
+class CamelToUnderscoresWalker:
+    """A class to convert the keys in dict/list hierarchical data structures from CamelCase to snake_case (underscores)"""
+
+    @staticmethod
+    def parse(x):
+        if isinstance(x, dict):
+            return CamelToUnderscoresWalker.parse_dict(x)
+        elif isinstance(x, list):
+            return CamelToUnderscoresWalker.parse_list(x)
+        else:
+            return CamelToUnderscoresWalker.parse_scalar(x)
+
+    @staticmethod
+    def parse_dict(x):
+        temp = {}
+        for key in x.keys():
+            temp[camelcase_to_underscores(key)] = CamelToUnderscoresWalker.parse(x[key])
+        return temp
+
+    @staticmethod
+    def parse_list(x):
+        temp = []
+        for i in x:
+            temp.append(CamelToUnderscoresWalker.parse(i))
+        return temp
+
+    @staticmethod
+    def parse_scalar(x):
+        return x

--- a/moto/emr/utils.py
+++ b/moto/emr/utils.py
@@ -61,7 +61,7 @@ class Unflattener:
         for k in items_to_process.keys():
             del input_dict[k]
 
-        for k in items_to_process.keys():
+        for k in sorted(items_to_process.keys()):
             Unflattener._set_deep(k, input_dict, items_to_process[k])
 
     @staticmethod

--- a/tests/test_emr/test_emr_boto3.py
+++ b/tests/test_emr/test_emr_boto3.py
@@ -554,6 +554,7 @@ def test_put_remove_auto_scaling_policy():
     auto_scaling_policy_with_cluster_id = _patch_cluster_id_placeholder_in_autoscaling_policy(
         auto_scaling_policy, cluster_id
     )
+    resp["AutoScalingPolicy"]["Status"]["State"].should.equal("ATTACHED")
     del resp["AutoScalingPolicy"]["Status"]
     resp["AutoScalingPolicy"].should.equal(auto_scaling_policy_with_cluster_id)
 

--- a/tests/test_emr/test_utils.py
+++ b/tests/test_emr/test_utils.py
@@ -1,0 +1,125 @@
+import sure  # noqa
+from nose.tools import assert_true, assert_equal, assert_in
+from moto.emr.utils import Unflattener, CamelToUnderscoresWalker
+
+
+def test_unflattener_just_dicts():
+    prefix = "a"
+    data = {"a.a.a": 1, "a.a.b": 2, "a.b.a": 3, "a.c": 6, "b.a.a": 4, "c.a.a": 5}
+
+    Unflattener.unflatten_complex_params(data, prefix)
+
+    expected = {
+        "a": {"a": {"a": 1, "b": 2}, "b": {"a": 3}, "c": 6},
+        "b.a.a": 4,
+        "c.a.a": 5,
+    }
+    assert_equal(data, expected)
+
+
+def test_unflattener_list_of_scalars():
+    prefix = "a"
+    data = {
+        "a.member.1": 1,
+        "a.member.2": 2,
+        "a.member.3": 3,
+        "a.member.4": 4,
+        "b.member.1.a.a": 5,
+    }
+
+    Unflattener.unflatten_complex_params(data, prefix)
+
+    expected = {"a": [1, 2, 3, 4], "b.member.1.a.a": 5}
+    assert_equal(data, expected)
+
+
+def test_unflattener_list_dicts():
+    prefix = "a"
+    data = {
+        "a.member.1.a.a": 1,
+        "a.member.1.a.b": 2,
+        "a.member.1.b.c": 3,
+        "a.member.2.d.e": 4,
+        "b.member.1.a.a": 5,
+        "a.member.3": 6,
+        "a.member.4.a.member.1": 7,
+        "a.member.4.a.member.2.a": 8,
+        "a.member.5.member.1": 9,
+    }
+
+    Unflattener.unflatten_complex_params(data, prefix)
+
+    expected = {
+        "a": [
+            {"a": {"a": 1, "b": 2}, "b": {"c": 3}},
+            {"d": {"e": 4,},},
+            6,
+            {"a": [7, {"a": 8}]},
+            [9],
+        ],
+        "b.member.1.a.a": 5,
+    }
+    assert_equal(data, expected)
+
+
+def test_camels_to_underscores_walker_flat_dict():
+    input = {
+        "CamelCase1": 1,
+        "CamelCase2": 2,
+        "CamelCase3": 3,
+    }
+    output = CamelToUnderscoresWalker.parse(input)
+    expected = {
+        "camel_case1": 1,
+        "camel_case2": 2,
+        "camel_case3": 3,
+    }
+    assert_equal(output, expected)
+
+
+def test_camels_to_underscores_walker_deeper_dict():
+    input = {
+        "CamelCase1": {"CamelCase1A": 1, "CamelCase1B": 2},
+        "CamelCase2": {"CamelCase2A": 3, "CamelCase2B": 4},
+    }
+    output = CamelToUnderscoresWalker.parse(input)
+    expected = {
+        "camel_case1": {"camel_case1_a": 1, "camel_case1_b": 2},
+        "camel_case2": {"camel_case2_a": 3, "camel_case2_b": 4},
+    }
+    assert_equal(output, expected)
+
+
+def test_camels_to_underscores_walker_lists_of_dicts():
+    input = [{"CamelCase1A": 1, "CamelCase1B": 2}, {"CamelCase2A": 3, "CamelCase2B": 4}]
+    output = CamelToUnderscoresWalker.parse(input)
+    expected = [
+        {"camel_case1_a": 1, "camel_case1_b": 2},
+        {"camel_case2_a": 3, "camel_case2_b": 4},
+    ]
+    assert_equal(output, expected)
+
+
+def test_camels_to_underscores_walker_dicts_of_lists():
+    input = {
+        "CamelCase1": [
+            {"CamelCase11A": 1, "CamelCase11B": 2},
+            {"CamelCase12A": 3, "CamelCase12B": 4},
+        ],
+        "CamelCase2": [
+            {"CamelCase21A": 5, "CamelCase21B": 6},
+            {"CamelCase22A": 7, "CamelCase22B": 8},
+        ],
+    }
+    output = CamelToUnderscoresWalker.parse(input)
+    expected = {
+        "camel_case1": [
+            {"camel_case11_a": 1, "camel_case11_b": 2},
+            {"camel_case12_a": 3, "camel_case12_b": 4},
+        ],
+        "camel_case2": [
+            {"camel_case21_a": 5, "camel_case21_b": 6},
+            {"camel_case22_a": 7, "camel_case22_b": 8},
+        ],
+    }
+    assert_equal(output, expected)

--- a/tests/test_emr/test_utils.py
+++ b/tests/test_emr/test_utils.py
@@ -52,7 +52,7 @@ def test_unflattener_list_dicts():
     expected = {
         "a": [
             {"a": {"a": 1, "b": 2}, "b": {"c": 3}},
-            {"d": {"e": 4,},},
+            {"d": {"e": 4}},
             6,
             {"a": [7, {"a": 8}]},
             [9],


### PR DESCRIPTION
Fixes #3085 

Support for autoscaling policies in run_jobflow, add_instance_group and list_instance_groups.
Support for cluster_id parameter substitution in autoscaling policy cloudwatch alarm dimensions.
New methods put_autoscaling_policy and remove_autoscaling_policy support.

I faced several obstacles to this otherwise straightforward extension, and want to call them out here, as those in-the-know may have recommendations for better ways (i.e. without the utility functions I added...), so I anticipate discussion about these.

The first was in passing the "deep" AutoScalingPolicy in add_instance_group, as existing code made use of the flattened querystring parameters, retreived via _get_list_prefix().  _get_list_prefix only seems to be able to deal with param structures that are themselves flat beyond the prefix.  Prior efforts to support EbsConfiguration params (also deep) were handled by a purpose-built function that unflattened them.  I elected instead to create a generic Unflattener utility.  I'm not in love with the approach, but didn't feel up for writing a _get_list_prefix variant that could deal with  params of depth in the list.  See moto/emr/responses.py and utils.py.

For put_auto_scaling_policy I went with _get_parm() to fetch the policy param.  It preserves the params depth.  But doesn't convert key format from Camel to underscore.  I added a generic utility for doing this to dict/list structures, also in moto/emr/utils.py.  I perform this transformation in the model to all AutoScalingPolicies.
 