### PR TITLE
Feature: DynamoDB: Support projectiontype KEYS_ONLY for GSI/LSI

### DIFF
--- a/tests/test_dynamodb2/test_dynamodb.py
+++ b/tests/test_dynamodb2/test_dynamodb.py
@@ -5316,3 +5316,47 @@ def test_transact_write_items_fails_with_transaction_canceled_exception():
     ex.exception.response["Error"]["Message"].should.equal(
         "Transaction cancelled, please refer cancellation reasons for specific reasons [None, ConditionalCheckFailed]"
     )
+
+
+@mock_dynamodb2
+def test_gsi_projection_type_keys_only():
+    table_schema = {
+        "KeySchema": [{"AttributeName": "partitionKey", "KeyType": "HASH"}],
+        "GlobalSecondaryIndexes": [
+            {
+                "IndexName": "GSI-K1",
+                "KeySchema": [
+                    {"AttributeName": "gsiK1PartitionKey", "KeyType": "HASH"},
+                    {"AttributeName": "gsiK1SortKey", "KeyType": "RANGE"},
+                ],
+                "Projection": {"ProjectionType": "KEYS_ONLY",},
+            }
+        ],
+        "AttributeDefinitions": [
+            {"AttributeName": "partitionKey", "AttributeType": "S"},
+            {"AttributeName": "gsiK1PartitionKey", "AttributeType": "S"},
+            {"AttributeName": "gsiK1SortKey", "AttributeType": "S"},
+        ],
+    }
+
+    item = {
+        "partitionKey": "pk-1",
+        "gsiK1PartitionKey": "gsi-pk",
+        "gsiK1SortKey": "gsi-sk",
+        "someAttribute": "lore ipsum",
+    }
+
+    dynamodb = boto3.resource("dynamodb", region_name="us-east-1")
+    dynamodb.create_table(
+        TableName="test-table", BillingMode="PAY_PER_REQUEST", **table_schema
+    )
+    table = dynamodb.Table("test-table")
+    table.put_item(Item=item)
+
+    items = table.query(
+        KeyConditionExpression=Key("gsiK1PartitionKey").eq("gsi-pk"),
+        IndexName="GSI-K1",
+    )["Items"]
+    items.should.have.length_of(1)
+    # Item should only include GSI Keys, as per the ProjectionType
+    items[0].should.equal({"gsiK1PartitionKey": "gsi-pk", "gsiK1SortKey": "gsi-sk"})


### PR DESCRIPTION
Fixes #3055 

GSI's/LSI's can be configured to only store a subset of the data, to save space/money, by specifying a ProjectionType.
This PR adds support for the projection type KEYS_ONLY.

The ProjectionType 'ALL' is supported by default.
The ProjectionType 'INCLUDE' is not yet supported, but can be easily added later on.