### PR TITLE
Transfer Region in UserAgent-header

### DIFF
--- a/moto/core/models.py
+++ b/moto/core/models.py
@@ -417,8 +417,9 @@ class ServerModeMockAWS(BaseMockAWS):
         import mock
 
         def fake_boto3_client(*args, **kwargs):
-            service, region = args
-            kwargs["config"] = Config(user_agent_extra="region/" + region)
+            region = self._get_region(*args, **kwargs)
+            if region:
+                kwargs["config"] = Config(user_agent_extra="region/" + region)
             if "endpoint_url" not in kwargs:
                 kwargs["endpoint_url"] = "http://localhost:5000"
             return real_boto3_client(*args, **kwargs)
@@ -465,6 +466,14 @@ class ServerModeMockAWS(BaseMockAWS):
         self._resource_patcher.start()
         if six.PY2:
             self._httplib_patcher.start()
+
+    def _get_region(self, *args, **kwargs):
+        if "region_name" in kwargs:
+            return kwargs["region_name"]
+        if type(args) == tuple:
+            service, region = args
+            return region
+        return None
 
     def disable_patching(self):
         if self._client_patcher:

--- a/moto/core/models.py
+++ b/moto/core/models.py
@@ -419,7 +419,11 @@ class ServerModeMockAWS(BaseMockAWS):
         def fake_boto3_client(*args, **kwargs):
             region = self._get_region(*args, **kwargs)
             if region:
-                kwargs["config"] = Config(user_agent_extra="region/" + region)
+                if "config" in kwargs:
+                    kwargs["config"].__dict__["user_agent_extra"] += " region/" + region
+                else:
+                    config = Config(user_agent_extra="region/" + region)
+                    kwargs["config"] = config
             if "endpoint_url" not in kwargs:
                 kwargs["endpoint_url"] = "http://localhost:5000"
             return real_boto3_client(*args, **kwargs)

--- a/moto/core/models.py
+++ b/moto/core/models.py
@@ -418,7 +418,7 @@ class ServerModeMockAWS(BaseMockAWS):
 
         def fake_boto3_client(*args, **kwargs):
             service, region = args
-            kwargs["config"] = Config(user_agent_extra="region/"+region)
+            kwargs["config"] = Config(user_agent_extra="region/" + region)
             if "endpoint_url" not in kwargs:
                 kwargs["endpoint_url"] = "http://localhost:5000"
             return real_boto3_client(*args, **kwargs)

--- a/moto/core/models.py
+++ b/moto/core/models.py
@@ -10,6 +10,7 @@ import six
 import types
 from io import BytesIO
 from collections import defaultdict
+from botocore.config import Config
 from botocore.handlers import BUILTIN_HANDLERS
 from botocore.awsrequest import AWSResponse
 from six.moves.urllib.parse import urlparse
@@ -416,6 +417,8 @@ class ServerModeMockAWS(BaseMockAWS):
         import mock
 
         def fake_boto3_client(*args, **kwargs):
+            service, region = args
+            kwargs["config"] = Config(user_agent_extra="region/"+region)
             if "endpoint_url" not in kwargs:
                 kwargs["endpoint_url"] = "http://localhost:5000"
             return real_boto3_client(*args, **kwargs)

--- a/moto/core/models.py
+++ b/moto/core/models.py
@@ -470,7 +470,7 @@ class ServerModeMockAWS(BaseMockAWS):
     def _get_region(self, *args, **kwargs):
         if "region_name" in kwargs:
             return kwargs["region_name"]
-        if type(args) == tuple:
+        if type(args) == tuple and len(args) == 2:
             service, region = args
             return region
         return None

--- a/moto/core/responses.py
+++ b/moto/core/responses.py
@@ -188,7 +188,9 @@ class BaseResponse(_TemplateEnvironmentMixin, ActionAuthenticatorMixin):
     default_region = "us-east-1"
     # to extract region, use [^.]
     region_regex = re.compile(r"\.(?P<region>[a-z]{2}-[a-z]+-\d{1})\.amazonaws\.com")
-    region_from_useragent_regex = re.compile(r"region/(?P<region>[a-z]{2}-[a-z]+-\d{1})")
+    region_from_useragent_regex = re.compile(
+        r"region/(?P<region>[a-z]{2}-[a-z]+-\d{1})"
+    )
     param_list_regex = re.compile(r"(.*)\.(\d+)\.")
     access_key_regex = re.compile(
         r"AWS.*(?P<access_key>(?<![A-Z0-9])[A-Z0-9]{20}(?![A-Z0-9]))[:/]"
@@ -274,7 +276,9 @@ class BaseResponse(_TemplateEnvironmentMixin, ActionAuthenticatorMixin):
 
     def get_region_from_url(self, request, full_url):
         url_match = self.region_regex.search(full_url)
-        user_agent_match = self.region_from_useragent_regex.search(request.headers["User-Agent"])
+        user_agent_match = self.region_from_useragent_regex.search(
+            request.headers.get("User-Agent", "")
+        )
         if url_match:
             region = url_match.group(1)
         elif user_agent_match:

--- a/moto/core/responses.py
+++ b/moto/core/responses.py
@@ -188,6 +188,7 @@ class BaseResponse(_TemplateEnvironmentMixin, ActionAuthenticatorMixin):
     default_region = "us-east-1"
     # to extract region, use [^.]
     region_regex = re.compile(r"\.(?P<region>[a-z]{2}-[a-z]+-\d{1})\.amazonaws\.com")
+    region_from_useragent_regex = re.compile(r"region/(?P<region>[a-z]{2}-[a-z]+-\d{1})")
     param_list_regex = re.compile(r"(.*)\.(\d+)\.")
     access_key_regex = re.compile(
         r"AWS.*(?P<access_key>(?<![A-Z0-9])[A-Z0-9]{20}(?![A-Z0-9]))[:/]"
@@ -272,9 +273,12 @@ class BaseResponse(_TemplateEnvironmentMixin, ActionAuthenticatorMixin):
         self.response_headers = {"server": "amazon.com"}
 
     def get_region_from_url(self, request, full_url):
-        match = self.region_regex.search(full_url)
-        if match:
-            region = match.group(1)
+        url_match = self.region_regex.search(full_url)
+        user_agent_match = self.region_from_useragent_regex.search(request.headers["User-Agent"])
+        if url_match:
+            region = url_match.group(1)
+        elif user_agent_match:
+            region = user_agent_match.group(1)
         elif (
             "Authorization" in request.headers
             and "AWS4" in request.headers["Authorization"]


### PR DESCRIPTION
Fixes #3098 

Stores the region in the UserAgent-header in the following format:  
`User-Agent: Boto3/1.14.12 Python/2.7.15+ Linux/4.15.0-106-generic Botocore/1.17.12 region/us-west-2`

~~Marked as draft, as I haven't accounted for the fact that the user might have provided their own extra user-agent information - just verifying the POC for now~~

Edit: Changed the PR to extend the UserAgent-header, in case the user has supplied their own Config object with a UserAgentExtra-option. Ready for review now