### PR TITLE
SSM: Use EC2 region

### DIFF
--- a/moto/ssm/models.py
+++ b/moto/ssm/models.py
@@ -1,11 +1,11 @@
 from __future__ import unicode_literals
 
 import re
+from boto3 import Session
 from collections import defaultdict
 
 from moto.core import BaseBackend, BaseModel
 from moto.core.exceptions import RESTError
-from moto.ec2 import ec2_backends
 from moto.cloudformation import cloudformation_backends
 
 import datetime
@@ -807,5 +807,9 @@ class SimpleSystemManagerBackend(BaseBackend):
 
 
 ssm_backends = {}
-for region, ec2_backend in ec2_backends.items():
+for region in Session().get_available_regions("ssm"):
+    ssm_backends[region] = SimpleSystemManagerBackend(region)
+for region in Session().get_available_regions("ssm", partition_name="aws-us-gov"):
+    ssm_backends[region] = SimpleSystemManagerBackend(region)
+for region in Session().get_available_regions("ssm", partition_name="aws-cn"):
     ssm_backends[region] = SimpleSystemManagerBackend(region)

--- a/moto/ssm/models.py
+++ b/moto/ssm/models.py
@@ -270,7 +270,8 @@ class Command(BaseModel):
 
 
 class SimpleSystemManagerBackend(BaseBackend):
-    def __init__(self):
+    def __init__(self, region_name=None):
+        super(SimpleSystemManagerBackend, self).__init__()
         # each value is a list of all of the versions for a parameter
         # to get the current value, grab the last item of the list
         self._parameters = defaultdict(list)
@@ -279,10 +280,12 @@ class SimpleSystemManagerBackend(BaseBackend):
         self._commands = []
         self._errors = []
 
-        # figure out what region we're in
-        for region, backend in ssm_backends.items():
-            if backend == self:
-                self._region = region
+        self._region = region_name
+
+    def reset(self):
+        region_name = self._region
+        self.__dict__ = {}
+        self.__init__(region_name)
 
     def delete_parameter(self, name):
         return self._parameters.pop(name, None)
@@ -805,4 +808,4 @@ class SimpleSystemManagerBackend(BaseBackend):
 
 ssm_backends = {}
 for region, ec2_backend in ec2_backends.items():
-    ssm_backends[region] = SimpleSystemManagerBackend()
+    ssm_backends[region] = SimpleSystemManagerBackend(region)


### PR DESCRIPTION
Passes in the region to SSMBackend, instead of cycling through the dict of known backends.
This aligns with how all other backends handle the region.

Fixes https://github.com/localstack/localstack/issues/2618