### PR TITLE
Config - implement Organization Conformance Pack functionality

### DIFF
--- a/moto/config/exceptions.py
+++ b/moto/config/exceptions.py
@@ -388,11 +388,7 @@ class ValidationException(JsonRESTError):
 class NoSuchOrganizationConformancePackException(JsonRESTError):
     code = 400
 
-    def __init__(self):
-        message = (
-            "One or more organization conformance packs with specified names are not present. "
-            "Ensure your names are correct and try your request again later."
-        )
+    def __init__(self, message):
         super(NoSuchOrganizationConformancePackException, self).__init__(
             "NoSuchOrganizationConformancePackException", message
         )

--- a/moto/config/exceptions.py
+++ b/moto/config/exceptions.py
@@ -376,3 +376,10 @@ class InvalidResultTokenException(JsonRESTError):
         super(InvalidResultTokenException, self).__init__(
             "InvalidResultTokenException", message
         )
+
+
+class ValidationException(JsonRESTError):
+    code = 400
+
+    def __init__(self, message):
+        super(ValidationException, self).__init__("ValidationException", message)

--- a/moto/config/exceptions.py
+++ b/moto/config/exceptions.py
@@ -383,3 +383,16 @@ class ValidationException(JsonRESTError):
 
     def __init__(self, message):
         super(ValidationException, self).__init__("ValidationException", message)
+
+
+class NoSuchOrganizationConformancePackException(JsonRESTError):
+    code = 400
+
+    def __init__(self):
+        message = (
+            "One or more organization conformance packs with specified names are not present. "
+            "Ensure your names are correct and try your request again later."
+        )
+        super(NoSuchOrganizationConformancePackException, self).__init__(
+            "NoSuchOrganizationConformancePackException", message
+        )

--- a/moto/config/models.py
+++ b/moto/config/models.py
@@ -397,6 +397,21 @@ class OrganizationConformancePack(ConfigEmptyDictable):
         )
         self.organization_conformance_pack_name = name
 
+    def update(
+        self,
+        delivery_s3_bucket,
+        delivery_s3_key_prefix,
+        input_parameters,
+        excluded_accounts,
+    ):
+        self._status = "UPDATE_SUCCESSFUL"
+
+        self.conformance_pack_input_parameters = input_parameters
+        self.delivery_s3_bucket = delivery_s3_bucket
+        self.delivery_s3_key_prefix = delivery_s3_key_prefix
+        self.excluded_accounts = excluded_accounts
+        self.last_update_time = datetime2int(datetime.utcnow())
+
 
 class ConfigBackend(BaseBackend):
     def __init__(self):
@@ -1168,17 +1183,17 @@ class ConfigBackend(BaseBackend):
         pack = self.organization_conformance_packs.get(name)
 
         if pack:
-            pack.conformance_pack_input_parameters = input_parameters
-            pack.delivery_s3_bucket = delivery_s3_bucket
-            pack.delivery_s3_key_prefix = delivery_s3_key_prefix
-            pack.excluded_accounts = excluded_accounts
-            pack.last_update_time = datetime2int(datetime.utcnow())
-            pack._status = "UPDATE_SUCCESSFUL"
+            pack.update(
+                delivery_s3_bucket=delivery_s3_bucket,
+                delivery_s3_key_prefix=delivery_s3_key_prefix,
+                input_parameters=input_parameters,
+                excluded_accounts=excluded_accounts,
+            )
         else:
             pack = OrganizationConformancePack(
-                region,
-                name,
-                delivery_s3_bucket,
+                region=region,
+                name=name,
+                delivery_s3_bucket=delivery_s3_bucket,
                 delivery_s3_key_prefix=delivery_s3_key_prefix,
                 input_parameters=input_parameters,
                 excluded_accounts=excluded_accounts,

--- a/moto/config/models.py
+++ b/moto/config/models.py
@@ -42,6 +42,7 @@ from moto.config.exceptions import (
     TooManyResourceKeys,
     InvalidResultTokenException,
     ValidationException,
+    NoSuchOrganizationConformancePackException,
 )
 
 from moto.core import BaseBackend, BaseModel
@@ -1178,6 +1179,19 @@ class ConfigBackend(BaseBackend):
         return {
             "OrganizationConformancePackArn": pack.organization_conformance_pack_arn
         }
+
+    def describe_organization_conformance_packs(self, names):
+        packs = []
+
+        for name in names:
+            pack = self.organization_conformance_packs.get(name)
+
+            if not pack:
+                raise NoSuchOrganizationConformancePackException
+
+            packs.append(pack.to_dict())
+
+        return {"OrganizationConformancePacks": packs}
 
 
 config_backends = {}

--- a/moto/config/responses.py
+++ b/moto/config/responses.py
@@ -180,3 +180,11 @@ class ConfigResponse(BaseResponse):
         )
 
         return json.dumps(conformance_packs)
+
+    def get_organization_conformance_pack_detailed_status(self):
+        # 'Filters' parameter is not implemented yet
+        statuses = self.config_backend.get_organization_conformance_pack_detailed_status(
+            self._get_param("OrganizationConformancePackName")
+        )
+
+        return json.dumps(statuses)

--- a/moto/config/responses.py
+++ b/moto/config/responses.py
@@ -195,3 +195,10 @@ class ConfigResponse(BaseResponse):
         )
 
         return json.dumps(statuses)
+
+    def delete_organization_conformance_pack(self):
+        self.config_backend.delete_organization_conformance_pack(
+            self._get_param("OrganizationConformancePackName")
+        )
+
+        return ""

--- a/moto/config/responses.py
+++ b/moto/config/responses.py
@@ -181,6 +181,13 @@ class ConfigResponse(BaseResponse):
 
         return json.dumps(conformance_packs)
 
+    def describe_organization_conformance_pack_statuses(self):
+        statuses = self.config_backend.describe_organization_conformance_pack_statuses(
+            self._get_param("OrganizationConformancePackNames")
+        )
+
+        return json.dumps(statuses)
+
     def get_organization_conformance_pack_detailed_status(self):
         # 'Filters' parameter is not implemented yet
         statuses = self.config_backend.get_organization_conformance_pack_detailed_status(

--- a/moto/config/responses.py
+++ b/moto/config/responses.py
@@ -173,3 +173,10 @@ class ConfigResponse(BaseResponse):
         )
 
         return json.dumps(conformance_pack)
+
+    def describe_organization_conformance_packs(self):
+        conformance_packs = self.config_backend.describe_organization_conformance_packs(
+            self._get_param("OrganizationConformancePackNames")
+        )
+
+        return json.dumps(conformance_packs)

--- a/moto/config/responses.py
+++ b/moto/config/responses.py
@@ -162,14 +162,14 @@ class ConfigResponse(BaseResponse):
 
     def put_organization_conformance_pack(self):
         conformance_pack = self.config_backend.put_organization_conformance_pack(
-            self.region,
-            self._get_param("OrganizationConformancePackName"),
-            self._get_param("TemplateS3Uri"),
-            self._get_param("TemplateBody"),
-            self._get_param("DeliveryS3Bucket"),
-            self._get_param("DeliveryS3KeyPrefix"),
-            self._get_param("ConformancePackInputParameters"),
-            self._get_param("ExcludedAccounts"),
+            region=self.region,
+            name=self._get_param("OrganizationConformancePackName"),
+            template_s3_uri=self._get_param("TemplateS3Uri"),
+            template_body=self._get_param("TemplateBody"),
+            delivery_s3_bucket=self._get_param("DeliveryS3Bucket"),
+            delivery_s3_key_prefix=self._get_param("DeliveryS3KeyPrefix"),
+            input_parameters=self._get_param("ConformancePackInputParameters"),
+            excluded_accounts=self._get_param("ExcludedAccounts"),
         )
 
         return json.dumps(conformance_pack)

--- a/moto/config/responses.py
+++ b/moto/config/responses.py
@@ -159,3 +159,17 @@ class ConfigResponse(BaseResponse):
             self._get_param("TestMode"),
         )
         return json.dumps(evaluations)
+
+    def put_organization_conformance_pack(self):
+        conformance_pack = self.config_backend.put_organization_conformance_pack(
+            self.region,
+            self._get_param("OrganizationConformancePackName"),
+            self._get_param("TemplateS3Uri"),
+            self._get_param("TemplateBody"),
+            self._get_param("DeliveryS3Bucket"),
+            self._get_param("DeliveryS3KeyPrefix"),
+            self._get_param("ConformancePackInputParameters"),
+            self._get_param("ExcludedAccounts"),
+        )
+
+        return json.dumps(conformance_pack)


### PR DESCRIPTION
I added all endpoints with some sanity checks, but there are still parts missing. The code doesn't pull the conformance pack from S3 and all the Config Rules inside that template would result in a creation of those Config Rules in all accounts. Due to the lack of an implementation of Config Rules at the moment, this should/could be done an other time.