### PR TITLE
Always return 'HardExpiry' for account password policy.

### DIFF
--- a/moto/iam/responses.py
+++ b/moto/iam/responses.py
@@ -2423,9 +2423,7 @@ GET_ACCOUNT_PASSWORD_POLICY_TEMPLATE = """<GetAccountPasswordPolicyResponse xmln
     <PasswordPolicy>
       <AllowUsersToChangePassword>{{ password_policy.allow_users_to_change_password | lower }}</AllowUsersToChangePassword>
       <ExpirePasswords>{{ password_policy.expire_passwords | lower }}</ExpirePasswords>
-      {% if password_policy.hard_expiry %}
       <HardExpiry>{{ password_policy.hard_expiry | lower }}</HardExpiry>
-      {% endif %}
       {% if password_policy.max_password_age %}
       <MaxPasswordAge>{{ password_policy.max_password_age }}</MaxPasswordAge>
       {% endif %}

--- a/tests/test_iam/test_iam.py
+++ b/tests/test_iam/test_iam.py
@@ -2608,6 +2608,7 @@ def test_update_account_password_policy():
             "RequireNumbers": False,
             "RequireSymbols": False,
             "RequireUppercaseCharacters": False,
+            "HardExpiry": False,
         }
     )
 


### PR DESCRIPTION
When calling actual (boto3 or via aws cli) `iam.get_account_password_policy()`, AWS always returns a value for `HardExpiry` whether its value is `true` or `false`.  This can be replicated via the aws cli or boto3. 

Sample output:
```
{
    "PasswordPolicy": {
        "MinimumPasswordLength": 12,
        "RequireSymbols": false,
        "RequireNumbers": true,
        "RequireUppercaseCharacters": true,
        "RequireLowercaseCharacters": true,
        "AllowUsersToChangePassword": true,
        "ExpirePasswords": true,
        "MaxPasswordAge": 90,
        "PasswordReusePrevention": 3,
        "HardExpiry": false
    }
}
```

When using moto, `HardExpiry` is only returned if it happens to be `true`.

Sample moto output:
```
{
    "PasswordPolicy": {
        "MinimumPasswordLength": 12,
        "RequireSymbols": false,
        "RequireNumbers": true,
        "RequireUppercaseCharacters": true,
        "RequireLowercaseCharacters": true,
        "AllowUsersToChangePassword": true,
        "ExpirePasswords": true,
        "MaxPasswordAge": 90,
        "PasswordReusePrevention": 3,
    }
}
```

I've updated the PasswordPolicy template and the associated unit tests so that `HardExpiry` is always returned.
