### PR TITLE
Add NUMBER and LIST<NUMBER> parsing to cloudformation/parsing.py

### DIFF
--- a/moto/cloudformation/parsing.py
+++ b/moto/cloudformation/parsing.py
@@ -560,6 +560,23 @@ class ResourceMap(collections_abc.Mapping):
                 if value_type == "CommaDelimitedList" or value_type.startswith("List"):
                     value = value.split(",")
 
+                def _parse_number_parameter(num_string):
+                    """CloudFormation NUMBER types can be an int or float.
+                    Try int first and then fall back to float if that fails
+                    """
+                    try:
+                        return int(num_string)
+                    except ValueError:
+                        return float(num_string)
+
+                if value_type == "List<Number>":
+                    # The if statement directly above already converted
+                    # to a list. Now we convert each element to a number
+                    value = [_parse_number_parameter(v) for v in value]
+
+                if value_type == "Number":
+                    value = _parse_number_parameter(value)
+
                 if parameter_slot.get("NoEcho"):
                     self.no_echo_parameter_keys.append(key)
 

--- a/tests/test_cloudformation/test_stack_parsing.py
+++ b/tests/test_cloudformation/test_stack_parsing.py
@@ -67,6 +67,8 @@ get_availability_zones_output = {"Outputs": {"Output1": {"Value": {"Fn::GetAZs":
 parameters = {
     "Parameters": {
         "Param": {"Type": "String"},
+        "NumberParam": {"Type": "Number"},
+        "NumberListParam": {"Type": "List<Number>"},
         "NoEchoParam": {"Type": "String", "NoEcho": True},
     }
 }
@@ -303,12 +305,21 @@ def test_parse_stack_with_parameters():
         stack_id="test_id",
         name="test_stack",
         template=parameters_template_json,
-        parameters={"Param": "visible value", "NoEchoParam": "hidden value"},
+        parameters={
+            "Param": "visible value",
+            "NumberParam": "42",
+            "NumberListParam": "42,3.14159",
+            "NoEchoParam": "hidden value",
+        },
         region_name="us-west-1",
     )
 
     stack.resource_map.no_echo_parameter_keys.should.have("NoEchoParam")
     stack.resource_map.no_echo_parameter_keys.should_not.have("Param")
+    stack.resource_map.no_echo_parameter_keys.should_not.have("NumberParam")
+    stack.resource_map.no_echo_parameter_keys.should_not.have("NumberListParam")
+    stack.resource_map.resolved_parameters["NumberParam"].should.equal(42)
+    stack.resource_map.resolved_parameters["NumberListParam"].should.equal([42, 3.14159])
 
 
 def test_parse_equals_condition():

--- a/tests/test_cloudformation/test_stack_parsing.py
+++ b/tests/test_cloudformation/test_stack_parsing.py
@@ -319,7 +319,9 @@ def test_parse_stack_with_parameters():
     stack.resource_map.no_echo_parameter_keys.should_not.have("NumberParam")
     stack.resource_map.no_echo_parameter_keys.should_not.have("NumberListParam")
     stack.resource_map.resolved_parameters["NumberParam"].should.equal(42)
-    stack.resource_map.resolved_parameters["NumberListParam"].should.equal([42, 3.14159])
+    stack.resource_map.resolved_parameters["NumberListParam"].should.equal(
+        [42, 3.14159]
+    )
 
 
 def test_parse_equals_condition():


### PR DESCRIPTION
Resolves #3109.

Thanks @bblommers for the suggestion on where to start. This PR adds "NUMBER" and "LIST<NUMBER>" type parsing to `cloudformation/parsing.py`. Since CloudFormation "NUMBER" parameters can be either ints or floats, this PR uses a function that first tries to convert to int and then falls back to float if that doesn't work. I added tests to cover the additions and I think the new tests also cover the pre-existing "LIST*" if statement.