### PR TITLE
CFN - Allow DynamoDB table as an Output

### DIFF
--- a/moto/dynamodb2/models/__init__.py
+++ b/moto/dynamodb2/models/__init__.py
@@ -413,6 +413,10 @@ class Table(BaseModel):
 
         raise UnformattedGetAttTemplateException()
 
+    @property
+    def physical_resource_id(self):
+        return self.name
+
     @classmethod
     def create_from_cloudformation_json(
         cls, resource_name, cloudformation_json, region_name


### PR DESCRIPTION
Fixes #3114 

Used to throw an error because, without the `physical_resource_id`-attribute, the object-representation would be used instead of the name (`<OutputValue><moto.dynamodb2.models.Table object at 0x7f5ce7c3b240></OutputValue>`)