### PR TITLE
Add batch resources to UNDOCUMENTED_NAME_TYPE_MAP in cloudformation/parsing.py

### DIFF
--- a/moto/cloudformation/parsing.py
+++ b/moto/cloudformation/parsing.py
@@ -102,6 +102,10 @@ MODEL_MAP = {
 UNDOCUMENTED_NAME_TYPE_MAP = {
     "AWS::AutoScaling::AutoScalingGroup": "AutoScalingGroupName",
     "AWS::AutoScaling::LaunchConfiguration": "LaunchConfigurationName",
+    "AWS::Batch::ComputeEnvironment": "ComputeEnvironmentName",
+    "AWS::Batch::JobDefinition": "JobDefinitionName",
+    "AWS::Batch::JobQueue": "JobQueueName",
+    "AWS::EC2::LaunchTemplate": "LaunchTemplateName",
     "AWS::IAM::InstanceProfile": "InstanceProfileName",
 }
 


### PR DESCRIPTION
Resolves #3127, at least partially.

However, as noted in #3127, other services could be added to the map.