### PR TITLE
fix #3129 API Gateway create_api_key generate wrong default value

### DIFF
--- a/moto/apigateway/models.py
+++ b/moto/apigateway/models.py
@@ -400,10 +400,10 @@ class ApiKey(BaseModel, dict):
         self,
         name=None,
         description=None,
-        enabled=True,
+        enabled=False,
         generateDistinctId=False,
         value=None,
-        stageKeys=None,
+        stageKeys=[],
         tags=None,
         customerId=None,
     ):

--- a/tests/test_apigateway/test_apigateway.py
+++ b/tests/test_apigateway/test_apigateway.py
@@ -1845,7 +1845,11 @@ def test_create_api_key():
     apikey_name = "TESTKEY1"
     payload = {"value": apikey_value, "name": apikey_name}
 
-    client.create_api_key(**payload)
+    response = client.create_api_key(**payload)
+    response["name"].should.equal(apikey_name)
+    response["value"].should.equal(apikey_value)
+    response["enabled"].should.equal(False)
+    response["stageKeys"].should.equal([])
 
     response = client.get_api_keys()
     len(response["items"]).should.equal(1)


### PR DESCRIPTION
This pull request will fix #3129.

Fix invalid default value

- `enabled` should be return False
- `stageKeys` should be return empty list