### PR TITLE
fix API Gateway:create_usage_plan_key return wrong status code

### DIFF
--- a/moto/apigateway/responses.py
+++ b/moto/apigateway/responses.py
@@ -526,12 +526,10 @@ class APIGatewayResponse(BaseResponse):
                         error.message, error.error_type
                     ),
                 )
-
+            return 201, {}, json.dumps(usage_plan_response)
         elif self.method == "GET":
             usage_plans_response = self.backend.get_usage_plan_keys(usage_plan_id)
             return 200, {}, json.dumps({"item": usage_plans_response})
-
-        return 200, {}, json.dumps(usage_plan_response)
 
     def usage_plan_key_individual(self, request, full_url, headers):
         self.setup_class(request, full_url, headers)

--- a/tests/test_apigateway/test_apigateway.py
+++ b/tests/test_apigateway/test_apigateway.py
@@ -1987,6 +1987,7 @@ def test_usage_plan_keys():
     key_type = "API_KEY"
     payload = {"usagePlanId": usage_plan_id, "keyId": key_id, "keyType": key_type}
     response = client.create_usage_plan_key(**payload)
+    response["ResponseMetadata"]["HTTPStatusCode"].should.equals(201)
     usage_plan_key_id = response["id"]
 
     # Get current plan keys (expect 1)


### PR DESCRIPTION
create_usage_plan_key should return 201.

https://docs.aws.amazon.com/apigateway/api-reference/link-relation/usageplankey-create/