### PR TITLE
fix API Gateway:create_api_key return wrong status code

### DIFF
--- a/moto/apigateway/responses.py
+++ b/moto/apigateway/responses.py
@@ -454,11 +454,10 @@ class APIGatewayResponse(BaseResponse):
                         error.message, error.error_type
                     ),
                 )
-
+            return 201, {}, json.dumps(apikey_response)
         elif self.method == "GET":
             apikeys_response = self.backend.get_apikeys()
             return 200, {}, json.dumps({"item": apikeys_response})
-        return 200, {}, json.dumps(apikey_response)
 
     def apikey_individual(self, request, full_url, headers):
         self.setup_class(request, full_url, headers)

--- a/tests/test_apigateway/test_apigateway.py
+++ b/tests/test_apigateway/test_apigateway.py
@@ -1846,6 +1846,7 @@ def test_create_api_key():
     payload = {"value": apikey_value, "name": apikey_name}
 
     response = client.create_api_key(**payload)
+    response["ResponseMetadata"]["HTTPStatusCode"].should.equal(201)
     response["name"].should.equal(apikey_name)
     response["value"].should.equal(apikey_value)
     response["enabled"].should.equal(False)


### PR DESCRIPTION
create_api_key should return 201.

https://docs.aws.amazon.com/apigateway/api-reference/link-relation/apikey-create/