### PR TITLE
Fix: Put Events API

### DIFF
--- a/moto/events/models.py
+++ b/moto/events/models.py
@@ -340,17 +340,13 @@ class EventsBackend(BaseBackend):
     def put_events(self, events):
         num_events = len(events)
 
-        response = {"FailedEntryCount": 0, "Entries": []}
-        for _ in events:
-            response["Entries"].append({"EventId": str(uuid4())})
-
         if num_events < 1:
             raise JsonRESTError("ValidationError", "Need at least 1 event")
         elif num_events > 10:
             raise JsonRESTError("ValidationError", "Can only submit 10 events at once")
 
         # We dont really need to store the events yet
-        return response
+        return [{"EventId": str(uuid4())} for _ in events]
 
     def remove_targets(self, name, ids):
         rule = self.rules.get(name)

--- a/moto/events/models.py
+++ b/moto/events/models.py
@@ -8,6 +8,8 @@ from moto.core import BaseBackend, BaseModel
 from moto.sts.models import ACCOUNT_ID
 from moto.utilities.tagging_service import TaggingService
 
+from uuid import uuid4
+
 
 class Rule(BaseModel):
     def _generate_arn(self, name):
@@ -338,13 +340,17 @@ class EventsBackend(BaseBackend):
     def put_events(self, events):
         num_events = len(events)
 
+        response = {"FailedEntryCount": 0, "Entries": []}
+        for _ in events:
+            response["Entries"].append({"EventId": str(uuid4())})
+
         if num_events < 1:
             raise JsonRESTError("ValidationError", "Need at least 1 event")
         elif num_events > 10:
             raise JsonRESTError("ValidationError", "Can only submit 10 events at once")
 
         # We dont really need to store the events yet
-        return []
+        return response
 
     def remove_targets(self, name, ids):
         rule = self.rules.get(name)

--- a/moto/events/responses.py
+++ b/moto/events/responses.py
@@ -150,14 +150,9 @@ class EventsHandler(BaseResponse):
     def put_events(self):
         events = self._get_param("Entries")
 
-        failed_entries = self.events_backend.put_events(events)
+        response = self.events_backend.put_events(events)
 
-        if failed_entries:
-            return json.dumps(
-                {"FailedEntryCount": len(failed_entries), "Entries": failed_entries}
-            )
-
-        return "", self.response_headers
+        return json.dumps(response)
 
     def put_rule(self):
         name = self._get_param("Name")

--- a/moto/events/responses.py
+++ b/moto/events/responses.py
@@ -150,7 +150,13 @@ class EventsHandler(BaseResponse):
     def put_events(self):
         events = self._get_param("Entries")
 
-        response = self.events_backend.put_events(events)
+        entries = self.events_backend.put_events(events)
+
+        failed_count = len([e for e in entries if "ErrorCode" in e])
+        response = {
+            "FailedEntryCount": failed_count,
+            "Entries": entries,
+        }
 
         return json.dumps(response)
 

--- a/tests/test_events/test_events.py
+++ b/tests/test_events/test_events.py
@@ -312,8 +312,10 @@ def test_put_events():
         "DetailType": "myDetailType",
     }
 
-    client.put_events(Entries=[event])
+    response = client.put_events(Entries=[event])
     # Boto3 would error if it didn't return 200 OK
+    response["FailedEntryCount"].should.equal(0)
+    response["Entries"].should.have.length_of(1)
 
     with assert_raises(ClientError):
         client.put_events(Entries=[event] * 20)


### PR DESCRIPTION
Hi All,

Thanks for the library. I wanted to use it to test an application I'm working on that is using the PutEvents API and noticed that there is a discrepancy for the events service between what Amazon says it returns and what moto returns. This change fixes that issue.

* [AWS API Documentation for Put Events](https://docs.aws.amazon.com/eventbridge/latest/APIReference/API_PutEvents.html)

The current response looks like this:

```
{
    "ResponseMetadata": {
        "HTTPStatusCode": 200,
        "HTTPHeaders": {"server": "amazon.com"}, 
        "RetryAttempts": 0
    }
}
```

This merge request changes to match the API documentation:

```
{
    "FailedEntryCount": 0,
    "Entries": [
        {"EventId": "uuid"}
    ]
}
```

Thanks again and let me know if you have any questions, comments or concerns!