### PR TITLE
Resolving #2566 Class decoration preventing environment variable mocking in unit test setup/teardown

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -58,3 +58,4 @@ Moto is written by Steve Pulec with contributions from:
 * [Craig Anderson](https://github.com/craiga)
 * [Robert Lewis](https://github.com/ralewis85)
 * [Kyle Jones](https://github.com/Kerl1310)
+* [Jason Clow](https://github.com/clowtown)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,3 +59,12 @@ You'll need a PyPi account and a DockerHub account to release Moto. After we rel
 * First, `scripts/bump_version` modifies the version and opens a PR
 * Then, merge the new pull request
 * Finally, generate and ship the new artifacts with `make publish`
+
+## Windows Developers
+
+### lxml not working?
+[lxml](https://lxml.de/installation.html)
+
+[windows-binaries](https://www.lfd.uci.edu/~gohlke/pythonlibs/#lxml)
+
+requirements-dev changes: lxml==4.5.2 since they do not provide any older versions

--- a/moto/__init__.py
+++ b/moto/__init__.py
@@ -112,7 +112,7 @@ mock_swf_deprecated = lazy_load(".swf", "mock_swf_deprecated")
 XRaySegment = lazy_load(".xray", "XRaySegment")
 mock_xray = lazy_load(".xray", "mock_xray")
 mock_xray_client = lazy_load(".xray", "mock_xray_client")
-
+mock_nono_moto = lazy_load(".utilities", "mock_nono_moto")
 # import logging
 # logging.getLogger('boto').setLevel(logging.CRITICAL)
 

--- a/moto/core/models.py
+++ b/moto/core/models.py
@@ -28,6 +28,7 @@ from .utils import (
 
 
 ACCOUNT_ID = os.environ.get("MOTO_ACCOUNT_ID", "123456789012")
+MOTO_NONO_ATTR = "__moto_nono__"
 
 
 class BaseMockAWS(object):

--- a/moto/core/models.py
+++ b/moto/core/models.py
@@ -71,6 +71,15 @@ class BaseMockAWS(object):
     def __exit__(self, *args):
         self.stop()
 
+    def reset(self):
+        pass
+
+    def enable_patching(self):
+        pass
+
+    def disable_patching(self):
+        pass
+
     def start(self, reset=True):
         self.default_session_mock.start()
         self.env_variables_mocks.start()

--- a/moto/utilities/__init__.py
+++ b/moto/utilities/__init__.py
@@ -8,7 +8,7 @@ class NoNoBackend(BaseMockAWS):
         raise NotImplementedError()
 
     def decorate_callable(self, func, reset):
-        wrapped = super().decorate_callable(func, reset)
+        wrapped = super(NoNoBackend, self).decorate_callable(func, reset)
         setattr(wrapped, MOTO_NONO_ATTR, True)
         return wrapped
 

--- a/moto/utilities/__init__.py
+++ b/moto/utilities/__init__.py
@@ -1,0 +1,37 @@
+from __future__ import unicode_literals
+
+from ..core.models import BaseMockAWS, MOTO_NONO_ATTR
+
+
+class NoNoBackend(BaseMockAWS):
+    def decorate_class(self, klass):
+        raise NotImplementedError()
+
+    def decorate_callable(self, func, reset):
+        wrapped = super().decorate_callable(func, reset)
+        setattr(wrapped, MOTO_NONO_ATTR, True)
+        return wrapped
+
+    def start(self, reset=True):
+        pass
+
+    def stop(self):
+        pass
+
+
+class nono_decorator(object):
+    mock_backend = NoNoBackend
+
+    def __init__(self):
+        pass
+
+    def __call__(self, func=None):
+        mocked_backend = self.mock_backend(backends={})
+
+        if func:
+            return mocked_backend(func)
+        else:
+            return mocked_backend
+
+
+mock_nono_moto = nono_decorator()

--- a/tests/test_core/test_decorator_calls.py
+++ b/tests/test_core/test_decorator_calls.py
@@ -10,7 +10,7 @@ import unittest
 import tests.backport_assert_raises  # noqa
 from nose.tools import assert_raises
 
-from moto import mock_ec2_deprecated, mock_s3_deprecated, mock_s3
+from moto import mock_ec2_deprecated, mock_s3_deprecated, mock_s3, mock_nono_moto
 
 """
 Test the different ways that the decorator can be used
@@ -101,6 +101,7 @@ class TesterWithStaticmethod(object):
 
 @mock_s3
 class MotoUpdateBrokeTest(unittest.TestCase):
+    @mock_nono_moto
     def setUp(self) -> None:
         os.environ["GLUE_JOB_NAME"] = "glue-job"
 

--- a/tests/test_core/test_decorator_calls.py
+++ b/tests/test_core/test_decorator_calls.py
@@ -1,4 +1,7 @@
 from __future__ import unicode_literals
+
+import os
+
 import boto
 from boto.exception import EC2ResponseError
 import sure  # noqa
@@ -7,7 +10,7 @@ import unittest
 import tests.backport_assert_raises  # noqa
 from nose.tools import assert_raises
 
-from moto import mock_ec2_deprecated, mock_s3_deprecated
+from moto import mock_ec2_deprecated, mock_s3_deprecated, mock_s3
 
 """
 Test the different ways that the decorator can be used
@@ -94,3 +97,15 @@ class TesterWithStaticmethod(object):
 
     def test_no_instance_sent_to_staticmethod(self):
         self.static()
+
+
+@mock_s3
+class MotoUpdateBrokeTest(unittest.TestCase):
+    def setUp(self) -> None:
+        os.environ["GLUE_JOB_NAME"] = "glue-job"
+
+    def tearDown(self):
+        pass
+
+    def test_env_is_set(self):
+        self.assertEqual(os.environ["GLUE_JOB_NAME"], "glue-job")

--- a/tests/test_core/test_decorator_calls.py
+++ b/tests/test_core/test_decorator_calls.py
@@ -102,7 +102,7 @@ class TesterWithStaticmethod(object):
 @mock_s3
 class MotoUpdateBrokeTest(unittest.TestCase):
     @mock_nono_moto
-    def setUp(self) -> None:
+    def setUp(self):
         os.environ["GLUE_JOB_NAME"] = "glue-job"
 
     def tearDown(self):


### PR DESCRIPTION
Added decorator `mock_nono_moto` to demonstrate need to allow class level moto decorators for broad simplicity, but to control environment patching/unpatching around each method that breaks testing setup/teardown built in expectations. 