### PR TITLE
Fix: Api-Gateway ApiKeyAlreadyExists headers change.

### DIFF
--- a/moto/apigateway/responses.py
+++ b/moto/apigateway/responses.py
@@ -449,7 +449,7 @@ class APIGatewayResponse(BaseResponse):
             except ApiKeyAlreadyExists as error:
                 return (
                     error.code,
-                    self.headers,
+                    {},
                     '{{"message":"{0}","code":"{1}"}}'.format(
                         error.message, error.error_type
                     ),

--- a/tests/test_apigateway/test_apigateway.py
+++ b/tests/test_apigateway/test_apigateway.py
@@ -1868,7 +1868,7 @@ def test_create_api_headers():
     payload = {"value": apikey_value, "name": apikey_name}
 
     response = client.create_api_key(**payload)
-    response["ResponseMetadata"]['HTTPHeaders'].should.equal({})
+    response.get("ResponseMetadata", {}).get('HTTPHeaders', {}).should.equal({})
 
 
 @mock_apigateway

--- a/tests/test_apigateway/test_apigateway.py
+++ b/tests/test_apigateway/test_apigateway.py
@@ -1859,6 +1859,19 @@ def test_create_api_key():
 
 
 @mock_apigateway
+def test_create_api_headers():
+    region_name = "us-west-2"
+    client = boto3.client("apigateway", region_name=region_name)
+
+    apikey_value = "12345"
+    apikey_name = "TESTKEY1"
+    payload = {"value": apikey_value, "name": apikey_name}
+
+    response = client.create_api_key(**payload)
+    response["ResponseMetadata"]['HTTPHeaders'].should.equal({})
+
+
+@mock_apigateway
 def test_api_keys():
     region_name = "us-west-2"
     client = boto3.client("apigateway", region_name=region_name)

--- a/tests/test_apigateway/test_apigateway.py
+++ b/tests/test_apigateway/test_apigateway.py
@@ -1867,8 +1867,10 @@ def test_create_api_headers():
     apikey_name = "TESTKEY1"
     payload = {"value": apikey_value, "name": apikey_name}
 
-    response = client.create_api_key(**payload)
-    response.get("ResponseMetadata", {}).get('HTTPHeaders', {}).should.equal({})
+    client.create_api_key(**payload)
+    with assert_raises(ClientError) as ex:
+        client.create_api_key(**payload)
+    ex.exception.response["Error"]["Code"].should.equal("ConflictException")
 
 
 @mock_apigateway

--- a/tests/test_apigateway/test_apigateway.py
+++ b/tests/test_apigateway/test_apigateway.py
@@ -1871,6 +1871,8 @@ def test_create_api_headers():
     with assert_raises(ClientError) as ex:
         client.create_api_key(**payload)
     ex.exception.response["Error"]["Code"].should.equal("ConflictException")
+    if not settings.TEST_SERVER_MODE:
+        ex.exception.response["ResponseMetadata"]["HTTPHeaders"].should.equal({})
 
 
 @mock_apigateway


### PR DESCRIPTION
Fix: Api-Gateway ApiKeyAlreadyExists headers change.
https://github.com/localstack/localstack/issues/2753