### PR TITLE
When generating multi-part upload IDs remove `/` characters

### DIFF
--- a/moto/s3/models.py
+++ b/moto/s3/models.py
@@ -280,7 +280,7 @@ class FakeMultipart(BaseModel):
         self.parts = {}
         self.partlist = []  # ordered list of part ID's
         rand_b64 = base64.b64encode(os.urandom(UPLOAD_ID_BYTES))
-        self.id = rand_b64.decode("utf-8").replace("=", "").replace("+", "")
+        self.id = rand_b64.decode("utf-8").replace("=", "").replace("+", "").replace("/", "")
 
     def complete(self, body):
         decode_hex = codecs.getdecoder("hex_codec")

--- a/moto/s3/models.py
+++ b/moto/s3/models.py
@@ -280,7 +280,9 @@ class FakeMultipart(BaseModel):
         self.parts = {}
         self.partlist = []  # ordered list of part ID's
         rand_b64 = base64.b64encode(os.urandom(UPLOAD_ID_BYTES))
-        self.id = rand_b64.decode("utf-8").replace("=", "").replace("+", "").replace("/", "")
+        self.id = (
+            rand_b64.decode("utf-8").replace("=", "").replace("+", "").replace("/", "")
+        )
 
     def complete(self, body):
         decode_hex = codecs.getdecoder("hex_codec")


### PR DESCRIPTION
Currently when generating an S3 multi-part upload ID, occasionally an upload ID will contain a `/` character. This is not consistent with how the actual API creates IDs (it does contain special characters `.` and `-` characters, but not `/`).

This small PR simply filters out `/` characters when generating S3 multi-part upload IDs in a similar way as how the code was already filtering out `=` and `+` characters.