### PR TITLE
fix cognito-idp UserPool ClientId

### DIFF
--- a/moto/cognitoidp/models.py
+++ b/moto/cognitoidp/models.py
@@ -23,6 +23,7 @@ from .exceptions import (
     UsernameExistsException,
     InvalidParameterException,
 )
+from .utils import create_id
 
 UserStatus = {
     "FORCE_CHANGE_PASSWORD": "FORCE_CHANGE_PASSWORD",
@@ -214,7 +215,7 @@ class CognitoIdpUserPoolDomain(BaseModel):
 class CognitoIdpUserPoolClient(BaseModel):
     def __init__(self, user_pool_id, generate_secret, extended_config):
         self.user_pool_id = user_pool_id
-        self.id = str(uuid.uuid4())
+        self.id = create_id()
         self.secret = str(uuid.uuid4())
         self.generate_secret = generate_secret or False
         self.extended_config = extended_config or {}

--- a/moto/cognitoidp/utils.py
+++ b/moto/cognitoidp/utils.py
@@ -1,0 +1,10 @@
+from __future__ import unicode_literals
+import six
+import random
+import string
+
+
+def create_id():
+    size = 26
+    chars = list(range(10)) + list(string.ascii_lowercase)
+    return "".join(six.text_type(random.choice(chars)) for x in range(size))

--- a/tests/test_cognitoidp/test_cognitoidp.py
+++ b/tests/test_cognitoidp/test_cognitoidp.py
@@ -17,6 +17,7 @@ from jose import jws, jwk, jwt
 from nose.tools import assert_raises
 
 from moto import mock_cognitoidp, settings
+from moto.cognitoidp.utils import create_id
 from moto.core import ACCOUNT_ID
 
 
@@ -1336,9 +1337,7 @@ def test_change_password__using_custom_user_agent_header():
 def test_forgot_password():
     conn = boto3.client("cognito-idp", "us-west-2")
 
-    result = conn.forgot_password(
-        ClientId=str(uuid.uuid4()), Username=str(uuid.uuid4())
-    )
+    result = conn.forgot_password(ClientId=create_id(), Username=str(uuid.uuid4()))
     result["CodeDeliveryDetails"].should_not.be.none
 
 

--- a/tests/test_cognitoidp/test_cognitoidp.py
+++ b/tests/test_cognitoidp/test_cognitoidp.py
@@ -3,6 +3,8 @@ from __future__ import unicode_literals
 import json
 import os
 import random
+import re
+
 import requests
 import uuid
 
@@ -211,7 +213,7 @@ def test_create_user_pool_client():
     )
 
     result["UserPoolClient"]["UserPoolId"].should.equal(user_pool_id)
-    result["UserPoolClient"]["ClientId"].should_not.be.none
+    bool(re.match(r"^[0-9a-z]{26}$", result["UserPoolClient"]["ClientId"])).should.be.ok
     result["UserPoolClient"]["ClientName"].should.equal(client_name)
     result["UserPoolClient"].should_not.have.key("ClientSecret")
     result["UserPoolClient"]["CallbackURLs"].should.have.length_of(1)
@@ -233,7 +235,7 @@ def test_create_user_pool_client_returns_secret():
     )
 
     result["UserPoolClient"]["UserPoolId"].should.equal(user_pool_id)
-    result["UserPoolClient"]["ClientId"].should_not.be.none
+    bool(re.match(r"^[0-9a-z]{26}$", result["UserPoolClient"]["ClientId"])).should.be.ok
     result["UserPoolClient"]["ClientName"].should.equal(client_name)
     result["UserPoolClient"]["ClientSecret"].should_not.be.none
     result["UserPoolClient"]["CallbackURLs"].should.have.length_of(1)


### PR DESCRIPTION
cognito-idp `ClientId` created by `create_user_pool_client` is too long (Because it's using `uuid.uuid4()`)

According to boto3 `ClientId` should be 26 characters