### PR TITLE
Fixed Failures in CloudFormation Provisioning of S3 Buckets When Stack has Long Name...

### DIFF
--- a/moto/cloudformation/parsing.py
+++ b/moto/cloudformation/parsing.py
@@ -317,6 +317,12 @@ def generate_resource_name(resource_type, stack_name, logical_id):
         if truncated_name_prefix.endswith("-"):
             truncated_name_prefix = truncated_name_prefix[:-1]
         return "{0}-{1}".format(truncated_name_prefix, my_random_suffix)
+    elif resource_type == "AWS::S3::Bucket":
+        right_hand_part_of_name = "-{0}-{1}".format(logical_id, random_suffix())
+        max_stack_name_portion_len = 63 - len(right_hand_part_of_name)
+        return "{0}{1}".format(
+            stack_name[:max_stack_name_portion_len], right_hand_part_of_name
+        )
     else:
         return "{0}-{1}-{2}".format(stack_name, logical_id, random_suffix())
 

--- a/moto/cloudformation/parsing.py
+++ b/moto/cloudformation/parsing.py
@@ -322,7 +322,7 @@ def generate_resource_name(resource_type, stack_name, logical_id):
         max_stack_name_portion_len = 63 - len(right_hand_part_of_name)
         return "{0}{1}".format(
             stack_name[:max_stack_name_portion_len], right_hand_part_of_name
-        )
+        ).lower()
     else:
         return "{0}-{1}-{2}".format(stack_name, logical_id, random_suffix())
 

--- a/tests/test_cloudformation/test_cloudformation_stack_crud_boto3.py
+++ b/tests/test_cloudformation/test_cloudformation_stack_crud_boto3.py
@@ -647,6 +647,21 @@ def test_boto3_create_stack():
 
 
 @mock_cloudformation
+def test_boto3_create_stack_s3_long_name():
+    cf_conn = boto3.client("cloudformation", region_name="us-east-1")
+
+    stack_name = "MyLongStackName01234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012"
+
+    template = '{"Resources":{"HelloBucket":{"Type":"AWS::S3::Bucket"}}}'
+
+    cf_conn.create_stack(StackName=stack_name, TemplateBody=template)
+
+    cf_conn.get_template(StackName=stack_name)["TemplateBody"].should.equal(
+        json.loads(template, object_pairs_hook=OrderedDict)
+    )
+
+
+@mock_cloudformation
 def test_boto3_create_stack_with_yaml():
     cf_conn = boto3.client("cloudformation", region_name="us-east-1")
     cf_conn.create_stack(StackName="test_stack", TemplateBody=dummy_template_yaml)

--- a/tests/test_cloudformation/test_cloudformation_stack_crud_boto3.py
+++ b/tests/test_cloudformation/test_cloudformation_stack_crud_boto3.py
@@ -659,6 +659,16 @@ def test_boto3_create_stack_s3_long_name():
     cf_conn.get_template(StackName=stack_name)["TemplateBody"].should.equal(
         json.loads(template, object_pairs_hook=OrderedDict)
     )
+    provisioned_resource = cf_conn.list_stack_resources(StackName=stack_name)[
+        "StackResourceSummaries"
+    ][0]
+    provisioned_bucket_name = provisioned_resource["PhysicalResourceId"]
+    len(provisioned_bucket_name).should.be.lower_than(64)
+    logical_name_lower_case = provisioned_resource["LogicalResourceId"].lower()
+    bucket_name_stack_name_prefix = provisioned_bucket_name[
+        : provisioned_bucket_name.index("-" + logical_name_lower_case)
+    ]
+    stack_name.lower().should.contain(bucket_name_stack_name_prefix)
 
 
 @mock_cloudformation


### PR DESCRIPTION
...which causes the default S3 bucket name's length to exceed its 63 char limit.
Issue #3168.