### PR TITLE
Bugfix: S3 time precision issue fixed

### DIFF
--- a/moto/core/utils.py
+++ b/moto/core/utils.py
@@ -187,7 +187,7 @@ def iso_8601_datetime_with_milliseconds(datetime):
 
 
 def iso_8601_datetime_without_milliseconds(datetime):
-    return None if datetime is None else datetime.strftime("%Y-%m-%dT%H:%M:%S") + "Z"
+    return None if datetime is None else datetime.strftime("%Y-%m-%dT%H:%M:%S.000") + "Z"
 
 
 RFC1123 = "%a, %d %b %Y %H:%M:%S GMT"

--- a/moto/core/utils.py
+++ b/moto/core/utils.py
@@ -187,8 +187,12 @@ def iso_8601_datetime_with_milliseconds(datetime):
 
 
 def iso_8601_datetime_without_milliseconds(datetime):
+    return None if datetime is None else datetime.strftime("%Y-%m-%dT%H:%M:%S") + "Z"
+
+
+def iso_8601_datetime_without_milliseconds_s3(datetime):
     return (
-        None if datetime is None else datetime.strftime("%Y-%m-%dT%H:%M:%S") + "Z"
+        None if datetime is None else datetime.strftime("%Y-%m-%dT%H:%M:%S.000") + "Z"
     )
 
 

--- a/moto/core/utils.py
+++ b/moto/core/utils.py
@@ -187,7 +187,9 @@ def iso_8601_datetime_with_milliseconds(datetime):
 
 
 def iso_8601_datetime_without_milliseconds(datetime):
-    return None if datetime is None else datetime.strftime("%Y-%m-%dT%H:%M:%S.000") + "Z"
+    return (
+        None if datetime is None else datetime.strftime("%Y-%m-%dT%H:%M:%S") + ".000Z"
+    )
 
 
 RFC1123 = "%a, %d %b %Y %H:%M:%S GMT"

--- a/moto/core/utils.py
+++ b/moto/core/utils.py
@@ -188,7 +188,7 @@ def iso_8601_datetime_with_milliseconds(datetime):
 
 def iso_8601_datetime_without_milliseconds(datetime):
     return (
-        None if datetime is None else datetime.strftime("%Y-%m-%dT%H:%M:%S") + ".000Z"
+        None if datetime is None else datetime.strftime("%Y-%m-%dT%H:%M:%S") + "Z"
     )
 
 

--- a/moto/s3/models.py
+++ b/moto/s3/models.py
@@ -22,7 +22,7 @@ import six
 
 from bisect import insort
 from moto.core import ACCOUNT_ID, BaseBackend, BaseModel
-from moto.core.utils import iso_8601_datetime_with_milliseconds, rfc_1123_datetime
+from moto.core.utils import iso_8601_datetime_without_milliseconds, rfc_1123_datetime
 from moto.cloudwatch.models import MetricDatum
 from moto.utilities.tagging_service import TaggingService
 from .exceptions import (
@@ -79,7 +79,7 @@ class FakeDeleteMarker(BaseModel):
 
     @property
     def last_modified_ISO8601(self):
-        return iso_8601_datetime_with_milliseconds(self.last_modified)
+        return iso_8601_datetime_without_milliseconds(self.last_modified)
 
     @property
     def version_id(self):
@@ -206,7 +206,7 @@ class FakeKey(BaseModel):
 
     @property
     def last_modified_ISO8601(self):
-        return iso_8601_datetime_with_milliseconds(self.last_modified)
+        return iso_8601_datetime_without_milliseconds(self.last_modified)
 
     @property
     def last_modified_RFC1123(self):

--- a/moto/s3/models.py
+++ b/moto/s3/models.py
@@ -22,7 +22,7 @@ import six
 
 from bisect import insort
 from moto.core import ACCOUNT_ID, BaseBackend, BaseModel
-from moto.core.utils import iso_8601_datetime_without_milliseconds, rfc_1123_datetime
+from moto.core.utils import iso_8601_datetime_without_milliseconds_s3, rfc_1123_datetime
 from moto.cloudwatch.models import MetricDatum
 from moto.utilities.tagging_service import TaggingService
 from .exceptions import (
@@ -79,7 +79,7 @@ class FakeDeleteMarker(BaseModel):
 
     @property
     def last_modified_ISO8601(self):
-        return iso_8601_datetime_without_milliseconds(self.last_modified)
+        return iso_8601_datetime_without_milliseconds_s3(self.last_modified)
 
     @property
     def version_id(self):
@@ -206,7 +206,7 @@ class FakeKey(BaseModel):
 
     @property
     def last_modified_ISO8601(self):
-        return iso_8601_datetime_without_milliseconds(self.last_modified)
+        return iso_8601_datetime_without_milliseconds_s3(self.last_modified)
 
     @property
     def last_modified_RFC1123(self):


### PR DESCRIPTION
As per amazon s3's documentation, they are not storing time with milliseconds precision.
While in moto it was storing it in milliseconds. Which was causing s3 sync command with --exact-timestamp to download the files everytime when syncing data from s3 to local.
This fix solved the bug.