### PR TITLE
#3127 - Decentralize CF naming responsibilities

### DIFF
--- a/moto/core/__init__.py
+++ b/moto/core/__init__.py
@@ -1,6 +1,7 @@
 from __future__ import unicode_literals
 
 from .models import BaseModel, BaseBackend, moto_api_backend, ACCOUNT_ID  # noqa
+from .models import CloudFormationModel  # noqa
 from .responses import ActionAuthenticatorMixin
 
 moto_api_backends = {"global": moto_api_backend}

--- a/moto/core/models.py
+++ b/moto/core/models.py
@@ -8,6 +8,7 @@ import os
 import re
 import six
 import types
+from abc import abstractmethod
 from io import BytesIO
 from collections import defaultdict
 from botocore.config import Config
@@ -532,6 +533,20 @@ class BaseModel(object):
         instance = super(BaseModel, cls).__new__(cls)
         cls.instances.append(instance)
         return instance
+
+
+# Parent class for every Model that can be instantiated by CloudFormation
+# On subclasses, implement the two methods as @staticmethod to ensure correct behaviour of the CF parser
+class CloudFormationModel(BaseModel):
+    @abstractmethod
+    def cloudformation_name_type(self):
+        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-name.html
+        pass
+
+    @abstractmethod
+    def cloudformation_type(self):
+        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dynamodb-table.html
+        return "AWS::SERVICE::RESOURCE"
 
 
 class BaseBackend(object):

--- a/moto/dynamodb2/models/__init__.py
+++ b/moto/dynamodb2/models/__init__.py
@@ -9,7 +9,7 @@ import uuid
 
 from boto3 import Session
 from moto.compat import OrderedDict
-from moto.core import BaseBackend, BaseModel
+from moto.core import BaseBackend, BaseModel, CloudFormationModel
 from moto.core.utils import unix_time
 from moto.core.exceptions import JsonRESTError
 from moto.dynamodb2.comparisons import get_filter_expression
@@ -359,7 +359,7 @@ class GlobalSecondaryIndex(SecondaryIndex):
         self.throughput = u.get("ProvisionedThroughput", self.throughput)
 
 
-class Table(BaseModel):
+class Table(CloudFormationModel):
     def __init__(
         self,
         table_name,
@@ -430,6 +430,15 @@ class Table(BaseModel):
     @property
     def physical_resource_id(self):
         return self.name
+
+    @staticmethod
+    def cloudformation_name_type():
+        return "TableName"
+
+    @staticmethod
+    def cloudformation_type():
+        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dynamodb-table.html
+        return "AWS::DynamoDB::Table"
 
     @classmethod
     def create_from_cloudformation_json(


### PR DESCRIPTION
First pass at decentralizing the CF responsibility to individual models.
Each Model that wants to be recognized by CloudFormation's parser now needs to:
 - Extend the moto.core.CloudFormationModel class
 - Implement the abstract method `cloudformation_type`
 - Implement the abstract method `cloudformation_name_type`
 - Implement the `create/update/delete_from_cloudformation_json` methods (as before)

This removes the need to explicitly list all known/supported models in our CloudFormation-service.

TODO: 
 

 -  [ ] Change all other models to subclass CloudFormationModel (Only DynamoDB::Table is done atm)
 - [ ] Add the create_from_cloudformation_json-methods to `CloudFormationModel`, to ensure clarity on what to do when implementing a new model
 -  [ ] Instead of cycling through the MODEL_LIST at runtime, we can probably dynamically recreate the structures we have now: 
```
MODEL_MAP = {model.cloudformation_type(): model for model in CloudFormationModel.__subclasses__()
NAME_TYPE_MAP = {model.cloudformation_type(): model.cloudformation_name_type() for model in CloudFormationModel.__subclasses__()
```
That would eliminate the need for the two new for-loops