### PR TITLE
Implement Filter: Contains functionality for describe_params

### DIFF
--- a/moto/ssm/models.py
+++ b/moto/ssm/models.py
@@ -1025,11 +1025,12 @@ class SimpleSystemManagerBackend(BaseBackend):
                         )
 
             if key != "Path" and option not in ["Equals", "BeginsWith"]:
-                raise InvalidFilterOption(
-                    "The following filter option is not valid: {option}. Valid options include: [BeginsWith, Equals].".format(
-                        option=option
+                if not (key == "Name" and option in ["Contains"]):
+                    raise InvalidFilterOption(
+                        "The following filter option is not valid: {option}. Valid options include: [BeginsWith, Equals].".format(
+                            option=option
+                        )
                     )
-                )
 
             filter_keys.append(key)
 
@@ -1134,7 +1135,8 @@ class SimpleSystemManagerBackend(BaseBackend):
                 what = parameter.keyid
             elif key == "Name":
                 what = "/" + parameter.name.lstrip("/")
-                values = ["/" + value.lstrip("/") for value in values]
+                if option != "Contains":
+                    values = ["/" + value.lstrip("/") for value in values]
             elif key == "Path":
                 what = "/" + parameter.name.lstrip("/")
                 values = ["/" + value.strip("/") for value in values]
@@ -1145,6 +1147,10 @@ class SimpleSystemManagerBackend(BaseBackend):
                 return False
             elif option == "BeginsWith" and not any(
                 what.startswith(value) for value in values
+            ):
+                return False
+            elif option == "Contains" and not any(
+                value in what for value in values
             ):
                 return False
             elif option == "Equals" and not any(what == value for value in values):

--- a/moto/ssm/models.py
+++ b/moto/ssm/models.py
@@ -1031,13 +1031,15 @@ class SimpleSystemManagerBackend(BaseBackend):
                             )
                         )
 
-            if key != "Path" and option not in ["Equals", "BeginsWith"]:
-                if not (key == "Name" and option in ["Contains"]):
-                    raise InvalidFilterOption(
-                        "The following filter option is not valid: {option}. Valid options include: [BeginsWith, Equals].".format(
-                            option=option
-                        )
+            allowed_options = ["Equals", "BeginsWith"]
+            if key == "Name":
+                allowed_options += ["Contains"]
+            if key != "Path" and option not in allowed_options:
+                raise InvalidFilterOption(
+                    "The following filter option is not valid: {option}. Valid options include: [BeginsWith, Equals].".format(
+                        option=option
                     )
+                )
 
             filter_keys.append(key)
 

--- a/moto/ssm/models.py
+++ b/moto/ssm/models.py
@@ -965,6 +965,13 @@ class SimpleSystemManagerBackend(BaseBackend):
                     "The following filter key is not valid: Label. Valid filter keys include: [Path, Name, Type, KeyId, Tier]."
                 )
 
+            if by_path and key in ["Name", "Path", "Tier"]:
+                raise InvalidFilterKey(
+                    "The following filter key is not valid: {key}. Valid filter keys include: [Type, KeyId].".format(
+                        key=key
+                    )
+                )
+
             if not values:
                 raise InvalidFilterValue(
                     "The following filter values are missing : null for filter key Name."
@@ -1085,6 +1092,9 @@ class SimpleSystemManagerBackend(BaseBackend):
         max_results=10,
     ):
         """Implement the get-parameters-by-path-API in the backend."""
+
+        self._validate_parameter_filters(filters, by_path=True)
+
         result = []
         # path could be with or without a trailing /. we handle this
         # difference here.

--- a/moto/ssm/models.py
+++ b/moto/ssm/models.py
@@ -1159,9 +1159,7 @@ class SimpleSystemManagerBackend(BaseBackend):
                 what.startswith(value) for value in values
             ):
                 return False
-            elif option == "Contains" and not any(
-                value in what for value in values
-            ):
+            elif option == "Contains" and not any(value in what for value in values):
                 return False
             elif option == "Equals" and not any(what == value for value in values):
                 return False

--- a/tests/test_ssm/test_ssm_boto3.py
+++ b/tests/test_ssm/test_ssm_boto3.py
@@ -198,6 +198,33 @@ def test_get_parameters_by_path():
     len(response["Parameters"]).should.equal(1)
     response.should_not.have.key("NextToken")
 
+    filters = [{"Key": "Name", "Values": ["error"]}]
+    client.get_parameters_by_path.when.called_with(
+        Path="/baz", ParameterFilters=filters
+    ).should.throw(
+        ClientError,
+        "The following filter key is not valid: Name. "
+        "Valid filter keys include: [Type, KeyId]."
+    )
+
+    filters = [{"Key": "Path", "Values": ["/error"]}]
+    client.get_parameters_by_path.when.called_with(
+        Path="/baz", ParameterFilters=filters
+    ).should.throw(
+        ClientError,
+        "The following filter key is not valid: Path. "
+        "Valid filter keys include: [Type, KeyId]."
+    )
+
+    filters = [{"Key": "Tier", "Values": ["Standard"]}]
+    client.get_parameters_by_path.when.called_with(
+        Path="/baz", ParameterFilters=filters
+    ).should.throw(
+        ClientError,
+        "The following filter key is not valid: Tier. "
+        "Valid filter keys include: [Type, KeyId]."
+    )
+
 @mock_ssm
 def test_put_parameter():
     client = boto3.client("ssm", region_name="us-east-1")

--- a/tests/test_ssm/test_ssm_boto3.py
+++ b/tests/test_ssm/test_ssm_boto3.py
@@ -198,7 +198,6 @@ def test_get_parameters_by_path():
     len(response["Parameters"]).should.equal(1)
     response.should_not.have.key("NextToken")
 
-
 @mock_ssm
 def test_put_parameter():
     client = boto3.client("ssm", region_name="us-east-1")
@@ -504,6 +503,9 @@ def test_describe_parameters_with_parameter_filters_name():
     client = boto3.client("ssm", region_name="us-east-1")
     client.put_parameter(Name="param", Value="value", Type="String")
     client.put_parameter(Name="/param-2", Value="value-2", Type="String")
+    client.put_parameter(Name="/tangent-3", Value="value-3", Type="String")
+    client.put_parameter(Name="tangram-4", Value="value-4", Type="String")
+    client.put_parameter(Name="standby-5", Value="value-5", Type="String")
 
     response = client.describe_parameters(
         ParameterFilters=[{"Key": "Name", "Values": ["param"]}]
@@ -537,6 +539,22 @@ def test_describe_parameters_with_parameter_filters_name():
 
     response = client.describe_parameters(
         ParameterFilters=[{"Key": "Name", "Option": "BeginsWith", "Values": ["param"]}]
+    )
+
+    parameters = response["Parameters"]
+    parameters.should.have.length_of(2)
+    response.should_not.have.key("NextToken")
+
+    response = client.describe_parameters(
+        ParameterFilters=[{"Key": "Name", "Option": "Contains", "Values": ["ram"]}]
+    )
+
+    parameters = response["Parameters"]
+    parameters.should.have.length_of(3)
+    response.should_not.have.key("NextToken")
+
+    response = client.describe_parameters(
+        ParameterFilters=[{"Key": "Name", "Option": "Contains", "Values": ["/tan"]}]
     )
 
     parameters = response["Parameters"]

--- a/tests/test_ssm/test_ssm_boto3.py
+++ b/tests/test_ssm/test_ssm_boto3.py
@@ -204,7 +204,7 @@ def test_get_parameters_by_path():
     ).should.throw(
         ClientError,
         "The following filter key is not valid: Name. "
-        "Valid filter keys include: [Type, KeyId]."
+        "Valid filter keys include: [Type, KeyId].",
     )
 
     filters = [{"Key": "Path", "Values": ["/error"]}]
@@ -213,7 +213,7 @@ def test_get_parameters_by_path():
     ).should.throw(
         ClientError,
         "The following filter key is not valid: Path. "
-        "Valid filter keys include: [Type, KeyId]."
+        "Valid filter keys include: [Type, KeyId].",
     )
 
     filters = [{"Key": "Tier", "Values": ["Standard"]}]
@@ -222,8 +222,9 @@ def test_get_parameters_by_path():
     ).should.throw(
         ClientError,
         "The following filter key is not valid: Tier. "
-        "Valid filter keys include: [Type, KeyId]."
+        "Valid filter keys include: [Type, KeyId].",
     )
+
 
 @mock_ssm
 def test_put_parameter():


### PR DESCRIPTION
This PR adds the Contains functionality (Issue #3159). Tests were created to mimic behavior in AWS/boto3, including that filters with values in the form of `/string` will match parameters named `string...` but not parameters named `...string...`. In the test example, a Contains filter with the value `/tan` would match both `/tangent-3` and `tangram-4` but not `standby-5`.

This PR also enforces the parameter filter restrictions on `get_parameters_by_path`. According to the boto3 documentation [1], `Name`, `Path`, and `Tier` are not allowed values for `Key` in a parameter filter for `get_parameters_by_path`. This PR enforces this by calling `_validate_parameter_filters` from the `get_parameters_by_path` method, and adding a check to `_validate_parameter_filters`. I added 3 test cases to `test_get_parameters_by_path` which check for the correct exception when calling with a parameter filter using any of these keys.

[1]: https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/ssm.html#SSM.Client.get_parameters_by_path