### PR TITLE
Enforce parameter naming

### DIFF
--- a/moto/ssm/exceptions.py
+++ b/moto/ssm/exceptions.py
@@ -78,6 +78,13 @@ class InvalidDocumentOperation(JsonRESTError):
         )
 
 
+class AccessDeniedException(JsonRESTError):
+    code = 400
+
+    def __init__(self, message):
+        super(AccessDeniedException, self).__init__("AccessDeniedException", message)
+
+
 class InvalidDocumentContent(JsonRESTError):
     code = 400
 

--- a/moto/ssm/models.py
+++ b/moto/ssm/models.py
@@ -27,6 +27,7 @@ from .exceptions import (
     ParameterNotFound,
     DocumentAlreadyExists,
     InvalidDocumentOperation,
+    AccessDeniedException,
     InvalidDocument,
     InvalidDocumentContent,
     InvalidDocumentVersion,
@@ -1238,6 +1239,23 @@ class SimpleSystemManagerBackend(BaseBackend):
     def put_parameter(
         self, name, description, value, type, allowed_pattern, keyid, overwrite
     ):
+        if name.lower().lstrip("/").startswith("aws") or name.lower().lstrip(
+            "/"
+        ).startswith("ssm"):
+            is_path = name.count("/") > 1
+            if name.lower().startswith("/aws") and is_path:
+                raise AccessDeniedException(
+                    f"No access to reserved parameter name: {name}."
+                )
+            if not is_path:
+                invalid_prefix_error = 'Parameter name: can\'t be prefixed with "aws" or "ssm" (case-insensitive).'
+            else:
+                invalid_prefix_error = (
+                    'Parameter name: can\'t be prefixed with "ssm" (case-insensitive). '
+                    "If formed as a path, it can consist of sub-paths divided by slash symbol; each sub-path can be "
+                    "formed as a mix of letters, numbers and the following 3 symbols .-_"
+                )
+            raise ValidationException(invalid_prefix_error)
         previous_parameter_versions = self._parameters[name]
         if len(previous_parameter_versions) == 0:
             previous_parameter = None

--- a/moto/ssm/models.py
+++ b/moto/ssm/models.py
@@ -1245,7 +1245,7 @@ class SimpleSystemManagerBackend(BaseBackend):
             is_path = name.count("/") > 1
             if name.lower().startswith("/aws") and is_path:
                 raise AccessDeniedException(
-                    f"No access to reserved parameter name: {name}."
+                    "No access to reserved parameter name: {name}.".format(name=name)
                 )
             if not is_path:
                 invalid_prefix_error = 'Parameter name: can\'t be prefixed with "aws" or "ssm" (case-insensitive).'

--- a/tests/test_ssm/test_ssm_boto3.py
+++ b/tests/test_ssm/test_ssm_boto3.py
@@ -328,14 +328,14 @@ def test_put_parameter_invalid_names():
     client.put_parameter.when.called_with(
         Name=aws_path, Value="value", Type="String"
     ).should.throw(
-        ClientError, f"No access to reserved parameter name: {aws_path}.",
+        ClientError, "No access to reserved parameter name: {}.".format(aws_path),
     )
 
     aws_path = "/AWS/PATH/TO/VAR"
     client.put_parameter.when.called_with(
         Name=aws_path, Value="value", Type="String"
     ).should.throw(
-        ClientError, f"No access to reserved parameter name: {aws_path}.",
+        ClientError, "No access to reserved parameter name: {}.".format(aws_path),
     )
 
 


### PR DESCRIPTION
Parameters are not allowed to start with `ssm` or `aws`. This PR adds error messages which
correspond exactly to the error messages returned by boto3.