### PR TITLE
Fix XML schema for ec2.describe_instance_types

### DIFF
--- a/moto/ec2/responses/instances.py
+++ b/moto/ec2/responses/instances.py
@@ -818,13 +818,25 @@ EC2_DESCRIBE_INSTANCE_TYPES = """<?xml version="1.0" encoding="UTF-8"?>
     <instanceTypeSet>
     {% for instance_type in instance_types %}
         <item>
-            <name>{{ instance_type.name }}</name>
-            <vcpu>{{ instance_type.cores }}</vcpu>
-            <memory>{{ instance_type.memory }}</memory>
-            <storageSize>{{ instance_type.disk }}</storageSize>
-            <storageCount>{{ instance_type.storageCount }}</storageCount>
-            <maxIpAddresses>{{ instance_type.maxIpAddresses }}</maxIpAddresses>
-            <ebsOptimizedAvailable>{{ instance_type.ebsOptimizedAvailable }}</ebsOptimizedAvailable>
+            <instanceType>{{ instance_type.name }}</instanceType>
+            <vCpuInfo>
+                <defaultVCpus>{{ instance_type.cores }}</defaultVCpus>
+                <defaultCores>{{ instance_type.cores }}</defaultCores>
+                <defaultThreadsPerCore>1</defaultThreadsPerCore>
+            </vCpuInfo>
+            <memoryInfo>
+                <sizeInMiB>{{ instance_type.memory }}</sizeInMiB>
+            </memoryInfo>
+            <instanceStorageInfo>
+                <totalSizeInGB>{{ instance_type.disk }}</totalSizeInGB>
+            </instanceStorageInfo>
+            <processorInfo>
+                <supportedArchitectures>
+                    <item>
+                        x86_64
+                    </item>
+                </supportedArchitectures>
+            </processorInfo>
         </item>
     {% endfor %}
     </instanceTypeSet>

--- a/tests/test_ec2/test_instance_types.py
+++ b/tests/test_ec2/test_instance_types.py
@@ -1,0 +1,16 @@
+from __future__ import unicode_literals
+
+import boto3
+import sure  # noqa
+
+from moto import mock_ec2
+
+
+@mock_ec2
+def test_describe_instance_types():
+    client = boto3.client("ec2", "us-east-1")
+    instance_types = client.describe_instance_types()
+
+    instance_types.get("InstanceTypes").should_not.equal(None)
+    instance_types["InstanceTypes"].should_not.be.empty
+    instance_types["InstanceTypes"][0].should.have.key("InstanceType")

--- a/tests/test_ec2/test_instance_types.py
+++ b/tests/test_ec2/test_instance_types.py
@@ -11,6 +11,8 @@ def test_describe_instance_types():
     client = boto3.client("ec2", "us-east-1")
     instance_types = client.describe_instance_types()
 
-    instance_types.get("InstanceTypes").should_not.equal(None)
+    instance_types.should.have.key("InstanceTypes")
     instance_types["InstanceTypes"].should_not.be.empty
     instance_types["InstanceTypes"][0].should.have.key("InstanceType")
+    instance_types["InstanceTypes"][0].should.have.key("MemoryInfo")
+    instance_types["InstanceTypes"][0]["MemoryInfo"].should.have.key("SizeInMiB")


### PR DESCRIPTION
The [`ec2.describe_instance_types`](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/ec2.html#EC2.Client.describe_instance_types) endpoint is already implemented in moto but it is using an incorrect XML schema. This means that the current output is:

```python
{'InstanceTypes': [{}],
 'ResponseMetadata': {'HTTPHeaders': {'server': 'amazon.com'},
                      'HTTPStatusCode': 200,
                      'RequestId': 'f8b86168-d034-4e65-b48d-3b84c78e64af',
                      'RetryAttempts': 0}}
```

This PR changes the schema (and adds a test to check the output) such that the output is now:

```python
{'InstanceTypes': [{'InstanceStorageInfo': {'TotalSizeInGB': 0},
                    'InstanceType': 't1.micro',
                    'MemoryInfo': {'SizeInMiB': 644874240},
                    'ProcessorInfo': {'SupportedArchitectures': ['x86_64']},
                    'VCpuInfo': {'DefaultCores': 1,
                                 'DefaultThreadsPerCore': 1,
                                 'DefaultVCpus': 1}}],
 'ResponseMetadata': {'HTTPHeaders': {'server': 'amazon.com'},
                      'HTTPStatusCode': 200,
                      'RequestId': 'f8b86168-d034-4e65-b48d-3b84c78e64af',
                      'RetryAttempts': 0}}
```