### PR TITLE
Decentralize cloudformation naming responsibilities

### DIFF
--- a/moto/autoscaling/models.py
+++ b/moto/autoscaling/models.py
@@ -133,7 +133,7 @@ class FakeLaunchConfiguration(CloudFormationModel):
 
     @staticmethod
     def cloudformation_type():
-        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dynamodb-table.html
+        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-autoscaling-launchconfiguration.html
         return "AWS::AutoScaling::LaunchConfiguration"
 
     @classmethod
@@ -324,7 +324,7 @@ class FakeAutoScalingGroup(CloudFormationModel):
 
     @staticmethod
     def cloudformation_type():
-        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dynamodb-table.html
+        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-autoscaling-autoscalinggroup.html
         return "AWS::AutoScaling::AutoScalingGroup"
 
     @classmethod

--- a/moto/autoscaling/models.py
+++ b/moto/autoscaling/models.py
@@ -6,7 +6,7 @@ from boto.ec2.blockdevicemapping import BlockDeviceType, BlockDeviceMapping
 from moto.ec2.exceptions import InvalidInstanceIdError
 
 from moto.compat import OrderedDict
-from moto.core import BaseBackend, BaseModel
+from moto.core import BaseBackend, BaseModel, CloudFormationModel
 from moto.ec2 import ec2_backends
 from moto.elb import elb_backends
 from moto.elbv2 import elbv2_backends
@@ -74,7 +74,7 @@ class FakeScalingPolicy(BaseModel):
             )
 
 
-class FakeLaunchConfiguration(BaseModel):
+class FakeLaunchConfiguration(CloudFormationModel):
     def __init__(
         self,
         name,
@@ -126,6 +126,15 @@ class FakeLaunchConfiguration(BaseModel):
             block_device_mappings=instance.block_device_mapping,
         )
         return config
+
+    @staticmethod
+    def cloudformation_name_type():
+        return "LaunchConfigurationName"
+
+    @staticmethod
+    def cloudformation_type():
+        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dynamodb-table.html
+        return "AWS::AutoScaling::LaunchConfiguration"
 
     @classmethod
     def create_from_cloudformation_json(
@@ -215,7 +224,7 @@ class FakeLaunchConfiguration(BaseModel):
         return block_device_map
 
 
-class FakeAutoScalingGroup(BaseModel):
+class FakeAutoScalingGroup(CloudFormationModel):
     def __init__(
         self,
         name,
@@ -308,6 +317,15 @@ class FakeAutoScalingGroup(BaseModel):
             if "PropagateAtLaunch" in tag:
                 tag["PropagateAtLaunch"] = bool_to_string[tag["PropagateAtLaunch"]]
         return tags
+
+    @staticmethod
+    def cloudformation_name_type():
+        return "AutoScalingGroupName"
+
+    @staticmethod
+    def cloudformation_type():
+        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dynamodb-table.html
+        return "AWS::AutoScaling::AutoScalingGroup"
 
     @classmethod
     def create_from_cloudformation_json(

--- a/moto/awslambda/models.py
+++ b/moto/awslambda/models.py
@@ -498,7 +498,7 @@ class LambdaFunction(CloudFormationModel):
 
     @staticmethod
     def cloudformation_type():
-        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dynamodb-table.html
+        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-function.html
         return "AWS::Lambda::Function"
 
     @classmethod
@@ -648,7 +648,7 @@ class EventSourceMapping(CloudFormationModel):
 
     @staticmethod
     def cloudformation_type():
-        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dynamodb-table.html
+        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-eventsourcemapping.html
         return "AWS::Lambda::EventSourceMapping"
 
     @classmethod
@@ -698,7 +698,7 @@ class LambdaVersion(CloudFormationModel):
 
     @staticmethod
     def cloudformation_type():
-        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dynamodb-table.html
+        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-version.html
         return "AWS::Lambda::Version"
 
     @classmethod

--- a/moto/awslambda/models.py
+++ b/moto/awslambda/models.py
@@ -28,7 +28,7 @@ import requests.adapters
 from boto3 import Session
 
 from moto.awslambda.policy import Policy
-from moto.core import BaseBackend, BaseModel
+from moto.core import BaseBackend, BaseModel, CloudFormationModel
 from moto.core.exceptions import RESTError
 from moto.iam.models import iam_backend
 from moto.iam.exceptions import IAMNotFoundException
@@ -151,7 +151,7 @@ class _DockerDataVolumeContext:
                     raise  # multiple processes trying to use same volume?
 
 
-class LambdaFunction(BaseModel):
+class LambdaFunction(CloudFormationModel):
     def __init__(self, spec, region, validate_s3=True, version=1):
         # required
         self.region = region
@@ -492,6 +492,15 @@ class LambdaFunction(BaseModel):
 
         return result
 
+    @staticmethod
+    def cloudformation_name_type():
+        return "FunctionName"
+
+    @staticmethod
+    def cloudformation_type():
+        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dynamodb-table.html
+        return "AWS::Lambda::Function"
+
     @classmethod
     def create_from_cloudformation_json(
         cls, resource_name, cloudformation_json, region_name
@@ -556,7 +565,7 @@ class LambdaFunction(BaseModel):
         lambda_backends[region].delete_function(self.function_name)
 
 
-class EventSourceMapping(BaseModel):
+class EventSourceMapping(CloudFormationModel):
     def __init__(self, spec):
         # required
         self.function_name = spec["FunctionName"]
@@ -633,6 +642,15 @@ class EventSourceMapping(BaseModel):
         lambda_backend = lambda_backends[region_name]
         lambda_backend.delete_event_source_mapping(self.uuid)
 
+    @staticmethod
+    def cloudformation_name_type():
+        return None
+
+    @staticmethod
+    def cloudformation_type():
+        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dynamodb-table.html
+        return "AWS::Lambda::EventSourceMapping"
+
     @classmethod
     def create_from_cloudformation_json(
         cls, resource_name, cloudformation_json, region_name
@@ -667,12 +685,21 @@ class EventSourceMapping(BaseModel):
                 esm.delete(region_name)
 
 
-class LambdaVersion(BaseModel):
+class LambdaVersion(CloudFormationModel):
     def __init__(self, spec):
         self.version = spec["Version"]
 
     def __repr__(self):
         return str(self.logical_resource_id)
+
+    @staticmethod
+    def cloudformation_name_type():
+        return None
+
+    @staticmethod
+    def cloudformation_type():
+        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dynamodb-table.html
+        return "AWS::Lambda::Version"
 
     @classmethod
     def create_from_cloudformation_json(

--- a/moto/awslambda/models.py
+++ b/moto/awslambda/models.py
@@ -28,7 +28,7 @@ import requests.adapters
 from boto3 import Session
 
 from moto.awslambda.policy import Policy
-from moto.core import BaseBackend, BaseModel, CloudFormationModel
+from moto.core import BaseBackend, CloudFormationModel
 from moto.core.exceptions import RESTError
 from moto.iam.models import iam_backend
 from moto.iam.exceptions import IAMNotFoundException

--- a/moto/batch/models.py
+++ b/moto/batch/models.py
@@ -13,7 +13,7 @@ import threading
 import dateutil.parser
 from boto3 import Session
 
-from moto.core import BaseBackend, BaseModel
+from moto.core import BaseBackend, BaseModel, CloudFormationModel
 from moto.iam import iam_backends
 from moto.ec2 import ec2_backends
 from moto.ecs import ecs_backends
@@ -42,7 +42,7 @@ def datetime2int(date):
     return int(time.mktime(date.timetuple()))
 
 
-class ComputeEnvironment(BaseModel):
+class ComputeEnvironment(CloudFormationModel):
     def __init__(
         self,
         compute_environment_name,
@@ -76,6 +76,15 @@ class ComputeEnvironment(BaseModel):
     def physical_resource_id(self):
         return self.arn
 
+    @staticmethod
+    def cloudformation_name_type():
+        return "ComputeEnvironmentName"
+
+    @staticmethod
+    def cloudformation_type():
+        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dynamodb-table.html
+        return "AWS::Batch::ComputeEnvironment"
+
     @classmethod
     def create_from_cloudformation_json(
         cls, resource_name, cloudformation_json, region_name
@@ -95,7 +104,7 @@ class ComputeEnvironment(BaseModel):
         return backend.get_compute_environment_by_arn(arn)
 
 
-class JobQueue(BaseModel):
+class JobQueue(CloudFormationModel):
     def __init__(
         self, name, priority, state, environments, env_order_json, region_name
     ):
@@ -139,6 +148,15 @@ class JobQueue(BaseModel):
     def physical_resource_id(self):
         return self.arn
 
+    @staticmethod
+    def cloudformation_name_type():
+        return "JobQueueName"
+
+    @staticmethod
+    def cloudformation_type():
+        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dynamodb-table.html
+        return "AWS::Batch::JobQueue"
+
     @classmethod
     def create_from_cloudformation_json(
         cls, resource_name, cloudformation_json, region_name
@@ -164,7 +182,7 @@ class JobQueue(BaseModel):
         return backend.get_job_queue_by_arn(arn)
 
 
-class JobDefinition(BaseModel):
+class JobDefinition(CloudFormationModel):
     def __init__(
         self,
         name,
@@ -263,6 +281,15 @@ class JobDefinition(BaseModel):
     @property
     def physical_resource_id(self):
         return self.arn
+
+    @staticmethod
+    def cloudformation_name_type():
+        return "JobDefinitionName"
+
+    @staticmethod
+    def cloudformation_type():
+        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dynamodb-table.html
+        return "AWS::Batch::JobDefinition"
 
     @classmethod
     def create_from_cloudformation_json(

--- a/moto/batch/models.py
+++ b/moto/batch/models.py
@@ -82,7 +82,7 @@ class ComputeEnvironment(CloudFormationModel):
 
     @staticmethod
     def cloudformation_type():
-        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dynamodb-table.html
+        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-batch-computeenvironment.html
         return "AWS::Batch::ComputeEnvironment"
 
     @classmethod
@@ -154,7 +154,7 @@ class JobQueue(CloudFormationModel):
 
     @staticmethod
     def cloudformation_type():
-        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dynamodb-table.html
+        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-batch-jobqueue.html
         return "AWS::Batch::JobQueue"
 
     @classmethod
@@ -288,7 +288,7 @@ class JobDefinition(CloudFormationModel):
 
     @staticmethod
     def cloudformation_type():
-        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dynamodb-table.html
+        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-batch-jobdefinition.html
         return "AWS::Batch::JobDefinition"
 
     @classmethod

--- a/moto/cloudformation/parsing.py
+++ b/moto/cloudformation/parsing.py
@@ -39,7 +39,7 @@ from moto.sqs import models as sqs_models  # noqa
 # End ugly list of imports
 
 from moto.ec2 import models as ec2_models
-from moto.s3 import models as _, s3_backend
+from moto.s3 import models as _, s3_backend  # noqa
 from moto.s3.utils import bucket_and_name_from_url
 from moto.core import ACCOUNT_ID, CloudFormationModel
 from .utils import random_suffix

--- a/moto/cloudformation/parsing.py
+++ b/moto/cloudformation/parsing.py
@@ -6,29 +6,10 @@ import copy
 import warnings
 import re
 
-from moto.autoscaling import models as autoscaling_models
-from moto.awslambda import models as lambda_models
-from moto.batch import models as batch_models
-from moto.cloudwatch import models as cloudwatch_models
-from moto.cognitoidentity import models as cognitoidentity_models
 from moto.compat import collections_abc
-from moto.datapipeline import models as datapipeline_models
 from moto.ec2 import models as ec2_models
-from moto.ecs import models as ecs_models
-from moto.elb import models as elb_models
-from moto.elbv2 import models as elbv2_models
-from moto.events import models as events_models
-from moto.iam import models as iam_models
-from moto.kinesis import models as kinesis_models
-from moto.kms import models as kms_models
-from moto.rds import models as rds_models
-from moto.rds2 import models as rds2_models
-from moto.redshift import models as redshift_models
-from moto.route53 import models as route53_models
-from moto.s3 import models as s3_models, s3_backend
+from moto.s3 import models as s3_backend
 from moto.s3.utils import bucket_and_name_from_url
-from moto.sns import models as sns_models
-from moto.sqs import models as sqs_models
 from moto.core import ACCOUNT_ID, CloudFormationModel
 from .utils import random_suffix
 from .exceptions import (
@@ -41,103 +22,8 @@ from boto.cloudformation.stack import Output
 
 # List of supported CloudFormation models
 MODEL_LIST = CloudFormationModel.__subclasses__()
-MODEL_MAP = {
-    "AWS::AutoScaling::AutoScalingGroup": autoscaling_models.FakeAutoScalingGroup,
-    "AWS::AutoScaling::LaunchConfiguration": autoscaling_models.FakeLaunchConfiguration,
-    "AWS::Batch::JobDefinition": batch_models.JobDefinition,
-    "AWS::Batch::JobQueue": batch_models.JobQueue,
-    "AWS::Batch::ComputeEnvironment": batch_models.ComputeEnvironment,
-    "AWS::Kinesis::Stream": kinesis_models.Stream,
-    "AWS::Lambda::EventSourceMapping": lambda_models.EventSourceMapping,
-    "AWS::Lambda::Function": lambda_models.LambdaFunction,
-    "AWS::Lambda::Version": lambda_models.LambdaVersion,
-    "AWS::EC2::EIP": ec2_models.ElasticAddress,
-    "AWS::EC2::Instance": ec2_models.Instance,
-    "AWS::EC2::InternetGateway": ec2_models.InternetGateway,
-    "AWS::EC2::NatGateway": ec2_models.NatGateway,
-    "AWS::EC2::NetworkInterface": ec2_models.NetworkInterface,
-    "AWS::EC2::Route": ec2_models.Route,
-    "AWS::EC2::RouteTable": ec2_models.RouteTable,
-    "AWS::EC2::SecurityGroup": ec2_models.SecurityGroup,
-    "AWS::EC2::SecurityGroupIngress": ec2_models.SecurityGroupIngress,
-    "AWS::EC2::SpotFleet": ec2_models.SpotFleetRequest,
-    "AWS::EC2::Subnet": ec2_models.Subnet,
-    "AWS::EC2::SubnetRouteTableAssociation": ec2_models.SubnetRouteTableAssociation,
-    "AWS::EC2::Volume": ec2_models.Volume,
-    "AWS::EC2::VolumeAttachment": ec2_models.VolumeAttachment,
-    "AWS::EC2::VPC": ec2_models.VPC,
-    "AWS::EC2::VPCGatewayAttachment": ec2_models.VPCGatewayAttachment,
-    "AWS::EC2::VPCPeeringConnection": ec2_models.VPCPeeringConnection,
-    "AWS::ECS::Cluster": ecs_models.Cluster,
-    "AWS::ECS::TaskDefinition": ecs_models.TaskDefinition,
-    "AWS::ECS::Service": ecs_models.Service,
-    "AWS::ElasticLoadBalancing::LoadBalancer": elb_models.FakeLoadBalancer,
-    "AWS::ElasticLoadBalancingV2::LoadBalancer": elbv2_models.FakeLoadBalancer,
-    "AWS::ElasticLoadBalancingV2::TargetGroup": elbv2_models.FakeTargetGroup,
-    "AWS::ElasticLoadBalancingV2::Listener": elbv2_models.FakeListener,
-    "AWS::Cognito::IdentityPool": cognitoidentity_models.CognitoIdentity,
-    "AWS::DataPipeline::Pipeline": datapipeline_models.Pipeline,
-    "AWS::IAM::InstanceProfile": iam_models.InstanceProfile,
-    "AWS::IAM::Role": iam_models.Role,
-    "AWS::KMS::Key": kms_models.Key,
-    "AWS::Logs::LogGroup": cloudwatch_models.LogGroup,
-    "AWS::RDS::DBInstance": rds_models.Database,
-    "AWS::RDS::DBSecurityGroup": rds_models.SecurityGroup,
-    "AWS::RDS::DBSubnetGroup": rds_models.SubnetGroup,
-    "AWS::RDS::DBParameterGroup": rds2_models.DBParameterGroup,
-    "AWS::Redshift::Cluster": redshift_models.Cluster,
-    "AWS::Redshift::ClusterParameterGroup": redshift_models.ParameterGroup,
-    "AWS::Redshift::ClusterSubnetGroup": redshift_models.SubnetGroup,
-    "AWS::Route53::HealthCheck": route53_models.HealthCheck,
-    "AWS::Route53::HostedZone": route53_models.FakeZone,
-    "AWS::Route53::RecordSet": route53_models.RecordSet,
-    "AWS::Route53::RecordSetGroup": route53_models.RecordSetGroup,
-    "AWS::SNS::Topic": sns_models.Topic,
-    "AWS::S3::Bucket": s3_models.FakeBucket,
-    "AWS::SQS::Queue": sqs_models.Queue,
-    "AWS::Events::Rule": events_models.Rule,
-    "AWS::Events::EventBus": events_models.EventBus,
-}
-
-UNDOCUMENTED_NAME_TYPE_MAP = {
-    "AWS::AutoScaling::AutoScalingGroup": "AutoScalingGroupName",
-    "AWS::AutoScaling::LaunchConfiguration": "LaunchConfigurationName",
-    "AWS::IAM::InstanceProfile": "InstanceProfileName",
-}
-
-# http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-name.html
-NAME_TYPE_MAP = {
-    "AWS::ApiGateway::ApiKey": "Name",
-    "AWS::ApiGateway::Model": "Name",
-    "AWS::CloudWatch::Alarm": "AlarmName",
-    "AWS::ElasticBeanstalk::Application": "ApplicationName",
-    "AWS::ElasticBeanstalk::Environment": "EnvironmentName",
-    "AWS::CodeDeploy::Application": "ApplicationName",
-    "AWS::CodeDeploy::DeploymentConfig": "DeploymentConfigName",
-    "AWS::CodeDeploy::DeploymentGroup": "DeploymentGroupName",
-    "AWS::Config::ConfigRule": "ConfigRuleName",
-    "AWS::Config::DeliveryChannel": "Name",
-    "AWS::Config::ConfigurationRecorder": "Name",
-    "AWS::ElasticLoadBalancing::LoadBalancer": "LoadBalancerName",
-    "AWS::ElasticLoadBalancingV2::LoadBalancer": "Name",
-    "AWS::ElasticLoadBalancingV2::TargetGroup": "Name",
-    "AWS::EC2::SecurityGroup": "GroupName",
-    "AWS::ElastiCache::CacheCluster": "ClusterName",
-    "AWS::ECR::Repository": "RepositoryName",
-    "AWS::ECS::Cluster": "ClusterName",
-    "AWS::Elasticsearch::Domain": "DomainName",
-    "AWS::Events::Rule": "Name",
-    "AWS::IAM::Group": "GroupName",
-    "AWS::IAM::ManagedPolicy": "ManagedPolicyName",
-    "AWS::IAM::Role": "RoleName",
-    "AWS::IAM::User": "UserName",
-    "AWS::Lambda::Function": "FunctionName",
-    "AWS::RDS::DBInstance": "DBInstanceIdentifier",
-    "AWS::S3::Bucket": "BucketName",
-    "AWS::SNS::Topic": "TopicName",
-    "AWS::SQS::Queue": "QueueName",
-}
-NAME_TYPE_MAP.update(UNDOCUMENTED_NAME_TYPE_MAP)
+MODEL_MAP = {model.cloudformation_type(): model for model in MODEL_LIST}
+NAME_TYPE_MAP = {model.cloudformation_type(): model.cloudformation_name_type() for model in MODEL_LIST}
 
 # Just ignore these models types for now
 NULL_MODELS = [
@@ -291,19 +177,15 @@ def clean_json(resource_json, resources_map):
 def resource_class_from_type(resource_type):
     if resource_type in NULL_MODELS:
         return None
-    for model in MODEL_LIST:
-        if model.cloudformation_type() == resource_type:
-            return model
+    
     if resource_type not in MODEL_MAP:
         logger.warning("No Moto CloudFormation support for %s", resource_type)
         return None
+
     return MODEL_MAP.get(resource_type)
 
 
 def resource_name_property_from_type(resource_type):
-    for model in MODEL_LIST:
-        if model.cloudformation_type() == resource_type:
-            return model.cloudformation_name_type()
     return NAME_TYPE_MAP.get(resource_type)
 
 

--- a/moto/cloudformation/parsing.py
+++ b/moto/cloudformation/parsing.py
@@ -60,9 +60,6 @@ NAME_TYPE_MAP = {
     for model in MODEL_LIST
 }
 
-for model_type in sorted(list(MODEL_MAP.keys())):
-    print(model_type)
-
 # Just ignore these models types for now
 NULL_MODELS = [
     "AWS::CloudFormation::WaitCondition",

--- a/moto/cloudformation/parsing.py
+++ b/moto/cloudformation/parsing.py
@@ -23,7 +23,10 @@ from boto.cloudformation.stack import Output
 # List of supported CloudFormation models
 MODEL_LIST = CloudFormationModel.__subclasses__()
 MODEL_MAP = {model.cloudformation_type(): model for model in MODEL_LIST}
-NAME_TYPE_MAP = {model.cloudformation_type(): model.cloudformation_name_type() for model in MODEL_LIST}
+NAME_TYPE_MAP = {
+    model.cloudformation_type(): model.cloudformation_name_type()
+    for model in MODEL_LIST
+}
 
 # Just ignore these models types for now
 NULL_MODELS = [

--- a/moto/cloudformation/parsing.py
+++ b/moto/cloudformation/parsing.py
@@ -7,8 +7,39 @@ import warnings
 import re
 
 from moto.compat import collections_abc
+
+# This ugly section of imports is necessary because we
+# build the list of CloudFormationModel subclasses using
+# CloudFormationModel.__subclasses__(). However, if the class
+# definition of a subclass hasn't been executed yet - for example, if
+# the subclass's module hasn't been imported yet - then that subclass
+# doesn't exist yet, and __subclasses__ won't find it.
+# So we import here to populate the list of subclasses.
+from moto.autoscaling import models as autoscaling_models  # noqa
+from moto.awslambda import models as awslambda_models  # noqa
+from moto.batch import models as batch_models  # noqa
+from moto.cloudwatch import models as cloudwatch_models  # noqa
+from moto.datapipeline import models as datapipeline_models  # noqa
+from moto.dynamodb2 import models as dynamodb2_models  # noqa
+from moto.ecr import models as ecr_models  # noqa
+from moto.ecs import models as ecs_models  # noqa
+from moto.elb import models as elb_models  # noqa
+from moto.elbv2 import models as elbv2_models  # noqa
+from moto.events import models as events_models  # noqa
+from moto.iam import models as iam_models  # noqa
+from moto.kinesis import models as kinesis_models  # noqa
+from moto.kms import models as kms_models  # noqa
+from moto.rds import models as rds_models  # noqa
+from moto.rds2 import models as rds2_models  # noqa
+from moto.redshift import models as redshift_models  # noqa
+from moto.route53 import models as route53_models  # noqa
+from moto.s3 import models as s3_models  # noqa
+from moto.sns import models as sns_models  # noqa
+from moto.sqs import models as sqs_models  # noqa
+# End ugly list of imports
+
 from moto.ec2 import models as ec2_models
-from moto.s3 import models as s3_backend
+from moto.s3 import models as _, s3_backend
 from moto.s3.utils import bucket_and_name_from_url
 from moto.core import ACCOUNT_ID, CloudFormationModel
 from .utils import random_suffix
@@ -27,6 +58,9 @@ NAME_TYPE_MAP = {
     model.cloudformation_type(): model.cloudformation_name_type()
     for model in MODEL_LIST
 }
+
+for model_type in sorted(list(MODEL_MAP.keys())):
+    print(model_type)
 
 # Just ignore these models types for now
 NULL_MODELS = [

--- a/moto/cloudformation/parsing.py
+++ b/moto/cloudformation/parsing.py
@@ -177,7 +177,7 @@ def clean_json(resource_json, resources_map):
 def resource_class_from_type(resource_type):
     if resource_type in NULL_MODELS:
         return None
-    
+
     if resource_type not in MODEL_MAP:
         logger.warning("No Moto CloudFormation support for %s", resource_type)
         return None

--- a/moto/cloudformation/parsing.py
+++ b/moto/cloudformation/parsing.py
@@ -36,6 +36,7 @@ from moto.route53 import models as route53_models  # noqa
 from moto.s3 import models as s3_models  # noqa
 from moto.sns import models as sns_models  # noqa
 from moto.sqs import models as sqs_models  # noqa
+
 # End ugly list of imports
 
 from moto.ec2 import models as ec2_models

--- a/moto/cloudwatch/models.py
+++ b/moto/cloudwatch/models.py
@@ -3,7 +3,7 @@ import json
 from boto3 import Session
 
 from moto.core.utils import iso_8601_datetime_without_milliseconds
-from moto.core import BaseBackend, BaseModel
+from moto.core import BaseBackend, BaseModel, CloudFormationModel
 from moto.core.exceptions import RESTError
 from moto.logs import logs_backends
 from datetime import datetime, timedelta
@@ -490,12 +490,21 @@ class CloudWatchBackend(BaseBackend):
             return None, metrics
 
 
-class LogGroup(BaseModel):
+class LogGroup(CloudFormationModel):
     def __init__(self, spec):
         # required
         self.name = spec["LogGroupName"]
         # optional
         self.tags = spec.get("Tags", [])
+
+    @staticmethod
+    def cloudformation_name_type():
+        return "LogGroupName"
+
+    @staticmethod
+    def cloudformation_type():
+        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dynamodb-table.html
+        return "AWS::Logs::LogGroup"
 
     @classmethod
     def create_from_cloudformation_json(

--- a/moto/cloudwatch/models.py
+++ b/moto/cloudwatch/models.py
@@ -503,7 +503,7 @@ class LogGroup(CloudFormationModel):
 
     @staticmethod
     def cloudformation_type():
-        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dynamodb-table.html
+        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-logs-loggroup.html
         return "AWS::Logs::LogGroup"
 
     @classmethod

--- a/moto/core/__init__.py
+++ b/moto/core/__init__.py
@@ -1,6 +1,7 @@
 from __future__ import unicode_literals
 
 from .models import BaseModel, BaseBackend, moto_api_backend, ACCOUNT_ID  # noqa
+from .models import CloudFormationModel  # noqa
 from .responses import ActionAuthenticatorMixin
 
 moto_api_backends = {"global": moto_api_backend}

--- a/moto/core/models.py
+++ b/moto/core/models.py
@@ -8,6 +8,7 @@ import os
 import re
 import six
 import types
+from abc import abstractmethod
 from io import BytesIO
 from collections import defaultdict
 from botocore.config import Config
@@ -532,6 +533,20 @@ class BaseModel(object):
         instance = super(BaseModel, cls).__new__(cls)
         cls.instances.append(instance)
         return instance
+
+
+# Parent class for every Model that can be instantiated by CloudFormation
+# On subclasses, implement the two methods as @staticmethod to ensure correct behaviour of the CF parser
+class CloudFormationModel(BaseModel):
+    @abstractmethod
+    def cloudformation_name_type(self):
+        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-name.html
+        pass
+
+    @abstractmethod
+    def cloudformation_type(self):
+        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dynamodb-table.html
+        return "AWS::SERVICE::RESOURCE"
 
 
 class BaseBackend(object):

--- a/moto/core/models.py
+++ b/moto/core/models.py
@@ -540,13 +540,40 @@ class BaseModel(object):
 class CloudFormationModel(BaseModel):
     @abstractmethod
     def cloudformation_name_type(self):
-        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-name.html
+        # This must be implemented as a staticmethod with no parameters
+        # Return None for resources that do not have a name property
         pass
 
     @abstractmethod
     def cloudformation_type(self):
-        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dynamodb-table.html
+        # This must be implemented as a staticmethod with no parameters
+        # See for example https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dynamodb-table.html
         return "AWS::SERVICE::RESOURCE"
+
+    @abstractmethod
+    def create_from_cloudformation_json(self):
+        # This must be implemented as a classmethod with parameters:
+        # cls, resource_name, cloudformation_json, region_name
+        # Extract the resource parameters from the cloudformation json
+        # and return an instance of the resource class
+        pass
+
+    @abstractmethod
+    def update_from_cloudformation_json(self):
+        # This must be implemented as a classmethod with parameters:
+        # cls, original_resource, new_resource_name, cloudformation_json, region_name
+        # Extract the resource parameters from the cloudformation json,
+        # delete the old resource and return the new one. Optionally inspect
+        # the change in parameters and no-op when nothing has changed.
+        pass
+
+    @abstractmethod
+    def delete_from_cloudformation_json(self):
+        # This must be implemented as a classmethod with parameters:
+        # cls, resource_name, cloudformation_json, region_name
+        # Extract the resource parameters from the cloudformation json
+        # and delete the resource. Do not include a return statement.
+        pass
 
 
 class BaseBackend(object):

--- a/moto/datapipeline/models.py
+++ b/moto/datapipeline/models.py
@@ -80,7 +80,7 @@ class Pipeline(CloudFormationModel):
 
     @staticmethod
     def cloudformation_type():
-        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dynamodb-table.html
+        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-datapipeline-pipeline.html
         return "AWS::DataPipeline::Pipeline"
 
     @classmethod

--- a/moto/datapipeline/models.py
+++ b/moto/datapipeline/models.py
@@ -4,7 +4,7 @@ import datetime
 from boto3 import Session
 
 from moto.compat import OrderedDict
-from moto.core import BaseBackend, BaseModel
+from moto.core import BaseBackend, BaseModel, CloudFormationModel
 from .utils import get_random_pipeline_id, remove_capitalization_of_dict_keys
 
 
@@ -18,7 +18,7 @@ class PipelineObject(BaseModel):
         return {"fields": self.fields, "id": self.object_id, "name": self.name}
 
 
-class Pipeline(BaseModel):
+class Pipeline(CloudFormationModel):
     def __init__(self, name, unique_id, **kwargs):
         self.name = name
         self.unique_id = unique_id
@@ -73,6 +73,15 @@ class Pipeline(BaseModel):
 
     def activate(self):
         self.status = "SCHEDULED"
+
+    @staticmethod
+    def cloudformation_name_type():
+        return "Name"
+
+    @staticmethod
+    def cloudformation_type():
+        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dynamodb-table.html
+        return "AWS::DataPipeline::Pipeline"
 
     @classmethod
     def create_from_cloudformation_json(

--- a/moto/dynamodb/models.py
+++ b/moto/dynamodb/models.py
@@ -4,7 +4,7 @@ import datetime
 import json
 
 from moto.compat import OrderedDict
-from moto.core import BaseBackend, BaseModel
+from moto.core import BaseBackend, BaseModel, CloudFormationModel
 from moto.core.utils import unix_time
 from moto.core import ACCOUNT_ID
 from .comparisons import get_comparison_func
@@ -82,7 +82,7 @@ class Item(BaseModel):
         return {"Item": included}
 
 
-class Table(BaseModel):
+class Table(CloudFormationModel):
     def __init__(
         self,
         name,
@@ -134,6 +134,15 @@ class Table(BaseModel):
                 "AttributeType": self.range_key_type,
             }
         return results
+
+    @staticmethod
+    def cloudformation_name_type():
+        return "TableName"
+
+    @staticmethod
+    def cloudformation_type():
+        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dynamodb-table.html
+        return "AWS::DynamoDB::Table"
 
     @classmethod
     def create_from_cloudformation_json(

--- a/moto/dynamodb2/models/__init__.py
+++ b/moto/dynamodb2/models/__init__.py
@@ -9,7 +9,7 @@ import uuid
 
 from boto3 import Session
 from moto.compat import OrderedDict
-from moto.core import BaseBackend, BaseModel
+from moto.core import BaseBackend, BaseModel, CloudFormationModel
 from moto.core.utils import unix_time
 from moto.core.exceptions import JsonRESTError
 from moto.dynamodb2.comparisons import get_filter_expression
@@ -359,7 +359,7 @@ class GlobalSecondaryIndex(SecondaryIndex):
         self.throughput = u.get("ProvisionedThroughput", self.throughput)
 
 
-class Table(BaseModel):
+class Table(CloudFormationModel):
     def __init__(
         self,
         table_name,
@@ -430,6 +430,15 @@ class Table(BaseModel):
     @property
     def physical_resource_id(self):
         return self.name
+
+    @staticmethod
+    def cloudformation_name_type():
+        return "TableName"
+
+    @staticmethod
+    def cloudformation_type():
+        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dynamodb-table.html
+        return "AWS::DynamoDB::Table"
 
     @classmethod
     def create_from_cloudformation_json(

--- a/moto/ec2/models.py
+++ b/moto/ec2/models.py
@@ -274,7 +274,7 @@ class NetworkInterface(TaggedEC2Resource, CloudFormationModel):
 
     @staticmethod
     def cloudformation_type():
-        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dynamodb-table.html
+        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-networkinterface.html
         return "AWS::EC2::NetworkInterface"
 
     @classmethod
@@ -636,7 +636,7 @@ class Instance(TaggedEC2Resource, BotoInstance, CloudFormationModel):
 
     @staticmethod
     def cloudformation_type():
-        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dynamodb-table.html
+        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-instance.html
         return "AWS::EC2::Instance"
 
     @classmethod
@@ -1885,7 +1885,7 @@ class SecurityGroup(TaggedEC2Resource, CloudFormationModel):
 
     @staticmethod
     def cloudformation_type():
-        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dynamodb-table.html
+        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-securitygroup.html
         return "AWS::EC2::SecurityGroup"
 
     @classmethod
@@ -2298,7 +2298,7 @@ class SecurityGroupIngress(CloudFormationModel):
 
     @staticmethod
     def cloudformation_type():
-        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dynamodb-table.html
+        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-securitygroupingress.html
         return "AWS::EC2::SecurityGroupIngress"
 
     @classmethod
@@ -2378,7 +2378,7 @@ class VolumeAttachment(CloudFormationModel):
 
     @staticmethod
     def cloudformation_type():
-        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dynamodb-table.html
+        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-volumeattachment.html
         return "AWS::EC2::VolumeAttachment"
 
     @classmethod
@@ -2418,7 +2418,7 @@ class Volume(TaggedEC2Resource, CloudFormationModel):
 
     @staticmethod
     def cloudformation_type():
-        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dynamodb-table.html
+        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-volume.html
         return "AWS::EC2::Volume"
 
     @classmethod
@@ -2716,7 +2716,7 @@ class VPC(TaggedEC2Resource, CloudFormationModel):
 
     @staticmethod
     def cloudformation_type():
-        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dynamodb-table.html
+        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-vpc.html
         return "AWS::EC2::VPC"
 
     @classmethod
@@ -3098,7 +3098,7 @@ class VPCPeeringConnection(TaggedEC2Resource, CloudFormationModel):
 
     @staticmethod
     def cloudformation_type():
-        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dynamodb-table.html
+        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-vpcpeeringconnection.html
         return "AWS::EC2::VPCPeeringConnection"
 
     @classmethod
@@ -3228,7 +3228,7 @@ class Subnet(TaggedEC2Resource, CloudFormationModel):
 
     @staticmethod
     def cloudformation_type():
-        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dynamodb-table.html
+        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-subnet.html
         return "AWS::EC2::Subnet"
 
     @classmethod
@@ -3469,7 +3469,7 @@ class SubnetRouteTableAssociation(CloudFormationModel):
 
     @staticmethod
     def cloudformation_type():
-        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dynamodb-table.html
+        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-subnetroutetableassociation.html
         return "AWS::EC2::SubnetRouteTableAssociation"
 
     @classmethod
@@ -3516,7 +3516,7 @@ class RouteTable(TaggedEC2Resource, CloudFormationModel):
 
     @staticmethod
     def cloudformation_type():
-        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dynamodb-table.html
+        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-routetable.html
         return "AWS::EC2::RouteTable"
 
     @classmethod
@@ -3686,7 +3686,7 @@ class Route(CloudFormationModel):
 
     @staticmethod
     def cloudformation_type():
-        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dynamodb-table.html
+        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-route.html
         return "AWS::EC2::Route"
 
     @classmethod
@@ -3868,7 +3868,7 @@ class InternetGateway(TaggedEC2Resource, CloudFormationModel):
 
     @staticmethod
     def cloudformation_type():
-        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dynamodb-table.html
+        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-internetgateway.html
         return "AWS::EC2::InternetGateway"
 
     @classmethod
@@ -3954,7 +3954,7 @@ class VPCGatewayAttachment(CloudFormationModel):
 
     @staticmethod
     def cloudformation_type():
-        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dynamodb-table.html
+        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-vpcgatewayattachment.html
         return "AWS::EC2::VPCGatewayAttachment"
 
     @classmethod
@@ -4232,7 +4232,7 @@ class SpotFleetRequest(TaggedEC2Resource, CloudFormationModel):
 
     @staticmethod
     def cloudformation_type():
-        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dynamodb-table.html
+        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-spotfleet.html
         return "AWS::EC2::SpotFleet"
 
     @classmethod
@@ -4476,7 +4476,7 @@ class ElasticAddress(CloudFormationModel):
 
     @staticmethod
     def cloudformation_type():
-        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dynamodb-table.html
+        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-eip.html
         return "AWS::EC2::EIP"
 
     @classmethod
@@ -5283,7 +5283,7 @@ class NatGateway(CloudFormationModel):
 
     @staticmethod
     def cloudformation_type():
-        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dynamodb-table.html
+        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-natgateway.html
         return "AWS::EC2::NatGateway"
 
     @classmethod

--- a/moto/ec2/models.py
+++ b/moto/ec2/models.py
@@ -22,7 +22,7 @@ from boto.ec2.launchspecification import LaunchSpecification
 
 from moto.compat import OrderedDict
 from moto.core import BaseBackend
-from moto.core.models import Model, BaseModel
+from moto.core.models import Model, BaseModel, CloudFormationModel
 from moto.core.utils import (
     iso_8601_datetime_with_milliseconds,
     camelcase_to_underscores,
@@ -219,7 +219,7 @@ class TaggedEC2Resource(BaseModel):
             raise FilterNotImplementedError(filter_name, method_name)
 
 
-class NetworkInterface(TaggedEC2Resource):
+class NetworkInterface(TaggedEC2Resource, CloudFormationModel):
     def __init__(
         self,
         ec2_backend,
@@ -267,6 +267,15 @@ class NetworkInterface(TaggedEC2Resource):
                     self.ec2_backend.groups[subnet.vpc_id][group_id] = group
                 if group:
                     self._group_set.append(group)
+
+    @staticmethod
+    def cloudformation_name_type():
+        return None
+
+    @staticmethod
+    def cloudformation_type():
+        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dynamodb-table.html
+        return "AWS::EC2::NetworkInterface"
 
     @classmethod
     def create_from_cloudformation_json(
@@ -454,7 +463,7 @@ class NetworkInterfaceBackend(object):
         return generic_filter(filters, enis)
 
 
-class Instance(TaggedEC2Resource, BotoInstance):
+class Instance(TaggedEC2Resource, BotoInstance, CloudFormationModel):
     VALID_ATTRIBUTES = {
         "instanceType",
         "kernel",
@@ -620,6 +629,15 @@ class Instance(TaggedEC2Resource, BotoInstance):
                 return "ec2-{0}.{1}.compute.amazonaws.com".format(
                     formatted_ip, self.region_name
                 )
+
+    @staticmethod
+    def cloudformation_name_type():
+        return None
+
+    @staticmethod
+    def cloudformation_type():
+        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dynamodb-table.html
+        return "AWS::EC2::Instance"
 
     @classmethod
     def create_from_cloudformation_json(
@@ -1843,7 +1861,7 @@ class SecurityRule(object):
         return True
 
 
-class SecurityGroup(TaggedEC2Resource):
+class SecurityGroup(TaggedEC2Resource, CloudFormationModel):
     def __init__(self, ec2_backend, group_id, name, description, vpc_id=None):
         self.ec2_backend = ec2_backend
         self.id = group_id
@@ -1860,6 +1878,15 @@ class SecurityGroup(TaggedEC2Resource):
             vpc = self.ec2_backend.vpcs.get(vpc_id)
             if vpc and len(vpc.get_cidr_block_association_set(ipv6=True)) > 0:
                 self.egress_rules.append(SecurityRule("-1", None, None, [], []))
+
+    @staticmethod
+    def cloudformation_name_type():
+        return "GroupName"
+
+    @staticmethod
+    def cloudformation_type():
+        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dynamodb-table.html
+        return "AWS::EC2::SecurityGroup"
 
     @classmethod
     def create_from_cloudformation_json(
@@ -2260,10 +2287,19 @@ class SecurityGroupBackend(object):
             raise RulesPerSecurityGroupLimitExceededError
 
 
-class SecurityGroupIngress(object):
+class SecurityGroupIngress(CloudFormationModel):
     def __init__(self, security_group, properties):
         self.security_group = security_group
         self.properties = properties
+
+    @staticmethod
+    def cloudformation_name_type():
+        return None
+
+    @staticmethod
+    def cloudformation_type():
+        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dynamodb-table.html
+        return "AWS::EC2::SecurityGroupIngress"
 
     @classmethod
     def create_from_cloudformation_json(
@@ -2328,13 +2364,22 @@ class SecurityGroupIngress(object):
         return cls(security_group, properties)
 
 
-class VolumeAttachment(object):
+class VolumeAttachment(CloudFormationModel):
     def __init__(self, volume, instance, device, status):
         self.volume = volume
         self.attach_time = utc_date_and_time()
         self.instance = instance
         self.device = device
         self.status = status
+
+    @staticmethod
+    def cloudformation_name_type():
+        return None
+
+    @staticmethod
+    def cloudformation_type():
+        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dynamodb-table.html
+        return "AWS::EC2::VolumeAttachment"
 
     @classmethod
     def create_from_cloudformation_json(
@@ -2354,7 +2399,7 @@ class VolumeAttachment(object):
         return attachment
 
 
-class Volume(TaggedEC2Resource):
+class Volume(TaggedEC2Resource, CloudFormationModel):
     def __init__(
         self, ec2_backend, volume_id, size, zone, snapshot_id=None, encrypted=False
     ):
@@ -2366,6 +2411,15 @@ class Volume(TaggedEC2Resource):
         self.snapshot_id = snapshot_id
         self.ec2_backend = ec2_backend
         self.encrypted = encrypted
+
+    @staticmethod
+    def cloudformation_name_type():
+        return None
+
+    @staticmethod
+    def cloudformation_type():
+        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dynamodb-table.html
+        return "AWS::EC2::Volume"
 
     @classmethod
     def create_from_cloudformation_json(
@@ -2623,7 +2677,7 @@ class EBSBackend(object):
         return True
 
 
-class VPC(TaggedEC2Resource):
+class VPC(TaggedEC2Resource, CloudFormationModel):
     def __init__(
         self,
         ec2_backend,
@@ -2655,6 +2709,15 @@ class VPC(TaggedEC2Resource):
                 cidr_block,
                 amazon_provided_ipv6_cidr_block=amazon_provided_ipv6_cidr_block,
             )
+
+    @staticmethod
+    def cloudformation_name_type():
+        return None
+
+    @staticmethod
+    def cloudformation_type():
+        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dynamodb-table.html
+        return "AWS::EC2::VPC"
 
     @classmethod
     def create_from_cloudformation_json(
@@ -3022,12 +3085,21 @@ class VPCPeeringConnectionStatus(object):
         self.message = "Inactive"
 
 
-class VPCPeeringConnection(TaggedEC2Resource):
+class VPCPeeringConnection(TaggedEC2Resource, CloudFormationModel):
     def __init__(self, vpc_pcx_id, vpc, peer_vpc):
         self.id = vpc_pcx_id
         self.vpc = vpc
         self.peer_vpc = peer_vpc
         self._status = VPCPeeringConnectionStatus()
+
+    @staticmethod
+    def cloudformation_name_type():
+        return None
+
+    @staticmethod
+    def cloudformation_type():
+        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dynamodb-table.html
+        return "AWS::EC2::VPCPeeringConnection"
 
     @classmethod
     def create_from_cloudformation_json(
@@ -3114,7 +3186,7 @@ class VPCPeeringConnectionBackend(object):
         return vpc_pcx
 
 
-class Subnet(TaggedEC2Resource):
+class Subnet(TaggedEC2Resource, CloudFormationModel):
     def __init__(
         self,
         ec2_backend,
@@ -3149,6 +3221,15 @@ class Subnet(TaggedEC2Resource):
         ]  # Reserved by AWS
         self._unused_ips = set()  # if instance is destroyed hold IP here for reuse
         self._subnet_ips = {}  # has IP: instance
+
+    @staticmethod
+    def cloudformation_name_type():
+        return None
+
+    @staticmethod
+    def cloudformation_type():
+        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dynamodb-table.html
+        return "AWS::EC2::Subnet"
 
     @classmethod
     def create_from_cloudformation_json(
@@ -3377,10 +3458,19 @@ class SubnetBackend(object):
             raise InvalidParameterValueError(attr_name)
 
 
-class SubnetRouteTableAssociation(object):
+class SubnetRouteTableAssociation(CloudFormationModel):
     def __init__(self, route_table_id, subnet_id):
         self.route_table_id = route_table_id
         self.subnet_id = subnet_id
+
+    @staticmethod
+    def cloudformation_name_type():
+        return None
+
+    @staticmethod
+    def cloudformation_type():
+        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dynamodb-table.html
+        return "AWS::EC2::SubnetRouteTableAssociation"
 
     @classmethod
     def create_from_cloudformation_json(
@@ -3411,7 +3501,7 @@ class SubnetRouteTableAssociationBackend(object):
         return subnet_association
 
 
-class RouteTable(TaggedEC2Resource):
+class RouteTable(TaggedEC2Resource, CloudFormationModel):
     def __init__(self, ec2_backend, route_table_id, vpc_id, main=False):
         self.ec2_backend = ec2_backend
         self.id = route_table_id
@@ -3419,6 +3509,15 @@ class RouteTable(TaggedEC2Resource):
         self.main = main
         self.associations = {}
         self.routes = {}
+
+    @staticmethod
+    def cloudformation_name_type():
+        return None
+
+    @staticmethod
+    def cloudformation_type():
+        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dynamodb-table.html
+        return "AWS::EC2::RouteTable"
 
     @classmethod
     def create_from_cloudformation_json(
@@ -3555,7 +3654,7 @@ class RouteTableBackend(object):
         return self.associate_route_table(route_table_id, subnet_id)
 
 
-class Route(object):
+class Route(CloudFormationModel):
     def __init__(
         self,
         route_table,
@@ -3580,6 +3679,15 @@ class Route(object):
         self.nat_gateway = nat_gateway
         self.interface = interface
         self.vpc_pcx = vpc_pcx
+
+    @staticmethod
+    def cloudformation_name_type():
+        return None
+
+    @staticmethod
+    def cloudformation_type():
+        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dynamodb-table.html
+        return "AWS::EC2::Route"
 
     @classmethod
     def create_from_cloudformation_json(
@@ -3748,11 +3856,20 @@ class RouteBackend(object):
         return deleted
 
 
-class InternetGateway(TaggedEC2Resource):
+class InternetGateway(TaggedEC2Resource, CloudFormationModel):
     def __init__(self, ec2_backend):
         self.ec2_backend = ec2_backend
         self.id = random_internet_gateway_id()
         self.vpc = None
+
+    @staticmethod
+    def cloudformation_name_type():
+        return None
+
+    @staticmethod
+    def cloudformation_type():
+        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dynamodb-table.html
+        return "AWS::EC2::InternetGateway"
 
     @classmethod
     def create_from_cloudformation_json(
@@ -3826,10 +3943,19 @@ class InternetGatewayBackend(object):
         return self.describe_internet_gateways(internet_gateway_ids=igw_ids)[0]
 
 
-class VPCGatewayAttachment(BaseModel):
+class VPCGatewayAttachment(CloudFormationModel):
     def __init__(self, gateway_id, vpc_id):
         self.gateway_id = gateway_id
         self.vpc_id = vpc_id
+
+    @staticmethod
+    def cloudformation_name_type():
+        return None
+
+    @staticmethod
+    def cloudformation_type():
+        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dynamodb-table.html
+        return "AWS::EC2::VPCGatewayAttachment"
 
     @classmethod
     def create_from_cloudformation_json(
@@ -4051,7 +4177,7 @@ class SpotFleetLaunchSpec(object):
         self.weighted_capacity = float(weighted_capacity)
 
 
-class SpotFleetRequest(TaggedEC2Resource):
+class SpotFleetRequest(TaggedEC2Resource, CloudFormationModel):
     def __init__(
         self,
         ec2_backend,
@@ -4099,6 +4225,15 @@ class SpotFleetRequest(TaggedEC2Resource):
     @property
     def physical_resource_id(self):
         return self.id
+
+    @staticmethod
+    def cloudformation_name_type():
+        return None
+
+    @staticmethod
+    def cloudformation_type():
+        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dynamodb-table.html
+        return "AWS::EC2::SpotFleet"
 
     @classmethod
     def create_from_cloudformation_json(
@@ -4323,7 +4458,7 @@ class SpotFleetBackend(object):
         return True
 
 
-class ElasticAddress(object):
+class ElasticAddress(CloudFormationModel):
     def __init__(self, domain, address=None):
         if address:
             self.public_ip = address
@@ -4334,6 +4469,15 @@ class ElasticAddress(object):
         self.instance = None
         self.eni = None
         self.association_id = None
+
+    @staticmethod
+    def cloudformation_name_type():
+        return None
+
+    @staticmethod
+    def cloudformation_type():
+        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dynamodb-table.html
+        return "AWS::EC2::EIP"
 
     @classmethod
     def create_from_cloudformation_json(
@@ -5095,7 +5239,7 @@ class CustomerGatewayBackend(object):
         return deleted
 
 
-class NatGateway(object):
+class NatGateway(CloudFormationModel):
     def __init__(self, backend, subnet_id, allocation_id):
         # public properties
         self.id = random_nat_gateway_id()
@@ -5132,6 +5276,15 @@ class NatGateway(object):
     def public_ip(self):
         eips = self._backend.address_by_allocation([self.allocation_id])
         return eips[0].public_ip
+
+    @staticmethod
+    def cloudformation_name_type():
+        return None
+
+    @staticmethod
+    def cloudformation_type():
+        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dynamodb-table.html
+        return "AWS::EC2::NatGateway"
 
     @classmethod
     def create_from_cloudformation_json(

--- a/moto/ecr/models.py
+++ b/moto/ecr/models.py
@@ -7,7 +7,7 @@ from random import random
 
 from botocore.exceptions import ParamValidationError
 
-from moto.core import BaseBackend, BaseModel
+from moto.core import BaseBackend, BaseModel, CloudFormationModel
 from moto.ec2 import ec2_backends
 from moto.ecr.exceptions import ImageNotFoundException, RepositoryNotFoundException
 
@@ -38,7 +38,7 @@ class BaseObject(BaseModel):
         return self.gen_response_object()
 
 
-class Repository(BaseObject):
+class Repository(BaseObject, CloudFormationModel):
     def __init__(self, repository_name):
         self.registry_id = DEFAULT_REGISTRY_ID
         self.arn = "arn:aws:ecr:us-east-1:{0}:repository/{1}".format(
@@ -66,6 +66,15 @@ class Repository(BaseObject):
         # response_object['createdAt'] = self.created
         del response_object["arn"], response_object["name"], response_object["images"]
         return response_object
+
+    @staticmethod
+    def cloudformation_name_type():
+        return "RepositoryName"
+
+    @staticmethod
+    def cloudformation_type():
+        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dynamodb-table.html
+        return "AWS::ECR::Repository"
 
     @classmethod
     def create_from_cloudformation_json(

--- a/moto/ecr/models.py
+++ b/moto/ecr/models.py
@@ -73,7 +73,7 @@ class Repository(BaseObject, CloudFormationModel):
 
     @staticmethod
     def cloudformation_type():
-        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dynamodb-table.html
+        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ecr-repository.html
         return "AWS::ECR::Repository"
 
     @classmethod

--- a/moto/ecs/models.py
+++ b/moto/ecs/models.py
@@ -75,7 +75,7 @@ class Cluster(BaseObject, CloudFormationModel):
 
     @staticmethod
     def cloudformation_type():
-        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dynamodb-table.html
+        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ecs-cluster.html
         return "AWS::ECS::Cluster"
 
     @classmethod
@@ -174,7 +174,7 @@ class TaskDefinition(BaseObject, CloudFormationModel):
 
     @staticmethod
     def cloudformation_type():
-        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dynamodb-table.html
+        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ecs-taskdefinition.html
         return "AWS::ECS::TaskDefinition"
 
     @classmethod
@@ -339,7 +339,7 @@ class Service(BaseObject, CloudFormationModel):
 
     @staticmethod
     def cloudformation_type():
-        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dynamodb-table.html
+        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ecs-service.html
         return "AWS::ECS::Service"
 
     @classmethod

--- a/moto/ecs/models.py
+++ b/moto/ecs/models.py
@@ -8,7 +8,7 @@ import pytz
 from boto3 import Session
 
 from moto.core.exceptions import JsonRESTError
-from moto.core import BaseBackend, BaseModel
+from moto.core import BaseBackend, BaseModel, CloudFormationModel
 from moto.core.utils import unix_time
 from moto.ec2 import ec2_backends
 from copy import copy
@@ -44,7 +44,7 @@ class BaseObject(BaseModel):
         return self.gen_response_object()
 
 
-class Cluster(BaseObject):
+class Cluster(BaseObject, CloudFormationModel):
     def __init__(self, cluster_name, region_name):
         self.active_services_count = 0
         self.arn = "arn:aws:ecs:{0}:012345678910:cluster/{1}".format(
@@ -68,6 +68,15 @@ class Cluster(BaseObject):
         response_object["clusterName"] = self.name
         del response_object["arn"], response_object["name"]
         return response_object
+
+    @staticmethod
+    def cloudformation_name_type():
+        return "ClusterName"
+
+    @staticmethod
+    def cloudformation_type():
+        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dynamodb-table.html
+        return "AWS::ECS::Cluster"
 
     @classmethod
     def create_from_cloudformation_json(
@@ -116,7 +125,7 @@ class Cluster(BaseObject):
         raise UnformattedGetAttTemplateException()
 
 
-class TaskDefinition(BaseObject):
+class TaskDefinition(BaseObject, CloudFormationModel):
     def __init__(
         self,
         family,
@@ -158,6 +167,15 @@ class TaskDefinition(BaseObject):
     @property
     def physical_resource_id(self):
         return self.arn
+
+    @staticmethod
+    def cloudformation_name_type():
+        return None
+
+    @staticmethod
+    def cloudformation_type():
+        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dynamodb-table.html
+        return "AWS::ECS::TaskDefinition"
 
     @classmethod
     def create_from_cloudformation_json(
@@ -235,7 +253,7 @@ class Task(BaseObject):
         return response_object
 
 
-class Service(BaseObject):
+class Service(BaseObject, CloudFormationModel):
     def __init__(
         self,
         cluster,
@@ -314,6 +332,15 @@ class Service(BaseObject):
                 )
 
         return response_object
+
+    @staticmethod
+    def cloudformation_name_type():
+        return "ServiceName"
+
+    @staticmethod
+    def cloudformation_type():
+        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dynamodb-table.html
+        return "AWS::ECS::Service"
 
     @classmethod
     def create_from_cloudformation_json(

--- a/moto/elb/models.py
+++ b/moto/elb/models.py
@@ -125,7 +125,7 @@ class FakeLoadBalancer(CloudFormationModel):
 
     @staticmethod
     def cloudformation_type():
-        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dynamodb-table.html
+        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticloadbalancing-loadbalancer.html
         return "AWS::ElasticLoadBalancing::LoadBalancer"
 
     @classmethod

--- a/moto/elb/models.py
+++ b/moto/elb/models.py
@@ -13,7 +13,7 @@ from boto.ec2.elb.attributes import (
 )
 from boto.ec2.elb.policies import Policies, OtherPolicy
 from moto.compat import OrderedDict
-from moto.core import BaseBackend, BaseModel
+from moto.core import BaseBackend, BaseModel, CloudFormationModel
 from moto.ec2.models import ec2_backends
 from .exceptions import (
     BadHealthCheckDefinition,
@@ -69,7 +69,7 @@ class FakeBackend(BaseModel):
         )
 
 
-class FakeLoadBalancer(BaseModel):
+class FakeLoadBalancer(CloudFormationModel):
     def __init__(
         self,
         name,
@@ -118,6 +118,15 @@ class FakeLoadBalancer(BaseModel):
                 instance_port=(port.get("instance_port") or port["InstancePort"])
             )
             self.backends.append(backend)
+
+    @staticmethod
+    def cloudformation_name_type():
+        return "LoadBalancerName"
+
+    @staticmethod
+    def cloudformation_type():
+        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dynamodb-table.html
+        return "AWS::ElasticLoadBalancing::LoadBalancer"
 
     @classmethod
     def create_from_cloudformation_json(

--- a/moto/elbv2/models.py
+++ b/moto/elbv2/models.py
@@ -149,7 +149,7 @@ class FakeTargetGroup(CloudFormationModel):
 
     @staticmethod
     def cloudformation_type():
-        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dynamodb-table.html
+        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticloadbalancingv2-targetgroup.html
         return "AWS::ElasticLoadBalancingV2::TargetGroup"
 
     @classmethod
@@ -243,7 +243,7 @@ class FakeListener(CloudFormationModel):
 
     @staticmethod
     def cloudformation_type():
-        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dynamodb-table.html
+        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticloadbalancingv2-listener.html
         return "AWS::ElasticLoadBalancingV2::Listener"
 
     @classmethod
@@ -426,7 +426,7 @@ class FakeLoadBalancer(CloudFormationModel):
 
     @staticmethod
     def cloudformation_type():
-        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dynamodb-table.html
+        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticloadbalancingv2-loadbalancer.html
         return "AWS::ElasticLoadBalancingV2::LoadBalancer"
 
     @classmethod

--- a/moto/elbv2/models.py
+++ b/moto/elbv2/models.py
@@ -6,7 +6,7 @@ from jinja2 import Template
 from botocore.exceptions import ParamValidationError
 from moto.compat import OrderedDict
 from moto.core.exceptions import RESTError
-from moto.core import BaseBackend, BaseModel
+from moto.core import BaseBackend, BaseModel, CloudFormationModel
 from moto.core.utils import camelcase_to_underscores, underscores_to_camelcase
 from moto.ec2.models import ec2_backends
 from moto.acm.models import acm_backends
@@ -50,7 +50,7 @@ class FakeHealthStatus(BaseModel):
         self.description = description
 
 
-class FakeTargetGroup(BaseModel):
+class FakeTargetGroup(CloudFormationModel):
     HTTP_CODE_REGEX = re.compile(r"(?:(?:\d+-\d+|\d+),?)+")
 
     def __init__(
@@ -143,6 +143,15 @@ class FakeTargetGroup(BaseModel):
                 )
         return FakeHealthStatus(t["id"], t["port"], self.healthcheck_port, "healthy")
 
+    @staticmethod
+    def cloudformation_name_type():
+        return "Name"
+
+    @staticmethod
+    def cloudformation_type():
+        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dynamodb-table.html
+        return "AWS::ElasticLoadBalancingV2::TargetGroup"
+
     @classmethod
     def create_from_cloudformation_json(
         cls, resource_name, cloudformation_json, region_name
@@ -183,7 +192,7 @@ class FakeTargetGroup(BaseModel):
         return target_group
 
 
-class FakeListener(BaseModel):
+class FakeListener(CloudFormationModel):
     def __init__(
         self,
         load_balancer_arn,
@@ -227,6 +236,15 @@ class FakeListener(BaseModel):
         self._non_default_rules = sorted(
             self._non_default_rules, key=lambda x: x.priority
         )
+
+    @staticmethod
+    def cloudformation_name_type():
+        return None
+
+    @staticmethod
+    def cloudformation_type():
+        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dynamodb-table.html
+        return "AWS::ElasticLoadBalancingV2::Listener"
 
     @classmethod
     def create_from_cloudformation_json(
@@ -343,7 +361,7 @@ class FakeBackend(BaseModel):
         )
 
 
-class FakeLoadBalancer(BaseModel):
+class FakeLoadBalancer(CloudFormationModel):
     VALID_ATTRS = {
         "access_logs.s3.enabled",
         "access_logs.s3.bucket",
@@ -401,6 +419,15 @@ class FakeLoadBalancer(BaseModel):
     def delete(self, region):
         """ Not exposed as part of the ELB API - used for CloudFormation. """
         elbv2_backends[region].delete_load_balancer(self.arn)
+
+    @staticmethod
+    def cloudformation_name_type():
+        return "Name"
+
+    @staticmethod
+    def cloudformation_type():
+        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dynamodb-table.html
+        return "AWS::ElasticLoadBalancingV2::LoadBalancer"
 
     @classmethod
     def create_from_cloudformation_json(

--- a/moto/events/models.py
+++ b/moto/events/models.py
@@ -4,14 +4,14 @@ import json
 from boto3 import Session
 
 from moto.core.exceptions import JsonRESTError
-from moto.core import BaseBackend, BaseModel
+from moto.core import BaseBackend, BaseModel, CloudFormationModel
 from moto.sts.models import ACCOUNT_ID
 from moto.utilities.tagging_service import TaggingService
 
 from uuid import uuid4
 
 
-class Rule(BaseModel):
+class Rule(CloudFormationModel):
     def _generate_arn(self, name):
         return "arn:aws:events:{region_name}:111111111111:rule/{name}".format(
             region_name=self.region_name, name=name
@@ -73,6 +73,15 @@ class Rule(BaseModel):
 
         raise UnformattedGetAttTemplateException()
 
+    @staticmethod
+    def cloudformation_name_type():
+        return "Name"
+
+    @staticmethod
+    def cloudformation_type():
+        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dynamodb-table.html
+        return "AWS::Events::Rule"
+
     @classmethod
     def create_from_cloudformation_json(
         cls, resource_name, cloudformation_json, region_name
@@ -101,7 +110,7 @@ class Rule(BaseModel):
         event_backend.delete_rule(name=event_name)
 
 
-class EventBus(BaseModel):
+class EventBus(CloudFormationModel):
     def __init__(self, region_name, name):
         self.region = region_name
         self.name = name
@@ -151,6 +160,15 @@ class EventBus(BaseModel):
             return self.policy
 
         raise UnformattedGetAttTemplateException()
+
+    @staticmethod
+    def cloudformation_name_type():
+        return "Name"
+
+    @staticmethod
+    def cloudformation_type():
+        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dynamodb-table.html
+        return "AWS::Events::EventBus"
 
     @classmethod
     def create_from_cloudformation_json(

--- a/moto/events/models.py
+++ b/moto/events/models.py
@@ -4,7 +4,7 @@ import json
 from boto3 import Session
 
 from moto.core.exceptions import JsonRESTError
-from moto.core import BaseBackend, BaseModel, CloudFormationModel
+from moto.core import BaseBackend, CloudFormationModel
 from moto.sts.models import ACCOUNT_ID
 from moto.utilities.tagging_service import TaggingService
 

--- a/moto/events/models.py
+++ b/moto/events/models.py
@@ -79,7 +79,7 @@ class Rule(CloudFormationModel):
 
     @staticmethod
     def cloudformation_type():
-        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dynamodb-table.html
+        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-events-rule.html
         return "AWS::Events::Rule"
 
     @classmethod
@@ -167,7 +167,7 @@ class EventBus(CloudFormationModel):
 
     @staticmethod
     def cloudformation_type():
-        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dynamodb-table.html
+        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-events-eventbus.html
         return "AWS::Events::EventBus"
 
     @classmethod

--- a/moto/iam/models.py
+++ b/moto/iam/models.py
@@ -15,7 +15,7 @@ from six.moves.urllib.parse import urlparse
 from uuid import uuid4
 
 from moto.core.exceptions import RESTError
-from moto.core import BaseBackend, BaseModel, ACCOUNT_ID
+from moto.core import BaseBackend, BaseModel, ACCOUNT_ID, CloudFormationModel
 from moto.core.utils import (
     iso_8601_datetime_without_milliseconds,
     iso_8601_datetime_with_milliseconds,
@@ -299,7 +299,7 @@ class InlinePolicy(Policy):
     """TODO: is this needed?"""
 
 
-class Role(BaseModel):
+class Role(CloudFormationModel):
     def __init__(
         self,
         role_id,
@@ -326,6 +326,15 @@ class Role(BaseModel):
     @property
     def created_iso_8601(self):
         return iso_8601_datetime_with_milliseconds(self.create_date)
+
+    @staticmethod
+    def cloudformation_name_type():
+        return "RoleName"
+
+    @staticmethod
+    def cloudformation_type():
+        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dynamodb-table.html
+        return "AWS::IAM::Role"
 
     @classmethod
     def create_from_cloudformation_json(
@@ -384,7 +393,7 @@ class Role(BaseModel):
         return [self.tags[tag] for tag in self.tags]
 
 
-class InstanceProfile(BaseModel):
+class InstanceProfile(CloudFormationModel):
     def __init__(self, instance_profile_id, name, path, roles):
         self.id = instance_profile_id
         self.name = name
@@ -395,6 +404,15 @@ class InstanceProfile(BaseModel):
     @property
     def created_iso_8601(self):
         return iso_8601_datetime_with_milliseconds(self.create_date)
+
+    @staticmethod
+    def cloudformation_name_type():
+        return "InstanceProfileName"
+
+    @staticmethod
+    def cloudformation_type():
+        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dynamodb-table.html
+        return "AWS::IAM::InstanceProfile"
 
     @classmethod
     def create_from_cloudformation_json(

--- a/moto/iam/models.py
+++ b/moto/iam/models.py
@@ -333,7 +333,7 @@ class Role(CloudFormationModel):
 
     @staticmethod
     def cloudformation_type():
-        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dynamodb-table.html
+        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-role.html
         return "AWS::IAM::Role"
 
     @classmethod
@@ -411,7 +411,7 @@ class InstanceProfile(CloudFormationModel):
 
     @staticmethod
     def cloudformation_type():
-        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dynamodb-table.html
+        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-instanceprofile.html
         return "AWS::IAM::InstanceProfile"
 
     @classmethod

--- a/moto/kinesis/models.py
+++ b/moto/kinesis/models.py
@@ -129,7 +129,7 @@ class Shard(BaseModel):
         }
 
 
-class Stream(CloudformationModel):
+class Stream(CloudFormationModel):
     def __init__(self, stream_name, shard_count, region):
         self.stream_name = stream_name
         self.shard_count = shard_count

--- a/moto/kinesis/models.py
+++ b/moto/kinesis/models.py
@@ -12,7 +12,7 @@ from hashlib import md5
 from boto3 import Session
 
 from moto.compat import OrderedDict
-from moto.core import BaseBackend, BaseModel
+from moto.core import BaseBackend, BaseModel, CloudFormationModel
 from moto.core.utils import unix_time
 from moto.core import ACCOUNT_ID
 from .exceptions import (
@@ -129,7 +129,7 @@ class Shard(BaseModel):
         }
 
 
-class Stream(BaseModel):
+class Stream(CloudformationModel):
     def __init__(self, stream_name, shard_count, region):
         self.stream_name = stream_name
         self.shard_count = shard_count
@@ -215,6 +215,15 @@ class Stream(BaseModel):
                 "OpenShardCount": self.shard_count,
             }
         }
+
+    @staticmethod
+    def cloudformation_name_type():
+        return "Name"
+
+    @staticmethod
+    def cloudformation_type():
+        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dynamodb-table.html
+        return "AWS::Kinesis::Stream"
 
     @classmethod
     def create_from_cloudformation_json(

--- a/moto/kinesis/models.py
+++ b/moto/kinesis/models.py
@@ -222,7 +222,7 @@ class Stream(CloudformationModel):
 
     @staticmethod
     def cloudformation_type():
-        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dynamodb-table.html
+        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-kinesis-stream.html
         return "AWS::Kinesis::Stream"
 
     @classmethod

--- a/moto/kms/models.py
+++ b/moto/kms/models.py
@@ -105,7 +105,7 @@ class Key(CloudFormationModel):
 
     @staticmethod
     def cloudformation_type():
-        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dynamodb-table.html
+        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-kms-key.html
         return "AWS::KMS::Key"
 
     @classmethod

--- a/moto/kms/models.py
+++ b/moto/kms/models.py
@@ -6,7 +6,7 @@ from datetime import datetime, timedelta
 
 from boto3 import Session
 
-from moto.core import BaseBackend, BaseModel, CloudFormationModel
+from moto.core import BaseBackend, CloudFormationModel
 from moto.core.utils import unix_time
 from moto.utilities.tagging_service import TaggingService
 from moto.core.exceptions import JsonRESTError

--- a/moto/kms/models.py
+++ b/moto/kms/models.py
@@ -6,7 +6,7 @@ from datetime import datetime, timedelta
 
 from boto3 import Session
 
-from moto.core import BaseBackend, BaseModel
+from moto.core import BaseBackend, BaseModel, CloudFormationModel
 from moto.core.utils import unix_time
 from moto.utilities.tagging_service import TaggingService
 from moto.core.exceptions import JsonRESTError
@@ -15,7 +15,7 @@ from moto.iam.models import ACCOUNT_ID
 from .utils import decrypt, encrypt, generate_key_id, generate_master_key
 
 
-class Key(BaseModel):
+class Key(CloudFormationModel):
     def __init__(
         self, policy, key_usage, customer_master_key_spec, description, region
     ):
@@ -98,6 +98,15 @@ class Key(BaseModel):
 
     def delete(self, region_name):
         kms_backends[region_name].delete_key(self.id)
+
+    @staticmethod
+    def cloudformation_name_type():
+        return None
+
+    @staticmethod
+    def cloudformation_type():
+        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dynamodb-table.html
+        return "AWS::KMS::Key"
 
     @classmethod
     def create_from_cloudformation_json(

--- a/moto/rds/models.py
+++ b/moto/rds/models.py
@@ -24,7 +24,7 @@ class Database(CloudFormationModel):
 
     @staticmethod
     def cloudformation_type():
-        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dynamodb-table.html
+        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-rds-dbinstance.html
         return "AWS::RDS::DBInstance"
 
     @classmethod
@@ -221,7 +221,7 @@ class SecurityGroup(CloudFormationModel):
 
     @staticmethod
     def cloudformation_type():
-        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dynamodb-table.html
+        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-rds-dbsecuritygroup.html
         return "AWS::RDS::DBSecurityGroup"
 
     @classmethod
@@ -295,7 +295,7 @@ class SubnetGroup(CloudFormationModel):
 
     @staticmethod
     def cloudformation_type():
-        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dynamodb-table.html
+        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-rds-dbsubnetgroup.html
         return "AWS::RDS::DBSubnetGroup"
 
     @classmethod

--- a/moto/rds/models.py
+++ b/moto/rds/models.py
@@ -3,7 +3,7 @@ from __future__ import unicode_literals
 import boto.rds
 from jinja2 import Template
 
-from moto.core import BaseBackend, BaseModel, CloudFormationModel
+from moto.core import BaseBackend, CloudFormationModel
 from moto.core.utils import get_random_hex
 from moto.ec2.models import ec2_backends
 from moto.rds.exceptions import UnformattedGetAttTemplateException
@@ -33,7 +33,7 @@ class Database(CloudFormationModel):
     ):
         properties = cloudformation_json["Properties"]
 
-        db_instance_identifier = properties.get(self.cloudformation_name_type())
+        db_instance_identifier = properties.get(cls.cloudformation_name_type())
         if not db_instance_identifier:
             db_instance_identifier = resource_name.lower() + get_random_hex(12)
         db_security_groups = properties.get("DBSecurityGroups")
@@ -303,7 +303,7 @@ class SubnetGroup(CloudFormationModel):
         cls, resource_name, cloudformation_json, region_name
     ):
         properties = cloudformation_json["Properties"]
-        subnet_name = properties.get(self.cloudformation_name_type())
+        subnet_name = properties.get(cls.cloudformation_name_type())
         if not subnet_name:
             subnet_name = resource_name.lower() + get_random_hex(12)
         description = properties["DBSubnetGroupDescription"]

--- a/moto/rds2/models.py
+++ b/moto/rds2/models.py
@@ -362,7 +362,7 @@ class Database(CloudFormationModel):
 
     @staticmethod
     def cloudformation_type():
-        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dynamodb-table.html
+        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-rds-dbinstance.html
         return "AWS::RDS::DBInstance"
 
     @classmethod
@@ -642,7 +642,7 @@ class SecurityGroup(CloudFormationModel):
 
     @staticmethod
     def cloudformation_type():
-        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dynamodb-table.html
+        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-rds-dbsecuritygroup.html
         return "AWS::RDS::DBSecurityGroup"
 
     @classmethod
@@ -750,7 +750,7 @@ class SubnetGroup(CloudFormationModel):
 
     @staticmethod
     def cloudformation_type():
-        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dynamodb-table.html
+        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-rds-dbsubnetgroup.html
         return "AWS::RDS::DBSubnetGroup"
 
     @classmethod
@@ -1515,7 +1515,7 @@ class DBParameterGroup(CloudFormationModel):
 
     @staticmethod
     def cloudformation_type():
-        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dynamodb-table.html
+        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-rds-dbparametergroup.html
         return "AWS::RDS::DBParameterGroup"
 
     @classmethod

--- a/moto/rds2/models.py
+++ b/moto/rds2/models.py
@@ -371,7 +371,7 @@ class Database(CloudFormationModel):
     ):
         properties = cloudformation_json["Properties"]
 
-        db_instance_identifier = properties.get(self.cloudformation_name_type())
+        db_instance_identifier = properties.get(cls.cloudformation_name_type())
         if not db_instance_identifier:
             db_instance_identifier = resource_name.lower() + get_random_hex(12)
         db_security_groups = properties.get("DBSecurityGroups")
@@ -759,7 +759,7 @@ class SubnetGroup(CloudFormationModel):
     ):
         properties = cloudformation_json["Properties"]
 
-        subnet_name = properties.get(self.cloudformation_name_type())
+        subnet_name = properties.get(cls.cloudformation_name_type())
         if not subnet_name:
             subnet_name = resource_name.lower() + get_random_hex(12)
         description = properties["DBSubnetGroupDescription"]

--- a/moto/redshift/models.py
+++ b/moto/redshift/models.py
@@ -6,7 +6,7 @@ import datetime
 from boto3 import Session
 from botocore.exceptions import ClientError
 from moto.compat import OrderedDict
-from moto.core import BaseBackend, BaseModel
+from moto.core import BaseBackend, BaseModel, CloudFormationModel
 from moto.core.utils import iso_8601_datetime_with_milliseconds
 from moto.ec2 import ec2_backends
 from .exceptions import (
@@ -63,7 +63,7 @@ class TaggableResourceMixin(object):
         return self.tags
 
 
-class Cluster(TaggableResourceMixin, BaseModel):
+class Cluster(TaggableResourceMixin, CloudFormationModel):
 
     resource_type = "cluster"
 
@@ -157,6 +157,15 @@ class Cluster(TaggableResourceMixin, BaseModel):
         self.iam_roles_arn = iam_roles_arn or []
         self.restored_from_snapshot = restored_from_snapshot
 
+    @staticmethod
+    def cloudformation_name_type():
+        return None
+
+    @staticmethod
+    def cloudformation_type():
+        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dynamodb-table.html
+        return "AWS::Redshift::Cluster"
+
     @classmethod
     def create_from_cloudformation_json(
         cls, resource_name, cloudformation_json, region_name
@@ -170,6 +179,7 @@ class Cluster(TaggableResourceMixin, BaseModel):
             ].cluster_subnet_group_name
         else:
             subnet_group_name = None
+
         cluster = redshift_backend.create_cluster(
             cluster_identifier=resource_name,
             node_type=properties.get("NodeType"),
@@ -321,7 +331,7 @@ class SnapshotCopyGrant(TaggableResourceMixin, BaseModel):
         }
 
 
-class SubnetGroup(TaggableResourceMixin, BaseModel):
+class SubnetGroup(TaggableResourceMixin, CloudFormationModel):
 
     resource_type = "subnetgroup"
 
@@ -341,6 +351,15 @@ class SubnetGroup(TaggableResourceMixin, BaseModel):
         self.subnet_ids = subnet_ids
         if not self.subnets:
             raise InvalidSubnetError(subnet_ids)
+
+    @staticmethod
+    def cloudformation_name_type():
+        return None
+
+    @staticmethod
+    def cloudformation_type():
+        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dynamodb-table.html
+        return "AWS::Redshift::ClusterSubnetGroup"
 
     @classmethod
     def create_from_cloudformation_json(
@@ -412,7 +431,7 @@ class SecurityGroup(TaggableResourceMixin, BaseModel):
         }
 
 
-class ParameterGroup(TaggableResourceMixin, BaseModel):
+class ParameterGroup(TaggableResourceMixin, CloudFormationModel):
 
     resource_type = "parametergroup"
 
@@ -428,6 +447,15 @@ class ParameterGroup(TaggableResourceMixin, BaseModel):
         self.cluster_parameter_group_name = cluster_parameter_group_name
         self.group_family = group_family
         self.description = description
+
+    @staticmethod
+    def cloudformation_name_type():
+        return None
+
+    @staticmethod
+    def cloudformation_type():
+        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dynamodb-table.html
+        return "AWS::Redshift::ClusterParameterGroup"
 
     @classmethod
     def create_from_cloudformation_json(

--- a/moto/redshift/models.py
+++ b/moto/redshift/models.py
@@ -163,7 +163,7 @@ class Cluster(TaggableResourceMixin, CloudFormationModel):
 
     @staticmethod
     def cloudformation_type():
-        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dynamodb-table.html
+        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-redshift-cluster.html
         return "AWS::Redshift::Cluster"
 
     @classmethod
@@ -358,7 +358,7 @@ class SubnetGroup(TaggableResourceMixin, CloudFormationModel):
 
     @staticmethod
     def cloudformation_type():
-        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dynamodb-table.html
+        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-redshift-clustersubnetgroup.html
         return "AWS::Redshift::ClusterSubnetGroup"
 
     @classmethod
@@ -454,7 +454,7 @@ class ParameterGroup(TaggableResourceMixin, CloudFormationModel):
 
     @staticmethod
     def cloudformation_type():
-        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dynamodb-table.html
+        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-redshift-clusterparametergroup.html
         return "AWS::Redshift::ClusterParameterGroup"
 
     @classmethod

--- a/moto/route53/models.py
+++ b/moto/route53/models.py
@@ -40,7 +40,7 @@ class HealthCheck(CloudFormationModel):
 
     @staticmethod
     def cloudformation_type():
-        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dynamodb-table.html
+        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-route53-healthcheck.html
         return "AWS::Route53::HealthCheck"
 
     @classmethod
@@ -106,7 +106,7 @@ class RecordSet(CloudFormationModel):
 
     @staticmethod
     def cloudformation_type():
-        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dynamodb-table.html
+        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-route53-recordset.html
         return "AWS::Route53::RecordSet"
 
     @classmethod
@@ -291,7 +291,7 @@ class FakeZone(CloudFormationModel):
 
     @staticmethod
     def cloudformation_type():
-        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dynamodb-table.html
+        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-route53-hostedzone.html
         return "AWS::Route53::HostedZone"
 
     @classmethod
@@ -320,7 +320,7 @@ class RecordSetGroup(CloudFormationModel):
 
     @staticmethod
     def cloudformation_type():
-        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dynamodb-table.html
+        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-route53-recordsetgroup.html
         return "AWS::Route53::RecordSetGroup"
 
     @classmethod

--- a/moto/route53/models.py
+++ b/moto/route53/models.py
@@ -7,7 +7,7 @@ import random
 import uuid
 from jinja2 import Template
 
-from moto.core import BaseBackend, BaseModel, CloudFormationModel
+from moto.core import BaseBackend, CloudFormationModel
 
 
 ROUTE53_ID_CHOICE = string.ascii_uppercase + string.digits

--- a/moto/route53/models.py
+++ b/moto/route53/models.py
@@ -7,7 +7,7 @@ import random
 import uuid
 from jinja2 import Template
 
-from moto.core import BaseBackend, BaseModel
+from moto.core import BaseBackend, BaseModel, CloudFormationModel
 
 
 ROUTE53_ID_CHOICE = string.ascii_uppercase + string.digits
@@ -18,7 +18,7 @@ def create_route53_zone_id():
     return "".join([random.choice(ROUTE53_ID_CHOICE) for _ in range(0, 15)])
 
 
-class HealthCheck(BaseModel):
+class HealthCheck(CloudFormationModel):
     def __init__(self, health_check_id, health_check_args):
         self.id = health_check_id
         self.ip_address = health_check_args.get("ip_address")
@@ -33,6 +33,15 @@ class HealthCheck(BaseModel):
     @property
     def physical_resource_id(self):
         return self.id
+
+    @staticmethod
+    def cloudformation_name_type():
+        return None
+
+    @staticmethod
+    def cloudformation_type():
+        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dynamodb-table.html
+        return "AWS::Route53::HealthCheck"
 
     @classmethod
     def create_from_cloudformation_json(
@@ -75,7 +84,7 @@ class HealthCheck(BaseModel):
         return template.render(health_check=self)
 
 
-class RecordSet(BaseModel):
+class RecordSet(CloudFormationModel):
     def __init__(self, kwargs):
         self.name = kwargs.get("Name")
         self.type_ = kwargs.get("Type")
@@ -90,6 +99,15 @@ class RecordSet(BaseModel):
         self.alias_target = kwargs.get("AliasTarget")
         self.failover = kwargs.get("Failover")
         self.geo_location = kwargs.get("GeoLocation")
+
+    @staticmethod
+    def cloudformation_name_type():
+        return "Name"
+
+    @staticmethod
+    def cloudformation_type():
+        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dynamodb-table.html
+        return "AWS::Route53::RecordSet"
 
     @classmethod
     def create_from_cloudformation_json(
@@ -202,7 +220,7 @@ def reverse_domain_name(domain_name):
     return ".".join(reversed(domain_name.split(".")))
 
 
-class FakeZone(BaseModel):
+class FakeZone(CloudFormationModel):
     def __init__(self, name, id_, private_zone, comment=None):
         self.name = name
         self.id = id_
@@ -267,6 +285,15 @@ class FakeZone(BaseModel):
     def physical_resource_id(self):
         return self.id
 
+    @staticmethod
+    def cloudformation_name_type():
+        return "Name"
+
+    @staticmethod
+    def cloudformation_type():
+        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dynamodb-table.html
+        return "AWS::Route53::HostedZone"
+
     @classmethod
     def create_from_cloudformation_json(
         cls, resource_name, cloudformation_json, region_name
@@ -278,7 +305,7 @@ class FakeZone(BaseModel):
         return hosted_zone
 
 
-class RecordSetGroup(BaseModel):
+class RecordSetGroup(CloudFormationModel):
     def __init__(self, hosted_zone_id, record_sets):
         self.hosted_zone_id = hosted_zone_id
         self.record_sets = record_sets
@@ -286,6 +313,15 @@ class RecordSetGroup(BaseModel):
     @property
     def physical_resource_id(self):
         return "arn:aws:route53:::hostedzone/{0}".format(self.hosted_zone_id)
+
+    @staticmethod
+    def cloudformation_name_type():
+        return None
+
+    @staticmethod
+    def cloudformation_type():
+        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dynamodb-table.html
+        return "AWS::Route53::RecordSetGroup"
 
     @classmethod
     def create_from_cloudformation_json(

--- a/moto/s3/models.py
+++ b/moto/s3/models.py
@@ -1076,7 +1076,7 @@ class FakeBucket(CloudFormationModel):
 
     @staticmethod
     def cloudformation_type():
-        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dynamodb-table.html
+        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-s3-bucket.html
         return "AWS::S3::Bucket"
 
     @classmethod

--- a/moto/s3/models.py
+++ b/moto/s3/models.py
@@ -21,7 +21,7 @@ import uuid
 import six
 
 from bisect import insort
-from moto.core import ACCOUNT_ID, BaseBackend, BaseModel
+from moto.core import ACCOUNT_ID, BaseBackend, BaseModel, CloudFormationModel
 from moto.core.utils import iso_8601_datetime_without_milliseconds_s3, rfc_1123_datetime
 from moto.cloudwatch.models import MetricDatum
 from moto.utilities.tagging_service import TaggingService
@@ -763,7 +763,7 @@ class PublicAccessBlock(BaseModel):
         }
 
 
-class FakeBucket(BaseModel):
+class FakeBucket(CloudFormationModel):
     def __init__(self, name, region_name):
         self.name = name
         self.region_name = region_name
@@ -1069,6 +1069,15 @@ class FakeBucket(BaseModel):
     @property
     def physical_resource_id(self):
         return self.name
+
+    @staticmethod
+    def cloudformation_name_type():
+        return "BucketName"
+
+    @staticmethod
+    def cloudformation_type():
+        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dynamodb-table.html
+        return "AWS::S3::Bucket"
 
     @classmethod
     def create_from_cloudformation_json(

--- a/moto/sns/models.py
+++ b/moto/sns/models.py
@@ -103,7 +103,7 @@ class Topic(CloudFormationModel):
         sns_backend = sns_backends[region_name]
         properties = cloudformation_json["Properties"]
 
-        topic = sns_backend.create_topic(properties.get(self.cloudformation_name_type()))
+        topic = sns_backend.create_topic(properties.get(cls.cloudformation_name_type()))
         for subscription in properties.get("Subscription", []):
             sns_backend.subscribe(
                 topic.arn, subscription["Endpoint"], subscription["Protocol"]

--- a/moto/sns/models.py
+++ b/moto/sns/models.py
@@ -93,7 +93,7 @@ class Topic(CloudFormationModel):
 
     @staticmethod
     def cloudformation_type():
-        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dynamodb-table.html
+        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sns-topic.html
         return "AWS::SNS::Topic"
 
     @classmethod

--- a/moto/sqs/models.py
+++ b/moto/sqs/models.py
@@ -360,7 +360,7 @@ class Queue(CloudFormationModel):
 
     @staticmethod
     def cloudformation_type():
-        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dynamodb-table.html
+        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sqs-queue.html
         return "AWS::SQS::Queue"
 
     @classmethod

--- a/moto/sqs/models.py
+++ b/moto/sqs/models.py
@@ -12,7 +12,7 @@ from xml.sax.saxutils import escape
 from boto3 import Session
 
 from moto.core.exceptions import RESTError
-from moto.core import BaseBackend, BaseModel
+from moto.core import BaseBackend, BaseModel, CloudFormationModel
 from moto.core.utils import (
     camelcase_to_underscores,
     get_random_message_id,
@@ -188,7 +188,7 @@ class Message(BaseModel):
         return False
 
 
-class Queue(BaseModel):
+class Queue(CloudFormationModel):
     BASE_ATTRIBUTES = [
         "ApproximateNumberOfMessages",
         "ApproximateNumberOfMessagesDelayed",
@@ -353,6 +353,15 @@ class Queue(BaseModel):
                     self.redrive_policy["deadLetterTargetArn"]
                 ),
             )
+
+    @staticmethod
+    def cloudformation_name_type():
+        return "QueueName"
+
+    @staticmethod
+    def cloudformation_type():
+        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dynamodb-table.html
+        return "AWS::SQS::Queue"
 
     @classmethod
     def create_from_cloudformation_json(


### PR DESCRIPTION
Continuing from #3185 opened by @bblommers.

From the original PR:

> First pass at decentralizing the CF responsibility to individual models.
> Each Model that wants to be recognized by CloudFormation's parser now needs to:
> 
> - Extend the moto.core.CloudFormationModel class
> - Implement the abstract method cloudformation_type
> - Implement the abstract method cloudformation_name_type
> - Implement the create/update/delete_from_cloudformation_json methods (as before)
> 
> This removes the need to explicitly list all known/supported models in our CloudFormation-service.
> 
> TODO:
> 
> - [x] Change all other models to subclass CloudFormationModel (Only DynamoDB::Table is done atm)
> - [x] Add the create_from_cloudformation_json-methods to CloudFormationModel, to ensure clarity on what to do when implementing a new model
> - [x] Instead of cycling through the MODEL_LIST at runtime, we can probably dynamically recreate the structures we have now...That would eliminate the need for the two new for-loops

This PR completes the remaining TODO items from @bblommers original PR (so I checked them in the quote above).

## One question for the maintainers:

This almost entirely decentralizes the cloudformation resource type and naming conventions. However, using `CloudFormationModel.__subclasses__()` doesn't generate a complete list of subclasses unless they have all been "readied" by importing the relevant models. See comment before the long block of import statements in `cloudformation/parsing.py`. This means that if a future developer wants to add a new CloudFormationModel, they'll have to update the model in situ and then also add the import statement to `parsing.py`. It's much better than before but still slightly clunky.

Resolves #3127