### PR TITLE
Fix DynamoDb2 ExpressionAttributeNames can start with a number

### DIFF
--- a/moto/dynamodb2/parsing/tokens.py
+++ b/moto/dynamodb2/parsing/tokens.py
@@ -109,7 +109,7 @@ class ExpressionTokenizer(object):
 
     @classmethod
     def is_expression_attribute(cls, input_string):
-        return re.compile("^[a-zA-Z][a-zA-Z0-9_]*$").match(input_string) is not None
+        return re.compile("^[a-zA-Z0-9][a-zA-Z0-9_]*$").match(input_string) is not None
 
     @classmethod
     def is_expression_attribute_name(cls, input_string):

--- a/tests/test_dynamodb2/test_dynamodb_expression_tokenizer.py
+++ b/tests/test_dynamodb2/test_dynamodb_expression_tokenizer.py
@@ -219,6 +219,18 @@ def test_expression_tokenizer_single_set_action_attribute_name_valid_key():
     ]
 
 
+def test_expression_tokenizer_single_set_action_attribute_name_leading_number():
+    set_action = "SET attr=#0"
+    token_list = ExpressionTokenizer.make_list(set_action)
+    assert token_list == [
+        Token(Token.ATTRIBUTE, "SET"),
+        Token(Token.WHITESPACE, " "),
+        Token(Token.ATTRIBUTE, "attr"),
+        Token(Token.EQUAL_SIGN, "="),
+        Token(Token.ATTRIBUTE_NAME, "#0"),
+    ]
+
+
 def test_expression_tokenizer_just_a_pipe():
     set_action = "|"
     try:


### PR DESCRIPTION
When using pynamodb's support for transactions it makes use of of `ExpressionAttributeNames` that look like `#0` `#1` etc. According to the [ExpressionAttributeName documentation](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.ExpressionAttributeNames.html) and when testing against dynamodb-local these names work. However, when testing with moto they fail.

This PR modifies the regex for an expression attribute to allow for names that start with a number. This fix allows for tests in my codebase to pass.

As an aside - when reading the documentation it specifies that `ExpressionAttributeNames` must be alphanumeric, however, looking at the regex and moto tests `_` appears to be used. Possibly I'm slightly confused or this regex is used in multiple places??