### PR TITLE
fix: clear pending messages when call purge_queue

### DIFF
--- a/moto/sqs/models.py
+++ b/moto/sqs/models.py
@@ -844,6 +844,7 @@ class SQSBackend(BaseBackend):
     def purge_queue(self, queue_name):
         queue = self.get_queue(queue_name)
         queue._messages = []
+        queue._pending_messages = set()
 
     def list_dead_letter_source_queues(self, queue_name):
         dlq = self.get_queue(queue_name)


### PR DESCRIPTION
I'm using this product through localstack, and always helped me.

Compared to the real SQS behavior, it seems that some messages may not be retrieved after calling `purge_queue`.
I thought it was due to lack of clearing `_pending_messages` in `purge_queue`, but I'm not confident...
(I'm using FIFO Queue in my test code because that was exactly where I encountered the problem.)