### PR TITLE
Iam cloudformation update, singificant cloudformation refactoring

### DIFF
--- a/moto/awslambda/models.py
+++ b/moto/awslambda/models.py
@@ -685,9 +685,12 @@ class EventSourceMapping(CloudFormationModel):
         )
 
         for esm in esms:
-            if esm.logical_resource_id in resource_name:
-                lambda_backend.delete_event_source_mapping
+            if esm.uuid == resource_name:
                 esm.delete(region_name)
+
+    @property
+    def physical_resource_id(self):
+        return self.uuid
 
 
 class LambdaVersion(CloudFormationModel):

--- a/moto/cloudformation/parsing.py
+++ b/moto/cloudformation/parsing.py
@@ -326,15 +326,20 @@ def parse_and_update_resource(logical_id, resource_json, resources_map, region_n
         logical_id, resource_json, resources_map
     )
     original_resource = resources_map[logical_id]
-    new_resource = resource_class.update_from_cloudformation_json(
-        original_resource=original_resource,
-        new_resource_name=new_resource_name,
-        cloudformation_json=resource_json,
-        region_name=region_name,
-    )
-    new_resource.type = resource_json["Type"]
-    new_resource.logical_resource_id = logical_id
-    return new_resource
+    if not hasattr(
+        resource_class.update_from_cloudformation_json, "__isabstractmethod__"
+    ):
+        new_resource = resource_class.update_from_cloudformation_json(
+            original_resource=original_resource,
+            new_resource_name=new_resource_name,
+            cloudformation_json=resource_json,
+            region_name=region_name,
+        )
+        new_resource.type = resource_json["Type"]
+        new_resource.logical_resource_id = logical_id
+        return new_resource
+    else:
+        return None
 
 
 def parse_and_delete_resource(resource_name, resource_json, resources_map, region_name):

--- a/moto/cloudformation/parsing.py
+++ b/moto/cloudformation/parsing.py
@@ -253,11 +253,7 @@ def generate_resource_name(resource_type, stack_name, logical_id):
 
 
 def parse_resource(
-    logical_id,
-    resource_json,
-    resources_map,
-    add_name_to_resource_json=True,
-    generate_name=True,
+    resource_json, resources_map,
 ):
     resource_type = resource_json["Type"]
     resource_class = resource_class_from_type(resource_type)
@@ -269,24 +265,37 @@ def parse_resource(
         )
         return None
 
+    if "Properties" not in resource_json:
+        resource_json["Properties"] = {}
+
     resource_json = clean_json(resource_json, resources_map)
-    if generate_name:
-        resource_name = generate_resource_name(
-            resource_type, resources_map.get("AWS::StackName"), logical_id
-        )
-    else:
-        resource_name = logical_id
+
+    return resource_class, resource_json, resource_type
+
+
+def parse_resource_and_generate_name(
+    logical_id, resource_json, resources_map,
+):
+    resource_tuple = parse_resource(resource_json, resources_map)
+    if not resource_tuple:
+        return None
+    resource_class, resource_json, resource_type = resource_tuple
+
+    generated_resource_name = generate_resource_name(
+        resource_type, resources_map.get("AWS::StackName"), logical_id
+    )
+
     resource_name_property = resource_name_property_from_type(resource_type)
     if resource_name_property:
-        if "Properties" not in resource_json:
-            resource_json["Properties"] = dict()
         if (
-            add_name_to_resource_json
-            and resource_name_property not in resource_json["Properties"]
+            "Properties" in resource_json
+            and resource_name_property in resource_json["Properties"]
         ):
-            resource_json["Properties"][resource_name_property] = resource_name
-        if resource_name_property in resource_json["Properties"]:
             resource_name = resource_json["Properties"][resource_name_property]
+        else:
+            resource_name = generated_resource_name
+    else:
+        resource_name = generated_resource_name
 
     return resource_class, resource_json, resource_name
 
@@ -298,12 +307,14 @@ def parse_and_create_resource(logical_id, resource_json, resources_map, region_n
         return None
 
     resource_type = resource_json["Type"]
-    resource_tuple = parse_resource(logical_id, resource_json, resources_map)
+    resource_tuple = parse_resource_and_generate_name(
+        logical_id, resource_json, resources_map
+    )
     if not resource_tuple:
         return None
-    resource_class, resource_json, resource_name = resource_tuple
+    resource_class, resource_json, resource_physical_name = resource_tuple
     resource = resource_class.create_from_cloudformation_json(
-        resource_name, resource_json, region_name
+        resource_physical_name, resource_json, region_name
     )
     resource.type = resource_type
     resource.logical_resource_id = logical_id
@@ -311,14 +322,14 @@ def parse_and_create_resource(logical_id, resource_json, resources_map, region_n
 
 
 def parse_and_update_resource(logical_id, resource_json, resources_map, region_name):
-    resource_class, new_resource_json, new_resource_name = parse_resource(
-        logical_id, resource_json, resources_map, False
+    resource_class, resource_json, new_resource_name = parse_resource_and_generate_name(
+        logical_id, resource_json, resources_map
     )
     original_resource = resources_map[logical_id]
     new_resource = resource_class.update_from_cloudformation_json(
         original_resource=original_resource,
         new_resource_name=new_resource_name,
-        cloudformation_json=new_resource_json,
+        cloudformation_json=resource_json,
         region_name=region_name,
     )
     new_resource.type = resource_json["Type"]
@@ -326,15 +337,14 @@ def parse_and_update_resource(logical_id, resource_json, resources_map, region_n
     return new_resource
 
 
-def parse_and_delete_resource(
-    logical_id, resource_json, resources_map, region_name, generate_name=True
-):
-    resource_class, resource_json, resource_name = parse_resource(
-        logical_id, resource_json, resources_map, generate_name=generate_name
-    )
-    resource_class.delete_from_cloudformation_json(
-        resource_name, resource_json, region_name
-    )
+def parse_and_delete_resource(resource_name, resource_json, resources_map, region_name):
+    resource_class, resource_json, _ = parse_resource(resource_json, resources_map)
+    if not hasattr(
+        resource_class.delete_from_cloudformation_json, "__isabstractmethod__"
+    ):
+        resource_class.delete_from_cloudformation_json(
+            resource_name, resource_json, region_name
+        )
 
 
 def parse_condition(condition, resources_map, condition_map):
@@ -625,28 +635,36 @@ class ResourceMap(collections_abc.Mapping):
             )
             self._parsed_resources[resource_name] = new_resource
 
-        for resource_name, resource in resources_by_action["Remove"].items():
-            resource_json = old_template[resource_name]
+        for logical_name, _ in resources_by_action["Remove"].items():
+            resource_json = old_template[logical_name]
+            resource = self._parsed_resources[logical_name]
+            # ToDo: Standardize this.
+            if hasattr(resource, "physical_resource_id"):
+                resource_name = self._parsed_resources[
+                    logical_name
+                ].physical_resource_id
+            else:
+                resource_name = None
             parse_and_delete_resource(
                 resource_name, resource_json, self, self._region_name
             )
-            self._parsed_resources.pop(resource_name)
+            self._parsed_resources.pop(logical_name)
 
         tries = 1
         while resources_by_action["Modify"] and tries < 5:
-            for resource_name, resource in resources_by_action["Modify"].copy().items():
-                resource_json = new_template[resource_name]
+            for logical_name, _ in resources_by_action["Modify"].copy().items():
+                resource_json = new_template[logical_name]
                 try:
                     changed_resource = parse_and_update_resource(
-                        resource_name, resource_json, self, self._region_name
+                        logical_name, resource_json, self, self._region_name
                     )
                 except Exception as e:
                     # skip over dependency violations, and try again in a
                     # second pass
                     last_exception = e
                 else:
-                    self._parsed_resources[resource_name] = changed_resource
-                    del resources_by_action["Modify"][resource_name]
+                    self._parsed_resources[logical_name] = changed_resource
+                    del resources_by_action["Modify"][logical_name]
             tries += 1
         if tries == 5:
             raise last_exception
@@ -661,43 +679,20 @@ class ResourceMap(collections_abc.Mapping):
                     if parsed_resource and hasattr(parsed_resource, "delete"):
                         parsed_resource.delete(self._region_name)
                     else:
-                        resource_name_attribute = (
-                            parsed_resource.cloudformation_name_type()
-                            if hasattr(parsed_resource, "cloudformation_name_type")
-                            else resource_name_property_from_type(parsed_resource.type)
-                        )
+                        if hasattr(parsed_resource, "physical_resource_id"):
+                            resource_name = parsed_resource.physical_resource_id
+                        else:
+                            resource_name = None
+
                         resource_json = self._resource_json_map[
                             parsed_resource.logical_resource_id
                         ]
 
-                        if (
-                            "Properties" in resource_json
-                            and resource_json["Properties"]
-                            and resource_name_attribute in resource_json["Properties"]
-                        ):
-                            resource_name = resource_json["Properties"][
-                                resource_name_attribute
-                            ]
-                            generate_name = True
-                            parse_and_delete_resource(
-                                resource_name,
-                                resource_json,
-                                self,
-                                self._region_name,
-                                generate_name,
-                            )
-                        else:
-                            if hasattr(parsed_resource, "name"):
-                                resource_name = parsed_resource.name
-                                generate_name = False
-                                parse_and_delete_resource(
-                                    resource_name,
-                                    resource_json,
-                                    self,
-                                    self._region_name,
-                                    generate_name,
-                                )
-                        self._parsed_resources.pop(parsed_resource.logical_resource_id)
+                        parse_and_delete_resource(
+                            resource_name, resource_json, self, self._region_name,
+                        )
+
+                    self._parsed_resources.pop(parsed_resource.logical_resource_id)
                 except Exception as e:
                     # skip over dependency violations, and try again in a
                     # second pass

--- a/moto/cloudwatch/models.py
+++ b/moto/cloudwatch/models.py
@@ -511,10 +511,9 @@ class LogGroup(CloudFormationModel):
         cls, resource_name, cloudformation_json, region_name
     ):
         properties = cloudformation_json["Properties"]
-        log_group_name = properties["LogGroupName"]
         tags = properties.get("Tags", {})
         return logs_backends[region_name].create_log_group(
-            log_group_name, tags, **properties
+            resource_name, tags, **properties
         )
 
 

--- a/moto/datapipeline/models.py
+++ b/moto/datapipeline/models.py
@@ -90,9 +90,9 @@ class Pipeline(CloudFormationModel):
         datapipeline_backend = datapipeline_backends[region_name]
         properties = cloudformation_json["Properties"]
 
-        cloudformation_unique_id = "cf-" + properties["Name"]
+        cloudformation_unique_id = "cf-" + resource_name
         pipeline = datapipeline_backend.create_pipeline(
-            properties["Name"], cloudformation_unique_id
+            resource_name, cloudformation_unique_id
         )
         datapipeline_backend.put_pipeline_definition(
             pipeline.pipeline_id, properties["PipelineObjects"]

--- a/moto/dynamodb2/models/__init__.py
+++ b/moto/dynamodb2/models/__init__.py
@@ -461,7 +461,7 @@ class Table(CloudFormationModel):
             params["streams"] = properties["StreamSpecification"]
 
         table = dynamodb_backends[region_name].create_table(
-            name=properties["TableName"], **params
+            name=resource_name, **params
         )
         return table
 
@@ -469,11 +469,7 @@ class Table(CloudFormationModel):
     def delete_from_cloudformation_json(
         cls, resource_name, cloudformation_json, region_name
     ):
-        properties = cloudformation_json["Properties"]
-
-        table = dynamodb_backends[region_name].delete_table(
-            name=properties["TableName"]
-        )
+        table = dynamodb_backends[region_name].delete_table(name=resource_name)
         return table
 
     def _generate_arn(self, name):

--- a/moto/ecr/models.py
+++ b/moto/ecr/models.py
@@ -80,15 +80,11 @@ class Repository(BaseObject, CloudFormationModel):
     def create_from_cloudformation_json(
         cls, resource_name, cloudformation_json, region_name
     ):
-        properties = cloudformation_json["Properties"]
-
         ecr_backend = ecr_backends[region_name]
         return ecr_backend.create_repository(
             # RepositoryName is optional in CloudFormation, thus create a random
             # name if necessary
-            repository_name=properties.get(
-                "RepositoryName", "ecrrepository{0}".format(int(random() * 10 ** 6))
-            )
+            repository_name=resource_name
         )
 
     @classmethod

--- a/moto/elbv2/models.py
+++ b/moto/elbv2/models.py
@@ -160,7 +160,6 @@ class FakeTargetGroup(CloudFormationModel):
 
         elbv2_backend = elbv2_backends[region_name]
 
-        name = properties.get("Name")
         vpc_id = properties.get("VpcId")
         protocol = properties.get("Protocol")
         port = properties.get("Port")
@@ -175,7 +174,7 @@ class FakeTargetGroup(CloudFormationModel):
         target_type = properties.get("TargetType")
 
         target_group = elbv2_backend.create_target_group(
-            name=name,
+            name=resource_name,
             vpc_id=vpc_id,
             protocol=protocol,
             port=port,

--- a/moto/elbv2/models.py
+++ b/moto/elbv2/models.py
@@ -436,13 +436,12 @@ class FakeLoadBalancer(CloudFormationModel):
 
         elbv2_backend = elbv2_backends[region_name]
 
-        name = properties.get("Name", resource_name)
         security_groups = properties.get("SecurityGroups")
         subnet_ids = properties.get("Subnets")
         scheme = properties.get("Scheme", "internet-facing")
 
         load_balancer = elbv2_backend.create_load_balancer(
-            name, security_groups, subnet_ids, scheme=scheme
+            resource_name, security_groups, subnet_ids, scheme=scheme
         )
         return load_balancer
 

--- a/moto/events/models.py
+++ b/moto/events/models.py
@@ -88,7 +88,7 @@ class Rule(CloudFormationModel):
     ):
         properties = cloudformation_json["Properties"]
         event_backend = events_backends[region_name]
-        event_name = properties.get("Name") or resource_name
+        event_name = resource_name
         return event_backend.put_rule(name=event_name, **properties)
 
     @classmethod
@@ -175,7 +175,7 @@ class EventBus(CloudFormationModel):
     ):
         properties = cloudformation_json["Properties"]
         event_backend = events_backends[region_name]
-        event_name = properties["Name"]
+        event_name = resource_name
         event_source_name = properties.get("EventSourceName")
         return event_backend.create_event_bus(
             name=event_name, event_source_name=event_source_name

--- a/moto/events/models.py
+++ b/moto/events/models.py
@@ -104,9 +104,8 @@ class Rule(CloudFormationModel):
     def delete_from_cloudformation_json(
         cls, resource_name, cloudformation_json, region_name
     ):
-        properties = cloudformation_json["Properties"]
         event_backend = events_backends[region_name]
-        event_name = properties.get("Name") or resource_name
+        event_name = resource_name
         event_backend.delete_rule(name=event_name)
 
 
@@ -195,9 +194,8 @@ class EventBus(CloudFormationModel):
     def delete_from_cloudformation_json(
         cls, resource_name, cloudformation_json, region_name
     ):
-        properties = cloudformation_json["Properties"]
         event_backend = events_backends[region_name]
-        event_bus_name = properties["Name"]
+        event_bus_name = resource_name
         event_backend.delete_event_bus(event_bus_name)
 
 

--- a/moto/iam/models.py
+++ b/moto/iam/models.py
@@ -709,6 +709,12 @@ class Group(BaseModel):
     def list_policies(self):
         return self.policies.keys()
 
+    def delete_policy(self, policy_name):
+        if policy_name not in self.policies:
+            raise IAMNotFoundException("Policy {0} not found".format(policy_name))
+
+        del self.policies[policy_name]
+
 
 class User(CloudFormationModel):
     def __init__(self, name, path=None, tags=None):

--- a/moto/kinesis/models.py
+++ b/moto/kinesis/models.py
@@ -276,9 +276,7 @@ class Stream(CloudFormationModel):
         cls, resource_name, cloudformation_json, region_name
     ):
         backend = kinesis_backends[region_name]
-        properties = cloudformation_json.get("Properties", {})
-        stream_name = properties.get(cls.cloudformation_name_type(), resource_name)
-        backend.delete_stream(stream_name)
+        backend.delete_stream(resource_name)
 
     @staticmethod
     def is_replacement_update(properties):

--- a/moto/kinesis/responses.py
+++ b/moto/kinesis/responses.py
@@ -25,7 +25,10 @@ class KinesisResponse(BaseResponse):
     def create_stream(self):
         stream_name = self.parameters.get("StreamName")
         shard_count = self.parameters.get("ShardCount")
-        self.kinesis_backend.create_stream(stream_name, shard_count, self.region)
+        retention_period_hours = self.parameters.get("RetentionPeriodHours")
+        self.kinesis_backend.create_stream(
+            stream_name, shard_count, retention_period_hours, self.region
+        )
         return ""
 
     def describe_stream(self):

--- a/moto/rds/models.py
+++ b/moto/rds/models.py
@@ -4,7 +4,6 @@ import boto.rds
 from jinja2 import Template
 
 from moto.core import BaseBackend, CloudFormationModel
-from moto.core.utils import get_random_hex
 from moto.ec2.models import ec2_backends
 from moto.rds.exceptions import UnformattedGetAttTemplateException
 from moto.rds2.models import rds2_backends
@@ -33,9 +32,6 @@ class Database(CloudFormationModel):
     ):
         properties = cloudformation_json["Properties"]
 
-        db_instance_identifier = properties.get(cls.cloudformation_name_type())
-        if not db_instance_identifier:
-            db_instance_identifier = resource_name.lower() + get_random_hex(12)
         db_security_groups = properties.get("DBSecurityGroups")
         if not db_security_groups:
             db_security_groups = []
@@ -48,7 +44,7 @@ class Database(CloudFormationModel):
             "availability_zone": properties.get("AvailabilityZone"),
             "backup_retention_period": properties.get("BackupRetentionPeriod"),
             "db_instance_class": properties.get("DBInstanceClass"),
-            "db_instance_identifier": db_instance_identifier,
+            "db_instance_identifier": resource_name,
             "db_name": properties.get("DBName"),
             "db_subnet_group_name": db_subnet_group_name,
             "engine": properties.get("Engine"),
@@ -229,7 +225,7 @@ class SecurityGroup(CloudFormationModel):
         cls, resource_name, cloudformation_json, region_name
     ):
         properties = cloudformation_json["Properties"]
-        group_name = resource_name.lower() + get_random_hex(12)
+        group_name = resource_name.lower()
         description = properties["GroupDescription"]
         security_group_ingress_rules = properties.get("DBSecurityGroupIngress", [])
         tags = properties.get("Tags")
@@ -303,9 +299,7 @@ class SubnetGroup(CloudFormationModel):
         cls, resource_name, cloudformation_json, region_name
     ):
         properties = cloudformation_json["Properties"]
-        subnet_name = properties.get(cls.cloudformation_name_type())
-        if not subnet_name:
-            subnet_name = resource_name.lower() + get_random_hex(12)
+        subnet_name = resource_name.lower()
         description = properties["DBSubnetGroupDescription"]
         subnet_ids = properties["SubnetIds"]
         tags = properties.get("Tags")

--- a/moto/route53/models.py
+++ b/moto/route53/models.py
@@ -298,10 +298,9 @@ class FakeZone(CloudFormationModel):
     def create_from_cloudformation_json(
         cls, resource_name, cloudformation_json, region_name
     ):
-        properties = cloudformation_json["Properties"]
-        name = properties["Name"]
-
-        hosted_zone = route53_backend.create_hosted_zone(name, private_zone=False)
+        hosted_zone = route53_backend.create_hosted_zone(
+            resource_name, private_zone=False
+        )
         return hosted_zone
 
 

--- a/moto/s3/models.py
+++ b/moto/s3/models.py
@@ -1086,7 +1086,7 @@ class FakeBucket(CloudFormationModel):
     ):
         bucket = s3_backend.create_bucket(resource_name, region_name)
 
-        properties = cloudformation_json["Properties"]
+        properties = cloudformation_json.get("Properties", {})
 
         if "BucketEncryption" in properties:
             bucket_encryption = cfn_to_api_encryption(properties["BucketEncryption"])
@@ -1129,9 +1129,7 @@ class FakeBucket(CloudFormationModel):
     def delete_from_cloudformation_json(
         cls, resource_name, cloudformation_json, region_name
     ):
-        properties = cloudformation_json["Properties"]
-        bucket_name = properties[cls.cloudformation_name_type()]
-        s3_backend.delete_bucket(bucket_name)
+        s3_backend.delete_bucket(resource_name)
 
     def to_config_dict(self):
         """Return the AWS Config JSON format of this S3 bucket.

--- a/moto/sns/models.py
+++ b/moto/sns/models.py
@@ -104,7 +104,7 @@ class Topic(CloudFormationModel):
         sns_backend = sns_backends[region_name]
         properties = cloudformation_json["Properties"]
 
-        topic = sns_backend.create_topic(properties.get(cls.cloudformation_name_type()))
+        topic = sns_backend.create_topic(resource_name)
         for subscription in properties.get("Subscription", []):
             sns_backend.subscribe(
                 topic.arn, subscription["Endpoint"], subscription["Protocol"]

--- a/moto/sqs/models.py
+++ b/moto/sqs/models.py
@@ -374,10 +374,7 @@ class Queue(CloudFormationModel):
 
         sqs_backend = sqs_backends[region_name]
         return sqs_backend.create_queue(
-            name=properties["QueueName"],
-            tags=tags_dict,
-            region=region_name,
-            **properties
+            name=resource_name, tags=tags_dict, region=region_name, **properties
         )
 
     @classmethod
@@ -402,10 +399,8 @@ class Queue(CloudFormationModel):
     def delete_from_cloudformation_json(
         cls, resource_name, cloudformation_json, region_name
     ):
-        properties = cloudformation_json["Properties"]
-        queue_name = properties["QueueName"]
         sqs_backend = sqs_backends[region_name]
-        sqs_backend.delete_queue(queue_name)
+        sqs_backend.delete_queue(resource_name)
 
     @property
     def approximate_number_of_messages_delayed(self):

--- a/moto/sqs/models.py
+++ b/moto/sqs/models.py
@@ -382,7 +382,7 @@ class Queue(CloudFormationModel):
         cls, original_resource, new_resource_name, cloudformation_json, region_name
     ):
         properties = cloudformation_json["Properties"]
-        queue_name = properties["QueueName"]
+        queue_name = original_resource.name
 
         sqs_backend = sqs_backends[region_name]
         queue = sqs_backend.get_queue(queue_name)

--- a/tests/test_cloudformation/test_cloudformation_stack_crud_boto3.py
+++ b/tests/test_cloudformation/test_cloudformation_stack_crud_boto3.py
@@ -592,7 +592,7 @@ def test_boto3_create_stack_set_with_yaml():
 @mock_cloudformation
 @mock_s3
 def test_create_stack_set_from_s3_url():
-    s3 = boto3.client("s3")
+    s3 = boto3.client("s3", region_name="us-east-1")
     s3_conn = boto3.resource("s3", region_name="us-east-1")
     s3_conn.create_bucket(Bucket="foobar")
 
@@ -704,7 +704,7 @@ def test_boto3_create_stack_with_short_form_func_yaml():
 @mock_s3
 @mock_cloudformation
 def test_get_template_summary():
-    s3 = boto3.client("s3")
+    s3 = boto3.client("s3", region_name="us-east-1")
     s3_conn = boto3.resource("s3", region_name="us-east-1")
 
     conn = boto3.client("cloudformation", region_name="us-east-1")
@@ -802,7 +802,7 @@ def test_create_stack_with_role_arn():
 @mock_cloudformation
 @mock_s3
 def test_create_stack_from_s3_url():
-    s3 = boto3.client("s3")
+    s3 = boto3.client("s3", region_name="us-east-1")
     s3_conn = boto3.resource("s3", region_name="us-east-1")
     s3_conn.create_bucket(Bucket="foobar")
 
@@ -857,7 +857,7 @@ def test_update_stack_with_previous_value():
 @mock_s3
 @mock_ec2
 def test_update_stack_from_s3_url():
-    s3 = boto3.client("s3")
+    s3 = boto3.client("s3", region_name="us-east-1")
     s3_conn = boto3.resource("s3", region_name="us-east-1")
 
     cf_conn = boto3.client("cloudformation", region_name="us-east-1")
@@ -886,7 +886,7 @@ def test_update_stack_from_s3_url():
 @mock_cloudformation
 @mock_s3
 def test_create_change_set_from_s3_url():
-    s3 = boto3.client("s3")
+    s3 = boto3.client("s3", region_name="us-east-1")
     s3_conn = boto3.resource("s3", region_name="us-east-1")
     s3_conn.create_bucket(Bucket="foobar")
 

--- a/tests/test_cloudformation/test_validate.py
+++ b/tests/test_cloudformation/test_validate.py
@@ -118,7 +118,7 @@ def test_boto3_yaml_validate_successful():
 @mock_cloudformation
 @mock_s3
 def test_boto3_yaml_validate_template_url_successful():
-    s3 = boto3.client("s3")
+    s3 = boto3.client("s3", region_name="us-east-1")
     s3_conn = boto3.resource("s3", region_name="us-east-1")
     s3_conn.create_bucket(Bucket="foobar")
 

--- a/tests/test_iam/test_iam.py
+++ b/tests/test_iam/test_iam.py
@@ -5,12 +5,9 @@ import json
 import boto
 import boto3
 import csv
-import os
 import sure  # noqa
-import sys
 from boto.exception import BotoServerError
 from botocore.exceptions import ClientError
-from dateutil.tz import tzutc
 
 from moto import mock_iam, mock_iam_deprecated, settings
 from moto.core import ACCOUNT_ID

--- a/tests/test_iam/test_iam_cloudformation.py
+++ b/tests/test_iam/test_iam_cloudformation.py
@@ -1,0 +1,188 @@
+import boto3
+import sure  # noqa
+
+from nose.tools import assert_raises
+from botocore.exceptions import ClientError
+
+from moto import mock_iam, mock_cloudformation
+
+
+@mock_iam
+@mock_cloudformation
+def test_iam_cloudformation_create_user():
+    cf_client = boto3.client("cloudformation", region_name="us-east-1")
+
+    stack_name = "MyStack"
+    user_name = "MyUser"
+
+    template = """
+Resources:
+  TheUser:
+    Type: AWS::Iam::User
+    Properties:
+      UserName: {0}
+""".strip().format(
+        user_name
+    )
+
+    cf_client.create_stack(StackName=stack_name, TemplateBody=template)
+
+    provisioned_resource = cf_client.list_stack_resources(StackName=stack_name)[
+        "StackResourceSummaries"
+    ][0]
+    provisioned_resource["LogicalResourceId"].should.equal("TheUser")
+    provisioned_resource["PhysicalResourceId"].should.equal(user_name)
+
+
+@mock_iam
+@mock_cloudformation
+def test_iam_cloudformation_update_user_no_interruption():
+    cf_client = boto3.client("cloudformation", region_name="us-east-1")
+
+    stack_name = "MyStack"
+
+    template = """
+Resources:
+  TheUser:
+    Type: AWS::Iam::User
+""".strip()
+
+    cf_client.create_stack(StackName=stack_name, TemplateBody=template)
+    provisioned_resource = cf_client.list_stack_resources(StackName=stack_name)[
+        "StackResourceSummaries"
+    ][0]
+    user_name = provisioned_resource["PhysicalResourceId"]
+
+    iam_client = boto3.client("iam")
+    user = iam_client.get_user(UserName=user_name)["User"]
+    user["Path"].should.equal("/")
+
+    path = "/MyPath/"
+    template = """
+Resources:
+  TheUser:
+    Type: AWS::Iam::User
+    Properties:
+      Path: {0}
+""".strip().format(
+        path
+    )
+
+    cf_client.update_stack(StackName=stack_name, TemplateBody=template)
+
+    user = iam_client.get_user(UserName=user_name)["User"]
+    user["Path"].should.equal(path)
+
+
+@mock_iam
+@mock_cloudformation
+def test_iam_cloudformation_update_user_replacement():
+    cf_client = boto3.client("cloudformation", region_name="us-east-1")
+
+    stack_name = "MyStack"
+
+    template = """
+Resources:
+  TheUser:
+    Type: AWS::Iam::User
+""".strip()
+
+    cf_client.create_stack(StackName=stack_name, TemplateBody=template)
+    provisioned_resource = cf_client.list_stack_resources(StackName=stack_name)[
+        "StackResourceSummaries"
+    ][0]
+    original_user_name = provisioned_resource["PhysicalResourceId"]
+
+    iam_client = boto3.client("iam")
+    user = iam_client.get_user(UserName=original_user_name)["User"]
+    user["Path"].should.equal("/")
+
+    new_user_name = "MyUser"
+    template = """
+Resources:
+  TheUser:
+    Type: AWS::Iam::User
+    Properties:
+      UserName: {0}
+""".strip().format(
+        new_user_name
+    )
+
+    cf_client.update_stack(StackName=stack_name, TemplateBody=template)
+
+    with assert_raises(ClientError) as e:
+        iam_client.get_user(UserName=original_user_name)
+    e.exception.response["Error"]["Code"].should.equal("NoSuchEntity")
+
+    iam_client.get_user(UserName=new_user_name)
+
+
+@mock_iam
+@mock_cloudformation
+def test_iam_cloudformation_delete_user():
+    cf_client = boto3.client("cloudformation", region_name="us-east-1")
+
+    stack_name = "MyStack"
+    user_name = "MyUser"
+
+    template = """
+Resources:
+  TheUser:
+    Type: AWS::Iam::User
+    Properties:
+      UserName: {}
+""".strip().format(
+        user_name
+    )
+
+    cf_client.create_stack(StackName=stack_name, TemplateBody=template)
+
+    iam_client = boto3.client("iam")
+    user = iam_client.get_user(UserName=user_name)
+
+    cf_client.delete_stack(StackName=stack_name)
+
+    with assert_raises(ClientError) as e:
+        user = iam_client.get_user(UserName=user_name)
+    e.exception.response["Error"]["Code"].should.equal("NoSuchEntity")
+
+
+@mock_iam
+@mock_cloudformation
+def test_iam_cloudformation_get_attr():
+    cf_client = boto3.client("cloudformation", region_name="us-east-1")
+
+    stack_name = "MyStack"
+    user_name = "MyUser"
+
+    template = """
+Resources:
+  TheUser:
+    Type: AWS::Iam::User
+    Properties:
+      UserName: {0}
+Outputs:
+  UserName:
+    Value: !Ref TheUser
+  UserArn:
+    Value: !GetAtt TheUser.Arn
+""".strip().format(
+        user_name
+    )
+
+    cf_client.create_stack(StackName=stack_name, TemplateBody=template)
+    stack_description = cf_client.describe_stacks(StackName=stack_name)["Stacks"][0]
+    output_user_name = [
+        output["OutputValue"]
+        for output in stack_description["Outputs"]
+        if output["OutputKey"] == "UserName"
+    ][0]
+    output_user_arn = [
+        output["OutputValue"]
+        for output in stack_description["Outputs"]
+        if output["OutputKey"] == "UserArn"
+    ][0]
+
+    iam_client = boto3.client("iam")
+    user_description = iam_client.get_user(UserName=output_user_name)["User"]
+    output_user_arn.should.equal(user_description["Arn"])

--- a/tests/test_iam/test_iam_cloudformation.py
+++ b/tests/test_iam/test_iam_cloudformation.py
@@ -412,3 +412,391 @@ Resources:
     iam_client.get_user_policy.when.called_with(
         UserName=user_name, PolicyName=policy_name
     ).should.throw(iam_client.exceptions.NoSuchEntityException)
+
+
+@mock_s3
+@mock_iam
+@mock_cloudformation
+def test_iam_cloudformation_create_role_policy():
+    iam_client = boto3.client("iam")
+    role_name = "MyRole"
+    iam_client.create_role(RoleName=role_name, AssumeRolePolicyDocument="{}")
+
+    s3_client = boto3.client("s3")
+    bucket_name = "my-bucket"
+    s3_client.create_bucket(Bucket=bucket_name)
+    bucket_arn = "arn:aws:s3:::{0}".format(bucket_name)
+
+    cf_client = boto3.client("cloudformation", region_name="us-east-1")
+    stack_name = "MyStack"
+    policy_name = "MyPolicy"
+
+    template = """
+Resources:
+  ThePolicy:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyName: {0}
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+        - Effect: Allow
+          Action: s3:*
+          Resource: {1}
+      Roles:
+        - {2}
+""".strip().format(
+        policy_name, bucket_arn, role_name
+    )
+
+    cf_client.create_stack(StackName=stack_name, TemplateBody=template)
+
+    provisioned_resource = cf_client.list_stack_resources(StackName=stack_name)[
+        "StackResourceSummaries"
+    ][0]
+    logical_resource_id = provisioned_resource["LogicalResourceId"]
+    logical_resource_id.should.equal("ThePolicy")
+
+    original_policy_document = yaml.load(template, Loader=yaml.FullLoader)["Resources"][
+        logical_resource_id
+    ]["Properties"]["PolicyDocument"]
+    policy = iam_client.get_role_policy(RoleName=role_name, PolicyName=policy_name)
+    policy["PolicyDocument"].should.equal(original_policy_document)
+
+
+@mock_s3
+@mock_iam
+@mock_cloudformation
+def test_iam_cloudformation_update_role_policy():
+    iam_client = boto3.client("iam")
+    role_name_1 = "MyRole1"
+    iam_client.create_role(RoleName=role_name_1, AssumeRolePolicyDocument="{}")
+    role_name_2 = "MyRole2"
+    iam_client.create_role(RoleName=role_name_2, AssumeRolePolicyDocument="{}")
+
+    s3_client = boto3.client("s3")
+    bucket_name = "my-bucket"
+    s3_client.create_bucket(Bucket=bucket_name)
+    bucket_arn = "arn:aws:s3:::{0}".format(bucket_name)
+
+    cf_client = boto3.client("cloudformation", region_name="us-east-1")
+    stack_name = "MyStack"
+    policy_name = "MyPolicy"
+
+    template = """
+Resources:
+  ThePolicy:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyName: {0}
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+        - Effect: Allow
+          Action: s3:*
+          Resource: {1}
+      Roles:
+        - {2}
+""".strip().format(
+        policy_name, bucket_arn, role_name_1
+    )
+
+    cf_client.create_stack(StackName=stack_name, TemplateBody=template)
+
+    provisioned_resource = cf_client.list_stack_resources(StackName=stack_name)[
+        "StackResourceSummaries"
+    ][0]
+    logical_resource_id = provisioned_resource["LogicalResourceId"]
+    logical_resource_id.should.equal("ThePolicy")
+
+    original_policy_document = yaml.load(template, Loader=yaml.FullLoader)["Resources"][
+        logical_resource_id
+    ]["Properties"]["PolicyDocument"]
+    policy = iam_client.get_role_policy(RoleName=role_name_1, PolicyName=policy_name)
+    policy["PolicyDocument"].should.equal(original_policy_document)
+
+    # Change template and user
+    template = """
+Resources:
+  ThePolicy:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyName: {0}
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+        - Effect: Allow
+          Action: s3:ListBuckets
+          Resource: {1}
+      Roles:
+        - {2}
+""".strip().format(
+        policy_name, bucket_arn, role_name_2
+    )
+
+    cf_client.update_stack(StackName=stack_name, TemplateBody=template)
+
+    provisioned_resource = cf_client.list_stack_resources(StackName=stack_name)[
+        "StackResourceSummaries"
+    ][0]
+    logical_resource_id = provisioned_resource["LogicalResourceId"]
+    logical_resource_id.should.equal("ThePolicy")
+
+    original_policy_document = yaml.load(template, Loader=yaml.FullLoader)["Resources"][
+        logical_resource_id
+    ]["Properties"]["PolicyDocument"]
+    policy = iam_client.get_role_policy(RoleName=role_name_2, PolicyName=policy_name)
+    policy["PolicyDocument"].should.equal(original_policy_document)
+
+    iam_client.get_role_policy.when.called_with(
+        RoleName=role_name_1, PolicyName=policy_name
+    ).should.throw(iam_client.exceptions.NoSuchEntityException)
+
+
+@mock_s3
+@mock_iam
+@mock_cloudformation
+def test_iam_cloudformation_delete_role_policy_having_generated_name():
+    iam_client = boto3.client("iam")
+    role_name = "MyRole"
+    iam_client.create_role(RoleName=role_name, AssumeRolePolicyDocument="{}")
+
+    s3_client = boto3.client("s3")
+    bucket_name = "my-bucket"
+    s3_client.create_bucket(Bucket=bucket_name)
+    bucket_arn = "arn:aws:s3:::{0}".format(bucket_name)
+
+    cf_client = boto3.client("cloudformation", region_name="us-east-1")
+    stack_name = "MyStack"
+    policy_name = "MyPolicy"
+
+    template = """
+Resources:
+  ThePolicy:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyName: MyPolicy
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+        - Effect: Allow
+          Action: s3:*
+          Resource: {0}
+      Roles:
+        - {1}
+""".strip().format(
+        bucket_arn, role_name
+    )
+
+    cf_client.create_stack(StackName=stack_name, TemplateBody=template)
+
+    provisioned_resource = cf_client.list_stack_resources(StackName=stack_name)[
+        "StackResourceSummaries"
+    ][0]
+    logical_resource_id = provisioned_resource["LogicalResourceId"]
+    logical_resource_id.should.equal("ThePolicy")
+
+    original_policy_document = yaml.load(template, Loader=yaml.FullLoader)["Resources"][
+        logical_resource_id
+    ]["Properties"]["PolicyDocument"]
+    policy = iam_client.get_role_policy(RoleName=role_name, PolicyName=policy_name)
+    policy["PolicyDocument"].should.equal(original_policy_document)
+
+    cf_client.delete_stack(StackName=stack_name)
+    iam_client.get_role_policy.when.called_with(
+        RoleName=role_name, PolicyName=policy_name
+    ).should.throw(iam_client.exceptions.NoSuchEntityException)
+
+
+@mock_s3
+@mock_iam
+@mock_cloudformation
+def test_iam_cloudformation_create_group_policy():
+    iam_client = boto3.client("iam")
+    group_name = "MyGroup"
+    iam_client.create_group(GroupName=group_name)
+
+    s3_client = boto3.client("s3")
+    bucket_name = "my-bucket"
+    s3_client.create_bucket(Bucket=bucket_name)
+    bucket_arn = "arn:aws:s3:::{0}".format(bucket_name)
+
+    cf_client = boto3.client("cloudformation", region_name="us-east-1")
+    stack_name = "MyStack"
+    policy_name = "MyPolicy"
+
+    template = """
+Resources:
+  ThePolicy:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyName: {0}
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+        - Effect: Allow
+          Action: s3:*
+          Resource: {1}
+      Groups:
+        - {2}
+""".strip().format(
+        policy_name, bucket_arn, group_name
+    )
+
+    cf_client.create_stack(StackName=stack_name, TemplateBody=template)
+
+    provisioned_resource = cf_client.list_stack_resources(StackName=stack_name)[
+        "StackResourceSummaries"
+    ][0]
+    logical_resource_id = provisioned_resource["LogicalResourceId"]
+    logical_resource_id.should.equal("ThePolicy")
+
+    original_policy_document = yaml.load(template, Loader=yaml.FullLoader)["Resources"][
+        logical_resource_id
+    ]["Properties"]["PolicyDocument"]
+    policy = iam_client.get_group_policy(GroupName=group_name, PolicyName=policy_name)
+    policy["PolicyDocument"].should.equal(original_policy_document)
+
+
+@mock_s3
+@mock_iam
+@mock_cloudformation
+def test_iam_cloudformation_update_group_policy():
+    iam_client = boto3.client("iam")
+    group_name_1 = "MyGroup1"
+    iam_client.create_group(GroupName=group_name_1)
+    group_name_2 = "MyGroup2"
+    iam_client.create_group(GroupName=group_name_2)
+
+    s3_client = boto3.client("s3")
+    bucket_name = "my-bucket"
+    s3_client.create_bucket(Bucket=bucket_name)
+    bucket_arn = "arn:aws:s3:::{0}".format(bucket_name)
+
+    cf_client = boto3.client("cloudformation", region_name="us-east-1")
+    stack_name = "MyStack"
+    policy_name = "MyPolicy"
+
+    template = """
+Resources:
+  ThePolicy:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyName: {0}
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+        - Effect: Allow
+          Action: s3:*
+          Resource: {1}
+      Groups:
+        - {2}
+""".strip().format(
+        policy_name, bucket_arn, group_name_1
+    )
+
+    cf_client.create_stack(StackName=stack_name, TemplateBody=template)
+
+    provisioned_resource = cf_client.list_stack_resources(StackName=stack_name)[
+        "StackResourceSummaries"
+    ][0]
+    logical_resource_id = provisioned_resource["LogicalResourceId"]
+    logical_resource_id.should.equal("ThePolicy")
+
+    original_policy_document = yaml.load(template, Loader=yaml.FullLoader)["Resources"][
+        logical_resource_id
+    ]["Properties"]["PolicyDocument"]
+    policy = iam_client.get_group_policy(GroupName=group_name_1, PolicyName=policy_name)
+    policy["PolicyDocument"].should.equal(original_policy_document)
+
+    # Change template and user
+    template = """
+Resources:
+  ThePolicy:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyName: {0}
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+        - Effect: Allow
+          Action: s3:ListBuckets
+          Resource: {1}
+      Groups:
+        - {2}
+""".strip().format(
+        policy_name, bucket_arn, group_name_2
+    )
+
+    cf_client.update_stack(StackName=stack_name, TemplateBody=template)
+
+    provisioned_resource = cf_client.list_stack_resources(StackName=stack_name)[
+        "StackResourceSummaries"
+    ][0]
+    logical_resource_id = provisioned_resource["LogicalResourceId"]
+    logical_resource_id.should.equal("ThePolicy")
+
+    original_policy_document = yaml.load(template, Loader=yaml.FullLoader)["Resources"][
+        logical_resource_id
+    ]["Properties"]["PolicyDocument"]
+    policy = iam_client.get_group_policy(GroupName=group_name_2, PolicyName=policy_name)
+    policy["PolicyDocument"].should.equal(original_policy_document)
+
+    iam_client.get_group_policy.when.called_with(
+        GroupName=group_name_1, PolicyName=policy_name
+    ).should.throw(iam_client.exceptions.NoSuchEntityException)
+
+
+@mock_s3
+@mock_iam
+@mock_cloudformation
+def test_iam_cloudformation_delete_group_policy_having_generated_name():
+    iam_client = boto3.client("iam")
+    group_name = "MyGroup"
+    iam_client.create_group(GroupName=group_name)
+
+    s3_client = boto3.client("s3")
+    bucket_name = "my-bucket"
+    s3_client.create_bucket(Bucket=bucket_name)
+    bucket_arn = "arn:aws:s3:::{0}".format(bucket_name)
+
+    cf_client = boto3.client("cloudformation", region_name="us-east-1")
+    stack_name = "MyStack"
+    policy_name = "MyPolicy"
+
+    template = """
+Resources:
+  ThePolicy:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyName: MyPolicy
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+        - Effect: Allow
+          Action: s3:*
+          Resource: {0}
+      Groups:
+        - {1}
+""".strip().format(
+        bucket_arn, group_name
+    )
+
+    cf_client.create_stack(StackName=stack_name, TemplateBody=template)
+
+    provisioned_resource = cf_client.list_stack_resources(StackName=stack_name)[
+        "StackResourceSummaries"
+    ][0]
+    logical_resource_id = provisioned_resource["LogicalResourceId"]
+    logical_resource_id.should.equal("ThePolicy")
+
+    original_policy_document = yaml.load(template, Loader=yaml.FullLoader)["Resources"][
+        logical_resource_id
+    ]["Properties"]["PolicyDocument"]
+    policy = iam_client.get_group_policy(GroupName=group_name, PolicyName=policy_name)
+    policy["PolicyDocument"].should.equal(original_policy_document)
+
+    cf_client.delete_stack(StackName=stack_name)
+    iam_client.get_group_policy.when.called_with(
+        GroupName=group_name, PolicyName=policy_name
+    ).should.throw(iam_client.exceptions.NoSuchEntityException)

--- a/tests/test_iam/test_iam_cloudformation.py
+++ b/tests/test_iam/test_iam_cloudformation.py
@@ -54,7 +54,7 @@ Resources:
     ][0]
     user_name = provisioned_resource["PhysicalResourceId"]
 
-    iam_client = boto3.client("iam")
+    iam_client = boto3.client("iam", region_name="us-east-1")
     user = iam_client.get_user(UserName=user_name)["User"]
     user["Path"].should.equal("/")
 
@@ -94,7 +94,7 @@ Resources:
     ][0]
     original_user_name = provisioned_resource["PhysicalResourceId"]
 
-    iam_client = boto3.client("iam")
+    iam_client = boto3.client("iam", region_name="us-east-1")
     user = iam_client.get_user(UserName=original_user_name)["User"]
     user["Path"].should.equal("/")
 
@@ -151,7 +151,7 @@ Resources:
     first_user_name = first_provisioned_user["PhysicalResourceId"]
     second_user_name = second_provisioned_user["PhysicalResourceId"]
 
-    iam_client = boto3.client("iam")
+    iam_client = boto3.client("iam", region_name="us-east-1")
     iam_client.get_user(UserName=first_user_name)
     iam_client.get_user(UserName=second_user_name)
 
@@ -200,7 +200,7 @@ Resources:
 
     cf_client.create_stack(StackName=stack_name, TemplateBody=template)
 
-    iam_client = boto3.client("iam")
+    iam_client = boto3.client("iam", region_name="us-east-1")
     user = iam_client.get_user(UserName=user_name)
 
     cf_client.delete_stack(StackName=stack_name)
@@ -230,7 +230,7 @@ Resources:
     provisioned_resource["LogicalResourceId"].should.equal("TheUser")
     user_name = provisioned_resource["PhysicalResourceId"]
 
-    iam_client = boto3.client("iam")
+    iam_client = boto3.client("iam", region_name="us-east-1")
     user = iam_client.get_user(UserName=user_name)
 
     cf_client.delete_stack(StackName=stack_name)
@@ -276,7 +276,7 @@ Outputs:
         if output["OutputKey"] == "UserArn"
     ][0]
 
-    iam_client = boto3.client("iam")
+    iam_client = boto3.client("iam", region_name="us-east-1")
     user_description = iam_client.get_user(UserName=output_user_name)["User"]
     output_user_arn.should.equal(user_description["Arn"])
 
@@ -286,11 +286,11 @@ Outputs:
 @mock_iam
 @mock_cloudformation
 def test_iam_cloudformation_create_user_policy():
-    iam_client = boto3.client("iam")
+    iam_client = boto3.client("iam", region_name="us-east-1")
     user_name = "MyUser"
     iam_client.create_user(UserName=user_name)
 
-    s3_client = boto3.client("s3")
+    s3_client = boto3.client("s3", region_name="us-east-1")
     bucket_name = "my-bucket"
     bucket = s3_client.create_bucket(Bucket=bucket_name)
     bucket_arn = "arn:aws:s3:::{0}".format(bucket_name)
@@ -336,13 +336,13 @@ Resources:
 @mock_iam
 @mock_cloudformation
 def test_iam_cloudformation_update_user_policy():
-    iam_client = boto3.client("iam")
+    iam_client = boto3.client("iam", region_name="us-east-1")
     user_name_1 = "MyUser1"
     iam_client.create_user(UserName=user_name_1)
     user_name_2 = "MyUser2"
     iam_client.create_user(UserName=user_name_2)
 
-    s3_client = boto3.client("s3")
+    s3_client = boto3.client("s3", region_name="us-east-1")
     bucket_name = "my-bucket"
     s3_client.create_bucket(Bucket=bucket_name)
     bucket_arn = "arn:aws:s3:::{0}".format(bucket_name)
@@ -425,11 +425,11 @@ Resources:
 @mock_iam
 @mock_cloudformation
 def test_iam_cloudformation_delete_user_policy_having_generated_name():
-    iam_client = boto3.client("iam")
+    iam_client = boto3.client("iam", region_name="us-east-1")
     user_name = "MyUser"
     iam_client.create_user(UserName=user_name)
 
-    s3_client = boto3.client("s3")
+    s3_client = boto3.client("s3", region_name="us-east-1")
     bucket_name = "my-bucket"
     bucket = s3_client.create_bucket(Bucket=bucket_name)
     bucket_arn = "arn:aws:s3:::{0}".format(bucket_name)
@@ -480,11 +480,11 @@ Resources:
 @mock_iam
 @mock_cloudformation
 def test_iam_cloudformation_create_role_policy():
-    iam_client = boto3.client("iam")
+    iam_client = boto3.client("iam", region_name="us-east-1")
     role_name = "MyRole"
     iam_client.create_role(RoleName=role_name, AssumeRolePolicyDocument="{}")
 
-    s3_client = boto3.client("s3")
+    s3_client = boto3.client("s3", region_name="us-east-1")
     bucket_name = "my-bucket"
     s3_client.create_bucket(Bucket=bucket_name)
     bucket_arn = "arn:aws:s3:::{0}".format(bucket_name)
@@ -530,13 +530,13 @@ Resources:
 @mock_iam
 @mock_cloudformation
 def test_iam_cloudformation_update_role_policy():
-    iam_client = boto3.client("iam")
+    iam_client = boto3.client("iam", region_name="us-east-1")
     role_name_1 = "MyRole1"
     iam_client.create_role(RoleName=role_name_1, AssumeRolePolicyDocument="{}")
     role_name_2 = "MyRole2"
     iam_client.create_role(RoleName=role_name_2, AssumeRolePolicyDocument="{}")
 
-    s3_client = boto3.client("s3")
+    s3_client = boto3.client("s3", region_name="us-east-1")
     bucket_name = "my-bucket"
     s3_client.create_bucket(Bucket=bucket_name)
     bucket_arn = "arn:aws:s3:::{0}".format(bucket_name)
@@ -619,11 +619,11 @@ Resources:
 @mock_iam
 @mock_cloudformation
 def test_iam_cloudformation_delete_role_policy_having_generated_name():
-    iam_client = boto3.client("iam")
+    iam_client = boto3.client("iam", region_name="us-east-1")
     role_name = "MyRole"
     iam_client.create_role(RoleName=role_name, AssumeRolePolicyDocument="{}")
 
-    s3_client = boto3.client("s3")
+    s3_client = boto3.client("s3", region_name="us-east-1")
     bucket_name = "my-bucket"
     s3_client.create_bucket(Bucket=bucket_name)
     bucket_arn = "arn:aws:s3:::{0}".format(bucket_name)
@@ -674,11 +674,11 @@ Resources:
 @mock_iam
 @mock_cloudformation
 def test_iam_cloudformation_create_group_policy():
-    iam_client = boto3.client("iam")
+    iam_client = boto3.client("iam", region_name="us-east-1")
     group_name = "MyGroup"
     iam_client.create_group(GroupName=group_name)
 
-    s3_client = boto3.client("s3")
+    s3_client = boto3.client("s3", region_name="us-east-1")
     bucket_name = "my-bucket"
     s3_client.create_bucket(Bucket=bucket_name)
     bucket_arn = "arn:aws:s3:::{0}".format(bucket_name)
@@ -724,13 +724,13 @@ Resources:
 @mock_iam
 @mock_cloudformation
 def test_iam_cloudformation_update_group_policy():
-    iam_client = boto3.client("iam")
+    iam_client = boto3.client("iam", region_name="us-east-1")
     group_name_1 = "MyGroup1"
     iam_client.create_group(GroupName=group_name_1)
     group_name_2 = "MyGroup2"
     iam_client.create_group(GroupName=group_name_2)
 
-    s3_client = boto3.client("s3")
+    s3_client = boto3.client("s3", region_name="us-east-1")
     bucket_name = "my-bucket"
     s3_client.create_bucket(Bucket=bucket_name)
     bucket_arn = "arn:aws:s3:::{0}".format(bucket_name)
@@ -813,11 +813,11 @@ Resources:
 @mock_iam
 @mock_cloudformation
 def test_iam_cloudformation_delete_group_policy_having_generated_name():
-    iam_client = boto3.client("iam")
+    iam_client = boto3.client("iam", region_name="us-east-1")
     group_name = "MyGroup"
     iam_client.create_group(GroupName=group_name)
 
-    s3_client = boto3.client("s3")
+    s3_client = boto3.client("s3", region_name="us-east-1")
     bucket_name = "my-bucket"
     s3_client.create_bucket(Bucket=bucket_name)
     bucket_arn = "arn:aws:s3:::{0}".format(bucket_name)
@@ -902,7 +902,7 @@ Resources:
     ]
     len(provisioned_access_keys).should.equal(1)
 
-    iam_client = boto3.client("iam")
+    iam_client = boto3.client("iam", region_name="us-east-1")
     user = iam_client.get_user(UserName=user_name)["User"]
     user["UserName"].should.equal(user_name)
     access_keys = iam_client.list_access_keys(UserName=user_name)
@@ -960,6 +960,7 @@ Outputs:
         "sts",
         aws_access_key_id=output_access_key_id,
         aws_secret_access_key=output_secret_key,
+        region_name="us-east-1",
     )
     caller_identity = sts_client.get_caller_identity()
     caller_identity["Arn"].split("/")[1].should.equal(user_name)
@@ -1003,7 +1004,7 @@ def test_iam_cloudformation_delete_users_access_key():
     ][0]
     access_key_id = provisioned_access_key["PhysicalResourceId"]
 
-    iam_client = boto3.client("iam")
+    iam_client = boto3.client("iam", region_name="us-east-1")
     user = iam_client.get_user(UserName=user_name)
     access_keys = iam_client.list_access_keys(UserName=user_name)
 
@@ -1056,7 +1057,7 @@ def test_iam_cloudformation_delete_users_access_key():
     ]
     len(provisioned_access_keys).should.equal(1)
 
-    iam_client = boto3.client("iam")
+    iam_client = boto3.client("iam", region_name="us-east-1")
     user = iam_client.get_user(UserName=user_name)["User"]
     user["UserName"].should.equal(user_name)
     access_keys = iam_client.list_access_keys(UserName=user_name)
@@ -1109,7 +1110,7 @@ Resources:
     ][0]
     access_key_id = provisioned_access_key["PhysicalResourceId"]
 
-    iam_client = boto3.client("iam")
+    iam_client = boto3.client("iam", region_name="us-east-1")
     user = iam_client.get_user(UserName=user_name)
     access_keys = iam_client.list_access_keys(UserName=user_name)
     access_key_id.should.equal(access_keys["AccessKeyMetadata"][0]["AccessKeyId"])
@@ -1166,7 +1167,7 @@ Resources:
     ][0]
     access_key_id = provisioned_access_key["PhysicalResourceId"]
 
-    iam_client = boto3.client("iam")
+    iam_client = boto3.client("iam", region_name="us-east-1")
     user = iam_client.get_user(UserName=user_name)
     access_keys = iam_client.list_access_keys(UserName=user_name)
     access_key_id.should.equal(access_keys["AccessKeyMetadata"][0]["AccessKeyId"])

--- a/tests/test_kinesis/test_kinesis_cloudformation.py
+++ b/tests/test_kinesis/test_kinesis_cloudformation.py
@@ -74,6 +74,11 @@ Resources:
       Name: MyStream
       ShardCount: 4
       RetentionPeriodHours: 48
+      Tags:
+      - Key: TagKey1
+        Value: TagValue1
+      - Key: TagKey2
+        Value: TagValue2
 """.strip()
 
     cf_conn.create_stack(StackName=stack_name, TemplateBody=template)
@@ -85,6 +90,12 @@ Resources:
         "StreamDescription"
     ]
     stream_description["RetentionPeriodHours"].should.equal(48)
+
+    tags = kinesis_conn.list_tags_for_stream(StreamName="MyStream")["Tags"]
+    tag1_value = [tag for tag in tags if tag["Key"] == "TagKey1"][0]["Value"]
+    tag2_value = [tag for tag in tags if tag["Key"] == "TagKey2"][0]["Value"]
+    tag1_value.should.equal("TagValue1")
+    tag2_value.should.equal("TagValue2")
 
     shards_provisioned = len(
         [
@@ -102,6 +113,12 @@ Resources:
         Properties:
           ShardCount: 6
           RetentionPeriodHours: 24
+          Tags:
+          - Key: TagKey1
+            Value: TagValue1a
+          - Key: TagKey2
+            Value: TagValue2a
+
     """.strip()
     cf_conn.update_stack(StackName=stack_name, TemplateBody=template)
 
@@ -109,6 +126,12 @@ Resources:
         "StreamDescription"
     ]
     stream_description["RetentionPeriodHours"].should.equal(24)
+
+    tags = kinesis_conn.list_tags_for_stream(StreamName="MyStream")["Tags"]
+    tag1_value = [tag for tag in tags if tag["Key"] == "TagKey1"][0]["Value"]
+    tag2_value = [tag for tag in tags if tag["Key"] == "TagKey2"][0]["Value"]
+    tag1_value.should.equal("TagValue1a")
+    tag2_value.should.equal("TagValue2a")
 
     shards_provisioned = len(
         [

--- a/tests/test_kinesis/test_kinesis_cloudformation.py
+++ b/tests/test_kinesis/test_kinesis_cloudformation.py
@@ -73,6 +73,7 @@ Resources:
     Properties:
       Name: MyStream
       ShardCount: 4
+      RetentionPeriodHours: 48
 """.strip()
 
     cf_conn.create_stack(StackName=stack_name, TemplateBody=template)
@@ -83,6 +84,8 @@ Resources:
     stream_description = kinesis_conn.describe_stream(StreamName="MyStream")[
         "StreamDescription"
     ]
+    stream_description["RetentionPeriodHours"].should.equal(48)
+
     shards_provisioned = len(
         [
             shard
@@ -98,12 +101,15 @@ Resources:
         Type: AWS::Kinesis::Stream
         Properties:
           ShardCount: 6
+          RetentionPeriodHours: 24
     """.strip()
     cf_conn.update_stack(StackName=stack_name, TemplateBody=template)
 
     stream_description = kinesis_conn.describe_stream(StreamName="MyStream")[
         "StreamDescription"
     ]
+    stream_description["RetentionPeriodHours"].should.equal(24)
+
     shards_provisioned = len(
         [
             shard

--- a/tests/test_s3/test_s3_cloudformation.py
+++ b/tests/test_s3/test_s3_cloudformation.py
@@ -1,0 +1,145 @@
+import json
+import boto3
+
+import sure  # noqa
+
+from moto import mock_s3, mock_cloudformation
+
+
+@mock_s3
+@mock_cloudformation
+def test_s3_bucket_cloudformation_basic():
+    s3 = boto3.client("s3", region_name="us-east-1")
+    cf = boto3.client("cloudformation", region_name="us-east-1")
+
+    template = {
+        "AWSTemplateFormatVersion": "2010-09-09",
+        "Resources": {"testInstance": {"Type": "AWS::S3::Bucket", "Properties": {},}},
+        "Outputs": {"Bucket": {"Value": {"Ref": "testInstance"}}},
+    }
+    template_json = json.dumps(template)
+    stack_id = cf.create_stack(StackName="test_stack", TemplateBody=template_json)[
+        "StackId"
+    ]
+    stack_description = cf.describe_stacks(StackName="test_stack")["Stacks"][0]
+
+    s3.head_bucket(Bucket=stack_description["Outputs"][0]["OutputValue"])
+
+
+@mock_s3
+@mock_cloudformation
+def test_s3_bucket_cloudformation_with_properties():
+    s3 = boto3.client("s3", region_name="us-east-1")
+    cf = boto3.client("cloudformation", region_name="us-east-1")
+
+    bucket_name = "MyBucket"
+    template = {
+        "AWSTemplateFormatVersion": "2010-09-09",
+        "Resources": {
+            "testInstance": {
+                "Type": "AWS::S3::Bucket",
+                "Properties": {
+                    "BucketName": bucket_name,
+                    "BucketEncryption": {
+                        "ServerSideEncryptionConfiguration": [
+                            {
+                                "ServerSideEncryptionByDefault": {
+                                    "SSEAlgorithm": "AES256"
+                                }
+                            }
+                        ]
+                    },
+                },
+            }
+        },
+        "Outputs": {"Bucket": {"Value": {"Ref": "testInstance"}}},
+    }
+    template_json = json.dumps(template)
+    stack_id = cf.create_stack(StackName="test_stack", TemplateBody=template_json)[
+        "StackId"
+    ]
+    stack_description = cf.describe_stacks(StackName="test_stack")["Stacks"][0]
+    s3.head_bucket(Bucket=bucket_name)
+
+    encryption = s3.get_bucket_encryption(Bucket=bucket_name)
+    encryption["ServerSideEncryptionConfiguration"]["Rules"][0][
+        "ApplyServerSideEncryptionByDefault"
+    ]["SSEAlgorithm"].should.equal("AES256")
+
+
+@mock_s3
+@mock_cloudformation
+def test_s3_bucket_cloudformation_update_no_interruption():
+    s3 = boto3.client("s3", region_name="us-east-1")
+    cf = boto3.client("cloudformation", region_name="us-east-1")
+
+    template = {
+        "AWSTemplateFormatVersion": "2010-09-09",
+        "Resources": {"testInstance": {"Type": "AWS::S3::Bucket"}},
+        "Outputs": {"Bucket": {"Value": {"Ref": "testInstance"}}},
+    }
+    template_json = json.dumps(template)
+    cf.create_stack(StackName="test_stack", TemplateBody=template_json)
+    stack_description = cf.describe_stacks(StackName="test_stack")["Stacks"][0]
+    s3.head_bucket(Bucket=stack_description["Outputs"][0]["OutputValue"])
+
+    template = {
+        "AWSTemplateFormatVersion": "2010-09-09",
+        "Resources": {
+            "testInstance": {
+                "Type": "AWS::S3::Bucket",
+                "Properties": {
+                    "BucketEncryption": {
+                        "ServerSideEncryptionConfiguration": [
+                            {
+                                "ServerSideEncryptionByDefault": {
+                                    "SSEAlgorithm": "AES256"
+                                }
+                            }
+                        ]
+                    }
+                },
+            }
+        },
+        "Outputs": {"Bucket": {"Value": {"Ref": "testInstance"}}},
+    }
+    template_json = json.dumps(template)
+    cf.update_stack(StackName="test_stack", TemplateBody=template_json)
+    encryption = s3.get_bucket_encryption(
+        Bucket=stack_description["Outputs"][0]["OutputValue"]
+    )
+    encryption["ServerSideEncryptionConfiguration"]["Rules"][0][
+        "ApplyServerSideEncryptionByDefault"
+    ]["SSEAlgorithm"].should.equal("AES256")
+
+
+@mock_s3
+@mock_cloudformation
+def test_s3_bucket_cloudformation_update_replacement():
+    s3 = boto3.client("s3", region_name="us-east-1")
+    cf = boto3.client("cloudformation", region_name="us-east-1")
+
+    template = {
+        "AWSTemplateFormatVersion": "2010-09-09",
+        "Resources": {"testInstance": {"Type": "AWS::S3::Bucket"}},
+        "Outputs": {"Bucket": {"Value": {"Ref": "testInstance"}}},
+    }
+    template_json = json.dumps(template)
+    cf.create_stack(StackName="test_stack", TemplateBody=template_json)
+    stack_description = cf.describe_stacks(StackName="test_stack")["Stacks"][0]
+    s3.head_bucket(Bucket=stack_description["Outputs"][0]["OutputValue"])
+
+    template = {
+        "AWSTemplateFormatVersion": "2010-09-09",
+        "Resources": {
+            "testInstance": {
+                "Type": "AWS::S3::Bucket",
+                "Properties": {"BucketName": "MyNewBucketName"},
+            }
+        },
+        "Outputs": {"Bucket": {"Value": {"Ref": "testInstance"}}},
+    }
+    template_json = json.dumps(template)
+    cf.update_stack(StackName="test_stack", TemplateBody=template_json)
+    stack_description = cf.describe_stacks(StackName="test_stack")["Stacks"][0]
+    s3.head_bucket(Bucket=stack_description["Outputs"][0]["OutputValue"])


### PR DESCRIPTION
I set out to add CloudFormation support for a few IAM entities I need in my current project, and quickly found myself adding special cases to funcs in the CloudFormation parsing.py to cope with things like un-specified names and deletion of resources without unique identities.  I found myself struggling to understand the resulting logic, with the troubling sense that it had unnecessarily grown unmaintainable, and perhaps some of the existing logic wasn't quite right.  IMO the generalized logic for creating, updating and deleting stacks should be pretty straightforward.  So I got up my courage and wrote them how I figured they should be, made my IAM models work with them, and then fixed up the rest.  

Listing my general strategies first:
-	Resource names never get injected into the json.  They are only provided to models' create/update/delete_from_cloudformation_json methods as parameters (resource_name / new_resource_name)
-	The name passed to these is _either_ the caller specified name from the json, _or_ a generated name.  The model’s CF code should generally not be responsible for deciding which to use.
-	Some models _DO_ need to generate their own name.  The CF code that follows create_from_cloudformation_json() gets the final name from the created resource.
-	update_from_cloudformation_json() is expected to delete/recreate the resource when a “replacement” type parameter changes.  While _name_ is the most common replacement parameter, others exist, and re-creation is required so that new generated names get used for the replacing resources if the caller didn’t specify an explicit name param.
-	update_from_cloudformation_json() is expected to _not_ delete/recreate the resource when a NoInterruption or UpdatesWithSomeInterruption parameter changes.  It must do an in-place update of the resource so the resource name doesn’t change, particularly if generated.
-	ResourceMap.update() and delete() look up the resource_name of the existing resource to be updated/deleted, they don't generate it.  (A generated name cannot not match that of the existing resource).  update_from_cloudformation_json() is provided a (proposed) new_resource_name (which contains either the user specified name or a generated name) and uses it for resource recreation in replacement updates.
-	delete_from_cloudformation_json generally should use resource_name to find the resource it wants to delete (when its resources are named, at least).   Note, though, that without a resource name a model probably cannot implement a reliable delete_from_cloudformation_json.  (i.e. when owning models get deleted before the sub-resources they own).
-	I want to avoid implementing model delete() methods.  Models can rarely delete themselves without help of their backend.  IMO a model shouldn’t know its backend (which is typically how delete()’s were implemented).  delete_from_cloudformation_json is a class-level method which IMO can more appropriately know its backend.

Some notes:

ResourceMap.delete() should be modified to delete in reverse-dependency order.  As is, there’s at least one case where a delete required the existence of the resource’s “parent” to find it, which had been deleted already.  I took the shortcut and re-coded it to be able to delete itself.

One interesting twist with the CloudFormationModel ABC: Not all of the current CloudFormationModel subclasses implement update/delete_from_cloudformation_json.  ResourceMap.delete() already introspects models to see if they have a delete() method, and needed to similarly do so if they have delete_from_cloudformation_json methods.  The ABC, though, assures that hasattr always returns true for delete_from_cloudformation_json on CloudFormationModel subclasses.  A technique of looking for the __isabstractmethod__ attribute on the function was found to reliably tell whether a subclass had implemented the method.  The method still silently ignores the non-deletes when no deletion methods are provided.

A similar technique was put into place for update_from_cloudformation_json that will cause a failure if it’s not implemented.  There are no tests that exhibit this problem today.  (Though end-users could experience it).

Some resources just don’t have physical ids.  (i.e. Route53 RecordSetGroups).   I haven’t messed with their XXX_from_cloudformation_json() methods, but without some sort of unique ID it will be challenging to implement delete_from_cloudformation successfully.  (Typically this func will need to know what resource “owns” the resource in question, and deletes it through an operation on its parent.  But a) the CF code for deletion doesn’t execute deletes in dependency order, so an owner can get deleted ahead of the resources it owns, and b) the json passed to delete may not always have all the info needed to find the resource in question.

The looped retrier may have been expected to deal with a, but in some circumstances one must look up the owner to do the deletion, so a premature deletion always thwarts that.

Model’s update_cloudformation_json must always determine if the update is are replacement update, deleting/re-creating if it is, updating in-place if it isn’t.  Some current ones only do one or the other, which is incorrect.  This logic is necessary so that a) generated names change upon replacement, and b) generated names don’t change otherwise.

The generate_resource_name has special cases in it.  These should be moved to the model via yet-another ABC method in a future update.

After making all unit tests pass, I did an inspection of the XXX_from_cloudformation_json methods of models that implement them and modified a few that were inappropriately doing their own resource naming.  A very few that required unique naming techniques were left as is.
