### PR TITLE
Convert `cognitoidp_backends.keys()` to list before attempting to access by index

### DIFF
--- a/moto/cognitoidp/models.py
+++ b/moto/cognitoidp/models.py
@@ -831,4 +831,4 @@ def find_region_by_value(key, value):
             if key == "access_token" and value in user_pool.access_tokens:
                 return region
 
-    return cognitoidp_backends.keys()[0]
+    return list(cognitoidp_backends.keys())[0]


### PR DESCRIPTION
Otherwise a `TypeError: 'dict_keys' object is not subscriptable` exception is raised in Python 3.