### PR TITLE
SES: Fix sending email when use verify_email_address

### DIFF
--- a/moto/ses/models.py
+++ b/moto/ses/models.py
@@ -103,6 +103,8 @@ class SESBackend(BaseBackend):
         _, address = parseaddr(source)
         if address in self.addresses:
             return True
+        if address in self.email_addresses:
+            return True
         user, host = address.split("@", 1)
         return host in self.domains
 


### PR DESCRIPTION
When sending emails by SES, it allows use source addresses that were verified by `verify_email_address` method.

Fix #3240 