### PR TITLE
Set lambda credentials' variables in runtime

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ install:
     docker run --rm -t --name motoserver -e TEST_SERVER_MODE=true -e AWS_SECRET_ACCESS_KEY=server_secret -e AWS_ACCESS_KEY_ID=server_key -v `pwd`:/moto -p 5000:5000 -v /var/run/docker.sock:/var/run/docker.sock python:${PYTHON_DOCKER_TAG} /moto/travis_moto_server.sh &
   fi
   travis_retry pip install -r requirements-dev.txt
+  travis_retry pip install "docker>=2.5.1,<=4.2.2" # Limit version due to old Docker Engine in Travis https://github.com/docker/docker-py/issues/2639
   travis_retry pip install boto==2.45.0
   travis_retry pip install boto3
   travis_retry pip install dist/moto*.gz

--- a/moto/awslambda/models.py
+++ b/moto/awslambda/models.py
@@ -388,11 +388,16 @@ class LambdaFunction(CloudFormationModel):
             #       also need to hook it up to the other services so it can make kws/s3 etc calls
             #  Should get invoke_id /RequestId from invocation
             env_vars = {
+                "_HANDLER": self.handler,
+                "AWS_EXECUTION_ENV": "AWS_Lambda_{}".format(self.run_time),
                 "AWS_LAMBDA_FUNCTION_TIMEOUT": self.timeout,
                 "AWS_LAMBDA_FUNCTION_NAME": self.function_name,
                 "AWS_LAMBDA_FUNCTION_MEMORY_SIZE": self.memory_size,
                 "AWS_LAMBDA_FUNCTION_VERSION": self.version,
                 "AWS_REGION": self.region,
+                "AWS_ACCESS_KEY_ID": "role-account-id",
+                "AWS_SECRET_ACCESS_KEY": "role-secret-key",
+                "AWS_SESSION_TOKEN": "session-token",
             }
 
             env_vars.update(self.environment_vars)

--- a/travis_moto_server.sh
+++ b/travis_moto_server.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 set -e
 pip install flask
+# TravisCI on bionic dist uses old version of Docker Engine
+# which is incompatibile with newer docker-py
+# See https://github.com/docker/docker-py/issues/2639
+pip install "docker>=2.5.1,<=4.2.2"
 pip install /moto/dist/moto*.gz
 moto_server -H 0.0.0.0 -p 5000


### PR DESCRIPTION
AWS Lambda runtime sets a few envs, according to:
https://docs.aws.amazon.com/lambda/latest/dg/configuration-envvars.html#configuration-envvars-runtime

This PR set credentials and two other basic envs. It's another approach to fix #3225 (also try in #3220)