### PR TITLE
upgrade prompt-toolkit to make scaffold.py work

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -12,7 +12,7 @@ boto3>=1.4.4
 botocore>=1.15.13
 six>=1.9
 parameterized>=0.7.0
-prompt-toolkit==1.0.14
+prompt-toolkit==3.0.6
 click==6.7
 inflection==0.3.1
 lxml==4.2.3


### PR DESCRIPTION
Upgraded `prompt-toolkit` to make scaffold.py work

```python
$ python scripts/scaffold.py
```