### PR TITLE
Fix scaffold.py

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -12,7 +12,7 @@ boto3>=1.4.4
 botocore>=1.15.13
 six>=1.9
 parameterized>=0.7.0
-prompt-toolkit==1.0.14
+prompt-toolkit==3.0.6
 click==6.7
 inflection==0.3.1
 lxml==4.2.3

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -12,7 +12,7 @@ boto3>=1.4.4
 botocore>=1.15.13
 six>=1.9
 parameterized>=0.7.0
-prompt-toolkit==3.0.6
+prompt-toolkit==2.0.10 # 3.x is not available with python2
 click==6.7
 inflection==0.3.1
 lxml==4.2.3

--- a/scripts/scaffold.py
+++ b/scripts/scaffold.py
@@ -127,23 +127,6 @@ def append_mock_to_init_py(service):
         f.write(body)
 
 
-def append_mock_import_to_backends_py(service):
-    path = os.path.join(os.path.dirname(__file__), '..', 'moto', 'backends.py')
-    with open(path) as f:
-        lines = [_.replace('\n', '') for _ in f.readlines()]
-
-    if any(_ for _ in lines if re.match('^from moto\.{}.*{}_backends.*$'.format(service, service), _)):
-        return
-    filtered_lines = [_ for _ in lines if re.match('^from.*backends.*$', _)]
-    last_import_line_index = lines.index(filtered_lines[-1])
-
-    new_line = 'from moto.{} import {}_backends'.format(get_escaped_service(service), get_escaped_service(service))
-    lines.insert(last_import_line_index + 1, new_line)
-
-    body = '\n'.join(lines) + '\n'
-    with open(path, 'w') as f:
-        f.write(body)
-
 def append_mock_dict_to_backends_py(service):
     path = os.path.join(os.path.dirname(__file__), '..', 'moto', 'backends.py')
     with open(path) as f:
@@ -154,7 +137,7 @@ def append_mock_dict_to_backends_py(service):
     filtered_lines = [_ for _ in lines if re.match(".*\".*\":.*_backends.*", _)]
     last_elem_line_index = lines.index(filtered_lines[-1])
 
-    new_line = "    \"{}\": {}_backends,".format(service, get_escaped_service(service))
+    new_line = "    \"{}\": (\"{}\": \"{}_backends\"),".format(service, get_escaped_service(service), get_escaped_service(service))
     prev_line = lines[last_elem_line_index]
     if not prev_line.endswith('{') and not prev_line.endswith(','):
         lines[last_elem_line_index] += ','
@@ -212,8 +195,7 @@ def initialize_service(service, operation, api_protocol):
 
     # append mock to init files
     append_mock_to_init_py(service)
-    # append_mock_import_to_backends_py(service)
-    # append_mock_dict_to_backends_py(service)
+    append_mock_dict_to_backends_py(service)
 
 
 def to_upper_camel_case(s):

--- a/scripts/scaffold.py
+++ b/scripts/scaffold.py
@@ -137,7 +137,7 @@ def append_mock_dict_to_backends_py(service):
     filtered_lines = [_ for _ in lines if re.match(".*\".*\":.*_backends.*", _)]
     last_elem_line_index = lines.index(filtered_lines[-1])
 
-    new_line = "    \"{}\": (\"{}\": \"{}_backends\"),".format(service, get_escaped_service(service), get_escaped_service(service))
+    new_line = "    \"{}\": (\"{}\", \"{}_backends\"),".format(service, get_escaped_service(service), get_escaped_service(service))
     prev_line = lines[last_elem_line_index]
     if not prev_line.endswith('{') and not prev_line.endswith(','):
         lines[last_elem_line_index] += ','

--- a/scripts/scaffold.py
+++ b/scripts/scaffold.py
@@ -114,12 +114,12 @@ def append_mock_to_init_py(service):
     with open(path) as f:
         lines = [_.replace('\n', '') for _ in f.readlines()]
 
-    if any(_ for _ in lines if re.match('^from.*mock_{}.*$'.format(service), _)):
+    if any(_ for _ in lines if re.match('^mock_{}.*lazy_load(.*)$'.format(service), _)):
         return
-    filtered_lines = [_ for _ in lines if re.match('^from.*mock.*$', _)]
+    filtered_lines = [_ for _ in lines if re.match('^mock_.*lazy_load(.*)$', _)]
     last_import_line_index = lines.index(filtered_lines[-1])
 
-    new_line = 'from .{} import mock_{}  # noqa'.format(get_escaped_service(service), get_escaped_service(service))
+    new_line = 'mock_{} = lazy_load(".{}", "mock_{}")'.format(get_escaped_service(service), get_escaped_service(service), get_escaped_service(service))
     lines.insert(last_import_line_index + 1, new_line)
 
     body = '\n'.join(lines) + '\n'
@@ -212,8 +212,8 @@ def initialize_service(service, operation, api_protocol):
 
     # append mock to init files
     append_mock_to_init_py(service)
-    append_mock_import_to_backends_py(service)
-    append_mock_dict_to_backends_py(service)
+    # append_mock_import_to_backends_py(service)
+    # append_mock_dict_to_backends_py(service)
 
 
 def to_upper_camel_case(s):


### PR DESCRIPTION
Fixed `scripts/scaffold.py` to work again.
- Upgraded prompt-toolkit
- Support new format of `moto/__init__.py` and `moto/backends.py`
- Support AWS operation name that is not pure upper camel case.