### PR TITLE
Implement Execution inputs for Step Functions

### DIFF
--- a/moto/stepfunctions/models.py
+++ b/moto/stepfunctions/models.py
@@ -34,6 +34,7 @@ class Execution:
         state_machine_name,
         execution_name,
         state_machine_arn,
+        execution_input,
     ):
         execution_arn = "arn:aws:states:{}:{}:execution:{}:{}"
         execution_arn = execution_arn.format(
@@ -43,6 +44,7 @@ class Execution:
         self.name = execution_name
         self.start_date = iso_8601_datetime_without_milliseconds(datetime.now())
         self.state_machine_arn = state_machine_arn
+        self.execution_input = execution_input
         self.status = "RUNNING"
         self.stop_date = None
 
@@ -204,7 +206,7 @@ class StepFunctionBackend(BaseBackend):
         if sm:
             self.state_machines.remove(sm)
 
-    def start_execution(self, state_machine_arn, name=None):
+    def start_execution(self, state_machine_arn, name=None, execution_input=None):
         state_machine_name = self.describe_state_machine(state_machine_arn).name
         self._ensure_execution_name_doesnt_exist(name)
         execution = Execution(
@@ -213,6 +215,7 @@ class StepFunctionBackend(BaseBackend):
             state_machine_name=state_machine_name,
             execution_name=name or str(uuid4()),
             state_machine_arn=state_machine_arn,
+            execution_input=execution_input,
         )
         self.executions.append(execution)
         return execution

--- a/moto/stepfunctions/responses.py
+++ b/moto/stepfunctions/responses.py
@@ -95,8 +95,11 @@ class StepFunctionResponse(BaseResponse):
     def start_execution(self):
         arn = self._get_param("stateMachineArn")
         name = self._get_param("name")
+        execution_input = self._get_param("input", if_none="{}")
         try:
-            execution = self.stepfunction_backend.start_execution(arn, name)
+            execution = self.stepfunction_backend.start_execution(
+                arn, name, execution_input
+            )
         except AWSError as err:
             return err.response()
         response = {
@@ -129,7 +132,7 @@ class StepFunctionResponse(BaseResponse):
             execution = self.stepfunction_backend.describe_execution(arn)
             response = {
                 "executionArn": arn,
-                "input": "{}",
+                "input": execution.execution_input,
                 "name": execution.name,
                 "startDate": execution.start_date,
                 "stateMachineArn": execution.state_machine_arn,

--- a/tests/test_stepfunctions/test_stepfunctions.py
+++ b/tests/test_stepfunctions/test_stepfunctions.py
@@ -427,7 +427,7 @@ def test_state_machine_start_execution_fails_on_duplicate_execution_name():
 
 @mock_stepfunctions
 @mock_sts
-def test_state_machine_list_executions_with_default_input():
+def test_state_machine_list_executions():
     client = boto3.client("stepfunctions", region_name=region)
     #
     sm = client.create_state_machine(

--- a/tests/test_stepfunctions/test_stepfunctions.py
+++ b/tests/test_stepfunctions/test_stepfunctions.py
@@ -1,8 +1,8 @@
 from __future__ import unicode_literals
 
 import boto3
+import json
 import sure  # noqa
-import datetime
 
 from datetime import datetime
 from botocore.exceptions import ClientError
@@ -134,7 +134,7 @@ def test_state_machine_creation_fails_with_invalid_names():
     #
 
     for invalid_name in invalid_names:
-        with assert_raises(ClientError) as exc:
+        with assert_raises(ClientError):
             client.create_state_machine(
                 name=invalid_name,
                 definition=str(simple_definition),
@@ -147,7 +147,7 @@ def test_state_machine_creation_requires_valid_role_arn():
     client = boto3.client("stepfunctions", region_name=region)
     name = "example_step_function"
     #
-    with assert_raises(ClientError) as exc:
+    with assert_raises(ClientError):
         client.create_state_machine(
             name=name,
             definition=str(simple_definition),
@@ -242,7 +242,7 @@ def test_state_machine_creation_can_be_described():
 def test_state_machine_throws_error_when_describing_unknown_machine():
     client = boto3.client("stepfunctions", region_name=region)
     #
-    with assert_raises(ClientError) as exc:
+    with assert_raises(ClientError):
         unknown_state_machine = (
             "arn:aws:states:"
             + region
@@ -258,7 +258,7 @@ def test_state_machine_throws_error_when_describing_unknown_machine():
 def test_state_machine_throws_error_when_describing_bad_arn():
     client = boto3.client("stepfunctions", region_name=region)
     #
-    with assert_raises(ClientError) as exc:
+    with assert_raises(ClientError):
         client.describe_state_machine(stateMachineArn="bad")
 
 
@@ -267,7 +267,7 @@ def test_state_machine_throws_error_when_describing_bad_arn():
 def test_state_machine_throws_error_when_describing_machine_in_different_account():
     client = boto3.client("stepfunctions", region_name=region)
     #
-    with assert_raises(ClientError) as exc:
+    with assert_raises(ClientError):
         unknown_state_machine = (
             "arn:aws:states:" + region + ":000000000000:stateMachine:unknown"
         )
@@ -376,7 +376,7 @@ def test_state_machine_start_execution():
 def test_state_machine_start_execution_bad_arn_raises_exception():
     client = boto3.client("stepfunctions", region_name=region)
     #
-    with assert_raises(ClientError) as exc:
+    with assert_raises(ClientError):
         client.start_execution(stateMachineArn="bad")
 
 
@@ -427,7 +427,7 @@ def test_state_machine_start_execution_fails_on_duplicate_execution_name():
 
 @mock_stepfunctions
 @mock_sts
-def test_state_machine_list_executions():
+def test_state_machine_list_executions_with_default_input():
     client = boto3.client("stepfunctions", region_name=region)
     #
     sm = client.create_state_machine(
@@ -464,7 +464,7 @@ def test_state_machine_list_executions_when_none_exist():
 
 @mock_stepfunctions
 @mock_sts
-def test_state_machine_describe_execution():
+def test_state_machine_describe_execution_with_no_input():
     client = boto3.client("stepfunctions", region_name=region)
     #
     sm = client.create_state_machine(
@@ -485,10 +485,34 @@ def test_state_machine_describe_execution():
 
 @mock_stepfunctions
 @mock_sts
+def test_state_machine_describe_execution_with_custom_input():
+    client = boto3.client("stepfunctions", region_name=region)
+    #
+    execution_input = json.dumps({"input_key": "input_val"})
+    sm = client.create_state_machine(
+        name="name", definition=str(simple_definition), roleArn=_get_default_role()
+    )
+    execution = client.start_execution(
+        stateMachineArn=sm["stateMachineArn"], input=execution_input
+    )
+    description = client.describe_execution(executionArn=execution["executionArn"])
+    #
+    description["ResponseMetadata"]["HTTPStatusCode"].should.equal(200)
+    description["executionArn"].should.equal(execution["executionArn"])
+    description["input"].should.equal(execution_input)
+    description["name"].shouldnt.be.empty
+    description["startDate"].should.equal(execution["startDate"])
+    description["stateMachineArn"].should.equal(sm["stateMachineArn"])
+    description["status"].should.equal("RUNNING")
+    description.shouldnt.have("stopDate")
+
+
+@mock_stepfunctions
+@mock_sts
 def test_execution_throws_error_when_describing_unknown_execution():
     client = boto3.client("stepfunctions", region_name=region)
     #
-    with assert_raises(ClientError) as exc:
+    with assert_raises(ClientError):
         unknown_execution = (
             "arn:aws:states:" + region + ":" + _get_account_id() + ":execution:unknown"
         )
@@ -519,7 +543,7 @@ def test_state_machine_can_be_described_by_execution():
 def test_state_machine_throws_error_when_describing_unknown_execution():
     client = boto3.client("stepfunctions", region_name=region)
     #
-    with assert_raises(ClientError) as exc:
+    with assert_raises(ClientError):
         unknown_execution = (
             "arn:aws:states:" + region + ":" + _get_account_id() + ":execution:unknown"
         )


### PR DESCRIPTION
Closes #3283 

* Allows for `start_execution(<..>, input=<an-input>)` - Not just defaulting to `'{}'`
* Add test to ensure that a custom input is returned correctly by `describe_execution`
* Remove unnecessary `as exc`'s