### PR TITLE
fix: deleting non-existent topic shouldn't raise KeyError

### DIFF
--- a/moto/sns/models.py
+++ b/moto/sns/models.py
@@ -426,7 +426,10 @@ class SNSBackend(BaseBackend):
         return self._get_values_nexttoken(self.topics, next_token)
 
     def delete_topic(self, arn):
-        self.topics.pop(arn)
+        try:
+            self.topics.pop(arn)
+        except KeyError:
+            raise SNSNotFoundError("Topic with arn {0} not found".format(arn))
 
     def get_topic(self, arn):
         try:

--- a/tests/test_sns/test_topics.py
+++ b/tests/test_sns/test_topics.py
@@ -33,6 +33,12 @@ def test_create_and_delete_topic():
 
 
 @mock_sns_deprecated
+def test_delete_non_existent_topic():
+    conn = boto.connect_sns()
+    conn.delete_topic.when.called_with("a-fake-arn").should.throw(BotoServerError)
+
+
+@mock_sns_deprecated
 def test_get_missing_topic():
     conn = boto.connect_sns()
     conn.get_topic_attributes.when.called_with("a-fake-arn").should.throw(

--- a/tests/test_sns/test_topics_boto3.py
+++ b/tests/test_sns/test_topics_boto3.py
@@ -36,6 +36,15 @@ def test_create_and_delete_topic():
 
 
 @mock_sns
+def test_delete_non_existent_topic():
+    conn = boto3.client("sns", region_name="us-east-1")
+
+    conn.delete_topic.when.called_with(
+        TopicArn="arn:aws:sns:us-east-1:123456789012:fake-topic"
+    ).should.throw(conn.exceptions.NotFoundException)
+
+
+@mock_sns
 def test_create_topic_with_attributes():
     conn = boto3.client("sns", region_name="us-east-1")
     conn.create_topic(


### PR DESCRIPTION
Deleting a non-existent topic shouldn't raise KeyError

<!-- https://github.com/spulec/moto/commit/2fb5004dc2147925b512fa9706061cbb39486a62 -->

Related Issues:
- https://github.com/spulec/moto/issues/2992 <- slightly different, here they called `unsubscribe` instead of `delete_topic`