### PR TITLE
Add Step Function Execution Input validation

### DIFF
--- a/moto/stepfunctions/exceptions.py
+++ b/moto/stepfunctions/exceptions.py
@@ -38,6 +38,11 @@ class InvalidName(AWSError):
     STATUS = 400
 
 
+class InvalidExecutionInput(AWSError):
+    TYPE = "InvalidExecutionInput"
+    STATUS = 400
+
+
 class StateMachineDoesNotExist(AWSError):
     TYPE = "StateMachineDoesNotExist"
     STATUS = 400

--- a/moto/stepfunctions/models.py
+++ b/moto/stepfunctions/models.py
@@ -1,3 +1,4 @@
+import json
 import re
 from datetime import datetime
 
@@ -11,6 +12,7 @@ from .exceptions import (
     ExecutionAlreadyExists,
     ExecutionDoesNotExist,
     InvalidArn,
+    InvalidExecutionInput,
     InvalidName,
     StateMachineDoesNotExist,
 )
@@ -209,6 +211,7 @@ class StepFunctionBackend(BaseBackend):
     def start_execution(self, state_machine_arn, name=None, execution_input=None):
         state_machine_name = self.describe_state_machine(state_machine_arn).name
         self._ensure_execution_name_doesnt_exist(name)
+        self._validate_execution_input(execution_input)
         execution = Execution(
             region_name=self.region_name,
             account_id=self._get_account_id(),
@@ -289,6 +292,14 @@ class StepFunctionBackend(BaseBackend):
                 raise ExecutionAlreadyExists(
                     "Execution Already Exists: '" + execution.execution_arn + "'"
                 )
+
+    def _validate_execution_input(self, execution_input):
+        try:
+            json.loads(execution_input)
+        except Exception as ex:
+            raise InvalidExecutionInput(
+                "Invalid State Machine Execution Input: '" + str(ex) + "'"
+            )
 
     def _get_account_id(self):
         return ACCOUNT_ID


### PR DESCRIPTION
* Validates that the input is a valid JSON string
* Adds `InvalidExecutionInput` from exceptions [here](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/stepfunctions.html#SFN.Client.start_execution)
* Adds another test to cover valid custom inputs to `start_execution`
* Non-string inputs are already caught via `moto.core.responses._get_param` 