### PR TITLE
#3290 - Add additional dependencies in extras_require

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -99,25 +99,27 @@ all_extra_deps = [
     _dep_sshpubkeys_py2,
     _dep_sshpubkeys_py3,
 ]
+all_server_deps = all_extra_deps + ['flask']
 
 # TODO: do we want to add ALL services here?
 # i.e. even those without extra dependencies.
 # Would be good for future-compatibility, I guess.
 extras_per_service = {
-    "ec2": [_dep_cryptography, _dep_sshpubkeys_py2, _dep_sshpubkeys_py3],
     'acm': [_dep_cryptography],
-    'iam': [_dep_cryptography],
-    'cloudformation': [_dep_PyYAML, _dep_cfn_lint],
-    'cognitoidp': [_dep_python_jose, _dep_python_jose_ecdsa_pin],
     'awslambda': [_dep_docker],
     'batch': [_dep_docker],
+    'cloudformation': [_dep_PyYAML, _dep_cfn_lint],
+    'cognitoidp': [_dep_python_jose, _dep_python_jose_ecdsa_pin],
+    "ec2": [_dep_cryptography, _dep_sshpubkeys_py2, _dep_sshpubkeys_py3],
+    'iam': [_dep_cryptography],
     'iotdata': [_dep_jsondiff],
+    's3': [_dep_cryptography],
     'xray': [_dep_aws_xray_sdk],
 }
 
 extras_require = {
     'all': all_extra_deps,
-    'server': ['flask'],
+    'server': all_server_deps,
 }
 
 extras_require.update(extras_per_service)


### PR DESCRIPTION
Fixes #3290 

S3 is dependent on IAM, which is dependent on the cryptography-module.
This PR adds S3 as an additional service (`pip install moto[s3]`) to ensure it installs the required dependencies.

This also adds all dependencies to the [server], as at the moment people would have to use `pip install moto[server,all]` to get the full functionality.

FYI @spulec - this might need a new release, considering it broke 1.3.15

Edit: Considering it was a breaking change in the API, we could make this a major version change to reflect this? (2.0.0)

Edit 2: Marking it as draft, because the SNS/SQS services also need additional dependencies - will need to do more testing to verify other services