### PR TITLE
feature added: support for api RolePermissionsBoundary

### DIFF
--- a/moto/iam/models.py
+++ b/moto/iam/models.py
@@ -1292,6 +1292,23 @@ class IAMBackend(BaseBackend):
         role.max_session_duration = max_session_duration
         return role
 
+    def put_role_permissions_boundary(self, role_name, permissions_boundary):
+        if permissions_boundary and not self.policy_arn_regex.match(
+            permissions_boundary
+        ):
+            raise RESTError(
+                "InvalidParameterValue",
+                "Value ({}) for parameter PermissionsBoundary is invalid.".format(
+                    permissions_boundary
+                ),
+            )
+        role = self.get_role(role_name)
+        role.permissions_boundary = permissions_boundary
+    
+    def delete_role_permissions_boundary(self, role_name):
+        role = self.get_role(role_name)
+        role.permissions_boundary = None
+
     def detach_role_policy(self, policy_arn, role_name):
         arns = dict((p.arn, p) for p in self.managed_policies.values())
         try:

--- a/moto/iam/models.py
+++ b/moto/iam/models.py
@@ -1304,7 +1304,7 @@ class IAMBackend(BaseBackend):
             )
         role = self.get_role(role_name)
         role.permissions_boundary = permissions_boundary
-    
+
     def delete_role_permissions_boundary(self, role_name):
         role = self.get_role(role_name)
         role.permissions_boundary = None

--- a/moto/iam/responses.py
+++ b/moto/iam/responses.py
@@ -265,6 +265,19 @@ class IamResponse(BaseResponse):
         template = self.response_template(UPDATE_ROLE_TEMPLATE)
         return template.render(role=role)
 
+    def put_role_permissions_boundary(self):
+        permissions_boundary = self._get_param("PermissionsBoundary")
+        role_name = self._get_param("RoleName")
+        iam_backend.put_role_permissions_boundary(role_name, permissions_boundary)
+        template = self.response_template(GENERIC_EMPTY_TEMPLATE)
+        return template.render(name="PutRolePermissionsBoundary")
+
+    def delete_role_permissions_boundary(self):
+        role_name = self._get_param("RoleName")
+        iam_backend.delete_role_permissions_boundary(role_name)
+        template = self.response_template(GENERIC_EMPTY_TEMPLATE)
+        return template.render(name="DeleteRolePermissionsBoundary")
+
     def create_policy_version(self):
         policy_arn = self._get_param("PolicyArn")
         policy_document = self._get_param("PolicyDocument")
@@ -1315,6 +1328,12 @@ GET_ROLE_TEMPLATE = """<GetRoleResponse xmlns="https://iam.amazonaws.com/doc/201
       <CreateDate>{{ role.created_iso_8601 }}</CreateDate>
       <RoleId>{{ role.id }}</RoleId>
       <MaxSessionDuration>{{ role.max_session_duration }}</MaxSessionDuration>
+      {% if role.permissions_boundary %}
+      <PermissionsBoundary>
+          <PermissionsBoundaryType>PermissionsBoundaryPolicy</PermissionsBoundaryType>
+          <PermissionsBoundaryArn>{{ role.permissions_boundary }}</PermissionsBoundaryArn>
+      </PermissionsBoundary>
+      {% endif %}
       {% if role.tags %}
       <Tags>
         {% for tag in role.get_tags() %}

--- a/moto/s3/models.py
+++ b/moto/s3/models.py
@@ -169,6 +169,9 @@ class FakeKey(BaseModel):
             raise InvalidStorageClass(storage=storage)
         self._storage_class = storage
 
+    def set_expiry(self, expiry):
+        self._expiry = expiry
+
     def set_acl(self, acl):
         self.acl = acl
 
@@ -1689,6 +1692,9 @@ class S3Backend(BaseBackend):
             new_key.set_storage_class(storage)
         if acl is not None:
             new_key.set_acl(acl)
+        if key.storage_class in "GLACIER":
+            # Object copied from Glacier object should not have expiry
+            new_key.set_expiry(None)
 
         dest_bucket.keys[dest_key_name] = new_key
 

--- a/moto/s3/responses.py
+++ b/moto/s3/responses.py
@@ -1276,7 +1276,13 @@ class ResponseObject(_TemplateEnvironmentMixin, ActionAuthenticatorMixin):
 
             if key is not None:
                 if key.storage_class in ["GLACIER", "DEEP_ARCHIVE"]:
-                    raise ObjectNotInActiveTierError(key)
+                    if key.response_dict.get(
+                        "x-amz-restore"
+                    ) is None or 'ongoing-request="true"' in key.response_dict.get(
+                        "x-amz-restore"
+                    ):
+                        raise ObjectNotInActiveTierError(key)
+
                 self.backend.copy_key(
                     src_bucket,
                     src_key,

--- a/moto/s3/responses.py
+++ b/moto/s3/responses.py
@@ -1774,7 +1774,9 @@ S3_BUCKET_GET_RESPONSE = """<?xml version="1.0" encoding="UTF-8"?>
   <Prefix>{{ prefix }}</Prefix>
   {% endif %}
   <MaxKeys>{{ max_keys }}</MaxKeys>
-  <Delimiter>{{ delimiter }}</Delimiter>
+  {% if delimiter %}
+    <Delimiter>{{ delimiter }}</Delimiter>
+  {% endif %}
   <IsTruncated>{{ is_truncated }}</IsTruncated>
   {% if next_marker %}
     <NextMarker>{{ next_marker }}</NextMarker>

--- a/tests/test_iam/test_iam.py
+++ b/tests/test_iam/test_iam.py
@@ -2381,6 +2381,12 @@ def test_create_role_with_permissions_boundary():
     resp.get("Role").get("PermissionsBoundary").should.equal(expected)
 
     invalid_boundary_arn = "arn:aws:iam::123456789:not_a_boundary"
+
+    with assert_raises(ClientError):
+        conn.put_role_permissions_boundary(
+            RoleName="my-role", PermissionsBoundary=invalid_boundary_arn
+        )
+
     with assert_raises(ClientError):
         conn.create_role(
             RoleName="bad-boundary",

--- a/tests/test_iam/test_iam.py
+++ b/tests/test_iam/test_iam.py
@@ -868,9 +868,7 @@ def test_list_access_keys():
     conn = boto3.client("iam", region_name="us-east-1")
     conn.create_user(UserName="my-user")
     response = conn.list_access_keys(UserName="my-user")
-    assert_equals(
-        response["AccessKeyMetadata"], [],
-    )
+    assert_equals(response["AccessKeyMetadata"], [])
     access_key = conn.create_access_key(UserName="my-user")["AccessKey"]
     response = conn.list_access_keys(UserName="my-user")
     assert_equals(
@@ -2376,15 +2374,10 @@ def test_create_role_with_permissions_boundary():
     resp.get("Role").get("PermissionsBoundary").should.equal(expected)
     resp.get("Role").get("Description").should.equal("test")
 
-    conn.delete_role_permissions_boundary(
-        RoleName="my-role",
-    )
-    conn.list_roles().get("Roles")[0].should_not.have.key('PermissionsBoundary')
+    conn.delete_role_permissions_boundary(RoleName="my-role")
+    conn.list_roles().get("Roles")[0].should_not.have.key("PermissionsBoundary")
 
-    conn.put_role_permissions_boundary(
-        RoleName="my-role",
-        PermissionsBoundary=boundary,
-    )
+    conn.put_role_permissions_boundary(RoleName="my-role", PermissionsBoundary=boundary)
     resp.get("Role").get("PermissionsBoundary").should.equal(expected)
 
     invalid_boundary_arn = "arn:aws:iam::123456789:not_a_boundary"

--- a/tests/test_iam/test_iam.py
+++ b/tests/test_iam/test_iam.py
@@ -2376,6 +2376,17 @@ def test_create_role_with_permissions_boundary():
     resp.get("Role").get("PermissionsBoundary").should.equal(expected)
     resp.get("Role").get("Description").should.equal("test")
 
+    conn.delete_role_permissions_boundary(
+        RoleName="my-role",
+    )
+    conn.list_roles().get("Roles")[0].get('Role').should_not.have.key('PermissionsBoundary')
+
+    conn.put_role_permissions_boundary(
+        RoleName="my-role",
+        PermissionsBoundary=boundary,
+    )
+    resp.get("Role").get("PermissionsBoundary").should.equal(expected)
+
     invalid_boundary_arn = "arn:aws:iam::123456789:not_a_boundary"
     with assert_raises(ClientError):
         conn.create_role(

--- a/tests/test_iam/test_iam.py
+++ b/tests/test_iam/test_iam.py
@@ -2379,7 +2379,7 @@ def test_create_role_with_permissions_boundary():
     conn.delete_role_permissions_boundary(
         RoleName="my-role",
     )
-    conn.list_roles().get("Roles")[0].get('Role').should_not.have.key('PermissionsBoundary')
+    conn.list_roles().get("Roles")[0].should_not.have.key('PermissionsBoundary')
 
     conn.put_role_permissions_boundary(
         RoleName="my-role",

--- a/tests/test_s3/test_s3.py
+++ b/tests/test_s3/test_s3.py
@@ -1710,6 +1710,17 @@ def test_website_redirect_location():
 
 
 @mock_s3
+def test_delimiter_optional_in_response():
+    s3 = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
+    s3.create_bucket(Bucket="mybucket")
+    s3.put_object(Bucket="mybucket", Key="one", Body=b"1")
+    resp = s3.list_objects(Bucket="mybucket", MaxKeys=1)
+    assert resp.get("Delimiter") is None
+    resp = s3.list_objects(Bucket="mybucket", MaxKeys=1, Delimiter="/")
+    assert resp.get("Delimiter") == "/"
+
+
+@mock_s3
 def test_boto3_list_objects_truncated_response():
     s3 = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
     s3.create_bucket(Bucket="mybucket")
@@ -1725,7 +1736,7 @@ def test_boto3_list_objects_truncated_response():
     assert resp["MaxKeys"] == 1
     assert resp["IsTruncated"] == True
     assert resp.get("Prefix") is None
-    assert resp["Delimiter"] == "None"
+    assert resp.get("Delimiter") is None
     assert "NextMarker" in resp
 
     next_marker = resp["NextMarker"]
@@ -1738,7 +1749,7 @@ def test_boto3_list_objects_truncated_response():
     assert resp["MaxKeys"] == 1
     assert resp["IsTruncated"] == True
     assert resp.get("Prefix") is None
-    assert resp["Delimiter"] == "None"
+    assert resp.get("Delimiter") is None
     assert "NextMarker" in resp
 
     next_marker = resp["NextMarker"]
@@ -1751,7 +1762,7 @@ def test_boto3_list_objects_truncated_response():
     assert resp["MaxKeys"] == 1
     assert resp["IsTruncated"] == False
     assert resp.get("Prefix") is None
-    assert resp["Delimiter"] == "None"
+    assert resp.get("Delimiter") is None
     assert "NextMarker" not in resp
 
 


### PR DESCRIPTION
This PR adds support for `PutRolePermissionsBoundary` and `DeleteRolePermissionsBoundary`.
Fixed the response template `GET_ROLE_TEMPLATE` for RolePermissionBoundary support.
Added test case for `PutRolePermissionsBoundary` and `DeleteRolePermissionsBoundary`.

This PR should fix the issue in localstack: [localstack/localstack#2888](https://github.com/localstack/localstack/issues/2888)