### PR TITLE
Make IoT certificate ID generation deterministic and prevent duplicate certificates from being created

### DIFF
--- a/moto/iot/exceptions.py
+++ b/moto/iot/exceptions.py
@@ -52,3 +52,11 @@ class DeleteConflictException(IoTClientError):
     def __init__(self, msg):
         self.code = 409
         super(DeleteConflictException, self).__init__("DeleteConflictException", msg)
+
+
+class ResourceAlreadyExistsException(IoTClientError):
+    def __init__(self, msg):
+        self.code = 409
+        super(ResourceAlreadyExistsException, self).__init__(
+            "ResourceAlreadyExistsException", msg or "The resource already exists."
+        )

--- a/moto/iot/models.py
+++ b/moto/iot/models.py
@@ -130,7 +130,7 @@ class FakeThingGroup(BaseModel):
 class FakeCertificate(BaseModel):
     def __init__(self, certificate_pem, status, region_name, ca_certificate_pem=None):
         m = hashlib.sha256()
-        m.update(str(uuid.uuid4()).encode("utf-8"))
+        m.update(certificate_pem.encode("utf-8"))
         self.certificate_id = m.hexdigest()
         self.arn = "arn:aws:iot:%s:1:cert/%s" % (region_name, self.certificate_id)
         self.certificate_pem = certificate_pem
@@ -145,7 +145,7 @@ class FakeCertificate(BaseModel):
         self.ca_certificate_id = None
         self.ca_certificate_pem = ca_certificate_pem
         if ca_certificate_pem:
-            m.update(str(uuid.uuid4()).encode("utf-8"))
+            m.update(ca_certificate_pem.encode("utf-8"))
             self.ca_certificate_id = m.hexdigest()
 
     def to_dict(self):

--- a/tests/test_iot/test_iot.py
+++ b/tests/test_iot/test_iot.py
@@ -599,6 +599,29 @@ def test_certs():
 
 
 @mock_iot
+def test_create_certificate_validation():
+    # Test we can't create a cert that already exists
+    client = boto3.client("iot", region_name="us-east-1")
+    cert = client.create_keys_and_certificate(setAsActive=False)
+
+    with assert_raises(ClientError) as e:
+        client.register_certificate(
+            certificatePem=cert["certificatePem"], setAsActive=False
+        )
+    e.exception.response["Error"]["Message"].should.contain(
+        "The certificate is already provisioned or registered"
+    )
+
+    with assert_raises(ClientError) as e:
+        client.register_certificate_without_ca(
+            certificatePem=cert["certificatePem"], status="ACTIVE"
+        )
+    e.exception.response["Error"]["Message"].should.contain(
+        "The certificate is already provisioned or registered"
+    )
+
+
+@mock_iot
 def test_delete_policy_validation():
     doc = """{
     "Version": "2012-10-17",

--- a/tests/test_iot/test_iot.py
+++ b/tests/test_iot/test_iot.py
@@ -504,6 +504,20 @@ def test_endpoints():
 
 
 @mock_iot
+def test_certificate_id_generation_deterministic():
+    # Creating the same certificate twice should result in the same certificate ID
+    client = boto3.client("iot", region_name="us-east-1")
+    cert1 = client.create_keys_and_certificate(setAsActive=False)
+    client.delete_certificate(certificateId=cert1["certificateId"])
+
+    cert2 = client.register_certificate(
+        certificatePem=cert1["certificatePem"], setAsActive=False
+    )
+    cert2.should.have.key("certificateId").which.should.equal(cert1["certificateId"])
+    client.delete_certificate(certificateId=cert2["certificateId"])
+
+
+@mock_iot
 def test_certs():
     client = boto3.client("iot", region_name="us-east-1")
     cert = client.create_keys_and_certificate(setAsActive=True)


### PR DESCRIPTION
Fixes #3320

When using boto3, trying to register a certificate that already
exists will throw a ResourceAlreadyExistsException. Moto should
follow the same pattern to allow testing error handling code in
this area.

---

Fixes #3321

As per https://stackoverflow.com/questions/55847788/how-does-aws-iot-generate-a-certificate-id,
the IoT certificate ID is the SHA256 fingerprint of the
certificate. Since moto doesn't generate full certificates we will
instead use the SHA256 hash of the passed certificate pem.