### PR TITLE
feat: update events remove_targets API response

### DIFF
--- a/moto/events/models.py
+++ b/moto/events/models.py
@@ -368,9 +368,12 @@ class EventsBackend(BaseBackend):
 
         if rule:
             rule.remove_targets(ids)
-            return True
-
-        return False
+            return {"FailedEntries": [], "FailedEntryCount": 0}
+        else:
+            raise JsonRESTError(
+                "ResourceNotFoundException",
+                "An entity that you specified does not exist",
+            )
 
     def test_event_pattern(self):
         raise NotImplementedError()

--- a/moto/events/responses.py
+++ b/moto/events/responses.py
@@ -238,7 +238,10 @@ class EventsHandler(BaseResponse):
                 "ResourceNotFoundException", "Rule " + rule_name + " does not exist."
             )
 
-        return "", self.response_headers
+        return (
+            json.dumps({"FailedEntryCount": 0, "FailedEntries": []}),
+            self.response_headers,
+        )
 
     def test_event_pattern(self):
         pass

--- a/tests/test_events/test_events.py
+++ b/tests/test_events/test_events.py
@@ -195,7 +195,9 @@ def test_remove_targets():
     targets_before = len(targets)
     assert targets_before > 0
 
-    client.remove_targets(Rule=rule_name, Ids=[targets[0]["Id"]])
+    response = client.remove_targets(Rule=rule_name, Ids=[targets[0]["Id"]])
+    response["FailedEntryCount"].should.equal(0)
+    response["FailedEntries"].should.have.length_of(0)
 
     targets = client.list_targets_by_rule(Rule=rule_name)["Targets"]
     targets_after = len(targets)

--- a/tests/test_events/test_events.py
+++ b/tests/test_events/test_events.py
@@ -205,6 +205,18 @@ def test_remove_targets():
 
 
 @mock_events
+def test_remove_targets_errors():
+    client = boto3.client("events", "us-east-1")
+
+    client.remove_targets.when.called_with(
+        Rule="non-existent", Ids=["Id12345678"]
+    ).should.throw(
+        client.exceptions.ResourceNotFoundException,
+        "An entity that you specified does not exist",
+    )
+
+
+@mock_events
 def test_put_targets():
     client = boto3.client("events", "us-west-2")
     rule_name = "my-event"


### PR DESCRIPTION
This PR updates the response for the Events `RemoveTargets` API call.

https://docs.aws.amazon.com/eventbridge/latest/APIReference/API_RemoveTargets.html

The response will now return a JSON formatted object including the `FailedEntryCount` and `FailedEntries` as expected from the AWS API.