### PR TITLE
Update IMPLEMENTATION_COVERAGE.md

### DIFF
--- a/IMPLEMENTATION_COVERAGE.md
+++ b/IMPLEMENTATION_COVERAGE.md
@@ -2968,7 +2968,7 @@
 - [ ] revoke_client_vpn_ingress
 - [X] revoke_security_group_egress
 - [X] revoke_security_group_ingress
-- [ ] run_instances
+- [X] run_instances
 - [ ] run_scheduled_instances
 - [ ] search_local_gateway_routes
 - [ ] search_transit_gateway_multicast_groups


### PR DESCRIPTION
ec2 `run_instances()` seems to be implemented [here](https://github.com/spulec/moto/blob/3bc18455a2dad70148dc095435a55b2a43eaeac1/moto/ec2/responses/instances.py#L48) and should be marked as such