### PR TITLE
Fix:SQS md5 calculation for custom string data type.

### DIFF
--- a/moto/sqs/models.py
+++ b/moto/sqs/models.py
@@ -43,7 +43,12 @@ DEFAULT_SENDER_ID = "AIDAIT2UOQQY3AUEKVGXU"
 
 MAXIMUM_MESSAGE_LENGTH = 262144  # 256 KiB
 
-TRANSPORT_TYPE_ENCODINGS = {"String": b"\x01", "Binary": b"\x02", "Number": b"\x01", "String.custom": b"\x01"}
+TRANSPORT_TYPE_ENCODINGS = {
+    "String": b"\x01",
+    "Binary": b"\x02",
+    "Number": b"\x01",
+    "String.custom": b"\x01",
+}
 
 
 class Message(BaseModel):
@@ -95,12 +100,7 @@ class Message(BaseModel):
                 data_type_parts = attr["data_type"].split(".")
                 data_type = data_type_parts[0]
 
-            if data_type not in [
-                "String",
-                "Binary",
-                "Number",
-                "String.custom"
-            ]:
+            if data_type not in ["String", "Binary", "Number", "String.custom"]:
                 raise MessageAttributesInvalid(
                     "The message attribute '{0}' has an invalid message attribute type, the set of supported type prefixes is Binary, Number, and String.".format(
                         name[0]
@@ -117,7 +117,7 @@ class Message(BaseModel):
             encoded += struct.pack(struct_format, len(data_type)) + utf8(data_type)
             encoded += TRANSPORT_TYPE_ENCODINGS[data_type]
 
-            if data_type in ["String" , "Number" ,"String.custom"]:
+            if data_type in ["String", "Number", "String.custom"]:
                 value = attr["string_value"]
             elif data_type == "Binary":
                 value = base64.b64decode(attr["binary_value"])

--- a/tests/test_sqs/test_sqs.py
+++ b/tests/test_sqs/test_sqs.py
@@ -649,10 +649,7 @@ def test_send_receive_message_with_attributes_with_labels():
     response = queue.send_message(
         MessageBody="test message",
         MessageAttributes={
-            "somevalue": {
-                "StringValue": "somevalue",
-                "DataType": "String.custom",
-            }
+            "somevalue": {"StringValue": "somevalue", "DataType": "String.custom",}
         },
     )
 

--- a/tests/test_sqs/test_sqs.py
+++ b/tests/test_sqs/test_sqs.py
@@ -646,6 +646,20 @@ def test_send_receive_message_with_attributes_with_labels():
         "994258b45346a2cc3f9cbb611aa7af30"
     )
 
+    response = queue.send_message(
+        MessageBody="test message",
+        MessageAttributes={
+            "somevalue": {
+                "StringValue": "somevalue",
+                "DataType": "String.custom",
+            }
+        },
+    )
+
+    response.get("MD5OfMessageAttributes").should.equal(
+        "9e05cca738e70ff6c6041e82d5e77ef1"
+    )
+
 
 @mock_sqs
 def test_send_receive_message_timestamps():


### PR DESCRIPTION
Fix:SQS md5 calculation for custom string data type.

https://github.com/localstack/localstack/issues/2976