### PR TITLE
Add `set_default_policy_version` to the IAM backend

### DIFF
--- a/moto/iam/models.py
+++ b/moto/iam/models.py
@@ -1550,7 +1550,9 @@ class IAMBackend(BaseBackend):
 
         if re.match("v[1-9][0-9]*(\.[A-Za-z0-9-]*)?", version_id) is None:
             raise ValidationError(
-                "Value '{0}' at 'versionId' failed to satisfy constraint: Member must satisfy regular expression pattern: v[1-9][0-9]*(\.[A-Za-z0-9-]*)?".format(version_id)
+                "Value '{0}' at 'versionId' failed to satisfy constraint: Member must satisfy regular expression pattern: v[1-9][0-9]*(\.[A-Za-z0-9-]*)?".format(
+                    version_id
+                )
             )
 
         policy = self.get_policy(policy_arn)
@@ -1561,10 +1563,10 @@ class IAMBackend(BaseBackend):
                 return True
 
         raise NoSuchEntity(
-            "Policy {0} version {1} does not exist or is not attachable.".format(policy_arn, version_id)
+            "Policy {0} version {1} does not exist or is not attachable.".format(
+                policy_arn, version_id
+            )
         )
-
-
 
     def _filter_attached_policies(self, policies, marker, max_items, path_prefix):
         if path_prefix:

--- a/moto/iam/responses.py
+++ b/moto/iam/responses.py
@@ -175,6 +175,13 @@ class IamResponse(BaseResponse):
             roles=entity_roles, users=entity_users, groups=entity_groups
         )
 
+    def set_default_policy_version(self):
+        policy_arn = self._get_param("PolicyArn")
+        version_id = self._get_param("VersionId")
+        iam_backend.set_default_policy_version(policy_arn, version_id)
+        template = self.response_template(SET_DEFAULT_POLICY_VERSION_TEMPLATE)
+        return template.render()
+
     def create_role(self):
         role_name = self._get_param("RoleName")
         path = self._get_param("Path")
@@ -1008,6 +1015,13 @@ LIST_ENTITIES_FOR_POLICY_TEMPLATE = """<ListEntitiesForPolicyResponse>
  <RequestId>eb358e22-9d1f-11e4-93eb-190ecEXAMPLE</RequestId>
  </ResponseMetadata>
 </ListEntitiesForPolicyResponse>"""
+
+
+SET_DEFAULT_POLICY_VERSION_TEMPLATE = """<SetDefaultPolicyVersionResponse xmlns="https://iam.amazonaws.com/doc/2010-05-08/">
+  <ResponseMetadata>
+    <RequestId>35f241af-3ebc-11e4-9d0d-6f969EXAMPLE</RequestId>
+  </ResponseMetadata>
+</SetDefaultPolicyVersionResponse>"""
 
 
 ATTACH_ROLE_POLICY_TEMPLATE = """<AttachRolePolicyResponse>

--- a/tests/test_iam/test_iam.py
+++ b/tests/test_iam/test_iam.py
@@ -549,6 +549,61 @@ def test_set_default_policy_version():
     versions.get("Versions")[2].get("Document").should.equal(json.loads(MOCK_POLICY_3))
     versions.get("Versions")[2].get("IsDefaultVersion").should.be.ok
 
+    conn.set_default_policy_version(
+        PolicyArn="arn:aws:iam::{}:policy/TestSetDefaultPolicyVersion".format(
+            ACCOUNT_ID
+        ),
+        VersionId="v1"
+    )
+    versions = conn.list_policy_versions(
+        PolicyArn="arn:aws:iam::{}:policy/TestSetDefaultPolicyVersion".format(
+            ACCOUNT_ID
+        )
+    )
+    versions.get("Versions")[0].get("Document").should.equal(json.loads(MOCK_POLICY))
+    versions.get("Versions")[0].get("IsDefaultVersion").should.be.ok
+    versions.get("Versions")[1].get("Document").should.equal(json.loads(MOCK_POLICY_2))
+    versions.get("Versions")[1].get("IsDefaultVersion").shouldnt.be.ok
+    versions.get("Versions")[2].get("Document").should.equal(json.loads(MOCK_POLICY_3))
+    versions.get("Versions")[2].get("IsDefaultVersion").shouldnt.be.ok
+
+    # Set default version for non-existing policy
+    conn.set_default_policy_version.when.called_with(
+        PolicyArn="arn:aws:iam::{}:policy/TestNonExistingPolicy".format(
+            ACCOUNT_ID
+        ),
+        VersionId="v1"
+    ).should.throw(
+        ClientError,
+        "Policy arn:aws:iam::{}:policy/TestNonExistingPolicy not found".format(
+            ACCOUNT_ID
+        )
+    )
+
+    # Set default version for incorrect version
+    conn.set_default_policy_version.when.called_with(
+        PolicyArn="arn:aws:iam::{}:policy/TestSetDefaultPolicyVersion".format(
+            ACCOUNT_ID
+        ),
+        VersionId="wrong_version_id"
+    ).should.throw(
+        ClientError,
+        "Value 'wrong_version_id' at 'versionId' failed to satisfy constraint: Member must satisfy regular expression pattern: v[1-9][0-9]*(\.[A-Za-z0-9-]*)?"
+    )
+
+    # Set default version for non-existing version
+    conn.set_default_policy_version.when.called_with(
+        PolicyArn="arn:aws:iam::{}:policy/TestSetDefaultPolicyVersion".format(
+            ACCOUNT_ID
+        ),
+        VersionId="v4"
+    ).should.throw(
+        ClientError,
+        "Policy arn:aws:iam::{}:policy/TestSetDefaultPolicyVersion version v4 does not exist or is not attachable.".format(
+            ACCOUNT_ID
+        )
+    )
+
 
 @mock_iam
 def test_get_policy():

--- a/tests/test_iam/test_iam.py
+++ b/tests/test_iam/test_iam.py
@@ -553,7 +553,7 @@ def test_set_default_policy_version():
         PolicyArn="arn:aws:iam::{}:policy/TestSetDefaultPolicyVersion".format(
             ACCOUNT_ID
         ),
-        VersionId="v1"
+        VersionId="v1",
     )
     versions = conn.list_policy_versions(
         PolicyArn="arn:aws:iam::{}:policy/TestSetDefaultPolicyVersion".format(
@@ -569,15 +569,13 @@ def test_set_default_policy_version():
 
     # Set default version for non-existing policy
     conn.set_default_policy_version.when.called_with(
-        PolicyArn="arn:aws:iam::{}:policy/TestNonExistingPolicy".format(
-            ACCOUNT_ID
-        ),
-        VersionId="v1"
+        PolicyArn="arn:aws:iam::{}:policy/TestNonExistingPolicy".format(ACCOUNT_ID),
+        VersionId="v1",
     ).should.throw(
         ClientError,
         "Policy arn:aws:iam::{}:policy/TestNonExistingPolicy not found".format(
             ACCOUNT_ID
-        )
+        ),
     )
 
     # Set default version for incorrect version
@@ -585,10 +583,10 @@ def test_set_default_policy_version():
         PolicyArn="arn:aws:iam::{}:policy/TestSetDefaultPolicyVersion".format(
             ACCOUNT_ID
         ),
-        VersionId="wrong_version_id"
+        VersionId="wrong_version_id",
     ).should.throw(
         ClientError,
-        "Value 'wrong_version_id' at 'versionId' failed to satisfy constraint: Member must satisfy regular expression pattern: v[1-9][0-9]*(\.[A-Za-z0-9-]*)?"
+        "Value 'wrong_version_id' at 'versionId' failed to satisfy constraint: Member must satisfy regular expression pattern: v[1-9][0-9]*(\.[A-Za-z0-9-]*)?",
     )
 
     # Set default version for non-existing version
@@ -596,12 +594,12 @@ def test_set_default_policy_version():
         PolicyArn="arn:aws:iam::{}:policy/TestSetDefaultPolicyVersion".format(
             ACCOUNT_ID
         ),
-        VersionId="v4"
+        VersionId="v4",
     ).should.throw(
         ClientError,
         "Policy arn:aws:iam::{}:policy/TestSetDefaultPolicyVersion version v4 does not exist or is not attachable.".format(
             ACCOUNT_ID
-        )
+        ),
     )
 
 


### PR DESCRIPTION
Playing with the Ansible's `iam_managed_policy` I noticed it uses the `set_default_policy_version` which is currently not supported in `moto`. Would you be interested in this PR?