### PR TITLE
Fix issue with wrong parameter signed to secret_binary during secret rotation in Secrets Manager

### DIFF
--- a/moto/secretsmanager/models.py
+++ b/moto/secretsmanager/models.py
@@ -408,8 +408,8 @@ class SecretsManagerBackend(BaseBackend):
         self._add_secret(
             secret_id,
             old_secret_version["secret_string"],
-            secret.description,
-            secret.tags,
+            description=secret.description,
+            tags=secret.tags,
             version_id=new_version_id,
             version_stages=["AWSCURRENT"],
         )

--- a/tests/test_secretsmanager/test_secretsmanager.py
+++ b/tests/test_secretsmanager/test_secretsmanager.py
@@ -502,7 +502,7 @@ def test_restore_secret_that_does_not_exist():
 @mock_secretsmanager
 def test_rotate_secret():
     conn = boto3.client("secretsmanager", region_name="us-west-2")
-    conn.create_secret(Name=DEFAULT_SECRET_NAME, SecretString="foosecret")
+    conn.create_secret(Name=DEFAULT_SECRET_NAME, SecretString="foosecret", Description="foodescription")
 
     rotated_secret = conn.rotate_secret(SecretId=DEFAULT_SECRET_NAME)
 
@@ -510,6 +510,11 @@ def test_rotate_secret():
     assert rotated_secret["ARN"] != ""  # Test arn not empty
     assert rotated_secret["Name"] == DEFAULT_SECRET_NAME
     assert rotated_secret["VersionId"] != ""
+
+    describe_secret = conn.describe_secret(
+        SecretId=DEFAULT_SECRET_NAME
+    )
+    assert describe_secret["Description"] == "foodescription"
 
 
 @mock_secretsmanager

--- a/tests/test_secretsmanager/test_secretsmanager.py
+++ b/tests/test_secretsmanager/test_secretsmanager.py
@@ -502,7 +502,9 @@ def test_restore_secret_that_does_not_exist():
 @mock_secretsmanager
 def test_rotate_secret():
     conn = boto3.client("secretsmanager", region_name="us-west-2")
-    conn.create_secret(Name=DEFAULT_SECRET_NAME, SecretString="foosecret", Description="foodescription")
+    conn.create_secret(
+        Name=DEFAULT_SECRET_NAME, SecretString="foosecret", Description="foodescription"
+    )
 
     rotated_secret = conn.rotate_secret(SecretId=DEFAULT_SECRET_NAME)
 
@@ -511,9 +513,8 @@ def test_rotate_secret():
     assert rotated_secret["Name"] == DEFAULT_SECRET_NAME
     assert rotated_secret["VersionId"] != ""
 
-    describe_secret = conn.describe_secret(
-        SecretId=DEFAULT_SECRET_NAME
-    )
+    describe_secret = conn.describe_secret(SecretId=DEFAULT_SECRET_NAME)
+
     assert describe_secret["Description"] == "foodescription"
 
 


### PR DESCRIPTION
There is an issue with secret rotation. During the call secret_binary has got the value of the description and the description has got the tags value.