### PR TITLE
[SecretsManager] Handle missing secrets versions

### DIFF
--- a/moto/secretsmanager/models.py
+++ b/moto/secretsmanager/models.py
@@ -187,7 +187,7 @@ class SecretsManagerBackend(BaseBackend):
         secret_binary=None,
         description=None,
         tags=[],
-        **kwargs,
+        **kwargs
     ):
 
         # error if secret exists

--- a/moto/secretsmanager/models.py
+++ b/moto/secretsmanager/models.py
@@ -114,8 +114,10 @@ class SecretsManagerBackend(BaseBackend):
         secret_version = secret["versions"].get(version_id)
         if not secret_version:
             raise ResourceNotFoundException(
-                "An error occurred (ResourceNotFoundException) when calling the GetSecretValue operation: Secrets "
-                f"Manager can't find the specified secret value for VersionId: {version_id}"
+                "An error occurred (ResourceNotFoundException) when calling the GetSecretValue operation: Secrets \
+                Manager can't find the specified secret value for VersionId: {}".format(
+                    version_id
+                )
             )
 
         response_data = {

--- a/moto/secretsmanager/models.py
+++ b/moto/secretsmanager/models.py
@@ -185,7 +185,7 @@ class SecretsManagerBackend(BaseBackend):
         secret_binary=None,
         description=None,
         tags=[],
-        **kwargs
+        **kwargs,
     ):
 
         # error if secret exists

--- a/moto/secretsmanager/models.py
+++ b/moto/secretsmanager/models.py
@@ -14,6 +14,7 @@ from .exceptions import (
     SecretHasNoValueException,
     InvalidParameterException,
     ResourceExistsException,
+    ResourceNotFoundException,
     InvalidRequestException,
     ClientError,
 )
@@ -110,7 +111,12 @@ class SecretsManagerBackend(BaseBackend):
         secret = self.secrets[secret_id]
         version_id = version_id or secret["default_version_id"]
 
-        secret_version = secret["versions"][version_id]
+        secret_version = secret["versions"].get(version_id)
+        if not secret_version:
+            raise ResourceNotFoundException(
+                "An error occurred (ResourceNotFoundException) when calling the GetSecretValue operation: Secrets "
+                f"Manager can't find the specified secret value for VersionId: {version_id}"
+            )
 
         response_data = {
             "ARN": secret_arn(self.region, secret["secret_id"]),

--- a/moto/secretsmanager/models.py
+++ b/moto/secretsmanager/models.py
@@ -206,11 +206,11 @@ class SecretsManagerBackend(BaseBackend):
         secret = self.secrets[secret_id]
         version_id = version_id or secret.default_version_id
 
-        secret_version = secret["versions"].get(version_id)
+        secret_version = secret.versions.get(version_id)
         if not secret_version:
             raise ResourceNotFoundException(
-                "An error occurred (ResourceNotFoundException) when calling the GetSecretValue operation: Secrets \
-                Manager can't find the specified secret value for VersionId: {}".format(
+                "An error occurred (ResourceNotFoundException) when calling the GetSecretValue operation: Secrets "
+                "Manager can't find the specified secret value for VersionId: {}".format(
                     version_id
                 )
             )

--- a/tests/test_secretsmanager/test_secretsmanager.py
+++ b/tests/test_secretsmanager/test_secretsmanager.py
@@ -104,6 +104,27 @@ def test_get_secret_that_has_no_value():
         cm.exception.response["Error"]["Message"],
     )
 
+@mock_secretsmanager
+def test_get_secret_version_that_does_not_exist():
+    conn = boto3.client("secretsmanager", region_name="us-west-2")
+
+    result = conn.create_secret(
+        Name="java-util-test-password"
+    )
+    secret_arn = result["ARN"]
+    missing_version_id = "00000000-0000-0000-0000-000000000000"
+
+    with assert_raises(ClientError) as cm:
+        conn.get_secret_value(
+            SecretId=secret_arn, VersionId=missing_version_id)
+
+    assert_equal(
+        (
+            "An error occurred (ResourceNotFoundException) when calling the GetSecretValue operation: Secrets "
+            "Manager can't find the specified secret value for VersionId: 00000000-0000-0000-0000-000000000000"
+        ),
+        cm.exception.response["Error"]["Message"],
+    )
 
 @mock_secretsmanager
 def test_create_secret():

--- a/tests/test_secretsmanager/test_secretsmanager.py
+++ b/tests/test_secretsmanager/test_secretsmanager.py
@@ -104,19 +104,17 @@ def test_get_secret_that_has_no_value():
         cm.exception.response["Error"]["Message"],
     )
 
+
 @mock_secretsmanager
 def test_get_secret_version_that_does_not_exist():
     conn = boto3.client("secretsmanager", region_name="us-west-2")
 
-    result = conn.create_secret(
-        Name="java-util-test-password"
-    )
+    result = conn.create_secret(Name="java-util-test-password")
     secret_arn = result["ARN"]
     missing_version_id = "00000000-0000-0000-0000-000000000000"
 
     with assert_raises(ClientError) as cm:
-        conn.get_secret_value(
-            SecretId=secret_arn, VersionId=missing_version_id)
+        conn.get_secret_value(SecretId=secret_arn, VersionId=missing_version_id)
 
     assert_equal(
         (
@@ -125,6 +123,7 @@ def test_get_secret_version_that_does_not_exist():
         ),
         cm.exception.response["Error"]["Message"],
     )
+
 
 @mock_secretsmanager
 def test_create_secret():


### PR DESCRIPTION
The get_secret_value method should raise ResourceNotFoundException
if a secret exists but the provided VersionId does not.