### PR TITLE
fix(dynamodb2): Fix update_item nested insert

### DIFF
--- a/moto/dynamodb2/responses.py
+++ b/moto/dynamodb2/responses.py
@@ -826,7 +826,7 @@ class DynamoHandler(BaseResponse):
                         original.get(key, None), changed[key]
                     )
                     for key in changed.keys()
-                    if changed[key] != original.get(key, None)
+                    if key not in original or changed[key] != original[key]
                 }
             elif type(changed) in (set, list):
                 if len(changed) != len(original):


### PR DESCRIPTION
Started working on a testcase to repro this issue when I encountered it in one 
of my codebases, but then the fix seemed pretty simple so figured I'd throw this
up here!

When comparing old and new values when doing a nested item update, the
`!=` implementation fails when the value being compared is `None`. This
results in an exception when trying to insert a new item into a nested
map. So just do a quick check that the original value is exists before
doing the comparison, as the `None` default is what is tripping this.