### PR TITLE
Fixes acm:describe_certificate for imported certificates having no SAN extension

### DIFF
--- a/moto/acm/models.py
+++ b/moto/acm/models.py
@@ -293,9 +293,12 @@ class CertBundle(BaseModel):
             key_algo = "EC_prime256v1"
 
         # Look for SANs
-        san_obj = self._cert.extensions.get_extension_for_oid(
-            cryptography.x509.OID_SUBJECT_ALTERNATIVE_NAME
-        )
+        try:
+            san_obj = self._cert.extensions.get_extension_for_oid(
+                cryptography.x509.OID_SUBJECT_ALTERNATIVE_NAME
+            )
+        except cryptography.x509.ExtensionNotFound:
+            san_obj = None
         sans = []
         if san_obj is not None:
             sans = [item.value for item in san_obj.value]

--- a/tests/test_acm/test_acm.py
+++ b/tests/test_acm/test_acm.py
@@ -140,7 +140,7 @@ def test_describe_certificate():
 
 
 @mock_acm
-def test_describe_certificate():
+def test_describe_certificate_with_bad_arn():
     client = boto3.client("acm", region_name="eu-central-1")
 
     try:


### PR DESCRIPTION
https://github.com/spulec/moto/blob/c4b630e20fb9004ef4b1eab345ceab5ef9e4c2ff/moto/acm/models.py#L230-L235

While describing imported acm certificate, if the certificate does not have any SANs, `get_extension_for_oid()` could throw a `cryptography.x509.ExtensionNotFound.`

The [unit test](https://github.com/spulec/moto/blob/d00cefa25cfd338caaabcefc7a79e6e803f577cf/tests/test_acm/test_acm.py#L129) should have failed here. But unfortunately, it is overwritten by next function with same name.

This PR fixes `describe_certificate()` to handle imported certificates with missing SAN extension. unit test is updated to run the corresponding tests.

Fixes #3371