### PR TITLE
Enable more unit tests for ACM

### DIFF
--- a/tests/test_acm/test_acm.py
+++ b/tests/test_acm/test_acm.py
@@ -8,9 +8,10 @@ import uuid
 
 from botocore.exceptions import ClientError
 
-from moto import mock_acm
+from moto import mock_acm, settings
 from moto.core import ACCOUNT_ID
 
+from nose import SkipTest
 
 RESOURCE_FOLDER = os.path.join(os.path.dirname(__file__), "resources")
 _GET_RESOURCE = lambda x: open(os.path.join(RESOURCE_FOLDER, x), "rb").read()
@@ -330,66 +331,75 @@ def test_request_certificate_no_san():
 def test_request_certificate_issued_status(frozen_time):
     # After requesting a certificate, it should then auto-validate after 1 minute
     # Some sneaky programming for that ;-)
-    client = boto3.client('acm', region_name='eu-central-1')
+    client = boto3.client("acm", region_name="eu-central-1")
 
     resp = client.request_certificate(
-        DomainName='google.com',
-        SubjectAlternativeNames=['google.com', 'www.google.com', 'mail.google.com'],
+        DomainName="google.com",
+        SubjectAlternativeNames=["google.com", "www.google.com", "mail.google.com"],
     )
-    arn = resp['CertificateArn']
+    arn = resp["CertificateArn"]
 
     resp = client.describe_certificate(CertificateArn=arn)
-    resp['Certificate']['CertificateArn'].should.equal(arn)
-    resp['Certificate']['DomainName'].should.equal('google.com')
-    resp['Certificate']['Issuer'].should.equal('Amazon')
-    resp['Certificate']['KeyAlgorithm'].should.equal('RSA_2048')
-    resp['Certificate']['Status'].should.equal('PENDING_VALIDATION')
-    resp['Certificate']['Type'].should.equal('AMAZON_ISSUED')
-    len(resp['Certificate']['SubjectAlternativeNames']).should.equal(3)
+    resp["Certificate"]["CertificateArn"].should.equal(arn)
+    resp["Certificate"]["DomainName"].should.equal("google.com")
+    resp["Certificate"]["Issuer"].should.equal("Amazon")
+    resp["Certificate"]["KeyAlgorithm"].should.equal("RSA_2048")
+    resp["Certificate"]["Status"].should.equal("PENDING_VALIDATION")
+    resp["Certificate"]["Type"].should.equal("AMAZON_ISSUED")
+    len(resp["Certificate"]["SubjectAlternativeNames"]).should.equal(3)
 
     # validation will be pending for 1 minute.
     resp = client.describe_certificate(CertificateArn=arn)
-    resp['Certificate']['CertificateArn'].should.equal(arn)
-    resp['Certificate']['Status'].should.equal('PENDING_VALIDATION')
+    resp["Certificate"]["CertificateArn"].should.equal(arn)
+    resp["Certificate"]["Status"].should.equal("PENDING_VALIDATION")
 
-    # Move time to get it issued.
-    frozen_time.move_to('2012-01-01 12:02:00')
-    resp = client.describe_certificate(CertificateArn=arn)
-    resp['Certificate']['CertificateArn'].should.equal(arn)
-    resp['Certificate']['Status'].should.equal('ISSUED')
+    if not settings.TEST_SERVER_MODE:
+        # Move time to get it issued.
+        frozen_time.move_to("2012-01-01 12:02:00")
+        resp = client.describe_certificate(CertificateArn=arn)
+        resp["Certificate"]["CertificateArn"].should.equal(arn)
+        resp["Certificate"]["Status"].should.equal("ISSUED")
+
 
 @freeze_time("2012-01-01 12:00:00", as_arg=True)
 @mock_acm
 def test_request_certificate_with_mutiple_times(frozen_time):
+    if settings.TEST_SERVER_MODE:
+        raise SkipTest("Cant manipulate time in server mode")
+
     # After requesting a certificate, it should then auto-validate after 1 minute
     # Some sneaky programming for that ;-)
-    client = boto3.client('acm', region_name='eu-central-1')
+    client = boto3.client("acm", region_name="eu-central-1")
 
     resp = client.request_certificate(
-        IdempotencyToken='test_token',
-        DomainName='google.com',
-        SubjectAlternativeNames=['google.com', 'www.google.com', 'mail.google.com'],
+        IdempotencyToken="test_token",
+        DomainName="google.com",
+        SubjectAlternativeNames=["google.com", "www.google.com", "mail.google.com"],
     )
-    original_arn = resp['CertificateArn']
+    original_arn = resp["CertificateArn"]
 
     # Should be able to request a certificate multiple times in an hour
     # after that it makes a new one
-    for time_intervals in ('2012-01-01 12:15:00', '2012-01-01 12:30:00', '2012-01-01 12:45:00'):
+    for time_intervals in (
+        "2012-01-01 12:15:00",
+        "2012-01-01 12:30:00",
+        "2012-01-01 12:45:00",
+    ):
         frozen_time.move_to(time_intervals)
         resp = client.request_certificate(
-            IdempotencyToken='test_token',
-            DomainName='google.com',
-            SubjectAlternativeNames=['google.com', 'www.google.com', 'mail.google.com'],
+            IdempotencyToken="test_token",
+            DomainName="google.com",
+            SubjectAlternativeNames=["google.com", "www.google.com", "mail.google.com"],
         )
-        arn = resp['CertificateArn']
+        arn = resp["CertificateArn"]
         arn.should.equal(original_arn)
 
     # Move time
-    frozen_time.move_to('2012-01-01 13:01:00')
+    frozen_time.move_to("2012-01-01 13:01:00")
     resp = client.request_certificate(
-        IdempotencyToken='test_token',
-        DomainName='google.com',
-        SubjectAlternativeNames=['google.com', 'www.google.com', 'mail.google.com'],
+        IdempotencyToken="test_token",
+        DomainName="google.com",
+        SubjectAlternativeNames=["google.com", "www.google.com", "mail.google.com"],
     )
-    arn = resp['CertificateArn']
+    arn = resp["CertificateArn"]
     arn.should_not.equal(original_arn)

--- a/tests/test_acm/test_acm.py
+++ b/tests/test_acm/test_acm.py
@@ -324,70 +324,72 @@ def test_request_certificate_no_san():
     resp2.should.contain("Certificate")
 
 
-# # Also tests the SAN code
-# # requires Pull: https://github.com/spulec/freezegun/pull/210
-# @freeze_time("2012-01-01 12:00:00", as_arg=True)
-# @mock_acm
-# def test_request_certificate(frozen_time):
-#     # After requesting a certificate, it should then auto-validate after 1 minute
-#     # Some sneaky programming for that ;-)
-#     client = boto3.client('acm', region_name='eu-central-1')
-#
-#     resp = client.request_certificate(
-#         DomainName='google.com',
-#         SubjectAlternativeNames=['google.com', 'www.google.com', 'mail.google.com'],
-#     )
-#     arn = resp['CertificateArn']
-#
-#     resp = client.describe_certificate(CertificateArn=arn)
-#     resp['Certificate']['CertificateArn'].should.equal(arn)
-#     resp['Certificate']['DomainName'].should.equal('google.com')
-#     resp['Certificate']['Issuer'].should.equal('Amazon')
-#     resp['Certificate']['KeyAlgorithm'].should.equal('RSA_2048')
-#     resp['Certificate']['Status'].should.equal('PENDING_VALIDATION')
-#     resp['Certificate']['Type'].should.equal('AMAZON_ISSUED')
-#     len(resp['Certificate']['SubjectAlternativeNames']).should.equal(3)
-#
-#     # Move time
-#     frozen_time.move_to('2012-01-01 12:02:00')
-#     resp = client.describe_certificate(CertificateArn=arn)
-#     resp['Certificate']['CertificateArn'].should.equal(arn)
-#     resp['Certificate']['Status'].should.equal('ISSUED')
-#
-#
-# # requires Pull: https://github.com/spulec/freezegun/pull/210
-# @freeze_time("2012-01-01 12:00:00", as_arg=True)
-# @mock_acm
-# def test_request_certificate(frozen_time):
-#     # After requesting a certificate, it should then auto-validate after 1 minute
-#     # Some sneaky programming for that ;-)
-#     client = boto3.client('acm', region_name='eu-central-1')
-#
-#     resp = client.request_certificate(
-#         IdempotencyToken='test_token',
-#         DomainName='google.com',
-#         SubjectAlternativeNames=['google.com', 'www.google.com', 'mail.google.com'],
-#     )
-#     original_arn = resp['CertificateArn']
-#
-#     # Should be able to request a certificate multiple times in an hour
-#     # after that it makes a new one
-#     for time_intervals in ('2012-01-01 12:15:00', '2012-01-01 12:30:00', '2012-01-01 12:45:00'):
-#         frozen_time.move_to(time_intervals)
-#         resp = client.request_certificate(
-#             IdempotencyToken='test_token',
-#             DomainName='google.com',
-#             SubjectAlternativeNames=['google.com', 'www.google.com', 'mail.google.com'],
-#         )
-#         arn = resp['CertificateArn']
-#         arn.should.equal(original_arn)
-#
-#     # Move time
-#     frozen_time.move_to('2012-01-01 13:01:00')
-#     resp = client.request_certificate(
-#         IdempotencyToken='test_token',
-#         DomainName='google.com',
-#         SubjectAlternativeNames=['google.com', 'www.google.com', 'mail.google.com'],
-#     )
-#     arn = resp['CertificateArn']
-#     arn.should_not.equal(original_arn)
+# Also tests the SAN code
+@freeze_time("2012-01-01 12:00:00", as_arg=True)
+@mock_acm
+def test_request_certificate_issued_status(frozen_time):
+    # After requesting a certificate, it should then auto-validate after 1 minute
+    # Some sneaky programming for that ;-)
+    client = boto3.client('acm', region_name='eu-central-1')
+
+    resp = client.request_certificate(
+        DomainName='google.com',
+        SubjectAlternativeNames=['google.com', 'www.google.com', 'mail.google.com'],
+    )
+    arn = resp['CertificateArn']
+
+    resp = client.describe_certificate(CertificateArn=arn)
+    resp['Certificate']['CertificateArn'].should.equal(arn)
+    resp['Certificate']['DomainName'].should.equal('google.com')
+    resp['Certificate']['Issuer'].should.equal('Amazon')
+    resp['Certificate']['KeyAlgorithm'].should.equal('RSA_2048')
+    resp['Certificate']['Status'].should.equal('PENDING_VALIDATION')
+    resp['Certificate']['Type'].should.equal('AMAZON_ISSUED')
+    len(resp['Certificate']['SubjectAlternativeNames']).should.equal(3)
+
+    # validation will be pending for 1 minute.
+    resp = client.describe_certificate(CertificateArn=arn)
+    resp['Certificate']['CertificateArn'].should.equal(arn)
+    resp['Certificate']['Status'].should.equal('PENDING_VALIDATION')
+
+    # Move time to get it issued.
+    frozen_time.move_to('2012-01-01 12:02:00')
+    resp = client.describe_certificate(CertificateArn=arn)
+    resp['Certificate']['CertificateArn'].should.equal(arn)
+    resp['Certificate']['Status'].should.equal('ISSUED')
+
+@freeze_time("2012-01-01 12:00:00", as_arg=True)
+@mock_acm
+def test_request_certificate_with_mutiple_times(frozen_time):
+    # After requesting a certificate, it should then auto-validate after 1 minute
+    # Some sneaky programming for that ;-)
+    client = boto3.client('acm', region_name='eu-central-1')
+
+    resp = client.request_certificate(
+        IdempotencyToken='test_token',
+        DomainName='google.com',
+        SubjectAlternativeNames=['google.com', 'www.google.com', 'mail.google.com'],
+    )
+    original_arn = resp['CertificateArn']
+
+    # Should be able to request a certificate multiple times in an hour
+    # after that it makes a new one
+    for time_intervals in ('2012-01-01 12:15:00', '2012-01-01 12:30:00', '2012-01-01 12:45:00'):
+        frozen_time.move_to(time_intervals)
+        resp = client.request_certificate(
+            IdempotencyToken='test_token',
+            DomainName='google.com',
+            SubjectAlternativeNames=['google.com', 'www.google.com', 'mail.google.com'],
+        )
+        arn = resp['CertificateArn']
+        arn.should.equal(original_arn)
+
+    # Move time
+    frozen_time.move_to('2012-01-01 13:01:00')
+    resp = client.request_certificate(
+        IdempotencyToken='test_token',
+        DomainName='google.com',
+        SubjectAlternativeNames=['google.com', 'www.google.com', 'mail.google.com'],
+    )
+    arn = resp['CertificateArn']
+    arn.should_not.equal(original_arn)


### PR DESCRIPTION
Some unit tests for ACM implementation were [commented](https://github.com/spulec/moto/pull/1174/files?file-filters%5B%5D=.md&file-filters%5B%5D=.py#r140904537) out due to a then pending [PR](https://github.com/spulec/freezegun/pull/210) on **freezegun**

Enabling those tests with minor changes.
