### PR TITLE
Allow creation of subnets from secondary VPC IPv4 CIDR blocks

### DIFF
--- a/tests/test_ec2/test_subnets.py
+++ b/tests/test_ec2/test_subnets.py
@@ -437,6 +437,47 @@ def test_create_subnet_with_invalid_cidr_block_parameter():
 
 
 @mock_ec2
+def test_create_subnets_with_multiple_vpc_cidr_blocks():
+    ec2 = boto3.resource("ec2", region_name="us-west-1")
+    client = boto3.client("ec2", region_name="us-west-1")
+
+    vpc = ec2.create_vpc(CidrBlock="10.0.0.0/16")
+    ec2.meta.client.associate_vpc_cidr_block(CidrBlock="10.1.0.0/16", VpcId=vpc.id)
+
+    vpc.reload()
+    vpc.is_default.shouldnt.be.ok
+
+    subnet_cidr_block_primary = "10.0.0.0/24"
+    subnet_primary = ec2.create_subnet(
+        VpcId=vpc.id, CidrBlock=subnet_cidr_block_primary
+    )
+
+    subnet_cidr_block_secondary = "10.1.0.0/24"
+    subnet_secondary = ec2.create_subnet(
+        VpcId=vpc.id, CidrBlock=subnet_cidr_block_secondary
+    )
+
+    subnets = client.describe_subnets(
+        SubnetIds=[subnet_primary.id, subnet_secondary.id]
+    )["Subnets"]
+    subnets.should.have.length_of(2)
+
+    for subnet in subnets:
+        subnet.should.have.key("AvailabilityZone")
+        subnet.should.have.key("AvailabilityZoneId")
+        subnet.should.have.key("AvailableIpAddressCount")
+        subnet.should.have.key("CidrBlock")
+        subnet.should.have.key("State")
+        subnet.should.have.key("SubnetId")
+        subnet.should.have.key("VpcId")
+        subnet.shouldnt.have.key("Tags")
+        subnet.should.have.key("DefaultForAz").which.should.equal(False)
+        subnet.should.have.key("MapPublicIpOnLaunch").which.should.equal(False)
+        subnet.should.have.key("OwnerId")
+        subnet.should.have.key("AssignIpv6AddressOnCreation").which.should.equal(False)
+
+
+@mock_ec2
 def test_create_subnets_with_overlapping_cidr_blocks():
     ec2 = boto3.resource("ec2", region_name="us-west-1")
 


### PR DESCRIPTION
This change allows creation of subnets from secondary VPC IPv4 CIDR blocks in the `mock_ec2` framework.

Previously, if you attempted to create a subnet in a secondary VPC CIDR you would get a IP range validation error.

Fixes #3385