### PR TITLE
Add missing `Fn::GetAtt` attributes to S3 bucket mock

### DIFF
--- a/moto/s3/models.py
+++ b/moto/s3/models.py
@@ -523,10 +523,7 @@ class LifecycleAndFilter(BaseModel):
 
         for key, value in self.tags.items():
             data.append(
-                {
-                    "type": "LifecycleTagPredicate",
-                    "tag": {"key": key, "value": value},
-                }
+                {"type": "LifecycleTagPredicate", "tag": {"key": key, "value": value},}
             )
 
         return data
@@ -1132,11 +1129,7 @@ class FakeBucket(CloudFormationModel):
 
     @classmethod
     def update_from_cloudformation_json(
-        cls,
-        original_resource,
-        new_resource_name,
-        cloudformation_json,
-        region_name,
+        cls, original_resource, new_resource_name, cloudformation_json, region_name,
     ):
         properties = cloudformation_json["Properties"]
 
@@ -1476,8 +1469,7 @@ class S3Backend(BaseBackend):
             raise MissingKey(key_name)
         self.tagger.delete_all_tags_for_resource(key.arn)
         self.tagger.tag_resource(
-            key.arn,
-            [{"Key": k, "Value": v} for (k, v) in tags.items()],
+            key.arn, [{"Key": k, "Value": v} for (k, v) in tags.items()],
         )
         return key
 
@@ -1489,8 +1481,7 @@ class S3Backend(BaseBackend):
         bucket = self.get_bucket(bucket_name)
         self.tagger.delete_all_tags_for_resource(bucket.arn)
         self.tagger.tag_resource(
-            bucket.arn,
-            [{"Key": key, "Value": value} for key, value in tags.items()],
+            bucket.arn, [{"Key": key, "Value": value} for key, value in tags.items()],
         )
 
     def delete_bucket_tagging(self, bucket_name):

--- a/moto/s3/models.py
+++ b/moto/s3/models.py
@@ -1061,12 +1061,16 @@ class FakeBucket(CloudFormationModel):
     def get_cfn_attribute(self, attribute_name):
         from moto.cloudformation.exceptions import UnformattedGetAttTemplateException
 
-        if attribute_name == "DomainName":
-            raise NotImplementedError('"Fn::GetAtt" : [ "{0}" , "DomainName" ]"')
-        elif attribute_name == "WebsiteURL":
-            raise NotImplementedError('"Fn::GetAtt" : [ "{0}" , "WebsiteURL" ]"')
-        elif attribute_name == "Arn":
+        if attribute_name == "Arn":
             return self.arn
+        elif attribute_name == "DomainName":
+            return self.domain_name
+        elif attribute_name == "DualStackDomainName":
+            return self.dual_stack_domain_name
+        elif attribute_name == "RegionalDomainName":
+            return self.regional_domain_name
+        elif attribute_name == "WebsiteURL":
+            return self.website_url
         raise UnformattedGetAttTemplateException()
 
     def set_acl(self, acl):
@@ -1075,6 +1079,22 @@ class FakeBucket(CloudFormationModel):
     @property
     def arn(self):
         return "arn:aws:s3:::{}".format(self.name)
+
+    @property
+    def domain_name(self):
+        return "{}.s3.amazonaws.com".format(self.name)
+
+    @property
+    def dual_stack_domain_name(self):
+        return "{}.s3.dualstack.{}.amazonaws.com".format(self.name, self.region_name)
+
+    @property
+    def regional_domain_name(self):
+        return "{}.s3.{}.amazonaws.com".format(self.name, self.region_name)
+
+    @property
+    def website_url(self):
+        return "http://{}.s3-website.{}.amazonaws.com".format(self.name, self.region_name)
 
     @property
     def physical_resource_id(self):

--- a/moto/s3/models.py
+++ b/moto/s3/models.py
@@ -66,7 +66,7 @@ OWNER = "75aa57f09aa0c8caeab4f8c24e99d10f8e7faeebf76c078efc7c6caea54ba06a"
 
 def get_moto_s3_account_id():
     """This makes it easy for mocking AWS Account IDs when using AWS Config
-       -- Simply mock.patch the ACCOUNT_ID here, and Config gets it for free.
+    -- Simply mock.patch the ACCOUNT_ID here, and Config gets it for free.
     """
     return ACCOUNT_ID
 
@@ -523,7 +523,10 @@ class LifecycleAndFilter(BaseModel):
 
         for key, value in self.tags.items():
             data.append(
-                {"type": "LifecycleTagPredicate", "tag": {"key": key, "value": value},}
+                {
+                    "type": "LifecycleTagPredicate",
+                    "tag": {"key": key, "value": value},
+                }
             )
 
         return data
@@ -1094,7 +1097,9 @@ class FakeBucket(CloudFormationModel):
 
     @property
     def website_url(self):
-        return "http://{}.s3-website.{}.amazonaws.com".format(self.name, self.region_name)
+        return "http://{}.s3-website.{}.amazonaws.com".format(
+            self.name, self.region_name
+        )
 
     @property
     def physical_resource_id(self):
@@ -1127,7 +1132,11 @@ class FakeBucket(CloudFormationModel):
 
     @classmethod
     def update_from_cloudformation_json(
-        cls, original_resource, new_resource_name, cloudformation_json, region_name,
+        cls,
+        original_resource,
+        new_resource_name,
+        cloudformation_json,
+        region_name,
     ):
         properties = cloudformation_json["Properties"]
 
@@ -1467,7 +1476,8 @@ class S3Backend(BaseBackend):
             raise MissingKey(key_name)
         self.tagger.delete_all_tags_for_resource(key.arn)
         self.tagger.tag_resource(
-            key.arn, [{"Key": k, "Value": v} for (k, v) in tags.items()],
+            key.arn,
+            [{"Key": k, "Value": v} for (k, v) in tags.items()],
         )
         return key
 
@@ -1479,7 +1489,8 @@ class S3Backend(BaseBackend):
         bucket = self.get_bucket(bucket_name)
         self.tagger.delete_all_tags_for_resource(bucket.arn)
         self.tagger.tag_resource(
-            bucket.arn, [{"Key": key, "Value": value} for key, value in tags.items()],
+            bucket.arn,
+            [{"Key": key, "Value": value} for key, value in tags.items()],
         )
 
     def delete_bucket_tagging(self, bucket_name):

--- a/tests/test_s3/test_s3_cloudformation.py
+++ b/tests/test_s3/test_s3_cloudformation.py
@@ -14,12 +14,7 @@ def test_s3_bucket_cloudformation_basic():
 
     template = {
         "AWSTemplateFormatVersion": "2010-09-09",
-        "Resources": {
-            "testInstance": {
-                "Type": "AWS::S3::Bucket",
-                "Properties": {},
-            }
-        },
+        "Resources": {"testInstance": {"Type": "AWS::S3::Bucket", "Properties": {},}},
         "Outputs": {"Bucket": {"Value": {"Ref": "testInstance"}}},
     }
     template_json = json.dumps(template)

--- a/tests/test_s3/test_s3_cloudformation.py
+++ b/tests/test_s3/test_s3_cloudformation.py
@@ -14,7 +14,12 @@ def test_s3_bucket_cloudformation_basic():
 
     template = {
         "AWSTemplateFormatVersion": "2010-09-09",
-        "Resources": {"testInstance": {"Type": "AWS::S3::Bucket", "Properties": {},}},
+        "Resources": {
+            "testInstance": {
+                "Type": "AWS::S3::Bucket",
+                "Properties": {},
+            }
+        },
         "Outputs": {"Bucket": {"Value": {"Ref": "testInstance"}}},
     }
     template_json = json.dumps(template)
@@ -172,11 +177,15 @@ def test_s3_bucket_cloudformation_outputs():
             },
             "BucketDualStackDomainName": {
                 "Value": {"Fn::GetAtt": ["TestBucket", "DualStackDomainName"]},
-                "Export": {"Name": {"Fn::Sub": "${AWS::StackName}:BucketDualStackDomainName"}},
+                "Export": {
+                    "Name": {"Fn::Sub": "${AWS::StackName}:BucketDualStackDomainName"}
+                },
             },
             "BucketRegionalDomainName": {
                 "Value": {"Fn::GetAtt": ["TestBucket", "RegionalDomainName"]},
-                "Export": {"Name": {"Fn::Sub": "${AWS::StackName}:BucketRegionalDomainName"}},
+                "Export": {
+                    "Name": {"Fn::Sub": "${AWS::StackName}:BucketRegionalDomainName"}
+                },
             },
             "BucketWebsiteURL": {
                 "Value": {"Fn::GetAtt": ["TestBucket", "WebsiteURL"]},
@@ -193,14 +202,22 @@ def test_s3_bucket_cloudformation_outputs():
     output = {item["OutputKey"]: item["OutputValue"] for item in outputs_list}
     s3.head_bucket(Bucket=output["BucketName"])
     output["BucketARN"].should.match("arn:aws:s3.+{bucket}".format(bucket=bucket_name))
-    output["BucketDomainName"].should.equal("{bucket}.s3.amazonaws.com".format(bucket=bucket_name))
+    output["BucketDomainName"].should.equal(
+        "{bucket}.s3.amazonaws.com".format(bucket=bucket_name)
+    )
     output["BucketDualStackDomainName"].should.equal(
-        "{bucket}.s3.dualstack.{region}.amazonaws.com".format(bucket=bucket_name, region=region_name)
+        "{bucket}.s3.dualstack.{region}.amazonaws.com".format(
+            bucket=bucket_name, region=region_name
+        )
     )
     output["BucketRegionalDomainName"].should.equal(
-        "{bucket}.s3.{region}.amazonaws.com".format(bucket=bucket_name, region=region_name)
+        "{bucket}.s3.{region}.amazonaws.com".format(
+            bucket=bucket_name, region=region_name
+        )
     )
     output["BucketWebsiteURL"].should.equal(
-        "http://{bucket}.s3-website.{region}.amazonaws.com".format(bucket=bucket_name, region=region_name)
+        "http://{bucket}.s3-website.{region}.amazonaws.com".format(
+            bucket=bucket_name, region=region_name
+        )
     )
     output["BucketName"].should.equal(bucket_name)


### PR DESCRIPTION
Prevent valid CloudFormation templates containing S3 `Fn::GetAtt` from raising unexpected `ValidationError`.

Spec for valid cases referenced from https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket.html#aws-properties-s3-bucket-return-values.

Addresses an issue reported here: https://github.com/localstack/aws-cdk-local/issues/1