### PR TITLE
Fix SQS md5 attribute hashing.

### DIFF
--- a/moto/sqs/models.py
+++ b/moto/sqs/models.py
@@ -100,7 +100,9 @@ class Message(BaseModel):
 
             if attrValue.get("string_value"):
                 md5.update(bytearray([STRING_TYPE_FIELD_INDEX]))
-                self.update_binary_length_and_value(md5, self.utf8(attrValue.get("string_value")))
+                self.update_binary_length_and_value(
+                    md5, self.utf8(attrValue.get("string_value"))
+                )
             elif attrValue.get("binary_value"):
                 md5.update(bytearray([BINARY_TYPE_FIELD_INDEX]))
                 decoded_binary_value = base64.b64decode(attrValue.get("binary_value"))

--- a/tests/test_sqs/test_sqs.py
+++ b/tests/test_sqs/test_sqs.py
@@ -256,7 +256,10 @@ def test_message_send_with_attributes():
     msg = queue.send_message(
         MessageBody="derp",
         MessageAttributes={
-            "SOME_Valid.attribute-Name": {"StringValue": "1493147359900", "DataType": "Number"}
+            "SOME_Valid.attribute-Name": {
+                "StringValue": "1493147359900",
+                "DataType": "Number",
+            }
         },
     )
     msg.get("MD5OfMessageBody").should.equal("58fd9edd83341c29f1aebba81c31e257")
@@ -285,6 +288,7 @@ def test_message_with_invalid_attributes():
         "Attribute name can contain A-Z, a-z, 0-9, underscore (_), hyphen (-), and period (.) characters."
     )
 
+
 @mock_sqs
 def test_message_with_string_attributes():
     sqs = boto3.resource("sqs", region_name="us-east-1")
@@ -292,9 +296,15 @@ def test_message_with_string_attributes():
     msg = queue.send_message(
         MessageBody="derp",
         MessageAttributes={
-            "id": {"StringValue": "2018fc74-4f77-1a5a-1be0-c2d037d5052b", "DataType": "String"},
+            "id": {
+                "StringValue": "2018fc74-4f77-1a5a-1be0-c2d037d5052b",
+                "DataType": "String",
+            },
             "contentType": {"StringValue": "application/json", "DataType": "String"},
-            "timestamp": {"StringValue": "1602845432024", "DataType": "Number.java.lang.Long"}
+            "timestamp": {
+                "StringValue": "1602845432024",
+                "DataType": "Number.java.lang.Long",
+            },
         },
     )
     msg.get("MD5OfMessageBody").should.equal("58fd9edd83341c29f1aebba81c31e257")
@@ -302,7 +312,8 @@ def test_message_with_string_attributes():
     msg.get("MessageId").should_not.contain(" \n")
 
     messages = queue.receive_messages()
-    messages.should.have.length_of(1)\
+    messages.should.have.length_of(1)
+
 
 @mock_sqs
 def test_message_with_binary_attribute():
@@ -311,10 +322,16 @@ def test_message_with_binary_attribute():
     msg = queue.send_message(
         MessageBody="derp",
         MessageAttributes={
-            "id": {"StringValue": "453ae55e-f03b-21a6-a4b1-70c2e2e8fe71", "DataType": "String"},
+            "id": {
+                "StringValue": "453ae55e-f03b-21a6-a4b1-70c2e2e8fe71",
+                "DataType": "String",
+            },
             "mybin": {"BinaryValue": "kekchebukek", "DataType": "Binary"},
-            "timestamp": {"StringValue": "1603134247654", "DataType": "Number.java.lang.Long"},
-            "contentType": {"StringValue": "application/json", "DataType": "String"}
+            "timestamp": {
+                "StringValue": "1603134247654",
+                "DataType": "Number.java.lang.Long",
+            },
+            "contentType": {"StringValue": "application/json", "DataType": "String"},
         },
     )
     msg.get("MD5OfMessageBody").should.equal("58fd9edd83341c29f1aebba81c31e257")

--- a/tests/test_sqs/test_sqs.py
+++ b/tests/test_sqs/test_sqs.py
@@ -305,7 +305,7 @@ def test_message_with_string_attributes():
     messages.should.have.length_of(1)\
 
 @mock_sqs
-def test_message_with_string_xxx_attributes():
+def test_message_with_binary_attribute():
     sqs = boto3.resource("sqs", region_name="us-east-1")
     queue = sqs.create_queue(QueueName="blah")
     msg = queue.send_message(

--- a/tests/test_sqs/test_sqs.py
+++ b/tests/test_sqs/test_sqs.py
@@ -256,11 +256,11 @@ def test_message_send_with_attributes():
     msg = queue.send_message(
         MessageBody="derp",
         MessageAttributes={
-            "timestamp": {"StringValue": "1493147359900", "DataType": "Number"}
+            "SOME_Valid.attribute-Name": {"StringValue": "1493147359900", "DataType": "Number"}
         },
     )
     msg.get("MD5OfMessageBody").should.equal("58fd9edd83341c29f1aebba81c31e257")
-    msg.get("MD5OfMessageAttributes").should.equal("235c5c510d26fb653d073faed50ae77c")
+    msg.get("MD5OfMessageAttributes").should.equal("36655e7e9d7c0e8479fa3f3f42247ae7")
     msg.get("MessageId").should_not.contain(" \n")
 
     messages = queue.receive_messages()
@@ -268,20 +268,57 @@ def test_message_send_with_attributes():
 
 
 @mock_sqs
-def test_message_with_complex_attributes():
+def test_message_with_invalid_attributes():
+    sqs = boto3.resource("sqs", region_name="us-east-1")
+    queue = sqs.create_queue(QueueName="blah")
+    with assert_raises(ClientError) as e:
+        queue.send_message(
+            MessageBody="derp",
+            MessageAttributes={
+                "öther_encodings": {"DataType": "String", "StringValue": "str"},
+            },
+        )
+    ex = e.exception
+    ex.response["Error"]["Code"].should.equal("MessageAttributesInvalid")
+    ex.response["Error"]["Message"].should.equal(
+        "The message attribute name 'öther_encodings' is invalid. "
+        "Attribute name can contain A-Z, a-z, 0-9, underscore (_), hyphen (-), and period (.) characters."
+    )
+
+@mock_sqs
+def test_message_with_string_attributes():
     sqs = boto3.resource("sqs", region_name="us-east-1")
     queue = sqs.create_queue(QueueName="blah")
     msg = queue.send_message(
         MessageBody="derp",
         MessageAttributes={
-            "ccc": {"StringValue": "testjunk", "DataType": "String"},
-            "aaa": {"BinaryValue": b"\x02\x03\x04", "DataType": "Binary"},
-            "zzz": {"DataType": "Number", "StringValue": "0230.01"},
-            "öther_encodings": {"DataType": "String", "StringValue": "T\xFCst"},
+            "id": {"StringValue": "2018fc74-4f77-1a5a-1be0-c2d037d5052b", "DataType": "String"},
+            "contentType": {"StringValue": "application/json", "DataType": "String"},
+            "timestamp": {"StringValue": "1602845432024", "DataType": "Number.java.lang.Long"}
         },
     )
     msg.get("MD5OfMessageBody").should.equal("58fd9edd83341c29f1aebba81c31e257")
-    msg.get("MD5OfMessageAttributes").should.equal("8ae21a7957029ef04146b42aeaa18a22")
+    msg.get("MD5OfMessageAttributes").should.equal("b12289320bb6e494b18b645ef562b4a9")
+    msg.get("MessageId").should_not.contain(" \n")
+
+    messages = queue.receive_messages()
+    messages.should.have.length_of(1)\
+
+@mock_sqs
+def test_message_with_string_xxx_attributes():
+    sqs = boto3.resource("sqs", region_name="us-east-1")
+    queue = sqs.create_queue(QueueName="blah")
+    msg = queue.send_message(
+        MessageBody="derp",
+        MessageAttributes={
+            "id": {"StringValue": "453ae55e-f03b-21a6-a4b1-70c2e2e8fe71", "DataType": "String"},
+            "mybin": {"BinaryValue": "kekchebukek", "DataType": "Binary"},
+            "timestamp": {"StringValue": "1603134247654", "DataType": "Number.java.lang.Long"},
+            "contentType": {"StringValue": "application/json", "DataType": "String"}
+        },
+    )
+    msg.get("MD5OfMessageBody").should.equal("58fd9edd83341c29f1aebba81c31e257")
+    msg.get("MD5OfMessageAttributes").should.equal("049075255ebc53fb95f7f9f3cedf3c50")
     msg.get("MessageId").should_not.contain(" \n")
 
     messages = queue.receive_messages()
@@ -302,7 +339,7 @@ def test_message_with_attributes_have_labels():
         },
     )
     msg.get("MD5OfMessageBody").should.equal("58fd9edd83341c29f1aebba81c31e257")
-    msg.get("MD5OfMessageAttributes").should.equal("235c5c510d26fb653d073faed50ae77c")
+    msg.get("MD5OfMessageAttributes").should.equal("2e2e4876d8e0bd6b8c2c8f556831c349")
     msg.get("MessageId").should_not.contain(" \n")
 
     messages = queue.receive_messages()
@@ -657,10 +694,10 @@ def test_send_receive_message_with_attributes_with_labels():
     message2.get("Body").should.equal(body_two)
 
     message1.get("MD5OfMessageAttributes").should.equal(
-        "235c5c510d26fb653d073faed50ae77c"
+        "2e2e4876d8e0bd6b8c2c8f556831c349"
     )
     message2.get("MD5OfMessageAttributes").should.equal(
-        "994258b45346a2cc3f9cbb611aa7af30"
+        "cfa7c73063c6e2dbf9be34232a1978cf"
     )
 
     response = queue.send_message(


### PR DESCRIPTION
## Description

Issue: https://github.com/spulec/moto/issues/3399

### Why?
Wrong attributes md5 hash is generated. Client side application fails after comparing hashes. 

### What's Changing?
Added md5 attribute hashing according to aws sqs documentation.
https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-message-metadata.html#sqs-message-attributes

## Demo
### Generated md5 hash with aws-sqs-java-sdk [calculateMessageAttributesMd5](https://github.com/aws/aws-sdk-java/blob/081d7eb34543b281765c6253dd9e3d0767873474/aws-java-sdk-sqs/src/main/java/com/amazonaws/services/sqs/MessageMD5ChecksumHandler.java#L215) method
![image](https://user-images.githubusercontent.com/23436851/96968687-014ba600-151a-11eb-94df-b5750452bc6c.png)

### Fixed generation in moto
![image](https://user-images.githubusercontent.com/23436851/96968941-67382d80-151a-11eb-8336-958276d728b4.png)
