### PR TITLE
Metric data query alarms

### DIFF
--- a/moto/cloudwatch/models.py
+++ b/moto/cloudwatch/models.py
@@ -95,6 +95,7 @@ class FakeAlarm(BaseModel):
         metric_data_queries,
         comparison_operator,
         evaluation_periods,
+        datapoints_to_alarm,
         period,
         threshold,
         statistic,
@@ -112,6 +113,7 @@ class FakeAlarm(BaseModel):
         self.metric_data_queries = metric_data_queries
         self.comparison_operator = comparison_operator
         self.evaluation_periods = evaluation_periods
+        self.datapoints_to_alarm = datapoints_to_alarm
         self.period = period
         self.threshold = threshold
         self.statistic = statistic
@@ -267,6 +269,7 @@ class CloudWatchBackend(BaseBackend):
         metric_data_queries,
         comparison_operator,
         evaluation_periods,
+        datapoints_to_alarm,
         period,
         threshold,
         statistic,
@@ -285,6 +288,7 @@ class CloudWatchBackend(BaseBackend):
             metric_data_queries,
             comparison_operator,
             evaluation_periods,
+            datapoints_to_alarm,
             period,
             threshold,
             statistic,

--- a/moto/cloudwatch/models.py
+++ b/moto/cloudwatch/models.py
@@ -31,6 +31,33 @@ class Dimension(object):
         return self != item
 
 
+class Metric(object):
+    def __init__(self, metric_name, namespace, dimensions):
+        self.metric_name = metric_name
+        self.namespace = namespace
+        self.dimensions = dimensions
+
+
+class MetricStat(object):
+    def __init__(self, metric, period, stat, unit):
+        self.metric = metric
+        self.period = period
+        self.stat = stat
+        self.unit = unit
+
+
+class MetricDataQuery(object):
+    def __init__(
+        self, id, label, period, return_data, expression=None, metric_stat=None
+    ):
+        self.id = id
+        self.label = label
+        self.period = period
+        self.return_data = return_data
+        self.expression = expression
+        self.metric_stat = metric_stat
+
+
 def daterange(start, stop, step=timedelta(days=1), inclusive=False):
     """
     This method will iterate from `start` to `stop` datetimes with a timedelta step of `step`
@@ -65,6 +92,7 @@ class FakeAlarm(BaseModel):
         name,
         namespace,
         metric_name,
+        metric_data_queries,
         comparison_operator,
         evaluation_periods,
         period,
@@ -81,6 +109,7 @@ class FakeAlarm(BaseModel):
         self.name = name
         self.namespace = namespace
         self.metric_name = metric_name
+        self.metric_data_queries = metric_data_queries
         self.comparison_operator = comparison_operator
         self.evaluation_periods = evaluation_periods
         self.period = period
@@ -235,6 +264,7 @@ class CloudWatchBackend(BaseBackend):
         name,
         namespace,
         metric_name,
+        metric_data_queries,
         comparison_operator,
         evaluation_periods,
         period,
@@ -252,6 +282,7 @@ class CloudWatchBackend(BaseBackend):
             name,
             namespace,
             metric_name,
+            metric_data_queries,
             comparison_operator,
             evaluation_periods,
             period,

--- a/moto/cloudwatch/responses.py
+++ b/moto/cloudwatch/responses.py
@@ -49,6 +49,7 @@ class CloudWatchResponse(BaseResponse):
             ]
         comparison_operator = self._get_param("ComparisonOperator")
         evaluation_periods = self._get_param("EvaluationPeriods")
+        datapoints_to_alarm = self._get_param("DatapointsToAlarm")
         period = self._get_param("Period")
         threshold = self._get_param("Threshold")
         statistic = self._get_param("Statistic")
@@ -68,6 +69,7 @@ class CloudWatchResponse(BaseResponse):
             metric_data_queries,
             comparison_operator,
             evaluation_periods,
+            datapoints_to_alarm,
             period,
             threshold,
             statistic,
@@ -301,6 +303,9 @@ DESCRIBE_ALARMS_TEMPLATE = """<DescribeAlarmsResponse xmlns="http://monitoring.a
                     </Dimensions>
                 {% endif %}
                 <EvaluationPeriods>{{ alarm.evaluation_periods }}</EvaluationPeriods>
+                {% if alarm.datapoints_to_alarm is not none %}
+                <DatapointsToAlarm>{{ alarm.datapoints_to_alarm }}</DatapointsToAlarm>
+                {% endif %}
                 <InsufficientDataActions>
                     {% for action in alarm.insufficient_data_actions %}
                     <member>{{ action }}</member>

--- a/moto/cloudwatch/responses.py
+++ b/moto/cloudwatch/responses.py
@@ -1,7 +1,7 @@
 import json
 from moto.core.utils import amzn_request_id
 from moto.core.responses import BaseResponse
-from .models import cloudwatch_backends
+from .models import cloudwatch_backends, MetricDataQuery, MetricStat, Metric, Dimension
 from dateutil.parser import parse as dtparse
 
 
@@ -19,6 +19,34 @@ class CloudWatchResponse(BaseResponse):
         name = self._get_param("AlarmName")
         namespace = self._get_param("Namespace")
         metric_name = self._get_param("MetricName")
+        metrics = self._get_multi_param("Metrics.member")
+        metric_data_queries = None
+        if metrics:
+            metric_data_queries = [
+                MetricDataQuery(
+                    id=metric.get("Id"),
+                    label=metric.get("Label"),
+                    period=metric.get("Period"),
+                    return_data=metric.get("ReturnData"),
+                    expression=metric.get("Expression"),
+                    metric_stat=MetricStat(
+                        metric=Metric(
+                            metric_name=metric.get("MetricStat.Metric.MetricName"),
+                            namespace=metric.get("MetricStat.Metric.Namespace"),
+                            dimensions=[
+                                Dimension(name=dim["Name"], value=dim["Value"])
+                                for dim in metric["MetricStat.Metric.Dimensions.member"]
+                            ],
+                        ),
+                        period=metric.get("MetricStat.Period"),
+                        stat=metric.get("MetricStat.Stat"),
+                        unit=metric.get("MetricStat.Unit"),
+                    )
+                    if "MetricStat.Metric.MetricName" in metric
+                    else None,
+                )
+                for metric in metrics
+            ]
         comparison_operator = self._get_param("ComparisonOperator")
         evaluation_periods = self._get_param("EvaluationPeriods")
         period = self._get_param("Period")
@@ -37,6 +65,7 @@ class CloudWatchResponse(BaseResponse):
             name,
             namespace,
             metric_name,
+            metric_data_queries,
             comparison_operator,
             evaluation_periods,
             period,
@@ -261,35 +290,89 @@ DESCRIBE_ALARMS_TEMPLATE = """<DescribeAlarmsResponse xmlns="http://monitoring.a
                 <AlarmDescription>{{ alarm.description }}</AlarmDescription>
                 <AlarmName>{{ alarm.name }}</AlarmName>
                 <ComparisonOperator>{{ alarm.comparison_operator }}</ComparisonOperator>
-                <Dimensions>
-                    {% for dimension in alarm.dimensions %}
-                    <member>
-                        <Name>{{ dimension.name }}</Name>
-                        <Value>{{ dimension.value }}</Value>
-                    </member>
-                    {% endfor %}
-                </Dimensions>
+                {% if alarm.dimensions is not none %}
+                    <Dimensions>
+                        {% for dimension in alarm.dimensions %}
+                        <member>
+                            <Name>{{ dimension.name }}</Name>
+                            <Value>{{ dimension.value }}</Value>
+                        </member>
+                        {% endfor %}
+                    </Dimensions>
+                {% endif %}
                 <EvaluationPeriods>{{ alarm.evaluation_periods }}</EvaluationPeriods>
                 <InsufficientDataActions>
                     {% for action in alarm.insufficient_data_actions %}
                     <member>{{ action }}</member>
                     {% endfor %}
                 </InsufficientDataActions>
+                {% if alarm.metric_name is not none %}
                 <MetricName>{{ alarm.metric_name }}</MetricName>
+                {% endif %}
+                {% if alarm.metric_data_queries is not none %}
+                <Metrics>
+                    {% for metric in alarm.metric_data_queries %}
+                     <member>
+                        <Id>{{ metric.id }}</Id>
+                        {% if metric.label is not none %}
+                        <Label>{{ metric.label }}</Label>
+                        {% endif %}
+                        {% if metric.expression is not none %}
+                        <Expression>{{ metric.expression }}</Expression>
+                        {% endif %}
+                        {% if metric.metric_stat is not none %}
+                        <MetricStat>
+                            <Metric>
+                                <Namespace>{{ metric.metric_stat.metric.namespace }}</Namespace>
+                                <MetricName>{{ metric.metric_stat.metric.metric_name }}</MetricName>
+                                <Dimensions>
+                                {% for dim in metric.metric_stat.metric.dimensions %}
+                                    <member>
+                                        <Name>{{ dim.name }}</Name>
+                                        <Value>{{ dim.value }}</Value> 
+                                    </member>
+                                {% endfor %}
+                                </Dimensions>
+                            </Metric>
+                            {% if metric.metric_stat.period is not none %}
+                            <Period>{{ metric.metric_stat.period }}</Period>
+                            {% endif %}
+                            <Stat>{{ metric.metric_stat.stat }}</Stat>
+                            {% if metric.metric_stat.unit is not none %}
+                            <Unit>{{ metric.metric_stat.unit }}</Unit>
+                            {% endif %}
+                        </MetricStat>
+                        {% endif %}
+                        {% if metric.period is not none %}
+                        <Period>{{ metric.period }}</Period>
+                        {% endif %}
+                        <ReturnData>{{ metric.return_data }}</ReturnData>
+                    </member>
+                    {% endfor %}
+                </Metrics>
+                {% endif %}
+                {% if alarm.namespace is not none %}
                 <Namespace>{{ alarm.namespace }}</Namespace>
+                {% endif %}
                 <OKActions>
                     {% for action in alarm.ok_actions %}
                     <member>{{ action }}</member>
                     {% endfor %}
                 </OKActions>
+                {% if alarm.period is not none %}
                 <Period>{{ alarm.period }}</Period>
+                {% endif %}
                 <StateReason>{{ alarm.state_reason }}</StateReason>
                 <StateReasonData>{{ alarm.state_reason_data }}</StateReasonData>
                 <StateUpdatedTimestamp>{{ alarm.state_updated_timestamp }}</StateUpdatedTimestamp>
                 <StateValue>{{ alarm.state_value }}</StateValue>
+                {% if alarm.statistic is not none %}
                 <Statistic>{{ alarm.statistic }}</Statistic>
+                {% endif %}
                 <Threshold>{{ alarm.threshold }}</Threshold>
+                {% if alarm.unit is not none %}
                 <Unit>{{ alarm.unit }}</Unit>
+                {% endif %}
             </member>
             {% endfor %}
         </MetricAlarms>

--- a/moto/cloudwatch/responses.py
+++ b/moto/cloudwatch/responses.py
@@ -329,7 +329,7 @@ DESCRIBE_ALARMS_TEMPLATE = """<DescribeAlarmsResponse xmlns="http://monitoring.a
                                 {% for dim in metric.metric_stat.metric.dimensions %}
                                     <member>
                                         <Name>{{ dim.name }}</Name>
-                                        <Value>{{ dim.value }}</Value> 
+                                        <Value>{{ dim.value }}</Value>
                                     </member>
                                 {% endfor %}
                                 </Dimensions>

--- a/tests/test_cloudwatch/test_cloudwatch_boto3.py
+++ b/tests/test_cloudwatch/test_cloudwatch_boto3.py
@@ -201,10 +201,28 @@ def test_describe_alarms():
     alarms = conn.describe_alarms()
     metric_alarms = alarms.get("MetricAlarms")
     metric_alarms.should.have.length_of(2)
-    single_metric_alarm = [_ for _ in metric_alarms if "MetricName" in _][0]
-    multiple_metric_alarm = [_ for _ in metric_alarms if "MetricName" not in _][0]
+    single_metric_alarm = [
+        alarm for alarm in metric_alarms if alarm["AlarmName"] == "testalarm1"
+    ][0]
+    multiple_metric_alarm = [
+        alarm for alarm in metric_alarms if alarm["AlarmName"] == "testalarm2"
+    ][0]
+
     single_metric_alarm["MetricName"].should.equal("cpu")
+    single_metric_alarm.shouldnt.have.property("Metrics")
+    single_metric_alarm["Namespace"].should.equal("blah")
+    single_metric_alarm["Period"].should.equal(10)
+    single_metric_alarm["EvaluationPeriods"].should.equal(5)
+    single_metric_alarm["Statistic"].should.equal("Average")
+    single_metric_alarm["ComparisonOperator"].should.equal("GreaterThanThreshold")
+    single_metric_alarm["Threshold"].should.equal(2)
+
+    multiple_metric_alarm.shouldnt.have.property("MetricName")
+    multiple_metric_alarm["EvaluationPeriods"].should.equal(1)
+    multiple_metric_alarm["DatapointsToAlarm"].should.equal(1)
     multiple_metric_alarm["Metrics"].should.equal(metric_data_queries)
+    multiple_metric_alarm["ComparisonOperator"].should.equal("GreaterThanThreshold")
+    multiple_metric_alarm["Threshold"].should.equal(1.0)
 
 
 @mock_cloudwatch

--- a/tests/test_cloudwatch/test_cloudwatch_boto3.py
+++ b/tests/test_cloudwatch/test_cloudwatch_boto3.py
@@ -199,9 +199,12 @@ def test_describe_alarms():
         Threshold=1.0,
     )
     alarms = conn.describe_alarms()
-    alarms.get("MetricAlarms").should.have.length_of(2)
-    alarms.get("MetricAlarms")[0]["MetricName"].should.equal("cpu")
-    alarms.get("MetricAlarms")[1]["Metrics"].should.equal(metric_data_queries)
+    metric_alarms = alarms.get("MetricAlarms")
+    metric_alarms.should.have.length_of(2)
+    single_metric_alarm = [_ for _ in metric_alarms if "MetricName" in _][0]
+    multiple_metric_alarm = [_ for _ in metric_alarms if "MetricName" not in _][0]
+    single_metric_alarm["MetricName"].should.equal("cpu")
+    multiple_metric_alarm["Metrics"].should.equal(metric_data_queries)
 
 
 @mock_cloudwatch


### PR DESCRIPTION
Fixes issue #3408

I added support for metric data queries in PutMetricAlarms sufficiently for my own needs. I'm not sure if the style in the implementation is ideal, but can modify as required.

- Add support for Metric Data Queries in `PutMetricAlarms` and `DescribeAlarms`
- Add unit test for `describe_alarms`

