### PR TITLE
Fix `dynamodb:TransactGetItems` response for items that do not exist

### DIFF
--- a/moto/dynamodb2/responses.py
+++ b/moto/dynamodb2/responses.py
@@ -906,6 +906,7 @@ class DynamoHandler(BaseResponse):
                 return self.error(er, "Requested resource not found")
 
             if not item:
+                responses.append({})
                 continue
 
             item_describe = item.describe_attrs(False)


### PR DESCRIPTION
If the requested item has no projected attributes, the corresponding ItemResponse
object is an empty Map.[1]  Verified against real AWS.

Fix existing general test case and add an explicit test case to cover this scenario.

[1]: https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_TransactGetItems.html#API_TransactGetItems_ResponseElements

Fixes #3404