### PR TITLE
Fix: eventName for a deleted record should be REMOVE instead of DELETE

### DIFF
--- a/moto/dynamodb2/models/__init__.py
+++ b/moto/dynamodb2/models/__init__.py
@@ -245,7 +245,7 @@ class StreamShard(BaseModel):
         if old is None:
             event_name = "INSERT"
         elif new is None:
-            event_name = "DELETE"
+            event_name = "REMOVE"
         else:
             event_name = "MODIFY"
         seq = len(self.items) + self.starting_sequence_number

--- a/tests/test_dynamodbstreams/test_dynamodbstreams.py
+++ b/tests/test_dynamodbstreams/test_dynamodbstreams.py
@@ -155,7 +155,7 @@ class TestCore:
         assert len(resp["Records"]) == 3
         assert resp["Records"][0]["eventName"] == "INSERT"
         assert resp["Records"][1]["eventName"] == "MODIFY"
-        assert resp["Records"][2]["eventName"] == "DELETE"
+        assert resp["Records"][2]["eventName"] == "REMOVE"
 
         sequence_number_modify = resp["Records"][1]["dynamodb"]["SequenceNumber"]
 
@@ -175,7 +175,7 @@ class TestCore:
         resp = conn.get_records(ShardIterator=iterator_id)
         assert len(resp["Records"]) == 2
         assert resp["Records"][0]["eventName"] == "MODIFY"
-        assert resp["Records"][1]["eventName"] == "DELETE"
+        assert resp["Records"][1]["eventName"] == "REMOVE"
 
         # check that if we get the shard iterator AFTER_SEQUENCE_NUMBER will get the DELETE event
         resp = conn.get_shard_iterator(
@@ -187,7 +187,7 @@ class TestCore:
         iterator_id = resp["ShardIterator"]
         resp = conn.get_records(ShardIterator=iterator_id)
         assert len(resp["Records"]) == 1
-        assert resp["Records"][0]["eventName"] == "DELETE"
+        assert resp["Records"][0]["eventName"] == "REMOVE"
 
 
 class TestEdges:


### PR DESCRIPTION
Verified API documentation[1] against the real AWS backend.

[1]: https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_streams_Record.html#DDB-Type-streams_Record-eventName

Fixes #3400