### PR TITLE
Fix: describe/list attribute discrepancy in Secrets Manager

### DIFF
--- a/moto/secretsmanager/models.py
+++ b/moto/secretsmanager/models.py
@@ -136,6 +136,7 @@ class FakeSecret:
             "DeletedDate": self.deleted_date,
             "Tags": self.tags,
             "VersionIdsToStages": version_id_to_stages,
+            "SecretVersionsToStages": version_id_to_stages,
         }
 
     def _form_version_ids_to_stages(self):

--- a/tests/test_secretsmanager/test_list_secrets.py
+++ b/tests/test_secretsmanager/test_list_secrets.py
@@ -43,9 +43,11 @@ def test_list_secrets():
 
     assert secrets["SecretList"][0]["ARN"] is not None
     assert secrets["SecretList"][0]["Name"] == "test-secret"
+    assert secrets["SecretList"][0]["SecretVersionsToStages"] is not None
     assert secrets["SecretList"][1]["ARN"] is not None
     assert secrets["SecretList"][1]["Name"] == "test-secret-2"
     assert secrets["SecretList"][1]["Tags"] == [{"Key": "a", "Value": "1"}]
+    assert secrets["SecretList"][1]["SecretVersionsToStages"] is not None
 
 
 @mock_secretsmanager


### PR DESCRIPTION
`secretsmanager:DescribeSecret` returns `VersionIdsToStages`
`secretsmanager:ListSecrets` returns the same information in `SecretVersionsToStages`

* Verified fix against real AWS backend.

Fixes #3406