### PR TITLE
Travis: Use Focal-distribution, so we no longer have to downgrade Docker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: bionic
+dist: focal
 language: python
 services:
 - docker
@@ -27,7 +27,7 @@ install:
     docker run --rm -t --name motoserver -e TEST_SERVER_MODE=true -e AWS_SECRET_ACCESS_KEY=server_secret -e AWS_ACCESS_KEY_ID=server_key -v `pwd`:/moto -p 5000:5000 -v /var/run/docker.sock:/var/run/docker.sock python:${PYTHON_DOCKER_TAG} /moto/travis_moto_server.sh &
   fi
   travis_retry pip install -r requirements-dev.txt
-  travis_retry pip install "docker>=2.5.1,<=4.2.2" # Limit version due to old Docker Engine in Travis https://github.com/docker/docker-py/issues/2639
+  travis_retry pip install docker>=2.5.1
   travis_retry pip install boto==2.45.0
   travis_retry pip install boto3
   travis_retry pip install dist/moto*.gz

--- a/travis_moto_server.sh
+++ b/travis_moto_server.sh
@@ -1,8 +1,4 @@
 #!/usr/bin/env bash
 set -e
-# TravisCI on bionic dist uses old version of Docker Engine
-# which is incompatibile with newer docker-py
-# See https://github.com/docker/docker-py/issues/2639
-pip install "docker>=2.5.1,<=4.2.2"
 pip install $(ls /moto/dist/moto*.gz)[server,all]
 moto_server -H 0.0.0.0 -p 5000


### PR DESCRIPTION
Focal is Ubuntu version 20.04, which is the latest available in Travis: https://docs.travis-ci.com/user/reference/linux