### PR TITLE
Fix: Return `Tags` in iam:CreateUserResponse

### DIFF
--- a/moto/iam/responses.py
+++ b/moto/iam/responses.py
@@ -1684,6 +1684,16 @@ USER_TEMPLATE = """<{{ action }}UserResponse>
          <UserId>{{ user.id }}</UserId>
          <CreateDate>{{ user.created_iso_8601 }}</CreateDate>
          <Arn>{{ user.arn }}</Arn>
+         {% if user.tags %}
+         <Tags>
+            {% for tag in user.tags %}
+            <member>
+                <Key>{{ tag['Key'] }}</Key>
+                <Value>{{ tag['Value'] }}</Value>
+            </member>
+            {% endfor %}
+         </Tags>
+         {% endif %}
      </User>
    </{{ action }}UserResult>
    <ResponseMetadata>

--- a/tests/test_iam/test_iam.py
+++ b/tests/test_iam/test_iam.py
@@ -4007,3 +4007,20 @@ def test_list_roles_none_found_returns_empty_list():
     response = iam.list_roles(MaxItems=10)
     roles = response["Roles"]
     assert len(roles) == 0
+
+
+@mock_iam()
+def test_create_user_with_tags():
+    conn = boto3.client("iam", region_name="us-east-1")
+    user_name = "test-user"
+    tags = [
+        {"Key": "somekey", "Value": "somevalue"},
+        {"Key": "someotherkey", "Value": "someothervalue"},
+    ]
+    resp = conn.create_user(UserName=user_name, Tags=tags)
+    assert resp["User"]["Tags"] == tags
+    resp = conn.list_user_tags(UserName=user_name)
+    assert resp["Tags"] == tags
+
+    resp = conn.create_user(UserName="test-create-user-no-tags")
+    assert "Tags" not in resp["User"]


### PR DESCRIPTION
Fixes #3450