### PR TITLE
dynamodb2 support for default Action ('Put') in update_item

### DIFF
--- a/moto/dynamodb2/models/__init__.py
+++ b/moto/dynamodb2/models/__init__.py
@@ -109,7 +109,10 @@ class Item(BaseModel):
 
     def update_with_attribute_updates(self, attribute_updates):
         for attribute_name, update_action in attribute_updates.items():
-            action = update_action["Action"]
+            # Use default Action value, if no explicit Action is passed.
+            # Default value is 'Put', according to
+            # Boto3 DynamoDB.Client.update_item documentation.
+            action = update_action.get("Action", "PUT")
             if action == "DELETE" and "Value" not in update_action:
                 if attribute_name in self.attrs:
                     del self.attrs[attribute_name]

--- a/tests/test_dynamodb2/test_dynamodb.py
+++ b/tests/test_dynamodb2/test_dynamodb.py
@@ -2251,6 +2251,30 @@ def test_update_item_with_list():
     resp["Item"].should.equal({"key": "the-key", "list": [1, 2]})
 
 
+# https://github.com/spulec/moto/issues/2328
+@mock_dynamodb2
+def test_update_item_with_no_action_passed_with_list():
+    dynamodb = boto3.resource("dynamodb", region_name="us-east-1")
+
+    # Create the DynamoDB table.
+    dynamodb.create_table(
+        TableName="Table",
+        KeySchema=[{"AttributeName": "key", "KeyType": "HASH"}],
+        AttributeDefinitions=[{"AttributeName": "key", "AttributeType": "S"}],
+        ProvisionedThroughput={"ReadCapacityUnits": 1, "WriteCapacityUnits": 1},
+    )
+    table = dynamodb.Table("Table")
+    table.update_item(
+        Key={"key": "the-key"},
+        # Do not pass 'Action' key, in order to check that the
+        # parameter's default value will be used.
+        AttributeUpdates={"list": {"Value": [1, 2]}},
+    )
+
+    resp = table.get_item(Key={"key": "the-key"})
+    resp["Item"].should.equal({"key": "the-key", "list": [1, 2]})
+
+
 # https://github.com/spulec/moto/issues/1342
 @mock_dynamodb2
 def test_update_item_on_map():


### PR DESCRIPTION
Linked GitHub Issue to be fixed by this PR: https://github.com/spulec/moto/issues/3441.

Implemented the fix to use the default value for `Action`, according to `boto3.DynamoDB.Client.update_item()` [documentation](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/dynamodb.html#DynamoDB.Client.update_item), which is 'Put'.

Added a unit test to make sure the default value is used in case of absence of `Action` passed by the caller.

Tests pass:

```
...
test_dynamodb.test_update_item_with_list ... ok
test_dynamodb.test_update_item_with_no_action_passed_with_list ... ok
...
```

as well as Black check.