### PR TITLE
Fix: `TagList` missing in rds:DescribeDBInstance response

### DIFF
--- a/moto/rds2/models.py
+++ b/moto/rds2/models.py
@@ -280,6 +280,14 @@ class Database(CloudFormationModel):
                 <Port>{{ database.port }}</Port>
               </Endpoint>
               <DBInstanceArn>{{ database.db_instance_arn }}</DBInstanceArn>
+              <TagList>
+              {%- for tag in database.tags -%}
+                <Tag>
+                  <Key>{{ tag['Key'] }}</Key>
+                  <Value>{{ tag['Value'] }}</Value>
+                </Tag>
+              {%- endfor -%}
+              </TagList>
             </DBInstance>"""
         )
         return template.render(database=self)

--- a/tests/test_rds2/test_rds2.py
+++ b/tests/test_rds2/test_rds2.py
@@ -1749,3 +1749,21 @@ def test_create_db_snapshot_with_iam_authentication():
     ).get("DBSnapshot")
 
     snapshot.get("IAMDatabaseAuthenticationEnabled").should.equal(True)
+
+
+@mock_rds2
+def test_create_db_instance_with_tags():
+    client = boto3.client("rds", region_name="us-west-2")
+    tags = [{"Key": "foo", "Value": "bar"}, {"Key": "foo1", "Value": "bar1"}]
+    db_instance_identifier = "test-db-instance"
+    resp = client.create_db_instance(
+        DBInstanceIdentifier=db_instance_identifier,
+        Engine="postgres",
+        DBName="staging-postgres",
+        DBInstanceClass="db.m1.small",
+        Tags=tags,
+    )
+    resp["DBInstance"]["TagList"].should.equal(tags)
+
+    resp = client.describe_db_instances(DBInstanceIdentifier=db_instance_identifier)
+    resp["DBInstances"][0]["TagList"].should.equal(tags)


### PR DESCRIPTION
Previously, tags were only available via rds:ListTagsForResource, but are now
included in the Create/DescribeDBInstance responses as of Botocore 1.18.17[1]

[1]: https://github.com/boto/botocore/commit/f29d23c53ec0477e58450744986b0f8f23c97da1#diff-d10722c0e11ded323c8d240066d7ed31e93a1e6423d54e091b7d54b86e6bd4e0

Fixes #3458