### PR TITLE
lift user_settable_fields from (old) boto

### DIFF
--- a/moto/s3/utils.py
+++ b/moto/s3/utils.py
@@ -2,7 +2,6 @@ from __future__ import unicode_literals
 import logging
 import os
 
-from boto.s3.key import Key
 import re
 import six
 from six.moves.urllib.parse import urlparse, unquote, quote
@@ -14,6 +13,16 @@ log = logging.getLogger(__name__)
 
 
 bucket_name_regex = re.compile("(.+).s3(.*).amazonaws.com")
+user_settable_fields = {
+    "content-md5",
+    "content-language",
+    "content-type",
+    "content-encoding",
+    "cache-control",
+    "expires",
+    "content-disposition",
+    "x-robots-tag",
+}
 
 
 def bucket_name_from_url(url):
@@ -72,7 +81,7 @@ def metadata_from_headers(headers):
             if result:
                 # Check for extra metadata
                 meta_key = result.group(0).lower()
-            elif header.lower() in Key.base_user_settable_fields:
+            elif header.lower() in user_settable_fields:
                 # Check for special metadata that doesn't start with x-amz-meta
                 meta_key = header
             if meta_key:


### PR DESCRIPTION
(old) `boto` is no longer being developed, and importing it raises
deprecation warnings. copy Key.base_user_settable_fields in here instead
of importing boto