### PR TITLE
EventBridge: put_rule and list_rules should store and retrieve EventBusName property

### DIFF
--- a/moto/events/models.py
+++ b/moto/events/models.py
@@ -25,6 +25,7 @@ class Rule(CloudFormationModel):
         self.state = kwargs.get("State") or "ENABLED"
         self.description = kwargs.get("Description")
         self.role_arn = kwargs.get("RoleArn")
+        self.event_bus_name = kwargs.get("EventBusName", "default")
         self.targets = []
 
     @property

--- a/moto/events/responses.py
+++ b/moto/events/responses.py
@@ -25,6 +25,7 @@ class EventsHandler(BaseResponse):
             "Description": rule.description,
             "ScheduleExpression": rule.schedule_exp,
             "RoleArn": rule.role_arn,
+            "EventBusName": rule.event_bus_name,
         }
 
     @property
@@ -167,6 +168,7 @@ class EventsHandler(BaseResponse):
         state = self._get_param("State")
         desc = self._get_param("Description")
         role_arn = self._get_param("RoleArn")
+        event_bus_name = self._get_param("EventBusName")
 
         if not name:
             return self.error("ValidationException", "Parameter Name is required.")
@@ -199,6 +201,7 @@ class EventsHandler(BaseResponse):
             State=state,
             Description=desc,
             RoleArn=role_arn,
+            EventBusName=event_bus_name,
         )
 
         return json.dumps({"RuleArn": rule.arn}), self.response_headers

--- a/tests/test_events/test_events.py
+++ b/tests/test_events/test_events.py
@@ -86,6 +86,7 @@ def test_put_rule():
         "Name": "my-event",
         "ScheduleExpression": "rate(5 minutes)",
         "EventPattern": '{"source": ["test-source"]}',
+        "EventBusName": "test-bus",
     }
 
     client.put_rule(**rule_data)
@@ -96,6 +97,7 @@ def test_put_rule():
     rules[0]["Name"].should.equal(rule_data["Name"])
     rules[0]["ScheduleExpression"].should.equal(rule_data["ScheduleExpression"])
     rules[0]["EventPattern"].should.equal(rule_data["EventPattern"])
+    rules[0]["EventBusName"].should.equal(rule_data["EventBusName"])
     rules[0]["State"].should.equal("ENABLED")
 
 


### PR DESCRIPTION
Store the `EventBusName` property in the `EventsBackend` and modify `test_put_rule` to verify it's stored by `put_rule` and returned by `list_rules`.

If an `EventBusName` isn't specified it defaults to the account's default event bus (named "default"):
https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/events.html#EventBridge.Client.put_rule