### PR TITLE
fixed issue in update_configuration for lambda when setting VPCconfig

### DIFF
--- a/moto/awslambda/models.py
+++ b/moto/awslambda/models.py
@@ -305,7 +305,7 @@ class LambdaFunction(CloudFormationModel, DockerModel):
             elif key == "Timeout":
                 self.timeout = value
             elif key == "VpcConfig":
-                self.vpc_config = value
+                self._vpc_config = value
             elif key == "Environment":
                 self.environment_vars = value["Variables"]
 

--- a/tests/test_awslambda/test_lambda.py
+++ b/tests/test_awslambda/test_lambda.py
@@ -1536,6 +1536,7 @@ def test_update_configuration():
         Handler="lambda_function.new_lambda_handler",
         Runtime="python3.6",
         Timeout=7,
+        VpcConfig={"SecurityGroupIds": ["sg-123abc"], "SubnetIds": ["subnet-123abc"]},
         Environment={"Variables": {"test_environment": "test_value"}},
     )
 
@@ -1547,6 +1548,11 @@ def test_update_configuration():
     assert updated_config["Timeout"] == 7
     assert updated_config["Environment"]["Variables"] == {
         "test_environment": "test_value"
+    }
+    assert updated_config["VpcConfig"] == {
+        "SecurityGroupIds": ["sg-123abc"],
+        "SubnetIds": ["subnet-123abc"],
+        "VpcId": "vpc-123abc",
     }
 
 


### PR DESCRIPTION
#### Reference Issue
https://github.com/spulec/moto/issues/3464

#### What does this implementation fix?
This implementation fixes the bug in awslambda/models.py when updating the VPCconfig. The code in def update_configuration was trying to set a value to vpc_config which is a property (not an attribute) that doesn't have a setter. Changing to setting self._vpc_config = value fixes the problem.

This PR also updates the test case "test_update_configuration" in tests/test_awslambda/test_lambda.py to add the VpcConfig property and an assertion to verify the change.