### PR TITLE
Fix: redshift:EnableSnapshotCopy raises incorrect Exception

### DIFF
--- a/moto/redshift/models.py
+++ b/moto/redshift/models.py
@@ -573,10 +573,8 @@ class RedshiftBackend(BaseBackend):
                 cluster.encrypted == "true"
                 and kwargs["snapshot_copy_grant_name"] is None
             ):
-                raise ClientError(
-                    "InvalidParameterValue",
-                    "SnapshotCopyGrantName is required for Snapshot Copy "
-                    "on KMS encrypted clusters.",
+                raise InvalidParameterValueError(
+                    "SnapshotCopyGrantName is required for Snapshot Copy on KMS encrypted clusters."
                 )
             status = {
                 "DestinationRegion": kwargs["destination_region"],

--- a/tests/test_redshift/test_redshift.py
+++ b/tests/test_redshift/test_redshift.py
@@ -12,6 +12,7 @@ from boto.redshift.exceptions import (
     InvalidSubnet,
 )
 from botocore.exceptions import ClientError
+import pytest
 import sure  # noqa
 
 from moto import mock_ec2
@@ -1259,6 +1260,14 @@ def test_enable_snapshot_copy():
         MasterUsername="user",
         MasterUserPassword="password",
         NodeType="ds2.xlarge",
+    )
+    with pytest.raises(ClientError) as ex:
+        client.enable_snapshot_copy(
+            ClusterIdentifier="test", DestinationRegion="us-west-2", RetentionPeriod=3,
+        )
+    ex.value.response["Error"]["Code"].should.equal("InvalidParameterValue")
+    ex.value.response["Error"]["Message"].should.contain(
+        "SnapshotCopyGrantName is required for Snapshot Copy on KMS encrypted clusters."
     )
     client.enable_snapshot_copy(
         ClusterIdentifier="test",


### PR DESCRIPTION
The previous code was trying to raise a botocore ClientError directly, which
was actually generating a secondary AttributeError because the arguments passed
to ClientError() were incorrect.

This replaces the ClientError() call with a proper moto exception class for
Redshift and fixes the test assertions appropriately.

Supersedes #1957