### PR TITLE
Route53: Implement dummy GetChange endpoint

### DIFF
--- a/moto/route53/responses.py
+++ b/moto/route53/responses.py
@@ -243,6 +243,15 @@ class Route53(BaseResponse):
 
             return 200, headers, template.render()
 
+    def get_change(self, request, full_url, headers):
+        self.setup_class(request, full_url, headers)
+
+        if request.method == "GET":
+            parsed_url = urlparse(full_url)
+            change_id = parsed_url.path.rstrip("/").rsplit("/", 1)[1]
+            template = Template(GET_CHANGE_RESPONSE)
+            return 200, headers, template.render(change_id=change_id)
+
 
 LIST_TAGS_FOR_RESOURCE_RESPONSE = """
 <ListTagsForResourceResponse xmlns="https://route53.amazonaws.com/doc/2015-01-01/">
@@ -382,3 +391,12 @@ LIST_HEALTH_CHECKS_RESPONSE = """<?xml version="1.0" encoding="UTF-8"?>
 DELETE_HEALTH_CHECK_RESPONSE = """<?xml version="1.0" encoding="UTF-8"?>
     <DeleteHealthCheckResponse xmlns="https://route53.amazonaws.com/doc/2013-04-01/">
 </DeleteHealthCheckResponse>"""
+
+GET_CHANGE_RESPONSE = """<?xml version="1.0" encoding="UTF-8"?>
+<GetChangeResponse xmlns="https://route53.amazonaws.com/doc/2013-04-01/">
+   <ChangeInfo>
+      <Status>INSYNC</Status>
+      <SubmittedAt>2010-09-10T01:36:41.958Z</SubmittedAt>
+      <Id>/change/{{ change_id }}</Id>
+   </ChangeInfo>
+</GetChangeResponse>"""

--- a/moto/route53/responses.py
+++ b/moto/route53/responses.py
@@ -397,6 +397,6 @@ GET_CHANGE_RESPONSE = """<?xml version="1.0" encoding="UTF-8"?>
    <ChangeInfo>
       <Status>INSYNC</Status>
       <SubmittedAt>2010-09-10T01:36:41.958Z</SubmittedAt>
-      <Id>/change/{{ change_id }}</Id>
+      <Id>{{ change_id }}</Id>
    </ChangeInfo>
 </GetChangeResponse>"""

--- a/moto/route53/urls.py
+++ b/moto/route53/urls.py
@@ -21,4 +21,5 @@ url_paths = {
     r"{0}/(?P<api_version>[\d_-]+)/tags/healthcheck/(?P<zone_id>[^/]+)$": tag_response1,
     r"{0}/(?P<api_version>[\d_-]+)/tags/hostedzone/(?P<zone_id>[^/]+)$": tag_response2,
     r"{0}/(?P<api_version>[\d_-]+)/trafficpolicyinstances/*": Route53().not_implemented_response,
+    r"{0}/(?P<api_version>[\d_-]+)/change/(?P<change_id>[^/]+)$": Route53().get_change,
 }

--- a/tests/test_route53/test_route53.py
+++ b/tests/test_route53/test_route53.py
@@ -1031,3 +1031,14 @@ def test_list_resource_record_sets_name_type_filters():
     len(returned_records).should.equal(len(all_records) - start_with)
     for desired_record in all_records[start_with:]:
         returned_records.should.contain(desired_record)
+
+
+@mock_route53
+def test_get_change():
+    conn = boto3.client("route53", region_name="us-east-2")
+
+    change_id = "123456"
+    response = conn.get_change(Id=change_id)
+
+    response["ChangeInfo"]["Id"].should.equal(change_id)
+    response["ChangeInfo"]["Status"].should.equal("INSYNC")


### PR DESCRIPTION
## Description
This PR implements a dummy GetChange endpoint for the Route53 mock within moto. This change has been discussed in #3449.

The Route53 mock in moto does not store Change IDs in it's backend at the moment, this is why I created a dummy endpoint that always returns INSYNC status together with the same SubmittedAt date for all requests.

Ideally, the Route53 mock backend would store Change IDs the same way it stores hostedzones, healthchecks, etc. I've discussed the possibility of doing this with @bblommers and he's keen on that, but for now I'll stick with this approach as the ideal option would require significant changes in the route53 mock to support and store those change IDs.

## Why
GetChange is used by existing tooling around Route53, which makes supporting this endpoint in moto very advantageous when using moto in local development environments as well as testing for Route53.

## Testing
I've added one test to ensure `get_change` always return the `Id` it was asked for as part if it's response and `Status` is `INSYNC`.