### PR TITLE
#3494 fix using EventBridge via Go SDK

### DIFF
--- a/moto/server.py
+++ b/moto/server.py
@@ -93,6 +93,11 @@ class DomainDispatcherApplication(object):
                 # S3 is the last resort when the target is also unknown
                 service, region = DEFAULT_SERVICE_REGION
 
+        if service == "EventBridge":
+            # Go SDK uses 'EventBridge' in the SigV4 request instead of 'events'
+            # see https://github.com/spulec/moto/issues/3494
+            service = "events"
+
         if service == "dynamodb":
             if environ["HTTP_X_AMZ_TARGET"].startswith("DynamoDBStreams"):
                 host = "dynamodbstreams"


### PR DESCRIPTION
As already mentioned in #3494 I verified this fix by modifying this file locally on my system and re-running the reproducer given in the issue.

The issue is that the Go SDK uses `EventBridge` in the SigV4 header instead of `events` as expected by moto.