### PR TITLE
Add basic get_execution_history implementation for Step Functions

### DIFF
--- a/IMPLEMENTATION_COVERAGE.md
+++ b/IMPLEMENTATION_COVERAGE.md
@@ -8115,7 +8115,7 @@
 - [X] describe_state_machine
 - [ ] describe_state_machine_for_execution
 - [ ] get_activity_task
-- [ ] get_execution_history
+- [X] get_execution_history
 - [ ] list_activities
 - [X] list_executions
 - [X] list_state_machines

--- a/Makefile
+++ b/Makefile
@@ -20,11 +20,13 @@ lint:
 	flake8 moto
 	black --check moto/ tests/
 
+format:
+	black moto/ tests/
+
 test-only:
 	rm -f .coverage
 	rm -rf cover
 	@pytest -sv --cov=moto --cov-report html ./tests/ $(TEST_EXCLUDE)
-
 
 test: lint test-only
 

--- a/moto/settings.py
+++ b/moto/settings.py
@@ -6,7 +6,7 @@ INITIAL_NO_AUTH_ACTION_COUNT = float(
 )
 
 
-def get_sf_execution_history_type() -> str:
+def get_sf_execution_history_type():
     """
     Determines which execution history events `get_execution_history` returns
     :returns: str representing the type of Step Function Execution Type events should be

--- a/moto/settings.py
+++ b/moto/settings.py
@@ -4,3 +4,12 @@ TEST_SERVER_MODE = os.environ.get("TEST_SERVER_MODE", "0").lower() == "true"
 INITIAL_NO_AUTH_ACTION_COUNT = float(
     os.environ.get("INITIAL_NO_AUTH_ACTION_COUNT", float("inf"))
 )
+
+
+def get_sf_execution_history_type() -> str:
+    """
+    Determines which execution history events `get_execution_history` returns
+    :returns: str representing the type of Step Function Execution Type events should be
+        returned. Default value is SUCCESS, currently supports (SUCCESS || FAILURE)
+    """
+    return os.environ.get("SF_EXECUTION_HISTORY_TYPE", "SUCCESS")

--- a/moto/stepfunctions/models.py
+++ b/moto/stepfunctions/models.py
@@ -264,7 +264,7 @@ class Execution:
                     },
                 },
             ]
-        else:
+        elif execution_history_type == "FAILURE":
             return [
                 {
                     "timestamp": iso_8601_datetime_with_milliseconds(

--- a/moto/stepfunctions/models.py
+++ b/moto/stepfunctions/models.py
@@ -48,6 +48,17 @@ class StateMachine(CloudFormationModel):
         self.executions.append(execution)
         return execution
 
+    def stop_execution(self, execution_arn):
+        execution = next(
+            (x for x in self.executions if x.execution_arn == execution_arn), None
+        )
+        if not execution:
+            raise ExecutionDoesNotExist(
+                "Execution Does Not Exist: '" + execution_arn + "'"
+            )
+        execution.stop()
+        return execution
+
     def _ensure_execution_name_doesnt_exist(self, name):
         for execution in self.executions:
             if execution.name == name:
@@ -488,17 +499,7 @@ class StepFunctionBackend(BaseBackend):
     def stop_execution(self, execution_arn):
         self._validate_execution_arn(execution_arn)
         state_machine = self._get_state_machine_for_execution(execution_arn)
-        executions = state_machine.executions
-
-        execution = next(
-            (x for x in executions if x.execution_arn == execution_arn), None
-        )
-        if not execution:
-            raise ExecutionDoesNotExist(
-                "Execution Does Not Exist: '" + execution_arn + "'"
-            )
-        execution.stop()
-        return execution
+        return state_machine.stop_execution(execution_arn)
 
     @paginate
     def list_executions(self, state_machine_arn, status_filter=None):

--- a/moto/stepfunctions/models.py
+++ b/moto/stepfunctions/models.py
@@ -19,6 +19,7 @@ from .exceptions import (
     StateMachineDoesNotExist,
 )
 from .utils import paginate, api_to_cfn_tags, cfn_to_api_tags
+from moto import settings
 
 
 class StateMachine(CloudFormationModel):
@@ -220,8 +221,8 @@ class Execution:
         self.stop_date = None
 
     def get_execution_history(self, roleArn):
-        execution_history_type = os.environ.get("EXECUTION_HISTORY_TYPE", "SUCCESS")
-        if execution_history_type == "SUCCESS":
+        sf_execution_history_type = settings.get_sf_execution_history_type()
+        if sf_execution_history_type == "SUCCESS":
             return [
                 {
                     "timestamp": iso_8601_datetime_with_milliseconds(
@@ -275,7 +276,7 @@ class Execution:
                     },
                 },
             ]
-        elif execution_history_type == "FAILURE":
+        elif sf_execution_history_type == "FAILURE":
             return [
                 {
                     "timestamp": iso_8601_datetime_with_milliseconds(

--- a/moto/stepfunctions/models.py
+++ b/moto/stepfunctions/models.py
@@ -1,5 +1,4 @@
 import json
-import os
 import re
 from datetime import datetime
 from dateutil.tz import tzlocal

--- a/moto/stepfunctions/responses.py
+++ b/moto/stepfunctions/responses.py
@@ -208,6 +208,21 @@ class StepFunctionResponse(BaseResponse):
     @amzn_request_id
     def stop_execution(self):
         arn = self._get_param("executionArn")
-        execution = self.stepfunction_backend.stop_execution(arn)
-        response = {"stopDate": execution.stop_date}
-        return 200, {}, json.dumps(response)
+        try:
+            execution = self.stepfunction_backend.stop_execution(arn)
+            response = {"stopDate": execution.stop_date}
+            return 200, {}, json.dumps(response)
+        except AWSError as err:
+            return err.response()
+
+    @amzn_request_id
+    def get_execution_history(self):
+        execution_arn = self._get_param("executionArn")
+        try:
+            execution_history = self.stepfunction_backend.get_execution_history(
+                execution_arn
+            )
+            response = {"events": execution_history}
+            return 200, {}, json.dumps(response)
+        except AWSError as err:
+            return err.response()

--- a/tests/test_stepfunctions/test_stepfunctions.py
+++ b/tests/test_stepfunctions/test_stepfunctions.py
@@ -2,12 +2,14 @@ from __future__ import unicode_literals
 
 import boto3
 import json
+import os
 import sure  # noqa
+from unittest import mock
 
 from datetime import datetime
+from dateutil.tz import tzlocal
 from botocore.exceptions import ClientError
 import pytest
-from freezegun import freeze_time
 
 from moto import mock_cloudformation, mock_sts, mock_stepfunctions
 from moto.core import ACCOUNT_ID
@@ -803,11 +805,17 @@ def test_state_machine_stop_execution():
 def test_state_machine_stop_raises_error_when_unknown_execution():
     client = boto3.client("stepfunctions", region_name=region)
     client.create_state_machine(
-        name="test-state-machine", definition=str(simple_definition), roleArn=_get_default_role()
+        name="test-state-machine",
+        definition=str(simple_definition),
+        roleArn=_get_default_role(),
     )
     with pytest.raises(ClientError) as ex:
         unknown_execution = (
-            "arn:aws:states:" + region + ":" + _get_account_id() + ":execution:test-state-machine:unknown"
+            "arn:aws:states:"
+            + region
+            + ":"
+            + _get_account_id()
+            + ":execution:test-state-machine:unknown"
         )
         client.stop_execution(executionArn=unknown_execution)
     ex.value.response["Error"]["Code"].should.equal("ExecutionDoesNotExist")
@@ -835,11 +843,17 @@ def test_state_machine_describe_execution_after_stoppage():
 def test_state_machine_get_execution_history_throws_error_with_unknown_execution():
     client = boto3.client("stepfunctions", region_name=region)
     client.create_state_machine(
-        name="test-state-machine", definition=str(simple_definition), roleArn=_get_default_role()
+        name="test-state-machine",
+        definition=str(simple_definition),
+        roleArn=_get_default_role(),
     )
     with pytest.raises(ClientError) as ex:
         unknown_execution = (
-            "arn:aws:states:" + region + ":" + _get_account_id() + ":execution:test-state-machine:unknown"
+            "arn:aws:states:"
+            + region
+            + ":"
+            + _get_account_id()
+            + ":execution:test-state-machine:unknown"
         )
         client.get_execution_history(executionArn=unknown_execution)
     ex.value.response["Error"]["Code"].should.equal("ExecutionDoesNotExist")
@@ -848,15 +862,118 @@ def test_state_machine_get_execution_history_throws_error_with_unknown_execution
 
 @mock_stepfunctions
 @mock_sts
-@freeze_time("2020-01-01 00:00:00")
-def test_state_machine_get_execution_history_contains_expected_events_when_started():
+def test_state_machine_get_execution_history_contains_expected_success_events_when_started():
+    expected_events = [
+        {
+            "timestamp": datetime(2020, 1, 1, 0, 0, 0, tzinfo=tzlocal()),
+            "type": "ExecutionStarted",
+            "id": 1,
+            "previousEventId": 0,
+            "executionStartedEventDetails": {
+                "input": "{}",
+                "inputDetails": {"truncated": False},
+                "roleArn": _get_default_role(),
+            },
+        },
+        {
+            "timestamp": datetime(2020, 1, 1, 0, 0, 10, tzinfo=tzlocal()),
+            "type": "PassStateEntered",
+            "id": 2,
+            "previousEventId": 0,
+            "stateEnteredEventDetails": {
+                "name": "A State",
+                "input": "{}",
+                "inputDetails": {"truncated": False},
+            },
+        },
+        {
+            "timestamp": datetime(2020, 1, 1, 0, 0, 10, tzinfo=tzlocal()),
+            "type": "PassStateExited",
+            "id": 3,
+            "previousEventId": 2,
+            "stateExitedEventDetails": {
+                "name": "A State",
+                "output": "An output",
+                "outputDetails": {"truncated": False},
+            },
+        },
+        {
+            "timestamp": datetime(2020, 1, 1, 0, 0, 20, tzinfo=tzlocal()),
+            "type": "ExecutionSucceeded",
+            "id": 4,
+            "previousEventId": 3,
+            "executionSucceededEventDetails": {
+                "output": "An output",
+                "outputDetails": {"truncated": False},
+            },
+        },
+    ]
+
     client = boto3.client("stepfunctions", region_name=region)
     sm = client.create_state_machine(
-        name="test-state-machine", definition=str(simple_definition), roleArn=_get_default_role()
+        name="test-state-machine",
+        definition=simple_definition,
+        roleArn=_get_default_role(),
     )
     execution = client.start_execution(stateMachineArn=sm["stateMachineArn"])
-    execution_history = client.get_execution_history(executionArn=execution["executionArn"])
-    
+    execution_history = client.get_execution_history(
+        executionArn=execution["executionArn"]
+    )
+    execution_history["events"].should.have.length_of(4)
+    execution_history["events"].should.equal(expected_events)
+
+
+@mock_stepfunctions
+@mock_sts
+@mock.patch.dict(os.environ, {"EXECUTION_HISTORY_TYPE": "blah"})
+def test_state_machine_get_execution_history_contains_expected_failure_events_when_started():
+    expected_events = [
+        {
+            "timestamp": datetime(2020, 1, 1, 0, 0, 0, tzinfo=tzlocal()),
+            "type": "ExecutionStarted",
+            "id": 1,
+            "previousEventId": 0,
+            "executionStartedEventDetails": {
+                "input": "{}",
+                "inputDetails": {"truncated": False},
+                "roleArn": _get_default_role(),
+            },
+        },
+        {
+            "timestamp": datetime(2020, 1, 1, 0, 0, 10, tzinfo=tzlocal()),
+            "type": "FailStateEntered",
+            "id": 2,
+            "previousEventId": 0,
+            "stateEnteredEventDetails": {
+                "name": "A State",
+                "input": "{}",
+                "inputDetails": {"truncated": False},
+            },
+        },
+        {
+            "timestamp": datetime(2020, 1, 1, 0, 0, 10, tzinfo=tzlocal()),
+            "type": "ExecutionFailed",
+            "id": 3,
+            "previousEventId": 2,
+            "executionFailedEventDetails": {
+                "error": "AnError",
+                "cause": "An error occurred!",
+            },
+        },
+    ]
+
+    client = boto3.client("stepfunctions", region_name=region)
+    sm = client.create_state_machine(
+        name="test-state-machine",
+        definition=simple_definition,
+        roleArn=_get_default_role(),
+    )
+    execution = client.start_execution(stateMachineArn=sm["stateMachineArn"])
+    execution_history = client.get_execution_history(
+        executionArn=execution["executionArn"]
+    )
+    execution_history["events"].should.have.length_of(3)
+    execution_history["events"].should.equal(expected_events)
 
 
 @mock_stepfunctions

--- a/tests/test_stepfunctions/test_stepfunctions.py
+++ b/tests/test_stepfunctions/test_stepfunctions.py
@@ -4,7 +4,7 @@ import boto3
 import json
 import os
 import sure  # noqa
-from unittest import mock
+from unittest import SkipTest, mock
 
 from datetime import datetime
 from dateutil.tz import tzlocal
@@ -927,6 +927,8 @@ def test_state_machine_get_execution_history_contains_expected_success_events_wh
 @mock_sts
 @mock.patch.dict(os.environ, {"EXECUTION_HISTORY_TYPE": "FAILURE"})
 def test_state_machine_get_execution_history_contains_expected_failure_events_when_started():
+    if os.environ.get("TEST_SERVER_MODE", "false").lower() == "true":
+        raise SkipTest("Cant pass environment variable in server mode")
     expected_events = [
         {
             "timestamp": datetime(2020, 1, 1, 0, 0, 0, tzinfo=tzlocal()),

--- a/tests/test_stepfunctions/test_stepfunctions.py
+++ b/tests/test_stepfunctions/test_stepfunctions.py
@@ -4,8 +4,7 @@ import boto3
 import json
 import os
 import sure  # noqa
-from unittest import SkipTest, mock
-
+import sys
 from datetime import datetime
 from dateutil.tz import tzlocal
 from botocore.exceptions import ClientError
@@ -13,6 +12,12 @@ import pytest
 
 from moto import mock_cloudformation, mock_sts, mock_stepfunctions
 from moto.core import ACCOUNT_ID
+
+if sys.version_info[0] < 3:
+    import mock
+    from unittest import SkipTest
+else:
+    from unittest import SkipTest, mock
 
 region = "us-east-1"
 simple_definition = (

--- a/tests/test_stepfunctions/test_stepfunctions.py
+++ b/tests/test_stepfunctions/test_stepfunctions.py
@@ -925,7 +925,7 @@ def test_state_machine_get_execution_history_contains_expected_success_events_wh
 
 @mock_stepfunctions
 @mock_sts
-@mock.patch.dict(os.environ, {"EXECUTION_HISTORY_TYPE": "blah"})
+@mock.patch.dict(os.environ, {"EXECUTION_HISTORY_TYPE": "FAILURE"})
 def test_state_machine_get_execution_history_contains_expected_failure_events_when_started():
     expected_events = [
         {

--- a/tests/test_stepfunctions/test_stepfunctions.py
+++ b/tests/test_stepfunctions/test_stepfunctions.py
@@ -930,7 +930,7 @@ def test_state_machine_get_execution_history_contains_expected_success_events_wh
 
 @mock_stepfunctions
 @mock_sts
-@mock.patch.dict(os.environ, {"EXECUTION_HISTORY_TYPE": "FAILURE"})
+@mock.patch.dict(os.environ, {"SF_EXECUTION_HISTORY_TYPE": "FAILURE"})
 def test_state_machine_get_execution_history_contains_expected_failure_events_when_started():
     if os.environ.get("TEST_SERVER_MODE", "false").lower() == "true":
         raise SkipTest("Cant pass environment variable in server mode")


### PR DESCRIPTION
## What I am changing

This PR adds a very simplistic implementation of the [`get_execution_history`](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/stepfunctions.html#SFN.Client.get_execution_history) method on the Step Function client. For now it only uses the parameter `executionArn`.

I've hard coded two histories to be returned:

**A successful execution (Presumably useful to 99% of users) with events :**
```
ExecutionStarted -> PassStateEntered -> PassStateExited -> ExecutionSucceeded
```

**A failed execution (We have a use case where we need failures in the execution history for our testing) with events:**
```
ExecutionStarted -> FailStateEntered -> ExecutionFailed
```

One can enforce which history they want with the environment variable `EXECUTION_HISTORY_TYPE`. If `SUCCESS` (Which is the default if no env var is present) then we return the successful history otherwise, if it's `FAILURE` we return the failed history.

---

I've also added `format` as a Makefile command, it simply calls the formatting equivalents of the `lint` command.

## How I did it

* Add `format` to `Makefile` 
* Moved `start_execution` to be a function of the `StateMachine` class
* Added `executions` as an attribute of the `StateMachine` class
* Refactor `start_execution`, `stop_execution`, `list_executions`, and `describe_execution` in `StepFunctionBackend` to correctly operate on the executions for the correct state machine
* Added `_get_state_machine_for_execution` as a helper function in `StepFunctionBackend` to return the associated `StateMachine` for a given executions ARN
* Added `get_execution_history` as a function of the `StateMachine` class - this returns a failure or a success event history, depending on the `EVENT_HISTORY_TYPE` environment variable
* Add an except block to `stop_execution` in `moto/stepfunctions/responses.py` to accommodate failure cases
* Add `get_execution_history` in `moto/stepfunctions/responses.py`
* Add unit test to cover case where `stop_execution` would get into a failure state
* Add unit tests to cover success history, failure history, and failure case of `get_execution_history` invocations

## How you can test it

```bash
# In the repo root
$ pytest ./tests/test_stepfunctions
```

## Questions

I'll namedrop @bblommers 😇  - I think the `EVENT_HISTORY_TYPE` environment variable usage needs documenting somewhere but I couldn't decide _where_... is the README OK? If so, where abouts?

Again, all the thanks for the `moto` crew! ❤️ 🚀 