### PR TITLE
Fix: elasticbeanstalk ApplicationArn does not contain ApplicationName

### DIFF
--- a/moto/elasticbeanstalk/responses.py
+++ b/moto/elasticbeanstalk/responses.py
@@ -91,7 +91,7 @@ EB_CREATE_APPLICATION = """
           </MaxCountRule>
         </VersionLifecycleConfig>
       </ResourceLifecycleConfig>
-      <ApplicationArn>arn:aws:elasticbeanstalk:{{ region_name }}:111122223333:application/{{ application_name }}</ApplicationArn>
+      <ApplicationArn>arn:aws:elasticbeanstalk:{{ region_name }}:111122223333:application/{{ application.application_name }}</ApplicationArn>
       <ApplicationName>{{ application.application_name }}</ApplicationName>
       <DateUpdated>2019-09-03T13:08:29.049Z</DateUpdated>
     </Application>
@@ -125,7 +125,7 @@ EB_DESCRIBE_APPLICATIONS = """
             </MaxCountRule>
           </VersionLifecycleConfig>
         </ResourceLifecycleConfig>
-        <ApplicationArn>arn:aws:elasticbeanstalk:{{ region_name }}:111122223333:application/{{ application.name }}</ApplicationArn>
+        <ApplicationArn>arn:aws:elasticbeanstalk:{{ region_name }}:111122223333:application/{{ application.application_name }}</ApplicationArn>
         <ApplicationName>{{ application.application_name }}</ApplicationName>
         <DateUpdated>2019-09-03T13:08:29.049Z</DateUpdated>
       </member>

--- a/tests/test_elasticbeanstalk/test_eb.py
+++ b/tests/test_elasticbeanstalk/test_eb.py
@@ -11,6 +11,7 @@ def test_create_application():
     conn = boto3.client("elasticbeanstalk", region_name="us-east-1")
     app = conn.create_application(ApplicationName="myapp",)
     app["Application"]["ApplicationName"].should.equal("myapp")
+    app["Application"]["ApplicationArn"].should.contain("myapp")
 
 
 @mock_elasticbeanstalk
@@ -31,6 +32,7 @@ def test_describe_applications():
     apps = conn.describe_applications()
     len(apps["Applications"]).should.equal(1)
     apps["Applications"][0]["ApplicationName"].should.equal("myapp")
+    apps["Applications"][0]["ApplicationArn"].should.contain("myapp")
 
 
 @mock_elasticbeanstalk


### PR DESCRIPTION
Fixes #3510

There's quite a bit of hardcoded stuff in `responses.py` (e.g. aws account_id) that I may try to address in a future PR, but this fixes the immediate problem.