### PR TITLE
Refactor tests marked `xfail` to use proper assertions

### DIFF
--- a/tests/test_iam/test_iam.py
+++ b/tests/test_iam/test_iam.py
@@ -134,19 +134,21 @@ def test_delete_server_cert():
 
 
 @mock_iam_deprecated()
-@pytest.mark.xfail(raises=BotoServerError)
 def test_get_role__should_throw__when_role_does_not_exist():
     conn = boto.connect_iam()
-
-    conn.get_role("unexisting_role")
+    with pytest.raises(BotoServerError) as ex:
+        conn.get_role("unexisting_role")
+    ex.value.error_code.should.equal("NoSuchEntity")
+    ex.value.message.should.contain("not found")
 
 
 @mock_iam_deprecated()
-@pytest.mark.xfail(raises=BotoServerError)
 def test_get_instance_profile__should_throw__when_instance_profile_does_not_exist():
     conn = boto.connect_iam()
-
-    conn.get_instance_profile("unexisting_instance_profile")
+    with pytest.raises(BotoServerError) as ex:
+        conn.get_instance_profile("unexisting_instance_profile")
+    ex.value.error_code.should.equal("NoSuchEntity")
+    ex.value.message.should.contain("not found")
 
 
 @mock_iam_deprecated()


### PR DESCRIPTION
There were only two of these left after the migration to pytest, so I refactored them to be a bit more explicit in their assertions.