### PR TITLE
DynamoDB - Allow StringSets to be passed to update_item()

### DIFF
--- a/moto/dynamodb2/models/__init__.py
+++ b/moto/dynamodb2/models/__init__.py
@@ -128,10 +128,10 @@ class Item(BaseModel):
             new_value = list(update_action["Value"].values())[0]
             if action == "PUT":
                 # TODO deal with other types
-                if isinstance(new_value, list):
-                    self.attrs[attribute_name] = DynamoType({"L": new_value})
-                elif isinstance(new_value, set):
+                if set(update_action["Value"].keys()) == set(["SS"]):
                     self.attrs[attribute_name] = DynamoType({"SS": new_value})
+                elif isinstance(new_value, list):
+                    self.attrs[attribute_name] = DynamoType({"L": new_value})
                 elif isinstance(new_value, dict):
                     self.attrs[attribute_name] = DynamoType({"M": new_value})
                 elif set(update_action["Value"].keys()) == set(["N"]):

--- a/tests/test_dynamodb2/test_dynamodb.py
+++ b/tests/test_dynamodb2/test_dynamodb.py
@@ -5628,3 +5628,24 @@ def test_transact_get_items_should_return_empty_map_for_non_existent_item():
     items.should.have.length_of(2)
     items[0].should.equal({"Item": item})
     items[1].should.equal({})
+
+
+@mock_dynamodb2
+def test_dynamodb_update_item_fails_on_string_sets():
+    dynamodb = boto3.resource("dynamodb", region_name="eu-west-1")
+    client = boto3.client("dynamodb", region_name="eu-west-1")
+
+    table = dynamodb.create_table(
+        TableName="test",
+        KeySchema=[{"AttributeName": "record_id", "KeyType": "HASH"},],
+        AttributeDefinitions=[{"AttributeName": "record_id", "AttributeType": "S"},],
+        BillingMode="PAY_PER_REQUEST",
+    )
+    table.meta.client.get_waiter("table_exists").wait(TableName="test")
+    attribute = {"test_field": {"Value": {"SS": ["test1", "test2"],}, "Action": "PUT"}}
+
+    client.update_item(
+        TableName="test",
+        Key={"record_id": {"S": "testrecord"}},
+        AttributeUpdates=attribute,
+    )


### PR DESCRIPTION
Fixes #3506 

The core of this issue is a lack of input validation (raised in #3231).

Until that's fixed, there are two choices when determining the data type: 
1) check which type is supplied by the user
2) check the type of the user-supplied value.

As the user-supplied value of a StringSets might be a list, we have to accept the type supplied by the user.

When proper validation is implemented, and we know 1) and 2) match up, we can refactor this entire logic flow to always accept the type supplied by the user.