### PR TITLE
Pass the default ECS cluster and raise accurate exceptions

### DIFF
--- a/moto/ecs/exceptions.py
+++ b/moto/ecs/exceptions.py
@@ -5,11 +5,9 @@ from moto.core.exceptions import RESTError, JsonRESTError
 class ServiceNotFoundException(RESTError):
     code = 400
 
-    def __init__(self, service_name):
+    def __init__(self):
         super(ServiceNotFoundException, self).__init__(
-            error_type="ServiceNotFoundException",
-            message="The service {0} does not exist".format(service_name),
-            template="error_json",
+            error_type="ServiceNotFoundException", message="Service not found."
         )
 
 
@@ -20,6 +18,15 @@ class TaskDefinitionNotFoundException(JsonRESTError):
         super(TaskDefinitionNotFoundException, self).__init__(
             error_type="ClientException",
             message="The specified task definition does not exist.",
+        )
+
+
+class RevisionNotFoundException(JsonRESTError):
+    code = 400
+
+    def __init__(self):
+        super(RevisionNotFoundException, self).__init__(
+            error_type="ClientException", message="Revision is missing.",
         )
 
 
@@ -39,4 +46,13 @@ class ClusterNotFoundException(JsonRESTError):
     def __init__(self):
         super(ClusterNotFoundException, self).__init__(
             error_type="ClientException", message="Cluster not found",
+        )
+
+
+class InvalidParameterException(JsonRESTError):
+    code = 400
+
+    def __init__(self, message):
+        super(InvalidParameterException, self).__init__(
+            error_type="ClientException", message=message,
         )

--- a/moto/ecs/responses.py
+++ b/moto/ecs/responses.py
@@ -100,7 +100,7 @@ class EC2ContainerServiceResponse(BaseResponse):
         return json.dumps({"taskDefinition": task_definition.response_object})
 
     def run_task(self):
-        cluster_str = self._get_param("cluster")
+        cluster_str = self._get_param("cluster", "default")
         overrides = self._get_param("overrides")
         task_definition_str = self._get_param("taskDefinition")
         count = self._get_int_param("count")
@@ -113,7 +113,7 @@ class EC2ContainerServiceResponse(BaseResponse):
         )
 
     def describe_tasks(self):
-        cluster = self._get_param("cluster")
+        cluster = self._get_param("cluster", "default")
         tasks = self._get_param("tasks")
         data = self.ecs_backend.describe_tasks(cluster, tasks)
         return json.dumps(
@@ -121,7 +121,7 @@ class EC2ContainerServiceResponse(BaseResponse):
         )
 
     def start_task(self):
-        cluster_str = self._get_param("cluster")
+        cluster_str = self._get_param("cluster", "default")
         overrides = self._get_param("overrides")
         task_definition_str = self._get_param("taskDefinition")
         container_instances = self._get_param("containerInstances")
@@ -134,7 +134,7 @@ class EC2ContainerServiceResponse(BaseResponse):
         )
 
     def list_tasks(self):
-        cluster_str = self._get_param("cluster")
+        cluster_str = self._get_param("cluster", "default")
         container_instance = self._get_param("containerInstance")
         family = self._get_param("family")
         started_by = self._get_param("startedBy")
@@ -151,14 +151,14 @@ class EC2ContainerServiceResponse(BaseResponse):
         return json.dumps({"taskArns": task_arns})
 
     def stop_task(self):
-        cluster_str = self._get_param("cluster")
+        cluster_str = self._get_param("cluster", "default")
         task = self._get_param("task")
         reason = self._get_param("reason")
         task = self.ecs_backend.stop_task(cluster_str, task, reason)
         return json.dumps({"task": task.response_object})
 
     def create_service(self):
-        cluster_str = self._get_param("cluster")
+        cluster_str = self._get_param("cluster", "default")
         service_name = self._get_param("serviceName")
         task_definition_str = self._get_param("taskDefinition")
         desired_count = self._get_int_param("desiredCount")
@@ -179,7 +179,7 @@ class EC2ContainerServiceResponse(BaseResponse):
         return json.dumps({"service": service.response_object})
 
     def list_services(self):
-        cluster_str = self._get_param("cluster")
+        cluster_str = self._get_param("cluster", "default")
         scheduling_strategy = self._get_param("schedulingStrategy")
         service_arns = self.ecs_backend.list_services(cluster_str, scheduling_strategy)
         return json.dumps(
@@ -191,7 +191,7 @@ class EC2ContainerServiceResponse(BaseResponse):
         )
 
     def describe_services(self):
-        cluster_str = self._get_param("cluster")
+        cluster_str = self._get_param("cluster", "default")
         service_names = self._get_param("services")
         services = self.ecs_backend.describe_services(cluster_str, service_names)
         resp = {
@@ -206,7 +206,7 @@ class EC2ContainerServiceResponse(BaseResponse):
         return json.dumps(resp)
 
     def update_service(self):
-        cluster_str = self._get_param("cluster")
+        cluster_str = self._get_param("cluster", "default")
         service_name = self._get_param("service")
         task_definition = self._get_param("taskDefinition")
         desired_count = self._get_int_param("desiredCount")
@@ -217,12 +217,12 @@ class EC2ContainerServiceResponse(BaseResponse):
 
     def delete_service(self):
         service_name = self._get_param("service")
-        cluster_name = self._get_param("cluster")
+        cluster_name = self._get_param("cluster", "default")
         service = self.ecs_backend.delete_service(cluster_name, service_name)
         return json.dumps({"service": service.response_object})
 
     def register_container_instance(self):
-        cluster_str = self._get_param("cluster")
+        cluster_str = self._get_param("cluster", "default")
         instance_identity_document_str = self._get_param("instanceIdentityDocument")
         instance_identity_document = json.loads(instance_identity_document_str)
         ec2_instance_id = instance_identity_document["instanceId"]
@@ -232,9 +232,7 @@ class EC2ContainerServiceResponse(BaseResponse):
         return json.dumps({"containerInstance": container_instance.response_object})
 
     def deregister_container_instance(self):
-        cluster_str = self._get_param("cluster")
-        if not cluster_str:
-            cluster_str = "default"
+        cluster_str = self._get_param("cluster", "default")
         container_instance_str = self._get_param("containerInstance")
         force = self._get_param("force")
         container_instance, failures = self.ecs_backend.deregister_container_instance(
@@ -243,12 +241,12 @@ class EC2ContainerServiceResponse(BaseResponse):
         return json.dumps({"containerInstance": container_instance.response_object})
 
     def list_container_instances(self):
-        cluster_str = self._get_param("cluster")
+        cluster_str = self._get_param("cluster", "default")
         container_instance_arns = self.ecs_backend.list_container_instances(cluster_str)
         return json.dumps({"containerInstanceArns": container_instance_arns})
 
     def describe_container_instances(self):
-        cluster_str = self._get_param("cluster")
+        cluster_str = self._get_param("cluster", "default")
         list_container_instance_arns = self._get_param("containerInstances")
         container_instances, failures = self.ecs_backend.describe_container_instances(
             cluster_str, list_container_instance_arns
@@ -263,7 +261,7 @@ class EC2ContainerServiceResponse(BaseResponse):
         )
 
     def update_container_instances_state(self):
-        cluster_str = self._get_param("cluster")
+        cluster_str = self._get_param("cluster", "default")
         list_container_instance_arns = self._get_param("containerInstances")
         status_str = self._get_param("status")
         (
@@ -312,7 +310,7 @@ class EC2ContainerServiceResponse(BaseResponse):
         return json.dumps({"attributes": formatted_results})
 
     def delete_attributes(self):
-        cluster_name = self._get_param("cluster")
+        cluster_name = self._get_param("cluster", "default")
         attributes = self._get_param("attributes")
 
         self.ecs_backend.delete_attributes(cluster_name, attributes)
@@ -359,7 +357,7 @@ class EC2ContainerServiceResponse(BaseResponse):
 
     def create_task_set(self):
         service_str = self._get_param("service")
-        cluster_str = self._get_param("cluster")
+        cluster_str = self._get_param("cluster", "default")
         task_definition = self._get_param("taskDefinition")
         external_id = self._get_param("externalId")
         network_configuration = self._get_param("networkConfiguration")
@@ -389,7 +387,7 @@ class EC2ContainerServiceResponse(BaseResponse):
         return json.dumps({"taskSet": task_set.response_object})
 
     def describe_task_sets(self):
-        cluster_str = self._get_param("cluster")
+        cluster_str = self._get_param("cluster", "default")
         service_str = self._get_param("service")
         task_sets = self._get_param("taskSets")
         include = self._get_param("include", [])
@@ -414,7 +412,7 @@ class EC2ContainerServiceResponse(BaseResponse):
         return json.dumps({"taskSet": task_set.response_object})
 
     def update_task_set(self):
-        cluster_str = self._get_param("cluster")
+        cluster_str = self._get_param("cluster", "default")
         service_str = self._get_param("service")
         task_set = self._get_param("taskSet")
         scale = self._get_param("scale")
@@ -425,7 +423,7 @@ class EC2ContainerServiceResponse(BaseResponse):
         return json.dumps({"taskSet": task_set.response_object})
 
     def update_service_primary_task_set(self):
-        cluster_str = self._get_param("cluster")
+        cluster_str = self._get_param("cluster", "default")
         service_str = self._get_param("service")
         primary_task_set = self._get_param("primaryTaskSet")
 


### PR DESCRIPTION
There are two fundamental changes to behavior in this PR that brings the Mock ECS implementation more in line with the behavior of real ECS:

- For many actions, the "default" cluster is now passed if a cluster is not provided. Most notably, this (correctly) changes the behavior of Mock ECS's ListTasks action to only list tasks for a single cluster.
- Many exceptions have been changed from custom moto exceptions to mirror the actual ECS exception.

I expect that both of these could represent breaking changes to users' tests - but they're changes that better represent the actual behavior of ECS.

This does not provide full coverage of exceptions. In general, I ran these operations against actual ECS resources and cross-referenced the documentation to figure out what actual exceptions should be thrown and what the messages should be. Consequently, I didn't update any exceptions that took more than trivial amount of time to reproduce with real resources.

There's also a lot of opportunity for refactoring of both existing tests and implementation code and to add some additional test coverage - in general, I added exceptions testing where it was easy but didn't go so far as to add tests where the action wasn't already tested (for example, PutAttributes) or where the change was relatively trivial (for example, switching from throwing `"{0} is not a cluster"` to `ClusterNotFoundException`)