### PR TITLE
Leave the global responses configuration alone

### DIFF
--- a/moto/apigateway/models.py
+++ b/moto/apigateway/models.py
@@ -41,6 +41,7 @@ from .exceptions import (
     RestAPINotFound,
     ModelNotFound,
 )
+from ..core.models import responses_mock
 
 STAGE_URL = "https://{api_id}.execute-api.{region_name}.amazonaws.com/{stage_name}"
 
@@ -565,7 +566,7 @@ class RestAPI(BaseModel):
         )
 
         for url in [stage_url_lower, stage_url_upper]:
-            responses._default_mock._matches.insert(
+            responses_mock._matches.insert(
                 0,
                 responses.CallbackResponse(
                     url=url,

--- a/moto/core/models.py
+++ b/moto/core/models.py
@@ -248,7 +248,7 @@ botocore_mock = responses.RequestsMock(
     target="botocore.vendored.requests.adapters.HTTPAdapter.send",
 )
 
-responses_mock = responses._default_mock
+responses_mock = responses.RequestsMock(assert_all_requests_are_fired=False)
 # Add passthrough to allow any other requests to work
 # Since this uses .startswith, it applies to http and https requests.
 responses_mock.add_passthru("http")

--- a/tests/test_apigateway/test_apigateway.py
+++ b/tests/test_apigateway/test_apigateway.py
@@ -8,9 +8,9 @@ import requests
 import sure  # noqa
 from botocore.exceptions import ClientError
 
-import responses
 from moto import mock_apigateway, mock_cognitoidp, settings
 from moto.core import ACCOUNT_ID
+from moto.core.models import responses_mock
 import pytest
 
 
@@ -1786,8 +1786,8 @@ def test_get_model_with_invalid_name():
 
 @mock_apigateway
 def test_http_proxying_integration():
-    responses.add(
-        responses.GET, "http://httpbin.org/robots.txt", body="a fake response"
+    responses_mock.add(
+        responses_mock.GET, "http://httpbin.org/robots.txt", body="a fake response"
     )
 
     region_name = "us-west-2"

--- a/tests/test_sns/test_publishing_boto3.py
+++ b/tests/test_sns/test_publishing_boto3.py
@@ -8,11 +8,11 @@ import re
 from freezegun import freeze_time
 import sure  # noqa
 
-import responses
 from botocore.exceptions import ClientError
 import pytest
 from moto import mock_sns, mock_sqs, settings
 from moto.core import ACCOUNT_ID
+from moto.core.models import responses_mock
 from moto.sns import sns_backend
 
 MESSAGE_FROM_SQS_TEMPLATE = (
@@ -332,7 +332,7 @@ def test_publish_to_http():
         json.loads.when.called_with(request.body.decode()).should_not.throw(Exception)
         return 200, {}, ""
 
-    responses.add_callback(
+    responses_mock.add_callback(
         method="POST", url="http://example.com/foobar", callback=callback
     )
 


### PR DESCRIPTION
Instead of modifying `responses._default_mock`, create our own `responses.RequestsMock` object that we can modify as needed without interfering with other users of the `responses` library.

Fixes #3264.