### PR TITLE
S3 - GetObject - Treat empty Range-argument as a regular GET

### DIFF
--- a/moto/s3/responses.py
+++ b/moto/s3/responses.py
@@ -971,7 +971,11 @@ class ResponseObject(_TemplateEnvironmentMixin, ActionAuthenticatorMixin):
         else:
             status_code, response_headers, response_content = response
 
-        if status_code == 200 and "range" in request.headers:
+        if (
+            status_code == 200
+            and "range" in request.headers
+            and request.headers["range"] != ""
+        ):
             try:
                 return self._handle_range_header(
                     request, response_headers, response_content

--- a/tests/test_s3/test_s3.py
+++ b/tests/test_s3/test_s3.py
@@ -4911,3 +4911,16 @@ def test_request_partial_content_should_contain_actual_content_length():
         )
         e.response["Error"]["ActualObjectSize"].should.equal("9")
         e.response["Error"]["RangeRequested"].should.equal(requested_range)
+
+
+@mock_s3
+def test_request_partial_content_without_specifying_range_should_return_full_object():
+    bucket = "bucket"
+    object_key = "key"
+    s3 = boto3.resource("s3", region_name="us-east-1")
+    s3.create_bucket(Bucket=bucket)
+    s3.Object(bucket, object_key).put(Body="some text that goes a long way")
+
+    file = s3.Object(bucket, object_key)
+    response = file.get(Range="")
+    response["ContentLength"].should.equal(30)


### PR DESCRIPTION
Fixes #2965 

Special use case in S3 - when specifying an empty Range-argument, it will ignore it, returning the full object. This PR mimicks this edge case in moto.
