### PR TITLE
Tech Debt - Remove unknown ImageID in internal tests

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -6,3 +6,7 @@ import logging
 logging.getLogger("boto").setLevel(logging.CRITICAL)
 logging.getLogger("boto3").setLevel(logging.CRITICAL)
 logging.getLogger("botocore").setLevel(logging.CRITICAL)
+
+
+EXAMPLE_AMI_ID = "ami-12c6146b"
+EXAMPLE_AMI_ID2 = "ami-03cf127a"

--- a/tests/test_autoscaling/test_autoscaling.py
+++ b/tests/test_autoscaling/test_autoscaling.py
@@ -26,6 +26,7 @@ from .utils import (
     setup_networking_deprecated,
     setup_instance_with_networking,
 )
+from tests import EXAMPLE_AMI_ID
 
 
 @mock_autoscaling_deprecated
@@ -37,7 +38,7 @@ def test_create_autoscaling_group():
 
     conn = boto.ec2.autoscale.connect_to_region("us-east-1")
     config = LaunchConfiguration(
-        name="tester", image_id="ami-abcd1234", instance_type="t2.medium"
+        name="tester", image_id=EXAMPLE_AMI_ID, instance_type="t2.medium"
     )
     conn.create_launch_configuration(config)
 
@@ -103,7 +104,7 @@ def test_create_autoscaling_groups_defaults():
     mocked_networking = setup_networking_deprecated()
     conn = boto.connect_autoscale()
     config = LaunchConfiguration(
-        name="tester", image_id="ami-abcd1234", instance_type="t2.medium"
+        name="tester", image_id=EXAMPLE_AMI_ID, instance_type="t2.medium"
     )
     conn.create_launch_configuration(config)
 
@@ -200,7 +201,7 @@ def test_autoscaling_group_describe_filter():
     mocked_networking = setup_networking_deprecated()
     conn = boto.connect_autoscale()
     config = LaunchConfiguration(
-        name="tester", image_id="ami-abcd1234", instance_type="t2.medium"
+        name="tester", image_id=EXAMPLE_AMI_ID, instance_type="t2.medium"
     )
     conn.create_launch_configuration(config)
 
@@ -228,7 +229,7 @@ def test_autoscaling_update():
     mocked_networking = setup_networking_deprecated()
     conn = boto.connect_autoscale()
     config = LaunchConfiguration(
-        name="tester", image_id="ami-abcd1234", instance_type="t2.medium"
+        name="tester", image_id=EXAMPLE_AMI_ID, instance_type="t2.medium"
     )
     conn.create_launch_configuration(config)
 
@@ -260,7 +261,7 @@ def test_autoscaling_tags_update():
     mocked_networking = setup_networking_deprecated()
     conn = boto.connect_autoscale()
     config = LaunchConfiguration(
-        name="tester", image_id="ami-abcd1234", instance_type="t2.medium"
+        name="tester", image_id=EXAMPLE_AMI_ID, instance_type="t2.medium"
     )
     conn.create_launch_configuration(config)
 
@@ -308,7 +309,7 @@ def test_autoscaling_group_delete():
     mocked_networking = setup_networking_deprecated()
     conn = boto.connect_autoscale()
     config = LaunchConfiguration(
-        name="tester", image_id="ami-abcd1234", instance_type="t2.medium"
+        name="tester", image_id=EXAMPLE_AMI_ID, instance_type="t2.medium"
     )
     conn.create_launch_configuration(config)
 
@@ -333,7 +334,7 @@ def test_autoscaling_group_describe_instances():
     mocked_networking = setup_networking_deprecated()
     conn = boto.ec2.autoscale.connect_to_region("us-east-1")
     config = LaunchConfiguration(
-        name="tester", image_id="ami-abcd1234", instance_type="t2.medium"
+        name="tester", image_id=EXAMPLE_AMI_ID, instance_type="t2.medium"
     )
     conn.create_launch_configuration(config)
 
@@ -367,7 +368,7 @@ def test_set_desired_capacity_up():
     mocked_networking = setup_networking_deprecated()
     conn = boto.connect_autoscale()
     config = LaunchConfiguration(
-        name="tester", image_id="ami-abcd1234", instance_type="t2.medium"
+        name="tester", image_id=EXAMPLE_AMI_ID, instance_type="t2.medium"
     )
     conn.create_launch_configuration(config)
 
@@ -401,7 +402,7 @@ def test_set_desired_capacity_down():
     mocked_networking = setup_networking_deprecated()
     conn = boto.connect_autoscale()
     config = LaunchConfiguration(
-        name="tester", image_id="ami-abcd1234", instance_type="t2.medium"
+        name="tester", image_id=EXAMPLE_AMI_ID, instance_type="t2.medium"
     )
     conn.create_launch_configuration(config)
 
@@ -435,7 +436,7 @@ def test_set_desired_capacity_the_same():
     mocked_networking = setup_networking_deprecated()
     conn = boto.connect_autoscale()
     config = LaunchConfiguration(
-        name="tester", image_id="ami-abcd1234", instance_type="t2.medium"
+        name="tester", image_id=EXAMPLE_AMI_ID, instance_type="t2.medium"
     )
     conn.create_launch_configuration(config)
 
@@ -476,7 +477,7 @@ def test_autoscaling_group_with_elb():
 
     conn = boto.connect_autoscale()
     config = LaunchConfiguration(
-        name="tester", image_id="ami-abcd1234", instance_type="t2.medium"
+        name="tester", image_id=EXAMPLE_AMI_ID, instance_type="t2.medium"
     )
     conn.create_launch_configuration(config)
     group = AutoScalingGroup(
@@ -727,7 +728,7 @@ def test_create_autoscaling_group_boto3():
 @mock_autoscaling
 def test_create_autoscaling_group_from_instance():
     autoscaling_group_name = "test_asg"
-    image_id = "ami-0cc293023f983ed53"
+    image_id = EXAMPLE_AMI_ID
     instance_type = "t2.micro"
 
     mocked_instance_with_networking = setup_instance_with_networking(
@@ -806,10 +807,7 @@ def test_create_autoscaling_group_from_template():
     ec2_client = boto3.client("ec2", region_name="us-east-1")
     template = ec2_client.create_launch_template(
         LaunchTemplateName="test_launch_template",
-        LaunchTemplateData={
-            "ImageId": "ami-0cc293023f983ed53",
-            "InstanceType": "t2.micro",
-        },
+        LaunchTemplateData={"ImageId": EXAMPLE_AMI_ID, "InstanceType": "t2.micro",},
     )["LaunchTemplate"]
     client = boto3.client("autoscaling", region_name="us-east-1")
     response = client.create_auto_scaling_group(
@@ -835,10 +833,7 @@ def test_create_autoscaling_group_no_template_ref():
     ec2_client = boto3.client("ec2", region_name="us-east-1")
     template = ec2_client.create_launch_template(
         LaunchTemplateName="test_launch_template",
-        LaunchTemplateData={
-            "ImageId": "ami-0cc293023f983ed53",
-            "InstanceType": "t2.micro",
-        },
+        LaunchTemplateData={"ImageId": EXAMPLE_AMI_ID, "InstanceType": "t2.micro",},
     )["LaunchTemplate"]
     client = boto3.client("autoscaling", region_name="us-east-1")
 
@@ -867,10 +862,7 @@ def test_create_autoscaling_group_multiple_template_ref():
     ec2_client = boto3.client("ec2", region_name="us-east-1")
     template = ec2_client.create_launch_template(
         LaunchTemplateName="test_launch_template",
-        LaunchTemplateData={
-            "ImageId": "ami-0cc293023f983ed53",
-            "InstanceType": "t2.micro",
-        },
+        LaunchTemplateData={"ImageId": EXAMPLE_AMI_ID, "InstanceType": "t2.micro",},
     )["LaunchTemplate"]
     client = boto3.client("autoscaling", region_name="us-east-1")
 
@@ -924,10 +916,7 @@ def test_create_autoscaling_group_boto3_multiple_launch_configurations():
     ec2_client = boto3.client("ec2", region_name="us-east-1")
     template = ec2_client.create_launch_template(
         LaunchTemplateName="test_launch_template",
-        LaunchTemplateData={
-            "ImageId": "ami-0cc293023f983ed53",
-            "InstanceType": "t2.micro",
-        },
+        LaunchTemplateData={"ImageId": EXAMPLE_AMI_ID, "InstanceType": "t2.micro",},
     )["LaunchTemplate"]
     client = boto3.client("autoscaling", region_name="us-east-1")
     client.create_launch_configuration(
@@ -997,10 +986,7 @@ def test_describe_autoscaling_groups_boto3_launch_template():
     ec2_client = boto3.client("ec2", region_name="us-east-1")
     template = ec2_client.create_launch_template(
         LaunchTemplateName="test_launch_template",
-        LaunchTemplateData={
-            "ImageId": "ami-0cc293023f983ed53",
-            "InstanceType": "t2.micro",
-        },
+        LaunchTemplateData={"ImageId": EXAMPLE_AMI_ID, "InstanceType": "t2.micro",},
     )["LaunchTemplate"]
     client = boto3.client("autoscaling", region_name="us-east-1")
     client.create_auto_scaling_group(
@@ -1070,10 +1056,7 @@ def test_describe_autoscaling_instances_boto3_launch_template():
     ec2_client = boto3.client("ec2", region_name="us-east-1")
     template = ec2_client.create_launch_template(
         LaunchTemplateName="test_launch_template",
-        LaunchTemplateData={
-            "ImageId": "ami-0cc293023f983ed53",
-            "InstanceType": "t2.micro",
-        },
+        LaunchTemplateData={"ImageId": EXAMPLE_AMI_ID, "InstanceType": "t2.micro",},
     )["LaunchTemplate"]
     client = boto3.client("autoscaling", region_name="us-east-1")
     client.create_auto_scaling_group(
@@ -1180,10 +1163,7 @@ def test_update_autoscaling_group_boto3_launch_template():
     ec2_client = boto3.client("ec2", region_name="us-east-1")
     ec2_client.create_launch_template(
         LaunchTemplateName="test_launch_template",
-        LaunchTemplateData={
-            "ImageId": "ami-0cc293023f983ed53",
-            "InstanceType": "t2.micro",
-        },
+        LaunchTemplateData={"ImageId": EXAMPLE_AMI_ID, "InstanceType": "t2.micro",},
     )
     template = ec2_client.create_launch_template(
         LaunchTemplateName="test_launch_template_new",

--- a/tests/test_autoscaling/test_autoscaling_cloudformation.py
+++ b/tests/test_autoscaling/test_autoscaling_cloudformation.py
@@ -8,6 +8,7 @@ from moto import (
 )
 
 from .utils import setup_networking
+from tests import EXAMPLE_AMI_ID
 
 
 @mock_autoscaling
@@ -23,13 +24,15 @@ Resources:
     LaunchConfiguration:
         Type: AWS::AutoScaling::LaunchConfiguration
         Properties:
-            ImageId: ami-0cc293023f983ed53
+            ImageId: {0}
             InstanceType: t2.micro
             LaunchConfigurationName: test_launch_configuration
 Outputs:
     LaunchConfigurationName:
         Value: !Ref LaunchConfiguration
-""".strip()
+""".strip().format(
+        EXAMPLE_AMI_ID
+    )
 
     cf_client.create_stack(
         StackName=stack_name, TemplateBody=cf_template,
@@ -39,7 +42,7 @@ Outputs:
 
     lc = client.describe_launch_configurations()["LaunchConfigurations"][0]
     lc["LaunchConfigurationName"].should.be.equal("test_launch_configuration")
-    lc["ImageId"].should.be.equal("ami-0cc293023f983ed53")
+    lc["ImageId"].should.be.equal(EXAMPLE_AMI_ID)
     lc["InstanceType"].should.be.equal("t2.micro")
 
     cf_template = """
@@ -47,13 +50,15 @@ Resources:
     LaunchConfiguration:
         Type: AWS::AutoScaling::LaunchConfiguration
         Properties:
-            ImageId: ami-1ea5b10a3d8867db4
+            ImageId: {0}
             InstanceType: m5.large
             LaunchConfigurationName: test_launch_configuration
 Outputs:
     LaunchConfigurationName:
         Value: !Ref LaunchConfiguration
-""".strip()
+""".strip().format(
+        EXAMPLE_AMI_ID
+    )
 
     cf_client.update_stack(
         StackName=stack_name, TemplateBody=cf_template,
@@ -63,7 +68,7 @@ Outputs:
 
     lc = client.describe_launch_configurations()["LaunchConfigurations"][0]
     lc["LaunchConfigurationName"].should.be.equal("test_launch_configuration")
-    lc["ImageId"].should.be.equal("ami-1ea5b10a3d8867db4")
+    lc["ImageId"].should.be.equal(EXAMPLE_AMI_ID)
     lc["InstanceType"].should.be.equal("m5.large")
 
 
@@ -168,10 +173,7 @@ def test_autoscaling_group_from_launch_template():
 
     template_response = ec2_client.create_launch_template(
         LaunchTemplateName="test_launch_template",
-        LaunchTemplateData={
-            "ImageId": "ami-0cc293023f983ed53",
-            "InstanceType": "t2.micro",
-        },
+        LaunchTemplateData={"ImageId": EXAMPLE_AMI_ID, "InstanceType": "t2.micro",},
     )
     launch_template_id = template_response["LaunchTemplate"]["LaunchTemplateId"]
     stack_name = "test-auto-scaling-group"
@@ -223,10 +225,7 @@ Outputs:
 
     template_response = ec2_client.create_launch_template(
         LaunchTemplateName="test_launch_template_new",
-        LaunchTemplateData={
-            "ImageId": "ami-1ea5b10a3d8867db4",
-            "InstanceType": "m5.large",
-        },
+        LaunchTemplateData={"ImageId": EXAMPLE_AMI_ID, "InstanceType": "m5.large",},
     )
     launch_template_id = template_response["LaunchTemplate"]["LaunchTemplateId"]
 

--- a/tests/test_autoscaling/test_policies.py
+++ b/tests/test_autoscaling/test_policies.py
@@ -8,13 +8,14 @@ import sure  # noqa
 from moto import mock_autoscaling_deprecated
 
 from .utils import setup_networking_deprecated
+from tests import EXAMPLE_AMI_ID
 
 
 def setup_autoscale_group():
     mocked_networking = setup_networking_deprecated()
     conn = boto.connect_autoscale()
     config = LaunchConfiguration(
-        name="tester", image_id="ami-abcd1234", instance_type="m1.small"
+        name="tester", image_id=EXAMPLE_AMI_ID, instance_type="m1.small"
     )
     conn.create_launch_configuration(config)
 

--- a/tests/test_cloudformation/test_cloudformation_stack_crud_boto3.py
+++ b/tests/test_cloudformation/test_cloudformation_stack_crud_boto3.py
@@ -14,6 +14,7 @@ import pytest
 from moto import mock_cloudformation, mock_s3, mock_sqs, mock_ec2
 from moto.core import ACCOUNT_ID
 from .test_cloudformation_stack_crud import dummy_template_json2
+from tests import EXAMPLE_AMI_ID
 
 dummy_template = {
     "AWSTemplateFormatVersion": "2010-09-09",
@@ -22,7 +23,7 @@ dummy_template = {
         "EC2Instance1": {
             "Type": "AWS::EC2::Instance",
             "Properties": {
-                "ImageId": "ami-d3adb33f",
+                "ImageId": EXAMPLE_AMI_ID,
                 "KeyName": "dummy",
                 "InstanceType": "t2.micro",
                 "Tags": [
@@ -112,7 +113,7 @@ dummy_update_template = {
     "Resources": {
         "Instance": {
             "Type": "AWS::EC2::Instance",
-            "Properties": {"ImageId": "ami-08111162"},
+            "Properties": {"ImageId": EXAMPLE_AMI_ID},
         }
     },
 }
@@ -123,7 +124,7 @@ dummy_output_template = {
     "Resources": {
         "Instance": {
             "Type": "AWS::EC2::Instance",
-            "Properties": {"ImageId": "ami-08111162"},
+            "Properties": {"ImageId": EXAMPLE_AMI_ID},
         }
     },
     "Outputs": {
@@ -177,7 +178,7 @@ dummy_template_special_chars_in_description = {
         "EC2Instance1": {
             "Type": "AWS::EC2::Instance",
             "Properties": {
-                "ImageId": "ami-d3adb33f",
+                "ImageId": EXAMPLE_AMI_ID,
                 "KeyName": "dummy",
                 "InstanceType": "t2.micro",
                 "Tags": [

--- a/tests/test_cloudformation/test_cloudformation_stack_integration.py
+++ b/tests/test_cloudformation/test_cloudformation_stack_integration.py
@@ -45,6 +45,7 @@ from moto import (
 )
 from moto.core import ACCOUNT_ID
 
+from tests import EXAMPLE_AMI_ID, EXAMPLE_AMI_ID2
 from tests.test_cloudformation.fixtures import (
     ec2_classic_eip,
     fn_join,
@@ -208,7 +209,7 @@ def test_stack_ec2_integration():
         "Resources": {
             "WebServerGroup": {
                 "Type": "AWS::EC2::Instance",
-                "Properties": {"ImageId": "ami-1234abcd", "UserData": "some user data"},
+                "Properties": {"ImageId": EXAMPLE_AMI_ID, "UserData": "some user data"},
             }
         },
     }
@@ -252,7 +253,7 @@ def test_stack_elb_integration_with_attached_ec2_instances():
             },
             "Ec2Instance1": {
                 "Type": "AWS::EC2::Instance",
-                "Properties": {"ImageId": "ami-1234abcd", "UserData": "some user data"},
+                "Properties": {"ImageId": EXAMPLE_AMI_ID, "UserData": "some user data"},
             },
         },
     }
@@ -418,7 +419,7 @@ def test_stack_security_groups():
                 "Type": "AWS::EC2::Instance",
                 "Properties": {
                     "SecurityGroups": [{"Ref": "InstanceSecurityGroup"}],
-                    "ImageId": "ami-1234abcd",
+                    "ImageId": EXAMPLE_AMI_ID,
                 },
             },
             "InstanceSecurityGroup": {
@@ -513,7 +514,7 @@ def test_autoscaling_group_with_elb():
             },
             "my-launch-config": {
                 "Type": "AWS::AutoScaling::LaunchConfiguration",
-                "Properties": {"ImageId": "ami-1234abcd", "UserData": "some user data"},
+                "Properties": {"ImageId": EXAMPLE_AMI_ID, "UserData": "some user data"},
             },
             "my-elb": {
                 "Type": "AWS::ElasticLoadBalancing::LoadBalancer",
@@ -609,7 +610,7 @@ def test_autoscaling_group_update():
             },
             "my-launch-config": {
                 "Type": "AWS::AutoScaling::LaunchConfiguration",
-                "Properties": {"ImageId": "ami-1234abcd", "UserData": "some user data"},
+                "Properties": {"ImageId": EXAMPLE_AMI_ID, "UserData": "some user data"},
             },
         },
     }
@@ -844,7 +845,7 @@ def test_iam_roles():
             "my-launch-config": {
                 "Properties": {
                     "IamInstanceProfile": {"Ref": "my-instance-profile-with-path"},
-                    "ImageId": "ami-1234abcd",
+                    "ImageId": EXAMPLE_AMI_ID,
                 },
                 "Type": "AWS::AutoScaling::LaunchConfiguration",
             },
@@ -1132,7 +1133,7 @@ def test_conditional_if_handling():
             "App1": {
                 "Properties": {
                     "ImageId": {
-                        "Fn::If": ["EnvEqualsPrd", "ami-00000000", "ami-ffffffff"]
+                        "Fn::If": ["EnvEqualsPrd", EXAMPLE_AMI_ID, EXAMPLE_AMI_ID2]
                     }
                 },
                 "Type": "AWS::EC2::Instance",
@@ -1146,7 +1147,7 @@ def test_conditional_if_handling():
     ec2_conn = boto.ec2.connect_to_region("us-west-1")
     reservation = ec2_conn.get_all_instances()[0]
     ec2_instance = reservation.instances[0]
-    ec2_instance.image_id.should.equal("ami-ffffffff")
+    ec2_instance.image_id.should.equal(EXAMPLE_AMI_ID2)
     ec2_instance.terminate()
 
     conn = boto.cloudformation.connect_to_region("us-west-2")
@@ -1156,7 +1157,7 @@ def test_conditional_if_handling():
     ec2_conn = boto.ec2.connect_to_region("us-west-2")
     reservation = ec2_conn.get_all_instances()[0]
     ec2_instance = reservation.instances[0]
-    ec2_instance.image_id.should.equal("ami-00000000")
+    ec2_instance.image_id.should.equal(EXAMPLE_AMI_ID)
 
 
 @mock_cloudformation_deprecated()
@@ -1927,7 +1928,7 @@ def test_stack_spot_fleet():
                             {
                                 "EbsOptimized": "false",
                                 "InstanceType": "t2.small",
-                                "ImageId": "ami-1234",
+                                "ImageId": EXAMPLE_AMI_ID,
                                 "SubnetId": subnet_id,
                                 "WeightedCapacity": "2",
                                 "SpotPrice": "0.13",
@@ -1935,7 +1936,7 @@ def test_stack_spot_fleet():
                             {
                                 "EbsOptimized": "true",
                                 "InstanceType": "t2.large",
-                                "ImageId": "ami-1234",
+                                "ImageId": EXAMPLE_AMI_ID,
                                 "Monitoring": {"Enabled": "true"},
                                 "SecurityGroups": [{"GroupId": "sg-123"}],
                                 "SubnetId": subnet_id,
@@ -1984,7 +1985,7 @@ def test_stack_spot_fleet():
     launch_spec = spot_fleet_config["LaunchSpecifications"][0]
 
     launch_spec["EbsOptimized"].should.equal(False)
-    launch_spec["ImageId"].should.equal("ami-1234")
+    launch_spec["ImageId"].should.equal(EXAMPLE_AMI_ID)
     launch_spec["InstanceType"].should.equal("t2.small")
     launch_spec["SubnetId"].should.equal(subnet_id)
     launch_spec["SpotPrice"].should.equal("0.13")
@@ -2015,14 +2016,14 @@ def test_stack_spot_fleet_should_figure_out_default_price():
                             {
                                 "EbsOptimized": "false",
                                 "InstanceType": "t2.small",
-                                "ImageId": "ami-1234",
+                                "ImageId": EXAMPLE_AMI_ID,
                                 "SubnetId": subnet_id,
                                 "WeightedCapacity": "2",
                             },
                             {
                                 "EbsOptimized": "true",
                                 "InstanceType": "t2.large",
-                                "ImageId": "ami-1234",
+                                "ImageId": EXAMPLE_AMI_ID,
                                 "Monitoring": {"Enabled": "true"},
                                 "SecurityGroups": [{"GroupId": "sg-123"}],
                                 "SubnetId": subnet_id,
@@ -2165,7 +2166,7 @@ def test_stack_elbv2_resources_integration():
             },
             "ec2instance": {
                 "Type": "AWS::EC2::Instance",
-                "Properties": {"ImageId": "ami-1234abcd", "UserData": "some user data"},
+                "Properties": {"ImageId": EXAMPLE_AMI_ID, "UserData": "some user data"},
             },
         },
     }

--- a/tests/test_cloudformation/test_validate.py
+++ b/tests/test_cloudformation/test_validate.py
@@ -19,6 +19,7 @@ from moto.s3.models import FakeBucket
 from moto.cloudformation.utils import yaml_tag_constructor
 from boto.cloudformation.stack import Output
 from moto import mock_cloudformation, mock_s3, mock_sqs, mock_ec2
+from tests import EXAMPLE_AMI_ID
 
 json_template = {
     "AWSTemplateFormatVersion": "2010-09-09",
@@ -27,7 +28,7 @@ json_template = {
         "EC2Instance1": {
             "Type": "AWS::EC2::Instance",
             "Properties": {
-                "ImageId": "ami-d3adb33f",
+                "ImageId": EXAMPLE_AMI_ID,
                 "KeyName": "dummy",
                 "InstanceType": "t2.micro",
                 "Tags": [

--- a/tests/test_ec2/test_amis.py
+++ b/tests/test_ec2/test_amis.py
@@ -13,6 +13,7 @@ import sure  # noqa
 from moto import mock_ec2_deprecated, mock_ec2
 from moto.ec2.models import AMIS, OWNER_ID
 from moto.core import ACCOUNT_ID
+from tests import EXAMPLE_AMI_ID
 from tests.helpers import requires_boto_gte
 
 
@@ -24,7 +25,7 @@ def test_ami_create_and_delete():
     conn.get_all_volumes().should.have.length_of(0)
     conn.get_all_snapshots().should.have.length_of(initial_ami_count)
 
-    reservation = conn.run_instances("ami-1234abcd")
+    reservation = conn.run_instances(EXAMPLE_AMI_ID)
     instance = reservation.instances[0]
 
     with pytest.raises(EC2ResponseError) as ex:
@@ -103,7 +104,7 @@ def test_ami_copy():
     conn.get_all_volumes().should.have.length_of(0)
     conn.get_all_snapshots().should.have.length_of(initial_ami_count)
 
-    reservation = conn.run_instances("ami-1234abcd")
+    reservation = conn.run_instances(EXAMPLE_AMI_ID)
     instance = reservation.instances[0]
 
     source_image_id = conn.create_image(instance.id, "test-ami", "this is a test ami")
@@ -203,7 +204,7 @@ def test_copy_image_changes_owner_id():
 @mock_ec2_deprecated
 def test_ami_tagging():
     conn = boto.connect_vpc("the_key", "the_secret")
-    reservation = conn.run_instances("ami-1234abcd")
+    reservation = conn.run_instances(EXAMPLE_AMI_ID)
     instance = reservation.instances[0]
     conn.create_image(instance.id, "test-ami", "this is a test ami")
     image = conn.get_all_images()[0]
@@ -243,7 +244,7 @@ def test_ami_create_from_missing_instance():
 @mock_ec2_deprecated
 def test_ami_pulls_attributes_from_instance():
     conn = boto.connect_ec2("the_key", "the_secret")
-    reservation = conn.run_instances("ami-1234abcd")
+    reservation = conn.run_instances(EXAMPLE_AMI_ID)
     instance = reservation.instances[0]
     instance.modify_attribute("kernel", "test-kernel")
 
@@ -256,7 +257,7 @@ def test_ami_pulls_attributes_from_instance():
 def test_ami_uses_account_id_if_valid_access_key_is_supplied():
     access_key = "AKIAXXXXXXXXXXXXXXXX"
     conn = boto.connect_ec2(access_key, "the_secret")
-    reservation = conn.run_instances("ami-1234abcd")
+    reservation = conn.run_instances(EXAMPLE_AMI_ID)
     instance = reservation.instances[0]
     instance.modify_attribute("kernel", "test-kernel")
 
@@ -269,7 +270,7 @@ def test_ami_uses_account_id_if_valid_access_key_is_supplied():
 def test_ami_filters():
     conn = boto.connect_ec2("the_key", "the_secret")
 
-    reservationA = conn.run_instances("ami-1234abcd")
+    reservationA = conn.run_instances(EXAMPLE_AMI_ID)
     instanceA = reservationA.instances[0]
     instanceA.modify_attribute("architecture", "i386")
     instanceA.modify_attribute("kernel", "k-1234abcd")
@@ -278,7 +279,7 @@ def test_ami_filters():
     imageA_id = conn.create_image(instanceA.id, "test-ami-A", "this is a test ami")
     imageA = conn.get_image(imageA_id)
 
-    reservationB = conn.run_instances("ami-abcd1234")
+    reservationB = conn.run_instances(EXAMPLE_AMI_ID)
     instanceB = reservationB.instances[0]
     instanceB.modify_attribute("architecture", "x86_64")
     instanceB.modify_attribute("kernel", "k-abcd1234")
@@ -330,13 +331,13 @@ def test_ami_filters():
 def test_ami_filtering_via_tag():
     conn = boto.connect_vpc("the_key", "the_secret")
 
-    reservationA = conn.run_instances("ami-1234abcd")
+    reservationA = conn.run_instances(EXAMPLE_AMI_ID)
     instanceA = reservationA.instances[0]
     imageA_id = conn.create_image(instanceA.id, "test-ami-A", "this is a test ami")
     imageA = conn.get_image(imageA_id)
     imageA.add_tag("a key", "some value")
 
-    reservationB = conn.run_instances("ami-abcd1234")
+    reservationB = conn.run_instances(EXAMPLE_AMI_ID)
     instanceB = reservationB.instances[0]
     imageB_id = conn.create_image(instanceB.id, "test-ami-B", "this is a test ami")
     imageB = conn.get_image(imageB_id)
@@ -374,7 +375,7 @@ def test_getting_malformed_ami():
 @mock_ec2_deprecated
 def test_ami_attribute_group_permissions():
     conn = boto.connect_ec2("the_key", "the_secret")
-    reservation = conn.run_instances("ami-1234abcd")
+    reservation = conn.run_instances(EXAMPLE_AMI_ID)
     instance = reservation.instances[0]
     image_id = conn.create_image(instance.id, "test-ami", "this is a test ami")
     image = conn.get_image(image_id)
@@ -437,7 +438,7 @@ def test_ami_attribute_group_permissions():
 @mock_ec2_deprecated
 def test_ami_attribute_user_permissions():
     conn = boto.connect_ec2("the_key", "the_secret")
-    reservation = conn.run_instances("ami-1234abcd")
+    reservation = conn.run_instances(EXAMPLE_AMI_ID)
     instance = reservation.instances[0]
     image_id = conn.create_image(instance.id, "test-ami", "this is a test ami")
     image = conn.get_image(image_id)
@@ -513,7 +514,7 @@ def test_ami_attribute_user_permissions():
 def test_ami_describe_executable_users():
     conn = boto3.client("ec2", region_name="us-east-1")
     ec2 = boto3.resource("ec2", "us-east-1")
-    ec2.create_instances(ImageId="", MinCount=1, MaxCount=1)
+    ec2.create_instances(ImageId=EXAMPLE_AMI_ID, MinCount=1, MaxCount=1)
     response = conn.describe_instances(
         Filters=[{"Name": "instance-state-name", "Values": ["running"]}]
     )
@@ -546,7 +547,7 @@ def test_ami_describe_executable_users():
 def test_ami_describe_executable_users_negative():
     conn = boto3.client("ec2", region_name="us-east-1")
     ec2 = boto3.resource("ec2", "us-east-1")
-    ec2.create_instances(ImageId="", MinCount=1, MaxCount=1)
+    ec2.create_instances(ImageId=EXAMPLE_AMI_ID, MinCount=1, MaxCount=1)
     response = conn.describe_instances(
         Filters=[{"Name": "instance-state-name", "Values": ["running"]}]
     )
@@ -580,7 +581,7 @@ def test_ami_describe_executable_users_negative():
 def test_ami_describe_executable_users_and_filter():
     conn = boto3.client("ec2", region_name="us-east-1")
     ec2 = boto3.resource("ec2", "us-east-1")
-    ec2.create_instances(ImageId="", MinCount=1, MaxCount=1)
+    ec2.create_instances(ImageId=EXAMPLE_AMI_ID, MinCount=1, MaxCount=1)
     response = conn.describe_instances(
         Filters=[{"Name": "instance-state-name", "Values": ["running"]}]
     )
@@ -621,7 +622,7 @@ def test_ami_attribute_user_and_group_permissions():
       via user-specific and group-specific tests above.
     """
     conn = boto.connect_ec2("the_key", "the_secret")
-    reservation = conn.run_instances("ami-1234abcd")
+    reservation = conn.run_instances(EXAMPLE_AMI_ID)
     instance = reservation.instances[0]
     image_id = conn.create_image(instance.id, "test-ami", "this is a test ami")
     image = conn.get_image(image_id)
@@ -672,7 +673,7 @@ def test_ami_attribute_user_and_group_permissions():
 @mock_ec2_deprecated
 def test_ami_attribute_error_cases():
     conn = boto.connect_ec2("the_key", "the_secret")
-    reservation = conn.run_instances("ami-1234abcd")
+    reservation = conn.run_instances(EXAMPLE_AMI_ID)
     instance = reservation.instances[0]
     image_id = conn.create_image(instance.id, "test-ami", "this is a test ami")
     image = conn.get_image(image_id)
@@ -799,7 +800,7 @@ def test_ami_filter_wildcard():
     ec2_client = boto3.client("ec2", region_name="us-west-1")
 
     instance = ec2_resource.create_instances(
-        ImageId="ami-1234abcd", MinCount=1, MaxCount=1
+        ImageId=EXAMPLE_AMI_ID, MinCount=1, MaxCount=1
     )[0]
     instance.create_image(Name="test-image")
 
@@ -840,7 +841,7 @@ def test_ami_filter_by_self():
 
     # Create a new image
     instance = ec2_resource.create_instances(
-        ImageId="ami-1234abcd", MinCount=1, MaxCount=1
+        ImageId=EXAMPLE_AMI_ID, MinCount=1, MaxCount=1
     )[0]
     instance.create_image(Name="test-image")
 

--- a/tests/test_ec2/test_ec2_cloudformation.py
+++ b/tests/test_ec2/test_ec2_cloudformation.py
@@ -1,5 +1,6 @@
 from moto import mock_cloudformation_deprecated, mock_ec2_deprecated
 from moto import mock_cloudformation, mock_ec2
+from tests import EXAMPLE_AMI_ID
 from tests.test_cloudformation.fixtures import vpc_eni
 import boto
 import boto.ec2
@@ -46,7 +47,7 @@ def test_volume_size_through_cloudformation():
             "testInstance": {
                 "Type": "AWS::EC2::Instance",
                 "Properties": {
-                    "ImageId": "ami-d3adb33f",
+                    "ImageId": EXAMPLE_AMI_ID,
                     "KeyName": "dummy",
                     "InstanceType": "t2.micro",
                     "BlockDeviceMappings": [

--- a/tests/test_ec2/test_elastic_block_store.py
+++ b/tests/test_ec2/test_elastic_block_store.py
@@ -12,6 +12,7 @@ from moto import mock_ec2, mock_ec2_deprecated
 from moto.ec2 import ec2_backends
 from moto.ec2.models import OWNER_ID
 from moto.kms import mock_kms
+from tests import EXAMPLE_AMI_ID
 
 
 @mock_ec2_deprecated
@@ -54,7 +55,7 @@ def test_create_and_delete_volume():
 @mock_ec2_deprecated
 def test_delete_attached_volume():
     conn = boto.ec2.connect_to_region("us-east-1")
-    reservation = conn.run_instances("ami-1234abcd")
+    reservation = conn.run_instances(EXAMPLE_AMI_ID)
     # create an instance
     instance = reservation.instances[0]
     # create a volume
@@ -143,7 +144,7 @@ def test_filter_volume_by_id():
 def test_volume_filters():
     conn = boto.ec2.connect_to_region("us-east-1")
 
-    reservation = conn.run_instances("ami-1234abcd")
+    reservation = conn.run_instances(EXAMPLE_AMI_ID)
     instance = reservation.instances[0]
 
     instance.update()
@@ -250,7 +251,7 @@ def test_volume_filters():
 @mock_ec2_deprecated
 def test_volume_attach_and_detach():
     conn = boto.ec2.connect_to_region("us-east-1")
-    reservation = conn.run_instances("ami-1234abcd")
+    reservation = conn.run_instances(EXAMPLE_AMI_ID)
     instance = reservation.instances[0]
     volume = conn.create_volume(80, "us-east-1a")
 
@@ -780,7 +781,7 @@ def test_modify_attribute_blockDeviceMapping():
     """
     conn = boto.ec2.connect_to_region("us-east-1")
 
-    reservation = conn.run_instances("ami-1234abcd")
+    reservation = conn.run_instances(EXAMPLE_AMI_ID)
 
     instance = reservation.instances[0]
 

--- a/tests/test_ec2/test_elastic_ip_addresses.py
+++ b/tests/test_ec2/test_elastic_ip_addresses.py
@@ -11,6 +11,7 @@ import six
 import sure  # noqa
 
 from moto import mock_ec2, mock_ec2_deprecated
+from tests import EXAMPLE_AMI_ID
 
 import logging
 
@@ -95,7 +96,7 @@ def test_eip_associate_classic():
     """Associate/Disassociate EIP to classic instance"""
     conn = boto.connect_ec2("the_key", "the_secret")
 
-    reservation = conn.run_instances("ami-1234abcd")
+    reservation = conn.run_instances(EXAMPLE_AMI_ID)
     instance = reservation.instances[0]
 
     eip = conn.allocate_address()
@@ -146,7 +147,7 @@ def test_eip_associate_vpc():
     """Associate/Disassociate EIP to VPC instance"""
     conn = boto.connect_ec2("the_key", "the_secret")
 
-    reservation = conn.run_instances("ami-1234abcd")
+    reservation = conn.run_instances(EXAMPLE_AMI_ID)
     instance = reservation.instances[0]
 
     eip = conn.allocate_address(domain="vpc")
@@ -194,7 +195,7 @@ def test_eip_boto3_vpc_association():
     instance = service.create_instances(
         **{
             "InstanceType": "t2.micro",
-            "ImageId": "ami-test",
+            "ImageId": EXAMPLE_AMI_ID,
             "MinCount": 1,
             "MaxCount": 1,
             "SubnetId": subnet_res["Subnet"]["SubnetId"],
@@ -265,7 +266,7 @@ def test_eip_reassociate():
     """reassociate EIP"""
     conn = boto.connect_ec2("the_key", "the_secret")
 
-    reservation = conn.run_instances("ami-1234abcd", min_count=2)
+    reservation = conn.run_instances(EXAMPLE_AMI_ID, min_count=2)
     instance1, instance2 = reservation.instances
 
     eip = conn.allocate_address()
@@ -330,7 +331,7 @@ def test_eip_associate_invalid_args():
     """Associate EIP, invalid args """
     conn = boto.connect_ec2("the_key", "the_secret")
 
-    reservation = conn.run_instances("ami-1234abcd")
+    reservation = conn.run_instances(EXAMPLE_AMI_ID)
     instance = reservation.instances[0]
 
     eip = conn.allocate_address()
@@ -457,7 +458,7 @@ def test_eip_filters():
         instance = service.create_instances(
             **{
                 "InstanceType": "t2.micro",
-                "ImageId": "ami-test",
+                "ImageId": EXAMPLE_AMI_ID,
                 "MinCount": 1,
                 "MaxCount": 1,
                 "SubnetId": subnet_res["Subnet"]["SubnetId"],

--- a/tests/test_ec2/test_general.py
+++ b/tests/test_ec2/test_general.py
@@ -9,12 +9,13 @@ from boto.exception import EC2ResponseError
 import sure  # noqa
 
 from moto import mock_ec2_deprecated, mock_ec2
+from tests import EXAMPLE_AMI_ID
 
 
 @mock_ec2_deprecated
 def test_console_output():
     conn = boto.connect_ec2("the_key", "the_secret")
-    reservation = conn.run_instances("ami-1234abcd")
+    reservation = conn.run_instances(EXAMPLE_AMI_ID)
     instance_id = reservation.instances[0].id
     output = conn.get_console_output(instance_id)
     output.output.should_not.equal(None)
@@ -34,7 +35,7 @@ def test_console_output_without_instance():
 @mock_ec2
 def test_console_output_boto3():
     conn = boto3.resource("ec2", "us-east-1")
-    instances = conn.create_instances(ImageId="ami-1234abcd", MinCount=1, MaxCount=1)
+    instances = conn.create_instances(ImageId=EXAMPLE_AMI_ID, MinCount=1, MaxCount=1)
 
     output = instances[0].console_output()
     output.get("Output").should_not.equal(None)

--- a/tests/test_ec2/test_iam_instance_profile_associations.py
+++ b/tests/test_ec2/test_iam_instance_profile_associations.py
@@ -10,12 +10,14 @@ from botocore.exceptions import ClientError
 import sure  # noqa
 
 from moto import mock_ec2, mock_iam, mock_cloudformation
+from tests import EXAMPLE_AMI_ID
 
 
 def quick_instance_creation():
-    image_id = "ami-1234abcd"
     conn_ec2 = boto3.resource("ec2", "us-east-1")
-    test_instance = conn_ec2.create_instances(ImageId=image_id, MinCount=1, MaxCount=1)
+    test_instance = conn_ec2.create_instances(
+        ImageId=EXAMPLE_AMI_ID, MinCount=1, MaxCount=1
+    )
     # We only need instance id for this tests
     return test_instance[0].id
 
@@ -323,7 +325,7 @@ def test_cloudformation():
                 "Properties": {
                     "IamInstanceProfile": {"Ref": "InstanceProfile"},
                     "KeyName": "mykey1",
-                    "ImageId": "ami-7a11e213",
+                    "ImageId": EXAMPLE_AMI_ID,
                 },
             },
         },

--- a/tests/test_ec2/test_regions.py
+++ b/tests/test_ec2/test_regions.py
@@ -8,6 +8,7 @@ from boto3 import Session
 from moto import mock_ec2_deprecated, mock_autoscaling_deprecated, mock_elb_deprecated
 
 from moto.ec2 import ec2_backends
+from tests import EXAMPLE_AMI_ID, EXAMPLE_AMI_ID2
 
 
 def test_use_boto_regions():
@@ -32,24 +33,23 @@ def add_servers_to_region(ami_id, count, region):
 @mock_ec2_deprecated
 def test_add_servers_to_a_single_region():
     region = "ap-northeast-1"
-    add_servers_to_region("ami-1234abcd", 1, region)
-    add_servers_to_region("ami-5678efgh", 1, region)
+    add_servers_to_region(EXAMPLE_AMI_ID, 1, region)
+    add_servers_to_region(EXAMPLE_AMI_ID2, 1, region)
 
     conn = boto.ec2.connect_to_region(region)
     reservations = conn.get_all_instances()
     len(reservations).should.equal(2)
-    reservations.sort(key=lambda x: x.instances[0].image_id)
 
-    reservations[0].instances[0].image_id.should.equal("ami-1234abcd")
-    reservations[1].instances[0].image_id.should.equal("ami-5678efgh")
+    image_ids = [r.instances[0].image_id for r in reservations]
+    image_ids.should.equal([EXAMPLE_AMI_ID, EXAMPLE_AMI_ID2])
 
 
 @mock_ec2_deprecated
 def test_add_servers_to_multiple_regions():
     region1 = "us-east-1"
     region2 = "ap-northeast-1"
-    add_servers_to_region("ami-1234abcd", 1, region1)
-    add_servers_to_region("ami-5678efgh", 1, region2)
+    add_servers_to_region(EXAMPLE_AMI_ID, 1, region1)
+    add_servers_to_region(EXAMPLE_AMI_ID2, 1, region2)
 
     us_conn = boto.ec2.connect_to_region(region1)
     ap_conn = boto.ec2.connect_to_region(region2)
@@ -59,8 +59,8 @@ def test_add_servers_to_multiple_regions():
     len(us_reservations).should.equal(1)
     len(ap_reservations).should.equal(1)
 
-    us_reservations[0].instances[0].image_id.should.equal("ami-1234abcd")
-    ap_reservations[0].instances[0].image_id.should.equal("ami-5678efgh")
+    us_reservations[0].instances[0].image_id.should.equal(EXAMPLE_AMI_ID)
+    ap_reservations[0].instances[0].image_id.should.equal(EXAMPLE_AMI_ID2)
 
 
 @mock_autoscaling_deprecated
@@ -77,7 +77,7 @@ def test_create_autoscaling_group():
 
     us_conn = boto.ec2.autoscale.connect_to_region("us-east-1")
     config = boto.ec2.autoscale.LaunchConfiguration(
-        name="us_tester", image_id="ami-abcd1234", instance_type="m1.small"
+        name="us_tester", image_id=EXAMPLE_AMI_ID, instance_type="m1.small"
     )
     x = us_conn.create_launch_configuration(config)
 
@@ -104,7 +104,7 @@ def test_create_autoscaling_group():
 
     ap_conn = boto.ec2.autoscale.connect_to_region("ap-northeast-1")
     config = boto.ec2.autoscale.LaunchConfiguration(
-        name="ap_tester", image_id="ami-efgh5678", instance_type="m1.small"
+        name="ap_tester", image_id=EXAMPLE_AMI_ID, instance_type="m1.small"
     )
     ap_conn.create_launch_configuration(config)
 

--- a/tests/test_ec2/test_route_tables.py
+++ b/tests/test_ec2/test_route_tables.py
@@ -10,6 +10,7 @@ from botocore.exceptions import ClientError
 import sure  # noqa
 
 from moto import mock_ec2, mock_ec2_deprecated
+from tests import EXAMPLE_AMI_ID
 from tests.helpers import requires_boto_gte
 
 
@@ -408,7 +409,7 @@ def test_routes_replace():
     # Various route targets
     igw = conn.create_internet_gateway()
 
-    reservation = conn.run_instances("ami-1234abcd")
+    reservation = conn.run_instances(EXAMPLE_AMI_ID)
     instance = reservation.instances[0]
 
     # Create initial route

--- a/tests/test_ec2/test_server.py
+++ b/tests/test_ec2/test_server.py
@@ -3,6 +3,7 @@ import re
 import sure  # noqa
 
 import moto.server as server
+from tests import EXAMPLE_AMI_ID
 
 """
 Test the different server responses
@@ -14,7 +15,7 @@ def test_ec2_server_get():
     test_client = backend.test_client()
 
     res = test_client.get(
-        "/?Action=RunInstances&ImageId=ami-60a54009",
+        "/?Action=RunInstances&ImageId=" + EXAMPLE_AMI_ID,
         headers={"Host": "ec2.us-east-1.amazonaws.com"},
     )
 

--- a/tests/test_ec2/test_spot_fleet.py
+++ b/tests/test_ec2/test_spot_fleet.py
@@ -5,6 +5,7 @@ import sure  # noqa
 
 from moto import mock_ec2
 from moto.core import ACCOUNT_ID
+from tests import EXAMPLE_AMI_ID
 
 
 def get_subnet_id(conn):
@@ -24,7 +25,7 @@ def spot_config(subnet_id, allocation_strategy="lowestPrice"):
         "IamFleetRole": "arn:aws:iam::{}:role/fleet".format(ACCOUNT_ID),
         "LaunchSpecifications": [
             {
-                "ImageId": "ami-123",
+                "ImageId": EXAMPLE_AMI_ID,
                 "KeyName": "my-key",
                 "SecurityGroups": [{"GroupId": "sg-123"}],
                 "UserData": "some user data",
@@ -54,7 +55,7 @@ def spot_config(subnet_id, allocation_strategy="lowestPrice"):
                 "SpotPrice": "0.13",
             },
             {
-                "ImageId": "ami-123",
+                "ImageId": EXAMPLE_AMI_ID,
                 "KeyName": "my-key",
                 "SecurityGroups": [{"GroupId": "sg-123"}],
                 "UserData": "some user data",
@@ -108,7 +109,7 @@ def test_create_spot_fleet_with_lowest_price():
     launch_spec["IamInstanceProfile"].should.equal(
         {"Arn": "arn:aws:iam::{}:role/fleet".format(ACCOUNT_ID)}
     )
-    launch_spec["ImageId"].should.equal("ami-123")
+    launch_spec["ImageId"].should.equal(EXAMPLE_AMI_ID)
     launch_spec["InstanceType"].should.equal("t2.small")
     launch_spec["KeyName"].should.equal("my-key")
     launch_spec["Monitoring"].should.equal({"Enabled": True})

--- a/tests/test_ec2/test_spot_instances.py
+++ b/tests/test_ec2/test_spot_instances.py
@@ -12,6 +12,7 @@ import sure  # noqa
 from moto import mock_ec2, mock_ec2_deprecated, settings
 from moto.ec2.models import ec2_backends
 from moto.core.utils import iso_8601_datetime_with_milliseconds
+from tests import EXAMPLE_AMI_ID
 
 
 @mock_ec2
@@ -41,7 +42,7 @@ def test_request_spot_instances():
             LaunchGroup="the-group",
             AvailabilityZoneGroup="my-group",
             LaunchSpecification={
-                "ImageId": "ami-abcd1234",
+                "ImageId": EXAMPLE_AMI_ID,
                 "KeyName": "test",
                 "SecurityGroups": ["group1", "group2"],
                 "UserData": "some test data",
@@ -69,7 +70,7 @@ def test_request_spot_instances():
         LaunchGroup="the-group",
         AvailabilityZoneGroup="my-group",
         LaunchSpecification={
-            "ImageId": "ami-abcd1234",
+            "ImageId": EXAMPLE_AMI_ID,
             "KeyName": "test",
             "SecurityGroups": ["group1", "group2"],
             "UserData": "some test data",
@@ -100,7 +101,7 @@ def test_request_spot_instances():
     ]
     set(security_group_names).should.equal(set(["group1", "group2"]))
 
-    launch_spec["ImageId"].should.equal("ami-abcd1234")
+    launch_spec["ImageId"].should.equal(EXAMPLE_AMI_ID)
     launch_spec["KeyName"].should.equal("test")
     launch_spec["InstanceType"].should.equal("m1.small")
     launch_spec["KernelId"].should.equal("test-kernel")
@@ -116,7 +117,7 @@ def test_request_spot_instances_default_arguments():
     conn = boto3.client("ec2", "us-east-1")
 
     request = conn.request_spot_instances(
-        SpotPrice="0.5", LaunchSpecification={"ImageId": "ami-abcd1234"}
+        SpotPrice="0.5", LaunchSpecification={"ImageId": EXAMPLE_AMI_ID}
     )
 
     requests = conn.describe_spot_instance_requests()["SpotInstanceRequests"]
@@ -138,7 +139,7 @@ def test_request_spot_instances_default_arguments():
     ]
     security_group_names.should.equal(["default"])
 
-    launch_spec["ImageId"].should.equal("ami-abcd1234")
+    launch_spec["ImageId"].should.equal(EXAMPLE_AMI_ID)
     request.shouldnt.contain("KeyName")
     launch_spec["InstanceType"].should.equal("m1.small")
     request.shouldnt.contain("KernelId")
@@ -150,7 +151,7 @@ def test_request_spot_instances_default_arguments():
 def test_cancel_spot_instance_request():
     conn = boto.connect_ec2()
 
-    conn.request_spot_instances(price=0.5, image_id="ami-abcd1234")
+    conn.request_spot_instances(price=0.5, image_id=EXAMPLE_AMI_ID)
 
     requests = conn.get_all_spot_instance_requests()
     requests.should.have.length_of(1)
@@ -176,7 +177,7 @@ def test_request_spot_instances_fulfilled():
     """
     conn = boto.ec2.connect_to_region("us-east-1")
 
-    request = conn.request_spot_instances(price=0.5, image_id="ami-abcd1234")
+    request = conn.request_spot_instances(price=0.5, image_id=EXAMPLE_AMI_ID)
 
     requests = conn.get_all_spot_instance_requests()
     requests.should.have.length_of(1)
@@ -201,7 +202,7 @@ def test_tag_spot_instance_request():
     """
     conn = boto.connect_ec2()
 
-    request = conn.request_spot_instances(price=0.5, image_id="ami-abcd1234")
+    request = conn.request_spot_instances(price=0.5, image_id=EXAMPLE_AMI_ID)
     request[0].add_tag("tag1", "value1")
     request[0].add_tag("tag2", "value2")
 
@@ -220,9 +221,9 @@ def test_get_all_spot_instance_requests_filtering():
     """
     conn = boto.connect_ec2()
 
-    request1 = conn.request_spot_instances(price=0.5, image_id="ami-abcd1234")
-    request2 = conn.request_spot_instances(price=0.5, image_id="ami-abcd1234")
-    conn.request_spot_instances(price=0.5, image_id="ami-abcd1234")
+    request1 = conn.request_spot_instances(price=0.5, image_id=EXAMPLE_AMI_ID)
+    request2 = conn.request_spot_instances(price=0.5, image_id=EXAMPLE_AMI_ID)
+    conn.request_spot_instances(price=0.5, image_id=EXAMPLE_AMI_ID)
     request1[0].add_tag("tag1", "value1")
     request1[0].add_tag("tag2", "value2")
     request2[0].add_tag("tag1", "value1")
@@ -246,7 +247,7 @@ def test_get_all_spot_instance_requests_filtering():
 @mock_ec2_deprecated
 def test_request_spot_instances_setting_instance_id():
     conn = boto.ec2.connect_to_region("us-east-1")
-    request = conn.request_spot_instances(price=0.5, image_id="ami-abcd1234")
+    request = conn.request_spot_instances(price=0.5, image_id=EXAMPLE_AMI_ID)
 
     if not settings.TEST_SERVER_MODE:
         req = ec2_backends["us-east-1"].spot_instance_requests[request[0].id]

--- a/tests/test_ec2/test_subnets.py
+++ b/tests/test_ec2/test_subnets.py
@@ -12,6 +12,7 @@ import sure  # noqa
 from boto.exception import EC2ResponseError
 from botocore.exceptions import ClientError, ParamValidationError
 from moto import mock_ec2, mock_ec2_deprecated
+from tests import EXAMPLE_AMI_ID
 
 
 @mock_ec2_deprecated
@@ -661,7 +662,9 @@ def test_run_instances_should_attach_to_default_subnet():
     client = boto3.client("ec2", region_name="us-west-1")
     ec2.create_security_group(GroupName="sg01", Description="Test security group sg01")
     # run_instances
-    instances = client.run_instances(MinCount=1, MaxCount=1, SecurityGroups=["sg01"],)
+    instances = client.run_instances(
+        ImageId=EXAMPLE_AMI_ID, MinCount=1, MaxCount=1, SecurityGroups=["sg01"],
+    )
     # Assert subnet is created appropriately
     subnets = client.describe_subnets()["Subnets"]
     default_subnet_id = subnets[0]["SubnetId"]

--- a/tests/test_ec2/test_tags.py
+++ b/tests/test_ec2/test_tags.py
@@ -12,12 +12,13 @@ import sure  # noqa
 
 from moto import mock_ec2_deprecated, mock_ec2
 import pytest
+from tests import EXAMPLE_AMI_ID
 
 
 @mock_ec2_deprecated
 def test_add_tag():
     conn = boto.connect_ec2("the_key", "the_secret")
-    reservation = conn.run_instances("ami-1234abcd")
+    reservation = conn.run_instances(EXAMPLE_AMI_ID)
     instance = reservation.instances[0]
 
     with pytest.raises(EC2ResponseError) as ex:
@@ -41,7 +42,7 @@ def test_add_tag():
 @mock_ec2_deprecated
 def test_remove_tag():
     conn = boto.connect_ec2("the_key", "the_secret")
-    reservation = conn.run_instances("ami-1234abcd")
+    reservation = conn.run_instances(EXAMPLE_AMI_ID)
     instance = reservation.instances[0]
 
     instance.add_tag("a key", "some value")
@@ -70,7 +71,7 @@ def test_remove_tag():
 @mock_ec2_deprecated
 def test_get_all_tags():
     conn = boto.connect_ec2("the_key", "the_secret")
-    reservation = conn.run_instances("ami-1234abcd")
+    reservation = conn.run_instances(EXAMPLE_AMI_ID)
     instance = reservation.instances[0]
 
     instance.add_tag("a key", "some value")
@@ -84,7 +85,7 @@ def test_get_all_tags():
 @mock_ec2_deprecated
 def test_get_all_tags_with_special_characters():
     conn = boto.connect_ec2("the_key", "the_secret")
-    reservation = conn.run_instances("ami-1234abcd")
+    reservation = conn.run_instances(EXAMPLE_AMI_ID)
     instance = reservation.instances[0]
 
     instance.add_tag("a key", "some<> value")
@@ -98,7 +99,7 @@ def test_get_all_tags_with_special_characters():
 @mock_ec2_deprecated
 def test_create_tags():
     conn = boto.connect_ec2("the_key", "the_secret")
-    reservation = conn.run_instances("ami-1234abcd")
+    reservation = conn.run_instances(EXAMPLE_AMI_ID)
     instance = reservation.instances[0]
     tag_dict = {
         "a key": "some value",
@@ -125,7 +126,7 @@ def test_create_tags():
 @mock_ec2_deprecated
 def test_tag_limit_exceeded():
     conn = boto.connect_ec2("the_key", "the_secret")
-    reservation = conn.run_instances("ami-1234abcd")
+    reservation = conn.run_instances(EXAMPLE_AMI_ID)
     instance = reservation.instances[0]
     tag_dict = {}
     for i in range(51):
@@ -154,7 +155,7 @@ def test_tag_limit_exceeded():
 @mock_ec2_deprecated
 def test_invalid_parameter_tag_null():
     conn = boto.connect_ec2("the_key", "the_secret")
-    reservation = conn.run_instances("ami-1234abcd")
+    reservation = conn.run_instances(EXAMPLE_AMI_ID)
     instance = reservation.instances[0]
 
     with pytest.raises(EC2ResponseError) as cm:
@@ -183,7 +184,7 @@ def test_invalid_id():
 @mock_ec2_deprecated
 def test_get_all_tags_resource_id_filter():
     conn = boto.connect_ec2("the_key", "the_secret")
-    reservation = conn.run_instances("ami-1234abcd")
+    reservation = conn.run_instances(EXAMPLE_AMI_ID)
     instance = reservation.instances[0]
     instance.add_tag("an instance key", "some value")
     image_id = conn.create_image(instance.id, "test-ami", "this is a test ami")
@@ -210,7 +211,7 @@ def test_get_all_tags_resource_id_filter():
 @mock_ec2_deprecated
 def test_get_all_tags_resource_type_filter():
     conn = boto.connect_ec2("the_key", "the_secret")
-    reservation = conn.run_instances("ami-1234abcd")
+    reservation = conn.run_instances(EXAMPLE_AMI_ID)
     instance = reservation.instances[0]
     instance.add_tag("an instance key", "some value")
     image_id = conn.create_image(instance.id, "test-ami", "this is a test ami")
@@ -237,7 +238,7 @@ def test_get_all_tags_resource_type_filter():
 @mock_ec2_deprecated
 def test_get_all_tags_key_filter():
     conn = boto.connect_ec2("the_key", "the_secret")
-    reservation = conn.run_instances("ami-1234abcd")
+    reservation = conn.run_instances(EXAMPLE_AMI_ID)
     instance = reservation.instances[0]
     instance.add_tag("an instance key", "some value")
     image_id = conn.create_image(instance.id, "test-ami", "this is a test ami")
@@ -256,19 +257,19 @@ def test_get_all_tags_key_filter():
 @mock_ec2_deprecated
 def test_get_all_tags_value_filter():
     conn = boto.connect_ec2("the_key", "the_secret")
-    reservation = conn.run_instances("ami-1234abcd")
+    reservation = conn.run_instances(EXAMPLE_AMI_ID)
     instance = reservation.instances[0]
     instance.add_tag("an instance key", "some value")
-    reservation_b = conn.run_instances("ami-1234abcd")
+    reservation_b = conn.run_instances(EXAMPLE_AMI_ID)
     instance_b = reservation_b.instances[0]
     instance_b.add_tag("an instance key", "some other value")
-    reservation_c = conn.run_instances("ami-1234abcd")
+    reservation_c = conn.run_instances(EXAMPLE_AMI_ID)
     instance_c = reservation_c.instances[0]
     instance_c.add_tag("an instance key", "other value*")
-    reservation_d = conn.run_instances("ami-1234abcd")
+    reservation_d = conn.run_instances(EXAMPLE_AMI_ID)
     instance_d = reservation_d.instances[0]
     instance_d.add_tag("an instance key", "other value**")
-    reservation_e = conn.run_instances("ami-1234abcd")
+    reservation_e = conn.run_instances(EXAMPLE_AMI_ID)
     instance_e = reservation_e.instances[0]
     instance_e.add_tag("an instance key", "other value*?")
     image_id = conn.create_image(instance.id, "test-ami", "this is a test ami")
@@ -304,7 +305,7 @@ def test_retrieved_instances_must_contain_their_tags():
     tags_to_be_set = {tag_key: tag_value}
 
     conn = boto.connect_ec2("the_key", "the_secret")
-    reservation = conn.run_instances("ami-1234abcd")
+    reservation = conn.run_instances(EXAMPLE_AMI_ID)
     reservation.should.be.a(Reservation)
     reservation.instances.should.have.length_of(1)
     instance = reservation.instances[0]
@@ -380,10 +381,10 @@ def test_filter_instances_by_wildcard_tags():
     conn = boto.connect_ec2(
         aws_access_key_id="the_key", aws_secret_access_key="the_secret"
     )
-    reservation = conn.run_instances("ami-1234abcd")
+    reservation = conn.run_instances(EXAMPLE_AMI_ID)
     instance_a = reservation.instances[0]
     instance_a.add_tag("Key1", "Value1")
-    reservation_b = conn.run_instances("ami-1234abcd")
+    reservation_b = conn.run_instances(EXAMPLE_AMI_ID)
     instance_b = reservation_b.instances[0]
     instance_b.add_tag("Key1", "Value2")
 
@@ -473,7 +474,7 @@ def test_delete_tag_empty_resource():
 @mock_ec2
 def test_retrieve_resource_with_multiple_tags():
     ec2 = boto3.resource("ec2", region_name="us-west-1")
-    blue, green = ec2.create_instances(ImageId="ANY_ID", MinCount=2, MaxCount=2)
+    blue, green = ec2.create_instances(ImageId=EXAMPLE_AMI_ID, MinCount=2, MaxCount=2)
     ec2.create_tags(
         Resources=[blue.instance_id],
         Tags=[

--- a/tests/test_ecs/test_ecs_boto3.py
+++ b/tests/test_ecs/test_ecs_boto3.py
@@ -18,6 +18,7 @@ from moto.ecs.exceptions import (
     RevisionNotFoundException,
 )
 import pytest
+from tests import EXAMPLE_AMI_ID
 
 
 @mock_ecs
@@ -846,7 +847,7 @@ def test_register_container_instance():
     _ = ecs_client.create_cluster(clusterName=test_cluster_name)
 
     test_instance = ec2.create_instances(
-        ImageId="ami-1234abcd", MinCount=1, MaxCount=1
+        ImageId=EXAMPLE_AMI_ID, MinCount=1, MaxCount=1
     )[0]
 
     instance_id_document = json.dumps(
@@ -884,7 +885,7 @@ def test_deregister_container_instance():
     _ = ecs_client.create_cluster(clusterName=test_cluster_name)
 
     test_instance = ec2.create_instances(
-        ImageId="ami-1234abcd", MinCount=1, MaxCount=1
+        ImageId=EXAMPLE_AMI_ID, MinCount=1, MaxCount=1
     )[0]
 
     instance_id_document = json.dumps(
@@ -961,7 +962,7 @@ def test_list_container_instances():
     test_instance_arns = []
     for i in range(0, instance_to_create):
         test_instance = ec2.create_instances(
-            ImageId="ami-1234abcd", MinCount=1, MaxCount=1
+            ImageId=EXAMPLE_AMI_ID, MinCount=1, MaxCount=1
         )[0]
 
         instance_id_document = json.dumps(
@@ -994,7 +995,7 @@ def test_describe_container_instances():
     test_instance_arns = []
     for i in range(0, instance_to_create):
         test_instance = ec2.create_instances(
-            ImageId="ami-1234abcd", MinCount=1, MaxCount=1
+            ImageId=EXAMPLE_AMI_ID, MinCount=1, MaxCount=1
         )[0]
 
         instance_id_document = json.dumps(
@@ -1059,7 +1060,7 @@ def test_update_container_instances_state():
     test_instance_arns = []
     for i in range(0, instance_to_create):
         test_instance = ec2.create_instances(
-            ImageId="ami-1234abcd", MinCount=1, MaxCount=1
+            ImageId=EXAMPLE_AMI_ID, MinCount=1, MaxCount=1
         )[0]
 
         instance_id_document = json.dumps(
@@ -1121,7 +1122,7 @@ def test_update_container_instances_state_by_arn():
     test_instance_arns = []
     for i in range(0, instance_to_create):
         test_instance = ec2.create_instances(
-            ImageId="ami-1234abcd", MinCount=1, MaxCount=1
+            ImageId=EXAMPLE_AMI_ID, MinCount=1, MaxCount=1
         )[0]
 
         instance_id_document = json.dumps(
@@ -1182,7 +1183,7 @@ def test_run_task():
     _ = client.create_cluster(clusterName=test_cluster_name)
 
     test_instance = ec2.create_instances(
-        ImageId="ami-1234abcd", MinCount=1, MaxCount=1
+        ImageId=EXAMPLE_AMI_ID, MinCount=1, MaxCount=1
     )[0]
 
     instance_id_document = json.dumps(
@@ -1247,7 +1248,7 @@ def test_run_task_default_cluster():
     _ = client.create_cluster(clusterName=test_cluster_name)
 
     test_instance = ec2.create_instances(
-        ImageId="ami-1234abcd", MinCount=1, MaxCount=1
+        ImageId=EXAMPLE_AMI_ID, MinCount=1, MaxCount=1
     )[0]
 
     instance_id_document = json.dumps(
@@ -1332,7 +1333,7 @@ def test_start_task():
     _ = client.create_cluster(clusterName=test_cluster_name)
 
     test_instance = ec2.create_instances(
-        ImageId="ami-1234abcd", MinCount=1, MaxCount=1
+        ImageId=EXAMPLE_AMI_ID, MinCount=1, MaxCount=1
     )[0]
 
     instance_id_document = json.dumps(
@@ -1431,7 +1432,7 @@ def test_list_tasks():
     _ = client.create_cluster()
 
     test_instance = ec2.create_instances(
-        ImageId="ami-1234abcd", MinCount=1, MaxCount=1
+        ImageId=EXAMPLE_AMI_ID, MinCount=1, MaxCount=1
     )[0]
 
     instance_id_document = json.dumps(
@@ -1501,7 +1502,7 @@ def test_describe_tasks():
     _ = client.create_cluster(clusterName=test_cluster_name)
 
     test_instance = ec2.create_instances(
-        ImageId="ami-1234abcd", MinCount=1, MaxCount=1
+        ImageId=EXAMPLE_AMI_ID, MinCount=1, MaxCount=1
     )[0]
 
     instance_id_document = json.dumps(
@@ -1601,7 +1602,7 @@ def test_stop_task():
     _ = client.create_cluster(clusterName=test_cluster_name)
 
     test_instance = ec2.create_instances(
-        ImageId="ami-1234abcd", MinCount=1, MaxCount=1
+        ImageId=EXAMPLE_AMI_ID, MinCount=1, MaxCount=1
     )[0]
 
     instance_id_document = json.dumps(
@@ -1669,7 +1670,7 @@ def test_resource_reservation_and_release():
     _ = client.create_cluster(clusterName=test_cluster_name)
 
     test_instance = ec2.create_instances(
-        ImageId="ami-1234abcd", MinCount=1, MaxCount=1
+        ImageId=EXAMPLE_AMI_ID, MinCount=1, MaxCount=1
     )[0]
 
     instance_id_document = json.dumps(
@@ -1744,7 +1745,7 @@ def test_resource_reservation_and_release_memory_reservation():
     _ = client.create_cluster(clusterName=test_cluster_name)
 
     test_instance = ec2.create_instances(
-        ImageId="ami-1234abcd", MinCount=1, MaxCount=1
+        ImageId=EXAMPLE_AMI_ID, MinCount=1, MaxCount=1
     )[0]
 
     instance_id_document = json.dumps(
@@ -1817,7 +1818,7 @@ def test_task_definitions_unable_to_be_placed():
     _ = client.create_cluster(clusterName=test_cluster_name)
 
     test_instance = ec2.create_instances(
-        ImageId="ami-1234abcd", MinCount=1, MaxCount=1
+        ImageId=EXAMPLE_AMI_ID, MinCount=1, MaxCount=1
     )[0]
 
     instance_id_document = json.dumps(
@@ -1865,7 +1866,7 @@ def test_task_definitions_with_port_clash():
     _ = client.create_cluster(clusterName=test_cluster_name)
 
     test_instance = ec2.create_instances(
-        ImageId="ami-1234abcd", MinCount=1, MaxCount=1
+        ImageId=EXAMPLE_AMI_ID, MinCount=1, MaxCount=1
     )[0]
 
     instance_id_document = json.dumps(
@@ -1933,7 +1934,7 @@ def test_attributes():
 
     instances = []
     test_instance = ec2.create_instances(
-        ImageId="ami-1234abcd", MinCount=1, MaxCount=1
+        ImageId=EXAMPLE_AMI_ID, MinCount=1, MaxCount=1
     )[0]
     instances.append(test_instance)
 
@@ -1949,7 +1950,7 @@ def test_attributes():
     full_arn1 = response["containerInstance"]["containerInstanceArn"]
 
     test_instance = ec2.create_instances(
-        ImageId="ami-1234abcd", MinCount=1, MaxCount=1
+        ImageId=EXAMPLE_AMI_ID, MinCount=1, MaxCount=1
     )[0]
     instances.append(test_instance)
 
@@ -2094,7 +2095,7 @@ def test_default_container_instance_attributes():
     _ = ecs_client.create_cluster(clusterName=test_cluster_name)
 
     test_instance = ec2.create_instances(
-        ImageId="ami-1234abcd", MinCount=1, MaxCount=1
+        ImageId=EXAMPLE_AMI_ID, MinCount=1, MaxCount=1
     )[0]
 
     instance_id_document = json.dumps(
@@ -2138,7 +2139,7 @@ def test_describe_container_instances_with_attributes():
     _ = ecs_client.create_cluster(clusterName=test_cluster_name)
 
     test_instance = ec2.create_instances(
-        ImageId="ami-1234abcd", MinCount=1, MaxCount=1
+        ImageId=EXAMPLE_AMI_ID, MinCount=1, MaxCount=1
     )[0]
 
     instance_id_document = json.dumps(
@@ -2904,7 +2905,7 @@ def test_list_tasks_with_filters():
     _ = ecs.create_cluster(clusterName="test_cluster_2")
 
     test_instance = ec2.create_instances(
-        ImageId="ami-1234abcd", MinCount=1, MaxCount=1
+        ImageId=EXAMPLE_AMI_ID, MinCount=1, MaxCount=1
     )[0]
 
     instance_id_document = json.dumps(

--- a/tests/test_resourcegroupstaggingapi/test_resourcegroupstaggingapi.py
+++ b/tests/test_resourcegroupstaggingapi/test_resourcegroupstaggingapi.py
@@ -7,6 +7,7 @@ from moto import mock_elbv2
 from moto import mock_kms
 from moto import mock_resourcegroupstaggingapi
 from moto import mock_s3
+from tests import EXAMPLE_AMI_ID, EXAMPLE_AMI_ID2
 
 
 @mock_ec2
@@ -15,7 +16,7 @@ def test_get_resources_ec2():
     client = boto3.client("ec2", region_name="eu-central-1")
 
     instances = client.run_instances(
-        ImageId="ami-123",
+        ImageId=EXAMPLE_AMI_ID,
         MinCount=1,
         MaxCount=1,
         InstanceType="t2.micro",
@@ -88,7 +89,7 @@ def test_get_tag_keys_ec2():
     client = boto3.client("ec2", region_name="eu-central-1")
 
     client.run_instances(
-        ImageId="ami-123",
+        ImageId=EXAMPLE_AMI_ID,
         MinCount=1,
         MaxCount=1,
         InstanceType="t2.micro",
@@ -123,7 +124,7 @@ def test_get_tag_values_ec2():
     client = boto3.client("ec2", region_name="eu-central-1")
 
     client.run_instances(
-        ImageId="ami-123",
+        ImageId=EXAMPLE_AMI_ID,
         MinCount=1,
         MaxCount=1,
         InstanceType="t2.micro",
@@ -142,7 +143,7 @@ def test_get_tag_values_ec2():
         ],
     )
     client.run_instances(
-        ImageId="ami-123",
+        ImageId=EXAMPLE_AMI_ID,
         MinCount=1,
         MaxCount=1,
         InstanceType="t2.micro",
@@ -322,7 +323,7 @@ def test_multiple_tag_filters():
     client = boto3.client("ec2", region_name="eu-central-1")
 
     resp = client.run_instances(
-        ImageId="ami-123",
+        ImageId=EXAMPLE_AMI_ID,
         MinCount=1,
         MaxCount=1,
         InstanceType="t2.micro",
@@ -343,7 +344,7 @@ def test_multiple_tag_filters():
     instance_1_id = resp["Instances"][0]["InstanceId"]
 
     resp = client.run_instances(
-        ImageId="ami-456",
+        ImageId=EXAMPLE_AMI_ID2,
         MinCount=1,
         MaxCount=1,
         InstanceType="t2.micro",


### PR DESCRIPTION
Unknown image ID's would show this warning:
`PendingDeprecationWarning: Could not find AMI with image-id:ami-123456, in the near future this will cause an error.\nUse ec2_backend.describe_images() to find suitable image for your test`

The build log was completely full of warnings like this.
Not all warnings are gone with this change, but it's a start.