### PR TITLE
Run tests in parallel

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ test-only:
 test-coverage:
 	rm -f .coverage
 	rm -rf cover
-	pytest -sv --cov=moto --cov-report xml ./tests/ $(TEST_EXCLUDE)
+	pytest -n=4 --dist loadfile -sv --cov=moto --cov-report xml ./tests/ $(TEST_EXCLUDE)
 
 test: lint test-only
 

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -1,4 +1,5 @@
 pytest
 pytest-cov
+pytest-xdist
 sure==1.4.11
 freezegun


### PR DESCRIPTION
Improve test performance by running tests in parallel.
(Server mode still runs sequentially, as the reset()-method is not threadsafe)

Runs 4 processes/cores in parallel, [as suggested by Travis](https://docs.travis-ci.com/user/common-build-problems/#parallel-processes).


(TravisCI has been a little finicky lately, so this will probably fail initially.. but at least it fails quickly? ¯\_(ツ)_/¯)