### PR TITLE
Added explicit exception raise when no stack found.

### DIFF
--- a/moto/cloudformation/models.py
+++ b/moto/cloudformation/models.py
@@ -707,6 +707,7 @@ class CloudFormationBackend(BaseBackend):
             for stack in self.stacks.values():
                 if stack.name == name_or_stack_id:
                     return stack
+            raise ValidationError(name_or_stack_id)
 
     def update_stack(self, name, template, role_arn=None, parameters=None, tags=None):
         stack = self.get_stack(name)

--- a/moto/cloudformation/models.py
+++ b/moto/cloudformation/models.py
@@ -716,8 +716,6 @@ class CloudFormationBackend(BaseBackend):
 
     def list_stack_resources(self, stack_name_or_id):
         stack = self.get_stack(stack_name_or_id)
-        if stack is None:
-            return None
         return stack.stack_resources
 
     def delete_stack(self, name_or_stack_id):

--- a/moto/cloudformation/responses.py
+++ b/moto/cloudformation/responses.py
@@ -265,9 +265,6 @@ class CloudFormationResponse(BaseResponse):
         stack_name_or_id = self._get_param("StackName")
         resources = self.cloudformation_backend.list_stack_resources(stack_name_or_id)
 
-        if resources is None:
-            raise ValidationError(stack_name_or_id)
-
         template = self.response_template(LIST_STACKS_RESOURCES_RESPONSE)
         return template.render(resources=resources)
 

--- a/moto/cloudformation/responses.py
+++ b/moto/cloudformation/responses.py
@@ -232,8 +232,6 @@ class CloudFormationResponse(BaseResponse):
             if stack_resource.logical_resource_id == logical_resource_id:
                 resource = stack_resource
                 break
-        else:
-            raise ValidationError(logical_resource_id)
 
         template = self.response_template(DESCRIBE_STACK_RESOURCE_RESPONSE_TEMPLATE)
         return template.render(stack=stack, resource=resource)

--- a/tests/test_cloudformation/test_cloudformation_stack_crud.py
+++ b/tests/test_cloudformation/test_cloudformation_stack_crud.py
@@ -446,6 +446,9 @@ def test_update_stack_with_previous_template():
     conn.create_stack("test_stack", template_body=dummy_template_json)
     conn.update_stack("test_stack", use_previous_template=True)
 
+    with pytest.raises(BotoServerError):
+        conn.update_stack("non_existing_stack", use_previous_template=True)
+
     stack = conn.describe_stacks()[0]
     stack.stack_status.should.equal("UPDATE_COMPLETE")
     stack.get_template().should.equal(

--- a/tests/test_cloudformation/test_cloudformation_stack_crud.py
+++ b/tests/test_cloudformation/test_cloudformation_stack_crud.py
@@ -446,9 +446,6 @@ def test_update_stack_with_previous_template():
     conn.create_stack("test_stack", template_body=dummy_template_json)
     conn.update_stack("test_stack", use_previous_template=True)
 
-    with pytest.raises(BotoServerError):
-        conn.update_stack("non_existing_stack", use_previous_template=True)
-
     stack = conn.describe_stacks()[0]
     stack.stack_status.should.equal("UPDATE_COMPLETE")
     stack.get_template().should.equal(
@@ -570,6 +567,9 @@ def test_describe_stack_events_shows_create_update_and_delete():
                     event.resource_status_reason.should.equal(reason_to_look_for)
     except StopIteration:
         assert False, "Too many stack events"
+
+    with pytest.raises(BotoServerError):
+        conn.describe_stack_events("non_existing_stack")
 
     list(stack_events_to_look_for).should.be.empty
 

--- a/tests/test_cloudformation/test_cloudformation_stack_crud.py
+++ b/tests/test_cloudformation/test_cloudformation_stack_crud.py
@@ -568,10 +568,16 @@ def test_describe_stack_events_shows_create_update_and_delete():
     except StopIteration:
         assert False, "Too many stack events"
 
-    with pytest.raises(BotoServerError):
-        conn.describe_stack_events("non_existing_stack")
-
     list(stack_events_to_look_for).should.be.empty
+
+    with pytest.raises(BotoServerError) as exp:
+        conn.describe_stack_events("non_existing_stack")
+    err = exp.value
+    err.message.should.equal("Stack with id non_existing_stack does not exist")
+    err.body.should.match(r"Stack with id non_existing_stack does not exist")
+    err.error_code.should.equal("ValidationError")
+    err.reason.should.equal("Bad Request")
+    err.status.should.equal(400)
 
 
 @mock_cloudformation_deprecated

--- a/tests/test_cloudformation/test_cloudformation_stack_crud_boto3.py
+++ b/tests/test_cloudformation/test_cloudformation_stack_crud_boto3.py
@@ -255,9 +255,6 @@ def test_boto3_filter_stacks():
     conn.create_stack(StackName="test_stack2", TemplateBody=dummy_template_json)
     conn.update_stack(StackName="test_stack", TemplateBody=dummy_template_json2)
 
-    with pytest.raises(ClientError):
-        conn.update_stack(StackName="non_existing_stack", TemplateBody=dummy_template_json2)
-
     stacks = conn.list_stacks(StackStatusFilter=["CREATE_COMPLETE"])
     stacks.get("StackSummaries").should.have.length_of(1)
     stacks = conn.list_stacks(StackStatusFilter=["UPDATE_COMPLETE"])
@@ -1309,6 +1306,10 @@ def test_stack_events():
                     event.resource_status_reason.should.equal(reason_to_look_for)
     except StopIteration:
         assert False, "Too many stack events"
+
+    with pytest.raises(ClientError):
+        stack = cf.Stack('non_existing_stack')
+        events = list(stack.events.all())
 
     list(stack_events_to_look_for).should.be.empty
 

--- a/tests/test_cloudformation/test_cloudformation_stack_crud_boto3.py
+++ b/tests/test_cloudformation/test_cloudformation_stack_crud_boto3.py
@@ -254,6 +254,10 @@ def test_boto3_filter_stacks():
     conn.create_stack(StackName="test_stack", TemplateBody=dummy_template_json)
     conn.create_stack(StackName="test_stack2", TemplateBody=dummy_template_json)
     conn.update_stack(StackName="test_stack", TemplateBody=dummy_template_json2)
+
+    with pytest.raises(ClientError):
+        conn.update_stack(StackName="non_existing_stack", TemplateBody=dummy_template_json2)
+
     stacks = conn.list_stacks(StackStatusFilter=["CREATE_COMPLETE"])
     stacks.get("StackSummaries").should.have.length_of(1)
     stacks = conn.list_stacks(StackStatusFilter=["UPDATE_COMPLETE"])

--- a/tests/test_cloudformation/test_cloudformation_stack_crud_boto3.py
+++ b/tests/test_cloudformation/test_cloudformation_stack_crud_boto3.py
@@ -318,7 +318,10 @@ def test_boto3_describe_stack_set_operation():
 
     response["StackSetOperation"]["Status"].should.equal("STOPPED")
     response["StackSetOperation"]["Action"].should.equal("CREATE")
-
+    with pytest.raises(ClientError):
+        cf_conn.describe_stack_set_operation(
+            StackSetName="test_stack_set", OperationId='non_existing_operation'
+        )
 
 @mock_cloudformation
 def test_boto3_list_stack_set_operation_results():
@@ -1135,6 +1138,17 @@ def test_delete_change_set():
     cf_conn.list_change_sets(StackName="NewStack")["Summaries"].should.have.length_of(1)
     cf_conn.delete_change_set(ChangeSetName="NewChangeSet", StackName="NewStack")
     cf_conn.list_change_sets(StackName="NewStack")["Summaries"].should.have.length_of(0)
+
+    # Testing deletion by arn
+    result = cf_conn.create_change_set(
+        StackName="NewStack",
+        TemplateBody=dummy_template_json,
+        ChangeSetName="NewChangeSet1",
+        ChangeSetType="CREATE",
+    )
+    cf_conn.delete_change_set(ChangeSetName=result.get('Id'), StackName="NewStack")
+    cf_conn.list_change_sets(StackName="NewStack")["Summaries"].should.have.length_of(0)
+
 
 
 @mock_cloudformation

--- a/tests/test_cloudformation/test_cloudformation_stack_crud_boto3.py
+++ b/tests/test_cloudformation/test_cloudformation_stack_crud_boto3.py
@@ -320,14 +320,17 @@ def test_boto3_describe_stack_set_operation():
     response["StackSetOperation"]["Action"].should.equal("CREATE")
     with pytest.raises(ClientError) as exp:
         cf_conn.describe_stack_set_operation(
-            StackSetName="test_stack_set", OperationId='non_existing_operation'
+            StackSetName="test_stack_set", OperationId="non_existing_operation"
         )
     exp_err = exp.value.response.get("Error")
     exp_metadata = exp.value.response.get("ResponseMetadata")
 
     exp_err.get("Code").should.match(r"ValidationError")
-    exp_err.get("Message").should.match(r"Stack with id non_existing_operation does not exist")
+    exp_err.get("Message").should.match(
+        r"Stack with id non_existing_operation does not exist"
+    )
     exp_metadata.get("HTTPStatusCode").should.equal(400)
+
 
 @mock_cloudformation
 def test_boto3_list_stack_set_operation_results():
@@ -1152,9 +1155,8 @@ def test_delete_change_set():
         ChangeSetName="NewChangeSet1",
         ChangeSetType="CREATE",
     )
-    cf_conn.delete_change_set(ChangeSetName=result.get('Id'), StackName="NewStack")
+    cf_conn.delete_change_set(ChangeSetName=result.get("Id"), StackName="NewStack")
     cf_conn.list_change_sets(StackName="NewStack")["Summaries"].should.have.length_of(0)
-
 
 
 @mock_cloudformation
@@ -1330,15 +1332,18 @@ def test_stack_events():
     list(stack_events_to_look_for).should.be.empty
 
     with pytest.raises(ClientError) as exp:
-        stack = cf.Stack('non_existing_stack')
+        stack = cf.Stack("non_existing_stack")
         events = list(stack.events.all())
 
     exp_err = exp.value.response.get("Error")
     exp_metadata = exp.value.response.get("ResponseMetadata")
 
     exp_err.get("Code").should.match(r"ValidationError")
-    exp_err.get("Message").should.match(r"Stack with id non_existing_stack does not exist")
+    exp_err.get("Message").should.match(
+        r"Stack with id non_existing_stack does not exist"
+    )
     exp_metadata.get("HTTPStatusCode").should.equal(400)
+
 
 @mock_cloudformation
 def test_list_exports():


### PR DESCRIPTION
Currently, any operation that uses 'get_stack' method from 'CloudFormationBackend' class
will fail with AttributeError or jinja2 exception if ran against non-existing stack(created/deleted)
To fix the issue I explicitly raised a 'ValidationError' exception.
Added tests for boto and boto3 responses.
Fixes  #3558 