### PR TITLE
Add get_function_configuration support for Lambda

### DIFF
--- a/moto/awslambda/responses.py
+++ b/moto/awslambda/responses.py
@@ -131,6 +131,8 @@ class LambdaResponse(BaseResponse):
         self.setup_class(request, full_url, headers)
         if request.method == "PUT":
             return self._put_configuration(request)
+        if request.method == "GET":
+            return self._get_function_configuration(request, full_url, headers)
         else:
             raise ValueError("Cannot handle request")
 
@@ -300,6 +302,15 @@ class LambdaResponse(BaseResponse):
         else:
             return 404, {}, "{}"
 
+    @staticmethod
+    def _update_function_configuration(configuration, qualifier):
+        configuration = {k: v for k, v in configuration.items()}
+        if qualifier is None or qualifier == "$LATEST":
+            configuration["Version"] = "$LATEST"
+        if qualifier == "$LATEST":
+            configuration["FunctionArn"] += ":$LATEST"
+        return configuration
+
     def _get_function(self, request, full_url, headers):
         function_name = unquote(self.path.rsplit("/", 1)[-1])
         qualifier = self._get_param("Qualifier", None)
@@ -308,11 +319,24 @@ class LambdaResponse(BaseResponse):
 
         if fn:
             code = fn.get_code()
-            if qualifier is None or qualifier == "$LATEST":
-                code["Configuration"]["Version"] = "$LATEST"
-            if qualifier == "$LATEST":
-                code["Configuration"]["FunctionArn"] += ":$LATEST"
+            code["Configuration"] = self._update_function_configuration(
+                code["Configuration"], qualifier
+            )
             return 200, {}, json.dumps(code)
+        else:
+            return 404, {"x-amzn-ErrorType": "ResourceNotFoundException"}, "{}"
+
+    def _get_function_configuration(self, request, full_url, headers):
+        function_name = unquote(self.path.rsplit("/", 2)[-2])
+        qualifier = self._get_param("Qualifier", None)
+
+        fn = self.lambda_backend.get_function(function_name, qualifier)
+
+        if fn:
+            configuration = self._update_function_configuration(
+                fn.get_configuration(), qualifier
+            )
+            return 200, {}, json.dumps(configuration)
         else:
             return 404, {"x-amzn-ErrorType": "ResourceNotFoundException"}, "{}"
 

--- a/moto/awslambda/responses.py
+++ b/moto/awslambda/responses.py
@@ -303,8 +303,7 @@ class LambdaResponse(BaseResponse):
             return 404, {}, "{}"
 
     @staticmethod
-    def _update_function_configuration(configuration, qualifier):
-        configuration = {k: v for k, v in configuration.items()}
+    def _set_configuration_qualifier(configuration, qualifier):
         if qualifier is None or qualifier == "$LATEST":
             configuration["Version"] = "$LATEST"
         if qualifier == "$LATEST":
@@ -319,7 +318,7 @@ class LambdaResponse(BaseResponse):
 
         if fn:
             code = fn.get_code()
-            code["Configuration"] = self._update_function_configuration(
+            code["Configuration"] = self._set_configuration_qualifier(
                 code["Configuration"], qualifier
             )
             return 200, {}, json.dumps(code)
@@ -333,7 +332,7 @@ class LambdaResponse(BaseResponse):
         fn = self.lambda_backend.get_function(function_name, qualifier)
 
         if fn:
-            configuration = self._update_function_configuration(
+            configuration = self._set_configuration_qualifier(
                 fn.get_configuration(), qualifier
             )
             return 200, {}, json.dumps(configuration)

--- a/tests/test_awslambda/test_lambda.py
+++ b/tests/test_awslambda/test_lambda.py
@@ -534,11 +534,6 @@ def test_get_function_configuration():
     )
 
     result = conn.get_function_configuration(FunctionName="testFunction")
-    # this is hard to match against, so remove it
-    result["ResponseMetadata"].pop("HTTPHeaders", None)
-    # Botocore inserts retry attempts not seen in Python27
-    result["ResponseMetadata"].pop("RetryAttempts", None)
-    result.pop("LastModified")
 
     result["CodeSha256"].should.equal(hashlib.sha256(zip_content).hexdigest())
     result["CodeSize"].should.equal(len(zip_content))
@@ -562,7 +557,7 @@ def test_get_function_configuration():
     )
     result["Version"].should.equal("$LATEST")
     result["FunctionArn"].should.equal(
-        "arn:aws:lambda:us-west-2:{}:function:testFunction:$LATEST".format(ACCOUNT_ID)
+        "arn:aws:lambda:{}:{}:function:testFunction:$LATEST".format(_lambda_region, ACCOUNT_ID)
     )
 
     # Test get function when can't find function name

--- a/tests/test_awslambda/test_lambda.py
+++ b/tests/test_awslambda/test_lambda.py
@@ -557,7 +557,9 @@ def test_get_function_configuration():
     )
     result["Version"].should.equal("$LATEST")
     result["FunctionArn"].should.equal(
-        "arn:aws:lambda:{}:{}:function:testFunction:$LATEST".format(_lambda_region, ACCOUNT_ID)
+        "arn:aws:lambda:{}:{}:function:testFunction:$LATEST".format(
+            _lambda_region, ACCOUNT_ID
+        )
     )
 
     # Test get function when can't find function name


### PR DESCRIPTION
This adds support for `boto3.client('lambda').get_function_configuration(FunctionName='blalbla')`