### PR TITLE
Fix Blockchain to work with new API

### DIFF
--- a/moto/managedblockchain/responses.py
+++ b/moto/managedblockchain/responses.py
@@ -10,7 +10,7 @@ from .utils import (
     networkid_from_managedblockchain_url,
     proposalid_from_managedblockchain_url,
     invitationid_from_managedblockchain_url,
-    memberid_from_managedblockchain_url,
+    memberid_from_managedblockchain_request,
     nodeid_from_managedblockchain_url,
 )
 
@@ -297,7 +297,7 @@ class ManagedBlockchainResponse(BaseResponse):
         else:
             body = request.data
         network_id = networkid_from_managedblockchain_url(full_url)
-        member_id = memberid_from_managedblockchain_url(full_url)
+        member_id = memberid_from_managedblockchain_request(full_url, body)
         if method == "GET":
             return self._memberid_response_get(network_id, member_id, headers)
         elif method == "PATCH":
@@ -343,7 +343,7 @@ class ManagedBlockchainResponse(BaseResponse):
         parsed_url = urlparse(full_url)
         querystring = parse_qs(parsed_url.query, keep_blank_values=True)
         network_id = networkid_from_managedblockchain_url(full_url)
-        member_id = memberid_from_managedblockchain_url(full_url)
+        member_id = memberid_from_managedblockchain_request(full_url, body)
         if method == "GET":
             status = None
             if "status" in querystring:
@@ -394,7 +394,7 @@ class ManagedBlockchainResponse(BaseResponse):
         else:
             body = request.data
         network_id = networkid_from_managedblockchain_url(full_url)
-        member_id = memberid_from_managedblockchain_url(full_url)
+        member_id = memberid_from_managedblockchain_request(full_url, body)
         node_id = nodeid_from_managedblockchain_url(full_url)
         if method == "GET":
             return self._nodeid_response_get(network_id, member_id, node_id, headers)

--- a/moto/managedblockchain/urls.py
+++ b/moto/managedblockchain/urls.py
@@ -16,4 +16,7 @@ url_paths = {
     "{0}/networks/(?P<networkid>[^/.]+)/members/(?P<memberid>[^/.]+)/nodes$": ManagedBlockchainResponse.node_response,
     "{0}/networks/(?P<networkid>[^/.]+)/members/(?P<memberid>[^/.]+)/nodes?(?P<querys>[^/.]+)$": ManagedBlockchainResponse.node_response,
     "{0}/networks/(?P<networkid>[^/.]+)/members/(?P<memberid>[^/.]+)/nodes/(?P<nodeid>[^/.]+)$": ManagedBlockchainResponse.nodeid_response,
+    # >= botocore 1.19.41 (API change - memberId is now part of query-string or body)
+    "{0}/networks/(?P<networkid>[^/.]+)/nodes$": ManagedBlockchainResponse.node_response,
+    "{0}/networks/(?P<networkid>[^/.]+)/nodes/(?P<nodeid>[^/.]+)$": ManagedBlockchainResponse.nodeid_response,
 }

--- a/moto/managedblockchain/utils.py
+++ b/moto/managedblockchain/utils.py
@@ -1,8 +1,9 @@
+import json
 import random
 import re
 import string
 
-from six.moves.urllib.parse import urlparse
+from six.moves.urllib.parse import parse_qs, urlparse
 
 
 def region_from_managedblckchain_url(url):
@@ -27,11 +28,20 @@ def get_network_id():
     )
 
 
-def memberid_from_managedblockchain_url(full_url):
+def memberid_from_managedblockchain_request(full_url, body):
     id_search = re.search(r"\/m-[A-Z0-9]{26}", full_url, re.IGNORECASE)
     return_id = None
     if id_search:
         return_id = id_search.group(0).replace("/", "")
+    else:
+        # >= botocore 1.19.41 can add the memberId as a query parameter, or in the body
+        parsed_url = urlparse(full_url)
+        qs = parse_qs(parsed_url.query)
+        if "memberId" in qs:
+            return_id = qs.get("memberId")[0]
+        elif body:
+            body = json.loads(body)
+            return_id = body["MemberId"]
     return return_id
 
 

--- a/moto/sqs/models.py
+++ b/moto/sqs/models.py
@@ -518,10 +518,8 @@ class Queue(CloudFormationModel):
             if result:
                 [backend.delete_message(self.name, m.receipt_handle) for m in messages]
             else:
-                [
-                    backend.change_message_visibility(self.name, m.receipt_handle, 0)
-                    for m in messages
-                ]
+                # Make messages visible again
+                [m.change_visibility(visibility_timeout=0) for m in messages]
 
     def get_cfn_attribute(self, attribute_name):
         from moto.cloudformation.exceptions import UnformattedGetAttTemplateException

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -21,7 +21,7 @@ beautifulsoup4==4.6.0
 # The below pins mirror the Python version-conditional pins in setup.py
 #
 Jinja2>=2.10.1; python_version >= '3.6'
-mock; python_version >= '3.6'
+mock<=4.0.2; python_version >= '3.6'
 more-itertools; python_version >= '3.6'
 setuptools; python_version >= '3.6'
 sshpubkeys>=3.1.0; python_version >= '3.6'

--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ if PY2:
 else:
     install_requires += [
         "Jinja2>=2.10.1",
-        "mock",
+        "mock<=4.0.2",
         "more-itertools",
         "setuptools",
         "zipp",


### PR DESCRIPTION
The AWS HTTP API changed for the ManagedBlockchain service.
TLDR: For some actions, the memberId variable is no longer part of the REST URL, but is passed through as a query-string or in the body.

These changes came into effect as of botocore >= 1.19.41: https://github.com/boto/botocore/commit/5a79e3e757e92f68565dafeeb86dee429774cfe9#diff-7114261314a2eb504c53bfc9322e5104a6dd124518e7a51f0fcebdf93facb823R58

The changes in this PR ensure moto support both API versions.

Also includes a downgrade for the mock-requirement, to make Travis until we have a more permanent fix.