### PR TITLE
Add validation to put_events

### DIFF
--- a/moto/events/exceptions.py
+++ b/moto/events/exceptions.py
@@ -1,0 +1,9 @@
+from __future__ import unicode_literals
+from moto.core.exceptions import JsonRESTError
+
+
+class ValidationException(JsonRESTError):
+    code = 400
+
+    def __init__(self, message):
+        super(ValidationException, self).__init__("ValidationException", message)

--- a/moto/events/exceptions.py
+++ b/moto/events/exceptions.py
@@ -2,6 +2,15 @@ from __future__ import unicode_literals
 from moto.core.exceptions import JsonRESTError
 
 
+class ResourceNotFoundException(JsonRESTError):
+    code = 400
+
+    def __init__(self, message):
+        super(ResourceNotFoundException, self).__init__(
+            "ResourceNotFoundException", message
+        )
+
+
 class ValidationException(JsonRESTError):
     code = 400
 

--- a/moto/events/models.py
+++ b/moto/events/models.py
@@ -393,7 +393,7 @@ class EventsBackend(BaseBackend):
             else:
                 try:
                     json.loads(event["Detail"])
-                except json.JSONDecodeError:
+                except ValueError:  # json.JSONDecodeError exists since Python 3.5
                     entries.append(
                         {
                             "ErrorCode": "MalformedDetail",

--- a/moto/events/models.py
+++ b/moto/events/models.py
@@ -5,7 +5,7 @@ from boto3 import Session
 
 from moto.core.exceptions import JsonRESTError
 from moto.core import ACCOUNT_ID, BaseBackend, CloudFormationModel
-from moto.events.exceptions import ValidationException
+from moto.events.exceptions import ValidationException, ResourceNotFoundException
 from moto.utilities.tagging_service import TaggingService
 
 from uuid import uuid4
@@ -522,8 +522,8 @@ class EventsBackend(BaseBackend):
         name = arn.split("/")[-1]
         if name in self.rules:
             return self.tagger.list_tags_for_resource(self.rules[name].arn)
-        raise JsonRESTError(
-            "ResourceNotFoundException", "An entity that you specified does not exist."
+        raise ResourceNotFoundException(
+            "Rule {0} does not exist on EventBus default.".format(name)
         )
 
     def tag_resource(self, arn, tags):
@@ -531,8 +531,8 @@ class EventsBackend(BaseBackend):
         if name in self.rules:
             self.tagger.tag_resource(self.rules[name].arn, tags)
             return {}
-        raise JsonRESTError(
-            "ResourceNotFoundException", "An entity that you specified does not exist."
+        raise ResourceNotFoundException(
+            "Rule {0} does not exist on EventBus default.".format(name)
         )
 
     def untag_resource(self, arn, tag_names):
@@ -540,8 +540,8 @@ class EventsBackend(BaseBackend):
         if name in self.rules:
             self.tagger.untag_resource_using_names(self.rules[name].arn, tag_names)
             return {}
-        raise JsonRESTError(
-            "ResourceNotFoundException", "An entity that you specified does not exist."
+        raise ResourceNotFoundException(
+            "Rule {0} does not exist on EventBus default.".format(name)
         )
 
 


### PR DESCRIPTION
Fixes #3384 

It is a quite interesting behaviour of the `put_events` endpoint, because each event is validated separately and the status is send back for all of them.