### PR TITLE
Bump cryptography library

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ def get_version():
 install_requires = [
     "boto3>=1.9.201",
     "botocore>=1.12.201",
-    "cryptography>=2.3.0",
+    "cryptography>=3.3.1",
     "requests>=2.5",
     "xmltodict",
     "six>1.9",


### PR DESCRIPTION
From Python Safety:

Cryptography 3.3 no longer allows loading of finite field Diffie-Hellman parameters of less than 512 bits in length. This change is to conform with an upcoming OpenSSL release that no longer supports smaller sizes. These keys were already wildly insecure and should not have been used in any application outside of testing.