### PR TITLE
s3 metadata with dot fix

### DIFF
--- a/moto/s3/utils.py
+++ b/moto/s3/utils.py
@@ -73,7 +73,7 @@ def parse_region_from_url(url):
 
 def metadata_from_headers(headers):
     metadata = CaseInsensitiveDict()
-    meta_regex = re.compile(r"^x-amz-meta-([a-zA-Z0-9\-_]+)$", flags=re.IGNORECASE)
+    meta_regex = re.compile(r"^x-amz-meta-([a-zA-Z0-9.\-_]+)$", flags=re.IGNORECASE)
     for header, value in headers.items():
         if isinstance(header, six.string_types):
             result = meta_regex.match(header)


### PR DESCRIPTION
**fixed**
- s3 with meta keys not showing if contains dot in it.

Example: 
```
awslocal s3 mb s3://my-bucket
awslocal s3api put-object --bucket my-bucket --key my-key --metadata key-with.dot=123143123
awslocal s3api head-object --bucket my-bucket --key my-key
```

this PR will fix issue [localstack/issue/3423](https://github.com/localstack/localstack/issues/3423)