### PR TITLE
Fix ResourceNotFoundError exception message

### DIFF
--- a/moto/cognitoidentity/models.py
+++ b/moto/cognitoidentity/models.py
@@ -45,7 +45,7 @@ class CognitoIdentityBackend(BaseBackend):
         identity_pool = self.identity_pools.get(identity_pool_id, None)
 
         if not identity_pool:
-            raise ResourceNotFoundError(identity_pool)
+            raise ResourceNotFoundError(identity_pool_id)
 
         response = json.dumps(
             {

--- a/tests/test_cognitoidentity/test_cognitoidentity.py
+++ b/tests/test_cognitoidentity/test_cognitoidentity.py
@@ -74,13 +74,13 @@ def test_describe_identity_pool():
 @mock_cognitoidentity
 def test_describe_identity_pool_with_invalid_id_raises_error():
     conn = boto3.client("cognito-identity", "us-west-2")
-
     with pytest.raises(ClientError) as cm:
         conn.describe_identity_pool(IdentityPoolId="us-west-2_non-existent")
 
-        cm.value.operation_name.should.equal("DescribeIdentityPool")
-        cm.value.response["Error"]["Code"].should.equal("ResourceNotFoundException")
-        cm.value.response["ResponseMetadata"]["HTTPStatusCode"].should.equal(400)
+    cm.value.operation_name.should.equal("DescribeIdentityPool")
+    cm.value.response["Error"]["Code"].should.equal("ResourceNotFoundException")
+    cm.value.response["Error"]["Message"].should.equal("us-west-2_non-existent")
+    cm.value.response["ResponseMetadata"]["HTTPStatusCode"].should.equal(400)
 
 
 # testing a helper function


### PR DESCRIPTION
From `None` to the `identity_pool_id`.