### PR TITLE
More accurately mock ECS RegisterTaskDefinition

### DIFF
--- a/moto/ecs/models.py
+++ b/moto/ecs/models.py
@@ -126,25 +126,57 @@ class TaskDefinition(BaseObject, CloudFormationModel):
         volumes=None,
         tags=None,
         placement_constraints=None,
+        requires_compatibilities=None,
+        cpu=None,
+        memory=None,
     ):
         self.family = family
         self.revision = revision
         self.arn = "arn:aws:ecs:{0}:012345678910:task-definition/{1}:{2}".format(
             region_name, family, revision
         )
-        self.container_definitions = container_definitions
+
+        default_container_definition = {
+            "cpu": 0,
+            "portMappings": [],
+            "essential": True,
+            "environment": [],
+            "mountPoints": [],
+            "volumesFrom": [],
+        }
+        self.container_definitions = []
+        for container_definition in container_definitions:
+            full_definition = default_container_definition.copy()
+            full_definition.update(container_definition)
+            self.container_definitions.append(full_definition)
+
         self.tags = tags if tags is not None else []
+
         if volumes is None:
             self.volumes = []
         else:
             self.volumes = volumes
-        if network_mode is None:
+
+        if not requires_compatibilities or requires_compatibilities == ["EC2"]:
+            self.compatibilities = ["EC2"]
+        else:
+            self.compatibilities = ["EC2", "FARGATE"]
+
+        if network_mode is None and "FARGATE" not in self.compatibilities:
             self.network_mode = "bridge"
+        elif "FARGATE" in self.compatibilities:
+            self.network_mode = "awsvpc"
         else:
             self.network_mode = network_mode
+
         self.placement_constraints = (
             placement_constraints if placement_constraints is not None else []
         )
+
+        self.requires_compatibilities = requires_compatibilities
+
+        self.cpu = cpu
+        self.memory = memory
 
     @property
     def response_object(self):
@@ -152,6 +184,14 @@ class TaskDefinition(BaseObject, CloudFormationModel):
         response_object["taskDefinitionArn"] = response_object["arn"]
         del response_object["arn"]
         del response_object["tags"]
+
+        if not response_object["requiresCompatibilities"]:
+            del response_object["requiresCompatibilities"]
+        if not response_object["cpu"]:
+            del response_object["cpu"]
+        if not response_object["memory"]:
+            del response_object["memory"]
+
         return response_object
 
     @property
@@ -680,6 +720,9 @@ class EC2ContainerServiceBackend(BaseBackend):
         network_mode=None,
         tags=None,
         placement_constraints=None,
+        requires_compatibilities=None,
+        cpu=None,
+        memory=None,
     ):
         if family in self.task_definitions:
             last_id = self._get_last_task_definition_revision_id(family)
@@ -696,6 +739,9 @@ class EC2ContainerServiceBackend(BaseBackend):
             network_mode=network_mode,
             tags=tags,
             placement_constraints=placement_constraints,
+            requires_compatibilities=requires_compatibilities,
+            cpu=cpu,
+            memory=memory,
         )
         self.task_definitions[family][revision] = task_definition
 

--- a/moto/ecs/responses.py
+++ b/moto/ecs/responses.py
@@ -64,6 +64,9 @@ class EC2ContainerServiceResponse(BaseResponse):
         tags = self._get_param("tags")
         network_mode = self._get_param("networkMode")
         placement_constraints = self._get_param("placementConstraints")
+        requires_compatibilities = self._get_param("requiresCompatibilities")
+        cpu = self._get_param("cpu")
+        memory = self._get_param("memory")
         task_definition = self.ecs_backend.register_task_definition(
             family,
             container_definitions,
@@ -71,6 +74,9 @@ class EC2ContainerServiceResponse(BaseResponse):
             network_mode=network_mode,
             tags=tags,
             placement_constraints=placement_constraints,
+            requires_compatibilities=requires_compatibilities,
+            cpu=cpu,
+            memory=memory,
         )
         return json.dumps({"taskDefinition": task_definition.response_object})
 

--- a/tests/test_ecs/test_ecs_cloudformation.py
+++ b/tests/test_ecs/test_ecs_cloudformation.py
@@ -269,6 +269,5 @@ def test_create_task_definition_through_cloudformation():
         template["Resources"]["testTaskDefinition"]["Properties"], pascal_to_camelcase
     )
     task_definition["volumes"].should.equal(expected_properties["volumes"])
-    task_definition["containerDefinitions"].should.equal(
-        expected_properties["containerDefinitions"]
-    )
+    for key, value in expected_properties["containerDefinitions"][0].items():
+        task_definition["containerDefinitions"][0][key].should.equal(value)


### PR DESCRIPTION
The mocked response for ECS RegisterTaskDefinition has drifted from what actually returns when run against a real ECS endpoint. I created a minimal task definition for both EC2:

```python
>>> ecs.register_task_definition(
      family="moto",
      containerDefinitions=[
          {
              "name": "hello_world",
              "image": "hello-world:latest",
              "memory": 400
           }
       ]
  )["taskDefinition"]

{'taskDefinitionArn': 'arn:aws:ecs:us-east-1:************:task-definition/moto:1',
 'containerDefinitions': [{'name': 'hello_world',
   'image': 'hello-world:latest',
   'cpu': 0,
   'memory': 400,
   'portMappings': [],
   'essential': True,
   'environment': [],
   'mountPoints': [],
   'volumesFrom': []}],
 'family': 'moto',
 'revision': 1,
 'volumes': [],
 'status': 'ACTIVE',
 'placementConstraints': [],
 'compatibilities': ['EC2']}
```

and Fargate:
```python
>>> ecs.register_task_definition(
      family="moto",
      containerDefinitions=[
          {
              "name": "hello_world",
              "image": "hello-world:latest",
              "memory": 400
           }
       ],
       requiresCompatibilities=["FARGATE"],
       networkMode="awsvpc",
       cpu="256",
       memory="512"
  )["taskDefinition"]

{'taskDefinitionArn': 'arn:aws:ecs:us-east-1:************:task-definition/moto:2',
 'containerDefinitions': [{'name': 'hello_world',
   'image': 'hello-world:latest',
   'cpu': 0,
   'memory': 400,
   'portMappings': [],
   'essential': True,
   'environment': [],
   'mountPoints': [],
   'volumesFrom': []}],
 'family': 'moto',
 'networkMode': 'awsvpc',
 'revision': 2,
 'volumes': [],
 'status': 'ACTIVE',
 'requiresAttributes': [{'name': 'com.amazonaws.ecs.capability.docker-remote-api.1.18'},
  {'name': 'ecs.capability.task-eni'}],
 'placementConstraints': [],
 'compatibilities': ['EC2', 'FARGATE'],
 'requiresCompatibilities': ['FARGATE'],
 'cpu': '256',
 'memory': '512'}
```

This change adds several default keys to the task based on those two real responses and the AWS documentation:
https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_RegisterTaskDefinition.html

The mock still doesn't match the real response exactly.  For example, I didn't handle the `requiresAttributes` key because while I think it's just a static set of attributes based on whether you specify `FARGATE`, I'm not entirely sure that's the case and I'd prefer the response be under-mocked than incorrectly mocked. But it's a lot closer to the real response than it was before!