### PR TITLE
Implement Add to List for dynamodb:UpdateItem

### DIFF
--- a/moto/dynamodb2/models/__init__.py
+++ b/moto/dynamodb2/models/__init__.py
@@ -156,6 +156,10 @@ class Item(BaseModel):
                     existing = self.attrs.get(attribute_name, DynamoType({"SS": {}}))
                     new_set = set(existing.value).union(set(new_value))
                     self.attrs[attribute_name] = DynamoType({"SS": list(new_set)})
+                elif set(update_action["Value"].keys()) == {"L"}:
+                    existing = self.attrs.get(attribute_name, DynamoType({"L": []}))
+                    new_list = existing.value + new_value
+                    self.attrs[attribute_name] = DynamoType({"L": new_list})
                 else:
                     # TODO: implement other data types
                     raise NotImplementedError(


### PR DESCRIPTION
This handles the add-to-list case using the legacy `AttributeUpdates` parameter.

* Added test coverage.
* Verified against real AWS backend.

Closes #3561