### PR TITLE
Expose contextual data when Lambda test fails

### DIFF
--- a/tests/test_awslambda/test_lambda.py
+++ b/tests/test_awslambda/test_lambda.py
@@ -125,6 +125,9 @@ def test_invoke_requestresponse_function():
         LogType="Tail",
     )
 
+    if "FunctionError" in success_result:
+        assert False, success_result["Payload"].read().decode("utf-8")
+
     success_result["StatusCode"].should.equal(200)
     logs = base64.b64decode(success_result["LogResult"]).decode("utf-8")
 


### PR DESCRIPTION
This test is flaky, but when it fails we don't get any indication as to why.
This commit ensures that the reason for failure will be part of the assertion
message.

Once we have information about why this test fails, we can troubleshoot further
and hopefully come up with a permanent fix.