### PR TITLE
server: explicit signal handler for SIGINT and SIGTERM

### DIFF
--- a/moto/server.py
+++ b/moto/server.py
@@ -4,6 +4,7 @@ import argparse
 import io
 import json
 import re
+import signal
 import sys
 from threading import Lock
 
@@ -245,6 +246,11 @@ def create_backend_app(service):
     return backend_app
 
 
+def signal_handler(signum, frame):
+    print("Received signal %d" % signum)
+    sys.exit(0)
+
+
 def main(argv=sys.argv[1:]):
     parser = argparse.ArgumentParser()
 
@@ -283,6 +289,9 @@ def main(argv=sys.argv[1:]):
     )
 
     args = parser.parse_args(argv)
+
+    signal.signal(signal.SIGINT, signal_handler)
+    signal.signal(signal.SIGTERM, signal_handler)
 
     # Wrap the main application
     main_app = DomainDispatcherApplication(create_backend_app, service=args.service)


### PR DESCRIPTION
When running alone as pid 1 in a container, most signals that would
cause the process to exit by default, are instead ignored by default.
The container runtime will send SIGTERM, wait 10 seconds, then send
SIGKILL, which will work, but moto.server can exit much faster if
it has an explicit SIGTERM handler.

------

An alternative way to fix the slow-container-stop problem is to use a separate "init" process, which forwards signals to the actual container command running as a child process (which then has PID != 1). You can get very easily get this with "docker run --init ..." which uses the "tini" init process included in docker ... but kubernetes doesn't offer this option, and the separate init process isn't _really_ necessary.

------

If I could switch from `werkzeug.serving.run_simple()` to `werkzeug.serving.make_server()`, it would be more elegant: I could probably use the server object's log method and shutdown method (though I might need to spawn a thread for that too, long story). But only `run_simple()` provides convenient access to the auto-reloader functionality, it would be a lot of copied code to get that back for the `make_server()` way.

Anyway, I've tested by running this locally, it works :)