### PR TITLE
Add TagSpecification support to ec2:CreateImage

### DIFF
--- a/moto/ec2/exceptions.py
+++ b/moto/ec2/exceptions.py
@@ -615,3 +615,13 @@ class InvalidVpcEndPointIdError(EC2ClientError):
             "InvalidVpcEndPointId.NotFound",
             "The VpcEndPoint ID '{0}' does not exist".format(vpc_end_point_id),
         )
+
+
+class InvalidTaggableResourceType(EC2ClientError):
+    def __init__(self, resource_type):
+        super(InvalidTaggableResourceType, self).__init__(
+            "InvalidParameterValue",
+            "'{}' is not a valid taggable resource type for this operation.".format(
+                resource_type
+            ),
+        )

--- a/moto/ec2/responses/amis.py
+++ b/moto/ec2/responses/amis.py
@@ -8,9 +8,14 @@ class AmisResponse(BaseResponse):
         name = self.querystring.get("Name")[0]
         description = self._get_param("Description", if_none="")
         instance_id = self._get_param("InstanceId")
+        tag_specifications = self._get_multi_param("TagSpecification")
         if self.is_not_dryrun("CreateImage"):
             image = self.ec2_backend.create_image(
-                instance_id, name, description, context=self
+                instance_id,
+                name,
+                description,
+                context=self,
+                tag_specifications=tag_specifications,
             )
             template = self.response_template(CREATE_IMAGE_RESPONSE)
             return template.render(image=image)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,7 +9,7 @@ flask
 flask-cors
 boto>=2.45.0
 boto3>=1.4.4
-botocore>=1.18.17
+botocore>=1.19.30
 six>=1.9
 prompt-toolkit==2.0.10 # 3.x is not available with python2
 click==6.7


### PR DESCRIPTION
* Bump `botocore` to minimum version that supports TagSpecifications for this action.
* Add test coverage.

Closes #3602