### PR TITLE
Fix ec2 filter by empty tag value

### DIFF
--- a/moto/ec2/models.py
+++ b/moto/ec2/models.py
@@ -248,7 +248,7 @@ class TaggedEC2Resource(BaseModel):
                 if tag["key"] == tagname:
                     return tag["value"]
 
-            return ""
+            return None
         elif filter_name == "tag-key":
             return [tag["key"] for tag in tags]
         elif filter_name == "tag-value":

--- a/moto/ec2/utils.py
+++ b/moto/ec2/utils.py
@@ -458,7 +458,7 @@ def filter_internet_gateways(igws, filter_dict):
 def is_filter_matching(obj, filter, filter_value):
     value = obj.get_filter_value(filter)
 
-    if not filter_value:
+    if filter_value is None:
         return False
 
     if isinstance(value, six.string_types):

--- a/tests/test_ec2/test_amis.py
+++ b/tests/test_ec2/test_amis.py
@@ -879,30 +879,6 @@ def test_ami_snapshots_have_correct_owner():
 
 
 @mock_ec2
-def test_ami_filter_by_empty_tag():
-    ec2 = boto3.resource("ec2", region_name="us-west-1")
-    client = boto3.client("ec2", region_name="us-west-1")
-
-    instance = ec2.create_instances(ImageId=EXAMPLE_AMI_ID, MinCount=1, MaxCount=1)[0]
-    image_id = client.create_image(
-        InstanceId=instance.instance_id, Name="test-image", Description="test ami",
-    )["ImageId"]
-    ec2.create_tags(
-        Resources=[image_id], Tags=[{"Key": "empty", "Value": ""}],
-    )
-
-    resp = client.describe_images(Filters=[{"Name": "tag-key", "Values": ["empty"]}])
-    assert len(resp["Images"]) == 1
-    assert resp["Images"][0]["ImageId"] == image_id
-
-    resp2 = client.describe_images(Filters=[{"Name": "tag:empty", "Values": [""]}])
-    assert len(resp["Images"]) == 1
-    assert resp["Images"][0]["ImageId"] == image_id
-
-    assert resp["Images"] == resp2["Images"]
-
-
-@mock_ec2
 def test_create_image_with_tag_specification():
     ec2 = boto3.resource("ec2", region_name="us-west-1")
     client = boto3.client("ec2", region_name="us-west-1")
@@ -945,3 +921,44 @@ def test_create_image_with_tag_specification():
     ex.value.response["Error"]["Message"].should.equal(
         "'invalid-resource-type' is not a valid taggable resource type for this operation."
     )
+
+
+@mock_ec2
+def test_ami_filter_by_empty_tag():
+    ec2 = boto3.resource("ec2", region_name="us-west-1")
+    client = boto3.client("ec2", region_name="us-west-1")
+
+    fake_images = []
+    instance = ec2.create_instances(ImageId=EXAMPLE_AMI_ID, MinCount=1, MaxCount=1)[0]
+    for i in range(10):
+        image = client.create_image(
+            InstanceId=instance.instance_id,
+            Name="MyAMI{}".format(i),
+            Description="Test",
+        )
+
+        ec2.create_tags(
+            Resources=[image["ImageId"]],
+            Tags=[
+                {
+                    "Key": "Base_AMI_Name",
+                    "Value": "Deep Learning Base AMI (Amazon Linux 2) Version 31.0",
+                },
+                {"Key": "OS_Version", "Value": "AWS Linux 2"},
+            ],
+        )
+        fake_images.append(image)
+    # Add release tags to some of the images in the middle
+    for image in fake_images[3:6]:
+        ec2.create_tags(
+            Resources=[image["ImageId"]], Tags=[{"Key": "RELEASE", "Value": ""}]
+        )
+    images_filter = [
+        {
+            "Name": "tag:Base_AMI_Name",
+            "Values": ["Deep Learning Base AMI (Amazon Linux 2) Version 31.0"],
+        },
+        {"Name": "tag:OS_Version", "Values": ["AWS Linux 2"]},
+        {"Name": "tag:RELEASE", "Values": [""]},
+    ]
+    assert len(client.describe_images(Filters=images_filter)["Images"]) == 3


### PR DESCRIPTION
Return `None` instead of an empty string when the tag key does not exist
and replace the falsy check with a more explicit `is None`, which allows
empty string values to correctly pass through the filter comparator.

Behavior confirmed against a real AWS backend.

Closes #3603