### PR TITLE
Assume synchronous Lambda invocation by default

### DIFF
--- a/moto/awslambda/models.py
+++ b/moto/awslambda/models.py
@@ -621,7 +621,8 @@ class LambdaFunction(CloudFormationModel, DockerModel):
 
         # Get the invocation type:
         res, errored, logs = self._invoke_lambda(code=self.code, event=body)
-        if request_headers.get("x-amz-invocation-type") == "RequestResponse":
+        inv_type = request_headers.get("x-amz-invocation-type", "RequestResponse")
+        if inv_type == "RequestResponse":
             encoded = base64.b64encode(logs.encode("utf-8"))
             response_headers["x-amz-log-result"] = encoded.decode("utf-8")
             result = res.encode("utf-8")

--- a/tests/test_awslambda/test_lambda.py
+++ b/tests/test_awslambda/test_lambda.py
@@ -127,10 +127,7 @@ def test_invoke_requestresponse_function(invocation_type):
 
     in_data = {"msg": "So long and thanks for all the fish"}
     success_result = conn.invoke(
-        FunctionName="testFunction",
-        Payload=json.dumps(in_data),
-        LogType="Tail",
-        **kw,
+        FunctionName="testFunction", Payload=json.dumps(in_data), LogType="Tail", **kw
     )
 
     if "FunctionError" in success_result:
@@ -148,9 +145,7 @@ def test_invoke_requestresponse_function(invocation_type):
 
     # Logs should not be returned by default, only when the LogType-param is supplied
     success_result = conn.invoke(
-        FunctionName="testFunction",
-        Payload=json.dumps(in_data),
-        **kw,
+        FunctionName="testFunction", Payload=json.dumps(in_data), **kw
     )
 
     success_result["StatusCode"].should.equal(200)

--- a/tests/test_awslambda/test_lambda.py
+++ b/tests/test_awslambda/test_lambda.py
@@ -103,8 +103,9 @@ def test_list_functions():
 
 
 @pytest.mark.network
+@pytest.mark.parametrize("invocation_type", [None, "RequestResponse"])
 @mock_lambda
-def test_invoke_requestresponse_function():
+def test_invoke_requestresponse_function(invocation_type):
     conn = boto3.client("lambda", _lambda_region)
     conn.create_function(
         FunctionName="testFunction",
@@ -118,12 +119,18 @@ def test_invoke_requestresponse_function():
         Publish=True,
     )
 
+    # Only add invocation-type keyword-argument when provided, otherwise the request
+    # fails to be validated
+    kw = {}
+    if invocation_type:
+        kw["InvocationType"] = invocation_type
+
     in_data = {"msg": "So long and thanks for all the fish"}
     success_result = conn.invoke(
         FunctionName="testFunction",
-        InvocationType="RequestResponse",
         Payload=json.dumps(in_data),
         LogType="Tail",
+        **kw,
     )
 
     if "FunctionError" in success_result:
@@ -142,8 +149,8 @@ def test_invoke_requestresponse_function():
     # Logs should not be returned by default, only when the LogType-param is supplied
     success_result = conn.invoke(
         FunctionName="testFunction",
-        InvocationType="RequestResponse",
         Payload=json.dumps(in_data),
+        **kw,
     )
 
     success_result["StatusCode"].should.equal(200)


### PR DESCRIPTION
If `InvocationType` is not provided to `boto.client("lambda").invoke`, then the request header `x-amz-invocation-type` is not present, which breaks an assumption in the model's implementation `moto.awslambda.models.LambdaFunction.invoke`.

In the tests, this results in the response not having a `LogResult` key (when `LogType="Tail"`), or trying to delete a non-existent response header key `x-amz-log-result` (when `LogType` is not provided).

This PR updates the assumption to match the current API definition.