### PR TITLE
Address `boto` deprecation warnings

### DIFF
--- a/tests/test_ec2/test_regions.py
+++ b/tests/test_ec2/test_regions.py
@@ -37,7 +37,7 @@ def test_add_servers_to_a_single_region():
     add_servers_to_region(EXAMPLE_AMI_ID2, 1, region)
 
     conn = boto.ec2.connect_to_region(region)
-    reservations = conn.get_all_instances()
+    reservations = conn.get_all_reservations()
     len(reservations).should.equal(2)
 
     image_ids = [r.instances[0].image_id for r in reservations]
@@ -53,8 +53,8 @@ def test_add_servers_to_multiple_regions():
 
     us_conn = boto.ec2.connect_to_region(region1)
     ap_conn = boto.ec2.connect_to_region(region2)
-    us_reservations = us_conn.get_all_instances()
-    ap_reservations = ap_conn.get_all_instances()
+    us_reservations = us_conn.get_all_reservations()
+    ap_reservations = ap_conn.get_all_reservations()
 
     len(us_reservations).should.equal(1)
     len(ap_reservations).should.equal(1)

--- a/tests/test_ec2/test_tags.py
+++ b/tests/test_ec2/test_tags.py
@@ -32,7 +32,7 @@ def test_add_tag():
     instance.add_tag("a key", "some value")
     chain = itertools.chain.from_iterable
     existing_instances = list(
-        chain([res.instances for res in conn.get_all_instances()])
+        chain([res.instances for res in conn.get_all_reservations()])
     )
     existing_instances.should.have.length_of(1)
     existing_instance = existing_instances[0]
@@ -310,7 +310,7 @@ def test_retrieved_instances_must_contain_their_tags():
     reservation.instances.should.have.length_of(1)
     instance = reservation.instances[0]
 
-    reservations = conn.get_all_instances()
+    reservations = conn.get_all_reservations()
     reservations.should.have.length_of(1)
     reservations[0].id.should.equal(reservation.id)
     instances = reservations[0].instances
@@ -318,7 +318,7 @@ def test_retrieved_instances_must_contain_their_tags():
     instances[0].id.should.equal(instance.id)
 
     conn.create_tags([instance.id], tags_to_be_set)
-    reservations = conn.get_all_instances()
+    reservations = conn.get_all_reservations()
     instance = reservations[0].instances[0]
     retrieved_tags = instance.tags
 
@@ -388,13 +388,13 @@ def test_filter_instances_by_wildcard_tags():
     instance_b = reservation_b.instances[0]
     instance_b.add_tag("Key1", "Value2")
 
-    reservations = conn.get_all_instances(filters={"tag:Key1": "Value*"})
+    reservations = conn.get_all_reservations(filters={"tag:Key1": "Value*"})
     reservations.should.have.length_of(2)
 
-    reservations = conn.get_all_instances(filters={"tag-key": "Key*"})
+    reservations = conn.get_all_reservations(filters={"tag-key": "Key*"})
     reservations.should.have.length_of(2)
 
-    reservations = conn.get_all_instances(filters={"tag-value": "Value*"})
+    reservations = conn.get_all_reservations(filters={"tag-value": "Value*"})
     reservations.should.have.length_of(2)
 
 


### PR DESCRIPTION
This commit eliminates the following warning (of which there are currently dozens):

../boto/ec2/connection.py:582:
  PendingDeprecationWarning: The current get_all_instances implementation will be replaced with get_all_reservations.

`boto` isn't likely to ever make good on this warning, but doing the replacement will
declutter the `moto` test output.