### PR TITLE
requirements-dev.txt: Remove requirements copied from setup.py

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,36 +1,13 @@
--r requirements.txt
+-e .[all,server]
 -r requirements-tests.txt
 
 black==19.10b0; python_version >= '3.6'
 regex==2019.11.1; python_version >= '3.6'   # Needed for black
 coverage==4.5.4
 flake8==3.7.8
-flask
-flask-cors
 boto>=2.45.0
-boto3>=1.4.4
-botocore>=1.19.30
-six>=1.9
 prompt-toolkit==2.0.10 # 3.x is not available with python2
 click==6.7
 inflection==0.3.1
 lxml==4.2.3
 beautifulsoup4==4.6.0
-
-#
-# The below pins mirror the Python version-conditional pins in setup.py
-#
-Jinja2>=2.10.1; python_version >= '3.6'
-mock<=4.0.2; python_version >= '3.6'
-more-itertools; python_version >= '3.6'
-setuptools; python_version >= '3.6'
-sshpubkeys>=3.1.0; python_version >= '3.6'
-zipp; python_version >= '3.6'
-
-configparser<5.0; python_version == '2.7'
-Jinja2<3.0.0,>=2.10.1; python_version == '2.7'
-mock<=3.0.5; python_version == '2.7'
-more-itertools==5.0.0; python_version == '2.7'
-setuptools==44.0.0; python_version == '2.7'
-sshpubkeys==3.1.0; python_version == '2.7'
-zipp==0.6.0; python_version == '2.7'


### PR DESCRIPTION
Most of these were already pulled in via `-r requirements.txt` → `-e .[all]`; add the remainder with `-e [all,server]`.