### PR TITLE
Tech Debt - Use known AMI in internal tests

### DIFF
--- a/tests/test_autoscaling/test_autoscaling.py
+++ b/tests/test_autoscaling/test_autoscaling.py
@@ -140,7 +140,11 @@ def test_create_autoscaling_groups_defaults():
 def test_list_many_autoscaling_groups():
     mocked_networking = setup_networking()
     conn = boto3.client("autoscaling", region_name="us-east-1")
-    conn.create_launch_configuration(LaunchConfigurationName="TestLC")
+    conn.create_launch_configuration(
+        LaunchConfigurationName="TestLC",
+        ImageId=EXAMPLE_AMI_ID,
+        InstanceType="t2.medium",
+    )
 
     for i in range(51):
         conn.create_auto_scaling_group(
@@ -169,7 +173,11 @@ def test_list_many_autoscaling_groups():
 def test_propogate_tags():
     mocked_networking = setup_networking()
     conn = boto3.client("autoscaling", region_name="us-east-1")
-    conn.create_launch_configuration(LaunchConfigurationName="TestLC")
+    conn.create_launch_configuration(
+        LaunchConfigurationName="TestLC",
+        ImageId=EXAMPLE_AMI_ID,
+        InstanceType="t2.medium",
+    )
 
     conn.create_auto_scaling_group(
         AutoScalingGroupName="TestGroup1",
@@ -534,7 +542,9 @@ def test_describe_load_balancers():
 
     client = boto3.client("autoscaling", region_name="us-east-1")
     client.create_launch_configuration(
-        LaunchConfigurationName="test_launch_configuration"
+        LaunchConfigurationName="test_launch_configuration",
+        ImageId=EXAMPLE_AMI_ID,
+        InstanceType="t2.medium",
     )
     client.create_auto_scaling_group(
         AutoScalingGroupName="test_asg",
@@ -576,7 +586,9 @@ def test_create_elb_and_autoscaling_group_no_relationship():
 
     client = boto3.client("autoscaling", region_name="us-east-1")
     client.create_launch_configuration(
-        LaunchConfigurationName="test_launch_configuration"
+        LaunchConfigurationName="test_launch_configuration",
+        ImageId=EXAMPLE_AMI_ID,
+        InstanceType="t2.medium",
     )
 
     client.create_auto_scaling_group(
@@ -610,7 +622,9 @@ def test_attach_load_balancer():
 
     client = boto3.client("autoscaling", region_name="us-east-1")
     client.create_launch_configuration(
-        LaunchConfigurationName="test_launch_configuration"
+        LaunchConfigurationName="test_launch_configuration",
+        ImageId=EXAMPLE_AMI_ID,
+        InstanceType="t2.medium",
     )
     client.create_auto_scaling_group(
         AutoScalingGroupName="test_asg",
@@ -658,7 +672,9 @@ def test_detach_load_balancer():
 
     client = boto3.client("autoscaling", region_name="us-east-1")
     client.create_launch_configuration(
-        LaunchConfigurationName="test_launch_configuration"
+        LaunchConfigurationName="test_launch_configuration",
+        ImageId=EXAMPLE_AMI_ID,
+        InstanceType="t2.medium",
     )
     client.create_auto_scaling_group(
         AutoScalingGroupName="test_asg",
@@ -695,7 +711,9 @@ def test_create_autoscaling_group_boto3():
     mocked_networking = setup_networking()
     client = boto3.client("autoscaling", region_name="us-east-1")
     client.create_launch_configuration(
-        LaunchConfigurationName="test_launch_configuration"
+        LaunchConfigurationName="test_launch_configuration",
+        ImageId=EXAMPLE_AMI_ID,
+        InstanceType="t2.medium",
     )
     response = client.create_auto_scaling_group(
         AutoScalingGroupName="test_asg",
@@ -920,7 +938,9 @@ def test_create_autoscaling_group_boto3_multiple_launch_configurations():
     )["LaunchTemplate"]
     client = boto3.client("autoscaling", region_name="us-east-1")
     client.create_launch_configuration(
-        LaunchConfigurationName="test_launch_configuration"
+        LaunchConfigurationName="test_launch_configuration",
+        ImageId=EXAMPLE_AMI_ID,
+        InstanceType="t2.medium",
     )
 
     with pytest.raises(ClientError) as ex:
@@ -950,7 +970,9 @@ def test_describe_autoscaling_groups_boto3_launch_config():
     mocked_networking = setup_networking()
     client = boto3.client("autoscaling", region_name="us-east-1")
     client.create_launch_configuration(
-        LaunchConfigurationName="test_launch_configuration", InstanceType="t2.micro",
+        LaunchConfigurationName="test_launch_configuration",
+        InstanceType="t2.micro",
+        ImageId=EXAMPLE_AMI_ID,
     )
     client.create_auto_scaling_group(
         AutoScalingGroupName="test_asg",
@@ -1026,7 +1048,9 @@ def test_describe_autoscaling_instances_boto3_launch_config():
     mocked_networking = setup_networking()
     client = boto3.client("autoscaling", region_name="us-east-1")
     client.create_launch_configuration(
-        LaunchConfigurationName="test_launch_configuration", InstanceType="t2.micro",
+        LaunchConfigurationName="test_launch_configuration",
+        InstanceType="t2.micro",
+        ImageId=EXAMPLE_AMI_ID,
     )
     client.create_auto_scaling_group(
         AutoScalingGroupName="test_asg",
@@ -1090,7 +1114,9 @@ def test_describe_autoscaling_instances_instanceid_filter():
     mocked_networking = setup_networking()
     client = boto3.client("autoscaling", region_name="us-east-1")
     _ = client.create_launch_configuration(
-        LaunchConfigurationName="test_launch_configuration"
+        LaunchConfigurationName="test_launch_configuration",
+        ImageId=EXAMPLE_AMI_ID,
+        InstanceType="t2.medium",
     )
     _ = client.create_auto_scaling_group(
         AutoScalingGroupName="test_asg",
@@ -1123,10 +1149,14 @@ def test_update_autoscaling_group_boto3_launch_config():
     mocked_networking = setup_networking()
     client = boto3.client("autoscaling", region_name="us-east-1")
     client.create_launch_configuration(
-        LaunchConfigurationName="test_launch_configuration"
+        LaunchConfigurationName="test_launch_configuration",
+        ImageId=EXAMPLE_AMI_ID,
+        InstanceType="t2.medium",
     )
     client.create_launch_configuration(
-        LaunchConfigurationName="test_launch_configuration_new"
+        LaunchConfigurationName="test_launch_configuration_new",
+        ImageId=EXAMPLE_AMI_ID,
+        InstanceType="t2.medium",
     )
     client.create_auto_scaling_group(
         AutoScalingGroupName="test_asg",
@@ -1216,7 +1246,9 @@ def test_update_autoscaling_group_min_size_desired_capacity_change():
     client = boto3.client("autoscaling", region_name="us-east-1")
 
     client.create_launch_configuration(
-        LaunchConfigurationName="test_launch_configuration"
+        LaunchConfigurationName="test_launch_configuration",
+        ImageId=EXAMPLE_AMI_ID,
+        InstanceType="t2.medium",
     )
     client.create_auto_scaling_group(
         AutoScalingGroupName="test_asg",
@@ -1240,7 +1272,9 @@ def test_update_autoscaling_group_max_size_desired_capacity_change():
     client = boto3.client("autoscaling", region_name="us-east-1")
 
     client.create_launch_configuration(
-        LaunchConfigurationName="test_launch_configuration"
+        LaunchConfigurationName="test_launch_configuration",
+        ImageId=EXAMPLE_AMI_ID,
+        InstanceType="t2.medium",
     )
     client.create_auto_scaling_group(
         AutoScalingGroupName="test_asg",
@@ -1263,7 +1297,9 @@ def test_autoscaling_tags_update_boto3():
     mocked_networking = setup_networking()
     client = boto3.client("autoscaling", region_name="us-east-1")
     _ = client.create_launch_configuration(
-        LaunchConfigurationName="test_launch_configuration"
+        LaunchConfigurationName="test_launch_configuration",
+        ImageId=EXAMPLE_AMI_ID,
+        InstanceType="t2.medium",
     )
     _ = client.create_auto_scaling_group(
         AutoScalingGroupName="test_asg",
@@ -1308,7 +1344,9 @@ def test_autoscaling_describe_policies_boto3():
     mocked_networking = setup_networking()
     client = boto3.client("autoscaling", region_name="us-east-1")
     _ = client.create_launch_configuration(
-        LaunchConfigurationName="test_launch_configuration"
+        LaunchConfigurationName="test_launch_configuration",
+        ImageId=EXAMPLE_AMI_ID,
+        InstanceType="t2.medium",
     )
     _ = client.create_auto_scaling_group(
         AutoScalingGroupName="test_asg",
@@ -1371,7 +1409,9 @@ def test_detach_one_instance_decrement():
     mocked_networking = setup_networking()
     client = boto3.client("autoscaling", region_name="us-east-1")
     _ = client.create_launch_configuration(
-        LaunchConfigurationName="test_launch_configuration"
+        LaunchConfigurationName="test_launch_configuration",
+        ImageId=EXAMPLE_AMI_ID,
+        InstanceType="t2.medium",
     )
     client.create_auto_scaling_group(
         AutoScalingGroupName="test_asg",
@@ -1446,7 +1486,9 @@ def test_detach_one_instance():
     mocked_networking = setup_networking()
     client = boto3.client("autoscaling", region_name="us-east-1")
     _ = client.create_launch_configuration(
-        LaunchConfigurationName="test_launch_configuration"
+        LaunchConfigurationName="test_launch_configuration",
+        ImageId=EXAMPLE_AMI_ID,
+        InstanceType="t2.medium",
     )
     client.create_auto_scaling_group(
         AutoScalingGroupName="test_asg",
@@ -1517,7 +1559,9 @@ def test_standby_one_instance_decrement():
     mocked_networking = setup_networking()
     client = boto3.client("autoscaling", region_name="us-east-1")
     _ = client.create_launch_configuration(
-        LaunchConfigurationName="test_launch_configuration"
+        LaunchConfigurationName="test_launch_configuration",
+        ImageId=EXAMPLE_AMI_ID,
+        InstanceType="t2.medium",
     )
     client.create_auto_scaling_group(
         AutoScalingGroupName="test_asg",
@@ -1590,7 +1634,9 @@ def test_standby_one_instance():
     mocked_networking = setup_networking()
     client = boto3.client("autoscaling", region_name="us-east-1")
     _ = client.create_launch_configuration(
-        LaunchConfigurationName="test_launch_configuration"
+        LaunchConfigurationName="test_launch_configuration",
+        ImageId=EXAMPLE_AMI_ID,
+        InstanceType="t2.medium",
     )
     client.create_auto_scaling_group(
         AutoScalingGroupName="test_asg",
@@ -1663,7 +1709,9 @@ def test_standby_elb_update():
     mocked_networking = setup_networking()
     client = boto3.client("autoscaling", region_name="us-east-1")
     _ = client.create_launch_configuration(
-        LaunchConfigurationName="test_launch_configuration"
+        LaunchConfigurationName="test_launch_configuration",
+        ImageId=EXAMPLE_AMI_ID,
+        InstanceType="t2.medium",
     )
     client.create_auto_scaling_group(
         AutoScalingGroupName="test_asg",
@@ -1726,7 +1774,9 @@ def test_standby_terminate_instance_decrement():
     mocked_networking = setup_networking()
     client = boto3.client("autoscaling", region_name="us-east-1")
     _ = client.create_launch_configuration(
-        LaunchConfigurationName="test_launch_configuration"
+        LaunchConfigurationName="test_launch_configuration",
+        ImageId=EXAMPLE_AMI_ID,
+        InstanceType="t2.medium",
     )
     client.create_auto_scaling_group(
         AutoScalingGroupName="test_asg",
@@ -1815,7 +1865,9 @@ def test_standby_terminate_instance_no_decrement():
     mocked_networking = setup_networking()
     client = boto3.client("autoscaling", region_name="us-east-1")
     _ = client.create_launch_configuration(
-        LaunchConfigurationName="test_launch_configuration"
+        LaunchConfigurationName="test_launch_configuration",
+        ImageId=EXAMPLE_AMI_ID,
+        InstanceType="t2.medium",
     )
     client.create_auto_scaling_group(
         AutoScalingGroupName="test_asg",
@@ -1904,7 +1956,9 @@ def test_standby_detach_instance_decrement():
     mocked_networking = setup_networking()
     client = boto3.client("autoscaling", region_name="us-east-1")
     _ = client.create_launch_configuration(
-        LaunchConfigurationName="test_launch_configuration"
+        LaunchConfigurationName="test_launch_configuration",
+        ImageId=EXAMPLE_AMI_ID,
+        InstanceType="t2.medium",
     )
     client.create_auto_scaling_group(
         AutoScalingGroupName="test_asg",
@@ -1991,7 +2045,9 @@ def test_standby_detach_instance_no_decrement():
     mocked_networking = setup_networking()
     client = boto3.client("autoscaling", region_name="us-east-1")
     _ = client.create_launch_configuration(
-        LaunchConfigurationName="test_launch_configuration"
+        LaunchConfigurationName="test_launch_configuration",
+        ImageId=EXAMPLE_AMI_ID,
+        InstanceType="t2.medium",
     )
     client.create_auto_scaling_group(
         AutoScalingGroupName="test_asg",
@@ -2078,7 +2134,9 @@ def test_standby_exit_standby():
     mocked_networking = setup_networking()
     client = boto3.client("autoscaling", region_name="us-east-1")
     _ = client.create_launch_configuration(
-        LaunchConfigurationName="test_launch_configuration"
+        LaunchConfigurationName="test_launch_configuration",
+        ImageId=EXAMPLE_AMI_ID,
+        InstanceType="t2.medium",
     )
     client.create_auto_scaling_group(
         AutoScalingGroupName="test_asg",
@@ -2165,7 +2223,9 @@ def test_attach_one_instance():
     mocked_networking = setup_networking()
     client = boto3.client("autoscaling", region_name="us-east-1")
     _ = client.create_launch_configuration(
-        LaunchConfigurationName="test_launch_configuration"
+        LaunchConfigurationName="test_launch_configuration",
+        ImageId=EXAMPLE_AMI_ID,
+        InstanceType="t2.medium",
     )
     client.create_auto_scaling_group(
         AutoScalingGroupName="test_asg",
@@ -2200,7 +2260,8 @@ def test_attach_one_instance():
 
     ec2 = boto3.resource("ec2", "us-east-1")
     instances_to_add = [
-        x.id for x in ec2.create_instances(ImageId="", MinCount=1, MaxCount=1)
+        x.id
+        for x in ec2.create_instances(ImageId=EXAMPLE_AMI_ID, MinCount=1, MaxCount=1)
     ]
 
     response = client.attach_instances(
@@ -2224,7 +2285,9 @@ def test_describe_instance_health():
     mocked_networking = setup_networking()
     client = boto3.client("autoscaling", region_name="us-east-1")
     _ = client.create_launch_configuration(
-        LaunchConfigurationName="test_launch_configuration"
+        LaunchConfigurationName="test_launch_configuration",
+        ImageId=EXAMPLE_AMI_ID,
+        InstanceType="t2.medium",
     )
     client.create_auto_scaling_group(
         AutoScalingGroupName="test_asg",
@@ -2247,7 +2310,9 @@ def test_set_instance_health():
     mocked_networking = setup_networking()
     client = boto3.client("autoscaling", region_name="us-east-1")
     _ = client.create_launch_configuration(
-        LaunchConfigurationName="test_launch_configuration"
+        LaunchConfigurationName="test_launch_configuration",
+        ImageId=EXAMPLE_AMI_ID,
+        InstanceType="t2.medium",
     )
     client.create_auto_scaling_group(
         AutoScalingGroupName="test_asg",
@@ -2277,7 +2342,9 @@ def test_set_instance_health():
 def test_suspend_processes():
     mocked_networking = setup_networking()
     client = boto3.client("autoscaling", region_name="us-east-1")
-    client.create_launch_configuration(LaunchConfigurationName="lc")
+    client.create_launch_configuration(
+        LaunchConfigurationName="lc", ImageId=EXAMPLE_AMI_ID, InstanceType="t2.medium"
+    )
     client.create_auto_scaling_group(
         LaunchConfigurationName="lc",
         AutoScalingGroupName="test-asg",
@@ -2307,7 +2374,9 @@ def test_set_instance_protection():
     mocked_networking = setup_networking()
     client = boto3.client("autoscaling", region_name="us-east-1")
     _ = client.create_launch_configuration(
-        LaunchConfigurationName="test_launch_configuration"
+        LaunchConfigurationName="test_launch_configuration",
+        ImageId=EXAMPLE_AMI_ID,
+        InstanceType="t2.medium",
     )
     _ = client.create_auto_scaling_group(
         AutoScalingGroupName="test_asg",
@@ -2344,7 +2413,9 @@ def test_set_desired_capacity_up_boto3():
     mocked_networking = setup_networking()
     client = boto3.client("autoscaling", region_name="us-east-1")
     _ = client.create_launch_configuration(
-        LaunchConfigurationName="test_launch_configuration"
+        LaunchConfigurationName="test_launch_configuration",
+        ImageId=EXAMPLE_AMI_ID,
+        InstanceType="t2.medium",
     )
     _ = client.create_auto_scaling_group(
         AutoScalingGroupName="test_asg",
@@ -2370,7 +2441,9 @@ def test_set_desired_capacity_down_boto3():
     mocked_networking = setup_networking()
     client = boto3.client("autoscaling", region_name="us-east-1")
     _ = client.create_launch_configuration(
-        LaunchConfigurationName="test_launch_configuration"
+        LaunchConfigurationName="test_launch_configuration",
+        ImageId=EXAMPLE_AMI_ID,
+        InstanceType="t2.medium",
     )
     _ = client.create_auto_scaling_group(
         AutoScalingGroupName="test_asg",
@@ -2411,7 +2484,9 @@ def test_terminate_instance_via_ec2_in_autoscaling_group():
     mocked_networking = setup_networking()
     client = boto3.client("autoscaling", region_name="us-east-1")
     _ = client.create_launch_configuration(
-        LaunchConfigurationName="test_launch_configuration"
+        LaunchConfigurationName="test_launch_configuration",
+        ImageId=EXAMPLE_AMI_ID,
+        InstanceType="t2.medium",
     )
     _ = client.create_auto_scaling_group(
         AutoScalingGroupName="test_asg",
@@ -2445,7 +2520,9 @@ def test_terminate_instance_in_auto_scaling_group_decrement():
     mocked_networking = setup_networking()
     client = boto3.client("autoscaling", region_name="us-east-1")
     _ = client.create_launch_configuration(
-        LaunchConfigurationName="test_launch_configuration"
+        LaunchConfigurationName="test_launch_configuration",
+        ImageId=EXAMPLE_AMI_ID,
+        InstanceType="t2.medium",
     )
     _ = client.create_auto_scaling_group(
         AutoScalingGroupName="test_asg",
@@ -2493,7 +2570,9 @@ def test_terminate_instance_in_auto_scaling_group_no_decrement():
     mocked_networking = setup_networking()
     client = boto3.client("autoscaling", region_name="us-east-1")
     _ = client.create_launch_configuration(
-        LaunchConfigurationName="test_launch_configuration"
+        LaunchConfigurationName="test_launch_configuration",
+        ImageId=EXAMPLE_AMI_ID,
+        InstanceType="t2.medium",
     )
     _ = client.create_auto_scaling_group(
         AutoScalingGroupName="test_asg",

--- a/tests/test_autoscaling/test_autoscaling_cloudformation.py
+++ b/tests/test_autoscaling/test_autoscaling_cloudformation.py
@@ -81,7 +81,9 @@ def test_autoscaling_group_from_launch_config():
     client = boto3.client("autoscaling", region_name="us-east-1")
 
     client.create_launch_configuration(
-        LaunchConfigurationName="test_launch_configuration", InstanceType="t2.micro",
+        LaunchConfigurationName="test_launch_configuration",
+        InstanceType="t2.micro",
+        ImageId=EXAMPLE_AMI_ID,
     )
     stack_name = "test-auto-scaling-group"
 
@@ -123,6 +125,7 @@ Outputs:
     client.create_launch_configuration(
         LaunchConfigurationName="test_launch_configuration_new",
         InstanceType="t2.micro",
+        ImageId=EXAMPLE_AMI_ID,
     )
 
     cf_template = """

--- a/tests/test_autoscaling/test_elbv2.py
+++ b/tests/test_autoscaling/test_elbv2.py
@@ -5,6 +5,7 @@ import sure  # noqa
 from moto import mock_autoscaling, mock_ec2, mock_elbv2
 
 from .utils import setup_networking
+from tests import EXAMPLE_AMI_ID
 
 
 @mock_elbv2
@@ -32,7 +33,9 @@ def test_attach_detach_target_groups():
     target_group_arn = response["TargetGroups"][0]["TargetGroupArn"]
 
     client.create_launch_configuration(
-        LaunchConfigurationName="test_launch_configuration"
+        LaunchConfigurationName="test_launch_configuration",
+        ImageId=EXAMPLE_AMI_ID,
+        InstanceType="t2.medium",
     )
 
     # create asg, attach to target group on create
@@ -102,7 +105,9 @@ def test_detach_all_target_groups():
     target_group_arn = response["TargetGroups"][0]["TargetGroupArn"]
 
     client.create_launch_configuration(
-        LaunchConfigurationName="test_launch_configuration"
+        LaunchConfigurationName="test_launch_configuration",
+        ImageId=EXAMPLE_AMI_ID,
+        InstanceType="t2.medium",
     )
 
     client.create_auto_scaling_group(

--- a/tests/test_autoscaling/test_launch_configurations.py
+++ b/tests/test_autoscaling/test_launch_configurations.py
@@ -10,6 +10,7 @@ from moto import mock_autoscaling_deprecated
 from moto import mock_autoscaling
 from moto.core import ACCOUNT_ID
 from tests.helpers import requires_boto_gte
+from tests import EXAMPLE_AMI_ID
 
 
 @mock_autoscaling_deprecated
@@ -207,7 +208,11 @@ def test_launch_configuration_describe_filter():
 def test_launch_configuration_describe_paginated():
     conn = boto3.client("autoscaling", region_name="us-east-1")
     for i in range(51):
-        conn.create_launch_configuration(LaunchConfigurationName="TestLC%d" % i)
+        conn.create_launch_configuration(
+            LaunchConfigurationName="TestLC%d" % i,
+            ImageId=EXAMPLE_AMI_ID,
+            InstanceType="t2.medium",
+        )
 
     response = conn.describe_launch_configurations()
     lcs = response["LaunchConfigurations"]

--- a/tests/test_cloudformation/test_cloudformation_depends_on.py
+++ b/tests/test_cloudformation/test_cloudformation_depends_on.py
@@ -1,6 +1,7 @@
 import boto3
 from moto import mock_cloudformation, mock_ecs, mock_autoscaling, mock_s3
 import json
+from tests import EXAMPLE_AMI_ID
 
 depends_on_template_list = {
     "AWSTemplateFormatVersion": "2010-09-09",
@@ -23,7 +24,11 @@ depends_on_template_list = {
         },
         "LaunchConfig": {
             "Type": "AWS::AutoScaling::LaunchConfiguration",
-            "Properties": {"LaunchConfigurationName": "test-launch-config",},
+            "Properties": {
+                "LaunchConfigurationName": "test-launch-config",
+                "ImageId": EXAMPLE_AMI_ID,
+                "InstanceType": "t2.medium",
+            },
         },
     },
 }
@@ -45,7 +50,11 @@ depends_on_template_string = {
         },
         "LaunchConfig": {
             "Type": "AWS::AutoScaling::LaunchConfiguration",
-            "Properties": {"LaunchConfigurationName": "test-launch-config",},
+            "Properties": {
+                "LaunchConfigurationName": "test-launch-config",
+                "ImageId": EXAMPLE_AMI_ID,
+                "InstanceType": "t2.medium",
+            },
         },
     },
 }

--- a/tests/test_cloudformation/test_cloudformation_stack_integration.py
+++ b/tests/test_cloudformation/test_cloudformation_stack_integration.py
@@ -13,6 +13,7 @@ import boto.ec2.autoscale
 import boto.ec2.elb
 from boto.exception import BotoServerError
 import boto.iam
+import boto.rds
 import boto.redshift
 import boto.sns
 import boto.sqs
@@ -516,7 +517,11 @@ def test_autoscaling_group_with_elb():
             },
             "my-launch-config": {
                 "Type": "AWS::AutoScaling::LaunchConfiguration",
-                "Properties": {"ImageId": EXAMPLE_AMI_ID, "UserData": "some user data"},
+                "Properties": {
+                    "ImageId": EXAMPLE_AMI_ID,
+                    "InstanceType": "t2.medium",
+                    "UserData": "some user data",
+                },
             },
             "my-elb": {
                 "Type": "AWS::ElasticLoadBalancing::LoadBalancer",
@@ -612,7 +617,11 @@ def test_autoscaling_group_update():
             },
             "my-launch-config": {
                 "Type": "AWS::AutoScaling::LaunchConfiguration",
-                "Properties": {"ImageId": EXAMPLE_AMI_ID, "UserData": "some user data"},
+                "Properties": {
+                    "ImageId": EXAMPLE_AMI_ID,
+                    "InstanceType": "t2.medium",
+                    "UserData": "some user data",
+                },
             },
         },
     }
@@ -848,6 +857,7 @@ def test_iam_roles():
                 "Properties": {
                     "IamInstanceProfile": {"Ref": "my-instance-profile-with-path"},
                     "ImageId": EXAMPLE_AMI_ID,
+                    "InstanceType": "t2.medium",
                 },
                 "Type": "AWS::AutoScaling::LaunchConfiguration",
             },
@@ -2646,7 +2656,11 @@ def test_autoscaling_propagate_tags():
             },
             "LaunchConfig": {
                 "Type": "AWS::AutoScaling::LaunchConfiguration",
-                "Properties": {"LaunchConfigurationName": "test-launch-config"},
+                "Properties": {
+                    "LaunchConfigurationName": "test-launch-config",
+                    "ImageId": EXAMPLE_AMI_ID,
+                    "InstanceType": "t2.medium",
+                },
             },
         },
     }


### PR DESCRIPTION
Moto's implementation of autoscaling:CreateLaunchConfiguration is a little too loose,
allowing the ImageId parameter to be omitted and defaulting it to None, which results
in dozens of deprecation warnings:

`PendingDeprecationWarning: Could not find AMI with image-id:ami-123456, in the near future this will cause an error.`

This commit refactors calls to CreateLaunchConfiguration to explicitly pass in a known
AMI ImageId in order to avoid these warnings.

The integrity of the tests is unaffected by this change.