### PR TITLE
Enable GitHub Actions to run successfully on forks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,10 +1,6 @@
 name: TestNDeploy
 
-on:
-  push:
-    branches:
-      - master
-  pull_request:
+on: [push, pull_request]
 
 jobs:
   # Install and cache dependencies
@@ -119,7 +115,7 @@ jobs:
       run: |
         make test-coverage
     - name: "Upload coverage to Codecov"
-      if: ${{ matrix.python-version == 3.7 }}
+      if: ${{ matrix.python-version == 3.7 && github.repository == 'spulec/moto'}}
       uses: codecov/codecov-action@v1
       with:
         fail_ci_if_error: true
@@ -170,7 +166,7 @@ jobs:
     name: Deploy
     runs-on: ubuntu-latest
     needs: [test, testserver]
-    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
+    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' && github.repository == 'spulec/moto' }}
     strategy:
       matrix:
         python-version: [3.8]


### PR DESCRIPTION
* Trigger workflow on any push or pull request.
* Conditionally run Codecov Upload and Deploy *only* on `spulec/moto` repository.

This allows contributors to get CI results on their forked repo before
submitting PRs to `moto`.  Previously, forked repos could not run the
actions on any non-master branch and the master branch workflow
would fail (rightfully) on the steps that should only be run on the
main repo (and require tokens/secrets).