### PR TITLE
Address pytest warnings

### DIFF
--- a/moto/awslambda/models.py
+++ b/moto/awslambda/models.py
@@ -20,7 +20,6 @@ import uuid
 import tarfile
 import calendar
 import threading
-import traceback
 import weakref
 import requests.exceptions
 
@@ -608,7 +607,6 @@ class LambdaFunction(CloudFormationModel, DockerModel):
             # Docker itself is probably not running - there will be no Lambda-logs to handle
             return "error running docker: {}".format(e), True, ""
         except BaseException as e:
-            traceback.print_exc()
             logs = os.linesep.join(
                 [line for line in self.convert(output).splitlines()[:-1]]
             )

--- a/moto/batch/models.py
+++ b/moto/batch/models.py
@@ -794,7 +794,7 @@ class BatchBackend(BaseBackend):
 
             for instance_type in needed_instance_types:
                 reservation = self.ec2_backend.add_instances(
-                    image_id="ami-ecs-optimised",  # Todo import AMIs
+                    image_id="ami-03cf127a",  # Todo import AMIs
                     count=1,
                     user_data=None,
                     security_group_names=[],

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -7,6 +7,7 @@ logging.getLogger("boto").setLevel(logging.CRITICAL)
 logging.getLogger("boto3").setLevel(logging.CRITICAL)
 logging.getLogger("botocore").setLevel(logging.CRITICAL)
 
-
+# Sample pre-loaded Image Ids for use with tests.
+# (Source: moto/ec2/resources/amis.json)
 EXAMPLE_AMI_ID = "ami-12c6146b"
 EXAMPLE_AMI_ID2 = "ami-03cf127a"

--- a/tests/test_autoscaling/test_autoscaling.py
+++ b/tests/test_autoscaling/test_autoscaling.py
@@ -362,7 +362,7 @@ def test_autoscaling_group_describe_instances():
     autoscale_instance_ids = [instance.instance_id for instance in instances]
 
     ec2_conn = boto.ec2.connect_to_region("us-east-1")
-    reservations = ec2_conn.get_all_instances()
+    reservations = ec2_conn.get_all_reservations()
     instances = reservations[0].instances
     instances.should.have.length_of(2)
     instance_ids = [instance.id for instance in instances]

--- a/tests/test_cloudformation/fixtures/route53_ec2_instance_with_public_ip.py
+++ b/tests/test_cloudformation/fixtures/route53_ec2_instance_with_public_ip.py
@@ -1,11 +1,13 @@
 from __future__ import unicode_literals
 
+from tests import EXAMPLE_AMI_ID
+
 template = {
     "Parameters": {"R53ZoneName": {"Type": "String", "Default": "my_zone"}},
     "Resources": {
         "Ec2Instance": {
             "Type": "AWS::EC2::Instance",
-            "Properties": {"ImageId": "ami-1234abcd", "PrivateIpAddress": "10.0.0.25"},
+            "Properties": {"ImageId": EXAMPLE_AMI_ID, "PrivateIpAddress": "10.0.0.25"},
         },
         "HostedZone": {
             "Type": "AWS::Route53::HostedZone",

--- a/tests/test_cloudformation/fixtures/single_instance_with_ebs_volume.py
+++ b/tests/test_cloudformation/fixtures/single_instance_with_ebs_volume.py
@@ -1,5 +1,7 @@
 from __future__ import unicode_literals
 
+from tests import EXAMPLE_AMI_ID, EXAMPLE_AMI_ID2
+
 template = {
     "Description": "AWS CloudFormation Sample Template Gollum_Single_Instance_With_EBS_Volume: Gollum is a simple wiki system built on top of Git that powers GitHub Wikis. This template installs a Gollum Wiki stack on a single EC2 instance with an EBS volume for storage and demonstrates using the AWS CloudFormation bootstrap scripts to install the packages and files necessary at instance launch time. **WARNING** This template creates an Amazon EC2 instance and an EBS volume. You will be billed for the AWS resources used if you create a stack from this template.",
     "Parameters": {
@@ -217,43 +219,43 @@ template = {
         "AWSRegionArch2AMI": {
             "ap-southeast-1": {
                 "64HVM": "NOT_YET_SUPPORTED",
-                "32": "ami-b4b0cae6",
-                "64": "ami-beb0caec",
+                "32": EXAMPLE_AMI_ID,
+                "64": EXAMPLE_AMI_ID2,
             },
             "ap-southeast-2": {
                 "64HVM": "NOT_YET_SUPPORTED",
-                "32": "ami-b3990e89",
-                "64": "ami-bd990e87",
+                "32": EXAMPLE_AMI_ID,
+                "64": EXAMPLE_AMI_ID2,
             },
             "us-west-2": {
                 "64HVM": "NOT_YET_SUPPORTED",
-                "32": "ami-38fe7308",
-                "64": "ami-30fe7300",
+                "32": EXAMPLE_AMI_ID,
+                "64": EXAMPLE_AMI_ID2,
             },
             "us-east-1": {
                 "64HVM": "ami-0da96764",
-                "32": "ami-31814f58",
-                "64": "ami-1b814f72",
+                "32": EXAMPLE_AMI_ID,
+                "64": EXAMPLE_AMI_ID2,
             },
             "ap-northeast-1": {
                 "64HVM": "NOT_YET_SUPPORTED",
-                "32": "ami-0644f007",
-                "64": "ami-0a44f00b",
+                "32": EXAMPLE_AMI_ID,
+                "64": EXAMPLE_AMI_ID2,
             },
             "us-west-1": {
                 "64HVM": "NOT_YET_SUPPORTED",
-                "32": "ami-11d68a54",
-                "64": "ami-1bd68a5e",
+                "32": EXAMPLE_AMI_ID,
+                "64": EXAMPLE_AMI_ID2,
             },
             "eu-west-1": {
                 "64HVM": "NOT_YET_SUPPORTED",
-                "32": "ami-973b06e3",
-                "64": "ami-953b06e1",
+                "32": EXAMPLE_AMI_ID,
+                "64": EXAMPLE_AMI_ID2,
             },
             "sa-east-1": {
                 "64HVM": "NOT_YET_SUPPORTED",
-                "32": "ami-3e3be423",
-                "64": "ami-3c3be421",
+                "32": EXAMPLE_AMI_ID,
+                "64": EXAMPLE_AMI_ID2,
             },
         },
     },

--- a/tests/test_cloudformation/fixtures/vpc_single_instance_in_subnet.py
+++ b/tests/test_cloudformation/fixtures/vpc_single_instance_in_subnet.py
@@ -1,5 +1,7 @@
 from __future__ import unicode_literals
 
+from tests import EXAMPLE_AMI_ID
+
 template = {
     "Description": "AWS CloudFormation Sample Template vpc_single_instance_in_subnet.template: Sample template showing how to create a VPC and add an EC2 instance with an Elastic IP address and a security group. **WARNING** This template creates an Amazon EC2 instance. You will be billed for the AWS resources used if you create a stack from this template.",
     "Parameters": {
@@ -263,14 +265,14 @@ template = {
     },
     "Mappings": {
         "RegionMap": {
-            "ap-southeast-1": {"AMI": "ami-74dda626"},
-            "ap-southeast-2": {"AMI": "ami-b3990e89"},
-            "us-west-2": {"AMI": "ami-16fd7026"},
-            "us-east-1": {"AMI": "ami-7f418316"},
-            "ap-northeast-1": {"AMI": "ami-dcfa4edd"},
-            "us-west-1": {"AMI": "ami-951945d0"},
-            "eu-west-1": {"AMI": "ami-24506250"},
-            "sa-east-1": {"AMI": "ami-3e3be423"},
+            "ap-southeast-1": {"AMI": EXAMPLE_AMI_ID},
+            "ap-southeast-2": {"AMI": EXAMPLE_AMI_ID},
+            "us-west-2": {"AMI": EXAMPLE_AMI_ID},
+            "us-east-1": {"AMI": EXAMPLE_AMI_ID},
+            "ap-northeast-1": {"AMI": EXAMPLE_AMI_ID},
+            "us-west-1": {"AMI": EXAMPLE_AMI_ID},
+            "eu-west-1": {"AMI": EXAMPLE_AMI_ID},
+            "sa-east-1": {"AMI": EXAMPLE_AMI_ID},
         }
     },
 }

--- a/tests/test_cloudformation/test_cloudformation_stack_crud_boto3.py
+++ b/tests/test_cloudformation/test_cloudformation_stack_crud_boto3.py
@@ -50,7 +50,7 @@ Resources:
   EC2Instance1:
     Type: AWS::EC2::Instance
     Properties:
-      ImageId: ami-d3adb33f
+      ImageId: ami-03cf127a
       KeyName: dummy
       InstanceType: t2.micro
       Tags:
@@ -67,7 +67,7 @@ Resources:
   EC2Instance1:
     Type: AWS::EC2::Instance
     Properties:
-      ImageId: ami-d3adb33f
+      ImageId: ami-03cf127a
       KeyName: !Join [ ":", [ du, m, my ] ]
       InstanceType: t2.micro
       Tags:
@@ -90,7 +90,7 @@ Resources:
   EC2Instance1:
     Type: AWS::EC2::Instance
     Properties:
-      ImageId: ami-d3adb33f
+      ImageId: ami-03cf127a
       KeyName: dummy
       InstanceType: t2.micro
       Tags:

--- a/tests/test_cloudformation/test_cloudformation_stack_integration.py
+++ b/tests/test_cloudformation/test_cloudformation_stack_integration.py
@@ -1179,11 +1179,11 @@ def test_cloudformation_mapping():
         "AWSTemplateFormatVersion": "2010-09-09",
         "Mappings": {
             "RegionMap": {
-                "us-east-1": {"32": "ami-6411e20d", "64": "ami-7a11e213"},
-                "us-west-1": {"32": "ami-c9c7978c", "64": "ami-cfc7978a"},
-                "eu-west-1": {"32": "ami-37c2f643", "64": "ami-31c2f645"},
-                "ap-southeast-1": {"32": "ami-66f28c34", "64": "ami-60f28c32"},
-                "ap-northeast-1": {"32": "ami-9c03a89d", "64": "ami-a003a8a1"},
+                "us-east-1": {"32": EXAMPLE_AMI_ID, "64": EXAMPLE_AMI_ID2},
+                "us-west-1": {"32": EXAMPLE_AMI_ID, "64": EXAMPLE_AMI_ID2},
+                "eu-west-1": {"32": EXAMPLE_AMI_ID, "64": EXAMPLE_AMI_ID2},
+                "ap-southeast-1": {"32": EXAMPLE_AMI_ID, "64": EXAMPLE_AMI_ID2},
+                "ap-northeast-1": {"32": EXAMPLE_AMI_ID, "64": EXAMPLE_AMI_ID2},
             }
         },
         "Resources": {
@@ -1195,7 +1195,6 @@ def test_cloudformation_mapping():
                     },
                     "InstanceType": "m1.small",
                 },
-                "Type": "AWS::EC2::Instance",
             }
         },
     }
@@ -1207,14 +1206,14 @@ def test_cloudformation_mapping():
     ec2_conn = boto.ec2.connect_to_region("us-east-1")
     reservation = ec2_conn.get_all_reservations()[0]
     ec2_instance = reservation.instances[0]
-    ec2_instance.image_id.should.equal("ami-6411e20d")
+    ec2_instance.image_id.should.equal(EXAMPLE_AMI_ID)
 
     conn = boto.cloudformation.connect_to_region("us-west-1")
     conn.create_stack("test_stack1", template_body=dummy_template_json)
     ec2_conn = boto.ec2.connect_to_region("us-west-1")
     reservation = ec2_conn.get_all_reservations()[0]
     ec2_instance = reservation.instances[0]
-    ec2_instance.image_id.should.equal("ami-c9c7978c")
+    ec2_instance.image_id.should.equal(EXAMPLE_AMI_ID)
 
 
 @mock_cloudformation_deprecated()

--- a/tests/test_cloudformation/test_cloudformation_stack_integration.py
+++ b/tests/test_cloudformation/test_cloudformation_stack_integration.py
@@ -222,7 +222,7 @@ def test_stack_ec2_integration():
     conn.create_stack("ec2_stack", template_body=ec2_template_json)
 
     ec2_conn = boto.ec2.connect_to_region("us-west-1")
-    reservation = ec2_conn.get_all_instances()[0]
+    reservation = ec2_conn.get_all_reservations()[0]
     ec2_instance = reservation.instances[0]
 
     stack = conn.describe_stacks()[0]
@@ -269,7 +269,7 @@ def test_stack_elb_integration_with_attached_ec2_instances():
     load_balancer = elb_conn.get_all_load_balancers()[0]
 
     ec2_conn = boto.ec2.connect_to_region("us-west-1")
-    reservation = ec2_conn.get_all_instances()[0]
+    reservation = ec2_conn.get_all_reservations()[0]
     ec2_instance = reservation.instances[0]
 
     load_balancer.instances[0].id.should.equal(ec2_instance.id)
@@ -465,7 +465,7 @@ def test_stack_security_groups():
         filters={"description": ["My other group"]}
     )[0]
 
-    reservation = ec2_conn.get_all_instances()[0]
+    reservation = ec2_conn.get_all_reservations()[0]
     ec2_instance = reservation.instances[0]
 
     ec2_instance.groups[0].id.should.equal(instance_group.id)
@@ -692,7 +692,7 @@ def test_vpc_single_instance_in_subnet():
     subnet.vpc_id.should.equal(vpc.id)
 
     ec2_conn = boto.ec2.connect_to_region("us-west-1")
-    reservation = ec2_conn.get_all_instances()[0]
+    reservation = ec2_conn.get_all_reservations()[0]
     instance = reservation.instances[0]
     instance.tags["Foo"].should.equal("Bar")
     # Check that the EIP is attached the the EC2 instance
@@ -1011,7 +1011,7 @@ def test_single_instance_with_ebs_volume():
     )
 
     ec2_conn = boto.ec2.connect_to_region("us-west-1")
-    reservation = ec2_conn.get_all_instances()[0]
+    reservation = ec2_conn.get_all_reservations()[0]
     ec2_instance = reservation.instances[0]
 
     volumes = ec2_conn.get_all_volumes()
@@ -1157,7 +1157,7 @@ def test_conditional_if_handling():
     conn = boto.cloudformation.connect_to_region("us-west-1")
     conn.create_stack("test_stack1", template_body=dummy_template_json)
     ec2_conn = boto.ec2.connect_to_region("us-west-1")
-    reservation = ec2_conn.get_all_instances()[0]
+    reservation = ec2_conn.get_all_reservations()[0]
     ec2_instance = reservation.instances[0]
     ec2_instance.image_id.should.equal(EXAMPLE_AMI_ID2)
     ec2_instance.terminate()
@@ -1167,7 +1167,7 @@ def test_conditional_if_handling():
         "test_stack1", template_body=dummy_template_json, parameters=[("ENV", "prd")]
     )
     ec2_conn = boto.ec2.connect_to_region("us-west-2")
-    reservation = ec2_conn.get_all_instances()[0]
+    reservation = ec2_conn.get_all_reservations()[0]
     ec2_instance = reservation.instances[0]
     ec2_instance.image_id.should.equal(EXAMPLE_AMI_ID)
 
@@ -1205,14 +1205,14 @@ def test_cloudformation_mapping():
     conn = boto.cloudformation.connect_to_region("us-east-1")
     conn.create_stack("test_stack1", template_body=dummy_template_json)
     ec2_conn = boto.ec2.connect_to_region("us-east-1")
-    reservation = ec2_conn.get_all_instances()[0]
+    reservation = ec2_conn.get_all_reservations()[0]
     ec2_instance = reservation.instances[0]
     ec2_instance.image_id.should.equal("ami-6411e20d")
 
     conn = boto.cloudformation.connect_to_region("us-west-1")
     conn.create_stack("test_stack1", template_body=dummy_template_json)
     ec2_conn = boto.ec2.connect_to_region("us-west-1")
-    reservation = ec2_conn.get_all_instances()[0]
+    reservation = ec2_conn.get_all_reservations()[0]
     ec2_instance = reservation.instances[0]
     ec2_instance.image_id.should.equal("ami-c9c7978c")
 

--- a/tests/test_core/test_decorator_calls.py
+++ b/tests/test_core/test_decorator_calls.py
@@ -21,38 +21,38 @@ def test_basic_connect():
 @mock_ec2_deprecated
 def test_basic_decorator():
     conn = boto.connect_ec2("the_key", "the_secret")
-    list(conn.get_all_instances()).should.equal([])
+    list(conn.get_all_reservations()).should.equal([])
 
 
 @pytest.mark.network
 def test_context_manager():
     conn = boto.connect_ec2("the_key", "the_secret")
     with pytest.raises(EC2ResponseError):
-        conn.get_all_instances()
+        conn.get_all_reservations()
 
     with mock_ec2_deprecated():
         conn = boto.connect_ec2("the_key", "the_secret")
-        list(conn.get_all_instances()).should.equal([])
+        list(conn.get_all_reservations()).should.equal([])
 
     with pytest.raises(EC2ResponseError):
         conn = boto.connect_ec2("the_key", "the_secret")
-        conn.get_all_instances()
+        conn.get_all_reservations()
 
 
 @pytest.mark.network
 def test_decorator_start_and_stop():
     conn = boto.connect_ec2("the_key", "the_secret")
     with pytest.raises(EC2ResponseError):
-        conn.get_all_instances()
+        conn.get_all_reservations()
 
     mock = mock_ec2_deprecated()
     mock.start()
     conn = boto.connect_ec2("the_key", "the_secret")
-    list(conn.get_all_instances()).should.equal([])
+    list(conn.get_all_reservations()).should.equal([])
     mock.stop()
 
     with pytest.raises(EC2ResponseError):
-        conn.get_all_instances()
+        conn.get_all_reservations()
 
 
 @mock_ec2_deprecated
@@ -69,11 +69,11 @@ def test_decorater_wrapped_gets_set():
 class Tester(object):
     def test_the_class(self):
         conn = boto.connect_ec2()
-        list(conn.get_all_instances()).should.have.length_of(0)
+        list(conn.get_all_reservations()).should.have.length_of(0)
 
     def test_still_the_same(self):
         conn = boto.connect_ec2()
-        list(conn.get_all_instances()).should.have.length_of(0)
+        list(conn.get_all_reservations()).should.have.length_of(0)
 
 
 @mock_s3_deprecated

--- a/tests/test_core/test_nested.py
+++ b/tests/test_core/test_nested.py
@@ -6,6 +6,7 @@ from boto.sqs.message import Message
 from boto.ec2 import EC2Connection
 
 from moto import mock_sqs_deprecated, mock_ec2_deprecated
+from tests import EXAMPLE_AMI_ID
 
 
 class TestNestedDecorators(unittest.TestCase):
@@ -25,4 +26,4 @@ class TestNestedDecorators(unittest.TestCase):
         self.setup_sqs_queue()
 
         conn = EC2Connection()
-        conn.run_instances("ami-123456")
+        conn.run_instances(EXAMPLE_AMI_ID)

--- a/tests/test_elb/test_elb.py
+++ b/tests/test_elb/test_elb.py
@@ -16,6 +16,7 @@ import sure  # noqa
 
 from moto import mock_elb, mock_ec2, mock_elb_deprecated, mock_ec2_deprecated
 from moto.core import ACCOUNT_ID
+from tests import EXAMPLE_AMI_ID
 
 
 @mock_elb_deprecated
@@ -378,7 +379,7 @@ def test_create_health_check_boto3():
 @mock_elb_deprecated
 def test_register_instances():
     ec2_conn = boto.connect_ec2()
-    reservation = ec2_conn.run_instances("ami-1234abcd", 2)
+    reservation = ec2_conn.run_instances(EXAMPLE_AMI_ID, 2)
     instance_id1 = reservation.instances[0].id
     instance_id2 = reservation.instances[1].id
 
@@ -397,7 +398,7 @@ def test_register_instances():
 @mock_elb
 def test_register_instances_boto3():
     ec2 = boto3.resource("ec2", region_name="us-east-1")
-    response = ec2.create_instances(ImageId="ami-1234abcd", MinCount=2, MaxCount=2)
+    response = ec2.create_instances(ImageId=EXAMPLE_AMI_ID, MinCount=2, MaxCount=2)
     instance_id1 = response[0].id
     instance_id2 = response[1].id
 
@@ -420,7 +421,7 @@ def test_register_instances_boto3():
 @mock_elb_deprecated
 def test_deregister_instances():
     ec2_conn = boto.connect_ec2()
-    reservation = ec2_conn.run_instances("ami-1234abcd", 2)
+    reservation = ec2_conn.run_instances(EXAMPLE_AMI_ID, 2)
     instance_id1 = reservation.instances[0].id
     instance_id2 = reservation.instances[1].id
 
@@ -442,7 +443,7 @@ def test_deregister_instances():
 @mock_elb
 def test_deregister_instances_boto3():
     ec2 = boto3.resource("ec2", region_name="us-east-1")
-    response = ec2.create_instances(ImageId="ami-1234abcd", MinCount=2, MaxCount=2)
+    response = ec2.create_instances(ImageId=EXAMPLE_AMI_ID, MinCount=2, MaxCount=2)
     instance_id1 = response[0].id
     instance_id2 = response[1].id
 
@@ -679,7 +680,7 @@ def test_set_policies_of_backend_server():
 @mock_elb_deprecated
 def test_describe_instance_health():
     ec2_conn = boto.connect_ec2()
-    reservation = ec2_conn.run_instances("ami-1234abcd", 2)
+    reservation = ec2_conn.run_instances(EXAMPLE_AMI_ID, 2)
     instance_id1 = reservation.instances[0].id
     instance_id2 = reservation.instances[1].id
 
@@ -710,7 +711,9 @@ def test_describe_instance_health():
 def test_describe_instance_health_boto3():
     elb = boto3.client("elb", region_name="us-east-1")
     ec2 = boto3.client("ec2", region_name="us-east-1")
-    instances = ec2.run_instances(MinCount=2, MaxCount=2)["Instances"]
+    instances = ec2.run_instances(ImageId=EXAMPLE_AMI_ID, MinCount=2, MaxCount=2)[
+        "Instances"
+    ]
     lb_name = "my_load_balancer"
     elb.create_load_balancer(
         Listeners=[{"InstancePort": 80, "LoadBalancerPort": 8080, "Protocol": "HTTP"}],

--- a/tests/test_elbv2/test_elbv2.py
+++ b/tests/test_elbv2/test_elbv2.py
@@ -10,6 +10,7 @@ import sure  # noqa
 from moto import mock_elbv2, mock_ec2, mock_acm
 from moto.elbv2 import elbv2_backends
 from moto.core import ACCOUNT_ID
+from tests import EXAMPLE_AMI_ID
 
 
 @mock_elbv2
@@ -643,7 +644,7 @@ def test_register_targets():
     )
     response.get("TargetHealthDescriptions").should.have.length_of(0)
 
-    response = ec2.create_instances(ImageId="ami-1234abcd", MinCount=2, MaxCount=2)
+    response = ec2.create_instances(ImageId=EXAMPLE_AMI_ID, MinCount=2, MaxCount=2)
     instance_id1 = response[0].id
     instance_id2 = response[1].id
 
@@ -719,7 +720,7 @@ def test_stopped_instance_target():
     )
     response.get("TargetHealthDescriptions").should.have.length_of(0)
 
-    response = ec2.create_instances(ImageId="ami-1234abcd", MinCount=1, MaxCount=1)
+    response = ec2.create_instances(ImageId=EXAMPLE_AMI_ID, MinCount=1, MaxCount=1)
     instance = response[0]
 
     target_dict = {"Id": instance.id, "Port": 500}
@@ -804,7 +805,7 @@ def test_terminated_instance_target():
     )
     response.get("TargetHealthDescriptions").should.have.length_of(0)
 
-    response = ec2.create_instances(ImageId="ami-1234abcd", MinCount=1, MaxCount=1)
+    response = ec2.create_instances(ImageId=EXAMPLE_AMI_ID, MinCount=1, MaxCount=1)
     instance = response[0]
 
     target_dict = {"Id": instance.id, "Port": 500}

--- a/tests/test_opsworks/test_instances.py
+++ b/tests/test_opsworks/test_instances.py
@@ -4,6 +4,7 @@ import sure  # noqa
 
 from moto import mock_opsworks
 from moto import mock_ec2
+from tests import EXAMPLE_AMI_ID
 
 
 @mock_opsworks
@@ -183,6 +184,7 @@ def test_ec2_integration():
     )["LayerId"]
 
     instance_id = opsworks.create_instance(
+        AmiId=EXAMPLE_AMI_ID,
         StackId=stack_id,
         LayerIds=[layer_id],
         InstanceType="t2.micro",

--- a/tests/test_ssm/test_ssm_boto3.py
+++ b/tests/test_ssm/test_ssm_boto3.py
@@ -12,6 +12,7 @@ from botocore.exceptions import ClientError, ParamValidationError
 import pytest
 
 from moto import mock_ec2, mock_ssm
+from tests import EXAMPLE_AMI_ID
 
 
 @mock_ssm
@@ -1696,7 +1697,7 @@ def test_get_command_invocations_by_instance_tag():
     ]
     num_instances = 3
     resp = ec2.run_instances(
-        ImageId="ami-1234abcd",
+        ImageId=EXAMPLE_AMI_ID,
         MaxCount=num_instances,
         MinCount=num_instances,
         TagSpecifications=tag_specifications,

--- a/tests/test_ssm/test_ssm_cloudformation.py
+++ b/tests/test_ssm/test_ssm_cloudformation.py
@@ -3,6 +3,7 @@ import json
 
 
 from moto import mock_ssm, mock_cloudformation
+from tests import EXAMPLE_AMI_ID
 
 
 @mock_ssm
@@ -15,7 +16,7 @@ def test_get_command_invocations_from_stack():
             "EC2Instance1": {
                 "Type": "AWS::EC2::Instance",
                 "Properties": {
-                    "ImageId": "ami-test-image-id",
+                    "ImageId": EXAMPLE_AMI_ID,
                     "KeyName": "test",
                     "InstanceType": "t2.micro",
                     "Tags": [


### PR DESCRIPTION
This should just about do it for cleaning up the pytest output.

Commits are atomic and probably best left un-squashed for git blame/history purposes.