### PR TITLE
** Merge me first - I fix the build! **

### DIFF
--- a/tests/test_sagemaker/test_sagemaker_notebooks.py
+++ b/tests/test_sagemaker/test_sagemaker_notebooks.py
@@ -3,7 +3,7 @@ from __future__ import unicode_literals
 
 import datetime
 import boto3
-from botocore.exceptions import ClientError, ParamValidationError
+from botocore.exceptions import ClientError
 import sure  # noqa
 
 from moto import mock_sagemaker
@@ -120,27 +120,6 @@ def test_create_notebook_instance_params():
 
     resp = sagemaker.list_tags(ResourceArn=resp["NotebookInstanceArn"])
     assert resp["Tags"] == GENERIC_TAGS_PARAM
-
-
-@mock_sagemaker
-def test_create_notebook_instance_bad_volume_size():
-
-    sagemaker = boto3.client("sagemaker", region_name="us-east-1")
-
-    vol_size = 2
-    args = {
-        "NotebookInstanceName": "MyNotebookInstance",
-        "InstanceType": "ml.t2.medium",
-        "RoleArn": FAKE_ROLE_ARN,
-        "VolumeSizeInGB": vol_size,
-    }
-    with pytest.raises(ParamValidationError) as ex:
-        sagemaker.create_notebook_instance(**args)
-    assert ex.value.args[
-        0
-    ] == "Parameter validation failed:\nInvalid range for parameter VolumeSizeInGB, value: {}, valid range: 5-inf".format(
-        vol_size
-    )
 
 
 @mock_sagemaker

--- a/tests/test_ssm/test_ssm_boto3.py
+++ b/tests/test_ssm/test_ssm_boto3.py
@@ -8,7 +8,7 @@ import sure  # noqa
 import datetime
 import uuid
 
-from botocore.exceptions import ClientError, ParamValidationError
+from botocore.exceptions import ClientError
 import pytest
 
 from moto import mock_ec2, mock_ssm
@@ -935,25 +935,6 @@ def test_describe_parameters_invalid_path(value):
         'Special characters are not allowed. All sub-paths, if specified, must use the forward slash symbol "/".'
     )
     msg.should.contain("Valid example: /get/parameters2-/by1./path0_.")
-
-
-@pytest.mark.parametrize(
-    "filters,error_msg",
-    [
-        ([{}], 'Missing required parameter in ParameterFilters[0]: "Key"',),
-        (
-            [{"Key": "Name", "Values": []}],
-            "Invalid length for parameter ParameterFilters[0].Values, value: 0, valid range: 1-inf",
-        ),
-    ],
-)
-@mock_ssm
-def test_describe_parameters_parameter_validation(filters, error_msg):
-    client = boto3.client("ssm", region_name="us-east-1")
-
-    with pytest.raises(ParamValidationError) as e:
-        client.describe_parameters(ParameterFilters=filters)
-    e.value.kwargs["report"].should.contain(error_msg)
 
 
 @mock_ssm


### PR DESCRIPTION
Fix: broken build with release of botocore 1.19.62

The latest release of `botocore` (1.19.62) makes changes to the parameter
validation code, which for some reason was also covered by a couple of
`moto` tests.

These tests, when run, do not execute any `moto` code.  They fail the
parameter validation check in `botocore`, which raises an exception
before ever sending a request.  These tests do not cover or verify
any `moto` behavior and have been removed.

Ref: https://github.com/boto/botocore/commit/ff8ae76ecc0ee29713c51fd2a17c945d776dc44b

Closes #3627