### PR TITLE
Add support for the force argument for ecs.delete_service

### DIFF
--- a/moto/ecs/models.py
+++ b/moto/ecs/models.py
@@ -1147,14 +1147,14 @@ class EC2ContainerServiceBackend(BaseBackend):
         else:
             raise ServiceNotFoundException
 
-    def delete_service(self, cluster_name, service_name):
+    def delete_service(self, cluster_name, service_name, force):
         cluster_service_pair = "{0}:{1}".format(cluster_name, service_name)
         if cluster_name not in self.clusters:
             raise ClusterNotFoundException
 
         if cluster_service_pair in self.services:
             service = self.services[cluster_service_pair]
-            if service.desired_count > 0:
+            if service.desired_count > 0 and not force:
                 raise InvalidParameterException(
                     "The service cannot be stopped while it is scaled above 0."
                 )

--- a/moto/ecs/responses.py
+++ b/moto/ecs/responses.py
@@ -226,7 +226,8 @@ class EC2ContainerServiceResponse(BaseResponse):
     def delete_service(self):
         service_name = self._get_param("service")
         cluster_name = self._get_param("cluster", "default")
-        service = self.ecs_backend.delete_service(cluster_name, service_name)
+        force = self._get_param("force", False)
+        service = self.ecs_backend.delete_service(cluster_name, service_name, force)
         return json.dumps({"service": service.response_object})
 
     def register_container_instance(self):


### PR DESCRIPTION
This argument allows you to delete a service even when its DesiredCount is non-zero.

https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/ecs.html#ECS.Client.delete_service