### PR TITLE
Update SNS get_endpoint_attributes response for Not Found endpoints #3477

### DIFF
--- a/moto/sns/exceptions.py
+++ b/moto/sns/exceptions.py
@@ -1,12 +1,24 @@
 from __future__ import unicode_literals
 from moto.core.exceptions import RESTError
 
+NOT_FOUND_ENDPOINT_ERROR = """<ErrorResponse xmlns="http://sns.amazonaws.com/doc/2010-03-31/">
+  <Error>
+    <Type>{{ sender }}</Type>
+    <Code>{{ error_type }}</Code>
+    <Message>{{ message }}</Message>
+  </Error>
+  <RequestId>9dd01905-5012-5f99-8663-4b3ecd0dfaef</RequestId>
+</ErrorResponse>"""
+
 
 class SNSNotFoundError(RESTError):
     code = 404
 
-    def __init__(self, message):
-        super(SNSNotFoundError, self).__init__("NotFound", message)
+    def __init__(self, message, **kwargs):
+        kwargs.setdefault("template", "endpoint_error")
+        kwargs.setdefault("sender", "Sender")
+        self.templates["endpoint_error"] = NOT_FOUND_ENDPOINT_ERROR
+        super(SNSNotFoundError, self).__init__("NotFound", message, **kwargs)
 
 
 class ResourceNotFoundError(RESTError):

--- a/moto/sns/models.py
+++ b/moto/sns/models.py
@@ -593,7 +593,7 @@ class SNSBackend(BaseBackend):
         try:
             return self.platform_endpoints[arn]
         except KeyError:
-            raise SNSNotFoundError("Endpoint with arn {0} not found".format(arn))
+            raise SNSNotFoundError("Endpoint does not exist")
 
     def set_endpoint_attributes(self, arn, attributes):
         endpoint = self.get_endpoint(arn)

--- a/tests/test_sns/test_application_boto3.py
+++ b/tests/test_sns/test_application_boto3.py
@@ -5,6 +5,7 @@ from botocore.exceptions import ClientError
 from moto import mock_sns
 import sure  # noqa
 from moto.core import ACCOUNT_ID
+import pytest
 
 
 @mock_sns
@@ -204,6 +205,18 @@ def test_get_endpoint_attributes():
     attributes.should.equal(
         {"Token": "some_unique_id", "Enabled": "false", "CustomUserData": "some data"}
     )
+
+
+@mock_sns
+def test_get_non_existent_endpoint_attributes():
+    conn = boto3.client("sns", region_name="us-east-1")
+    endpoint_arn = "arn:aws:sns:us-east-1:123456789012:endpoint/APNS/my-application/c1f76c42-192a-4e75-b04f-a9268ce2abf3"
+    with pytest.raises(conn.exceptions.NotFoundException) as excinfo:
+        conn.get_endpoint_attributes(EndpointArn=endpoint_arn)
+    error = excinfo.value.response["Error"]
+    error["Type"].should.equal("Sender")
+    error["Code"].should.equal("NotFound")
+    error["Message"].should.equal("Endpoint does not exist")
 
 
 @mock_sns


### PR DESCRIPTION
Currently the response to `get_endpoint_attributes` for a non existent endpoint
differ from boto and moto, in the following way (shown in JSON instead of xml
for shortness):

* **boto**: `{ErrorResponse:  { Error: { Code: "... ", Type: "... ", Sender: "..." }}`
* **moto**: ` { ErrorResponse: { Errors: [ { Error: { Code: "... ", Type: "... ", Sender: "..." }}]}}`

The template used to generate the NotFound error was the default for [RESTError](https://github.com/spulec/moto/blob/master/moto/core/exceptions.py).

Moreover, although `RESTError` has another template called [SINGLE_ERROR_RESPONSE](https://github.com/spulec/moto/blob/master/moto/core/exceptions.py#L8). 
That at first sight looks like the right one, it lacks the `ErrorResponse` node at the root
of the XML, which causes an error when parsing that XML later in the application, and
results in a `ClientError` instead of a `NotFound` exception.

This PR takes the approach suggested in the [issue conversation](https://github.com/spulec/moto/issues/3477#issuecomment-729090978).
Although there is one thing I personally do not entirely like, which is the fact there is yet 
another variation of this template:

* One in [moto/core/exceptions.py](https://github.com/spulec/moto/blob/master/moto/core/exceptions.py#L8)
* One in [moto/sns/responses.py](https://github.com/spulec/moto/blob/master/moto/sns/responses.py#L1095)
* Plus the one added in this commit

An alternative, which avoids creating the third template is not to catch the exception in [moto/sns/models.py](https://github.com/spulec/moto/blob/master/moto/sns/models.py#L608), 
allowing the exception to "bubble" up to [moto/sns/responses.py](https://github.com/spulec/moto/blob/master/moto/sns/responses.py#L544)
where it can be caught, and return an error response using the already existing
template in that module.

The issue with this later approach, would be that it differs a bit more from the current
implementation, since `moto/sns/models.py` does catch all exceptions for all other
functions, and it is also nicer to catch exceptions sooner than later.
    