### PR TITLE
Link remaining badges in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,10 @@
 [![Build Status](https://github.com/spulec/moto/workflows/TestNDeploy/badge.svg)](https://github.com/spulec/moto/actions)
 [![Coverage Status](https://codecov.io/gh/spulec/moto/branch/master/graph/badge.svg)](https://codecov.io/gh/spulec/moto)
 [![Docs](https://readthedocs.org/projects/pip/badge/?version=stable)](http://docs.getmoto.org)
-![PyPI](https://img.shields.io/pypi/v/moto.svg)
-![PyPI - Python Version](https://img.shields.io/pypi/pyversions/moto.svg)
-![PyPI - Downloads](https://img.shields.io/pypi/dw/moto.svg) [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
+[![PyPI](https://img.shields.io/pypi/v/moto.svg)](https://pypi.org/project/moto/)
+[![PyPI - Python Version](https://img.shields.io/pypi/pyversions/moto.svg)](#)
+[![PyPI - Downloads](https://img.shields.io/pypi/dw/moto.svg)](https://pypistats.org/packages/moto)
+[![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 
 
 ## Install


### PR DESCRIPTION
- Adds a link to moto’s PyPI page
- Makes the “Python Versions” badge unclickable (nobody wants to see the badge image in a new tab when clicking a badge)
- Adds a link to PyPIstats for download stats