### PR TITLE
Remove redundant test code

### DIFF
--- a/tests/test_applicationautoscaling/test_validation.py
+++ b/tests/test_applicationautoscaling/test_validation.py
@@ -3,7 +3,6 @@ import boto3
 from moto import mock_applicationautoscaling, mock_ecs
 from moto.applicationautoscaling import models
 from moto.applicationautoscaling.exceptions import AWSValidationException
-from botocore.exceptions import ParamValidationError
 import pytest
 import sure  # noqa
 from botocore.exceptions import ClientError
@@ -19,27 +18,6 @@ DEFAULT_SCALABLE_DIMENSION = "ecs:service:DesiredCount"
 DEFAULT_MIN_CAPACITY = 1
 DEFAULT_MAX_CAPACITY = 1
 DEFAULT_ROLE_ARN = "test:arn"
-
-
-@mock_applicationautoscaling
-def test_describe_scalable_targets_no_params_should_raise_param_validation_errors():
-    client = boto3.client("application-autoscaling", region_name=DEFAULT_REGION)
-    with pytest.raises(ParamValidationError):
-        client.describe_scalable_targets()
-
-
-@mock_applicationautoscaling
-def test_register_scalable_target_no_params_should_raise_param_validation_errors():
-    client = boto3.client("application-autoscaling", region_name=DEFAULT_REGION)
-    with pytest.raises(ParamValidationError):
-        client.register_scalable_target()
-
-
-@mock_applicationautoscaling
-def test_register_scalable_target_with_none_service_namespace_should_raise_param_validation_errors():
-    client = boto3.client("application-autoscaling", region_name=DEFAULT_REGION)
-    with pytest.raises(ParamValidationError):
-        register_scalable_target(client, ServiceNamespace=None)
 
 
 @mock_applicationautoscaling

--- a/tests/test_ec2/test_flow_logs.py
+++ b/tests/test_ec2/test_flow_logs.py
@@ -4,7 +4,7 @@ import pytest
 
 import boto3
 
-from botocore.exceptions import ParamValidationError, ClientError
+from botocore.exceptions import ClientError
 from botocore.parsers import ResponseParserError
 import json
 import sure  # noqa

--- a/tests/test_ec2/test_subnets.py
+++ b/tests/test_ec2/test_subnets.py
@@ -10,7 +10,7 @@ import boto.vpc
 import pytest
 import sure  # noqa
 from boto.exception import EC2ResponseError
-from botocore.exceptions import ClientError, ParamValidationError
+from botocore.exceptions import ClientError
 from moto import mock_ec2, mock_ec2_deprecated
 from tests import EXAMPLE_AMI_ID
 
@@ -201,11 +201,6 @@ def test_modify_subnet_attribute_validation():
     subnet = ec2.create_subnet(
         VpcId=vpc.id, CidrBlock="10.0.0.0/24", AvailabilityZone="us-west-1a"
     )
-
-    with pytest.raises(ParamValidationError):
-        client.modify_subnet_attribute(
-            SubnetId=subnet.id, MapPublicIpOnLaunch={"Value": "invalid"}
-        )
 
 
 @mock_ec2_deprecated

--- a/tests/test_ecr/test_ecr_boto3.py
+++ b/tests/test_ecr/test_ecr_boto3.py
@@ -11,7 +11,7 @@ import re
 import sure  # noqa
 
 import boto3
-from botocore.exceptions import ClientError, ParamValidationError
+from botocore.exceptions import ClientError
 from dateutil.tz import tzlocal
 
 from moto import mock_ecr
@@ -719,26 +719,6 @@ def test_batch_get_image_that_doesnt_exist():
     response["failures"][0]["failureReason"].should.equal("Requested image not found")
     response["failures"][0]["failureCode"].should.equal("ImageNotFound")
     response["failures"][0]["imageId"]["imageTag"].should.equal("v5")
-
-
-@mock_ecr
-def test_batch_get_image_no_tags():
-    client = boto3.client("ecr", region_name="us-east-1")
-    _ = client.create_repository(repositoryName="test_repository")
-
-    _ = client.put_image(
-        repositoryName="test_repository",
-        imageManifest=json.dumps(_create_image_manifest()),
-        imageTag="latest",
-    )
-
-    error_msg = re.compile(
-        r".*Missing required parameter in input: \"imageIds\".*", re.MULTILINE
-    )
-
-    client.batch_get_image.when.called_with(
-        repositoryName="test_repository"
-    ).should.throw(ParamValidationError, error_msg)
 
 
 @mock_ecr

--- a/tests/test_kms/test_kms_boto3.py
+++ b/tests/test_kms/test_kms_boto3.py
@@ -395,7 +395,6 @@ def test_generate_data_key_decrypt():
         dict(KeySpec="AES_257"),
         dict(KeySpec="AES_128", NumberOfBytes=16),
         dict(NumberOfBytes=2048),
-        dict(NumberOfBytes=0),
         dict(),
     ],
 )
@@ -404,9 +403,7 @@ def test_generate_data_key_invalid_size_params(kwargs):
     client = boto3.client("kms", region_name="us-east-1")
     key = client.create_key(Description="generate-data-key-size")
 
-    with pytest.raises(
-        (botocore.exceptions.ClientError, botocore.exceptions.ParamValidationError)
-    ) as err:
+    with pytest.raises(botocore.exceptions.ClientError):
         client.generate_data_key(KeyId=key["KeyMetadata"]["KeyId"], **kwargs)
 
 
@@ -538,13 +535,7 @@ def test_generate_random(number_of_bytes):
 
 @pytest.mark.parametrize(
     "number_of_bytes,error_type",
-    [
-        (2048, botocore.exceptions.ClientError),
-        (1025, botocore.exceptions.ClientError),
-        (0, botocore.exceptions.ParamValidationError),
-        (-1, botocore.exceptions.ParamValidationError),
-        (-1024, botocore.exceptions.ParamValidationError),
-    ],
+    [(2048, botocore.exceptions.ClientError), (1025, botocore.exceptions.ClientError),],
 )
 @mock_kms
 def test_generate_random_invalid_number_of_bytes(number_of_bytes, error_type):

--- a/tests/test_rds2/test_rds2.py
+++ b/tests/test_rds2/test_rds2.py
@@ -1,6 +1,6 @@
 from __future__ import unicode_literals
 
-from botocore.exceptions import ClientError, ParamValidationError
+from botocore.exceptions import ClientError
 import boto3
 import sure  # noqa
 from moto import mock_ec2, mock_kms, mock_rds2
@@ -786,16 +786,8 @@ def test_modify_non_existent_option_group():
     conn = boto3.client("rds", region_name="us-west-2")
     conn.modify_option_group.when.called_with(
         OptionGroupName="non-existent",
-        OptionsToInclude=[
-            (
-                "OptionName",
-                "Port",
-                "DBSecurityGroupMemberships",
-                "VpcSecurityGroupMemberships",
-                "OptionSettings",
-            )
-        ],
-    ).should.throw(ParamValidationError)
+        OptionsToInclude=[{"OptionName": "test-option"}],
+    ).should.throw(ClientError, "Specified OptionGroupName: non-existent not found.")
 
 
 @mock_rds2

--- a/tests/test_s3/test_s3.py
+++ b/tests/test_s3/test_s3.py
@@ -4807,29 +4807,6 @@ def test_encryption():
 
 
 @mock_s3
-def test_presigned_url_restrict_parameters():
-    # Only specific params can be set
-    # Ensure error is thrown when adding custom metadata this way
-    bucket = str(uuid.uuid4())
-    key = "file.txt"
-    conn = boto3.resource("s3", region_name="us-east-1")
-    conn.create_bucket(Bucket=bucket)
-    s3 = boto3.client("s3", region_name="us-east-1")
-
-    # Create a pre-signed url with some metadata.
-    with pytest.raises(botocore.exceptions.ParamValidationError) as err:
-        s3.generate_presigned_url(
-            ClientMethod="put_object",
-            Params={"Bucket": bucket, "Key": key, "Unknown": "metadata"},
-        )
-    assert str(err.value).should.match(
-        r'Parameter validation failed:\nUnknown parameter in input: "Unknown", must be one of:.*'
-    )
-
-    s3.delete_bucket(Bucket=bucket)
-
-
-@mock_s3
 def test_presigned_put_url_with_approved_headers():
     bucket = str(uuid.uuid4())
     key = "file.txt"


### PR DESCRIPTION
These tests, when run, do not execute any `moto` code. They fail the
parameter validation check in `botocore`, which raises an exception
before ever sending a request.  These tests do not cover or verify
any `moto` behavior and have been removed.

* Where possible, tests were modified to exercise `moto` backend code 
   instead of `botocore` code.
* The weird diff in `test_elbv2` is because the original commit that added 
  `test_fixed_response_action_listener_rule_validates_status_code` accidentally 
   copy/pasted the test into itself one indentation level. (https://github.com/spulec/moto/commit/2b8bdc9bca85d97852e0bd9b4fddccd009554d35)