### PR TITLE
Remove duplicate template of SNS error response #3646

### DIFF
--- a/moto/sns/exceptions.py
+++ b/moto/sns/exceptions.py
@@ -1,23 +1,11 @@
 from __future__ import unicode_literals
 from moto.core.exceptions import RESTError
 
-NOT_FOUND_ENDPOINT_ERROR = """<ErrorResponse xmlns="http://sns.amazonaws.com/doc/2010-03-31/">
-  <Error>
-    <Type>{{ sender }}</Type>
-    <Code>{{ error_type }}</Code>
-    <Message>{{ message }}</Message>
-  </Error>
-  <RequestId>9dd01905-5012-5f99-8663-4b3ecd0dfaef</RequestId>
-</ErrorResponse>"""
-
 
 class SNSNotFoundError(RESTError):
     code = 404
 
     def __init__(self, message, **kwargs):
-        kwargs.setdefault("template", "endpoint_error")
-        kwargs.setdefault("sender", "Sender")
-        self.templates["endpoint_error"] = NOT_FOUND_ENDPOINT_ERROR
         super(SNSNotFoundError, self).__init__("NotFound", message, **kwargs)
 
 


### PR DESCRIPTION
In e9dc5ed a custom error template was added to correct the response
returned by get_endpoint_attributes for a non-existent endpoint.

However, after some more inspection, it was found that a valid template
already existed in moto/sns/responses.py. This commit removes the 
template introduced in e9dc5ed and takes into use the existing template.

It is a marginal improvement, but helps keeping a cleaner code base.

fixes #3646