### PR TITLE
(fix) Fixes #3648

### DIFF
--- a/moto/elbv2/models.py
+++ b/moto/elbv2/models.py
@@ -827,9 +827,10 @@ Member must satisfy regular expression pattern: {}".format(
         for load_balancer in self.load_balancers.values():
             for listener_arn in listener_arns:
                 listener = load_balancer.listeners.get(listener_arn)
-                if not listener:
-                    raise ListenerNotFoundError()
-                matched.append(listener)
+                if listener:
+                    matched.append(listener)
+        if listener_arns and len(matched) == 0:
+            raise ListenerNotFoundError()
         return matched
 
     def delete_load_balancer(self, arn):

--- a/tests/test_elbv2/test_elbv2.py
+++ b/tests/test_elbv2/test_elbv2.py
@@ -415,8 +415,9 @@ def test_create_target_group_and_listeners():
     response.get("LoadBalancers").should.have.length_of(0)
 
     # And it deleted the remaining listener
-    with pytest.raises(ClientError):
+    with pytest.raises(ClientError) as e:
         conn.describe_listeners(ListenerArns=[http_listener_arn, https_listener_arn])
+    e.value.response["Error"]["Code"].should.equal("ListenerNotFound")
 
     # But not the target groups
     response = conn.describe_target_groups()

--- a/tests/test_elbv2/test_elbv2.py
+++ b/tests/test_elbv2/test_elbv2.py
@@ -415,10 +415,10 @@ def test_create_target_group_and_listeners():
     response.get("LoadBalancers").should.have.length_of(0)
 
     # And it deleted the remaining listener
-    response = conn.describe_listeners(
-        ListenerArns=[http_listener_arn, https_listener_arn]
-    )
-    response.get("Listeners").should.have.length_of(0)
+    with pytest.raises(ClientError):
+        conn.describe_listeners(
+            ListenerArns=[http_listener_arn, https_listener_arn]
+        )
 
     # But not the target groups
     response = conn.describe_target_groups()

--- a/tests/test_elbv2/test_elbv2.py
+++ b/tests/test_elbv2/test_elbv2.py
@@ -416,9 +416,7 @@ def test_create_target_group_and_listeners():
 
     # And it deleted the remaining listener
     with pytest.raises(ClientError):
-        conn.describe_listeners(
-            ListenerArns=[http_listener_arn, https_listener_arn]
-        )
+        conn.describe_listeners(ListenerArns=[http_listener_arn, https_listener_arn])
 
     # But not the target groups
     response = conn.describe_target_groups()


### PR DESCRIPTION
Fixes `create_rule` and `describe_listener` behaviors to more closely mock actual AWS behavior.