### PR TITLE
Add KmsKeyId to Redshift Cluster

### DIFF
--- a/moto/redshift/models.py
+++ b/moto/redshift/models.py
@@ -97,6 +97,7 @@ class Cluster(TaggableResourceMixin, CloudFormationModel):
         iam_roles_arn=None,
         enhanced_vpc_routing=None,
         restored_from_snapshot=False,
+        kms_key_id=None
     ):
         super(Cluster, self).__init__(region_name, tags)
         self.redshift_backend = redshift_backend
@@ -159,6 +160,7 @@ class Cluster(TaggableResourceMixin, CloudFormationModel):
 
         self.iam_roles_arn = iam_roles_arn or []
         self.restored_from_snapshot = restored_from_snapshot
+        self.kms_key_id = kms_key_id
 
     @staticmethod
     def cloudformation_name_type():
@@ -207,6 +209,7 @@ class Cluster(TaggableResourceMixin, CloudFormationModel):
             publicly_accessible=properties.get("PubliclyAccessible"),
             encrypted=properties.get("Encrypted"),
             region_name=region_name,
+            kms_key_id=properties.get("KmsKeyId")
         )
         return cluster
 
@@ -300,6 +303,7 @@ class Cluster(TaggableResourceMixin, CloudFormationModel):
                 {"ApplyStatus": "in-sync", "IamRoleArn": iam_role_arn}
                 for iam_role_arn in self.iam_roles_arn
             ],
+            "KmsKeyId": self.kms_key_id
         }
         if self.restored_from_snapshot:
             json_response["RestoreStatus"] = {

--- a/moto/redshift/models.py
+++ b/moto/redshift/models.py
@@ -97,7 +97,7 @@ class Cluster(TaggableResourceMixin, CloudFormationModel):
         iam_roles_arn=None,
         enhanced_vpc_routing=None,
         restored_from_snapshot=False,
-        kms_key_id=None
+        kms_key_id=None,
     ):
         super(Cluster, self).__init__(region_name, tags)
         self.redshift_backend = redshift_backend
@@ -209,7 +209,7 @@ class Cluster(TaggableResourceMixin, CloudFormationModel):
             publicly_accessible=properties.get("PubliclyAccessible"),
             encrypted=properties.get("Encrypted"),
             region_name=region_name,
-            kms_key_id=properties.get("KmsKeyId")
+            kms_key_id=properties.get("KmsKeyId"),
         )
         return cluster
 
@@ -303,7 +303,7 @@ class Cluster(TaggableResourceMixin, CloudFormationModel):
                 {"ApplyStatus": "in-sync", "IamRoleArn": iam_role_arn}
                 for iam_role_arn in self.iam_roles_arn
             ],
-            "KmsKeyId": self.kms_key_id
+            "KmsKeyId": self.kms_key_id,
         }
         if self.restored_from_snapshot:
             json_response["RestoreStatus"] = {

--- a/moto/redshift/responses.py
+++ b/moto/redshift/responses.py
@@ -147,6 +147,7 @@ class RedshiftResponse(BaseResponse):
             "tags": self.unpack_complex_list_params("Tags.Tag", ("Key", "Value")),
             "iam_roles_arn": self._get_iam_roles(),
             "enhanced_vpc_routing": self._get_param("EnhancedVpcRouting"),
+            "kms_key_id": self._get_param("KmsKeyId")
         }
         cluster = self.redshift_backend.create_cluster(**cluster_kwargs).to_json()
         cluster["ClusterStatus"] = "creating"

--- a/moto/redshift/responses.py
+++ b/moto/redshift/responses.py
@@ -147,7 +147,7 @@ class RedshiftResponse(BaseResponse):
             "tags": self.unpack_complex_list_params("Tags.Tag", ("Key", "Value")),
             "iam_roles_arn": self._get_iam_roles(),
             "enhanced_vpc_routing": self._get_param("EnhancedVpcRouting"),
-            "kms_key_id": self._get_param("KmsKeyId")
+            "kms_key_id": self._get_param("KmsKeyId"),
         }
         cluster = self.redshift_backend.create_cluster(**cluster_kwargs).to_json()
         cluster["ClusterStatus"] = "creating"

--- a/tests/test_redshift/test_redshift.py
+++ b/tests/test_redshift/test_redshift.py
@@ -1289,9 +1289,7 @@ def test_enable_snapshot_copy():
     )
     with pytest.raises(ClientError) as ex:
         client.enable_snapshot_copy(
-            ClusterIdentifier="test",
-            DestinationRegion="us-west-2",
-            RetentionPeriod=3,
+            ClusterIdentifier="test", DestinationRegion="us-west-2", RetentionPeriod=3,
         )
     ex.value.response["Error"]["Code"].should.equal("InvalidParameterValue")
     ex.value.response["Error"]["Message"].should.contain(
@@ -1488,25 +1486,20 @@ def test_resize_cluster():
     resp["Cluster"]["NumberOfNodes"].should.equal(1)
 
     client.modify_cluster(
-        ClusterIdentifier="test",
-        ClusterType="multi-node",
-        NumberOfNodes=2,
+        ClusterIdentifier="test", ClusterType="multi-node", NumberOfNodes=2,
     )
     resp = client.describe_clusters(ClusterIdentifier="test")
     resp["Clusters"][0]["NumberOfNodes"].should.equal(2)
 
     client.modify_cluster(
-        ClusterIdentifier="test",
-        ClusterType="single-node",
+        ClusterIdentifier="test", ClusterType="single-node",
     )
     resp = client.describe_clusters(ClusterIdentifier="test")
     resp["Clusters"][0]["NumberOfNodes"].should.equal(1)
 
     with pytest.raises(ClientError) as ex:
         client.modify_cluster(
-            ClusterIdentifier="test",
-            ClusterType="multi-node",
-            NumberOfNodes=1,
+            ClusterIdentifier="test", ClusterType="multi-node", NumberOfNodes=1,
         )
     ex.value.response["Error"]["Code"].should.equal("InvalidParameterCombination")
     ex.value.response["Error"]["Message"].should.contain(
@@ -1598,8 +1591,7 @@ def test_get_cluster_credentials():
     )
     db_user = "some_user"
     response = client.get_cluster_credentials(
-        ClusterIdentifier=cluster_identifier,
-        DbUser=db_user,
+        ClusterIdentifier=cluster_identifier, DbUser=db_user,
     )
     response["DbUser"].should.equal("IAM:%s" % db_user)
     assert time.mktime((response["Expiration"]).timetuple()) == pytest.approx(
@@ -1621,9 +1613,7 @@ def test_get_cluster_credentials():
         (datetime.datetime.now() + datetime.timedelta(0, 3000)).timetuple()
     )
     response = client.get_cluster_credentials(
-        ClusterIdentifier=cluster_identifier,
-        DbUser=db_user,
-        DurationSeconds=3000,
+        ClusterIdentifier=cluster_identifier, DbUser=db_user, DurationSeconds=3000,
     )
     assert time.mktime(response["Expiration"].timetuple()) == pytest.approx(
         expected_expiration


### PR DESCRIPTION
Add the KmsKeyId property when creating a cluster so that it is also returned when querying the describe_clusters endpoint.

Resolves https://github.com/spulec/moto/issues/3665