### PR TITLE
#3667: Update the s3 post functionality to better support success_action_redirect

### DIFF
--- a/moto/s3/responses.py
+++ b/moto/s3/responses.py
@@ -1,5 +1,6 @@
 from __future__ import unicode_literals
 
+import os
 import re
 import sys
 
@@ -11,7 +12,14 @@ from moto.core.utils import (
     py2_strip_unicode_keys,
     unix_time_millis,
 )
-from six.moves.urllib.parse import parse_qs, urlparse, unquote, parse_qsl
+from six.moves.urllib.parse import (
+    parse_qs,
+    parse_qsl,
+    urlparse,
+    unquote,
+    urlencode,
+    urlunparse,
+)
 
 import xmltodict
 
@@ -859,10 +867,28 @@ class ResponseObject(_TemplateEnvironmentMixin, ActionAuthenticatorMixin):
         if "file" in form:
             f = form["file"]
         else:
-            f = request.files["file"].stream.read()
+            fobj = request.files["file"]
+            f = fobj.stream.read()
+            key = key.replace("${filename}", os.path.basename(fobj.filename))
 
         if "success_action_redirect" in form:
-            response_headers["Location"] = form["success_action_redirect"]
+            redirect = form["success_action_redirect"]
+            parts = urlparse(redirect)
+            queryargs = parse_qs(parts.query)
+            queryargs["key"] = key
+            queryargs["bucket"] = bucket_name
+            redirect_queryargs = urlencode(queryargs, doseq=True)
+            newparts = (
+                parts.scheme,
+                parts.netloc,
+                parts.path,
+                parts.params,
+                redirect_queryargs,
+                parts.fragment,
+            )
+            fixed_redirect = urlunparse(newparts)
+
+            response_headers["Location"] = fixed_redirect
 
         if "success_action_status" in form:
             status_code = form["success_action_status"]

--- a/tests/test_s3/test_s3.py
+++ b/tests/test_s3/test_s3.py
@@ -7,12 +7,12 @@ import os
 from boto3 import Session
 from six.moves.urllib.request import urlopen
 from six.moves.urllib.error import HTTPError
+from six.moves.urllib.parse import urlparse, parse_qs
 from functools import wraps
 from gzip import GzipFile
 from io import BytesIO
 import zlib
 import pickle
-import urllib.parse
 import uuid
 
 import json
@@ -4834,8 +4834,8 @@ def test_creating_presigned_post():
     assert resp.status_code == 303
     redirect = resp.headers["Location"]
     assert redirect.startswith(success_url)
-    parts = urllib.parse.urlparse(redirect)
-    args = urllib.parse.parse_qs(parts.query)
+    parts = urlparse(redirect)
+    args = parse_qs(parts.query)
     assert args["key"][0] == real_key
     assert args["bucket"][0] == bucket
 

--- a/tests/test_s3/test_server.py
+++ b/tests/test_s3/test_server.py
@@ -1,6 +1,8 @@
 # coding=utf-8
 
 from __future__ import unicode_literals
+import io
+import urllib.parse
 import sure  # noqa
 
 from flask.testing import FlaskClient
@@ -78,6 +80,39 @@ def test_s3_server_post_to_bucket():
     res = test_client.get("/the-key", "http://tester.localhost:5000/")
     res.status_code.should.equal(200)
     res.data.should.equal(b"nothing")
+
+
+def test_s3_server_post_to_bucket_redirect():
+    test_client = authenticated_client()
+
+    res = test_client.put("/", "http://tester.localhost:5000/")
+    res.status_code.should.equal(200)
+
+    redirect_base = "https://redirect.com/success/"
+    filecontent = "nothing"
+    filename = "test_filename.txt"
+    res = test_client.post(
+        "/",
+        "https://tester.localhost:5000/",
+        data={
+            "key": "asdf/the-key/${filename}",
+            "file": (io.BytesIO(filecontent.encode("utf8")), filename),
+            "success_action_redirect": redirect_base,
+        },
+    )
+    real_key = f"asdf/the-key/{filename}"
+    res.status_code.should.equal(303)
+    redirect = res.headers["location"]
+    assert redirect.startswith(redirect_base)
+
+    parts = urllib.parse.urlparse(redirect)
+    args = urllib.parse.parse_qs(parts.query)
+    assert args["key"][0] == real_key
+    assert args["bucket"][0] == "tester"
+
+    res = test_client.get(f"/{real_key}", "http://tester.localhost:5000/")
+    res.status_code.should.equal(200)
+    res.data.should.equal(filecontent.encode("utf8"))
 
 
 def test_s3_server_post_without_content_length():

--- a/tests/test_s3/test_server.py
+++ b/tests/test_s3/test_server.py
@@ -2,7 +2,7 @@
 
 from __future__ import unicode_literals
 import io
-import urllib.parse
+from six.moves.urllib.parse import urlparse, parse_qs
 import sure  # noqa
 
 from flask.testing import FlaskClient
@@ -100,17 +100,17 @@ def test_s3_server_post_to_bucket_redirect():
             "success_action_redirect": redirect_base,
         },
     )
-    real_key = f"asdf/the-key/{filename}"
+    real_key = "asdf/the-key/{}".format(filename)
     res.status_code.should.equal(303)
     redirect = res.headers["location"]
     assert redirect.startswith(redirect_base)
 
-    parts = urllib.parse.urlparse(redirect)
-    args = urllib.parse.parse_qs(parts.query)
+    parts = urlparse(redirect)
+    args = parse_qs(parts.query)
     assert args["key"][0] == real_key
     assert args["bucket"][0] == "tester"
 
-    res = test_client.get(f"/{real_key}", "http://tester.localhost:5000/")
+    res = test_client.get("/{}".format(real_key), "http://tester.localhost:5000/")
     res.status_code.should.equal(200)
     res.data.should.equal(filecontent.encode("utf8"))
 


### PR DESCRIPTION
…irect

- Add the bucket/key values to the redirect url like s3 does, which
supports code that relies on the key value being there on the
redirect.
- Add support for replacing ${filename} in the key value with the actual
filename from the form upload.

See Issue #3667