### PR TITLE
moved iteritems backwards compatibility to six

### DIFF
--- a/moto/forecast/models.py
+++ b/moto/forecast/models.py
@@ -2,7 +2,7 @@ import re
 from datetime import datetime
 
 from boto3 import Session
-from future.utils import iteritems
+from six import iteritems
 
 from moto.core import ACCOUNT_ID, BaseBackend
 from moto.core.utils import iso_8601_datetime_without_milliseconds


### PR DESCRIPTION
I noticed in testing today that we weren't using `six` for the `iteritems` import. This avoids the needless dependency on `future` in this file by using `six` instead. This matches how `iteritems` is imported across the remainder of the project. 