### PR TITLE
Fix response parsing error on Java SDK v2 for CW GetMetricData (#3645)

### DIFF
--- a/moto/cloudformation/responses.py
+++ b/moto/cloudformation/responses.py
@@ -1108,7 +1108,8 @@ STOP_STACK_SET_OPERATION_RESPONSE_TEMPLATE = """<StopStackSetOperationResponse x
   <StopStackSetOperationResult/>
   <ResponseMetadata>
     <RequestId>2188554a-07c6-4396-b2c5-example</RequestId>
-  </ResponseMetadata>                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     </StopStackSetOperationResponse>
+  </ResponseMetadata>
+</StopStackSetOperationResponse>
 """
 
 DESCRIBE_STACKSET_OPERATION_RESPONSE_TEMPLATE = (

--- a/moto/cloudwatch/responses.py
+++ b/moto/cloudwatch/responses.py
@@ -455,11 +455,6 @@ PUT_METRIC_DATA_TEMPLATE = """<PutMetricDataResponse xmlns="http://monitoring.am
 </PutMetricDataResponse>"""
 
 GET_METRIC_DATA_TEMPLATE = """<GetMetricDataResponse xmlns="http://monitoring.amazonaws.com/doc/2010-08-01/">
-   <ResponseMetadata>
-      <RequestId>
-         {{ request_id }}
-      </RequestId>
-   </ResponseMetadata>
    <GetMetricDataResult>
        <MetricDataResults>
            {% for result in results %}
@@ -481,15 +476,14 @@ GET_METRIC_DATA_TEMPLATE = """<GetMetricDataResponse xmlns="http://monitoring.am
             {% endfor %}
        </MetricDataResults>
    </GetMetricDataResult>
+   <ResponseMetadata>
+       <RequestId>
+            {{ request_id }}
+       </RequestId>
+   </ResponseMetadata>
 </GetMetricDataResponse>"""
 
 GET_METRIC_STATISTICS_TEMPLATE = """<GetMetricStatisticsResponse xmlns="http://monitoring.amazonaws.com/doc/2010-08-01/">
-   <ResponseMetadata>
-      <RequestId>
-         {{ request_id }}
-      </RequestId>
-   </ResponseMetadata>
-
   <GetMetricStatisticsResult>
       <Label>{{ label }}</Label>
       <Datapoints>
@@ -525,6 +519,11 @@ GET_METRIC_STATISTICS_TEMPLATE = """<GetMetricStatisticsResponse xmlns="http://m
         {% endfor %}
       </Datapoints>
     </GetMetricStatisticsResult>
+    <ResponseMetadata>
+      <RequestId>
+        {{ request_id }}
+      </RequestId>
+    </ResponseMetadata>
 </GetMetricStatisticsResponse>"""
 
 LIST_METRICS_TEMPLATE = """<ListMetricsResponse xmlns="http://monitoring.amazonaws.com/doc/2010-08-01/">

--- a/moto/ses/responses.py
+++ b/moto/ses/responses.py
@@ -341,10 +341,10 @@ GET_SEND_STATISTICS = """<GetSendStatisticsResponse xmlns="http://ses.amazonaws.
             </item>
         {% endfor %}
       </SendDataPoints>
-      <ResponseMetadata>
-        <RequestId>e0abcdfa-c866-11e0-b6d0-273d09173z49</RequestId>
-      </ResponseMetadata>
   </GetSendStatisticsResult>
+  <ResponseMetadata>
+    <RequestId>e0abcdfa-c866-11e0-b6d0-273d09173z49</RequestId>
+  </ResponseMetadata>
 </GetSendStatisticsResponse>"""
 
 CREATE_CONFIGURATION_SET = """<CreateConfigurationSetResponse xmlns="http://ses.amazonaws.com/doc/2010-12-01/">


### PR DESCRIPTION
Fixing invalid XML node order in some response, the node order is important for valid XML unmarshalling in the Java AWS SDK v2.

Par of unmarshalling code in Java AWS SDK v2

```java
XmlElement resultRoot = hasResultWrapper ? document.getFirstChild() : document;
``` 

Closes #3645 