### PR TITLE
Add CRC32 to DynamoDB responses

### DIFF
--- a/moto/core/utils.py
+++ b/moto/core/utils.py
@@ -227,10 +227,14 @@ def gen_amz_crc32(response, headerdict=None):
     if not isinstance(response, bytes):
         response = response.encode()
 
-    crc = str(binascii.crc32(response))
+    crc = binascii.crc32(response)
+    if six.PY2:
+        # https://python.readthedocs.io/en/v2.7.2/library/binascii.html
+        # TLDR: Use bitshift to match Py3 behaviour
+        crc = crc & 0xFFFFFFFF
 
     if headerdict is not None and isinstance(headerdict, dict):
-        headerdict.update({"x-amz-crc32": crc})
+        headerdict.update({"x-amz-crc32": str(crc)})
 
     return crc
 

--- a/moto/dynamodb2/responses.py
+++ b/moto/dynamodb2/responses.py
@@ -8,7 +8,7 @@ import itertools
 import six
 
 from moto.core.responses import BaseResponse
-from moto.core.utils import camelcase_to_underscores, amzn_request_id
+from moto.core.utils import camelcase_to_underscores, amz_crc32, amzn_request_id
 from .exceptions import (
     InvalidIndexNameError,
     ItemSizeTooLarge,
@@ -80,6 +80,7 @@ class DynamoHandler(BaseResponse):
         """
         return dynamodb_backends[self.region]
 
+    @amz_crc32
     @amzn_request_id
     def call_action(self):
         self.body = json.loads(self.body or "{}")

--- a/tests/test_dynamodb2/test_server.py
+++ b/tests/test_dynamodb2/test_server.py
@@ -17,4 +17,4 @@ def test_table_list():
     headers = {"X-Amz-Target": "TestTable.ListTables"}
     res = test_client.get("/", headers=headers)
     res.data.should.contain(b"TableNames")
-    res.headers["X-Amz-Crc32"].should.equal("363771991")
+    res.headers.should.have.key("X-Amz-Crc32")

--- a/tests/test_dynamodb2/test_server.py
+++ b/tests/test_dynamodb2/test_server.py
@@ -17,3 +17,4 @@ def test_table_list():
     headers = {"X-Amz-Target": "TestTable.ListTables"}
     res = test_client.get("/", headers=headers)
     res.data.should.contain(b"TableNames")
+    res.headers["X-Amz-Crc32"].should.equal("363771991")


### PR DESCRIPTION
Hi, when we point [aws-sdk-v2-go](https://github.com/aws/aws-sdk-go-v2)'s DynamoDB client at the Moto server, the SDK complains that the responses don't have the `X-Amz-Crc32` header. This PR adds the decorator which populates those checksums on the responses from the DynamoDBv2 API.