### PR TITLE
Fix heartbeatTimeout of NONE and polling responses when there are no tasks

### DIFF
--- a/moto/swf/models/activity_task.py
+++ b/moto/swf/models/activity_task.py
@@ -73,7 +73,10 @@ class ActivityTask(BaseModel):
     def first_timeout(self):
         if not self.open or not self.workflow_execution.open:
             return None
-        # TODO: handle the "NONE" case
+
+        if self.timeouts["heartbeatTimeout"] == "NONE":
+            return None
+
         heartbeat_timeout_at = self.last_heartbeat_timestamp + int(
             self.timeouts["heartbeatTimeout"]
         )

--- a/moto/swf/responses.py
+++ b/moto/swf/responses.py
@@ -446,9 +446,7 @@ class SWFResponse(BaseResponse):
         if decision:
             return json.dumps(decision.to_full_dict(reverse_order=reverse_order))
         else:
-            return json.dumps(
-                {"previousStartedEventId": 0, "startedEventId": 0, "taskToken": ""}
-            )
+            return json.dumps({"previousStartedEventId": 0, "startedEventId": 0})
 
     def count_pending_decision_tasks(self):
         domain_name = self._params["domain"]
@@ -482,7 +480,7 @@ class SWFResponse(BaseResponse):
         if activity_task:
             return json.dumps(activity_task.to_full_dict())
         else:
-            return json.dumps({"startedEventId": 0, "taskToken": ""})
+            return json.dumps({"startedEventId": 0})
 
     def count_pending_activity_tasks(self):
         domain_name = self._params["domain"]

--- a/tests/test_swf/models/test_activity_task.py
+++ b/tests/test_swf/models/test_activity_task.py
@@ -108,6 +108,24 @@ def test_activity_task_first_timeout():
         task.timeout_type.should.equal("HEARTBEAT")
 
 
+def test_activity_task_first_timeout_with_heartbeat_timeout_none():
+    wfe = make_workflow_execution()
+
+    activity_task_timeouts = ACTIVITY_TASK_TIMEOUTS.copy()
+    activity_task_timeouts["heartbeatTimeout"] = "NONE"
+
+    with freeze_time("2015-01-01 12:00:00"):
+        task = ActivityTask(
+            activity_id="my-activity-123",
+            activity_type="foo",
+            input="optional",
+            scheduled_event_id=117,
+            timeouts=activity_task_timeouts,
+            workflow_execution=wfe,
+        )
+        task.first_timeout().should.be.none
+
+
 def test_activity_task_cannot_timeout_on_closed_workflow_execution():
     with freeze_time("2015-01-01 12:00:00"):
         wfe = make_workflow_execution()

--- a/tests/test_swf/responses/test_activity_tasks.py
+++ b/tests/test_swf/responses/test_activity_tasks.py
@@ -35,7 +35,7 @@ def test_poll_for_activity_task_when_one():
 def test_poll_for_activity_task_when_none():
     conn = setup_workflow()
     resp = conn.poll_for_activity_task("test-domain", "activity-task-list")
-    resp.should.equal({"startedEventId": 0, "taskToken": ""})
+    resp.should.equal({"startedEventId": 0})
 
 
 @mock_swf_deprecated

--- a/tests/test_swf/responses/test_activity_tasks.py
+++ b/tests/test_swf/responses/test_activity_tasks.py
@@ -42,7 +42,7 @@ def test_poll_for_activity_task_when_none():
 def test_poll_for_activity_task_on_non_existent_queue():
     conn = setup_workflow()
     resp = conn.poll_for_activity_task("test-domain", "non-existent-queue")
-    resp.should.equal({"startedEventId": 0, "taskToken": ""})
+    resp.should.equal({"startedEventId": 0})
 
 
 # CountPendingActivityTasks endpoint

--- a/tests/test_swf/responses/test_decision_tasks.py
+++ b/tests/test_swf/responses/test_decision_tasks.py
@@ -62,9 +62,7 @@ def test_poll_for_decision_task_when_none():
     resp = conn.poll_for_decision_task("test-domain", "queue")
     # this is the DecisionTask representation you get from the real SWF
     # after waiting 60s when there's no decision to be taken
-    resp.should.equal(
-        {"previousStartedEventId": 0, "startedEventId": 0, "taskToken": ""}
-    )
+    resp.should.equal({"previousStartedEventId": 0, "startedEventId": 0})
 
 
 @mock_swf_deprecated

--- a/tests/test_swf/responses/test_decision_tasks.py
+++ b/tests/test_swf/responses/test_decision_tasks.py
@@ -69,9 +69,7 @@ def test_poll_for_decision_task_when_none():
 def test_poll_for_decision_task_on_non_existent_queue():
     conn = setup_workflow()
     resp = conn.poll_for_decision_task("test-domain", "non-existent-queue")
-    resp.should.equal(
-        {"previousStartedEventId": 0, "startedEventId": 0, "taskToken": ""}
-    )
+    resp.should.equal({"previousStartedEventId": 0, "startedEventId": 0})
 
 
 @mock_swf_deprecated


### PR DESCRIPTION
While using moto swf with AWS Java Flow SDK 1.11.22, I found some incompatibilities with activity heartbeatTimeout and decision/activity polling.

### heartbeatTimeout
When activities don't define a heartbeatTimeout, moto/swf/models/activity_task.py fails and returns:
`ValueError: invalid literal for int() with base 10: 'NONE'`
when this code runs:
`
        heartbeat_timeout_at = self.last_heartbeat_timestamp + int(
            self.timeouts["heartbeatTimeout"]
        )
`

### decision/activity polling
When poll_for_decision_task and poll_for_activity_task in moto/swf/responses.py execute, they currently return an empty string for taskToken:
`return json.dumps({"startedEventId": 0, "taskToken": ""})`
or
```
return json.dumps(
    {"previousStartedEventId": 0, "startedEventId": 0, "taskToken": ""}
)
```
But this results in an exception thrown by my Java decision/activity pollers:
```
java.lang.IllegalArgumentException: No implementation was found for null
	at com.amazonaws.services.simpleworkflow.flow.worker.AsyncDecisionTaskHandler.createDecider(AsyncDecisionTaskHandler.java:111)
	at com.amazonaws.services.simpleworkflow.flow.worker.AsyncDecisionTaskHandler.handleDecisionTask(AsyncDecisionTaskHandler.java:49)
	at com.amazonaws.services.simpleworkflow.flow.worker.DecisionTaskPoller.pollAndProcessSingleTask(DecisionTaskPoller.java:201)
	at com.amazonaws.services.simpleworkflow.flow.worker.GenericWorker$PollServiceTask.run(GenericWorker.java:94)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:834)
```
It can be confirmed here that decision pollers don't expect an empty string for taskToken but rather null:
https://github.com/aws/aws-swf-flow-library/blob/b2fee40ca289f6cd882b3289d65795d10f0b092b/src/main/java/com/amazonaws/services/simpleworkflow/flow/worker/DecisionTaskPoller.java#L198
```
        if (result == null || result.getTaskToken() == null) {
            return null;
        }
```
And the same for activity pollers:
https://github.com/aws/aws-swf-flow-library/blob/b2fee40ca289f6cd882b3289d65795d10f0b092b/src/main/java/com/amazonaws/services/simpleworkflow/flow/worker/ActivityTaskPoller.java#L174
```
        if (result == null || result.getTaskToken() == null) {
            if (log.isDebugEnabled()) {
                log.debug("poll request returned no task");
            }
            return null;
        }
```