### PR TITLE
Minor RDS Clean up

### DIFF
--- a/moto/rds2/exceptions.py
+++ b/moto/rds2/exceptions.py
@@ -24,7 +24,8 @@ class RDSClientError(BadRequest):
 class DBInstanceNotFoundError(RDSClientError):
     def __init__(self, database_identifier):
         super(DBInstanceNotFoundError, self).__init__(
-            "DBInstanceNotFound", "Database {0} not found.".format(database_identifier)
+            "DBInstanceNotFound",
+            "DBInstance {0} not found.".format(database_identifier),
         )
 
 

--- a/tests/test_rds2/test_filters.py
+++ b/tests/test_rds2/test_filters.py
@@ -127,7 +127,7 @@ class TestDBInstanceFilters(object):
             )
         ex.value.response["Error"]["Code"].should.equal("DBInstanceNotFound")
         ex.value.response["Error"]["Message"].should.equal(
-            "Database non-existent not found."
+            "DBInstance non-existent not found."
         )
 
     def test_valid_db_instance_identifier_with_exclusive_filter(self):
@@ -172,7 +172,7 @@ class TestDBInstanceFilters(object):
             )
         ex.value.response["Error"]["Code"].should.equal("DBInstanceNotFound")
         ex.value.response["Error"]["Message"].should.equal(
-            "Database db-instance-0 not found."
+            "DBInstance db-instance-0 not found."
         )
 
 


### PR DESCRIPTION
Just some minor clean up of some things I found while working on something else.

Changes the DBInstanceNotFound message to match what is returned from a real AWS backend.

Removes a duplicate test that was not getting run (and wouldn't have succeeded if it had run).

Makes the existing test (that was duplicated) a little more explicit.