### PR TITLE
Improve autoscaling:CreateLaunchConfiguration request validation

### DIFF
--- a/moto/autoscaling/models.py
+++ b/moto/autoscaling/models.py
@@ -616,7 +616,19 @@ class AutoScalingBackend(BaseBackend):
         ebs_optimized,
         associate_public_ip_address,
         block_device_mappings,
+        instance_id=None,
     ):
+        valid_requests = [
+            instance_id is not None,
+            image_id is not None and instance_type is not None,
+        ]
+        if not any(valid_requests):
+            raise ValidationError(
+                "Valid requests must contain either the InstanceID parameter or both the ImageId and InstanceType parameters."
+            )
+        if instance_id is not None:
+            # TODO: https://docs.aws.amazon.com/autoscaling/ec2/userguide/create-lc-with-instanceID.html
+            pass
         launch_configuration = FakeLaunchConfiguration(
             name=name,
             image_id=image_id,

--- a/moto/autoscaling/responses.py
+++ b/moto/autoscaling/responses.py
@@ -36,6 +36,7 @@ class AutoScalingResponse(BaseResponse):
             ebs_optimized=self._get_param("EbsOptimized"),
             associate_public_ip_address=self._get_param("AssociatePublicIpAddress"),
             block_device_mappings=self._get_list_prefix("BlockDeviceMappings.member"),
+            instance_id=self._get_param("InstanceId"),
         )
         template = self.response_template(CREATE_LAUNCH_CONFIGURATION_TEMPLATE)
         return template.render()


### PR DESCRIPTION
Something I discovered when cleaning up the "missing AMI" warnings (#3620) was that the implementation of CreateLaunchConfiguration was a bit too permissive.

AWS requires certain parameters to be mutually inclusive.

Moto wasn't doing anything with the InstanceId parameter, which is now made clear with a TODO.