### PR TITLE
EC2: Enhancement: implement EC2 instance filtering by `subnet-id`  #3693

### DIFF
--- a/moto/ec2/utils.py
+++ b/moto/ec2/utils.py
@@ -379,6 +379,7 @@ filter_dict_attribute_mapping = {
     "network-interface.private-dns-name": "private_dns",
     "private-dns-name": "private_dns",
     "owner-id": "owner_id",
+    "subnet-id": "subnet_id",
 }
 
 


### PR DESCRIPTION
Closes: https://github.com/spulec/moto/issues/3693

One thing to note, if an EC2 instance is created without a subnet, that instance is _not_ searchable with this addition (or even using `vpc-id` as the filter) `aws --endpoint-url=http://localhost:5000 --region eu-west-1 ec2 run-instances --output json`
```json
{
    "Groups": [
        {
            "GroupName": "default",
            "GroupId": "sg-245f6a01"
        }
    ],
    "Instances": [
        {
            "AmiLaunchIndex": 0,
            "ImageId": "None",
            "InstanceId": "i-dad0ab2131fc1975f",
            "InstanceType": "m1.small",
            "KernelId": "None",
            "KeyName": "None",
            "LaunchTime": "2021-02-14T21:49:14+00:00",
            "Monitoring": {
                "State": "enabled"
            },
            "Placement": {
                "AvailabilityZone": "eu-west-1a",
                "GroupName": "",
                "Tenancy": "default"
            },
            "PrivateDnsName": "ip-10-162-83-21.eu-west-1.compute.internal",
            "PrivateIpAddress": "10.162.83.21",
            "PublicDnsName": "ec2-54-214-126-145.eu-west-1.compute.amazonaws.com",
            "PublicIpAddress": "54.214.126.145",
            "State": {
                "Code": 0,
                "Name": "pending"
            },
            "StateTransitionReason": "",
            "SubnetId": "subnet-74d1ef41",
            "VpcId": "vpc-779d1a8e",
...
```
And then `aws --endpoint-url=http://localhost:5000 --region eu-west-1 ec2 describe-instances --filters Name=subnet-id,Values=subnet-74d1ef41` or `aws --endpoint-url=http://localhost:5000 --region eu-west-1 ec2 describe-instances --filters Name=vpc-id,Values=vpc-779d1a8e`
```json
{
    "Reservations": []
}
```

So I'm not sure if these are normally defaults from a region or account basis in AWS?