### PR TITLE
Enable Py2 test coverage

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -105,16 +105,10 @@ jobs:
         pip install -r requirements-dev.txt
         pip install pytest-cov
     - name: Test with pytest
-      if: ${{ matrix.python-version == 2.7 }}
-      run: |
-        make test-coverage
-    # Pytest-cov explicitly fails in Py2 for XRay tests
-    - name: Test with pytest/coverage
-      if: ${{ matrix.python-version != 2.7 }}
       run: |
         make test-coverage
     - name: "Upload coverage to Codecov"
-      if: ${{ matrix.python-version != 2.7 && github.repository == 'spulec/moto'}}
+      if: ${{ github.repository == 'spulec/moto'}}
       uses: codecov/codecov-action@v1
       with:
         fail_ci_if_error: true
@@ -158,20 +152,13 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements-dev.txt
-    - name: Test ServerMode
-      if: ${{ matrix.python-version == 2.7 }}
-      env:
-        TEST_SERVER_MODE: ${{ true }}
-      run: |
-        make test-only
     - name: Test ServerMode/Coverage
-      if: ${{ matrix.python-version != 2.7 }}
       env:
         TEST_SERVER_MODE: ${{ true }}
       run: |
         make test-coverage
     - name: "Upload coverage to Codecov"
-      if: ${{ matrix.python-version != 2.7 && github.repository == 'spulec/moto'}}
+      if: ${{ github.repository == 'spulec/moto'}}
       uses: codecov/codecov-action@v1
       with:
         fail_ci_if_error: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -107,7 +107,7 @@ jobs:
     - name: Test with pytest
       if: ${{ matrix.python-version == 2.7 }}
       run: |
-        make test-only
+        make test-coverage
     # Pytest-cov explicitly fails in Py2 for XRay tests
     - name: Test with pytest/coverage
       if: ${{ matrix.python-version != 2.7 }}

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,7 +1,7 @@
 codecov:
   notify:
-    # Leave a GitHub comment after all Py3 builds have passed
-    after_n_builds: 6
+    # Leave a GitHub comment after all builds have passed
+    after_n_builds: 8
 coverage:
   status:
     project:

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -1,5 +1,7 @@
 pytest
 pytest-cov; python_version >= '3.6'
+# https://github.com/aws/aws-xray-sdk-python/issues/196
+# Downgrade pytest-cov to the last version that uses coverage < 5
 pytest-cov<=2.10.1; python_version < '3.6'
 sure==1.4.11
 freezegun

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -1,4 +1,5 @@
 pytest
-pytest-cov
+pytest-cov; python_version >= '3.6'
+pytest-cov<=2.10.1; python_version < '3.6'
 sure==1.4.11
 freezegun

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,6 +5,5 @@ universal=1
 markers =
     network: marks tests which require network connection
 
-[run]
-omit =
-    tests/test_xray/test_xray_client.py
+[coverage:run]
+relative_files = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,5 +5,6 @@ universal=1
 markers =
     network: marks tests which require network connection
 
-[coverage:run]
-relative_files = True
+[run]
+omit =
+    tests/test_xray/test_xray_client.py


### PR DESCRIPTION
When enabling coverage, the XRay tests are throwing an error in Py2:
 INTERNALERROR> SegmentNotFoundException: cannot find the current segment/subsegment, please make sure you have a segment open

Edit:
This was a known bug in coverage 5, and was already prevented in moto by pinning the coverage to 4.5.
After moving to codecov.io, we needed pytest-cov - which required coverage > 5.

The downgraded pytest-cov that is now in place for Py2 does not require coverage > 5, so it's back to using the tried and tested coverage 4.5