### PR TITLE
Support Podman for mocking Lambda

### DIFF
--- a/moto/awslambda/models.py
+++ b/moto/awslambda/models.py
@@ -575,7 +575,9 @@ class LambdaFunction(CloudFormationModel, DockerModel):
                         if settings.TEST_SERVER_MODE
                         else {}
                     )
-                    self.docker_client.images.pull("docker.io/lambci/lambda", tag=self.run_time)
+                    self.docker_client.images.pull(
+                        "docker.io/lambci/lambda", tag=self.run_time
+                    )
                     container = self.docker_client.containers.run(
                         "lambci/lambda:{}".format(self.run_time),
                         [self.handler, json.dumps(event)],

--- a/moto/awslambda/models.py
+++ b/moto/awslambda/models.py
@@ -51,7 +51,7 @@ from moto.sqs import sqs_backends
 from moto.dynamodb2 import dynamodb_backends2
 from moto.dynamodbstreams import dynamodbstreams_backends
 from moto.core import ACCOUNT_ID
-from moto.utilities.docker_utilities import DockerModel
+from moto.utilities.docker_utilities import DockerModel, parse_image_ref
 
 logger = logging.getLogger(__name__)
 
@@ -131,7 +131,9 @@ class _DockerDataVolumeContext:
                 volumes = {self.name: {"bind": "/tmp/data", "mode": "rw"}}
             else:
                 volumes = {self.name: "/tmp/data"}
-            self._lambda_func.docker_client.images.pull("docker.io/library/alpine")
+            self._lambda_func.docker_client.images.pull(
+                ":".join(parse_image_ref("alpine"))
+            )
             container = self._lambda_func.docker_client.containers.run(
                 "alpine", "sleep 100", volumes=volumes, detach=True
             )
@@ -575,11 +577,10 @@ class LambdaFunction(CloudFormationModel, DockerModel):
                         if settings.TEST_SERVER_MODE
                         else {}
                     )
-                    self.docker_client.images.pull(
-                        "docker.io/lambci/lambda", tag=self.run_time
-                    )
+                    image_ref = "lambci/lambda:{}".format(self.run_time)
+                    self.docker_client.images.pull(":".join(parse_image_ref(image_ref)))
                     container = self.docker_client.containers.run(
-                        "lambci/lambda:{}".format(self.run_time),
+                        image_ref,
                         [self.handler, json.dumps(event)],
                         remove=False,
                         mem_limit="{}m".format(self.memory_size),

--- a/moto/awslambda/models.py
+++ b/moto/awslambda/models.py
@@ -131,6 +131,7 @@ class _DockerDataVolumeContext:
                 volumes = {self.name: {"bind": "/tmp/data", "mode": "rw"}}
             else:
                 volumes = {self.name: "/tmp/data"}
+            self._lambda_func.docker_client.images.pull("docker.io/library/alpine")
             container = self._lambda_func.docker_client.containers.run(
                 "alpine", "sleep 100", volumes=volumes, detach=True
             )
@@ -574,6 +575,7 @@ class LambdaFunction(CloudFormationModel, DockerModel):
                         if settings.TEST_SERVER_MODE
                         else {}
                     )
+                    self.docker_client.images.pull("docker.io/lambci/lambda", tag=self.run_time)
                     container = self.docker_client.containers.run(
                         "lambci/lambda:{}".format(self.run_time),
                         [self.handler, json.dumps(event)],

--- a/moto/batch/models.py
+++ b/moto/batch/models.py
@@ -28,7 +28,7 @@ from moto.ec2.exceptions import InvalidSubnetIdError
 from moto.ec2.models import INSTANCE_TYPES as EC2_INSTANCE_TYPES
 from moto.iam.exceptions import IAMNotFoundException
 from moto.core import ACCOUNT_ID as DEFAULT_ACCOUNT_ID
-from moto.utilities.docker_utilities import DockerModel
+from moto.utilities.docker_utilities import DockerModel, parse_image_name
 
 logger = logging.getLogger(__name__)
 COMPUTE_ENVIRONMENT_NAME_REGEX = re.compile(
@@ -428,6 +428,8 @@ class Job(threading.Thread, BaseModel, DockerModel):
             self.job_started_at = datetime.datetime.now()
             self.job_state = "STARTING"
             log_config = docker.types.LogConfig(type=docker.types.LogConfig.types.JSON)
+            image_repository, image_tag = parse_image_name(image)
+            self.docker_client.images.pull(image_repository, image_tag)
             container = self.docker_client.containers.run(
                 image,
                 cmd,

--- a/moto/batch/models.py
+++ b/moto/batch/models.py
@@ -28,7 +28,7 @@ from moto.ec2.exceptions import InvalidSubnetIdError
 from moto.ec2.models import INSTANCE_TYPES as EC2_INSTANCE_TYPES
 from moto.iam.exceptions import IAMNotFoundException
 from moto.core import ACCOUNT_ID as DEFAULT_ACCOUNT_ID
-from moto.utilities.docker_utilities import DockerModel, parse_image_name
+from moto.utilities.docker_utilities import DockerModel, parse_image_ref
 
 logger = logging.getLogger(__name__)
 COMPUTE_ENVIRONMENT_NAME_REGEX = re.compile(
@@ -428,7 +428,7 @@ class Job(threading.Thread, BaseModel, DockerModel):
             self.job_started_at = datetime.datetime.now()
             self.job_state = "STARTING"
             log_config = docker.types.LogConfig(type=docker.types.LogConfig.types.JSON)
-            image_repository, image_tag = parse_image_name(image)
+            image_repository, image_tag = parse_image_ref(image)
             self.docker_client.images.pull(image_repository, image_tag)
             container = self.docker_client.containers.run(
                 image,

--- a/moto/settings.py
+++ b/moto/settings.py
@@ -4,6 +4,7 @@ TEST_SERVER_MODE = os.environ.get("TEST_SERVER_MODE", "0").lower() == "true"
 INITIAL_NO_AUTH_ACTION_COUNT = float(
     os.environ.get("INITIAL_NO_AUTH_ACTION_COUNT", float("inf"))
 )
+DEFAULT_CONTAINER_REGISTRY = os.environ.get("DEFAULT_CONTAINER_REGISTRY", "docker.io")
 
 
 def get_sf_execution_history_type():

--- a/moto/utilities/docker_utilities.py
+++ b/moto/utilities/docker_utilities.py
@@ -36,7 +36,7 @@ class DockerModel:
 def parse_image_name(image_name):
     # podman does not support short container image name out of box - try to make a full name
     if ":" in image_name:
-        image_repository, image_tag = image_name.split(":", maxsplit=1)
+        image_repository, image_tag = image_name.split(":", 1)
     else:
         image_repository = image_name
         image_tag = "latest"

--- a/moto/utilities/docker_utilities.py
+++ b/moto/utilities/docker_utilities.py
@@ -31,3 +31,17 @@ class DockerModel:
 
                 self.docker_client.api.get_adapter = replace_adapter_send
         return self.__docker_client
+
+
+def parse_image_name(image_name):
+    # podman does not support short container image name out of box - try to make a full name
+    if ":" in image_name:
+        image_repository, image_tag = image_name.split(":", maxsplit=1)
+    else:
+        image_repository = image_name
+        image_tag = "latest"
+    if "/" not in image_repository:
+        image_repository = "library/" + image_repository
+    if len(image_repository.split("/")) < 3:
+        image_repository = "docker.io/" + image_repository
+    return image_repository, image_tag

--- a/tests/test_utilities/test_docker_utilities.py
+++ b/tests/test_utilities/test_docker_utilities.py
@@ -1,7 +1,7 @@
 import sure
 import pytest
 
-from moto.utilities.docker_utilities import parse_image_name
+from moto.utilities.docker_utilities import parse_image_ref
 
 
 @pytest.mark.parametrize(
@@ -9,6 +9,8 @@ from moto.utilities.docker_utilities import parse_image_name
     [
         ("python", ("docker.io/library/python", "latest")),
         ("python:3.9", ("docker.io/library/python", "3.9")),
+        ("docker.io/python", ("docker.io/library/python", "latest")),
+        ("localhost/foobar", ("localhost/foobar", "latest")),
         ("lambci/lambda:python2.7", ("docker.io/lambci/lambda", "python2.7")),
         (
             "gcr.io/google.com/cloudsdktool/cloud-sdk",
@@ -16,5 +18,14 @@ from moto.utilities.docker_utilities import parse_image_name
         ),
     ],
 )
-def test_parse_image_name(image_name, expected):
-    expected.should.be.equal(parse_image_name(image_name))
+def test_parse_image_ref(image_name, expected):
+    expected.should.be.equal(parse_image_ref(image_name))
+
+
+def test_parse_image_ref_default_container_registry(monkeypatch):
+    import moto.settings
+
+    monkeypatch.setattr(moto.settings, "DEFAULT_CONTAINER_REGISTRY", "quay.io")
+    ("quay.io/centos/centos", "latest").should.be.equal(
+        parse_image_ref("centos/centos")
+    )

--- a/tests/test_utilities/test_docker_utilities.py
+++ b/tests/test_utilities/test_docker_utilities.py
@@ -1,0 +1,14 @@
+import sure
+import pytest
+
+from moto.utilities.docker_utilities import parse_image_name
+
+
+@pytest.mark.parametrize("image_name,expected", [
+    ("python", ("docker.io/library/python", "latest")),
+    ("python:3.9", ("docker.io/library/python", "3.9")),
+    ("lambci/lambda:python2.7", ("docker.io/lambci/lambda", "python2.7")),
+    ("gcr.io/google.com/cloudsdktool/cloud-sdk", ("gcr.io/google.com/cloudsdktool/cloud-sdk", "latest")),
+])
+def test_parse_image_name(image_name, expected):
+    expected.should.be.equal(parse_image_name(image_name))

--- a/tests/test_utilities/test_docker_utilities.py
+++ b/tests/test_utilities/test_docker_utilities.py
@@ -4,11 +4,17 @@ import pytest
 from moto.utilities.docker_utilities import parse_image_name
 
 
-@pytest.mark.parametrize("image_name,expected", [
-    ("python", ("docker.io/library/python", "latest")),
-    ("python:3.9", ("docker.io/library/python", "3.9")),
-    ("lambci/lambda:python2.7", ("docker.io/lambci/lambda", "python2.7")),
-    ("gcr.io/google.com/cloudsdktool/cloud-sdk", ("gcr.io/google.com/cloudsdktool/cloud-sdk", "latest")),
-])
+@pytest.mark.parametrize(
+    "image_name,expected",
+    [
+        ("python", ("docker.io/library/python", "latest")),
+        ("python:3.9", ("docker.io/library/python", "3.9")),
+        ("lambci/lambda:python2.7", ("docker.io/lambci/lambda", "python2.7")),
+        (
+            "gcr.io/google.com/cloudsdktool/cloud-sdk",
+            ("gcr.io/google.com/cloudsdktool/cloud-sdk", "latest"),
+        ),
+    ],
+)
 def test_parse_image_name(image_name, expected):
     expected.should.be.equal(parse_image_name(image_name))


### PR DESCRIPTION
Podman supports all Docker APIs used in moto since version 3.0. Note
that Podman requires pulling the image before creating a container
using a fully-qualified image name (e.g., "docker.io/library/busybox"
instead of "busybox").

Test plan:
$ podman system service -t 0
$ DOCKER_HOST="unix://$XDG_RUNTIME_DIR/podman/podman.sock" pytest

Fixes https://github.com/spulec/moto/issues/3276