### PR TITLE
dynamodb: fix deleting last set element (w/attr name)

### DIFF
--- a/moto/dynamodb2/parsing/executors.py
+++ b/moto/dynamodb2/parsing/executors.py
@@ -165,8 +165,18 @@ class DeleteExecutor(NodeExecutor):
         # the last item in the set, we have to remove the attribute.
         if not string_set_list:
             element = self.get_element_to_action()
+            if isinstance(element, ExpressionAttributeName):
+                attribute_name = self.expression_attribute_names[
+                    element.get_attribute_name_placeholder()
+                ]
+            elif isinstance(element, ExpressionAttribute):
+                attribute_name = element.get_attribute_name()
+            else:
+                raise NotImplementedError(
+                    "Moto does not support deleting {t} yet".format(t=type(element))
+                )
             container = self.get_item_before_end_of_path(item)
-            container.pop(element.get_attribute_name())
+            del container[attribute_name]
 
 
 class RemoveExecutor(NodeExecutor):


### PR DESCRIPTION
When deleting last element(s) of a set, the attribute itself is cleared from the container. This is fixing support for specifying such attributes through attribute name placeholders in update expressions.