### PR TITLE
Update stackset create operation to correctly return the resource's ID.

### DIFF
--- a/moto/cloudformation/responses.py
+++ b/moto/cloudformation/responses.py
@@ -438,7 +438,7 @@ class CloudFormationResponse(BaseResponse):
             return json.dumps(
                 {
                     "CreateStackSetResponse": {
-                        "CreateStackSetResult": {"StackSetId": stackset.stackset_id}
+                        "CreateStackSetResult": {"StackSetId": stackset.id}
                     }
                 }
             )
@@ -926,7 +926,7 @@ LIST_EXPORTS_RESPONSE = """<ListExportsResponse xmlns="http://cloudformation.ama
 
 CREATE_STACK_SET_RESPONSE_TEMPLATE = """<CreateStackSetResponse xmlns="http://internal.amazon.com/coral/com.amazonaws.maestro.service.v20160713/">
   <CreateStackSetResult>
-    <StackSetId>{{ stackset.stackset_id }}</StackSetId>
+    <StackSetId>{{ stackset.id }}</StackSetId>
   </CreateStackSetResult>
   <ResponseMetadata>
     <RequestId>f457258c-391d-41d1-861f-example</RequestId>

--- a/tests/test_cloudformation/test_cloudformation_stack_crud_boto3.py
+++ b/tests/test_cloudformation/test_cloudformation_stack_crud_boto3.py
@@ -603,13 +603,14 @@ def test_boto3_delete_stack_set():
 @mock_cloudformation
 def test_boto3_create_stack_set():
     cf_conn = boto3.client("cloudformation", region_name="us-east-1")
-    cf_conn.create_stack_set(
+    response = cf_conn.create_stack_set(
         StackSetName="test_stack_set", TemplateBody=dummy_template_json
     )
 
     cf_conn.describe_stack_set(StackSetName="test_stack_set")["StackSet"][
         "TemplateBody"
     ].should.equal(dummy_template_json)
+    response["StackSetId"].should_not.be.empty
 
 
 @mock_cloudformation


### PR DESCRIPTION
'FakeStackSet' does not have a 'stackset_id' attribute, the current implementation silently returns a blank ID.