### PR TITLE
Fix stackset describe/delete. Fix stackset update.

### DIFF
--- a/moto/cloudformation/models.py
+++ b/moto/cloudformation/models.py
@@ -494,6 +494,8 @@ class CloudFormationBackend(BaseBackend):
 
     def get_stack_set(self, name):
         stacksets = self.stacksets.keys()
+        if name in stacksets:
+            return self.stacksets[name]
         for stackset in stacksets:
             if self.stacksets[stackset].name == name:
                 return self.stacksets[stackset]
@@ -501,6 +503,8 @@ class CloudFormationBackend(BaseBackend):
 
     def delete_stack_set(self, name):
         stacksets = self.stacksets.keys()
+        if name in stacksets:
+            self.stacksets[name].delete()
         for stackset in stacksets:
             if self.stacksets[stackset].name == name:
                 self.stacksets[stackset].delete()

--- a/moto/cloudformation/models.py
+++ b/moto/cloudformation/models.py
@@ -467,6 +467,28 @@ class CloudFormationBackend(BaseBackend):
         self.exports = OrderedDict()
         self.change_sets = OrderedDict()
 
+    def _resolve_update_parameters(self, instance, incoming_params):
+        parameters = dict(
+            [
+                (parameter["parameter_key"], parameter["parameter_value"])
+                for parameter in incoming_params
+                if "parameter_value" in parameter
+            ]
+        )
+        previous = dict(
+            [
+                (
+                    parameter["parameter_key"],
+                    instance.parameters[parameter["parameter_key"]],
+                )
+                for parameter in incoming_params
+                if "use_previous_value" in parameter
+            ]
+        )
+        parameters.update(previous)
+
+        return parameters
+
     def create_stack_set(
         self,
         name,
@@ -536,10 +558,11 @@ class CloudFormationBackend(BaseBackend):
         operation_id=None,
     ):
         stackset = self.get_stack_set(stackset_name)
+        resolved_parameters = self._resolve_update_parameters(instance=stackset, incoming_params=parameters)
         update = stackset.update(
             template=template,
             description=description,
-            parameters=parameters,
+            parameters=resolved_parameters,
             tags=tags,
             admin_role=admin_role,
             execution_role=execution_role,
@@ -715,7 +738,8 @@ class CloudFormationBackend(BaseBackend):
 
     def update_stack(self, name, template, role_arn=None, parameters=None, tags=None):
         stack = self.get_stack(name)
-        stack.update(template, role_arn, parameters=parameters, tags=tags)
+        resolved_parameters = self._resolve_update_parameters(instance=stack, incoming_params=parameters)
+        stack.update(template, role_arn, parameters=resolved_parameters, tags=tags)
         return stack
 
     def list_stack_resources(self, stack_name_or_id):

--- a/moto/cloudformation/models.py
+++ b/moto/cloudformation/models.py
@@ -558,7 +558,9 @@ class CloudFormationBackend(BaseBackend):
         operation_id=None,
     ):
         stackset = self.get_stack_set(stackset_name)
-        resolved_parameters = self._resolve_update_parameters(instance=stackset, incoming_params=parameters)
+        resolved_parameters = self._resolve_update_parameters(
+            instance=stackset, incoming_params=parameters
+        )
         update = stackset.update(
             template=template,
             description=description,
@@ -738,7 +740,9 @@ class CloudFormationBackend(BaseBackend):
 
     def update_stack(self, name, template, role_arn=None, parameters=None, tags=None):
         stack = self.get_stack(name)
-        resolved_parameters = self._resolve_update_parameters(instance=stack, incoming_params=parameters)
+        resolved_parameters = self._resolve_update_parameters(
+            instance=stack, incoming_params=parameters
+        )
         stack.update(template, role_arn, parameters=resolved_parameters, tags=tags)
         return stack
 

--- a/tests/test_cloudformation/test_cloudformation_stack_crud_boto3.py
+++ b/tests/test_cloudformation/test_cloudformation_stack_crud_boto3.py
@@ -735,8 +735,7 @@ def test_boto3_describe_stack_set_params():
 def test_boto3_describe_stack_set_by_id():
     cf_conn = boto3.client("cloudformation", region_name="us-east-1")
     response = cf_conn.create_stack_set(
-        StackSetName="test_stack",
-        TemplateBody=dummy_template_json,
+        StackSetName="test_stack", TemplateBody=dummy_template_json,
     )
 
     stack_set_id = response["StackSetId"]

--- a/tests/test_cloudformation/test_cloudformation_stack_crud_boto3.py
+++ b/tests/test_cloudformation/test_cloudformation_stack_crud_boto3.py
@@ -638,7 +638,7 @@ def test_boto3_delete_stack_set_by_name():
 
 
 @mock_cloudformation
-def test_boto3_delete_stack_set_by_name():
+def test_boto3_delete_stack_set_by_id():
     cf_conn = boto3.client("cloudformation", region_name="us-east-1")
     response = cf_conn.create_stack_set(
         StackSetName="test_stack_set", TemplateBody=dummy_template_json

--- a/tests/test_cloudformation/test_cloudformation_stack_crud_boto3.py
+++ b/tests/test_cloudformation/test_cloudformation_stack_crud_boto3.py
@@ -588,12 +588,26 @@ def test_boto3_bad_list_stack_resources():
 
 
 @mock_cloudformation
-def test_boto3_delete_stack_set():
+def test_boto3_delete_stack_set_by_name():
     cf_conn = boto3.client("cloudformation", region_name="us-east-1")
     cf_conn.create_stack_set(
         StackSetName="test_stack_set", TemplateBody=dummy_template_json
     )
     cf_conn.delete_stack_set(StackSetName="test_stack_set")
+
+    cf_conn.describe_stack_set(StackSetName="test_stack_set")["StackSet"][
+        "Status"
+    ].should.equal("DELETED")
+
+
+@mock_cloudformation
+def test_boto3_delete_stack_set_by_name():
+    cf_conn = boto3.client("cloudformation", region_name="us-east-1")
+    response = cf_conn.create_stack_set(
+        StackSetName="test_stack_set", TemplateBody=dummy_template_json
+    )
+    stack_set_id = response["StackSetId"]
+    cf_conn.delete_stack_set(StackSetName=stack_set_id)
 
     cf_conn.describe_stack_set(StackSetName="test_stack_set")["StackSet"][
         "Status"
@@ -678,6 +692,20 @@ def test_boto3_describe_stack_set_params():
     cf_conn.describe_stack_set(StackSetName="test_stack")["StackSet"][
         "Parameters"
     ].should.equal(params)
+
+
+@mock_cloudformation
+def test_boto3_describe_stack_set_by_id():
+    cf_conn = boto3.client("cloudformation", region_name="us-east-1")
+    response = cf_conn.create_stack_set(
+        StackSetName="test_stack",
+        TemplateBody=dummy_template_json,
+    )
+
+    stack_set_id = response["StackSetId"]
+    cf_conn.describe_stack_set(StackSetName=stack_set_id)["StackSet"][
+        "TemplateBody"
+    ].should.equal(dummy_template_json)
 
 
 @mock_cloudformation


### PR DESCRIPTION
StackSets can be described/deleted using their name or id (as per docs [here](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/cloudformation.html#CloudFormation.Client.describe_stack_set) and [here](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/cloudformation.html#CloudFormation.Client.delete_stack_set)). 

Updating StackSet parameters should support omitting providing a value and specifying a `UsePreviousValue` flag [instead](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/cloudformation.html#CloudFormation.Client.update_stack_set
), as it does for Stack updates. Refactored the mechanism for resolving the parameters to be shared by both FakeStacks and FakeStackSets.