### PR TITLE
Add the status field to ECS task definitions

### DIFF
--- a/moto/ecs/models.py
+++ b/moto/ecs/models.py
@@ -177,6 +177,7 @@ class TaskDefinition(BaseObject, CloudFormationModel):
 
         self.cpu = cpu
         self.memory = memory
+        self.status = "ACTIVE"
 
     @property
     def response_object(self):
@@ -788,7 +789,9 @@ class EC2ContainerServiceBackend(BaseBackend):
             family in self.task_definitions
             and revision in self.task_definitions[family]
         ):
-            return self.task_definitions[family].pop(revision)
+            task_definition = self.task_definitions[family].pop(revision)
+            task_definition.status = "INACTIVE"
+            return task_definition
         else:
             raise TaskDefinitionNotFoundException
 

--- a/tests/test_ecs/test_ecs_boto3.py
+++ b/tests/test_ecs/test_ecs_boto3.py
@@ -312,7 +312,7 @@ def test_list_task_definitions_with_family_prefix():
 
 
 @mock_ecs
-def test_describe_task_definition():
+def test_describe_task_definitions():
     client = boto3.client("ecs", region_name="us-east-1")
     _ = client.register_task_definition(
         family="test_ecs_task",
@@ -380,7 +380,7 @@ def test_describe_task_definition():
 
 
 @mock_ecs
-def test_deregister_task_definition():
+def test_deregister_task_definition_1():
     client = boto3.client("ecs", region_name="us-east-1")
     _ = client.register_task_definition(
         family="test_ecs_task",
@@ -400,8 +400,9 @@ def test_deregister_task_definition():
     )
     response = client.deregister_task_definition(taskDefinition="test_ecs_task:1")
     type(response["taskDefinition"]).should.be(dict)
+    response["taskDefinition"]["status"].should.equal("INACTIVE")
     response["taskDefinition"]["taskDefinitionArn"].should.equal(
-        "arn:aws:ecs:us-east-1:012345678910:task-definition/test_ecs_task:1"
+        "arn:aws:ecs:us-east-1:{}:task-definition/test_ecs_task:1".format(ACCOUNT_ID)
     )
     response["taskDefinition"]["containerDefinitions"][0]["name"].should.equal(
         "hello_world"
@@ -426,7 +427,7 @@ def test_deregister_task_definition():
 
 
 @mock_ecs
-def test_deregister_task_definition():
+def test_deregister_task_definition_2():
     client = boto3.client("ecs", region_name="us-east-1")
     client.deregister_task_definition.when.called_with(
         taskDefinition="fake_task"
@@ -1814,7 +1815,7 @@ def test_describe_tasks_exceptions():
 
 
 @mock_ecs
-def describe_task_definition():
+def test_describe_task_definition_by_family():
     client = boto3.client("ecs", region_name="us-east-1")
     container_definition = {
         "name": "hello_world",
@@ -1828,13 +1829,19 @@ def describe_task_definition():
     task_definition = client.register_task_definition(
         family="test_ecs_task", containerDefinitions=[container_definition]
     )
-    family = task_definition["family"]
-    task = client.describe_task_definition(taskDefinition=family)
-    task["containerDefinitions"][0].should.equal(container_definition)
+    family = task_definition["taskDefinition"]["family"]
+    task = client.describe_task_definition(taskDefinition=family)["taskDefinition"]
+    task["containerDefinitions"][0].should.equal(
+        dict(
+            container_definition,
+            **{"mountPoints": [], "portMappings": [], "volumesFrom": []}
+        )
+    )
     task["taskDefinitionArn"].should.equal(
-        "arn:aws:ecs:us-east-1:012345678910:task-definition/test_ecs_task2:1"
+        "arn:aws:ecs:us-east-1:{}:task-definition/test_ecs_task:1".format(ACCOUNT_ID)
     )
     task["volumes"].should.equal([])
+    task["status"].should.equal("ACTIVE")
 
 
 @mock_ec2


### PR DESCRIPTION
Also I found extra tests for describe_task_definition and deregister_task_definition that were not being run,
so I changed their names so they are found by pytest and made them pass.  I also added checks to them for the new
status field.