### PR TITLE
Fixes for IAM Role Description field in responses from list_roles and create_roles

### DIFF
--- a/moto/iam/responses.py
+++ b/moto/iam/responses.py
@@ -1275,7 +1275,7 @@ CREATE_ROLE_TEMPLATE = """<CreateRoleResponse xmlns="https://iam.amazonaws.com/d
       <Arn>{{ role.arn }}</Arn>
       <RoleName>{{ role.name }}</RoleName>
       <AssumeRolePolicyDocument>{{ role.assume_role_policy_document }}</AssumeRolePolicyDocument>
-      {% if role.description %}
+      {% if role.description is not none %}
       <Description>{{role.description}}</Description>
       {% endif %}
       <CreateDate>{{ role.created_iso_8601 }}</CreateDate>
@@ -1420,7 +1420,7 @@ LIST_ROLES_TEMPLATE = """<ListRolesResponse xmlns="https://iam.amazonaws.com/doc
           <PermissionsBoundaryArn>{{ role.permissions_boundary }}</PermissionsBoundaryArn>
         </PermissionsBoundary>
         {% endif %}
-        {% if role.description %}
+        {% if role.description is not none %}
         <Description>{{ role.description }}</Description>
         {% endif %}
       </member>

--- a/moto/iam/responses.py
+++ b/moto/iam/responses.py
@@ -1420,6 +1420,9 @@ LIST_ROLES_TEMPLATE = """<ListRolesResponse xmlns="https://iam.amazonaws.com/doc
           <PermissionsBoundaryArn>{{ role.permissions_boundary }}</PermissionsBoundaryArn>
         </PermissionsBoundary>
         {% endif %}
+        {% if role.description %}
+        <Description>{{ role.description }}</Description>
+        {% endif %}
       </member>
       {% endfor %}
     </Roles>

--- a/tests/test_iam/test_iam.py
+++ b/tests/test_iam/test_iam.py
@@ -4043,13 +4043,11 @@ def test_list_roles_with_description():
     # Ensure the Description is included in role listing as well
     conn.list_roles().get("Roles")[0].get("Description").should.equal(description)
 
+
 @mock_iam()
 def test_list_roles_without_description():
     conn = boto3.client("iam", region_name="us-east-1")
-    resp = conn.create_role(
-        RoleName="my-role",
-        AssumeRolePolicyDocument="some policy",
-    )
+    resp = conn.create_role(RoleName="my-role", AssumeRolePolicyDocument="some policy",)
     resp.get("Role").should_not.have.key("Description")
 
     # Ensure the Description is not included in role listing as well

--- a/tests/test_iam/test_iam.py
+++ b/tests/test_iam/test_iam.py
@@ -4030,6 +4030,32 @@ def test_list_roles_none_found_returns_empty_list():
 
 
 @mock_iam()
+def test_list_roles_with_description():
+    conn = boto3.client("iam", region_name="us-east-1")
+    description = "Test Description"
+    resp = conn.create_role(
+        RoleName="my-role",
+        AssumeRolePolicyDocument="some policy",
+        Description=description,
+    )
+    resp.get("Role").get("Description").should.equal(description)
+
+    # Ensure the Description is included in role listing as well
+    conn.list_roles().get("Roles")[0].get("Description").should.equal(description)
+
+@mock_iam()
+def test_list_roles_without_description():
+    conn = boto3.client("iam", region_name="us-east-1")
+    conn.create_role(
+        RoleName="my-role",
+        AssumeRolePolicyDocument="some policy",
+    )
+
+    # Ensure the Description is not included in role listing as well
+    conn.list_roles().get("Roles")[0].should_not.have.key("Description")
+
+
+@mock_iam()
 def test_create_user_with_tags():
     conn = boto3.client("iam", region_name="us-east-1")
     user_name = "test-user"

--- a/tests/test_iam/test_iam.py
+++ b/tests/test_iam/test_iam.py
@@ -4029,8 +4029,8 @@ def test_list_roles_none_found_returns_empty_list():
     assert len(roles) == 0
 
 
-@mock_iam()
 @pytest.mark.parametrize("desc", ["", "Test Description"])
+@mock_iam()
 def test_list_roles_with_description(desc):
     conn = boto3.client("iam", region_name="us-east-1")
     resp = conn.create_role(

--- a/tests/test_iam/test_iam.py
+++ b/tests/test_iam/test_iam.py
@@ -4030,18 +4030,16 @@ def test_list_roles_none_found_returns_empty_list():
 
 
 @mock_iam()
-def test_list_roles_with_description():
+@pytest.mark.parametrize("desc", ["", "Test Description"])
+def test_list_roles_with_description(desc):
     conn = boto3.client("iam", region_name="us-east-1")
-    description = "Test Description"
     resp = conn.create_role(
-        RoleName="my-role",
-        AssumeRolePolicyDocument="some policy",
-        Description=description,
+        RoleName="my-role", AssumeRolePolicyDocument="some policy", Description=desc,
     )
-    resp.get("Role").get("Description").should.equal(description)
+    resp.get("Role").get("Description").should.equal(desc)
 
     # Ensure the Description is included in role listing as well
-    conn.list_roles().get("Roles")[0].get("Description").should.equal(description)
+    conn.list_roles().get("Roles")[0].get("Description").should.equal(desc)
 
 
 @mock_iam()
@@ -4052,21 +4050,6 @@ def test_list_roles_without_description():
 
     # Ensure the Description is not included in role listing as well
     conn.list_roles().get("Roles")[0].should_not.have.key("Description")
-
-
-@mock_iam()
-def test_list_roles_with_empty_string_description():
-    conn = boto3.client("iam", region_name="us-east-1")
-    description = ""
-    resp = conn.create_role(
-        RoleName="my-role",
-        AssumeRolePolicyDocument="some policy",
-        Description=description,
-    )
-    resp.get("Role").get("Description").should.equal(description)
-
-    # Ensure the Description is included in role listing as well
-    conn.list_roles().get("Roles")[0].get("Description").should.equal(description)
 
 
 @mock_iam()

--- a/tests/test_iam/test_iam.py
+++ b/tests/test_iam/test_iam.py
@@ -4046,13 +4046,29 @@ def test_list_roles_with_description():
 @mock_iam()
 def test_list_roles_without_description():
     conn = boto3.client("iam", region_name="us-east-1")
-    conn.create_role(
+    resp = conn.create_role(
         RoleName="my-role",
         AssumeRolePolicyDocument="some policy",
     )
+    resp.get("Role").should_not.have.key("Description")
 
     # Ensure the Description is not included in role listing as well
     conn.list_roles().get("Roles")[0].should_not.have.key("Description")
+
+
+@mock_iam()
+def test_list_roles_with_empty_string_description():
+    conn = boto3.client("iam", region_name="us-east-1")
+    description = ""
+    resp = conn.create_role(
+        RoleName="my-role",
+        AssumeRolePolicyDocument="some policy",
+        Description=description,
+    )
+    resp.get("Role").get("Description").should.equal(description)
+
+    # Ensure the Description is included in role listing as well
+    conn.list_roles().get("Roles")[0].get("Description").should.equal(description)
 
 
 @mock_iam()


### PR DESCRIPTION
`list_roles` and `create_roles` should return the `Description` field if it is non-null.