### PR TITLE
Automate releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,21 @@
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version'
+        required: true
+        default: ''
+
+jobs:
+  hello_world_job:
+    runs-on: ubuntu-latest
+    name: A job to say hello
+    steps:
+    - name: Hello world action step
+      id: hello
+      uses: bblommers/moto-release-action@v1
+      with:
+        who-to-greet: 'Mona the Octocat wants to release ${{ github.event.inputs.version }}'
+    # Use the output from the `hello` step
+    - name: Get the output time
+      run: echo "The time was ${{ steps.hello.outputs.time }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,21 +1,69 @@
+name: Release
+
 on:
   workflow_dispatch:
     inputs:
       version:
         description: 'Version'
         required: true
-        default: ''
 
 jobs:
-  hello_world_job:
+  release-moto-job:
     runs-on: ubuntu-latest
-    name: A job to say hello
+    name: Release Moto
+    env:
+      VERSION: 0.0.0
     steps:
-    - name: Hello world action step
-      id: hello
-      uses: bblommers/moto-release-action@v1
+    - name: Set Env
+      run: |
+        echo "VERSION=${{ github.event.inputs.version }}" >> $GITHUB_ENV
+    - uses: actions/checkout@v2
       with:
-        who-to-greet: 'Mona the Octocat wants to release ${{ github.event.inputs.version }}'
-    # Use the output from the `hello` step
-    - name: Get the output time
-      run: echo "The time was ${{ steps.hello.outputs.time }}"
+        fetch-depth: 0
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.8
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install wheel setuptools packaging twine --upgrade
+    - name: Verify Tag does not exist
+      run: |
+        ! git rev-parse ${{ env.VERSION }} || { echo "Ensure that no tag exists for ${{ env.VERSION }}" ; exit 1; }
+    - name: Verify supplied version exists in the CHANGELOG
+      run: |
+        grep ${{ env.VERSION }} CHANGELOG.md || { echo "Ensure that the CHANGELOG contains an entry for ${{ env.VERSION }}" ; exit 1; }
+    - name: Set version number
+      run: python update_version_from_git.py ${{ env.VERSION }}
+    - name: Build
+      run: python setup.py sdist bdist_wheel
+    - name: Publish to PyPI
+      uses: pypa/gh-action-pypi-publish@master
+      with:
+        password: ${{ secrets.PYPI_API_TOKEN }}
+    - name: Tag version on Github
+      run: |
+        git tag ${{ env.VERSION }}
+        git push origin ${{ env.VERSION }}
+    - name: Build Docker release
+      run: |
+        docker build -t motoserver/moto . --tag moto:${{ env.VERSION }}
+    - name: Login to DockerHub
+      uses: docker/login-action@v1
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+    - name: Build and push
+      uses: docker/build-push-action@v2
+      with:
+        push: true
+        tags: motoserver/moto:${{ env.VERSION }}
+    - name: Increase patch version number
+      run: |
+        python update_version_from_git.py patch
+        git config --local user.email "admin@getmoto.org"
+        git config --local user.name "Moto Admin"
+        git add moto/__init__.py
+        git commit -m "Increase version number post-release"
+        git push

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,7 @@
 on:
+  push:
+    branches:
+      - master
   workflow_dispatch:
     inputs:
       version:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -10,4 +10,5 @@ prompt-toolkit==2.0.10 # 3.x is not available with python2
 click==6.7
 inflection==0.3.1
 lxml==4.2.3
+packaging
 

--- a/update_version_from_git.py
+++ b/update_version_from_git.py
@@ -4,6 +4,9 @@ Adapted from https://github.com/pygame/pygameweb/blob/master/pygameweb/builds/up
 For updating the version from git.
 __init__.py contains a __version__ field.
 Update that.
+If the user supplies "patch" as a CLi argument, we want to bump the existing patch version
+If the user supplied the full version as a CLI argument, we want to use that version.
+Otherwise,
 If we are on master, we want to update the version as a pre-release.
 git describe --tags
 With these:
@@ -22,6 +25,8 @@ import io
 import os
 import re
 import subprocess
+import sys
+from packaging.version import Version
 
 
 def migrate_source_attribute(attr, to_this, target_file, regex):
@@ -49,7 +54,7 @@ def migrate_version(target_file, new_version):
     regex = r"['\"](.*)['\"]"
     migrate_source_attribute(
         "__version__",
-        "'{new_version}'".format(new_version=new_version),
+        "\"{new_version}\"".format(new_version=new_version),
         target_file,
         regex,
     )
@@ -114,6 +119,15 @@ def get_version():
     raise RuntimeError("Unable to find version string.")
 
 
+def increase_patch_version(old_version):
+    """
+    :param old_version: 2.0.1
+    :return: 2.0.2.dev
+    """
+    v = Version(old_version)
+    return "{}.{}.{}.dev".format(v.major, v.minor, v.micro + 1)
+
+
 def release_version_correct():
     """Makes sure the:
     - prerelease verion for master is correct.
@@ -142,4 +156,16 @@ def release_version_correct():
 
 
 if __name__ == "__main__":
-    release_version_correct()
+    new_version = None
+    if len(sys.argv) == 1:
+        release_version_correct()
+    elif len(sys.argv) == 2:
+        for _, arg in enumerate(sys.argv):
+            new_version = arg
+        if new_version == "patch":
+            new_version = increase_patch_version(get_version())
+        initpy = os.path.abspath("moto/__init__.py")
+        migrate_version(initpy, new_version)
+    else:
+        print("Invalid usage. Supply 0 or 1 arguments. "
+              "Argument can be either a version '1.2.3' or 'patch' if you want to increase the patch-version (1.2.3 -> 1.2.4.dev)")


### PR DESCRIPTION
This workflow would automate the release flow.

For this to work, we do need to add Docker credentials to the repository secrets:
DOCKERHUB_USERNAME
DOCKERHUB_TOKEN
(https://docs.docker.com/docker-hub/access-tokens/)

Before a release:

Manual steps required:
 - Create an entry in CHANGELOG

To create a release:
Go to https://github.com/spulec/moto/actions/workflows/release.yml
Click 'Run workflow', and type the version that you want to release


Steps automated with this workflow:
 - Validation that the version does not exist yet as a tag
 - Validation that the version does have an entry in the Changelog
 - Upload to PyPi
 - Tag Github
 - Upload to Docker
 - Increase the version in moto/__init__.py


Example run:
https://github.com/bblommers/moto/runs/1989056691

