### PR TITLE
Remove Docker-dependency from SQS

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,12 +22,7 @@ If you don't care about the number of dependencies, or if you want to mock many 
 ```console
 $ pip install moto[all]
 ```
-Not all services might be covered, in which case you might see a warning:  
-`moto 1.3.16 does not provide the extra 'service'`.  
-You can ignore the warning, or simply install moto as is:
-```console
-$ pip install moto
-```
+
 
 ## In a nutshell
 

--- a/docs/docs/getting_started.rst
+++ b/docs/docs/getting_started.rst
@@ -17,13 +17,6 @@ If you don't care about the number of dependencies, or if you want to mock many 
 
     pip install moto[all]
 
-Not all services might be covered, in which case you might see a warning:
-`moto 1.3.16 does not provide the extra 'service'`.
-
-You can ignore the warning, or simply install moto as is::
-
-    pip install moto
-
 If you want to install ``moto`` from source::
 
     git clone git://github.com/spulec/moto.git

--- a/moto/sqs/models.py
+++ b/moto/sqs/models.py
@@ -508,6 +508,8 @@ class Queue(CloudFormationModel):
         self._messages.append(message)
 
         for arn, esm in self.lambda_event_source_mappings.items():
+            from moto.awslambda import lambda_backends
+
             backend = sqs_backends[self.region]
 
             """

--- a/moto/sqs/models.py
+++ b/moto/sqs/models.py
@@ -508,8 +508,6 @@ class Queue(CloudFormationModel):
         self._messages.append(message)
 
         for arn, esm in self.lambda_event_source_mappings.items():
-            from moto.awslambda import lambda_backends
-
             backend = sqs_backends[self.region]
 
             """

--- a/scripts/dependency_test.sh
+++ b/scripts/dependency_test.sh
@@ -33,7 +33,7 @@ valid_service() {
   # Verify whether this is a valid service
   # We'll ignore metadata folders, and folders that test generic Moto behaviour
   # We'll also ignore CloudFormation, as it will always depend on other services
-  local ignore_moto_folders="core instance_metadata __pycache__ templates cloudformation utilities"
+  local ignore_moto_folders="core instance_metadata __pycache__ templates cloudformation packages utilities s3bucket_path"
   if echo $ignore_moto_folders | grep -q "$1"; then
     return 1
   else

--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,8 @@ from io import open
 import os
 import re
 from setuptools import setup, find_packages
+import sys
+import moto.__init__ as service_list
 
 # Borrowed from pip at https://github.com/pypa/pip/blob/62c27dee45625e1b63d1e023b0656310f276e050/setup.py#L11-L15
 here = os.path.abspath(os.path.dirname(__file__))
@@ -69,10 +71,11 @@ all_extra_deps = [
 ]
 all_server_deps = all_extra_deps + ["flask", "flask-cors"]
 
-# TODO: do we want to add ALL services here?
-# i.e. even those without extra dependencies.
-# Would be good for future-compatibility, I guess.
-extras_per_service = {
+extras_per_service = {}
+for service_name in [service[5:] for service in dir(service_list) if service.startswith("mock_")]:
+    extras_per_service[service_name] = []
+extras_per_service.update(
+{
     "apigateway": [_dep_python_jose, _dep_python_jose_ecdsa_pin],
     "awslambda": [_dep_docker],
     "batch": [_dep_docker],
@@ -88,7 +91,7 @@ extras_per_service = {
     # XRay module uses pkg_resources, but doesn't have an explicit dependency listed
     # This should be fixed in the next version: https://github.com/aws/aws-xray-sdk-python/issues/305
     "xray": [_dep_aws_xray_sdk, _setuptools],
-}
+})
 # When a Table has a Stream, we'll always need to import AWSLambda to search for a corresponding function to send the table data to
 extras_per_service["dynamodb2"] = extras_per_service["awslambda"]
 extras_per_service["dynamodbstreams"] = extras_per_service["awslambda"]

--- a/tests/test_sqs/test_integration.py
+++ b/tests/test_sqs/test_integration.py
@@ -1,0 +1,73 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+import base64
+import json
+import time
+import uuid
+import hashlib
+
+import boto
+import boto3
+import sure  # noqa
+from moto import mock_sqs, mock_lambda, mock_logs
+
+from tests.test_awslambda.test_lambda import get_test_zip_file1, get_role_name
+
+
+@mock_logs
+@mock_lambda
+@mock_sqs
+def test_invoke_function_from_sqs_exception():
+    logs_conn = boto3.client("logs", region_name="us-east-1")
+    sqs = boto3.resource("sqs", region_name="us-east-1")
+    queue = sqs.create_queue(QueueName="test-sqs-queue1")
+
+    conn = boto3.client("lambda", region_name="us-east-1")
+    func = conn.create_function(
+        FunctionName="testFunction",
+        Runtime="python2.7",
+        Role=get_role_name(),
+        Handler="lambda_function.lambda_handler",
+        Code={"ZipFile": get_test_zip_file1()},
+        Description="test lambda function",
+        Timeout=3,
+        MemorySize=128,
+        Publish=True,
+    )
+
+    response = conn.create_event_source_mapping(
+        EventSourceArn=queue.attributes["QueueArn"], FunctionName=func["FunctionArn"]
+    )
+
+    assert response["EventSourceArn"] == queue.attributes["QueueArn"]
+    assert response["State"] == "Enabled"
+
+    entries = [
+        {
+            "Id": "1",
+            "MessageBody": json.dumps({"uuid": str(uuid.uuid4()), "test": "test"}),
+        }
+    ]
+
+    queue.send_messages(Entries=entries)
+
+    start = time.time()
+    while (time.time() - start) < 30:
+        result = logs_conn.describe_log_streams(logGroupName="/aws/lambda/testFunction")
+        log_streams = result.get("logStreams")
+        if not log_streams:
+            time.sleep(1)
+            continue
+        assert len(log_streams) >= 1
+
+        result = logs_conn.get_log_events(
+            logGroupName="/aws/lambda/testFunction",
+            logStreamName=log_streams[0]["logStreamName"],
+        )
+        for event in result.get("events"):
+            if "custom log event" in event["message"]:
+                return
+        time.sleep(1)
+
+    assert False, "Test Failed"

--- a/tests/test_sqs/test_sqs.py
+++ b/tests/test_sqs/test_sqs.py
@@ -15,9 +15,10 @@ from boto.exception import SQSError
 from boto.sqs.message import Message, RawMessage
 from botocore.exceptions import ClientError
 from freezegun import freeze_time
-from moto import mock_sqs, mock_sqs_deprecated, mock_logs, settings
+from moto import mock_sqs, mock_sqs_deprecated, settings
 
 from unittest import SkipTest, mock
+
 import pytest
 from tests.helpers import requires_boto_gte
 from moto.core import ACCOUNT_ID


### PR DESCRIPTION
Fixes #3737 

We only need to import AWS Lambda if we have entries in the `lambda_event_source_mappings`-map, i.e. if there are any Lambda-functions registered.

Also changes the installation-method to support all services, i.e.
`pip install moto[acm]`
will no longer give a warning `moto 2.x.x does not provide the extra 'acm'`

