### PR TITLE
Fix/autoscaling elb interaction

### DIFF
--- a/moto/autoscaling/models.py
+++ b/moto/autoscaling/models.py
@@ -946,10 +946,10 @@ class AutoScalingBackend(BaseBackend):
         for elb in elbs:
             elb_instace_ids = set(elb.instance_ids)
             self.elb_backend.register_instances(
-                elb.name, group_instance_ids - elb_instace_ids
+                elb.name, group_instance_ids - elb_instace_ids, from_autoscaling=True,
             )
             self.elb_backend.deregister_instances(
-                elb.name, elb_instace_ids - group_instance_ids
+                elb.name, elb_instace_ids - group_instance_ids, from_autoscaling=True,
             )
 
     def update_attached_target_groups(self, group_name):
@@ -1007,7 +1007,9 @@ class AutoScalingBackend(BaseBackend):
         group_instance_ids = set(state.instance.id for state in group.instance_states)
         elbs = self.elb_backend.describe_load_balancers(names=group.load_balancers)
         for elb in elbs:
-            self.elb_backend.deregister_instances(elb.name, group_instance_ids)
+            self.elb_backend.deregister_instances(
+                elb.name, group_instance_ids, from_autoscaling=True
+            )
         group.load_balancers = [
             x for x in group.load_balancers if x not in load_balancer_names
         ]

--- a/moto/elb/models.py
+++ b/moto/elb/models.py
@@ -82,7 +82,8 @@ class FakeLoadBalancer(CloudFormationModel):
     ):
         self.name = name
         self.health_check = None
-        self.instance_ids = []
+        self.instance_sparse_ids = []
+        self.instance_autoscaling_ids = []
         self.zones = zones
         self.listeners = []
         self.backends = []
@@ -118,6 +119,11 @@ class FakeLoadBalancer(CloudFormationModel):
                 instance_port=(port.get("instance_port") or port["InstancePort"])
             )
             self.backends.append(backend)
+
+    @property
+    def instance_ids(self):
+        """Return all the instances attached to the ELB"""
+        return self.instance_sparse_ids + self.instance_autoscaling_ids
 
     @staticmethod
     def cloudformation_name_type():
@@ -403,19 +409,39 @@ class ELBBackend(BaseBackend):
 
         return balancer
 
-    def register_instances(self, load_balancer_name, instance_ids):
+    def register_instances(
+        self, load_balancer_name, instance_ids, from_autoscaling=False
+    ):
         load_balancer = self.get_load_balancer(load_balancer_name)
-        load_balancer.instance_ids.extend(instance_ids)
+        attr_name = (
+            "instance_sparse_ids"
+            if not from_autoscaling
+            else "instance_autoscaling_ids"
+        )
+
+        actual_instance_ids = getattr(load_balancer, attr_name)
+        actual_instance_ids.extend(instance_ids)
         return load_balancer
 
-    def deregister_instances(self, load_balancer_name, instance_ids):
+    def deregister_instances(
+        self, load_balancer_name, instance_ids, from_autoscaling=False
+    ):
         load_balancer = self.get_load_balancer(load_balancer_name)
+        attr_name = (
+            "instance_sparse_ids"
+            if not from_autoscaling
+            else "instance_autoscaling_ids"
+        )
+        actual_instance_ids = getattr(load_balancer, attr_name)
+
         new_instance_ids = [
             instance_id
-            for instance_id in load_balancer.instance_ids
+            for instance_id in actual_instance_ids
             if instance_id not in instance_ids
         ]
-        load_balancer.instance_ids = new_instance_ids
+
+        setattr(load_balancer, attr_name, new_instance_ids)
+
         return load_balancer
 
     def set_cross_zone_load_balancing_attribute(self, load_balancer_name, attribute):


### PR DESCRIPTION
This is a first attempt to fix issue #3748 in a pretty hacky way: in the original code the assumption is that all the instances attached to a load balancer are only by an autoscaling group, so when the group is modified it acts on the load balancer so to have only its own instances attached, but this is not how the ELB behaves, you can manually attach isolated machines that remain independent by the group.

For now I'm using an internal attribute to take note of which instances are intended to be deregistered from the load balancer but I'm pretty sure it's not a very good way of do it, maybe I'm missing some subtle point about instances, however the tests seem to pass. So if someone more experienced with the code want to give me feedback I can try to improve it.

I also improved a test to catch the bug, if it's ok I'm going to extend to other tests involving this service.