### PR TITLE
Fix: `ApproximateArrivalTimestamp` should be epoch with millisecond precision

### DIFF
--- a/moto/kinesis/models.py
+++ b/moto/kinesis/models.py
@@ -43,7 +43,7 @@ class Record(BaseModel):
             "Data": self.data,
             "PartitionKey": self.partition_key,
             "SequenceNumber": str(self.sequence_number),
-            "ApproximateArrivalTimestamp": self.created_at_datetime.isoformat(),
+            "ApproximateArrivalTimestamp": self.created_at,
         }
 
 

--- a/tests/test_kinesis/test_kinesis.py
+++ b/tests/test_kinesis/test_kinesis.py
@@ -6,6 +6,7 @@ import time
 import boto.kinesis
 import boto3
 from boto.kinesis.exceptions import ResourceNotFoundException, InvalidArgumentException
+from dateutil.tz import tzlocal
 
 from moto import mock_kinesis, mock_kinesis_deprecated
 from moto.core import ACCOUNT_ID
@@ -378,7 +379,7 @@ def test_get_records_timestamp_filtering():
     conn.put_record(StreamName=stream_name, Data="0", PartitionKey="0")
 
     time.sleep(1.0)
-    timestamp = datetime.datetime.utcnow()
+    timestamp = datetime.datetime.now(tz=tzlocal())
 
     conn.put_record(StreamName=stream_name, Data="1", PartitionKey="1")
 


### PR DESCRIPTION
The Record class was already capturing a unix timestamp, but it was incorrectly
converting it to ISO format when sending back to the client.

Updating the model to return the correct timestamp necessitated a minor change
to one of the tests because `botocore` converts non-timezone aware timestamps
to local time.

Defect and fix were verified using the example Java code referenced in the 
issue description.

Fixes #3749 