### PR TITLE
Cognito IdP: Raise UsernameExistsException from sign_up when user exists

### DIFF
--- a/moto/cognitoidp/models.py
+++ b/moto/cognitoidp/models.py
@@ -883,6 +883,8 @@ class CognitoIdpBackend(BaseBackend):
                 user_pool = p
         if user_pool is None:
             raise ResourceNotFoundError(client_id)
+        elif username in user_pool.users:
+            raise UsernameExistsException(username)
 
         user = CognitoIdpUser(
             user_pool_id=user_pool.id,

--- a/tests/test_cognitoidp/test_cognitoidp.py
+++ b/tests/test_cognitoidp/test_cognitoidp.py
@@ -1613,15 +1613,10 @@ def test_sign_up_existing_user():
     username = str(uuid.uuid4())
     password = str(uuid.uuid4())
 
-    conn.sign_up(ClientId=client_id, Username=username, Password=password)
-
-    caught = False
-    try:
+    with pytest.raises(ClientError) as err:
         conn.sign_up(ClientId=client_id, Username=username, Password=password)
-    except conn.exceptions.UsernameExistsException:
-        caught = True
 
-    caught.should.be.true
+    err.value.response["Error"]["Code"].should.equal("UsernameExistsException")
 
 
 @mock_cognitoidp

--- a/tests/test_cognitoidp/test_cognitoidp.py
+++ b/tests/test_cognitoidp/test_cognitoidp.py
@@ -1608,8 +1608,7 @@ def test_sign_up_existing_user():
     conn = boto3.client("cognito-idp", "us-west-2")
     user_pool_id = conn.create_user_pool(PoolName=str(uuid.uuid4()))["UserPool"]["Id"]
     client_id = conn.create_user_pool_client(
-        UserPoolId=user_pool_id,
-        ClientName=str(uuid.uuid4()),
+        UserPoolId=user_pool_id, ClientName=str(uuid.uuid4()),
     )["UserPoolClient"]["ClientId"]
     username = str(uuid.uuid4())
     password = str(uuid.uuid4())

--- a/tests/test_cognitoidp/test_cognitoidp.py
+++ b/tests/test_cognitoidp/test_cognitoidp.py
@@ -1613,7 +1613,11 @@ def test_sign_up_existing_user():
     username = str(uuid.uuid4())
     password = str(uuid.uuid4())
 
+    # Add initial user
+    conn.sign_up(ClientId=client_id, Username=username, Password=password)
+
     with pytest.raises(ClientError) as err:
+        # Attempt to add user again
         conn.sign_up(ClientId=client_id, Username=username, Password=password)
 
     err.value.response["Error"]["Code"].should.equal("UsernameExistsException")

--- a/tests/test_cognitoidp/test_cognitoidp.py
+++ b/tests/test_cognitoidp/test_cognitoidp.py
@@ -1604,6 +1604,28 @@ def test_sign_up():
 
 
 @mock_cognitoidp
+def test_sign_up_existing_user():
+    conn = boto3.client("cognito-idp", "us-west-2")
+    user_pool_id = conn.create_user_pool(PoolName=str(uuid.uuid4()))["UserPool"]["Id"]
+    client_id = conn.create_user_pool_client(
+        UserPoolId=user_pool_id,
+        ClientName=str(uuid.uuid4()),
+    )["UserPoolClient"]["ClientId"]
+    username = str(uuid.uuid4())
+    password = str(uuid.uuid4())
+
+    conn.sign_up(ClientId=client_id, Username=username, Password=password)
+
+    caught = False
+    try:
+        conn.sign_up(ClientId=client_id, Username=username, Password=password)
+    except conn.exceptions.UsernameExistsException:
+        caught = True
+
+    caught.should.be.true
+
+
+@mock_cognitoidp
 def test_confirm_sign_up():
     conn = boto3.client("cognito-idp", "us-west-2")
     username = str(uuid.uuid4())


### PR DESCRIPTION
Similar to `admin_create_user` (#2357), the `sign_up` method in the Cognito identity provider client should raise a `UsernameExistsException` if a user already exists within the user pool