### PR TITLE
Feature: Batch: cancel_job

### DIFF
--- a/IMPLEMENTATION_COVERAGE.md
+++ b/IMPLEMENTATION_COVERAGE.md
@@ -1028,7 +1028,7 @@
 <details>
 <summary>78% implemented</summary>
 
-- [ ] cancel_job
+- [X] cancel_job
 - [X] create_compute_environment
 - [X] create_job_queue
 - [X] delete_compute_environment

--- a/moto/batch/responses.py
+++ b/moto/batch/responses.py
@@ -292,7 +292,9 @@ class BatchResponse(BaseResponse):
         return ""
 
     # CancelJob
-    def canceljob(
-        self,
-    ):  # Theres some AWS semantics on the differences but for us they're identical ;-)
-        return self.terminatejob()
+    def canceljob(self,):
+        job_id = self._get_param("jobId")
+        reason = self._get_param("reason")
+        self.batch_backend.cancel_job(job_id, reason)
+
+        return ""

--- a/tests/test_batch/test_batch_job_queue.py
+++ b/tests/test_batch/test_batch_job_queue.py
@@ -34,50 +34,95 @@ def test_create_job_queue():
     queue_arn = resp["jobQueueArn"]
 
     resp = batch_client.describe_job_queues()
-
-    resp.should.contain("jobQueues")
-    len(resp["jobQueues"]).should.equal(1)
+    resp.should.have.key("jobQueues").being.length_of(1)
     resp["jobQueues"][0]["jobQueueArn"].should.equal(queue_arn)
 
-    resp = batch_client.describe_job_queues(jobQueues=["test_invalid_queue"])
-    resp.should.contain("jobQueues")
-    len(resp["jobQueues"]).should.equal(0)
 
-    # Create job queue which already exists
-    try:
-        resp = batch_client.create_job_queue(
+@mock_ec2
+@mock_ecs
+@mock_iam
+@mock_batch
+def test_describe_job_queue_unknown_value():
+    ec2_client, iam_client, ecs_client, logs_client, batch_client = _get_clients()
+
+    resp = batch_client.describe_job_queues(jobQueues=["test_invalid_queue"])
+    resp.should.have.key("jobQueues").being.length_of(0)
+
+
+@mock_ec2
+@mock_ecs
+@mock_iam
+@mock_batch
+def test_create_job_queue_twice():
+    ec2_client, iam_client, ecs_client, logs_client, batch_client = _get_clients()
+    vpc_id, subnet_id, sg_id, iam_arn = _setup(ec2_client, iam_client)
+
+    compute_name = "test_compute_env"
+    resp = batch_client.create_compute_environment(
+        computeEnvironmentName=compute_name,
+        type="UNMANAGED",
+        state="ENABLED",
+        serviceRole=iam_arn,
+    )
+    compute_env_arn = resp["computeEnvironmentArn"]
+
+    batch_client.create_job_queue(
+        jobQueueName="test_job_queue",
+        state="ENABLED",
+        priority=123,
+        computeEnvironmentOrder=[{"order": 123, "computeEnvironment": compute_env_arn}],
+    )
+    with pytest.raises(ClientError) as ex:
+        batch_client.create_job_queue(
             jobQueueName="test_job_queue",
             state="ENABLED",
             priority=123,
-            computeEnvironmentOrder=[{"order": 123, "computeEnvironment": arn}],
+            computeEnvironmentOrder=[
+                {"order": 123, "computeEnvironment": compute_env_arn}
+            ],
         )
 
-    except ClientError as err:
-        err.response["Error"]["Code"].should.equal("ClientException")
+    err = ex.value.response["Error"]
+    err["Code"].should.equal("ClientException")
+    err["Message"].should.equal("Job queue test_job_queue already exists")
 
-    # Create job queue with incorrect state
-    try:
-        resp = batch_client.create_job_queue(
+
+@mock_ec2
+@mock_ecs
+@mock_iam
+@mock_batch
+def test_create_job_queue_incorrect_state():
+    ec2_client, iam_client, ecs_client, logs_client, batch_client = _get_clients()
+
+    with pytest.raises(ClientError) as ex:
+        batch_client.create_job_queue(
             jobQueueName="test_job_queue2",
-            state="JUNK",
-            priority=123,
-            computeEnvironmentOrder=[{"order": 123, "computeEnvironment": arn}],
-        )
-
-    except ClientError as err:
-        err.response["Error"]["Code"].should.equal("ClientException")
-
-    # Create job queue with no compute env
-    try:
-        resp = batch_client.create_job_queue(
-            jobQueueName="test_job_queue3",
             state="JUNK",
             priority=123,
             computeEnvironmentOrder=[],
         )
+    err = ex.value.response["Error"]
+    err["Code"].should.equal("ClientException")
+    err["Message"].should.equal("state JUNK must be one of ENABLED | DISABLED")
 
-    except ClientError as err:
-        err.response["Error"]["Code"].should.equal("ClientException")
+
+@mock_ec2
+@mock_ecs
+@mock_iam
+@mock_batch
+def test_create_job_queue_without_compute_environment():
+    ec2_client, iam_client, ecs_client, logs_client, batch_client = _get_clients()
+
+    with pytest.raises(ClientError) as ex:
+        batch_client.create_job_queue(
+            jobQueueName="test_job_queue3",
+            state="ENABLED",
+            priority=123,
+            computeEnvironmentOrder=[],
+        )
+    err = ex.value.response["Error"]
+    err["Code"].should.equal("ClientException")
+    err["Message"].should.equal("At least 1 compute environment must be provided")
 
 
 @mock_ec2

--- a/tests/test_batch/test_batch_job_queue.py
+++ b/tests/test_batch/test_batch_job_queue.py
@@ -34,8 +34,50 @@ def test_create_job_queue():
     queue_arn = resp["jobQueueArn"]
 
     resp = batch_client.describe_job_queues()
-    resp.should.have.key("jobQueues").being.length_of(1)
+
+    resp.should.contain("jobQueues")
+    len(resp["jobQueues"]).should.equal(1)
     resp["jobQueues"][0]["jobQueueArn"].should.equal(queue_arn)
+
+    resp = batch_client.describe_job_queues(jobQueues=["test_invalid_queue"])
+    resp.should.contain("jobQueues")
+    len(resp["jobQueues"]).should.equal(0)
+
+    # Create job queue which already exists
+    try:
+        resp = batch_client.create_job_queue(
+            jobQueueName="test_job_queue",
+            state="ENABLED",
+            priority=123,
+            computeEnvironmentOrder=[{"order": 123, "computeEnvironment": arn}],
+        )
+
+    except ClientError as err:
+        err.response["Error"]["Code"].should.equal("ClientException")
+
+    # Create job queue with incorrect state
+    try:
+        resp = batch_client.create_job_queue(
+            jobQueueName="test_job_queue2",
+            state="JUNK",
+            priority=123,
+            computeEnvironmentOrder=[{"order": 123, "computeEnvironment": arn}],
+        )
+
+    except ClientError as err:
+        err.response["Error"]["Code"].should.equal("ClientException")
+
+    # Create job queue with no compute env
+    try:
+        resp = batch_client.create_job_queue(
+            jobQueueName="test_job_queue3",
+            state="JUNK",
+            priority=123,
+            computeEnvironmentOrder=[],
+        )
+
+    except ClientError as err:
+        err.response["Error"]["Code"].should.equal("ClientException")
 
 
 @mock_ec2


### PR DESCRIPTION
Fixes #1850

Note that the method was already implemented, it was just a simplified implementation without any tests.

Docs for reference: https://docs.aws.amazon.com/batch/latest/APIReference/API_CancelJob.html

Includes some refactoring as well, to make the tests more readable/maintainable