### PR TITLE
DNSName key retrieval for list-hosted-zones-by-dns-name

### DIFF
--- a/moto/route53/responses.py
+++ b/moto/route53/responses.py
@@ -61,8 +61,6 @@ class Route53(BaseResponse):
                 for zone in route53_backend.get_all_hosted_zones()
                 if zone.name == dnsname
             ]
-            template = Template(LIST_HOSTED_ZONES_BY_NAME_RESPONSE)
-            return 200, headers, template.render(zones=zones, dnsname=dnsname)
         else:
             # sort by names, but with domain components reversed
             # see http://boto3.readthedocs.io/en/latest/reference/services/route53.html#Route53.Client.list_hosted_zones_by_name
@@ -75,11 +73,9 @@ class Route53(BaseResponse):
 
             zones = route53_backend.get_all_hosted_zones()
             zones = sorted(zones, key=sort_key)
-            template = Template(LIST_HOSTED_ZONES_BY_NAME_RESPONSE)
-            return 200, headers, template.render(zones=zones, dnsname=dnsname)
 
-        # template = Template(LIST_HOSTED_ZONES_BY_NAME_RESPONSE)
-        # return 200, headers, template.render(zones=zones)
+        template = Template(LIST_HOSTED_ZONES_BY_NAME_RESPONSE)
+        return 200, headers, template.render(zones=zones, dnsname=dnsname)
 
     def get_or_delete_hostzone_response(self, request, full_url, headers):
         self.setup_class(request, full_url, headers)

--- a/tests/test_route53/test_route53.py
+++ b/tests/test_route53/test_route53.py
@@ -507,6 +507,51 @@ def test_list_hosted_zones_by_name():
 
 
 @mock_route53
+def test_list_hosted_zones_by_dns_name():
+    conn = boto3.client("route53", region_name="us-east-1")
+    conn.create_hosted_zone(
+        Name="test.b.com.",
+        CallerReference=str(hash("foo")),
+        HostedZoneConfig=dict(PrivateZone=True, Comment="test com"),
+    )
+    conn.create_hosted_zone(
+        Name="test.a.org.",
+        CallerReference=str(hash("bar")),
+        HostedZoneConfig=dict(PrivateZone=True, Comment="test org"),
+    )
+    conn.create_hosted_zone(
+        Name="test.a.org.",
+        CallerReference=str(hash("bar")),
+        HostedZoneConfig=dict(PrivateZone=True, Comment="test org 2"),
+    )
+    conn.create_hosted_zone(
+        Name="ent-dev.plat.farm.",
+        CallerReference=str(hash("psh")),
+        HostedZoneConfig=dict(PrivateZone=False, Comment="infra dev moto"),
+    )
+
+    # test lookup
+    zones = conn.list_hosted_zones_by_name(DNSName="test.b.com.")
+    len(zones["HostedZones"]).should.equal(1)
+    zones["DNSName"].should.equal("test.b.com.")
+    zones = conn.list_hosted_zones_by_name(DNSName="test.a.org.")
+    len(zones["HostedZones"]).should.equal(2)
+    zones["DNSName"].should.equal("test.a.org.")
+    zones["DNSName"].should.equal("test.a.org.")
+    zones = conn.list_hosted_zones_by_name(DNSName="ent-dev.plat.farm.")
+    len(zones["HostedZones"]).should.equal(1)
+    zones["DNSName"].should.equal("ent-dev.plat.farm.")
+
+    # test sort order
+    zones = conn.list_hosted_zones_by_name()
+    len(zones["HostedZones"]).should.equal(4)
+    zones["HostedZones"][0]["Name"].should.equal("test.b.com.")
+    zones["HostedZones"][1]["Name"].should.equal("ent-dev.plat.farm.")
+    zones["HostedZones"][2]["Name"].should.equal("test.a.org.")
+    zones["HostedZones"][3]["Name"].should.equal("test.a.org.")
+
+
+@mock_route53
 def test_change_resource_record_sets_crud_valid():
     conn = boto3.client("route53", region_name="us-east-1")
     conn.create_hosted_zone(

--- a/tests/test_route53/test_route53.py
+++ b/tests/test_route53/test_route53.py
@@ -525,9 +525,9 @@ def test_list_hosted_zones_by_dns_name():
         HostedZoneConfig=dict(PrivateZone=True, Comment="test org 2"),
     )
     conn.create_hosted_zone(
-        Name="ent-dev.plat.farm.",
-        CallerReference=str(hash("psh")),
-        HostedZoneConfig=dict(PrivateZone=False, Comment="infra dev moto"),
+        Name="my.test.net.",
+        CallerReference=str(hash("baz")),
+        HostedZoneConfig=dict(PrivateZone=False, Comment="test net"),
     )
 
     # test lookup
@@ -538,15 +538,18 @@ def test_list_hosted_zones_by_dns_name():
     len(zones["HostedZones"]).should.equal(2)
     zones["DNSName"].should.equal("test.a.org.")
     zones["DNSName"].should.equal("test.a.org.")
-    zones = conn.list_hosted_zones_by_name(DNSName="ent-dev.plat.farm.")
+    zones = conn.list_hosted_zones_by_name(DNSName="my.test.net.")
     len(zones["HostedZones"]).should.equal(1)
-    zones["DNSName"].should.equal("ent-dev.plat.farm.")
+    zones["DNSName"].should.equal("my.test.net.")
+    zones = conn.list_hosted_zones_by_name(DNSName="my.test.net")
+    len(zones["HostedZones"]).should.equal(1)
+    zones["DNSName"].should.equal("my.test.net.")
 
     # test sort order
     zones = conn.list_hosted_zones_by_name()
     len(zones["HostedZones"]).should.equal(4)
     zones["HostedZones"][0]["Name"].should.equal("test.b.com.")
-    zones["HostedZones"][1]["Name"].should.equal("ent-dev.plat.farm.")
+    zones["HostedZones"][1]["Name"].should.equal("my.test.net.")
     zones["HostedZones"][2]["Name"].should.equal("test.a.org.")
     zones["HostedZones"][3]["Name"].should.equal("test.a.org.")
 


### PR DESCRIPTION
DNSName key retrieval for list-hosted-zones-by-dns-name per https://docs.aws.amazon.com/Route53/latest/APIReference/API_ListHostedZonesByName.html#API_ListHostedZonesByName_RequestSyntax
