### PR TITLE
S3 - Make put-object-acl return 404 if the object does not exist

### DIFF
--- a/moto/s3/responses.py
+++ b/moto/s3/responses.py
@@ -1305,8 +1305,11 @@ class ResponseObject(_TemplateEnvironmentMixin, ActionAuthenticatorMixin):
         if "acl" in query:
             key = self.backend.get_object(bucket_name, key_name)
             # TODO: Support the XML-based ACL format
-            key.set_acl(acl)
-            return 200, response_headers, ""
+            if key is not None:
+                key.set_acl(acl)
+                return 200, response_headers, ""
+            else:
+                raise MissingKey(key_name)
 
         if "tagging" in query:
             if "versionId" in query:

--- a/tests/test_s3/test_s3.py
+++ b/tests/test_s3/test_s3.py
@@ -979,6 +979,17 @@ def test_acl_switching():
     ), grants
 
 
+@mock_s3
+def test_acl_switching_nonexistent_key():
+    s3 = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
+    s3.create_bucket(Bucket="mybucket")
+
+    with pytest.raises(ClientError) as e:
+        s3.put_object_acl(Bucket="mybucket", Key="nonexistent", ACL="private")
+
+    e.value.response["Error"]["Code"].should.equal("NoSuchKey")
+
+
 @mock_s3_deprecated
 def test_bucket_acl_setting():
     conn = boto.connect_s3()


### PR DESCRIPTION
Currently trying to set ACL on a key does not exist fails with 

```
AttributeError: 'NoneType' object has no attribute 'set_acl'
```

S3 returns 404 (`NoSuchKey`) if the object referenced by the key does not exist