### PR TITLE
Update Message spec to respect SQS message class

### DIFF
--- a/moto/sqs/models.py
+++ b/moto/sqs/models.py
@@ -71,7 +71,7 @@ DEDUPLICATION_TIME_IN_SECONDS = 300
 
 class Message(BaseModel):
     def __init__(self, message_id, body):
-        self.id = message_id
+        self.message_id = message_id
         self._body = body
         self.message_attributes = {}
         self.receipt_handle = None


### PR DESCRIPTION
In SQS Message, there's an attribute called [message_id](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/sqs.html#SQS.Message.message_id) which holds the id of the message. This is correctly reflected within moto as far as I can tell from [test cases](https://github.com/spulec/moto/blob/master/tests/test_sqs/test_sqs.py#L2428) but in the model for some reason it's just called `id`. Unless I'm wrong this should be `message_id`