### PR TITLE
Raise `TemplateDoesNotExist` if template does not exist

### DIFF
--- a/moto/ses/models.py
+++ b/moto/ses/models.py
@@ -164,6 +164,9 @@ class SESBackend(BaseBackend):
             self.rejected_messages_count += 1
             raise MessageRejectedError("Email address not verified %s" % source)
 
+        if not self.templates.get(template[0]):
+            raise TemplateDoesNotExist("Template (%s) does not exist" % template[0])
+
         self.__process_sns_feedback__(source, destinations, region)
 
         message_id = get_random_message_id()

--- a/tests/test_ses/test_ses_boto3.py
+++ b/tests/test_ses/test_ses_boto3.py
@@ -132,6 +132,21 @@ def test_send_templated_email():
     conn.send_templated_email.when.called_with(**kwargs).should.throw(ClientError)
 
     conn.verify_domain_identity(Domain="example.com")
+
+    with pytest.raises(ClientError) as ex:
+        conn.send_templated_email(**kwargs).when.called_with(**kwargs)
+
+    ex.value.response["Error"]["Code"].should.equal("TemplateDoesNotExist")
+
+    conn.create_template(
+        Template={
+            "TemplateName": "test_template",
+            "SubjectPart": "lalala",
+            "HtmlPart": "",
+            "TextPart": "",
+        }
+    )
+
     conn.send_templated_email(**kwargs)
 
     too_many_addresses = list("to%s@example.com" % i for i in range(51))

--- a/tests/test_ses/test_ses_boto3.py
+++ b/tests/test_ses/test_ses_boto3.py
@@ -134,7 +134,7 @@ def test_send_templated_email():
     conn.verify_domain_identity(Domain="example.com")
 
     with pytest.raises(ClientError) as ex:
-        conn.send_templated_email(**kwargs).when.called_with(**kwargs)
+        conn.send_templated_email(**kwargs)
 
     ex.value.response["Error"]["Code"].should.equal("TemplateDoesNotExist")
 


### PR DESCRIPTION
When sending templated emails

Closes #3783 