### PR TITLE
Route53 - Persist CallerReference

### DIFF
--- a/moto/route53/models.py
+++ b/moto/route53/models.py
@@ -30,6 +30,11 @@ class HealthCheck(CloudFormationModel):
         self.request_interval = health_check_args.get("request_interval") or 30
         self.failure_threshold = health_check_args.get("failure_threshold") or 3
         self.health_threshold = health_check_args.get("health_threshold")
+        self.measure_latency = health_check_args.get("measure_latency") or False
+        self.inverted = health_check_args.get("inverted") or False
+        self.disabled = health_check_args.get("disabled") or False
+        self.enable_sni = health_check_args.get("enable_sni") or False
+        self.children = health_check_args.get("children") or None
         self.caller_reference = caller_reference
 
     @property
@@ -85,16 +90,23 @@ class HealthCheck(CloudFormationModel):
                 {% if health_check.type_ != "CALCULATED" %}
                     <RequestInterval>{{ health_check.request_interval }}</RequestInterval>
                     <FailureThreshold>{{ health_check.failure_threshold }}</FailureThreshold>
-                    <MeasureLatency>False</MeasureLatency>
+                    <MeasureLatency>{{ health_check.measure_latency }}</MeasureLatency>
                 {% endif %}
                 {% if health_check.type_ == "CALCULATED" %}
                     <HealthThreshold>{{ health_check.health_threshold }}</HealthThreshold>
                 {% endif %}
-                <Inverted>False</Inverted>
-                <Disabled>False</Disabled>
-                <EnableSNI>False</EnableSNI>
+                <Inverted>{{ health_check.inverted }}</Inverted>
+                <Disabled>{{ health_check.disabled }}</Disabled>
+                <EnableSNI>{{ health_check.enable_sni }}</EnableSNI>
                 {% if health_check.search_string %}
                     <SearchString>{{ health_check.search_string }}</SearchString>
+                {% endif %}
+                {% if health_check.children %}
+                    <ChildHealthChecks>
+                    {% for child in health_check.children %}
+                        <member>{{ child }}</member>
+                    {% endfor %}
+                    </ChildHealthChecks>
                 {% endif %}
             </HealthCheckConfig>
             <HealthCheckVersion>1</HealthCheckVersion>

--- a/moto/route53/responses.py
+++ b/moto/route53/responses.py
@@ -190,6 +190,11 @@ class Route53(BaseResponse):
                 "request_interval": config.get("RequestInterval"),
                 "failure_threshold": config.get("FailureThreshold"),
                 "health_threshold": config.get("HealthThreshold"),
+                "measure_latency": config.get("MeasureLatency"),
+                "inverted": config.get("Inverted"),
+                "disabled": config.get("Disabled"),
+                "enable_sni": config.get("EnableSNI"),
+                "children": config.get("ChildHealthChecks", {}).get("ChildHealthCheck"),
             }
             health_check = route53_backend.create_health_check(
                 caller_reference, health_check_args

--- a/moto/route53/responses.py
+++ b/moto/route53/responses.py
@@ -177,20 +177,23 @@ class Route53(BaseResponse):
         method = request.method
 
         if method == "POST":
-            properties = xmltodict.parse(self.body)["CreateHealthCheckRequest"][
-                "HealthCheckConfig"
-            ]
+            json_body = xmltodict.parse(self.body)["CreateHealthCheckRequest"]
+            caller_reference = json_body["CallerReference"]
+            config = json_body["HealthCheckConfig"]
             health_check_args = {
-                "ip_address": properties.get("IPAddress"),
-                "port": properties.get("Port"),
-                "type": properties["Type"],
-                "resource_path": properties.get("ResourcePath"),
-                "fqdn": properties.get("FullyQualifiedDomainName"),
-                "search_string": properties.get("SearchString"),
-                "request_interval": properties.get("RequestInterval"),
-                "failure_threshold": properties.get("FailureThreshold"),
+                "ip_address": config.get("IPAddress"),
+                "port": config.get("Port"),
+                "type": config["Type"],
+                "resource_path": config.get("ResourcePath"),
+                "fqdn": config.get("FullyQualifiedDomainName"),
+                "search_string": config.get("SearchString"),
+                "request_interval": config.get("RequestInterval"),
+                "failure_threshold": config.get("FailureThreshold"),
+                "health_threshold": config.get("HealthThreshold"),
             }
-            health_check = route53_backend.create_health_check(health_check_args)
+            health_check = route53_backend.create_health_check(
+                caller_reference, health_check_args
+            )
             template = Template(CREATE_HEALTH_CHECK_RESPONSE)
             return 201, headers, template.render(health_check=health_check)
         elif method == "DELETE":

--- a/tests/test_route53/test_route53_boto3.py
+++ b/tests/test_route53/test_route53_boto3.py
@@ -46,6 +46,41 @@ def test_create_health_check():
 
 
 @mock_route53
+def test_create_health_check_with_additional_options():
+    client = boto3.client("route53", region_name="us-east-1")
+
+    response = client.create_health_check(
+        CallerReference="test-route53-health-HealthCheck-asdf",
+        HealthCheckConfig={
+            "IPAddress": "93.184.216.34",
+            "Port": 80,
+            "Type": "HTTP",
+            "ResourcePath": "/",
+            "FullyQualifiedDomainName": "example.com",
+            "RequestInterval": 10,
+            "FailureThreshold": 2,
+            "MeasureLatency": True,
+            "Inverted": True,
+            "Disabled": True,
+            "EnableSNI": True,
+        },
+    )
+    response["ResponseMetadata"]["HTTPStatusCode"].should.equal(201)
+    #
+    check = response["HealthCheck"]
+    check.should.have.key("CallerReference").being.equal(
+        "test-route53-health-HealthCheck-asdf"
+    )
+    check.should.have.key("HealthCheckConfig")
+    #
+    config = check["HealthCheckConfig"]
+    config.should.have.key("MeasureLatency").being.equal(True)
+    config.should.have.key("Inverted").being.equal(True)
+    config.should.have.key("Disabled").being.equal(True)
+    config.should.have.key("EnableSNI").being.equal(True)
+
+
+@mock_route53
 def test_create_calculated_health_check():
     client = boto3.client("route53", region_name="us-east-1")
 
@@ -78,3 +113,57 @@ def test_create_calculated_health_check():
     config.shouldnt.have.key("RequestInterval")
     config.shouldnt.have.key("FailureThreshold")
     config.shouldnt.have.key("MeasureLatency")
+
+
+@mock_route53
+def test_create_calculated_health_check_with_children():
+    client = boto3.client("route53", region_name="us-east-1")
+
+    child1 = client.create_health_check(
+        CallerReference="test-route53-health-HealthCheck-child1",
+        HealthCheckConfig={
+            "Type": "CALCULATED",
+            "Inverted": False,
+            "Disabled": False,
+            "HealthThreshold": 1,
+        },
+    )
+
+    child2 = client.create_health_check(
+        CallerReference="test-route53-health-HealthCheck-child2",
+        HealthCheckConfig={
+            "Type": "CALCULATED",
+            "Inverted": False,
+            "Disabled": False,
+            "HealthThreshold": 1,
+        },
+    )
+
+    parent = client.create_health_check(
+        CallerReference="test-route53-health-HealthCheck-parent",
+        HealthCheckConfig={
+            "Type": "CALCULATED",
+            "Inverted": False,
+            "Disabled": False,
+            "HealthThreshold": 1,
+            "ChildHealthChecks": [
+                child1["HealthCheck"]["Id"],
+                child2["HealthCheck"]["Id"],
+            ],
+        },
+    )
+
+    check = parent["HealthCheck"]
+    check.should.have.key("Id")
+    check.should.have.key("CallerReference").being.equal(
+        "test-route53-health-HealthCheck-parent"
+    )
+    #
+    config = check["HealthCheckConfig"]
+    config.should.have.key("Type").being.equal("CALCULATED")
+    config.should.have.key("Inverted").being.equal(False)
+    config.should.have.key("Disabled").being.equal(False)
+    config.should.have.key("HealthThreshold").being.equal(1)
+    config.should.have.key("ChildHealthChecks").being.equal(
+        [child1["HealthCheck"]["Id"], child2["HealthCheck"]["Id"]]
+    )

--- a/tests/test_route53/test_route53_boto3.py
+++ b/tests/test_route53/test_route53_boto3.py
@@ -1,0 +1,80 @@
+import boto3
+import sure  # noqa
+from moto import mock_route53
+
+
+@mock_route53
+def test_create_health_check():
+    client = boto3.client("route53", region_name="us-east-1")
+
+    response = client.create_health_check(
+        CallerReference="test-route53-health-HealthCheck-asdf",
+        HealthCheckConfig={
+            "IPAddress": "93.184.216.34",
+            "Port": 80,
+            "Type": "HTTP",
+            "ResourcePath": "/",
+            "FullyQualifiedDomainName": "example.com",
+            "RequestInterval": 10,
+            "FailureThreshold": 2,
+        },
+    )
+    response["ResponseMetadata"]["HTTPStatusCode"].should.equal(201)
+    #
+    check = response["HealthCheck"]
+    check.should.have.key("Id")
+    check.should.have.key("CallerReference").being.equal(
+        "test-route53-health-HealthCheck-asdf"
+    )
+    check.should.have.key("HealthCheckConfig")
+    #
+    config = check["HealthCheckConfig"]
+    config.should.have.key("IPAddress").being.equal("93.184.216.34")
+    config.should.have.key("Port").being.equal(80)
+    config.should.have.key("Type").being.equal("HTTP")
+    config.should.have.key("ResourcePath").being.equal("/")
+    config.should.have.key("FullyQualifiedDomainName").being.equal("example.com")
+    config.should.have.key("RequestInterval").being.equal(10)
+    config.should.have.key("FailureThreshold").being.equal(2)
+    config.should.have.key("MeasureLatency").being.equal(False)
+    config.should.have.key("Inverted").being.equal(False)
+    config.should.have.key("Disabled").being.equal(False)
+    config.should.have.key("EnableSNI").being.equal(False)
+
+    config.shouldnt.have.key("ChildHealthChecks")
+    config.shouldnt.have.key("HealthThreshold")
+
+
+@mock_route53
+def test_create_calculated_health_check():
+    client = boto3.client("route53", region_name="us-east-1")
+
+    response = client.create_health_check(
+        CallerReference="test-route53-health-HealthCheck-ZHV123",
+        HealthCheckConfig={
+            "Type": "CALCULATED",
+            "Inverted": False,
+            "Disabled": False,
+            "HealthThreshold": 1,
+        },
+    )
+
+    check = response["HealthCheck"]
+    check.should.have.key("Id")
+    check.should.have.key("CallerReference").being.equal(
+        "test-route53-health-HealthCheck-ZHV123"
+    )
+    #
+    config = check["HealthCheckConfig"]
+    config.should.have.key("Type").being.equal("CALCULATED")
+    config.should.have.key("Inverted").being.equal(False)
+    config.should.have.key("Disabled").being.equal(False)
+    config.should.have.key("HealthThreshold").being.equal(1)
+    #
+    config.shouldnt.have.key("IPAddress")
+    config.shouldnt.have.key("Port")
+    config.shouldnt.have.key("ResourcePath")
+    config.shouldnt.have.key("FullyQualifiedDomainName")
+    config.shouldnt.have.key("RequestInterval")
+    config.shouldnt.have.key("FailureThreshold")
+    config.shouldnt.have.key("MeasureLatency")


### PR DESCRIPTION
Fixes #3786 
Fixes #3787 

 - Persists and returns CallerReference
 - Fixes default values for some integers
 - Modifies response-values based on whether it's a calculated healthcheck or not

The new test cases have been verified against AWS itself.

~~Marking it as draft for now, as I need to add tests to verify what happens when we add parameters:~~

Edit: Ready for review now