### PR TITLE
adding physical_resource_id in SubnetRouteTableAssociation, Route and NatGW classes

### DIFF
--- a/moto/ec2/models.py
+++ b/moto/ec2/models.py
@@ -4029,6 +4029,10 @@ class SubnetRouteTableAssociation(CloudFormationModel):
     def __init__(self, route_table_id, subnet_id):
         self.route_table_id = route_table_id
         self.subnet_id = subnet_id
+    
+    @property
+    def physical_resource_id(self):
+        return self.route_table_id
 
     @staticmethod
     def cloudformation_name_type():
@@ -4253,6 +4257,10 @@ class Route(CloudFormationModel):
         self.nat_gateway = nat_gateway
         self.interface = interface
         self.vpc_pcx = vpc_pcx
+    
+    @property
+    def physical_resource_id(self):
+        return self.id
 
     @staticmethod
     def cloudformation_name_type():
@@ -5842,6 +5850,10 @@ class NatGateway(CloudFormationModel):
         # associate allocation with ENI
         self._backend.associate_address(eni=self._eni, allocation_id=self.allocation_id)
         self.tags = tags
+
+    @property
+    def physical_resource_id(self):
+        return self.id
 
     @property
     def vpc_id(self):

--- a/moto/ec2/models.py
+++ b/moto/ec2/models.py
@@ -4029,7 +4029,7 @@ class SubnetRouteTableAssociation(CloudFormationModel):
     def __init__(self, route_table_id, subnet_id):
         self.route_table_id = route_table_id
         self.subnet_id = subnet_id
-    
+
     @property
     def physical_resource_id(self):
         return self.route_table_id
@@ -4257,7 +4257,7 @@ class Route(CloudFormationModel):
         self.nat_gateway = nat_gateway
         self.interface = interface
         self.vpc_pcx = vpc_pcx
-    
+
     @property
     def physical_resource_id(self):
         return self.id

--- a/tests/test_cloudformation/test_cloudformation_stack_integration.py
+++ b/tests/test_cloudformation/test_cloudformation_stack_integration.py
@@ -1861,10 +1861,7 @@ def lambda_handler(event, context):
             "lambdaTest": {
                 "Type": "AWS::Lambda::LayerVersion",
                 "Properties": {
-                    "Content": {
-                        "S3Bucket": bucket_name,
-                        "S3Key": "test.zip",
-                    },
+                    "Content": {"S3Bucket": bucket_name, "S3Key": "test.zip",},
                     "LayerName": "testLayer",
                     "Description": "Test Layer",
                     "CompatibleRuntimes": ["python2.7", "python3.6"],
@@ -2411,10 +2408,7 @@ def test_stack_dynamodb_resources_integration():
     dynamodb_client = boto3.client("dynamodb", region_name="us-east-1")
     table_desc = dynamodb_client.describe_table(TableName="myTableName")["Table"]
     table_desc["StreamSpecification"].should.equal(
-        {
-            "StreamEnabled": True,
-            "StreamViewType": "KEYS_ONLY",
-        }
+        {"StreamEnabled": True, "StreamViewType": "KEYS_ONLY",}
     )
 
     dynamodb_conn = boto3.resource("dynamodb", region_name="us-east-1")
@@ -2872,9 +2866,7 @@ def test_stack_events_get_attribute_integration():
 @mock_dynamodb2
 def test_dynamodb_table_creation():
     CFN_TEMPLATE = {
-        "Outputs": {
-            "MyTableName": {"Value": {"Ref": "MyTable"}},
-        },
+        "Outputs": {"MyTableName": {"Value": {"Ref": "MyTable"}},},
         "Resources": {
             "MyTable": {
                 "Type": "AWS::DynamoDB::Table",

--- a/tests/test_cloudformation/test_cloudformation_stack_integration.py
+++ b/tests/test_cloudformation/test_cloudformation_stack_integration.py
@@ -1861,7 +1861,10 @@ def lambda_handler(event, context):
             "lambdaTest": {
                 "Type": "AWS::Lambda::LayerVersion",
                 "Properties": {
-                    "Content": {"S3Bucket": bucket_name, "S3Key": "test.zip",},
+                    "Content": {
+                        "S3Bucket": bucket_name,
+                        "S3Key": "test.zip",
+                    },
                     "LayerName": "testLayer",
                     "Description": "Test Layer",
                     "CompatibleRuntimes": ["python2.7", "python3.6"],
@@ -1949,8 +1952,11 @@ def test_nat_gateway():
     result["NatGateways"][0]["VpcId"].should.equal(vpc_id)
     result["NatGateways"][0]["SubnetId"].should.equal(subnet_id)
     result["NatGateways"][0]["State"].should.equal("available")
-    result["NatGateways"][0]["NatGatewayId"].should.equal(nat_gateway_resource.get("PhysicalResourceId"))
-    route_resource.get("PhysicalResourceId").should.contain('rtb-')
+    result["NatGateways"][0]["NatGatewayId"].should.equal(
+        nat_gateway_resource.get("PhysicalResourceId")
+    )
+    route_resource.get("PhysicalResourceId").should.contain("rtb-")
+
 
 @mock_cloudformation()
 @mock_kms()
@@ -2405,7 +2411,10 @@ def test_stack_dynamodb_resources_integration():
     dynamodb_client = boto3.client("dynamodb", region_name="us-east-1")
     table_desc = dynamodb_client.describe_table(TableName="myTableName")["Table"]
     table_desc["StreamSpecification"].should.equal(
-        {"StreamEnabled": True, "StreamViewType": "KEYS_ONLY",}
+        {
+            "StreamEnabled": True,
+            "StreamViewType": "KEYS_ONLY",
+        }
     )
 
     dynamodb_conn = boto3.resource("dynamodb", region_name="us-east-1")
@@ -2863,7 +2872,9 @@ def test_stack_events_get_attribute_integration():
 @mock_dynamodb2
 def test_dynamodb_table_creation():
     CFN_TEMPLATE = {
-        "Outputs": {"MyTableName": {"Value": {"Ref": "MyTable"}},},
+        "Outputs": {
+            "MyTableName": {"Value": {"Ref": "MyTable"}},
+        },
         "Resources": {
             "MyTable": {
                 "Type": "AWS::DynamoDB::Table",

--- a/tests/test_cloudformation/test_cloudformation_stack_integration.py
+++ b/tests/test_cloudformation/test_cloudformation_stack_integration.py
@@ -1940,14 +1940,17 @@ def test_nat_gateway():
 
     cf_conn = boto3.client("cloudformation", "us-east-1")
     cf_conn.create_stack(StackName="test_stack", TemplateBody=json.dumps(template))
-
+    stack_resources = cf_conn.list_stack_resources(StackName="test_stack")
+    nat_gateway_resource = stack_resources.get("StackResourceSummaries")[0]
+    route_resource = stack_resources.get("StackResourceSummaries")[2]
     result = ec2_conn.describe_nat_gateways()
 
     result["NatGateways"].should.have.length_of(1)
     result["NatGateways"][0]["VpcId"].should.equal(vpc_id)
     result["NatGateways"][0]["SubnetId"].should.equal(subnet_id)
     result["NatGateways"][0]["State"].should.equal("available")
-
+    result["NatGateways"][0]["NatGatewayId"].should.equal(nat_gateway_resource.get("PhysicalResourceId"))
+    route_resource.get("PhysicalResourceId").should.contain('rtb-')
 
 @mock_cloudformation()
 @mock_kms()

--- a/tests/test_cloudformation/test_cloudformation_stack_integration.py
+++ b/tests/test_cloudformation/test_cloudformation_stack_integration.py
@@ -1942,9 +1942,13 @@ def test_nat_gateway():
     cf_conn.create_stack(StackName="test_stack", TemplateBody=json.dumps(template))
     stack_resources = cf_conn.list_stack_resources(StackName="test_stack")
     nat_gateway_resource = stack_resources.get("StackResourceSummaries")[0]
-    route_resource = stack_resources.get("StackResourceSummaries")[2]
-    result = ec2_conn.describe_nat_gateways()
+    for resource in stack_resources["StackResourceSummaries"]:
+        if resource["ResourceType"] == "AWS::EC2::NatGateway":
+            nat_gateway_resource = resource
+        elif resource["ResourceType"] == "AWS::EC2::Route":
+            route_resource = resource
 
+    result = ec2_conn.describe_nat_gateways()
     result["NatGateways"].should.have.length_of(1)
     result["NatGateways"][0]["VpcId"].should.equal(vpc_id)
     result["NatGateways"][0]["SubnetId"].should.equal(subnet_id)


### PR DESCRIPTION
Adding physical_resource_id in SubnetRouteTableAssociation, Route and NatGW classes in `moto/ec2/models.py` in order to avoid https://github.com/localstack/aws-cdk-local/issues/44
