### PR TITLE
Admin - Use GraphQL to find PR, instead of commit msg

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -193,10 +193,39 @@ jobs:
         run: |
           version=$(grep -oP '(?<=__version__ = ")[0-9.a-z]+(?=")' moto/__init__.py)
           echo "moto_version=$version" >> $GITHUB_ENV
+      - uses: octokit/graphql-action@v2.x
+        name: Get PR info
+        id: get_pr
+        with:
+          query: |
+            query get_pr($owner:String!,$repo:String!,$commit:GitObjectID) {
+              repository(owner:$owner,name:$repo) {
+                object(oid:$commit) {
+                  ... on Commit {
+                    associatedPullRequests(last: 1){
+                      edges {
+                        node {
+                          baseRepository {
+                            nameWithOwner
+                          }
+                          merged
+                          number
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          owner: ${{ github.event.repository.owner.name }}
+          repo: ${{ github.event.repository.name }}
+          commit: "${{ github.sha }}"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Get PR number
         run: |
-          msg="${{ github.event.commits[0].message }}"
-          nr=$(grep -oP '\(#\K[0-9]+' <<< "$msg" | head -n 1)
+          nr="${{ fromJSON(steps.get_pr.outputs.data).repository.object.associatedPullRequests.edges[0].node.number }}"
+          repo="${{ fromJSON(steps.get_pr.outputs.data).repository.object.associatedPullRequests.edges[0].node.baseRepository.nameWithOwner }}"
           if [ -z "$nr" ]
           then
             echo "PR nr not found in $msg"
@@ -204,11 +233,12 @@ jobs:
           else
             echo "PR NR: $nr"
             echo "pr_nr=$nr" >> $GITHUB_ENV
+            echo "pr_repo=$repo" >> $GITHUB_ENV
             echo "pr_found=true" >> $GITHUB_ENV
           fi
       - name: Leave PR comment with Moto version
         uses: peter-evans/create-or-update-comment@v1
-        if: env.pr_found == 'true'
+        if: env.pr_found == 'true' && env.pr_repo == 'spulec/moto'
         with:
           issue-number: ${{ env.pr_nr }}
           body: |

--- a/update_version_from_git.py
+++ b/update_version_from_git.py
@@ -95,7 +95,7 @@ def prerelease_version():
     assert (
         initpy_ver > ver
     ), "the moto/__init__.py version should be newer than the last tagged release."
-    return "{initpy_ver}.{commits_since}".format(
+    return "{initpy_ver}{commits_since}".format(
         initpy_ver=initpy_ver, commits_since=commits_since
     )
 


### PR DESCRIPTION
Parsing the msg was quicker, but also uglier and more difficult, as the message will differ depending on whether it's a straight merge or squashed merge.

Still outstanding: 
If there are multiple associated PR's, we should leave a message on all PR's that have been merged