### PR TITLE
Check S3_IGNORE_SUBDOMAIN_BUCKETNAME environment variable

### DIFF
--- a/moto/s3/responses.py
+++ b/moto/s3/responses.py
@@ -27,6 +27,7 @@ from moto.packages.httpretty.core import HTTPrettyRequest
 from moto.core.responses import _TemplateEnvironmentMixin, ActionAuthenticatorMixin
 from moto.core.utils import path_url
 from moto.core import ACCOUNT_ID
+from moto.settings import S3_IGNORE_SUBDOMAIN_BUCKETNAME
 
 from moto.s3bucket_path.utils import (
     bucket_name_from_url as bucketpath_bucket_name_from_url,
@@ -186,7 +187,7 @@ class ResponseObject(_TemplateEnvironmentMixin, ActionAuthenticatorMixin):
         return template.render(buckets=all_buckets)
 
     def subdomain_based_buckets(self, request):
-        if os.environ.get("S3_IGNORE_SUBDOMAIN_BUCKETNAME", "") in ["1", "true"]:
+        if S3_IGNORE_SUBDOMAIN_BUCKETNAME:
             return False
         host = request.headers.get("host", request.headers.get("Host"))
         if not host:

--- a/moto/s3/responses.py
+++ b/moto/s3/responses.py
@@ -186,6 +186,8 @@ class ResponseObject(_TemplateEnvironmentMixin, ActionAuthenticatorMixin):
         return template.render(buckets=all_buckets)
 
     def subdomain_based_buckets(self, request):
+        if os.environ.get("S3_IGNORE_SUBDOMAIN_BUCKETNAME", "") in ["1", "true"]:
+            return False
         host = request.headers.get("host", request.headers.get("Host"))
         if not host:
             host = urlparse(request.url).netloc

--- a/moto/s3/utils.py
+++ b/moto/s3/utils.py
@@ -1,12 +1,12 @@
 from __future__ import unicode_literals
 import logging
-import os
 
 import re
 import six
 from six.moves.urllib.parse import urlparse, unquote, quote
 from requests.structures import CaseInsensitiveDict
 import sys
+from moto.settings import S3_IGNORE_SUBDOMAIN_BUCKETNAME
 
 
 log = logging.getLogger(__name__)
@@ -26,7 +26,7 @@ user_settable_fields = {
 
 
 def bucket_name_from_url(url):
-    if os.environ.get("S3_IGNORE_SUBDOMAIN_BUCKETNAME", "") in ["1", "true"]:
+    if S3_IGNORE_SUBDOMAIN_BUCKETNAME:
         return None
     domain = urlparse(url).netloc
 

--- a/moto/settings.py
+++ b/moto/settings.py
@@ -6,6 +6,10 @@ INITIAL_NO_AUTH_ACTION_COUNT = float(
 )
 DEFAULT_CONTAINER_REGISTRY = os.environ.get("DEFAULT_CONTAINER_REGISTRY", "docker.io")
 
+S3_IGNORE_SUBDOMAIN_BUCKETNAME = os.environ.get(
+    "S3_IGNORE_SUBDOMAIN_BUCKETNAME", ""
+) in ["1", "true"]
+
 
 def get_sf_execution_history_type():
     """

--- a/tests/compat.py
+++ b/tests/compat.py
@@ -1,0 +1,5 @@
+try:
+    from unittest.mock import patch
+except ImportError:
+    # for python 2.7
+    from mock import patch

--- a/tests/test_s3/test_s3_utils.py
+++ b/tests/test_s3/test_s3_utils.py
@@ -1,5 +1,4 @@
 from __future__ import unicode_literals
-import os
 import pytest
 from sure import expect
 from moto.s3.utils import (
@@ -9,6 +8,7 @@ from moto.s3.utils import (
     clean_key_name,
     undo_clean_key_name,
 )
+from tests.compat import patch
 
 
 def test_base_url():
@@ -25,12 +25,11 @@ def test_localhost_without_bucket():
     expect(bucket_name_from_url("https://www.localhost:5000/def")).should.equal(None)
 
 
-def test_force_ignore_subdomain_for_bucketnames():
-    os.environ["S3_IGNORE_SUBDOMAIN_BUCKETNAME"] = "1"
-    expect(
-        bucket_name_from_url("https://subdomain.localhost:5000/abc/resource")
-    ).should.equal(None)
-    del os.environ["S3_IGNORE_SUBDOMAIN_BUCKETNAME"]
+def test_force_ignore_subdomain_for_bucketnames(monkeypatch):
+    with patch("moto.s3.utils.S3_IGNORE_SUBDOMAIN_BUCKETNAME", True):
+        expect(
+            bucket_name_from_url("https://subdomain.localhost:5000/abc/resource")
+        ).should.equal(None)
 
 
 def test_versioned_key_store():

--- a/tests/test_s3/test_server.py
+++ b/tests/test_s3/test_server.py
@@ -2,6 +2,7 @@
 
 from __future__ import unicode_literals
 import io
+import os
 from six.moves.urllib.parse import urlparse, parse_qs
 import sure  # noqa
 
@@ -54,6 +55,17 @@ def test_s3_server_bucket_create():
     res = test_client.get("/bar", "http://foobaz.localhost:5000/")
     res.status_code.should.equal(200)
     res.data.should.equal(b"test value")
+
+
+def test_s3_server_ignore_subdomain_for_bucketnames():
+    os.environ["S3_IGNORE_SUBDOMAIN_BUCKETNAME"] = "1"
+    test_client = authenticated_client()
+
+    res = test_client.put("/mybucket", "http://foobaz.localhost:5000/")
+    res.status_code.should.equal(200)
+    res.data.should.contain(b"mybucket")
+
+    del os.environ["S3_IGNORE_SUBDOMAIN_BUCKETNAME"]
 
 
 def test_s3_server_bucket_versioning():

--- a/tests/test_s3/test_server.py
+++ b/tests/test_s3/test_server.py
@@ -2,12 +2,12 @@
 
 from __future__ import unicode_literals
 import io
-import os
 from six.moves.urllib.parse import urlparse, parse_qs
 import sure  # noqa
 
 from flask.testing import FlaskClient
 import moto.server as server
+from tests.compat import patch
 
 """
 Test the different server responses
@@ -58,14 +58,12 @@ def test_s3_server_bucket_create():
 
 
 def test_s3_server_ignore_subdomain_for_bucketnames():
-    os.environ["S3_IGNORE_SUBDOMAIN_BUCKETNAME"] = "1"
-    test_client = authenticated_client()
+    with patch("moto.s3.responses.S3_IGNORE_SUBDOMAIN_BUCKETNAME", True):
+        test_client = authenticated_client()
 
-    res = test_client.put("/mybucket", "http://foobaz.localhost:5000/")
-    res.status_code.should.equal(200)
-    res.data.should.contain(b"mybucket")
-
-    del os.environ["S3_IGNORE_SUBDOMAIN_BUCKETNAME"]
+        res = test_client.put("/mybucket", "http://foobaz.localhost:5000/")
+        res.status_code.should.equal(200)
+        res.data.should.contain(b"mybucket")
 
 
 def test_s3_server_bucket_versioning():


### PR DESCRIPTION
This PR fixes #3795 by checking the `S3_IGNORE_SUBDOMAIN_BUCKETNAME` environment variable in the same way `bucket_name_from_url` does in utils.py

With this PR, performing the test as described in #3795 creates the bucket as expected.

Also a unittest was added to test the change