### PR TITLE
Improve dynamodb query case sensitivity

### DIFF
--- a/moto/dynamodb2/responses.py
+++ b/moto/dynamodb2/responses.py
@@ -510,7 +510,7 @@ class DynamoHandler(BaseResponse):
                 range_key_expression_components = range_key_expression.split()
                 range_comparison = range_key_expression_components[1]
 
-                if "AND" in range_key_expression:
+                if " and " in range_key_expression.lower():
                     range_comparison = "BETWEEN"
                     range_values = [
                         value_alias_map[range_key_expression_components[2]],
@@ -521,6 +521,18 @@ class DynamoHandler(BaseResponse):
                     range_values = [
                         value_alias_map[range_key_expression_components[-1]]
                     ]
+                elif "begins_with" in range_key_expression.lower():
+                    function_used = range_key_expression[
+                        range_key_expression.lower().index("begins_with") : len(
+                            "begins_with"
+                        )
+                    ]
+                    return self.error(
+                        "com.amazonaws.dynamodb.v20111205#ValidationException",
+                        "Invalid KeyConditionExpression: Invalid function name; function: {}".format(
+                            function_used
+                        ),
+                    )
                 else:
                     range_values = [value_alias_map[range_key_expression_components[2]]]
             else:


### PR DESCRIPTION
See #3799

When using the compact API this would not be an issue, since `Key("whatever").eq("the-key")
        & Key("range-attribute").begins_with("some_text")` would use "begins_with" behind the scenes. 

The same goes for *between*, which would set it to uppercase.

Almost all tests use the compact version, and both conditions are thoroughly being tested.

However, KeyConditionExpression "text" syntax is also supported allowing something like `"KeyConditionExpression="key_attribute = :key_value and BEGINS_WITH(range_attribute, :some_text )"`

This should raise a controlled exception:

```botocore.exceptions.ClientError: An error occurred (ValidationException) when calling the Query operation: Invalid KeyConditionExpression: Invalid function name; function: BEGINS_WITH```

However, moto would raise an unexpected error.

A lowercase clause like this `KeyConditionExpression="key_attribute = :key_value  and range_attribute between :start  and  :end" ` should succeed but moto would raise an unexpected exception.

This PR would fix this two behaviors.