### PR TITLE
Raise error when adding duplicate egress rule to ec2:SecurityGroup

### DIFF
--- a/moto/ec2/models.py
+++ b/moto/ec2/models.py
@@ -2151,10 +2151,11 @@ class SecurityGroup(TaggedEC2Resource, CloudFormationModel):
     def add_ingress_rule(self, rule):
         if rule in self.ingress_rules:
             raise InvalidPermissionDuplicateError()
-        else:
-            self.ingress_rules.append(rule)
+        self.ingress_rules.append(rule)
 
     def add_egress_rule(self, rule):
+        if rule in self.egress_rules:
+            raise InvalidPermissionDuplicateError()
         self.egress_rules.append(rule)
 
     def get_number_of_ingress_rules(self):


### PR DESCRIPTION
The `InvalidPermission.Duplicate` error was already implemented for inbound rules,
but AWS also returns this error for duplicate outbound rules.

Very minor changes were needed on existing tests that were adding duplicate
outbound rules (when testing the RulesPerSecurityGroupLimitExceeded error).