### PR TITLE
Modify Rule.send_to_targets() to handle event_bus_name as ARN

### DIFF
--- a/moto/events/models.py
+++ b/moto/events/models.py
@@ -82,6 +82,7 @@ class Rule(CloudFormationModel):
                 self.targets.pop(index)
 
     def send_to_targets(self, event_bus_name, event):
+        event_bus_name = event_bus_name.split("/")[-1]
         if event_bus_name != self.event_bus_name:
             return
 

--- a/tests/test_events/test_events.py
+++ b/tests/test_events/test_events.py
@@ -1330,7 +1330,7 @@ def test_archive_event_with_bus_arn():
         "Source": "source",
         "DetailType": "type",
         "Detail": '{ "key1": "value1" }',
-        "EventBusName": event_bus_arn
+        "EventBusName": event_bus_arn,
     }
     client.create_archive(ArchiveName=archive_name, EventSourceArn=event_bus_arn)
 


### PR DESCRIPTION
Fixes #3803 by converting `event_bus_name` (which could be an ARN) to a simple name when sending an event to a Rule's targets. This is verified through a new test that constructs an Archive, sends an event where EventBusName is an ARN, and confrims that the event is routed to the Archive.