### PR TITLE
Modify SSM `put_parameter()` to raise ValidationException if value is empty string

### DIFF
--- a/moto/ssm/models.py
+++ b/moto/ssm/models.py
@@ -1284,6 +1284,11 @@ class SimpleSystemManagerBackend(BaseBackend):
     def put_parameter(
         self, name, description, value, type, allowed_pattern, keyid, overwrite, tags,
     ):
+        if value == "":
+            raise ValidationException(
+                "1 validation error detected: Value '' at 'value' failed to satisfy"
+                " constraint: Member must have length greater than or equal to 1."
+            )
         if name.lower().lstrip("/").startswith("aws") or name.lower().lstrip(
             "/"
         ).startswith("ssm"):

--- a/moto/ssm/models.py
+++ b/moto/ssm/models.py
@@ -1284,7 +1284,7 @@ class SimpleSystemManagerBackend(BaseBackend):
     def put_parameter(
         self, name, description, value, type, allowed_pattern, keyid, overwrite, tags,
     ):
-        if value == "":
+        if not value:
             raise ValidationException(
                 "1 validation error detected: Value '' at 'value' failed to satisfy"
                 " constraint: Member must have length greater than or equal to 1."

--- a/tests/test_ssm/test_ssm_boto3.py
+++ b/tests/test_ssm/test_ssm_boto3.py
@@ -300,6 +300,22 @@ def test_put_parameter():
 
 
 @mock_ssm
+def test_put_parameter_empty_string_value():
+    client = boto3.client("ssm", region_name="us-east-1")
+    with pytest.raises(ClientError) as e:
+        client.put_parameter(Name="test_name", Value="", Type="String")
+    ex = e.value
+    ex.operation_name.should.equal("PutParameter")
+    ex.response["ResponseMetadata"]["HTTPStatusCode"].should.equal(400)
+    ex.response["Error"]["Code"].should.contain("ValidationException")
+    ex.response["Error"]["Message"].should.equal(
+        "1 validation error detected: "
+        "Value '' at 'value' failed to satisfy constraint: "
+        "Member must have length greater than or equal to 1."
+    )
+
+
+@mock_ssm
 def test_put_parameter_invalid_names():
     client = boto3.client("ssm", region_name="us-east-1")
 


### PR DESCRIPTION
Fixes #3794 by checking `put_parameter()` value for an empty string and raising a ValidationException if this is the case. 