### PR TITLE
Use `MOTO_ACCOUNT_ID` when building default `Rule` ARN

### DIFF
--- a/moto/events/models.py
+++ b/moto/events/models.py
@@ -28,8 +28,8 @@ class Rule(CloudFormationModel):
     Arn = namedtuple("Arn", ["service", "resource_type", "resource_id"])
 
     def _generate_arn(self, name):
-        return "arn:aws:events:{region_name}:111111111111:rule/{name}".format(
-            region_name=self.region_name, name=name
+        return "arn:aws:events:{region_name}:{account}:rule/{name}".format(
+            region_name=self.region_name, account=ACCOUNT_ID, name=name
         )
 
     def __init__(self, name, region_name, **kwargs):

--- a/tests/test_events/test_events.py
+++ b/tests/test_events/test_events.py
@@ -120,9 +120,11 @@ def test_describe_rule():
 
     assert response is not None
     assert response.get("Name") == rule_name
-    assert response.get(
-        "Arn"
-    ) == "arn:aws:events:us-west-2:111111111111:rule/{0}".format(rule_name)
+
+    rule_arn = response.get("Arn")
+    assert rule_arn == "arn:aws:events:us-west-2:{account}:rule/{name}".format(
+        account=ACCOUNT_ID, name=rule_name
+    )
 
 
 @mock_events


### PR DESCRIPTION
Fixes #3807. Updates default `Rule` ARN building logic to use the `MOTO_ACCOUNT_ID` environment variable. Updates relevant `describe_rule()` unit test.