### PR TITLE
Make security rules consistent between direct (backend) and indirect (api) boundaries

### DIFF
--- a/moto/ec2/models.py
+++ b/moto/ec2/models.py
@@ -1984,10 +1984,11 @@ class SecurityRule(object):
         self.ip_protocol = ip_protocol
         self.ip_ranges = ip_ranges or []
         self.source_groups = source_groups
+        self.from_port = self.to_port = None
 
         if ip_protocol != "-1":
-            self.from_port = from_port
-            self.to_port = to_port
+            self.from_port = int(from_port)
+            self.to_port = int(to_port)
 
     def __eq__(self, other):
         if self.ip_protocol != other.ip_protocol:

--- a/moto/ec2/responses/security_groups.py
+++ b/moto/ec2/responses/security_groups.py
@@ -196,10 +196,10 @@ DESCRIBE_SECURITY_GROUPS_RESPONSE = (
                {% for rule in group.ingress_rules %}
                     <item>
                        <ipProtocol>{{ rule.ip_protocol }}</ipProtocol>
-                       {% if rule.from_port %}
+                       {% if rule.from_port is not none %}
                        <fromPort>{{ rule.from_port }}</fromPort>
                        {% endif %}
-                       {% if rule.to_port %}
+                       {% if rule.to_port is not none %}
                        <toPort>{{ rule.to_port }}</toPort>
                        {% endif %}
                        <groups>
@@ -230,10 +230,10 @@ DESCRIBE_SECURITY_GROUPS_RESPONSE = (
                {% for rule in group.egress_rules %}
                     <item>
                        <ipProtocol>{{ rule.ip_protocol }}</ipProtocol>
-                       {% if rule.from_port %}
+                       {% if rule.from_port is not none %}
                        <fromPort>{{ rule.from_port }}</fromPort>
                        {% endif %}
-                       {% if rule.to_port %}
+                       {% if rule.to_port is not none %}
                        <toPort>{{ rule.to_port }}</toPort>
                        {% endif %}
                        <groups>


### PR DESCRIPTION
[Discovered while working on adding support for [Managed Security Groups in EMR](https://docs.aws.amazon.com/emr/latest/ManagementGuide/emr-man-sec-groups.html)]

Security rules added directly via the backend were unable to be revoked via the API
because the port values were being stored as strings but were always coerced back
to integers by the botocore model.  `"0" != 0`, so the rules would never match,
raising an `InvalidPermissionNotFoundError`.

This change ensures that the port values for a security group rule are always of type
`Union[int, None]`.

No tests needed to be modified as a result of this change.  A new test was added that
explicitly covers the behavior that had been failing.