### PR TITLE
Enhancement/3821

### DIFF
--- a/moto/events/models.py
+++ b/moto/events/models.py
@@ -91,6 +91,7 @@ class Rule(CloudFormationModel):
         return True
 
     def _does_event_item_match_pattern_item(self, event_item, pattern_item):
+        #  Only supports "key: [value]" filters currently
         if not event_item:
             return False
         if isinstance(pattern_item, list):

--- a/moto/events/models.py
+++ b/moto/events/models.py
@@ -81,6 +81,23 @@ class Rule(CloudFormationModel):
             if index is not None:
                 self.targets.pop(index)
 
+    def _does_event_match_pattern(self, event, pattern):
+        if not pattern:
+            return True
+        event_pattern_pairs = [(event.get(k), v) for k, v in pattern.items()]
+        for event_item, pattern_item in event_pattern_pairs:
+            if not self._does_event_item_match_pattern_item(event_item, pattern_item):
+                return False
+        return True
+
+    def _does_event_item_match_pattern_item(self, event_item, pattern_item):
+        if not event_item:
+            return False
+        if isinstance(pattern_item, list):
+            return event_item in pattern_item
+        if isinstance(pattern_item, dict):
+            return self._does_event_match_pattern(event_item, pattern_item)
+
     def send_to_targets(self, event_bus_name, event):
         if event_bus_name != self.event_bus_name:
             return
@@ -169,9 +186,12 @@ class Rule(CloudFormationModel):
     def _send_to_events_archive(self, resource_id, event):
         archive_name, archive_uuid = resource_id.split(":")
         archive = events_backends[self.region_name].archives.get(archive_name)
-
+        pattern = archive.event_pattern
         if archive.uuid == archive_uuid:
-            archive.events.append(event)
+            event = json.loads(json.dumps(event))
+            pattern = json.loads(pattern) if pattern else None
+            if self._does_event_match_pattern(event, pattern):
+                archive.events.append(event)
 
     def get_cfn_attribute(self, attribute_name):
         from moto.cloudformation.exceptions import UnformattedGetAttTemplateException

--- a/tests/test_events/test_events.py
+++ b/tests/test_events/test_events.py
@@ -1508,20 +1508,18 @@ def test_event_not_routed_to_archive_when_detail_does_not_match_pattern():
 
     # when
     event_matching_detail = {
-        "Source": "source", "DetailType": "type", "Detail": '{"foo": "bar"}'
+        "Source": "source",
+        "DetailType": "type",
+        "Detail": '{"foo": "bar"}',
     }
     event_not_matching_detail = {
-        "Source": "source", "DetailType": "type", "Detail": '{"foo": "baz"}'
+        "Source": "source",
+        "DetailType": "type",
+        "Detail": '{"foo": "baz"}',
     }
-    event_matching_source_foo = {
-        "Source": "foo", "DetailType": "type", "Detail": '{}'
-    }
-    event_matching_source_bar = {
-        "Source": "bar", "DetailType": "type", "Detail": '{}'
-    }
-    event_not_matching_source = {
-        "Source": "baz", "DetailType": "type", "Detail": '{}'
-    }
+    event_matching_source_foo = {"Source": "foo", "DetailType": "type", "Detail": "{}"}
+    event_matching_source_bar = {"Source": "bar", "DetailType": "type", "Detail": "{}"}
+    event_not_matching_source = {"Source": "baz", "DetailType": "type", "Detail": "{}"}
 
     client.put_events(
         Entries=[
@@ -1529,7 +1527,7 @@ def test_event_not_routed_to_archive_when_detail_does_not_match_pattern():
             event_not_matching_detail,
             event_matching_source_foo,
             event_matching_source_bar,
-            event_not_matching_source
+            event_not_matching_source,
         ]
     )
 

--- a/tests/test_events/test_events.py
+++ b/tests/test_events/test_events.py
@@ -1496,19 +1496,51 @@ def test_event_not_routed_to_archive_when_detail_does_not_match_pattern():
         ACCOUNT_ID
     )
     client.create_archive(
-        ArchiveName="no-matches-detail",
+        ArchiveName="archive-with-dict-filter",
         EventSourceArn=event_bus_arn,
         EventPattern=json.dumps({"detail": {"foo": ["bar"]}}),
     )
+    client.create_archive(
+        ArchiveName="archive-with-list-filter",
+        EventSourceArn=event_bus_arn,
+        EventPattern=json.dumps({"source": ["foo", "bar"]}),
+    )
 
     # when
-    event = {"Source": "source", "DetailType": "type", "Detail": '{"foo": "baz"}'}
-    client.put_events(Entries=[event])
+    event_matching_detail = {
+        "Source": "source", "DetailType": "type", "Detail": '{"foo": "bar"}'
+    }
+    event_not_matching_detail = {
+        "Source": "source", "DetailType": "type", "Detail": '{"foo": "baz"}'
+    }
+    event_matching_source_foo = {
+        "Source": "foo", "DetailType": "type", "Detail": '{}'
+    }
+    event_matching_source_bar = {
+        "Source": "bar", "DetailType": "type", "Detail": '{}'
+    }
+    event_not_matching_source = {
+        "Source": "baz", "DetailType": "type", "Detail": '{}'
+    }
+
+    client.put_events(
+        Entries=[
+            event_matching_detail,
+            event_not_matching_detail,
+            event_matching_source_foo,
+            event_matching_source_bar,
+            event_not_matching_source
+        ]
+    )
 
     # then
-    response = client.describe_archive(ArchiveName="no-matches-detail")
-    response["EventCount"].should.equal(0)
-    response["SizeBytes"].should.equal(0)
+    response = client.describe_archive(ArchiveName="archive-with-dict-filter")
+    response["EventCount"].should.equal(1)
+    response["SizeBytes"].should.be.greater_than(0)
+
+    response = client.describe_archive(ArchiveName="archive-with-list-filter")
+    response["EventCount"].should.equal(2)
+    response["SizeBytes"].should.be.greater_than(0)
 
 
 @mock_events


### PR DESCRIPTION
Fixes #3821 by adding a `_does_event_match_pattern()` function to `EventsBackend`, which is now used to determine whether an event should be sent to an `Archive`.

Note that the pattern matching code currently only supports list matching i.e. `{"key": ["val1", "val2", ...]}` and recursive dict matching i.e. `{"key1": {"key2": {"key3": ["val1"]}}}` `EventPattern` syntax.

Adds a new unit test verifying that unmatching events are not archived.