### PR TITLE
Support - Ensure advisors_checks-file is properly encoded

### DIFF
--- a/moto/utilities/utils.py
+++ b/moto/utilities/utils.py
@@ -19,4 +19,4 @@ def load_resource(filename):
     load_resource(resource_filename(__name__, "resources/file.json"))
     """
     with open(filename, "r") as f:
-        return json.load(f)
+        return json.load(f, encoding="utf-8")


### PR DESCRIPTION
Apparently this breaks on Windows-7 machines, as the default encoding is not UTF-8

Fixes #3772 