### PR TITLE
IAM - get_user() #3828

### DIFF
--- a/moto/iam/responses.py
+++ b/moto/iam/responses.py
@@ -484,9 +484,9 @@ class IamResponse(BaseResponse):
                 user = User("default_user")
         else:
             user = iam_backend.get_user(user_name)
-
+        tags = iam_backend.tagger.list_tags_for_resource(user.arn).get("Tags", [])
         template = self.response_template(USER_TEMPLATE)
-        return template.render(action="Get", user=user)
+        return template.render(action="Get", user=user, tags=tags)
 
     def list_users(self):
         path_prefix = self._get_param("PathPrefix")

--- a/tests/test_iam/test_iam.py
+++ b/tests/test_iam/test_iam.py
@@ -4075,7 +4075,8 @@ def test_create_user_with_tags():
     assert resp["User"]["Tags"] == tags
     resp = conn.list_user_tags(UserName=user_name)
     assert resp["Tags"] == tags
-
+    resp = conn.get_user(UserName=user_name)
+    assert resp["User"]["Tags"] == tags
     resp = conn.create_user(UserName="test-create-user-no-tags")
     assert "Tags" not in resp["User"]
 


### PR DESCRIPTION
- fixing issue where the get_user method does not return tags

Fixes #3828

Documentation:
https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/iam.html#IAM.Client.get_user