### PR TITLE
Add exists filtering functionality to `Archive`

### DIFF
--- a/moto/events/models.py
+++ b/moto/events/models.py
@@ -113,7 +113,8 @@ class Rule(CloudFormationModel):
         allowed_values_match = item in allowed_values if allowed_values else True
         named_filter_matches = [
             self._does_item_match_named_filter(item, filter)
-            for filter in filters if isinstance(filter, dict)
+            for filter in filters
+            if isinstance(filter, dict)
         ]
         return allowed_values_match and all(named_filter_matches)
 
@@ -131,7 +132,6 @@ class Rule(CloudFormationModel):
             raise NotImplementedError
         elif filter_name == "numeric":
             raise NotImplementedError
-
 
     def send_to_targets(self, event_bus_name, event):
         event_bus_name = event_bus_name.split("/")[-1]

--- a/moto/events/models.py
+++ b/moto/events/models.py
@@ -9,6 +9,7 @@ from datetime import datetime
 from enum import Enum, unique
 
 from boto3 import Session
+from six import string_types
 
 from moto.core.exceptions import JsonRESTError
 from moto.core import ACCOUNT_ID, BaseBackend, CloudFormationModel, BaseModel
@@ -110,8 +111,9 @@ class Rule(CloudFormationModel):
         return all(nested_filter_matches + filter_list_matches)
 
     def _does_item_match_filters(self, item, filters):
-        allowed_values = [value for value in filters if isinstance(value, str)]
+        allowed_values = [value for value in filters if isinstance(value, string_types)]
         allowed_values_match = item in allowed_values if allowed_values else True
+        print(item, filters, allowed_values)
         named_filter_matches = [
             self._does_item_match_named_filter(item, filter)
             for filter in filters
@@ -131,7 +133,7 @@ class Rule(CloudFormationModel):
                     filter_name
                 )
             )
-            return True
+            return False
 
     def send_to_targets(self, event_bus_name, event):
         event_bus_name = event_bus_name.split("/")[-1]

--- a/moto/events/models.py
+++ b/moto/events/models.py
@@ -126,13 +126,18 @@ class Rule(CloudFormationModel):
             should_exist = filter_value
             return item_exists if should_exist else not item_exists
         elif filter_name == "prefix":
-            raise NotImplementedError
+            warnings.warn("'prefix' filter logic unimplemented. defaulting to True")
+            return True
         elif filter_name == "anything-but":
-            raise NotImplementedError
+            warnings.warn(
+                "'anything-but' filter logic unimplemented. defaulting to True"
+            )
+            return True
         elif filter_name == "cidr":
-            raise NotImplementedError
+            warnings.warn("'cidr' filter logic unimplemented. defaulting to True")
+            return True
         elif filter_name == "numeric":
-            raise NotImplementedError
+            warnings.warn("'numeric' filter logic unimplemented. defaulting to True")
 
     def send_to_targets(self, event_bus_name, event):
         event_bus_name = event_bus_name.split("/")[-1]

--- a/moto/events/models.py
+++ b/moto/events/models.py
@@ -125,19 +125,13 @@ class Rule(CloudFormationModel):
             item_exists = item is not None
             should_exist = filter_value
             return item_exists if should_exist else not item_exists
-        elif filter_name == "prefix":
-            warnings.warn("'prefix' filter logic unimplemented. defaulting to True")
-            return True
-        elif filter_name == "anything-but":
+        else:
             warnings.warn(
-                "'anything-but' filter logic unimplemented. defaulting to True"
+                "'{}' filter logic unimplemented. defaulting to True".format(
+                    filter_name
+                )
             )
             return True
-        elif filter_name == "cidr":
-            warnings.warn("'cidr' filter logic unimplemented. defaulting to True")
-            return True
-        elif filter_name == "numeric":
-            warnings.warn("'numeric' filter logic unimplemented. defaulting to True")
 
     def send_to_targets(self, event_bus_name, event):
         event_bus_name = event_bus_name.split("/")[-1]

--- a/tests/test_events/test_events.py
+++ b/tests/test_events/test_events.py
@@ -1556,7 +1556,7 @@ def test_archive_with_exists_event_filter():
         EventPattern=json.dumps({"detail": {"bar": [{"exists": False}]}}),
     )
     foo_exists_event = {"Source": "", "DetailType": "", "Detail": '{"foo": "bar"}'}
-    foo_not_exists_event = {"Source": "", "DetailType": "", "Detail": '{}'}
+    foo_not_exists_event = {"Source": "", "DetailType": "", "Detail": "{}"}
     response = client.put_events(Entries=[foo_exists_event, foo_not_exists_event])
     response["FailedEntryCount"].should.equal(0)
     response = client.describe_archive(ArchiveName="foo-exists-filter")


### PR DESCRIPTION
Fixes #3831  by adding "exists" filtering functionality when determining to route an event to an `Archive` using an `EventPattern` and adding a test case. I've also refactored the existing `Archive` filtering functionality to make it easier to add the remaining filter types and refactored the existing `Archive` filtering tests to make them more isolated.