### PR TITLE
Make it possible to customize the ACM cert validation wait time.

### DIFF
--- a/moto/acm/models.py
+++ b/moto/acm/models.py
@@ -5,7 +5,7 @@ import datetime
 from moto.core import BaseBackend, BaseModel
 from moto.core.exceptions import AWSError
 from moto.ec2 import ec2_backends
-from moto.settings import ACM_VALIDATION_WAIT
+from moto import settings
 
 from .utils import make_arn_for_certificate
 
@@ -332,7 +332,7 @@ class CertBundle(BaseModel):
         if (
             self.type == "AMAZON_ISSUED"
             and self.status == "PENDING_VALIDATION"
-            and waited_seconds > ACM_VALIDATION_WAIT
+            and waited_seconds > settings.ACM_VALIDATION_WAIT
         ):
             self.status = "ISSUED"
 

--- a/moto/acm/models.py
+++ b/moto/acm/models.py
@@ -1,6 +1,7 @@
 from __future__ import unicode_literals
 
 import re
+import os
 import datetime
 from moto.core import BaseBackend, BaseModel
 from moto.core.exceptions import AWSError
@@ -324,13 +325,15 @@ class CertBundle(BaseModel):
             )
 
     def check(self):
-        # Basically, if the certificate is pending, and then checked again after 1 min
-        # It will appear as if its been validated
+        # Basically, if the certificate is pending, and then checked again after a
+        # while, it will appear as if its been validated. The default wait time is 60
+        # seconds but you can set an environment to change it.
+        wait = os.environ.get("MOTO_ACM_VALIDATION_WAIT", 60)
         if (
             self.type == "AMAZON_ISSUED"
             and self.status == "PENDING_VALIDATION"
-            and (datetime.datetime.now() - self.created_at).total_seconds() > 60
-        ):  # 1min
+            and (datetime.datetime.now() - self.created_at).total_seconds() > wait
+        ):
             self.status = "ISSUED"
 
     def describe(self):

--- a/moto/acm/models.py
+++ b/moto/acm/models.py
@@ -1,11 +1,11 @@
 from __future__ import unicode_literals
 
 import re
-import os
 import datetime
 from moto.core import BaseBackend, BaseModel
 from moto.core.exceptions import AWSError
 from moto.ec2 import ec2_backends
+from moto.settings import ACM_VALIDATION_WAIT
 
 from .utils import make_arn_for_certificate
 
@@ -328,11 +328,11 @@ class CertBundle(BaseModel):
         # Basically, if the certificate is pending, and then checked again after a
         # while, it will appear as if its been validated. The default wait time is 60
         # seconds but you can set an environment to change it.
-        wait = os.environ.get("MOTO_ACM_VALIDATION_WAIT", 60)
+        waited_seconds = (datetime.datetime.now() - self.created_at).total_seconds()
         if (
             self.type == "AMAZON_ISSUED"
             and self.status == "PENDING_VALIDATION"
-            and (datetime.datetime.now() - self.created_at).total_seconds() > wait
+            and waited_seconds > ACM_VALIDATION_WAIT
         ):
             self.status = "ISSUED"
 

--- a/moto/settings.py
+++ b/moto/settings.py
@@ -10,6 +10,9 @@ S3_IGNORE_SUBDOMAIN_BUCKETNAME = os.environ.get(
     "S3_IGNORE_SUBDOMAIN_BUCKETNAME", ""
 ) in ["1", "true"]
 
+# How many seconds to wait before we "validate" a new certificate in ACM.
+ACM_VALIDATION_WAIT = os.environ.get("MOTO_ACM_VALIDATION_WAIT", 60)
+
 
 def get_sf_execution_history_type():
     """

--- a/moto/settings.py
+++ b/moto/settings.py
@@ -11,7 +11,7 @@ S3_IGNORE_SUBDOMAIN_BUCKETNAME = os.environ.get(
 ) in ["1", "true"]
 
 # How many seconds to wait before we "validate" a new certificate in ACM.
-ACM_VALIDATION_WAIT = os.environ.get("MOTO_ACM_VALIDATION_WAIT", 60)
+ACM_VALIDATION_WAIT = int(os.environ.get("MOTO_ACM_VALIDATION_WAIT", "60"))
 
 
 def get_sf_execution_history_type():

--- a/tests/test_acm/test_acm.py
+++ b/tests/test_acm/test_acm.py
@@ -6,11 +6,17 @@ import uuid
 import boto3
 import pytest
 import sure  # noqa
+import sys
 from botocore.exceptions import ClientError
 from freezegun import freeze_time
 from moto import mock_acm, settings
 from moto.core import ACCOUNT_ID
-from unittest import SkipTest
+
+if sys.version_info[0] < 3:
+    import mock
+    from unittest import SkipTest
+else:
+    from unittest import SkipTest, mock
 
 RESOURCE_FOLDER = os.path.join(os.path.dirname(__file__), "resources")
 _GET_RESOURCE = lambda x: open(os.path.join(RESOURCE_FOLDER, x), "rb").read()
@@ -528,6 +534,37 @@ def test_request_certificate_issued_status():
             resp = client.describe_certificate(CertificateArn=arn)
         resp["Certificate"]["CertificateArn"].should.equal(arn)
         resp["Certificate"]["Status"].should.equal("ISSUED")
+
+
+@mock_acm
+@mock.patch.dict(os.environ, {"MOTO_ACM_VALIDATION_WAIT": 3})
+def test_request_certificate_issued_status_with_wait_in_envvar():
+    # After requesting a certificate, it should then auto-validate after 1 minute
+    # Some sneaky programming for that ;-)
+    if settings.TEST_SERVER_MODE:
+        raise SkipTest("Cant manipulate time in server mode")
+
+    client = boto3.client("acm", region_name="eu-central-1")
+
+    with freeze_time("2012-01-01 12:00:00"):
+        resp = client.request_certificate(DomainName="google.com",)
+    arn = resp["CertificateArn"]
+
+    with freeze_time("2012-01-01 12:00:00"):
+        resp = client.describe_certificate(CertificateArn=arn)
+    resp["Certificate"]["CertificateArn"].should.equal(arn)
+    resp["Certificate"]["Status"].should.equal("PENDING_VALIDATION")
+
+    # validation will be pending for 3 seconds.
+    with freeze_time("2012-01-01 12:00:02"):
+        resp = client.describe_certificate(CertificateArn=arn)
+    resp["Certificate"]["CertificateArn"].should.equal(arn)
+    resp["Certificate"]["Status"].should.equal("PENDING_VALIDATION")
+
+    with freeze_time("2012-01-01 12:00:04"):
+        resp = client.describe_certificate(CertificateArn=arn)
+    resp["Certificate"]["CertificateArn"].should.equal(arn)
+    resp["Certificate"]["Status"].should.equal("ISSUED")
 
 
 @mock_acm

--- a/tests/test_acm/test_acm.py
+++ b/tests/test_acm/test_acm.py
@@ -536,11 +536,10 @@ def test_request_certificate_issued_status():
         resp["Certificate"]["Status"].should.equal("ISSUED")
 
 
+@mock.patch("moto.settings.ACM_VALIDATION_WAIT", 3)
 @mock_acm
-@mock.patch.dict(os.environ, {"MOTO_ACM_VALIDATION_WAIT": 3})
 def test_request_certificate_issued_status_with_wait_in_envvar():
-    # After requesting a certificate, it should then auto-validate after 1 minute
-    # Some sneaky programming for that ;-)
+    # After requesting a certificate, it should then auto-validate after 3 seconds
     if settings.TEST_SERVER_MODE:
         raise SkipTest("Cant manipulate time in server mode")
 


### PR DESCRIPTION
We are using AWS lambda to create/delete the acm certificates and doing the validation via DNS, when writing unittest for these lambdas we'll have to wait 60 seconds. This PR make it possible to customize this wait time.