### PR TITLE
Add CloudFormation support for SageMaker Notebook Instances

### DIFF
--- a/moto/cloudformation/parsing.py
+++ b/moto/cloudformation/parsing.py
@@ -37,6 +37,7 @@ from moto.redshift import models as redshift_models  # noqa
 from moto.route53 import models as route53_models  # noqa
 from moto.s3 import models as s3_models, s3_backend  # noqa
 from moto.s3.utils import bucket_and_name_from_url
+from moto.sagemaker import models as sagemaker_models  # noqa
 from moto.sns import models as sns_models  # noqa
 from moto.sqs import models as sqs_models  # noqa
 from moto.stepfunctions import models as stepfunctions_models  # noqa

--- a/moto/sagemaker/models.py
+++ b/moto/sagemaker/models.py
@@ -507,6 +507,14 @@ class FakeSagemakerNotebookInstance(CloudFormationModel):
     def physical_resource_id(self):
         return self.arn
 
+    def get_cfn_attribute(self, attribute_name):
+        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sagemaker-notebookinstance.html#aws-resource-sagemaker-notebookinstance-return-values
+        from moto.cloudformation.exceptions import UnformattedGetAttTemplateException
+
+        if attribute_name == "NotebookInstanceName":
+            return self.notebook_instance_name
+        raise UnformattedGetAttTemplateException()
+
     @staticmethod
     def cloudformation_name_type():
         return None

--- a/moto/sagemaker/models.py
+++ b/moto/sagemaker/models.py
@@ -540,6 +540,19 @@ class FakeSagemakerNotebookInstance(CloudFormationModel):
         )
         return notebook
 
+    @classmethod
+    def delete_from_cloudformation_json(
+        cls, resource_name, cloudformation_json, region_name
+    ):
+        # Get actual name because resource_name actually provides the ARN
+        # since the Physical Resource ID is the ARN despite SageMaker
+        # using the name for most of its operations.
+        notebook_instance_name = resource_name.split("/")[-1]
+
+        backend = sagemaker_backends[region_name]
+        backend.stop_notebook_instance(notebook_instance_name)
+        backend.delete_notebook_instance(notebook_instance_name)
+
 
 class FakeSageMakerNotebookInstanceLifecycleConfig(BaseObject):
     def __init__(

--- a/moto/sagemaker/models.py
+++ b/moto/sagemaker/models.py
@@ -541,6 +541,19 @@ class FakeSagemakerNotebookInstance(CloudFormationModel):
         return notebook
 
     @classmethod
+    def update_from_cloudformation_json(
+        cls, original_resource, new_resource_name, cloudformation_json, region_name,
+    ):
+        # Operations keep same resource name so delete old and create new to mimic update
+        cls.delete_from_cloudformation_json(
+            original_resource.arn, cloudformation_json, region_name
+        )
+        new_resource = cls.create_from_cloudformation_json(
+            original_resource.notebook_instance_name, cloudformation_json, region_name
+        )
+        return new_resource
+
+    @classmethod
     def delete_from_cloudformation_json(
         cls, resource_name, cloudformation_json, region_name
     ):

--- a/tests/test_sagemaker/test_sagemaker_cloudformation.py
+++ b/tests/test_sagemaker/test_sagemaker_cloudformation.py
@@ -1,0 +1,37 @@
+import json
+import boto3
+
+import sure  # noqa
+
+from moto import mock_cloudformation
+from moto.sts.models import ACCOUNT_ID
+
+
+FAKE_ROLE_ARN = "arn:aws:iam::{}:role/FakeRole".format(ACCOUNT_ID)
+
+
+@mock_cloudformation
+def test_sagemaker_cloudformation_create_notebook_instance():
+    cf = boto3.client("cloudformation", region_name="us-east-1")
+
+    stack_name = "test_sagemaker_notebook_instance"
+
+    template = {
+        "AWSTemplateFormatVersion": "2010-09-09",
+        "Resources": {
+            "TestNotebookInstance": {
+                "Type": "AWS::SageMaker::NotebookInstance",
+                "Properties": {
+                    "InstanceType": "ml.c4.xlarge",
+                    "RoleArn": FAKE_ROLE_ARN,
+                },
+            },
+        },
+    }
+    cf.create_stack(StackName=stack_name, TemplateBody=json.dumps(template))
+
+    provisioned_resource = cf.list_stack_resources(StackName=stack_name)[
+        "StackResourceSummaries"
+    ][0]
+    provisioned_resource["LogicalResourceId"].should.equal("TestNotebookInstance")
+    len(provisioned_resource["PhysicalResourceId"]).should.be.greater_than(0)

--- a/tests/test_sagemaker/test_sagemaker_cloudformation.py
+++ b/tests/test_sagemaker/test_sagemaker_cloudformation.py
@@ -3,7 +3,7 @@ import boto3
 
 import sure  # noqa
 
-from moto import mock_cloudformation
+from moto import mock_cloudformation, mock_sagemaker
 from moto.sts.models import ACCOUNT_ID
 
 
@@ -35,3 +35,49 @@ def test_sagemaker_cloudformation_create_notebook_instance():
     ][0]
     provisioned_resource["LogicalResourceId"].should.equal("TestNotebookInstance")
     len(provisioned_resource["PhysicalResourceId"]).should.be.greater_than(0)
+
+
+@mock_cloudformation
+@mock_sagemaker
+def test_sagemaker_cloudformation_notebook_instance_get_attr():
+    cf = boto3.client("cloudformation", region_name="us-east-1")
+    sm = boto3.client("sagemaker", region_name="us-east-1")
+
+    stack_name = "test_sagemaker_notebook_instance"
+
+    template = {
+        "AWSTemplateFormatVersion": "2010-09-09",
+        "Resources": {
+            "TestNotebookInstance": {
+                "Type": "AWS::SageMaker::NotebookInstance",
+                "Properties": {
+                    "InstanceType": "ml.c4.xlarge",
+                    "RoleArn": FAKE_ROLE_ARN,
+                },
+            },
+        },
+        "Outputs": {
+            "NotebookInstanceArn": {"Value": {"Ref": "TestNotebookInstance"}},
+            "NotebookInstanceName": {
+                "Value": {
+                    "Fn::GetAtt": ["TestNotebookInstance", "NotebookInstanceName"]
+                },
+            },
+        },
+    }
+    cf.create_stack(StackName=stack_name, TemplateBody=json.dumps(template))
+
+    stack_description = cf.describe_stacks(StackName=stack_name)["Stacks"][0]
+    outputs = {
+        output["OutputKey"]: output["OutputValue"]
+        for output in stack_description["Outputs"]
+    }
+    notebook_instance_name = outputs["NotebookInstanceName"]
+    notebook_instance_arn = outputs["NotebookInstanceArn"]
+
+    notebook_instance_description = sm.describe_notebook_instance(
+        NotebookInstanceName=notebook_instance_name,
+    )
+    notebook_instance_arn.should.equal(
+        notebook_instance_description["NotebookInstanceArn"]
+    )


### PR DESCRIPTION
Issue: https://github.com/spulec/moto/issues/3568

Updates the `FakeSagemakerNotebookInstance` class to inherit from `CloudFormationModel` and adds tests around the creation, deletion, and updating of a Notebook Instance via CloudFormation templates.