### PR TITLE
Rewrite deprecated CloudWatch tests

### DIFF
--- a/tests/test_cloudwatch/test_cloudwatch.py
+++ b/tests/test_cloudwatch/test_cloudwatch.py
@@ -29,6 +29,7 @@ def alarm_fixture(name="tester", action=None):
     )
 
 
+# Has boto3 equivalent
 @mock_cloudwatch_deprecated
 def test_create_alarm():
     conn = boto.connect_cloudwatch()
@@ -56,6 +57,7 @@ def test_create_alarm():
     assert "tester" in alarm.alarm_arn
 
 
+# Has boto3 equivalent
 @mock_cloudwatch_deprecated
 def test_delete_alarm():
     conn = boto.connect_cloudwatch()
@@ -75,6 +77,7 @@ def test_delete_alarm():
     alarms.should.have.length_of(0)
 
 
+# Has boto3 equivalent
 @mock_cloudwatch_deprecated
 def test_put_metric_data():
     conn = boto.connect_cloudwatch()
@@ -95,6 +98,7 @@ def test_put_metric_data():
     dict(metric.dimensions).should.equal({"InstanceId": ["i-0123456,i-0123457"]})
 
 
+# Has boto3 equivalent
 @mock_cloudwatch_deprecated
 def test_describe_alarms():
     conn = boto.connect_cloudwatch()
@@ -130,6 +134,7 @@ def test_describe_alarms():
     alarms.should.have.length_of(0)
 
 
+# Has boto3 equivalent
 @mock_cloudwatch_deprecated
 def test_describe_alarms_for_metric():
     conn = boto.connect_cloudwatch()
@@ -146,6 +151,7 @@ def test_describe_alarms_for_metric():
     alarms.should.have.length_of(1)
 
 
+# Has boto3 equivalent
 @mock_cloudwatch_deprecated
 def test_get_metric_statistics():
     conn = boto.connect_cloudwatch()


### PR DESCRIPTION
See #3842  - adds equivalent boto3 tests for CloudWatch, so that the deprecated tests can be removed without losing any test coverage

(Most functionality was already duplicated for this service.)