### PR TITLE
Add CloudFormation support for SageMaker Endpoint Configs and Endpoints

### DIFF
--- a/tests/test_sagemaker/cloudformation_test_configs.py
+++ b/tests/test_sagemaker/cloudformation_test_configs.py
@@ -194,7 +194,7 @@ class ModelTestConfig(TestConfig):
         if include_outputs:
             template["Outputs"] = {
                 "Arn": {"Value": {"Ref": self.resource_name}},
-                "Name": {"Value": {"Fn::GetAtt": [self.resource_name, "ModelName"],}},
+                "Name": {"Value": {"Fn::GetAtt": [self.resource_name, "ModelName"]}},
             }
         return json.dumps(template)
 
@@ -237,7 +237,7 @@ class EndpointConfigTestConfig(TestConfig):
             "Resources": {
                 self.resource_name: {
                     "Type": "AWS::SageMaker::EndpointConfig",
-                    "Properties": {"ProductionVariants": production_variants,},
+                    "Properties": {"ProductionVariants": production_variants},
                 },
             },
         }

--- a/tests/test_sagemaker/cloudformation_test_configs.py
+++ b/tests/test_sagemaker/cloudformation_test_configs.py
@@ -260,3 +260,65 @@ class EndpointConfigTestConfig(TestConfig):
                 "Image": "404615174143.dkr.ecr.us-east-2.amazonaws.com/linear-learner:1",
             },
         )
+
+
+class EndpointTestConfig(TestConfig):
+    """Test configuration for SageMaker Endpoints."""
+
+    @property
+    def resource_name(self):
+        return "TestEndpoint"
+
+    @property
+    def describe_function_name(self):
+        return "describe_endpoint"
+
+    @property
+    def name_parameter(self):
+        return "EndpointName"
+
+    @property
+    def arn_parameter(self):
+        return "EndpointArn"
+
+    def get_cloudformation_template(self, include_outputs=True, **kwargs):
+        endpoint_config_name = kwargs.get("endpoint_config_name", self.resource_name)
+
+        template = {
+            "AWSTemplateFormatVersion": "2010-09-09",
+            "Resources": {
+                self.resource_name: {
+                    "Type": "AWS::SageMaker::Endpoint",
+                    "Properties": {"EndpointConfigName": endpoint_config_name},
+                },
+            },
+        }
+        if include_outputs:
+            template["Outputs"] = {
+                "Arn": {"Value": {"Ref": self.resource_name}},
+                "Name": {"Value": {"Fn::GetAtt": [self.resource_name, "EndpointName"]}},
+            }
+        return json.dumps(template)
+
+    def run_setup_procedure(self, sagemaker_client):
+        """Adds Model and Endpoint Config that can be referenced in the CloudFormation template."""
+
+        sagemaker_client.create_model(
+            ModelName=self.resource_name,
+            ExecutionRoleArn="arn:aws:iam::{}:role/FakeRole".format(ACCOUNT_ID),
+            PrimaryContainer={
+                "Image": "404615174143.dkr.ecr.us-east-2.amazonaws.com/linear-learner:1",
+            },
+        )
+        sagemaker_client.create_endpoint_config(
+            EndpointConfigName=self.resource_name,
+            ProductionVariants=[
+                {
+                    "InitialInstanceCount": 1,
+                    "InitialVariantWeight": 1,
+                    "InstanceType": "ml.c4.xlarge",
+                    "ModelName": self.resource_name,
+                    "VariantName": "variant-name-1",
+                },
+            ],
+        )

--- a/tests/test_sagemaker/test_sagemaker_cloudformation.py
+++ b/tests/test_sagemaker/test_sagemaker_cloudformation.py
@@ -141,7 +141,7 @@ def test_sagemaker_cloudformation_notebook_instance_update():
 
     test_config = NotebookInstanceTestConfig()
 
-    # Set up template for stack with initial and update instance types
+    # Set up template for stack with two different instance types
     stack_name = "{}_stack".format(test_config.resource_name)
     initial_instance_type = "ml.c4.xlarge"
     updated_instance_type = "ml.c4.4xlarge"
@@ -162,7 +162,7 @@ def test_sagemaker_cloudformation_notebook_instance_update():
     )
     initial_instance_type.should.equal(resource_description["InstanceType"])
 
-    # Update stack with new instance type and check attributes
+    # Update stack and check attributes
     cf.update_stack(StackName=stack_name, TemplateBody=updated_template_json)
     outputs = _get_stack_outputs(cf, stack_name)
 
@@ -183,7 +183,7 @@ def test_sagemaker_cloudformation_notebook_instance_lifecycle_config_update():
 
     test_config = NotebookInstanceLifecycleConfigTestConfig()
 
-    # Set up template for stack with initial and update instance types
+    # Set up template for stack with two different OnCreate scripts
     stack_name = "{}_stack".format(test_config.resource_name)
     initial_on_create_script = "echo Hello World"
     updated_on_create_script = "echo Goodbye World"
@@ -207,7 +207,7 @@ def test_sagemaker_cloudformation_notebook_instance_lifecycle_config_update():
         resource_description["OnCreate"][0]["Content"]
     )
 
-    # Update stack with new instance type and check attributes
+    # Update stack and check attributes
     cf.update_stack(StackName=stack_name, TemplateBody=updated_template_json)
     outputs = _get_stack_outputs(cf, stack_name)
 
@@ -231,7 +231,7 @@ def test_sagemaker_cloudformation_model_update():
 
     test_config = ModelTestConfig()
 
-    # Set up template for stack with initial and update instance types
+    # Set up template for stack with two different image versions
     stack_name = "{}_stack".format(test_config.resource_name)
     image = "404615174143.dkr.ecr.us-east-2.amazonaws.com/kmeans:{}"
     initial_image_version = 1
@@ -255,7 +255,7 @@ def test_sagemaker_cloudformation_model_update():
         image.format(initial_image_version)
     )
 
-    # Update stack with new instance type and check attributes
+    # Update stack and check attributes
     cf.update_stack(StackName=stack_name, TemplateBody=updated_template_json)
     outputs = _get_stack_outputs(cf, stack_name)
 
@@ -281,7 +281,7 @@ def test_sagemaker_cloudformation_endpoint_config_update():
     # Utilize test configuration to set-up any mock SageMaker resources
     test_config.run_setup_procedure(sm)
 
-    # Set up template for stack with initial and update instance types
+    # Set up template for stack with two different production variant counts
     stack_name = "{}_stack".format(test_config.resource_name)
     initial_num_production_variants = 1
     updated_num_production_variants = 2
@@ -304,7 +304,7 @@ def test_sagemaker_cloudformation_endpoint_config_update():
         initial_num_production_variants
     )
 
-    # Update stack with new instance type and check attributes
+    # Update stack and check attributes
     cf.update_stack(StackName=stack_name, TemplateBody=updated_template_json)
     outputs = _get_stack_outputs(cf, stack_name)
 


### PR DESCRIPTION
Closes https://github.com/spulec/moto/issues/3846

- Updates the `FakeEndpoint` and `FakeEndpointConfig` classes to inherit from `CloudFormationModel` and adds tests around the creation, deletion, and updating of an Endpoint/EndpointConfig via CloudFormation templates.
- Also needed to add the `run_setup_procedure` method to the test configuration class so that I was able to easily add prerequisite SageMaker resources during the parametrized CloudFormation tests.
- Typo fixes from my previous contributions.