### PR TITLE
Unpin LXML dependency

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,10 +27,6 @@ jobs:
         with:
           path: ${{ steps.pip-cache-dir.outputs.dir }}
           key: pip-${{ matrix.python-version }}-${{ hashFiles('**/setup.py') }}
-      - name: Install Linux dependencies
-        if: ${{ matrix.python-version == 3.8 && steps.pip-cache.outputs.cache-hit != 'true' }}
-        run: |
-          sudo apt-get install libxslt-dev libxml2-dev -y
       - name: Update pip
         if: ${{ steps.pip-cache.outputs.cache-hit != 'true' && matrix.python-version != '2.7' }}
         run: |
@@ -102,10 +98,6 @@ jobs:
       with:
         path: ${{ steps.pip-cache.outputs.dir }}
         key: pip-${{ matrix.python-version }}-${{ hashFiles('**/setup.py') }}
-    - name: Install Linux dependencies
-      if: ${{ matrix.python-version == 3.8 }}
-      run: |
-        sudo apt-get install libxslt-dev libxml2-dev -y
     - name: Update pip
       if: ${{ matrix.python-version != '2.7' }}
       run: |
@@ -154,10 +146,6 @@ jobs:
       with:
         path: ${{ steps.pip-cache.outputs.dir }}
         key: pip-${{ matrix.python-version }}-${{ hashFiles('**/setup.py') }}
-    - name: Install Linux dependencies
-      if: ${{ matrix.python-version == 3.8 }}
-      run: |
-        sudo apt-get install libxslt-dev libxml2-dev -y
     - name: Update pip
       if: ${{ matrix.python-version != '2.7' }}
       run: |

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,6 +9,6 @@ boto>=2.45.0
 prompt-toolkit==2.0.10 # 3.x is not available with python2
 click==6.7
 inflection==0.3.1
-lxml==4.2.3
+lxml
 packaging
 


### PR DESCRIPTION
This lxml-dependency is only required for the scaffold-script, not for regular development, so pinning it to any specific version is not necessary as far as I can tell.

It also doesn't support Python 3.8 and 3.9 natively, so unpinning it will simplify `make init` for many people