### PR TITLE
Fix: `nextToken` value in `logs:FilterLogEvents` response

### DIFF
--- a/moto/logs/models.py
+++ b/moto/logs/models.py
@@ -366,13 +366,32 @@ class LogGroup:
         if interleaved:
             events = sorted(events, key=lambda event: event["timestamp"])
 
-        if next_token is None:
-            next_token = 0
+        first_index = 0
+        if next_token:
+            try:
+                group, stream, event_id = next_token.split('/')
+                if group != log_group_name:
+                    raise ValueError()
+                first_index = (
+                    next(
+                        index for (index, e) in enumerate(events)
+                        if e["logStreamName"] == stream and e["eventId"] == event_id
+                    )
+                    + 1
+                )
+            except (ValueError, StopIteration):
+                first_index = 0
+                # AWS returns an empty list if it receives an invalid token.
+                events = []
 
-        events_page = events[next_token : next_token + limit]
-        next_token += limit
-        if next_token >= len(events):
-            next_token = None
+        last_index = first_index + limit
+        if last_index > len(events):
+            last_index = len(events)
+        events_page = events[first_index : last_index]
+        next_token = None
+        if events_page and last_index < len(events):
+            last_event = events_page[-1]
+            next_token = "{}/{}/{}".format(log_group_name, last_event["logStreamName"], last_event["eventId"])
 
         searched_streams = [
             {"logStreamName": stream.logStreamName, "searchedCompletely": True}

--- a/moto/logs/models.py
+++ b/moto/logs/models.py
@@ -369,12 +369,13 @@ class LogGroup:
         first_index = 0
         if next_token:
             try:
-                group, stream, event_id = next_token.split('/')
+                group, stream, event_id = next_token.split("/")
                 if group != log_group_name:
                     raise ValueError()
                 first_index = (
                     next(
-                        index for (index, e) in enumerate(events)
+                        index
+                        for (index, e) in enumerate(events)
                         if e["logStreamName"] == stream and e["eventId"] == event_id
                     )
                     + 1
@@ -387,11 +388,13 @@ class LogGroup:
         last_index = first_index + limit
         if last_index > len(events):
             last_index = len(events)
-        events_page = events[first_index : last_index]
+        events_page = events[first_index:last_index]
         next_token = None
         if events_page and last_index < len(events):
             last_event = events_page[-1]
-            next_token = "{}/{}/{}".format(log_group_name, last_event["logStreamName"], last_event["eventId"])
+            next_token = "{}/{}/{}".format(
+                log_group_name, last_event["logStreamName"], last_event["eventId"]
+            )
 
         searched_streams = [
             {"logStreamName": stream.logStreamName, "searchedCompletely": True}

--- a/tests/test_logs/test_logs.py
+++ b/tests/test_logs/test_logs.py
@@ -137,10 +137,9 @@ def test_filter_logs_paging():
     timestamp = int(start_date.timestamp())
     messages = []
     for i in range(25):
-        messages.append({
-            "message": "Message number {}".format(i),
-            "timestamp": timestamp
-        })
+        messages.append(
+            {"message": "Message number {}".format(i), "timestamp": timestamp}
+        )
         timestamp += 100
 
     conn.put_log_events(
@@ -154,8 +153,10 @@ def test_filter_logs_paging():
     res["nextToken"].should.equal("dummy/stream/" + events[-1]["eventId"])
 
     res = conn.filter_log_events(
-        logGroupName=log_group_name, logStreamNames=[log_stream_name],
-        limit=20, nextToken=res["nextToken"]
+        logGroupName=log_group_name,
+        logStreamNames=[log_stream_name],
+        limit=20,
+        nextToken=res["nextToken"],
     )
     events += res["events"]
     events.should.have.length_of(25)
@@ -167,8 +168,10 @@ def test_filter_logs_paging():
         resulting_event["message"].should.equal(original_message["message"])
 
     res = conn.filter_log_events(
-        logGroupName=log_group_name, logStreamNames=[log_stream_name],
-        limit=20, nextToken="invalid-token"
+        logGroupName=log_group_name,
+        logStreamNames=[log_stream_name],
+        limit=20,
+        nextToken="invalid-token",
     )
     res["events"].should.have.length_of(0)
     res.should_not.have.key("nextToken")

--- a/tests/test_logs/test_logs.py
+++ b/tests/test_logs/test_logs.py
@@ -1,5 +1,5 @@
-from datetime import datetime
 import os
+import time
 from unittest import SkipTest
 import boto3
 import six
@@ -133,8 +133,7 @@ def test_filter_logs_paging():
     log_stream_name = "stream"
     conn.create_log_group(logGroupName=log_group_name)
     conn.create_log_stream(logGroupName=log_group_name, logStreamName=log_stream_name)
-    start_date = datetime(2021, 4, 28, 12, 34, 56, 0)
-    timestamp = int(start_date.timestamp())
+    timestamp = int(time.time())
     messages = []
     for i in range(25):
         messages.append(

--- a/tests/test_logs/test_logs.py
+++ b/tests/test_logs/test_logs.py
@@ -1,12 +1,13 @@
-import boto3
+from datetime import datetime, timezone
 import os
-import sure  # noqa
+from unittest import SkipTest
+import boto3
 import six
 from botocore.exceptions import ClientError
+import pytest
+import sure  # noqa
 
 from moto import mock_logs, settings
-import pytest
-from unittest import SkipTest
 
 _logs_region = "us-east-1" if settings.TEST_SERVER_MODE else "us-west-2"
 
@@ -123,6 +124,54 @@ def test_filter_logs_raises_if_filter_pattern():
             logStreamNames=[log_stream_name],
             filterPattern='{$.message = "hello"}',
         )
+
+
+@mock_logs
+def test_filter_logs_paging():
+    conn = boto3.client("logs", "us-west-2")
+    log_group_name = "dummy"
+    log_stream_name = "stream"
+    conn.create_log_group(logGroupName=log_group_name)
+    conn.create_log_stream(logGroupName=log_group_name, logStreamName=log_stream_name)
+    start_date = datetime(2021, 4, 28, 12, 34, 56, 0, tzinfo=timezone.utc)
+    timestamp = int(start_date.timestamp())
+    messages = []
+    for i in range(25):
+        messages.append({
+            "message": "Message number {}".format(i),
+            "timestamp": timestamp
+        })
+        timestamp += 100
+
+    conn.put_log_events(
+        logGroupName=log_group_name, logStreamName=log_stream_name, logEvents=messages
+    )
+    res = conn.filter_log_events(
+        logGroupName=log_group_name, logStreamNames=[log_stream_name], limit=20
+    )
+    events = res["events"]
+    events.should.have.length_of(20)
+    res["nextToken"].should.equal("dummy/stream/" + events[-1]["eventId"])
+
+    res = conn.filter_log_events(
+        logGroupName=log_group_name, logStreamNames=[log_stream_name],
+        limit=20, nextToken=res["nextToken"]
+    )
+    events += res["events"]
+    events.should.have.length_of(25)
+    res.should_not.have.key("nextToken")
+
+    for original_message, resulting_event in zip(messages, events):
+        resulting_event["eventId"].should.equal(str(resulting_event["eventId"]))
+        resulting_event["timestamp"].should.equal(original_message["timestamp"])
+        resulting_event["message"].should.equal(original_message["message"])
+
+    res = conn.filter_log_events(
+        logGroupName=log_group_name, logStreamNames=[log_stream_name],
+        limit=20, nextToken="invalid-token"
+    )
+    res["events"].should.have.length_of(0)
+    res.should_not.have.key("nextToken")
 
 
 @mock_logs

--- a/tests/test_logs/test_logs.py
+++ b/tests/test_logs/test_logs.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timezone
+from datetime import datetime
 import os
 from unittest import SkipTest
 import boto3
@@ -133,7 +133,7 @@ def test_filter_logs_paging():
     log_stream_name = "stream"
     conn.create_log_group(logGroupName=log_group_name)
     conn.create_log_stream(logGroupName=log_group_name, logStreamName=log_stream_name)
-    start_date = datetime(2021, 4, 28, 12, 34, 56, 0, tzinfo=timezone.utc)
+    start_date = datetime(2021, 4, 28, 12, 34, 56, 0)
     timestamp = int(start_date.timestamp())
     messages = []
     for i in range(25):

--- a/tests/test_logs/test_logs.py
+++ b/tests/test_logs/test_logs.py
@@ -175,6 +175,15 @@ def test_filter_logs_paging():
     res["events"].should.have.length_of(0)
     res.should_not.have.key("nextToken")
 
+    res = conn.filter_log_events(
+        logGroupName=log_group_name,
+        logStreamNames=[log_stream_name],
+        limit=20,
+        nextToken="wrong-group/stream/999",
+    )
+    res["events"].should.have.length_of(0)
+    res.should_not.have.key("nextToken")
+
 
 @mock_logs
 def test_put_retention_policy():


### PR DESCRIPTION
Plagiarizing freely from @bpandola and his PR #3398, I have
modified the pagination for FilterLogEvents to more closely follow
the real AWS behaviour.

Fixes #3882