### PR TITLE
S3 - Fix exceptions for VersionID (#3884)

### DIFF
--- a/moto/s3/exceptions.py
+++ b/moto/s3/exceptions.py
@@ -76,12 +76,21 @@ class MissingKey(S3ClientError):
 class MissingVersion(S3ClientError):
     code = 404
 
+    def __init__(self, *args, **kwargs):
+        super(MissingVersion, self).__init__(
+            "NoSuchVersion", "The specified version does not exist.", *args, **kwargs
+        )
+
+
+class InvalidVersion(S3ClientError):
+    code = 400
+
     def __init__(self, version_id, *args, **kwargs):
         kwargs.setdefault("template", "argument_error")
         kwargs["name"] = "versionId"
         kwargs["value"] = version_id
         self.templates["argument_error"] = ERROR_WITH_ARGUMENT
-        super(MissingVersion, self).__init__(
+        super(InvalidVersion, self).__init__(
             "InvalidArgument", "Invalid version id specified", *args, **kwargs
         )
 

--- a/moto/s3/responses.py
+++ b/moto/s3/responses.py
@@ -22,6 +22,7 @@ from six.moves.urllib.parse import (
 )
 
 import xmltodict
+from uuid import UUID
 
 from moto.packages.httpretty.core import HTTPrettyRequest
 from moto.core.responses import _TemplateEnvironmentMixin, ActionAuthenticatorMixin
@@ -49,6 +50,7 @@ from .exceptions import (
     IllegalLocationConstraintException,
     InvalidNotificationARN,
     InvalidNotificationEvent,
+    InvalidVersion,
     ObjectNotInActiveTierError,
     NoSystemTags,
     PreconditionFailed,
@@ -1206,11 +1208,15 @@ class ResponseObject(_TemplateEnvironmentMixin, ActionAuthenticatorMixin):
         if_none_match = headers.get("If-None-Match", None)
         if_unmodified_since = headers.get("If-Unmodified-Since", None)
 
+        try:
+            UUID(version_id, version=4)
+        except ValueError:
+            raise InvalidVersion(version_id)
         key = self.backend.get_object(bucket_name, key_name, version_id=version_id)
         if key is None and version_id is None:
             raise MissingKey(key_name)
         elif key is None:
-            raise MissingVersion(version_id)
+            raise MissingVersion()
 
         if if_unmodified_since:
             if_unmodified_since = str_to_rfc_1123_datetime(if_unmodified_since)

--- a/tests/test_s3/test_s3.py
+++ b/tests/test_s3/test_s3.py
@@ -5020,6 +5020,28 @@ def test_get_unknown_version_should_throw_specific_error():
 
 
 @mock_s3
+def test_syntatically_correct_invalid_verion():
+    bucket_name = "my_bucket"
+    object_key = "hello.txt"
+    s3 = boto3.resource("s3", region_name="us-east-1")
+    client = boto3.client("s3", region_name="us-east-1")
+    bucket = s3.create_bucket(Bucket=bucket_name)
+    bucket.Versioning().enable()
+    content = "some text"
+    s3.Object(bucket_name, object_key).put(Body=content)
+    random_version_id = str(uuid.uuid4())
+
+    with pytest.raises(ClientError) as e:
+        client.get_object(
+            Bucket=bucket_name, Key=object_key, VersionId=random_version_id
+        )
+    e.value.response["Error"]["Code"].should.equal("NoSuchVersion")
+    e.value.response["Error"]["Message"].should.equal(
+        "The specified version does not exist."
+    )
+
+
+@mock_s3
 def test_request_partial_content_without_specifying_range_should_return_full_object():
     bucket = "bucket"
     object_key = "key"


### PR DESCRIPTION
Add inspection to ensure VersionID is a valid uuid v4
Add inspection to raise exception `NoSuchVersion` if key and version are missing