### PR TITLE
S3 - Fix exception for missing versionID

### DIFF
--- a/moto/s3/exceptions.py
+++ b/moto/s3/exceptions.py
@@ -76,12 +76,21 @@ class MissingKey(S3ClientError):
 class MissingVersion(S3ClientError):
     code = 404
 
+    def __init__(self, *args, **kwargs):
+        super(MissingVersion, self).__init__(
+            "NoSuchVersion", "The specified version does not exist.", *args, **kwargs
+        )
+
+
+class InvalidVersion(S3ClientError):
+    code = 400
+
     def __init__(self, version_id, *args, **kwargs):
         kwargs.setdefault("template", "argument_error")
         kwargs["name"] = "versionId"
         kwargs["value"] = version_id
         self.templates["argument_error"] = ERROR_WITH_ARGUMENT
-        super(MissingVersion, self).__init__(
+        super(InvalidVersion, self).__init__(
             "InvalidArgument", "Invalid version id specified", *args, **kwargs
         )
 

--- a/moto/s3/responses.py
+++ b/moto/s3/responses.py
@@ -1210,7 +1210,7 @@ class ResponseObject(_TemplateEnvironmentMixin, ActionAuthenticatorMixin):
         if key is None and version_id is None:
             raise MissingKey(key_name)
         elif key is None:
-            raise MissingVersion(version_id)
+            raise MissingVersion()
 
         if if_unmodified_since:
             if_unmodified_since = str_to_rfc_1123_datetime(if_unmodified_since)

--- a/tests/test_s3/test_s3.py
+++ b/tests/test_s3/test_s3.py
@@ -5013,10 +5013,10 @@ def test_get_unknown_version_should_throw_specific_error():
 
     with pytest.raises(ClientError) as e:
         client.get_object(Bucket=bucket_name, Key=object_key, VersionId="unknown")
-    e.value.response["Error"]["Code"].should.equal("InvalidArgument")
-    e.value.response["Error"]["Message"].should.equal("Invalid version id specified")
-    e.value.response["Error"]["ArgumentName"].should.equal("versionId")
-    e.value.response["Error"]["ArgumentValue"].should.equal("unknown")
+    e.value.response["Error"]["Code"].should.equal("NoSuchVersion")
+    e.value.response["Error"]["Message"].should.equal(
+        "The specified version does not exist."
+    )
 
 
 @mock_s3


### PR DESCRIPTION
Fixes exception that is raised if a versionID is not found for calls to s3.