### PR TITLE
Rewrite deprecated S3 tests

### DIFF
--- a/tests/test_s3/test_s3.py
+++ b/tests/test_s3/test_s3.py
@@ -168,6 +168,7 @@ def test_key_etag():
     )
 
 
+# Has boto3 equivalent
 @mock_s3_deprecated
 def test_multipart_upload_too_small():
     conn = boto.connect_s3("the_key", "the_secret")
@@ -180,6 +181,47 @@ def test_multipart_upload_too_small():
     multipart.complete_upload.should.throw(S3ResponseError)
 
 
+@mock_s3
+def test_multipart_upload_too_small_boto3():
+    s3 = boto3.resource("s3", region_name=DEFAULT_REGION_NAME)
+    client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
+    s3.create_bucket(Bucket="foobar")
+
+    mp = client.create_multipart_upload(Bucket="foobar", Key="the-key")
+    up1 = client.upload_part(
+        Body=BytesIO(b"hello"),
+        PartNumber=1,
+        Bucket="foobar",
+        Key="the-key",
+        UploadId=mp["UploadId"],
+    )
+    up2 = client.upload_part(
+        Body=BytesIO(b"world"),
+        PartNumber=2,
+        Bucket="foobar",
+        Key="the-key",
+        UploadId=mp["UploadId"],
+    )
+    # Multipart with total size under 5MB is refused
+    with pytest.raises(ClientError) as ex:
+        client.complete_multipart_upload(
+            Bucket="foobar",
+            Key="the-key",
+            MultipartUpload={
+                "Parts": [
+                    {"ETag": up1["ETag"], "PartNumber": 1},
+                    {"ETag": up2["ETag"], "PartNumber": 2},
+                ]
+            },
+            UploadId=mp["UploadId"],
+        )
+    ex.value.response["Error"]["Code"].should.equal("EntityTooSmall")
+    ex.value.response["Error"]["Message"].should.equal(
+        "Your proposed upload is smaller than the minimum allowed object size."
+    )
+
+
+# Has boto3 equivalent
 @mock_s3_deprecated
 @reduced_min_part_size
 def test_multipart_upload():
@@ -197,6 +239,48 @@ def test_multipart_upload():
     bucket.get_key("the-key").get_contents_as_string().should.equal(part1 + part2)
 
 
+@mock_s3
+@reduced_min_part_size
+def test_multipart_upload_boto3():
+    s3 = boto3.resource("s3", region_name=DEFAULT_REGION_NAME)
+    client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
+    s3.create_bucket(Bucket="foobar")
+
+    part1 = b"0" * REDUCED_PART_SIZE
+    part2 = b"1"
+    mp = client.create_multipart_upload(Bucket="foobar", Key="the-key")
+    up1 = client.upload_part(
+        Body=BytesIO(part1),
+        PartNumber=1,
+        Bucket="foobar",
+        Key="the-key",
+        UploadId=mp["UploadId"],
+    )
+    up2 = client.upload_part(
+        Body=BytesIO(part2),
+        PartNumber=2,
+        Bucket="foobar",
+        Key="the-key",
+        UploadId=mp["UploadId"],
+    )
+
+    client.complete_multipart_upload(
+        Bucket="foobar",
+        Key="the-key",
+        MultipartUpload={
+            "Parts": [
+                {"ETag": up1["ETag"], "PartNumber": 1},
+                {"ETag": up2["ETag"], "PartNumber": 2},
+            ]
+        },
+        UploadId=mp["UploadId"],
+    )
+    # we should get both parts as the key contents
+    response = client.get_object(Bucket="foobar", Key="the-key")
+    response["Body"].read().should.equal(part1 + part2)
+
+
+# Has boto3 equivalent
 @mock_s3_deprecated
 @reduced_min_part_size
 def test_multipart_upload_out_of_order():
@@ -214,6 +298,48 @@ def test_multipart_upload_out_of_order():
     bucket.get_key("the-key").get_contents_as_string().should.equal(part1 + part2)
 
 
+@mock_s3
+@reduced_min_part_size
+def test_multipart_upload_out_of_order_boto3():
+    s3 = boto3.resource("s3", region_name=DEFAULT_REGION_NAME)
+    client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
+    s3.create_bucket(Bucket="foobar")
+
+    part1 = b"0" * REDUCED_PART_SIZE
+    part2 = b"1"
+    mp = client.create_multipart_upload(Bucket="foobar", Key="the-key")
+    up1 = client.upload_part(
+        Body=BytesIO(part1),
+        PartNumber=4,
+        Bucket="foobar",
+        Key="the-key",
+        UploadId=mp["UploadId"],
+    )
+    up2 = client.upload_part(
+        Body=BytesIO(part2),
+        PartNumber=2,
+        Bucket="foobar",
+        Key="the-key",
+        UploadId=mp["UploadId"],
+    )
+
+    client.complete_multipart_upload(
+        Bucket="foobar",
+        Key="the-key",
+        MultipartUpload={
+            "Parts": [
+                {"ETag": up1["ETag"], "PartNumber": 4},
+                {"ETag": up2["ETag"], "PartNumber": 2},
+            ]
+        },
+        UploadId=mp["UploadId"],
+    )
+    # we should get both parts as the key contents
+    response = client.get_object(Bucket="foobar", Key="the-key")
+    response["Body"].read().should.equal(part1 + part2)
+
+
+# Has boto3 equivalent
 @mock_s3_deprecated
 @reduced_min_part_size
 def test_multipart_upload_with_headers():
@@ -229,6 +355,37 @@ def test_multipart_upload_with_headers():
     key.metadata.should.equal({"foo": "bar"})
 
 
+@mock_s3
+@reduced_min_part_size
+def test_multipart_upload_with_headers_boto3():
+    s3 = boto3.resource("s3", region_name=DEFAULT_REGION_NAME)
+    client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
+    s3.create_bucket(Bucket="foobar")
+
+    part1 = b"0" * REDUCED_PART_SIZE
+    mp = client.create_multipart_upload(
+        Bucket="foobar", Key="the-key", Metadata={"meta": "data"}
+    )
+    up1 = client.upload_part(
+        Body=BytesIO(part1),
+        PartNumber=1,
+        Bucket="foobar",
+        Key="the-key",
+        UploadId=mp["UploadId"],
+    )
+
+    client.complete_multipart_upload(
+        Bucket="foobar",
+        Key="the-key",
+        MultipartUpload={"Parts": [{"ETag": up1["ETag"], "PartNumber": 1}]},
+        UploadId=mp["UploadId"],
+    )
+    # we should get both parts as the key contents
+    response = client.get_object(Bucket="foobar", Key="the-key")
+    response["Metadata"].should.equal({"meta": "data"})
+
+
+# Has boto3 equivalent
 @mock_s3_deprecated
 @reduced_min_part_size
 def test_multipart_upload_with_copy_key():
@@ -246,6 +403,46 @@ def test_multipart_upload_with_copy_key():
     bucket.get_key("the-key").get_contents_as_string().should.equal(part1 + b"key_")
 
 
+@mock_s3
+@reduced_min_part_size
+def test_multipart_upload_with_copy_key_boto3():
+    s3 = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
+    s3.create_bucket(Bucket="foobar")
+    s3.put_object(Bucket="foobar", Key="original-key", Body="key_value")
+
+    mpu = s3.create_multipart_upload(Bucket="foobar", Key="the-key")
+    part1 = b"0" * REDUCED_PART_SIZE
+    up1 = s3.upload_part(
+        Bucket="foobar",
+        Key="the-key",
+        PartNumber=1,
+        UploadId=mpu["UploadId"],
+        Body=BytesIO(part1),
+    )
+    up2 = s3.upload_part_copy(
+        Bucket="foobar",
+        Key="the-key",
+        CopySource={"Bucket": "foobar", "Key": "original-key"},
+        CopySourceRange="0-3",
+        PartNumber=2,
+        UploadId=mpu["UploadId"],
+    )
+    s3.complete_multipart_upload(
+        Bucket="foobar",
+        Key="the-key",
+        MultipartUpload={
+            "Parts": [
+                {"ETag": up1["ETag"], "PartNumber": 1},
+                {"ETag": up2["CopyPartResult"]["ETag"], "PartNumber": 2},
+            ]
+        },
+        UploadId=mpu["UploadId"],
+    )
+    response = s3.get_object(Bucket="foobar", Key="the-key")
+    response["Body"].read().should.equal(part1 + b"key_")
+
+
+# Has boto3 equivalent
 @mock_s3_deprecated
 @reduced_min_part_size
 def test_multipart_upload_cancel():
@@ -260,6 +457,32 @@ def test_multipart_upload_cancel():
     # have the ability to list mulipart uploads for a bucket.
 
 
+@mock_s3
+@reduced_min_part_size
+def test_multipart_upload_cancel_boto3():
+    s3 = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
+    s3.create_bucket(Bucket="foobar")
+
+    mpu = s3.create_multipart_upload(Bucket="foobar", Key="the-key")
+    part1 = b"0" * REDUCED_PART_SIZE
+    s3.upload_part(
+        Bucket="foobar",
+        Key="the-key",
+        PartNumber=1,
+        UploadId=mpu["UploadId"],
+        Body=BytesIO(part1),
+    )
+
+    uploads = s3.list_multipart_uploads(Bucket="foobar")["Uploads"]
+    uploads.should.have.length_of(1)
+    uploads[0]["Key"].should.equal("the-key")
+
+    s3.abort_multipart_upload(Bucket="foobar", Key="the-key", UploadId=mpu["UploadId"])
+
+    s3.list_multipart_uploads(Bucket="foobar").shouldnt.have.key("Uploads")
+
+
+# Has boto3 equivalent
 @mock_s3_deprecated
 @reduced_min_part_size
 def test_multipart_etag():
@@ -278,6 +501,7 @@ def test_multipart_etag():
     bucket.get_key("the-key").etag.should.equal(EXPECTED_ETAG)
 
 
+# Has boto3 equivalent
 @mock_s3_deprecated
 @reduced_min_part_size
 def test_multipart_version():
@@ -295,6 +519,8 @@ def test_multipart_version():
     resp.version_id.should_not.be.none
 
 
+# Not sure what's being tested here, as it throws an EntityTooSmall error
+# Different part order is allowed and tested for in other tests
 @mock_s3_deprecated
 @reduced_min_part_size
 def test_multipart_invalid_order():
@@ -316,6 +542,7 @@ def test_multipart_invalid_order():
     ).should.throw(S3ResponseError)
 
 
+# Has boto3 equivalent
 @mock_s3_deprecated
 @reduced_min_part_size
 def test_multipart_etag_quotes_stripped():
@@ -342,6 +569,48 @@ def test_multipart_etag_quotes_stripped():
     bucket.get_key("the-key").etag.should.equal(EXPECTED_ETAG)
 
 
+@mock_s3
+@reduced_min_part_size
+def test_multipart_etag_quotes_stripped_boto3():
+    s3 = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
+    s3.create_bucket(Bucket="foobar")
+    s3.put_object(Bucket="foobar", Key="original-key", Body="key_value")
+
+    mpu = s3.create_multipart_upload(Bucket="foobar", Key="the-key")
+    part1 = b"0" * REDUCED_PART_SIZE
+    up1 = s3.upload_part(
+        Bucket="foobar",
+        Key="the-key",
+        PartNumber=1,
+        UploadId=mpu["UploadId"],
+        Body=BytesIO(part1),
+    )
+    etag1 = up1["ETag"].replace('"', "")
+    up2 = s3.upload_part_copy(
+        Bucket="foobar",
+        Key="the-key",
+        CopySource={"Bucket": "foobar", "Key": "original-key"},
+        CopySourceRange="0-3",
+        PartNumber=2,
+        UploadId=mpu["UploadId"],
+    )
+    etag2 = up2["CopyPartResult"]["ETag"].replace('"', "")
+    s3.complete_multipart_upload(
+        Bucket="foobar",
+        Key="the-key",
+        MultipartUpload={
+            "Parts": [
+                {"ETag": etag1, "PartNumber": 1},
+                {"ETag": etag2, "PartNumber": 2},
+            ]
+        },
+        UploadId=mpu["UploadId"],
+    )
+    response = s3.get_object(Bucket="foobar", Key="the-key")
+    response["Body"].read().should.equal(part1 + b"key_")
+
+
+# Has boto3 equivalent
 @mock_s3_deprecated
 @reduced_min_part_size
 def test_multipart_duplicate_upload():
@@ -360,6 +629,56 @@ def test_multipart_duplicate_upload():
     bucket.get_key("the-key").get_contents_as_string().should.equal(part1 + part2)
 
 
+@mock_s3
+@reduced_min_part_size
+def test_multipart_duplicate_upload_boto3():
+    s3 = boto3.resource("s3", region_name=DEFAULT_REGION_NAME)
+    client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
+    s3.create_bucket(Bucket="foobar")
+
+    part1 = b"0" * REDUCED_PART_SIZE
+    part2 = b"1"
+    mp = client.create_multipart_upload(Bucket="foobar", Key="the-key")
+    client.upload_part(
+        Body=BytesIO(part1),
+        PartNumber=1,
+        Bucket="foobar",
+        Key="the-key",
+        UploadId=mp["UploadId"],
+    )
+    # same part again
+    up1 = client.upload_part(
+        Body=BytesIO(part1),
+        PartNumber=1,
+        Bucket="foobar",
+        Key="the-key",
+        UploadId=mp["UploadId"],
+    )
+    up2 = client.upload_part(
+        Body=BytesIO(part2),
+        PartNumber=2,
+        Bucket="foobar",
+        Key="the-key",
+        UploadId=mp["UploadId"],
+    )
+
+    client.complete_multipart_upload(
+        Bucket="foobar",
+        Key="the-key",
+        MultipartUpload={
+            "Parts": [
+                {"ETag": up1["ETag"], "PartNumber": 1},
+                {"ETag": up2["ETag"], "PartNumber": 2},
+            ]
+        },
+        UploadId=mp["UploadId"],
+    )
+    # we should get both parts as the key contents
+    response = client.get_object(Bucket="foobar", Key="the-key")
+    response["Body"].read().should.equal(part1 + part2)
+
+
+# Has boto3 equivalent
 @mock_s3_deprecated
 def test_list_multiparts():
     # Create Bucket so that test can run
@@ -382,6 +701,33 @@ def test_list_multiparts():
     uploads.should.be.empty
 
 
+@mock_s3
+def test_list_multiparts_boto3():
+    s3 = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
+    s3.create_bucket(Bucket="foobar")
+
+    mpu1 = s3.create_multipart_upload(Bucket="foobar", Key="one-key")
+    mpu2 = s3.create_multipart_upload(Bucket="foobar", Key="two-key")
+
+    uploads = s3.list_multipart_uploads(Bucket="foobar")["Uploads"]
+    uploads.should.have.length_of(2)
+    {u["Key"]: u["UploadId"] for u in uploads}.should.equal(
+        {"one-key": mpu1["UploadId"], "two-key": mpu2["UploadId"]}
+    )
+
+    s3.abort_multipart_upload(Bucket="foobar", Key="the-key", UploadId=mpu2["UploadId"])
+
+    uploads = s3.list_multipart_uploads(Bucket="foobar")["Uploads"]
+    uploads.should.have.length_of(1)
+    uploads[0]["Key"].should.equal("one-key")
+
+    s3.abort_multipart_upload(Bucket="foobar", Key="the-key", UploadId=mpu1["UploadId"])
+
+    res = s3.list_multipart_uploads(Bucket="foobar")
+    res.shouldnt.have.key("Uploads")
+
+
+# Has boto3 equivalent
 @mock_s3_deprecated
 def test_key_save_to_missing_bucket():
     conn = boto.connect_s3("the_key", "the_secret")
@@ -394,6 +740,21 @@ def test_key_save_to_missing_bucket():
     )
 
 
+@mock_s3
+def test_key_save_to_missing_bucket_boto3():
+    s3 = boto3.resource("s3")
+    bucket = s3.Bucket("mybucket")
+
+    key = s3.Object("mybucket", "the-key")
+    with pytest.raises(ClientError) as ex:
+        key.put(Body=b"foobar")
+    ex.value.response["Error"]["Code"].should.equal("NoSuchBucket")
+    ex.value.response["Error"]["Message"].should.equal(
+        "The specified bucket does not exist"
+    )
+
+
+# Can't really be converted for boto3, as the approach is very different
 @mock_s3_deprecated
 def test_missing_key():
     conn = boto.connect_s3("the_key", "the_secret")
@@ -401,6 +762,7 @@ def test_missing_key():
     bucket.get_key("the-key").should.equal(None)
 
 
+# Has boto3 equivalent
 @mock_s3_deprecated
 def test_missing_key_urllib2():
     conn = boto.connect_s3("the_key", "the_secret")
@@ -411,6 +773,16 @@ def test_missing_key_urllib2():
     )
 
 
+@mock_s3
+def test_missing_key_request_boto3():
+    s3 = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
+    s3.create_bucket(Bucket="foobar")
+
+    response = requests.get("http://foobar.s3.amazonaws.com/the-key")
+    response.status_code.should.equal(404)
+
+
+# Has boto3 equivalent
 @mock_s3_deprecated
 def test_empty_key():
     conn = boto.connect_s3("the_key", "the_secret")
@@ -424,6 +796,21 @@ def test_empty_key():
     key.get_contents_as_string().should.equal(b"")
 
 
+@mock_s3
+def test_empty_key_boto3():
+    s3 = boto3.resource("s3", region_name=DEFAULT_REGION_NAME)
+    client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
+    s3.create_bucket(Bucket="foobar")
+
+    key = s3.Object("foobar", "the-key")
+    key.put(Body=b"")
+
+    resp = client.get_object(Bucket="foobar", Key="the-key")
+    resp.should.have.key("ContentLength").equal(0)
+    resp["Body"].read().should.equal(b"")
+
+
+# Has boto3 equivalent
 @mock_s3_deprecated
 def test_empty_key_set_on_existing_key():
     conn = boto.connect_s3("the_key", "the_secret")
@@ -440,6 +827,27 @@ def test_empty_key_set_on_existing_key():
     bucket.get_key("the-key").get_contents_as_string().should.equal(b"")
 
 
+@mock_s3
+def test_empty_key_set_on_existing_key_boto3():
+    s3 = boto3.resource("s3", region_name=DEFAULT_REGION_NAME)
+    client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
+    s3.create_bucket(Bucket="foobar")
+
+    key = s3.Object("foobar", "the-key")
+    key.put(Body=b"some content")
+
+    resp = client.get_object(Bucket="foobar", Key="the-key")
+    resp.should.have.key("ContentLength").equal(12)
+    resp["Body"].read().should.equal(b"some content")
+
+    key.put(Body=b"")
+
+    resp = client.get_object(Bucket="foobar", Key="the-key")
+    resp.should.have.key("ContentLength").equal(0)
+    resp["Body"].read().should.equal(b"")
+
+
+# Has boto3 equivalent
 @mock_s3_deprecated
 def test_large_key_save():
     conn = boto.connect_s3("the_key", "the_secret")
@@ -451,6 +859,20 @@ def test_large_key_save():
     bucket.get_key("the-key").get_contents_as_string().should.equal(b"foobar" * 100000)
 
 
+@mock_s3
+def test_large_key_save_boto3():
+    s3 = boto3.resource("s3", region_name=DEFAULT_REGION_NAME)
+    client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
+    s3.create_bucket(Bucket="foobar")
+
+    key = s3.Object("foobar", "the-key")
+    key.put(Body=b"foobar" * 100000)
+
+    resp = client.get_object(Bucket="foobar", Key="the-key")
+    resp["Body"].read().should.equal(b"foobar" * 100000)
+
+
+# Has boto3 equivalent
 @mock_s3_deprecated
 def test_copy_key():
     conn = boto.connect_s3("the_key", "the_secret")
@@ -465,6 +887,7 @@ def test_copy_key():
     bucket.get_key("new-key").get_contents_as_string().should.equal(b"some value")
 
 
+# Has boto3 equivalent
 @pytest.mark.parametrize("key_name", ["the-unicode-💩-key", "key-with?question-mark"])
 @mock_s3_deprecated
 def test_copy_key_with_special_chars(key_name):
@@ -480,6 +903,28 @@ def test_copy_key_with_special_chars(key_name):
     bucket.get_key("new-key").get_contents_as_string().should.equal(b"some value")
 
 
+@pytest.mark.parametrize(
+    "key_name", ["the-key", "the-unicode-💩-key", "key-with?question-mark"]
+)
+@mock_s3
+def test_copy_key_boto3(key_name):
+    s3 = boto3.resource("s3", region_name=DEFAULT_REGION_NAME)
+    client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
+    s3.create_bucket(Bucket="foobar")
+
+    key = s3.Object("foobar", key_name)
+    key.put(Body=b"some value")
+
+    key2 = s3.Object("foobar", "new-key")
+    key2.copy_from(CopySource="foobar/{}".format(key_name))
+
+    resp = client.get_object(Bucket="foobar", Key=key_name)
+    resp["Body"].read().should.equal(b"some value")
+    resp = client.get_object(Bucket="foobar", Key="new-key")
+    resp["Body"].read().should.equal(b"some value")
+
+
+# Has boto3 equivalent
 @mock_s3_deprecated
 def test_copy_key_with_version():
     conn = boto.connect_s3("the_key", "the_secret")
@@ -497,6 +942,36 @@ def test_copy_key_with_version():
     bucket.get_key("new-key").get_contents_as_string().should.equal(b"some value")
 
 
+@mock_s3
+def test_copy_key_with_version_boto3():
+    s3 = boto3.resource("s3", region_name=DEFAULT_REGION_NAME)
+    client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
+    s3.create_bucket(Bucket="foobar")
+    client.put_bucket_versioning(
+        Bucket="foobar", VersioningConfiguration={"Status": "Enabled"}
+    )
+
+    key = s3.Object("foobar", "the-key")
+    key.put(Body=b"some value")
+    key.put(Body=b"another value")
+
+    all_versions = client.list_object_versions(Bucket="foobar", Prefix="the-key")[
+        "Versions"
+    ]
+    old_version = [v for v in all_versions if not v["IsLatest"]][0]
+
+    key2 = s3.Object("foobar", "new-key")
+    key2.copy_from(
+        CopySource="foobar/the-key?versionId={}".format(old_version["VersionId"])
+    )
+
+    resp = client.get_object(Bucket="foobar", Key="the-key")
+    resp["Body"].read().should.equal(b"another value")
+    resp = client.get_object(Bucket="foobar", Key="new-key")
+    resp["Body"].read().should.equal(b"some value")
+
+
+# Has boto3 equivalent
 @mock_s3_deprecated
 def test_set_metadata():
     conn = boto.connect_s3("the_key", "the_secret")
@@ -509,6 +984,20 @@ def test_set_metadata():
     bucket.get_key("the-key").get_metadata("md").should.equal("Metadatastring")
 
 
+@mock_s3
+def test_set_metadata_boto3():
+    s3 = boto3.resource("s3", region_name=DEFAULT_REGION_NAME)
+    client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
+    s3.create_bucket(Bucket="foobar")
+
+    key = s3.Object("foobar", "the-key")
+    key.put(Body=b"some value", Metadata={"md": "Metadatastring"})
+
+    resp = client.get_object(Bucket="foobar", Key="the-key")
+    resp["Metadata"].should.equal({"md": "Metadatastring"})
+
+
+# Has boto3 equivalent
 @mock_s3_deprecated
 def test_copy_key_replace_metadata():
     conn = boto.connect_s3("the_key", "the_secret")
@@ -526,6 +1015,28 @@ def test_copy_key_replace_metadata():
     bucket.get_key("new-key").get_metadata("momd").should.equal("Mometadatastring")
 
 
+@mock_s3
+def test_copy_key_replace_metadata_boto3():
+    s3 = boto3.resource("s3", region_name=DEFAULT_REGION_NAME)
+    client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
+    s3.create_bucket(Bucket="foobar")
+
+    key = s3.Object("foobar", "the-key")
+    key.put(Body=b"some value", Metadata={"md": "Metadatastring"})
+
+    client.copy_object(
+        Bucket="foobar",
+        CopySource="foobar/the-key",
+        Key="new-key",
+        Metadata={"momd": "Mometadatastring"},
+        MetadataDirective="REPLACE",
+    )
+
+    resp = client.get_object(Bucket="foobar", Key="new-key")
+    resp["Metadata"].should.equal({"momd": "Mometadatastring"})
+
+
+# Has boto3 equivalent
 @freeze_time("2012-01-01 12:00:00")
 @mock_s3_deprecated
 def test_last_modified():
@@ -544,18 +1055,57 @@ def test_last_modified():
     )
 
 
+@freeze_time("2012-01-01 12:00:00")
+@mock_s3
+def test_last_modified_boto3():
+    # See https://github.com/boto/boto/issues/466
+    s3 = boto3.resource("s3", region_name=DEFAULT_REGION_NAME)
+    client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
+    s3.create_bucket(Bucket="foobar")
+
+    key = s3.Object("foobar", "the-key")
+    key.put(Body=b"some value", Metadata={"md": "Metadatastring"})
+
+    rs = client.list_objects_v2(Bucket="foobar")["Contents"]
+    rs[0]["LastModified"].should.be.a(datetime.datetime)
+
+    resp = client.get_object(Bucket="foobar", Key="the-key")
+    resp["LastModified"].should.be.a(datetime.datetime)
+    as_header = resp["ResponseMetadata"]["HTTPHeaders"]["last-modified"]
+    as_header.should.be.a(str)
+    if not settings.TEST_SERVER_MODE:
+        as_header.should.equal("Sun, 01 Jan 2012 12:00:00 GMT")
+
+
+# Has boto3 equivalent
 @mock_s3_deprecated
 def test_missing_bucket():
     conn = boto.connect_s3("the_key", "the_secret")
     conn.get_bucket.when.called_with("mybucket").should.throw(S3ResponseError)
 
 
+# Has boto3 equivalent
 @mock_s3_deprecated
 def test_bucket_with_dash():
     conn = boto.connect_s3("the_key", "the_secret")
     conn.get_bucket.when.called_with("mybucket-test").should.throw(S3ResponseError)
 
 
+@mock_s3
+def test_missing_bucket_boto3():
+    client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
+    with pytest.raises(ClientError) as ex:
+        client.head_bucket(Bucket="mybucket")
+    ex.value.response["Error"]["Code"].should.equal("404")
+    ex.value.response["Error"]["Message"].should.equal("Not Found")
+
+    with pytest.raises(ClientError) as ex:
+        client.head_bucket(Bucket="dash-in-name")
+    ex.value.response["Error"]["Code"].should.equal("404")
+    ex.value.response["Error"]["Message"].should.equal("Not Found")
+
+
+# Has boto3 equivalent
 @mock_s3_deprecated
 def test_create_existing_bucket():
     "Trying to create a bucket that already exists should raise an Error"
@@ -565,6 +1115,24 @@ def test_create_existing_bucket():
         conn.create_bucket("foobar", location="us-west-2")
 
 
+@mock_s3
+def test_create_existing_bucket_boto3():
+    "Trying to create a bucket that already exists should raise an Error"
+    client = boto3.client("s3", region_name="us-west-2")
+    kwargs = {
+        "Bucket": "foobar",
+        "CreateBucketConfiguration": {"LocationConstraint": "us-west-2"},
+    }
+    client.create_bucket(**kwargs)
+    with pytest.raises(ClientError) as ex:
+        client.create_bucket(**kwargs)
+    ex.value.response["Error"]["Code"].should.equal("BucketAlreadyExists")
+    ex.value.response["Error"]["Message"].should.equal(
+        "The requested bucket name is not available. The bucket namespace is shared by all users of the system. Please select a different name and try again"
+    )
+
+
+# Has boto3 equivalent
 @mock_s3_deprecated
 def test_create_existing_bucket_in_us_east_1():
     "Trying to create a bucket that already exists in us-east-1 returns the bucket"
@@ -582,6 +1150,22 @@ def test_create_existing_bucket_in_us_east_1():
     bucket.name.should.equal("foobar")
 
 
+@mock_s3
+def test_create_existing_bucket_in_us_east_1_boto3():
+    "Trying to create a bucket that already exists in us-east-1 returns the bucket"
+
+    """"
+    http://docs.aws.amazon.com/AmazonS3/latest/API/ErrorResponses.html
+    Your previous request to create the named bucket succeeded and you already
+    own it. You get this error in all AWS regions except US Standard,
+    us-east-1. In us-east-1 region, you will get 200 OK, but it is no-op (if
+    bucket exists it Amazon S3 will not do anything).
+    """
+    client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
+    client.create_bucket(Bucket="foobar")
+    client.create_bucket(Bucket="foobar")
+
+
 @mock_s3_deprecated
 def test_other_region():
     conn = S3Connection("key", "secret", host="s3-website-ap-southeast-2.amazonaws.com")
@@ -589,6 +1173,7 @@ def test_other_region():
     list(conn.get_bucket("foobar").get_all_keys()).should.equal([])
 
 
+# Has boto3 equivalent
 @mock_s3_deprecated
 def test_bucket_deletion():
     conn = boto.connect_s3("the_key", "the_secret")
@@ -611,6 +1196,44 @@ def test_bucket_deletion():
     conn.delete_bucket.when.called_with("foobar").should.throw(S3ResponseError)
 
 
+@mock_s3
+def test_bucket_deletion_boto3():
+    s3 = boto3.resource("s3", region_name=DEFAULT_REGION_NAME)
+    client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
+    client.create_bucket(Bucket="foobar")
+
+    key = s3.Object("foobar", "the-key")
+    key.put(Body=b"some value")
+
+    # Try to delete a bucket that still has keys
+    with pytest.raises(ClientError) as ex:
+        client.delete_bucket(Bucket="foobar")
+    ex.value.response["Error"]["Code"].should.equal("BucketNotEmpty")
+    ex.value.response["Error"]["Message"].should.equal(
+        "The bucket you tried to delete is not empty"
+    )
+
+    client.delete_object(Bucket="foobar", Key="the-key")
+    client.delete_bucket(Bucket="foobar")
+
+    # Get non-existing bucket details
+    with pytest.raises(ClientError) as ex:
+        client.get_bucket_tagging(Bucket="foobar")
+    ex.value.response["Error"]["Code"].should.equal("NoSuchBucket")
+    ex.value.response["Error"]["Message"].should.equal(
+        "The specified bucket does not exist"
+    )
+
+    # Delete non-existent bucket
+    with pytest.raises(ClientError) as ex:
+        client.delete_bucket(Bucket="foobar")
+    ex.value.response["Error"]["Code"].should.equal("NoSuchBucket")
+    ex.value.response["Error"]["Message"].should.equal(
+        "The specified bucket does not exist"
+    )
+
+
+# Has boto3 equivalent
 @mock_s3_deprecated
 def test_get_all_buckets():
     conn = boto.connect_s3("the_key", "the_secret")
@@ -621,6 +1244,16 @@ def test_get_all_buckets():
     buckets.should.have.length_of(2)
 
 
+@mock_s3
+def test_get_all_buckets_boto3():
+    client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
+    client.create_bucket(Bucket="foobar")
+    client.create_bucket(Bucket="foobar2")
+
+    client.list_buckets()["Buckets"].should.have.length_of(2)
+
+
+# Has boto3 equivalent
 @mock_s3
 @mock_s3_deprecated
 def test_post_to_bucket():
@@ -635,6 +1268,20 @@ def test_post_to_bucket():
 
 
 @mock_s3
+def test_post_to_bucket_boto3():
+    client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
+    client.create_bucket(Bucket="foobar")
+
+    requests.post(
+        "https://foobar.s3.amazonaws.com/", {"key": "the-key", "file": "nothing"}
+    )
+
+    resp = client.get_object(Bucket="foobar", Key="the-key")
+    resp["Body"].read().should.equal(b"nothing")
+
+
+# Has boto3 equivalent
+@mock_s3
 @mock_s3_deprecated
 def test_post_with_metadata_to_bucket():
     conn = boto.connect_s3("the_key", "the_secret")
@@ -648,6 +1295,20 @@ def test_post_with_metadata_to_bucket():
     bucket.get_key("the-key").get_metadata("test").should.equal("metadata")
 
 
+@mock_s3
+def test_post_with_metadata_to_bucket_boto3():
+    client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
+    client.create_bucket(Bucket="foobar")
+
+    requests.post(
+        "https://foobar.s3.amazonaws.com/",
+        {"key": "the-key", "file": "nothing", "x-amz-meta-test": "metadata"},
+    )
+
+    resp = client.get_object(Bucket="foobar", Key="the-key")
+    resp["Metadata"].should.equal({"test": "metadata"})
+
+
 @mock_s3_deprecated
 def test_delete_missing_key():
     conn = boto.connect_s3("the_key", "the_secret")
@@ -657,6 +1318,7 @@ def test_delete_missing_key():
     deleted_key.key.should.equal("foobar")
 
 
+# Has boto3 equivalent
 @mock_s3_deprecated
 def test_delete_keys():
     conn = boto.connect_s3("the_key", "the_secret")
@@ -675,6 +1337,7 @@ def test_delete_keys():
     keys[0].name.should.equal("file1")
 
 
+# Has boto3 equivalent
 @mock_s3_deprecated
 def test_delete_keys_invalid():
     conn = boto.connect_s3("the_key", "the_secret")
@@ -701,12 +1364,42 @@ def test_delete_keys_invalid():
 
 
 @mock_s3
+def test_delete_missing_key_boto3():
+    s3 = boto3.resource("s3", region_name=DEFAULT_REGION_NAME)
+    client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
+    bucket = s3.Bucket("foobar")
+    bucket.create()
+
+    s3.Object("foobar", "key1").put(Body=b"some value")
+    s3.Object("foobar", "key2").put(Body=b"some value")
+    s3.Object("foobar", "key3").put(Body=b"some value")
+    s3.Object("foobar", "key4").put(Body=b"some value")
+
+    result = bucket.delete_objects(
+        Delete={
+            "Objects": [
+                {"Key": "unknown"},
+                {"Key": "key1"},
+                {"Key": "key3"},
+                {"Key": "typo"},
+            ]
+        }
+    )
+    result.should.have.key("Deleted").equal([{"Key": "key1"}, {"Key": "key3"}])
+    result.should.have.key("Errors").equal([{"Key": "unknown"}, {"Key": "typo"}])
+
+    objects = list(bucket.objects.all())
+    set([o.key for o in objects]).should.equal(set(["key2", "key4"]))
+
+
+@mock_s3
 def test_boto3_delete_empty_keys_list():
     with pytest.raises(ClientError) as err:
         boto3.client("s3").delete_objects(Bucket="foobar", Delete={"Objects": []})
     assert err.value.response["Error"]["Code"] == "MalformedXML"
 
 
+# Has boto3 equivalent
 @mock_s3_deprecated
 def test_bucket_name_with_dot():
     conn = boto.connect_s3()
@@ -716,6 +1409,20 @@ def test_bucket_name_with_dot():
     k.set_contents_from_string("somedata")
 
 
+@mock_s3
+def test_bucket_name_with_dot_boto3():
+    s3 = boto3.resource("s3", region_name=DEFAULT_REGION_NAME)
+    client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
+    bucket = s3.Bucket("firstname.lastname")
+    bucket.create()
+
+    s3.Object("firstname.lastname", "the-key").put(Body=b"some value")
+
+    resp = client.get_object(Bucket="firstname.lastname", Key="the-key")
+    resp["Body"].read().should.equal(b"some value")
+
+
+# Has boto3 equivalent
 @mock_s3_deprecated
 def test_key_with_special_characters():
     conn = boto.connect_s3()
@@ -729,6 +1436,7 @@ def test_key_with_special_characters():
     keys[0].name.should.equal("test_list_keys_2/x?y")
 
 
+# Has boto3 equivalent
 @mock_s3_deprecated
 def test_unicode_key_with_slash():
     conn = boto.connect_s3("the_key", "the_secret")
@@ -741,6 +1449,26 @@ def test_unicode_key_with_slash():
     key.get_contents_as_string().should.equal(b"value")
 
 
+@pytest.mark.parametrize(
+    "key", ["normal", "test_list_keys_2/x?y", "/the-key-unîcode/test"]
+)
+@mock_s3
+def test_key_with_special_characters_boto3(key):
+    s3 = boto3.resource("s3", region_name=DEFAULT_REGION_NAME)
+    client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
+    bucket = s3.Bucket("testname")
+    bucket.create()
+
+    s3.Object("testname", key).put(Body=b"value")
+
+    objects = list(bucket.objects.all())
+    [o.key for o in objects].should.equal([key])
+
+    resp = client.get_object(Bucket="testname", Key=key)
+    resp["Body"].read().should.equal(b"value")
+
+
+# Has boto3 equivalent
 @mock_s3_deprecated
 def test_bucket_key_listing_order():
     conn = boto.connect_s3()
@@ -789,6 +1517,50 @@ def test_bucket_key_listing_order():
     keys.should.equal(["toplevel/x/"])
 
 
+@mock_s3
+def test_bucket_key_listing_order_boto3():
+    s3 = boto3.resource("s3", region_name=DEFAULT_REGION_NAME)
+    client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
+    bucket_name = "test_bucket"
+    bucket = s3.Bucket(bucket_name)
+    bucket.create()
+    prefix = "toplevel/"
+
+    names = ["x/key", "y.key1", "y.key2", "y.key3", "x/y/key", "x/y/z/key"]
+
+    for name in names:
+        s3.Object(bucket_name, prefix + name).put(Body=b"somedata")
+
+    delimiter = ""
+    keys = [x.key for x in bucket.objects.filter(Prefix=prefix, Delimiter=delimiter)]
+    keys.should.equal(
+        [
+            "toplevel/x/key",
+            "toplevel/x/y/key",
+            "toplevel/x/y/z/key",
+            "toplevel/y.key1",
+            "toplevel/y.key2",
+            "toplevel/y.key3",
+        ]
+    )
+
+    delimiter = "/"
+    keys = [x.key for x in bucket.objects.filter(Prefix=prefix, Delimiter=delimiter)]
+    keys.should.equal(["toplevel/y.key1", "toplevel/y.key2", "toplevel/y.key3"])
+
+    # Test delimiter with no prefix
+    keys = [x.key for x in bucket.objects.filter(Delimiter=delimiter)]
+    keys.should.equal([])
+
+    prefix = "toplevel/x"
+    keys = [x.key for x in bucket.objects.filter(Prefix=prefix)]
+    keys.should.equal(["toplevel/x/key", "toplevel/x/y/key", "toplevel/x/y/z/key"])
+
+    keys = [x.key for x in bucket.objects.filter(Prefix=prefix, Delimiter=delimiter)]
+    keys.should.equal([])
+
+
+# Has boto3 equivalent
 @mock_s3_deprecated
 def test_key_with_reduced_redundancy():
     conn = boto.connect_s3()
@@ -801,6 +1573,24 @@ def test_key_with_reduced_redundancy():
     list(bucket)[0].storage_class.should.equal("REDUCED_REDUNDANCY")
 
 
+@mock_s3
+def test_key_with_reduced_redundancy_boto3():
+    s3 = boto3.resource("s3", region_name=DEFAULT_REGION_NAME)
+    client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
+    bucket_name = "test_bucket"
+    bucket = s3.Bucket(bucket_name)
+    bucket.create()
+
+    bucket.put_object(
+        Key="test_rr_key", Body=b"somedata", StorageClass="REDUCED_REDUNDANCY"
+    )
+
+    # we use the bucket iterator because of:
+    # https:/github.com/boto/boto/issues/1173
+    [x.storage_class for x in bucket.objects.all()].should.equal(["REDUCED_REDUNDANCY"])
+
+
+# Has boto3 equivalent
 @mock_s3_deprecated
 def test_copy_key_reduced_redundancy():
     conn = boto.connect_s3("the_key", "the_secret")
@@ -818,6 +1608,28 @@ def test_copy_key_reduced_redundancy():
     keys["the-key"].storage_class.should.equal("STANDARD")
 
 
+@mock_s3
+def test_copy_key_reduced_redundancy_boto3():
+    s3 = boto3.resource("s3", region_name=DEFAULT_REGION_NAME)
+    client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
+    bucket = s3.Bucket("test_bucket")
+    bucket.create()
+
+    bucket.put_object(Key="the-key", Body=b"somedata")
+
+    client.copy_object(
+        Bucket="test_bucket",
+        CopySource="test_bucket/the-key",
+        Key="new-key",
+        StorageClass="REDUCED_REDUNDANCY",
+    )
+
+    keys = dict([(k.key, k) for k in bucket.objects.all()])
+    keys["new-key"].storage_class.should.equal("REDUCED_REDUNDANCY")
+    keys["the-key"].storage_class.should.equal("STANDARD")
+
+
+# Has boto3 equivalent
 @freeze_time("2012-01-01 12:00:00")
 @mock_s3_deprecated
 def test_restore_key():
@@ -840,6 +1652,34 @@ def test_restore_key():
 
 
 @freeze_time("2012-01-01 12:00:00")
+@mock_s3
+def test_restore_key_boto3():
+    s3 = boto3.resource("s3", region_name=DEFAULT_REGION_NAME)
+    client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
+    bucket = s3.Bucket("foobar")
+    bucket.create()
+
+    key = bucket.put_object(Key="the-key", Body=b"somedata")
+    key.restore.should.be.none
+    key.restore_object(RestoreRequest={"Days": 1})
+    if settings.TEST_SERVER_MODE:
+        key.restore.should.contain('ongoing-request="false"')
+    else:
+        key.restore.should.equal(
+            'ongoing-request="false", expiry-date="Mon, 02 Jan 2012 12:00:00 GMT"'
+        )
+
+    key.restore_object(RestoreRequest={"Days": 2})
+
+    if settings.TEST_SERVER_MODE:
+        key.restore.should.contain('ongoing-request="false"')
+    else:
+        key.restore.should.equal(
+            'ongoing-request="false", expiry-date="Tue, 03 Jan 2012 12:00:00 GMT"'
+        )
+
+
+@freeze_time("2012-01-01 12:00:00")
 @mock_s3_deprecated
 def test_restore_key_headers():
     conn = boto.connect_s3("the_key", "the_secret")
@@ -854,6 +1694,7 @@ def test_restore_key_headers():
     key.expiry_date.should.equal("Mon, 02 Jan 2012 12:00:00 GMT")
 
 
+# Has boto3 equivalent
 @mock_s3_deprecated
 def test_get_versioning_status():
     conn = boto.connect_s3("the_key", "the_secret")
@@ -871,6 +1712,24 @@ def test_get_versioning_status():
     d.should.have.key("Versioning").being.equal("Suspended")
 
 
+@mock_s3
+def test_get_versioning_status_boto3():
+    s3 = boto3.resource("s3", region_name=DEFAULT_REGION_NAME)
+    client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
+    bucket = s3.Bucket("foobar")
+    bucket.create()
+
+    v = s3.BucketVersioning("foobar")
+    v.status.should.be.none
+
+    v.enable()
+    v.status.should.equal("Enabled")
+
+    v.suspend()
+    v.status.should.equal("Suspended")
+
+
+# Has boto3 equivalent
 @mock_s3_deprecated
 def test_key_version():
     conn = boto.connect_s3("the_key", "the_secret")
@@ -892,6 +1751,27 @@ def test_key_version():
     key.version_id.should.equal(versions[-1])
 
 
+@mock_s3
+def test_key_version_boto3():
+    s3 = boto3.resource("s3", region_name=DEFAULT_REGION_NAME)
+    client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
+    bucket = s3.Bucket("foobar")
+    bucket.create()
+    bucket.Versioning().enable()
+
+    versions = []
+
+    key = bucket.put_object(Key="the-key", Body=b"somedata")
+    versions.append(key.version_id)
+    key.put(Body=b"some string")
+    versions.append(key.version_id)
+    set(versions).should.have.length_of(2)
+
+    key = client.get_object(Bucket="foobar", Key="the-key")
+    key["VersionId"].should.equal(versions[-1])
+
+
+# Has boto3 equivalent
 @mock_s3_deprecated
 def test_list_versions():
     conn = boto.connect_s3("the_key", "the_secret")
@@ -928,6 +1808,49 @@ def test_list_versions():
     versions.should.have.length_of(1)
 
 
+@mock_s3
+def test_list_versions_boto3():
+    s3 = boto3.resource("s3", region_name=DEFAULT_REGION_NAME)
+    client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
+    bucket = s3.Bucket("foobar")
+    bucket.create()
+    bucket.Versioning().enable()
+
+    key_versions = []
+
+    key = bucket.put_object(Key="the-key", Body=b"Version 1")
+    key_versions.append(key.version_id)
+    key = bucket.put_object(Key="the-key", Body=b"Version 2")
+    key_versions.append(key.version_id)
+    key_versions.should.have.length_of(2)
+
+    versions = client.list_object_versions(Bucket="foobar")["Versions"]
+    versions.should.have.length_of(2)
+
+    versions[0]["Key"].should.equal("the-key")
+    versions[0]["VersionId"].should.equal(key_versions[1])
+    resp = client.get_object(Bucket="foobar", Key="the-key")
+    resp["Body"].read().should.equal(b"Version 2")
+    resp = client.get_object(
+        Bucket="foobar", Key="the-key", VersionId=versions[0]["VersionId"]
+    )
+    resp["Body"].read().should.equal(b"Version 2")
+
+    versions[1]["Key"].should.equal("the-key")
+    versions[1]["VersionId"].should.equal(key_versions[0])
+    resp = client.get_object(
+        Bucket="foobar", Key="the-key", VersionId=versions[1]["VersionId"]
+    )
+    resp["Body"].read().should.equal(b"Version 1")
+
+    bucket.put_object(Key="the2-key", Body=b"Version 1")
+
+    list(bucket.objects.all()).should.have.length_of(2)
+    versions = client.list_object_versions(Bucket="foobar", Prefix="the2")["Versions"]
+    versions.should.have.length_of(1)
+
+
+# Has boto3 equivalent
 @mock_s3_deprecated
 def test_acl_setting():
     conn = boto.connect_s3()
@@ -952,6 +1875,32 @@ def test_acl_setting():
     ), grants
 
 
+@mock_s3
+def test_acl_setting_boto3():
+    s3 = boto3.resource("s3", region_name=DEFAULT_REGION_NAME)
+    client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
+    bucket = s3.Bucket("foobar")
+    bucket.create()
+
+    content = b"imafile"
+    keyname = "test.txt"
+    bucket.put_object(
+        Key=keyname, Body=content, ContentType="text/plain", ACL="public-read"
+    )
+
+    grants = client.get_object_acl(Bucket="foobar", Key=keyname)["Grants"]
+    grants.should.contain(
+        {
+            "Grantee": {
+                "Type": "Group",
+                "URI": "http://acs.amazonaws.com/groups/global/AllUsers",
+            },
+            "Permission": "READ",
+        }
+    )
+
+
+# Has boto3 equivalent
 @mock_s3_deprecated
 def test_acl_setting_via_headers():
     conn = boto.connect_s3()
@@ -980,6 +1929,31 @@ def test_acl_setting_via_headers():
     ), grants
 
 
+@mock_s3
+def test_acl_setting_via_headers_boto3():
+    s3 = boto3.resource("s3", region_name=DEFAULT_REGION_NAME)
+    client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
+    bucket = s3.Bucket("foobar")
+    bucket.create()
+
+    keyname = "test.txt"
+
+    bucket.put_object(Key=keyname, Body=b"imafile")
+    client.put_object_acl(ACL="public-read", Bucket="foobar", Key=keyname)
+
+    grants = client.get_object_acl(Bucket="foobar", Key=keyname)["Grants"]
+    grants.should.contain(
+        {
+            "Grantee": {
+                "Type": "Group",
+                "URI": "http://acs.amazonaws.com/groups/global/AllUsers",
+            },
+            "Permission": "READ",
+        }
+    )
+
+
+# Has boto3 equivalent
 @mock_s3_deprecated
 def test_acl_switching():
     conn = boto.connect_s3()
@@ -998,6 +1972,29 @@ def test_acl_switching():
         and g.permission == "READ"
         for g in grants
     ), grants
+
+
+@mock_s3
+def test_acl_switching_boto3():
+    s3 = boto3.resource("s3", region_name=DEFAULT_REGION_NAME)
+    client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
+    bucket = s3.Bucket("foobar")
+    bucket.create()
+    keyname = "test.txt"
+
+    bucket.put_object(Key=keyname, Body=b"asdf", ACL="public-read")
+    client.put_object_acl(ACL="private", Bucket="foobar", Key=keyname)
+
+    grants = client.get_object_acl(Bucket="foobar", Key=keyname)["Grants"]
+    grants.shouldnt.contain(
+        {
+            "Grantee": {
+                "Type": "Group",
+                "URI": "http://acs.amazonaws.com/groups/global/AllUsers",
+            },
+            "Permission": "READ",
+        }
+    )
 
 
 @mock_s3
@@ -1216,6 +2213,7 @@ def test_s3_object_in_private_bucket():
     contents.should.equal(b"ABCD")
 
 
+# Has boto3 equivalent
 @mock_s3_deprecated
 def test_unicode_key():
     conn = boto.connect_s3()
@@ -1229,6 +2227,21 @@ def test_unicode_key():
     assert fetched_key.get_contents_as_string().decode("utf-8") == "Hello world!"
 
 
+@mock_s3
+def test_unicode_key_boto3():
+    s3 = boto3.resource("s3", region_name=DEFAULT_REGION_NAME)
+    bucket = s3.Bucket("mybucket")
+    bucket.create()
+
+    key = bucket.put_object(Key="こんにちは.jpg", Body=b"Hello world!")
+
+    [listed_key.key for listed_key in bucket.objects.all()].should.equal([key.key])
+    fetched_key = s3.Object("mybucket", key.key)
+    fetched_key.key.should.equal(key.key)
+    fetched_key.get()["Body"].read().decode("utf-8").should.equal("Hello world!")
+
+
+# Has boto3 equivalent
 @mock_s3_deprecated
 def test_unicode_value():
     conn = boto.connect_s3()
@@ -1241,6 +2254,19 @@ def test_unicode_value():
     assert key.get_contents_as_string().decode("utf-8") == "こんにちは.jpg"
 
 
+@mock_s3
+def test_unicode_value_boto3():
+    s3 = boto3.resource("s3", region_name=DEFAULT_REGION_NAME)
+    bucket = s3.Bucket("mybucket")
+    bucket.create()
+
+    bucket.put_object(Key="some_key", Body="こんにちは.jpg")
+
+    key = s3.Object("mybucket", "some_key")
+    key.get()["Body"].read().decode("utf-8").should.equal("こんにちは.jpg")
+
+
+# Has boto3 equivalent
 @mock_s3_deprecated
 def test_setting_content_encoding():
     conn = boto.connect_s3()
@@ -1251,6 +2277,19 @@ def test_setting_content_encoding():
     key.set_contents_from_string(compressed_data)
 
     key = bucket.get_key("keyname")
+    key.content_encoding.should.equal("gzip")
+
+
+@mock_s3
+def test_setting_content_encoding_boto3():
+    s3 = boto3.resource("s3", region_name=DEFAULT_REGION_NAME)
+    client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
+    bucket = s3.Bucket("mybucket")
+    bucket.create()
+
+    bucket.put_object(Body=b"abcdef", ContentEncoding="gzip", Key="keyname")
+
+    key = s3.Object("mybucket", "keyname")
     key.content_encoding.should.equal("gzip")
 
 
@@ -1672,6 +2711,7 @@ if not settings.TEST_SERVER_MODE:
             )
 
 
+# Has boto3 equivalent
 @mock_s3_deprecated
 def test_ranged_get():
     conn = boto.connect_s3()
@@ -1714,6 +2754,48 @@ def test_ranged_get():
     key.size.should.equal(100)
 
 
+@mock_s3
+def test_ranged_get_boto3():
+    s3 = boto3.resource("s3", region_name=DEFAULT_REGION_NAME)
+    bucket = s3.Bucket("mybucket")
+    bucket.create()
+    rep = b"0123456789"
+    key = bucket.put_object(Key="bigkey", Body=rep * 10)
+
+    # Implicitly bounded range requests.
+    key.get(Range="bytes=0-")["Body"].read().should.equal(rep * 10)
+    key.get(Range="bytes=50-")["Body"].read().should.equal(rep * 5)
+    key.get(Range="bytes=99-")["Body"].read().should.equal(b"9")
+
+    # Explicitly bounded range requests starting from the first byte.
+    key.get(Range="bytes=0-0")["Body"].read().should.equal(b"0")
+    key.get(Range="bytes=0-49")["Body"].read().should.equal(rep * 5)
+    key.get(Range="bytes=0-99")["Body"].read().should.equal(rep * 10)
+    key.get(Range="bytes=0-100")["Body"].read().should.equal(rep * 10)
+    key.get(Range="bytes=0-700")["Body"].read().should.equal(rep * 10)
+
+    # Explicitly bounded range requests starting from the / a middle byte.
+    key.get(Range="bytes=50-54")["Body"].read().should.equal(rep[:5])
+    key.get(Range="bytes=50-99")["Body"].read().should.equal(rep * 5)
+    key.get(Range="bytes=50-100")["Body"].read().should.equal(rep * 5)
+    key.get(Range="bytes=50-700")["Body"].read().should.equal(rep * 5)
+
+    # Explicitly bounded range requests starting from the last byte.
+    key.get(Range="bytes=99-99")["Body"].read().should.equal(b"9")
+    key.get(Range="bytes=99-100")["Body"].read().should.equal(b"9")
+    key.get(Range="bytes=99-700")["Body"].read().should.equal(b"9")
+
+    # Suffix range requests.
+    key.get(Range="bytes=-1")["Body"].read().should.equal(b"9")
+    key.get(Range="bytes=-60")["Body"].read().should.equal(rep * 6)
+    key.get(Range="bytes=-100")["Body"].read().should.equal(rep * 10)
+    key.get(Range="bytes=-101")["Body"].read().should.equal(rep * 10)
+    key.get(Range="bytes=-700")["Body"].read().should.equal(rep * 10)
+
+    key.content_length.should.equal(100)
+
+
+# Has boto3 equivalent
 @mock_s3_deprecated
 def test_policy():
     conn = boto.connect_s3()
@@ -1768,12 +2850,94 @@ def test_policy():
         bucket.get_policy()
 
 
+@mock_s3
+def test_policy_boto3():
+    s3 = boto3.resource("s3", region_name=DEFAULT_REGION_NAME)
+    client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
+    bucket_name = "mybucket"
+    bucket = s3.Bucket(bucket_name)
+    bucket.create()
+
+    policy = json.dumps(
+        {
+            "Version": "2012-10-17",
+            "Id": "PutObjPolicy",
+            "Statement": [
+                {
+                    "Sid": "DenyUnEncryptedObjectUploads",
+                    "Effect": "Deny",
+                    "Principal": "*",
+                    "Action": "s3:PutObject",
+                    "Resource": "arn:aws:s3:::{bucket_name}/*".format(
+                        bucket_name=bucket_name
+                    ),
+                    "Condition": {
+                        "StringNotEquals": {
+                            "s3:x-amz-server-side-encryption": "aws:kms"
+                        }
+                    },
+                }
+            ],
+        }
+    )
+
+    with pytest.raises(ClientError) as ex:
+        client.get_bucket_policy(Bucket=bucket_name)
+    ex.value.response["Error"]["Code"].should.equal("NoSuchBucketPolicy")
+    ex.value.response["Error"]["Message"].should.equal(
+        "The bucket policy does not exist"
+    )
+
+    client.put_bucket_policy(Bucket=bucket_name, Policy=policy)
+
+    client.get_bucket_policy(Bucket=bucket_name)["Policy"].should.equal(policy)
+
+    client.delete_bucket_policy(Bucket=bucket_name)
+
+    with pytest.raises(ClientError) as ex:
+        client.get_bucket_policy(Bucket=bucket_name)
+    ex.value.response["Error"]["Code"].should.equal("NoSuchBucketPolicy")
+
+
+# Has boto3 equivalent
 @mock_s3_deprecated
 def test_website_configuration_xml():
     conn = boto.connect_s3()
     bucket = conn.create_bucket("test-bucket")
     bucket.set_website_configuration_xml(TEST_XML)
     bucket.get_website_configuration_xml().should.equal(TEST_XML)
+
+
+@mock_s3
+def test_website_configuration_xml_boto3():
+    s3 = boto3.resource("s3", region_name=DEFAULT_REGION_NAME)
+    client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
+    bucket_name = "mybucket"
+    bucket = s3.Bucket(bucket_name)
+    bucket.create()
+
+    client.put_bucket_website(
+        Bucket=bucket_name,
+        WebsiteConfiguration={
+            "IndexDocument": {"Suffix": "index.html"},
+            "RoutingRules": [
+                {
+                    "Condition": {"KeyPrefixEquals": "test/testing"},
+                    "Redirect": {"ReplaceKeyWith": "test.txt"},
+                }
+            ],
+        },
+    )
+    c = client.get_bucket_website(Bucket=bucket_name)
+    c.should.have.key("IndexDocument").equals({"Suffix": "index.html"})
+    c.should.have.key("RoutingRules")
+    c["RoutingRules"].should.have.length_of(1)
+    rule = c["RoutingRules"][0]
+    rule.should.have.key("Condition").equals({"KeyPrefixEquals": "test/testing"})
+    rule.should.have.key("Redirect").equals({"ReplaceKeyWith": "test.txt"})
+
+    c.shouldnt.have.key("RedirectAllRequestsTo")
+    c.shouldnt.have.key("ErrorDocument")
 
 
 @mock_s3_deprecated


### PR DESCRIPTION
See #3842 - adds equivalent boto3 tests for S3, so that the deprecated tests can be removed without losing any test coverage