### PR TITLE
EC2 describe_network_acls: add support for owner-id filter

### DIFF
--- a/moto/ec2/models.py
+++ b/moto/ec2/models.py
@@ -5667,10 +5667,13 @@ class NetworkAclAssociation(object):
 
 
 class NetworkAcl(TaggedEC2Resource):
-    def __init__(self, ec2_backend, network_acl_id, vpc_id, default=False):
+    def __init__(
+        self, ec2_backend, network_acl_id, vpc_id, default=False, owner_id=OWNER_ID,
+    ):
         self.ec2_backend = ec2_backend
         self.id = network_acl_id
         self.vpc_id = vpc_id
+        self.owner_id = owner_id
         self.network_acl_entries = []
         self.associations = {}
         self.default = "true" if default is True else "false"
@@ -5684,6 +5687,8 @@ class NetworkAcl(TaggedEC2Resource):
             return self.id
         elif filter_name == "association.subnet-id":
             return [assoc.subnet_id for assoc in self.associations.values()]
+        elif filter_name == "owner-id":
+            return self.owner_id
         else:
             return super(NetworkAcl, self).get_filter_value(
                 filter_name, "DescribeNetworkAcls"

--- a/moto/ec2/responses/network_acls.py
+++ b/moto/ec2/responses/network_acls.py
@@ -132,6 +132,7 @@ DESCRIBE_NETWORK_ACL_RESPONSE = """
    <item>
      <networkAclId>{{ network_acl.id }}</networkAclId>
      <vpcId>{{ network_acl.vpc_id }}</vpcId>
+     <ownerId>{{ network_acl.owner_id }}</ownerId>
      <default>{{ network_acl.default }}</default>
      <entrySet>
        {% for entry in network_acl.network_acl_entries %}

--- a/tests/test_ec2/test_network_acls.py
+++ b/tests/test_ec2/test_network_acls.py
@@ -6,6 +6,7 @@ import pytest
 from botocore.exceptions import ClientError
 
 from moto import mock_ec2_deprecated, mock_ec2
+from moto.ec2.models import OWNER_ID
 
 
 @mock_ec2_deprecated
@@ -296,6 +297,11 @@ def test_describe_network_acls():
 
     resp2 = conn.describe_network_acls()["NetworkAcls"]
     resp2.should.have.length_of(3)
+
+    resp3 = conn.describe_network_acls(
+        Filters=[{"Name": "owner-id", "Values": [OWNER_ID]}]
+    )["NetworkAcls"]
+    resp3.should.have.length_of(3)
 
     with pytest.raises(ClientError) as ex:
         conn.describe_network_acls(NetworkAclIds=["1"])


### PR DESCRIPTION
Added `ownerId` to response: https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeNetworkAcls.html#API_DescribeNetworkAcls_Examples

I thought about adding support for the filter to the parent "TaggedEC2Resource" because many ec2 resources do support it, but wasn't sure if that would be welcome. Somebody would have to check that all the subclasses support it, and possibly add logic to prevent some subclasses from using that filter.

My previous contributions to this project:
https://github.com/spulec/moto/pulls?q=is%3Apr+author%3Akhneal+is%3Aclosed