### PR TITLE
allow specifying the service as env var

### DIFF
--- a/moto/server.py
+++ b/moto/server.py
@@ -3,6 +3,7 @@ from __future__ import unicode_literals
 import argparse
 import io
 import json
+import os
 import re
 import signal
 import sys

--- a/moto/server.py
+++ b/moto/server.py
@@ -262,7 +262,7 @@ def main(argv=sys.argv[1:]):
         "service",
         type=str,
         nargs="?",  # http://stackoverflow.com/a/4480202/731592
-        default=None,
+        default=os.environ.get('MOTO_SERVICE'),
     )
     parser.add_argument(
         "-H", "--host", type=str, help="Which host to bind", default="127.0.0.1"

--- a/moto/server.py
+++ b/moto/server.py
@@ -263,7 +263,7 @@ def main(argv=sys.argv[1:]):
         "service",
         type=str,
         nargs="?",  # http://stackoverflow.com/a/4480202/731592
-        default=os.environ.get('MOTO_SERVICE'),
+        default=os.environ.get("MOTO_SERVICE"),
     )
     parser.add_argument(
         "-H", "--host", type=str, help="Which host to bind", default="127.0.0.1"


### PR DESCRIPTION
This is required if running as a Github Action which doesn't allow passing parameters to `docker create` but allows environment variables