### PR TITLE
Implement User Pool MFA Actions

### DIFF
--- a/moto/cognitoidp/models.py
+++ b/moto/cognitoidp/models.py
@@ -83,6 +83,10 @@ class CognitoIdpUserPool(BaseModel):
         self.creation_date = datetime.datetime.utcnow()
         self.last_modified_date = datetime.datetime.utcnow()
 
+        self.mfa_config = "OFF"
+        self.sms_mfa_config = None
+        self.token_mfa_config = None
+
         self.clients = OrderedDict()
         self.identity_providers = OrderedDict()
         self.groups = OrderedDict()
@@ -105,6 +109,7 @@ class CognitoIdpUserPool(BaseModel):
             "Status": self.status,
             "CreationDate": time.mktime(self.creation_date.timetuple()),
             "LastModifiedDate": time.mktime(self.last_modified_date.timetuple()),
+            "MfaConfiguration": self.mfa_config,
         }
 
     def to_json(self, extended=False):
@@ -390,6 +395,25 @@ class CognitoIdpBackend(BaseBackend):
         user_pool = CognitoIdpUserPool(self.region, name, extended_config)
         self.user_pools[user_pool.id] = user_pool
         return user_pool
+
+    def set_user_pool_mfa_config(
+        self, user_pool_id, sms_config, token_config, mfa_config
+    ):
+        user_pool = self.describe_user_pool(user_pool_id)
+        user_pool.mfa_config = mfa_config
+        user_pool.sms_mfa_config = sms_config
+        user_pool.token_mfa_config = token_config
+
+        return self.get_user_pool_mfa_config(user_pool_id)
+
+    def get_user_pool_mfa_config(self, user_pool_id):
+        user_pool = self.describe_user_pool(user_pool_id)
+
+        return {
+            "SmsMfaConfiguration": user_pool.sms_mfa_config,
+            "SoftwareTokenMfaConfiguration": user_pool.token_mfa_config,
+            "MfaConfiguration": user_pool.mfa_config,
+        }
 
     @paginate(60)
     def list_user_pools(self, max_results=None, next_token=None):

--- a/moto/cognitoidp/responses.py
+++ b/moto/cognitoidp/responses.py
@@ -27,12 +27,12 @@ class CognitoIdpResponse(BaseResponse):
         mfa_config = self._get_param("MfaConfiguration")
 
         if sms_config is None and token_config is None:
-            raise ValueError
+            raise ValueError("At least one of [SmsMfaConfiguration] and [SoftwareTokenMfaConfiguration] must be provided.")
         if sms_config:
             if "SnsCallerArn" not in sms_config:
-                raise ValueError
+                raise ValueError("[SnsCallerArn] is a required member of [SoftwareTokenMfaConfiguration].")
         if mfa_config not in ["ON", "OFF", "OPTIONAL"]:
-            raise ValueError
+            raise ValueError("[MfaConfiguration] must be one of 'ON', 'OFF', or 'OPTIONAL'.")
         response = cognitoidp_backends[self.region].set_user_pool_mfa_config(
             user_pool_id, sms_config, token_config, mfa_config
         )

--- a/moto/cognitoidp/responses.py
+++ b/moto/cognitoidp/responses.py
@@ -27,13 +27,22 @@ class CognitoIdpResponse(BaseResponse):
         token_config = self._get_param("SoftwareTokenMfaConfiguration", None)
         mfa_config = self._get_param("MfaConfiguration")
 
-        if sms_config is None and token_config is None:
-            raise InvalidParameterException("At least one of [SmsMfaConfiguration] or [SoftwareTokenMfaConfiguration] must be provided.")
-        if sms_config:
-            if "SnsCallerArn" not in sms_config:
-                raise InvalidParameterException("[SnsCallerArn] is a required member of [SoftwareTokenMfaConfiguration].")
         if mfa_config not in ["ON", "OFF", "OPTIONAL"]:
-            raise InvalidParameterException("[MfaConfiguration] must be one of 'ON', 'OFF', or 'OPTIONAL'.")
+            raise InvalidParameterException(
+                "[MfaConfiguration] must be one of 'ON', 'OFF', or 'OPTIONAL'."
+            )
+
+        if mfa_config in ["ON", "OPTIONAL"]:
+            if sms_config is None and token_config is None:
+                raise InvalidParameterException(
+                    "At least one of [SmsMfaConfiguration] or [SoftwareTokenMfaConfiguration] must be provided."
+                )
+            if sms_config is not None:
+                if "SmsConfiguration" not in sms_config:
+                    raise InvalidParameterException(
+                        "[SmsConfiguration] is a required member of [SoftwareTokenMfaConfiguration]."
+                    )
+
         response = cognitoidp_backends[self.region].set_user_pool_mfa_config(
             user_pool_id, sms_config, token_config, mfa_config
         )

--- a/moto/cognitoidp/responses.py
+++ b/moto/cognitoidp/responses.py
@@ -5,6 +5,7 @@ import os
 
 from moto.core.responses import BaseResponse
 from .models import cognitoidp_backends, find_region_by_value, UserStatus
+from .exceptions import InvalidParameterException
 
 
 class CognitoIdpResponse(BaseResponse):
@@ -27,12 +28,12 @@ class CognitoIdpResponse(BaseResponse):
         mfa_config = self._get_param("MfaConfiguration")
 
         if sms_config is None and token_config is None:
-            raise ValueError("At least one of [SmsMfaConfiguration] and [SoftwareTokenMfaConfiguration] must be provided.")
+            raise InvalidParameterException("At least one of [SmsMfaConfiguration] or [SoftwareTokenMfaConfiguration] must be provided.")
         if sms_config:
             if "SnsCallerArn" not in sms_config:
-                raise ValueError("[SnsCallerArn] is a required member of [SoftwareTokenMfaConfiguration].")
+                raise InvalidParameterException("[SnsCallerArn] is a required member of [SoftwareTokenMfaConfiguration].")
         if mfa_config not in ["ON", "OFF", "OPTIONAL"]:
-            raise ValueError("[MfaConfiguration] must be one of 'ON', 'OFF', or 'OPTIONAL'.")
+            raise InvalidParameterException("[MfaConfiguration] must be one of 'ON', 'OFF', or 'OPTIONAL'.")
         response = cognitoidp_backends[self.region].set_user_pool_mfa_config(
             user_pool_id, sms_config, token_config, mfa_config
         )

--- a/moto/cognitoidp/responses.py
+++ b/moto/cognitoidp/responses.py
@@ -20,6 +20,31 @@ class CognitoIdpResponse(BaseResponse):
         )
         return json.dumps({"UserPool": user_pool.to_json(extended=True)})
 
+    def set_user_pool_mfa_config(self):
+        user_pool_id = self._get_param("UserPoolId")
+        sms_config = self._get_param("SmsMfaConfiguration", None)
+        token_config = self._get_param("SoftwareTokenMfaConfiguration", None)
+        mfa_config = self._get_param("MfaConfiguration")
+
+        if sms_config is None and token_config is None:
+            raise ValueError
+        if sms_config:
+            if "SnsCallerArn" not in sms_config:
+                raise ValueError
+        if mfa_config not in ["ON", "OFF", "OPTIONAL"]:
+            raise ValueError
+        response = cognitoidp_backends[self.region].set_user_pool_mfa_config(
+            user_pool_id, sms_config, token_config, mfa_config
+        )
+        return json.dumps(response)
+
+    def get_user_pool_mfa_config(self):
+        user_pool_id = self._get_param("UserPoolId")
+        response = cognitoidp_backends[self.region].get_user_pool_mfa_config(
+            user_pool_id
+        )
+        return json.dumps(response)
+
     def list_user_pools(self):
         max_results = self._get_param("MaxResults")
         next_token = self._get_param("NextToken", "0")

--- a/tests/test_cognitoidp/test_cognitoidp.py
+++ b/tests/test_cognitoidp/test_cognitoidp.py
@@ -55,6 +55,28 @@ def test_list_user_pools():
 
 
 @mock_cognitoidp
+def test_set_user_pool_mfa_config():
+    conn = boto3.client("cognito-idp", "us-west-2")
+
+    name = str(uuid.uuid4())
+    user_pool_id = conn.create_user_pool(PoolName=name)["UserPool"]["Id"]
+
+    # Enable software token MFA
+    mfa_config = conn.set_user_pool_mfa_config(
+        UserPoolId=user_pool_id,
+        SoftwareTokenMfaConfiguration={"Enabled": True},
+        MfaConfiguration="ON",
+    )
+
+    mfa_config.shouldnt.have.key("SmsMfaConfiguration")
+    mfa_config["MfaConfiguration"].should.equal("ON")
+
+    # Response from describe should match
+    pool = conn.describe_user_pool(UserPoolId=user_pool_id)["UserPool"]
+    pool["MfaConfiguration"].should.equal("ON")
+
+
+@mock_cognitoidp
 def test_list_user_pools_returns_max_items():
     conn = boto3.client("cognito-idp", "us-west-2")
 


### PR DESCRIPTION
## Description

Closes #3901

---

- Implements `set_user_pool_mfa_config`
- Implements `get_user_pool_mfa_config`
- Updates `CognitoUserPool`'s JSON representation to include `MfaConfiguration` field so that the `DescribeUserPool` endpoint remains correct
- Creates tests for the new actions

## Question

I have added some checks in the response layer to ensure that the input aligns with what boto3 expects, and then raise a `ValueError` if it doesn't. I don't see anything similar being done anywhere else, so I ask: Should I be raising a different error? Should I be checking at all? 

Thanks.