### PR TITLE
Rewrite deprecated DynamoDB2 tests

### DIFF
--- a/IMPLEMENTATION_COVERAGE.md
+++ b/IMPLEMENTATION_COVERAGE.md
@@ -22,7 +22,7 @@
 
 ## apigateway
 <details>
-<summary>43% implemented</summary>
+<summary>44% implemented</summary>
 
 - [X] create_api_key
 - [X] create_authorizer
@@ -50,7 +50,7 @@
 - [ ] delete_gateway_response
 - [X] delete_integration
 - [X] delete_integration_response
-- [ ] delete_method
+- [X] delete_method
 - [X] delete_method_response
 - [ ] delete_model
 - [ ] delete_request_validator

--- a/tests/test_core/test_socket.py
+++ b/tests/test_core/test_socket.py
@@ -15,6 +15,7 @@ class TestSocketPair(unittest.TestCase):
 
         self.assertIsNotNone(asyncio.get_event_loop())
 
+    # Has boto3 equivalent
     @mock_dynamodb2_deprecated
     def test_socket_pair_deprecated(self):
 

--- a/tests/test_dynamodb2/test_dynamodb_table_with_range_key.py
+++ b/tests/test_dynamodb2/test_dynamodb_table_with_range_key.py
@@ -6,6 +6,7 @@ import boto
 import boto3
 from boto3.dynamodb.conditions import Key
 from botocore.exceptions import ClientError
+from datetime import datetime
 import sure  # noqa
 from freezegun import freeze_time
 import pytest
@@ -57,6 +58,7 @@ def iterate_results(res):
 
 
 @requires_boto_gte("2.9")
+# Has boto3 equivalent
 @mock_dynamodb2_deprecated
 @freeze_time("2012-01-14")
 def test_create_table():
@@ -89,7 +91,52 @@ def test_create_table():
     table.describe().should.equal(expected)
 
 
+@mock_dynamodb2
+def test_create_table_boto3():
+    client = boto3.client("dynamodb", region_name="us-east-1")
+    client.create_table(
+        TableName="messages",
+        KeySchema=[
+            {"AttributeName": "id", "KeyType": "HASH"},
+            {"AttributeName": "subject", "KeyType": "RANGE"},
+        ],
+        AttributeDefinitions=[
+            {"AttributeName": "id", "AttributeType": "S"},
+            {"AttributeName": "subject", "AttributeType": "S"},
+        ],
+        ProvisionedThroughput={"ReadCapacityUnits": 1, "WriteCapacityUnits": 5},
+    )
+    actual = client.describe_table(TableName="messages")["Table"]
+
+    actual.should.have.key("AttributeDefinitions").equal(
+        [
+            {"AttributeName": "id", "AttributeType": "S"},
+            {"AttributeName": "subject", "AttributeType": "S"},
+        ]
+    )
+    actual.should.have.key("CreationDateTime").be.a(datetime)
+    actual.should.have.key("GlobalSecondaryIndexes").equal([])
+    actual.should.have.key("LocalSecondaryIndexes").equal([])
+    actual.should.have.key("ProvisionedThroughput").equal(
+        {"NumberOfDecreasesToday": 0, "ReadCapacityUnits": 1, "WriteCapacityUnits": 5}
+    )
+    actual.should.have.key("TableSizeBytes").equal(0)
+    actual.should.have.key("TableName").equal("messages")
+    actual.should.have.key("TableStatus").equal("ACTIVE")
+    actual.should.have.key("TableArn").equal(
+        "arn:aws:dynamodb:us-east-1:123456789011:table/messages"
+    )
+    actual.should.have.key("KeySchema").equal(
+        [
+            {"AttributeName": "id", "KeyType": "HASH"},
+            {"AttributeName": "subject", "KeyType": "RANGE"},
+        ]
+    )
+    actual.should.have.key("ItemCount").equal(0)
+
+
 @requires_boto_gte("2.9")
+# Has boto3 equivalent
 @mock_dynamodb2_deprecated
 @freeze_time("2012-01-14")
 def test_create_table_with_local_index():
@@ -132,7 +179,75 @@ def test_create_table_with_local_index():
     table.describe().should.equal(expected)
 
 
+@mock_dynamodb2
+def test_create_table_with_local_index_boto3():
+    client = boto3.client("dynamodb", region_name="us-east-1")
+    client.create_table(
+        TableName="messages",
+        KeySchema=[
+            {"AttributeName": "id", "KeyType": "HASH"},
+            {"AttributeName": "subject", "KeyType": "RANGE"},
+        ],
+        AttributeDefinitions=[
+            {"AttributeName": "id", "AttributeType": "S"},
+            {"AttributeName": "subject", "AttributeType": "S"},
+            {"AttributeName": "threads", "AttributeType": "S"},
+        ],
+        LocalSecondaryIndexes=[
+            {
+                "IndexName": "threads_index",
+                "KeySchema": [
+                    {"AttributeName": "id", "KeyType": "HASH"},
+                    {"AttributeName": "threads", "KeyType": "RANGE"},
+                ],
+                "Projection": {"ProjectionType": "ALL"},
+            }
+        ],
+        ProvisionedThroughput={"ReadCapacityUnits": 1, "WriteCapacityUnits": 5},
+    )
+    actual = client.describe_table(TableName="messages")["Table"]
+
+    actual.should.have.key("AttributeDefinitions").equal(
+        [
+            {"AttributeName": "id", "AttributeType": "S"},
+            {"AttributeName": "subject", "AttributeType": "S"},
+            {"AttributeName": "threads", "AttributeType": "S"},
+        ]
+    )
+    actual.should.have.key("CreationDateTime").be.a(datetime)
+    actual.should.have.key("GlobalSecondaryIndexes").equal([])
+    actual.should.have.key("LocalSecondaryIndexes").equal(
+        [
+            {
+                "IndexName": "threads_index",
+                "KeySchema": [
+                    {"AttributeName": "id", "KeyType": "HASH"},
+                    {"AttributeName": "threads", "KeyType": "RANGE"},
+                ],
+                "Projection": {"ProjectionType": "ALL"},
+            }
+        ]
+    )
+    actual.should.have.key("ProvisionedThroughput").equal(
+        {"NumberOfDecreasesToday": 0, "ReadCapacityUnits": 1, "WriteCapacityUnits": 5}
+    )
+    actual.should.have.key("TableSizeBytes").equal(0)
+    actual.should.have.key("TableName").equal("messages")
+    actual.should.have.key("TableStatus").equal("ACTIVE")
+    actual.should.have.key("TableArn").equal(
+        "arn:aws:dynamodb:us-east-1:123456789011:table/messages"
+    )
+    actual.should.have.key("KeySchema").equal(
+        [
+            {"AttributeName": "id", "KeyType": "HASH"},
+            {"AttributeName": "subject", "KeyType": "RANGE"},
+        ]
+    )
+    actual.should.have.key("ItemCount").equal(0)
+
+
 @requires_boto_gte("2.9")
+# Has boto3 equivalent
 @mock_dynamodb2_deprecated
 def test_delete_table():
     conn = boto.dynamodb2.layer1.DynamoDBConnection()
@@ -145,6 +260,7 @@ def test_delete_table():
 
 
 @requires_boto_gte("2.9")
+# Has boto3 equivalent
 @mock_dynamodb2_deprecated
 def test_update_table_throughput():
     table = create_table()
@@ -164,6 +280,7 @@ def test_update_table_throughput():
 
 
 @requires_boto_gte("2.9")
+# Has boto3 equivalent
 @mock_dynamodb2_deprecated
 def test_item_add_and_describe_and_update():
     table = create_table()
@@ -209,6 +326,7 @@ def test_item_add_and_describe_and_update():
 
 
 @requires_boto_gte("2.9")
+# Has boto3 equivalent
 @mock_dynamodb2_deprecated
 def test_item_partial_save():
     table = create_table()
@@ -238,6 +356,7 @@ def test_item_partial_save():
 
 
 @requires_boto_gte("2.9")
+# Has boto3 equivalent
 @mock_dynamodb2_deprecated
 def test_item_put_without_table():
     table = Table("undeclared-table")
@@ -252,6 +371,7 @@ def test_item_put_without_table():
 
 
 @requires_boto_gte("2.9")
+# Has boto3 equivalent
 @mock_dynamodb2_deprecated
 def test_get_missing_item():
     table = create_table()
@@ -262,6 +382,7 @@ def test_get_missing_item():
 
 
 @requires_boto_gte("2.9")
+# Has boto3 equivalent
 @mock_dynamodb2_deprecated
 def test_get_item_with_undeclared_table():
     table = Table("undeclared-table")
@@ -271,6 +392,7 @@ def test_get_item_with_undeclared_table():
 
 
 @requires_boto_gte("2.9")
+# Has boto3 equivalent
 @mock_dynamodb2_deprecated
 def test_get_item_without_range_key():
     table = Table.create(
@@ -287,7 +409,35 @@ def test_get_item_without_range_key():
     )
 
 
+@mock_dynamodb2
+def test_get_item_without_range_key_boto3():
+    client = boto3.resource("dynamodb", region_name="us-east-1")
+    table = client.create_table(
+        TableName="messages",
+        KeySchema=[
+            {"AttributeName": "id", "KeyType": "HASH"},
+            {"AttributeName": "subject", "KeyType": "RANGE"},
+        ],
+        AttributeDefinitions=[
+            {"AttributeName": "id", "AttributeType": "S"},
+            {"AttributeName": "subject", "AttributeType": "S"},
+        ],
+        ProvisionedThroughput={"ReadCapacityUnits": 1, "WriteCapacityUnits": 5},
+    )
+
+    hash_key = 3241526475
+    range_key = 1234567890987
+    table.put_item(Item={"id": hash_key, "subject": range_key})
+
+    with pytest.raises(ClientError) as ex:
+        table.get_item(Key={"id": hash_key})
+
+    ex.value.response["Error"]["Code"].should.equal("ValidationException")
+    ex.value.response["Error"]["Message"].should.equal("Validation Exception")
+
+
 @requires_boto_gte("2.30.0")
+# Has boto3 equivalent
 @mock_dynamodb2_deprecated
 def test_delete_item():
     table = create_table()
@@ -311,6 +461,7 @@ def test_delete_item():
 
 
 @requires_boto_gte("2.9")
+# Has boto3 equivalent
 @mock_dynamodb2_deprecated
 def test_delete_item_with_undeclared_table():
     table = Table("undeclared-table")
@@ -325,6 +476,7 @@ def test_delete_item_with_undeclared_table():
 
 
 @requires_boto_gte("2.9")
+# Has boto3 equivalent
 @mock_dynamodb2_deprecated
 def test_query():
     table = create_table()
@@ -384,6 +536,7 @@ def test_query():
 
 
 @requires_boto_gte("2.9")
+# Has boto3 equivalent
 @mock_dynamodb2_deprecated
 def test_query_with_undeclared_table():
     table = Table("undeclared")
@@ -394,6 +547,7 @@ def test_query_with_undeclared_table():
 
 
 @requires_boto_gte("2.9")
+# Has boto3 equivalent
 @mock_dynamodb2_deprecated
 def test_scan():
     table = create_table()
@@ -449,6 +603,7 @@ def test_scan():
 
 
 @requires_boto_gte("2.9")
+# Has boto3 equivalent
 @mock_dynamodb2_deprecated
 def test_scan_with_undeclared_table():
     conn = boto.dynamodb2.layer1.DynamoDBConnection()
@@ -464,6 +619,7 @@ def test_scan_with_undeclared_table():
 
 
 @requires_boto_gte("2.9")
+# Has boto3 equivalent
 @mock_dynamodb2_deprecated
 def test_write_batch():
     table = create_table()
@@ -495,6 +651,7 @@ def test_write_batch():
 
 
 @requires_boto_gte("2.9")
+# Has boto3 equivalent
 @mock_dynamodb2_deprecated
 def test_batch_read():
     table = create_table()
@@ -539,6 +696,7 @@ def test_batch_read():
 
 
 @requires_boto_gte("2.9")
+# Has boto3 equivalent
 @mock_dynamodb2_deprecated
 def test_get_key_fields():
     table = create_table()
@@ -547,6 +705,7 @@ def test_get_key_fields():
 
 
 @mock_dynamodb2_deprecated
+# Has boto3 equivalent
 def test_create_with_global_indexes():
     conn = boto.dynamodb2.layer1.DynamoDBConnection()
 
@@ -582,6 +741,7 @@ def test_create_with_global_indexes():
     )
 
 
+# Has boto3 equivalent
 @mock_dynamodb2_deprecated
 def test_query_with_global_indexes():
     table = Table.create(
@@ -617,6 +777,7 @@ def test_query_with_global_indexes():
     list(results).should.have.length_of(0)
 
 
+# Has boto3 equivalent
 @mock_dynamodb2_deprecated
 def test_query_with_local_indexes():
     table = create_table_with_local_indexes()
@@ -639,6 +800,7 @@ def test_query_with_local_indexes():
 
 
 @requires_boto_gte("2.9")
+# Has boto3 equivalent
 @mock_dynamodb2_deprecated
 def test_query_filter_eq():
     table = create_table_with_local_indexes()
@@ -672,6 +834,7 @@ def test_query_filter_eq():
 
 
 @requires_boto_gte("2.9")
+# Has boto3 equivalent
 @mock_dynamodb2_deprecated
 def test_query_filter_lt():
     table = create_table_with_local_indexes()
@@ -707,6 +870,7 @@ def test_query_filter_lt():
 
 
 @requires_boto_gte("2.9")
+# Has boto3 equivalent
 @mock_dynamodb2_deprecated
 def test_query_filter_gt():
     table = create_table_with_local_indexes()
@@ -741,6 +905,7 @@ def test_query_filter_gt():
 
 
 @requires_boto_gte("2.9")
+# Has boto3 equivalent
 @mock_dynamodb2_deprecated
 def test_query_filter_lte():
     table = create_table_with_local_indexes()
@@ -775,6 +940,7 @@ def test_query_filter_lte():
 
 
 @requires_boto_gte("2.9")
+# Has boto3 equivalent
 @mock_dynamodb2_deprecated
 def test_query_filter_gte():
     table = create_table_with_local_indexes()
@@ -808,7 +974,51 @@ def test_query_filter_gte():
     list(results).should.have.length_of(2)
 
 
+@mock_dynamodb2
+def test_query_filter_boto3():
+    table_schema = {
+        "KeySchema": [
+            {"AttributeName": "pk", "KeyType": "HASH"},
+            {"AttributeName": "sk", "KeyType": "RANGE"},
+        ],
+        "AttributeDefinitions": [
+            {"AttributeName": "pk", "AttributeType": "S"},
+            {"AttributeName": "sk", "AttributeType": "S"},
+        ],
+    }
+
+    dynamodb = boto3.resource("dynamodb", region_name="us-east-1")
+    table = dynamodb.create_table(
+        TableName="test-table", BillingMode="PAY_PER_REQUEST", **table_schema
+    )
+
+    for i in range(0, 3):
+        table.put_item(
+            Item={"pk": "pk".format(i), "sk": "sk-{}".format(i),}
+        )
+
+    res = table.query(KeyConditionExpression=Key("pk").eq("pk"))
+    res["Items"].should.have.length_of(3)
+
+    res = table.query(KeyConditionExpression=Key("pk").eq("pk") & Key("sk").lt("sk-1"))
+    res["Items"].should.have.length_of(1)
+    res["Items"].should.equal([{"pk": "pk", "sk": "sk-0"}])
+
+    res = table.query(KeyConditionExpression=Key("pk").eq("pk") & Key("sk").lte("sk-1"))
+    res["Items"].should.have.length_of(2)
+    res["Items"].should.equal([{"pk": "pk", "sk": "sk-0"}, {"pk": "pk", "sk": "sk-1"}])
+
+    res = table.query(KeyConditionExpression=Key("pk").eq("pk") & Key("sk").gt("sk-1"))
+    res["Items"].should.have.length_of(1)
+    res["Items"].should.equal([{"pk": "pk", "sk": "sk-2"}])
+
+    res = table.query(KeyConditionExpression=Key("pk").eq("pk") & Key("sk").gte("sk-1"))
+    res["Items"].should.have.length_of(2)
+    res["Items"].should.equal([{"pk": "pk", "sk": "sk-1"}, {"pk": "pk", "sk": "sk-2"}])
+
+
 @requires_boto_gte("2.9")
+# Has boto3 equivalent
 @mock_dynamodb2_deprecated
 def test_query_non_hash_range_key():
     table = create_table_with_local_indexes()
@@ -845,6 +1055,7 @@ def test_query_non_hash_range_key():
     results.should.have.length_of(2)
 
 
+# Has boto3 equivalent
 @mock_dynamodb2_deprecated
 def test_reverse_query():
     conn = boto.dynamodb2.layer1.DynamoDBConnection()
@@ -862,6 +1073,7 @@ def test_reverse_query():
     [r["created_at"] for r in results].should.equal(expected)
 
 
+# Has boto3 equivalent
 @mock_dynamodb2_deprecated
 def test_lookup():
     from decimal import Decimal
@@ -881,6 +1093,7 @@ def test_lookup():
     message.get("test_range").should.equal(Decimal(range_key))
 
 
+# Has boto3 equivalent
 @mock_dynamodb2_deprecated
 def test_failed_overwrite():
     table = Table.create(
@@ -910,6 +1123,7 @@ def test_failed_overwrite():
     dict(returned_item).should.equal(data4)
 
 
+# Has boto3 equivalent
 @mock_dynamodb2_deprecated
 def test_conflicting_writes():
     table = Table.create("messages", schema=[HashKey("id"), RangeKey("range")])


### PR DESCRIPTION
See #3842 - adds equivalent boto3 tests for DynamoDB2, so that the deprecated tests can be removed without losing any test coverage