### PR TITLE
Rewrite deprecated Autoscaling tests

### DIFF
--- a/IMPLEMENTATION_COVERAGE.md
+++ b/IMPLEMENTATION_COVERAGE.md
@@ -22,7 +22,7 @@
 
 ## apigateway
 <details>
-<summary>43% implemented</summary>
+<summary>44% implemented</summary>
 
 - [X] create_api_key
 - [X] create_authorizer
@@ -50,7 +50,7 @@
 - [ ] delete_gateway_response
 - [X] delete_integration
 - [X] delete_integration_response
-- [ ] delete_method
+- [X] delete_method
 - [X] delete_method_response
 - [ ] delete_model
 - [ ] delete_request_validator

--- a/tests/test_autoscaling/test_policies.py
+++ b/tests/test_autoscaling/test_policies.py
@@ -1,13 +1,15 @@
 from __future__ import unicode_literals
 import boto
+import boto3
 from boto.ec2.autoscale.launchconfig import LaunchConfiguration
 from boto.ec2.autoscale.group import AutoScalingGroup
 from boto.ec2.autoscale.policy import ScalingPolicy
+import pytest
 import sure  # noqa
 
-from moto import mock_autoscaling_deprecated
+from moto import mock_autoscaling_deprecated, mock_autoscaling
 
-from .utils import setup_networking_deprecated
+from .utils import setup_networking_deprecated, setup_networking
 from tests import EXAMPLE_AMI_ID
 
 
@@ -30,6 +32,25 @@ def setup_autoscale_group():
     return group
 
 
+def setup_autoscale_group_boto3():
+    mocked_networking = setup_networking()
+    client = boto3.client("autoscaling", region_name="us-east-1")
+    client.create_launch_configuration(
+        LaunchConfigurationName="tester",
+        ImageId=EXAMPLE_AMI_ID,
+        InstanceType="m1.small",
+    )
+
+    client.create_auto_scaling_group(
+        AutoScalingGroupName="tester_group",
+        LaunchConfigurationName="tester",
+        MinSize=2,
+        MaxSize=2,
+        VPCZoneIdentifier=mocked_networking["subnet1"],
+    )
+
+
+# Has boto3 equivalent
 @mock_autoscaling_deprecated
 def test_create_policy():
     setup_autoscale_group()
@@ -51,6 +72,27 @@ def test_create_policy():
     policy.cooldown.should.equal(60)
 
 
+@mock_autoscaling
+def test_create_policy_boto3():
+    setup_autoscale_group_boto3()
+    client = boto3.client("autoscaling", region_name="us-east-1")
+    client.put_scaling_policy(
+        PolicyName="ScaleUp",
+        AdjustmentType="ExactCapacity",
+        AutoScalingGroupName="tester_group",
+        ScalingAdjustment=3,
+        Cooldown=60,
+    )
+
+    policy = client.describe_policies()["ScalingPolicies"][0]
+    policy["PolicyName"].should.equal("ScaleUp")
+    policy["AdjustmentType"].should.equal("ExactCapacity")
+    policy["AutoScalingGroupName"].should.equal("tester_group")
+    policy["ScalingAdjustment"].should.equal(3)
+    policy["Cooldown"].should.equal(60)
+
+
+# Has boto3 equivalent
 @mock_autoscaling_deprecated
 def test_create_policy_default_values():
     setup_autoscale_group()
@@ -70,6 +112,25 @@ def test_create_policy_default_values():
     policy.cooldown.should.equal(300)
 
 
+@mock_autoscaling
+def test_create_policy_default_values_boto3():
+    setup_autoscale_group_boto3()
+    client = boto3.client("autoscaling", region_name="us-east-1")
+    client.put_scaling_policy(
+        PolicyName="ScaleUp",
+        AdjustmentType="ExactCapacity",
+        AutoScalingGroupName="tester_group",
+        ScalingAdjustment=3,
+    )
+
+    policy = client.describe_policies()["ScalingPolicies"][0]
+    policy["PolicyName"].should.equal("ScaleUp")
+
+    # Defaults
+    policy["Cooldown"].should.equal(300)
+
+
+# Has boto3 equivalent
 @mock_autoscaling_deprecated
 def test_update_policy():
     setup_autoscale_group()
@@ -97,6 +158,34 @@ def test_update_policy():
     policy.scaling_adjustment.should.equal(2)
 
 
+@mock_autoscaling
+def test_update_policy_boto3():
+    setup_autoscale_group_boto3()
+    client = boto3.client("autoscaling", region_name="us-east-1")
+    client.put_scaling_policy(
+        PolicyName="ScaleUp",
+        AdjustmentType="ExactCapacity",
+        AutoScalingGroupName="tester_group",
+        ScalingAdjustment=3,
+    )
+
+    client.describe_policies()["ScalingPolicies"].should.have.length_of(1)
+    policy = client.describe_policies()["ScalingPolicies"][0]
+    policy["ScalingAdjustment"].should.equal(3)
+
+    # Now update it by creating another with the same name
+    client.put_scaling_policy(
+        PolicyName="ScaleUp",
+        AdjustmentType="ExactCapacity",
+        AutoScalingGroupName="tester_group",
+        ScalingAdjustment=2,
+    )
+    client.describe_policies()["ScalingPolicies"].should.have.length_of(1)
+    policy = client.describe_policies()["ScalingPolicies"][0]
+    policy["ScalingAdjustment"].should.equal(2)
+
+
+# Has boto3 equivalent
 @mock_autoscaling_deprecated
 def test_delete_policy():
     setup_autoscale_group()
@@ -115,6 +204,24 @@ def test_delete_policy():
     conn.get_all_policies().should.have.length_of(0)
 
 
+@mock_autoscaling
+def test_delete_policy_boto3():
+    setup_autoscale_group_boto3()
+    client = boto3.client("autoscaling", region_name="us-east-1")
+    client.put_scaling_policy(
+        PolicyName="ScaleUp",
+        AdjustmentType="ExactCapacity",
+        AutoScalingGroupName="tester_group",
+        ScalingAdjustment=3,
+    )
+
+    client.describe_policies()["ScalingPolicies"].should.have.length_of(1)
+
+    client.delete_policy(PolicyName="ScaleUp")
+    client.describe_policies()["ScalingPolicies"].should.have.length_of(0)
+
+
+# Has boto3 equivalent
 @mock_autoscaling_deprecated
 def test_execute_policy_exact_capacity():
     setup_autoscale_group()
@@ -133,6 +240,24 @@ def test_execute_policy_exact_capacity():
     instances.should.have.length_of(3)
 
 
+@mock_autoscaling
+def test_execute_policy_exact_capacity_boto3():
+    setup_autoscale_group_boto3()
+    client = boto3.client("autoscaling", region_name="us-east-1")
+    client.put_scaling_policy(
+        PolicyName="ScaleUp",
+        AdjustmentType="ExactCapacity",
+        AutoScalingGroupName="tester_group",
+        ScalingAdjustment=3,
+    )
+
+    client.execute_policy(PolicyName="ScaleUp")
+
+    instances = client.describe_auto_scaling_instances()
+    instances["AutoScalingInstances"].should.have.length_of(3)
+
+
+# Has boto3 equivalent
 @mock_autoscaling_deprecated
 def test_execute_policy_positive_change_in_capacity():
     setup_autoscale_group()
@@ -151,6 +276,24 @@ def test_execute_policy_positive_change_in_capacity():
     instances.should.have.length_of(5)
 
 
+@mock_autoscaling
+def test_execute_policy_positive_change_in_capacity_boto3():
+    setup_autoscale_group_boto3()
+    client = boto3.client("autoscaling", region_name="us-east-1")
+    client.put_scaling_policy(
+        PolicyName="ScaleUp",
+        AdjustmentType="ChangeInCapacity",
+        AutoScalingGroupName="tester_group",
+        ScalingAdjustment=3,
+    )
+
+    client.execute_policy(PolicyName="ScaleUp")
+
+    instances = client.describe_auto_scaling_instances()
+    instances["AutoScalingInstances"].should.have.length_of(5)
+
+
+# Has boto3 equivalent
 @mock_autoscaling_deprecated
 def test_execute_policy_percent_change_in_capacity():
     setup_autoscale_group()
@@ -169,6 +312,30 @@ def test_execute_policy_percent_change_in_capacity():
     instances.should.have.length_of(3)
 
 
+@pytest.mark.parametrize(
+    "adjustment,nr_of_instances", [(1, 3), (50, 3), (100, 4), (250, 7)],
+)
+@mock_autoscaling
+def test_execute_policy_percent_change_in_capacity_boto3(adjustment, nr_of_instances):
+    """http://docs.aws.amazon.com/AutoScaling/latest/DeveloperGuide/as-scale-based-on-demand.html
+        If PercentChangeInCapacity returns a value between 0 and 1,
+        Auto Scaling will round it off to 1."""
+    setup_autoscale_group_boto3()
+    client = boto3.client("autoscaling", region_name="us-east-1")
+    client.put_scaling_policy(
+        PolicyName="ScaleUp",
+        AdjustmentType="PercentChangeInCapacity",
+        AutoScalingGroupName="tester_group",
+        ScalingAdjustment=adjustment,
+    )
+
+    client.execute_policy(PolicyName="ScaleUp")
+
+    instances = client.describe_auto_scaling_instances()
+    instances["AutoScalingInstances"].should.have.length_of(nr_of_instances)
+
+
+# Has boto3 equivalent
 @mock_autoscaling_deprecated
 def test_execute_policy_small_percent_change_in_capacity():
     """http://docs.aws.amazon.com/AutoScaling/latest/DeveloperGuide/as-scale-based-on-demand.html


### PR DESCRIPTION
See #3842 - adds equivalent boto3 tests for Autoscaling, so that the deprecated tests can be removed without losing any test coverage

