### PR TITLE
Add different versions of idna depending on the python version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -79,7 +79,8 @@ _dep_python_jose_ecdsa_pin = (
 _dep_docker = "docker>=2.5.1"
 _dep_jsondiff = "jsondiff>=1.1.2"
 _dep_aws_xray_sdk = "aws-xray-sdk!=0.96,>=0.93"
-_dep_idna = "idna<3,>=2.5"
+_dep_idna_py2 = "idna<3,>=2.5; python_version<'3'"
+_dep_idna_py3 = "idna>=3; python_version>'3'"
 _dep_cfn_lint = "cfn-lint>=0.4.0"
 _dep_decorator = "decorator<=4.4.2; python_version<'3'"  # Transitive dependency - last version that supports py2.7
 _dep_sshpubkeys_py2 = "sshpubkeys==3.1.0; python_version<'3'"
@@ -92,7 +93,8 @@ all_extra_deps = [
     _dep_docker,
     _dep_jsondiff,
     _dep_aws_xray_sdk,
-    _dep_idna,
+    _dep_idna_py2,
+    _dep_idna_py3,
     _dep_cfn_lint,
     _dep_decorator,
     _dep_sshpubkeys_py2,


### PR DESCRIPTION
idna has dropped support for Python 2 in version 3.0 ([link](https://github.com/kjd/idna/blob/master/HISTORY.rst#30-2021-01-01)).

I am running the tests on Ubuntu 20.04, Python 3.7. I got these errors when running them locally:

([gist with full log of errors](https://gist.github.com/edisongustavo/30c7f7dfaadfb2a36bdd0f3d9597d420))

```
FAILED tests/test_apigateway/test_apigateway.py::test_http_proxying_integration - AttributeError: 'HTTPHeaderDict' object has no attribute 'get_all'
FAILED tests/test_awslambda/test_lambda.py::test_invoke_requestresponse_function[None] - AssertionError: error running docker: 500 Server Error for http+docker://localhost/v1.41/images/create?tag=latest&fromImage=docker.io%2Flibrary%2Falpine: Internal Server Error ("toomanyrequests: You have reached your pull rate limit. You may increase...
FAILED tests/test_awslambda/test_lambda.py::test_invoke_requestresponse_function[RequestResponse] - AssertionError: error running docker: 500 Server Error for http+docker://localhost/v1.41/images/create?tag=latest&fromImage=docker.io%2Flibrary%2Falpine: Internal Server Error ("toomanyrequests: You have reached your pull rate limit. You m...
FAILED tests/test_awslambda/test_lambda.py::test_invoke_requestresponse_function_with_arn - json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
FAILED tests/test_awslambda/test_lambda.py::test_invoke_event_function - json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
FAILED tests/test_awslambda/test_lambda.py::test_invoke_function_from_sns - AssertionError: Test Failed
FAILED tests/test_awslambda/test_lambda.py::test_invoke_function_from_sqs - TypeError: can only concatenate str (not "list") to str
FAILED tests/test_awslambda/test_lambda.py::test_invoke_function_from_dynamodb_put - TypeError: can only concatenate str (not "list") to str
FAILED tests/test_awslambda/test_lambda.py::test_invoke_function_from_dynamodb_update - AssertionError: Only one item should be inserted
FAILED tests/test_awslambda/test_lambda.py::test_invoke_function_from_sqs_exception - AssertionError: Test Failed
FAILED tests/test_batch/test_batch.py::test_submit_job - RuntimeError: Time out waiting for job status SUCCEEDED!
FAILED tests/test_batch/test_batch.py::test_list_jobs - RuntimeError: Time out waiting for job status SUCCEEDED!
FAILED tests/test_batch/test_batch.py::test_terminate_job - RuntimeError: Time out waiting for job status RUNNING!
FAILED tests/test_logs/test_integration.py::test_put_subscription_filter_with_lambda - AssertionError: CloudWatch log event was not found. All logs: []
FAILED tests/test_s3/test_server.py::test_s3_server_post_without_content_length - AssertionError: given
FAILED tests/test_sns/test_publishing_boto3.py::test_publish_to_http - AttributeError: 'HTTPHeaderDict' object has no attribute 'get_all'
FAILED tests/test_sqs/test_sqs.py::test_invoke_function_from_sqs_exception - AssertionError: Test Failed
```

I don't think any of these errors is related to the function. I can investigate the errors more in depth if you feel any of them is important.