### PR TITLE
Fix separator in filter_log_events nextToken value.

### DIFF
--- a/moto/logs/models.py
+++ b/moto/logs/models.py
@@ -389,7 +389,7 @@ class LogGroup(BaseModel):
         first_index = 0
         if next_token:
             try:
-                group, stream, event_id = next_token.split("/")
+                group, stream, event_id = next_token.split("@")
                 if group != log_group_name:
                     raise ValueError()
                 first_index = (
@@ -412,7 +412,7 @@ class LogGroup(BaseModel):
         next_token = None
         if events_page and last_index < len(events):
             last_event = events_page[-1]
-            next_token = "{}/{}/{}".format(
+            next_token = "{}@{}@{}".format(
                 log_group_name, last_event["logStreamName"], last_event["eventId"]
             )
 

--- a/tests/test_logs/test_logs.py
+++ b/tests/test_logs/test_logs.py
@@ -129,8 +129,8 @@ def test_filter_logs_raises_if_filter_pattern():
 @mock_logs
 def test_filter_logs_paging():
     conn = boto3.client("logs", "us-west-2")
-    log_group_name = "dummy"
-    log_stream_name = "stream"
+    log_group_name = "/aws/dummy"
+    log_stream_name = "stream/stage"
     conn.create_log_group(logGroupName=log_group_name)
     conn.create_log_stream(logGroupName=log_group_name, logStreamName=log_stream_name)
     timestamp = int(time.time())
@@ -149,7 +149,7 @@ def test_filter_logs_paging():
     )
     events = res["events"]
     events.should.have.length_of(20)
-    res["nextToken"].should.equal("dummy/stream/" + events[-1]["eventId"])
+    res["nextToken"].should.equal("/aws/dummy@stream/stage@" + events[-1]["eventId"])
 
     res = conn.filter_log_events(
         logGroupName=log_group_name,
@@ -179,7 +179,7 @@ def test_filter_logs_paging():
         logGroupName=log_group_name,
         logStreamNames=[log_stream_name],
         limit=20,
-        nextToken="wrong-group/stream/999",
+        nextToken="wrong-group@stream@999",
     )
     res["events"].should.have.length_of(0)
     res.should_not.have.key("nextToken")


### PR DESCRIPTION
The old separator could be present in some of the values being concatenated.