### PR TITLE
KMS - rewrite deprecated boto tests

### DIFF
--- a/moto/kms/responses.py
+++ b/moto/kms/responses.py
@@ -5,6 +5,7 @@ import json
 import os
 import re
 
+from moto.core import ACCOUNT_ID
 from moto.core.responses import BaseResponse
 from .models import kms_backends
 from .exceptions import (
@@ -14,7 +15,6 @@ from .exceptions import (
     NotAuthorizedException,
 )
 
-ACCOUNT_ID = "012345678912"
 reserved_aliases = [
     "alias/aws/ebs",
     "alias/aws/s3",
@@ -227,8 +227,10 @@ class KmsResponse(BaseResponse):
 
         if self.kms_backend.alias_exists(alias_name):
             raise AlreadyExistsException(
-                "An alias with the name arn:aws:kms:{region}:012345678912:{alias_name} "
-                "already exists".format(region=self.region, alias_name=alias_name)
+                "An alias with the name arn:aws:kms:{region}:{account_id}:{alias_name} "
+                "already exists".format(
+                    region=self.region, account_id=ACCOUNT_ID, alias_name=alias_name
+                )
             )
 
         self._validate_cmk_id(target_key_id)
@@ -258,8 +260,8 @@ class KmsResponse(BaseResponse):
 
         response_aliases = [
             {
-                "AliasArn": "arn:aws:kms:{region}:012345678912:{reserved_alias}".format(
-                    region=region, reserved_alias=reserved_alias
+                "AliasArn": "arn:aws:kms:{region}:{account_id}:{reserved_alias}".format(
+                    region=region, account_id=ACCOUNT_ID, reserved_alias=reserved_alias
                 ),
                 "AliasName": reserved_alias,
             }
@@ -271,8 +273,8 @@ class KmsResponse(BaseResponse):
             for alias_name in aliases:
                 response_aliases.append(
                     {
-                        "AliasArn": "arn:aws:kms:{region}:012345678912:{alias_name}".format(
-                            region=region, alias_name=alias_name
+                        "AliasArn": "arn:aws:kms:{region}:{account_id}:{alias_name}".format(
+                            region=region, account_id=ACCOUNT_ID, alias_name=alias_name
                         ),
                         "AliasName": alias_name,
                         "TargetKeyId": target_key_id,

--- a/tests/test_kms/test_kms.py
+++ b/tests/test_kms/test_kms.py
@@ -28,6 +28,7 @@ def _get_encoded_value(plaintext):
     return plaintext.encode("utf-8")
 
 
+# Has boto3 equivalent
 @mock_kms_deprecated
 def test_describe_key():
     conn = boto.kms.connect_to_region("us-west-2")
@@ -41,6 +42,7 @@ def test_describe_key():
     key["KeyMetadata"]["KeyUsage"].should.equal("ENCRYPT_DECRYPT")
 
 
+# Has boto3 equivalent
 @mock_kms_deprecated
 def test_describe_key_via_alias():
     conn = boto.kms.connect_to_region("us-west-2")
@@ -57,6 +59,7 @@ def test_describe_key_via_alias():
     alias_key["KeyMetadata"]["Arn"].should.equal(key["KeyMetadata"]["Arn"])
 
 
+# Has boto3 equivalent
 @mock_kms_deprecated
 def test_describe_key_via_alias_not_found():
     conn = boto.kms.connect_to_region("us-west-2")
@@ -72,6 +75,7 @@ def test_describe_key_via_alias_not_found():
     )
 
 
+# Has boto3 equivalent
 @mock_kms_deprecated
 def test_describe_key_via_arn():
     conn = boto.kms.connect_to_region("us-west-2")
@@ -86,12 +90,14 @@ def test_describe_key_via_arn():
     the_key["KeyMetadata"]["KeyId"].should.equal(key["KeyMetadata"]["KeyId"])
 
 
+# Has boto3 equivalent
 @mock_kms_deprecated
 def test_describe_missing_key():
     conn = boto.kms.connect_to_region("us-west-2")
     conn.describe_key.when.called_with("not-a-key").should.throw(NotFoundException)
 
 
+# Has boto3 equivalent
 @mock_kms_deprecated
 def test_list_keys():
     conn = boto.kms.connect_to_region("us-west-2")
@@ -107,6 +113,7 @@ def test_list_keys():
     keys["Keys"].should.have.length_of(2)
 
 
+# Has boto3 equivalent
 @mock_kms_deprecated
 def test_enable_key_rotation():
     conn = boto.kms.connect_to_region("us-west-2")
@@ -121,6 +128,7 @@ def test_enable_key_rotation():
     conn.get_key_rotation_status(key_id)["KeyRotationEnabled"].should.equal(True)
 
 
+# Has boto3 equivalent
 @mock_kms_deprecated
 def test_enable_key_rotation_via_arn():
     conn = boto.kms.connect_to_region("us-west-2")
@@ -135,6 +143,7 @@ def test_enable_key_rotation_via_arn():
     conn.get_key_rotation_status(key_id)["KeyRotationEnabled"].should.equal(True)
 
 
+# Has boto3 equivalent
 @mock_kms_deprecated
 def test_enable_key_rotation_with_missing_key():
     conn = boto.kms.connect_to_region("us-west-2")
@@ -143,6 +152,7 @@ def test_enable_key_rotation_with_missing_key():
     )
 
 
+# Has boto3 equivalent
 @mock_kms_deprecated
 def test_enable_key_rotation_with_alias_name_should_fail():
     conn = boto.kms.connect_to_region("us-west-2")
@@ -161,6 +171,7 @@ def test_enable_key_rotation_with_alias_name_should_fail():
     )
 
 
+# Has boto3 equivalent
 @mock_kms_deprecated
 def test_disable_key_rotation():
     conn = boto.kms.connect_to_region("us-west-2")
@@ -177,6 +188,7 @@ def test_disable_key_rotation():
     conn.get_key_rotation_status(key_id)["KeyRotationEnabled"].should.equal(False)
 
 
+# Has boto3 equivalent
 @mock_kms_deprecated
 def test_generate_data_key():
     conn = boto.kms.connect_to_region("us-west-2")
@@ -199,6 +211,7 @@ def test_generate_data_key():
     response["KeyId"].should.equal(key_arn)
 
 
+# Has boto3 equivalent
 @mock_kms_deprecated
 def test_disable_key_rotation_with_missing_key():
     conn = boto.kms.connect_to_region("us-west-2")
@@ -207,6 +220,7 @@ def test_disable_key_rotation_with_missing_key():
     )
 
 
+# Has boto3 equivalent
 @mock_kms_deprecated
 def test_get_key_rotation_status_with_missing_key():
     conn = boto.kms.connect_to_region("us-west-2")
@@ -215,6 +229,7 @@ def test_get_key_rotation_status_with_missing_key():
     )
 
 
+# Has boto3 equivalent
 @mock_kms_deprecated
 def test_get_key_rotation_status():
     conn = boto.kms.connect_to_region("us-west-2")
@@ -227,6 +242,7 @@ def test_get_key_rotation_status():
     conn.get_key_rotation_status(key_id)["KeyRotationEnabled"].should.equal(False)
 
 
+# Has boto3 equivalent
 @mock_kms_deprecated
 def test_create_key_defaults_key_rotation():
     conn = boto.kms.connect_to_region("us-west-2")
@@ -239,6 +255,7 @@ def test_create_key_defaults_key_rotation():
     conn.get_key_rotation_status(key_id)["KeyRotationEnabled"].should.equal(False)
 
 
+# Has boto3 equivalent
 @mock_kms_deprecated
 def test_get_key_policy():
     conn = boto.kms.connect_to_region("us-west-2")
@@ -252,6 +269,7 @@ def test_get_key_policy():
     policy["Policy"].should.equal("my policy")
 
 
+# Has boto3 equivalent
 @mock_kms_deprecated
 def test_get_key_policy_via_arn():
     conn = boto.kms.connect_to_region("us-west-2")
@@ -264,6 +282,7 @@ def test_get_key_policy_via_arn():
     policy["Policy"].should.equal("my policy")
 
 
+# Has boto3 equivalent
 @mock_kms_deprecated
 def test_put_key_policy():
     conn = boto.kms.connect_to_region("us-west-2")
@@ -278,6 +297,7 @@ def test_put_key_policy():
     policy["Policy"].should.equal("new policy")
 
 
+# Has boto3 equivalent
 @mock_kms_deprecated
 def test_put_key_policy_via_arn():
     conn = boto.kms.connect_to_region("us-west-2")
@@ -292,6 +312,7 @@ def test_put_key_policy_via_arn():
     policy["Policy"].should.equal("new policy")
 
 
+# Has boto3 equivalent
 @mock_kms_deprecated
 def test_put_key_policy_via_alias_should_not_update():
     conn = boto.kms.connect_to_region("us-west-2")
@@ -311,6 +332,7 @@ def test_put_key_policy_via_alias_should_not_update():
     policy["Policy"].should.equal("my policy")
 
 
+# Has boto3 equivalent
 @mock_kms_deprecated
 def test_list_key_policies():
     conn = boto.kms.connect_to_region("us-west-2")
@@ -324,6 +346,7 @@ def test_list_key_policies():
     policies["PolicyNames"].should.equal(["default"])
 
 
+# Has boto3 equivalent
 @mock_kms_deprecated
 def test__create_alias__returns_none_if_correct():
     kms = boto.connect_kms()
@@ -335,6 +358,7 @@ def test__create_alias__returns_none_if_correct():
     resp.should.be.none
 
 
+# Has boto3 equivalent
 @mock_kms_deprecated
 def test__create_alias__raises_if_reserved_alias():
     kms = boto.connect_kms()
@@ -360,6 +384,7 @@ def test__create_alias__raises_if_reserved_alias():
         ex.status.should.equal(400)
 
 
+# Has boto3 equivalent
 @mock_kms_deprecated
 def test__create_alias__can_create_multiple_aliases_for_same_key_id():
     kms = boto.connect_kms()
@@ -371,6 +396,7 @@ def test__create_alias__can_create_multiple_aliases_for_same_key_id():
     kms.create_alias("alias/my-alias5", key_id).should.be.none
 
 
+# Has boto3 equivalent
 @mock_kms_deprecated
 def test__create_alias__raises_if_wrong_prefix():
     kms = boto.connect_kms()
@@ -390,6 +416,7 @@ def test__create_alias__raises_if_wrong_prefix():
     ex.status.should.equal(400)
 
 
+# Has boto3 equivalent
 @mock_kms_deprecated
 def test__create_alias__raises_if_duplicate():
     region = "us-west-2"
@@ -422,6 +449,7 @@ def test__create_alias__raises_if_duplicate():
     ex.status.should.equal(400)
 
 
+# Has boto3 equivalent
 @mock_kms_deprecated
 def test__create_alias__raises_if_alias_has_restricted_characters():
     kms = boto.connect_kms()
@@ -454,6 +482,7 @@ def test__create_alias__raises_if_alias_has_restricted_characters():
         ex.status.should.equal(400)
 
 
+# Has boto3 equivalent
 @mock_kms_deprecated
 def test__create_alias__raises_if_alias_has_colon_character():
     # For some reason, colons are not accepted for an alias, even though they
@@ -480,6 +509,7 @@ def test__create_alias__raises_if_alias_has_colon_character():
         ex.status.should.equal(400)
 
 
+# Has boto3 equivalent
 @pytest.mark.parametrize("alias_name", ["alias/my-alias_/", "alias/my_alias-/"])
 @mock_kms_deprecated
 def test__create_alias__accepted_characters(alias_name):
@@ -490,6 +520,7 @@ def test__create_alias__accepted_characters(alias_name):
     kms.create_alias(alias_name, key_id)
 
 
+# Has boto3 equivalent
 @mock_kms_deprecated
 def test__create_alias__raises_if_target_key_id_is_existing_alias():
     kms = boto.connect_kms()
@@ -511,6 +542,7 @@ def test__create_alias__raises_if_target_key_id_is_existing_alias():
     ex.status.should.equal(400)
 
 
+# Has boto3 equivalent
 @mock_kms_deprecated
 def test__delete_alias():
     kms = boto.connect_kms()
@@ -535,6 +567,7 @@ def test__delete_alias():
     kms.create_alias(alias, key_id)
 
 
+# Has boto3 equivalent
 @mock_kms_deprecated
 def test__delete_alias__raises_if_wrong_prefix():
     kms = boto.connect_kms()
@@ -551,6 +584,7 @@ def test__delete_alias__raises_if_wrong_prefix():
     ex.status.should.equal(400)
 
 
+# Has boto3 equivalent
 @mock_kms_deprecated
 def test__delete_alias__raises_if_alias_is_not_found():
     region = "us-west-2"
@@ -574,6 +608,7 @@ def test__delete_alias__raises_if_alias_is_not_found():
     ex.status.should.equal(400)
 
 
+# Has boto3 equivalent
 @mock_kms_deprecated
 def test__list_aliases():
     region = "eu-west-1"
@@ -735,6 +770,7 @@ def test_key_tag_added_arn_based_happy():
     _check_tags(key_id, tags, client)
 
 
+# Has boto3 equivalent
 @mock_kms_deprecated
 def test_key_tagging_sad():
     b = KmsBackend()


### PR DESCRIPTION
See #3842 - adds equivalent boto3 tests for KMS, so that the deprecated tests can be removed without losing any test coverage