### PR TITLE
Make Moto (tests) compatible with flask/werkzeug 2.x

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ${{ steps.pip-cache-dir.outputs.dir }}
-          key: pip-${{ matrix.python-version }}-${{ hashFiles('**/setup.py') }}-2
+          key: pip-${{ matrix.python-version }}-${{ hashFiles('**/setup.py') }}-3
       - name: Update pip
         if: ${{ steps.pip-cache.outputs.cache-hit != 'true' && matrix.python-version != '2.7' }}
         run: |
@@ -58,7 +58,7 @@ jobs:
       uses: actions/cache@v2
       with:
         path: ${{ steps.pip-cache.outputs.dir }}
-        key: pip-${{ matrix.python-version }}-${{ hashFiles('**/setup.py') }}-2
+        key: pip-${{ matrix.python-version }}-${{ hashFiles('**/setup.py') }}-3
     # Update PIP - recent version does not support PY2 though
     - name: Update pip
       if: ${{ matrix.python-version != '2.7' }}
@@ -97,7 +97,7 @@ jobs:
       uses: actions/cache@v2
       with:
         path: ${{ steps.pip-cache.outputs.dir }}
-        key: pip-${{ matrix.python-version }}-${{ hashFiles('**/setup.py') }}-2
+        key: pip-${{ matrix.python-version }}-${{ hashFiles('**/setup.py') }}-3
     - name: Update pip
       if: ${{ matrix.python-version != '2.7' }}
       run: |
@@ -145,7 +145,7 @@ jobs:
       uses: actions/cache@v2
       with:
         path: ${{ steps.pip-cache.outputs.dir }}
-        key: pip-${{ matrix.python-version }}-${{ hashFiles('**/setup.py') }}-2
+        key: pip-${{ matrix.python-version }}-${{ hashFiles('**/setup.py') }}-3
     - name: Update pip
       if: ${{ matrix.python-version != '2.7' }}
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -113,7 +113,7 @@ jobs:
       if: ${{ github.repository == 'spulec/moto'}}
       uses: codecov/codecov-action@v1
       with:
-        fail_ci_if_error: true
+        fail_ci_if_error: false
         flags: unittests
 
   testserver:
@@ -162,7 +162,7 @@ jobs:
       if: ${{ github.repository == 'spulec/moto'}}
       uses: codecov/codecov-action@v1
       with:
-        fail_ci_if_error: true
+        fail_ci_if_error: false
         flags: servertests
 
   deploy:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ${{ steps.pip-cache-dir.outputs.dir }}
-          key: pip-${{ matrix.python-version }}-${{ hashFiles('**/setup.py') }}-3
+          key: pip-${{ matrix.python-version }}-${{ hashFiles('**/setup.py') }}-4
       - name: Update pip
         if: ${{ steps.pip-cache.outputs.cache-hit != 'true' && matrix.python-version != '2.7' }}
         run: |
@@ -58,7 +58,7 @@ jobs:
       uses: actions/cache@v2
       with:
         path: ${{ steps.pip-cache.outputs.dir }}
-        key: pip-${{ matrix.python-version }}-${{ hashFiles('**/setup.py') }}-3
+        key: pip-${{ matrix.python-version }}-${{ hashFiles('**/setup.py') }}-4
     # Update PIP - recent version does not support PY2 though
     - name: Update pip
       if: ${{ matrix.python-version != '2.7' }}
@@ -97,7 +97,7 @@ jobs:
       uses: actions/cache@v2
       with:
         path: ${{ steps.pip-cache.outputs.dir }}
-        key: pip-${{ matrix.python-version }}-${{ hashFiles('**/setup.py') }}-3
+        key: pip-${{ matrix.python-version }}-${{ hashFiles('**/setup.py') }}-4
     - name: Update pip
       if: ${{ matrix.python-version != '2.7' }}
       run: |
@@ -145,7 +145,7 @@ jobs:
       uses: actions/cache@v2
       with:
         path: ${{ steps.pip-cache.outputs.dir }}
-        key: pip-${{ matrix.python-version }}-${{ hashFiles('**/setup.py') }}-3
+        key: pip-${{ matrix.python-version }}-${{ hashFiles('**/setup.py') }}-4
     - name: Update pip
       if: ${{ matrix.python-version != '2.7' }}
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ${{ steps.pip-cache-dir.outputs.dir }}
-          key: pip-${{ matrix.python-version }}-${{ hashFiles('**/setup.py') }}
+          key: pip-${{ matrix.python-version }}-${{ hashFiles('**/setup.py') }}-2
       - name: Update pip
         if: ${{ steps.pip-cache.outputs.cache-hit != 'true' && matrix.python-version != '2.7' }}
         run: |
@@ -58,7 +58,7 @@ jobs:
       uses: actions/cache@v2
       with:
         path: ${{ steps.pip-cache.outputs.dir }}
-        key: pip-${{ matrix.python-version }}-${{ hashFiles('**/setup.py') }}
+        key: pip-${{ matrix.python-version }}-${{ hashFiles('**/setup.py') }}-2
     # Update PIP - recent version does not support PY2 though
     - name: Update pip
       if: ${{ matrix.python-version != '2.7' }}
@@ -97,7 +97,7 @@ jobs:
       uses: actions/cache@v2
       with:
         path: ${{ steps.pip-cache.outputs.dir }}
-        key: pip-${{ matrix.python-version }}-${{ hashFiles('**/setup.py') }}
+        key: pip-${{ matrix.python-version }}-${{ hashFiles('**/setup.py') }}-2
     - name: Update pip
       if: ${{ matrix.python-version != '2.7' }}
       run: |
@@ -145,7 +145,7 @@ jobs:
       uses: actions/cache@v2
       with:
         path: ${{ steps.pip-cache.outputs.dir }}
-        key: pip-${{ matrix.python-version }}-${{ hashFiles('**/setup.py') }}
+        key: pip-${{ matrix.python-version }}-${{ hashFiles('**/setup.py') }}-2
     - name: Update pip
       if: ${{ matrix.python-version != '2.7' }}
       run: |

--- a/moto/managedblockchain/responses.py
+++ b/moto/managedblockchain/responses.py
@@ -4,7 +4,7 @@ import json
 from six.moves.urllib.parse import urlparse, parse_qs
 
 from moto.core.responses import BaseResponse
-from .exceptions import ManagedBlockchainClientError
+from .exceptions import exception_handler
 from .models import managedblockchain_backends
 from .utils import (
     region_from_managedblckchain_url,
@@ -22,6 +22,7 @@ class ManagedBlockchainResponse(BaseResponse):
         self.backend = backend
 
     @classmethod
+    @exception_handler
     def network_response(clazz, request, full_url, headers):
         region_name = region_from_managedblckchain_url(full_url)
         response_instance = ManagedBlockchainResponse(
@@ -74,6 +75,7 @@ class ManagedBlockchainResponse(BaseResponse):
         return 200, headers, json.dumps(response)
 
     @classmethod
+    @exception_handler
     def networkid_response(clazz, request, full_url, headers):
         region_name = region_from_managedblckchain_url(full_url)
         response_instance = ManagedBlockchainResponse(
@@ -95,6 +97,7 @@ class ManagedBlockchainResponse(BaseResponse):
         return 200, headers, response
 
     @classmethod
+    @exception_handler
     def proposal_response(clazz, request, full_url, headers):
         region_name = region_from_managedblckchain_url(full_url)
         response_instance = ManagedBlockchainResponse(
@@ -140,6 +143,7 @@ class ManagedBlockchainResponse(BaseResponse):
         return 200, headers, json.dumps(response)
 
     @classmethod
+    @exception_handler
     def proposalid_response(clazz, request, full_url, headers):
         region_name = region_from_managedblckchain_url(full_url)
         response_instance = ManagedBlockchainResponse(
@@ -161,6 +165,7 @@ class ManagedBlockchainResponse(BaseResponse):
         return 200, headers, response
 
     @classmethod
+    @exception_handler
     def proposal_votes_response(clazz, request, full_url, headers):
         region_name = region_from_managedblckchain_url(full_url)
         response_instance = ManagedBlockchainResponse(
@@ -204,6 +209,7 @@ class ManagedBlockchainResponse(BaseResponse):
         return 200, headers, ""
 
     @classmethod
+    @exception_handler
     def invitation_response(clazz, request, full_url, headers):
         region_name = region_from_managedblckchain_url(full_url)
         response_instance = ManagedBlockchainResponse(
@@ -225,6 +231,7 @@ class ManagedBlockchainResponse(BaseResponse):
         return 200, headers, response
 
     @classmethod
+    @exception_handler
     def invitationid_response(clazz, request, full_url, headers):
         region_name = region_from_managedblckchain_url(full_url)
         response_instance = ManagedBlockchainResponse(
@@ -244,6 +251,7 @@ class ManagedBlockchainResponse(BaseResponse):
         return 200, headers, ""
 
     @classmethod
+    @exception_handler
     def member_response(clazz, request, full_url, headers):
         region_name = region_from_managedblckchain_url(full_url)
         response_instance = ManagedBlockchainResponse(
@@ -284,6 +292,7 @@ class ManagedBlockchainResponse(BaseResponse):
         return 200, headers, json.dumps(response)
 
     @classmethod
+    @exception_handler
     def memberid_response(clazz, request, full_url, headers):
         region_name = region_from_managedblckchain_url(full_url)
         response_instance = ManagedBlockchainResponse(
@@ -328,6 +337,7 @@ class ManagedBlockchainResponse(BaseResponse):
         return 200, headers, ""
 
     @classmethod
+    @exception_handler
     def node_response(clazz, request, full_url, headers):
         region_name = region_from_managedblckchain_url(full_url)
         response_instance = ManagedBlockchainResponse(
@@ -371,19 +381,17 @@ class ManagedBlockchainResponse(BaseResponse):
             "LogPublishingConfiguration"
         ]
 
-        try:
-            response = self.backend.create_node(
-                network_id,
-                member_id,
-                availabilityzone,
-                instancetype,
-                logpublishingconfiguration,
-            )
-            return 200, headers, json.dumps(response)
-        except ManagedBlockchainClientError as err:
-            return err.code, err.get_headers(), err.description
+        response = self.backend.create_node(
+            network_id,
+            member_id,
+            availabilityzone,
+            instancetype,
+            logpublishingconfiguration,
+        )
+        return 200, headers, json.dumps(response)
 
     @classmethod
+    @exception_handler
     def nodeid_response(clazz, request, full_url, headers):
         region_name = region_from_managedblckchain_url(full_url)
         response_instance = ManagedBlockchainResponse(

--- a/moto/managedblockchain/responses.py
+++ b/moto/managedblockchain/responses.py
@@ -4,6 +4,7 @@ import json
 from six.moves.urllib.parse import urlparse, parse_qs
 
 from moto.core.responses import BaseResponse
+from .exceptions import ManagedBlockchainClientError
 from .models import managedblockchain_backends
 from .utils import (
     region_from_managedblckchain_url,
@@ -370,14 +371,17 @@ class ManagedBlockchainResponse(BaseResponse):
             "LogPublishingConfiguration"
         ]
 
-        response = self.backend.create_node(
-            network_id,
-            member_id,
-            availabilityzone,
-            instancetype,
-            logpublishingconfiguration,
-        )
-        return 200, headers, json.dumps(response)
+        try:
+            response = self.backend.create_node(
+                network_id,
+                member_id,
+                availabilityzone,
+                instancetype,
+                logpublishingconfiguration,
+            )
+            return 200, headers, json.dumps(response)
+        except ManagedBlockchainClientError as err:
+            return err.code, err.get_headers(), err.description
 
     @classmethod
     def nodeid_response(clazz, request, full_url, headers):

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,7 +7,7 @@ coverage==4.5.4
 flake8==3.7.8
 boto>=2.45.0
 prompt-toolkit==2.0.10 # 3.x is not available with python2
-click==6.7
+click
 inflection==0.3.1
 lxml
 packaging

--- a/setup.py
+++ b/setup.py
@@ -98,7 +98,7 @@ all_extra_deps = [
     _dep_sshpubkeys_py2,
     _dep_sshpubkeys_py3,
 ]
-all_server_deps = all_extra_deps + ["flask<2.0.0", "flask-cors"]
+all_server_deps = all_extra_deps + ["flask", "flask-cors"]
 
 # TODO: do we want to add ALL services here?
 # i.e. even those without extra dependencies.

--- a/setup.py
+++ b/setup.py
@@ -36,8 +36,7 @@ install_requires = [
     "requests>=2.5",
     "xmltodict",
     "six>1.9",
-    # TODO: werkzeug 2.x currently breaks test_s3_server_post_without_content_length
-    "werkzeug<2.0.0",
+    "werkzeug",
     "pytz",
     "python-dateutil<3.0.0,>=2.1",
     "responses>=0.9.0",

--- a/tests/test_managedblockchain/test_managedblockchain_invitations.py
+++ b/tests/test_managedblockchain/test_managedblockchain_invitations.py
@@ -1,8 +1,10 @@
 from __future__ import unicode_literals
 
 import boto3
+import pytest
 import sure  # noqa
 
+from botocore.exceptions import ClientError
 from moto import mock_managedblockchain
 from . import helpers
 
@@ -136,6 +138,10 @@ def test_reject_invitation_badinvitation():
         Vote="YES",
     )
 
-    response = conn.reject_invitation.when.called_with(
-        InvitationId="in-ABCDEFGHIJKLMNOP0123456789",
-    ).should.throw(Exception, "InvitationId in-ABCDEFGHIJKLMNOP0123456789 not found.")
+    with pytest.raises(ClientError) as ex:
+        conn.reject_invitation(InvitationId="in-ABCDEFGHIJKLMNOP0123456789")
+    err = ex.value.response["Error"]
+    err["Code"].should.equal("ResourceNotFoundException")
+    err["Message"].should.contain(
+        "InvitationId in-ABCDEFGHIJKLMNOP0123456789 not found."
+    )

--- a/tests/test_managedblockchain/test_managedblockchain_proposals.py
+++ b/tests/test_managedblockchain/test_managedblockchain_proposals.py
@@ -1,8 +1,10 @@
 from __future__ import unicode_literals
 
 import boto3
+import pytest
 import sure  # noqa
 
+from botocore.exceptions import ClientError
 from moto import mock_managedblockchain
 from . import helpers
 
@@ -82,11 +84,15 @@ def test_create_proposal_withopts():
 def test_create_proposal_badnetwork():
     conn = boto3.client("managedblockchain", region_name="us-east-1")
 
-    response = conn.create_proposal.when.called_with(
-        NetworkId="n-ABCDEFGHIJKLMNOP0123456789",
-        MemberId="m-ABCDEFGHIJKLMNOP0123456789",
-        Actions=helpers.default_policy_actions,
-    ).should.throw(Exception, "Network n-ABCDEFGHIJKLMNOP0123456789 not found")
+    with pytest.raises(ClientError) as ex:
+        conn.create_proposal(
+            NetworkId="n-ABCDEFGHIJKLMNOP0123456789",
+            MemberId="m-ABCDEFGHIJKLMNOP0123456789",
+            Actions=helpers.default_policy_actions,
+        )
+    err = ex.value.response["Error"]
+    err["Code"].should.equal("ResourceNotFoundException")
+    err["Message"].should.contain("Network n-ABCDEFGHIJKLMNOP0123456789 not found")
 
 
 @mock_managedblockchain
@@ -104,11 +110,15 @@ def test_create_proposal_badmember():
     )
     network_id = response["NetworkId"]
 
-    response = conn.create_proposal.when.called_with(
-        NetworkId=network_id,
-        MemberId="m-ABCDEFGHIJKLMNOP0123456789",
-        Actions=helpers.default_policy_actions,
-    ).should.throw(Exception, "Member m-ABCDEFGHIJKLMNOP0123456789 not found")
+    with pytest.raises(ClientError) as ex:
+        conn.create_proposal(
+            NetworkId=network_id,
+            MemberId="m-ABCDEFGHIJKLMNOP0123456789",
+            Actions=helpers.default_policy_actions,
+        )
+    err = ex.value.response["Error"]
+    err["Code"].should.equal("ResourceNotFoundException")
+    err["Message"].should.contain("Member m-ABCDEFGHIJKLMNOP0123456789 not found")
 
 
 @mock_managedblockchain
@@ -130,9 +140,15 @@ def test_create_proposal_badinvitationacctid():
     network_id = response["NetworkId"]
     member_id = response["MemberId"]
 
-    response = conn.create_proposal.when.called_with(
-        NetworkId=network_id, MemberId=member_id, Actions=actions,
-    ).should.throw(Exception, "Account ID format specified in proposal is not valid")
+    with pytest.raises(ClientError) as ex:
+        conn.create_proposal(
+            NetworkId=network_id, MemberId=member_id, Actions=actions,
+        )
+    err = ex.value.response["Error"]
+    err["Code"].should.equal("InvalidRequestException")
+    err["Message"].should.contain(
+        "Account ID format specified in proposal is not valid"
+    )
 
 
 @mock_managedblockchain
@@ -154,28 +170,38 @@ def test_create_proposal_badremovalmemid():
     network_id = response["NetworkId"]
     member_id = response["MemberId"]
 
-    response = conn.create_proposal.when.called_with(
-        NetworkId=network_id, MemberId=member_id, Actions=actions,
-    ).should.throw(Exception, "Member ID format specified in proposal is not valid")
+    with pytest.raises(ClientError) as ex:
+        conn.create_proposal(
+            NetworkId=network_id, MemberId=member_id, Actions=actions,
+        )
+    err = ex.value.response["Error"]
+    err["Code"].should.equal("InvalidRequestException")
+    err["Message"].should.contain("Member ID format specified in proposal is not valid")
 
 
 @mock_managedblockchain
 def test_list_proposal_badnetwork():
     conn = boto3.client("managedblockchain", region_name="us-east-1")
 
-    response = conn.list_proposals.when.called_with(
-        NetworkId="n-ABCDEFGHIJKLMNOP0123456789",
-    ).should.throw(Exception, "Network n-ABCDEFGHIJKLMNOP0123456789 not found")
+    with pytest.raises(ClientError) as ex:
+        conn.list_proposals(NetworkId="n-ABCDEFGHIJKLMNOP0123456789",)
+    err = ex.value.response["Error"]
+    err["Code"].should.equal("ResourceNotFoundException")
+    err["Message"].should.contain("Network n-ABCDEFGHIJKLMNOP0123456789 not found")
 
 
 @mock_managedblockchain
 def test_get_proposal_badnetwork():
     conn = boto3.client("managedblockchain", region_name="us-east-1")
 
-    response = conn.get_proposal.when.called_with(
-        NetworkId="n-ABCDEFGHIJKLMNOP0123456789",
-        ProposalId="p-ABCDEFGHIJKLMNOP0123456789",
-    ).should.throw(Exception, "Network n-ABCDEFGHIJKLMNOP0123456789 not found")
+    with pytest.raises(ClientError) as ex:
+        conn.get_proposal(
+            NetworkId="n-ABCDEFGHIJKLMNOP0123456789",
+            ProposalId="p-ABCDEFGHIJKLMNOP0123456789",
+        )
+    err = ex.value.response["Error"]
+    err["Code"].should.equal("ResourceNotFoundException")
+    err["Message"].should.contain("Network n-ABCDEFGHIJKLMNOP0123456789 not found")
 
 
 @mock_managedblockchain
@@ -193,6 +219,10 @@ def test_get_proposal_badproposal():
     )
     network_id = response["NetworkId"]
 
-    response = conn.get_proposal.when.called_with(
-        NetworkId=network_id, ProposalId="p-ABCDEFGHIJKLMNOP0123456789",
-    ).should.throw(Exception, "Proposal p-ABCDEFGHIJKLMNOP0123456789 not found")
+    with pytest.raises(ClientError) as ex:
+        conn.get_proposal(
+            NetworkId=network_id, ProposalId="p-ABCDEFGHIJKLMNOP0123456789",
+        )
+    err = ex.value.response["Error"]
+    err["Code"].should.equal("ResourceNotFoundException")
+    err["Message"].should.contain("Proposal p-ABCDEFGHIJKLMNOP0123456789 not found")


### PR DESCRIPTION
Fixes #3921 

With this  PR, moto will werk with both flask/werkzeug 1.x, and flask/werkzeug 2.x.

Issues encountered while trying to fix this

**Problem**: CodeCov throws an error for some builds:
`{'detail': ErrorDetail(string='Unable to locate build via Github Actions API. Please upload with the Codecov repository upload token to resolve issue.', code='not_found')}`
**Solution:** 
 - Don't fail if this happens - we'll notice it in the report if anything goes wrong

---------------

**Problem**: `test_s3_server_post_without_content_length ` fails with werkzeug 2.x/flash 1.x
**Solution**: Described in #3921 

---------------

**Problem**: `managedblockchain` error handling fails in werkzeug 2.x
**Underlying cause**:
This service would return XML-errors, when boto3 expects them in JSON format. This would cause boto3 to throw an error saying: `Unable to validate response: <error>Can't find network x</error>`

With werkzeug 2.x, some encoding acts differently, and the error returned suddenly looks like:
 `Unable to validate response: <error>Can&quot;t find network x</error>`

This caused the asserts to fail, as the error message no longer matches up.

**Solution**:
Rewrite all error scenarios to return JSON-formatted errors, and rewrite the tests to assert this is done correctly