### PR TITLE
Lock Flask

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -99,7 +99,7 @@ all_extra_deps = [
     _dep_sshpubkeys_py2,
     _dep_sshpubkeys_py3,
 ]
-all_server_deps = all_extra_deps + ["flask<=2.0.0", "flask-cors"]
+all_server_deps = all_extra_deps + ["flask<2.0.0", "flask-cors"]
 
 # TODO: do we want to add ALL services here?
 # i.e. even those without extra dependencies.

--- a/setup.py
+++ b/setup.py
@@ -99,7 +99,7 @@ all_extra_deps = [
     _dep_sshpubkeys_py2,
     _dep_sshpubkeys_py3,
 ]
-all_server_deps = all_extra_deps + ["flask", "flask-cors"]
+all_server_deps = all_extra_deps + ["flask<=2.0.0", "flask-cors"]
 
 # TODO: do we want to add ALL services here?
 # i.e. even those without extra dependencies.


### PR DESCRIPTION
This should fix #3922 and #3921. Pinning only Werkzeug doesn't solve the issue since sometimes flask dependency might be installed first creating an impossible lock state when using tools like Pipenv.

<img width="431" alt="Captura de Tela 2021-05-12 às 13 13 16" src="https://user-images.githubusercontent.com/4432205/118008811-d2651800-b323-11eb-837c-cdc75bdb2bb9.png">

This is a temporary fix until this project upgrades to Flask 2