### PR TITLE
SSM parameters in cloudformation (`AWS::SSM::Parameter::`) are not recognized and resolved

### DIFF
--- a/moto/cloudformation/parsing.py
+++ b/moto/cloudformation/parsing.py
@@ -41,7 +41,7 @@ from moto.sagemaker import models as sagemaker_models  # noqa
 from moto.sns import models as sns_models  # noqa
 from moto.sqs import models as sqs_models  # noqa
 from moto.stepfunctions import models as stepfunctions_models  # noqa
-from moto.ssm import models as ssm_models, ssm_backend  # noqa
+from moto.ssm import models as ssm_models, ssm_backends  # noqa
 
 # End ugly list of imports
 
@@ -522,7 +522,9 @@ class ResourceMap(collections_abc.Mapping):
                     # The Value in SSM parameters is the SSM parameter path
                     # we need to use ssm_backend to retreive the
                     # actual value from parameter store
-                    parameter = ssm_backend.get_parameter(value, False)
+                    parameter = ssm_backends[self._region_name].get_parameter(
+                        value, False
+                    )
                     actual_value = parameter.value
 
                     if value_type.find("List") > 0:

--- a/moto/cloudformation/parsing.py
+++ b/moto/cloudformation/parsing.py
@@ -519,10 +519,9 @@ class ResourceMap(collections_abc.Mapping):
                 value_type = parameter_slot.get("Type", "String")
 
                 def _parse_ssm_parameter(value, value_type):
-                    # the value in SSM parameters is the SSM parameter path
+                    # The Value in SSM parameters is the SSM parameter path
                     # we need to use ssm_backend to retreive the
                     # actual value from parameter store
-
                     parameter = ssm_backend.get_parameter(value, False)
 
                     actual_value = parameter.value

--- a/moto/cloudformation/parsing.py
+++ b/moto/cloudformation/parsing.py
@@ -526,7 +526,7 @@ class ResourceMap(collections_abc.Mapping):
                     actual_value = parameter.value
 
                     if value_type.find("List") > 0:
-                        return actual_value.split(',')
+                        return actual_value.split(",")
 
                     return actual_value
 

--- a/moto/cloudformation/parsing.py
+++ b/moto/cloudformation/parsing.py
@@ -518,12 +518,11 @@ class ResourceMap(collections_abc.Mapping):
 
                 value_type = parameter_slot.get("Type", "String")
 
-                def _parse_ssm_parameter(value, value_type):
+                def _parse_ssm_parameter(key, value, value_type):
                     # The Value in SSM parameters is the SSM parameter path
                     # we need to use ssm_backend to retreive the
                     # actual value from parameter store
-                    parameter = ssm_backend.get_parameter(value, False)
-
+                    parameter = ssm_backend.get_parameter(key, False)
                     actual_value = parameter.value
 
                     if value_type.find("List") > 0:
@@ -532,7 +531,7 @@ class ResourceMap(collections_abc.Mapping):
                     return actual_value
 
                 if value_type.startswith("AWS::SSM::Parameter::"):
-                    value = _parse_ssm_parameter(value, value_type)
+                    value = _parse_ssm_parameter(key, value, value_type)
                 if value_type == "CommaDelimitedList" or value_type.startswith("List"):
                     value = value.split(",")
 

--- a/moto/cloudformation/parsing.py
+++ b/moto/cloudformation/parsing.py
@@ -518,11 +518,11 @@ class ResourceMap(collections_abc.Mapping):
 
                 value_type = parameter_slot.get("Type", "String")
 
-                def _parse_ssm_parameter(key, value, value_type):
+                def _parse_ssm_parameter(value, value_type):
                     # The Value in SSM parameters is the SSM parameter path
                     # we need to use ssm_backend to retreive the
                     # actual value from parameter store
-                    parameter = ssm_backend.get_parameter(key, False)
+                    parameter = ssm_backend.get_parameter(value, False)
                     actual_value = parameter.value
 
                     if value_type.find("List") > 0:
@@ -531,7 +531,7 @@ class ResourceMap(collections_abc.Mapping):
                     return actual_value
 
                 if value_type.startswith("AWS::SSM::Parameter::"):
-                    value = _parse_ssm_parameter(key, value, value_type)
+                    value = _parse_ssm_parameter(value, value_type)
                 if value_type == "CommaDelimitedList" or value_type.startswith("List"):
                     value = value.split(",")
 

--- a/tests/test_cloudformation/test_stack_parsing.py
+++ b/tests/test_cloudformation/test_stack_parsing.py
@@ -515,6 +515,12 @@ def test_ssm():
     stack = FakeStack(
         stack_id="test_id",
         name="test_stack",
-        template=parameters_template_json,
-        parameters=ssm_parameter_template
+        template=ssm_parameter_template_json,
+        parameters={
+            "Param": "comma,seperated",
+        },
+        region_name="us-west-1",
     )
+
+    stack.resource_map.no_echo_parameter_keys.should_not.have("Param")
+    stack.resource_map.resolved_parameters["Params"].should.equal()

--- a/tests/test_cloudformation/test_stack_parsing.py
+++ b/tests/test_cloudformation/test_stack_parsing.py
@@ -13,7 +13,7 @@ from moto.cloudformation.parsing import (
     parse_condition,
     Export,
 )
-from moto import mock_ssm
+from moto import mock_ssm, settings
 from moto.sqs.models import Queue
 from moto.s3.models import FakeBucket
 from moto.cloudformation.utils import yaml_tag_constructor
@@ -521,18 +521,19 @@ def test_ssm_parameter_parsing():
         Name="/path/to/list/param", Value="comma,separated,string", Type="StringList"
     )
 
-    stack = FakeStack(
-        stack_id="test_id",
-        name="test_stack",
-        template=ssm_parameter_template_json,
-        parameters={
-            "SingleParamCfn": "/path/to/single/param",
-            "ListParamCfn": "/path/to/list/param",
-        },
-        region_name="us-west-1",
-    )
+    if not settings.TEST_SERVER_MODE:
+        stack = FakeStack(
+            stack_id="test_id",
+            name="test_stack",
+            template=ssm_parameter_template_json,
+            parameters={
+                "SingleParamCfn": "/path/to/single/param",
+                "ListParamCfn": "/path/to/list/param",
+            },
+            region_name="us-west-1",
+        )
 
-    stack.resource_map.resolved_parameters["SingleParamCfn"].should.equal("string")
-    stack.resource_map.resolved_parameters["ListParamCfn"].should.equal(
-        ["comma", "separated", "string"]
-    )
+        stack.resource_map.resolved_parameters["SingleParamCfn"].should.equal("string")
+        stack.resource_map.resolved_parameters["ListParamCfn"].should.equal(
+            ["comma", "separated", "strin"]
+        )

--- a/tests/test_cloudformation/test_stack_parsing.py
+++ b/tests/test_cloudformation/test_stack_parsing.py
@@ -1,4 +1,5 @@
 from __future__ import unicode_literals
+import boto3
 import json
 import yaml
 
@@ -12,6 +13,7 @@ from moto.cloudformation.parsing import (
     parse_condition,
     Export,
 )
+from moto import mock_ssm
 from moto.sqs.models import Queue
 from moto.s3.models import FakeBucket
 from moto.cloudformation.utils import yaml_tag_constructor
@@ -70,6 +72,13 @@ parameters = {
         "NumberParam": {"Type": "Number"},
         "NumberListParam": {"Type": "List<Number>"},
         "NoEchoParam": {"Type": "String", "NoEcho": True},
+    }
+}
+
+ssm_parameter = {
+    "Parameters": {
+        "ListParam": {"Type": "AWS::SSM::Parameter::Value<List<String>>"},
+        "SingleParam": {"Type": "AWS::SSM::Parameter::Value<String>"}
     }
 }
 
@@ -133,16 +142,6 @@ import_value_template = {
     },
 }
 
-ssm_parameter_template = {
-    "AWSTemplateFormatVersion": "2010-09-09",
-    "Parameters": {
-        "Queue": {
-            "Description": "Queue description",
-            "Type": "AWS::SSM::Parameter::Value<List<String>>"
-        }
-    }
-}
-
 outputs_template = dict(list(dummy_template.items()) + list(output_dict.items()))
 bad_outputs_template = dict(list(dummy_template.items()) + list(bad_output.items()))
 get_attribute_outputs_template = dict(
@@ -153,6 +152,7 @@ get_availability_zones_template = dict(
 )
 
 parameters_template = dict(list(dummy_template.items()) + list(parameters.items()))
+ssm_parameter_template = dict(list(dummy_template.items()) + list(ssm_parameter.items()))
 
 dummy_template_json = json.dumps(dummy_template)
 name_type_template_json = json.dumps(name_type_template)
@@ -161,6 +161,7 @@ bad_output_template_json = json.dumps(bad_outputs_template)
 get_attribute_outputs_template_json = json.dumps(get_attribute_outputs_template)
 get_availability_zones_template_json = json.dumps(get_availability_zones_template)
 parameters_template_json = json.dumps(parameters_template)
+ssm_parameter_template_json = json.dumps(ssm_parameter_template)
 split_select_template_json = json.dumps(split_select_template)
 sub_template_json = json.dumps(sub_template)
 export_value_template_json = json.dumps(export_value_template)
@@ -509,18 +510,22 @@ def test_short_form_func_in_yaml_teamplate():
     for k, v in key_and_expects:
         template_dict.should.have.key(k).which.should.be.equal(v)
 
-
-def test_ssm():
+@mock_ssm
+def test_ssm_parameter_parsing():
+    client = boto3.client("ssm")
+    client.put_parameter(Name="SingleParam", Value="10", Type="StringList")
+    client.put_parameter(Name="ListParam", Value="comma,separated,string", Type="StringList")
 
     stack = FakeStack(
         stack_id="test_id",
         name="test_stack",
         template=ssm_parameter_template_json,
         parameters={
-            "Param": "comma,seperated",
+            "SingleParam": "10",
+            "ListParam": "comma,separated,string",
         },
         region_name="us-west-1",
     )
 
-    stack.resource_map.no_echo_parameter_keys.should_not.have("Param")
-    stack.resource_map.resolved_parameters["Params"].should.equal()
+    stack.resource_map.resolved_parameters["SingleParam"].should.equal("10")
+    stack.resource_map.resolved_parameters["ListParam"].should.equal(["comma","separated","string"])

--- a/tests/test_cloudformation/test_stack_parsing.py
+++ b/tests/test_cloudformation/test_stack_parsing.py
@@ -515,7 +515,7 @@ def test_short_form_func_in_yaml_teamplate():
 
 @mock_ssm
 def test_ssm_parameter_parsing():
-    client = boto3.client("ssm", region_name="us-east-1")
+    client = boto3.client("ssm", region_name="us-west-1")
     client.put_parameter(
         Name="/path/to/single/param", Value="string", Type="StringList"
     )
@@ -531,7 +531,7 @@ def test_ssm_parameter_parsing():
             "SingleParamCfn": "/path/to/single/param",
             "ListParamCfn": "/path/to/list/param",
         },
-        region_name="us-east-1",
+        region_name="us-west-1",
     )
 
     stack.resource_map.resolved_parameters["SingleParamCfn"].should.equal("string")

--- a/tests/test_cloudformation/test_stack_parsing.py
+++ b/tests/test_cloudformation/test_stack_parsing.py
@@ -516,9 +516,7 @@ def test_short_form_func_in_yaml_teamplate():
 @mock_ssm
 def test_ssm_parameter_parsing():
     client = boto3.client("ssm", region_name="us-west-1")
-    client.put_parameter(
-        Name="/path/to/single/param", Value="string", Type="String"
-    )
+    client.put_parameter(Name="/path/to/single/param", Value="string", Type="String")
     client.put_parameter(
         Name="/path/to/list/param", Value="comma,separated,string", Type="StringList"
     )

--- a/tests/test_cloudformation/test_stack_parsing.py
+++ b/tests/test_cloudformation/test_stack_parsing.py
@@ -77,8 +77,8 @@ parameters = {
 
 ssm_parameter = {
     "Parameters": {
+        "SingleParam": {"Type": "AWS::SSM::Parameter::Value<String>"},
         "ListParam": {"Type": "AWS::SSM::Parameter::Value<List<String>>"},
-        "SingleParam": {"Type": "AWS::SSM::Parameter::Value<String>"}
     }
 }
 
@@ -152,7 +152,9 @@ get_availability_zones_template = dict(
 )
 
 parameters_template = dict(list(dummy_template.items()) + list(parameters.items()))
-ssm_parameter_template = dict(list(dummy_template.items()) + list(ssm_parameter.items()))
+ssm_parameter_template = dict(
+    list(dummy_template.items()) + list(ssm_parameter.items())
+)
 
 dummy_template_json = json.dumps(dummy_template)
 name_type_template_json = json.dumps(name_type_template)
@@ -510,22 +512,24 @@ def test_short_form_func_in_yaml_teamplate():
     for k, v in key_and_expects:
         template_dict.should.have.key(k).which.should.be.equal(v)
 
+
 @mock_ssm
 def test_ssm_parameter_parsing():
     client = boto3.client("ssm")
-    client.put_parameter(Name="SingleParam", Value="10", Type="StringList")
-    client.put_parameter(Name="ListParam", Value="comma,separated,string", Type="StringList")
+    client.put_parameter(Name="SingleParam", Value="string", Type="StringList")
+    client.put_parameter(
+        Name="ListParam", Value="comma,separated,string", Type="StringList"
+    )
 
     stack = FakeStack(
         stack_id="test_id",
         name="test_stack",
         template=ssm_parameter_template_json,
-        parameters={
-            "SingleParam": "10",
-            "ListParam": "comma,separated,string",
-        },
+        parameters={"SingleParam": "string", "ListParam": "comma,separated,string",},
         region_name="us-west-1",
     )
 
-    stack.resource_map.resolved_parameters["SingleParam"].should.equal("10")
-    stack.resource_map.resolved_parameters["ListParam"].should.equal(["comma","separated","string"])
+    stack.resource_map.resolved_parameters["SingleParam"].should.equal("string")
+    stack.resource_map.resolved_parameters["ListParam"].should.equal(
+        ["comma", "separated", "string"]
+    )

--- a/tests/test_cloudformation/test_stack_parsing.py
+++ b/tests/test_cloudformation/test_stack_parsing.py
@@ -133,6 +133,16 @@ import_value_template = {
     },
 }
 
+ssm_parameter_template = {
+    "AWSTemplateFormatVersion": "2010-09-09",
+    "Parameters": {
+        "Queue": {
+            "Description": "Queue description",
+            "Type": "AWS::SSM::Parameter::Value<List<String>>"
+        }
+    }
+}
+
 outputs_template = dict(list(dummy_template.items()) + list(output_dict.items()))
 bad_outputs_template = dict(list(dummy_template.items()) + list(bad_output.items()))
 get_attribute_outputs_template = dict(
@@ -498,3 +508,13 @@ def test_short_form_func_in_yaml_teamplate():
     ]
     for k, v in key_and_expects:
         template_dict.should.have.key(k).which.should.be.equal(v)
+
+
+def test_ssm():
+
+    stack = FakeStack(
+        stack_id="test_id",
+        name="test_stack",
+        template=parameters_template_json,
+        parameters=ssm_parameter_template
+    )

--- a/tests/test_cloudformation/test_stack_parsing.py
+++ b/tests/test_cloudformation/test_stack_parsing.py
@@ -515,7 +515,7 @@ def test_short_form_func_in_yaml_teamplate():
 
 @mock_ssm
 def test_ssm_parameter_parsing():
-    client = boto3.client("ssm")
+    client = boto3.client("ssm", region_name="us-east-1")
     client.put_parameter(
         Name="/path/to/single/param", Value="string", Type="StringList"
     )

--- a/tests/test_cloudformation/test_stack_parsing.py
+++ b/tests/test_cloudformation/test_stack_parsing.py
@@ -77,8 +77,8 @@ parameters = {
 
 ssm_parameter = {
     "Parameters": {
-        "SingleParam": {"Type": "AWS::SSM::Parameter::Value<String>"},
-        "ListParam": {"Type": "AWS::SSM::Parameter::Value<List<String>>"},
+        "SingleParamCfn": {"Type": "AWS::SSM::Parameter::Value<String>"},
+        "ListParamCfn": {"Type": "AWS::SSM::Parameter::Value<List<String>>"},
     }
 }
 
@@ -516,20 +516,25 @@ def test_short_form_func_in_yaml_teamplate():
 @mock_ssm
 def test_ssm_parameter_parsing():
     client = boto3.client("ssm")
-    client.put_parameter(Name="SingleParam", Value="string", Type="StringList")
     client.put_parameter(
-        Name="ListParam", Value="comma,separated,string", Type="StringList"
+        Name="/path/to/single/param", Value="string", Type="StringList"
+    )
+    client.put_parameter(
+        Name="/path/to/list/param", Value="comma,separated,string", Type="StringList"
     )
 
     stack = FakeStack(
         stack_id="test_id",
         name="test_stack",
         template=ssm_parameter_template_json,
-        parameters={"SingleParam": "string", "ListParam": "comma,separated,string",},
+        parameters={
+            "SingleParamCfn": "/path/to/single/param",
+            "ListParamCfn": "/path/to/list/param",
+        },
         region_name="us-west-1",
     )
 
-    stack.resource_map.resolved_parameters["SingleParam"].should.equal("string")
-    stack.resource_map.resolved_parameters["ListParam"].should.equal(
+    stack.resource_map.resolved_parameters["SingleParamCfn"].should.equal("string")
+    stack.resource_map.resolved_parameters["ListParamCfn"].should.equal(
         ["comma", "separated", "string"]
     )

--- a/tests/test_cloudformation/test_stack_parsing.py
+++ b/tests/test_cloudformation/test_stack_parsing.py
@@ -531,7 +531,7 @@ def test_ssm_parameter_parsing():
             "SingleParamCfn": "/path/to/single/param",
             "ListParamCfn": "/path/to/list/param",
         },
-        region_name="us-west-1",
+        region_name="us-east-1",
     )
 
     stack.resource_map.resolved_parameters["SingleParamCfn"].should.equal("string")

--- a/tests/test_cloudformation/test_stack_parsing.py
+++ b/tests/test_cloudformation/test_stack_parsing.py
@@ -535,5 +535,5 @@ def test_ssm_parameter_parsing():
 
         stack.resource_map.resolved_parameters["SingleParamCfn"].should.equal("string")
         stack.resource_map.resolved_parameters["ListParamCfn"].should.equal(
-            ["comma", "separated", "strin"]
+            ["comma", "separated", "string"]
         )

--- a/tests/test_cloudformation/test_stack_parsing.py
+++ b/tests/test_cloudformation/test_stack_parsing.py
@@ -517,7 +517,7 @@ def test_short_form_func_in_yaml_teamplate():
 def test_ssm_parameter_parsing():
     client = boto3.client("ssm", region_name="us-west-1")
     client.put_parameter(
-        Name="/path/to/single/param", Value="string", Type="StringList"
+        Name="/path/to/single/param", Value="string", Type="String"
     )
     client.put_parameter(
         Name="/path/to/list/param", Value="comma,separated,string", Type="StringList"


### PR DESCRIPTION
When using ssm parameters in cloudforamtion, and `Ref` node is replaced with the corresponding `physical_resource_id.`

Have mention more here:

Related issue:
https://github.com/spulec/moto/issues/3928
