### PR TITLE
feat: transition elbv2 state to `active` on first describe

### DIFF
--- a/moto/elbv2/models.py
+++ b/moto/elbv2/models.py
@@ -381,6 +381,7 @@ class FakeLoadBalancer(CloudFormationModel):
         vpc_id,
         arn,
         dns_name,
+        state,
         scheme="internet-facing",
     ):
         self.name = name
@@ -393,6 +394,7 @@ class FakeLoadBalancer(CloudFormationModel):
         self.tags = {}
         self.arn = arn
         self.dns_name = dns_name
+        self.state = state
 
         self.stack = "ipv4"
         self.attrs = {
@@ -517,6 +519,8 @@ class ELBv2Backend(BaseBackend):
     ):
         vpc_id = None
         subnets = []
+        state = "provisioning"
+
         if not subnet_ids:
             raise SubnetNotFoundError()
         for subnet_id in subnet_ids:
@@ -542,6 +546,7 @@ class ELBv2Backend(BaseBackend):
             subnets=subnets,
             vpc_id=vpc_id,
             dns_name=dns_name,
+            state=state,
         )
         self.load_balancers[arn] = new_load_balancer
         return new_load_balancer

--- a/moto/elbv2/models.py
+++ b/moto/elbv2/models.py
@@ -421,6 +421,10 @@ class FakeLoadBalancer(CloudFormationModel):
         if key in self.tags:
             del self.tags[key]
 
+    def activate(self):
+        if self.state == "provisioning":
+            self.state = "active"
+
     def delete(self, region):
         """ Not exposed as part of the ELB API - used for CloudFormation. """
         elbv2_backends[region].delete_load_balancer(self.arn)
@@ -745,6 +749,8 @@ Member must satisfy regular expression pattern: {}".format(
         arns = arns or []
         names = names or []
         if not arns and not names:
+            for balancer in balancers:
+                balancer.activate()
             return balancers
 
         matched_balancers = []
@@ -752,6 +758,7 @@ Member must satisfy regular expression pattern: {}".format(
 
         for arn in arns:
             for balancer in balancers:
+                balancer.activate()
                 if balancer.arn == arn:
                     matched_balancer = balancer
             if matched_balancer is None:
@@ -761,6 +768,7 @@ Member must satisfy regular expression pattern: {}".format(
 
         for name in names:
             for balancer in balancers:
+                balancer.activate()
                 if balancer.name == name:
                     matched_balancer = balancer
             if matched_balancer is None:

--- a/moto/elbv2/responses.py
+++ b/moto/elbv2/responses.py
@@ -877,7 +877,7 @@ DESCRIBE_LOAD_BALANCERS_TEMPLATE = """<DescribeLoadBalancersResponse xmlns="http
         </SecurityGroups>
         <DNSName>{{ load_balancer.dns_name }}</DNSName>
         <State>
-          <Code>provisioning</Code>
+          <Code>{{ load_balancer.state }}</Code>
         </State>
         <Type>application</Type>
         <IpAddressType>ipv4</IpAddressType>

--- a/moto/elbv2/responses.py
+++ b/moto/elbv2/responses.py
@@ -706,7 +706,7 @@ CREATE_LOAD_BALANCER_TEMPLATE = """<CreateLoadBalancerResponse xmlns="http://ela
         </SecurityGroups>
         <DNSName>{{ load_balancer.dns_name }}</DNSName>
         <State>
-          <Code>provisioning</Code>
+          <Code>{{ load_balancer.state }}</Code>
         </State>
         <Type>application</Type>
       </member>

--- a/tests/test_elbv2/test_elbv2.py
+++ b/tests/test_elbv2/test_elbv2.py
@@ -52,6 +52,7 @@ def test_create_load_balancer():
         ]
     )
     lb.get("CreatedTime").tzinfo.should_not.be.none
+    lb.get("State").get("Code").should.equal("provisioning")
 
     # Ensure the tags persisted
     response = conn.describe_tags(ResourceArns=[lb.get("LoadBalancerArn")])

--- a/tests/test_elbv2/test_elbv2.py
+++ b/tests/test_elbv2/test_elbv2.py
@@ -90,6 +90,7 @@ def test_describe_load_balancers():
     response.get("LoadBalancers").should.have.length_of(1)
     lb = response.get("LoadBalancers")[0]
     lb.get("LoadBalancerName").should.equal("my-lb")
+    lb.get("State").get("Code").should.equal("active")
 
     response = conn.describe_load_balancers(
         LoadBalancerArns=[lb.get("LoadBalancerArn")]


### PR DESCRIPTION
This change updates the elbv2 load balancer state from `provisioning` to `active` after the first call to `describe_load_balancers()`.