### PR TITLE
MediaStore delete container and list tags endpoints implemented

### DIFF
--- a/moto/mediastore/exceptions.py
+++ b/moto/mediastore/exceptions.py
@@ -1,9 +1,18 @@
 from __future__ import unicode_literals
+
 from moto.core.exceptions import JsonRESTError
 
 
 class MediaStoreClientError(JsonRESTError):
     code = 400
+
+
+class ContainerNotFoundException(MediaStoreClientError):
+    def __init__(self, msg=None):
+        self.code = 400
+        super(ContainerNotFoundException, self).__init__(
+            "ContainerNotFoundException", msg or "The specified container does not exist"
+        )
 
 
 class ResourceNotFoundException(MediaStoreClientError):

--- a/moto/mediastore/exceptions.py
+++ b/moto/mediastore/exceptions.py
@@ -11,7 +11,8 @@ class ContainerNotFoundException(MediaStoreClientError):
     def __init__(self, msg=None):
         self.code = 400
         super(ContainerNotFoundException, self).__init__(
-            "ContainerNotFoundException", msg or "The specified container does not exist"
+            "ContainerNotFoundException",
+            msg or "The specified container does not exist",
         )
 
 

--- a/moto/mediastore/models.py
+++ b/moto/mediastore/models.py
@@ -6,7 +6,11 @@ from datetime import date
 from boto3 import Session
 
 from moto.core import BaseBackend, BaseModel
-from .exceptions import ContainerNotFoundException, ResourceNotFoundException, PolicyNotFoundException
+from .exceptions import (
+    ContainerNotFoundException,
+    ResourceNotFoundException,
+    PolicyNotFoundException,
+)
 
 
 class Container(BaseModel):
@@ -28,7 +32,7 @@ class Container(BaseModel):
             "Endpoint": self.endpoint,
             "Status": self.status,
             "CreationTime": self.creation_time,
-            "Tags": self.tags
+            "Tags": self.tags,
         }
         if exclude:
             for key in exclude:
@@ -55,7 +59,7 @@ class MediaStoreBackend(BaseBackend):
             endpoint="/{}".format(name),
             status="CREATING",
             creation_time=date.today().strftime("%m/%d/%Y, %H:%M:%S"),
-            tags=tags
+            tags=tags,
         )
         self._containers[name] = container
         return container
@@ -128,7 +132,7 @@ mediastore_backends = {}
 for region in Session().get_available_regions("mediastore"):
     mediastore_backends[region] = MediaStoreBackend(region)
 for region in Session().get_available_regions(
-        "mediastore", partition_name="aws-us-gov"
+    "mediastore", partition_name="aws-us-gov"
 ):
     mediastore_backends[region] = MediaStoreBackend(region)
 for region in Session().get_available_regions("mediastore", partition_name="aws-cn"):

--- a/moto/mediastore/models.py
+++ b/moto/mediastore/models.py
@@ -1,9 +1,12 @@
 from __future__ import unicode_literals
-from boto3 import Session
-from moto.core import BaseBackend, BaseModel
+
 from collections import OrderedDict
 from datetime import date
-from .exceptions import ResourceNotFoundException, PolicyNotFoundException
+
+from boto3 import Session
+
+from moto.core import BaseBackend, BaseModel
+from .exceptions import ContainerNotFoundException, ResourceNotFoundException, PolicyNotFoundException
 
 
 class Container(BaseModel):
@@ -16,6 +19,7 @@ class Container(BaseModel):
         self.lifecycle_policy = None
         self.policy = None
         self.metric_policy = None
+        self.tags = kwargs.get("tags")
 
     def to_dict(self, exclude=None):
         data = {
@@ -24,6 +28,7 @@ class Container(BaseModel):
             "Endpoint": self.endpoint,
             "Status": self.status,
             "CreationTime": self.creation_time,
+            "Tags": self.tags
         }
         if exclude:
             for key in exclude:
@@ -50,9 +55,15 @@ class MediaStoreBackend(BaseBackend):
             endpoint="/{}".format(name),
             status="CREATING",
             creation_time=date.today().strftime("%m/%d/%Y, %H:%M:%S"),
+            tags=tags
         )
         self._containers[name] = container
         return container
+
+    def delete_container(self, name):
+        if name not in self._containers:
+            raise ContainerNotFoundException()
+        return {}
 
     def describe_container(self, name):
         if name not in self._containers:
@@ -65,6 +76,10 @@ class MediaStoreBackend(BaseBackend):
         containers = list(self._containers.values())
         response_containers = [c.to_dict() for c in containers]
         return response_containers, None
+
+    def list_tags_for_resource(self, name):
+        tags = self._containers[name].tags
+        return tags
 
     def put_lifecycle_policy(self, container_name, lifecycle_policy):
         if container_name not in self._containers:
@@ -113,7 +128,7 @@ mediastore_backends = {}
 for region in Session().get_available_regions("mediastore"):
     mediastore_backends[region] = MediaStoreBackend(region)
 for region in Session().get_available_regions(
-    "mediastore", partition_name="aws-us-gov"
+        "mediastore", partition_name="aws-us-gov"
 ):
     mediastore_backends[region] = MediaStoreBackend(region)
 for region in Session().get_available_regions("mediastore", partition_name="aws-cn"):

--- a/moto/mediastore/models.py
+++ b/moto/mediastore/models.py
@@ -67,6 +67,7 @@ class MediaStoreBackend(BaseBackend):
     def delete_container(self, name):
         if name not in self._containers:
             raise ContainerNotFoundException()
+        del self._containers[name]
         return {}
 
     def describe_container(self, name):

--- a/moto/mediastore/responses.py
+++ b/moto/mediastore/responses.py
@@ -87,4 +87,5 @@ class MediaStoreResponse(BaseResponse):
         )
         return json.dumps(dict(MetricPolicy=metric_policy))
 
+
 # add templates from here

--- a/moto/mediastore/responses.py
+++ b/moto/mediastore/responses.py
@@ -1,7 +1,9 @@
 from __future__ import unicode_literals
+
+import json
+
 from moto.core.responses import BaseResponse
 from .models import mediastore_backends
-import json
 
 
 class MediaStoreResponse(BaseResponse):
@@ -17,6 +19,11 @@ class MediaStoreResponse(BaseResponse):
         container = self.mediastore_backend.create_container(name=name, tags=tags)
         return json.dumps(dict(Container=container.to_dict()))
 
+    def delete_container(self):
+        name = self._get_param("ContainerName")
+        result = self.mediastore_backend.delete_container(name=name)
+        return json.dumps(result)
+
     def describe_container(self):
         name = self._get_param("ContainerName")
         container = self.mediastore_backend.describe_container(name=name)
@@ -29,6 +36,11 @@ class MediaStoreResponse(BaseResponse):
             next_token=next_token, max_results=max_results,
         )
         return json.dumps(dict(dict(Containers=containers), NextToken=next_token))
+
+    def list_tags_for_resource(self):
+        name = self._get_param("Resource")
+        tags = self.mediastore_backend.list_tags_for_resource(name)
+        return json.dumps(dict(Tags=tags))
 
     def put_lifecycle_policy(self):
         container_name = self._get_param("ContainerName")
@@ -74,6 +86,5 @@ class MediaStoreResponse(BaseResponse):
             container_name=container_name,
         )
         return json.dumps(dict(MetricPolicy=metric_policy))
-
 
 # add templates from here

--- a/tests/test_mediastore/test_mediastore.py
+++ b/tests/test_mediastore/test_mediastore.py
@@ -229,7 +229,7 @@ def test_delete_container():
     response = client.delete_container(ContainerName=container["Name"])
     response["ResponseMetadata"]["HTTPStatusCode"].should.equal(200)
     containers = client.list_containers(NextToken="next-token")["Containers"]
-    container_exists = any(d['Name'] == container_name for d in containers)
+    container_exists = any(d["Name"] == container_name for d in containers)
     container_exists.should.equal(False)
 
 

--- a/tests/test_mediastore/test_mediastore.py
+++ b/tests/test_mediastore/test_mediastore.py
@@ -1,10 +1,11 @@
 from __future__ import unicode_literals
 
 import boto3
-import sure  # noqa
 import pytest
-from moto import mock_mediastore
+import sure  # noqa
 from botocore.exceptions import ClientError
+
+from moto import mock_mediastore
 
 region = "eu-west-1"
 
@@ -192,3 +193,52 @@ def test_get_metric_policy_raises_error_if_container_does_not_have_metric_policy
     with pytest.raises(ClientError) as ex:
         client.get_metric_policy(ContainerName="container-name")
     ex.value.response["Error"]["Code"].should.equal("PolicyNotFoundException")
+
+
+@mock_mediastore
+def test_list_tags_for_resource():
+    client = boto3.client("mediastore", region_name=region)
+    tags = [{"Key": "customer"}]
+
+    create_response = client.create_container(
+        ContainerName="Awesome container!", Tags=tags
+    )
+    container = create_response["Container"]
+    response = client.list_tags_for_resource(Resource=container["Name"])
+    response["ResponseMetadata"]["HTTPStatusCode"].should.equal(200)
+    response["Tags"].should.equal(tags)
+
+
+@mock_mediastore
+def test_list_tags_for_resource_return_none_if_no_tags():
+    client = boto3.client("mediastore", region_name=region)
+
+    create_response = client.create_container(
+        ContainerName="Awesome container!"
+    )
+    container = create_response["Container"]
+    response = client.list_tags_for_resource(Resource=container["Name"])
+    response["ResponseMetadata"]["HTTPStatusCode"].should.equal(200)
+    response.get("Tags").should.equal(None)
+
+
+@mock_mediastore
+def test_delete_container():
+    client = boto3.client("mediastore", region_name=region)
+
+    create_response = client.create_container(
+        ContainerName="Awesome container!"
+    )
+    container = create_response["Container"]
+    response = client.delete_container(ContainerName=container["Name"])
+    response["ResponseMetadata"]["HTTPStatusCode"].should.equal(200)
+
+
+@mock_mediastore
+def test_delete_container_raise_error_if_container_not_found():
+    client = boto3.client("mediastore", region_name=region)
+    client.create_container(ContainerName="Awesome container!")
+
+    with pytest.raises(ClientError) as ex:
+        client.delete_container(ContainerName="notAvailable")
+    ex.value.response["Error"]["Code"].should.equal("ContainerNotFoundException")

--- a/tests/test_mediastore/test_mediastore.py
+++ b/tests/test_mediastore/test_mediastore.py
@@ -223,11 +223,14 @@ def test_list_tags_for_resource_return_none_if_no_tags():
 @mock_mediastore
 def test_delete_container():
     client = boto3.client("mediastore", region_name=region)
-
-    create_response = client.create_container(ContainerName="Awesome container!")
+    container_name = "Awesome container!"
+    create_response = client.create_container(ContainerName=container_name)
     container = create_response["Container"]
     response = client.delete_container(ContainerName=container["Name"])
     response["ResponseMetadata"]["HTTPStatusCode"].should.equal(200)
+    containers = client.list_containers(NextToken="next-token")["Containers"]
+    container_exists = any(d['Name'] == container_name for d in containers)
+    container_exists.should.equal(False)
 
 
 @mock_mediastore

--- a/tests/test_mediastore/test_mediastore.py
+++ b/tests/test_mediastore/test_mediastore.py
@@ -213,9 +213,7 @@ def test_list_tags_for_resource():
 def test_list_tags_for_resource_return_none_if_no_tags():
     client = boto3.client("mediastore", region_name=region)
 
-    create_response = client.create_container(
-        ContainerName="Awesome container!"
-    )
+    create_response = client.create_container(ContainerName="Awesome container!")
     container = create_response["Container"]
     response = client.list_tags_for_resource(Resource=container["Name"])
     response["ResponseMetadata"]["HTTPStatusCode"].should.equal(200)
@@ -226,9 +224,7 @@ def test_list_tags_for_resource_return_none_if_no_tags():
 def test_delete_container():
     client = boto3.client("mediastore", region_name=region)
 
-    create_response = client.create_container(
-        ContainerName="Awesome container!"
-    )
+    create_response = client.create_container(ContainerName="Awesome container!")
     container = create_response["Container"]
     response = client.delete_container(ContainerName=container["Name"])
     response["ResponseMetadata"]["HTTPStatusCode"].should.equal(200)


### PR DESCRIPTION
Idelete_container and list_tags_for_resource were not implemented. 
I did it following boto3 & AWS documentation. I added the ContainerNotFound exception which it's the actual being thrown when trying to delete an unexistent container. 
All tests are passing.
