### PR TITLE
Drop dependency on zipp

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -67,8 +67,6 @@ install_requires += [
     "rsa<=4.0; python_version < '3'",
     "setuptools",
     "setuptools==44.0.0; python_version < '3'",
-    "zipp",
-    "zipp==0.6.0; python_version < '3'",
 ]
 
 _dep_PyYAML = "PyYAML>=5.1"


### PR DESCRIPTION
A search of the repository shows zipp is not imported anywhere, so this PR removes the dependency.