### PR TITLE
Enforce SSM Parameter Version Limit

### DIFF
--- a/moto/ssm/exceptions.py
+++ b/moto/ssm/exceptions.py
@@ -115,3 +115,12 @@ class DuplicateDocumentContent(JsonRESTError):
         super(DuplicateDocumentContent, self).__init__(
             "DuplicateDocumentContent", message
         )
+
+
+class ParameterMaxVersionLimitExceeded(JsonRESTError):
+    code = 400
+
+    def __init__(self, message):
+        super(ParameterMaxVersionLimitExceeded, self).__init__(
+            "ParameterMaxVersionLimitExceeded", message
+        )

--- a/moto/ssm/models.py
+++ b/moto/ssm/models.py
@@ -32,7 +32,11 @@ from .exceptions import (
     InvalidDocumentVersion,
     DuplicateDocumentVersionName,
     DuplicateDocumentContent,
+    ParameterMaxVersionLimitExceeded,
 )
+
+
+PARAMETER_VERSION_LIMIT = 100
 
 
 class Parameter(BaseModel):
@@ -1281,6 +1285,18 @@ class SimpleSystemManagerBackend(BaseBackend):
                         parameter.labels.remove(label)
         return [invalid_labels, version]
 
+    def _check_for_parameter_version_limit_exception(self, name):
+        # https://docs.aws.amazon.com/systems-manager/latest/userguide/sysman-paramstore-versions.html
+        parameter_versions = self._parameters[name]
+        oldest_parameter = parameter_versions[0]
+        if oldest_parameter.labels:
+            raise ParameterMaxVersionLimitExceeded(
+                "You attempted to create a new version of %s by calling the PutParameter API "
+                "with the overwrite flag. Version %d, the oldest version, can't be deleted "
+                "because it has a label associated with it. Move the label to another version "
+                "of the parameter, and try again." % (name, oldest_parameter.version)
+            )
+
     def put_parameter(
         self, name, description, value, type, allowed_pattern, keyid, overwrite, tags,
     ):
@@ -1316,6 +1332,10 @@ class SimpleSystemManagerBackend(BaseBackend):
 
             if not overwrite:
                 return
+
+            if len(previous_parameter_versions) >= PARAMETER_VERSION_LIMIT:
+                self._check_for_parameter_version_limit_exception(name)
+                previous_parameter_versions.pop(0)
 
         last_modified_date = time.time()
         self._parameters[name].append(


### PR DESCRIPTION
Behavior verified against a real AWS backend.

Closes #3963 