### PR TITLE
SSM Parameter Store Error Message When Requesting Invalid Version

### DIFF
--- a/moto/ssm/models.py
+++ b/moto/ssm/models.py
@@ -1084,10 +1084,10 @@ class SimpleSystemManagerBackend(BaseBackend):
 
         for name in names:
             if name in self._parameters:
-                try:  
+                try:
                     result.append(self.get_parameter(name, with_decryption))
                 except ParameterVersionNotFound:
-                    pass 
+                    pass
         return result
 
     def get_parameters_by_path(

--- a/moto/ssm/models.py
+++ b/moto/ssm/models.py
@@ -1224,7 +1224,7 @@ class SimpleSystemManagerBackend(BaseBackend):
                         raise ParameterVersionNotFound(
                             "Systems Manager could not find version %s of %s. "
                             "Verify the version and try again."
-                            % (version_or_label, name)
+                            % (version_or_label, name_prefix)
                         )
                 result = list(
                     filter(lambda x: version_or_label in x.labels, parameters)

--- a/moto/ssm/models.py
+++ b/moto/ssm/models.py
@@ -1084,10 +1084,7 @@ class SimpleSystemManagerBackend(BaseBackend):
 
         for name in names:
             if name in self._parameters:
-                try:
-                    result.append(self.get_parameter(name, with_decryption))
-                except ParameterVersionNotFound:
-                    pass
+                result.append(self.get_parameter(name, with_decryption))
         return result
 
     def get_parameters_by_path(

--- a/moto/ssm/models.py
+++ b/moto/ssm/models.py
@@ -1084,7 +1084,10 @@ class SimpleSystemManagerBackend(BaseBackend):
 
         for name in names:
             if name in self._parameters:
-                result.append(self.get_parameter(name, with_decryption))
+                try:  
+                    result.append(self.get_parameter(name, with_decryption))
+                except ParameterVersionNotFound:
+                    pass 
         return result
 
     def get_parameters_by_path(
@@ -1217,7 +1220,11 @@ class SimpleSystemManagerBackend(BaseBackend):
                     )
                     if len(result) > 0:
                         return result[-1]
-
+                    elif len(parameters) > 0:
+                        raise ParameterVersionNotFound(
+                            "Systems Manager could not find version %s of %s. "
+                            "Verify the version and try again." % (version_or_label, name)
+                        )
                 result = list(
                     filter(lambda x: version_or_label in x.labels, parameters)
                 )

--- a/moto/ssm/models.py
+++ b/moto/ssm/models.py
@@ -1223,7 +1223,8 @@ class SimpleSystemManagerBackend(BaseBackend):
                     elif len(parameters) > 0:
                         raise ParameterVersionNotFound(
                             "Systems Manager could not find version %s of %s. "
-                            "Verify the version and try again." % (version_or_label, name)
+                            "Verify the version and try again."
+                            % (version_or_label, name)
                         )
                 result = list(
                     filter(lambda x: version_or_label in x.labels, parameters)

--- a/tests/test_ssm/test_ssm_boto3.py
+++ b/tests/test_ssm/test_ssm_boto3.py
@@ -467,7 +467,7 @@ def test_get_parameter_with_version_and_labels():
         client.get_parameter(Name="test-2:2", WithDecryption=False)
     ex.value.response["Error"]["Code"].should.equal("ParameterVersionNotFound")
     ex.value.response["Error"]["Message"].should.equal(
-        "Systems Manager could not find version 2 of test-2:2. Verify the version and try again."
+        "Systems Manager could not find version 2 of test-2. Verify the version and try again."
     )
 
     with pytest.raises(ClientError) as ex:

--- a/tests/test_ssm/test_ssm_boto3.py
+++ b/tests/test_ssm/test_ssm_boto3.py
@@ -1816,26 +1816,3 @@ def test_parameter_overwrite_fails_when_limit_reached_and_oldest_version_has_lab
     error["Message"].should.match(
         r"the oldest version, can't be deleted because it has a label associated with it. Move the label to another version of the parameter, and try again."
     )
-
-
-@mock_ssm
-def test_get_parameters_includes_invalid_parameter_when_requesting_invalid_version():
-    client = boto3.client("ssm", region_name="us-east-1")
-    parameter_name = "test-param"
-    versions_to_create = 5
-
-    for i in range(versions_to_create):
-        client.put_parameter(
-            Name=parameter_name,
-            Value="value-%d" % (i + 1),
-            Type="String",
-            Overwrite=True,
-        )
-
-    response = client.get_parameters(Names=["test-param:%d" % (versions_to_create + 1)])
-
-    len(response["Parameters"]).should.equal(0)
-    len(response["InvalidParameters"]).should.equal(1)
-    response["InvalidParameters"][0].should.equal(
-        "test-param:%d" % (versions_to_create + 1)
-    )


### PR DESCRIPTION
SSM Parameter Store returns a ParameterVersionNotFound error code when requesting a parameter with version where the parameter exists but the requested version does not. 

Provided example below with actual AWS responses. 

![image](https://user-images.githubusercontent.com/20068776/120404159-5c911280-c30b-11eb-9292-fdc963c25ce2.png)
