### PR TITLE
Streamline success/failure response from AWSLambda

### DIFF
--- a/moto/awslambda/models.py
+++ b/moto/awslambda/models.py
@@ -626,24 +626,17 @@ class LambdaFunction(CloudFormationModel, DockerModel):
                 self.logs_group_name, log_stream_name, log_events, None
             )
 
-            if exit_code != 0:
-                raise Exception("lambda invoke failed output: {}".format(output))
-
             # We only care about the response from the lambda
             # Which is the last line of the output, according to https://github.com/lambci/docker-lambda/issues/25
             resp = output.splitlines()[-1]
             logs = os.linesep.join(
                 [line for line in self.convert(output).splitlines()[:-1]]
             )
-            return resp, False, logs
+            invocation_error = exit_code != 0
+            return resp, invocation_error, logs
         except docker.errors.DockerException as e:
             # Docker itself is probably not running - there will be no Lambda-logs to handle
             return "error running docker: {}".format(e), True, ""
-        except BaseException as e:
-            logs = os.linesep.join(
-                [line for line in self.convert(output).splitlines()[:-1]]
-            )
-            return "error running lambda: {}".format(e), True, logs
 
     def invoke(self, body, request_headers, response_headers):
 

--- a/tests/test_awslambda/test_lambda.py
+++ b/tests/test_awslambda/test_lambda.py
@@ -79,7 +79,7 @@ def lambda_handler(event, context):
     return _process_lambda(pfunc)
 
 
-def get_test_zip_file4():
+def get_test_zip_file_error():
     pfunc = """
 def lambda_handler(event, context):
     raise Exception('I failed!')
@@ -100,6 +100,37 @@ def test_list_functions():
     conn = boto3.client("lambda", _lambda_region)
     result = conn.list_functions()
     result["Functions"].should.have.length_of(0)
+
+
+@pytest.mark.network
+@mock_lambda
+def test_invoke_function_that_throws_error():
+    conn = boto3.client("lambda", _lambda_region)
+    conn.create_function(
+        FunctionName="testFunction",
+        Runtime="python2.7",
+        Role=get_role_name(),
+        Handler="lambda_function.lambda_handler",
+        Code={"ZipFile": get_test_zip_file_error()},
+    )
+
+    failure_response = conn.invoke(
+        FunctionName="testFunction", Payload=json.dumps({}), LogType="Tail"
+    )
+
+    failure_response.should.have.key("FunctionError").being.equal("Handled")
+
+    payload = failure_response["Payload"].read().decode("utf-8")
+    payload = json.loads(payload)
+    payload["errorType"].should.equal("Exception")
+    payload["errorMessage"].should.equal("I failed!")
+    payload.should.have.key("stackTrace")
+
+    logs = base64.b64decode(failure_response["LogResult"]).decode("utf-8")
+    logs.should.contain("START RequestId:")
+    logs.should.contain("I failed!: Exception")
+    logs.should.contain("Traceback (most recent call last):")
+    logs.should.contain("END RequestId:")
 
 
 @pytest.mark.network
@@ -1390,7 +1421,7 @@ def test_invoke_function_from_sqs_exception():
         Runtime="python2.7",
         Role=get_role_name(),
         Handler="lambda_function.lambda_handler",
-        Code={"ZipFile": get_test_zip_file4()},
+        Code={"ZipFile": get_test_zip_file_error()},
         Description="test lambda function",
         Timeout=3,
         MemorySize=128,


### PR DESCRIPTION
Fixes #3992 

Failed Lambda invocations currently return a combination of log-statements and the actual error. This PR simplifies the response, so that we'll always separate the log-statements from the Docker-response, regardless of whether the invocation was successful.

See also: #2669