### PR TITLE
Refactor listener rule ARN generation to avoid collisions

### DIFF
--- a/moto/elbv2/models.py
+++ b/moto/elbv2/models.py
@@ -1,5 +1,4 @@
 from __future__ import unicode_literals
-import random
 
 import datetime
 import re
@@ -12,6 +11,7 @@ from moto.core.utils import (
     camelcase_to_underscores,
     underscores_to_camelcase,
     iso_8601_datetime_with_milliseconds,
+    get_random_hex,
 )
 from moto.ec2.models import ec2_backends
 from moto.acm.models import acm_backends
@@ -673,11 +673,8 @@ class ELBv2Backend(BaseBackend):
                 raise PriorityInUseError()
 
         self._validate_actions(actions)
-        arn = (
-            listener_arn.replace(":listener/", ":listener-rule/")
-            + "{}".format(random.randint(0, 50))
-            + "/%s" % (id(self))
-        )
+        arn = listener_arn.replace(":listener/", ":listener-rule/")
+        arn += "/%s" % (get_random_hex(16))
 
         # TODO: check for error 'TooManyRegistrationsForTargetId'
         # TODO: check for error 'TooManyRules'


### PR DESCRIPTION
The code that generates an ARN for a listener rule was relying on a random
number between 0 and 50 to ensure uniqueness.  As a result, there was a decent
chance of generating a collision, particularly when adding multiple rules.

When a collision occurred, the new rule simply overwrote an existing rule,
causing a test that asserts on an expected number of rules being returned
to fail.

Reference the following runs for related test failures:
https://github.com/spulec/moto/runs/2772429387
https://github.com/spulec/moto/runs/2786330037