### PR TITLE
Reduce default value for DEFAULT_KEY_BUFFER_SIZE

### DIFF
--- a/moto/s3/models.py
+++ b/moto/s3/models.py
@@ -50,7 +50,6 @@ from ..settings import get_s3_default_key_buffer_size
 MAX_BUCKET_NAME_LENGTH = 63
 MIN_BUCKET_NAME_LENGTH = 3
 UPLOAD_ID_BYTES = 43
-UPLOAD_PART_MIN_SIZE = 5242880
 STORAGE_CLASS = [
     "STANDARD",
     "REDUCED_REDUNDANCY",
@@ -318,7 +317,7 @@ class FakeMultipart(BaseModel):
                 etag = etag.replace('"', "")
             if part is None or part_etag != etag:
                 raise InvalidPart()
-            if last is not None and last.contentsize < UPLOAD_PART_MIN_SIZE:
+            if last is not None and last.contentsize < S3_UPLOAD_PART_MIN_SIZE:
                 raise EntityTooSmall()
             md5s.extend(decode_hex(part_etag)[0])
             total.extend(part.value)

--- a/moto/s3/models.py
+++ b/moto/s3/models.py
@@ -45,7 +45,7 @@ from .exceptions import (
 )
 from .cloud_formation import cfn_to_api_encryption, is_replacement_update
 from .utils import clean_key_name, _VersionedKeyStore
-from ..settings import get_default_key_buffer_size
+from ..settings import get_s3_default_key_buffer_size
 
 MAX_BUCKET_NAME_LENGTH = 63
 MIN_BUCKET_NAME_LENGTH = 3
@@ -116,7 +116,7 @@ class FakeKey(BaseModel):
         self.multipart = multipart
         self.bucket_name = bucket_name
 
-        self._max_buffer_size = max_buffer_size if max_buffer_size else get_default_key_buffer_size()
+        self._max_buffer_size = max_buffer_size if max_buffer_size else get_s3_default_key_buffer_size()
         self._value_buffer = tempfile.SpooledTemporaryFile(self._max_buffer_size)
         self.value = value
         self.lock = threading.Lock()

--- a/moto/s3/models.py
+++ b/moto/s3/models.py
@@ -45,7 +45,7 @@ from .exceptions import (
 )
 from .cloud_formation import cfn_to_api_encryption, is_replacement_update
 from .utils import clean_key_name, _VersionedKeyStore
-from ..settings import get_s3_default_key_buffer_size
+from ..settings import get_s3_default_key_buffer_size, S3_UPLOAD_PART_MIN_SIZE
 
 MAX_BUCKET_NAME_LENGTH = 63
 MIN_BUCKET_NAME_LENGTH = 3

--- a/moto/s3/models.py
+++ b/moto/s3/models.py
@@ -115,7 +115,9 @@ class FakeKey(BaseModel):
         self.multipart = multipart
         self.bucket_name = bucket_name
 
-        self._max_buffer_size = max_buffer_size if max_buffer_size else get_s3_default_key_buffer_size()
+        self._max_buffer_size = (
+            max_buffer_size if max_buffer_size else get_s3_default_key_buffer_size()
+        )
         self._value_buffer = tempfile.SpooledTemporaryFile(self._max_buffer_size)
         self.value = value
         self.lock = threading.Lock()
@@ -206,7 +208,7 @@ class FakeKey(BaseModel):
             value_md5 = hashlib.md5()
             self._value_buffer.seek(0)
             while True:
-                block = self._value_buffer.read(16*1024*1024)  # read in 16MB chunks
+                block = self._value_buffer.read(16 * 1024 * 1024)  # read in 16MB chunks
                 if not block:
                     break
                 value_md5.update(block)

--- a/moto/settings.py
+++ b/moto/settings.py
@@ -23,5 +23,5 @@ def get_sf_execution_history_type():
     return os.environ.get("SF_EXECUTION_HISTORY_TYPE", "SUCCESS")
 
 
-def get_default_key_buffer_size():
-    return int(os.environ.get("DEFAULT_KEY_BUFFER_SIZE", 16 * 1024 * 1024))
+def get_s3_default_key_buffer_size():
+    return int(os.environ.get("MOTO_S3_DEFAULT_KEY_BUFFER_SIZE", 16 * 1024 * 1024))

--- a/moto/settings.py
+++ b/moto/settings.py
@@ -23,5 +23,6 @@ def get_sf_execution_history_type():
     return os.environ.get("SF_EXECUTION_HISTORY_TYPE", "SUCCESS")
 
 
+S3_UPLOAD_PART_MIN_SIZE = 5242880
 def get_s3_default_key_buffer_size():
-    return int(os.environ.get("MOTO_S3_DEFAULT_KEY_BUFFER_SIZE", 16 * 1024 * 1024))
+    return int(os.environ.get("MOTO_S3_DEFAULT_KEY_BUFFER_SIZE", S3_UPLOAD_PART_MIN_SIZE - 1024))

--- a/moto/settings.py
+++ b/moto/settings.py
@@ -24,5 +24,11 @@ def get_sf_execution_history_type():
 
 
 S3_UPLOAD_PART_MIN_SIZE = 5242880
+
+
 def get_s3_default_key_buffer_size():
-    return int(os.environ.get("MOTO_S3_DEFAULT_KEY_BUFFER_SIZE", S3_UPLOAD_PART_MIN_SIZE - 1024))
+    return int(
+        os.environ.get(
+            "MOTO_S3_DEFAULT_KEY_BUFFER_SIZE", S3_UPLOAD_PART_MIN_SIZE - 1024
+        )
+    )

--- a/moto/settings.py
+++ b/moto/settings.py
@@ -21,3 +21,7 @@ def get_sf_execution_history_type():
         returned. Default value is SUCCESS, currently supports (SUCCESS || FAILURE)
     """
     return os.environ.get("SF_EXECUTION_HISTORY_TYPE", "SUCCESS")
+
+
+def get_default_key_buffer_size():
+    return int(os.environ.get("DEFAULT_KEY_BUFFER_SIZE", 16 * 1024 * 1024))

--- a/tests/test_s3/test_s3.py
+++ b/tests/test_s3/test_s3.py
@@ -1149,9 +1149,8 @@ def test_default_key_buffer_size():
     del os.environ["MOTO_S3_DEFAULT_KEY_BUFFER_SIZE"]
     assert get_s3_default_key_buffer_size() < S3_UPLOAD_PART_MIN_SIZE
 
-    if (
-        original_default_key_buffer_size
-    ):  # restore original environment variable content
+    # restore original environment variable content
+    if original_default_key_buffer_size:
         os.environ["MOTO_S3_DEFAULT_KEY_BUFFER_SIZE"] = original_default_key_buffer_size
 
 

--- a/tests/test_s3/test_s3.py
+++ b/tests/test_s3/test_s3.py
@@ -39,10 +39,10 @@ from moto import settings, mock_s3, mock_s3_deprecated, mock_config
 import moto.s3.models as s3model
 from moto.core.exceptions import InvalidNextTokenException
 from moto.core.utils import py2_strip_unicode_keys
-from moto.settings import get_s3_default_key_buffer_size
+from moto.settings import get_s3_default_key_buffer_size, S3_UPLOAD_PART_MIN_SIZE
 
 if settings.TEST_SERVER_MODE:
-    REDUCED_PART_SIZE = s3model.UPLOAD_PART_MIN_SIZE
+    REDUCED_PART_SIZE = S3_UPLOAD_PART_MIN_SIZE
     EXPECTED_ETAG = '"140f92a6df9f9e415f74a1463bcee9bb-2"'
 else:
     REDUCED_PART_SIZE = 256
@@ -53,15 +53,15 @@ def reduced_min_part_size(f):
     """speed up tests by temporarily making the multipart minimum part size
     small
     """
-    orig_size = s3model.UPLOAD_PART_MIN_SIZE
+    orig_size = S3_UPLOAD_PART_MIN_SIZE
 
     @wraps(f)
     def wrapped(*args, **kwargs):
         try:
-            s3model.UPLOAD_PART_MIN_SIZE = REDUCED_PART_SIZE
+            s3model.S3_UPLOAD_PART_MIN_SIZE = REDUCED_PART_SIZE
             return f(*args, **kwargs)
         finally:
-            s3model.UPLOAD_PART_MIN_SIZE = orig_size
+            s3model.S3_UPLOAD_PART_MIN_SIZE = orig_size
 
     return wrapped
 
@@ -1141,6 +1141,11 @@ def test_default_key_buffer_size():
     assert get_s3_default_key_buffer_size() == 1
     fk = models.FakeKey("a", os.urandom(3))  # 3 byte string
     assert fk._value_buffer._rolled == True
+
+    # if no MOTO_S3_DEFAULT_KEY_BUFFER_SIZE env variable is present the buffer size should be less than
+    # S3_UPLOAD_PART_MIN_SIZE to prevent in memory caching of multi part uploads
+    del os.environ["MOTO_S3_DEFAULT_KEY_BUFFER_SIZE"]
+    assert get_s3_default_key_buffer_size() < S3_UPLOAD_PART_MIN_SIZE
 
     if original_default_key_buffer_size:  # restore original environment variable content
         os.environ["MOTO_S3_DEFAULT_KEY_BUFFER_SIZE"] = original_default_key_buffer_size

--- a/tests/test_s3/test_s3.py
+++ b/tests/test_s3/test_s3.py
@@ -39,7 +39,7 @@ from moto import settings, mock_s3, mock_s3_deprecated, mock_config
 import moto.s3.models as s3model
 from moto.core.exceptions import InvalidNextTokenException
 from moto.core.utils import py2_strip_unicode_keys
-from moto.settings import get_default_key_buffer_size
+from moto.settings import get_s3_default_key_buffer_size
 
 if settings.TEST_SERVER_MODE:
     REDUCED_PART_SIZE = s3model.UPLOAD_PART_MIN_SIZE
@@ -1130,20 +1130,20 @@ def test_multipart_upload_from_file_to_presigned_url():
 @mock_s3
 def test_default_key_buffer_size():
     # save original DEFAULT_KEY_BUFFER_SIZE environment variable content
-    original_default_key_buffer_size = os.environ.get("DEFAULT_KEY_BUFFER_SIZE", None)
+    original_default_key_buffer_size = os.environ.get("MOTO_S3_DEFAULT_KEY_BUFFER_SIZE", None)
 
-    os.environ["DEFAULT_KEY_BUFFER_SIZE"] = "2"  # 2 bytes
-    assert get_default_key_buffer_size() == 2
+    os.environ["MOTO_S3_DEFAULT_KEY_BUFFER_SIZE"] = "2"  # 2 bytes
+    assert get_s3_default_key_buffer_size() == 2
     fk = models.FakeKey("a", os.urandom(1))  # 1 byte string
     assert fk._value_buffer._rolled == False
 
-    os.environ["DEFAULT_KEY_BUFFER_SIZE"] = "1"  # 1 byte
-    assert get_default_key_buffer_size() == 1
+    os.environ["MOTO_S3_DEFAULT_KEY_BUFFER_SIZE"] = "1"  # 1 byte
+    assert get_s3_default_key_buffer_size() == 1
     fk = models.FakeKey("a", os.urandom(3))  # 3 byte string
     assert fk._value_buffer._rolled == True
 
     if original_default_key_buffer_size:  # restore original environment variable content
-        os.environ["DEFAULT_KEY_BUFFER_SIZE"] = original_default_key_buffer_size
+        os.environ["MOTO_S3_DEFAULT_KEY_BUFFER_SIZE"] = original_default_key_buffer_size
 
 @mock_s3
 def test_s3_object_in_private_bucket():

--- a/tests/test_s3/test_s3.py
+++ b/tests/test_s3/test_s3.py
@@ -27,6 +27,8 @@ from boto.s3.key import Key
 from freezegun import freeze_time
 import six
 import requests
+
+from moto.s3 import models
 from moto.s3.responses import DEFAULT_REGION_NAME
 from unittest import SkipTest
 import pytest
@@ -37,7 +39,7 @@ from moto import settings, mock_s3, mock_s3_deprecated, mock_config
 import moto.s3.models as s3model
 from moto.core.exceptions import InvalidNextTokenException
 from moto.core.utils import py2_strip_unicode_keys
-
+from moto.settings import get_default_key_buffer_size
 
 if settings.TEST_SERVER_MODE:
     REDUCED_PART_SIZE = s3model.UPLOAD_PART_MIN_SIZE
@@ -1124,6 +1126,24 @@ def test_multipart_upload_from_file_to_presigned_url():
     # cleanup
     os.remove("text.txt")
 
+
+@mock_s3
+def test_default_key_buffer_size():
+    # save original DEFAULT_KEY_BUFFER_SIZE environment variable content
+    original_default_key_buffer_size = os.environ.get("DEFAULT_KEY_BUFFER_SIZE", None)
+
+    os.environ["DEFAULT_KEY_BUFFER_SIZE"] = "2"  # 2 bytes
+    assert get_default_key_buffer_size() == 2
+    fk = models.FakeKey("a", os.urandom(1))  # 1 byte string
+    assert fk._value_buffer._rolled == False
+
+    os.environ["DEFAULT_KEY_BUFFER_SIZE"] = "1"  # 1 byte
+    assert get_default_key_buffer_size() == 1
+    fk = models.FakeKey("a", os.urandom(3))  # 3 byte string
+    assert fk._value_buffer._rolled == True
+
+    if original_default_key_buffer_size:  # restore original environment variable content
+        os.environ["DEFAULT_KEY_BUFFER_SIZE"] = original_default_key_buffer_size
 
 @mock_s3
 def test_s3_object_in_private_bucket():

--- a/tests/test_s3/test_s3.py
+++ b/tests/test_s3/test_s3.py
@@ -1130,7 +1130,9 @@ def test_multipart_upload_from_file_to_presigned_url():
 @mock_s3
 def test_default_key_buffer_size():
     # save original DEFAULT_KEY_BUFFER_SIZE environment variable content
-    original_default_key_buffer_size = os.environ.get("MOTO_S3_DEFAULT_KEY_BUFFER_SIZE", None)
+    original_default_key_buffer_size = os.environ.get(
+        "MOTO_S3_DEFAULT_KEY_BUFFER_SIZE", None
+    )
 
     os.environ["MOTO_S3_DEFAULT_KEY_BUFFER_SIZE"] = "2"  # 2 bytes
     assert get_s3_default_key_buffer_size() == 2
@@ -1147,8 +1149,11 @@ def test_default_key_buffer_size():
     del os.environ["MOTO_S3_DEFAULT_KEY_BUFFER_SIZE"]
     assert get_s3_default_key_buffer_size() < S3_UPLOAD_PART_MIN_SIZE
 
-    if original_default_key_buffer_size:  # restore original environment variable content
+    if (
+        original_default_key_buffer_size
+    ):  # restore original environment variable content
         os.environ["MOTO_S3_DEFAULT_KEY_BUFFER_SIZE"] = original_default_key_buffer_size
+
 
 @mock_s3
 def test_s3_object_in_private_bucket():


### PR DESCRIPTION
This is a continuation of https://github.com/spulec/moto/pull/3994

This PR reduces the default value for DEFAULT_KEY_BUFFER_SIZE to 1KB less than the UPLOAD_PART_MIN_SIZE. This prevents in memory caching for multi part uploads. To facilitate this change I had to move the constant UPLOAD_PART_MIN_SIZE to the settings.py so that I was able to use it in the `get_s3_default_key_buffer_size` function without circular import issues.
