### PR TITLE
Escape Hyphen in Regular Expression

### DIFF
--- a/moto/ssm/models.py
+++ b/moto/ssm/models.py
@@ -1007,7 +1007,7 @@ class SimpleSystemManagerBackend(BaseBackend):
                     if (
                         "//" in value
                         or not value.startswith("/")
-                        or not re.match("^[a-zA-Z0-9_.\-/]*$", value)
+                        or not re.match(r"^[a-zA-Z0-9_.\-/]*$", value)
                     ):
                         raise ValidationException(
                             'The parameter doesn\'t meet the parameter name requirements. The parameter name must begin with a forward slash "/". '

--- a/moto/ssm/models.py
+++ b/moto/ssm/models.py
@@ -1007,7 +1007,7 @@ class SimpleSystemManagerBackend(BaseBackend):
                     if (
                         "//" in value
                         or not value.startswith("/")
-                        or not re.match("^[a-zA-Z0-9_.-/]*$", value)
+                        or not re.match("^[a-zA-Z0-9_.\-/]*$", value)
                     ):
                         raise ValidationException(
                             'The parameter doesn\'t meet the parameter name requirements. The parameter name must begin with a forward slash "/". '

--- a/tests/test_ssm/test_ssm_boto3.py
+++ b/tests/test_ssm/test_ssm_boto3.py
@@ -1394,7 +1394,7 @@ def test_label_parameter_version_invalid_name():
 
     test_parameter_name = "test"
 
-    response = client.label_parameter_version.when.called_with(
+    client.label_parameter_version.when.called_with(
         Name=test_parameter_name, Labels=["test-label"]
     ).should.throw(
         ClientError,
@@ -1415,7 +1415,7 @@ def test_label_parameter_version_invalid_parameter_version():
         Type="String",
     )
 
-    response = client.label_parameter_version.when.called_with(
+    client.label_parameter_version.when.called_with(
         Name=test_parameter_name, Labels=["test-label"], ParameterVersion=5
     ).should.throw(
         ClientError,

--- a/tests/test_ssm/test_ssm_boto3.py
+++ b/tests/test_ssm/test_ssm_boto3.py
@@ -247,7 +247,7 @@ def test_put_parameter(name):
     response["Parameters"][0]["Version"].should.equal(1)
     response["Parameters"][0]["LastModifiedDate"].should.be.a(datetime.datetime)
     response["Parameters"][0]["ARN"].should.equal(
-        f"arn:aws:ssm:us-east-1:1234567890:parameter/{name}"
+        "arn:aws:ssm:us-east-1:1234567890:parameter/{}".format(name)
     )
     initial_modification_date = response["Parameters"][0]["LastModifiedDate"]
 
@@ -258,7 +258,9 @@ def test_put_parameter(name):
         raise RuntimeError("Should fail")
     except botocore.exceptions.ClientError as err:
         err.operation_name.should.equal("PutParameter")
-        err.response["Error"]["Message"].should.equal(f"Parameter {name} already exists.")
+        err.response["Error"]["Message"].should.equal(
+            "Parameter {} already exists.".format(name)
+        )
 
     response = client.get_parameters(Names=[name], WithDecryption=False)
 
@@ -272,7 +274,7 @@ def test_put_parameter(name):
         initial_modification_date
     )
     response["Parameters"][0]["ARN"].should.equal(
-        f"arn:aws:ssm:us-east-1:1234567890:parameter/{name}"
+        "arn:aws:ssm:us-east-1:1234567890:parameter/{}".format(name)
     )
 
     response = client.put_parameter(
@@ -293,7 +295,7 @@ def test_put_parameter(name):
         initial_modification_date
     )
     response["Parameters"][0]["ARN"].should.equal(
-        f"arn:aws:ssm:us-east-1:1234567890:parameter/{name}"
+        "arn:aws:ssm:us-east-1:1234567890:parameter/{}".format(name)
     )
 
 

--- a/tests/test_ssm/test_ssm_boto3.py
+++ b/tests/test_ssm/test_ssm_boto3.py
@@ -276,11 +276,7 @@ def test_put_parameter(name):
     )
 
     response = client.put_parameter(
-        Name=name,
-        Description="desc 3",
-        Value="value 3",
-        Type="String",
-        Overwrite=True,
+        Name=name, Description="desc 3", Value="value 3", Type="String", Overwrite=True,
     )
 
     response["Version"].should.equal(2)

--- a/tests/test_ssm/test_ssm_boto3.py
+++ b/tests/test_ssm/test_ssm_boto3.py
@@ -227,78 +227,78 @@ def test_get_parameters_by_path():
     )
 
 
+@pytest.mark.parametrize("name", ["test", "/my-cool-parameter"])
 @mock_ssm
-def test_put_parameter():
+def test_put_parameter(name):
     client = boto3.client("ssm", region_name="us-east-1")
 
-    for name in ["test", "/my-cool-parameter"]:
-        response = client.put_parameter(
-            Name=name, Description="A test parameter", Value="value", Type="String"
+    response = client.put_parameter(
+        Name=name, Description="A test parameter", Value="value", Type="String"
+    )
+
+    response["Version"].should.equal(1)
+
+    response = client.get_parameters(Names=[name], WithDecryption=False)
+
+    len(response["Parameters"]).should.equal(1)
+    response["Parameters"][0]["Name"].should.equal(name)
+    response["Parameters"][0]["Value"].should.equal("value")
+    response["Parameters"][0]["Type"].should.equal("String")
+    response["Parameters"][0]["Version"].should.equal(1)
+    response["Parameters"][0]["LastModifiedDate"].should.be.a(datetime.datetime)
+    response["Parameters"][0]["ARN"].should.equal(
+        "arn:aws:ssm:us-east-1:1234567890:parameter/test"
+    )
+    initial_modification_date = response["Parameters"][0]["LastModifiedDate"]
+
+    try:
+        client.put_parameter(
+            Name=name, Description="desc 2", Value="value 2", Type="String"
         )
+        raise RuntimeError("Should fail")
+    except botocore.exceptions.ClientError as err:
+        err.operation_name.should.equal("PutParameter")
+        err.response["Error"]["Message"].should.equal("Parameter test already exists.")
 
-        response["Version"].should.equal(1)
+    response = client.get_parameters(Names=[name], WithDecryption=False)
 
-        response = client.get_parameters(Names=[name], WithDecryption=False)
+    # without overwrite nothing change
+    len(response["Parameters"]).should.equal(1)
+    response["Parameters"][0]["Name"].should.equal(name)
+    response["Parameters"][0]["Value"].should.equal("value")
+    response["Parameters"][0]["Type"].should.equal("String")
+    response["Parameters"][0]["Version"].should.equal(1)
+    response["Parameters"][0]["LastModifiedDate"].should.equal(
+        initial_modification_date
+    )
+    response["Parameters"][0]["ARN"].should.equal(
+        "arn:aws:ssm:us-east-1:1234567890:parameter/test"
+    )
 
-        len(response["Parameters"]).should.equal(1)
-        response["Parameters"][0]["Name"].should.equal(name)
-        response["Parameters"][0]["Value"].should.equal("value")
-        response["Parameters"][0]["Type"].should.equal("String")
-        response["Parameters"][0]["Version"].should.equal(1)
-        response["Parameters"][0]["LastModifiedDate"].should.be.a(datetime.datetime)
-        response["Parameters"][0]["ARN"].should.equal(
-            "arn:aws:ssm:us-east-1:1234567890:parameter/test"
-        )
-        initial_modification_date = response["Parameters"][0]["LastModifiedDate"]
+    response = client.put_parameter(
+        Name=name,
+        Description="desc 3",
+        Value="value 3",
+        Type="String",
+        Overwrite=True,
+    )
 
-        try:
-            client.put_parameter(
-                Name=name, Description="desc 2", Value="value 2", Type="String"
-            )
-            raise RuntimeError("Should fail")
-        except botocore.exceptions.ClientError as err:
-            err.operation_name.should.equal("PutParameter")
-            err.response["Error"]["Message"].should.equal("Parameter test already exists.")
+    response["Version"].should.equal(2)
 
-        response = client.get_parameters(Names=[name], WithDecryption=False)
+    response = client.get_parameters(Names=[name], WithDecryption=False)
 
-        # without overwrite nothing change
-        len(response["Parameters"]).should.equal(1)
-        response["Parameters"][0]["Name"].should.equal(name)
-        response["Parameters"][0]["Value"].should.equal("value")
-        response["Parameters"][0]["Type"].should.equal("String")
-        response["Parameters"][0]["Version"].should.equal(1)
-        response["Parameters"][0]["LastModifiedDate"].should.equal(
-            initial_modification_date
-        )
-        response["Parameters"][0]["ARN"].should.equal(
-            "arn:aws:ssm:us-east-1:1234567890:parameter/test"
-        )
-
-        response = client.put_parameter(
-            Name=name,
-            Description="desc 3",
-            Value="value 3",
-            Type="String",
-            Overwrite=True,
-        )
-
-        response["Version"].should.equal(2)
-
-        response = client.get_parameters(Names=[name], WithDecryption=False)
-
-        # without overwrite nothing change
-        len(response["Parameters"]).should.equal(1)
-        response["Parameters"][0]["Name"].should.equal(name)
-        response["Parameters"][0]["Value"].should.equal("value 3")
-        response["Parameters"][0]["Type"].should.equal("String")
-        response["Parameters"][0]["Version"].should.equal(2)
-        response["Parameters"][0]["LastModifiedDate"].should_not.equal(
-            initial_modification_date
-        )
-        response["Parameters"][0]["ARN"].should.equal(
-            "arn:aws:ssm:us-east-1:1234567890:parameter/test"
-        )
+    # without overwrite nothing change
+    len(response["Parameters"]).should.equal(1)
+    response["Parameters"][0]["Name"].should.equal(name)
+    response["Parameters"][0]["Value"].should.equal("value 3")
+    response["Parameters"][0]["Type"].should.equal("String")
+    response["Parameters"][0]["Version"].should.equal(2)
+    response["Parameters"][0]["LastModifiedDate"].should_not.equal(
+        initial_modification_date
+    )
+    response["Parameters"][0]["ARN"].should.equal(
+        "arn:aws:ssm:us-east-1:1234567890:parameter/test"
+    )
 
 
 @mock_ssm

--- a/tests/test_ssm/test_ssm_boto3.py
+++ b/tests/test_ssm/test_ssm_boto3.py
@@ -227,7 +227,7 @@ def test_get_parameters_by_path():
     )
 
 
-@pytest.mark.parametrize("name", ["test", "/my-cool-parameter"])
+@pytest.mark.parametrize("name", ["test", "my-cool-parameter"])
 @mock_ssm
 def test_put_parameter(name):
     client = boto3.client("ssm", region_name="us-east-1")
@@ -247,7 +247,7 @@ def test_put_parameter(name):
     response["Parameters"][0]["Version"].should.equal(1)
     response["Parameters"][0]["LastModifiedDate"].should.be.a(datetime.datetime)
     response["Parameters"][0]["ARN"].should.equal(
-        "arn:aws:ssm:us-east-1:1234567890:parameter/test"
+        f"arn:aws:ssm:us-east-1:1234567890:parameter/{name}"
     )
     initial_modification_date = response["Parameters"][0]["LastModifiedDate"]
 
@@ -258,7 +258,7 @@ def test_put_parameter(name):
         raise RuntimeError("Should fail")
     except botocore.exceptions.ClientError as err:
         err.operation_name.should.equal("PutParameter")
-        err.response["Error"]["Message"].should.equal("Parameter test already exists.")
+        err.response["Error"]["Message"].should.equal(f"Parameter {name} already exists.")
 
     response = client.get_parameters(Names=[name], WithDecryption=False)
 
@@ -272,7 +272,7 @@ def test_put_parameter(name):
         initial_modification_date
     )
     response["Parameters"][0]["ARN"].should.equal(
-        "arn:aws:ssm:us-east-1:1234567890:parameter/test"
+        f"arn:aws:ssm:us-east-1:1234567890:parameter/{name}"
     )
 
     response = client.put_parameter(
@@ -293,7 +293,7 @@ def test_put_parameter(name):
         initial_modification_date
     )
     response["Parameters"][0]["ARN"].should.equal(
-        "arn:aws:ssm:us-east-1:1234567890:parameter/test"
+        f"arn:aws:ssm:us-east-1:1234567890:parameter/{name}"
     )
 
 

--- a/tests/test_ssm/test_ssm_boto3.py
+++ b/tests/test_ssm/test_ssm_boto3.py
@@ -231,73 +231,74 @@ def test_get_parameters_by_path():
 def test_put_parameter():
     client = boto3.client("ssm", region_name="us-east-1")
 
-    response = client.put_parameter(
-        Name="test", Description="A test parameter", Value="value", Type="String"
-    )
-
-    response["Version"].should.equal(1)
-
-    response = client.get_parameters(Names=["test"], WithDecryption=False)
-
-    len(response["Parameters"]).should.equal(1)
-    response["Parameters"][0]["Name"].should.equal("test")
-    response["Parameters"][0]["Value"].should.equal("value")
-    response["Parameters"][0]["Type"].should.equal("String")
-    response["Parameters"][0]["Version"].should.equal(1)
-    response["Parameters"][0]["LastModifiedDate"].should.be.a(datetime.datetime)
-    response["Parameters"][0]["ARN"].should.equal(
-        "arn:aws:ssm:us-east-1:1234567890:parameter/test"
-    )
-    initial_modification_date = response["Parameters"][0]["LastModifiedDate"]
-
-    try:
-        client.put_parameter(
-            Name="test", Description="desc 2", Value="value 2", Type="String"
+    for name in ["test", "/my-cool-parameter"]:
+        response = client.put_parameter(
+            Name=name, Description="A test parameter", Value="value", Type="String"
         )
-        raise RuntimeError("Should fail")
-    except botocore.exceptions.ClientError as err:
-        err.operation_name.should.equal("PutParameter")
-        err.response["Error"]["Message"].should.equal("Parameter test already exists.")
 
-    response = client.get_parameters(Names=["test"], WithDecryption=False)
+        response["Version"].should.equal(1)
 
-    # without overwrite nothing change
-    len(response["Parameters"]).should.equal(1)
-    response["Parameters"][0]["Name"].should.equal("test")
-    response["Parameters"][0]["Value"].should.equal("value")
-    response["Parameters"][0]["Type"].should.equal("String")
-    response["Parameters"][0]["Version"].should.equal(1)
-    response["Parameters"][0]["LastModifiedDate"].should.equal(
-        initial_modification_date
-    )
-    response["Parameters"][0]["ARN"].should.equal(
-        "arn:aws:ssm:us-east-1:1234567890:parameter/test"
-    )
+        response = client.get_parameters(Names=[name], WithDecryption=False)
 
-    response = client.put_parameter(
-        Name="test",
-        Description="desc 3",
-        Value="value 3",
-        Type="String",
-        Overwrite=True,
-    )
+        len(response["Parameters"]).should.equal(1)
+        response["Parameters"][0]["Name"].should.equal(name)
+        response["Parameters"][0]["Value"].should.equal("value")
+        response["Parameters"][0]["Type"].should.equal("String")
+        response["Parameters"][0]["Version"].should.equal(1)
+        response["Parameters"][0]["LastModifiedDate"].should.be.a(datetime.datetime)
+        response["Parameters"][0]["ARN"].should.equal(
+            "arn:aws:ssm:us-east-1:1234567890:parameter/test"
+        )
+        initial_modification_date = response["Parameters"][0]["LastModifiedDate"]
 
-    response["Version"].should.equal(2)
+        try:
+            client.put_parameter(
+                Name=name, Description="desc 2", Value="value 2", Type="String"
+            )
+            raise RuntimeError("Should fail")
+        except botocore.exceptions.ClientError as err:
+            err.operation_name.should.equal("PutParameter")
+            err.response["Error"]["Message"].should.equal("Parameter test already exists.")
 
-    response = client.get_parameters(Names=["test"], WithDecryption=False)
+        response = client.get_parameters(Names=[name], WithDecryption=False)
 
-    # without overwrite nothing change
-    len(response["Parameters"]).should.equal(1)
-    response["Parameters"][0]["Name"].should.equal("test")
-    response["Parameters"][0]["Value"].should.equal("value 3")
-    response["Parameters"][0]["Type"].should.equal("String")
-    response["Parameters"][0]["Version"].should.equal(2)
-    response["Parameters"][0]["LastModifiedDate"].should_not.equal(
-        initial_modification_date
-    )
-    response["Parameters"][0]["ARN"].should.equal(
-        "arn:aws:ssm:us-east-1:1234567890:parameter/test"
-    )
+        # without overwrite nothing change
+        len(response["Parameters"]).should.equal(1)
+        response["Parameters"][0]["Name"].should.equal(name)
+        response["Parameters"][0]["Value"].should.equal("value")
+        response["Parameters"][0]["Type"].should.equal("String")
+        response["Parameters"][0]["Version"].should.equal(1)
+        response["Parameters"][0]["LastModifiedDate"].should.equal(
+            initial_modification_date
+        )
+        response["Parameters"][0]["ARN"].should.equal(
+            "arn:aws:ssm:us-east-1:1234567890:parameter/test"
+        )
+
+        response = client.put_parameter(
+            Name=name,
+            Description="desc 3",
+            Value="value 3",
+            Type="String",
+            Overwrite=True,
+        )
+
+        response["Version"].should.equal(2)
+
+        response = client.get_parameters(Names=[name], WithDecryption=False)
+
+        # without overwrite nothing change
+        len(response["Parameters"]).should.equal(1)
+        response["Parameters"][0]["Name"].should.equal(name)
+        response["Parameters"][0]["Value"].should.equal("value 3")
+        response["Parameters"][0]["Type"].should.equal("String")
+        response["Parameters"][0]["Version"].should.equal(2)
+        response["Parameters"][0]["LastModifiedDate"].should_not.equal(
+            initial_modification_date
+        )
+        response["Parameters"][0]["ARN"].should.equal(
+            "arn:aws:ssm:us-east-1:1234567890:parameter/test"
+        )
 
 
 @mock_ssm


### PR DESCRIPTION
Currently you cannot have a SSM parameter name that contains a hyphen such as `/my-cool-parameter` due to a missing backslash.