### PR TITLE
Only raise EmptyKeyAttributeException when the value node is empty

### DIFF
--- a/moto/dynamodb2/parsing/validators.py
+++ b/moto/dynamodb2/parsing/validators.py
@@ -332,7 +332,11 @@ class EmptyStringKeyValueValidator(DepthFirstTraverser):
         assert len(node.children) == 2
         key = node.children[0].children[0].children[0]
         val_node = node.children[1].children[0]
-        if val_node.type in ["S", "B"] and key in self.key_attributes:
+        if (
+            not val_node.value
+            and val_node.type in ["S", "B"]
+            and key in self.key_attributes
+        ):
             raise EmptyKeyAttributeException
         return node
 

--- a/tests/test_dynamodb2/test_dynamodb_validation.py
+++ b/tests/test_dynamodb2/test_dynamodb_validation.py
@@ -19,6 +19,29 @@ from moto.dynamodb2.parsing.expressions import UpdateExpressionParser
 from moto.dynamodb2.parsing.validators import UpdateExpressionValidator
 
 
+def test_valid_update_expression(table):
+    update_expression = "set forum_name=:NewName, forum_type=:NewType"
+    update_expression_values = {
+        ":NewName": {"S": "AmazingForum"},
+        ":NewType": {"S": "BASIC"},
+    }
+    update_expression_ast = UpdateExpressionParser.make(update_expression)
+    item = Item(
+        hash_key=DynamoType({"S": "forum_name"}),
+        hash_key_type="TYPE",
+        range_key=DynamoType({"S": "forum_type"}),
+        range_key_type="TYPE",
+        attrs={"forum_name": {"S": "hello"}},
+    )
+    UpdateExpressionValidator(
+        update_expression_ast,
+        expression_attribute_names=None,
+        expression_attribute_values=update_expression_values,
+        item=item,
+        table=table,
+    ).validate()
+
+
 def test_validation_of_empty_string_key_val(table):
     with pytest.raises(EmptyKeyAttributeException):
         update_expression = "set forum_name=:NewName"


### PR DESCRIPTION
This fixes a bug where all updates to keys (including GSIs) would raise
EmptyKeyAttributeException, even when the new value was not an empty string.