### PR TITLE
Added "isTruncated" attribute for listUsersResponse

### DIFF
--- a/moto/iam/responses.py
+++ b/moto/iam/responses.py
@@ -492,10 +492,9 @@ class IamResponse(BaseResponse):
         path_prefix = self._get_param("PathPrefix")
         marker = self._get_param("Marker")
         max_items = self._get_param("MaxItems")
-        is_truncated = self._get_bool_param("IsTruncated", False)
         users = iam_backend.list_users(path_prefix, marker, max_items)
         template = self.response_template(LIST_USERS_TEMPLATE)
-        return template.render(action="List", users=users, isTruncated=is_truncated)
+        return template.render(action="List", users=users, isTruncated=False)
 
     def update_user(self):
         user_name = self._get_param("UserName")

--- a/moto/iam/responses.py
+++ b/moto/iam/responses.py
@@ -492,9 +492,10 @@ class IamResponse(BaseResponse):
         path_prefix = self._get_param("PathPrefix")
         marker = self._get_param("Marker")
         max_items = self._get_param("MaxItems")
+        is_truncated = self._get_bool_param("IsTruncated", False)
         users = iam_backend.list_users(path_prefix, marker, max_items)
         template = self.response_template(LIST_USERS_TEMPLATE)
-        return template.render(action="List", users=users)
+        return template.render(action="List", users=users, isTruncated=is_truncated)
 
     def update_user(self):
         user_name = self._get_param("UserName")
@@ -1725,6 +1726,7 @@ USER_TEMPLATE = """<{{ action }}UserResponse>
 
 LIST_USERS_TEMPLATE = """<{{ action }}UsersResponse>
    <{{ action }}UsersResult>
+    <IsTruncated>{{ isTruncated }}</IsTruncated>
       <Users>
          {% for user in users %}
          <member>

--- a/tests/test_iam/test_iam.py
+++ b/tests/test_iam/test_iam.py
@@ -808,6 +808,7 @@ def test_list_users():
     user["UserName"].should.equal("my-user")
     user["Path"].should.equal("/")
     user["Arn"].should.equal("arn:aws:iam::{}:user/my-user".format(ACCOUNT_ID))
+    response["IsTruncated"].should.equal(False)
 
     conn.create_user(UserName="my-user-1", Path="myUser")
     response = conn.list_users(PathPrefix="my")


### PR DESCRIPTION
This PR adds the isTruncated attribute to the xml for the ListsUserResponse.

According to the documentation mentioned in the issue localstack/localstack#4150, the Java AWS SDK v2 is expecting the attribute when parsing the response. 