### PR TITLE
When matching URL patterns, the last elem should always at least one …

### DIFF
--- a/moto/core/responses.py
+++ b/moto/core/responses.py
@@ -333,7 +333,7 @@ class BaseResponse(_TemplateEnvironmentMixin, ActionAuthenticatorMixin):
                 .replace("-", "_")
             )
             if is_last:
-                return "(?P<%s>[^/]*)" % name
+                return "(?P<%s>[^/]+)" % name
             return "(?P<%s>.*)" % name
 
         elems = uri.split("/")


### PR DESCRIPTION
…char

Background:
For the MediaStoreData-service, there are two GET-methods:
_GetObject: /{Path}_
_ListObjects: /_

The `uri_to_regexp`-method will convert {Path} into `(?P<path>[^/]*)`, so the regex becomes:
_GetObject: /{some_path_with_0_or_more_characters}_

As a result, when matching the uri `/`, it can incorrectly match the GetObject.

This PR requires the object-name to have at least one character, so there's a clear difference between:
_GetObject: /a_
_ListObjects: /_
