### PR TITLE
Fix validation of values in case of DELETE action

### DIFF
--- a/moto/dynamodb2/models/__init__.py
+++ b/moto/dynamodb2/models/__init__.py
@@ -120,6 +120,8 @@ class Item(BaseModel):
     def validate_no_empty_key_values(self, attribute_updates, key_attributes):
         for attribute_name, update_action in attribute_updates.items():
             action = update_action.get("Action") or "PUT"  # PUT is default
+            if action == "DELETE":
+                continue
             new_value = next(iter(update_action["Value"].values()))
             if action == "PUT" and new_value == "" and attribute_name in key_attributes:
                 raise EmptyKeyAttributeException


### PR DESCRIPTION
In case of DELETE action we don't pass the value if we want to remove the attribute.
There are more cases but it's for you to handle.