### PR TITLE
S3 - Return appropriate error when provided with invalid multipart ID

### DIFF
--- a/moto/s3/models.py
+++ b/moto/s3/models.py
@@ -333,7 +333,7 @@ class FakeMultipart(BaseModel):
 
     def set_part(self, part_id, value):
         if part_id < 1:
-            return
+            raise NoSuchUpload(upload_id=part_id)
 
         key = FakeKey(part_id, value)
         self.parts[part_id] = key

--- a/tests/test_s3/test_s3_multipart.py
+++ b/tests/test_s3/test_s3_multipart.py
@@ -4,6 +4,8 @@ import boto3
 import pytest
 import sure  # noqa
 
+from .test_s3 import DEFAULT_REGION_NAME
+
 
 @mock_s3
 def test_multipart_should_throw_nosuchupload_if_there_are_no_parts():
@@ -22,3 +24,29 @@ def test_multipart_should_throw_nosuchupload_if_there_are_no_parts():
         "The specified upload does not exist. The upload ID may be invalid, or the upload may have been aborted or completed."
     )
     err["UploadId"].should.equal(multipart_upload.id)
+
+
+@mock_s3
+def test_boto3_multipart_part_size():
+    bucket_name = "mputest-3593"
+    s3 = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
+    s3.create_bucket(Bucket=bucket_name)
+
+    mpu = s3.create_multipart_upload(Bucket=bucket_name, Key="the-key")
+    mpu_id = mpu["UploadId"]
+
+    body = b"111"
+    with pytest.raises(ClientError) as ex:
+        s3.upload_part(
+            Bucket=bucket_name,
+            Key="the-key",
+            PartNumber=-1,
+            UploadId=mpu_id,
+            Body=body,
+            ContentLength=len(body),
+        )
+    err = ex.value.response["Error"]
+    err["Code"].should.equal("NoSuchUpload")
+    err["Message"].should.equal(
+        "The specified upload does not exist. The upload ID may be invalid, or the upload may have been aborted or completed."
+    )


### PR DESCRIPTION
Fixes #3593 

Verified test against AWS