### PR TITLE
AWSLambda:list_functions() should only return the latest version by default

### DIFF
--- a/moto/awslambda/responses.py
+++ b/moto/awslambda/responses.py
@@ -236,11 +236,12 @@ class LambdaResponse(BaseResponse):
             return 404, response_headers, "{}"
 
     def _list_functions(self, request, full_url, headers):
+        querystring = self.querystring
+        func_version = querystring.get("FunctionVersion", [None])[0]
         result = {"Functions": []}
 
-        for fn in self.lambda_backend.list_functions():
+        for fn in self.lambda_backend.list_functions(func_version):
             json_data = fn.get_configuration()
-            json_data["Version"] = "$LATEST"
             result["Functions"].append(json_data)
 
         return 200, {}, json.dumps(result)
@@ -298,8 +299,9 @@ class LambdaResponse(BaseResponse):
 
     def _publish_function(self, request, full_url, headers):
         function_name = self.path.rsplit("/", 2)[-2]
+        description = self._get_param("Description")
 
-        fn = self.lambda_backend.publish_function(function_name)
+        fn = self.lambda_backend.publish_function(function_name, description)
         if fn:
             config = fn.get_configuration()
             return 201, {}, json.dumps(config)


### PR DESCRIPTION
Fixes #3422 

Only return full version list when the user specifies `FunctionVersion="ALL"`

Also makes some changes to ensure that FunctionARN is always returned in the correct format.

Tests have been verified against AWS.