### PR TITLE
Enforce the same limit of ResourceRecord elements in a ChangeBatch as…

### DIFF
--- a/moto/route53/responses.py
+++ b/moto/route53/responses.py
@@ -122,11 +122,12 @@ class Route53(BaseResponse):
             effective_rr_count = 0
             for value in change_list:
                 record_set = value["ResourceRecordSet"]
-                if "ResourceRecords" not in record_set or not record_set["ResourceRecords"]:
+                if (
+                    "ResourceRecords" not in record_set
+                    or not record_set["ResourceRecords"]
+                ):
                     continue
-                resource_records = list(record_set["ResourceRecords"].values())[
-                            0
-                        ]
+                resource_records = list(record_set["ResourceRecords"].values())[0]
                 effective_rr_count += len(resource_records)
                 if value["Action"] == "UPSERT":
                     effective_rr_count += len(resource_records)

--- a/tests/test_route53/test_route53.py
+++ b/tests/test_route53/test_route53.py
@@ -1127,12 +1127,12 @@ def test_change_resource_record_sets_records_limit():
     for ci in range(4):
         resourcerecords = []
         for rri in range(250):
-            resourcerecords.append({"Value": f"127.0.0.{rri}"})
+            resourcerecords.append({"Value": "127.0.0.%d" % (rri)})
         changes.append(
             {
                 "Action": "CREATE",
                 "ResourceRecordSet": {
-                    "Name": f"foo{ci}.db.",
+                    "Name": "foo%d.db." % (ci),
                     "Type": "A",
                     "TTL": 10,
                     "ResourceRecords": resourcerecords,
@@ -1178,12 +1178,12 @@ def test_change_resource_record_sets_records_limit():
     for ci in range(2):
         resourcerecords = []
         for rri in range(250):
-            resourcerecords.append({"Value": f"127.0.0.{rri}"})
+            resourcerecords.append({"Value": "127.0.0.%d" % (rri)})
         changes.append(
             {
                 "Action": "UPSERT",
                 "ResourceRecordSet": {
-                    "Name": f"foo{ci}.db.",
+                    "Name": "foo%d.db." % (ci),
                     "Type": "A",
                     "TTL": 10,
                     "ResourceRecords": resourcerecords,

--- a/tests/test_route53/test_route53.py
+++ b/tests/test_route53/test_route53.py
@@ -1106,3 +1106,109 @@ def test_get_change():
 
     response["ChangeInfo"]["Id"].should.equal(change_id)
     response["ChangeInfo"]["Status"].should.equal("INSYNC")
+
+@mock_route53
+def test_change_resource_record_sets_records_limit():
+    conn = boto3.client("route53", region_name="us-east-1")
+    conn.create_hosted_zone(
+        Name="db.",
+        CallerReference=str(hash("foo")),
+        HostedZoneConfig=dict(PrivateZone=True, Comment="db"),
+    )
+
+    zones = conn.list_hosted_zones_by_name(DNSName="db.")
+    len(zones["HostedZones"]).should.equal(1)
+    zones["HostedZones"][0]["Name"].should.equal("db.")
+    hosted_zone_id = zones["HostedZones"][0]["Id"]
+
+    # Changes creating exactly 1,000 resource records.
+    changes = []
+    for ci in range(4):
+        resourcerecords = []
+        for rri in range(250):
+            resourcerecords.append({"Value": f"127.0.0.{rri}"})
+        changes.append({
+                "Action": "CREATE",
+                "ResourceRecordSet": {
+                    "Name": f"foo{ci}.db.",
+                    "Type": "A",
+                    "TTL": 10,
+                    "ResourceRecords": resourcerecords,
+                },
+            })
+    create_1000_resource_records_payload = {
+        "Comment": "Create four records with 250 resource records each",
+        "Changes": changes,
+    }
+
+    conn.change_resource_record_sets(
+        HostedZoneId=hosted_zone_id, ChangeBatch=create_1000_resource_records_payload
+    )
+
+    # Changes creating over 1,000 resource records.
+    too_many_changes = create_1000_resource_records_payload["Changes"].copy()
+    too_many_changes.append({
+                "Action": "CREATE",
+                "ResourceRecordSet": {
+                    "Name": "toomany.db.",
+                    "Type": "A",
+                    "TTL": 10,
+                    "ResourceRecords": [{"Value": "127.0.0.1"}],
+                },
+            })
+
+    create_1001_resource_records_payload = {
+        "Comment": "Create four records with 250 resource records each, plus one more",
+        "Changes": too_many_changes,
+    }
+
+    with pytest.raises(botocore.exceptions.ClientError):
+        conn.change_resource_record_sets(
+            HostedZoneId=hosted_zone_id, ChangeBatch=create_1001_resource_records_payload
+        )
+
+    # Changes upserting exactly 500 resource records.
+    changes = []
+    for ci in range(2):
+        resourcerecords = []
+        for rri in range(250):
+            resourcerecords.append({"Value": f"127.0.0.{rri}"})
+        changes.append({
+                "Action": "UPSERT",
+                "ResourceRecordSet": {
+                    "Name": f"foo{ci}.db.",
+                    "Type": "A",
+                    "TTL": 10,
+                    "ResourceRecords": resourcerecords,
+                },
+            })
+    upsert_500_resource_records_payload = {
+        "Comment": "Upsert two records with 250 resource records each",
+        "Changes": changes,
+    }
+
+    conn.change_resource_record_sets(
+        HostedZoneId=hosted_zone_id, ChangeBatch=upsert_500_resource_records_payload
+    )
+
+    # Changes upserting over 1,000 resource records.
+    too_many_changes = upsert_500_resource_records_payload["Changes"].copy()
+    too_many_changes.append({
+                "Action": "UPSERT",
+                "ResourceRecordSet": {
+                    "Name": "toomany.db.",
+                    "Type": "A",
+                    "TTL": 10,
+                    "ResourceRecords": [{"Value": "127.0.0.1"}],
+                },
+            })
+
+    upsert_501_resource_records_payload = {
+        "Comment": "Upsert two records with 250 resource records each, plus one more",
+        "Changes": too_many_changes,
+    }
+
+    with pytest.raises(botocore.exceptions.ClientError):
+        conn.change_resource_record_sets(
+            HostedZoneId=hosted_zone_id, ChangeBatch=upsert_501_resource_records_payload
+        )

--- a/tests/test_route53/test_route53.py
+++ b/tests/test_route53/test_route53.py
@@ -1107,6 +1107,7 @@ def test_get_change():
     response["ChangeInfo"]["Id"].should.equal(change_id)
     response["ChangeInfo"]["Status"].should.equal("INSYNC")
 
+
 @mock_route53
 def test_change_resource_record_sets_records_limit():
     conn = boto3.client("route53", region_name="us-east-1")
@@ -1127,7 +1128,8 @@ def test_change_resource_record_sets_records_limit():
         resourcerecords = []
         for rri in range(250):
             resourcerecords.append({"Value": f"127.0.0.{rri}"})
-        changes.append({
+        changes.append(
+            {
                 "Action": "CREATE",
                 "ResourceRecordSet": {
                     "Name": f"foo{ci}.db.",
@@ -1135,7 +1137,8 @@ def test_change_resource_record_sets_records_limit():
                     "TTL": 10,
                     "ResourceRecords": resourcerecords,
                 },
-            })
+            }
+        )
     create_1000_resource_records_payload = {
         "Comment": "Create four records with 250 resource records each",
         "Changes": changes,
@@ -1147,15 +1150,17 @@ def test_change_resource_record_sets_records_limit():
 
     # Changes creating over 1,000 resource records.
     too_many_changes = create_1000_resource_records_payload["Changes"].copy()
-    too_many_changes.append({
-                "Action": "CREATE",
-                "ResourceRecordSet": {
-                    "Name": "toomany.db.",
-                    "Type": "A",
-                    "TTL": 10,
-                    "ResourceRecords": [{"Value": "127.0.0.1"}],
-                },
-            })
+    too_many_changes.append(
+        {
+            "Action": "CREATE",
+            "ResourceRecordSet": {
+                "Name": "toomany.db.",
+                "Type": "A",
+                "TTL": 10,
+                "ResourceRecords": [{"Value": "127.0.0.1"}],
+            },
+        }
+    )
 
     create_1001_resource_records_payload = {
         "Comment": "Create four records with 250 resource records each, plus one more",
@@ -1164,7 +1169,8 @@ def test_change_resource_record_sets_records_limit():
 
     with pytest.raises(botocore.exceptions.ClientError):
         conn.change_resource_record_sets(
-            HostedZoneId=hosted_zone_id, ChangeBatch=create_1001_resource_records_payload
+            HostedZoneId=hosted_zone_id,
+            ChangeBatch=create_1001_resource_records_payload,
         )
 
     # Changes upserting exactly 500 resource records.
@@ -1173,7 +1179,8 @@ def test_change_resource_record_sets_records_limit():
         resourcerecords = []
         for rri in range(250):
             resourcerecords.append({"Value": f"127.0.0.{rri}"})
-        changes.append({
+        changes.append(
+            {
                 "Action": "UPSERT",
                 "ResourceRecordSet": {
                     "Name": f"foo{ci}.db.",
@@ -1181,7 +1188,8 @@ def test_change_resource_record_sets_records_limit():
                     "TTL": 10,
                     "ResourceRecords": resourcerecords,
                 },
-            })
+            }
+        )
     upsert_500_resource_records_payload = {
         "Comment": "Upsert two records with 250 resource records each",
         "Changes": changes,
@@ -1193,15 +1201,17 @@ def test_change_resource_record_sets_records_limit():
 
     # Changes upserting over 1,000 resource records.
     too_many_changes = upsert_500_resource_records_payload["Changes"].copy()
-    too_many_changes.append({
-                "Action": "UPSERT",
-                "ResourceRecordSet": {
-                    "Name": "toomany.db.",
-                    "Type": "A",
-                    "TTL": 10,
-                    "ResourceRecords": [{"Value": "127.0.0.1"}],
-                },
-            })
+    too_many_changes.append(
+        {
+            "Action": "UPSERT",
+            "ResourceRecordSet": {
+                "Name": "toomany.db.",
+                "Type": "A",
+                "TTL": 10,
+                "ResourceRecords": [{"Value": "127.0.0.1"}],
+            },
+        }
+    )
 
     upsert_501_resource_records_payload = {
         "Comment": "Upsert two records with 250 resource records each, plus one more",


### PR DESCRIPTION
… AWS implements.

Addresses #2843.

Sorry, Python is not my forte.