### PR TITLE
Support all ELBv2 ListenerRule condition types

### DIFF
--- a/moto/core/responses.py
+++ b/moto/core/responses.py
@@ -557,6 +557,81 @@ class BaseResponse(_TemplateEnvironmentMixin, ActionAuthenticatorMixin):
                 ]
         return params
 
+    def _get_params(self):
+        """
+        Given a querystring of
+        {
+            'Action': ['CreatRule'],
+            'Conditions.member.1.Field': ['http-header'],
+            'Conditions.member.1.HttpHeaderConfig.HttpHeaderName': ['User-Agent'],
+            'Conditions.member.1.HttpHeaderConfig.Values.member.1': ['curl'],
+            'Actions.member.1.FixedResponseConfig.StatusCode': ['200'],
+            'Actions.member.1.FixedResponseConfig.ContentType': ['text/plain'],
+            'Actions.member.1.Type': ['fixed-response']
+        }
+
+        returns
+        {
+            'Action': 'CreatRule',
+            'Conditions': [
+                {
+                    'Field': 'http-header',
+                    'HttpHeaderConfig': {
+                        'HttpHeaderName': 'User-Agent',
+                        'Values': ['curl']
+                    }
+                }
+            ],
+            'Actions': [
+                {
+                    'Type': 'fixed-response',
+                    'FixedResponseConfig': {
+                        'StatusCode': '200',
+                        'ContentType': 'text/plain'
+                    }
+                }
+            ]
+        }
+        """
+        params = {}
+        for k, v in sorted(self.querystring.items()):
+            self._parse_param(k, v[0], params)
+        return params
+
+    def _parse_param(self, key, value, params):
+        keylist = key.split(".")
+        obj = params
+        for i, key in enumerate(keylist[:-1]):
+            if key in obj:
+                # step into
+                parent = obj
+                obj = obj[key]
+            else:
+                if key == "member":
+                    if not isinstance(obj, list):
+                        # initialize list
+                        # reset parent
+                        obj = []
+                        parent[keylist[i - 1]] = obj
+                elif key.isdigit():
+                    index = int(key) - 1
+                    if len(obj) <= index:
+                        # initialize list element
+                        obj.insert(index, {})
+                    # step into
+                    parent = obj
+                    obj = obj[index]
+                else:
+                    # initialize dict
+                    obj[key] = {}
+                    # step into
+                    parent = obj
+                    obj = obj[key]
+        if isinstance(obj, list):
+            obj.append(value)
+        else:
+            obj[keylist[-1]] = value
+
     def _get_list_prefix(self, param_prefix):
         """
         Given a query dict like

--- a/moto/elbv2/models.py
+++ b/moto/elbv2/models.py
@@ -775,7 +775,26 @@ class ELBv2Backend(BaseBackend):
         pass
 
     def _validate_query_string_condition(self, condition):
-        pass
+        if "QueryStringConfig" in condition:
+            config = condition["QueryStringConfig"]
+            values = config["Values"]
+            for value in values:
+                if "Value" not in value:
+                    raise InvalidConditionValueError(
+                        "A 'Value' must be specified in 'QueryStringKeyValuePair'"
+                    )
+                if "Key" in value and len(value["Key"]) > 128:
+                    raise InvalidConditionValueError(
+                        "The 'Key' value is too long; the limit is '128'"
+                    )
+                if len(value["Value"]) > 128:
+                    raise InvalidConditionValueError(
+                        "The 'Value' value is too long; the limit is '128'"
+                    )
+        else:
+            raise InvalidConditionValueError(
+                "A 'QueryStringConfig' must be specified with 'query-string'"
+            )
 
     def _validate_actions(self, actions):
         # validate Actions

--- a/moto/elbv2/models.py
+++ b/moto/elbv2/models.py
@@ -714,7 +714,22 @@ class ELBv2Backend(BaseBackend):
                     func(condition)
 
     def _validate_host_header_condition(self, condition):
-        pass
+        values = None
+        if "HostHeaderConfig" in condition:
+            values = condition["HostHeaderConfig"]["Values"]
+        elif "Values" in condition:
+            values = condition["Values"]
+            if len(values) > 1:
+                raise InvalidConditionValueError(
+                    "The 'host-header' field contains too many values; the limit is '1'"
+                )
+        if values is None or len(values) == 0:
+            raise InvalidConditionValueError("A condition value must be specified")
+        for value in values:
+            if len(value) > 128:
+                raise InvalidConditionValueError(
+                    "The 'host-header' value is too long; the limit is '128'"
+                )
 
     def _validate_http_header_condition(self, condition):
         pass

--- a/moto/elbv2/models.py
+++ b/moto/elbv2/models.py
@@ -785,7 +785,16 @@ class ELBv2Backend(BaseBackend):
                 )
 
     def _validate_source_ip_condition(self, condition):
-        pass
+        if "SourceIpConfig" in condition:
+            values = condition["SourceIpConfig"].get("Values", [])
+            if len(values) == 0:
+                raise InvalidConditionValueError(
+                    "A 'source-ip' value must be specified"
+                )
+        else:
+            raise InvalidConditionValueError(
+                "A 'SourceIpConfig' must be specified with 'source-ip'"
+            )
 
     def _validate_query_string_condition(self, condition):
         if "QueryStringConfig" in condition:

--- a/moto/elbv2/models.py
+++ b/moto/elbv2/models.py
@@ -732,7 +732,23 @@ class ELBv2Backend(BaseBackend):
                 )
 
     def _validate_http_header_condition(self, condition):
-        pass
+        if "HttpHeaderConfig" in condition:
+            config = condition["HttpHeaderConfig"]
+            name = config.get("HttpHeaderName")
+            if len(name) > 40:
+                raise InvalidConditionValueError(
+                    "The 'HttpHeaderName' value is too long; the limit is '40'"
+                )
+            values = config["Values"]
+            for value in values:
+                if len(value) > 128:
+                    raise InvalidConditionValueError(
+                        "The 'http-header' value is too long; the limit is '128'"
+                    )
+        else:
+            raise InvalidConditionValueError(
+                "A 'HttpHeaderConfig' must be specified with 'http-header'"
+            )
 
     def _validate_http_request_method_condition(self, condition):
         pass

--- a/moto/elbv2/models.py
+++ b/moto/elbv2/models.py
@@ -751,7 +751,20 @@ class ELBv2Backend(BaseBackend):
             )
 
     def _validate_http_request_method_condition(self, condition):
-        pass
+        if "HttpRequestMethodConfig" in condition:
+            for value in condition["HttpRequestMethodConfig"]["Values"]:
+                if len(value) > 40:
+                    raise InvalidConditionValueError(
+                        "The 'http-request-method' value is too long; the limit is '40'"
+                    )
+                if not re.match("[A-Z_-]+", value):
+                    raise InvalidConditionValueError(
+                        "The 'http-request-method' value is invalid; the allowed characters are A-Z, hyphen and underscore"
+                    )
+        else:
+            raise InvalidConditionValueError(
+                "A 'HttpRequestMethodConfig' must be specified with 'http-request-method'"
+            )
 
     def _validate_path_pattern_condition(self, condition):
         values = None

--- a/moto/elbv2/models.py
+++ b/moto/elbv2/models.py
@@ -723,7 +723,22 @@ class ELBv2Backend(BaseBackend):
         pass
 
     def _validate_path_pattern_condition(self, condition):
-        pass
+        values = None
+        if "PathPatternConfig" in condition:
+            values = condition["PathPatternConfig"]["Values"]
+        elif "Values" in condition:
+            values = condition["Values"]
+            if len(values) > 1:
+                raise InvalidConditionValueError(
+                    "The 'path-pattern' field contains too many values; the limit is '1'"
+                )
+        if values is None or len(values) == 0:
+            raise InvalidConditionValueError("A condition value must be specified")
+        for value in values:
+            if len(value) > 128:
+                raise InvalidConditionValueError(
+                    "The 'path-pattern' value is too long; the limit is '128'"
+                )
 
     def _validate_source_ip_condition(self, condition):
         pass

--- a/moto/elbv2/responses.py
+++ b/moto/elbv2/responses.py
@@ -743,6 +743,15 @@ CREATE_RULE_TEMPLATE = """<CreateRuleResponse xmlns="http://elasticloadbalancing
               </Values>
             </QueryStringConfig>
             {% endif %}
+            {% if "SourceIpConfig" in condition %}
+            <SourceIpConfig>
+              <Values>
+                {% for value in condition["SourceIpConfig"]["Values"] %}
+                <member>{{ value }}</member>
+                {% endfor %}
+              </Values>
+            </SourceIpConfig>
+            {% endif %}
             {% if "PathPatternConfig" in condition %}
             <PathPatternConfig>
               <Values>
@@ -974,6 +983,15 @@ DESCRIBE_RULES_TEMPLATE = """<DescribeRulesResponse xmlns="http://elasticloadbal
               </Values>
             </QueryStringConfig>
             {% endif %}
+            {% if "SourceIpConfig" in condition %}
+            <SourceIpConfig>
+              <Values>
+                {% for value in condition["SourceIpConfig"]["Values"] %}
+                <member>{{ value }}</member>
+                {% endfor %}
+              </Values>
+            </SourceIpConfig>
+            {% endif %}
             {% if "PathPatternConfig" in condition %}
             <PathPatternConfig>
               <Values>
@@ -1183,6 +1201,15 @@ MODIFY_RULE_TEMPLATE = """<ModifyRuleResponse xmlns="http://elasticloadbalancing
                 {% endfor %}
               </Values>
             </QueryStringConfig>
+            {% endif %}
+            {% if "SourceIpConfig" in condition %}
+            <SourceIpConfig>
+              <Values>
+                {% for value in condition["SourceIpConfig"]["Values"] %}
+                <member>{{ value }}</member>
+                {% endfor %}
+              </Values>
+            </SourceIpConfig>
             {% endif %}
             {% if "Values" in condition %}
             <Values>

--- a/moto/elbv2/responses.py
+++ b/moto/elbv2/responses.py
@@ -712,6 +712,16 @@ CREATE_RULE_TEMPLATE = """<CreateRuleResponse xmlns="http://elasticloadbalancing
               {% endfor %}
             </Values>
             {% endif %}
+            {% if "HttpHeaderConfig" in condition %}
+            <HttpHeaderConfig>
+              <HttpHeaderName>{{ condition["HttpHeaderConfig"]["HttpHeaderName"] }}</HttpHeaderName>
+              <Values>
+                {% for value in condition["HttpHeaderConfig"]["Values"] %}
+                <member>{{ value }}</member>
+                {% endfor %}
+              </Values>
+            </HttpHeaderConfig>
+            {% endif %}
             {% if "PathPatternConfig" in condition %}
             <PathPatternConfig>
               <Values>
@@ -912,6 +922,16 @@ DESCRIBE_RULES_TEMPLATE = """<DescribeRulesResponse xmlns="http://elasticloadbal
           {% for condition in rule.conditions %}
           <member>
             <Field>{{ condition["Field"] }}</Field>
+            {% if "HttpHeaderConfig" in condition %}
+            <HttpHeaderConfig>
+              <HttpHeaderName>{{ condition["HttpHeaderConfig"]["HttpHeaderName"] }}</HttpHeaderName>
+              <Values>
+                {% for value in condition["HttpHeaderConfig"]["Values"] %}
+                  <member>{{ value }}</member>
+                {% endfor %}
+              </Values>
+            </HttpHeaderConfig>
+            {% endif %}
             {% if "PathPatternConfig" in condition %}
             <PathPatternConfig>
               <Values>
@@ -1090,6 +1110,16 @@ MODIFY_RULE_TEMPLATE = """<ModifyRuleResponse xmlns="http://elasticloadbalancing
                 {% endfor %}
               </Values>
             </HostHeaderConfig>
+            {% endif %}
+            {% if "HttpHeaderConfig" in condition %}
+            <HttpHeaderConfig>
+              <HttpHeaderName>{{ condition["HttpHeaderConfig"]["HttpHeaderName"] }}</HttpHeaderName>
+              <Values>
+                {% for value in condition["HttpHeaderConfig"]["Values"] %}
+                <member>{{ value }}</member>
+                {% endfor %}
+              </Values>
+            </HttpHeaderConfig>
             {% endif %}
             {% if "Values" in condition %}
             <Values>

--- a/moto/elbv2/responses.py
+++ b/moto/elbv2/responses.py
@@ -705,11 +705,22 @@ CREATE_RULE_TEMPLATE = """<CreateRuleResponse xmlns="http://elasticloadbalancing
           {% for condition in rules.conditions %}
           <member>
             <Field>{{ condition["Field"] }}</Field>
+            {% if "Values" in condition %}
             <Values>
               {% for value in condition["Values"] %}
               <member>{{ value }}</member>
               {% endfor %}
             </Values>
+            {% endif %}
+            {% if "PathPatternConfig" in condition %}
+            <PathPatternConfig>
+              <Values>
+                {% for value in condition["PathPatternConfig"]["Values"] %}
+                <member>{{ value }}</member>
+                {% endfor %}
+              </Values>
+            </PathPatternConfig>
+            {% endif %}
           </member>
           {% endfor %}
         </Conditions>
@@ -892,11 +903,22 @@ DESCRIBE_RULES_TEMPLATE = """<DescribeRulesResponse xmlns="http://elasticloadbal
           {% for condition in rule.conditions %}
           <member>
             <Field>{{ condition["Field"] }}</Field>
+            {% if "PathPatternConfig" in condition %}
+            <PathPatternConfig>
+              <Values>
+                {% for value in condition["PathPatternConfig"]["Values"] %}
+                <member>{{ value }}</member>
+                {% endfor %}
+              </Values>
+            </PathPatternConfig>
+            {% endif %}
+            {% if "Values" in condition %}
             <Values>
               {% for value in condition["Values"] %}
               <member>{{ value }}</member>
               {% endfor %}
             </Values>
+            {% endif %}
           </member>
           {% endfor %}
         </Conditions>
@@ -1033,11 +1055,22 @@ MODIFY_RULE_TEMPLATE = """<ModifyRuleResponse xmlns="http://elasticloadbalancing
           {% for condition in rules.conditions %}
           <member>
             <Field>{{ condition["Field"] }}</Field>
+            {% if "PathPatternConfig" in condition %}
+            <PathPatternConfig>
+              <Values>
+                {% for value in condition["PathPatternConfig"]["Values"] %}
+                <member>{{ value }}</member>
+                {% endfor %}
+              </Values>
+            </PathPatternConfig>
+            {% endif %}
+            {% if "Values" in condition %}
             <Values>
               {% for value in condition["Values"] %}
               <member>{{ value }}</member>
               {% endfor %}
             </Values>
+            {% endif %}
           </member>
           {% endfor %}
         </Conditions>

--- a/moto/elbv2/responses.py
+++ b/moto/elbv2/responses.py
@@ -721,6 +721,15 @@ CREATE_RULE_TEMPLATE = """<CreateRuleResponse xmlns="http://elasticloadbalancing
               </Values>
             </PathPatternConfig>
             {% endif %}
+            {% if "HostHeaderConfig" in condition %}
+            <HostHeaderConfig>
+              <Values>
+                {% for value in condition["HostHeaderConfig"]["Values"] %}
+                <member>{{ value }}</member>
+                {% endfor %}
+              </Values>
+            </HostHeaderConfig>
+            {% endif %}
           </member>
           {% endfor %}
         </Conditions>
@@ -912,6 +921,15 @@ DESCRIBE_RULES_TEMPLATE = """<DescribeRulesResponse xmlns="http://elasticloadbal
               </Values>
             </PathPatternConfig>
             {% endif %}
+            {% if "HostHeaderConfig" in condition %}
+            <HostHeaderConfig>
+              <Values>
+                {% for value in condition["HostHeaderConfig"]["Values"] %}
+                <member>{{ value }}</member>
+                {% endfor %}
+              </Values>
+            </HostHeaderConfig>
+            {% endif %}
             {% if "Values" in condition %}
             <Values>
               {% for value in condition["Values"] %}
@@ -1063,6 +1081,15 @@ MODIFY_RULE_TEMPLATE = """<ModifyRuleResponse xmlns="http://elasticloadbalancing
                 {% endfor %}
               </Values>
             </PathPatternConfig>
+            {% endif %}
+            {% if "HostHeaderConfig" in condition %}
+            <HostHeaderConfig>
+              <Values>
+                {% for value in condition["HostHeaderConfig"]["Values"] %}
+                <member>{{ value }}</member>
+                {% endfor %}
+              </Values>
+            </HostHeaderConfig>
             {% endif %}
             {% if "Values" in condition %}
             <Values>

--- a/moto/elbv2/responses.py
+++ b/moto/elbv2/responses.py
@@ -722,6 +722,18 @@ CREATE_RULE_TEMPLATE = """<CreateRuleResponse xmlns="http://elasticloadbalancing
               </Values>
             </HttpHeaderConfig>
             {% endif %}
+            {% if "QueryStringConfig" in condition %}
+            <QueryStringConfig>
+              <Values>
+                {% for value in condition["QueryStringConfig"]["Values"] %}
+                <member>
+                    <Key>{{ value["Key"] }}</Key>
+                    <Value>{{ value["Value"] }}</Value>
+                </member>
+                {% endfor %}
+              </Values>
+            </QueryStringConfig>
+            {% endif %}
             {% if "PathPatternConfig" in condition %}
             <PathPatternConfig>
               <Values>
@@ -932,6 +944,18 @@ DESCRIBE_RULES_TEMPLATE = """<DescribeRulesResponse xmlns="http://elasticloadbal
               </Values>
             </HttpHeaderConfig>
             {% endif %}
+            {% if "QueryStringConfig" in condition %}
+            <QueryStringConfig>
+              <Values>
+                {% for value in condition["QueryStringConfig"]["Values"] %}
+                <member>
+                    <Key>{{ value["Key"] }}</Key>
+                    <Value>{{ value["Value"] }}</Value>
+                </member>
+                {% endfor %}
+              </Values>
+            </QueryStringConfig>
+            {% endif %}
             {% if "PathPatternConfig" in condition %}
             <PathPatternConfig>
               <Values>
@@ -1120,6 +1144,18 @@ MODIFY_RULE_TEMPLATE = """<ModifyRuleResponse xmlns="http://elasticloadbalancing
                 {% endfor %}
               </Values>
             </HttpHeaderConfig>
+            {% endif %}
+            {% if "QueryStringConfig" in condition %}
+            <QueryStringConfig>
+              <Values>
+                {% for value in condition["QueryStringConfig"]["Values"] %}
+                <member>
+                    <Key>{{ value["Key"] }}</Key>
+                    <Value>{{ value["Value"] }}</Value>
+                </member>
+                {% endfor %}
+              </Values>
+            </QueryStringConfig>
             {% endif %}
             {% if "Values" in condition %}
             <Values>

--- a/moto/elbv2/responses.py
+++ b/moto/elbv2/responses.py
@@ -151,24 +151,12 @@ class ELBV2Response(BaseResponse):
 
     @amzn_request_id
     def create_rule(self):
-        listener_arn = self._get_param("ListenerArn")
-        _conditions = self._get_list_prefix("Conditions.member")
-        conditions = []
-        for _condition in _conditions:
-            condition = {}
-            condition["field"] = _condition["field"]
-            values = sorted(
-                [e for e in _condition.items() if "values.member" in e[0]],
-                key=lambda x: x[0],
-            )
-            condition["values"] = [e[1] for e in values]
-            conditions.append(condition)
-        priority = self._get_int_param("Priority")
+        params = self._get_params()
         actions = self._get_list_prefix("Actions.member")
         rules = self.elbv2_backend.create_rule(
-            listener_arn=listener_arn,
-            conditions=conditions,
-            priority=priority,
+            listener_arn=params["ListenerArn"],
+            conditions=params["Conditions"],
+            priority=params["Priority"],
             actions=actions,
         )
         template = self.response_template(CREATE_RULE_TEMPLATE)
@@ -350,17 +338,8 @@ class ELBV2Response(BaseResponse):
     @amzn_request_id
     def modify_rule(self):
         rule_arn = self._get_param("RuleArn")
-        _conditions = self._get_list_prefix("Conditions.member")
-        conditions = []
-        for _condition in _conditions:
-            condition = {}
-            condition["field"] = _condition["field"]
-            values = sorted(
-                [e for e in _condition.items() if "values.member" in e[0]],
-                key=lambda x: x[0],
-            )
-            condition["values"] = [e[1] for e in values]
-            conditions.append(condition)
+        params = self._get_params()
+        conditions = params["Conditions"]
         actions = self._get_list_prefix("Actions.member")
         rules = self.elbv2_backend.modify_rule(
             rule_arn=rule_arn, conditions=conditions, actions=actions
@@ -725,9 +704,9 @@ CREATE_RULE_TEMPLATE = """<CreateRuleResponse xmlns="http://elasticloadbalancing
         <Conditions>
           {% for condition in rules.conditions %}
           <member>
-            <Field>{{ condition["field"] }}</Field>
+            <Field>{{ condition["Field"] }}</Field>
             <Values>
-              {% for value in condition["values"] %}
+              {% for value in condition["Values"] %}
               <member>{{ value }}</member>
               {% endfor %}
             </Values>
@@ -912,9 +891,9 @@ DESCRIBE_RULES_TEMPLATE = """<DescribeRulesResponse xmlns="http://elasticloadbal
         <Conditions>
           {% for condition in rule.conditions %}
           <member>
-            <Field>{{ condition["field"] }}</Field>
+            <Field>{{ condition["Field"] }}</Field>
             <Values>
-              {% for value in condition["values"] %}
+              {% for value in condition["Values"] %}
               <member>{{ value }}</member>
               {% endfor %}
             </Values>
@@ -1053,9 +1032,9 @@ MODIFY_RULE_TEMPLATE = """<ModifyRuleResponse xmlns="http://elasticloadbalancing
         <Conditions>
           {% for condition in rules.conditions %}
           <member>
-            <Field>{{ condition["field"] }}</Field>
+            <Field>{{ condition["Field"] }}</Field>
             <Values>
-              {% for value in condition["values"] %}
+              {% for value in condition["Values"] %}
               <member>{{ value }}</member>
               {% endfor %}
             </Values>

--- a/moto/elbv2/responses.py
+++ b/moto/elbv2/responses.py
@@ -722,6 +722,15 @@ CREATE_RULE_TEMPLATE = """<CreateRuleResponse xmlns="http://elasticloadbalancing
               </Values>
             </HttpHeaderConfig>
             {% endif %}
+            {% if "HttpRequestMethodConfig" in condition %}
+            <HttpRequestMethodConfig>
+              <Values>
+                {% for value in condition["HttpRequestMethodConfig"]["Values"] %}
+                <member>{{ value }}</member>
+                {% endfor %}
+              </Values>
+            </HttpRequestMethodConfig>
+            {% endif %}
             {% if "QueryStringConfig" in condition %}
             <QueryStringConfig>
               <Values>
@@ -944,6 +953,15 @@ DESCRIBE_RULES_TEMPLATE = """<DescribeRulesResponse xmlns="http://elasticloadbal
               </Values>
             </HttpHeaderConfig>
             {% endif %}
+            {% if "HttpRequestMethodConfig" in condition %}
+            <HttpRequestMethodConfig>
+              <Values>
+                {% for value in condition["HttpRequestMethodConfig"]["Values"] %}
+                <member>{{ value }}</member>
+                {% endfor %}
+              </Values>
+            </HttpRequestMethodConfig>
+            {% endif %}
             {% if "QueryStringConfig" in condition %}
             <QueryStringConfig>
               <Values>
@@ -1144,6 +1162,15 @@ MODIFY_RULE_TEMPLATE = """<ModifyRuleResponse xmlns="http://elasticloadbalancing
                 {% endfor %}
               </Values>
             </HttpHeaderConfig>
+            {% endif %}
+            {% if "HttpRequestMethodConfig" in condition %}
+            <HttpRequestMethodConfig>
+              <Values>
+                {% for value in condition["HttpRequestMethodConfig"]["Values"] %}
+                <member>{{ value }}</member>
+                {% endfor %}
+              </Values>
+            </HttpRequestMethodConfig>
             {% endif %}
             {% if "QueryStringConfig" in condition %}
             <QueryStringConfig>

--- a/tests/test_core/test_responses.py
+++ b/tests/test_core/test_responses.py
@@ -2,6 +2,8 @@ from __future__ import unicode_literals
 
 import sure  # noqa
 
+from moto.compat import OrderedDict
+
 from botocore.awsrequest import AWSPreparedRequest
 
 from moto.core.responses import AWSServiceSpec, BaseResponse
@@ -92,3 +94,56 @@ def test_parse_qs_unicode_decode_error():
     body = b'{"key": "%D0"}, "C": "#0 = :0"}'
     request = AWSPreparedRequest("GET", "http://request", {"foo": "bar"}, body, False)
     BaseResponse().setup_class(request, request.url, request.headers)
+
+
+def test_get_params():
+    subject = BaseResponse()
+    subject.querystring = OrderedDict(
+        [
+            ("Action", ["CreateRule"]),
+            ("Version", ["2015-12-01"]),
+            (
+                "ListenerArn",
+                [
+                    "arn:aws:elasticloadbalancing:us-east-1:1:listener/my-lb/50dc6c495c0c9188/80139731473870416"
+                ],
+            ),
+            ("Priority", ["100"]),
+            ("Conditions.member.1.Field", ["http-header"]),
+            ("Conditions.member.1.HttpHeaderConfig.HttpHeaderName", ["User-Agent"]),
+            ("Conditions.member.1.HttpHeaderConfig.Values.member.2", ["curl"]),
+            ("Conditions.member.1.HttpHeaderConfig.Values.member.1", ["Mozilla"]),
+            ("Actions.member.1.FixedResponseConfig.StatusCode", ["200"]),
+            ("Actions.member.1.FixedResponseConfig.ContentType", ["text/plain"]),
+            ("Actions.member.1.Type", ["fixed-response"]),
+        ]
+    )
+
+    result = subject._get_params()
+
+    result.should.equal(
+        {
+            "Action": "CreateRule",
+            "Version": "2015-12-01",
+            "ListenerArn": "arn:aws:elasticloadbalancing:us-east-1:1:listener/my-lb/50dc6c495c0c9188/80139731473870416",
+            "Priority": "100",
+            "Conditions": [
+                {
+                    "Field": "http-header",
+                    "HttpHeaderConfig": {
+                        "HttpHeaderName": "User-Agent",
+                        "Values": ["Mozilla", "curl"],
+                    },
+                }
+            ],
+            "Actions": [
+                {
+                    "Type": "fixed-response",
+                    "FixedResponseConfig": {
+                        "StatusCode": "200",
+                        "ContentType": "text/plain",
+                    },
+                }
+            ],
+        }
+    )

--- a/tests/test_elbv2/test_elbv2.py
+++ b/tests/test_elbv2/test_elbv2.py
@@ -1213,7 +1213,7 @@ def test_handle_listener_rules():
     obtained_rule = rules["Rules"][0]
     obtained_rule["Conditions"][0]["Values"][0].should.equal(new_host)
     obtained_rule["Conditions"][1]["Values"][0].should.equal(new_path_pattern)
-    obtained_rule["Conditions"][2]["Values"][0].should.equal(
+    obtained_rule["Conditions"][2]["PathPatternConfig"]["Values"][0].should.equal(
         new_pathpatternconfig_pattern
     )
     obtained_rule["Actions"][0]["TargetGroupArn"].should.equal(
@@ -1253,7 +1253,7 @@ def test_handle_listener_rules():
     obtained_rule = rules["Rules"][2]
     obtained_rule["Conditions"][0]["Values"][0].should.equal(new_host_2)
     obtained_rule["Conditions"][1]["Values"][0].should.equal(new_path_pattern_2)
-    obtained_rule["Conditions"][2]["Values"][0].should.equal(
+    obtained_rule["Conditions"][2]["PathPatternConfig"]["Values"][0].should.equal(
         new_pathpatternconfig_pattern_2
     )
     obtained_rule["Actions"][0]["TargetGroupArn"].should.equal(

--- a/tests/test_elbv2/test_elbv2_listener_rules.py
+++ b/tests/test_elbv2/test_elbv2_listener_rules.py
@@ -1,0 +1,337 @@
+from __future__ import unicode_literals
+
+import boto3
+import botocore
+from botocore.exceptions import ClientError
+import pytest
+import sure  # noqa
+
+from moto import mock_elbv2, mock_ec2
+
+default_action = {
+    "FixedResponseConfig": {"StatusCode": "200", "ContentType": "text/plain"},
+    "Type": "fixed-response",
+}
+
+
+def setup_listener(conn):
+    ec2 = boto3.resource("ec2", region_name="us-east-1")
+
+    security_group = ec2.create_security_group(
+        GroupName="a-security-group", Description="First One"
+    )
+    vpc = ec2.create_vpc(CidrBlock="172.28.7.0/24", InstanceTenancy="default")
+    subnet1 = ec2.create_subnet(
+        VpcId=vpc.id, CidrBlock="172.28.7.192/26", AvailabilityZone="us-east-1a"
+    )
+    subnet2 = ec2.create_subnet(
+        VpcId=vpc.id, CidrBlock="172.28.7.0/26", AvailabilityZone="us-east-1b"
+    )
+
+    response = conn.create_load_balancer(
+        Name="my-lb",
+        Subnets=[subnet1.id, subnet2.id],
+        SecurityGroups=[security_group.id],
+        Scheme="internal",
+        Tags=[{"Key": "key_name", "Value": "a_value"}],
+    )
+
+    load_balancer_arn = response.get("LoadBalancers")[0].get("LoadBalancerArn")
+
+    # Plain HTTP listener
+    response = conn.create_listener(
+        LoadBalancerArn=load_balancer_arn,
+        Protocol="HTTP",
+        Port=80,
+        DefaultActions=[
+            {
+                "Type": "fixed-response",
+                "FixedResponseConfig": {
+                    "StatusCode": "503",
+                    "ContentType": "text/plain",
+                },
+            }
+        ],
+    )
+    listener = response.get("Listeners")[0]
+    http_listener_arn = listener.get("ListenerArn")
+    return http_listener_arn
+
+
+@mock_elbv2
+@mock_ec2
+def test_create_rule_with_one_path_pattern_condition():
+    conn = boto3.client("elbv2", region_name="us-east-1")
+
+    http_listener_arn = setup_listener(conn)
+
+    # create_rule
+    response = conn.create_rule(
+        ListenerArn=http_listener_arn,
+        Priority=100,
+        Conditions=[{"Field": "path-pattern", "Values": ["/home"]}],
+        Actions=[
+            {
+                "FixedResponseConfig": {
+                    "StatusCode": "200",
+                    "ContentType": "text/plain",
+                },
+                "Type": "fixed-response",
+            }
+        ],
+    )
+
+    # assert create_rule response
+    response["Rules"].should.have.length_of(1)
+    rule = response.get("Rules")[0]
+    rule["Priority"].should.equal("100")
+    rule["Conditions"].should.equal([{"Field": "path-pattern", "Values": ["/home"]}])
+
+    # assert describe_rules response
+    response = conn.describe_rules(ListenerArn=http_listener_arn)
+    response["Rules"].should.have.length_of(2)
+
+    # assert describe_rules with arn filter response
+    rule = response["Rules"][0]
+    rule["Conditions"].should.equal([{"Field": "path-pattern", "Values": ["/home"]}])
+    response = conn.describe_rules(RuleArns=[rule["RuleArn"]])
+    response["Rules"].should.equal([rule])
+
+
+@mock_elbv2
+@mock_ec2
+def test_create_rule_with_many_path_pattern_condition():
+    conn = boto3.client("elbv2", region_name="us-east-1")
+
+    http_listener_arn = setup_listener(conn)
+
+    # create_rule
+    response = conn.create_rule(
+        ListenerArn=http_listener_arn,
+        Priority=100,
+        Conditions=[
+            {
+                "Field": "path-pattern",
+                "PathPatternConfig": {"Values": ["/home", "/about"]},
+            },
+        ],
+        Actions=[
+            {
+                "FixedResponseConfig": {
+                    "StatusCode": "200",
+                    "ContentType": "text/plain",
+                },
+                "Type": "fixed-response",
+            }
+        ],
+    )
+
+    # assert create_rule response
+    response["Rules"].should.have.length_of(1)
+    rule = response.get("Rules")[0]
+    rule["Priority"].should.equal("100")
+    rule["Conditions"].should.equal(
+        [
+            {
+                "Field": "path-pattern",
+                "PathPatternConfig": {"Values": ["/home", "/about"]},
+            }
+        ]
+    )
+
+    # assert describe_rules response
+    response = conn.describe_rules(ListenerArn=http_listener_arn)
+    response["Rules"].should.have.length_of(2)
+
+    # assert describe_rules with arn filter response
+    rule = response["Rules"][0]
+    rule["Conditions"].should.equal(
+        [
+            {
+                "Field": "path-pattern",
+                "PathPatternConfig": {"Values": ["/home", "/about"]},
+            }
+        ]
+    )
+    response = conn.describe_rules(RuleArns=[rule["RuleArn"]])
+    response["Rules"].should.equal([rule])
+
+
+@mock_elbv2
+@mock_ec2
+def test_create_rule_with_one_host_header_condition():
+    conn = boto3.client("elbv2", region_name="us-east-1")
+
+    http_listener_arn = setup_listener(conn)
+
+    # create_rule
+    response = conn.create_rule(
+        ListenerArn=http_listener_arn,
+        Priority=100,
+        Conditions=[{"Field": "host-header", "Values": ["example.com"]}],
+        Actions=[
+            {
+                "FixedResponseConfig": {
+                    "StatusCode": "200",
+                    "ContentType": "text/plain",
+                },
+                "Type": "fixed-response",
+            }
+        ],
+    )
+
+    # assert create_rule response
+    response["Rules"].should.have.length_of(1)
+    rule = response.get("Rules")[0]
+    rule["Priority"].should.equal("100")
+    rule["Conditions"].should.equal(
+        [{"Field": "host-header", "Values": ["example.com"]}]
+    )
+
+    # assert describe_rules response
+    response = conn.describe_rules(ListenerArn=http_listener_arn)
+    response["Rules"].should.have.length_of(2)
+
+    # assert describe_rules with arn filter response
+    rule = response["Rules"][0]
+    rule["Conditions"].should.equal(
+        [{"Field": "host-header", "Values": ["example.com"]}]
+    )
+    response = conn.describe_rules(RuleArns=[rule["RuleArn"]])
+    response["Rules"].should.equal([rule])
+
+
+@mock_elbv2
+@mock_ec2
+def test_create_rule_with_many_host_header_condition():
+    conn = boto3.client("elbv2", region_name="us-east-1")
+
+    http_listener_arn = setup_listener(conn)
+
+    # create_rule
+    response = conn.create_rule(
+        ListenerArn=http_listener_arn,
+        Priority=100,
+        Conditions=[
+            {
+                "Field": "host-header",
+                "HostHeaderConfig": {"Values": ["example.com", "www.example.com"]},
+            },
+        ],
+        Actions=[
+            {
+                "FixedResponseConfig": {
+                    "StatusCode": "200",
+                    "ContentType": "text/plain",
+                },
+                "Type": "fixed-response",
+            }
+        ],
+    )
+
+    # assert create_rule response
+    response["Rules"].should.have.length_of(1)
+    rule = response.get("Rules")[0]
+    rule["Priority"].should.equal("100")
+    rule["Conditions"].should.equal(
+        [
+            {
+                "Field": "host-header",
+                "HostHeaderConfig": {"Values": ["example.com", "www.example.com"]},
+            }
+        ]
+    )
+
+    # assert describe_rules response
+    response = conn.describe_rules(ListenerArn=http_listener_arn)
+    response["Rules"].should.have.length_of(2)
+
+    # assert describe_rules with arn filter response
+    rule = response["Rules"][0]
+    rule["Conditions"].should.equal(
+        [
+            {
+                "Field": "host-header",
+                "HostHeaderConfig": {"Values": ["example.com", "www.example.com"]},
+            }
+        ]
+    )
+    response = conn.describe_rules(RuleArns=[rule["RuleArn"]])
+    response["Rules"].should.equal([rule])
+
+
+@mock_elbv2
+@mock_ec2
+def test_create_rule_validate_host_header_condition():
+    conn = boto3.client("elbv2", region_name="us-east-1")
+
+    http_listener_arn = setup_listener(conn)
+
+    # create_rule with long host header
+    with pytest.raises(ClientError) as ex:
+        response = conn.create_rule(
+            ListenerArn=http_listener_arn,
+            Priority=100,
+            Conditions=[{"Field": "host-header", "Values": ["x" * 256]}],
+            Actions=[default_action],
+        )
+
+    err = ex.value.response["Error"]
+    err["Code"].should.equal("ValidationError")
+    err["Message"].should.equal(
+        "The 'host-header' value is too long; the limit is '128'"
+    )
+
+    # create_rule with long host header
+    with pytest.raises(ClientError) as ex:
+        response = conn.create_rule(
+            ListenerArn=http_listener_arn,
+            Priority=100,
+            Conditions=[
+                {"Field": "host-header", "HostHeaderConfig": {"Values": ["x" * 256]}}
+            ],
+            Actions=[default_action],
+        )
+
+    err = ex.value.response["Error"]
+    err["Code"].should.equal("ValidationError")
+    err["Message"].should.equal(
+        "The 'host-header' value is too long; the limit is '128'"
+    )
+
+    # create_rule with too many values
+    with pytest.raises(ClientError) as ex:
+        response = conn.create_rule(
+            ListenerArn=http_listener_arn,
+            Priority=100,
+            Conditions=[{"Field": "host-header", "Values": ["one", "two"]}],
+            Actions=[default_action],
+        )
+
+    err = ex.value.response["Error"]
+    err["Code"].should.equal("ValidationError")
+    err["Message"].should.equal(
+        "The 'host-header' field contains too many values; the limit is '1'"
+    )
+
+    # create_rule with no value
+    with pytest.raises(ClientError) as ex:
+        response = conn.create_rule(
+            ListenerArn=http_listener_arn,
+            Priority=100,
+            Conditions=[{"Field": "host-header"}],
+            Actions=[default_action],
+        )
+
+    # create_rule with empty value
+    with pytest.raises(ClientError) as ex:
+        response = conn.create_rule(
+            ListenerArn=http_listener_arn,
+            Priority=100,
+            Conditions=[{"Field": "host-header", "HostHeaderConfig": {"Values": []}}],
+            Actions=[default_action],
+        )
+
+    err = ex.value.response["Error"]
+    err["Code"].should.equal("ValidationError")
+    err["Message"].should.equal("A condition value must be specified")

--- a/tests/test_elbv2/test_elbv2_listener_rules.py
+++ b/tests/test_elbv2/test_elbv2_listener_rules.py
@@ -60,7 +60,38 @@ def setup_listener(conn):
 
 @mock_elbv2
 @mock_ec2
-def test_create_rule_with_one_path_pattern_condition():
+@pytest.mark.parametrize(
+    "condition",
+    [
+        {"Field": "host-header", "Values": ["example.com"]},
+        {
+            "Field": "host-header",
+            "HostHeaderConfig": {"Values": ["example.com", "www.example.com"]},
+        },
+        {
+            "Field": "http-header",
+            "HttpHeaderConfig": {
+                "HttpHeaderName": "User-Agent",
+                "Values": ["Mozilla"],
+            },
+        },
+        {
+            "Field": "http-request-method",
+            "HttpRequestMethodConfig": {"Values": ["GET", "POST"]},
+        },
+        {"Field": "path-pattern", "Values": ["/home"]},
+        {
+            "Field": "path-pattern",
+            "PathPatternConfig": {"Values": ["/home", "/about"]},
+        },
+        {
+            "Field": "query-string",
+            "QueryStringConfig": {"Values": [{"Key": "hello", "Value": "world"}]},
+        },
+        {"Field": "source-ip", "SourceIpConfig": {"Values": ["172.28.7.0/24"]}},
+    ],
+)
+def test_create_rule_condition(condition):
     conn = boto3.client("elbv2", region_name="us-east-1")
 
     http_listener_arn = setup_listener(conn)
@@ -69,7 +100,7 @@ def test_create_rule_with_one_path_pattern_condition():
     response = conn.create_rule(
         ListenerArn=http_listener_arn,
         Priority=100,
-        Conditions=[{"Field": "path-pattern", "Values": ["/home"]}],
+        Conditions=[condition],
         Actions=[default_action],
     )
 
@@ -77,791 +108,190 @@ def test_create_rule_with_one_path_pattern_condition():
     response["Rules"].should.have.length_of(1)
     rule = response.get("Rules")[0]
     rule["Priority"].should.equal("100")
-    rule["Conditions"].should.equal([{"Field": "path-pattern", "Values": ["/home"]}])
+    rule["Conditions"].should.equal([condition])
 
     # assert describe_rules response
     response = conn.describe_rules(ListenerArn=http_listener_arn)
-    response["Rules"].should.have.length_of(2)
+    response["Rules"].should.have.length_of(2)  # including the default rule
 
     # assert describe_rules with arn filter response
     rule = response["Rules"][0]
-    rule["Conditions"].should.equal([{"Field": "path-pattern", "Values": ["/home"]}])
+    rule["Conditions"].should.equal([condition])
     response = conn.describe_rules(RuleArns=[rule["RuleArn"]])
     response["Rules"].should.equal([rule])
 
 
 @mock_elbv2
 @mock_ec2
-def test_create_rule_with_many_path_pattern_condition():
-    conn = boto3.client("elbv2", region_name="us-east-1")
-
-    http_listener_arn = setup_listener(conn)
-
-    # create_rule
-    response = conn.create_rule(
-        ListenerArn=http_listener_arn,
-        Priority=100,
-        Conditions=[
+@pytest.mark.parametrize(
+    "create_condition,modify_condition",
+    [
+        (
+            {"Field": "host-header", "Values": ["example.com"]},
+            {
+                "Field": "host-header",
+                "HostHeaderConfig": {"Values": ["example.com", "www.example.com"]},
+            },
+        ),
+        (
+            {
+                "Field": "http-header",
+                "HttpHeaderConfig": {
+                    "HttpHeaderName": "User-Agent",
+                    "Values": ["Mozilla"],
+                },
+            },
+            {
+                "Field": "http-header",
+                "HttpHeaderConfig": {
+                    "HttpHeaderName": "User-Agent",
+                    "Values": ["Mozilla", "curl"],
+                },
+            },
+        ),
+        (
+            {"Field": "path-pattern", "Values": ["/home"]},
             {
                 "Field": "path-pattern",
                 "PathPatternConfig": {"Values": ["/home", "/about"]},
             },
-        ],
-        Actions=[default_action],
-    )
-
-    # assert create_rule response
-    response["Rules"].should.have.length_of(1)
-    rule = response.get("Rules")[0]
-    rule["Priority"].should.equal("100")
-    rule["Conditions"].should.equal(
-        [
-            {
-                "Field": "path-pattern",
-                "PathPatternConfig": {"Values": ["/home", "/about"]},
-            }
-        ]
-    )
-
-    # assert describe_rules response
-    response = conn.describe_rules(ListenerArn=http_listener_arn)
-    response["Rules"].should.have.length_of(2)
-
-    # assert describe_rules with arn filter response
-    rule = response["Rules"][0]
-    rule["Conditions"].should.equal(
-        [
-            {
-                "Field": "path-pattern",
-                "PathPatternConfig": {"Values": ["/home", "/about"]},
-            }
-        ]
-    )
-    response = conn.describe_rules(RuleArns=[rule["RuleArn"]])
-    response["Rules"].should.equal([rule])
-
-
-@mock_elbv2
-@mock_ec2
-def test_modify_rule_path_pattern_condition():
+        ),
+    ],
+)
+def test_modify_rule_condition(create_condition, modify_condition):
     conn = boto3.client("elbv2", region_name="us-east-1")
 
     http_listener_arn = setup_listener(conn)
     response = conn.create_rule(
         ListenerArn=http_listener_arn,
         Priority=100,
-        Conditions=[{"Field": "path-pattern", "Values": ["/home"]}],
+        Conditions=[create_condition],
         Actions=[default_action],
     )
     rule = response.get("Rules")[0]
 
     # modify_rule
-    response = conn.modify_rule(
-        RuleArn=rule["RuleArn"],
-        Conditions=[
-            {
-                "Field": "path-pattern",
-                "PathPatternConfig": {"Values": ["/home", "/about"]},
-            }
-        ],
-    )
+    response = conn.modify_rule(RuleArn=rule["RuleArn"], Conditions=[modify_condition])
     response["Rules"].should.have.length_of(1)
     modified_rule = response.get("Rules")[0]
-    modified_rule["Conditions"].should.equal(
-        [
-            {
-                "Field": "path-pattern",
-                "PathPatternConfig": {"Values": ["/home", "/about"]},
-            }
-        ]
-    )
+    modified_rule["Conditions"].should.equal([modify_condition])
 
 
 @mock_elbv2
 @mock_ec2
-def test_create_rule_with_one_host_header_condition():
-    conn = boto3.client("elbv2", region_name="us-east-1")
-
-    http_listener_arn = setup_listener(conn)
-
-    # create_rule
-    response = conn.create_rule(
-        ListenerArn=http_listener_arn,
-        Priority=100,
-        Conditions=[{"Field": "host-header", "Values": ["example.com"]}],
-        Actions=[default_action],
-    )
-
-    # assert create_rule response
-    response["Rules"].should.have.length_of(1)
-    rule = response.get("Rules")[0]
-    rule["Priority"].should.equal("100")
-    rule["Conditions"].should.equal(
-        [{"Field": "host-header", "Values": ["example.com"]}]
-    )
-
-    # assert describe_rules response
-    response = conn.describe_rules(ListenerArn=http_listener_arn)
-    response["Rules"].should.have.length_of(2)
-
-    # assert describe_rules with arn filter response
-    rule = response["Rules"][0]
-    rule["Conditions"].should.equal(
-        [{"Field": "host-header", "Values": ["example.com"]}]
-    )
-    response = conn.describe_rules(RuleArns=[rule["RuleArn"]])
-    response["Rules"].should.equal([rule])
-
-
-@mock_elbv2
-@mock_ec2
-def test_create_rule_with_many_host_header_condition():
-    conn = boto3.client("elbv2", region_name="us-east-1")
-
-    http_listener_arn = setup_listener(conn)
-
-    # create_rule
-    response = conn.create_rule(
-        ListenerArn=http_listener_arn,
-        Priority=100,
-        Conditions=[
-            {
-                "Field": "host-header",
-                "HostHeaderConfig": {"Values": ["example.com", "www.example.com"]},
-            },
-        ],
-        Actions=[default_action],
-    )
-
-    # assert create_rule response
-    response["Rules"].should.have.length_of(1)
-    rule = response.get("Rules")[0]
-    rule["Priority"].should.equal("100")
-    rule["Conditions"].should.equal(
-        [
-            {
-                "Field": "host-header",
-                "HostHeaderConfig": {"Values": ["example.com", "www.example.com"]},
-            }
-        ]
-    )
-
-    # assert describe_rules response
-    response = conn.describe_rules(ListenerArn=http_listener_arn)
-    response["Rules"].should.have.length_of(2)
-
-    # assert describe_rules with arn filter response
-    rule = response["Rules"][0]
-    rule["Conditions"].should.equal(
-        [
-            {
-                "Field": "host-header",
-                "HostHeaderConfig": {"Values": ["example.com", "www.example.com"]},
-            }
-        ]
-    )
-    response = conn.describe_rules(RuleArns=[rule["RuleArn"]])
-    response["Rules"].should.equal([rule])
-
-
-@mock_elbv2
-@mock_ec2
-def test_modify_rule_host_header_condition():
-    conn = boto3.client("elbv2", region_name="us-east-1")
-
-    http_listener_arn = setup_listener(conn)
-    response = conn.create_rule(
-        ListenerArn=http_listener_arn,
-        Priority=100,
-        Conditions=[{"Field": "host-header", "Values": ["example.com"]}],
-        Actions=[default_action],
-    )
-    rule = response.get("Rules")[0]
-
-    # modify_rule
-    response = conn.modify_rule(
-        RuleArn=rule["RuleArn"],
-        Conditions=[
-            {
-                "Field": "host-header",
-                "HostHeaderConfig": {"Values": ["example.com", "www.example.com"]},
-            }
-        ],
-    )
-    response["Rules"].should.have.length_of(1)
-    modified_rule = response.get("Rules")[0]
-    modified_rule["Conditions"].should.equal(
-        [
-            {
-                "Field": "host-header",
-                "HostHeaderConfig": {"Values": ["example.com", "www.example.com"]},
-            }
-        ]
-    )
-
-
-@mock_elbv2
-@mock_ec2
-def test_create_rule_with_http_header_condition():
-    conn = boto3.client("elbv2", region_name="us-east-1")
-
-    http_listener_arn = setup_listener(conn)
-
-    # create_rule
-    response = conn.create_rule(
-        ListenerArn=http_listener_arn,
-        Priority=100,
-        Conditions=[
+@pytest.mark.parametrize(
+    "condition,expected_message",
+    [
+        (
+            {"Field": "host-header", "Values": ["x" * 256]},
+            "The 'host-header' value is too long; the limit is '128'",
+        ),
+        (
+            {"Field": "host-header", "HostHeaderConfig": {"Values": ["x" * 256]}},
+            "The 'host-header' value is too long; the limit is '128'",
+        ),
+        (
+            {"Field": "host-header", "Values": ["one", "two"]},
+            "The 'host-header' field contains too many values; the limit is '1'",
+        ),
+        ({"Field": "host-header"}, "A condition value must be specified"),
+        (
+            {"Field": "host-header", "HostHeaderConfig": {"Values": []}},
+            "A condition value must be specified",
+        ),
+        (
+            {"Field": "path-pattern", "Values": ["x" * 256]},
+            "The 'path-pattern' value is too long; the limit is '128'",
+        ),
+        (
+            {"Field": "path-pattern", "PathPatternConfig": {"Values": ["x" * 256]}},
+            "The 'path-pattern' value is too long; the limit is '128'",
+        ),
+        (
+            {"Field": "path-pattern", "Values": ["one", "two"]},
+            "The 'path-pattern' field contains too many values; the limit is '1'",
+        ),
+        ({"Field": "path-pattern"}, "A condition value must be specified"),
+        (
+            {"Field": "path-pattern", "PathPatternConfig": {"Values": []}},
+            "A condition value must be specified",
+        ),
+        (
             {
                 "Field": "http-header",
-                "HttpHeaderConfig": {
-                    "HttpHeaderName": "User-Agent",
-                    "Values": ["Mozilla"],
-                },
+                "HttpHeaderConfig": {"HttpHeaderName": "x" * 50, "Values": ["y"]},
             },
-        ],
-        Actions=[default_action],
-    )
-
-    # assert create_rule response
-    response["Rules"].should.have.length_of(1)
-    rule = response.get("Rules")[0]
-    rule["Priority"].should.equal("100")
-    rule["Conditions"].should.equal(
-        [
+            "The 'HttpHeaderName' value is too long; the limit is '40'",
+        ),
+        (
             {
                 "Field": "http-header",
-                "HttpHeaderConfig": {
-                    "HttpHeaderName": "User-Agent",
-                    "Values": ["Mozilla"],
-                },
-            }
-        ]
-    )
-
-    # assert describe_rules response
-    response = conn.describe_rules(ListenerArn=http_listener_arn)
-    response["Rules"].should.have.length_of(2)
-
-    # assert describe_rules with arn filter response
-    rule = response["Rules"][0]
-    rule["Conditions"].should.equal(
-        [
-            {
-                "Field": "http-header",
-                "HttpHeaderConfig": {
-                    "HttpHeaderName": "User-Agent",
-                    "Values": ["Mozilla"],
-                },
-            }
-        ]
-    )
-    response = conn.describe_rules(RuleArns=[rule["RuleArn"]])
-    response["Rules"].should.equal([rule])
-
-
-@mock_elbv2
-@mock_ec2
-def test_create_rule_with_http_request_method_condition():
-    conn = boto3.client("elbv2", region_name="us-east-1")
-
-    http_listener_arn = setup_listener(conn)
-
-    # create_rule
-    response = conn.create_rule(
-        ListenerArn=http_listener_arn,
-        Priority=100,
-        Conditions=[
-            {
-                "Field": "http-request-method",
-                "HttpRequestMethodConfig": {"Values": ["GET", "POST"]},
-            }
-        ],
-        Actions=[default_action],
-    )
-
-    # assert create_rule response
-    response["Rules"].should.have.length_of(1)
-    rule = response.get("Rules")[0]
-    rule["Priority"].should.equal("100")
-    rule["Conditions"].should.equal(
-        [
-            {
-                "Field": "http-request-method",
-                "HttpRequestMethodConfig": {"Values": ["GET", "POST"]},
-            }
-        ]
-    )
-
-    # assert describe_rules response
-    response = conn.describe_rules(ListenerArn=http_listener_arn)
-    response["Rules"].should.have.length_of(2)
-
-    # assert describe_rules with arn filter response
-    rule = response["Rules"][0]
-    rule["Conditions"].should.equal(
-        [
-            {
-                "Field": "http-request-method",
-                "HttpRequestMethodConfig": {"Values": ["GET", "POST"]},
-            }
-        ]
-    )
-    response = conn.describe_rules(RuleArns=[rule["RuleArn"]])
-    response["Rules"].should.equal([rule])
-
-
-@mock_elbv2
-@mock_ec2
-def test_create_rule_with_query_string_condition():
-    conn = boto3.client("elbv2", region_name="us-east-1")
-
-    http_listener_arn = setup_listener(conn)
-
-    # create_rule
-    response = conn.create_rule(
-        ListenerArn=http_listener_arn,
-        Priority=100,
-        Conditions=[
-            {
-                "Field": "query-string",
-                "QueryStringConfig": {"Values": [{"Key": "hello", "Value": "world"}]},
+                "HttpHeaderConfig": {"HttpHeaderName": "x", "Values": ["y" * 256]},
             },
-        ],
-        Actions=[default_action],
-    )
-
-    # assert create_rule response
-    response["Rules"].should.have.length_of(1)
-    rule = response.get("Rules")[0]
-    rule["Priority"].should.equal("100")
-    rule["Conditions"].should.equal(
-        [
+            "The 'http-header' value is too long; the limit is '128'",
+        ),
+        (
+            {
+                "Field": "http-request-method",
+                "HttpRequestMethodConfig": {"Values": ["get"]},
+            },
+            "The 'http-request-method' value is invalid; the allowed characters are A-Z, hyphen and underscore",
+        ),
+        (
+            {
+                "Field": "http-request-method",
+                "HttpRequestMethodConfig": {"Values": ["X" * 50]},
+            },
+            "The 'http-request-method' value is too long; the limit is '40'",
+        ),
+        (
+            {"Field": "http-request-method"},
+            "A 'HttpRequestMethodConfig' must be specified with 'http-request-method'",
+        ),
+        (
             {
                 "Field": "query-string",
-                "QueryStringConfig": {"Values": [{"Key": "hello", "Value": "world"}]},
-            }
-        ]
-    )
-
-    # assert describe_rules response
-    response = conn.describe_rules(ListenerArn=http_listener_arn)
-    response["Rules"].should.have.length_of(2)
-
-    # assert describe_rules with arn filter response
-    rule = response["Rules"][0]
-    rule["Conditions"].should.equal(
-        [
+                "QueryStringConfig": {"Values": [{"Key": "x" * 256, "Value": "world"}]},
+            },
+            "The 'Key' value is too long; the limit is '128'",
+        ),
+        (
             {
                 "Field": "query-string",
-                "QueryStringConfig": {"Values": [{"Key": "hello", "Value": "world"}]},
-            }
-        ]
-    )
-    response = conn.describe_rules(RuleArns=[rule["RuleArn"]])
-    response["Rules"].should.equal([rule])
-
-
-@mock_elbv2
-@mock_ec2
-def test_create_rule_with_source_ip_condition():
+                "QueryStringConfig": {"Values": [{"Key": "hello", "Value": "x" * 256}]},
+            },
+            "The 'Value' value is too long; the limit is '128'",
+        ),
+        (
+            {
+                "Field": "query-string",
+                "QueryStringConfig": {"Values": [{"Key": "hello"}]},
+            },
+            "A 'Value' must be specified in 'QueryStringKeyValuePair'",
+        ),
+        (
+            {"Field": "source-ip", "SourceIpConfig": {"Values": []}},
+            "A 'source-ip' value must be specified",
+        ),
+        (
+            {"Field": "source-ip",},
+            "A 'SourceIpConfig' must be specified with 'source-ip'",
+        ),
+    ],
+)
+def test_create_rule_validate_condition(condition, expected_message):
     conn = boto3.client("elbv2", region_name="us-east-1")
 
     http_listener_arn = setup_listener(conn)
 
-    # create_rule
-    response = conn.create_rule(
-        ListenerArn=http_listener_arn,
-        Priority=100,
-        Conditions=[
-            {"Field": "source-ip", "SourceIpConfig": {"Values": ["172.28.7.0/24"]}}
-        ],
-        Actions=[default_action],
-    )
-
-    # assert create_rule response
-    response["Rules"].should.have.length_of(1)
-    rule = response.get("Rules")[0]
-    rule["Priority"].should.equal("100")
-    rule["Conditions"].should.equal(
-        [{"Field": "source-ip", "SourceIpConfig": {"Values": ["172.28.7.0/24"]}}]
-    )
-
-    # assert describe_rules response
-    response = conn.describe_rules(ListenerArn=http_listener_arn)
-    response["Rules"].should.have.length_of(2)
-
-    # assert describe_rules with arn filter response
-    rule = response["Rules"][0]
-    rule["Conditions"].should.equal(
-        [{"Field": "source-ip", "SourceIpConfig": {"Values": ["172.28.7.0/24"]}}]
-    )
-    response = conn.describe_rules(RuleArns=[rule["RuleArn"]])
-    response["Rules"].should.equal([rule])
-
-
-@mock_elbv2
-@mock_ec2
-def test_create_rule_validate_host_header_condition():
-    conn = boto3.client("elbv2", region_name="us-east-1")
-
-    http_listener_arn = setup_listener(conn)
-
-    # create_rule with long host header
     with pytest.raises(ClientError) as ex:
         response = conn.create_rule(
             ListenerArn=http_listener_arn,
             Priority=100,
-            Conditions=[{"Field": "host-header", "Values": ["x" * 256]}],
+            Conditions=[condition],
             Actions=[default_action],
         )
 
     err = ex.value.response["Error"]
     err["Code"].should.equal("ValidationError")
-    err["Message"].should.equal(
-        "The 'host-header' value is too long; the limit is '128'"
-    )
-
-    # create_rule with long host header
-    with pytest.raises(ClientError) as ex:
-        response = conn.create_rule(
-            ListenerArn=http_listener_arn,
-            Priority=100,
-            Conditions=[
-                {"Field": "host-header", "HostHeaderConfig": {"Values": ["x" * 256]}}
-            ],
-            Actions=[default_action],
-        )
-
-    err = ex.value.response["Error"]
-    err["Code"].should.equal("ValidationError")
-    err["Message"].should.equal(
-        "The 'host-header' value is too long; the limit is '128'"
-    )
-
-    # create_rule with too many values
-    with pytest.raises(ClientError) as ex:
-        response = conn.create_rule(
-            ListenerArn=http_listener_arn,
-            Priority=100,
-            Conditions=[{"Field": "host-header", "Values": ["one", "two"]}],
-            Actions=[default_action],
-        )
-
-    err = ex.value.response["Error"]
-    err["Code"].should.equal("ValidationError")
-    err["Message"].should.equal(
-        "The 'host-header' field contains too many values; the limit is '1'"
-    )
-
-    # create_rule with no value
-    with pytest.raises(ClientError) as ex:
-        response = conn.create_rule(
-            ListenerArn=http_listener_arn,
-            Priority=100,
-            Conditions=[{"Field": "host-header"}],
-            Actions=[default_action],
-        )
-
-    # create_rule with empty value
-    with pytest.raises(ClientError) as ex:
-        response = conn.create_rule(
-            ListenerArn=http_listener_arn,
-            Priority=100,
-            Conditions=[{"Field": "host-header", "HostHeaderConfig": {"Values": []}}],
-            Actions=[default_action],
-        )
-
-    err = ex.value.response["Error"]
-    err["Code"].should.equal("ValidationError")
-    err["Message"].should.equal("A condition value must be specified")
-
-
-@mock_elbv2
-@mock_ec2
-def test_create_rule_validate_path_pattern_condition():
-    conn = boto3.client("elbv2", region_name="us-east-1")
-
-    http_listener_arn = setup_listener(conn)
-
-    # create_rule with long path pattern
-    with pytest.raises(ClientError) as ex:
-        response = conn.create_rule(
-            ListenerArn=http_listener_arn,
-            Priority=100,
-            Conditions=[{"Field": "path-pattern", "Values": ["x" * 256]}],
-            Actions=[default_action],
-        )
-
-    err = ex.value.response["Error"]
-    err["Code"].should.equal("ValidationError")
-    err["Message"].should.equal(
-        "The 'path-pattern' value is too long; the limit is '128'"
-    )
-
-    # create_rule with long path pattern
-    with pytest.raises(ClientError) as ex:
-        response = conn.create_rule(
-            ListenerArn=http_listener_arn,
-            Priority=100,
-            Conditions=[
-                {"Field": "path-pattern", "PathPatternConfig": {"Values": ["x" * 256]}}
-            ],
-            Actions=[default_action],
-        )
-
-    err = ex.value.response["Error"]
-    err["Code"].should.equal("ValidationError")
-    err["Message"].should.equal(
-        "The 'path-pattern' value is too long; the limit is '128'"
-    )
-
-    # create_rule with too many values
-    with pytest.raises(ClientError) as ex:
-        response = conn.create_rule(
-            ListenerArn=http_listener_arn,
-            Priority=100,
-            Conditions=[{"Field": "path-pattern", "Values": ["one", "two"]}],
-            Actions=[default_action],
-        )
-
-    err = ex.value.response["Error"]
-    err["Code"].should.equal("ValidationError")
-    err["Message"].should.equal(
-        "The 'path-pattern' field contains too many values; the limit is '1'"
-    )
-
-    # create_rule with no value
-    with pytest.raises(ClientError) as ex:
-        response = conn.create_rule(
-            ListenerArn=http_listener_arn,
-            Priority=100,
-            Conditions=[{"Field": "path-pattern"}],
-            Actions=[default_action],
-        )
-
-    # create_rule with empty value
-    with pytest.raises(ClientError) as ex:
-        response = conn.create_rule(
-            ListenerArn=http_listener_arn,
-            Priority=100,
-            Conditions=[{"Field": "path-pattern", "PathPatternConfig": {"Values": []}}],
-            Actions=[default_action],
-        )
-
-    err = ex.value.response["Error"]
-    err["Code"].should.equal("ValidationError")
-    err["Message"].should.equal("A condition value must be specified")
-
-
-@mock_elbv2
-@mock_ec2
-def test_create_rule_validate_http_header_condition():
-    conn = boto3.client("elbv2", region_name="us-east-1")
-
-    http_listener_arn = setup_listener(conn)
-
-    # create_rule with long http header name
-    with pytest.raises(ClientError) as ex:
-        response = conn.create_rule(
-            ListenerArn=http_listener_arn,
-            Priority=100,
-            Conditions=[
-                {
-                    "Field": "http-header",
-                    "HttpHeaderConfig": {"HttpHeaderName": "x" * 50, "Values": ["y"]},
-                }
-            ],
-            Actions=[default_action],
-        )
-
-    err = ex.value.response["Error"]
-    err["Code"].should.equal("ValidationError")
-    err["Message"].should.equal(
-        "The 'HttpHeaderName' value is too long; the limit is '40'"
-    )
-
-    # create_rule with long http header value
-    with pytest.raises(ClientError) as ex:
-        response = conn.create_rule(
-            ListenerArn=http_listener_arn,
-            Priority=100,
-            Conditions=[
-                {
-                    "Field": "http-header",
-                    "HttpHeaderConfig": {"HttpHeaderName": "x", "Values": ["y" * 256]},
-                }
-            ],
-            Actions=[default_action],
-        )
-
-    err = ex.value.response["Error"]
-    err["Code"].should.equal("ValidationError")
-    err["Message"].should.equal(
-        "The 'http-header' value is too long; the limit is '128'"
-    )
-
-
-@mock_elbv2
-@mock_ec2
-def test_create_rule_validate_http_request_method_condition():
-    conn = boto3.client("elbv2", region_name="us-east-1")
-
-    http_listener_arn = setup_listener(conn)
-
-    # create_rule with long host header
-    with pytest.raises(ClientError) as ex:
-        response = conn.create_rule(
-            ListenerArn=http_listener_arn,
-            Priority=100,
-            Conditions=[
-                {
-                    "Field": "http-request-method",
-                    "HttpRequestMethodConfig": {"Values": ["get"]},
-                }
-            ],
-            Actions=[default_action],
-        )
-
-    err = ex.value.response["Error"]
-    err["Code"].should.equal("ValidationError")
-    err["Message"].should.equal(
-        "The 'http-request-method' value is invalid; the allowed characters are A-Z, hyphen and underscore"
-    )
-
-    # create_rule with long host header
-    with pytest.raises(ClientError) as ex:
-        response = conn.create_rule(
-            ListenerArn=http_listener_arn,
-            Priority=100,
-            Conditions=[
-                {
-                    "Field": "http-request-method",
-                    "HttpRequestMethodConfig": {"Values": ["X" * 50]},
-                }
-            ],
-            Actions=[default_action],
-        )
-
-    err = ex.value.response["Error"]
-    err["Code"].should.equal("ValidationError")
-    err["Message"].should.equal(
-        "The 'http-request-method' value is too long; the limit is '40'"
-    )
-
-    # create_rule with no config
-    with pytest.raises(ClientError) as ex:
-        response = conn.create_rule(
-            ListenerArn=http_listener_arn,
-            Priority=100,
-            Conditions=[{"Field": "http-request-method",}],
-            Actions=[default_action],
-        )
-
-    err = ex.value.response["Error"]
-    err["Code"].should.equal("ValidationError")
-    err["Message"].should.equal(
-        "A 'HttpRequestMethodConfig' must be specified with 'http-request-method'"
-    )
-
-
-@mock_elbv2
-@mock_ec2
-def test_create_rule_validate_query_string_condition():
-    conn = boto3.client("elbv2", region_name="us-east-1")
-
-    http_listener_arn = setup_listener(conn)
-
-    # create_rule with long key
-    with pytest.raises(ClientError) as ex:
-        response = conn.create_rule(
-            ListenerArn=http_listener_arn,
-            Priority=100,
-            Conditions=[
-                {
-                    "Field": "query-string",
-                    "QueryStringConfig": {
-                        "Values": [{"Key": "x" * 256, "Value": "world"}]
-                    },
-                }
-            ],
-            Actions=[default_action],
-        )
-
-    err = ex.value.response["Error"]
-    err["Code"].should.equal("ValidationError")
-    err["Message"].should.equal("The 'Key' value is too long; the limit is '128'")
-
-    # create_rule with long value
-    with pytest.raises(ClientError) as ex:
-        response = conn.create_rule(
-            ListenerArn=http_listener_arn,
-            Priority=100,
-            Conditions=[
-                {
-                    "Field": "query-string",
-                    "QueryStringConfig": {
-                        "Values": [{"Key": "hello", "Value": "x" * 256}]
-                    },
-                }
-            ],
-            Actions=[default_action],
-        )
-
-    err = ex.value.response["Error"]
-    err["Code"].should.equal("ValidationError")
-    err["Message"].should.equal("The 'Value' value is too long; the limit is '128'")
-
-    # create_rule without value
-    with pytest.raises(ClientError) as ex:
-        response = conn.create_rule(
-            ListenerArn=http_listener_arn,
-            Priority=100,
-            Conditions=[
-                {
-                    "Field": "query-string",
-                    "QueryStringConfig": {"Values": [{"Key": "hello"}]},
-                }
-            ],
-            Actions=[default_action],
-        )
-
-    err = ex.value.response["Error"]
-    err["Code"].should.equal("ValidationError")
-    err["Message"].should.equal(
-        "A 'Value' must be specified in 'QueryStringKeyValuePair'"
-    )
-
-
-@mock_elbv2
-@mock_ec2
-def test_create_rule_validate_source_ip_condition():
-    conn = boto3.client("elbv2", region_name="us-east-1")
-
-    http_listener_arn = setup_listener(conn)
-
-    # create_rule with long host header
-    with pytest.raises(ClientError) as ex:
-        response = conn.create_rule(
-            ListenerArn=http_listener_arn,
-            Priority=100,
-            Conditions=[{"Field": "source-ip", "SourceIpConfig": {"Values": []}}],
-            Actions=[default_action],
-        )
-
-    err = ex.value.response["Error"]
-    err["Code"].should.equal("ValidationError")
-    err["Message"].should.equal("A 'source-ip' value must be specified")
-
-    # create_rule with no config
-    with pytest.raises(ClientError) as ex:
-        response = conn.create_rule(
-            ListenerArn=http_listener_arn,
-            Priority=100,
-            Conditions=[{"Field": "source-ip",}],
-            Actions=[default_action],
-        )
-
-    err = ex.value.response["Error"]
-    err["Code"].should.equal("ValidationError")
-    err["Message"].should.equal("A 'SourceIpConfig' must be specified with 'source-ip'")
+    err["Message"].should.equal(expected_message)


### PR DESCRIPTION
This PR adds support for the following condition types:
- http-header
- http-request-method
- host-header
- path-pattern
- query-string
- source-ip


Addresses #2544 