### PR TITLE
Remove cfn-lint as a dependency for ssm extra

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -117,7 +117,7 @@ extras_per_service = {
     "ses": [_dep_docker],
     "sns": [_dep_docker],
     "sqs": [_dep_docker],
-    "ssm": [_dep_docker, _dep_PyYAML, _dep_cfn_lint, _dep_decorator],
+    "ssm": [_dep_docker, _dep_PyYAML, _dep_decorator],
     "xray": [_dep_aws_xray_sdk],
 }
 extras_require = {


### PR DESCRIPTION
Since commit https://github.com/spulec/moto/commit/3b9635b3c72acc1770ef9666dadec6c3c650e712, the SSM module doesn't directly depend on the `cloudformation` module anymore.

The `cfn-lint` extra dependency shouldn't be required anymore for clients that install the `ssm` extra but don't need the `cloudformation` one.

This change avoids many big libraries like `numpy` or `pandas` to be installed when running `pip install 'moto[ssm]'`, which are indirect dependencies retrieved by `cfn-lint`->`networkx`.

Without this change:
> $ pip install 'moto[ssm]'
> (...)
> Successfully installed Jinja2-3.0.1 MarkupSafe-2.0.1 PyYAML-5.4.1 attrs-21.2.0 aws-sam-translator-1.37.0 boto3-1.17.111 botocore-1.20.111 certifi-2021.5.30 cffi-1.14.6 cfn-lint-0.52.0 charset-normalizer-2.0.1 cryptography-3.4.7 cycler-0.10.0 docker-5.0.0 idna-3.2 jmespath-0.10.0 jsonpatch-1.32 jsonpointer-2.1 jsonschema-3.2.0 junit-xml-1.9 kiwisolver-1.3.1 matplotlib-3.4.2 more-itertools-8.8.0 moto-2.0.11 networkx-2.6.1 numpy-1.21.0 pandas-1.3.0 pillow-8.3.1 pycparser-2.20 pyparsing-2.4.7 pyrsistent-0.18.0 python-dateutil-2.8.2 pytz-2021.1 requests-2.26.0 responses-0.13.3 s3transfer-0.4.2 scipy-1.7.0 six-1.16.0 urllib3-1.26.6 websocket-client-1.1.0 werkzeug-2.0.1 xmltodict-0.12.0

With this change:
> $ pip install -e '.[ssm]'
> (...)
> Successfully installed Jinja2-3.0.1 MarkupSafe-2.0.1 PyYAML-5.4.1 boto3-1.17.111 botocore-1.20.111 certifi-2021.5.30 cffi-1.14.6 charset-normalizer-2.0.1 cryptography-3.4.7 docker-5.0.0 idna-3.2 jmespath-0.10.0 more-itertools-8.8.0 moto pycparser-2.20 python-dateutil-2.8.2 pytz-2021.1 requests-2.26.0 responses-0.13.3 s3transfer-0.4.2 six-1.16.0 urllib3-1.26.6 websocket-client-1.1.0 werkzeug-2.0.1 xmltodict-0.12.0