### PR TITLE
Fix: Adding empty tags to SQS queue on creation time

### DIFF
--- a/moto/sqs/responses.py
+++ b/moto/sqs/responses.py
@@ -91,7 +91,14 @@ class SQSResponse(BaseResponse):
         request_url = urlparse(self.uri)
         queue_name = self._get_param("QueueName")
 
-        queue = self.sqs_backend.create_queue(queue_name, self.tags, **self.attribute)
+        tags = {}
+        tags_param = self._get_multi_param("Tag")
+        # Returns [{'Key': 'Foo', 'Value': 'Bar'}]
+        if tags_param:
+            for tag in tags_param:
+                tags[tag["Key"]] = tag["Value"]
+
+        queue = self.sqs_backend.create_queue(queue_name, tags, **self.attribute)
 
         template = self.response_template(CREATE_QUEUE_RESPONSE)
         return template.render(queue_url=queue.url(request_url))

--- a/tests/test_sqs/test_sqs.py
+++ b/tests/test_sqs/test_sqs.py
@@ -167,12 +167,13 @@ def test_create_queue_kms():
 def test_create_queue_with_tags():
     client = boto3.client("sqs", region_name="us-east-1")
     response = client.create_queue(
-        QueueName="test-queue-with-tags", tags={"tag_key_1": "tag_value_1"}
+        QueueName="test-queue-with-tags",
+        tags={"tag_key_1": "tag_value_1", "tag_key_2": ""},
     )
     queue_url = response["QueueUrl"]
 
     client.list_queue_tags(QueueUrl=queue_url)["Tags"].should.equal(
-        {"tag_key_1": "tag_value_1"}
+        {"tag_key_1": "tag_value_1", "tag_key_2": "tag_value_2",}
     )
 
 

--- a/tests/test_sqs/test_sqs.py
+++ b/tests/test_sqs/test_sqs.py
@@ -173,7 +173,7 @@ def test_create_queue_with_tags():
     queue_url = response["QueueUrl"]
 
     client.list_queue_tags(QueueUrl=queue_url)["Tags"].should.equal(
-        {"tag_key_1": "tag_value_1", "tag_key_2": "tag_value_2",}
+        {"tag_key_1": "tag_value_1", "tag_key_2": "",}
     )
 
 


### PR DESCRIPTION
Fixes https://github.com/localstack/localstack/issues/4343, it seems like newly created queues do not add tags if there is an empty among them. This behavior works in AWS but not in moto and is fixed by retrieving the missing params instead of passing `self.tags`