### PR TITLE
Fix: Adding fix when setting empty policy attr to queue

### DIFF
--- a/moto/sqs/responses.py
+++ b/moto/sqs/responses.py
@@ -202,8 +202,17 @@ class SQSResponse(BaseResponse):
 
     def set_queue_attributes(self):
         # TODO validate self.get_param('QueueUrl')
+        attribute = self.attribute
+
+        # Fixes issue with Policy set to empty str
+        attribute_names = self._get_multi_param("Attribute")
+        if attribute_names:
+            for attr in attribute_names:
+                if attr["Name"] == "Policy" and len(attr["Value"]) == 0:
+                    attribute = {attr["Name"]: None}
+
         queue_name = self._get_queue_name()
-        self.sqs_backend.set_queue_attributes(queue_name, self.attribute)
+        self.sqs_backend.set_queue_attributes(queue_name, attribute)
 
         return SET_QUEUE_ATTRIBUTE_RESPONSE
 

--- a/tests/test_sqs/test_sqs.py
+++ b/tests/test_sqs/test_sqs.py
@@ -206,6 +206,31 @@ def test_create_queue_with_policy():
 
 
 @mock_sqs
+def test_set_queue_attribute_empty_policy_removes_attr():
+    client = boto3.client("sqs", region_name="us-east-1")
+    response = client.create_queue(
+        QueueName="test-queue",
+        Attributes={
+            "Policy": json.dumps(
+                {
+                    "Version": "2012-10-17",
+                    "Id": "test",
+                    "Statement": [{"Effect": "Allow", "Principal": "*", "Action": "*"}],
+                }
+            )
+        },
+    )
+    queue_url = response["QueueUrl"]
+
+    empty_policy = {"Policy": ""}
+    client.set_queue_attributes(QueueUrl=queue_url, Attributes=empty_policy)
+    response = client.get_queue_attributes(QueueUrl=queue_url, AttributeNames=["All"])[
+        "Attributes"
+    ]
+    response.shouldnt.have.key("Policy")
+
+
+@mock_sqs
 def test_get_queue_url():
     client = boto3.client("sqs", region_name="us-east-1")
     client.create_queue(QueueName="test-queue")


### PR DESCRIPTION
Fixes https://github.com/localstack/localstack/issues/4225

Fixes an issue with the terraform AWS provider that sets the SQS policy to an empty string, as seen in [the following function](https://github.com/hashicorp/terraform-provider-aws/blob/ccc13f55709c860a2130ecee6e21acde2318e936/aws/resource_aws_sqs_queue_policy.go#L104) via query parameters in the URL, for example:

`Action=SetQueueAttributes&Attribute.1.Name=Policy&Attribute.1.Value=&QueueUrl=http%3A%2F%2Flocalhost%3A4566%2F000000000000%2Fdistributor_queue&Version=2012-11-05`

In the end the `set_queue_attributes` receives the following:
```
odict_items([('Action', ['SetQueueAttributes']), ('Attribute.1.Name', ['Policy']), ('Attribute.1.Value', ['']), ('QueueUrl', ['http://localhost:4566/000000000000/distributor_queue']), ('Version', ['2012-11-05'])])
```