### PR TITLE
Add support for admin_user_global_sign_out to cognitoidp

### DIFF
--- a/moto/cognitoidp/models.py
+++ b/moto/cognitoidp/models.py
@@ -900,6 +900,19 @@ class CognitoIdpBackend(BaseBackend):
         user = user_pool.users[username]
         user.update_attributes(attributes)
 
+    def admin_user_global_sign_out(self, user_pool_id, username):
+        user_pool = self.user_pools.get(user_pool_id)
+        if not user_pool:
+            raise ResourceNotFoundError(user_pool_id)
+
+        if username not in user_pool.users:
+            raise UserNotFoundError(username)
+
+        for token, token_tuple in list(user_pool.refresh_tokens.items()):
+            _, username = token_tuple
+            if username == username:
+                del user_pool.refresh_tokens[token]
+
     def create_resource_server(self, user_pool_id, identifier, name, scopes):
         user_pool = self.user_pools.get(user_pool_id)
         if not user_pool:
@@ -996,7 +1009,10 @@ class CognitoIdpBackend(BaseBackend):
             refresh_token = auth_parameters.get("REFRESH_TOKEN")
             if not refresh_token:
                 raise ResourceNotFoundError(refresh_token)
-
+            
+            if not user_pool.refresh_tokens.get(refresh_token, None):
+                raise ResourceNotFoundError(refresh_token)
+            
             client_id, username = user_pool.refresh_tokens[refresh_token]
             if not username:
                 raise ResourceNotFoundError(username)

--- a/moto/cognitoidp/models.py
+++ b/moto/cognitoidp/models.py
@@ -1011,7 +1011,7 @@ class CognitoIdpBackend(BaseBackend):
                 raise ResourceNotFoundError(refresh_token)
 
             if user_pool.refresh_tokens[refresh_token] is None:
-                raise NotAuthorizedError('Refresh Token has been revoked')
+                raise NotAuthorizedError("Refresh Token has been revoked")
 
             client_id, username = user_pool.refresh_tokens[refresh_token]
             if not username:

--- a/moto/cognitoidp/models.py
+++ b/moto/cognitoidp/models.py
@@ -911,7 +911,7 @@ class CognitoIdpBackend(BaseBackend):
         for token, token_tuple in list(user_pool.refresh_tokens.items()):
             _, username = token_tuple
             if username == username:
-                del user_pool.refresh_tokens[token]
+                user_pool.refresh_tokens[token] = None
 
     def create_resource_server(self, user_pool_id, identifier, name, scopes):
         user_pool = self.user_pools.get(user_pool_id)
@@ -1009,10 +1009,10 @@ class CognitoIdpBackend(BaseBackend):
             refresh_token = auth_parameters.get("REFRESH_TOKEN")
             if not refresh_token:
                 raise ResourceNotFoundError(refresh_token)
-            
-            if not user_pool.refresh_tokens.get(refresh_token, None):
-                raise ResourceNotFoundError(refresh_token)
-            
+
+            if user_pool.refresh_tokens[refresh_token] is None:
+                raise NotAuthorizedError('Refresh Token has been revoked')
+
             client_id, username = user_pool.refresh_tokens[refresh_token]
             if not username:
                 raise ResourceNotFoundError(username)

--- a/moto/cognitoidp/responses.py
+++ b/moto/cognitoidp/responses.py
@@ -429,7 +429,7 @@ class CognitoIdpResponse(BaseResponse):
             user_pool_id, username
         )
         return ""
-        
+
     # Resource Server
     def create_resource_server(self):
         user_pool_id = self._get_param("UserPoolId")

--- a/moto/cognitoidp/responses.py
+++ b/moto/cognitoidp/responses.py
@@ -422,6 +422,14 @@ class CognitoIdpResponse(BaseResponse):
         )
         return ""
 
+    def admin_user_global_sign_out(self):
+        user_pool_id = self._get_param("UserPoolId")
+        username = self._get_param("Username")
+        cognitoidp_backends[self.region].admin_user_global_sign_out(
+            user_pool_id, username
+        )
+        return ""
+        
     # Resource Server
     def create_resource_server(self):
         user_pool_id = self._get_param("UserPoolId")

--- a/tests/test_cognitoidp/test_cognitoidp.py
+++ b/tests/test_cognitoidp/test_cognitoidp.py
@@ -1660,14 +1660,14 @@ def test_confirm_forgot_password():
         Password=str(uuid.uuid4()),
     )
 
+
 @mock_cognitoidp
 def test_admin_user_global_sign_out():
     conn = boto3.client("cognito-idp", "us-west-2")
     result = user_authentication_flow(conn)
 
     conn.admin_user_global_sign_out(
-        UserPoolId=result['user_pool_id'],
-        Username=result['username'],
+        UserPoolId=result["user_pool_id"], Username=result["username"],
     )
 
     with pytest.raises(ClientError) as ex:
@@ -1683,17 +1683,18 @@ def test_admin_user_global_sign_out():
     err["Code"].should.equal("NotAuthorizedException")
     err["Message"].should.equal("Refresh Token has been revoked")
 
+
 @mock_cognitoidp
 def test_admin_user_global_sign_out_unknown_userpool():
     conn = boto3.client("cognito-idp", "us-west-2")
     result = user_authentication_flow(conn)
     with pytest.raises(ClientError) as ex:
         conn.admin_user_global_sign_out(
-            UserPoolId='n/a',
-            Username=result['username'],
+            UserPoolId="n/a", Username=result["username"],
         )
     err = ex.value.response["Error"]
     err["Code"].should.equal("ResourceNotFoundException")
+
 
 @mock_cognitoidp
 def test_admin_user_global_sign_out_unknown_user():
@@ -1701,11 +1702,11 @@ def test_admin_user_global_sign_out_unknown_user():
     result = user_authentication_flow(conn)
     with pytest.raises(ClientError) as ex:
         conn.admin_user_global_sign_out(
-            UserPoolId=result['user_pool_id'],
-            Username='n/a',
+            UserPoolId=result["user_pool_id"], Username="n/a",
         )
     err = ex.value.response["Error"]
     err["Code"].should.equal("UserNotFoundException")
+
 
 @mock_cognitoidp
 def test_admin_update_user_attributes():


### PR DESCRIPTION
This PR adds support for admin_user_global_sign_out for Cognito. 

[admin_user_global_sign_out](https://docs.aws.amazon.com/cli/latest/reference/cognito-idp/admin-user-global-sign-out.html) requires that refresh tokens are invalidated - hence the code removes any user specific refresh tokens. 

I added a check to `initiate_auth` to confirm if the refresh token exists - if it doesnt (which is shouldn't if `admin_user_global_sign_out` has been called) it responds with a ResourceNotFoundException

I've added a test case to cover this code and have run all cognitoidp test cases to confirm the small change to `initiate_auth` has not broken anything.