### PR TITLE
include associationState when DescribeRouteTables

### DIFF
--- a/moto/ec2/responses/route_tables.py
+++ b/moto/ec2/responses/route_tables.py
@@ -195,6 +195,9 @@ DESCRIBE_ROUTE_TABLES_RESPONSE = """
                 <routeTableId>{{ route_table.id }}</routeTableId>
                 <main>true</main>
                 <subnetId>{{ subnet_id }}</subnetId>
+                <associationState>
+                  <state>associated</state>
+                </associationState>
               </item>
             {% endfor %}
           </associationSet>


### PR DESCRIPTION
The AWS API documentation specifies that the [association state](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_RouteTableAssociationState.html) is a part of the [DescribeRouteTables](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeRouteTables.html) response object. Although it's not a required attribute of the object, it is consistently provided by the API and the Terraform AWS provider expects it to be present. Without including it in the response the provider throws a null pointer reference and testing can fail.