### PR TITLE
Fix regex URLs so that a dot is actually interpreted as a dot

### DIFF
--- a/moto/acm/urls.py
+++ b/moto/acm/urls.py
@@ -1,6 +1,6 @@
 from __future__ import unicode_literals
 from .responses import AWSCertificateManagerResponse
 
-url_bases = ["https?://acm.(.+).amazonaws.com"]
+url_bases = ["https?://acm\.(.+)\.amazonaws\.com"]
 
 url_paths = {"{0}/$": AWSCertificateManagerResponse.dispatch}

--- a/moto/athena/urls.py
+++ b/moto/athena/urls.py
@@ -1,6 +1,6 @@
 from __future__ import unicode_literals
 from .responses import AthenaResponse
 
-url_bases = ["https?://athena.(.+).amazonaws.com"]
+url_bases = ["https?://athena\.(.+)\.amazonaws\.com"]
 
 url_paths = {"{0}/$": AthenaResponse.dispatch}

--- a/moto/autoscaling/urls.py
+++ b/moto/autoscaling/urls.py
@@ -1,6 +1,6 @@
 from __future__ import unicode_literals
 from .responses import AutoScalingResponse
 
-url_bases = ["https?://autoscaling.(.+).amazonaws.com"]
+url_bases = [r"https?://autoscaling\.(.+)\.amazonaws\.com"]
 
 url_paths = {"{0}/$": AutoScalingResponse.dispatch}

--- a/moto/cloudformation/urls.py
+++ b/moto/cloudformation/urls.py
@@ -1,6 +1,6 @@
 from __future__ import unicode_literals
 from .responses import CloudFormationResponse
 
-url_bases = ["https?://cloudformation.(.+).amazonaws.com"]
+url_bases = [r"https?://cloudformation\.(.+)\.amazonaws\.com"]
 
 url_paths = {"{0}/$": CloudFormationResponse.dispatch}

--- a/moto/codecommit/urls.py
+++ b/moto/codecommit/urls.py
@@ -1,6 +1,6 @@
 from __future__ import unicode_literals
 from .responses import CodeCommitResponse
 
-url_bases = ["https?://codecommit.(.+).amazonaws.com"]
+url_bases = [r"https?://codecommit\.(.+)\.amazonaws\.com"]
 
 url_paths = {"{0}/$": CodeCommitResponse.dispatch}

--- a/moto/codepipeline/urls.py
+++ b/moto/codepipeline/urls.py
@@ -1,6 +1,6 @@
 from __future__ import unicode_literals
 from .responses import CodePipelineResponse
 
-url_bases = ["https?://codepipeline.(.+).amazonaws.com"]
+url_bases = [r"https?://codepipeline\.(.+)\.amazonaws\.com"]
 
 url_paths = {"{0}/$": CodePipelineResponse.dispatch}

--- a/moto/config/urls.py
+++ b/moto/config/urls.py
@@ -1,6 +1,6 @@
 from __future__ import unicode_literals
 from .responses import ConfigResponse
 
-url_bases = ["https?://config.(.+).amazonaws.com"]
+url_bases = [r"https?://config\.(.+)\.amazonaws\.com"]
 
 url_paths = {"{0}/$": ConfigResponse.dispatch}

--- a/moto/datapipeline/urls.py
+++ b/moto/datapipeline/urls.py
@@ -1,6 +1,6 @@
 from __future__ import unicode_literals
 from .responses import DataPipelineResponse
 
-url_bases = ["https?://datapipeline.(.+).amazonaws.com"]
+url_bases = [r"https?://datapipeline\.(.+)\.amazonaws\.com"]
 
 url_paths = {"{0}/$": DataPipelineResponse.dispatch}

--- a/moto/datasync/urls.py
+++ b/moto/datasync/urls.py
@@ -2,6 +2,6 @@ from __future__ import unicode_literals
 
 from .responses import DataSyncResponse
 
-url_bases = ["https?://(.*?)(datasync)(.*?).amazonaws.com"]
+url_bases = [r"https?://(.*?)(datasync)\.(.*?).amazonaws.com"]
 
 url_paths = {"{0}/$": DataSyncResponse.dispatch}

--- a/moto/datasync/urls.py
+++ b/moto/datasync/urls.py
@@ -2,6 +2,6 @@ from __future__ import unicode_literals
 
 from .responses import DataSyncResponse
 
-url_bases = [r"https?://(.*?)(datasync)\.(.*?).amazonaws.com"]
+url_bases = [r"https?://(.*\.)?(datasync)\.(.+).amazonaws.com"]
 
 url_paths = {"{0}/$": DataSyncResponse.dispatch}

--- a/moto/dms/urls.py
+++ b/moto/dms/urls.py
@@ -1,9 +1,7 @@
 from __future__ import unicode_literals
 from .responses import DatabaseMigrationServiceResponse
 
-url_bases = [
-    "https?://dms.(.+).amazonaws.com",
-]
+url_bases = [r"https?://dms\.(.+)\.amazonaws\.com"]
 
 
 url_paths = {

--- a/moto/dynamodb/urls.py
+++ b/moto/dynamodb/urls.py
@@ -1,6 +1,6 @@
 from __future__ import unicode_literals
 from .responses import DynamoHandler
 
-url_bases = ["https?://dynamodb.(.+).amazonaws.com"]
+url_bases = [r"https?://dynamodb\.(.+)\.amazonaws\.com"]
 
 url_paths = {"{0}/": DynamoHandler.dispatch}

--- a/moto/dynamodb2/urls.py
+++ b/moto/dynamodb2/urls.py
@@ -1,6 +1,6 @@
 from __future__ import unicode_literals
 from .responses import DynamoHandler
 
-url_bases = ["https?://dynamodb.(.+).amazonaws.com"]
+url_bases = [r"https?://dynamodb\.(.+)\.amazonaws\.com"]
 
 url_paths = {"{0}/": DynamoHandler.dispatch}

--- a/moto/ecr/urls.py
+++ b/moto/ecr/urls.py
@@ -1,6 +1,9 @@
 from __future__ import unicode_literals
 from .responses import ECRResponse
 
-url_bases = [r"https?://ecr\.(.+)\.amazonaws\.com", r"https?://api\.ecr\.(.+)\.amazonaws\.com"]
+url_bases = [
+    r"https?://ecr\.(.+)\.amazonaws\.com",
+    r"https?://api\.ecr\.(.+)\.amazonaws\.com",
+]
 
 url_paths = {"{0}/$": ECRResponse.dispatch}

--- a/moto/ecr/urls.py
+++ b/moto/ecr/urls.py
@@ -1,6 +1,6 @@
 from __future__ import unicode_literals
 from .responses import ECRResponse
 
-url_bases = ["https?://ecr.(.+).amazonaws.com", "https?://api.ecr.(.+).amazonaws.com"]
+url_bases = [r"https?://ecr\.(.+)\.amazonaws\.com", r"https?://api\.ecr\.(.+)\.amazonaws\.com"]
 
 url_paths = {"{0}/$": ECRResponse.dispatch}

--- a/moto/ecs/urls.py
+++ b/moto/ecs/urls.py
@@ -1,6 +1,6 @@
 from __future__ import unicode_literals
 from .responses import EC2ContainerServiceResponse
 
-url_bases = ["https?://ecs.(.+).amazonaws.com"]
+url_bases = [r"https?://ecs\.(.+)\.amazonaws\.com"]
 
 url_paths = {"{0}/$": EC2ContainerServiceResponse.dispatch}

--- a/moto/events/urls.py
+++ b/moto/events/urls.py
@@ -2,6 +2,6 @@ from __future__ import unicode_literals
 
 from .responses import EventsHandler
 
-url_bases = ["https?://events.(.+).amazonaws.com"]
+url_bases = [r"https?://events\.(.+)\.amazonaws\.com"]
 
 url_paths = {"{0}/": EventsHandler.dispatch}

--- a/moto/forecast/urls.py
+++ b/moto/forecast/urls.py
@@ -2,6 +2,6 @@ from __future__ import unicode_literals
 
 from .responses import ForecastResponse
 
-url_bases = ["https?://forecast.(.+).amazonaws.com"]
+url_bases = [r"https?://forecast\.(.+)\.amazonaws\.com"]
 
 url_paths = {"{0}/$": ForecastResponse.dispatch}

--- a/moto/glue/urls.py
+++ b/moto/glue/urls.py
@@ -2,6 +2,6 @@ from __future__ import unicode_literals
 
 from .responses import GlueResponse
 
-url_bases = ["https?://glue(.*).amazonaws.com"]
+url_bases = [r"https?://glue\.(.*)\.amazonaws\.com"]
 
 url_paths = {"{0}/$": GlueResponse.dispatch}

--- a/moto/glue/urls.py
+++ b/moto/glue/urls.py
@@ -2,6 +2,6 @@ from __future__ import unicode_literals
 
 from .responses import GlueResponse
 
-url_bases = [r"https?://glue\.(.*)\.amazonaws\.com"]
+url_bases = [r"https?://glue\.(.+)\.amazonaws\.com"]
 
 url_paths = {"{0}/$": GlueResponse.dispatch}

--- a/moto/iam/urls.py
+++ b/moto/iam/urls.py
@@ -1,6 +1,6 @@
 from __future__ import unicode_literals
 from .responses import IamResponse
 
-url_bases = [r"https?://iam\.(.*)amazonaws\.com"]
+url_bases = [r"https?://iam\.(.*\.)?amazonaws\.com"]
 
 url_paths = {"{0}/$": IamResponse.dispatch}

--- a/moto/iam/urls.py
+++ b/moto/iam/urls.py
@@ -1,6 +1,6 @@
 from __future__ import unicode_literals
 from .responses import IamResponse
 
-url_bases = ["https?://iam(.*).amazonaws.com"]
+url_bases = [r"https?://iam\.(.*)amazonaws\.com"]
 
 url_paths = {"{0}/$": IamResponse.dispatch}

--- a/moto/iot/urls.py
+++ b/moto/iot/urls.py
@@ -1,7 +1,7 @@
 from __future__ import unicode_literals
 from .responses import IoTResponse
 
-url_bases = ["https?://iot.(.+).amazonaws.com"]
+url_bases = [r"https?://iot\.(.+)\.amazonaws\.com"]
 
 
 response = IoTResponse()

--- a/moto/kinesis/urls.py
+++ b/moto/kinesis/urls.py
@@ -3,8 +3,8 @@ from .responses import KinesisResponse
 
 url_bases = [
     # Need to avoid conflicting with kinesisvideo
-    r"https?://kinesis\.(.+).amazonaws.com",
-    "https?://firehose.(.+).amazonaws.com",
+    r"https?://kinesis\.(.+)\.amazonaws\.com",
+    r"https?://firehose\.(.+)\.amazonaws\.com",
 ]
 
 url_paths = {"{0}/$": KinesisResponse.dispatch}

--- a/moto/kms/urls.py
+++ b/moto/kms/urls.py
@@ -1,6 +1,6 @@
 from __future__ import unicode_literals
 from .responses import KmsResponse
 
-url_bases = ["https?://kms.(.+).amazonaws.com"]
+url_bases = [r"https?://kms\.(.+)\.amazonaws\.com"]
 
 url_paths = {"{0}/$": KmsResponse.dispatch}

--- a/moto/logs/urls.py
+++ b/moto/logs/urls.py
@@ -1,5 +1,5 @@
 from .responses import LogsResponse
 
-url_bases = ["https?://logs.(.+).amazonaws.com"]
+url_bases = [r"https?://logs\.(.+)\.amazonaws\.com"]
 
 url_paths = {"{0}/$": LogsResponse.dispatch}

--- a/moto/mediastore/urls.py
+++ b/moto/mediastore/urls.py
@@ -2,9 +2,7 @@ from __future__ import unicode_literals
 
 from .responses import MediaStoreResponse
 
-url_bases = [
-    "https?://mediastore.(.+).amazonaws.com",
-]
+url_bases = [r"https?://mediastore\.(.+)\.amazonaws\.com"]
 
 response = MediaStoreResponse()
 

--- a/moto/organizations/urls.py
+++ b/moto/organizations/urls.py
@@ -1,6 +1,6 @@
 from __future__ import unicode_literals
 from .responses import OrganizationsResponse
 
-url_bases = ["https?://organizations.(.+).amazonaws.com"]
+url_bases = [r"https?://organizations\.(.+)\.amazonaws\.com"]
 
 url_paths = {"{0}/$": OrganizationsResponse.dispatch}

--- a/moto/rds2/urls.py
+++ b/moto/rds2/urls.py
@@ -1,6 +1,6 @@
 from __future__ import unicode_literals
 from .responses import RDS2Response
 
-url_bases = ["https?://rds.(.+).amazonaws.com", "https?://rds.amazonaws.com"]
+url_bases = [r"https?://rds\.(.+)\.amazonaws\.com", r"https?://rds\.amazonaws\.com"]
 
 url_paths = {"{0}/$": RDS2Response.dispatch}

--- a/moto/redshift/urls.py
+++ b/moto/redshift/urls.py
@@ -1,6 +1,6 @@
 from __future__ import unicode_literals
 from .responses import RedshiftResponse
 
-url_bases = ["https?://redshift.(.+).amazonaws.com"]
+url_bases = [r"https?://redshift\.(.+)\.amazonaws\.com"]
 
 url_paths = {"{0}/$": RedshiftResponse.dispatch}

--- a/moto/secretsmanager/urls.py
+++ b/moto/secretsmanager/urls.py
@@ -1,6 +1,6 @@
 from __future__ import unicode_literals
 from .responses import SecretsManagerResponse
 
-url_bases = ["https?://secretsmanager.(.+).amazonaws.com"]
+url_bases = [r"https?://secretsmanager\.(.+)\.amazonaws\.com"]
 
 url_paths = {"{0}/$": SecretsManagerResponse.dispatch}

--- a/moto/ses/urls.py
+++ b/moto/ses/urls.py
@@ -1,6 +1,9 @@
 from __future__ import unicode_literals
 from .responses import EmailResponse
 
-url_bases = [r"https?://email\.(.+)\.amazonaws\.com", r"https?://ses\.(.+)\.amazonaws\.com"]
+url_bases = [
+    r"https?://email\.(.+)\.amazonaws\.com",
+    r"https?://ses\.(.+)\.amazonaws\.com",
+]
 
 url_paths = {"{0}/$": EmailResponse.dispatch}

--- a/moto/ses/urls.py
+++ b/moto/ses/urls.py
@@ -1,6 +1,6 @@
 from __future__ import unicode_literals
 from .responses import EmailResponse
 
-url_bases = ["https?://email.(.+).amazonaws.com", "https?://ses.(.+).amazonaws.com"]
+url_bases = [r"https?://email\.(.+)\.amazonaws\.com", r"https?://ses\.(.+)\.amazonaws\.com"]
 
 url_paths = {"{0}/$": EmailResponse.dispatch}

--- a/moto/sns/urls.py
+++ b/moto/sns/urls.py
@@ -1,6 +1,6 @@
 from __future__ import unicode_literals
 from .responses import SNSResponse
 
-url_bases = ["https?://sns.(.+).amazonaws.com"]
+url_bases = [r"https?://sns\.(.+)\.amazonaws\.com"]
 
 url_paths = {"{0}/$": SNSResponse.dispatch}

--- a/moto/sqs/urls.py
+++ b/moto/sqs/urls.py
@@ -1,7 +1,7 @@
 from __future__ import unicode_literals
 from .responses import SQSResponse
 
-url_bases = [r"https?://(.*?)(queue|sqs)\.(.*?)amazonaws\.com"]
+url_bases = [r"https?://(.*\.)?(queue|sqs)\.(.*\.)?amazonaws\.com"]
 
 dispatch = SQSResponse().dispatch
 

--- a/moto/sqs/urls.py
+++ b/moto/sqs/urls.py
@@ -1,7 +1,7 @@
 from __future__ import unicode_literals
 from .responses import SQSResponse
 
-url_bases = ["https?://(.*?)(queue|sqs)(.*?).amazonaws.com"]
+url_bases = [r"https?://(.*?)(queue|sqs)\.(.*?)amazonaws\.com"]
 
 dispatch = SQSResponse().dispatch
 

--- a/moto/ssm/urls.py
+++ b/moto/ssm/urls.py
@@ -1,6 +1,6 @@
 from __future__ import unicode_literals
 from .responses import SimpleSystemManagerResponse
 
-url_bases = ["https?://ssm.(.+).amazonaws.com", "https?://ssm.(.+).amazonaws.com.cn"]
+url_bases = [r"https?://ssm\.(.+)\.amazonaws\.com", r"https?://ssm\.(.+)\.amazonaws\.com\.cn"]
 
 url_paths = {"{0}/$": SimpleSystemManagerResponse.dispatch}

--- a/moto/ssm/urls.py
+++ b/moto/ssm/urls.py
@@ -1,6 +1,9 @@
 from __future__ import unicode_literals
 from .responses import SimpleSystemManagerResponse
 
-url_bases = [r"https?://ssm\.(.+)\.amazonaws\.com", r"https?://ssm\.(.+)\.amazonaws\.com\.cn"]
+url_bases = [
+    r"https?://ssm\.(.+)\.amazonaws\.com",
+    r"https?://ssm\.(.+)\.amazonaws\.com\.cn",
+]
 
 url_paths = {"{0}/$": SimpleSystemManagerResponse.dispatch}

--- a/moto/sts/urls.py
+++ b/moto/sts/urls.py
@@ -1,6 +1,6 @@
 from __future__ import unicode_literals
 from .responses import TokenResponse
 
-url_bases = ["https?://sts(.*).amazonaws.com(|.cn)"]
+url_bases = [r"https?://sts\.(.*)amazonaws\.com(|.cn)"]
 
 url_paths = {"{0}/$": TokenResponse.dispatch}

--- a/moto/sts/urls.py
+++ b/moto/sts/urls.py
@@ -1,6 +1,6 @@
 from __future__ import unicode_literals
 from .responses import TokenResponse
 
-url_bases = [r"https?://sts\.(.*)amazonaws\.com(|.cn)"]
+url_bases = [r"https?://sts\.(.*\.)?amazonaws\.com(|.cn)"]
 
 url_paths = {"{0}/$": TokenResponse.dispatch}

--- a/moto/support/urls.py
+++ b/moto/support/urls.py
@@ -1,9 +1,7 @@
 from __future__ import unicode_literals
 from .responses import SupportResponse
 
-url_bases = [
-    "https?://support.(.+).amazonaws.com",
-]
+url_bases = [r"https?://support\.(.+)\.amazonaws\.com"]
 
 
 url_paths = {

--- a/moto/swf/urls.py
+++ b/moto/swf/urls.py
@@ -1,5 +1,5 @@
 from .responses import SWFResponse
 
-url_bases = ["https?://swf.(.+).amazonaws.com"]
+url_bases = [r"https?://swf\.(.+)\.amazonaws\.com"]
 
 url_paths = {"{0}/$": SWFResponse.dispatch}

--- a/moto/transcribe/urls.py
+++ b/moto/transcribe/urls.py
@@ -2,6 +2,6 @@ from __future__ import unicode_literals
 
 from .responses import TranscribeResponse
 
-url_bases = ["https?://transcribe.(.+).amazonaws.com"]
+url_bases = [r"https?://transcribe\.(.+)\.amazonaws\.com"]
 
 url_paths = {"{0}/$": TranscribeResponse.dispatch}

--- a/tests/test_core/test_url_base_regex.py
+++ b/tests/test_core/test_url_base_regex.py
@@ -6,12 +6,12 @@ from moto import mock_s3
 
 service_names = [
     (d[5:], "")
-        for d in dir(moto)
-        if d.startswith("mock_")
-           and not d.endswith("_deprecated")
-           and not d == "mock_xray_client"
-           and not d == "mock_all"
-    ]
+    for d in dir(moto)
+    if d.startswith("mock_")
+    and not d.endswith("_deprecated")
+    and not d == "mock_xray_client"
+    and not d == "mock_all"
+]
 
 
 class TestMockBucketStartingWithServiceName:
@@ -20,8 +20,7 @@ class TestMockBucketStartingWithServiceName:
     """
 
     @pytest.mark.parametrize(
-        "service_name,decorator",
-        service_names,
+        "service_name,decorator", service_names,
     )
     def test_bucketname_starting_with_service_name(self, service_name, decorator):
 

--- a/tests/test_core/test_url_base_regex.py
+++ b/tests/test_core/test_url_base_regex.py
@@ -1,0 +1,37 @@
+import boto3
+import moto
+import pytest
+from moto import mock_s3
+
+
+service_names = [
+    (d[5:], "")
+        for d in dir(moto)
+        if d.startswith("mock_")
+           and not d.endswith("_deprecated")
+           and not d == "mock_xray_client"
+           and not d == "mock_all"
+    ]
+
+
+class TestMockBucketStartingWithServiceName:
+    """
+    https://github.com/spulec/moto/issues/4099
+    """
+
+    @pytest.mark.parametrize(
+        "service_name,decorator",
+        service_names,
+    )
+    def test_bucketname_starting_with_service_name(self, service_name, decorator):
+
+        decorator = getattr(moto, "mock_{}".format(service_name))
+        with decorator():
+            with mock_s3():
+                s3_client = boto3.client("s3", "eu-west-1")
+                bucket_name = "{}-bucket".format(service_name)
+                s3_client.create_bucket(
+                    ACL="private",
+                    Bucket=bucket_name,
+                    CreateBucketConfiguration={"LocationConstraint": "eu-west-1"},
+                )


### PR DESCRIPTION
FIxes #4099

This PR partially fixes a bug so we can create S3 buckets that start with a service name, i.e. `iot-bucket`. 

Note that it is still not possible to create a S3 bucket that start with `{service}.`, such as `iot.bucket` - this will still be interpreted as a call to the IOT-module. This will be fixed with #3793 