### PR TITLE
Fix parsing regex to support request params with dicts of lists

### DIFF
--- a/moto/core/responses.py
+++ b/moto/core/responses.py
@@ -192,7 +192,8 @@ class BaseResponse(_TemplateEnvironmentMixin, ActionAuthenticatorMixin):
     region_from_useragent_regex = re.compile(
         r"region/(?P<region>[a-z]{2}-[a-z]+-\d{1})"
     )
-    param_list_regex = re.compile(r"^(\.?[^.]*(\.member)?)\.(\d+)\.")
+    # Note: technically, we could remove "member" from the regex below... (leaving it for clarity)
+    param_list_regex = re.compile(r"^(\.?[^.]*(\.member|\.[^.]+)?)\.(\d+)\.?")
     param_regex = re.compile(r"([^\.]*)\.(\w+)(\..+)?")
     access_key_regex = re.compile(
         r"AWS.*(?P<access_key>(?<![A-Z0-9])[A-Z0-9]{20}(?![A-Z0-9]))[:/]"

--- a/moto/ec2/models.py
+++ b/moto/ec2/models.py
@@ -2316,12 +2316,14 @@ class SecurityGroupBackend(object):
         source_groups = []
         for source_group_name in source_group_names:
             source_group = self.get_security_group_from_name(source_group_name, vpc_id)
+            # TODO raise exception if source_group is None?
             if source_group:
                 source_groups.append(source_group)
 
         # for VPCs
         for source_group_id in source_group_ids:
             source_group = self.get_security_group_from_id(source_group_id)
+            # TODO raise exception if source_group is None?
             if source_group:
                 source_groups.append(source_group)
 

--- a/tests/test_core/test_responses.py
+++ b/tests/test_core/test_responses.py
@@ -147,3 +147,21 @@ def test_get_params():
             ],
         }
     )
+
+
+def test_get_dict_list_params():
+    subject = BaseResponse()
+    subject.querystring = OrderedDict(
+        [
+            ("Action", ["CreateDBCluster"]),
+            ("Version", ["2014-10-31"]),
+            ("VpcSecurityGroupIds.VpcSecurityGroupId.1", ["sg-123"]),
+            ("VpcSecurityGroupIds.VpcSecurityGroupId.2", ["sg-456"]),
+            ("VpcSecurityGroupIds.VpcSecurityGroupId.3", ["sg-789"]),
+        ]
+    )
+
+    # TODO: extend test and logic such that we can call subject._get_params() directly here
+    result = subject._get_multi_param_dict("VpcSecurityGroupIds")
+
+    result.should.equal({"VpcSecurityGroupId": ["sg-123", "sg-456", "sg-789"]})


### PR DESCRIPTION
Fix parsing regex to support request parameters with dicts of lists. Example:
```
Action=CreateDBCluster&Version=2014-10-31&VpcSecurityGroupIds.VpcSecurityGroupId.1=sg-123&VpcSecurityGroupIds.VpcSecurityGroupId.2=sg-456...
```
The `VpcSecurityGroupIds` parameters should be parsed into:
```
{"VpcSecurityGroupId": ["sg-123", "sg-456"]}
```
... instead of:
```
{'VpcSecurityGroupId': {'1': 'sg-123', '2': 'sg-456'}}
```
/cc @bblommers 