### PR TITLE
fixed vpc with terraform; added modify vpc tenancy

### DIFF
--- a/moto/ec2/exceptions.py
+++ b/moto/ec2/exceptions.py
@@ -481,6 +481,14 @@ class CidrLimitExceeded(EC2ClientError):
         )
 
 
+class UnsupportedTenancy(EC2ClientError):
+    def __init__(self, tenancy):
+        super(UnsupportedTenancy, self).__init__(
+            "(UnsupportedTenancy",
+            "The tenancy value {0} is not supported.".format(tenancy),
+        )
+
+
 class OperationNotPermitted(EC2ClientError):
     def __init__(self, association_id):
         super(OperationNotPermitted, self).__init__(

--- a/moto/ec2/exceptions.py
+++ b/moto/ec2/exceptions.py
@@ -484,7 +484,7 @@ class CidrLimitExceeded(EC2ClientError):
 class UnsupportedTenancy(EC2ClientError):
     def __init__(self, tenancy):
         super(UnsupportedTenancy, self).__init__(
-            "(UnsupportedTenancy",
+            "UnsupportedTenancy",
             "The tenancy value {0} is not supported.".format(tenancy),
         )
 

--- a/moto/ec2/models.py
+++ b/moto/ec2/models.py
@@ -3017,10 +3017,9 @@ class VPC(TaggedEC2Resource, CloudFormationModel):
             return super(VPC, self).get_filter_value(filter_name, "DescribeVpcs")
 
     def modify_vpc_tenancy(self, tenancy):
-        if tenancy == "default":
-            self.instance_tenancy = tenancy
-        else:
+        if tenancy != "default":
             raise UnsupportedTenancy(tenancy)
+        self.instance_tenancy = tenancy
         return True
 
     def associate_vpc_cidr_block(

--- a/moto/ec2/models.py
+++ b/moto/ec2/models.py
@@ -3026,7 +3026,7 @@ class VPC(TaggedEC2Resource, CloudFormationModel):
     def associate_vpc_cidr_block(
         self, cidr_block, amazon_provided_ipv6_cidr_block=False
     ):
-        max_associations = 5
+        max_associations = 5 if not amazon_provided_ipv6_cidr_block else 1
 
         if (
             len(self.get_cidr_block_association_set(amazon_provided_ipv6_cidr_block))

--- a/moto/ec2/models.py
+++ b/moto/ec2/models.py
@@ -3028,6 +3028,14 @@ class VPC(TaggedEC2Resource, CloudFormationModel):
     ):
         max_associations = 5 if not amazon_provided_ipv6_cidr_block else 1
 
+        for cidr in self.cidr_block_association_set.copy():
+            if (
+                self.cidr_block_association_set.get(cidr)
+                .get("cidr_block_state")
+                .get("state")
+                == "disassociated"
+            ):
+                self.cidr_block_association_set.pop(cidr)
         if (
             len(self.get_cidr_block_association_set(amazon_provided_ipv6_cidr_block))
             >= max_associations

--- a/moto/ec2/responses/vpcs.py
+++ b/moto/ec2/responses/vpcs.py
@@ -51,6 +51,13 @@ class VPCs(BaseResponse):
         template = self.response_template(DESCRIBE_VPCS_RESPONSE)
         return template.render(vpcs=vpcs, doc_date=doc_date)
 
+    def modify_vpc_tenancy(self):
+        vpc_id = self._get_param("VpcId")
+        tenancy = self._get_param("InstanceTenancy")
+        value = self.ec2_backend.modify_vpc_tenancy(vpc_id, tenancy)
+        template = self.response_template(MODIFY_VPC_TENANCY_RESPONSE)
+        return template.render(value=value)
+
     def describe_vpc_attribute(self):
         vpc_id = self._get_param("VpcId")
         attribute = self._get_param("Attribute")
@@ -245,6 +252,7 @@ CREATE_VPC_RESPONSE = """
         {% endif %}
       <dhcpOptionsId>{% if vpc.dhcp_options %}{{ vpc.dhcp_options.id }}{% else %}dopt-1a2b3c4d2{% endif %}</dhcpOptionsId>
       <instanceTenancy>{{ vpc.instance_tenancy }}</instanceTenancy>
+      <ownerId> {{ vpc.owner_id }}</ownerId>
       <tagSet>
         {% for tag in vpc.get_tags() %}
           <item>
@@ -344,6 +352,7 @@ DESCRIBE_VPCS_RESPONSE = """
         <dhcpOptionsId>{% if vpc.dhcp_options %}{{ vpc.dhcp_options.id }}{% else %}dopt-7a8b9c2d{% endif %}</dhcpOptionsId>
         <instanceTenancy>{{ vpc.instance_tenancy }}</instanceTenancy>
         <isDefault>{{ vpc.is_default }}</isDefault>
+        <ownerId> {{ vpc.owner_id }}</ownerId>
         <tagSet>
           {% for tag in vpc.get_tags() %}
             <item>
@@ -364,6 +373,13 @@ DELETE_VPC_RESPONSE = """
    <requestId>7a62c49f-347e-4fc4-9331-6e8eEXAMPLE</requestId>
    <return>true</return>
 </DeleteVpcResponse>
+"""
+
+MODIFY_VPC_TENANCY_RESPONSE = """
+<ModifyVpcTenancyResponse xmlns="http://ec2.amazonaws.com/doc/2016-11-15/">
+   <requestId>7a62c49f-347e-4fc4-9331-6e8eEXAMPLE</requestId>
+   <return>true</return>
+</ModifyVpcTenancyResponse>
 """
 
 DESCRIBE_VPC_ATTRIBUTE_RESPONSE = """

--- a/tests/terraform-tests.success.txt
+++ b/tests/terraform-tests.success.txt
@@ -61,3 +61,4 @@ TestAccAWSSsmParameterDataSource
 TestAccAWSUserGroupMembership
 TestAccAWSUserPolicyAttachment
 TestAccAWSUserSSHKey
+TestAccAWSVpc_


### PR DESCRIPTION
### Fixed
- VPC was missing `ownerId` attribute which caused terraform to calculate wrong ARN

### Added
- Added ModifyVpcTenancy API

### TF Test
- All 21 cases under TestAccAWSVpc_ are working now