### PR TITLE
Add support for ConfigService APIs list_tags_for_resource, untag_resource, tag_resource

### DIFF
--- a/IMPLEMENTATION_COVERAGE.md
+++ b/IMPLEMENTATION_COVERAGE.md
@@ -2370,6 +2370,7 @@
 
 - [X] batch_get_aggregate_resource_config
 - [X] batch_get_resource_config
+- [ ] can_paginate
 - [X] delete_aggregation_authorization
 - [ ] delete_config_rule
 - [X] delete_configuration_aggregator
@@ -2411,6 +2412,7 @@
 - [ ] describe_remediation_exceptions
 - [ ] describe_remediation_execution_status
 - [ ] describe_retention_configurations
+- [ ] generate_presigned_url
 - [ ] get_aggregate_compliance_details_by_config_rule
 - [ ] get_aggregate_config_rule_compliance_summary
 - [ ] get_aggregate_conformance_pack_compliance_summary
@@ -2425,12 +2427,14 @@
 - [ ] get_discovered_resource_counts
 - [ ] get_organization_config_rule_detailed_status
 - [X] get_organization_conformance_pack_detailed_status
+- [ ] get_paginator
 - [X] get_resource_config_history
 - [ ] get_stored_query
+- [ ] get_waiter
 - [X] list_aggregate_discovered_resources
 - [X] list_discovered_resources
 - [ ] list_stored_queries
-- [ ] list_tags_for_resource
+- [X] list_tags_for_resource
 - [X] put_aggregation_authorization
 - [ ] put_config_rule
 - [X] put_configuration_aggregator
@@ -2452,8 +2456,8 @@
 - [X] start_configuration_recorder
 - [ ] start_remediation_execution
 - [X] stop_configuration_recorder
-- [ ] tag_resource
-- [ ] untag_resource
+- [X] tag_resource
+- [X] untag_resource
 </details>
 
 ## connect

--- a/moto/config/exceptions.py
+++ b/moto/config/exceptions.py
@@ -12,7 +12,7 @@ class NameTooLongException(JsonRESTError):
                 name=name, location=location
             )
         )
-        super(NameTooLongException, self).__init__("ValidationException", message)
+        super().__init__("ValidationException", message)
 
 
 class InvalidConfigurationRecorderNameException(JsonRESTError):
@@ -22,9 +22,7 @@ class InvalidConfigurationRecorderNameException(JsonRESTError):
         message = "The configuration recorder name '{name}' is not valid, blank string.".format(
             name=name
         )
-        super(InvalidConfigurationRecorderNameException, self).__init__(
-            "InvalidConfigurationRecorderNameException", message
-        )
+        super().__init__("InvalidConfigurationRecorderNameException", message)
 
 
 class MaxNumberOfConfigurationRecordersExceededException(JsonRESTError):
@@ -35,9 +33,7 @@ class MaxNumberOfConfigurationRecordersExceededException(JsonRESTError):
             "Failed to put configuration recorder '{name}' because the maximum number of "
             "configuration recorders: 1 is reached.".format(name=name)
         )
-        super(MaxNumberOfConfigurationRecordersExceededException, self).__init__(
-            "MaxNumberOfConfigurationRecordersExceededException", message
-        )
+        super().__init__("MaxNumberOfConfigurationRecordersExceededException", message)
 
 
 class InvalidRecordingGroupException(JsonRESTError):
@@ -45,9 +41,7 @@ class InvalidRecordingGroupException(JsonRESTError):
 
     def __init__(self):
         message = "The recording group provided is not valid"
-        super(InvalidRecordingGroupException, self).__init__(
-            "InvalidRecordingGroupException", message
-        )
+        super().__init__("InvalidRecordingGroupException", message)
 
 
 class InvalidResourceTypeException(JsonRESTError):
@@ -64,9 +58,7 @@ class InvalidResourceTypeException(JsonRESTError):
         # For PY2:
         message = str(message)
 
-        super(InvalidResourceTypeException, self).__init__(
-            "ValidationException", message
-        )
+        super().__init__("ValidationException", message)
 
 
 class NoSuchConfigurationAggregatorException(JsonRESTError):
@@ -80,9 +72,7 @@ class NoSuchConfigurationAggregatorException(JsonRESTError):
                 "At least one of the configuration aggregators does not exist. Check the configuration aggregator"
                 " names and try again."
             )
-        super(NoSuchConfigurationAggregatorException, self).__init__(
-            "NoSuchConfigurationAggregatorException", message
-        )
+        super().__init__("NoSuchConfigurationAggregatorException", message)
 
 
 class NoSuchConfigurationRecorderException(JsonRESTError):
@@ -92,9 +82,7 @@ class NoSuchConfigurationRecorderException(JsonRESTError):
         message = "Cannot find configuration recorder with the specified name '{name}'.".format(
             name=name
         )
-        super(NoSuchConfigurationRecorderException, self).__init__(
-            "NoSuchConfigurationRecorderException", message
-        )
+        super().__init__("NoSuchConfigurationRecorderException", message)
 
 
 class InvalidDeliveryChannelNameException(JsonRESTError):
@@ -104,9 +92,7 @@ class InvalidDeliveryChannelNameException(JsonRESTError):
         message = "The delivery channel name '{name}' is not valid, blank string.".format(
             name=name
         )
-        super(InvalidDeliveryChannelNameException, self).__init__(
-            "InvalidDeliveryChannelNameException", message
-        )
+        super().__init__("InvalidDeliveryChannelNameException", message)
 
 
 class NoSuchBucketException(JsonRESTError):
@@ -116,7 +102,7 @@ class NoSuchBucketException(JsonRESTError):
 
     def __init__(self):
         message = "Cannot find a S3 bucket with an empty bucket name."
-        super(NoSuchBucketException, self).__init__("NoSuchBucketException", message)
+        super().__init__("NoSuchBucketException", message)
 
 
 class InvalidNextTokenException(JsonRESTError):
@@ -124,9 +110,7 @@ class InvalidNextTokenException(JsonRESTError):
 
     def __init__(self):
         message = "The nextToken provided is invalid"
-        super(InvalidNextTokenException, self).__init__(
-            "InvalidNextTokenException", message
-        )
+        super().__init__("InvalidNextTokenException", message)
 
 
 class InvalidS3KeyPrefixException(JsonRESTError):
@@ -134,9 +118,7 @@ class InvalidS3KeyPrefixException(JsonRESTError):
 
     def __init__(self):
         message = "The s3 key prefix '' is not valid, empty s3 key prefix."
-        super(InvalidS3KeyPrefixException, self).__init__(
-            "InvalidS3KeyPrefixException", message
-        )
+        super().__init__("InvalidS3KeyPrefixException", message)
 
 
 class InvalidSNSTopicARNException(JsonRESTError):
@@ -146,9 +128,7 @@ class InvalidSNSTopicARNException(JsonRESTError):
 
     def __init__(self):
         message = "The sns topic arn '' is not valid."
-        super(InvalidSNSTopicARNException, self).__init__(
-            "InvalidSNSTopicARNException", message
-        )
+        super().__init__("InvalidSNSTopicARNException", message)
 
 
 class InvalidDeliveryFrequency(JsonRESTError):
@@ -162,9 +142,7 @@ class InvalidDeliveryFrequency(JsonRESTError):
                 value=value, good_list=good_list
             )
         )
-        super(InvalidDeliveryFrequency, self).__init__(
-            "InvalidDeliveryFrequency", message
-        )
+        super().__init__("InvalidDeliveryFrequency", message)
 
 
 class MaxNumberOfDeliveryChannelsExceededException(JsonRESTError):
@@ -175,9 +153,7 @@ class MaxNumberOfDeliveryChannelsExceededException(JsonRESTError):
             "Failed to put delivery channel '{name}' because the maximum number of "
             "delivery channels: 1 is reached.".format(name=name)
         )
-        super(MaxNumberOfDeliveryChannelsExceededException, self).__init__(
-            "MaxNumberOfDeliveryChannelsExceededException", message
-        )
+        super().__init__("MaxNumberOfDeliveryChannelsExceededException", message)
 
 
 class NoSuchDeliveryChannelException(JsonRESTError):
@@ -187,9 +163,7 @@ class NoSuchDeliveryChannelException(JsonRESTError):
         message = "Cannot find delivery channel with specified name '{name}'.".format(
             name=name
         )
-        super(NoSuchDeliveryChannelException, self).__init__(
-            "NoSuchDeliveryChannelException", message
-        )
+        super().__init__("NoSuchDeliveryChannelException", message)
 
 
 class NoAvailableConfigurationRecorderException(JsonRESTError):
@@ -197,9 +171,7 @@ class NoAvailableConfigurationRecorderException(JsonRESTError):
 
     def __init__(self):
         message = "Configuration recorder is not available to put delivery channel."
-        super(NoAvailableConfigurationRecorderException, self).__init__(
-            "NoAvailableConfigurationRecorderException", message
-        )
+        super().__init__("NoAvailableConfigurationRecorderException", message)
 
 
 class NoAvailableDeliveryChannelException(JsonRESTError):
@@ -207,9 +179,7 @@ class NoAvailableDeliveryChannelException(JsonRESTError):
 
     def __init__(self):
         message = "Delivery channel is not available to start configuration recorder."
-        super(NoAvailableDeliveryChannelException, self).__init__(
-            "NoAvailableDeliveryChannelException", message
-        )
+        super().__init__("NoAvailableDeliveryChannelException", message)
 
 
 class LastDeliveryChannelDeleteFailedException(JsonRESTError):
@@ -220,9 +190,7 @@ class LastDeliveryChannelDeleteFailedException(JsonRESTError):
             "Failed to delete last specified delivery channel with name '{name}', because there, "
             "because there is a running configuration recorder.".format(name=name)
         )
-        super(LastDeliveryChannelDeleteFailedException, self).__init__(
-            "LastDeliveryChannelDeleteFailedException", message
-        )
+        super().__init__("LastDeliveryChannelDeleteFailedException", message)
 
 
 class TooManyAccountSources(JsonRESTError):
@@ -237,14 +205,14 @@ class TooManyAccountSources(JsonRESTError):
                 locations=", ".join(locations)
             )
         )
-        super(TooManyAccountSources, self).__init__("ValidationException", message)
+        super().__init__("ValidationException", message)
 
 
 class DuplicateTags(JsonRESTError):
     code = 400
 
     def __init__(self):
-        super(DuplicateTags, self).__init__(
+        super().__init__(
             "InvalidInput",
             "Duplicate tag keys found. Please note that Tag keys are case insensitive.",
         )
@@ -254,7 +222,7 @@ class TagKeyTooBig(JsonRESTError):
     code = 400
 
     def __init__(self, tag, param="tags.X.member.key"):
-        super(TagKeyTooBig, self).__init__(
+        super().__init__(
             "ValidationException",
             "1 validation error detected: Value '{}' at '{}' failed to satisfy "
             "constraint: Member must have length less than or equal to 128".format(
@@ -267,7 +235,7 @@ class TagValueTooBig(JsonRESTError):
     code = 400
 
     def __init__(self, tag):
-        super(TagValueTooBig, self).__init__(
+        super().__init__(
             "ValidationException",
             "1 validation error detected: Value '{}' at 'tags.X.member.value' failed to satisfy "
             "constraint: Member must have length less than or equal to 256".format(tag),
@@ -278,9 +246,7 @@ class InvalidParameterValueException(JsonRESTError):
     code = 400
 
     def __init__(self, message):
-        super(InvalidParameterValueException, self).__init__(
-            "InvalidParameterValueException", message
-        )
+        super().__init__("InvalidParameterValueException", message)
 
 
 class InvalidTagCharacters(JsonRESTError):
@@ -292,14 +258,14 @@ class InvalidTagCharacters(JsonRESTError):
         )
         message += "constraint: Member must satisfy regular expression pattern: [\\\\p{L}\\\\p{Z}\\\\p{N}_.:/=+\\\\-@]+"
 
-        super(InvalidTagCharacters, self).__init__("ValidationException", message)
+        super().__init__("ValidationException", message)
 
 
 class TooManyTags(JsonRESTError):
     code = 400
 
     def __init__(self, tags, param="tags"):
-        super(TooManyTags, self).__init__(
+        super().__init__(
             "ValidationException",
             "1 validation error detected: Value '{}' at '{}' failed to satisfy "
             "constraint: Member must have length less than or equal to 50.".format(
@@ -312,20 +278,9 @@ class InvalidResourceParameters(JsonRESTError):
     code = 400
 
     def __init__(self):
-        super(InvalidResourceParameters, self).__init__(
+        super().__init__(
             "ValidationException",
             "Both Resource ID and Resource Name " "cannot be specified in the request",
-        )
-
-
-class InvalidLimit(JsonRESTError):
-    code = 400
-
-    def __init__(self, value):
-        super(InvalidLimit, self).__init__(
-            "ValidationException",
-            "Value '{value}' at 'limit' failed to satisify constraint: Member"
-            " must have value less than or equal to 100".format(value=value),
         )
 
 
@@ -333,7 +288,7 @@ class InvalidLimitException(JsonRESTError):
     code = 400
 
     def __init__(self, value):
-        super(InvalidLimit, self).__init__(
+        super().__init__(
             "ValidationException",
             "Value '{value}' at 'limit' failed to satisify constraint: Member"
             " must have value less than or equal to 100".format(value=value),
@@ -344,7 +299,7 @@ class TooManyResourceIds(JsonRESTError):
     code = 400
 
     def __init__(self):
-        super(TooManyResourceIds, self).__init__(
+        super().__init__(
             "ValidationException",
             "The specified list had more than 20 resource ID's. "
             "It must have '20' or less items",
@@ -354,11 +309,11 @@ class TooManyResourceIds(JsonRESTError):
 class ResourceNotDiscoveredException(JsonRESTError):
     code = 400
 
-    def __init__(self, type, resource):
-        super(ResourceNotDiscoveredException, self).__init__(
+    def __init__(self, resource_type, resource):
+        super().__init__(
             "ResourceNotDiscoveredException",
             "Resource {resource} of resourceType:{type} is unknown or has not been "
-            "discovered".format(resource=resource, type=type),
+            "discovered".format(resource=resource, type=resource_type),
         )
 
 
@@ -366,10 +321,11 @@ class ResourceNotFoundException(JsonRESTError):
     code = 400
 
     def __init__(self, resource_arn):
-        super(ResourceNotFoundException, self).__init__(
+        super().__init__(
             "ResourceNotFoundException",
             "ResourceArn '{resource_arn}' does not exist".format(
-                resource_arn=resource_arn),
+                resource_arn=resource_arn
+            ),
         )
 
 
@@ -387,7 +343,7 @@ class TooManyResourceKeys(JsonRESTError):
         # For PY2:
         message = str(message)
 
-        super(TooManyResourceKeys, self).__init__("ValidationException", message)
+        super().__init__("ValidationException", message)
 
 
 class InvalidResultTokenException(JsonRESTError):
@@ -395,22 +351,18 @@ class InvalidResultTokenException(JsonRESTError):
 
     def __init__(self):
         message = "The resultToken provided is invalid"
-        super(InvalidResultTokenException, self).__init__(
-            "InvalidResultTokenException", message
-        )
+        super().__init__("InvalidResultTokenException", message)
 
 
 class ValidationException(JsonRESTError):
     code = 400
 
     def __init__(self, message):
-        super(ValidationException, self).__init__("ValidationException", message)
+        super().__init__("ValidationException", message)
 
 
 class NoSuchOrganizationConformancePackException(JsonRESTError):
     code = 400
 
     def __init__(self, message):
-        super(NoSuchOrganizationConformancePackException, self).__init__(
-            "NoSuchOrganizationConformancePackException", message
-        )
+        super().__init__("NoSuchOrganizationConformancePackException", message)

--- a/moto/config/exceptions.py
+++ b/moto/config/exceptions.py
@@ -329,6 +329,17 @@ class InvalidLimit(JsonRESTError):
         )
 
 
+class InvalidLimitException(JsonRESTError):
+    code = 400
+
+    def __init__(self, value):
+        super(InvalidLimit, self).__init__(
+            "ValidationException",
+            "Value '{value}' at 'limit' failed to satisify constraint: Member"
+            " must have value less than or equal to 100".format(value=value),
+        )
+
+
 class TooManyResourceIds(JsonRESTError):
     code = 400
 
@@ -348,6 +359,17 @@ class ResourceNotDiscoveredException(JsonRESTError):
             "ResourceNotDiscoveredException",
             "Resource {resource} of resourceType:{type} is unknown or has not been "
             "discovered".format(resource=resource, type=type),
+        )
+
+
+class ResourceNotFoundException(JsonRESTError):
+    code = 400
+
+    def __init__(self, resource_arn):
+        super(ResourceNotFoundException, self).__init__(
+            "ResourceNotFoundException",
+            "ResourceArn '{resource_arn}' does not exist".format(
+                resource_arn=resource_arn),
         )
 
 

--- a/moto/config/exceptions.py
+++ b/moto/config/exceptions.py
@@ -289,8 +289,8 @@ class InvalidLimitException(JsonRESTError):
 
     def __init__(self, value):
         super().__init__(
-            "ValidationException",
-            "Value '{value}' at 'limit' failed to satisify constraint: Member"
+            "InvalidLimitException",
+            "Value '{value}' at 'limit' failed to satisfy constraint: Member"
             " must have value less than or equal to 100".format(value=value),
         )
 

--- a/moto/config/models.py
+++ b/moto/config/models.py
@@ -35,7 +35,6 @@ from moto.config.exceptions import (
     NoSuchConfigurationAggregatorException,
     InvalidTagCharacters,
     DuplicateTags,
-    InvalidLimit,
     InvalidLimitException,
     InvalidResourceParameters,
     TooManyResourceIds,
@@ -884,7 +883,7 @@ class ConfigBackend(BaseBackend):
 
         limit = limit or DEFAULT_PAGE_SIZE
         if limit > DEFAULT_PAGE_SIZE:
-            raise InvalidLimit(limit)
+            raise InvalidLimitException(limit)
 
         if resource_ids and resource_name:
             raise InvalidResourceParameters()
@@ -958,7 +957,7 @@ class ConfigBackend(BaseBackend):
 
         limit = limit or DEFAULT_PAGE_SIZE
         if limit > DEFAULT_PAGE_SIZE:
-            raise InvalidLimit(limit)
+            raise InvalidLimitException(limit)
 
         # If the resource type exists and the backend region is implemented in moto, then
         # call upon the resource type's Config Query class to retrieve the list of resources that match the criteria:

--- a/moto/config/responses.py
+++ b/moto/config/responses.py
@@ -213,13 +213,13 @@ class ConfigResponse(BaseResponse):
         return ""
 
     def tag_resource(self):
-        schema = self.config_backend.tag_resource(
+        self.config_backend.tag_resource(
             self._get_param("ResourceArn"), self._get_param("Tags"),
         )
         return ""
 
     def untag_resource(self):
-        schema = self.config_backend.untag_resource(
+        self.config_backend.untag_resource(
             self._get_param("ResourceArn"), self._get_param("TagKeys"),
         )
         return ""

--- a/moto/config/responses.py
+++ b/moto/config/responses.py
@@ -133,14 +133,13 @@ class ConfigResponse(BaseResponse):
         )
         return json.dumps(schema)
 
-    # TODO
-    # def list_tags_for_resource(self):
-    #     schema = self.config_backend.list_tags_for_resource(
-    #         self._get_param("ResourceArn"),
-    #         self._get_param("Limit"),
-    #         self._get_param("NextToken"),
-    #     )
-    #     return json.dumps(schema)
+    def list_tags_for_resource(self):
+        schema = self.config_backend.list_tags_for_resource(
+            self._get_param("ResourceArn"),
+            self._get_param("Limit"),
+            self._get_param("NextToken"),
+        )
+        return json.dumps(schema)
 
     def get_resource_config_history(self):
         schema = self.config_backend.get_resource_config_history(

--- a/moto/config/responses.py
+++ b/moto/config/responses.py
@@ -133,6 +133,15 @@ class ConfigResponse(BaseResponse):
         )
         return json.dumps(schema)
 
+    # TODO
+    # def list_tags_for_resource(self):
+    #     schema = self.config_backend.list_tags_for_resource(
+    #         self._get_param("ResourceArn"),
+    #         self._get_param("Limit"),
+    #         self._get_param("NextToken"),
+    #     )
+    #     return json.dumps(schema)
+
     def get_resource_config_history(self):
         schema = self.config_backend.get_resource_config_history(
             self._get_param("resourceType"), self._get_param("resourceId"), self.region
@@ -201,4 +210,16 @@ class ConfigResponse(BaseResponse):
             self._get_param("OrganizationConformancePackName")
         )
 
+        return ""
+
+    def tag_resource(self):
+        schema = self.config_backend.tag_resource(
+            self._get_param("ResourceArn"), self._get_param("Tags"),
+        )
+        return ""
+
+    def untag_resource(self):
+        schema = self.config_backend.untag_resource(
+            self._get_param("ResourceArn"), self._get_param("TagKeys"),
+        )
         return ""

--- a/tests/test_config/test_config_tags.py
+++ b/tests/test_config/test_config_tags.py
@@ -22,8 +22,8 @@ TEST_REGION = "us-east-1"
 def config_aggregators_info(client):
     """Return list of dicts of ConfigAggregators ARNs and tags.
 
-    One ConfigAggregator would do, but this help tests that a list
-    of configs can be handled by the caller.
+    One ConfigAggregator would do, but this tests that a list of
+    configs can be handled by the caller.
     """
     config_aggs = []
     for idx in range(3):

--- a/tests/test_config/test_config_tags.py
+++ b/tests/test_config/test_config_tags.py
@@ -1,0 +1,206 @@
+"""Unit tests specific to the tag-related ConfigService APIs.
+
+ These APIs include:
+   list_tags_for_resource
+   tag_resource
+   untag_resource
+
+"""
+import boto3
+from botocore.exceptions import ClientError
+from botocore.exceptions import ParamValidationError
+import pytest
+
+from moto.config import mock_config
+from moto.config.models import MAX_TAGS_IN_ARG
+from moto.config.models import random_string
+from moto.core import ACCOUNT_ID
+
+TEST_REGION = "us-east-1"
+
+
+def config_aggregators_info(client):
+    """Return list of dicts of ConfigAggregators ARNs and tags.
+
+    One ConfigAggregator would do, but this help tests that a list
+    of configs can be handled by the caller.
+    """
+    config_aggs = []
+    for idx in range(3):
+        tags = [
+            {"Key": f"{x}", "Value": f"{x}"} for x in range(idx * 10, idx * 10 + 10)
+        ]
+        response = client.put_configuration_aggregator(
+            ConfigurationAggregatorName=f"testing_{idx}_{random_string()}",
+            AccountAggregationSources=[
+                {"AccountIds": [ACCOUNT_ID], "AllAwsRegions": True}
+            ],
+            Tags=tags,
+        )
+        config_info = response["ConfigurationAggregator"]
+        config_aggs.append(
+            {"arn": config_info["ConfigurationAggregatorArn"], "tags": tags,}
+        )
+    return config_aggs
+
+
+@mock_config
+def test_tag_resource():
+    """Test the ConfigSource API tag_resource()."""
+    client = boto3.client("config", region_name="us-east-1")
+
+    # Try an ARN when there are no configs instantiated.
+    no_config_arn = "no_configs"
+    with pytest.raises(ClientError) as cerr:
+        client.tag_resource(
+            ResourceArn=no_config_arn, Tags=[{"Key": "test_key", "Value": "test_value"}]
+        )
+    assert cerr.value.response["Error"]["Code"] == "ResourceNotFoundException"
+    assert (
+        f"ResourceArn '{no_config_arn}' does not exist"
+        in cerr.value.response["Error"]["Message"]
+    )
+
+    # Try an invalid ARN.
+    bad_arn = "bad_arn"
+    with pytest.raises(ClientError) as cerr:
+        client.tag_resource(
+            ResourceArn=bad_arn, Tags=[{"Key": "test_key", "Value": "test_value"}]
+        )
+    assert cerr.value.response["Error"]["Code"] == "ResourceNotFoundException"
+    assert (
+        f"ResourceArn '{bad_arn}' does not exist"
+        in cerr.value.response["Error"]["Message"]
+    )
+
+    # Create some configs and use the ARN from one of them for testing the
+    # tags argument.
+    config_aggs = config_aggregators_info(client)
+    good_arn = config_aggs[1]["arn"]
+
+    # Try specifying more than 50 keys.
+    with pytest.raises(ClientError) as cerr:
+        client.tag_resource(
+            ResourceArn=good_arn,
+            Tags=[{"Key": f"{x}", "Value": f"{x}"} for x in range(MAX_TAGS_IN_ARG + 1)],
+        )
+    assert cerr.value.response["Error"]["Code"] == "ValidationException"
+    assert (
+        "at 'tags' failed to satisfy constraint: Member must have length "
+        "less than or equal to 50"
+    ) in cerr.value.response["Error"]["Message"]
+
+    # Try specifying an invalid key.
+    with pytest.raises(ParamValidationError) as cerr:
+        client.tag_resource(ResourceArn=good_arn, Tags=[{"Test": "abc"}])
+    assert cerr.typename == "ParamValidationError"
+    assert 'Unknown parameter in Tags[0]: "Test", must be one of: Key, Value' in str(
+        cerr
+    )
+
+    # Verify keys added to ConfigurationAggregator.
+    # TODO - use list_tags_for_resources() to get current set of tags.
+    new_tags = [{"Key": "test_key", "Value": "test_value"}]
+    client.tag_resource(ResourceArn=good_arn, Tags=new_tags)
+    # TODO - use list_tags_for_resources() to verify the list of tags include
+    #        the original set of tags, plus the new ones.
+
+    # Verify keys added to AggregationAuthorization.
+    response = client.put_aggregation_authorization(
+        AuthorizedAccountId=ACCOUNT_ID,
+        AuthorizedAwsRegion=TEST_REGION,
+        Tags=[{"Key": f"{x}", "Value": f"{x}"} for x in range(10)],
+    )
+    agg_auth_arn = response["AggregationAuthorization"]["AggregationAuthorizationArn"]
+    # TODO - use list_tags_for_resources() to get current set of tags.
+    client.tag_resource(ResourceArn=agg_auth_arn, Tags=new_tags)
+    # TODO - use list_tags_for_resources() to verify the list of tags include
+    #        the original set of tags, plus the new ones.
+
+    # TODO - Verify keys added to ConfigRule, when implemented.
+
+
+@mock_config
+def test_untag_resource():
+    """Test the ConfigSource API untag_resource()."""
+    client = boto3.client("config", region_name="us-east-1")
+
+    # Try an ARN when there are no configs instantiated.
+    no_config_arn = "no_configs"
+    with pytest.raises(ClientError) as cerr:
+        client.untag_resource(
+            ResourceArn=no_config_arn, TagKeys=["untest_key", "untest_value"]
+        )
+    assert cerr.value.response["Error"]["Code"] == "ResourceNotFoundException"
+    assert (
+        f"ResourceArn '{no_config_arn}' does not exist"
+        in cerr.value.response["Error"]["Message"]
+    )
+
+    # Try an invalid ARN.
+    bad_arn = "bad_arn"
+    with pytest.raises(ClientError) as cerr:
+        client.untag_resource(
+            ResourceArn=bad_arn, TagKeys=["untest_key", "untest_value"]
+        )
+    assert cerr.value.response["Error"]["Code"] == "ResourceNotFoundException"
+    assert (
+        f"ResourceArn '{bad_arn}' does not exist"
+        in cerr.value.response["Error"]["Message"]
+    )
+
+    # Create some configs and use the ARN from one of them for testing the
+    # tags argument.
+    config_aggs = config_aggregators_info(client)
+    good_arn = config_aggs[1]["arn"]
+
+    # Try specifying more than 50 keys.
+    with pytest.raises(ClientError) as cerr:
+        client.untag_resource(
+            ResourceArn=good_arn, TagKeys=[f"{x}" for x in range(MAX_TAGS_IN_ARG + 1)],
+        )
+    assert cerr.value.response["Error"]["Code"] == "ValidationException"
+    assert (
+        "at 'tags' failed to satisfy constraint: Member must have length "
+        "less than or equal to 50"
+    ) in cerr.value.response["Error"]["Message"]
+
+    # Try specifying an invalid key -- it should be ignored.
+    client.untag_resource(ResourceArn=good_arn, TagKeys=["foo"])
+
+    # Try a mix of existing and non-existing tags.
+    client.untag_resource(ResourceArn=good_arn, TagKeys=["0", "1", "foo", "3"])
+    # TODO - use list_tags_for_resources() to verify the existing tags are
+    #        removed
+
+    # Verify keys removed from ConfigurationAggregator.  Add a new tag to
+    # the current set of tags, then delete the new tag.  The original set
+    # of tags should remain.
+    # TODO - use list_tags_for_resources() to get current set of tags.
+    test_tags = [{"Key": "test_key", "Value": "test_value"}]
+    client.tag_resource(ResourceArn=good_arn, Tags=test_tags)
+    client.untag_resource(ResourceArn=good_arn, TagKeys=[test_tags[0]["Key"]])
+    # TODO - use list_tags_for_resources() to verify the list of tags only
+    #        contains the original set of tags.
+
+    # Verify keys removed from AggregationAuthorization.  Add a new tag to
+    # the current set of tags, then delete the new tag.  The original set
+    # of tags should remain.
+    response = client.put_aggregation_authorization(
+        AuthorizedAccountId=ACCOUNT_ID,
+        AuthorizedAwsRegion=TEST_REGION,
+        Tags=[{"Key": f"{x}", "Value": f"{x}"} for x in range(10)],
+    )
+    agg_auth_arn = response["AggregationAuthorization"]["AggregationAuthorizationArn"]
+    # TODO - use list_tags_for_resources() to get current set of tags.
+    test_tags = [{"Key": "test_key", "Value": "test_value"}]
+    client.tag_resource(ResourceArn=agg_auth_arn, Tags=test_tags)
+    client.untag_resource(ResourceArn=good_arn, TagKeys=[test_tags[0]["Key"]])
+    # TODO - use list_tags_for_resources() to verify the list of tags only
+    #        contains the original set of tags.
+
+    # Delete all the tags.
+    client.untag_resource(ResourceArn=good_arn, TagKeys=[f"{x}" for x in range(10)])
+    # TODO - use list_tags_for_resources() to verify there are no tags.
+
+    # TODO - Verify keys removed from ConfigRule, when implemented.


### PR DESCRIPTION
Implementation of three tag-related ConfigService APIs, with the exception of handling ConfigRule as that resource has not yet been implemented:

- `list_tags_for_resource`
- `tag_resource`
- `untag_resource`