### PR TITLE
Support cognito:user_status filter in cognito-idp list_users

### DIFF
--- a/moto/cognitoidp/responses.py
+++ b/moto/cognitoidp/responses.py
@@ -327,6 +327,11 @@ class CognitoIdpResponse(BaseResponse):
             user_pool_id, limit=limit, pagination_token=token
         )
         if filt:
+            inherent_attributes = {
+                "cognito:user_status": lambda u: u.status,
+                "status": lambda u: u.enabled,
+                "username": lambda u: u.username,
+            }
             name, value = filt.replace('"', "").replace(" ", "").split("=")
             users = [
                 user
@@ -336,6 +341,10 @@ class CognitoIdpResponse(BaseResponse):
                     for attr in user.attributes
                     if attr["Name"] == name and attr["Value"] == value
                 ]
+                or (
+                    name in inherent_attributes
+                    and inherent_attributes[name](user) == value
+                )
             ]
         response = {"Users": [user.to_json(extended=True) for user in users]}
         if token:

--- a/tests/test_cognitoidp/test_cognitoidp.py
+++ b/tests/test_cognitoidp/test_cognitoidp.py
@@ -1221,6 +1221,13 @@ def test_list_users():
     result["Users"].should.have.length_of(1)
     result["Users"][0]["Username"].should.equal(username_bis)
 
+    # checking Filter for inherent attributes
+    result = conn.list_users(
+        UserPoolId=user_pool_id, Filter='username = "{}"'.format(username_bis)
+    )
+    result["Users"].should.have.length_of(1)
+    result["Users"][0]["Username"].should.equal(username_bis)
+
 
 @mock_cognitoidp
 def test_get_user_unconfirmed():


### PR DESCRIPTION
Hi, I've added the option to filter users by implicit attributes in `users_list` endpoint:

- username
- status (`enabled` field)
- cognito:user_status (`status` field)

Those aren't stored in `user.attributes`, which lead to an empty response if such a filter was specified, even though they are listed in AWS [docs](https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_ListUsers.html#API_ListUsers_RequestSyntax).