### PR TITLE
Fix for 'status' filter, separate inherent_attributes test

### DIFF
--- a/moto/cognitoidp/responses.py
+++ b/moto/cognitoidp/responses.py
@@ -329,7 +329,7 @@ class CognitoIdpResponse(BaseResponse):
         if filt:
             inherent_attributes = {
                 "cognito:user_status": lambda u: u.status,
-                "status": lambda u: u.enabled,
+                "status": lambda u: "Enabled" if u.enabled else "Disabled",
                 "username": lambda u: u.username,
             }
             name, value = filt.replace('"', "").replace(" ", "").split("=")


### PR DESCRIPTION
Hi, coming back to the `inherent_attributes` filter. The `status` filter handling wasn't done correctly: 
- `user.enabled` is a `bool`, so `inherent_attributes['status'](user) == value` is a `bool == str` comparison - obviously failing.
- AWS expects a case-sensitive *Enabled* or *Disabled* value for this filter, as can be seen working correctly here:
![image](https://user-images.githubusercontent.com/38426907/128036458-62a58c45-c8fd-494d-8de7-fbc58be74636.png)


With that mistake out of the way, I've decided to make a separate test case, to verify **all** `inherent_attributes`.