### PR TITLE
Improve the tagging of resources in the elbv2 module

### DIFF
--- a/moto/elbv2/models.py
+++ b/moto/elbv2/models.py
@@ -134,6 +134,13 @@ class FakeTargetGroup(CloudFormationModel):
             raise TooManyTagsError()
         self.tags[key] = value
 
+    def list_tags(self):
+        return self.tags
+
+    def remove_tag(self, key):
+        if key in self.tags:
+            del self.tags[key]
+
     def health_for(self, target, ec2_backend):
         t = self.targets.get(target["id"])
         if t is None:
@@ -229,6 +236,18 @@ class FakeListener(CloudFormationModel):
         )
         self.tags = {}
 
+    def add_tag(self, key, value):
+        if len(self.tags) >= 10 and key not in self.tags:
+            raise TooManyTagsError()
+        self.tags[key] = value
+
+    def list_tags(self):
+        return self.tags
+
+    def remove_tag(self, key):
+        if key in self.tags:
+            del self.tags[key]
+
     @property
     def physical_resource_id(self):
         return self.arn
@@ -309,6 +328,19 @@ class FakeListenerRule(CloudFormationModel):
         self.conditions = conditions
         self.actions = actions
         self.priority = priority
+        self.tags = {}
+
+    def add_tag(self, key, value):
+        if len(self.tags) >= 10 and key not in self.tags:
+            raise TooManyTagsError()
+        self.tags[key] = value
+
+    def list_tags(self):
+        return self.tags
+
+    def remove_tag(self, key):
+        if key in self.tags:
+            del self.tags[key]
 
     @property
     def physical_resource_id(self):

--- a/moto/elbv2/responses.py
+++ b/moto/elbv2/responses.py
@@ -3,8 +3,6 @@ from moto.core.exceptions import RESTError
 from moto.core.utils import amzn_request_id
 from moto.core.responses import BaseResponse
 from .models import elbv2_backends
-from .models import FakeLoadBalancer
-from .models import FakeListener
 from .exceptions import DuplicateTagKeysError
 from .exceptions import LoadBalancerNotFoundError
 from .exceptions import TargetGroupNotFoundError
@@ -424,11 +422,17 @@ class ELBV2Response(BaseResponse):
                 if not resource:
                     raise LoadBalancerNotFoundError()
             elif ":listener-rule" in arn:
-                lb_arn, _, _ = arn.replace(":listener-rule", ":loadbalancer").rpartition("/")[0].rpartition("/")
+                lb_arn, _, _ = (
+                    arn.replace(":listener-rule", ":loadbalancer")
+                    .rpartition("/")[0]
+                    .rpartition("/")
+                )
                 balancer = self.elbv2_backend.load_balancers.get(lb_arn)
                 if not balancer:
                     raise LoadBalancerNotFoundError()
-                listener_arn, _, _ = arn.replace(":listener-rule", ":listener").rpartition("/")
+                listener_arn, _, _ = arn.replace(
+                    ":listener-rule", ":listener"
+                ).rpartition("/")
                 listener = balancer.listeners.get(listener_arn)
                 if not listener:
                     raise ListenerNotFoundError()
@@ -465,11 +469,17 @@ class ELBV2Response(BaseResponse):
                 if not resource:
                     raise LoadBalancerNotFoundError()
             elif ":listener-rule" in arn:
-                lb_arn, _, _ = arn.replace(":listener-rule", ":loadbalancer").rpartition("/")[0].rpartition("/")
+                lb_arn, _, _ = (
+                    arn.replace(":listener-rule", ":loadbalancer")
+                    .rpartition("/")[0]
+                    .rpartition("/")
+                )
                 balancer = self.elbv2_backend.load_balancers.get(lb_arn)
                 if not balancer:
                     raise LoadBalancerNotFoundError()
-                listener_arn, _, _ = arn.replace(":listener-rule", ":listener").rpartition("/")
+                listener_arn, _, _ = arn.replace(
+                    ":listener-rule", ":listener"
+                ).rpartition("/")
                 listener = balancer.listeners.get(listener_arn)
                 if not listener:
                     raise ListenerNotFoundError()
@@ -505,12 +515,17 @@ class ELBV2Response(BaseResponse):
                 if not resource:
                     raise LoadBalancerNotFoundError()
             elif ":listener-rule" in arn:
-                lb_arn, _, _ = arn.replace(":listener-rule", ":loadbalancer").rpartition("/")[
-                    0].rpartition("/")
+                lb_arn, _, _ = (
+                    arn.replace(":listener-rule", ":loadbalancer")
+                    .rpartition("/")[0]
+                    .rpartition("/")
+                )
                 balancer = self.elbv2_backend.load_balancers.get(lb_arn)
                 if not balancer:
                     raise LoadBalancerNotFoundError()
-                listener_arn, _, _ = arn.replace(":listener-rule", ":listener").rpartition("/")
+                listener_arn, _, _ = arn.replace(
+                    ":listener-rule", ":listener"
+                ).rpartition("/")
                 listener = balancer.listeners.get(listener_arn)
                 if not listener:
                     raise ListenerNotFoundError()

--- a/tests/test_elbv2/test_elbv2_listener_rules.py
+++ b/tests/test_elbv2/test_elbv2_listener_rules.py
@@ -309,9 +309,13 @@ def test_describe_tags_with_rule_arn():
         Priority=100,
         Conditions=[{"Field": "host-header", "Values": ["example-asdf.com"]}],
         Actions=[default_action],
-        Tags=[{'Key': 'test_k', 'Value': 'test_v'}]
+        Tags=[{"Key": "test_k", "Value": "test_v"}],
     )
-    rule_arn = response['Rules'][0]['RuleArn']
+    rule_arn = response["Rules"][0]["RuleArn"]
     response = conn.describe_tags(ResourceArns=[rule_arn])
-    expected_response = {'TagDescriptions': [{'ResourceArn': rule_arn, 'Tags': [{'Key': 'test_k', 'Value': 'test_v'}]}]}
-    assert response['TagDescriptions'] == expected_response['TagDescriptions']
+    expected_response = {
+        "TagDescriptions": [
+            {"ResourceArn": rule_arn, "Tags": [{"Key": "test_k", "Value": "test_v"}]}
+        ]
+    }
+    assert response["TagDescriptions"] == expected_response["TagDescriptions"]


### PR DESCRIPTION
tags were not being added to every kind of resource (listener, listener rule, etc) which was causing certain expected responses to fail.