### PR TITLE
added support for tags in vpc peering connections

### DIFF
--- a/moto/ec2/models.py
+++ b/moto/ec2/models.py
@@ -3389,7 +3389,6 @@ class VPCPeeringConnection(TaggedEC2Resource, CloudFormationModel):
         self.vpc = vpc
         self.peer_vpc = peer_vpc
         self.add_tags(tags or {})
-
         self._status = VPCPeeringConnectionStatus()
 
     @staticmethod

--- a/moto/ec2/models.py
+++ b/moto/ec2/models.py
@@ -127,6 +127,7 @@ from .utils import (
     random_ipv6_cidr,
     random_transit_gateway_attachment_id,
     random_transit_gateway_route_table_id,
+    random_vpc_ep_id,
     randor_ipv4_cidr,
     random_launch_template_id,
     random_nat_gateway_id,
@@ -137,7 +138,6 @@ from .utils import (
     random_reservation_id,
     random_route_table_id,
     generate_route_id,
-    generate_vpc_end_point_id,
     create_dns_entries,
     split_route_id,
     random_security_group_id,
@@ -3272,11 +3272,11 @@ class VPCBackend(object):
         dns_entries=None,
         client_token=None,
         security_group_ids=None,
-        tag_specifications=None,
+        tags=None,
         private_dns_enabled=None,
     ):
 
-        vpc_endpoint_id = generate_vpc_end_point_id(vpc_id)
+        vpc_endpoint_id = random_vpc_ep_id()
 
         # validates if vpc is present or not.
         self.get_vpc(vpc_id)
@@ -3313,7 +3313,7 @@ class VPCBackend(object):
             dns_entries,
             client_token,
             security_group_ids,
-            tag_specifications,
+            tags,
             private_dns_enabled,
         )
 
@@ -3383,7 +3383,7 @@ class PeeringConnectionStatus(object):
 
 
 class VPCPeeringConnection(TaggedEC2Resource, CloudFormationModel):
-    def __init__(self, backend, vpc_pcx_id, vpc, peer_vpc, tags=[]):
+    def __init__(self, backend, vpc_pcx_id, vpc, peer_vpc, tags=None):
         self.id = vpc_pcx_id
         self.ec2_backend = backend
         self.vpc = vpc
@@ -3435,7 +3435,7 @@ class VPCPeeringConnectionBackend(object):
             if inst is not None:
                 yield inst
 
-    def create_vpc_peering_connection(self, vpc, peer_vpc, tags):
+    def create_vpc_peering_connection(self, vpc, peer_vpc, tags=None):
         vpc_pcx_id = random_vpc_peering_connection_id()
         vpc_pcx = VPCPeeringConnection(self, vpc_pcx_id, vpc, peer_vpc, tags)
         vpc_pcx._status.pending()
@@ -4369,7 +4369,7 @@ class VPCEndPoint(TaggedEC2Resource):
         dns_entries=None,
         client_token=None,
         security_group_ids=None,
-        tag_specifications=None,
+        tags=None,
         private_dns_enabled=None,
     ):
         self.ec2_backend = ec2_backend
@@ -4383,10 +4383,10 @@ class VPCEndPoint(TaggedEC2Resource):
         self.subnet_ids = subnet_ids
         self.client_token = client_token
         self.security_group_ids = security_group_ids
-        self.tag_specifications = tag_specifications
         self.private_dns_enabled = private_dns_enabled
         self._created_at = datetime.utcnow()
         self.dns_entries = dns_entries
+        self.add_tags(tags or {})
 
     @property
     def created_at(self):

--- a/moto/ec2/models.py
+++ b/moto/ec2/models.py
@@ -3389,7 +3389,7 @@ class VPCPeeringConnection(TaggedEC2Resource, CloudFormationModel):
         self.vpc = vpc
         self.peer_vpc = peer_vpc
         self.add_tags(tags or {})
-        self._status = VPCPeeringConnectionStatus()
+        self._status = PeeringConnectionStatus()
 
     @staticmethod
     def cloudformation_name_type():

--- a/moto/ec2/utils.py
+++ b/moto/ec2/utils.py
@@ -5,7 +5,6 @@ import hashlib
 import fnmatch
 import random
 import re
-from sys import prefix
 
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.backends import default_backend

--- a/moto/ec2/utils.py
+++ b/moto/ec2/utils.py
@@ -5,6 +5,7 @@ import hashlib
 import fnmatch
 import random
 import re
+from sys import prefix
 
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.backends import default_backend
@@ -40,6 +41,7 @@ EC2_RESOURCE_TO_PREFIX = {
     "reservation": "r",
     "volume": "vol",
     "vpc": "vpc",
+    "vpc-endpoint": "vpce",
     "vpc-cidr-association-id": "vpc-cidr-assoc",
     "vpc-elastic-ip": "eipalloc",
     "vpc-elastic-ip-association": "eipassoc",
@@ -129,6 +131,10 @@ def random_volume_id():
 
 def random_vpc_id():
     return random_id(prefix=EC2_RESOURCE_TO_PREFIX["vpc"])
+
+
+def random_vpc_ep_id():
+    return random_id(prefix=EC2_RESOURCE_TO_PREFIX["vpc-endpoint"], size=8)
 
 
 def random_vpc_cidr_association_id():
@@ -223,10 +229,6 @@ def generate_route_id(route_table_id, cidr_block, ipv6_cidr_block=None):
     if ipv6_cidr_block and not cidr_block:
         cidr_block = ipv6_cidr_block
     return "%s~%s" % (route_table_id, cidr_block)
-
-
-def generate_vpc_end_point_id(vpc_id):
-    return "%s-%s%s" % ("vpce", vpc_id[4:], random_resource_id(4))
 
 
 def create_dns_entries(service_name, vpc_endpoint_id):

--- a/tests/terraform-tests.success.txt
+++ b/tests/terraform-tests.success.txt
@@ -66,3 +66,4 @@ TestAccAWSUserGroupMembership
 TestAccAWSUserPolicyAttachment
 TestAccAWSUserSSHKey
 TestAccAWSVpc_
+TestAccAWSVpcEndpointRouteTableAssociation

--- a/tests/terraform-tests.success.txt
+++ b/tests/terraform-tests.success.txt
@@ -66,4 +66,3 @@ TestAccAWSUserGroupMembership
 TestAccAWSUserPolicyAttachment
 TestAccAWSUserSSHKey
 TestAccAWSVpc_
-TestAccAWSVpcEndpointRouteTableAssociation


### PR DESCRIPTION
**Added**
- Added support for tags in VPCPeeringConnection

**Fixed**
- Refractored VPCEndpoint to streamline code
- Removed `generate_vpc_end_point_id` and added `random_vpc_ep_id`
- fixed responses with missing tagsets

Terraform script
```
resource "aws_vpc" "main" {
  cidr_block                       = "10.0.0.0/16"
  assign_generated_ipv6_cidr_block = false

  tags = {
    Name = "Main"
  }
}

resource "aws_vpc" "main1" {
  cidr_block = "10.2.0.0/16"
}

resource "aws_vpc_peering_connection" "foo" {
  peer_owner_id = "000000000000"
  peer_vpc_id   = aws_vpc.main.id
  vpc_id        = aws_vpc.main1.id
  auto_accept   = true

  tags = {
    Name = "VPC Connection"
  }
}
```