### PR TITLE
Add setuptools back, used by core/models.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,7 @@ install_requires = [
     "MarkupSafe!=2.0.0a1",  # This is a Jinja2 dependency, 2.0.0a1 currently seems broken
     "Jinja2>=2.10.1",
     "more-itertools",
+    "setuptools",
 ]
 
 _dep_PyYAML = "PyYAML>=5.1"


### PR DESCRIPTION
this package was removed in a recent PR: https://github.com/spulec/moto/pull/4124/files#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7L42
However, there is still [code that uses pkg_resources](https://github.com/spulec/moto/blob/master/moto/core/models.py#L8) which is [provided by setuptools](https://github.com/pypa/setuptools/tree/main/pkg_resources).
so removing this dependency breaks stuff.
```
REDACTED/lib/python3.8/site-packages/moto/acm/__init__.py:2: in <module>
    from .models import acm_backends
REDACTED/lib/python3.8/site-packages/moto/acm/models.py:5: in <module>
    from moto.core import BaseBackend, BaseModel
REDACTED/lib/python3.8/site-packages/moto/core/__init__.py:3: in <module>
    from .models import BaseModel, BaseBackend, moto_api_backend, ACCOUNT_ID  # noqa
REDACTED/lib/python3.8/site-packages/moto/core/models.py:8: in <module>
    import pkg_resources
E   ModuleNotFoundError: No module named 'pkg_resources'
```

@bblommers FYI