### PR TITLE
Remove pkg_resources module

### DIFF
--- a/moto/core/models.py
+++ b/moto/core/models.py
@@ -5,17 +5,18 @@ from __future__ import absolute_import
 import functools
 import inspect
 import os
-import pkg_resources
 import re
 import types
 from abc import abstractmethod
 from io import BytesIO
 from collections import defaultdict
+
 from botocore.config import Config
 from botocore.handlers import BUILTIN_HANDLERS
 from botocore.awsrequest import AWSResponse
 from distutils.version import LooseVersion
 from http.client import responses as http_responses
+from importlib_metadata import version
 from urllib.parse import urlparse
 from werkzeug.wrappers import Request
 
@@ -30,7 +31,6 @@ from .utils import (
 )
 
 ACCOUNT_ID = os.environ.get("MOTO_ACCOUNT_ID", "123456789012")
-RESPONSES_VERSION = pkg_resources.get_distribution("responses").version
 
 
 class BaseMockAWS:
@@ -306,6 +306,7 @@ def _find_first_match(self, request):
 #  - First request matches on the appropriate S3 URL
 #  - Same request, executed again, will be matched on the subsequent match, which happens to be the catch-all, not-yet-implemented, callback
 # Fix: Always return the first match
+RESPONSES_VERSION = version("responses")
 if LooseVersion(RESPONSES_VERSION) < LooseVersion("0.12.1"):
     responses_mock._find_match = types.MethodType(
         _find_first_match_legacy, responses_mock

--- a/moto/core/responses.py
+++ b/moto/core/responses.py
@@ -6,7 +6,6 @@ import datetime
 import json
 import logging
 import re
-import io
 import requests
 
 import pytz
@@ -22,6 +21,7 @@ from werkzeug.exceptions import HTTPException
 
 import boto3
 from collections import OrderedDict
+from importlib_resources import files
 from moto.core.utils import camelcase_to_underscores, method_names_from_class
 from moto import settings
 
@@ -903,12 +903,9 @@ class AWSServiceSpec(object):
     """
 
     def __init__(self, path):
-        # Importing pkg_resources takes ~60ms; keep it local
-        from pkg_resources import resource_filename  # noqa
+        spec = files("botocore").joinpath(path).read_text()
+        spec = json.loads(spec)
 
-        self.path = resource_filename("botocore", path)
-        with io.open(self.path, "r", encoding="utf-8") as f:
-            spec = json.load(f)
         self.metadata = spec["metadata"]
         self.operations = spec["operations"]
         self.shapes = spec["shapes"]

--- a/moto/core/responses.py
+++ b/moto/core/responses.py
@@ -21,8 +21,8 @@ from werkzeug.exceptions import HTTPException
 
 import boto3
 from collections import OrderedDict
-from importlib_resources import files
 from moto.core.utils import camelcase_to_underscores, method_names_from_class
+from moto.utilities.utils import load_resource
 from moto import settings
 
 log = logging.getLogger(__name__)
@@ -903,8 +903,7 @@ class AWSServiceSpec(object):
     """
 
     def __init__(self, path):
-        spec = files("botocore").joinpath(path).read_text()
-        spec = json.loads(spec)
+        spec = load_resource("botocore", path)
 
         self.metadata = spec["metadata"]
         self.operations = spec["operations"]

--- a/moto/dynamodb2/parsing/reserved_keywords.py
+++ b/moto/dynamodb2/parsing/reserved_keywords.py
@@ -21,5 +21,7 @@ class ReservedKeywords(list):
         """
         Get a list of reserved keywords of DynamoDB
         """
-        reserved_keywords = load_resource(__name__, "reserved_keywords.txt", as_json=False)
+        reserved_keywords = load_resource(
+            __name__, "reserved_keywords.txt", as_json=False
+        )
         return reserved_keywords.split()

--- a/moto/dynamodb2/parsing/reserved_keywords.py
+++ b/moto/dynamodb2/parsing/reserved_keywords.py
@@ -1,5 +1,5 @@
 from moto.utilities.utils import load_resource
-from pkg_resources import resource_filename
+from importlib_resources import files
 
 
 class ReservedKeywords(list):
@@ -23,6 +23,6 @@ class ReservedKeywords(list):
         Get a list of reserved keywords of DynamoDB
         """
         reserved_keywords = load_resource(
-            resource_filename(__name__, "reserved_keywords.txt"), as_json=False
+            files(__package__).joinpath("reserved_keywords.txt"), as_json=False
         )
         return reserved_keywords.split()

--- a/moto/dynamodb2/parsing/reserved_keywords.py
+++ b/moto/dynamodb2/parsing/reserved_keywords.py
@@ -1,5 +1,4 @@
 from moto.utilities.utils import load_resource
-from importlib_resources import files
 
 
 class ReservedKeywords(list):
@@ -22,7 +21,5 @@ class ReservedKeywords(list):
         """
         Get a list of reserved keywords of DynamoDB
         """
-        reserved_keywords = load_resource(
-            files(__package__).joinpath("reserved_keywords.txt"), as_json=False
-        )
+        reserved_keywords = load_resource(__name__, "reserved_keywords.txt", as_json=False)
         return reserved_keywords.split()

--- a/moto/ec2/models.py
+++ b/moto/ec2/models.py
@@ -5,6 +5,7 @@ import itertools
 import ipaddress
 import json
 import os
+import pathlib
 import re
 import warnings
 
@@ -24,7 +25,6 @@ from moto.packages.boto.ec2.spotinstancerequest import (
 from moto.packages.boto.ec2.launchspecification import LaunchSpecification
 
 from collections import OrderedDict
-from importlib_resources import files
 from moto.core import BaseBackend
 from moto.core.models import Model, BaseModel, CloudFormationModel
 from moto.core.utils import (
@@ -173,23 +173,25 @@ from .utils import (
     describe_tag_filter,
 )
 
-pck_files = files(__package__)
-INSTANCE_TYPES = load_resource(pck_files.joinpath("resources/instance_types.json"))
+INSTANCE_TYPES = load_resource(__name__, "resources/instance_types.json")
 
+root = pathlib.Path(__file__).parent
 offerings_path = "resources/instance_type_offerings"
 INSTANCE_TYPE_OFFERINGS = {}
-for location_type in listdir(pck_files / offerings_path):
+for location_type in listdir(root / offerings_path):
     INSTANCE_TYPE_OFFERINGS[location_type] = {}
-    for region in listdir(pck_files / offerings_path / location_type):
-        full_path = pck_files / offerings_path / location_type / region
+    for region in listdir(root / offerings_path / location_type):
+        full_path = offerings_path + "/" + location_type + "/" + region
         INSTANCE_TYPE_OFFERINGS[location_type][
             region.replace(".json", "")
-        ] = load_resource(full_path)
+        ] = load_resource(__name__, full_path)
 
 
-AMIS = load_resource(
-    os.environ.get("MOTO_AMIS_PATH") or pck_files.joinpath("resources/amis.json"),
-)
+if "MOTO_AMIS_PATH" in os.environ:
+    with open(os.environ.get("MOTO_AMIS_PATH"), "r", encoding="utf-8") as f:
+        AMIS = json.load(f)
+else:
+    AMIS = load_resource(__name__, "resources/amis.json")
 
 OWNER_ID = ACCOUNT_ID
 

--- a/moto/ec2/models.py
+++ b/moto/ec2/models.py
@@ -9,7 +9,6 @@ import re
 import warnings
 
 from boto3 import Session
-from pkg_resources import resource_filename
 
 from collections import defaultdict
 import weakref
@@ -25,6 +24,7 @@ from moto.packages.boto.ec2.spotinstancerequest import (
 from moto.packages.boto.ec2.launchspecification import LaunchSpecification
 
 from collections import OrderedDict
+from importlib_resources import files
 from moto.core import BaseBackend
 from moto.core.models import Model, BaseModel, CloudFormationModel
 from moto.core.utils import (
@@ -173,29 +173,22 @@ from .utils import (
     describe_tag_filter,
 )
 
-
-INSTANCE_TYPES = load_resource(
-    resource_filename(__name__, "resources/instance_types.json")
-)
+pck_files = files(__package__)
+INSTANCE_TYPES = load_resource(pck_files.joinpath("resources/instance_types.json"))
 
 offerings_path = "resources/instance_type_offerings"
 INSTANCE_TYPE_OFFERINGS = {}
-for location_type in listdir(resource_filename(__name__, offerings_path)):
+for location_type in listdir(pck_files / offerings_path):
     INSTANCE_TYPE_OFFERINGS[location_type] = {}
-    for region in listdir(
-        resource_filename(__name__, offerings_path + "/" + location_type)
-    ):
-        full_path = resource_filename(
-            __name__, offerings_path + "/" + location_type + "/" + region
-        )
+    for region in listdir(pck_files / offerings_path / location_type):
+        full_path = pck_files / offerings_path / location_type / region
         INSTANCE_TYPE_OFFERINGS[location_type][
             region.replace(".json", "")
         ] = load_resource(full_path)
 
 
 AMIS = load_resource(
-    os.environ.get("MOTO_AMIS_PATH")
-    or resource_filename(__name__, "resources/amis.json"),
+    os.environ.get("MOTO_AMIS_PATH") or pck_files.joinpath("resources/amis.json"),
 )
 
 OWNER_ID = ACCOUNT_ID

--- a/moto/support/models.py
+++ b/moto/support/models.py
@@ -1,6 +1,6 @@
 from __future__ import unicode_literals
 from boto3 import Session
-from pkg_resources import resource_filename
+from importlib_resources import files
 from moto.core import BaseBackend
 from moto.utilities.utils import load_resource
 import datetime
@@ -8,7 +8,7 @@ import random
 
 
 checks_json = "resources/describe_trusted_advisor_checks.json"
-ADVISOR_CHECKS = load_resource(resource_filename(__name__, checks_json))
+ADVISOR_CHECKS = load_resource(files(__package__).joinpath(checks_json))
 
 
 class SupportCase(object):

--- a/moto/support/models.py
+++ b/moto/support/models.py
@@ -1,6 +1,5 @@
 from __future__ import unicode_literals
 from boto3 import Session
-from importlib_resources import files
 from moto.core import BaseBackend
 from moto.utilities.utils import load_resource
 import datetime
@@ -8,7 +7,7 @@ import random
 
 
 checks_json = "resources/describe_trusted_advisor_checks.json"
-ADVISOR_CHECKS = load_resource(files(__package__).joinpath(checks_json))
+ADVISOR_CHECKS = load_resource(__name__, checks_json)
 
 
 class SupportCase(object):

--- a/moto/utilities/utils.py
+++ b/moto/utilities/utils.py
@@ -26,7 +26,7 @@ def load_resource(package, resource, as_json=True):
     load_resource(__name__, "resources/file.json")
     """
     resource = pkgutil.get_data(package, resource)
-    return json.loads(resource) if as_json else resource.decode('utf-8')
+    return json.loads(resource) if as_json else resource.decode("utf-8")
 
 
 def merge_multiple_dicts(*args):

--- a/moto/utilities/utils.py
+++ b/moto/utilities/utils.py
@@ -1,6 +1,7 @@
 import json
 import random
 import string
+import pkgutil
 
 
 def str2bool(v):
@@ -18,15 +19,14 @@ def random_string(length=None):
     return random_str
 
 
-def load_resource(filename, as_json=True):
+def load_resource(package, resource, as_json=True):
     """
     Open a file, and return the contents as JSON.
     Usage:
-    from importlib_resources import files
-    load_resource(files(__package__).joinpath("resources/file.json"))
+    load_resource(__name__, "resources/file.json")
     """
-    with open(filename, "r", encoding="utf-8") as f:
-        return json.load(f) if as_json else f.read()
+    resource = pkgutil.get_data(package, resource)
+    return json.loads(resource) if as_json else resource.decode('utf-8')
 
 
 def merge_multiple_dicts(*args):

--- a/moto/utilities/utils.py
+++ b/moto/utilities/utils.py
@@ -22,8 +22,8 @@ def load_resource(filename, as_json=True):
     """
     Open a file, and return the contents as JSON.
     Usage:
-    from pkg_resources import resource_filename
-    load_resource(resource_filename(__name__, "resources/file.json"))
+    from importlib_resources import files
+    load_resource(files(__package__).joinpath("resources/file.json"))
     """
     with open(filename, "r", encoding="utf-8") as f:
         return json.load(f) if as_json else f.read()

--- a/scripts/dependency_test.sh
+++ b/scripts/dependency_test.sh
@@ -52,7 +52,9 @@ test_service() {
   pip install -r requirements-tests.txt > /dev/null
   pip install .[$service] > /dev/null 2>&1
   pip install boto > /dev/null 2>&1
-  pip uninstall setuptools pkg_resources -y > /dev/null 2>&1
+  if [[ $service != "xray" ]]; then
+    pip uninstall setuptools pkg_resources -y > /dev/null 2>&1
+  fi
   # Restart venv - ensure these deps are loaded
   deactivate
   source ${venv_path}/bin/activate > /dev/null

--- a/scripts/dependency_test.sh
+++ b/scripts/dependency_test.sh
@@ -52,6 +52,7 @@ test_service() {
   pip install -r requirements-tests.txt > /dev/null
   pip install .[$service] > /dev/null 2>&1
   pip install boto > /dev/null 2>&1
+  pip uninstall setuptools pkg_resources -y > /dev/null 2>&1
   # Restart venv - ensure these deps are loaded
   deactivate
   source ${venv_path}/bin/activate > /dev/null

--- a/setup.py
+++ b/setup.py
@@ -39,8 +39,7 @@ install_requires = [
     "MarkupSafe!=2.0.0a1",  # This is a Jinja2 dependency, 2.0.0a1 currently seems broken
     "Jinja2>=2.10.1",
     "more-itertools",
-    "importlib_metadata",
-    "importlib_resources"
+    "importlib_metadata"
 ]
 
 _dep_PyYAML = "PyYAML>=5.1"
@@ -54,6 +53,7 @@ _dep_aws_xray_sdk = "aws-xray-sdk!=0.96,>=0.93"
 _dep_idna = "idna<3,>=2.5"
 _dep_cfn_lint = "cfn-lint>=0.4.0"
 _dep_sshpubkeys = "sshpubkeys>=3.1.0"
+_setuptools = "setuptools"
 
 all_extra_deps = [
     _dep_PyYAML,
@@ -65,6 +65,7 @@ all_extra_deps = [
     _dep_idna,
     _dep_cfn_lint,
     _dep_sshpubkeys,
+    _setuptools,
 ]
 all_server_deps = all_extra_deps + ["flask", "flask-cors"]
 
@@ -84,7 +85,9 @@ extras_per_service = {
     "sns": [],
     "sqs": [],
     "ssm": [_dep_PyYAML],
-    "xray": [_dep_aws_xray_sdk],
+    # XRay module uses pkg_resources, but doesn't have an explicit dependency listed
+    # This should be fixed in the next version: https://github.com/aws/aws-xray-sdk-python/issues/305
+    "xray": [_dep_aws_xray_sdk, _setuptools],
 }
 # When a Table has a Stream, we'll always need to import AWSLambda to search for a corresponding function to send the table data to
 extras_per_service["dynamodb2"] = extras_per_service["awslambda"]

--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,8 @@ install_requires = [
     "MarkupSafe!=2.0.0a1",  # This is a Jinja2 dependency, 2.0.0a1 currently seems broken
     "Jinja2>=2.10.1",
     "more-itertools",
+    "importlib_metadata",
+    "importlib_resources"
 ]
 
 _dep_PyYAML = "PyYAML>=5.1"

--- a/tests/test_ssm/test_ssm_docs.py
+++ b/tests/test_ssm/test_ssm_docs.py
@@ -5,19 +5,18 @@ import botocore.exceptions
 import sure  # noqa
 import datetime
 import json
-import pkg_resources
 import yaml
 import hashlib
 import copy
+import pkgutil
+
 from moto.core import ACCOUNT_ID
 
 from moto import mock_ssm
 
 
 def _get_yaml_template():
-    template_path = "/".join(["test_ssm", "test_templates", "good.yaml"])
-    resource_path = pkg_resources.resource_string("tests", template_path)
-    return resource_path
+    return pkgutil.get_data(__name__, "test_templates/good.yaml")
 
 
 def _validate_document_description(


### PR DESCRIPTION
As the `setuptools` dependency was removed, the `pkg_resources`-module is no longer available to Moto.

This PR rewrites all functionality that depended on pkg_resources, to instead use the `importlib_metadata` and `pgkdata`-modules.

It also explicitly removes the `pkg_resources`-module from the dependency test, to ensure it works.

(Note: XRay has an implicit dependency on pkg_resources, so we're adding setuptools back to that module only.)

(Note 2: For Py3.8, we could start using the buildin `importlib.metadata`, but for we'll need the backport for 3.6 and 3.7.)

Successful dependency test: https://github.com/bblommers/moto/runs/3253699280?check_suite_focus=true