### PR TITLE
Fixing UnboundLocalError

### DIFF
--- a/moto/kinesis/models.py
+++ b/moto/kinesis/models.py
@@ -350,6 +350,8 @@ class DeliveryStream(BaseModel):
             "redshift_s3_buffering_hints"
         )
 
+        self.elasticsearch_config = stream_kwargs.get("elasticsearch_config")
+
         self.records = []
         self.status = "ACTIVE"
         self.created_at = datetime.datetime.utcnow()
@@ -371,6 +373,23 @@ class DeliveryStream(BaseModel):
                 {
                     "DestinationId": "string",
                     "ExtendedS3DestinationDescription": self.extended_s3_config,
+                }
+            ]
+        elif self.elasticsearch_config:
+            return [
+                {
+                    "DestinationId": "string",
+                    "ElasticsearchDestinationDescription": {
+                        "RoleARN": self.elasticsearch_config.get('RoleARN'),
+                        "DomainARN": self.elasticsearch_config.get('DomainARN'),
+                        "ClusterEndpoint": self.elasticsearch_config.get('ClusterEndpoint'),
+                        "IndexName": self.elasticsearch_config.get('IndexName'),
+                        "TypeName": self.elasticsearch_config.get('TypeName'),
+                        "IndexRotationPeriod": self.elasticsearch_config.get('IndexRotationPeriod'),
+                        "BufferingHints": self.elasticsearch_config.get('BufferingHints'),
+                        "RetryOptions": self.elasticsearch_config.get('RetryOptions'),
+                        "S3DestinationDescription": self.elasticsearch_config.get('S3Configuration')
+                    }
                 }
             ]
         else:

--- a/moto/kinesis/models.py
+++ b/moto/kinesis/models.py
@@ -380,16 +380,24 @@ class DeliveryStream(BaseModel):
                 {
                     "DestinationId": "string",
                     "ElasticsearchDestinationDescription": {
-                        "RoleARN": self.elasticsearch_config.get('RoleARN'),
-                        "DomainARN": self.elasticsearch_config.get('DomainARN'),
-                        "ClusterEndpoint": self.elasticsearch_config.get('ClusterEndpoint'),
-                        "IndexName": self.elasticsearch_config.get('IndexName'),
-                        "TypeName": self.elasticsearch_config.get('TypeName'),
-                        "IndexRotationPeriod": self.elasticsearch_config.get('IndexRotationPeriod'),
-                        "BufferingHints": self.elasticsearch_config.get('BufferingHints'),
-                        "RetryOptions": self.elasticsearch_config.get('RetryOptions'),
-                        "S3DestinationDescription": self.elasticsearch_config.get('S3Configuration')
-                    }
+                        "RoleARN": self.elasticsearch_config.get("RoleARN"),
+                        "DomainARN": self.elasticsearch_config.get("DomainARN"),
+                        "ClusterEndpoint": self.elasticsearch_config.get(
+                            "ClusterEndpoint"
+                        ),
+                        "IndexName": self.elasticsearch_config.get("IndexName"),
+                        "TypeName": self.elasticsearch_config.get("TypeName"),
+                        "IndexRotationPeriod": self.elasticsearch_config.get(
+                            "IndexRotationPeriod"
+                        ),
+                        "BufferingHints": self.elasticsearch_config.get(
+                            "BufferingHints"
+                        ),
+                        "RetryOptions": self.elasticsearch_config.get("RetryOptions"),
+                        "S3DestinationDescription": self.elasticsearch_config.get(
+                            "S3Configuration"
+                        ),
+                    },
                 }
             ]
         else:

--- a/moto/kinesis/responses.py
+++ b/moto/kinesis/responses.py
@@ -172,6 +172,9 @@ class KinesisResponse(BaseResponse):
         redshift_config = self.parameters.get("RedshiftDestinationConfiguration")
         s3_config = self.parameters.get("S3DestinationConfiguration")
         extended_s3_config = self.parameters.get("ExtendedS3DestinationConfiguration")
+        elasticsearch_config = self.parameters.get(
+            "ElasticsearchDestinationConfiguration"
+        )
 
         if redshift_config:
             redshift_s3_config = redshift_config["S3Configuration"]
@@ -193,8 +196,10 @@ class KinesisResponse(BaseResponse):
             stream_kwargs = {"s3_config": s3_config}
         elif extended_s3_config:
             stream_kwargs = {"extended_s3_config": extended_s3_config}
+        elif elasticsearch_config:
+            stream_kwargs = {"elasticsearch_config": elasticsearch_config}
         else:
-            stream_kwargs = {}    
+            stream_kwargs = {}
 
         stream = self.kinesis_backend.create_delivery_stream(
             stream_name, **stream_kwargs

--- a/moto/kinesis/responses.py
+++ b/moto/kinesis/responses.py
@@ -193,6 +193,8 @@ class KinesisResponse(BaseResponse):
             stream_kwargs = {"s3_config": s3_config}
         elif extended_s3_config:
             stream_kwargs = {"extended_s3_config": extended_s3_config}
+        else:
+            stream_kwargs = {}    
 
         stream = self.kinesis_backend.create_delivery_stream(
             stream_name, **stream_kwargs

--- a/tests/test_kinesis/test_firehose.py
+++ b/tests/test_kinesis/test_firehose.py
@@ -62,6 +62,31 @@ def create_redshift_delivery_stream(client, stream_name):
     )
 
 
+def create_elasticsearch_delivery_stream(client, stream_name):
+    return client.create_delivery_stream(
+        DeliveryStreamName=stream_name,
+        DeliveryStreamType="DirectPut",
+        ElasticsearchDestinationConfiguration={
+            "RoleARN": "arn:aws:iam::{}:role/firehose_delivery_role".format(ACCOUNT_ID),
+            "DomainARN": "arn:aws:es:::domain/kinesis-test",
+            "IndexName": "myIndex",
+            "TypeName": "UNCOMPRESSED",
+            "IndexRotationPeriod": "NoRotation",
+            "BufferingHints": {"IntervalInSeconds": 123, "SizeInMBs": 123},
+            "RetryOptions": {"DurationInSeconds": 123},
+            "S3Configuration": {
+                "RoleARN": "arn:aws:iam::{}:role/firehose_delivery_role".format(
+                    ACCOUNT_ID
+                ),
+                "BucketARN": "arn:aws:s3:::kinesis-test",
+                "Prefix": "myFolder/",
+                "BufferingHints": {"SizeInMBs": 123, "IntervalInSeconds": 124},
+                "CompressionFormat": "UNCOMPRESSED",
+            },
+        },
+    )
+
+
 @mock_kinesis
 def test_create_redshift_delivery_stream():
     client = boto3.client("firehose", region_name="us-east-1")
@@ -162,6 +187,54 @@ def test_create_s3_delivery_stream():
                                 ),
                                 "TableName": "outputTable",
                             },
+                        },
+                    },
+                }
+            ],
+            "HasMoreDestinations": False,
+        }
+    )
+
+
+@mock_kinesis
+def test_create_elasticsearch_delivery_stream():
+    client = boto3.client("firehose", region_name="us-east-1")
+
+    response = create_elasticsearch_delivery_stream(client, "stream1")
+    stream_arn = response["DeliveryStreamARN"]
+
+    response = client.describe_delivery_stream(DeliveryStreamName="stream1")
+    stream_description = response["DeliveryStreamDescription"]
+
+    # Sure and Freezegun don't play nicely together
+    _ = stream_description.pop("CreateTimestamp")
+    _ = stream_description.pop("LastUpdateTimestamp")
+
+    stream_description.should.equal(
+        {
+            "DeliveryStreamName": "stream1",
+            "DeliveryStreamARN": stream_arn,
+            "DeliveryStreamStatus": "ACTIVE",
+            "VersionId": "string",
+            "Destinations": [
+                {
+                    "DestinationId": "string",
+                    "ElasticsearchDestinationDescription": {
+                        "RoleARN": "arn:aws:iam::{}:role/firehose_delivery_role".format(ACCOUNT_ID),
+                        "DomainARN": "arn:aws:es:::domain/kinesis-test",
+                        "IndexName": "myIndex",
+                        "TypeName": "UNCOMPRESSED",
+                        "IndexRotationPeriod": "NoRotation",
+                        "BufferingHints": {"IntervalInSeconds": 123, "SizeInMBs": 123},
+                        "RetryOptions": {"DurationInSeconds": 123},
+                        "S3DestinationDescription": {
+                            "RoleARN": "arn:aws:iam::{}:role/firehose_delivery_role".format(
+                                ACCOUNT_ID
+                            ),
+                            "BucketARN": "arn:aws:s3:::kinesis-test",
+                            "Prefix": "myFolder/",
+                            "BufferingHints": {"SizeInMBs": 123, "IntervalInSeconds": 124},
+                            "CompressionFormat": "UNCOMPRESSED",
                         },
                     },
                 }

--- a/tests/test_kinesis/test_firehose.py
+++ b/tests/test_kinesis/test_firehose.py
@@ -220,7 +220,9 @@ def test_create_elasticsearch_delivery_stream():
                 {
                     "DestinationId": "string",
                     "ElasticsearchDestinationDescription": {
-                        "RoleARN": "arn:aws:iam::{}:role/firehose_delivery_role".format(ACCOUNT_ID),
+                        "RoleARN": "arn:aws:iam::{}:role/firehose_delivery_role".format(
+                            ACCOUNT_ID
+                        ),
                         "DomainARN": "arn:aws:es:::domain/kinesis-test",
                         "IndexName": "myIndex",
                         "TypeName": "UNCOMPRESSED",
@@ -233,7 +235,10 @@ def test_create_elasticsearch_delivery_stream():
                             ),
                             "BucketARN": "arn:aws:s3:::kinesis-test",
                             "Prefix": "myFolder/",
-                            "BufferingHints": {"SizeInMBs": 123, "IntervalInSeconds": 124},
+                            "BufferingHints": {
+                                "SizeInMBs": 123,
+                                "IntervalInSeconds": 124,
+                            },
                             "CompressionFormat": "UNCOMPRESSED",
                         },
                     },


### PR DESCRIPTION
UnboundLocalError is thrown when creating a Firehose delivery stream.

Error:
moto/kinesis/responses.py:198: UnboundLocalError

Sample Code:
```
    firehose_client = boto3.client("firehose", region_name=REGION)
    firehose_client.create_delivery_stream(DeliveryStreamName=OUTPUT_STREAM_NAME)
```