### PR TITLE
Wafv2: Adds associate-web-acl, disassociate-web-acl, and get-web-acl-for-resource

### DIFF
--- a/moto/wafv2/exceptions.py
+++ b/moto/wafv2/exceptions.py
@@ -12,3 +12,11 @@ class WAFV2DuplicateItemException(WAFv2ClientError):
             "WafV2DuplicateItem",
             "AWS WAF could not perform the operation because some resource in your request is a duplicate of an existing one.",
         )
+
+
+class WAFNonexistentItemException(WAFv2ClientError):
+    def __init__(self):
+        super(WAFNonexistentItemException, self).__init__(
+            "WAFNonexistentItem",
+            "AWS WAF could not perform the operation because your resource does not exist.",
+        )

--- a/moto/wafv2/models.py
+++ b/moto/wafv2/models.py
@@ -4,15 +4,18 @@ from boto3 import Session
 from moto.core import BaseBackend, BaseModel
 from moto.wafv2 import utils
 
-# from moto.ec2.models import elbv2_backends
-from .utils import make_arn_for_wacl, pascal_to_underscores_dict
-from .exceptions import WAFV2DuplicateItemException
+from .utils import (
+    make_arn_for_wacl,
+    pascal_to_underscores_dict,
+    underscores_to_pascal_dict,
+)
+from .exceptions import WAFV2DuplicateItemException, WAFNonexistentItemException
 from moto.core.utils import iso_8601_datetime_with_milliseconds
+from moto.elbv2.models import elbv2_backends
 import datetime
 from collections import OrderedDict
 
 
-US_EAST_1_REGION = "us-east-1"
 GLOBAL_REGION = "global"
 
 
@@ -40,6 +43,8 @@ class DefaultAction(BaseModel):
 
 
 # TODO: Add remaining properties
+
+
 class FakeWebACL(BaseModel):
     """
     https://docs.aws.amazon.com/waf/latest/APIReference/API_WebACL.html
@@ -51,7 +56,7 @@ class FakeWebACL(BaseModel):
         self.id = id
         self.arn = arn
         self.description = "Mock WebACL named {0}".format(self.name)
-        self.capacity = 3
+        self.capacity = "Not Implemented"
         self.visibility_config = VisibilityConfig(
             **pascal_to_underscores_dict(visibility_config)
         )
@@ -69,6 +74,20 @@ class FakeWebACL(BaseModel):
             "Name": self.name,
         }
 
+    def to_dict_long(self):
+        # https://docs.aws.amazon.com/waf/latest/APIReference/API_GetWebACLForResource.html (response syntax section)
+        return {
+            "ARN": self.arn,
+            "Description": self.description,
+            "Id": self.id,
+            "Name": self.name,
+            "Capacity": self.capacity,
+            "DefaultAction": underscores_to_pascal_dict(self.default_action.__dict__),
+            "VisibilityConfig": underscores_to_pascal_dict(
+                self.visibility_config.__dict__
+            ),
+        }
+
 
 class WAFV2Backend(BaseBackend):
     """
@@ -79,7 +98,7 @@ class WAFV2Backend(BaseBackend):
         super(WAFV2Backend, self).__init__()
         self.region_name = region_name
         self.wacls = OrderedDict()  # self.wacls[ARN] = FakeWacl
-        # TODO: self.load_balancers = OrderedDict()
+        self.alb_to_wacl = {}  # self.alb_to_wacl[alb_ARN] = wacl_arn
 
     def reset(self):
         region_name = self.region_name
@@ -100,20 +119,48 @@ class WAFV2Backend(BaseBackend):
     def list_web_acls(self):
         return [wacl.to_dict() for wacl in self.wacls.values()]
 
+    # A wacl can be on many ALBS, but an ALB can only have one wacl
+    def associate_web_acl(self, resource_arn, web_acl_arn):
+        # verify valid ALB and valid wacl
+        if (
+            resource_arn not in self.elbv2_backend.load_balancers
+            or web_acl_arn not in self.wacls
+        ):
+            raise WAFNonexistentItemException()
+        self.alb_to_wacl[resource_arn] = web_acl_arn
+
+    def disassociate_web_acl(self, resource_arn):
+        if resource_arn not in self.elbv2_backend.load_balancers:
+            raise WAFNonexistentItemException()
+        self.alb_to_wacl.pop(resource_arn, None)
+
+    def get_web_acl_for_resource(self, resource_arn):
+        self._updateActiveELBv2s()
+        if resource_arn not in self.elbv2_backend.load_balancers:
+            raise WAFNonexistentItemException()
+        if resource_arn not in self.alb_to_wacl:
+            return None
+        return self.wacls[self.alb_to_wacl[resource_arn]].to_dict_long()
+
     def _is_duplicate_name(self, name):
         allWaclNames = set(wacl.name for wacl in self.wacls.values())
         return name in allWaclNames
 
-    # TODO: This is how you link wacl to ALB
-    # @property
-    # def elbv2_backend(self):
-    #     """
-    #     EC2 backend
+    # If you deleted a load balancer in an elbv2, then it should also be deleted here
+    def _updateActiveELBv2s(self):
+        for alb_arn in self.alb_to_wacl:
+            if alb_arn not in self.elbv2_backend.load_balancers:
+                self.alb_to_wacl.pop(alb_arn, None)
 
-    #     :return: EC2 Backend
-    #     :rtype: moto.ec2.models.EC2Backend
-    #     """
-    #     return ec2_backends[self.region_name]
+    @property
+    def elbv2_backend(self):
+        """
+        elbv2 backend
+
+        :return: elbv2 Backend
+        :rtype: moto.elbv2.models.ELBv2Backend
+        """
+        return elbv2_backends[self.region_name]
 
 
 wafv2_backends = {}

--- a/moto/wafv2/responses.py
+++ b/moto/wafv2/responses.py
@@ -12,6 +12,37 @@ class WAFV2Response(BaseResponse):
         return wafv2_backends[self.region]  # default region is "us-east-1"
 
     @amzn_request_id
+    def associate_web_acl(self):
+        """ https://docs.aws.amazon.com/waf/latest/APIReference/API_AssociateWebACL.html """
+
+        web_acl_arn = self._get_param("WebACLArn")
+        resource_arn = self._get_param("ResourceArn")
+
+        self.wafv2_backend.associate_web_acl(resource_arn, web_acl_arn)
+        response = {}
+        response_headers = {"Content-Type": "application/json"}
+        return 200, response_headers, json.dumps(response)
+
+    @amzn_request_id
+    def disassociate_web_acl(self):
+        """  https://docs.aws.amazon.com/waf/latest/APIReference/API_DisassociateWebACL.html """
+
+        resource_arn = self._get_param("ResourceArn")
+        self.wafv2_backend.disassociate_web_acl(resource_arn)
+        response = {}
+        response_headers = {"Content-Type": "application/json"}
+        return 200, response_headers, json.dumps(response)
+
+    @amzn_request_id
+    def get_web_acl_for_resource(self):
+        """ https://docs.aws.amazon.com/waf/latest/APIReference/API_GetWebACLForResource.html """
+        resource_arn = self._get_param("ResourceArn")
+        web_acl = self.wafv2_backend.get_web_acl_for_resource(resource_arn)
+        response = {"WebACL": web_acl} if web_acl else {}
+        response_headers = {"Content-Type": "application/json"}
+        return 200, response_headers, json.dumps(response)
+
+    @amzn_request_id
     def create_web_acl(self):
         """  https://docs.aws.amazon.com/waf/latest/APIReference/API_CreateWebACL.html (response syntax section) """
 

--- a/moto/wafv2/utils.py
+++ b/moto/wafv2/utils.py
@@ -1,5 +1,10 @@
 from moto.core import ACCOUNT_ID
-from moto.core.utils import pascal_to_camelcase, camelcase_to_underscores
+from moto.core.utils import (
+    pascal_to_camelcase,
+    camelcase_to_underscores,
+    underscores_to_camelcase,
+    camelcase_to_pascal,
+)
 
 
 def make_arn_for_wacl(name, region_name, id, scope):
@@ -18,4 +23,11 @@ def pascal_to_underscores_dict(original_dict):
     outdict = {}
     for k, v in original_dict.items():
         outdict[camelcase_to_underscores(pascal_to_camelcase(k))] = v
+    return outdict
+
+
+def underscores_to_pascal_dict(original_dict):
+    outdict = {}
+    for k, v in original_dict.items():
+        outdict[camelcase_to_pascal(underscores_to_camelcase(k))] = v
     return outdict

--- a/tests/test_wafv2/test_helper_functions.py
+++ b/tests/test_wafv2/test_helper_functions.py
@@ -1,4 +1,4 @@
-def CREATE_WEB_ACL_BODY(name: str, scope: str) -> dict:
+def CREATE_WEB_ACL_BODY(name, scope):
     return {
         "Scope": scope,
         "Name": name,
@@ -6,10 +6,54 @@ def CREATE_WEB_ACL_BODY(name: str, scope: str) -> dict:
         "VisibilityConfig": {
             "SampledRequestsEnabled": False,
             "CloudWatchMetricsEnabled": False,
-            "MetricName": "idk",
+            "MetricName": "test_metric_name",
         },
     }
 
 
-def LIST_WEB_ACL_BODY(scope: str) -> dict:
+def LIST_WEB_ACL_BODY(scope):
     return {"Scope": scope}
+
+
+def CREATE_ASSOCIATE_WEB_ACL_BODY(web_acl_arn, resource_arn):
+    return {
+        "WebACLArn": web_acl_arn,
+        "ResourceArn": resource_arn,
+    }
+
+
+def CREATE_DISASSOCIATE_WEB_ACL_BODY(resource_arn):
+    return {
+        "ResourceArn": resource_arn,
+    }
+
+
+def CREATE_GET_WEB_ACL_FOR_RESOURCE_BODY(resource_arn):
+    return {
+        "ResourceArn": resource_arn,
+    }
+
+
+# Return arn of new alb for testing WAF cmds
+def create_alb(elbv2_client, ec2_client):
+
+    security_group = ec2_client.create_security_group(
+        GroupName="a-security-group", Description="First One"
+    )
+    vpc = ec2_client.create_vpc(CidrBlock="172.28.7.0/24", InstanceTenancy="default")
+    subnet1 = ec2_client.create_subnet(
+        VpcId=vpc.id, CidrBlock="172.28.7.192/26", AvailabilityZone="us-east-1a"
+    )
+    subnet2 = ec2_client.create_subnet(
+        VpcId=vpc.id, CidrBlock="172.28.7.0/26", AvailabilityZone="us-east-1b"
+    )
+
+    response = elbv2_client.create_load_balancer(
+        Name="my-lb",
+        Subnets=[subnet1.id, subnet2.id],
+        SecurityGroups=[security_group.id],
+        Scheme="internal",
+    )
+
+    lb = response.get("LoadBalancers")[0]
+    return lb.get("LoadBalancerArn")

--- a/tests/test_wafv2/test_server.py
+++ b/tests/test_wafv2/test_server.py
@@ -8,8 +8,15 @@ import boto3
 import botocore
 from botocore.exceptions import ClientError
 import moto.server as server
-from moto import mock_wafv2
-from .test_helper_functions import CREATE_WEB_ACL_BODY, LIST_WEB_ACL_BODY
+from moto import mock_wafv2, mock_elbv2, mock_ec2
+from .test_helper_functions import (
+    CREATE_ASSOCIATE_WEB_ACL_BODY,
+    CREATE_WEB_ACL_BODY,
+    LIST_WEB_ACL_BODY,
+    CREATE_DISASSOCIATE_WEB_ACL_BODY,
+    CREATE_GET_WEB_ACL_FOR_RESOURCE_BODY,
+    create_alb,
+)
 from moto.core import ACCOUNT_ID
 
 CREATE_WEB_ACL_HEADERS = {
@@ -20,6 +27,22 @@ CREATE_WEB_ACL_HEADERS = {
 
 LIST_WEB_ACL_HEADERS = {
     "X-Amz-Target": "AWSWAF_20190729.ListWebACLs",
+    "Content-Type": "application/json",
+}
+
+ASSOCIATE_WEB_ACL_HEADERS = {
+    "X-Amz-Target": "AWSWAF_20190729.AssociateWebACL",
+    "Content-Type": "application/json",
+}
+
+
+DISASSOCIATE_WEB_ACL_HEADERS = {
+    "X-Amz-Target": "AWSWAF_20190729.DisassociateWebACL",
+    "Content-Type": "application/json",
+}
+
+GET_WEB_ACL_FOR_RESOURCE_HEADERS = {
+    "X-Amz-Target": "AWSWAF_20190729.GetWebACLForResource",
     "Content-Type": "application/json",
 }
 
@@ -103,3 +126,168 @@ def test_list_web_ac_ls():
     web_acls = res.json["WebACLs"]
     assert len(web_acls) == 1
     assert web_acls[0]["Name"] == "Sarah"
+
+
+@mock_ec2
+@mock_elbv2
+@mock_wafv2
+def test_associate_web_acl():
+
+    wafv2_backend = server.create_backend_app("wafv2")
+    wafv2_client = wafv2_backend.test_client()
+    elbv2_client = boto3.client("elbv2", region_name="us-east-1")
+    ec2_client = boto3.resource("ec2", region_name="us-east-1")
+    resource_arn = create_alb(elbv2_client, ec2_client)
+    wacl_arn = wafv2_client.post(
+        "/",
+        headers=CREATE_WEB_ACL_HEADERS,
+        json=CREATE_WEB_ACL_BODY("test_wacl_name", "REGIONAL"),
+    ).json["Summary"]["ARN"]
+
+    # Associate wacl with alb
+    res = wafv2_client.post(
+        "/",
+        headers=ASSOCIATE_WEB_ACL_HEADERS,
+        json=CREATE_ASSOCIATE_WEB_ACL_BODY(wacl_arn, resource_arn),
+    )
+    assert res.status_code == 200
+
+    # Try with invalid arns to see if WAFNonexistentItemException error is raised
+    res = wafv2_client.post(
+        "/",
+        headers=ASSOCIATE_WEB_ACL_HEADERS,
+        json=CREATE_ASSOCIATE_WEB_ACL_BODY(
+            "i_am_an_invalid_arn_this_should_raise_error", resource_arn
+        ),
+    )
+    assert res.status_code == 400
+    assert (
+        b"AWS WAF could not perform the operation because your resource does not exist."
+        in res.data
+    )
+    assert b"WAFNonexistentItem" in res.data
+
+    res = wafv2_client.post(
+        "/",
+        headers=ASSOCIATE_WEB_ACL_HEADERS,
+        json=CREATE_ASSOCIATE_WEB_ACL_BODY(
+            wacl_arn, "i_am_an_invalid_arn_this_should_raise_error"
+        ),
+    )
+    assert res.status_code == 400
+    assert (
+        b"AWS WAF could not perform the operation because your resource does not exist."
+        in res.data
+    )
+    assert b"WAFNonexistentItem" in res.data
+
+
+@mock_ec2
+@mock_elbv2
+@mock_wafv2
+def test_disassociate_web_acl():
+
+    wafv2_backend = server.create_backend_app("wafv2")
+    wafv2_client = wafv2_backend.test_client()
+    elbv2_client = boto3.client("elbv2", region_name="us-east-1")
+    ec2_client = boto3.resource("ec2", region_name="us-east-1")
+    resource_arn = create_alb(elbv2_client, ec2_client)
+    wacl_arn = wafv2_client.post(
+        "/",
+        headers=CREATE_WEB_ACL_HEADERS,
+        json=CREATE_WEB_ACL_BODY("test_wacl_name", "REGIONAL"),
+    ).json["Summary"]["ARN"]
+
+    # Associate the wacl
+    res = wafv2_client.post(
+        "/",
+        headers=ASSOCIATE_WEB_ACL_HEADERS,
+        json=CREATE_ASSOCIATE_WEB_ACL_BODY(wacl_arn, resource_arn),
+    )
+    assert res.status_code == 200
+
+    # Disassociate it
+    res = wafv2_client.post(
+        "/",
+        headers=DISASSOCIATE_WEB_ACL_HEADERS,
+        json=CREATE_DISASSOCIATE_WEB_ACL_BODY(resource_arn),
+    )
+    assert res.status_code == 200
+
+    # Delete ALB and disassociate it again - should raise error since ARN doesn't exist
+    elbv2_client.delete_load_balancer(LoadBalancerArn=resource_arn)
+    res = wafv2_client.post(
+        "/",
+        headers=DISASSOCIATE_WEB_ACL_HEADERS,
+        json=CREATE_DISASSOCIATE_WEB_ACL_BODY(resource_arn),
+    )
+    assert res.status_code == 400
+    assert (
+        b"AWS WAF could not perform the operation because your resource does not exist."
+        in res.data
+    )
+    assert b"WAFNonexistentItem" in res.data
+
+
+@mock_ec2
+@mock_elbv2
+@mock_wafv2
+def test_get_web_acl_for_resource():
+
+    wafv2_backend = server.create_backend_app("wafv2")
+    wafv2_client = wafv2_backend.test_client()
+    elbv2_client = boto3.client("elbv2", region_name="us-east-1")
+    ec2_client = boto3.resource("ec2", region_name="us-east-1")
+    resource_arn = create_alb(elbv2_client, ec2_client)
+    wacl_arn = wafv2_client.post(
+        "/",
+        headers=CREATE_WEB_ACL_HEADERS,
+        json=CREATE_WEB_ACL_BODY("test_wacl_name", "REGIONAL"),
+    ).json["Summary"]["ARN"]
+
+    # Associate the wacl
+    res = wafv2_client.post(
+        "/",
+        headers=ASSOCIATE_WEB_ACL_HEADERS,
+        json=CREATE_ASSOCIATE_WEB_ACL_BODY(wacl_arn, resource_arn),
+    )
+    assert res.status_code == 200
+
+    # Verify correct wacl is associated with resource (alb)
+    res = wafv2_client.post(
+        "/",
+        headers=GET_WEB_ACL_FOR_RESOURCE_HEADERS,
+        json=CREATE_GET_WEB_ACL_FOR_RESOURCE_BODY(resource_arn),
+    )
+    assert res.status_code == 200
+    web_acl = res.json["WebACL"]
+    assert web_acl.get("ARN") == wacl_arn
+
+    # Disassociate wacl and verify wacl is no longer associated with resource (alb)
+    res = wafv2_client.post(
+        "/",
+        headers=DISASSOCIATE_WEB_ACL_HEADERS,
+        json=CREATE_DISASSOCIATE_WEB_ACL_BODY(resource_arn),
+    )
+    assert res.status_code == 200
+    res = wafv2_client.post(
+        "/",
+        headers=GET_WEB_ACL_FOR_RESOURCE_HEADERS,
+        json=CREATE_GET_WEB_ACL_FOR_RESOURCE_BODY(resource_arn),
+    )
+    assert res.status_code == 200
+    assert len(res.json) == 0
+
+    # Try with non existent resource_arn (delete the resource so it's ARN should now not exist)
+    elbv2_client.delete_load_balancer(LoadBalancerArn=resource_arn)
+    res = wafv2_client.post(
+        "/",
+        headers=GET_WEB_ACL_FOR_RESOURCE_HEADERS,
+        json=CREATE_GET_WEB_ACL_FOR_RESOURCE_BODY(resource_arn),
+    )
+    assert res.status_code == 400
+    assert (
+        b"AWS WAF could not perform the operation because your resource does not exist."
+        in res.data
+    )
+    assert b"WAFNonexistentItem" in res.data


### PR DESCRIPTION
Adding support for the wafv2 services. This PR adds the `associate-web-acl`, `get-web-acl-for-resource`  and `disassociate-web-acl` commands.

Sample Output:

1) Create VPC and 2 subnets for load-balancer
2) Create load-balancer and web acl
3) Associate load-balancer and web-acl -> no output if successful
4) Show web-acl is associated with load-balancer with get-web-acl-for-resource
5) Disassociate load-balancer and web-acl -> no output if successful
6) Show web-acl is no longer associated with load-balancer with get-web-acl-for-resource

```
$ aws --endpoint-url=http://localhost:5000 ec2 create-vpc --cidr-block 172.28.7.0/24
{
    "Vpc": {
        "CidrBlock": "172.28.7.0/24",
        "DhcpOptionsId": "dopt-1a2b3c4d2",
        "State": "pending",
        "VpcId": "vpc-4898d358",
...

$ aws --endpoint-url=http://localhost:5000 ec2 create-subnet --vpc-id vpc-4898d358 --cidr-block 172.28.7.192/26
{
    "Subnet": {
        "AvailabilityZone": "us-east-2c",
        "AvailabilityZoneId": "use2-az3",
        "AvailableIpAddressCount": 59,
        "CidrBlock": "172.28.7.192/26",
        "DefaultForAz": false,
        "MapPublicIpOnLaunch": false,
        "State": "pending",
        "SubnetId": "subnet-a8c73b4b",
...

$ aws --endpoint-url=http://localhost:5000 ec2 create-subnet --vpc-id vpc-4898d358 --cidr-block 172.28.7.0/26
{
    "Subnet": {
        "AvailabilityZone": "us-east-2a",
        "AvailabilityZoneId": "use2-az1",
        "AvailableIpAddressCount": 59,
        "CidrBlock": "172.28.7.0/26",
        "DefaultForAz": false,
        "MapPublicIpOnLaunch": false,
        "State": "pending",
        "SubnetId": "subnet-078bbf49",
...

$ aws --endpoint-url=http://localhost:5000 elbv2 create-load-balancer --name test_alb1  --subnets subnet-a8c73b4b subnet-078bbf49
{
    "LoadBalancers": [
        {
            "LoadBalancerArn": "arn:aws:elasticloadbalancing:us-east-2:1:loadbalancer/test_alb1/50dc6c495c0c9188",
            "DNSName": "test_alb1-1.us-east-2.elb.amazonaws.com",
            "CanonicalHostedZoneId": "Z2P70J7EXAMPLE",
            "CreatedTime": "2021-08-05T14:17:58.081000+00:00",
            "LoadBalancerName": "test_alb1",
...

$ aws --endpoint-url=http://localhost:5000 wafv2 create-web-acl --name wacl1 --scope REGIONAL --default-action Allow={} --visibility-config SampledRequestsEnabled=false,CloudWatchMetricsEnabled=false,MetricName=testMetricName
{
    "Summary": {
        "Name": "wacl1",
        "Id": "2c00295e-f228-4c59-83b5-2bfb828b6a4e",
        "Description": "Mock WebACL named wacl1",
        "LockToken": "Not Implemented",
        "ARN": "arn:aws:wafv2:us-east-2:123456789012:regional/webacl/wacl1/2c00295e-f228-4c59-83b5-2bfb828b6a4e"
    }
}

$ aws --endpoint-url=http://localhost:5000 wafv2 associate-web-acl --resource-arn arn:aws:elasticloadbalancing:us-east-2:1:loadbalancer/test_alb1/50dc6c495c0c9188 --web-acl-arn arn:aws:wafv2:us-east-2:123456789012:regional/webacl/wacl1/2c00295e-f228-4c59-83b5-2bfb828b6a4e

$ aws --endpoint-url=http://localhost:5000 wafv2 get-web-acl-for-resource --resource-arn arn:aws:elasticloadbalancing:us-east-2:1:loadbalancer/test_alb1/50dc6c495c0c9188
{
    "WebACL": {
        "Name": "wacl1",
        "Id": "2c00295e-f228-4c59-83b5-2bfb828b6a4e",
        "ARN": "arn:aws:wafv2:us-east-2:123456789012:regional/webacl/wacl1/2c00295e-f228-4c59-83b5-2bfb828b6a4e",
        "DefaultAction": {
            "Block": {},
            "Allow": {}
        },
        "Description": "Mock WebACL named wacl1",
        "VisibilityConfig": {
            "SampledRequestsEnabled": false,
            "CloudWatchMetricsEnabled": false,
            "MetricName": "testMetricName"
        },
        "Capacity": "Not Implemented"
    }
}

$ aws --endpoint-url=http://localhost:5000 wafv2 disassociate-web-acl --resource-arn arn:aws:elasticloadbalancing:us-east-2:1:loadbalancer/test_alb1/50dc6c495c0c9188

$ aws --endpoint-url=http://localhost:5000 wafv2 get-web-acl-for-resource --resource-arn arn:aws:elasticloadbalancing:us-east-2:1:loadbalancer/test_alb1/50dc6c495c0c9188
```


