### PR TITLE
Added DisassociateTransitGatewayRouteTable API

### DIFF
--- a/moto/ec2/models.py
+++ b/moto/ec2/models.py
@@ -6240,12 +6240,8 @@ class TransitGatewayRouteTableBackend(object):
             "transitGatewayAttachmentId": transit_gateway_attachment_id,
         }
 
-    def unset_route_table_association(
-        self, tgw_rt_id
-    ):
-        tgw_rt = self.transit_gateways_route_tables[
-            tgw_rt_id
-        ]
+    def unset_route_table_association(self, tgw_rt_id):
+        tgw_rt = self.transit_gateways_route_tables[tgw_rt_id]
         tgw_rt.route_table_association = {}
 
     def set_route_table_propagation(
@@ -6264,12 +6260,8 @@ class TransitGatewayRouteTableBackend(object):
             "transitGatewayAttachmentId": transit_gateway_attachment_id,
         }
 
-    def unset_route_table_propagation(
-        self, tgw_rt_id
-    ):
-        tgw_rt = self.transit_gateways_route_tables[
-            tgw_rt_id
-        ]
+    def unset_route_table_propagation(self, tgw_rt_id):
+        tgw_rt = self.transit_gateways_route_tables[tgw_rt_id]
         tgw_rt.route_table_propagation = {}
 
     def disable_route_table_propagation(self, transit_gateway_route_table_id):
@@ -6554,9 +6546,7 @@ class TransitGatewayAttachmentBackend(object):
             "transitGatewayRouteTableId": transit_gateway_route_table_id,
         }
 
-    def unset_attachment_association(
-        self, tgw_attach_id
-    ):
+    def unset_attachment_association(self, tgw_attach_id):
         self.transit_gateway_attachments.get(tgw_attach_id).association = {}
 
     def set_attachment_propagation(
@@ -6567,9 +6557,7 @@ class TransitGatewayAttachmentBackend(object):
             "transitGatewayRouteTableId": transit_gateway_route_table_id,
         }
 
-    def unset_attachment_propagation(
-        self, tgw_attach_id
-    ):
+    def unset_attachment_propagation(self, tgw_attach_id):
         self.transit_gateway_attachments.get(tgw_attach_id).propagation = {}
 
     def disable_attachment_propagation(self, transit_gateway_attachment_id=None):

--- a/moto/ec2/models.py
+++ b/moto/ec2/models.py
@@ -6240,6 +6240,14 @@ class TransitGatewayRouteTableBackend(object):
             "transitGatewayAttachmentId": transit_gateway_attachment_id,
         }
 
+    def unset_route_table_association(
+        self, tgw_rt_id
+    ):
+        tgw_rt = self.transit_gateways_route_tables[
+            tgw_rt_id
+        ]
+        tgw_rt.route_table_association = {}
+
     def set_route_table_propagation(
         self, transit_gateway_attachment_id, transit_gateway_route_table_id
     ):
@@ -6255,6 +6263,14 @@ class TransitGatewayRouteTableBackend(object):
             "state": "enabled",
             "transitGatewayAttachmentId": transit_gateway_attachment_id,
         }
+
+    def unset_route_table_propagation(
+        self, tgw_rt_id
+    ):
+        tgw_rt = self.transit_gateways_route_tables[
+            tgw_rt_id
+        ]
+        tgw_rt.route_table_propagation = {}
 
     def disable_route_table_propagation(self, transit_gateway_route_table_id):
         self.transit_gateways_route_tables[
@@ -6538,6 +6554,11 @@ class TransitGatewayAttachmentBackend(object):
             "transitGatewayRouteTableId": transit_gateway_route_table_id,
         }
 
+    def unset_attachment_association(
+        self, tgw_attach_id
+    ):
+        self.transit_gateway_attachments.get(tgw_attach_id).association = {}
+
     def set_attachment_propagation(
         self, transit_gateway_attachment_id=None, transit_gateway_route_table_id=None
     ):
@@ -6545,6 +6566,11 @@ class TransitGatewayAttachmentBackend(object):
             "state": "enabled",
             "transitGatewayRouteTableId": transit_gateway_route_table_id,
         }
+
+    def unset_attachment_propagation(
+        self, tgw_attach_id
+    ):
+        self.transit_gateway_attachments.get(tgw_attach_id).propagation = {}
 
     def disable_attachment_propagation(self, transit_gateway_attachment_id=None):
         self.transit_gateway_attachments[transit_gateway_attachment_id].propagation[
@@ -6714,6 +6740,15 @@ class TransitGatewayRelationsBackend(object):
         )
 
         return transit_gateway_propagation
+
+    def disassociate_transit_gateway_route_table(self, tgw_attach_id, tgw_rt_id):
+        tgw_association = self.transit_gateway_associations.pop(tgw_attach_id)
+        tgw_association.state == "disassociated"
+
+        self.unset_route_table_association(tgw_rt_id)
+        self.unset_attachment_association(tgw_attach_id)
+
+        return tgw_association
 
 
 class NatGateway(CloudFormationModel):

--- a/moto/ec2/responses/transit_gateway_attachments.py
+++ b/moto/ec2/responses/transit_gateway_attachments.py
@@ -88,6 +88,17 @@ class TransitGatewayAttachment(BaseResponse):
         template = self.response_template(TRANSIT_GATEWAY_ASSOCIATION)
         return template.render(transit_gateway_association=transit_gateway_association)
 
+    def disassociate_transit_gateway_route_table(self,):
+        tgw_attach_id = self._get_param("TransitGatewayAttachmentId")
+        tgw_rt_id = self._get_param("TransitGatewayRouteTableId")
+
+        tgw_association = self.ec2_backend.disassociate_transit_gateway_route_table(
+            tgw_attach_id, tgw_rt_id
+        )
+        tgw_association.state == "disassociated"
+        template = self.response_template(TRANSIT_GATEWAY_DISASSOCIATION)
+        return template.render(tgw_association=tgw_association)
+
     def enable_transit_gateway_route_table_propagation(self):
         transit_gateway_attachment_id = self._get_param("TransitGatewayAttachmentId")
         transit_gateway_route_table_id = self._get_param("TransitGatewayRouteTableId")
@@ -348,6 +359,19 @@ TRANSIT_GATEWAY_ASSOCIATION = """<AssociateTransitGatewayRouteTableResponse xmln
         <transitGatewayRouteTableId>{{ transit_gateway_association.transit_gateway_route_table_id }}</transitGatewayRouteTableId>
     </association>
 </AssociateTransitGatewayRouteTableResponse>
+"""
+
+
+TRANSIT_GATEWAY_DISASSOCIATION = """<DisassociateTransitGatewayRouteTableResponse xmlns="http://ec2.amazonaws.com/doc/2016-11-15/">
+    <requestId>86a597cf-93ec-44a3-9559-4641863642a5</requestId>
+    <association>
+        <resourceId>{{ tgw_association.resource_id }}</resourceId>
+        <resourceType>{{ tgw_association.resource_type }}</resourceType>
+        <state>{{ tgw_association.state }}</state>
+        <transitGatewayAttachmentId>{{ tgw_association.transit_gateway_attachment_id }}</transitGatewayAttachmentId>
+        <transitGatewayRouteTableId>{{ tgw_association.transit_gateway_route_table_id }}</transitGatewayRouteTableId>
+    </association>
+</DisassociateTransitGatewayRouteTableResponse>
 """
 
 


### PR DESCRIPTION
## Added
- API `DisassociateTransitGatewayRouteTable`

## Test
- Terraform
```terraform
resource "aws_vpc" "main" {
  cidr_block = "10.0.0.0/16"
}

resource "aws_subnet" "example" {
  vpc_id            = aws_vpc.main.id
  availability_zone = "us-east-2a"
  cidr_block        = "10.0.1.0/24"
}

resource "aws_ec2_transit_gateway" "example" {
  description = "example"
}

resource "aws_ec2_transit_gateway_vpc_attachment" "example" {
  subnet_ids         = [aws_subnet.example.id]
  transit_gateway_id = aws_ec2_transit_gateway.example.id
  vpc_id             = aws_vpc.main.id
}

resource "aws_ec2_transit_gateway_route_table" "example" {
  transit_gateway_id = aws_ec2_transit_gateway.example.id
}

resource "aws_ec2_transit_gateway_route_table_association" "example" {
  transit_gateway_attachment_id  = aws_ec2_transit_gateway_vpc_attachment.example.id
  transit_gateway_route_table_id = aws_ec2_transit_gateway_route_table.example.id
}
```

## Fix for Issue
- #4130 