### PR TITLE
IoT: Add VersionsLimitExceededException

### DIFF
--- a/moto/iot/exceptions.py
+++ b/moto/iot/exceptions.py
@@ -60,3 +60,12 @@ class ResourceAlreadyExistsException(IoTClientError):
         super(ResourceAlreadyExistsException, self).__init__(
             "ResourceAlreadyExistsException", msg or "The resource already exists."
         )
+
+
+class VersionsLimitExceededException(IoTClientError):
+    def __init__(self, name):
+        self.code = 409
+        super(VersionsLimitExceededException, self).__init__(
+            "VersionsLimitExceededException",
+            "The policy %s already has the maximum number of versions (5)" % name,
+        )

--- a/moto/iot/models.py
+++ b/moto/iot/models.py
@@ -21,6 +21,7 @@ from .exceptions import (
     InvalidStateTransitionException,
     VersionConflictException,
     ResourceAlreadyExistsException,
+    VersionsLimitExceededException,
 )
 
 
@@ -815,6 +816,8 @@ class IoTBackend(BaseBackend):
         policy = self.get_policy(policy_name)
         if not policy:
             raise ResourceNotFoundException()
+        if len(policy.versions) >= 5:
+            raise VersionsLimitExceededException(policy_name)
         version = FakePolicyVersion(
             policy_name, policy_document, set_as_default, self.region_name
         )


### PR DESCRIPTION
IoT : `create_policy_version`  should throw `VersionsLimitExceededException` if the number of policy versions exceeds 5