### PR TITLE
Reset self._template during stack update

### DIFF
--- a/moto/cloudformation/parsing.py
+++ b/moto/cloudformation/parsing.py
@@ -667,7 +667,6 @@ class ResourceMap(collections_abc.Mapping):
             )
             self._parsed_resources[resource_name] = new_resource
 
-
         for logical_name, _ in resources_by_action["Remove"].items():
             resource_json = old_template_resources[logical_name]
             resource = self._parsed_resources[logical_name]


### PR DESCRIPTION
update calls diff. diff mutates self by calling load_parameters. but the latter reads the value of self._template, which is out of date when we are doing an update.

**Solution:** set self._template to the given template in diff.

also, change the following identifiers to be more clear (since they represent not templates but resource maps):

* `old_template` -> `old_template_resources`
* `new_template` -> `new_template_resources`