### PR TITLE
Resolve coverage dependency conflict

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,7 +64,7 @@ jobs:
       - name: Update pip
         if: ${{ steps.pip-cache.outputs.cache-hit != 'true' }}
         run: |
-          python -m pip install pip==21.1.3
+          python -m pip install --upgrade pip
       - name: Install project dependencies
         if: ${{ steps.pip-cache.outputs.cache-hit != 'true' }}
         run: |
@@ -96,8 +96,7 @@ jobs:
     # Update PIP
     - name: Update pip
       run: |
-        # https://github.com/pypa/pip/issues/10201
-        python -m pip install pip==21.1.3
+        python -m pip install --upgrade pip
     # Still need to properly install the dependencies - it will only skip the download part
     - name: Install project dependencies
       run: |
@@ -134,7 +133,7 @@ jobs:
         key: pip-${{ matrix.python-version }}-${{ hashFiles('**/setup.py') }}-4
     - name: Update pip
       run: |
-        python -m pip install pip==21.1.3
+        python -m pip install --upgrade pip
     - name: Install project dependencies
       run: |
         pip install -r requirements-dev.txt
@@ -182,7 +181,7 @@ jobs:
         key: pip-${{ matrix.python-version }}-${{ hashFiles('**/setup.py') }}-4
     - name: Update pip
       run: |
-        python -m pip install pip==21.1.3
+        python -m pip install --upgrade pip
     - name: Install project dependencies
       run: |
         pip install -r requirements-dev.txt

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -139,6 +139,8 @@ jobs:
         pip install -r requirements-dev.txt
         pip install pytest-cov
         pip install pytest-github-actions-annotate-failures
+        # https://github.com/aws/aws-xray-sdk-python/issues/196
+        pip install "coverage<=4.5.4"
     - name: Test with pytest
       run: |
         make test-coverage
@@ -185,6 +187,7 @@ jobs:
     - name: Install project dependencies
       run: |
         pip install -r requirements-dev.txt
+        pip install "coverage<=4.5.4"
     - name: Test ServerMode/Coverage
       env:
         TEST_SERVER_MODE: ${{ true }}

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,7 +3,6 @@
 
 black==19.10b0
 regex==2019.11.1
-coverage==4.5.4
 flake8==3.7.8
 boto>=2.45.0
 click

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -1,7 +1,4 @@
 pytest
-# Last dependency that has coverage<5
-# We need coverage<5 because of https://github.com/aws/aws-xray-sdk-python/issues/196
-# We can't pin coverage==4.5.4 as done before, because of https://github.com/pypa/pip/issues/10201
-pytest-cov<2.0.0
+pytest-cov
 sure==1.4.11
 freezegun

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -1,4 +1,7 @@
 pytest
-pytest-cov
+# Last dependency that has coverage<5
+# We need coverage<5 because of https://github.com/aws/aws-xray-sdk-python/issues/196
+# We can't pin coverage==4.5.4 as done before, because of https://github.com/pypa/pip/issues/10201
+pytest-cov<2.0.0
 sure==1.4.11
 freezegun


### PR DESCRIPTION
Reverts #4083 

Fixes #4190 

Relates to https://github.com/pypa/pip/issues/10201

Our coverage-dependency was unresolvable, with `pytest-cov` requiring `coverage>5`, but because of the XRay SDK we required `coverage<5`.
Before, pip would complain about it, but leave it up to us to figure it out. The new Pip resolver thinks it can fix it, but then takes literal hours trying to find a compatible set of dependencies.

Downgrading `pytest-cov` leads to an even bigger dependency hell, as it is quite tightly coupled with pytest itself.

Installing the old version of `coverage` separately when running the CI is IMO the least-impactful solution. 

Contributors would not normally run `make test-coverage` anyway - just `make test` - so this should not impact anyone.
