### PR TITLE
Raise error when attempting to terminate protected ec2 instance

### DIFF
--- a/moto/ec2/exceptions.py
+++ b/moto/ec2/exceptions.py
@@ -585,6 +585,15 @@ class OperationNotPermitted3(EC2ClientError):
         )
 
 
+class OperationNotPermitted4(EC2ClientError):
+    def __init__(self, instance_id):
+        super(OperationNotPermitted4, self).__init__(
+            "OperationNotPermitted",
+            "The instance '{0}' may not be terminated. Modify its 'disableApiTermination' "
+            "instance attribute and try again.".format(instance_id),
+        )
+
+
 class InvalidLaunchTemplateNameError(EC2ClientError):
     def __init__(self):
         super(InvalidLaunchTemplateNameError, self).__init__(

--- a/moto/ec2/models.py
+++ b/moto/ec2/models.py
@@ -103,6 +103,7 @@ from .exceptions import (
     OperationNotPermitted,
     OperationNotPermitted2,
     OperationNotPermitted3,
+    OperationNotPermitted4,
     ResourceAlreadyAssociatedError,
     RulesPerSecurityGroupLimitExceededError,
     TagLimitExceeded,
@@ -1024,6 +1025,8 @@ class InstanceBackend(object):
                 "InvalidParameterCombination", "No instances specified"
             )
         for instance in self.get_multi_instances_by_id(instance_ids):
+            if instance.disable_api_termination == "true":
+                raise OperationNotPermitted4(instance.id)
             instance.terminate()
             terminated_instances.append(instance)
 


### PR DESCRIPTION
Unfortunately `moto` does not store the `DisableApiTermination` attribute as a boolean value--and fixing that ended up being a lot of work--so I had to resort to a string comparison instead.

I followed the existing convention for OperationNotPermitted errors.

Closes #4097 