### PR TITLE
Only use backported importlib_metadata on Python < 3.8

### DIFF
--- a/moto/core/models.py
+++ b/moto/core/models.py
@@ -11,12 +11,16 @@ from abc import abstractmethod
 from io import BytesIO
 from collections import defaultdict
 
+try:
+    from importlib.metadata import version
+except ImportError:
+    from importlib_metadata import version
+
 from botocore.config import Config
 from botocore.handlers import BUILTIN_HANDLERS
 from botocore.awsrequest import AWSResponse
 from distutils.version import LooseVersion
 from http.client import responses as http_responses
-from importlib_metadata import version
 from urllib.parse import urlparse
 from werkzeug.wrappers import Request
 

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ install_requires = [
     "MarkupSafe!=2.0.0a1",  # This is a Jinja2 dependency, 2.0.0a1 currently seems broken
     "Jinja2>=2.10.1",
     "more-itertools",
-    "importlib_metadata"
+    "importlib_metadata ; python_version < '3.8'"
 ]
 
 _dep_PyYAML = "PyYAML>=5.1"


### PR DESCRIPTION
[`importlib.metadata`](https://docs.python.org/3/library/importlib.metadata.html) is in the standard library in Python ≥ 3.8, so we can avoid installing the backported `importlib_metadata` except on older Python versions, using an [environment marker](https://www.python.org/dev/peps/pep-0496/).