### PR TITLE
Throw ValidationError on null Outputs section

### DIFF
--- a/moto/cloudformation/parsing.py
+++ b/moto/cloudformation/parsing.py
@@ -745,6 +745,13 @@ class OutputMap(collections_abc.Mapping):
     def __init__(self, resources, template, stack_id):
         self._template = template
         self._stack_id = stack_id
+
+        if "Outputs" in template and template["Outputs"] is None:
+            raise ValidationError(
+                stack_id,  # not sure why we need to supply this when also supplying message
+                message="[/Outputs] 'null' values are not allowed in templates",
+            )
+
         self._output_json_map = template.get("Outputs")
 
         # Create the default resources

--- a/tests/test_cloudformation/test_stack_parsing.py
+++ b/tests/test_cloudformation/test_stack_parsing.py
@@ -56,6 +56,8 @@ output_dict = {
     }
 }
 
+null_output = {"Outputs": None}
+
 bad_output = {
     "Outputs": {"Output1": {"Value": {"Fn::GetAtt": ["Queue", "InvalidAttribute"]}}}
 }
@@ -146,6 +148,7 @@ import_value_template = {
 }
 
 outputs_template = dict(list(dummy_template.items()) + list(output_dict.items()))
+null_outputs_template = dict(list(dummy_template.items()) + list(null_output.items()))
 bad_outputs_template = dict(list(dummy_template.items()) + list(bad_output.items()))
 get_attribute_outputs_template = dict(
     list(dummy_template.items()) + list(get_attribute_output.items())
@@ -162,6 +165,7 @@ ssm_parameter_template = dict(
 dummy_template_json = json.dumps(dummy_template)
 name_type_template_json = json.dumps(name_type_template)
 output_type_template_json = json.dumps(outputs_template)
+null_output_template_json = json.dumps(null_outputs_template)
 bad_output_template_json = json.dumps(bad_outputs_template)
 get_attribute_outputs_template_json = json.dumps(get_attribute_outputs_template)
 get_availability_zones_template_json = json.dumps(get_availability_zones_template)
@@ -314,6 +318,14 @@ def test_parse_stack_with_bad_get_attribute_outputs():
     FakeStack.when.called_with(
         "test_id", "test_stack", bad_output_template_json, {}, "us-west-1"
     ).should.throw(ValidationError)
+
+
+def test_parse_stack_with_null_outputs_section():
+    FakeStack.when.called_with(
+        "test_id", "test_stack", null_output_template_json, {}, "us-west-1"
+    ).should.throw(
+        ValidationError, "[/Outputs] 'null' values are not allowed in templates"
+    )
 
 
 def test_parse_stack_with_parameters():


### PR DESCRIPTION
The CloudFormation API balks at any template containing an empty/null/None "Outputs" section. This change seeks to have moto
emulate that behavior.

e.g.

```python
>>> from boto3 import client
>>> c = client('cloudformation')
>>> template = '''
... AWSTemplateFormatVersion: 2010-09-09
... Resources: {"Q": {"Type": "AWS::SQS::Queue", "Properties": {}}}
... '''
>>> name = 'timski'
>>> c.create_stack(StackName=name, TemplateBody=template)
{'StackId': '...', 'ResponseMetadata': {...}}
>>> c.delete_stack(StackName=name)
{'ResponseMetadata': {...}}
>>> template = '''
... Resources: {"Q": {"Type": "AWS::SQS::Queue", "Properties": {}}}
... Outputs:
... '''
>>> c.create_stack(StackName=name, TemplateBody=template)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/timski/.local/share/virtualenvs/nebula-nsexPwTQ/lib/python3.9/site-packages/botocore/client.py", line 386, in _api_call
    return self._make_api_call(operation_name, kwargs)
  File "/home/timski/.local/share/virtualenvs/nebula-nsexPwTQ/lib/python3.9/site-packages/botocore/client.py", line 705, in _make_api_call
    raise error_class(parsed_response, operation_name)
botocore.exceptions.ClientError: An error occurred (ValidationError) when calling the CreateStack operation: [/Outputs] 'null' values are not allowed in templates
```