### PR TITLE
EC2:DescribeVpcPeeringConnection() - use VpcPeeringConnectionIds-param

### DIFF
--- a/moto/ec2/models.py
+++ b/moto/ec2/models.py
@@ -3563,7 +3563,9 @@ class VPCPeeringConnectionBackend(object):
                     vpc_pcx_cx.vpc_pcxs[vpc_pcx_id] = vpc_pcx
         return vpc_pcx
 
-    def get_all_vpc_peering_connections(self):
+    def get_all_vpc_peering_connections(self, vpc_peering_ids=None):
+        if vpc_peering_ids:
+            return [pcx for pcx in self.vpc_pcxs.values() if pcx.id in vpc_peering_ids]
         return self.vpc_pcxs.values()
 
     def get_vpc_peering_connection(self, vpc_pcx_id):

--- a/moto/ec2/responses/vpc_peering_connections.py
+++ b/moto/ec2/responses/vpc_peering_connections.py
@@ -29,7 +29,8 @@ class VPCPeeringConnections(BaseResponse):
         return template.render(vpc_pcx=vpc_pcx)
 
     def describe_vpc_peering_connections(self):
-        vpc_pcxs = self.ec2_backend.get_all_vpc_peering_connections()
+        ids = self._get_multi_param("VpcPeeringConnectionId")
+        vpc_pcxs = self.ec2_backend.get_all_vpc_peering_connections(vpc_peering_ids=ids)
         template = self.response_template(DESCRIBE_VPC_PEERING_CONNECTIONS_RESPONSE)
         return template.render(vpc_pcxs=vpc_pcxs)
 


### PR DESCRIPTION
Fixes #4218 

Terraform would call the DescribeVpcPeeringConnection-endpoint with a specific ID, expect only one result and only process the first result.
Moto, without checking whether a specific ID was provided, would return multiple results, so the first result returned to TF was often a completely different vpc_peering_connection than requested.

Hence the error message from the ticket: `unexpected state 'deleted', wanted target 'pending-acceptance, active'`