### PR TITLE
Fix: Issue with empty tags created on SQS queues

### DIFF
--- a/moto/core/responses.py
+++ b/moto/core/responses.py
@@ -723,7 +723,7 @@ class BaseResponse(_TemplateEnvironmentMixin, ActionAuthenticatorMixin):
                     elif key.endswith(value_end):
                         v = value[0]
 
-            if not (k and v):
+            if not (k and v is not None):
                 break
 
             results[k] = v

--- a/moto/sqs/responses.py
+++ b/moto/sqs/responses.py
@@ -95,14 +95,7 @@ class SQSResponse(BaseResponse):
         request_url = urlparse(self.uri)
         queue_name = self._get_param("QueueName")
 
-        tags = {}
-        tags_param = self._get_multi_param("Tag")
-        # Returns [{'Key': 'Foo', 'Value': 'Bar'}]
-        if tags_param:
-            for tag in tags_param:
-                tags[tag["Key"]] = tag["Value"]
-
-        queue = self.sqs_backend.create_queue(queue_name, tags, **self.attribute)
+        queue = self.sqs_backend.create_queue(queue_name, self.tags, **self.attribute)
 
         template = self.response_template(CREATE_QUEUE_RESPONSE)
         return template.render(queue_url=queue.url(request_url))


### PR DESCRIPTION
Relates to https://github.com/localstack/localstack/issues/4343 and https://github.com/localstack/localstack/pull/4365

When tagging an existing SQS queue and one of the values is an empty string, this line breaks the loop because `not(k and v)` does not expect an empty str.

Example:
```
response = self.client.tag_queue(
    QueueUrl=queue_url, Tags={"tag1": "value1", "tag2": "value2", "tag3": ""}
)
```

With this change, it won't break the tag (and hopefully won't break either for the rest of the modules using this, as empty tags are accepted across AWS services AFAIK)