### PR TITLE
S3 - Correct error when creating a bucket that already exists

### DIFF
--- a/moto/s3/exceptions.py
+++ b/moto/s3/exceptions.py
@@ -63,6 +63,8 @@ class BucketAlreadyExists(BucketError):
     code = 409
 
     def __init__(self, *args, **kwargs):
+        kwargs.setdefault("template", "bucket_error")
+        self.templates["bucket_error"] = ERROR_WITH_BUCKET_NAME
         super(BucketAlreadyExists, self).__init__(
             "BucketAlreadyExists",
             (


### PR DESCRIPTION
Fixes #1371

Supercedes #1390

Tests was verified against AWS

Edit:
Originally I wanted to also add the S3 Location header, to more closely resemble AWS' behaviour. This is a bit more complicated though, as Flask will mess with the output. AWS returns `Location: /{bucketname}`, and in it's infinite wisdom, Flask converts this into `Location: http://localhost:5000/{bucketname}`. See https://stackoverflow.com/a/22707491/13245310