### PR TITLE
Performance improvement - Only reset backends loaded into memory

### DIFF
--- a/moto/backends.py
+++ b/moto/backends.py
@@ -2,6 +2,7 @@ from __future__ import unicode_literals
 
 import importlib
 import moto
+import sys
 
 
 decorators = [
@@ -15,8 +16,6 @@ BACKENDS["moto_api"] = ("core", "moto_api_backends")
 BACKENDS["instance_metadata"] = ("instance_metadata", "instance_metadata_backends")
 BACKENDS["s3bucket_path"] = ("s3", "s3_backends")
 
-imported_backends = set()
-
 
 def _import_backend(module_name, backends_name):
     module = importlib.import_module("moto." + module_name)
@@ -29,6 +28,13 @@ def backends():
 
 
 def loaded_backends():
+    loaded_modules = sys.modules.keys()
+    loaded_modules = [m for m in loaded_modules if m.startswith("moto.")]
+    imported_backends = [
+        name
+        for name, (module_name, _) in BACKENDS.items()
+        if f"moto.{module_name}" in loaded_modules
+    ]
     for name in imported_backends:
         module_name, backends_name = BACKENDS[name]
         yield name, _import_backend(module_name, backends_name)
@@ -36,7 +42,6 @@ def loaded_backends():
 
 def get_backend(name):
     module_name, backends_name = BACKENDS[name]
-    imported_backends.add(name)
     return _import_backend(module_name, backends_name)
 
 

--- a/moto/backends.py
+++ b/moto/backends.py
@@ -15,6 +15,8 @@ BACKENDS["moto_api"] = ("core", "moto_api_backends")
 BACKENDS["instance_metadata"] = ("instance_metadata", "instance_metadata_backends")
 BACKENDS["s3bucket_path"] = ("s3", "s3_backends")
 
+imported_backends = set()
+
 
 def _import_backend(module_name, backends_name):
     module = importlib.import_module("moto." + module_name)
@@ -26,13 +28,15 @@ def backends():
         yield _import_backend(module_name, backends_name)
 
 
-def named_backends():
-    for name, (module_name, backends_name) in BACKENDS.items():
+def loaded_backends():
+    for name in imported_backends:
+        module_name, backends_name = BACKENDS[name]
         yield name, _import_backend(module_name, backends_name)
 
 
 def get_backend(name):
     module_name, backends_name = BACKENDS[name]
+    imported_backends.add(name)
     return _import_backend(module_name, backends_name)
 
 

--- a/moto/core/models.py
+++ b/moto/core/models.py
@@ -840,7 +840,7 @@ class MotoAPIBackend(BaseBackend):
     def reset(self):
         import moto.backends as backends
 
-        for name, backends_ in backends.named_backends():
+        for name, backends_ in backends.loaded_backends():
             if name == "moto_api":
                 continue
             for region_name, backend in backends_.items():

--- a/moto/mediapackage/models.py
+++ b/moto/mediapackage/models.py
@@ -74,13 +74,13 @@ class MediaPackageBackend(BaseBackend):
     def __init__(self, region_name=None):
         super(MediaPackageBackend, self).__init__()
         self.region_name = region_name
+        self._channels = OrderedDict()
+        self._origin_endpoints = OrderedDict()
 
     def reset(self):
         region_name = self.region_name
         self.__dict__ = {}
         self.__init__(region_name)
-        self._channels = OrderedDict()
-        self._origin_endpoints = OrderedDict()
 
     def create_channel(self, description, id, tags):
         arn = "arn:aws:mediapackage:channel:{}".format(id)

--- a/moto/server.py
+++ b/moto/server.py
@@ -68,10 +68,13 @@ class DomainDispatcherApplication(object):
             if pattern.match("http://%s" % host):
                 return backend
 
-        print(
-            "Unable to find appropriate URL for {}."
-            "Remember to add the URL to urls.py, and run script/update_backend_index.py to index it."
-        )
+        if "amazonaws.com" in host:
+            print(
+                "Unable to find appropriate backend for {}."
+                "Remember to add the URL to urls.py, and run script/update_backend_index.py to index it.".format(
+                    host
+                )
+            )
 
     def infer_service_region_host(self, environ):
         auth = environ.get("HTTP_AUTHORIZATION")


### PR DESCRIPTION
Follow up to #4209 
Only backends that are loaded into memory will now be reset when calling `/moto-api/reset`, reducing the waiting time drastically.

@whummer @thrau Does LocalStack use the reset-api, and/or you do expect there to be any impact for you?