### PR TITLE
Change message deletion behavior of SQS queue to use discard

### DIFF
--- a/moto/sqs/models.py
+++ b/moto/sqs/models.py
@@ -886,12 +886,11 @@ class SQSBackend(BaseBackend):
         ):
             raise ReceiptHandleIsInvalid()
 
+        # Delete message from queue regardless of pending state
         new_messages = []
         for message in queue._messages:
-            # Only delete message if it is not visible and the receipt_handle
-            # matches.
             if message.receipt_handle == receipt_handle:
-                queue.pending_messages.remove(message)
+                queue.pending_messages.discard(message)
                 continue
             new_messages.append(message)
         queue._messages = new_messages


### PR DESCRIPTION
Using `remove` in this case causes a `KeyError` when deleting messages with changed visibility (because those messages are not present in `pending_messages`). Changing it to `discard` avoids the error.

Also, the comment suggests the message is only removed from `pending_messages` but as messages which have the correct handle are not appended to the new list they will be removed regardless. The behavior is correct though (tested against AWS).

Relates to [issue in localstack](https://github.com/localstack/localstack/issues/4470)