### PR TITLE
Fix error when AWS::ECS::Service does not include a DesiredCount

### DIFF
--- a/moto/ecs/models.py
+++ b/moto/ecs/models.py
@@ -402,7 +402,7 @@ class Service(BaseObject, CloudFormationModel):
             task_definition = properties["TaskDefinition"].family
         else:
             task_definition = properties["TaskDefinition"]
-        desired_count = properties["DesiredCount"]
+        desired_count = properties.get("DesiredCount", None)
         # TODO: LoadBalancers
         # TODO: Role
 
@@ -424,7 +424,7 @@ class Service(BaseObject, CloudFormationModel):
             task_definition = properties["TaskDefinition"].family
         else:
             task_definition = properties["TaskDefinition"]
-        desired_count = properties["DesiredCount"]
+        desired_count = properties.get("DesiredCount", None)
 
         ecs_backend = ecs_backends[region_name]
         service_name = original_resource.name


### PR DESCRIPTION
I recently added Moto to a project, and got an error related to the DesiredCount on my Ecs Servie declaration in the CloudFormation template. According to [the AWS documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ecs-service.html#cfn-ecs-service-desiredcount), DesiredCount is not required in some circumstances.