### PR TITLE
Implement ACM export_certificate function

### DIFF
--- a/moto/acm/responses.py
+++ b/moto/acm/responses.py
@@ -264,3 +264,32 @@ class AWSCertificateManagerResponse(BaseResponse):
             return err.response()
 
         return ""
+
+    def export_certificate(self):
+        certificate_arn = self._get_param("CertificateArn")
+        passphrase = self._get_param("Passphrase")
+
+        if certificate_arn is None:
+            msg = "A required parameter for the specified action is not supplied."
+            return (
+                json.dumps({"__type": "MissingParameter", "message": msg}),
+                dict(status=400),
+            )
+
+        try:
+            (
+                certificate,
+                certificate_chain,
+                private_key,
+            ) = self.acm_backend.export_certificate(
+                certificate_arn=certificate_arn, passphrase=passphrase,
+            )
+            return json.dumps(
+                dict(
+                    Certificate=certificate,
+                    CertificateChain=certificate_chain,
+                    PrivateKey=private_key,
+                )
+            )
+        except AWSError as err:
+            return err.response()

--- a/tests/test_acm/test_acm.py
+++ b/tests/test_acm/test_acm.py
@@ -171,12 +171,10 @@ def test_describe_certificate():
 def test_describe_certificate_with_bad_arn():
     client = boto3.client("acm", region_name="eu-central-1")
 
-    try:
+    with pytest.raises(ClientError) as err:
         client.describe_certificate(CertificateArn=BAD_ARN)
-    except ClientError as err:
-        err.response["Error"]["Code"].should.equal("ResourceNotFoundException")
-    else:
-        raise RuntimeError("Should of raised ResourceNotFoundException")
+
+    err.value.response["Error"]["Code"].should.equal("ResourceNotFoundException")
 
 
 @mock_acm
@@ -204,12 +202,11 @@ def test_export_certificate():
 @mock_acm
 def test_export_certificate_with_bad_arn():
     client = boto3.client("acm", region_name="eu-central-1")
-    try:
+
+    with pytest.raises(ClientError) as err:
         client.export_certificate(CertificateArn=BAD_ARN, Passphrase="pass")
-    except ClientError as err:
-        err.response["Error"]["Code"].should.equal("ResourceNotFoundException")
-    else:
-        raise RuntimeError("Should of raised ResourceNotFoundException")
+
+    err.value.response["Error"]["Code"].should.equal("ResourceNotFoundException")
 
 
 # Also tests ListTagsForCertificate

--- a/tests/test_acm/test_acm.py
+++ b/tests/test_acm/test_acm.py
@@ -1,4 +1,5 @@
 from __future__ import unicode_literals
+from moto.acm.models import AWS_ROOT_CA
 
 import os
 import uuid
@@ -7,6 +8,8 @@ import boto3
 import pytest
 import sure  # noqa
 from botocore.exceptions import ClientError
+from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.primitives import serialization, hashes
 from freezegun import freeze_time
 from moto import mock_acm, settings
 from moto.core import ACCOUNT_ID
@@ -170,6 +173,39 @@ def test_describe_certificate_with_bad_arn():
 
     try:
         client.describe_certificate(CertificateArn=BAD_ARN)
+    except ClientError as err:
+        err.response["Error"]["Code"].should.equal("ResourceNotFoundException")
+    else:
+        raise RuntimeError("Should of raised ResourceNotFoundException")
+
+
+@mock_acm
+def test_export_certificate():
+    client = boto3.client("acm", region_name="eu-central-1")
+    arn = _import_cert(client)
+
+    resp = client.export_certificate(CertificateArn=arn, Passphrase="pass")
+    resp["Certificate"].should.equal(SERVER_CRT.decode())
+    resp["CertificateChain"].should.equal(CA_CRT.decode() + "\n" + AWS_ROOT_CA.decode())
+    resp.should.have.key("PrivateKey")
+
+    key = serialization.load_pem_private_key(
+        bytes(resp["PrivateKey"], "utf-8"), password=b"pass", backend=default_backend()
+    )
+
+    private_key = key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.TraditionalOpenSSL,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+    private_key.should.equal(SERVER_KEY)
+
+
+@mock_acm
+def test_export_certificate_with_bad_arn():
+    client = boto3.client("acm", region_name="eu-central-1")
+    try:
+        client.export_certificate(CertificateArn=BAD_ARN, Passphrase="pass")
     except ClientError as err:
         err.response["Error"]["Code"].should.equal("ResourceNotFoundException")
     else:


### PR DESCRIPTION
This is an implementation of the [ACM ExportCertificate action](https://docs.aws.amazon.com/acm/latest/APIReference/API_ExportCertificate.html). I changed the google root ca to the aws root ca [found here](https://censys.io/authorities/7a3a96e64a895c66676cc71400ed0e3ce9718be9ec5d46edb4f4a52d96a4414d) because it looks like that is the cert that matches the issuer in the `generate_cert()` method.