### PR TITLE
Fix CloudFormation create_stack returning stack_id with wrong region 

### DIFF
--- a/moto/cloudformation/models.py
+++ b/moto/cloudformation/models.py
@@ -623,7 +623,7 @@ class CloudFormationBackend(BaseBackend):
         tags=None,
         role_arn=None,
     ):
-        stack_id = generate_stack_id(name)
+        stack_id = generate_stack_id(name, region_name)
         new_stack = FakeStack(
             stack_id=stack_id,
             name=name,

--- a/tests/test_cloudformation/test_cloudformation_stack_crud.py
+++ b/tests/test_cloudformation/test_cloudformation_stack_crud.py
@@ -85,6 +85,29 @@ def test_create_stack():
     conn.create_stack("test_stack", template_body=dummy_template_json)
 
     stack = conn.describe_stacks()[0]
+    stack.stack_id.should.contain("arn:aws:cloudformation:us-east-1:123456789:stack/test_stack/")
+    stack.stack_name.should.equal("test_stack")
+    stack.get_template().should.equal(
+        {
+            "GetTemplateResponse": {
+                "GetTemplateResult": {
+                    "TemplateBody": dummy_template_json,
+                    "ResponseMetadata": {
+                        "RequestId": "2d06e36c-ac1d-11e0-a958-f9382b6eb86bEXAMPLE"
+                    },
+                }
+            }
+        }
+    )
+
+
+@mock_cloudformation_deprecated
+def test_create_stack_with_other_region():
+    conn = boto.cloudformation.connect_to_region("us-west-2")
+    conn.create_stack("test_stack", template_body=dummy_template_json)
+
+    stack = conn.describe_stacks()[0]
+    stack.stack_id.should.contain("arn:aws:cloudformation:us-west-2:123456789:stack/test_stack/")
     stack.stack_name.should.equal("test_stack")
     stack.get_template().should.equal(
         {

--- a/tests/test_cloudformation/test_cloudformation_stack_crud.py
+++ b/tests/test_cloudformation/test_cloudformation_stack_crud.py
@@ -85,7 +85,9 @@ def test_create_stack():
     conn.create_stack("test_stack", template_body=dummy_template_json)
 
     stack = conn.describe_stacks()[0]
-    stack.stack_id.should.contain("arn:aws:cloudformation:us-east-1:123456789:stack/test_stack/")
+    stack.stack_id.should.contain(
+        "arn:aws:cloudformation:us-east-1:123456789:stack/test_stack/"
+    )
     stack.stack_name.should.equal("test_stack")
     stack.get_template().should.equal(
         {
@@ -107,7 +109,9 @@ def test_create_stack_with_other_region():
     conn.create_stack("test_stack", template_body=dummy_template_json)
 
     stack = conn.describe_stacks()[0]
-    stack.stack_id.should.contain("arn:aws:cloudformation:us-west-2:123456789:stack/test_stack/")
+    stack.stack_id.should.contain(
+        "arn:aws:cloudformation:us-west-2:123456789:stack/test_stack/"
+    )
     stack.stack_name.should.equal("test_stack")
     stack.get_template().should.equal(
         {

--- a/tests/test_cloudformation/test_cloudformation_stack_crud_boto3.py
+++ b/tests/test_cloudformation/test_cloudformation_stack_crud_boto3.py
@@ -907,6 +907,9 @@ def test_creating_stacks_across_regions():
     list(west1_cf.stacks.all()).should.have.length_of(1)
     list(west2_cf.stacks.all()).should.have.length_of(1)
 
+    list(west1_cf.stacks.all())[0].stack_id.should.contain("arn:aws:cloudformation:us-west-1:123456789:stack/test_stack/")
+    list(west2_cf.stacks.all())[0].stack_id.should.contain("arn:aws:cloudformation:us-west-2:123456789:stack/test_stack/")
+
 
 @mock_cloudformation
 @mock_sns

--- a/tests/test_cloudformation/test_cloudformation_stack_crud_boto3.py
+++ b/tests/test_cloudformation/test_cloudformation_stack_crud_boto3.py
@@ -907,8 +907,12 @@ def test_creating_stacks_across_regions():
     list(west1_cf.stacks.all()).should.have.length_of(1)
     list(west2_cf.stacks.all()).should.have.length_of(1)
 
-    list(west1_cf.stacks.all())[0].stack_id.should.contain("arn:aws:cloudformation:us-west-1:123456789:stack/test_stack/")
-    list(west2_cf.stacks.all())[0].stack_id.should.contain("arn:aws:cloudformation:us-west-2:123456789:stack/test_stack/")
+    list(west1_cf.stacks.all())[0].stack_id.should.contain(
+        "arn:aws:cloudformation:us-west-1:123456789:stack/test_stack/"
+    )
+    list(west2_cf.stacks.all())[0].stack_id.should.contain(
+        "arn:aws:cloudformation:us-west-2:123456789:stack/test_stack/"
+    )
 
 
 @mock_cloudformation


### PR DESCRIPTION
Calling CloudFormation's CreateStack action seems to always return a StackId with 'us-east-1' in it.