### PR TITLE
Update README.md - clean up list of supported services

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,62 +70,58 @@ def test_my_model_save():
 
 With the decorator wrapping the test, all the calls to s3 are automatically mocked out. The mock keeps the state of the buckets and keys.
 
-It gets even better! Moto isn't just for Python code and it isn't just for S3. Look at the [standalone server mode](https://github.com/spulec/moto#stand-alone-server-mode) for more information about running Moto with other languages. Here's the status of the other AWS services implemented:
+It gets even better! Moto isn't just for Python code and it isn't just for S3. Look at the [standalone server mode](https://github.com/spulec/moto#stand-alone-server-mode) for more information about running Moto with other languages.  
+Here's the partial list of the AWS services that currently have support:
 
-| Service Name              | Decorator             | Development Status              | Comment                     |
-|---------------------------|-----------------------|---------------------------------|-----------------------------|
-| ACM                       | @mock_acm             | all endpoints done              |                             |
-| API Gateway               | @mock_apigateway      | core endpoints done             |                             |
-| Application Autoscaling   | @mock_applicationautoscaling | basic endpoints done     |                             |
-| Athena                    | @mock_athena          | core endpoints done             |                             |
-| Autoscaling               | @mock_autoscaling     | core endpoints done             |                             |
-| Cloudformation            | @mock_cloudformation  | core endpoints done             |                             |
-| Cloudwatch                | @mock_cloudwatch      | basic endpoints done            |                             |
-| CloudwatchEvents          | @mock_events          | all endpoints done              |                             |
-| Cognito Identity          | @mock_cognitoidentity | basic endpoints done            |                             |
-| Cognito Identity Provider | @mock_cognitoidp      | basic endpoints done            |                             |
-| Config                    | @mock_config          | basic + core endpoints done     |                             |
-| Data Pipeline             | @mock_datapipeline    | basic endpoints done            |                             |
-| DynamoDB                  | @mock_dynamodb        | core endpoints done             | API 20111205. Deprecated.   |
-| DynamoDB2                 | @mock_dynamodb2       | core endpoints done             | API 20120810 (Latest)       |
-| EC2                       | @mock_ec2             | core endpoints done             |                             |
-|     - AMI                 |                       | core endpoints done             |                             |
-|     - EBS                 |                       | core endpoints done             |                             |
-|     - Instances           |                       | all  endpoints done             |                             |
-|     - Security Groups     |                       | core endpoints done             |                             |
-|     - Tags                |                       | all  endpoints done             |                             |
-| ECR                       | @mock_ecr             | basic endpoints done            |                             |
-| ECS                       | @mock_ecs             | basic endpoints done            |                             |
-| ELB                       | @mock_elb             | core endpoints done             |                             |
-| ELBv2                     | @mock_elbv2           | all endpoints done              |                             |
-| EMR                       | @mock_emr             | core endpoints done             |                             |
-| Forecast                  | @mock_forecast        | some core endpoints done        |                             |                  
-| Glacier                   | @mock_glacier         | core endpoints done             |                             |
-| Glue                      | @mock_glue            | core endpoints done             |                             |
-| IAM                       | @mock_iam             | core endpoints done             |                             |
-| IoT                       | @mock_iot             | core endpoints done             |                             |
-| IoT data                  | @mock_iotdata         | core endpoints done             |                             |
-| Kinesis                   | @mock_kinesis         | core endpoints done             |                             |
-| KMS                       | @mock_kms             | basic endpoints done            |                             |
-| Lambda                    | @mock_lambda          | basic endpoints done, requires docker |                       |
-| Logs                      | @mock_logs            | basic endpoints done            |                             |
-| Organizations             | @mock_organizations   | some core endpoints done        |                             |
-| Polly                     | @mock_polly           | all endpoints done              |                             |
-| RAM                       | @mock_ram             | core endpoints done             |                             |
-| RDS                       | @mock_rds             | core endpoints done             |                             |
-| RDS2                      | @mock_rds2            | core endpoints done             |                             |
-| Redshift                  | @mock_redshift        | core endpoints done             |                             |
-| Route53                   | @mock_route53         | core endpoints done             |                             |
-| S3                        | @mock_s3              | core endpoints done             |                             |
-| SecretsManager            | @mock_secretsmanager  | basic endpoints done            |                             |
-| SES                       | @mock_ses             | all endpoints done              |                             |
-| SNS                       | @mock_sns             | all endpoints done              |                             |
-| SQS                       | @mock_sqs             | core endpoints done             |                             |
-| SSM                       | @mock_ssm             | core endpoints done             |                             |
-| Step Functions            | @mock_stepfunctions   | core endpoints done             |                             |
-| STS                       | @mock_sts             | core endpoints done             |                             |
-| SWF                       | @mock_swf             | basic endpoints done            |                             |
-| X-Ray                     | @mock_xray            | all endpoints done              |                             |
+| Service Name              | Decorator             | Comment                      |
+|---------------------------|-----------------------|------------------------------|
+| ACM                       | @mock_acm             |                              |
+| API Gateway               | @mock_apigateway      |                              |
+| Application Autoscaling   | @mock_applicationautoscaling |                       |
+| Athena                    | @mock_athena          |                              |
+| Autoscaling               | @mock_autoscaling     |                              |
+| Cloudformation            | @mock_cloudformation  |                              |
+| Cloudwatch                | @mock_cloudwatch      |                              |
+| CloudwatchEvents          | @mock_events          |                              |
+| Cognito Identity          | @mock_cognitoidentity |                              |
+| Cognito Identity Provider | @mock_cognitoidp      |                              |
+| Config                    | @mock_config          |                              |
+| Data Pipeline             | @mock_datapipeline    |                              |
+| DynamoDB                  | @mock_dynamodb        | API 20111205. Deprecated.    |
+| DynamoDB2                 | @mock_dynamodb2       | API 20120810 (Latest)        |
+| EC2                       | @mock_ec2             |                              |
+| ECR                       | @mock_ecr             |                              |
+| ECS                       | @mock_ecs             |                              |
+| ELB                       | @mock_elb             |                              |
+| ELBv2                     | @mock_elbv2           |                              |
+| EMR                       | @mock_emr             |                              |
+| Forecast                  | @mock_forecast        |                              |                  
+| Glacier                   | @mock_glacier         |                              |
+| Glue                      | @mock_glue            |                              |
+| IAM                       | @mock_iam             |                              |
+| IoT                       | @mock_iot             |                              |
+| IoT data                  | @mock_iotdata         |                              |
+| Kinesis                   | @mock_kinesis         |                              |
+| KMS                       | @mock_kms             |                              |
+| Lambda                    | @mock_lambda          | Invoking Lambdas requires docker |
+| Logs                      | @mock_logs            |                              |
+| Organizations             | @mock_organizations   |                              |
+| Polly                     | @mock_polly           |                              |
+| RAM                       | @mock_ram             |                              |
+| RDS                       | @mock_rds             |                              |
+| RDS2                      | @mock_rds2            |                              |
+| Redshift                  | @mock_redshift        |                              |
+| Route53                   | @mock_route53         |                              |
+| S3                        | @mock_s3              |                              |
+| SecretsManager            | @mock_secretsmanager  |                              |
+| SES                       | @mock_ses             |                              |
+| SNS                       | @mock_sns             |                              |
+| SQS                       | @mock_sqs             |                              |
+| SSM                       | @mock_ssm             |                              |
+| Step Functions            | @mock_stepfunctions   |                              |
+| STS                       | @mock_sts             |                              |
+| SWF                       | @mock_swf             |                              |
+| X-Ray                     | @mock_xray            |                              |
 
 For a full list of endpoint [implementation coverage](https://github.com/spulec/moto/blob/master/IMPLEMENTATION_COVERAGE.md)
 


### PR DESCRIPTION
The list of supported services is getting unwieldy, and is constantly out of date.
The development status is constantly out of date as well, either because we gain more support, or because AWS releases new methods, reducing our support.

This PR proposes an improvement to at least make the list consistent.

The ideal scenario, IMO, is to consolidate everything in IMPLEMENTATION_COVERAGE.md, and in the Readme we simply say: Please check this file for the latest support.

At the same time:
The IMPLEMENTATION_COVERAGE is quite large as well, so this also needs some maintenance.

Possible improvements:

 - Only show services that we support
 - Keep a separate list at the bottom for services that have no support at all. (We don't have to list the individual methods here, if none of them are supported anyway)
 - Some sort of index at the top - maybe just the alphabet, so users can immediately jump to the services that start with 'S' for example