### PR TITLE
Fix: Adding ClientRequestToken for SecretsManager update_secret method

### DIFF
--- a/moto/secretsmanager/models.py
+++ b/moto/secretsmanager/models.py
@@ -19,7 +19,7 @@ from .exceptions import (
     InvalidRequestException,
     ClientError,
 )
-from .utils import random_password, secret_arn, get_secret_name_from_arn
+from .utils import random_password, secret_arn, get_secret_name_from_arn, client_request_token_validator
 from .list_secrets.filters import all, tag_key, tag_value, description, name
 
 
@@ -266,12 +266,6 @@ class SecretsManagerBackend(BaseBackend):
                 "You can't perform this operation on the secret because it was marked for deletion."
             )
 
-        if client_request_token:
-            token_length = len(client_request_token)
-            if token_length < 32 or token_length > 64:
-                msg = "ClientRequestToken " "must be 32-64 characters long."
-                raise InvalidParameterException(msg)
-
         secret = self.secrets[secret_id]
         tags = secret.tags
         description = secret.description
@@ -330,7 +324,9 @@ class SecretsManagerBackend(BaseBackend):
         if version_stages is None:
             version_stages = ["AWSCURRENT"]
 
-        if not version_id:
+        if version_id:
+            utils.client_request_token_validator(version_id)
+        else:
             version_id = str(uuid.uuid4())
 
         secret_version = {
@@ -424,12 +420,6 @@ class SecretsManagerBackend(BaseBackend):
                 perform the operation on a secret that's currently marked deleted."
             )
 
-        if client_request_token:
-            token_length = len(client_request_token)
-            if token_length < 32 or token_length > 64:
-                msg = "ClientRequestToken " "must be 32-64 characters long."
-                raise InvalidParameterException(msg)
-
         if rotation_lambda_arn:
             if len(rotation_lambda_arn) > 2048:
                 msg = "RotationLambdaARN " "must <= 2048 characters long."
@@ -471,7 +461,12 @@ class SecretsManagerBackend(BaseBackend):
             pass
 
         old_secret_version = secret.versions[secret.default_version_id]
-        new_version_id = client_request_token or str(uuid.uuid4())
+
+        if client_request_token:
+            utils.client_request_token_validator(client_request_token)
+            new_version_id = client_request_token
+        else:
+            new_version_id = str(uuid.uuid4())
 
         # We add the new secret version as "pending". The previous version remains
         # as "current" for now. Once we've passed the new secret through the lambda

--- a/moto/secretsmanager/models.py
+++ b/moto/secretsmanager/models.py
@@ -192,7 +192,7 @@ class SecretsManagerBackend(BaseBackend):
     def _client_request_token_validator(client_request_token):
         token_length = len(client_request_token)
         if token_length < 32 or token_length > 64:
-            msg = "ClientRequestToken " "must be 32-64 characters long."
+            msg = "ClientRequestToken must be 32-64 characters long."
             raise InvalidParameterException(msg)
 
     def get_secret_value(self, secret_id, version_id, version_stage):

--- a/moto/secretsmanager/models.py
+++ b/moto/secretsmanager/models.py
@@ -251,6 +251,7 @@ class SecretsManagerBackend(BaseBackend):
         secret_id,
         secret_string=None,
         secret_binary=None,
+        client_request_token=None,
         kms_key_id=None,
         **kwargs
     ):
@@ -265,6 +266,12 @@ class SecretsManagerBackend(BaseBackend):
                 "You can't perform this operation on the secret because it was marked for deletion."
             )
 
+        if client_request_token:
+            token_length = len(client_request_token)
+            if token_length < 32 or token_length > 64:
+                msg = "ClientRequestToken " "must be 32-64 characters long."
+                raise InvalidParameterException(msg)
+
         secret = self.secrets[secret_id]
         tags = secret.tags
         description = secret.description
@@ -274,6 +281,7 @@ class SecretsManagerBackend(BaseBackend):
             secret_string=secret_string,
             secret_binary=secret_binary,
             description=description,
+            version_id=client_request_token,
             tags=tags,
             kms_key_id=kms_key_id,
         )

--- a/moto/secretsmanager/responses.py
+++ b/moto/secretsmanager/responses.py
@@ -60,11 +60,13 @@ class SecretsManagerResponse(BaseResponse):
         secret_id = self._get_param("SecretId")
         secret_string = self._get_param("SecretString")
         secret_binary = self._get_param("SecretBinary")
+        client_request_token = self._get_param("ClientRequestToken")
         kms_key_id = self._get_param("KmsKeyId", if_none=None)
         return secretsmanager_backends[self.region].update_secret(
             secret_id=secret_id,
             secret_string=secret_string,
             secret_binary=secret_binary,
+            client_request_token=client_request_token,
             kms_key_id=kms_key_id,
         )
 

--- a/moto/secretsmanager/utils.py
+++ b/moto/secretsmanager/utils.py
@@ -72,6 +72,13 @@ def secret_arn(region, secret_id):
     )
 
 
+def client_request_token_validator(client_request_token):
+    token_length = len(client_request_token)
+    if token_length < 32 or token_length > 64:
+        msg = "ClientRequestToken " "must be 32-64 characters long."
+        raise InvalidParameterException(msg)
+
+
 def get_secret_name_from_arn(secret_id):
     # can fetch by both arn and by name
     # but we are storing via name

--- a/moto/secretsmanager/utils.py
+++ b/moto/secretsmanager/utils.py
@@ -72,13 +72,6 @@ def secret_arn(region, secret_id):
     )
 
 
-def client_request_token_validator(client_request_token):
-    token_length = len(client_request_token)
-    if token_length < 32 or token_length > 64:
-        msg = "ClientRequestToken " "must be 32-64 characters long."
-        raise InvalidParameterException(msg)
-
-
 def get_secret_name_from_arn(secret_id):
     # can fetch by both arn and by name
     # but we are storing via name

--- a/tests/test_secretsmanager/test_secretsmanager.py
+++ b/tests/test_secretsmanager/test_secretsmanager.py
@@ -1205,13 +1205,13 @@ def test_update_secret_with_client_request_token():
     )
     assert client_request_token != updated_secret["VersionId"]
     invalid_request_token = "test-token"
-    with pytest.raises(ParamValidationError) as ipe:
+    with pytest.raises(ParamValidationError) as pve:
         client.update_secret(
             SecretId=secret_name,
             SecretString="fourth-secret",
             ClientRequestToken=invalid_request_token,
         )
-        ipe.value.response["Error"]["Code"].should.equal("InvalidParameterException")
-        ipe.value.response["Error"]["Message"].should.equal(
+        pve.value.response["Error"]["Code"].should.equal("InvalidParameterException")
+        pve.value.response["Error"]["Message"].should.equal(
             "ClientRequestToken must be 32-64 characters long."
         )


### PR DESCRIPTION
Fixes https://github.com/localstack/localstack/issues/4618

* Adds ClientRequestToken to the `update_secret` method.
* Improving validation of the param on most of methods using it