### PR TITLE
Add tagging to batch job definitions

### DIFF
--- a/moto/batch/models.py
+++ b/moto/batch/models.py
@@ -217,14 +217,7 @@ class JobDefinition(CloudFormationModel):
         self.tagger.tag_resource(self.arn, tags or [])
 
     def _format_tags(self, tags):
-        formatted_tags = []
-        for item in tags.items():
-            tag = {}
-            tag["Key"] = item[0]
-            tag["Value"] = item[1]
-            print(tag)
-            formatted_tags.append(tag)
-        return formatted_tags
+        return [{"Key": k, "Value": v} for k, v in tags.items()]
 
     def _update_arn(self):
         self.revision += 1

--- a/moto/batch/models.py
+++ b/moto/batch/models.py
@@ -16,7 +16,7 @@ from moto.ec2 import ec2_backends
 from moto.ecs import ecs_backends
 from moto.logs import logs_backends
 
-from .exceptions import InvalidParameterValueException, ClientException
+from .exceptions import InvalidParameterValueException, ClientException, ValidationError
 from .utils import (
     make_arn_for_compute_env,
     make_arn_for_job_queue,
@@ -28,6 +28,7 @@ from moto.ec2.models import INSTANCE_TYPES as EC2_INSTANCE_TYPES
 from moto.iam.exceptions import IAMNotFoundException
 from moto.core import ACCOUNT_ID as DEFAULT_ACCOUNT_ID
 from moto.utilities.docker_utilities import DockerModel, parse_image_ref
+from ..utilities.tagging_service import TaggingService
 
 logger = logging.getLogger(__name__)
 COMPUTE_ENVIRONMENT_NAME_REGEX = re.compile(
@@ -187,6 +188,7 @@ class JobDefinition(CloudFormationModel):
         _type,
         container_properties,
         region_name,
+        tags,
         revision=0,
         retry_strategy=0,
     ):
@@ -198,13 +200,31 @@ class JobDefinition(CloudFormationModel):
         self.container_properties = container_properties
         self.arn = None
         self.status = "ACTIVE"
-
+        self.tagger = TaggingService()
         if parameters is None:
             parameters = {}
         self.parameters = parameters
 
         self._validate()
         self._update_arn()
+
+        tags = self._format_tags(tags)
+        # Validate the tags before proceeding.
+        errmsg = self.tagger.validate_tags(tags or [])
+        if errmsg:
+            raise ValidationError(errmsg)
+
+        self.tagger.tag_resource(self.arn, tags or [])
+
+    def _format_tags(self, tags):
+        formatted_tags = []
+        for item in tags.items():
+            tag = {}
+            tag["Key"] = item[0]
+            tag["Value"] = item[1]
+            print(tag)
+            formatted_tags.append(tag)
+        return formatted_tags
 
     def _update_arn(self):
         self.revision += 1
@@ -267,6 +287,7 @@ class JobDefinition(CloudFormationModel):
             "revision": self.revision,
             "status": self.status,
             "type": self.type,
+            "tags": self.tagger.get_tag_dict_for_resource(self.arn),
         }
         if self.container_properties is not None:
             result["containerProperties"] = self.container_properties
@@ -294,15 +315,14 @@ class JobDefinition(CloudFormationModel):
     ):
         backend = batch_backends[region_name]
         properties = cloudformation_json["Properties"]
-
         res = backend.register_job_definition(
             def_name=resource_name,
             parameters=lowercase_first_key(properties.get("Parameters", {})),
             _type="container",
+            tags=lowercase_first_key(properties.get("Tags", {})),
             retry_strategy=lowercase_first_key(properties["RetryStrategy"]),
             container_properties=lowercase_first_key(properties["ContainerProperties"]),
         )
-
         arn = res[1]
 
         return backend.get_job_definition_by_arn(arn)
@@ -1209,7 +1229,7 @@ class BatchBackend(BaseBackend):
             del self._job_queues[job_queue.arn]
 
     def register_job_definition(
-        self, def_name, parameters, _type, retry_strategy, container_properties
+        self, def_name, parameters, _type, tags, retry_strategy, container_properties
     ):
         if def_name is None:
             raise ClientException("jobDefinitionName must be provided")
@@ -1220,13 +1240,13 @@ class BatchBackend(BaseBackend):
                 retry_strategy = retry_strategy["attempts"]
             except Exception:
                 raise ClientException("retryStrategy is malformed")
-
         if job_def is None:
             job_def = JobDefinition(
                 def_name,
                 parameters,
                 _type,
                 container_properties,
+                tags=tags,
                 region_name=self.region_name,
                 retry_strategy=retry_strategy,
             )

--- a/moto/batch/models.py
+++ b/moto/batch/models.py
@@ -188,7 +188,7 @@ class JobDefinition(CloudFormationModel):
         _type,
         container_properties,
         region_name,
-        tags,
+        tags={},
         revision=0,
         retry_strategy=0,
     ):
@@ -1241,6 +1241,8 @@ class BatchBackend(BaseBackend):
             except Exception:
                 raise ClientException("retryStrategy is malformed")
         if job_def is None:
+            if not tags:
+                tags = {}
             job_def = JobDefinition(
                 def_name,
                 parameters,
@@ -1295,6 +1297,8 @@ class BatchBackend(BaseBackend):
         # Got all the job defs were after, filter then by status
         if status is not None:
             return [job for job in jobs if job.status == status]
+        for job in jobs:
+            job.describe()
         return jobs
 
     def submit_job(

--- a/moto/batch/responses.py
+++ b/moto/batch/responses.py
@@ -177,14 +177,15 @@ class BatchResponse(BaseResponse):
         container_properties = self._get_param("containerProperties")
         def_name = self._get_param("jobDefinitionName")
         parameters = self._get_param("parameters")
+        tags = self._get_param("tags")
         retry_strategy = self._get_param("retryStrategy")
         _type = self._get_param("type")
-
         try:
             name, arn, revision = self.batch_backend.register_job_definition(
                 def_name=def_name,
                 parameters=parameters,
                 _type=_type,
+                tags=tags,
                 retry_strategy=retry_strategy,
                 container_properties=container_properties,
             )

--- a/tests/test_batch/test_batch_task_definition.py
+++ b/tests/test_batch/test_batch_task_definition.py
@@ -118,6 +118,7 @@ def test_describe_task_definition():
 
     resp = batch_client.describe_job_definitions(jobDefinitions=["sleep10", "test1"])
     len(resp["jobDefinitions"]).should.equal(3)
+    resp["jobDefinitions"][0]["tags"].should.equal({})
 
     resp = batch_client.describe_job_definitions(jobDefinitionName="tagged_def")
     resp["jobDefinitions"][0]["tags"].should.equal(

--- a/tests/test_batch/test_batch_task_definition.py
+++ b/tests/test_batch/test_batch_task_definition.py
@@ -27,6 +27,25 @@ def test_register_task_definition():
 @mock_ecs
 @mock_iam
 @mock_batch
+def test_register_task_definition_with_tags():
+    ec2_client, iam_client, ecs_client, logs_client, batch_client = _get_clients()
+    _setup(ec2_client, iam_client)
+
+    resp = register_job_def_with_tags(batch_client)
+
+    resp.should.contain("jobDefinitionArn")
+    resp.should.contain("jobDefinitionName")
+    resp.should.contain("revision")
+
+    assert resp["jobDefinitionArn"].endswith(
+        "{0}:{1}".format(resp["jobDefinitionName"], resp["revision"])
+    )
+
+
+@mock_ec2
+@mock_ecs
+@mock_iam
+@mock_batch
 def test_reregister_task_definition():
     # Reregistering task with the same name bumps the revision number
     ec2_client, iam_client, ecs_client, logs_client, batch_client = _get_clients()
@@ -89,15 +108,21 @@ def test_describe_task_definition():
     register_job_def(batch_client, definition_name="sleep10")
     register_job_def(batch_client, definition_name="sleep10")
     register_job_def(batch_client, definition_name="test1")
+    register_job_def_with_tags(batch_client, definition_name="tagged_def")
 
     resp = batch_client.describe_job_definitions(jobDefinitionName="sleep10")
     len(resp["jobDefinitions"]).should.equal(2)
 
     resp = batch_client.describe_job_definitions()
-    len(resp["jobDefinitions"]).should.equal(3)
+    len(resp["jobDefinitions"]).should.equal(4)
 
     resp = batch_client.describe_job_definitions(jobDefinitions=["sleep10", "test1"])
     len(resp["jobDefinitions"]).should.equal(3)
+
+    resp = batch_client.describe_job_definitions(jobDefinitionName="tagged_def")
+    resp["jobDefinitions"][0]["tags"].should.equal(
+        {"foo": "123", "bar": "456",}
+    )
 
     for job_definition in resp["jobDefinitions"]:
         job_definition["status"].should.equal("ACTIVE")
@@ -113,4 +138,18 @@ def register_job_def(batch_client, definition_name="sleep10"):
             "memory": random.randint(4, 128),
             "command": ["sleep", "10"],
         },
+    )
+
+
+def register_job_def_with_tags(batch_client, definition_name="sleep10"):
+    return batch_client.register_job_definition(
+        jobDefinitionName=definition_name,
+        type="container",
+        containerProperties={
+            "image": "busybox",
+            "vcpus": 1,
+            "memory": random.randint(4, 128),
+            "command": ["sleep", "10"],
+        },
+        tags={"foo": "123", "bar": "456",},
     )


### PR DESCRIPTION
resolves spulec/moto#4284

I have updated batch job definition creation, such that tags will be associated with the definition.
Following [boto3](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/batch.html#Batch.Client.describe_job_definitions), the tags are submitted with the job def as a dict: 
```
tags={
        'string': 'string'
    },
```
The tagging object is used to store the values, but when a batch job definition is retrieved, it will have the tags returned in a dict: 
```
'tags': {
                'string': 'string'
            },
```
If there are no tags, an empty dictionary will be returned:
```
'tags': {},
```
I have submitted at this point to check I am doing something along the lines you would find acceptable and any necessary feedback would be appreciated.

Currently this affects `register_job_definition()` and `describe_job_definitions()` as, admittedly, this solves the issue I need solving, however if there are other endpoints you feel are essential to change or add around tagging job definitions before this can be accepted, then let me know.