### PR TITLE
APIGateway - delete_method()

### DIFF
--- a/moto/apigateway/exceptions.py
+++ b/moto/apigateway/exceptions.py
@@ -215,5 +215,5 @@ class MethodNotFoundException(NotFoundException):
 
     def __init__(self):
         super(MethodNotFoundException, self).__init__(
-            "NotFoundException", "Invalid method properties specified"
+            "NotFoundException", "Invalid Method identifier specified"
         )

--- a/moto/apigateway/models.py
+++ b/moto/apigateway/models.py
@@ -343,6 +343,9 @@ class Resource(CloudFormationModel):
             raise MethodNotFoundException()
         return method
 
+    def delete_method(self, method_type):
+        self.resource_methods.pop(method_type)
+
     def add_integration(
         self,
         method_type,
@@ -1117,6 +1120,10 @@ class APIGatewayBackend(BaseBackend):
         resource = self.get_resource(function_id, resource_id)
         method = resource.get_method(method_type)
         return method.apply_operations(patch_operations)
+
+    def delete_method(self, function_id, resource_id, method_type):
+        resource = self.get_resource(function_id, resource_id)
+        resource.delete_method(method_type)
 
     def get_authorizer(self, restapi_id, authorizer_id):
         api = self.get_rest_api(restapi_id)

--- a/moto/apigateway/responses.py
+++ b/moto/apigateway/responses.py
@@ -180,8 +180,11 @@ class APIGatewayResponse(BaseResponse):
         method_type = url_path_parts[6]
 
         if self.method == "GET":
-            method = self.backend.get_method(function_id, resource_id, method_type)
-            return 200, {}, json.dumps(method)
+            try:
+                method = self.backend.get_method(function_id, resource_id, method_type)
+                return 200, {}, json.dumps(method)
+            except NotFoundException as nfe:
+                return self.error("NotFoundException", nfe.message)
         elif self.method == "PUT":
             authorization_type = self._get_param("authorizationType")
             api_key_required = self._get_param("apiKeyRequired")


### PR DESCRIPTION
The APIGatewayResponse-class already had an if/else clause to deal with a delete request, but it pointed to a `delete_method()` in APIGatewayBackend that didn't exist.
This PR adds the missing method.

It also adds appropriate validation when calling `get_method` on a non-existent HTTP method, with the error message validated against what AWS returns.

Supercedes #2832