### PR TITLE
EC2 - instance lifecycle defaults to None when not using spot

### DIFF
--- a/moto/ec2/models.py
+++ b/moto/ec2/models.py
@@ -566,7 +566,7 @@ class Instance(TaggedEC2Resource, BotoInstance, CloudFormationModel):
         super(Instance, self).__init__()
         self.ec2_backend = ec2_backend
         self.id = random_instance_id()
-        self.lifecycle = kwargs.get("lifecycle", "")
+        self.lifecycle = kwargs.get("lifecycle")
         self.image_id = image_id
         self._state = InstanceState("running", 16)
         self._reason = ""

--- a/moto/ec2/responses/instances.py
+++ b/moto/ec2/responses/instances.py
@@ -386,7 +386,9 @@ EC2_RUN_INSTANCES = (
           <amiLaunchIndex>{{ instance.ami_launch_index }}</amiLaunchIndex>
           <instanceType>{{ instance.instance_type }}</instanceType>
           <launchTime>{{ instance.launch_time }}</launchTime>
+          {% if instance.lifecycle %}
           <instanceLifecycle>{{ instance.lifecycle }}</instanceLifecycle>
+          {% endif %}
           <placement>
             <availabilityZone>{{ instance.placement}}</availabilityZone>
             <groupName/>
@@ -538,7 +540,9 @@ EC2_DESCRIBE_INSTANCES = (
                     <productCodes/>
                     <instanceType>{{ instance.instance_type }}</instanceType>
                     <launchTime>{{ instance.launch_time }}</launchTime>
+                    {% if instance.lifecycle %}
                     <instanceLifecycle>{{ instance.lifecycle }}</instanceLifecycle>
+                    {% endif %}
                     <placement>
                       <availabilityZone>{{ instance.placement }}</availabilityZone>
                       <groupName/>

--- a/tests/test_ec2/test_instances.py
+++ b/tests/test_ec2/test_instances.py
@@ -1786,3 +1786,23 @@ def test_instance_termination_protection():
     instances.should.have.length_of(1)
     instance = instances[0]
     instance["State"]["Name"].should.equal("terminated")
+
+
+@mock_ec2
+def test_instance_lifecycle():
+    ec2_resource = boto3.resource("ec2", "us-west-1")
+
+    result = ec2_resource.create_instances(
+        ImageId=EXAMPLE_AMI_ID,
+        MinCount=1,
+        MaxCount=1,
+        BlockDeviceMappings=[
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {"VolumeSize": 50, "DeleteOnTermination": True},
+            }
+        ],
+    )
+    instance = result[0]
+
+    assert instance.instance_lifecycle is None

--- a/tests/test_ec2/test_spot_instances.py
+++ b/tests/test_ec2/test_spot_instances.py
@@ -312,7 +312,7 @@ def test_launch_instance_instance_lifecycle():
 
     response = client.describe_instances()
     instance = response["Reservations"][0]["Instances"][0]
-    instance["InstanceLifecycle"].should.equal("")
+    instance.get("InstanceLifecycle").should.equal(None)
 
 
 @mock_ec2


### PR DESCRIPTION
Follow-up from spulec/moto#4260.

Using a real boto3 client:
```
>>> list(boto3.resource("ec2", region_name="us-west-2").instances.all())[0].instance_lifecycle is None
True
```