### PR TITLE
Fix list_job_excecutions_for_thing with status parameter

### DIFF
--- a/moto/iot/models.py
+++ b/moto/iot/models.py
@@ -1338,7 +1338,7 @@ class IoTBackend(BaseBackend):
         if status is not None:
             job_executions = list(
                 filter(
-                    lambda elem: status in elem["status"] and elem["status"] == status,
+                    lambda elem: "status" in elem["jobExecutionSummary"] and elem["jobExecutionSummary"]["status"] == status,
                     job_executions,
                 )
             )

--- a/moto/iot/models.py
+++ b/moto/iot/models.py
@@ -1338,7 +1338,7 @@ class IoTBackend(BaseBackend):
         if status is not None:
             job_executions = list(
                 filter(
-                    lambda elem: "status" in elem["jobExecutionSummary"] and elem["jobExecutionSummary"]["status"] == status,
+                    lambda elem: elem["jobExecutionSummary"].get("status") == status,
                     job_executions,
                 )
             )

--- a/moto/iot/models.py
+++ b/moto/iot/models.py
@@ -1306,7 +1306,7 @@ class IoTBackend(BaseBackend):
         if status is not None:
             job_executions = list(
                 filter(
-                    lambda elem: status in elem["status"] and elem["status"] == status,
+                    lambda elem: elem["jobExecutionSummary"].get("status") == status,
                     job_executions,
                 )
             )

--- a/tests/test_iot/test_iot.py
+++ b/tests/test_iot/test_iot.py
@@ -2054,7 +2054,9 @@ def test_list_job_executions_for_thing():
         job_id
     )
 
-    job_execution = client.list_job_executions_for_thing(thingName=name, status="QUEUED")
+    job_execution = client.list_job_executions_for_thing(
+        thingName=name, status="QUEUED"
+    )
     job_execution.should.have.key("executionSummaries")
     job_execution["executionSummaries"][0].should.have.key("jobId").which.should.equal(
         job_id

--- a/tests/test_iot/test_iot.py
+++ b/tests/test_iot/test_iot.py
@@ -2011,6 +2011,12 @@ def test_list_job_executions_for_job():
         "thingArn"
     ).which.should.equal(thing["thingArn"])
 
+    job_execution = client.list_job_executions_for_job(jobId=job_id, status="QUEUED")
+    job_execution.should.have.key("executionSummaries")
+    job_execution["executionSummaries"][0].should.have.key(
+        "thingArn"
+    ).which.should.equal(thing["thingArn"])
+
 
 @mock_iot
 def test_list_job_executions_for_thing():

--- a/tests/test_iot/test_iot.py
+++ b/tests/test_iot/test_iot.py
@@ -2048,6 +2048,12 @@ def test_list_job_executions_for_thing():
         job_id
     )
 
+    job_execution = client.list_job_executions_for_thing(thingName=name, status="QUEUED")
+    job_execution.should.have.key("executionSummaries")
+    job_execution["executionSummaries"][0].should.have.key("jobId").which.should.equal(
+        job_id
+    )
+
 
 class TestTopicRules:
     name = "my-rule"


### PR DESCRIPTION
If the methods `list_job_executions_for_thing` and `list_job_executions_for_job` are used with an explicit `status` parameter then it will always run into a `KeyError "status"`.

[log.txt](https://github.com/spulec/moto/files/7218426/log.txt)

This PR fixes a bug where wrong fields of job executions are accessed when filtering by status.