### PR TITLE
SES - SendEmail: source attr can contain chevrons

### DIFF
--- a/moto/core/exceptions.py
+++ b/moto/core/exceptions.py
@@ -31,7 +31,7 @@ ERROR_RESPONSE = """<?xml version="1.0" encoding="UTF-8"?>
     <Errors>
       <Error>
         <Code>{{error_type}}</Code>
-        <Message>{{message}}</Message>
+        <Message><![CDATA[{{message}}]]></Message>
         {% block extra %}{% endblock %}
       </Error>
     </Errors>


### PR DESCRIPTION
Fixes #4198 