### PR TITLE
Correct several issues in scripts/scaffold.py

### DIFF
--- a/scripts/scaffold.py
+++ b/scripts/scaffold.py
@@ -11,10 +11,10 @@ protocol is `query`, `json` or `rest-json`.  Even if aws adds new
 services, this script will work as long as the protocol is known.
 
 TODO:
-  - This scripts don't generates functions in `responses.py` for
-  `rest-json`, because I don't know the rule of it. want someone fix this.
-  - In some services's operations, this scripts might crash. Make new
-  issue on github then.
+  - This script doesn't generates functions in `responses.py` for
+    `rest-json`.  Someone will need to add this logic.
+  - In some services's operations, this script might crash. Create an
+    issue on github for the problem.
 """
 import os
 import re
@@ -132,7 +132,7 @@ def append_mock_to_init_py(service):
         get_escaped_service(service),
         get_escaped_service(service),
         get_escaped_service(service),
-        service
+        service,
     )
     lines.insert(last_import_line_index + 1, new_line)
 
@@ -141,30 +141,7 @@ def append_mock_to_init_py(service):
         fhandle.write(body)
 
 
-def append_mock_dict_to_backends_py(service):
-    path = os.path.join(os.path.dirname(__file__), "..", "moto", "backends.py")
-    with open(path) as fhandle:
-        lines = [_.replace("\n", "") for _ in fhandle.readlines()]
-
-    if any(_ for _ in lines if re.match(f'.*"{service}": {service}_backends.*', _)):
-        return
-    filtered_lines = [_ for _ in lines if re.match('.*".*":.*_backends.*', _)]
-    last_elem_line_index = lines.index(filtered_lines[-1])
-
-    new_line = '    "{}": ("{}", "{}_backends"),'.format(
-        service, get_escaped_service(service), get_escaped_service(service)
-    )
-    prev_line = lines[last_elem_line_index]
-    if not prev_line.endswith("{") and not prev_line.endswith(","):
-        lines[last_elem_line_index] += ","
-    lines.insert(last_elem_line_index + 1, new_line)
-
-    body = "\n".join(lines) + "\n"
-    with open(path, "w") as fhandle:
-        fhandle.write(body)
-
-
-def initialize_service(service, operation, api_protocol):
+def initialize_service(service, api_protocol):
     """create lib and test dirs if not exist"""
     lib_dir = get_lib_dir(service)
     test_dir = get_test_dir(service)
@@ -208,9 +185,6 @@ def initialize_service(service, operation, api_protocol):
             else None
         )
         render_template(tmpl_dir, tmpl_filename, tmpl_context, service, alt_filename)
-
-    # append mock to init files
-    append_mock_to_init_py(service)
 
 
 def to_upper_camel_case(string):
@@ -532,8 +506,8 @@ def main():
         )
 
     click.echo(
-        'You will still need to add the mock into "docs/index.rst" and '
-        '"IMPLEMENTATION_COVERAGE.md"'
+        'Remaining setup:  add the mock into "docs/index.rst" and '
+        '"IMPLEMENTATION_COVERAGE.md", and run scripts/update_backend_index.py.'
     )
 
 

--- a/scripts/scaffold.py
+++ b/scripts/scaffold.py
@@ -185,6 +185,8 @@ def initialize_service(service, api_protocol):
             else None
         )
         render_template(tmpl_dir, tmpl_filename, tmpl_context, service, alt_filename)
+    # append mock to initi files
+    append_mock_to_init_py(service)
 
 
 def to_upper_camel_case(string):
@@ -506,8 +508,10 @@ def main():
         )
 
     click.echo(
-        'Remaining setup:  add the mock into "docs/index.rst" and '
-        '"IMPLEMENTATION_COVERAGE.md", and run scripts/update_backend_index.py.'
+        'Remaining setup:\n'
+        '- Add the mock into "docs/index.rst",\n'
+        '- Add the mock into "IMPLEMENTATION_COVERAGE.md",\n'
+        '- Run scripts/update_backend_index.py.'
     )
 
 


### PR DESCRIPTION
This script was not properly updated after the handling of backends was changed.  

My original intention was to remove the function that updated `moto/backends.py` and to add a note to the user to run `scripts/update_backend_index.py`.  However, you can't just remove the logic to update the backends and have the user run `update_backend_index.py` afterwards, because `scaffold.py` needs the backend in place to finish the rest of its work.

I thought I would provided the changes I've made so far, but someone else will need to finish the changes as I need to move onto another project.

```
$ scaffold.py
Select service: ebs
==Current Implementation Status==
[ ] complete_snapshot
[ ] get_snapshot_block
[ ] list_changed_blocks
[ ] list_snapshot_blocks
[ ] put_snapshot_block
[ ] start_snapshot
=================================
Select Operation: get_snapshot_block
	Initializing service	ebs
	creating	moto/ebs
	creating	moto/ebs/responses.py
	creating	moto/ebs/urls.py
	creating	moto/ebs/__init__.py
	creating	moto/ebs/exceptions.py
	creating	moto/ebs/models.py
	creating	tests/test_ebs
	creating	tests/test_ebs/test_server.py
	creating	tests/test_ebs/test_ebs.py
	creating	tests/test_ebs/__init__.py
	inserting code	moto/ebs/responses.py
Traceback (most recent call last):
  File "./scaffold.py", line 515, in <module>
    main()
  File "/home/kbalk/.local/lib/python3.8/site-packages/click/core.py", line 829, in __call__
    return self.main(*args, **kwargs)
  File "/home/kbalk/.local/lib/python3.8/site-packages/click/core.py", line 782, in main
    rv = self.invoke(ctx)
  File "/home/kbalk/.local/lib/python3.8/site-packages/click/core.py", line 1066, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/kbalk/.local/lib/python3.8/site-packages/click/core.py", line 610, in invoke
    return callback(*args, **kwargs)
  File "./scaffold.py", line 500, in main
    insert_codes(service, operation, api_protocol)
  File "./scaffold.py", line 473, in insert_codes
    insert_code_to_class(responses_path, BaseResponse, func_in_responses)
  File "./scaffold.py", line 403, in insert_code_to_class
    mod = importlib.import_module(mod_path)
  File "/home/kbalk/.pyenv/versions/3.8.6/lib/python3.8/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1014, in _gcd_import
  File "<frozen importlib._bootstrap>", line 991, in _find_and_load
  File "<frozen importlib._bootstrap>", line 961, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "<frozen importlib._bootstrap>", line 1014, in _gcd_import
  File "<frozen importlib._bootstrap>", line 991, in _find_and_load
  File "<frozen importlib._bootstrap>", line 973, in _find_and_load_unlocked
ModuleNotFoundError: No module named 'moto.ebs'
```