### PR TITLE
Use proper xml tag for ListUserTagsResult's Tags

### DIFF
--- a/moto/iam/responses.py
+++ b/moto/iam/responses.py
@@ -1866,10 +1866,10 @@ LIST_USER_TAGS_TEMPLATE = """<ListUserTagsResponse>
    <ListUserTagsResult>
       <Tags>
         {% for tag in user_tags %}
-          <item>
+          <member>
             <Key>{{ tag.Key }}</Key>
             <Value>{{ tag.Value }}</Value>
-          </item>
+          </member>
         {% endfor %}
        </Tags>
       <IsTruncated>false</IsTruncated>


### PR DESCRIPTION
boto3 is forgiving on this front but other SDKS are not.  Since moto is
used behind localstack it causes some SDKs (namely Go SDK) to fail to
properly look up tags on localstack.

I made this change on my localstack container and it did indeed fix the Go SDK behavior.

https://docs.aws.amazon.com/IAM/latest/APIReference/API_ListUserTags.html

This should resolve https://github.com/spulec/moto/issues/4341