### PR TITLE
Parallelize tests - Part 1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -143,7 +143,7 @@ jobs:
         pip install "coverage<=4.5.4"
     - name: Test with pytest
       run: |
-        make test-coverage
+        make test-only
     - name: "Upload coverage to Codecov"
       if: ${{ github.repository == 'spulec/moto'}}
       uses: codecov/codecov-action@v1
@@ -192,7 +192,7 @@ jobs:
       env:
         TEST_SERVER_MODE: ${{ true }}
       run: |
-        make test-coverage
+        make test-only
     - name: "Upload coverage to Codecov"
       if: ${{ github.repository == 'spulec/moto'}}
       uses: codecov/codecov-action@v1
@@ -283,11 +283,14 @@ jobs:
     # So we simply split the list of tests, and ask our CI for separate VM's to run them in parallel
     - name: Get list of tests
       run: |
-        split -n l/3 tests/terraform-tests.success.txt tf-split-
+        cd moto-terraform-tests
+        bin/list-tests -i ../tests/terraform-tests.success.txt -e ../tests/terraform-tests.failures.txt > tftestlist.txt
+        split -n l/3 tftestlist.txt tf-split-
+        cd ..
     - name: Run Terraform Tests
       run: |
         cd moto-terraform-tests
-        AWS_DEFAULT_REGION=us-east-1 AWS_ALTERNATE_REGION=eu-west-1 bin/run-tests -t -i ../tf-split-${{ matrix.part }} -e ../tests/terraform-tests.failures.txt
+        AWS_DEFAULT_REGION=us-east-1 AWS_ALTERNATE_REGION=eu-west-1 bin/run-tests -t -i tf-split-${{ matrix.part }} -e ../tests/terraform-tests.failures.txt
         cd ..
     - name: "Create report"
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -199,6 +199,21 @@ jobs:
       with:
         fail_ci_if_error: false
         flags: servertests
+    - name: "Stop MotoServer"
+      if: always()
+      run: |
+        mkdir serverlogs
+        pwd
+        ls -la
+        cp server_output.log serverlogs/server_output.log
+        docker stop motoserver
+    - name: Archive TF logs
+      if: always()
+      uses: actions/upload-artifact@v2
+      with:
+        name: motoserver-${{ matrix.python-version }}
+        path: |
+          serverlogs/*
 
   test_responses:
     name: Test Responses==0.12.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,6 +54,10 @@ TEST_SERVER_MODE=true pytest -sv tests/test_service/..
   import warnings
   warnings.warn("The Filters-parameter is not yet implemented for client.method()")
   ```
+  - To speed up our CI, the ServerMode tests for the `awslambda`, `batch`, `ec2` and `sqs` services will run in parallel.    
+    This means the following:
+      - Make sure you use unique names for functions/queues/etc
+      - Calls to `describe_reservations()`/`list_queues()`/etc might return unexpected results 
 
 
 # Missing features

--- a/moto/core/models.py
+++ b/moto/core/models.py
@@ -481,9 +481,11 @@ MockAWS = BotocoreEventMockAWS
 
 class ServerModeMockAWS(BaseMockAWS):
     def reset(self):
-        import requests
+        call_reset_api = os.environ.get("MOTO_CALL_RESET_API")
+        if not call_reset_api or call_reset_api.lower() != "false":
+            import requests
 
-        requests.post("http://localhost:5000/moto-api/reset")
+            requests.post("http://localhost:5000/moto-api/reset")
 
     def enable_patching(self):
         if self.__class__.nested_count == 1:

--- a/moto/ec2/models.py
+++ b/moto/ec2/models.py
@@ -358,7 +358,9 @@ class NetworkInterface(TaggedEC2Resource, CloudFormationModel):
     def association(self):
         association = {}
         if self.public_ip:
-            eips = self.ec2_backend.address_by_ip([self.public_ip])
+            eips = self.ec2_backend.address_by_ip(
+                [self.public_ip], fail_if_not_found=False
+            )
             eip = eips[0] if len(eips) > 0 else None
             if eip:
                 association["allocationId"] = eip.allocation_id or None
@@ -538,7 +540,7 @@ class NetworkInterfaceBackend(object):
             eni.source_dest_check = source_dest_check
 
     def get_all_network_interfaces(self, eni_ids=None, filters=None):
-        enis = self.enis.values()
+        enis = self.enis.copy().values()
 
         if eni_ids:
             enis = [eni for eni in enis if eni.id in eni_ids]
@@ -1234,7 +1236,7 @@ class InstanceBackend(object):
 
     def all_reservations(self, filters=None):
         reservations = [
-            copy.copy(reservation) for reservation in self.reservations.values()
+            copy.copy(reservation) for reservation in self.reservations.copy().values()
         ]
         if filters is not None:
             reservations = filter_reservations(reservations, filters)
@@ -1441,7 +1443,7 @@ class TagBackend(object):
                             value_filters.append(
                                 re.compile(simple_aws_filter_to_re(value))
                             )
-        for resource_id, tags in self.tags.items():
+        for resource_id, tags in self.tags.copy().items():
             for key, value in tags.items():
                 add_result = False
                 if filters is None:
@@ -1486,9 +1488,9 @@ class TagBackend(object):
                         "resource_id": resource_id,
                         "key": key,
                         "value": value,
-                        "resource_type": EC2_PREFIX_TO_RESOURCE[
-                            get_prefix(resource_id)
-                        ],
+                        "resource_type": EC2_PREFIX_TO_RESOURCE.get(
+                            get_prefix(resource_id), ""
+                        ),
                     }
                     results.append(result)
         return results
@@ -1677,7 +1679,7 @@ class AmiBackend(object):
     def describe_images(
         self, ami_ids=(), filters=None, exec_users=None, owners=None, context=None
     ):
-        images = self.amis.values()
+        images = self.amis.copy().values()
 
         if len(ami_ids):
             # boto3 seems to default to just searching based on ami ids if that parameter is passed
@@ -2536,7 +2538,8 @@ class SecurityGroupBackend(object):
         return group
 
     def describe_security_groups(self, group_ids=None, groupnames=None, filters=None):
-        matches = itertools.chain(*[x.values() for x in self.groups.values()])
+        all_groups = self.groups.copy()
+        matches = itertools.chain(*[x.copy().values() for x in all_groups.values()])
         if group_ids:
             matches = [grp for grp in matches if grp.id in group_ids]
             if len(group_ids) > len(matches):
@@ -2578,7 +2581,7 @@ class SecurityGroupBackend(object):
     def get_security_group_from_id(self, group_id):
         # 2 levels of chaining necessary since it's a complex structure
         all_groups = itertools.chain.from_iterable(
-            [x.values() for x in self.groups.values()]
+            [x.copy().values() for x in self.groups.copy().values()]
         )
         for group in all_groups:
             if group.id == group_id:
@@ -3273,7 +3276,7 @@ class Volume(TaggedEC2Resource, CloudFormationModel):
         elif filter_name == "encrypted":
             return str(self.encrypted).lower()
         elif filter_name == "availability-zone":
-            return self.zone.name
+            return self.zone.name if self.zone else None
         else:
             return super().get_filter_value(filter_name, "DescribeVolumes")
 
@@ -3347,7 +3350,7 @@ class EBSBackend(object):
         return volume
 
     def describe_volumes(self, volume_ids=None, filters=None):
-        matches = self.volumes.values()
+        matches = self.volumes.copy().values()
         if volume_ids:
             matches = [vol for vol in matches if vol.id in volume_ids]
             if len(volume_ids) > len(matches):
@@ -3422,7 +3425,7 @@ class EBSBackend(object):
         return snapshot
 
     def describe_snapshots(self, snapshot_ids=None, filters=None):
-        matches = self.snapshots.values()
+        matches = self.snapshots.copy().values()
         if snapshot_ids:
             matches = [snap for snap in matches if snap.id in snapshot_ids]
             if len(snapshot_ids) > len(matches):
@@ -3776,7 +3779,7 @@ class VPCBackend(object):
         return match_vpc
 
     def describe_vpcs(self, vpc_ids=None, filters=None):
-        matches = self.vpcs.values()
+        matches = self.vpcs.copy().values()
         if vpc_ids:
             matches = [vpc for vpc in matches if vpc.id in vpc_ids]
             if len(vpc_ids) > len(matches):
@@ -3859,9 +3862,9 @@ class VPCBackend(object):
             raise InvalidParameterValueError(attr_name)
 
     def disassociate_vpc_cidr_block(self, association_id):
-        for vpc in self.vpcs.values():
+        for vpc in self.vpcs.copy().values():
             response = vpc.disassociate_vpc_cidr_block(association_id)
-            for route_table in self.route_tables.values():
+            for route_table in self.route_tables.copy().values():
                 if route_table.vpc_id == response.get("vpc_id"):
                     if "::/" in response.get("cidr_block"):
                         self.delete_route(
@@ -4277,9 +4280,10 @@ class VPCPeeringConnectionBackend(object):
         return vpc_pcx
 
     def describe_vpc_peering_connections(self, vpc_peering_ids=None):
+        all_pcxs = self.vpc_pcxs.copy().values()
         if vpc_peering_ids:
-            return [pcx for pcx in self.vpc_pcxs.values() if pcx.id in vpc_peering_ids]
-        return self.vpc_pcxs.values()
+            return [pcx for pcx in all_pcxs if pcx.id in vpc_peering_ids]
+        return all_pcxs
 
     def get_vpc_peering_connection(self, vpc_pcx_id):
         if vpc_pcx_id not in self.vpc_pcxs:
@@ -4346,9 +4350,7 @@ class Subnet(TaggedEC2Resource, CloudFormationModel):
         self.vpc_id = vpc_id
         self.cidr_block = cidr_block
         self.cidr = ipaddress.IPv4Network(str(self.cidr_block), strict=False)
-        self._available_ip_addresses = (
-            ipaddress.IPv4Network(str(self.cidr_block)).num_addresses - 5
-        )
+        self._available_ip_addresses = self.cidr.num_addresses - 5
         self._availability_zone = availability_zone
         self.default_for_az = default_for_az
         self.map_public_ip_on_launch = map_public_ip_on_launch
@@ -5111,7 +5113,7 @@ class RouteTableBackend(object):
         return route_table
 
     def describe_route_tables(self, route_table_ids=None, filters=None):
-        route_tables = self.route_tables.values()
+        route_tables = self.route_tables.copy().values()
 
         if route_table_ids:
             route_tables = [
@@ -5380,7 +5382,7 @@ class ManagedPrefixListBackend(object):
         return managed_prefix_list
 
     def describe_managed_prefix_lists(self, prefix_list_ids=None, filters=None):
-        managed_prefix_lists = list(self.managed_prefix_lists.values())
+        managed_prefix_lists = list(self.managed_prefix_lists.copy().values())
         attr_pairs = (
             ("owner-id", "owner_id"),
             ("prefix-list-id", "id"),
@@ -6036,8 +6038,11 @@ class SpotRequestBackend(object, metaclass=Model):
         return requests
 
     @Model.prop("SpotInstanceRequest")
-    def describe_spot_instance_requests(self, filters=None):
-        requests = self.spot_instance_requests.values()
+    def describe_spot_instance_requests(self, filters=None, spot_instance_ids=[]):
+        requests = self.spot_instance_requests.copy().values()
+
+        if spot_instance_ids:
+            requests = [i for i in requests if i.id in spot_instance_ids]
 
         return generic_filter(filters, requests)
 
@@ -6398,6 +6403,9 @@ class ElasticAddress(TaggedEC2Resource, CloudFormationModel):
         self.association_id = None
         self.add_tags(tags or {})
 
+    def __repr__(self):
+        return "ElasticAddress({}, {})".format(self.id, self.public_ip)
+
     @staticmethod
     def cloudformation_name_type():
         return None
@@ -6447,12 +6455,18 @@ class ElasticAddress(TaggedEC2Resource, CloudFormationModel):
             return self.association_id
         elif filter_name == "domain":
             return self.domain
-        elif filter_name == "instance-id" and self.instance:
-            return self.instance.id
-        elif filter_name == "network-interface-id" and self.eni:
-            return self.eni.id
-        elif filter_name == "private-ip-address" and self.eni:
-            return self.eni.private_ip_address
+        elif filter_name == "instance-id":
+            if self.instance:
+                return self.instance.id
+            return None
+        elif filter_name == "network-interface-id":
+            if self.eni:
+                return self.eni.id
+            return None
+        elif filter_name == "private-ip-address":
+            if self.eni:
+                return self.eni.private_ip_address
+            return None
         elif filter_name == "public-ip":
             return self.public_ip
         elif filter_name == "network-interface-owner-id":
@@ -6477,11 +6491,13 @@ class ElasticAddressBackend(object):
         self.addresses.append(address)
         return address
 
-    def address_by_ip(self, ips):
-        eips = [address for address in self.addresses if address.public_ip in ips]
+    def address_by_ip(self, ips, fail_if_not_found=True):
+        eips = [
+            address for address in self.addresses.copy() if address.public_ip in ips
+        ]
 
         # TODO: Trim error message down to specific invalid address.
-        if not eips or len(ips) > len(eips):
+        if (not eips or len(ips) > len(eips)) and fail_if_not_found:
             raise InvalidAddressError(ips)
 
         return eips
@@ -6548,7 +6564,7 @@ class ElasticAddressBackend(object):
         raise ResourceAlreadyAssociatedError(eip.public_ip)
 
     def describe_addresses(self, allocation_ids=None, public_ips=None, filters=None):
-        matches = self.addresses
+        matches = self.addresses.copy()
         if allocation_ids:
             matches = [addr for addr in matches if addr.allocation_id in allocation_ids]
             if len(allocation_ids) > len(matches):
@@ -6557,7 +6573,7 @@ class ElasticAddressBackend(object):
         if public_ips:
             matches = [addr for addr in matches if addr.public_ip in public_ips]
             if len(public_ips) > len(matches):
-                unknown_ips = set(allocation_ids) - set(matches)
+                unknown_ips = set(public_ips) - set(matches)
                 raise InvalidAddressError(unknown_ips)
         if filters:
             matches = generic_filter(filters, matches)
@@ -6690,7 +6706,7 @@ class DHCPOptionsSetBackend(object):
                 options_sets.append(self.dhcp_options_sets[option_id])
             else:
                 raise InvalidDHCPOptionsIdError(option_id)
-        return options_sets or self.dhcp_options_sets.values()
+        return options_sets or self.dhcp_options_sets.copy().values()
 
     def delete_dhcp_options_set(self, options_id):
         if not (options_id and options_id.startswith("dopt-")):
@@ -6988,7 +7004,7 @@ class NetworkAclBackend(object):
         )
 
     def describe_network_acls(self, network_acl_ids=None, filters=None):
-        network_acls = self.network_acls.values()
+        network_acls = self.network_acls.copy().values()
 
         if network_acl_ids:
             network_acls = [
@@ -7199,8 +7215,13 @@ class CustomerGatewayBackend(object):
         self.customer_gateways[customer_gateway_id] = customer_gateway
         return customer_gateway
 
-    def get_all_customer_gateways(self, filters=None):
-        customer_gateways = self.customer_gateways.values()
+    def get_all_customer_gateways(self, filters=None, customer_gateway_ids=None):
+        customer_gateways = self.customer_gateways.copy().values()
+        if customer_gateway_ids:
+            customer_gateways = [
+                cg for cg in customer_gateways if cg.id in customer_gateway_ids
+            ]
+
         if filters is not None:
             if filters.get("customer-gateway-id") is not None:
                 customer_gateways = [
@@ -7324,8 +7345,13 @@ class TransitGatewayBackend(object):
         self.transit_gateways[transit_gateway.id] = transit_gateway
         return transit_gateway
 
-    def describe_transit_gateways(self, filters):
-        transit_gateways = list(self.transit_gateways.values())
+    def describe_transit_gateways(self, filters, transit_gateway_ids):
+        transit_gateways = list(self.transit_gateways.copy().values())
+
+        if transit_gateway_ids:
+            transit_gateways = [
+                item for item in transit_gateways if item.id in transit_gateway_ids
+            ]
 
         attr_pairs = (
             ("transit-gateway-id", "id"),

--- a/moto/ec2/models.py
+++ b/moto/ec2/models.py
@@ -6403,9 +6403,6 @@ class ElasticAddress(TaggedEC2Resource, CloudFormationModel):
         self.association_id = None
         self.add_tags(tags or {})
 
-    def __repr__(self):
-        return "ElasticAddress({}, {})".format(self.id, self.public_ip)
-
     @staticmethod
     def cloudformation_name_type():
         return None

--- a/moto/ec2/responses/amis.py
+++ b/moto/ec2/responses/amis.py
@@ -52,7 +52,6 @@ class AmisResponse(BaseResponse):
             context=self,
         )
         template = self.response_template(DESCRIBE_IMAGES_RESPONSE)
-
         return template.render(images=images)
 
     def describe_image_attribute(self):

--- a/moto/ec2/responses/amis.py
+++ b/moto/ec2/responses/amis.py
@@ -52,6 +52,7 @@ class AmisResponse(BaseResponse):
             context=self,
         )
         template = self.response_template(DESCRIBE_IMAGES_RESPONSE)
+
         return template.render(images=images)
 
     def describe_image_attribute(self):

--- a/moto/ec2/responses/customer_gateways.py
+++ b/moto/ec2/responses/customer_gateways.py
@@ -27,7 +27,10 @@ class CustomerGateways(BaseResponse):
 
     def describe_customer_gateways(self):
         filters = filters_from_querystring(self.querystring)
-        customer_gateways = self.ec2_backend.get_all_customer_gateways(filters)
+        customer_gateway_ids = self._get_multi_param("CustomerGatewayId")
+        customer_gateways = self.ec2_backend.get_all_customer_gateways(
+            filters, customer_gateway_ids
+        )
         template = self.response_template(DESCRIBE_CUSTOMER_GATEWAYS_RESPONSE)
         return template.render(customer_gateways=customer_gateways)
 

--- a/moto/ec2/responses/spot_instances.py
+++ b/moto/ec2/responses/spot_instances.py
@@ -29,8 +29,11 @@ class SpotInstances(BaseResponse):
         )
 
     def describe_spot_instance_requests(self):
+        spot_instance_ids = self._get_multi_param("SpotInstanceRequestId")
         filters = filters_from_querystring(self.querystring)
-        requests = self.ec2_backend.describe_spot_instance_requests(filters=filters)
+        requests = self.ec2_backend.describe_spot_instance_requests(
+            filters=filters, spot_instance_ids=spot_instance_ids
+        )
         template = self.response_template(DESCRIBE_SPOT_INSTANCES_TEMPLATE)
         return template.render(requests=requests)
 

--- a/moto/ec2/responses/transit_gateway_attachments.py
+++ b/moto/ec2/responses/transit_gateway_attachments.py
@@ -256,11 +256,13 @@ DESCRIBE_TRANSIT_GATEWAY_VPC_ATTACHMENTS = """<DescribeTransitGatewayVpcAttachme
         {% for transit_gateway_vpc_attachment in transit_gateway_vpc_attachments %}
             <item>
                 <creationTime>2021-07-18T08:57:21.000Z</creationTime>
+                {% if transit_gateway_vpc_attachment.options %}
                 <options>
                     <applianceModeSupport>{{ transit_gateway_vpc_attachment.options.ApplianceModeSupport }}</applianceModeSupport>
                     <dnsSupport>{{ transit_gateway_vpc_attachment.options.DnsSupport }}</dnsSupport>
                     <ipv6Support>{{ transit_gateway_vpc_attachment.options.Ipv6Support }}</ipv6Support>
                 </options>
+                {% endif %}
                 <state>{{ transit_gateway_vpc_attachment.state }}</state>
                 <subnetIds>
                 {% for id in transit_gateway_vpc_attachment.subnet_ids %}
@@ -423,17 +425,23 @@ DESCRIBE_TRANSIT_GATEWAY_PEERING_ATTACHMENTS = """<DescribeTransitGatewayPeering
             <item>
                 <createTime>{{ transit_gateway_peering_attachment.create_time }}</createTime>
                 <state>{{ transit_gateway_peering_attachment.state }}</state>
+                {% if transit_gateway_peering_attachment.accepter_tgw_info %}
                 <accepterTgwInfo>
                     <ownerId>{{ transit_gateway_peering_attachment.accepter_tgw_info.ownerId or '' }}</ownerId>
                     <region>{{ transit_gateway_peering_attachment.accepter_tgw_info.region or '' }}</region>
                     <transitGatewayId>{{ transit_gateway_peering_attachment.accepter_tgw_info.transitGatewayId or '' }}</transitGatewayId>
                 </accepterTgwInfo>
+                {% endif %}
+                {% if transit_gateway_peering_attachment.requester_tgw_info %}
                 <requesterTgwInfo>
                     <ownerId>{{ transit_gateway_peering_attachment.requester_tgw_info.ownerId or '' }}</ownerId>
                     <region>{{ transit_gateway_peering_attachment.requester_tgw_info.region or '' }}</region>
                     <transitGatewayId>{{ transit_gateway_peering_attachment.requester_tgw_info.transitGatewayId or '' }}</transitGatewayId>
                 </requesterTgwInfo>
+                {% endif %}
+                {% if transit_gateway_peering_attachment.status %}
                 <status>{{ transit_gateway_peering_attachment.status.code }}</status>
+                {% endif %}
                 <tagSet>
                 {% for tag in transit_gateway_peering_attachment.get_tags() %}
                     <item>

--- a/moto/ec2/responses/transit_gateways.py
+++ b/moto/ec2/responses/transit_gateways.py
@@ -39,8 +39,11 @@ class TransitGateways(BaseResponse):
         return template.render(transit_gateway=transit_gateway)
 
     def describe_transit_gateways(self):
+        transit_gateway_ids = self._get_multi_param("TransitGatewayIds")
         filters = filters_from_querystring(self.querystring)
-        transit_gateways = self.ec2_backend.describe_transit_gateways(filters)
+        transit_gateways = self.ec2_backend.describe_transit_gateways(
+            filters, transit_gateway_ids
+        )
         template = self.response_template(DESCRIBE_TRANSIT_GATEWAY_RESPONSE)
         return template.render(transit_gateways=transit_gateways)
 

--- a/moto/ec2/responses/vpcs.py
+++ b/moto/ec2/responses/vpcs.py
@@ -826,7 +826,7 @@ DESCRIBE_PREFIX_LIST = """<DescribePrefixListsResponse xmlns="http://ec2.amazona
     <requestId>8a2ec0e2-6918-4270-ae45-58e61971e97d</requestId>
     <prefixListSet>
     {% for pl in managed_pls %}
-    {% if pl.prefix_list_name.startswith("com.amazonaws.") %}
+    {% if pl.prefix_list_name and pl.prefix_list_name.startswith("com.amazonaws.") %}
         <item>
             <cidrSet>
                 {% for entry in pl.entries.1 %}

--- a/moto/sqs/models.py
+++ b/moto/sqs/models.py
@@ -632,6 +632,8 @@ class SQSBackend(BaseBackend):
         prefix_re = re.compile(re_str)
         qs = []
         for name, q in self.queues.items():
+            if not isinstance(name, (str, bytes)):
+                print("Unable to search for {} (type: {})".format(name, type(name)))
             if prefix_re.search(name):
                 qs.append(q)
         return qs[:1000]

--- a/moto/sqs/models.py
+++ b/moto/sqs/models.py
@@ -402,6 +402,9 @@ class Queue(CloudFormationModel):
         tags = properties.pop("Tags", [])
         tags_dict = tags_from_cloudformation_tags_list(tags)
 
+        # Could be passed as an integer - just treat it as a string
+        resource_name = str(resource_name)
+
         sqs_backend = sqs_backends[region_name]
         return sqs_backend.create_queue(
             name=resource_name, tags=tags_dict, region=region_name, **properties
@@ -632,8 +635,6 @@ class SQSBackend(BaseBackend):
         prefix_re = re.compile(re_str)
         qs = []
         for name, q in self.queues.items():
-            if not isinstance(name, (str, bytes)):
-                print("Unable to search for {} (type: {})".format(name, type(name)))
             if prefix_re.search(name):
                 qs.append(q)
         return qs[:1000]

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -1,5 +1,6 @@
 pytest
 pytest-cov
+pytest-xdist
 sure
 freezegun
 pylint

--- a/tests/test_batch/__init__.py
+++ b/tests/test_batch/__init__.py
@@ -1,4 +1,5 @@
 import boto3
+from uuid import uuid4
 
 
 DEFAULT_REGION = "eu-central-1"
@@ -27,17 +28,18 @@ def _setup(ec2_client, iam_client):
     )
     subnet_id = resp["Subnet"]["SubnetId"]
     resp = ec2_client.create_security_group(
-        Description="test_sg_desc", GroupName="test_sg", VpcId=vpc_id
+        Description="test_sg_desc", GroupName=str(uuid4())[0:6], VpcId=vpc_id
     )
     sg_id = resp["GroupId"]
 
+    role_name = f"{str(uuid4())[0:6]}"
     resp = iam_client.create_role(
-        RoleName="TestRole", AssumeRolePolicyDocument="some_policy"
+        RoleName=role_name, AssumeRolePolicyDocument="some_policy"
     )
     iam_arn = resp["Role"]["Arn"]
-    iam_client.create_instance_profile(InstanceProfileName="TestRole")
+    iam_client.create_instance_profile(InstanceProfileName=role_name)
     iam_client.add_role_to_instance_profile(
-        InstanceProfileName="TestRole", RoleName="TestRole"
+        InstanceProfileName=role_name, RoleName=role_name
     )
 
     return vpc_id, subnet_id, sg_id, iam_arn

--- a/tests/test_batch/test_batch_compute_envs.py
+++ b/tests/test_batch/test_batch_compute_envs.py
@@ -2,7 +2,8 @@ from __future__ import unicode_literals
 
 from . import _get_clients, _setup
 import sure  # noqa
-from moto import mock_batch, mock_iam, mock_ec2, mock_ecs, mock_logs
+from moto import mock_batch, mock_iam, mock_ec2, mock_ecs, settings
+from uuid import uuid4
 
 
 # Yes, yes it talks to all the things
@@ -14,7 +15,7 @@ def test_create_managed_compute_environment():
     ec2_client, iam_client, ecs_client, logs_client, batch_client = _get_clients()
     vpc_id, subnet_id, sg_id, iam_arn = _setup(ec2_client, iam_client)
 
-    compute_name = "test_compute_env"
+    compute_name = str(uuid4())
     resp = batch_client.create_compute_environment(
         computeEnvironmentName=compute_name,
         type="MANAGED",
@@ -39,15 +40,20 @@ def test_create_managed_compute_environment():
     resp.should.contain("computeEnvironmentArn")
     resp["computeEnvironmentName"].should.equal(compute_name)
 
+    our_env = batch_client.describe_compute_environments(
+        computeEnvironments=[compute_name]
+    )["computeEnvironments"][0]
+
     # Given a t2.medium is 2 vcpu and t2.small is 1, therefore 2 mediums and 1 small should be created
-    resp = ec2_client.describe_instances()
-    resp.should.contain("Reservations")
-    len(resp["Reservations"]).should.equal(3)
+    if not settings.TEST_SERVER_MODE:
+        # Can't verify this in ServerMode, as other tests may have created instances
+        resp = ec2_client.describe_instances()
+        resp.should.contain("Reservations")
+        len(resp["Reservations"]).should.equal(3)
 
     # Should have created 1 ECS cluster
-    resp = ecs_client.list_clusters()
-    resp.should.contain("clusterArns")
-    len(resp["clusterArns"]).should.equal(1)
+    all_clusters = ecs_client.list_clusters()["clusterArns"]
+    all_clusters.should.contain(our_env["ecsClusterArn"])
 
 
 @mock_ec2
@@ -58,7 +64,7 @@ def test_create_unmanaged_compute_environment():
     ec2_client, iam_client, ecs_client, logs_client, batch_client = _get_clients()
     vpc_id, subnet_id, sg_id, iam_arn = _setup(ec2_client, iam_client)
 
-    compute_name = "test_compute_env"
+    compute_name = str(uuid4())
     resp = batch_client.create_compute_environment(
         computeEnvironmentName=compute_name,
         type="UNMANAGED",
@@ -68,15 +74,21 @@ def test_create_unmanaged_compute_environment():
     resp.should.contain("computeEnvironmentArn")
     resp["computeEnvironmentName"].should.equal(compute_name)
 
+    our_env = batch_client.describe_compute_environments(
+        computeEnvironments=[compute_name]
+    )["computeEnvironments"][0]
+    our_env.should.have.key("ecsClusterArn")
+
     # Its unmanaged so no instances should be created
-    resp = ec2_client.describe_instances()
-    resp.should.contain("Reservations")
-    len(resp["Reservations"]).should.equal(0)
+    if not settings.TEST_SERVER_MODE:
+        # Can't verify this in ServerMode, as other tests may have created instances
+        resp = ec2_client.describe_instances()
+        resp.should.contain("Reservations")
+        len(resp["Reservations"]).should.equal(0)
 
     # Should have created 1 ECS cluster
-    resp = ecs_client.list_clusters()
-    resp.should.contain("clusterArns")
-    len(resp["clusterArns"]).should.equal(1)
+    all_clusters = ecs_client.list_clusters()["clusterArns"]
+    all_clusters.should.contain(our_env["ecsClusterArn"])
 
 
 # TODO create 1000s of tests to test complex option combinations of create environment
@@ -90,7 +102,10 @@ def test_describe_compute_environment():
     ec2_client, iam_client, ecs_client, logs_client, batch_client = _get_clients()
     vpc_id, subnet_id, sg_id, iam_arn = _setup(ec2_client, iam_client)
 
-    compute_name = "test_compute_env"
+    compute_name = str(uuid4())
+    compute_arn = (
+        f"arn:aws:batch:eu-central-1:123456789012:compute-environment/{compute_name}"
+    )
     batch_client.create_compute_environment(
         computeEnvironmentName=compute_name,
         type="UNMANAGED",
@@ -98,9 +113,14 @@ def test_describe_compute_environment():
         serviceRole=iam_arn,
     )
 
-    resp = batch_client.describe_compute_environments()
-    len(resp["computeEnvironments"]).should.equal(1)
-    resp["computeEnvironments"][0]["computeEnvironmentName"].should.equal(compute_name)
+    all_envs = batch_client.describe_compute_environments()["computeEnvironments"]
+    our_envs = [e for e in all_envs if e["computeEnvironmentName"] == compute_name]
+    our_envs.should.have.length_of(1)
+    our_envs[0]["computeEnvironmentName"].should.equal(compute_name)
+    our_envs[0]["computeEnvironmentArn"].should.equal(compute_arn)
+    our_envs[0].should.have.key("ecsClusterArn")
+    our_envs[0].should.have.key("state").equal("ENABLED")
+    our_envs[0].should.have.key("status").equal("VALID")
 
     # Test filtering
     resp = batch_client.describe_compute_environments(computeEnvironments=["test1"])
@@ -115,7 +135,7 @@ def test_delete_unmanaged_compute_environment():
     ec2_client, iam_client, ecs_client, logs_client, batch_client = _get_clients()
     vpc_id, subnet_id, sg_id, iam_arn = _setup(ec2_client, iam_client)
 
-    compute_name = "test_compute_env"
+    compute_name = str(uuid4())
     batch_client.create_compute_environment(
         computeEnvironmentName=compute_name,
         type="UNMANAGED",
@@ -123,13 +143,18 @@ def test_delete_unmanaged_compute_environment():
         serviceRole=iam_arn,
     )
 
+    our_env = batch_client.describe_compute_environments(
+        computeEnvironments=[compute_name]
+    )["computeEnvironments"][0]
+
     batch_client.delete_compute_environment(computeEnvironment=compute_name)
 
-    resp = batch_client.describe_compute_environments()
-    len(resp["computeEnvironments"]).should.equal(0)
+    all_envs = batch_client.describe_compute_environments()["computeEnvironments"]
+    all_names = [e["computeEnvironmentName"] for e in all_envs]
+    all_names.shouldnt.contain(compute_name)
 
-    resp = ecs_client.list_clusters()
-    len(resp.get("clusterArns", [])).should.equal(0)
+    all_clusters = ecs_client.list_clusters()["clusterArns"]
+    all_clusters.shouldnt.contain(our_env["ecsClusterArn"])
 
 
 @mock_ec2
@@ -140,7 +165,7 @@ def test_delete_managed_compute_environment():
     ec2_client, iam_client, ecs_client, logs_client, batch_client = _get_clients()
     vpc_id, subnet_id, sg_id, iam_arn = _setup(ec2_client, iam_client)
 
-    compute_name = "test_compute_env"
+    compute_name = str(uuid4())
     batch_client.create_compute_environment(
         computeEnvironmentName=compute_name,
         type="MANAGED",
@@ -163,19 +188,26 @@ def test_delete_managed_compute_environment():
         serviceRole=iam_arn,
     )
 
+    our_env = batch_client.describe_compute_environments(
+        computeEnvironments=[compute_name]
+    )["computeEnvironments"][0]
+
     batch_client.delete_compute_environment(computeEnvironment=compute_name)
 
-    resp = batch_client.describe_compute_environments()
-    len(resp["computeEnvironments"]).should.equal(0)
+    all_envs = batch_client.describe_compute_environments()["computeEnvironments"]
+    all_names = [e["computeEnvironmentName"] for e in all_envs]
+    all_names.shouldnt.contain(compute_name)
 
-    resp = ec2_client.describe_instances()
-    resp.should.contain("Reservations")
-    len(resp["Reservations"]).should.equal(3)
-    for reservation in resp["Reservations"]:
-        reservation["Instances"][0]["State"]["Name"].should.equal("terminated")
+    if not settings.TEST_SERVER_MODE:
+        # Too many instances to know which one is ours in ServerMode
+        resp = ec2_client.describe_instances()
+        resp.should.contain("Reservations")
+        len(resp["Reservations"]).should.equal(3)
+        for reservation in resp["Reservations"]:
+            reservation["Instances"][0]["State"]["Name"].should.equal("terminated")
 
-    resp = ecs_client.list_clusters()
-    len(resp.get("clusterArns", [])).should.equal(0)
+    all_clusters = ecs_client.list_clusters()["clusterArns"]
+    all_clusters.shouldnt.contain(our_env["ecsClusterArn"])
 
 
 @mock_ec2
@@ -186,7 +218,7 @@ def test_update_unmanaged_compute_environment_state():
     ec2_client, iam_client, ecs_client, logs_client, batch_client = _get_clients()
     vpc_id, subnet_id, sg_id, iam_arn = _setup(ec2_client, iam_client)
 
-    compute_name = "test_compute_env"
+    compute_name = str(uuid4())
     batch_client.create_compute_environment(
         computeEnvironmentName=compute_name,
         type="UNMANAGED",
@@ -198,6 +230,7 @@ def test_update_unmanaged_compute_environment_state():
         computeEnvironment=compute_name, state="DISABLED"
     )
 
-    resp = batch_client.describe_compute_environments()
-    len(resp["computeEnvironments"]).should.equal(1)
-    resp["computeEnvironments"][0]["state"].should.equal("DISABLED")
+    all_envs = batch_client.describe_compute_environments()["computeEnvironments"]
+    our_envs = [e for e in all_envs if e["computeEnvironmentName"] == compute_name]
+    our_envs.should.have.length_of(1)
+    our_envs[0]["state"].should.equal("DISABLED")

--- a/tests/test_batch/test_batch_job_queue.py
+++ b/tests/test_batch/test_batch_job_queue.py
@@ -4,6 +4,7 @@ from botocore.exceptions import ClientError
 import pytest
 import sure  # noqa
 from moto import mock_batch, mock_iam, mock_ec2, mock_ecs
+from uuid import uuid4
 
 
 @mock_ec2
@@ -14,7 +15,7 @@ def test_create_job_queue():
     ec2_client, iam_client, ecs_client, logs_client, batch_client = _get_clients()
     vpc_id, subnet_id, sg_id, iam_arn = _setup(ec2_client, iam_client)
 
-    compute_name = "test_compute_env"
+    compute_name = str(uuid4())
     resp = batch_client.create_compute_environment(
         computeEnvironmentName=compute_name,
         type="UNMANAGED",
@@ -23,8 +24,9 @@ def test_create_job_queue():
     )
     arn = resp["computeEnvironmentArn"]
 
+    jq_name = str(uuid4())[0:6]
     resp = batch_client.create_job_queue(
-        jobQueueName="test_job_queue",
+        jobQueueName=jq_name,
         state="ENABLED",
         priority=123,
         computeEnvironmentOrder=[{"order": 123, "computeEnvironment": arn}],
@@ -33,9 +35,10 @@ def test_create_job_queue():
     resp.should.contain("jobQueueName")
     queue_arn = resp["jobQueueArn"]
 
-    resp = batch_client.describe_job_queues()
-    resp.should.have.key("jobQueues").being.length_of(1)
-    resp["jobQueues"][0]["jobQueueArn"].should.equal(queue_arn)
+    all_queues = batch_client.describe_job_queues()["jobQueues"]
+    our_queues = [q for q in all_queues if q["jobQueueName"] == jq_name]
+    our_queues.should.have.length_of(1)
+    our_queues[0]["jobQueueArn"].should.equal(queue_arn)
 
 
 @mock_ec2
@@ -57,7 +60,7 @@ def test_create_job_queue_twice():
     ec2_client, iam_client, ecs_client, logs_client, batch_client = _get_clients()
     vpc_id, subnet_id, sg_id, iam_arn = _setup(ec2_client, iam_client)
 
-    compute_name = "test_compute_env"
+    compute_name = str(uuid4())
     resp = batch_client.create_compute_environment(
         computeEnvironmentName=compute_name,
         type="UNMANAGED",
@@ -66,15 +69,16 @@ def test_create_job_queue_twice():
     )
     compute_env_arn = resp["computeEnvironmentArn"]
 
+    jq_name = str(uuid4())[0:6]
     batch_client.create_job_queue(
-        jobQueueName="test_job_queue",
+        jobQueueName=jq_name,
         state="ENABLED",
         priority=123,
         computeEnvironmentOrder=[{"order": 123, "computeEnvironment": compute_env_arn}],
     )
     with pytest.raises(ClientError) as ex:
         batch_client.create_job_queue(
-            jobQueueName="test_job_queue",
+            jobQueueName=jq_name,
             state="ENABLED",
             priority=123,
             computeEnvironmentOrder=[
@@ -84,7 +88,7 @@ def test_create_job_queue_twice():
 
     err = ex.value.response["Error"]
     err["Code"].should.equal("ClientException")
-    err["Message"].should.equal("Job queue test_job_queue already exists")
+    err["Message"].should.equal(f"Job queue {jq_name} already exists")
 
 
 @mock_ec2
@@ -96,7 +100,7 @@ def test_create_job_queue_incorrect_state():
 
     with pytest.raises(ClientError) as ex:
         batch_client.create_job_queue(
-            jobQueueName="test_job_queue2",
+            jobQueueName=str(uuid4()),
             state="JUNK",
             priority=123,
             computeEnvironmentOrder=[],
@@ -115,7 +119,7 @@ def test_create_job_queue_without_compute_environment():
 
     with pytest.raises(ClientError) as ex:
         batch_client.create_job_queue(
-            jobQueueName="test_job_queue3",
+            jobQueueName=str(uuid4()),
             state="ENABLED",
             priority=123,
             computeEnvironmentOrder=[],
@@ -133,7 +137,7 @@ def test_job_queue_bad_arn():
     ec2_client, iam_client, ecs_client, logs_client, batch_client = _get_clients()
     vpc_id, subnet_id, sg_id, iam_arn = _setup(ec2_client, iam_client)
 
-    compute_name = "test_compute_env"
+    compute_name = str(uuid4())
     resp = batch_client.create_compute_environment(
         computeEnvironmentName=compute_name,
         type="UNMANAGED",
@@ -144,7 +148,7 @@ def test_job_queue_bad_arn():
 
     with pytest.raises(ClientError) as ex:
         batch_client.create_job_queue(
-            jobQueueName="test_job_queue",
+            jobQueueName=str(uuid4()),
             state="ENABLED",
             priority=123,
             computeEnvironmentOrder=[
@@ -164,7 +168,7 @@ def test_update_job_queue():
     ec2_client, iam_client, ecs_client, logs_client, batch_client = _get_clients()
     vpc_id, subnet_id, sg_id, iam_arn = _setup(ec2_client, iam_client)
 
-    compute_name = "test_compute_env"
+    compute_name = str(uuid4())
     resp = batch_client.create_compute_environment(
         computeEnvironmentName=compute_name,
         type="UNMANAGED",
@@ -173,8 +177,9 @@ def test_update_job_queue():
     )
     arn = resp["computeEnvironmentArn"]
 
+    jq_name = str(uuid4())
     resp = batch_client.create_job_queue(
-        jobQueueName="test_job_queue",
+        jobQueueName=jq_name,
         state="ENABLED",
         priority=123,
         computeEnvironmentOrder=[{"order": 123, "computeEnvironment": arn}],
@@ -183,15 +188,16 @@ def test_update_job_queue():
 
     batch_client.update_job_queue(jobQueue=queue_arn, priority=5)
 
-    resp = batch_client.describe_job_queues()
-    resp.should.have.key("jobQueues").being.length_of(1)
-    resp["jobQueues"][0]["priority"].should.equal(5)
+    all_queues = batch_client.describe_job_queues()["jobQueues"]
+    our_queues = [q for q in all_queues if q["jobQueueName"] == jq_name]
+    our_queues[0]["priority"].should.equal(5)
 
-    batch_client.update_job_queue(jobQueue="test_job_queue", priority=5)
+    batch_client.update_job_queue(jobQueue=jq_name, priority=15)
 
-    resp = batch_client.describe_job_queues()
-    resp.should.have.key("jobQueues").being.length_of(1)
-    resp["jobQueues"][0]["priority"].should.equal(5)
+    all_queues = batch_client.describe_job_queues()["jobQueues"]
+    our_queues = [q for q in all_queues if q["jobQueueName"] == jq_name]
+    our_queues.should.have.length_of(1)
+    our_queues[0]["priority"].should.equal(15)
 
 
 @mock_ec2
@@ -202,7 +208,7 @@ def test_delete_job_queue():
     ec2_client, iam_client, ecs_client, logs_client, batch_client = _get_clients()
     vpc_id, subnet_id, sg_id, iam_arn = _setup(ec2_client, iam_client)
 
-    compute_name = "test_compute_env"
+    compute_name = str(uuid4())
     resp = batch_client.create_compute_environment(
         computeEnvironmentName=compute_name,
         type="UNMANAGED",
@@ -211,8 +217,9 @@ def test_delete_job_queue():
     )
     arn = resp["computeEnvironmentArn"]
 
+    jq_name = str(uuid4())
     resp = batch_client.create_job_queue(
-        jobQueueName="test_job_queue",
+        jobQueueName=jq_name,
         state="ENABLED",
         priority=123,
         computeEnvironmentOrder=[{"order": 123, "computeEnvironment": arn}],
@@ -221,5 +228,5 @@ def test_delete_job_queue():
 
     batch_client.delete_job_queue(jobQueue=queue_arn)
 
-    resp = batch_client.describe_job_queues()
-    resp.should.have.key("jobQueues").being.length_of(0)
+    all_queues = batch_client.describe_job_queues()["jobQueues"]
+    [q["jobQueueName"] for q in all_queues].shouldnt.contain(jq_name)

--- a/tests/test_batch/test_batch_jobs.py
+++ b/tests/test_batch/test_batch_jobs.py
@@ -185,7 +185,6 @@ def test_terminate_job():
     resp["jobs"][0]["statusReason"].should.equal("test_terminate")
 
     ls_name = f"{job_def_name}/default/{job_id}"
-    print(ls_name)
 
     resp = logs_client.get_log_events(
         logGroupName="/aws/batch/job", logStreamName=ls_name

--- a/tests/test_batch/test_batch_jobs.py
+++ b/tests/test_batch/test_batch_jobs.py
@@ -5,6 +5,7 @@ import sure  # noqa
 from moto import mock_batch, mock_iam, mock_ec2, mock_ecs, mock_logs
 import pytest
 import time
+from uuid import uuid4
 
 
 @mock_logs
@@ -16,7 +17,7 @@ def test_submit_job_by_name():
     ec2_client, iam_client, ecs_client, logs_client, batch_client = _get_clients()
     vpc_id, subnet_id, sg_id, iam_arn = _setup(ec2_client, iam_client)
 
-    compute_name = "test_compute_env"
+    compute_name = str(uuid4())
     resp = batch_client.create_compute_environment(
         computeEnvironmentName=compute_name,
         type="UNMANAGED",
@@ -26,14 +27,14 @@ def test_submit_job_by_name():
     arn = resp["computeEnvironmentArn"]
 
     resp = batch_client.create_job_queue(
-        jobQueueName="test_job_queue",
+        jobQueueName=str(uuid4()),
         state="ENABLED",
         priority=123,
         computeEnvironmentOrder=[{"order": 123, "computeEnvironment": arn}],
     )
     queue_arn = resp["jobQueueArn"]
 
-    job_definition_name = "sleep10"
+    job_definition_name = f"sleep10_{str(uuid4())[0:6]}"
 
     batch_client.register_job_definition(
         jobDefinitionName=job_definition_name,
@@ -95,12 +96,12 @@ def test_submit_job():
     ec2_client, iam_client, ecs_client, logs_client, batch_client = _get_clients()
     vpc_id, subnet_id, sg_id, iam_arn = _setup(ec2_client, iam_client)
 
-    job_def_name = "sayhellotomylittlefriend"
+    job_def_name = str(uuid4())[0:6]
     commands = ["echo", "hello"]
     job_def_arn, queue_arn = prepare_job(batch_client, commands, iam_arn, job_def_name)
 
     resp = batch_client.submit_job(
-        jobName="test1", jobQueue=queue_arn, jobDefinition=job_def_arn
+        jobName=str(uuid4())[0:6], jobQueue=queue_arn, jobDefinition=job_def_arn
     )
     job_id = resp["jobId"]
 
@@ -163,7 +164,7 @@ def test_terminate_job():
     ec2_client, iam_client, ecs_client, logs_client, batch_client = _get_clients()
     vpc_id, subnet_id, sg_id, iam_arn = _setup(ec2_client, iam_client)
 
-    job_def_name = "echo-sleep-echo"
+    job_def_name = f"echo-sleep-echo-{str(uuid4())[0:6]}"
     commands = ["sh", "-c", "echo start && sleep 30 && echo stop"]
     job_def_arn, queue_arn = prepare_job(batch_client, commands, iam_arn, job_def_name)
 
@@ -183,11 +184,8 @@ def test_terminate_job():
     resp["jobs"][0]["status"].should.equal("FAILED")
     resp["jobs"][0]["statusReason"].should.equal("test_terminate")
 
-    resp = logs_client.describe_log_streams(
-        logGroupName="/aws/batch/job", logStreamNamePrefix=job_def_name
-    )
-    resp["logStreams"].should.have.length_of(1)
-    ls_name = resp["logStreams"][0]["logStreamName"]
+    ls_name = f"{job_def_name}/default/{job_id}"
+    print(ls_name)
 
     resp = logs_client.get_log_events(
         logGroupName="/aws/batch/job", logStreamName=ls_name
@@ -365,15 +363,39 @@ def test_dependencies():
     else:
         raise RuntimeError("Batch job timed out")
 
-    resp = logs_client.describe_log_streams(logGroupName="/aws/batch/job")
-    len(resp["logStreams"]).should.equal(3)
-    for log_stream in resp["logStreams"]:
+    log_stream_name = "/aws/batch/job"
+    all_streams = retrieve_all_streams(log_stream_name, logs_client)
+
+    nr_logstreams_found = 0
+    expected_logstream_names = [
+        f"dependencytest/default/{_id}" for _id in [job_id1, job_id2, job_id3]
+    ]
+    for log_stream in all_streams:
         ls_name = log_stream["logStreamName"]
 
+        if ls_name not in expected_logstream_names:
+            continue
+
         resp = logs_client.get_log_events(
-            logGroupName="/aws/batch/job", logStreamName=ls_name
+            logGroupName=log_stream_name, logStreamName=ls_name
         )
         [event["message"] for event in resp["events"]].should.equal(["hello"])
+
+        nr_logstreams_found = nr_logstreams_found + 1
+    nr_logstreams_found.should.equal(3)
+
+
+def retrieve_all_streams(log_stream_name, logs_client):
+    resp = logs_client.describe_log_streams(logGroupName=log_stream_name)
+    all_streams = resp["logStreams"]
+    token = resp.get("nextToken")
+    while token:
+        resp = logs_client.describe_log_streams(
+            logGroupName=log_stream_name, nextToken=token
+        )
+        all_streams.extend(resp["logStreams"])
+        token = resp.get("nextToken")
+    return all_streams
 
 
 @mock_logs
@@ -385,7 +407,7 @@ def test_failed_dependencies():
     ec2_client, iam_client, ecs_client, logs_client, batch_client = _get_clients()
     vpc_id, subnet_id, sg_id, iam_arn = _setup(ec2_client, iam_client)
 
-    compute_name = "test_compute_env"
+    compute_name = str(uuid4())[0:6]
     resp = batch_client.create_compute_environment(
         computeEnvironmentName=compute_name,
         type="UNMANAGED",
@@ -395,7 +417,7 @@ def test_failed_dependencies():
     arn = resp["computeEnvironmentArn"]
 
     resp = batch_client.create_job_queue(
-        jobQueueName="test_job_queue",
+        jobQueueName=str(uuid4())[0:6],
         state="ENABLED",
         priority=123,
         computeEnvironmentOrder=[{"order": 123, "computeEnvironment": arn}],
@@ -485,7 +507,7 @@ def test_container_overrides():
     ec2_client, iam_client, ecs_client, logs_client, batch_client = _get_clients()
     vpc_id, subnet_id, sg_id, iam_arn = _setup(ec2_client, iam_client)
 
-    compute_name = "test_compute_env"
+    compute_name = str(uuid4())[0:6]
     resp = batch_client.create_compute_environment(
         computeEnvironmentName=compute_name,
         type="UNMANAGED",
@@ -495,14 +517,14 @@ def test_container_overrides():
     arn = resp["computeEnvironmentArn"]
 
     resp = batch_client.create_job_queue(
-        jobQueueName="test_job_queue",
+        jobQueueName=str(uuid4())[0:6],
         state="ENABLED",
         priority=123,
         computeEnvironmentOrder=[{"order": 123, "computeEnvironment": arn}],
     )
     queue_arn = resp["jobQueueArn"]
 
-    job_definition_name = "sleep10"
+    job_definition_name = f"sleep10_{str(uuid4())[0:6]}"
 
     # Set up Job Definition
     # We will then override the container properties in the actual job
@@ -600,7 +622,7 @@ def test_container_overrides():
 
 
 def prepare_job(batch_client, commands, iam_arn, job_def_name):
-    compute_name = "test_compute_env"
+    compute_name = str(uuid4())[0:6]
     resp = batch_client.create_compute_environment(
         computeEnvironmentName=compute_name,
         type="UNMANAGED",
@@ -610,7 +632,7 @@ def prepare_job(batch_client, commands, iam_arn, job_def_name):
     arn = resp["computeEnvironmentArn"]
 
     resp = batch_client.create_job_queue(
-        jobQueueName="test_job_queue",
+        jobQueueName=str(uuid4())[0:6],
         state="ENABLED",
         priority=123,
         computeEnvironmentOrder=[{"order": 123, "computeEnvironment": arn}],

--- a/tests/test_batch/test_batch_task_definition.py
+++ b/tests/test_batch/test_batch_task_definition.py
@@ -2,6 +2,7 @@ from . import _get_clients, _setup
 import random
 import sure  # noqa
 from moto import mock_batch, mock_iam, mock_ec2, mock_ecs
+from uuid import uuid4
 
 
 @mock_ec2
@@ -51,10 +52,11 @@ def test_reregister_task_definition():
     ec2_client, iam_client, ecs_client, logs_client, batch_client = _get_clients()
     _setup(ec2_client, iam_client)
 
-    resp1 = register_job_def(batch_client)
+    job_def_name = str(uuid4())[0:6]
+    resp1 = register_job_def(batch_client, definition_name=job_def_name)
 
     resp1.should.contain("jobDefinitionArn")
-    resp1.should.contain("jobDefinitionName")
+    resp1.should.have.key("jobDefinitionName").equals(job_def_name)
     resp1.should.contain("revision")
 
     assert resp1["jobDefinitionArn"].endswith(
@@ -62,18 +64,18 @@ def test_reregister_task_definition():
     )
     resp1["revision"].should.equal(1)
 
-    resp2 = register_job_def(batch_client)
+    resp2 = register_job_def(batch_client, definition_name=job_def_name)
     resp2["revision"].should.equal(2)
 
     resp2["jobDefinitionArn"].should_not.equal(resp1["jobDefinitionArn"])
 
-    resp3 = register_job_def(batch_client)
+    resp3 = register_job_def(batch_client, definition_name=job_def_name)
     resp3["revision"].should.equal(3)
 
     resp3["jobDefinitionArn"].should_not.equal(resp1["jobDefinitionArn"])
     resp3["jobDefinitionArn"].should_not.equal(resp2["jobDefinitionArn"])
 
-    resp4 = register_job_def(batch_client)
+    resp4 = register_job_def(batch_client, definition_name=job_def_name)
     resp4["revision"].should.equal(4)
 
     resp4["jobDefinitionArn"].should_not.equal(resp1["jobDefinitionArn"])
@@ -89,12 +91,13 @@ def test_delete_task_definition():
     ec2_client, iam_client, ecs_client, logs_client, batch_client = _get_clients()
     _setup(ec2_client, iam_client)
 
-    resp = register_job_def(batch_client)
+    resp = register_job_def(batch_client, definition_name=str(uuid4()))
+    name = resp["jobDefinitionName"]
 
     batch_client.deregister_job_definition(jobDefinition=resp["jobDefinitionArn"])
 
-    resp = batch_client.describe_job_definitions()
-    len(resp["jobDefinitions"]).should.equal(0)
+    all_defs = batch_client.describe_job_definitions()["jobDefinitions"]
+    [jobdef["jobDefinitionName"] for jobdef in all_defs].shouldnt.contain(name)
 
 
 @mock_ec2
@@ -105,14 +108,13 @@ def test_delete_task_definition_by_name():
     ec2_client, iam_client, ecs_client, logs_client, batch_client = _get_clients()
     _setup(ec2_client, iam_client)
 
-    resp = register_job_def(batch_client)
+    resp = register_job_def(batch_client, definition_name=str(uuid4()))
+    name = resp["jobDefinitionName"]
 
-    batch_client.deregister_job_definition(
-        jobDefinition=f"{resp['jobDefinitionName']}:{resp['revision']}"
-    )
+    batch_client.deregister_job_definition(jobDefinition=f"{name}:{resp['revision']}")
 
-    resp = batch_client.describe_job_definitions()
-    len(resp["jobDefinitions"]).should.equal(0)
+    all_defs = batch_client.describe_job_definitions()["jobDefinitions"]
+    [jobdef["jobDefinitionName"] for jobdef in all_defs].shouldnt.contain(name)
 
 
 @mock_ec2
@@ -123,22 +125,30 @@ def test_describe_task_definition():
     ec2_client, iam_client, ecs_client, logs_client, batch_client = _get_clients()
     _setup(ec2_client, iam_client)
 
-    register_job_def(batch_client, definition_name="sleep10")
-    register_job_def(batch_client, definition_name="sleep10")
-    register_job_def(batch_client, definition_name="test1")
-    register_job_def_with_tags(batch_client, definition_name="tagged_def")
+    sleep_def_name = f"sleep10_{str(uuid4())[0:6]}"
+    other_name = str(uuid4())[0:6]
+    tagged_name = str(uuid4())[0:6]
+    register_job_def(batch_client, definition_name=sleep_def_name)
+    register_job_def(batch_client, definition_name=sleep_def_name)
+    register_job_def(batch_client, definition_name=other_name)
+    register_job_def_with_tags(batch_client, definition_name=tagged_name)
 
-    resp = batch_client.describe_job_definitions(jobDefinitionName="sleep10")
+    resp = batch_client.describe_job_definitions(jobDefinitionName=sleep_def_name)
     len(resp["jobDefinitions"]).should.equal(2)
 
-    resp = batch_client.describe_job_definitions()
-    len(resp["jobDefinitions"]).should.equal(4)
+    job_defs = batch_client.describe_job_definitions()["jobDefinitions"]
+    all_names = [jd["jobDefinitionName"] for jd in job_defs]
+    all_names.should.contain(sleep_def_name)
+    all_names.should.contain(other_name)
+    all_names.should.contain(tagged_name)
 
-    resp = batch_client.describe_job_definitions(jobDefinitions=["sleep10", "test1"])
+    resp = batch_client.describe_job_definitions(
+        jobDefinitions=[sleep_def_name, other_name]
+    )
     len(resp["jobDefinitions"]).should.equal(3)
     resp["jobDefinitions"][0]["tags"].should.equal({})
 
-    resp = batch_client.describe_job_definitions(jobDefinitionName="tagged_def")
+    resp = batch_client.describe_job_definitions(jobDefinitionName=tagged_name)
     resp["jobDefinitions"][0]["tags"].should.equal(
         {"foo": "123", "bar": "456",}
     )

--- a/tests/test_ec2/test_ec2_integration.py
+++ b/tests/test_ec2/test_ec2_integration.py
@@ -33,9 +33,14 @@ def test_run_instance_with_encrypted_ebs():
             }
         ],
     }
-    ec2.run_instances(**kwargs)
+    instance = ec2.run_instances(**kwargs)
+    instance_id = instance["Instances"][0]["InstanceId"]
 
-    instances = ec2.describe_instances().get("Reservations")[0].get("Instances")
+    instances = (
+        ec2.describe_instances(InstanceIds=[instance_id])
+        .get("Reservations")[0]
+        .get("Instances")
+    )
     volume = instances[0]["BlockDeviceMappings"][0]["Ebs"]
 
     volumes = ec2.describe_volumes(VolumeIds=[volume["VolumeId"]])

--- a/tests/test_ec2/test_egress_only_igw.py
+++ b/tests/test_ec2/test_egress_only_igw.py
@@ -48,7 +48,7 @@ def test_describe_all():
     gateways = client.describe_egress_only_internet_gateways()[
         "EgressOnlyInternetGateways"
     ]
-    gateways.should.have.length_of(2)
+    assert len(gateways) >= 2, "Should have two recently created gateways"
     gateways.should.contain(gw1)
     gateways.should.contain(gw2)
 
@@ -90,12 +90,12 @@ def test_create_and_delete():
     ]
     gw1_id = gw1["EgressOnlyInternetGatewayId"]
 
-    client.describe_egress_only_internet_gateways()[
-        "EgressOnlyInternetGateways"
-    ].should.have.length_of(1)
+    client.describe_egress_only_internet_gateways(
+        EgressOnlyInternetGatewayIds=[gw1_id]
+    )["EgressOnlyInternetGateways"].should.have.length_of(1)
 
     client.delete_egress_only_internet_gateway(EgressOnlyInternetGatewayId=gw1_id)
 
-    client.describe_egress_only_internet_gateways()[
-        "EgressOnlyInternetGateways"
-    ].should.have.length_of(0)
+    client.describe_egress_only_internet_gateways(
+        EgressOnlyInternetGatewayIds=[gw1_id]
+    )["EgressOnlyInternetGateways"].should.have.length_of(0)

--- a/tests/test_ec2/test_flow_logs_cloudformation.py
+++ b/tests/test_ec2/test_flow_logs_cloudformation.py
@@ -10,7 +10,9 @@ from moto import (
     mock_ec2,
     mock_s3,
 )
+from moto.core import ACCOUNT_ID
 from tests import EXAMPLE_AMI_ID
+from uuid import uuid4
 
 
 @mock_cloudformation
@@ -23,8 +25,9 @@ def test_flow_logs_by_cloudformation():
 
     vpc = client.create_vpc(CidrBlock="10.0.0.0/16")["Vpc"]
 
+    bucket_name = str(uuid4())
     bucket = s3.create_bucket(
-        Bucket="test-flow-logs",
+        Bucket=bucket_name,
         CreateBucketConfiguration={"LocationConstraint": "us-west-1"},
     )
 
@@ -47,11 +50,14 @@ def test_flow_logs_by_cloudformation():
         },
     }
     flow_log_template_json = json.dumps(flow_log_template)
+    stack_name = str(uuid4())
     stack_id = cf_client.create_stack(
-        StackName="test_stack", TemplateBody=flow_log_template_json
+        StackName=stack_name, TemplateBody=flow_log_template_json
     )["StackId"]
 
-    flow_logs = client.describe_flow_logs()["FlowLogs"]
+    flow_logs = client.describe_flow_logs(
+        Filters=[{"Name": "resource-id", "Values": [vpc["VpcId"]]}]
+    )["FlowLogs"]
     flow_logs.should.have.length_of(1)
     flow_logs[0]["ResourceId"].should.equal(vpc["VpcId"])
     flow_logs[0]["LogDestination"].should.equal("arn:aws:s3:::" + bucket.name)
@@ -81,15 +87,26 @@ def test_cloudformation():
 
     client = boto3.client("ec2", region_name="us-east-1")
     cf_conn = boto3.client("cloudformation", region_name="us-east-1")
+    stack_name = str(uuid4())
     cf_conn.create_stack(
-        StackName="test_stack", TemplateBody=json.dumps(dummy_template_json)
+        StackName=stack_name, TemplateBody=json.dumps(dummy_template_json)
     )
-    associations = client.describe_iam_instance_profile_associations()
-    associations["IamInstanceProfileAssociations"].should.have.length_of(1)
-    associations["IamInstanceProfileAssociations"][0]["IamInstanceProfile"][
-        "Arn"
-    ].should.contain("test_stack")
 
-    cf_conn.delete_stack(StackName="test_stack")
-    associations = client.describe_iam_instance_profile_associations()
-    associations["IamInstanceProfileAssociations"].should.have.length_of(0)
+    resources = cf_conn.list_stack_resources(StackName=stack_name)[
+        "StackResourceSummaries"
+    ]
+    iam_id = resources[0]["PhysicalResourceId"]
+    iam_ip_arn = f"arn:aws:iam::{ACCOUNT_ID}:instance-profile/{iam_id}"
+
+    all_assocs = client.describe_iam_instance_profile_associations()[
+        "IamInstanceProfileAssociations"
+    ]
+    our_assoc = [a for a in all_assocs if a["IamInstanceProfile"]["Arn"] == iam_ip_arn]
+    our_assoc[0]["IamInstanceProfile"]["Arn"].should.contain(stack_name)
+    our_assoc_id = our_assoc[0]["AssociationId"]
+
+    cf_conn.delete_stack(StackName=stack_name)
+    associations = client.describe_iam_instance_profile_associations()[
+        "IamInstanceProfileAssociations"
+    ]
+    [a["AssociationId"] for a in associations].shouldnt.contain(our_assoc_id)

--- a/tests/test_ec2/test_key_pairs.py
+++ b/tests/test_ec2/test_key_pairs.py
@@ -8,7 +8,9 @@ import sure  # noqa
 
 from boto.exception import EC2ResponseError
 from botocore.exceptions import ClientError
-from moto import mock_ec2, mock_ec2_deprecated
+from moto import mock_ec2, mock_ec2_deprecated, settings
+from uuid import uuid4
+from unittest import SkipTest
 
 from .helpers import rsa_check_private_key
 
@@ -55,6 +57,8 @@ def test_key_pairs_empty():
 
 @mock_ec2
 def test_key_pairs_empty_boto3():
+    if settings.TEST_SERVER_MODE:
+        raise SkipTest("ServerMode is not guaranteed to be empty")
     ec2 = boto3.resource("ec2", "us-west-1")
     client = boto3.client("ec2", "us-west-1")
     client.describe_key_pairs()["KeyPairs"].should.be.empty
@@ -78,7 +82,7 @@ def test_key_pairs_invalid_id_boto3():
     client = boto3.client("ec2", "us-west-1")
 
     with pytest.raises(ClientError) as ex:
-        client.describe_key_pairs(KeyNames=["foo"])
+        client.describe_key_pairs(KeyNames=[str(uuid4())])
     ex.value.response["ResponseMetadata"]["HTTPStatusCode"].should.equal(400)
     ex.value.response["ResponseMetadata"].should.have.key("RequestId")
     ex.value.response["Error"]["Code"].should.equal("InvalidKeyPair.NotFound")
@@ -145,21 +149,24 @@ def test_key_pairs_create_boto3():
     ec2 = boto3.resource("ec2", "us-west-1")
     client = boto3.client("ec2", "us-west-1")
 
-    kp = ec2.create_key_pair(KeyName="foo")
+    key_name = str(uuid4())[0:6]
+    kp = ec2.create_key_pair(KeyName=key_name)
     rsa_check_private_key(kp.key_material)
     # Verify the client can create a key_pair as well - should behave the same
-    kp2 = client.create_key_pair(KeyName="foo2")
+    key_name2 = str(uuid4())
+    kp2 = client.create_key_pair(KeyName=key_name2)
     rsa_check_private_key(kp2["KeyMaterial"])
 
     kp.key_material.shouldnt.equal(kp2["KeyMaterial"])
 
     kps = client.describe_key_pairs()["KeyPairs"]
-    kps.should.have.length_of(2)
-    set([k["KeyName"] for k in kps]).should.equal(set(["foo", "foo2"]))
+    all_names = set([k["KeyName"] for k in kps])
+    all_names.should.contain(key_name)
+    all_names.should.contain(key_name2)
 
-    kps = client.describe_key_pairs(KeyNames=["foo"])["KeyPairs"]
+    kps = client.describe_key_pairs(KeyNames=[key_name])["KeyPairs"]
     kps.should.have.length_of(1)
-    kps[0].should.have.key("KeyName").equal("foo")
+    kps[0].should.have.key("KeyName").equal(key_name)
     kps[0].should.have.key("KeyFingerprint")
 
 
@@ -180,10 +187,11 @@ def test_key_pairs_create_exist():
 @mock_ec2
 def test_key_pairs_create_exist_boto3():
     client = boto3.client("ec2", "us-west-1")
-    client.create_key_pair(KeyName="foo")
+    key_name = str(uuid4())[0:6]
+    client.create_key_pair(KeyName=key_name)
 
     with pytest.raises(ClientError) as ex:
-        client.create_key_pair(KeyName="foo")
+        client.create_key_pair(KeyName=key_name)
     ex.value.response["ResponseMetadata"]["HTTPStatusCode"].should.equal(400)
     ex.value.response["ResponseMetadata"].should.have.key("RequestId")
     ex.value.response["Error"]["Code"].should.equal("InvalidKeyPair.Duplicate")
@@ -201,8 +209,7 @@ def test_key_pairs_delete_no_exist():
 @mock_ec2
 def test_key_pairs_delete_no_exist_boto3():
     client = boto3.client("ec2", "us-west-1")
-    client.describe_key_pairs()["KeyPairs"].should.have.length_of(0)
-    client.delete_key_pair(KeyName="non-existing")
+    client.delete_key_pair(KeyName=str(uuid4())[0:6])
 
 
 # Has boto3 equivalent
@@ -228,18 +235,21 @@ def test_key_pairs_delete_exist():
 def test_key_pairs_delete_exist_boto3():
     ec2 = boto3.resource("ec2", "us-west-1")
     client = boto3.client("ec2", "us-west-1")
-    client.create_key_pair(KeyName="foo")
+    key_name = str(uuid4())[0:6]
+    client.create_key_pair(KeyName=key_name)
 
     with pytest.raises(ClientError) as ex:
-        client.delete_key_pair(KeyName="foo", DryRun=True)
+        client.delete_key_pair(KeyName=key_name, DryRun=True)
     ex.value.response["Error"]["Code"].should.equal("DryRunOperation")
     ex.value.response["ResponseMetadata"]["HTTPStatusCode"].should.equal(412)
     ex.value.response["Error"]["Message"].should.equal(
         "An error occurred (DryRunOperation) when calling the DeleteKeyPair operation: Request would have succeeded, but DryRun flag is set"
     )
 
-    client.delete_key_pair(KeyName="foo")
-    client.describe_key_pairs()["KeyPairs"].should.equal([])
+    client.delete_key_pair(KeyName=key_name)
+    [kp.get("Name") for kp in client.describe_key_pairs()["KeyPairs"]].shouldnt.contain(
+        key_name
+    )
 
 
 # Has boto3 equivalent
@@ -274,9 +284,10 @@ def test_key_pairs_import_boto3():
     ec2 = boto3.resource("ec2", "us-west-1")
     client = boto3.client("ec2", "us-west-1")
 
+    key_name = str(uuid4())[0:6]
     with pytest.raises(ClientError) as ex:
         client.import_key_pair(
-            KeyName="foo", PublicKeyMaterial=RSA_PUBLIC_KEY_OPENSSH, DryRun=True
+            KeyName=key_name, PublicKeyMaterial=RSA_PUBLIC_KEY_OPENSSH, DryRun=True
         )
     ex.value.response["Error"]["Code"].should.equal("DryRunOperation")
     ex.value.response["ResponseMetadata"]["HTTPStatusCode"].should.equal(412)
@@ -285,22 +296,23 @@ def test_key_pairs_import_boto3():
     )
 
     kp1 = client.import_key_pair(
-        KeyName="foo", PublicKeyMaterial=RSA_PUBLIC_KEY_OPENSSH
+        KeyName=key_name, PublicKeyMaterial=RSA_PUBLIC_KEY_OPENSSH
     )
-    print(kp1)
-    kp1.should.have.key("KeyName").equal("foo")
+
+    kp1.should.have.key("KeyName").equal(key_name)
     kp1.should.have.key("KeyFingerprint").equal(RSA_PUBLIC_KEY_FINGERPRINT)
 
+    key_name2 = str(uuid4())
     kp2 = client.import_key_pair(
-        KeyName="foo2", PublicKeyMaterial=RSA_PUBLIC_KEY_RFC4716
+        KeyName=key_name2, PublicKeyMaterial=RSA_PUBLIC_KEY_RFC4716
     )
-    kp2.should.have.key("KeyName").equal("foo2")
+    kp2.should.have.key("KeyName").equal(key_name2)
     kp2.should.have.key("KeyFingerprint").equal(RSA_PUBLIC_KEY_FINGERPRINT)
 
-    kps = client.describe_key_pairs()["KeyPairs"]
-    kps.should.have.length_of(2)
-    kps[0]["KeyName"].should.equal(kp1["KeyName"])
-    kps[1]["KeyName"].should.equal(kp2["KeyName"])
+    all_kps = client.describe_key_pairs()["KeyPairs"]
+    all_names = [kp["KeyName"] for kp in all_kps]
+    all_names.should.contain(kp1["KeyName"])
+    all_names.should.contain(kp2["KeyName"])
 
 
 # Has boto3 equivalent
@@ -323,12 +335,16 @@ def test_key_pairs_import_exist_boto3():
     ec2 = boto3.resource("ec2", "us-west-1")
     client = boto3.client("ec2", "us-west-1")
 
-    kp = client.import_key_pair(KeyName="foo", PublicKeyMaterial=RSA_PUBLIC_KEY_OPENSSH)
-    kp["KeyName"].should.equal("foo")
-    client.describe_key_pairs()["KeyPairs"].should.have.length_of(1)
+    key_name = str(uuid4())[0:6]
+    kp = client.import_key_pair(
+        KeyName=key_name, PublicKeyMaterial=RSA_PUBLIC_KEY_OPENSSH
+    )
+    kp["KeyName"].should.equal(key_name)
+
+    client.describe_key_pairs(KeyNames=[key_name])["KeyPairs"].should.have.length_of(1)
 
     with pytest.raises(ClientError) as ex:
-        client.create_key_pair(KeyName="foo")
+        client.create_key_pair(KeyName=key_name)
     ex.value.response["ResponseMetadata"]["HTTPStatusCode"].should.equal(400)
     ex.value.response["ResponseMetadata"].should.have.key("RequestId")
     ex.value.response["Error"]["Code"].should.equal("InvalidKeyPair.Duplicate")
@@ -406,12 +422,15 @@ def test_key_pair_filters_boto3():
     ec2 = boto3.resource("ec2", "us-west-1")
     client = boto3.client("ec2", "us-west-1")
 
-    _ = ec2.create_key_pair(KeyName="kpfltr1")
-    kp2 = ec2.create_key_pair(KeyName="kpfltr2")
-    kp3 = ec2.create_key_pair(KeyName="kpfltr3")
+    key_name_1 = str(uuid4())[0:6]
+    key_name_2 = str(uuid4())[0:6]
+    key_name_3 = str(uuid4())[0:6]
+    _ = ec2.create_key_pair(KeyName=key_name_1)
+    kp2 = ec2.create_key_pair(KeyName=key_name_2)
+    kp3 = ec2.create_key_pair(KeyName=key_name_3)
 
     kp_by_name = client.describe_key_pairs(
-        Filters=[{"Name": "key-name", "Values": ["kpfltr2"]}]
+        Filters=[{"Name": "key-name", "Values": [key_name_2]}]
     )["KeyPairs"]
     set([kp["KeyName"] for kp in kp_by_name]).should.equal(set([kp2.name]))
 

--- a/tests/test_ec2/test_security_groups_cloudformation.py
+++ b/tests/test_ec2/test_security_groups_cloudformation.py
@@ -3,9 +3,13 @@ import json
 import sure  # noqa
 from moto import mock_cloudformation, mock_ec2
 from tests import EXAMPLE_AMI_ID
+from string import Template
+from uuid import uuid4
+from .test_instances import retrieve_all_instances
 
 
-SEC_GROUP_INGRESS = """{
+SEC_GROUP_INGRESS = Template(
+    """{
     "AWSTemplateFormatVersion": "2010-09-09",
     "Description": "AWS CloudFormation Template to create an EC2 instance",
     "Parameters": {
@@ -20,7 +24,7 @@ SEC_GROUP_INGRESS = """{
             "Type": "AWS::EC2::SecurityGroup",
             "Properties": {
                 "GroupDescription": "Test VPC security group",
-                "GroupName": "My-SG",
+                "GroupName": $group_name,
                 "VpcId": {
                     "Ref": "VPCId"
                 }
@@ -45,9 +49,11 @@ SEC_GROUP_INGRESS = """{
     }
 }
 """
+)
 
 
-SEC_GROUP_INGRESS_WITHOUT_DESC = """{
+SEC_GROUP_INGRESS_WITHOUT_DESC = Template(
+    """{
     "AWSTemplateFormatVersion": "2010-09-09",
     "Description": "AWS CloudFormation Template to create an EC2 instance",
     "Parameters": {
@@ -62,7 +68,7 @@ SEC_GROUP_INGRESS_WITHOUT_DESC = """{
             "Type": "AWS::EC2::SecurityGroup",
             "Properties": {
                 "GroupDescription": "Test VPC security group",
-                "GroupName": "My-SG",
+                "GroupName": "$group_name",
                 "VpcId": {
                     "Ref": "VPCId"
                 }
@@ -86,6 +92,7 @@ SEC_GROUP_INGRESS_WITHOUT_DESC = """{
     }
 }
 """
+)
 
 SEC_GROUP_SOURCE = {
     "AWSTemplateFormatVersion": "2010-09-09",
@@ -133,17 +140,18 @@ def test_security_group_ingress():
     ec2 = boto3.resource("ec2", region_name="us-west-1")
     ec2_client = boto3.client("ec2", region_name="us-east-1")
 
+    group_name = str(uuid4())
     vpc = ec2.create_vpc(CidrBlock="10.0.0.0/16")
     cf_client.create_stack(
-        StackName="test_stack",
-        TemplateBody=SEC_GROUP_INGRESS,
+        StackName=str(uuid4()),
+        TemplateBody=SEC_GROUP_INGRESS.substitute(group_name=group_name),
         Parameters=[{"ParameterKey": "VPCId", "ParameterValue": vpc.id}],
         Capabilities=["CAPABILITY_NAMED_IAM"],
         OnFailure="DELETE",
     )
 
     groups = ec2_client.describe_security_groups()["SecurityGroups"]
-    group = [g for g in groups if g["GroupName"] == "My-SG"][0]
+    group = [g for g in groups if g["GroupName"] == group_name][0]
     group["Description"].should.equal("Test VPC security group")
     len(group["IpPermissions"]).should.be(1)
     ingress = group["IpPermissions"][0]
@@ -162,17 +170,18 @@ def test_security_group_ingress_without_description():
     ec2 = boto3.resource("ec2", region_name="us-west-1")
     ec2_client = boto3.client("ec2", region_name="us-east-1")
 
+    group_name = str(uuid4())
     vpc = ec2.create_vpc(CidrBlock="10.0.0.0/16")
     cf_client.create_stack(
-        StackName="test_stack",
-        TemplateBody=SEC_GROUP_INGRESS_WITHOUT_DESC,
+        StackName=str(uuid4()),
+        TemplateBody=SEC_GROUP_INGRESS_WITHOUT_DESC.substitute(group_name=group_name),
         Parameters=[{"ParameterKey": "VPCId", "ParameterValue": vpc.id}],
         Capabilities=["CAPABILITY_NAMED_IAM"],
         OnFailure="DELETE",
     )
 
     groups = ec2_client.describe_security_groups()["SecurityGroups"]
-    group = [g for g in groups if g["GroupName"] == "My-SG"][0]
+    group = [g for g in groups if g["GroupName"] == group_name][0]
     group["Description"].should.equal("Test VPC security group")
     len(group["IpPermissions"]).should.be(1)
     ingress = group["IpPermissions"][0]
@@ -183,28 +192,46 @@ def test_security_group_ingress_without_description():
 @mock_cloudformation
 def test_stack_security_groups():
 
-    template = json.dumps(SEC_GROUP_SOURCE)
+    first_desc = str(uuid4())
+    second_desc = str(uuid4())
+    our_template = SEC_GROUP_SOURCE.copy()
+    our_template["Resources"]["my-security-group"]["Properties"][
+        "GroupDescription"
+    ] = second_desc
+    our_template["Resources"]["InstanceSecurityGroup"]["Properties"][
+        "GroupDescription"
+    ] = first_desc
+
+    template = json.dumps(our_template)
 
     cf = boto3.client("cloudformation", region_name="us-west-1")
+    stack_name = str(uuid4())[0:6]
     cf.create_stack(
-        StackName="security_group_stack",
+        StackName=stack_name,
         TemplateBody=template,
         Tags=[{"Key": "foo", "Value": "bar"}],
     )
 
     ec2 = boto3.client("ec2", region_name="us-west-1")
     instance_group = ec2.describe_security_groups(
-        Filters=[{"Name": "description", "Values": ["My security group"]}]
+        Filters=[{"Name": "description", "Values": [first_desc]}]
     )["SecurityGroups"][0]
-    instance_group.should.have.key("Description").equal("My security group")
+    instance_group.should.have.key("Description").equal(first_desc)
     instance_group.should.have.key("Tags")
     instance_group["Tags"].should.contain({"Key": "bar", "Value": "baz"})
     instance_group["Tags"].should.contain({"Key": "foo", "Value": "bar"})
     other_group = ec2.describe_security_groups(
-        Filters=[{"Name": "description", "Values": ["My other group"]}]
+        Filters=[{"Name": "description", "Values": [second_desc]}]
     )["SecurityGroups"][0]
 
-    ec2_instance = ec2.describe_instances()["Reservations"][0]["Instances"][0]
+    instance = cf.list_stack_resources(StackName=stack_name)["StackResourceSummaries"][
+        1
+    ]
+    instance_id = instance["PhysicalResourceId"]
+
+    ec2_instance = ec2.describe_instances(InstanceIds=[instance_id])["Reservations"][0][
+        "Instances"
+    ][0]
 
     ec2_instance["NetworkInterfaces"][0]["Groups"][0]["GroupId"].should.equal(
         instance_group["GroupId"]

--- a/tests/test_ec2/test_vpc_endpoint_services.py
+++ b/tests/test_ec2/test_vpc_endpoint_services.py
@@ -4,11 +4,16 @@ import pytest
 import boto3
 from botocore.exceptions import ClientError
 
-from moto import mock_ec2
+from moto import mock_ec2, settings
+from unittest import SkipTest
 
 
 @mock_ec2
 def test_describe_vpc_endpoint_services_bad_args():
+    if settings.TEST_SERVER_MODE:
+        # Long-running operation - doesn't quite work in ServerMode, with parallel tests
+        # Probably needs some locking to force the initialization to only occur once
+        raise SkipTest("Can't run in ServerMode")
     """Verify exceptions are raised for bad arguments."""
     ec2 = boto3.client("ec2", region_name="us-west-1")
 

--- a/tests/test_sqs/test_sqs_cloudformation.py
+++ b/tests/test_sqs/test_sqs_cloudformation.py
@@ -4,18 +4,21 @@ import json
 import sure  # noqa
 from moto import mock_sqs, mock_cloudformation
 from moto.core import ACCOUNT_ID
+from string import Template
 from uuid import uuid4
 
-simple_queue = {
+simple_queue = Template(
+    """{
     "AWSTemplateFormatVersion": "2010-09-09",
     "Resources": {
         "QueueGroup": {
             "Type": "AWS::SQS::Queue",
-            "Properties": {"QueueName": "my-queue", "VisibilityTimeout": 60},
+            "Properties": {"QueueName": $q_name, "VisibilityTimeout": 60},
         }
     },
-}
-simple_queue_json = json.dumps(simple_queue)
+}"""
+)
+
 sqs_template_with_tags = """
 {
     "AWSTemplateFormatVersion": "2010-09-09",
@@ -47,16 +50,18 @@ def test_describe_stack_subresources():
     client = boto3.client("sqs", region_name="us-east-1")
 
     stack_name = str(uuid4())[0:6]
-    cf.create_stack(StackName=stack_name, TemplateBody=simple_queue_json)
+    q_name = str(uuid4())[0:6]
+    template_body = simple_queue.substitute(q_name=q_name)
+    cf.create_stack(StackName=stack_name, TemplateBody=template_body)
 
-    queue_url = client.list_queues()["QueueUrls"][0]
-    queue_url.should.contain("{}/{}".format(ACCOUNT_ID, "my-queue"))
+    queue_urls = client.list_queues()["QueueUrls"]
+    assert any(["{}/{}".format(ACCOUNT_ID, q_name) in url for url in queue_urls])
 
     stack = res.Stack(stack_name)
     for s in stack.resource_summaries.all():
         s.resource_type.should.equal("AWS::SQS::Queue")
         s.logical_id.should.equal("QueueGroup")
-        s.physical_resource_id.should.equal("my-queue")
+        s.physical_resource_id.should.equal(q_name)
 
 
 @mock_sqs
@@ -66,16 +71,18 @@ def test_list_stack_resources():
     client = boto3.client("sqs", region_name="us-east-1")
 
     stack_name = str(uuid4())[0:6]
-    cf.create_stack(StackName=stack_name, TemplateBody=simple_queue_json)
+    q_name = str(uuid4())[0:6]
+    template_body = simple_queue.substitute(q_name=q_name)
+    cf.create_stack(StackName=stack_name, TemplateBody=template_body)
 
-    queue_url = client.list_queues()["QueueUrls"][0]
-    queue_url.should.contain("{}/{}".format(ACCOUNT_ID, "my-queue"))
+    queue_urls = client.list_queues()["QueueUrls"]
+    assert any(["{}/{}".format(ACCOUNT_ID, q_name) in url for url in queue_urls])
 
     queue = cf.list_stack_resources(StackName=stack_name)["StackResourceSummaries"][0]
 
     queue.should.have.key("ResourceType").equal("AWS::SQS::Queue")
     queue.should.have.key("LogicalResourceId").should.equal("QueueGroup")
-    queue.should.have.key("PhysicalResourceId").should.equal("my-queue")
+    queue.should.have.key("PhysicalResourceId").should.equal(q_name)
 
 
 @mock_sqs
@@ -100,12 +107,13 @@ def test_create_from_cloudformation_json_with_tags():
 @mock_cloudformation
 @mock_sqs
 def test_update_stack():
+    q_name = str(uuid4())[0:6]
     sqs_template = {
         "AWSTemplateFormatVersion": "2010-09-09",
         "Resources": {
             "QueueGroup": {
                 "Type": "AWS::SQS::Queue",
-                "Properties": {"QueueName": "my-queue", "VisibilityTimeout": 60},
+                "Properties": {"QueueName": q_name, "VisibilityTimeout": 60},
             }
         },
     }
@@ -116,7 +124,7 @@ def test_update_stack():
     cf.create_stack(StackName=stack_name, TemplateBody=sqs_template_json)
 
     client = boto3.client("sqs", region_name="us-west-1")
-    queues = client.list_queues()["QueueUrls"]
+    queues = client.list_queues(QueueNamePrefix=q_name)["QueueUrls"]
     queues.should.have.length_of(1)
     attrs = client.get_queue_attributes(QueueUrl=queues[0], AttributeNames=["All"])[
         "Attributes"
@@ -129,7 +137,7 @@ def test_update_stack():
     cf.update_stack(StackName=stack_name, TemplateBody=sqs_template_json)
 
     # then the attribute should be updated
-    queues = client.list_queues()["QueueUrls"]
+    queues = client.list_queues(QueueNamePrefix=q_name)["QueueUrls"]
     queues.should.have.length_of(1)
     attrs = client.get_queue_attributes(QueueUrl=queues[0], AttributeNames=["All"])[
         "Attributes"
@@ -140,12 +148,13 @@ def test_update_stack():
 @mock_cloudformation
 @mock_sqs
 def test_update_stack_and_remove_resource():
+    q_name = str(uuid4())[0:6]
     sqs_template = {
         "AWSTemplateFormatVersion": "2010-09-09",
         "Resources": {
             "QueueGroup": {
                 "Type": "AWS::SQS::Queue",
-                "Properties": {"QueueName": "my-queue", "VisibilityTimeout": 60},
+                "Properties": {"QueueName": q_name, "VisibilityTimeout": 60},
             }
         },
     }
@@ -156,15 +165,14 @@ def test_update_stack_and_remove_resource():
     cf.create_stack(StackName=stack_name, TemplateBody=sqs_template_json)
 
     client = boto3.client("sqs", region_name="us-west-1")
-    client.list_queues()["QueueUrls"].should.have.length_of(1)
+    client.list_queues(QueueNamePrefix=q_name)["QueueUrls"].should.have.length_of(1)
 
     sqs_template["Resources"].pop("QueueGroup")
     sqs_template_json = json.dumps(sqs_template)
     cf.update_stack(StackName=stack_name, TemplateBody=sqs_template_json)
 
-    client.list_queues().shouldnt.have.key(
-        "QueueUrls"
-    )  # No queues exist, so the key is not passed through
+    # No queues exist, so the key is not passed through
+    client.list_queues(QueueNamePrefix=q_name).shouldnt.have.key("QueueUrls")
 
 
 @mock_cloudformation
@@ -173,23 +181,25 @@ def test_update_stack_and_add_resource():
     sqs_template = {"AWSTemplateFormatVersion": "2010-09-09", "Resources": {}}
     sqs_template_json = json.dumps(sqs_template)
 
+    q_name = str(uuid4())[0:6]
+
     cf = boto3.client("cloudformation", region_name="us-west-1")
     stack_name = str(uuid4())[0:6]
     cf.create_stack(StackName=stack_name, TemplateBody=sqs_template_json)
 
     client = boto3.client("sqs", region_name="us-west-1")
-    client.list_queues().shouldnt.have.key("QueueUrls")
+    client.list_queues(QueueNamePrefix=q_name).shouldnt.have.key("QueueUrls")
 
     sqs_template = {
         "AWSTemplateFormatVersion": "2010-09-09",
         "Resources": {
             "QueueGroup": {
                 "Type": "AWS::SQS::Queue",
-                "Properties": {"QueueName": "my-queue", "VisibilityTimeout": 60},
+                "Properties": {"QueueName": q_name, "VisibilityTimeout": 60},
             }
         },
     }
     sqs_template_json = json.dumps(sqs_template)
     cf.update_stack(StackName=stack_name, TemplateBody=sqs_template_json)
 
-    client.list_queues()["QueueUrls"].should.have.length_of(1)
+    client.list_queues(QueueNamePrefix=q_name)["QueueUrls"].should.have.length_of(1)

--- a/travis_moto_server.sh
+++ b/travis_moto_server.sh
@@ -4,4 +4,4 @@ export MOTO_PORT=${MOTO_PORT:-5000}
 
 set -e
 pip install $(ls /moto/dist/moto*.gz)[server,all]
-moto_server -H 0.0.0.0 -p ${MOTO_PORT}
+moto_server -H 0.0.0.0 -p ${MOTO_PORT} > /moto/server_output.log 2>&1


### PR DESCRIPTION
To speed up our CI, this PR introduces parallelized ServerMode tests for the `awslambda`, `batch`, `ec2` and `sqs` services.

Initial tests show that this reduces the CI-time by about 10 minutes.
The services were chosen as guinea pigs because they took the longest to execute sequentially, and would give the biggest ROI.
We could expand to other services, but I don't expect to drastically improve on the current runtime.

This PR consists of a few parts:
 - Introduces pytest-xdist, for the actual parallelization
 - Introduces is a new environment variable to disable the reset-API, `MOTO_CALL_RESET_API=false`. This is to prevent from tests calling the reset-API while other tests are modifying the state.  
This env variable defaults to True, i.e. for all other tests the reset-API will behave like normal.
 - Rewrites Batch/EC2/SQS tests to assume the state is not empty (i.e., using unique queue-names, assuming `describe_reservations` returns instances from other tests, etc
 - (AWS Lambda tests were already prepared in #4317 )
 - Some minor changes in the logic to allow parallel access, such as creating copies of a list to prevent other tests from modifying the list while we're iterating over it
 - Adds support for the CustomerGatewayIds-parameter in describe_customer_gateways()
 - Adds support for the SpotInstanceRequestIds-parameter in spot_instance_ids()
 - Adds support for the TransitGatewayIds-parameter in describe_transit_gateways()
 - Fixed a bug in SQS where the queue-name could be passed as an integer when  using CloudFormation

Also adds some minor janitorial improvements:
 - Remove old/outdated Make-targets
 - Improve the way the Terraform tests are split, by seeing which tests we'll actually execute, instead of basing it on the tests that are listed
 - The MotoServer logs are now archived after every CI run, even if it failed, for debugging purposes

The decorator-tests still run sequentially, because there will always be tests that depend on an clean state, such as verifying whether a default VPC exists.

