### PR TITLE
DynamoDB - Validate the nr of Add-clauses on update

### DIFF
--- a/moto/dynamodb2/exceptions.py
+++ b/moto/dynamodb2/exceptions.py
@@ -204,3 +204,10 @@ class UpdateHashRangeKeyException(MockValidationException):
 
     def __init__(self, key_name):
         super(UpdateHashRangeKeyException, self).__init__(self.msg.format(key_name))
+
+
+class TooManyAddClauses(InvalidUpdateExpression):
+    msg = 'The "ADD" section can only be used once in an update expression;'
+
+    def __init__(self):
+        super(TooManyAddClauses, self).__init__(self.msg)

--- a/moto/dynamodb2/models/__init__.py
+++ b/moto/dynamodb2/models/__init__.py
@@ -1388,6 +1388,7 @@ class DynamoDBBackend(BaseBackend):
             # Parse expression to get validation errors
             update_expression_ast = UpdateExpressionParser.make(update_expression)
             update_expression = re.sub(r"\s*([=\+-])\s*", "\\1", update_expression)
+            update_expression_ast.validate()
 
         if all([table.hash_key_attr in key, table.range_key_attr in key]):
             # Covers cases where table has hash and range keys, ``key`` param


### PR DESCRIPTION
Fixes #3972. Only a single ADD-clause can be added to an UpdateExpression in the `update_item()` feature.

There are probably other rules like this, so I've made it somewhat extendable.

The test has been validated against AWS.