### PR TITLE
EC2 - Bugfix where associate_public_ip was always True

### DIFF
--- a/moto/ec2/models.py
+++ b/moto/ec2/models.py
@@ -410,7 +410,10 @@ class NetworkInterface(TaggedEC2Resource, CloudFormationModel):
         self.check_auto_public_ip()
 
     def check_auto_public_ip(self):
-        if self.public_ip_auto_assign:
+        if (
+            self.public_ip_auto_assign
+            and str(self.public_ip_auto_assign).lower() == "true"
+        ):
             self.public_ip = random_public_ip()
 
     @property


### PR DESCRIPTION
Fixes #2762

The `public_ip_auto_assign`-attribute was persisted as a string, so `if"false"` would always evaluate to True