### PR TITLE
add host.docker.internal for inter-AWS communication mocking on linux

### DIFF
--- a/moto/awslambda/models.py
+++ b/moto/awslambda/models.py
@@ -635,12 +635,8 @@ class LambdaFunction(CloudFormationModel, DockerModel):
     def save_logs(self, output):
         # Send output to "logs" backend
         invoke_id = uuid.uuid4().hex
-        log_stream_name = (
-            "{date.year}/{date.month:02d}/{date.day:02d}/[{version}]{invoke_id}".format(
-                date=datetime.datetime.utcnow(),
-                version=self.version,
-                invoke_id=invoke_id,
-            )
+        log_stream_name = "{date.year}/{date.month:02d}/{date.day:02d}/[{version}]{invoke_id}".format(
+            date=datetime.datetime.utcnow(), version=self.version, invoke_id=invoke_id,
         )
         self.logs_backend.create_log_stream(self.logs_group_name, log_stream_name)
         log_events = [


### PR DESCRIPTION
I am open to feedback here if you don't like my approach.

### The problem

I couldn't communicate between my lambda and moto running in server mode. We have lambdas that interact with S3 and we want to mock their behavior in server mode. Unfortunately, the lambdas run in docker so they have no access to localhost on the host machine when running on Linux, which is where our CICD runs. This makes sense because the whole point of docker is isolation but for testing purposes we need some way of breaking out.

### The Change

On the desktop versions of docker for Mac and Windows they add `host.docker.internal` as an extra host mapped to the host gateway. This allows for communication like this locally. The problem I had is that I can't modify the docker command that runs the lambda docker containers. So I created this PR to emulate that behavior on linux.

### Some other stuff I considered

Using host networking. I ultimately decided that this was way messier.

Adding this as an environment variable/config. I felt like this was a bit overly complex though I am still open to it. However, this behavior already exists on some platforms as is.

Adding a configurable docker network. This would probably be the most thorough way to solve this issue. In this scenario the user could configure a network to be passed in and communication could be handled using docker networking. I also felt this was a little overly complex though I am open to it as well.