### PR TITLE
EC2 - Implement DryRun-flag on various operations

### DIFF
--- a/moto/core/responses.py
+++ b/moto/core/responses.py
@@ -802,7 +802,11 @@ class BaseResponse(_TemplateEnvironmentMixin, ActionAuthenticatorMixin):
     def request_json(self):
         return "JSON" in self.querystring.get("ContentType", [])
 
-    def is_not_dryrun(self, action):
+    def error_on_dryrun(self):
+        self.is_not_dryrun()
+
+    def is_not_dryrun(self, action=None):
+        action = action or self._get_param("Action")
         if "true" in self.querystring.get("DryRun", ["false"]):
             message = (
                 "An error occurred (DryRunOperation) when calling the %s operation: Request would have succeeded, but DryRun flag is set"

--- a/moto/ec2/responses/amis.py
+++ b/moto/ec2/responses/amis.py
@@ -40,6 +40,7 @@ class AmisResponse(BaseResponse):
             return template.render(success=str(success).lower())
 
     def describe_images(self):
+        self.error_on_dryrun()
         ami_ids = self._get_multi_param("ImageId")
         filters = filters_from_querystring(self.querystring)
         owners = self._get_multi_param("Owner")

--- a/moto/ec2/responses/availability_zones_and_regions.py
+++ b/moto/ec2/responses/availability_zones_and_regions.py
@@ -4,11 +4,13 @@ from moto.core.responses import BaseResponse
 
 class AvailabilityZonesAndRegions(BaseResponse):
     def describe_availability_zones(self):
+        self.error_on_dryrun()
         zones = self.ec2_backend.describe_availability_zones()
         template = self.response_template(DESCRIBE_ZONES_RESPONSE)
         return template.render(zones=zones)
 
     def describe_regions(self):
+        self.error_on_dryrun()
         region_names = self._get_multi_param("RegionName")
         regions = self.ec2_backend.describe_regions(region_names)
         template = self.response_template(DESCRIBE_REGIONS_RESPONSE)

--- a/moto/ec2/responses/customer_gateways.py
+++ b/moto/ec2/responses/customer_gateways.py
@@ -26,6 +26,7 @@ class CustomerGateways(BaseResponse):
         return template.render(delete_status=delete_status)
 
     def describe_customer_gateways(self):
+        self.error_on_dryrun()
         filters = filters_from_querystring(self.querystring)
         customer_gateway_ids = self._get_multi_param("CustomerGatewayId")
         customer_gateways = self.ec2_backend.get_all_customer_gateways(

--- a/moto/ec2/responses/elastic_ip_addresses.py
+++ b/moto/ec2/responses/elastic_ip_addresses.py
@@ -70,6 +70,7 @@ class ElasticIPAddresses(BaseResponse):
             return template.render(address=eip)
 
     def describe_addresses(self):
+        self.error_on_dryrun()
         allocation_ids = self._get_multi_param("AllocationId")
         public_ips = self._get_multi_param("PublicIp")
         filters = filters_from_querystring(self.querystring)

--- a/moto/ec2/responses/instances.py
+++ b/moto/ec2/responses/instances.py
@@ -16,6 +16,7 @@ from copy import deepcopy
 
 class InstanceResponse(BaseResponse):
     def describe_instances(self):
+        self.error_on_dryrun()
         filter_dict = filters_from_querystring(self.querystring)
         instance_ids = self._get_multi_param("InstanceId")
         token = self._get_param("NextToken")

--- a/moto/ec2/responses/subnets.py
+++ b/moto/ec2/responses/subnets.py
@@ -39,6 +39,7 @@ class Subnets(BaseResponse):
         return template.render(subnet=subnet)
 
     def describe_subnets(self):
+        self.error_on_dryrun()
         subnet_ids = self._get_multi_param("SubnetId")
         filters = filters_from_querystring(self.querystring)
         subnets = self.ec2_backend.get_all_subnets(subnet_ids, filters)

--- a/moto/ec2/responses/vpcs.py
+++ b/moto/ec2/responses/vpcs.py
@@ -40,6 +40,7 @@ class VPCs(BaseResponse):
         return template.render(vpc=vpc)
 
     def describe_vpcs(self):
+        self.error_on_dryrun()
         vpc_ids = self._get_multi_param("VpcId")
         filters = filters_from_querystring(self.querystring)
         vpcs = self.ec2_backend.describe_vpcs(vpc_ids=vpc_ids, filters=filters)

--- a/tests/test_ec2/test_amis.py
+++ b/tests/test_ec2/test_amis.py
@@ -1761,3 +1761,16 @@ def test_ami_filter_by_unknown_ownerid():
         Filters=[{"Name": "owner-alias", "Values": ["unknown",]},]
     )["Images"]
     images.should.have.length_of(0)
+
+
+@mock_ec2
+def test_describe_images_dryrun():
+    client = boto3.client("ec2", region_name="us-east-1")
+
+    with pytest.raises(ClientError) as ex:
+        client.describe_images(DryRun=True)
+    ex.value.response["ResponseMetadata"]["HTTPStatusCode"].should.equal(412)
+    ex.value.response["Error"]["Code"].should.equal("DryRunOperation")
+    ex.value.response["Error"]["Message"].should.equal(
+        "An error occurred (DryRunOperation) when calling the DescribeImages operation: Request would have succeeded, but DryRun flag is set"
+    )

--- a/tests/test_ec2/test_customer_gateways.py
+++ b/tests/test_ec2/test_customer_gateways.py
@@ -44,6 +44,19 @@ def test_describe_customer_gateways():
 
 
 @mock_ec2
+def test_describe_customer_gateways_dryrun():
+    client = boto3.client("ec2", region_name="us-east-1")
+
+    with pytest.raises(ClientError) as ex:
+        client.describe_customer_gateways(DryRun=True)
+    ex.value.response["ResponseMetadata"]["HTTPStatusCode"].should.equal(412)
+    ex.value.response["Error"]["Code"].should.equal("DryRunOperation")
+    ex.value.response["Error"]["Message"].should.equal(
+        "An error occurred (DryRunOperation) when calling the DescribeCustomerGateways operation: Request would have succeeded, but DryRun flag is set"
+    )
+
+
+@mock_ec2
 def test_describe_customer_gateways_boto3():
     ec2 = boto3.client("ec2", region_name="us-east-1")
 

--- a/tests/test_ec2/test_elastic_ip_addresses.py
+++ b/tests/test_ec2/test_elastic_ip_addresses.py
@@ -107,6 +107,19 @@ def test_eip_allocate_vpc():
 
 
 @mock_ec2
+def test_describe_addresses_dryrun():
+    client = boto3.client("ec2", region_name="us-east-1")
+
+    with pytest.raises(ClientError) as ex:
+        client.describe_addresses(DryRun=True)
+    ex.value.response["ResponseMetadata"]["HTTPStatusCode"].should.equal(412)
+    ex.value.response["Error"]["Code"].should.equal("DryRunOperation")
+    ex.value.response["Error"]["Message"].should.equal(
+        "An error occurred (DryRunOperation) when calling the DescribeAddresses operation: Request would have succeeded, but DryRun flag is set"
+    )
+
+
+@mock_ec2
 def test_eip_allocate_vpc_boto3():
     """Allocate/release VPC EIP"""
     client = boto3.client("ec2", region_name="us-east-1")

--- a/tests/test_ec2/test_instances.py
+++ b/tests/test_ec2/test_instances.py
@@ -3096,6 +3096,19 @@ def test_run_instance_and_associate_public_ip():
     addresses["Association"].should.have.key("PublicIp")
 
 
+@mock_ec2
+def test_describe_instances_dryrun():
+    client = boto3.client("ec2", region_name="us-east-1")
+
+    with pytest.raises(ClientError) as ex:
+        client.describe_instances(DryRun=True)
+    ex.value.response["ResponseMetadata"]["HTTPStatusCode"].should.equal(412)
+    ex.value.response["Error"]["Code"].should.equal("DryRunOperation")
+    ex.value.response["Error"]["Message"].should.equal(
+        "An error occurred (DryRunOperation) when calling the DescribeInstances operation: Request would have succeeded, but DryRun flag is set"
+    )
+
+
 def retrieve_all_reservations(client, filters=[]):
     resp = client.describe_instances(Filters=filters)
     all_reservations = resp["Reservations"]

--- a/tests/test_ec2/test_regions.py
+++ b/tests/test_ec2/test_regions.py
@@ -3,9 +3,11 @@ import boto.ec2
 import boto.ec2.autoscale
 import boto.ec2.elb
 import boto3
-import sure
+import pytest
+import sure  # noqa
 from boto3 import Session
 
+from botocore.exceptions import ClientError
 from moto import mock_ec2_deprecated, mock_autoscaling_deprecated, mock_elb_deprecated
 from moto import mock_autoscaling, mock_ec2, mock_elb
 
@@ -283,3 +285,16 @@ def test_create_autoscaling_group_boto3():
         group["LoadBalancerNames"].should.equal([lb_name])
         group["PlacementGroup"].should.equal("us_test_placement")
         group["TerminationPolicies"].should.equal(["OldestInstance", "NewestInstance"])
+
+
+@mock_ec2
+def test_describe_regions_dryrun():
+    client = boto3.client("ec2", region_name="us-east-1")
+
+    with pytest.raises(ClientError) as ex:
+        client.describe_regions(DryRun=True)
+    ex.value.response["ResponseMetadata"]["HTTPStatusCode"].should.equal(412)
+    ex.value.response["Error"]["Code"].should.equal("DryRunOperation")
+    ex.value.response["Error"]["Message"].should.equal(
+        "An error occurred (DryRunOperation) when calling the DescribeRegions operation: Request would have succeeded, but DryRun flag is set"
+    )

--- a/tests/test_ec2/test_subnets.py
+++ b/tests/test_ec2/test_subnets.py
@@ -1026,3 +1026,16 @@ def test_disassociate_subnet_cidr_block():
     association_set = subnets[0]["Ipv6CidrBlockAssociationSet"]
     association_set.should.have.length_of(1)
     association_set[0]["Ipv6CidrBlock"].should.equal("1080::1:200C:417A/111")
+
+
+@mock_ec2
+def test_describe_subnets_dryrun():
+    client = boto3.client("ec2", region_name="us-east-1")
+
+    with pytest.raises(ClientError) as ex:
+        client.describe_subnets(DryRun=True)
+    ex.value.response["ResponseMetadata"]["HTTPStatusCode"].should.equal(412)
+    ex.value.response["Error"]["Code"].should.equal("DryRunOperation")
+    ex.value.response["Error"]["Message"].should.equal(
+        "An error occurred (DryRunOperation) when calling the DescribeSubnets operation: Request would have succeeded, but DryRun flag is set"
+    )

--- a/tests/test_ec2/test_vpcs.py
+++ b/tests/test_ec2/test_vpcs.py
@@ -1296,3 +1296,16 @@ def test_delete_vpc_end_points():
         "VpcEndpoints"
     ][0]
     ep2["State"].should.equal("available")
+
+
+@mock_ec2
+def test_describe_vpcs_dryrun():
+    client = boto3.client("ec2", region_name="us-east-1")
+
+    with pytest.raises(ClientError) as ex:
+        client.describe_vpcs(DryRun=True)
+    ex.value.response["ResponseMetadata"]["HTTPStatusCode"].should.equal(412)
+    ex.value.response["Error"]["Code"].should.equal("DryRunOperation")
+    ex.value.response["Error"]["Message"].should.equal(
+        "An error occurred (DryRunOperation) when calling the DescribeVpcs operation: Request would have succeeded, but DryRun flag is set"
+    )


### PR DESCRIPTION
Existing methods typically use:
```
if self.is_not_dryrun("ExplicitlyNamedAction"):
    # execute action
```
Ideally, all methods use the same style. I've gone with a more straight-forward `error_on_dryrun` to avoid having to indent the entire method.

Future improvement: for a lot of methods, this could be rewritten as a decorator.

Closes #1980