### PR TITLE
Fix generation of random_ipv6_cidr

### DIFF
--- a/moto/ec2/utils.py
+++ b/moto/ec2/utils.py
@@ -254,7 +254,7 @@ def randor_ipv4_cidr():
 
 
 def random_ipv6_cidr():
-    return "2400:6500:{}:{}::/56".format(random_resource_id(4), random_resource_id(4))
+    return "2400:6500:{}:{}00::/56".format(random_resource_id(4), random_resource_id(2))
 
 
 def generate_route_id(

--- a/tests/test_ec2/test_utils.py
+++ b/tests/test_ec2/test_utils.py
@@ -1,3 +1,6 @@
+import ipaddress
+from unittest.mock import patch
+
 from moto.ec2 import utils
 
 from .helpers import rsa_check_private_key
@@ -10,3 +13,13 @@ def test_random_key_pair():
     # AWS uses MD5 fingerprints, which are 47 characters long, *not* SHA1
     # fingerprints with 59 characters.
     assert len(key_pair["fingerprint"]) == 47
+
+
+def test_random_ipv6_cidr():
+    def mocked_random_resource_id(chars: int):
+        return "a" * chars
+
+    with patch("moto.ec2.utils.random_resource_id", mocked_random_resource_id):
+        cidr_address = utils.random_ipv6_cidr()
+        # this will throw value error if host bits are set
+        ipaddress.ip_network(cidr_address)


### PR DESCRIPTION
When describing an IPv6 network with CIDR notation, in case of a /56 network, the first 56 bits can be set, but when describing a network (and not a host inside it), the last 72 bits (in this case) must not be set.

The current random generation only assures this 1/256 of the times.

This PR fixes that issue, generating correct ipv6 networks, and adds a tests, which patches the random_resource_id generation to ensure determination (otherwise the old implementation would succeed 1/256 of the times).