### PR TITLE
Autoscaling - add support for TargetTracking/StepAdjustments in policy

### DIFF
--- a/tests/test_autoscaling/utils.py
+++ b/tests/test_autoscaling/utils.py
@@ -4,14 +4,14 @@ from moto import mock_ec2, mock_ec2_deprecated
 
 
 @mock_ec2
-def setup_networking():
-    ec2 = boto3.resource("ec2", region_name="us-east-1")
+def setup_networking(region_name="us-east-1"):
+    ec2 = boto3.resource("ec2", region_name=region_name)
     vpc = ec2.create_vpc(CidrBlock="10.11.0.0/16")
     subnet1 = ec2.create_subnet(
-        VpcId=vpc.id, CidrBlock="10.11.1.0/24", AvailabilityZone="us-east-1a"
+        VpcId=vpc.id, CidrBlock="10.11.1.0/24", AvailabilityZone=f"{region_name}a"
     )
     subnet2 = ec2.create_subnet(
-        VpcId=vpc.id, CidrBlock="10.11.2.0/24", AvailabilityZone="us-east-1b"
+        VpcId=vpc.id, CidrBlock="10.11.2.0/24", AvailabilityZone=f"{region_name}b"
     )
     return {"vpc": vpc.id, "subnet1": subnet1.id, "subnet2": subnet2.id}
 


### PR DESCRIPTION
 - Closes #1458

Fixes response template so `describe_policies()` no longer throws an error when the `ScalingAdjustment` is not present on a policy

Also adds support for the additional parameters required for `PolicyType='TargetTrackingScaling'` and `PolicyType='StepAdjustments`