### PR TITLE
ECS - Enable option to use new ARN format

### DIFF
--- a/moto/settings.py
+++ b/moto/settings.py
@@ -32,3 +32,7 @@ def get_s3_default_key_buffer_size():
             "MOTO_S3_DEFAULT_KEY_BUFFER_SIZE", S3_UPLOAD_PART_MIN_SIZE - 1024
         )
     )
+
+
+def ecs_new_arn_format():
+    return os.environ.get("MOTO_ECS_NEW_ARN", "false").lower() == "true"


### PR DESCRIPTION
 - Closes #3497

Enables the option to use the new ARN format for ECS. 
Environment variable that should be set to `true` for this feature to be enabled: `MOTO_ECS_NEW_ARN`

This defaults to False for now, i.e. no impact for new users.
