### PR TITLE
Firehose timestamps need a timezone or a 'Z' at the end

### DIFF
--- a/moto/firehose/models.py
+++ b/moto/firehose/models.py
@@ -16,7 +16,7 @@ Incomplete list of unfinished items:
   - put_record(), put_record_batch() always set "Encrypted" to False.
 """
 from base64 import b64decode, b64encode
-from datetime import datetime
+from datetime import datetime, timezone
 from gzip import GzipFile
 import io
 import json
@@ -154,11 +154,11 @@ class DeliveryStream(
         self.delivery_stream_status = "ACTIVE"
         self.delivery_stream_arn = f"arn:aws:firehose:{region}:{ACCOUNT_ID}:/delivery_stream/{delivery_stream_name}"
 
-        self.create_timestamp = datetime.utcnow().isoformat() + "Z"
+        self.create_timestamp = datetime.now(timezone.utc).isoformat()
         self.version_id = "1"  # Used to track updates of destination configs
 
         # I believe boto3 only adds this field after an update ...
-        self.last_update_timestamp = datetime.utcnow().isoformat() + "Z"
+        self.last_update_timestamp = datetime.now(timezone.utc).isoformat()
 
 
 class FirehoseBackend(BaseBackend):
@@ -622,7 +622,7 @@ class FirehoseBackend(BaseBackend):
 
         # Increment version number and update the timestamp.
         delivery_stream.version_id = str(int(current_delivery_stream_version_id) + 1)
-        delivery_stream.last_update_timestamp = datetime.utcnow().isoformat() + "Z"
+        delivery_stream.last_update_timestamp = datetime.now(timezone.utc).isoformat()
 
         # Unimplemented: processing of the "S3BackupMode" parameter.  Per the
         # documentation:  "You can update a delivery stream to enable Amazon


### PR DESCRIPTION
The timestamps were fine at one point, but when I reran some Terraform scripts with Terraform 1.07, there were failures.

```
Unmarshal Response firehose/DescribeDeliveryStream failed, attempt 16/25, error SerializationError: failed decoding JSON RPC response
	status code: 200, request id: 
caused by: unable to parse time string, parse errors:
 * "2006-01-02T15:04:05.999999999Z": parsing time "2021-10-21T21:16:13.586622" as "2006-01-02T15:04:05.999999999Z": cannot parse "" as "Z"
 * "2006-01-02T15:04:05.999999999Z07:00": parsing time "2021-10-21T21:16:13.586622" as "2006-01-02T15:04:05.999999999Z07:00": cannot parse "" as "Z07:00"
 * "2006-01-02T15:04:05Z07:00": parsing time "2021-10-21T21:16:13.586622" as "2006-01-02T15:04:05Z07:00": cannot parse "" as "Z07:00": timestamp=2021-10-21T17:35:35.185-0400
```