### PR TITLE
EC2 - Filtering on plain property didn't work with wildcard

### DIFF
--- a/moto/ec2/models.py
+++ b/moto/ec2/models.py
@@ -270,7 +270,7 @@ class TaggedEC2Resource(BaseModel):
 
         value = getattr(self, filter_name.lower().replace("-", "_"), None)
         if value is not None:
-            return [value]
+            return value
 
         raise FilterNotImplementedError(filter_name, method_name)
 

--- a/tests/test_ec2/test_amis.py
+++ b/tests/test_ec2/test_amis.py
@@ -1339,6 +1339,31 @@ def test_ami_attribute_user_and_group_permissions_boto3():
     image.public.should.equal(False)
 
 
+@mock_ec2
+def test_filter_description():
+    # https://github.com/spulec/moto/issues/4460
+    client = boto3.client("ec2", region_name="us-west-2")
+
+    # Search for partial description
+    resp = client.describe_images(
+        Owners=["amazon"],
+        Filters=[{"Name": "description", "Values": ["Amazon Linux AMI*"]}],
+    )["Images"]
+    resp.should.have.length_of(4)
+
+    # Search for full description
+    resp = client.describe_images(
+        Owners=["amazon"],
+        Filters=[
+            {
+                "Name": "description",
+                "Values": ["Amazon Linux AMI 2018.03.0.20210721.0 x86_64 VPC HVM ebs"],
+            }
+        ],
+    )["Images"]
+    resp.should.have.length_of(1)
+
+
 # Has boto3 equivalent
 @mock_ec2_deprecated
 def test_ami_attribute_error_cases():


### PR DESCRIPTION
Bug that I came across when debugging #4460 

The filter-process is pretty straight-forward:
```
  For each resource of this type:
    retrieve the actual value
    check whether the supplied value matches the actual value
```
When checking whether the values match, the following considerations are in place:
```
  if the actual value is a string, match for wildcards (using `fnmatch`)
  if the actual value is a dict, the supplied value should be a key of that dict
  if the actual value is a list, the supplied value should be in the list (`contains`)
```

----
By sending the value as `[actual_value]`, the value-matching no longer worked. When sending a complete value, it can find that value in the list just fine, but when the user supplies a value with a wildcard, it would check whether `[actual_value] contains "val*"` - instead of `fnmatch(actual_value, value)`

------

@whummer This bug crept in during the initial LS PR. We didn't have any test cases for it yet, that's why it went undiscovered.
Do you see any issues with (/have objections to) this fix? 

(I realize this may be a needle in a haystack, to figure out whether it could break anything on your side...)