### PR TITLE
Use a different method to compute a timestamp in milliseconds for describe output()

### DIFF
--- a/moto/batch/models.py
+++ b/moto/batch/models.py
@@ -360,6 +360,7 @@ class Job(threading.Thread, BaseModel, DockerModel):
         self.job_queue = job_queue
         self.job_state = "SUBMITTED"  # One of SUBMITTED | PENDING | RUNNABLE | STARTING | RUNNING | SUCCEEDED | FAILED
         self.job_queue.jobs.append(self)
+        self.job_created_at = datetime.datetime.now()
         self.job_started_at = datetime.datetime(1970, 1, 1)
         self.job_stopped_at = datetime.datetime(1970, 1, 1)
         self.job_stopped = False
@@ -383,6 +384,7 @@ class Job(threading.Thread, BaseModel, DockerModel):
             "jobQueue": self.job_queue.arn,
             "status": self.job_state,
             "dependsOn": self.depends_on if self.depends_on else [],
+            "createdAt": datetime2int_milliseconds(self.job_created_at),
         }
         if result["status"] not in ["SUBMITTED", "PENDING", "RUNNABLE", "STARTING"]:
             result["startedAt"] = datetime2int_milliseconds(self.job_started_at)

--- a/tests/test_batch/test_batch_jobs.py
+++ b/tests/test_batch/test_batch_jobs.py
@@ -106,6 +106,12 @@ def test_submit_job():
     )
     job_id = resp["jobId"]
 
+    # Test that describe_jobs() returns 'createdAt'
+    # github.com/spulec/moto/issues/4364
+    resp = batch_client.describe_jobs(jobs=[job_id])
+    created_at = resp["jobs"][0]["createdAt"]
+    created_at.should.be.greater_than(start_time_milliseconds)
+
     _wait_for_job_status(batch_client, job_id, "SUCCEEDED")
 
     resp = logs_client.describe_log_streams(
@@ -122,10 +128,12 @@ def test_submit_job():
     # Test that describe_jobs() returns timestamps in milliseconds
     # github.com/spulec/moto/issues/4364
     resp = batch_client.describe_jobs(jobs=[job_id])
-    created_at = resp["jobs"][0]["startedAt"]
+    created_at = resp["jobs"][0]["createdAt"]
+    started_at = resp["jobs"][0]["startedAt"]
     stopped_at = resp["jobs"][0]["stoppedAt"]
 
     created_at.should.be.greater_than(start_time_milliseconds)
+    started_at.should.be.greater_than(start_time_milliseconds)
     stopped_at.should.be.greater_than(start_time_milliseconds)
 
 


### PR DESCRIPTION
Hacktoberfest contribution 🎃 

Fixes https://github.com/spulec/moto/issues/4364

- Straightforward fix:  return a timestamp multiplied by 1000. We already have milliseconds precision in datetime objects
    We can't change all timestamps to milliseconds because we use timestamps internally to fetch container logs and it doesn't support milliseconds.

- I didn't create a specific test for this because they require spinning up a Docker container which is quite slow