### PR TITLE
Fix #4228: support Fargate batch compute environment

### DIFF
--- a/tests/test_batch/test_batch_compute_envs.py
+++ b/tests/test_batch/test_batch_compute_envs.py
@@ -1,4 +1,5 @@
 from . import _get_clients, _setup
+import pytest
 import sure  # noqa # pylint: disable=unused-import
 from moto import mock_batch, mock_iam, mock_ec2, mock_ecs, settings
 from uuid import uuid4
@@ -232,3 +233,38 @@ def test_update_unmanaged_compute_environment_state():
     our_envs = [e for e in all_envs if e["computeEnvironmentName"] == compute_name]
     our_envs.should.have.length_of(1)
     our_envs[0]["state"].should.equal("DISABLED")
+
+
+@pytest.mark.parametrize("compute_env_type", ["FARGATE", "FARGATE_SPOT"])
+@mock_ec2
+@mock_ecs
+@mock_iam
+@mock_batch
+def test_create_fargate_managed_compute_environment(compute_env_type):
+    ec2_client, iam_client, ecs_client, _, batch_client = _get_clients()
+    _, subnet_id, sg_id, iam_arn = _setup(ec2_client, iam_client)
+
+    compute_name = str(uuid4())
+    resp = batch_client.create_compute_environment(
+        computeEnvironmentName=compute_name,
+        type="MANAGED",
+        state="ENABLED",
+        computeResources={
+            "type": compute_env_type,
+            "maxvCpus": 10,
+            "subnets": [subnet_id],
+            "securityGroupIds": [sg_id],
+        },
+        serviceRole=iam_arn,
+    )
+    resp.should.contain("computeEnvironmentArn")
+    resp["computeEnvironmentName"].should.equal(compute_name)
+
+    our_env = batch_client.describe_compute_environments(
+        computeEnvironments=[compute_name]
+    )["computeEnvironments"][0]
+
+    our_env["computeResources"]["type"].should.equal(compute_env_type)
+    # Should have created 1 ECS cluster
+    all_clusters = ecs_client.list_clusters()["clusterArns"]
+    all_clusters.should.contain(our_env["ecsClusterArn"])


### PR DESCRIPTION
Hacktoberfest contribution 🎃 

- allow `FARGATE` and `FARGATE_SPOT` as compute environment types
- Don't check parameters that are not applicable to Fargate: `instanceRole`, `minvCpus`, `instanceTypes`, `desiredvCpus`
- Don't create any EC2 instances if we're using Fargate

I don't know Fargate compute environment well enough to know if there is anything else to mock