### PR TITLE
Set the appropriate SNS subject when sending CloudFormation stack events

### DIFF
--- a/moto/cloudformation/models.py
+++ b/moto/cloudformation/models.py
@@ -477,7 +477,9 @@ ClientRequestToken='{client_request_token}'""".format(
         )
 
         for sns_topic_arn in sns_topic_arns:
-            sns_backends[region].publish(message, arn=sns_topic_arn)
+            sns_backends[region].publish(
+                message, subject="AWS CloudFormation Notification", arn=sns_topic_arn
+            )
 
 
 def filter_stacks(all_stacks, status_filter):

--- a/tests/test_cloudformation/test_cloudformation_stack_crud.py
+++ b/tests/test_cloudformation/test_cloudformation_stack_crud.py
@@ -209,6 +209,7 @@ def test_create_stack_with_notification_arn():
         message = queue.read(1)
 
     msg = json.loads(message.get_body())
+    msg["Subject"].should.equal("AWS CloudFormation Notification")
     msg["Message"].should.contain("StackId='{}'\n".format(stack.stack_id))
     msg["Message"].should.contain("Timestamp='2015-01-01T12:00:00.000Z'\n")
     msg["Message"].should.contain("LogicalResourceId='test_stack_with_notifications'\n")

--- a/tests/test_cloudformation/test_cloudformation_stack_crud_boto3.py
+++ b/tests/test_cloudformation/test_cloudformation_stack_crud_boto3.py
@@ -1047,6 +1047,7 @@ def test_create_stack_with_notification_arn():
     messages = queue.receive_messages()
     messages.should.have.length_of(1)
     msg = json.loads(messages[0].body)
+    msg["Subject"].should.equal("AWS CloudFormation Notification")
     msg["Message"].should.contain("StackId='{}'\n".format(stack.stack_id))
     msg["Message"].should.contain("LogicalResourceId='test_stack_with_notifications'\n")
     msg["Message"].should.contain("ResourceStatus='CREATE_IN_PROGRESS'\n")


### PR DESCRIPTION
Currently, when a CloudFormation stack event is sent to SNS, it has the default subject of "my subject". It appears that AWS actually uses the subject "AWS CloudFormation Notification".