### PR TITLE
Remove use of the deprecated `stream` argument to Responses

### DIFF
--- a/moto/core/models.py
+++ b/moto/core/models.py
@@ -442,7 +442,6 @@ class BotocoreEventMockAWS(BaseMockAWS):
                             method=method,
                             url=re.compile(key),
                             callback=convert_flask_to_responses_response(value),
-                            stream=True,
                             match_querystring=False,
                         )
                     )
@@ -451,7 +450,6 @@ class BotocoreEventMockAWS(BaseMockAWS):
                     method=method,
                     url=re.compile(r"https?://.+\.amazonaws.com/.*"),
                     callback=not_implemented_callback,
-                    stream=True,
                     match_querystring=False,
                 )
             )
@@ -460,7 +458,6 @@ class BotocoreEventMockAWS(BaseMockAWS):
                     method=method,
                     url=re.compile(r"https?://.+\.amazonaws.com/.*"),
                     callback=not_implemented_callback,
-                    stream=True,
                     match_querystring=False,
                 )
             )


### PR DESCRIPTION
Responses version 0.15.0 includes the change in https://github.com/getsentry/responses/pull/413, which marks the `stream` argument as deprecated.

Moto makes use of this argument which means lots of warnings are emitted whenever Moto is used with the latest version of Responses.

This fixes that by removing the `stream` argument where it's used.