### PR TITLE
Publishing to SNS topics with a null subject should be allowed

### DIFF
--- a/moto/sns/models.py
+++ b/moto/sns/models.py
@@ -308,7 +308,7 @@ class Subscription(BaseModel):
             "Type": "Notification",
             "MessageId": message_id,
             "TopicArn": self.topic.arn,
-            "Subject": subject or "my subject",
+            "Subject": subject,
             "Message": message,
             "Timestamp": iso_8601_datetime_with_milliseconds(
                 datetime.datetime.utcnow()


### PR DESCRIPTION
The [documentation](https://docs.aws.amazon.com/sns/latest/api/API_Publish.html) for SNS publish lists the Subject field as optional, but sending a message to a topic through Moto results in the subject being changed to "my subject".