### PR TITLE
fix incomplete LastEvaluatedKey when using Global Secondary Index

### DIFF
--- a/moto/dynamodb2/models/__init__.py
+++ b/moto/dynamodb2/models/__init__.py
@@ -825,7 +825,7 @@ class Table(CloudFormationModel):
                 result.filter(projection_expression)
 
         results, last_evaluated_key = self._trim_results(
-            results, limit, exclusive_start_key
+            results, limit, exclusive_start_key, scanned_index=index_name
         )
         return results, scanned_count, last_evaluated_key
 
@@ -917,7 +917,7 @@ class Table(CloudFormationModel):
                 result.filter(projection_expression)
 
         results, last_evaluated_key = self._trim_results(
-            results, limit, exclusive_start_key, index_name
+            results, limit, exclusive_start_key, scanned_index=index_name
         )
         return results, scanned_count, last_evaluated_key
 


### PR DESCRIPTION
Hacktoberfest contribution 🎃 

Fix #3968

Credits to @questsul for the test script and the fix.
I refactored the test script into a minimal test and made sure it reproduced the issue

I also changed the calls to `_trim_results()` to use the explicit `scanned_index` keyword argument