### PR TITLE
 S3: Implement CORS headers in OPTIONS requests 

### DIFF
--- a/moto/s3/models.py
+++ b/moto/s3/models.py
@@ -1015,8 +1015,8 @@ class FakeBucket(CloudFormationModel):
             assert isinstance(rule.get("AllowedHeader", []), list) or isinstance(
                 rule.get("AllowedHeader", ""), str
             )
-            assert isinstance(rule.get("ExposedHeader", []), list) or isinstance(
-                rule.get("ExposedHeader", ""), str
+            assert isinstance(rule.get("ExposeHeader", []), list) or isinstance(
+                rule.get("ExposeHeader", ""), str
             )
             assert isinstance(rule.get("MaxAgeSeconds", "0"), str)
 
@@ -1034,7 +1034,7 @@ class FakeBucket(CloudFormationModel):
                     rule["AllowedMethod"],
                     rule["AllowedOrigin"],
                     rule.get("AllowedHeader"),
-                    rule.get("ExposedHeader"),
+                    rule.get("ExposeHeader"),
                     rule.get("MaxAgeSecond"),
                 )
             )

--- a/moto/s3/models.py
+++ b/moto/s3/models.py
@@ -1035,7 +1035,7 @@ class FakeBucket(CloudFormationModel):
                     rule["AllowedOrigin"],
                     rule.get("AllowedHeader"),
                     rule.get("ExposeHeader"),
-                    rule.get("MaxAgeSecond"),
+                    rule.get("MaxAgeSeconds"),
                 )
             )
 

--- a/moto/s3/responses.py
+++ b/moto/s3/responses.py
@@ -261,9 +261,8 @@ class ResponseObject(_TemplateEnvironmentMixin, ActionAuthenticatorMixin):
         self.path = self._get_path(request)
         # Make a copy of request.headers because it's immutable
         self.headers = dict(request.headers)
-        if "host" not in self.headers:
-            self.headers["host"] = urlparse(full_url).netloc
-
+        if "Host" not in self.headers:
+            self.headers["Host"] = urlparse(full_url).netloc
         try:
             response = self._bucket_response(request, full_url, headers)
         except S3ClientError as s3error:
@@ -1099,8 +1098,8 @@ class ResponseObject(_TemplateEnvironmentMixin, ActionAuthenticatorMixin):
         self.path = self._get_path(request)
         # Make a copy of request.headers because it's immutable
         self.headers = dict(request.headers)
-        if "host" not in self.headers:
-            self.headers["host"] = urlparse(full_url).netloc
+        if "Host" not in self.headers:
+            self.headers["Host"] = urlparse(full_url).netloc
         response_headers = {}
 
         try:

--- a/moto/s3/responses.py
+++ b/moto/s3/responses.py
@@ -356,6 +356,7 @@ class ResponseObject(_TemplateEnvironmentMixin, ActionAuthenticatorMixin):
         This here just uses all rules and the last rule will override the previous ones
         if they are re-defining the same headers.
         """
+
         def _to_string(header: Union[List[str], str]) -> str:
             # We allow list and strs in header values. Transform lists in comma-separated strings
             if isinstance(header, list):
@@ -364,17 +365,25 @@ class ResponseObject(_TemplateEnvironmentMixin, ActionAuthenticatorMixin):
 
         for cors_rule in bucket.cors:
             if cors_rule.allowed_methods is not None:
-                self.headers["Access-Control-Allow-Methods"] = _to_string(cors_rule.allowed_methods)
+                self.headers["Access-Control-Allow-Methods"] = _to_string(
+                    cors_rule.allowed_methods
+                )
             if cors_rule.allowed_origins is not None:
-                self.headers["Access-Control-Allow-Origin"] = _to_string(cors_rule.allowed_origins)
+                self.headers["Access-Control-Allow-Origin"] = _to_string(
+                    cors_rule.allowed_origins
+                )
             if cors_rule.allowed_headers is not None:
-                self.headers["Access-Control-Allow-Headers"] = _to_string(cors_rule.allowed_headers)
+                self.headers["Access-Control-Allow-Headers"] = _to_string(
+                    cors_rule.allowed_headers
+                )
             if cors_rule.exposed_headers is not None:
-                self.headers[
-                    "Access-Control-Expose-Headers"
-                ] = _to_string(cors_rule.exposed_headers)
+                self.headers["Access-Control-Expose-Headers"] = _to_string(
+                    cors_rule.exposed_headers
+                )
             if cors_rule.max_age_seconds is not None:
-                self.headers["Access-Control-Max-Age"] = _to_string(cors_rule.max_age_seconds)
+                self.headers["Access-Control-Max-Age"] = _to_string(
+                    cors_rule.max_age_seconds
+                )
 
         return self.headers
 

--- a/moto/s3/responses.py
+++ b/moto/s3/responses.py
@@ -259,6 +259,8 @@ class ResponseObject(_TemplateEnvironmentMixin, ActionAuthenticatorMixin):
     def bucket_response(self, request, full_url, headers):
         self.method = request.method
         self.path = self._get_path(request)
+        # Make a copy of request.headers because it's immutable
+        self.headers = dict(request.headers)
         if "host" not in self.headers:
             self.headers["host"] = urlparse(full_url).netloc
 
@@ -1095,6 +1097,8 @@ class ResponseObject(_TemplateEnvironmentMixin, ActionAuthenticatorMixin):
         # Key and Control are lumped in because splitting out the regex is too much of a pain :/
         self.method = request.method
         self.path = self._get_path(request)
+        # Make a copy of request.headers because it's immutable
+        self.headers = dict(request.headers)
         if "host" not in self.headers:
             self.headers["host"] = urlparse(full_url).netloc
         response_headers = {}

--- a/moto/server.py
+++ b/moto/server.py
@@ -18,7 +18,7 @@ import moto.backends as backends
 import moto.backend_index as backend_index
 from moto.core.utils import convert_flask_to_httpretty_response
 
-HTTP_METHODS = ["GET", "POST", "PUT", "DELETE", "HEAD", "PATCH"]
+HTTP_METHODS = ["GET", "POST", "PUT", "DELETE", "HEAD", "PATCH", "OPTIONS"]
 
 
 DEFAULT_SERVICE_REGION = ("s3", "us-east-1")

--- a/tests/test_s3/test_s3.py
+++ b/tests/test_s3/test_s3.py
@@ -4094,7 +4094,7 @@ def test_boto3_put_bucket_cors():
                     "AllowedOrigins": ["*"],
                     "AllowedMethods": ["GET", "POST"],
                     "AllowedHeaders": ["Authorization"],
-                    "ExposeHeaders": ["x-amz-request-id"],
+                    "ExposeHeaders": ["ETag"],
                     "MaxAgeSeconds": 123,
                 },
                 {

--- a/tests/test_s3/test_s3.py
+++ b/tests/test_s3/test_s3.py
@@ -4094,7 +4094,7 @@ def test_boto3_put_bucket_cors():
                     "AllowedOrigins": ["*"],
                     "AllowedMethods": ["GET", "POST"],
                     "AllowedHeaders": ["Authorization"],
-                    "ExposeHeaders": ["ETag"],
+                    "ExposeHeaders": ["x-amz-request-id"],
                     "MaxAgeSeconds": 123,
                 },
                 {

--- a/tests/test_s3/test_server.py
+++ b/tests/test_s3/test_server.py
@@ -202,6 +202,16 @@ def test_s3_server_post_cors_exposed_header():
     """
 
     test_client = authenticated_client()
+    preflight_headers = {
+        "Access-Control-Request-Method": "POST",
+        "Access-Control-Request-Headers": "origin, x-requested-with",
+        "Origin": "https://localhost:9000",
+    }
+    # Returns 403 on non existing bucket
+    preflight_response = test_client.options(
+        "/", "http://testcors.localhost:5000/", headers=preflight_headers
+    )
+    assert preflight_response.status_code == 403
 
     # Create the bucket
     test_client.put("/", "http://testcors.localhost:5000/")
@@ -212,12 +222,6 @@ def test_s3_server_post_cors_exposed_header():
 
     cors_res = test_client.get("/?cors", "http://testcors.localhost:5000")
     assert b"<ExposedHeader>ETag</ExposedHeader>" in cors_res.data
-
-    preflight_headers = {
-        "Access-Control-Request-Method": "POST",
-        "Access-Control-Request-Headers": "origin, x-requested-with",
-        "Origin": "https://localhost:9000",
-    }
 
     preflight_response = test_client.options(
         "/", "http://testcors.localhost:5000/", headers=preflight_headers

--- a/tests/test_s3/test_server.py
+++ b/tests/test_s3/test_server.py
@@ -196,6 +196,7 @@ def test_s3_server_post_cors_exposed_header():
     <AllowedMethod>DELETE</AllowedMethod>
     <AllowedHeader>*</AllowedHeader>
     <ExposeHeader>ETag</ExposeHeader>
+    <MaxAgeSeconds>3000</MaxAgeSeconds>
   </CORSRule>
 </CORSConfiguration>
     """
@@ -227,6 +228,7 @@ def test_s3_server_post_cors_exposed_header():
         "Access-Control-Allow-Origin": "https://example.org",
         "Access-Control-Allow-Headers": "*",
         "Access-Control-Expose-Headers": "ETag",
+        "Access-Control-Max-Age": "3000",
     }
     for header_name, header_value in expected_cors_headers.items():
         assert header_name in preflight_response.headers


### PR DESCRIPTION
Hacktoberfest contribution 🎃 

Fixes #4220 

The default headers from CORS plugin was not enough to mock S3 CORS Rules behavior
We need to manually define response headers depending on the bucket rules

- Fixed typos:
  -  `ExposedHeader` --> `ExposeHeader` (defined as such in AWS documentation)
  - `MaxAgeSecond` --> `MaxAgeSeconds`(defined as such in AWS documentation)
- I implemented OPTIONS method instead of relying on the defaults from Flask

- Iterated through CORS rule to return some CORS headers
This is not a perfectly accurate strategy: I didn't check but according to the docs, when multiple CORS Rules are defined, S3 returns the most relevant (I suppose the most permissive one, depending on the request)
In the strategy I implemented, the last rule takes precedence over the other rules.
It's not ideal but I consider that defining multiple rules is an edge case

- Removed a test about `Allow` headers: these headers were automatically set by flask-cors but they are not technically CORS?
I didn't add these headers back because they are not required and from my testing on a real S3 bucket, I didn't receive any `Allow` header, only `Access-Control-Allow-Methods`