### PR TITLE
Ensure that imagePushedAt fields from ECR is timezone aware

### DIFF
--- a/moto/ecr/models.py
+++ b/moto/ecr/models.py
@@ -3,7 +3,7 @@ import json
 import re
 import uuid
 from collections import namedtuple
-from datetime import datetime
+from datetime import datetime, timezone
 from random import random
 from typing import Dict, List
 
@@ -235,7 +235,7 @@ class Image(BaseObject):
         self.repository = repository
         self.registry_id = registry_id
         self.image_digest = digest
-        self.image_pushed_at = str(datetime.utcnow().isoformat())
+        self.image_pushed_at = str(datetime.now(timezone.utc).isoformat())
         self.last_scan = None
 
     def _create_digest(self):

--- a/tests/test_ecr/test_ecr_boto3.py
+++ b/tests/test_ecr/test_ecr_boto3.py
@@ -361,7 +361,7 @@ def test_put_image_with_push_date():
     _ = client.create_repository(repositoryName="test_repository")
 
     with freeze_time("2018-08-28 00:00:00"):
-        image1_date = datetime.now()
+        image1_date = datetime.now(tzlocal())
         _ = client.put_image(
             repositoryName="test_repository",
             imageManifest=json.dumps(_create_image_manifest()),
@@ -369,7 +369,7 @@ def test_put_image_with_push_date():
         )
 
     with freeze_time("2019-05-31 00:00:00"):
-        image2_date = datetime.now()
+        image2_date = datetime.now(tzlocal())
         _ = client.put_image(
             repositoryName="test_repository",
             imageManifest=json.dumps(_create_image_manifest()),


### PR DESCRIPTION
Fix: #4499 

This PR ensures that the `imagePushedAt` field returned by `describe_images` has a timezone set. This matches the behaviour or `boto3` when not mocked.