### PR TITLE
Fix range headers: use response_headers parameters instead of creating a new dict

### DIFF
--- a/moto/s3/responses.py
+++ b/moto/s3/responses.py
@@ -984,8 +984,7 @@ class ResponseObject(_TemplateEnvironmentMixin, ActionAuthenticatorMixin):
             template.render(deleted=deleted_objects, delete_errors=error_names),
         )
 
-    def _handle_range_header(self, request, headers, response_content):
-        response_headers = {}
+    def _handle_range_header(self, request, response_headers, response_content):
         length = len(response_content)
         last = length - 1
         _, rspec = request.headers.get("range").split("=")

--- a/tests/test_s3/test_s3.py
+++ b/tests/test_s3/test_s3.py
@@ -6486,3 +6486,25 @@ def test_head_object_should_return_default_content_type():
     s3.Object("testbucket", "testobject").content_type.should.equal(
         "binary/octet-stream"
     )
+
+@mock_s3
+def test_request_partial_content_should_contain_all_metadata():
+    # github.com/spulec/moto/issues/4203
+    bucket = "bucket"
+    object_key = "key"
+    body = "some text"
+    query_range = "0-3"
+
+    s3 = boto3.resource("s3", region_name=DEFAULT_REGION_NAME)
+    s3.create_bucket(Bucket=bucket)
+    obj = boto3.resource('s3').Object(bucket, object_key)
+
+    obj.put(Body=body)
+
+    file = s3.Object(bucket, object_key)
+    response = obj.get(Range="bytes={}".format(query_range))
+
+    assert response["ETag"] == obj.e_tag
+    assert response["LastModified"] == obj.last_modified
+    assert response["ContentLength"] == 4
+    assert response["ContentRange"] == 'bytes {}/{}'.format(query_range, len(body))

--- a/tests/test_s3/test_s3.py
+++ b/tests/test_s3/test_s3.py
@@ -6487,6 +6487,7 @@ def test_head_object_should_return_default_content_type():
         "binary/octet-stream"
     )
 
+
 @mock_s3
 def test_request_partial_content_should_contain_all_metadata():
     # github.com/spulec/moto/issues/4203
@@ -6497,14 +6498,12 @@ def test_request_partial_content_should_contain_all_metadata():
 
     s3 = boto3.resource("s3", region_name=DEFAULT_REGION_NAME)
     s3.create_bucket(Bucket=bucket)
-    obj = boto3.resource('s3').Object(bucket, object_key)
-
+    obj = boto3.resource("s3").Object(bucket, object_key)
     obj.put(Body=body)
 
-    file = s3.Object(bucket, object_key)
     response = obj.get(Range="bytes={}".format(query_range))
 
     assert response["ETag"] == obj.e_tag
     assert response["LastModified"] == obj.last_modified
     assert response["ContentLength"] == 4
-    assert response["ContentRange"] == 'bytes {}/{}'.format(query_range, len(body))
+    assert response["ContentRange"] == "bytes {}/{}".format(query_range, len(body))


### PR DESCRIPTION
Fixes #4203

`headers` parameter was unused in `_handle_range_header()` method, causing some headers to be lost

This looked like a typo as the method is invoked using `response_headers` as argument name:
https://github.com/spulec/moto/blob/5771dcf73bef22adb2e7c54ee4787ea6eebceebd/moto/s3/responses.py#L1063-L1065
I simply changed the argument back to `response_headers` and it fixed the issue.