### PR TITLE
fix: S3 CopyObjects with embedded percent encoding

### DIFF
--- a/moto/s3/models.py
+++ b/moto/s3/models.py
@@ -1638,8 +1638,6 @@ class S3Backend(BaseBackend):
         key.lock_until = retention[1]
 
     def append_to_key(self, bucket_name, key_name, value):
-        key_name = clean_key_name(key_name)
-
         key = self.get_object(bucket_name, key_name)
         key.append_to_value(value)
         return key
@@ -2014,7 +2012,6 @@ class S3Backend(BaseBackend):
         acl=None,
         src_version_id=None,
     ):
-        src_key_name = clean_key_name(src_key_name)
         dest_key_name = clean_key_name(dest_key_name)
         dest_bucket = self.get_bucket(dest_bucket_name)
         key = self.get_object(src_bucket_name, src_key_name, version_id=src_version_id)

--- a/tests/test_s3/test_s3.py
+++ b/tests/test_s3/test_s3.py
@@ -380,29 +380,47 @@ def test_multipart_upload_with_headers_boto3():
 
 
 # Has boto3 equivalent
+@pytest.mark.parametrize(
+    "original_key_name",
+    [
+        "original-key",
+        "the-unicode-💩-key",
+        "key-with?question-mark",
+        "key-with%2Fembedded%2Furl%2Fencoding",
+    ],
+)
 @mock_s3_deprecated
 @reduced_min_part_size
-def test_multipart_upload_with_copy_key():
+def test_multipart_upload_with_copy_key(original_key_name):
     conn = boto.connect_s3("the_key", "the_secret")
     bucket = conn.create_bucket("foobar")
     key = Key(bucket)
-    key.key = "original-key"
+    key.key = original_key_name
     key.set_contents_from_string("key_value")
 
     multipart = bucket.initiate_multipart_upload("the-key")
     part1 = b"0" * REDUCED_PART_SIZE
     multipart.upload_part_from_file(BytesIO(part1), 1)
-    multipart.copy_part_from_key("foobar", "original-key", 2, 0, 3)
+    multipart.copy_part_from_key("foobar", original_key_name, 2, 0, 3)
     multipart.complete_upload()
     bucket.get_key("the-key").get_contents_as_string().should.equal(part1 + b"key_")
 
 
+@pytest.mark.parametrize(
+    "original_key_name",
+    [
+        "original-key",
+        "the-unicode-💩-key",
+        "key-with?question-mark",
+        "key-with%2Fembedded%2Furl%2Fencoding",
+    ],
+)
 @mock_s3
 @reduced_min_part_size
-def test_multipart_upload_with_copy_key_boto3():
+def test_multipart_upload_with_copy_key_boto3(original_key_name):
     s3 = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
     s3.create_bucket(Bucket="foobar")
-    s3.put_object(Bucket="foobar", Key="original-key", Body="key_value")
+    s3.put_object(Bucket="foobar", Key=original_key_name, Body="key_value")
 
     mpu = s3.create_multipart_upload(Bucket="foobar", Key="the-key")
     part1 = b"0" * REDUCED_PART_SIZE
@@ -416,7 +434,7 @@ def test_multipart_upload_with_copy_key_boto3():
     up2 = s3.upload_part_copy(
         Bucket="foobar",
         Key="the-key",
-        CopySource={"Bucket": "foobar", "Key": "original-key"},
+        CopySource={"Bucket": "foobar", "Key": original_key_name},
         CopySourceRange="0-3",
         PartNumber=2,
         UploadId=mpu["UploadId"],
@@ -884,7 +902,14 @@ def test_copy_key():
 
 
 # Has boto3 equivalent
-@pytest.mark.parametrize("key_name", ["the-unicode-💩-key", "key-with?question-mark"])
+@pytest.mark.parametrize(
+    "key_name",
+    [
+        "the-unicode-💩-key",
+        "key-with?question-mark",
+        "key-with%2Fembedded%2Furl%2Fencoding",
+    ],
+)
 @mock_s3_deprecated
 def test_copy_key_with_special_chars(key_name):
     conn = boto.connect_s3("the_key", "the_secret")
@@ -900,7 +925,13 @@ def test_copy_key_with_special_chars(key_name):
 
 
 @pytest.mark.parametrize(
-    "key_name", ["the-key", "the-unicode-💩-key", "key-with?question-mark"]
+    "key_name",
+    [
+        "the-key",
+        "the-unicode-💩-key",
+        "key-with?question-mark",
+        "key-with%2Fembedded%2Furl%2Fencoding",
+    ],
 )
 @mock_s3
 def test_copy_key_boto3(key_name):


### PR DESCRIPTION
There were a few areas where a provided S3 object key was being URL decoded multiple times, which created a problem for S3 objects whose key contained embedded percent encodings. This looked to be happening mostly in areas where existing functions that already decoded the object key were being reused by higher level functions that were themselves decoding the key.

These changes defer the URL decoding until the last moment to prevent passing already decoded keys into functions that are expecting keys to be url encoded. I've added a couple of test cases for the copy object calls and multipart copy object calls.

There is one change below to `moto/s3/models.py:append_to_key` that does not have an associated test with it. It doesn't seem to have any current test coverage and I did not quite understand how to cause the streaming request code path that calls this method (it looks like this is supposed to be triggered by the `test_large_key_save_boto3` and `test_large_key_save` test cases but neither triggers the code path here). The change to that function removes the `clean_key_name` call since the `key_name` will already be cleaned inside the `get_object` function call and is otherwise not used within the `append_to_key` function. I expect this to be the correct behavior, and would love to add a test for it if there is some guidance on how to cause that code path to trigger.

Resolves #4513.