### PR TITLE
Feature - emr-containers - jobs

### DIFF
--- a/IMPLEMENTATION_COVERAGE.md
+++ b/IMPLEMENTATION_COVERAGE.md
@@ -1930,7 +1930,7 @@
 - [ ] list_managed_endpoints
 - [ ] list_tags_for_resource
 - [X] list_virtual_clusters
-- [ ] start_job_run
+- [X] start_job_run
 - [ ] tag_resource
 - [ ] untag_resource
 </details>

--- a/IMPLEMENTATION_COVERAGE.md
+++ b/IMPLEMENTATION_COVERAGE.md
@@ -1918,15 +1918,15 @@
 <details>
 <summary>27% implemented</summary>
 
-- [ ] cancel_job_run
+- [X] cancel_job_run
 - [ ] create_managed_endpoint
 - [X] create_virtual_cluster
 - [ ] delete_managed_endpoint
 - [X] delete_virtual_cluster
-- [ ] describe_job_run
+- [X] describe_job_run
 - [ ] describe_managed_endpoint
 - [X] describe_virtual_cluster
-- [ ] list_job_runs
+- [X] list_job_runs
 - [ ] list_managed_endpoints
 - [ ] list_tags_for_resource
 - [X] list_virtual_clusters

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -64,6 +64,8 @@ Currently implemented Services:
 +---------------------------+-----------------------+------------------------------------+
 | EMR                       | @mock_emr             | core endpoints done                |
 +---------------------------+-----------------------+------------------------------------+
+| EMRContainers             | @mock_emrcontainers   | core endpoints done                |
++---------------------------+-----------------------+------------------------------------+
 | Firehose                  | @mock_firehose        | basic endpoints done               |
 +---------------------------+-----------------------+------------------------------------+
 | Forecast                  | @mock_forecast        | basic endpoints done               |

--- a/moto/emrcontainers/exceptions.py
+++ b/moto/emrcontainers/exceptions.py
@@ -1,2 +1,9 @@
 """Exceptions raised by the emrcontainers service."""
-# from moto.core.exceptions import JsonRESTError
+from moto.core.exceptions import JsonRESTError
+
+
+class ResourceNotFoundException(JsonRESTError):
+    code = 400
+
+    def __init__(self, resource):
+        super().__init__("ResourceNotFoundException", resource)

--- a/moto/emrcontainers/models.py
+++ b/moto/emrcontainers/models.py
@@ -7,9 +7,9 @@ from moto.core import BaseBackend, BaseModel, ACCOUNT_ID
 from moto.core.utils import iso_8601_datetime_without_milliseconds
 
 from .utils import random_cluster_id, random_job_id, get_partition, paginated_list
+from .exceptions import ResourceNotFoundException
 
-# String Templates
-from ..config.exceptions import ValidationException, ResourceNotFoundException
+from ..config.exceptions import ValidationException
 
 VIRTUAL_CLUSTER_ARN_TEMPLATE = (
     "arn:{partition}:emr-containers:{region}:"

--- a/moto/emrcontainers/models.py
+++ b/moto/emrcontainers/models.py
@@ -361,6 +361,18 @@ class EMRContainersBackend(BaseBackend):
         sort_key = "id"
         return paginated_list(jobs, sort_key, max_results, next_token)
 
+    def describe_job_run(self, id, virtual_cluster_id):
+        if not re.match(r"[a-z,A-Z,0-9]{19}", id):
+            raise ValidationException("Invalid job run short id")
+
+        if id not in self.jobs.keys():
+            raise ResourceNotFoundException(f"Job run {id} doesn't exist.")
+
+        if virtual_cluster_id != self.jobs[id].virtual_cluster_id:
+            raise ResourceNotFoundException(f"Job run {id} doesn't exist.")
+
+        return self.jobs[id].to_dict()
+
 
 emrcontainers_backends = {}
 for available_region in Session().get_available_regions("emr-containers"):

--- a/moto/emrcontainers/models.py
+++ b/moto/emrcontainers/models.py
@@ -134,8 +134,6 @@ class FakeJob(BaseModel):
         yield "tags", self.tags
 
 
-
-
 class EMRContainersBackend(BaseBackend):
     """Implementation of EMRContainers APIs."""
 

--- a/moto/emrcontainers/responses.py
+++ b/moto/emrcontainers/responses.py
@@ -122,3 +122,14 @@ class EMRContainersResponse(BaseResponse):
 
         response = {"jobRuns": job_runs, "nextToken": next_token}
         return 200, {}, json.dumps(response)
+
+    def describe_job_run(self):
+        id = self._get_param("jobRunId")
+        virtual_cluster_id = self._get_param("virtualClusterId")
+
+        job_run = self.emrcontainers_backend.describe_job_run(
+            id=id, virtual_cluster_id=virtual_cluster_id,
+        )
+
+        response = {"jobRun": job_run}
+        return 200, {}, json.dumps(response)

--- a/moto/emrcontainers/responses.py
+++ b/moto/emrcontainers/responses.py
@@ -91,3 +91,12 @@ class EMRContainersResponse(BaseResponse):
             tags=tags,
         )
         return 200, {}, json.dumps(dict(job))
+
+    def cancel_job_run(self):
+        id = self._get_param("jobRunId")
+        virtual_cluster_id = self._get_param("virtualClusterId")
+
+        job = self.emrcontainers_backend.cancel_job_run(
+            id=id, virtual_cluster_id=virtual_cluster_id,
+        )
+        return 200, {}, json.dumps(dict(job))

--- a/moto/emrcontainers/responses.py
+++ b/moto/emrcontainers/responses.py
@@ -100,3 +100,25 @@ class EMRContainersResponse(BaseResponse):
             id=id, virtual_cluster_id=virtual_cluster_id,
         )
         return 200, {}, json.dumps(dict(job))
+
+    def list_job_runs(self):
+        virtual_cluster_id = self._get_param("virtualClusterId")
+        created_before = self._get_param("createdBefore")
+        created_after = self._get_param("createdAfter")
+        name = self._get_param("name")
+        states = self.querystring.get("states", [])
+        max_results = self._get_int_param("maxResults", DEFAULT_MAX_RESULTS)
+        next_token = self._get_param("nextToken", DEFAULT_NEXT_TOKEN)
+
+        job_runs, next_token = self.emrcontainers_backend.list_job_runs(
+            virtual_cluster_id=virtual_cluster_id,
+            created_before=created_before,
+            created_after=created_after,
+            name=name,
+            states=states,
+            max_results=max_results,
+            next_token=next_token,
+        )
+
+        response = {"jobRuns": job_runs, "nextToken": next_token}
+        return 200, {}, json.dumps(response)

--- a/moto/emrcontainers/responses.py
+++ b/moto/emrcontainers/responses.py
@@ -69,3 +69,25 @@ class EMRContainersResponse(BaseResponse):
 
         response = {"virtualClusters": virtual_clusters, "nextToken": next_token}
         return 200, {}, json.dumps(response)
+
+    def start_job_run(self):
+        name = self._get_param("name")
+        virtual_cluster_id = self._get_param("virtualClusterId")
+        client_token = self._get_param("clientToken")
+        execution_role_arn = self._get_param("executionRoleArn")
+        release_label = self._get_param("releaseLabel")
+        job_driver = self._get_param("jobDriver")
+        configuration_overrides = self._get_param("configurationOverrides")
+        tags = self._get_param("tags")
+
+        job = self.emrcontainers_backend.start_job_run(
+            name=name,
+            virtual_cluster_id=virtual_cluster_id,
+            client_token=client_token,
+            execution_role_arn=execution_role_arn,
+            release_label=release_label,
+            job_driver=job_driver,
+            configuration_overrides=configuration_overrides,
+            tags=tags,
+        )
+        return 200, {}, json.dumps(dict(job))

--- a/moto/emrcontainers/urls.py
+++ b/moto/emrcontainers/urls.py
@@ -8,5 +8,6 @@ url_bases = [
 
 url_paths = {
     "{0}/virtualclusters$": EMRContainersResponse.dispatch,
-    "{0}/virtualclusters/(?P<virtualClusterId>[^/]+)/?$": EMRContainersResponse.dispatch,
+    "{0}/virtualclusters/(?P<virtualClusterId>[^/]+)$": EMRContainersResponse.dispatch,
+    "{0}/virtualclusters/(?P<virtualClusterId>[^/]+)/jobruns$": EMRContainersResponse.dispatch,
 }

--- a/moto/emrcontainers/urls.py
+++ b/moto/emrcontainers/urls.py
@@ -10,4 +10,5 @@ url_paths = {
     "{0}/virtualclusters$": EMRContainersResponse.dispatch,
     "{0}/virtualclusters/(?P<virtualClusterId>[^/]+)$": EMRContainersResponse.dispatch,
     "{0}/virtualclusters/(?P<virtualClusterId>[^/]+)/jobruns$": EMRContainersResponse.dispatch,
+    "{0}/virtualclusters/(?P<virtualClusterId>[^/]+)/jobruns/(?P<jobRunId>[^/]+)$": EMRContainersResponse.dispatch,
 }

--- a/moto/emrcontainers/utils.py
+++ b/moto/emrcontainers/utils.py
@@ -31,7 +31,7 @@ def random_job_id():
     return random_id(size=19)
 
 
-def paginated_list(full_list, max_results, next_token):
+def paginated_list(full_list, sort_key, max_results, next_token):
     """
     Returns a tuple containing a slice of the full list starting at next_token and ending with at most the max_results
     number of elements, and the new next_token which can be passed back in for the next segment of the full list.
@@ -40,7 +40,7 @@ def paginated_list(full_list, max_results, next_token):
         next_token = 0
     next_token = int(next_token)
 
-    sorted_list = sorted(full_list, key=lambda d: d["name"])
+    sorted_list = sorted(full_list, key=lambda d: d[sort_key])
 
     values = sorted_list[next_token : next_token + max_results]
     if len(values) == max_results:

--- a/moto/emrcontainers/utils.py
+++ b/moto/emrcontainers/utils.py
@@ -23,8 +23,12 @@ def random_id(size=13):
     return "".join(str(random.choice(chars)) for x in range(size))
 
 
-def random_cluster_id(size=13):
+def random_cluster_id():
     return random_id(size=25)
+
+
+def random_job_id():
+    return random_id(size=19)
 
 
 def paginated_list(full_list, max_results, next_token):

--- a/tests/test_emrcontainers/test_emrcontainers.py
+++ b/tests/test_emrcontainers/test_emrcontainers.py
@@ -346,39 +346,31 @@ class TestStartJobRun:
             in exc.value.args
         )
 
-    # todo: Fix this case
-    # Original message: Virtual cluster foobaa doesn't exist.
-    # Mocked message: ResourceArn 'Virtual cluster string doesn't exist.' does not exist
-    # def test_invalid_virtual_cluster_id(self):
-    #     with pytest.raises(ClientError) as exc:
-    #         self.client.start_job_run(
-    #             name="test_job",
-    #             virtualClusterId="foobaa",
-    #             executionRoleArn=self.default_execution_role_arn,
-    #             releaseLabel="foobaa",
-    #             jobDriver={}
-    #         )
-    #
-    #     err = exc.value.response["Error"]
-    #
-    #     assert err["Code"] == "ResourceNotFoundException"
-    #     assert (
-    #         err["Message"] == "Virtual cluster foobaa doesn't exist."
-    #     )
+    def test_invalid_virtual_cluster_id(self):
+        with pytest.raises(ClientError) as exc:
+            self.client.start_job_run(
+                name="test_job",
+                virtualClusterId="foobaa",
+                executionRoleArn=self.default_execution_role_arn,
+                releaseLabel="foobaa",
+                jobDriver={},
+            )
 
-    # todo: Fix this case
-    # Original message: Release foobaa doesn't exist.
-    # Mocked message: ResourceArn  'Release foobaa doesn't exist.' does not exist.
-    # def test_invalid_release_label(self):
-    #     with pytest.raises(ClientError) as exc:
-    #         self.client.start_job_run(
-    #             name="test_job",
-    #             virtualClusterId=self.virtual_cluster_id,
-    #             executionRoleArn=self.default_execution_role_arn,
-    #             releaseLabel="foobaa",
-    #             jobDriver={},
-    #         )
-    #     err = exc.value.response["Error"]
-    #
-    #     assert err["Code"] == "ResourceNotFoundException"
-    #     assert err["Message"] == "Release foobaa doesn't exist."
+        err = exc.value.response["Error"]
+
+        assert err["Code"] == "ResourceNotFoundException"
+        assert err["Message"] == "Virtual cluster foobaa doesn't exist."
+
+    def test_invalid_release_label(self):
+        with pytest.raises(ClientError) as exc:
+            self.client.start_job_run(
+                name="test_job",
+                virtualClusterId=self.virtual_cluster_id,
+                executionRoleArn=self.default_execution_role_arn,
+                releaseLabel="foobaa",
+                jobDriver={},
+            )
+        err = exc.value.response["Error"]
+
+        assert err["Code"] == "ResourceNotFoundException"
+        assert err["Message"] == "Release foobaa doesn't exist."


### PR DESCRIPTION
Hi All,

I have created a new feature for [EMRContainers](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/emr-containers.html) service. In the second PR I focused only operations with `jobs`.

Upon request I can add missing EMRContainers features (endpoints, tags).  Next item on my roadmap [Managed Streaming for Kafka](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/kafka.html), however that will be more complicated to mock.

Thanks,
Andor