### PR TITLE
[BUGFIX] Can't perform GET/PUT operations against server from inside docker container 

### DIFF
--- a/moto/s3/responses.py
+++ b/moto/s3/responses.py
@@ -196,6 +196,7 @@ class ResponseObject(_TemplateEnvironmentMixin, ActionAuthenticatorMixin):
             not host
             or host.startswith("localhost")
             or host.startswith("localstack")
+            or host.startswith("host.docker.internal")
             or re.match(r"^[^.]+$", host)
             or re.match(r"^.*\.svc\.cluster\.local:?\d*$", host)
         ):


### PR DESCRIPTION
Whitelists `host.docker.internal` in `subdomain_based_buckets`. Fixes issue 4521.

Signed-off-by: eric schkufza <eric.schkufza@gmail.com>