### PR TITLE
Feature: S3 -  enable encryption when copying keys

### DIFF
--- a/moto/s3/models.py
+++ b/moto/s3/models.py
@@ -173,15 +173,6 @@ class FakeKey(BaseModel):
         self._value_buffer.write(new_value)
         self.contentsize = len(new_value)
 
-    def copy(self, new_name=None, new_is_versioned=None):
-        r = copy.deepcopy(self)
-        if new_name is not None:
-            r.name = new_name
-        if new_is_versioned is not None:
-            r._is_versioned = new_is_versioned
-            r.refresh_version()
-        return r
-
     def set_metadata(self, metadata, replace=False):
         if replace:
             self._metadata = {}
@@ -212,10 +203,6 @@ class FakeKey(BaseModel):
 
     def restore(self, days):
         self._expiry = datetime.datetime.utcnow() + datetime.timedelta(days)
-
-    def refresh_version(self):
-        self._version_id = str(uuid.uuid4())
-        self.last_modified = datetime.datetime.utcnow()
 
     @property
     def etag(self):

--- a/tests/test_s3/test_s3.py
+++ b/tests/test_s3/test_s3.py
@@ -6165,47 +6165,6 @@ def test_creating_presigned_post():
 
 
 @mock_s3
-def test_encryption():
-    # Create Bucket so that test can run
-    conn = boto3.client("s3", region_name="us-east-1")
-    conn.create_bucket(Bucket="mybucket")
-
-    with pytest.raises(ClientError):
-        conn.get_bucket_encryption(Bucket="mybucket")
-
-    sse_config = {
-        "Rules": [
-            {
-                "ApplyServerSideEncryptionByDefault": {
-                    "SSEAlgorithm": "aws:kms",
-                    "KMSMasterKeyID": "12345678",
-                }
-            }
-        ]
-    }
-
-    conn.put_bucket_encryption(
-        Bucket="mybucket", ServerSideEncryptionConfiguration=sse_config
-    )
-
-    resp = conn.get_bucket_encryption(Bucket="mybucket")
-    assert "ServerSideEncryptionConfiguration" in resp
-    return_config = sse_config.copy()
-    return_config["Rules"][0]["BucketKeyEnabled"] = False
-    assert resp["ServerSideEncryptionConfiguration"].should.equal(return_config)
-
-    conn.delete_bucket_encryption(Bucket="mybucket")
-    with pytest.raises(ClientError) as exc:
-        conn.get_bucket_encryption(Bucket="mybucket")
-    err = exc.value.response["Error"]
-    err["Code"].should.equal("ServerSideEncryptionConfigurationNotFoundError")
-    err["Message"].should.equal(
-        "The server side encryption configuration was not found"
-    )
-    err["BucketName"].should.equal("mybucket")
-
-
-@mock_s3
 def test_presigned_put_url_with_approved_headers():
     bucket = str(uuid.uuid4())
     key = "file.txt"

--- a/tests/test_s3/test_s3_encryption.py
+++ b/tests/test_s3/test_s3_encryption.py
@@ -1,0 +1,77 @@
+import boto3
+import pytest
+
+from botocore.exceptions import ClientError
+from moto import mock_s3
+
+
+@mock_s3
+def test_encryption_on_new_bucket_fails():
+    conn = boto3.client("s3", region_name="us-east-1")
+    conn.create_bucket(Bucket="mybucket")
+
+    with pytest.raises(ClientError) as exc:
+        conn.get_bucket_encryption(Bucket="mybucket")
+    err = exc.value.response["Error"]
+    err["Code"].should.equal("ServerSideEncryptionConfigurationNotFoundError")
+    err["Message"].should.equal(
+        "The server side encryption configuration was not found"
+    )
+    err["BucketName"].should.equal("mybucket")
+
+
+@mock_s3
+def test_put_and_get_encryption():
+    # Create Bucket so that test can run
+    conn = boto3.client("s3", region_name="us-east-1")
+    conn.create_bucket(Bucket="mybucket")
+
+    sse_config = {
+        "Rules": [
+            {
+                "ApplyServerSideEncryptionByDefault": {
+                    "SSEAlgorithm": "aws:kms",
+                    "KMSMasterKeyID": "12345678",
+                }
+            }
+        ]
+    }
+
+    conn.put_bucket_encryption(
+        Bucket="mybucket", ServerSideEncryptionConfiguration=sse_config
+    )
+
+    resp = conn.get_bucket_encryption(Bucket="mybucket")
+    assert "ServerSideEncryptionConfiguration" in resp
+    return_config = sse_config.copy()
+    return_config["Rules"][0]["BucketKeyEnabled"] = False
+    assert resp["ServerSideEncryptionConfiguration"].should.equal(return_config)
+
+
+@mock_s3
+def test_delete_and_get_encryption():
+    # Create Bucket so that test can run
+    conn = boto3.client("s3", region_name="us-east-1")
+    conn.create_bucket(Bucket="mybucket")
+
+    sse_config = {
+        "Rules": [
+            {
+                "ApplyServerSideEncryptionByDefault": {
+                    "SSEAlgorithm": "aws:kms",
+                    "KMSMasterKeyID": "12345678",
+                }
+            }
+        ]
+    }
+
+    conn.put_bucket_encryption(
+        Bucket="mybucket", ServerSideEncryptionConfiguration=sse_config
+    )
+
+    conn.delete_bucket_encryption(Bucket="mybucket")
+    # GET now fails, after deleting it, as it no longer exists
+    with pytest.raises(ClientError) as exc:
+        conn.get_bucket_encryption(Bucket="mybucket")
+    err = exc.value.response["Error"]
+    err["Code"].should.equal("ServerSideEncryptionConfigurationNotFoundError")


### PR DESCRIPTION
Fixes #4172 

Improved behaviour of `put_bucket_encryption`

Reuse existing `put_object` logic when copying keys, to ensure that the encryption config is set correctly.

Tests have been verified against AWS