### PR TITLE
Kinesis - Fix split_shards behaviour

### DIFF
--- a/moto/kinesis/exceptions.py
+++ b/moto/kinesis/exceptions.py
@@ -27,9 +27,9 @@ class StreamNotFoundError(ResourceNotFoundError):
 
 
 class ShardNotFoundError(ResourceNotFoundError):
-    def __init__(self, shard_id):
+    def __init__(self, shard_id, stream):
         super(ShardNotFoundError, self).__init__(
-            "Shard {0} under account {1} not found.".format(shard_id, ACCOUNT_ID)
+            f"Could not find shard {shard_id} in stream {stream} under account {ACCOUNT_ID}."
         )
 
 
@@ -38,4 +38,15 @@ class InvalidArgumentError(BadRequest):
         super(InvalidArgumentError, self).__init__()
         self.description = json.dumps(
             {"message": message, "__type": "InvalidArgumentException"}
+        )
+
+
+class ValidationException(BadRequest):
+    def __init__(self, value, position, regex_to_match):
+        super(ValidationException, self).__init__()
+        self.description = json.dumps(
+            {
+                "message": f"1 validation error detected: Value '{value}' at '{position}' failed to satisfy constraint: Member must satisfy regular expression pattern: {regex_to_match}",
+                "__type": "ValidationException",
+            }
         )

--- a/tests/test_kinesis/test_kinesis.py
+++ b/tests/test_kinesis/test_kinesis.py
@@ -28,7 +28,7 @@ def test_create_cluster():
     stream["StreamName"].should.equal("my_stream")
     stream["HasMoreShards"].should.equal(False)
     stream["StreamARN"].should.equal(
-        "arn:aws:kinesis:us-west-2:{}:my_stream".format(ACCOUNT_ID)
+        "arn:aws:kinesis:us-west-2:{}:stream/my_stream".format(ACCOUNT_ID)
     )
     stream["StreamStatus"].should.equal("ACTIVE")
 
@@ -134,7 +134,7 @@ def test_describe_stream_summary():
     stream["StreamName"].should.equal(stream_name)
     stream["OpenShardCount"].should.equal(shard_count)
     stream["StreamARN"].should.equal(
-        "arn:aws:kinesis:us-west-2:{}:{}".format(ACCOUNT_ID, stream_name)
+        "arn:aws:kinesis:us-west-2:{}:stream/{}".format(ACCOUNT_ID, stream_name)
     )
     stream["StreamStatus"].should.equal("ACTIVE")
 
@@ -204,7 +204,11 @@ def test_get_invalid_shard_iterator_boto3():
         )
     err = exc.value.response["Error"]
     err["Code"].should.equal("ResourceNotFoundException")
-    err["Message"].should.equal("Shard 123 under account 123456789012 not found.")
+    # There is some magic in AWS, that '123' is automatically converted into 'shardId-000000000123'
+    # AWS itself returns this normalized ID in the error message, not the given id
+    err["Message"].should.equal(
+        f"Shard 123 in stream {stream_name} under account {ACCOUNT_ID} does not exist"
+    )
 
 
 # Has boto3 equivalent
@@ -969,95 +973,6 @@ def test_remove_tags():
         ]
     )
     tags.get("tag2").should.equal(None)
-
-
-# Has boto3 equivalent
-@mock_kinesis_deprecated
-def test_split_shard():
-    conn = boto.kinesis.connect_to_region("us-west-2")
-    stream_name = "my_stream"
-
-    conn.create_stream(stream_name, 2)
-
-    # Create some data
-    for index in range(1, 100):
-        conn.put_record(stream_name, str(index), str(index))
-
-    stream_response = conn.describe_stream(stream_name)
-
-    stream = stream_response["StreamDescription"]
-    shards = stream["Shards"]
-    shards.should.have.length_of(2)
-
-    shard_range = shards[0]["HashKeyRange"]
-    new_starting_hash = (
-        int(shard_range["EndingHashKey"]) + int(shard_range["StartingHashKey"])
-    ) // 2
-    conn.split_shard("my_stream", shards[0]["ShardId"], str(new_starting_hash))
-
-    stream_response = conn.describe_stream(stream_name)
-
-    stream = stream_response["StreamDescription"]
-    shards = stream["Shards"]
-    shards.should.have.length_of(3)
-
-    shard_range = shards[2]["HashKeyRange"]
-    new_starting_hash = (
-        int(shard_range["EndingHashKey"]) + int(shard_range["StartingHashKey"])
-    ) // 2
-    conn.split_shard("my_stream", shards[2]["ShardId"], str(new_starting_hash))
-
-    stream_response = conn.describe_stream(stream_name)
-
-    stream = stream_response["StreamDescription"]
-    shards = stream["Shards"]
-    shards.should.have.length_of(4)
-
-
-@mock_kinesis
-def test_split_shard_boto3():
-    client = boto3.client("kinesis", region_name="eu-west-2")
-    stream_name = "my_stream_summary"
-    client.create_stream(StreamName=stream_name, ShardCount=2)
-
-    for index in range(1, 100):
-        client.put_record(
-            StreamName=stream_name,
-            Data=f"data_{index}".encode("utf-8"),
-            PartitionKey=str(index),
-        )
-
-    stream = client.describe_stream(StreamName=stream_name)["StreamDescription"]
-    shards = stream["Shards"]
-    shards.should.have.length_of(2)
-
-    shard_range = shards[0]["HashKeyRange"]
-    new_starting_hash = (
-        int(shard_range["EndingHashKey"]) + int(shard_range["StartingHashKey"])
-    ) // 2
-    client.split_shard(
-        StreamName=stream_name,
-        ShardToSplit=shards[0]["ShardId"],
-        NewStartingHashKey=str(new_starting_hash),
-    )
-
-    stream = client.describe_stream(StreamName=stream_name)["StreamDescription"]
-    shards = stream["Shards"]
-    shards.should.have.length_of(3)
-
-    shard_range = shards[2]["HashKeyRange"]
-    new_starting_hash = (
-        int(shard_range["EndingHashKey"]) + int(shard_range["StartingHashKey"])
-    ) // 2
-    client.split_shard(
-        StreamName=stream_name,
-        ShardToSplit=shards[2]["ShardId"],
-        NewStartingHashKey=str(new_starting_hash),
-    )
-
-    stream = client.describe_stream(StreamName=stream_name)["StreamDescription"]
-    shards = stream["Shards"]
-    shards.should.have.length_of(4)
 
 
 # Has boto3 equivalent


### PR DESCRIPTION
Fixes `split_shards` behaviour to create two new shards, instead of the existing behaviour of reusing one
Adds error scenarios, and fixes existing error messages
Fixes some erroneous Response-attributes when describing a stream

All new tests were validated against AWS.

Closes #1405
Closes #1475