### PR TITLE
Directory Service: Handle IPV6 addresses and no tags

### DIFF
--- a/moto/ds/models.py
+++ b/moto/ds/models.py
@@ -107,7 +107,7 @@ class Directory(BaseModel):  # pylint: disable=too-many-instance-attributes
         """
         ip_addrs = []
         for subnet in subnets:
-            ips = ipaddress.IPv4Network(subnet.cidr_block)
+            ips = ipaddress.ip_network(subnet.cidr_block)
             # Not sure if the following could occur, but if it does,
             # the situation will be ignored.
             if ips:

--- a/moto/ds/models.py
+++ b/moto/ds/models.py
@@ -254,7 +254,7 @@ class DirectoryServiceBackend(BaseBackend):
         errmsg = self.tagger.validate_tags(tags or [])
         if errmsg:
             raise ValidationException(errmsg)
-        if len(tags) > Directory.MAX_TAGS_PER_DIRECTORY:
+        if tags and len(tags) > Directory.MAX_TAGS_PER_DIRECTORY:
             raise DirectoryLimitExceededException("Tag Limit is exceeding")
 
         directory = Directory(
@@ -303,7 +303,7 @@ class DirectoryServiceBackend(BaseBackend):
         errmsg = self.tagger.validate_tags(tags or [])
         if errmsg:
             raise ValidationException(errmsg)
-        if len(tags) > Directory.MAX_TAGS_PER_DIRECTORY:
+        if tags and len(tags) > Directory.MAX_TAGS_PER_DIRECTORY:
             raise DirectoryLimitExceededException("Tag Limit is exceeding")
 
         directory = Directory(
@@ -389,7 +389,7 @@ class DirectoryServiceBackend(BaseBackend):
         errmsg = self.tagger.validate_tags(tags or [])
         if errmsg:
             raise ValidationException(errmsg)
-        if len(tags) > Directory.MAX_TAGS_PER_DIRECTORY:
+        if tags and len(tags) > Directory.MAX_TAGS_PER_DIRECTORY:
             raise DirectoryLimitExceededException("Tag Limit is exceeding")
 
         directory = Directory(
@@ -489,7 +489,7 @@ class DirectoryServiceBackend(BaseBackend):
         errmsg = self.tagger.validate_tags(tags)
         if errmsg:
             raise ValidationException(errmsg)
-        if len(tags) > Directory.MAX_TAGS_PER_DIRECTORY:
+        if tags and len(tags) > Directory.MAX_TAGS_PER_DIRECTORY:
             raise TagLimitExceededException("Tag limit exceeded")
         self.tagger.tag_resource(resource_id, tags)
 

--- a/moto/ds/models.py
+++ b/moto/ds/models.py
@@ -254,7 +254,7 @@ class DirectoryServiceBackend(BaseBackend):
         errmsg = self.tagger.validate_tags(tags or [])
         if errmsg:
             raise ValidationException(errmsg)
-        if tags and len(tags) > Directory.MAX_TAGS_PER_DIRECTORY:
+        if len(tags) > Directory.MAX_TAGS_PER_DIRECTORY:
             raise DirectoryLimitExceededException("Tag Limit is exceeding")
 
         directory = Directory(
@@ -303,7 +303,7 @@ class DirectoryServiceBackend(BaseBackend):
         errmsg = self.tagger.validate_tags(tags or [])
         if errmsg:
             raise ValidationException(errmsg)
-        if tags and len(tags) > Directory.MAX_TAGS_PER_DIRECTORY:
+        if len(tags) > Directory.MAX_TAGS_PER_DIRECTORY:
             raise DirectoryLimitExceededException("Tag Limit is exceeding")
 
         directory = Directory(
@@ -389,7 +389,7 @@ class DirectoryServiceBackend(BaseBackend):
         errmsg = self.tagger.validate_tags(tags or [])
         if errmsg:
             raise ValidationException(errmsg)
-        if tags and len(tags) > Directory.MAX_TAGS_PER_DIRECTORY:
+        if len(tags) > Directory.MAX_TAGS_PER_DIRECTORY:
             raise DirectoryLimitExceededException("Tag Limit is exceeding")
 
         directory = Directory(
@@ -489,7 +489,7 @@ class DirectoryServiceBackend(BaseBackend):
         errmsg = self.tagger.validate_tags(tags)
         if errmsg:
             raise ValidationException(errmsg)
-        if tags and len(tags) > Directory.MAX_TAGS_PER_DIRECTORY:
+        if len(tags) > Directory.MAX_TAGS_PER_DIRECTORY:
             raise TagLimitExceededException("Tag limit exceeded")
         self.tagger.tag_resource(resource_id, tags)
 

--- a/moto/ds/responses.py
+++ b/moto/ds/responses.py
@@ -23,7 +23,7 @@ class DirectoryServiceResponse(BaseResponse):
         description = self._get_param("Description")
         size = self._get_param("Size")
         connect_settings = self._get_param("ConnectSettings")
-        tags = self._get_param("Tags")
+        tags = self._get_param("Tags", [])
         directory_id = self.ds_backend.connect_directory(
             region=self.region,
             name=name,
@@ -44,7 +44,7 @@ class DirectoryServiceResponse(BaseResponse):
         description = self._get_param("Description")
         size = self._get_param("Size")
         vpc_settings = self._get_param("VpcSettings")
-        tags = self._get_param("Tags")
+        tags = self._get_param("Tags", [])
         directory_id = self.ds_backend.create_directory(
             region=self.region,
             name=name,
@@ -72,7 +72,7 @@ class DirectoryServiceResponse(BaseResponse):
         description = self._get_param("Description")
         vpc_settings = self._get_param("VpcSettings")
         edition = self._get_param("Edition")
-        tags = self._get_param("Tags")
+        tags = self._get_param("Tags", [])
         directory_id = self.ds_backend.create_microsoft_ad(
             region=self.region,
             name=name,


### PR DESCRIPTION
Issues fixed:

- `ipaddress.ip_network()` should be used instead of `ipaddress.IPv4Network()` in order to handle both IPv4 and IPv6 addresses.
- 
- There are checks for the maximum number of tags, but those checks don't account for no tags being present.  Set the default value for tags to an empty list.