### PR TITLE
Add support for Label filter in get_parameters_by_path

### DIFF
--- a/moto/ssm/models.py
+++ b/moto/ssm/models.py
@@ -1388,6 +1388,13 @@ class SimpleSystemManagerBackend(BaseBackend):
                 values = ["/" + value.strip("/") for value in values]
             elif key == "Type":
                 what = parameter.type
+            elif key == "Label":
+                what = parameter.labels
+                # Label filter can only have option="Equals" (also valid implicitly)
+                if len(what) == 0 or not all(label in values for label in what):
+                    return False
+                else:
+                    continue
             elif key.startswith("tag:"):
                 what = key[4:] or None
                 for tag in parameter.tags:

--- a/tests/test_ssm/test_ssm_boto3.py
+++ b/tests/test_ssm/test_ssm_boto3.py
@@ -225,6 +225,14 @@ def test_get_parameters_by_path():
         "Valid filter keys include: [Type, KeyId].",
     )
 
+    # Label filter in get_parameters_by_path
+    client.label_parameter_version(Name="/foo/name2", Labels=["Label1"])
+
+    filters = [{"Key": "Label", "Values": ["Label1"]}]
+    response = client.get_parameters_by_path(Path="/foo", ParameterFilters=filters)
+    len(response["Parameters"]).should.equal(1)
+    {p["Name"] for p in response["Parameters"]}.should.equal(set(["/foo/name2"]))
+
 
 @pytest.mark.parametrize("name", ["test", "my-cool-parameter"])
 @mock_ssm


### PR DESCRIPTION
See: https://docs.aws.amazon.com/systems-manager/latest/APIReference/API_GetParametersByPath.html

Adds the option to filter SSM parameters by their labels.


Example usage: `aws ssm get-parameters-by-path --path "/foo" --parameter-filters Key=Label,Values=label1`