### PR TITLE
Cloudtrail `get_trail_status()` also accepts ARN in `Name` parameter

### DIFF
--- a/moto/cloudtrail/models.py
+++ b/moto/cloudtrail/models.py
@@ -215,11 +215,19 @@ class CloudTrailBackend(BaseBackend):
     def get_trail_status(self, name):
         if len(name) < 3:
             raise TrailNameTooShort(actual_length=len(name))
-        if name not in self.trails:
+        trail_name = next(
+            (
+                trail.trail_name
+                for trail in self.trails.values()
+                if trail.trail_name == name or trail.arn == name
+            ),
+            None,
+        )
+        if not trail_name:
             # This particular method returns the ARN as part of the error message
             arn = f"arn:aws:cloudtrail:{self.region_name}:{ACCOUNT_ID}:trail/{name}"
             raise TrailNotFoundException(name=arn)
-        trail = self.trails[name]
+        trail = self.trails[trail_name]
         return trail.status
 
     def describe_trails(self, include_shadow_trails):

--- a/tests/test_cloudtrail/test_cloudtrail.py
+++ b/tests/test_cloudtrail/test_cloudtrail.py
@@ -253,6 +253,22 @@ def test_get_trail_status_inactive():
 
 @mock_cloudtrail
 @mock_s3
+def test_get_trail_status_arn_inactive():
+    client = boto3.client("cloudtrail", region_name="us-east-1")
+    _, resp, _ = create_trail_simple()
+    status = client.get_trail_status(Name=resp["TrailARN"])
+    status.should.have.key("IsLogging").equal(False)
+    status.should.have.key("LatestDeliveryAttemptTime").equal("")
+    status.should.have.key("LatestNotificationAttemptTime").equal("")
+    status.should.have.key("LatestNotificationAttemptSucceeded").equal("")
+    status.should.have.key("LatestDeliveryAttemptSucceeded").equal("")
+    status.should.have.key("TimeLoggingStarted").equal("")
+    status.should.have.key("TimeLoggingStopped").equal("")
+    status.shouldnt.have.key("StartLoggingTime")
+
+
+@mock_cloudtrail
+@mock_s3
 def test_get_trail_status_after_starting():
     client = boto3.client("cloudtrail", region_name="eu-west-3")
     _, _, trail_name = create_trail_simple(region_name="eu-west-3")


### PR DESCRIPTION
Fix for the issue #4544 