### PR TITLE
EC2 - fix missing AZ on auto-generated volumes for instances

### DIFF
--- a/moto/ec2/models.py
+++ b/moto/ec2/models.py
@@ -694,7 +694,7 @@ class Instance(TaggedEC2Resource, BotoInstance, CloudFormationModel):
     ):
         volume = self.ec2_backend.create_volume(
             size=size,
-            zone_name=self.region_name,
+            zone_name=self._placement.zone,
             snapshot_id=snapshot_id,
             encrypted=encrypted,
             kms_key_id=kms_key_id,
@@ -706,7 +706,7 @@ class Instance(TaggedEC2Resource, BotoInstance, CloudFormationModel):
     def setup_defaults(self):
         # Default have an instance with root volume should you not wish to
         # override with attach volume cmd.
-        volume = self.ec2_backend.create_volume(size=8, zone_name="us-east-1a")
+        volume = self.ec2_backend.create_volume(size=8, zone_name=self._placement.zone)
         self.ec2_backend.attach_volume(volume.id, self.id, "/dev/sda1", True)
 
     def teardown_defaults(self):

--- a/tests/test_ec2/test_elastic_block_store.py
+++ b/tests/test_ec2/test_elastic_block_store.py
@@ -561,6 +561,11 @@ def test_volume_attach_and_detach_boto3():
     ec2 = boto3.resource("ec2", region_name="us-east-1")
     reservation = client.run_instances(ImageId=EXAMPLE_AMI_ID, MinCount=1, MaxCount=1)
     instance = reservation["Instances"][0]
+
+    volumes = client.describe_volumes()['Volumes']
+    volumes.should.have.length_of(1)
+    volumes[0]['AvailabilityZone'].should.equal("us-east-1a")
+
     volume = ec2.create_volume(Size=80, AvailabilityZone="us-east-1a")
 
     volume.reload()

--- a/tests/test_ec2/test_elastic_block_store.py
+++ b/tests/test_ec2/test_elastic_block_store.py
@@ -562,7 +562,9 @@ def test_volume_attach_and_detach_boto3():
     reservation = client.run_instances(ImageId=EXAMPLE_AMI_ID, MinCount=1, MaxCount=1)
     instance = reservation["Instances"][0]
 
-    volumes = client.describe_volumes()["Volumes"]
+    volumes = client.describe_volumes(
+        Filters=[{"Name": "attachment.instance-id", "Values": [instance["InstanceId"]]}]
+    )["Volumes"]
     volumes.should.have.length_of(1)
     volumes[0]["AvailabilityZone"].should.equal("us-east-1a")
 

--- a/tests/test_ec2/test_elastic_block_store.py
+++ b/tests/test_ec2/test_elastic_block_store.py
@@ -562,9 +562,9 @@ def test_volume_attach_and_detach_boto3():
     reservation = client.run_instances(ImageId=EXAMPLE_AMI_ID, MinCount=1, MaxCount=1)
     instance = reservation["Instances"][0]
 
-    volumes = client.describe_volumes()['Volumes']
+    volumes = client.describe_volumes()["Volumes"]
     volumes.should.have.length_of(1)
-    volumes[0]['AvailabilityZone'].should.equal("us-east-1a")
+    volumes[0]["AvailabilityZone"].should.equal("us-east-1a")
 
     volume = ec2.create_volume(Size=80, AvailabilityZone="us-east-1a")
 


### PR DESCRIPTION
Using `aws ec2 run-instance ...` automatically creates a Volume. This volume had an empty AvailabilityZone field when not deployed in us-east-1 since this was hardcoded previously. Creating Volumes manually did set the AZ properly, so no changes where necessary in this case.