### PR TITLE
S3 - Remove double quotes on ETag after copy

### DIFF
--- a/moto/s3/models.py
+++ b/moto/s3/models.py
@@ -2016,7 +2016,6 @@ class S3Backend(BaseBackend):
             key_name=dest_key_name,
             value=key.value,
             storage=storage or key.storage_class,
-            etag=key.etag,
             multipart=key.multipart,
             encryption=key.encryption,
             kms_key_id=key.kms_key_id,

--- a/tests/test_s3/test_s3.py
+++ b/tests/test_s3/test_s3.py
@@ -1049,7 +1049,7 @@ def test_copy_key_replace_metadata_boto3():
     s3.create_bucket(Bucket="foobar")
 
     key = s3.Object("foobar", "the-key")
-    key.put(Body=b"some value", Metadata={"md": "Metadatastring"})
+    initial = key.put(Body=b"some value", Metadata={"md": "Metadatastring"})
 
     client.copy_object(
         Bucket="foobar",
@@ -1061,6 +1061,7 @@ def test_copy_key_replace_metadata_boto3():
 
     resp = client.get_object(Bucket="foobar", Key="new-key")
     resp["Metadata"].should.equal({"momd": "Mometadatastring"})
+    resp["ETag"].should.equal(initial["ETag"])
 
 
 # Has boto3 equivalent


### PR DESCRIPTION
Potential fix for #4551. Bug was introduced in #4535 

The internal value of the `etag`-parameter _should_ be the md5 representation of the content. Whenever someone calls the property `key.etag`, Moto will then add the required quotes around it.

The line `etag=key.etag` on copy would ensure that the internal value of the etag already had quotes. Calling the `copied_key.etag` property would add another set of quotes. (Presumably ad-infinitum, if you would copy the same object over and over...)

By not supplying the etag-parameter it will be recalculated, so this way we don't have to worry about removing/counting quotes.