### PR TITLE
CloudwatchLogs - implement validation for old/new messages

### DIFF
--- a/moto/batch/models.py
+++ b/moto/batch/models.py
@@ -26,6 +26,7 @@ from moto.ec2.exceptions import InvalidSubnetIdError
 from moto.ec2.models import INSTANCE_TYPES as EC2_INSTANCE_TYPES
 from moto.iam.exceptions import IAMNotFoundException
 from moto.core import ACCOUNT_ID as DEFAULT_ACCOUNT_ID
+from moto.core.utils import unix_time_millis
 from moto.utilities.docker_utilities import DockerModel, parse_image_ref
 from ..utilities.tagging_service import TaggingService
 
@@ -582,11 +583,8 @@ class Job(threading.Thread, BaseModel, DockerModel):
                 logs = []
                 for line in logs_stdout + logs_stderr:
                     date, line = line.split(" ", 1)
-                    date = dateutil.parser.parse(date)
-                    # TODO: Replace with int(date.timestamp()) once we yeet Python2 out of the window
-                    date = int(
-                        (time.mktime(date.timetuple()) + date.microsecond / 1000000.0)
-                    )
+                    date_obj = dateutil.parser.parse(date, ignoretz=True)
+                    date = unix_time_millis(date_obj)
                     logs.append({"timestamp": date, "message": line.strip()})
 
                 # Send to cloudwatch

--- a/moto/events/models.py
+++ b/moto/events/models.py
@@ -15,7 +15,11 @@ from boto3 import Session
 from collections import OrderedDict
 from moto.core.exceptions import JsonRESTError
 from moto.core import ACCOUNT_ID, BaseBackend, CloudFormationModel, BaseModel
-from moto.core.utils import unix_time, iso_8601_datetime_without_milliseconds
+from moto.core.utils import (
+    unix_time,
+    unix_time_millis,
+    iso_8601_datetime_without_milliseconds,
+)
 from moto.events.exceptions import (
     ValidationException,
     ResourceNotFoundException,
@@ -176,7 +180,7 @@ class Rule(CloudFormationModel):
         log_stream_name = str(uuid4())
         log_events = [
             {
-                "timestamp": unix_time(datetime.utcnow()),
+                "timestamp": unix_time_millis(datetime.utcnow()),
                 "message": json.dumps(event_copy),
             }
         ]

--- a/moto/logs/responses.py
+++ b/moto/logs/responses.py
@@ -214,10 +214,18 @@ class LogsResponse(BaseResponse):
         log_events = self._get_param("logEvents")
         sequence_token = self._get_param("sequenceToken")
 
-        next_sequence_token = self.logs_backend.put_log_events(
+        next_sequence_token, rejected_info = self.logs_backend.put_log_events(
             log_group_name, log_stream_name, log_events, sequence_token
         )
-        return json.dumps({"nextSequenceToken": next_sequence_token})
+        if rejected_info:
+            return json.dumps(
+                {
+                    "nextSequenceToken": next_sequence_token,
+                    "rejectedLogEventsInfo": rejected_info,
+                }
+            )
+        else:
+            return json.dumps({"nextSequenceToken": next_sequence_token})
 
     def get_log_events(self):
         log_group_name = self._get_param("logGroupName")

--- a/tests/test_events/test_events_integration.py
+++ b/tests/test_events/test_events_integration.py
@@ -36,7 +36,7 @@ def test_send_to_cw_log_group():
     )
 
     # when
-    event_time = datetime(2021, 1, 1, 12, 23, 34)
+    event_time = datetime.utcnow()
     client_events.put_events(
         Entries=[
             {

--- a/tests/test_logs/test_integration.py
+++ b/tests/test_logs/test_integration.py
@@ -8,7 +8,9 @@ import zlib
 
 import boto3
 from botocore.exceptions import ClientError
+from datetime import datetime
 from moto import mock_logs, mock_lambda, mock_iam, mock_firehose, mock_s3
+from moto.core.utils import unix_time_millis
 import pytest
 
 
@@ -141,12 +143,14 @@ def test_put_subscription_filter_with_lambda():
     sub_filter["filterPattern"] = ""
 
     # when
+    ts_0 = int(unix_time_millis(datetime.utcnow()))
+    ts_1 = int(unix_time_millis(datetime.utcnow())) + 10
     client_logs.put_log_events(
         logGroupName=log_group_name,
         logStreamName=log_stream_name,
         logEvents=[
-            {"timestamp": 0, "message": "test"},
-            {"timestamp": 0, "message": "test 2"},
+            {"timestamp": ts_0, "message": "test"},
+            {"timestamp": ts_1, "message": "test 2"},
         ],
     )
 
@@ -171,10 +175,10 @@ def test_put_subscription_filter_with_lambda():
     log_events.should.have.length_of(2)
     log_events[0]["id"].should.be.a(int)
     log_events[0]["message"].should.equal("test")
-    log_events[0]["timestamp"].should.equal(0)
+    log_events[0]["timestamp"].should.equal(ts_0)
     log_events[1]["id"].should.be.a(int)
     log_events[1]["message"].should.equal("test 2")
-    log_events[1]["timestamp"].should.equal(0)
+    log_events[1]["timestamp"].should.equal(ts_1)
 
 
 @mock_s3
@@ -233,12 +237,14 @@ def test_put_subscription_filter_with_firehose():
     _filter["filterPattern"] = ""
 
     # when
+    ts_0 = int(unix_time_millis(datetime.utcnow()))
+    ts_1 = int(unix_time_millis(datetime.utcnow()))
     client_logs.put_log_events(
         logGroupName=log_group_name,
         logStreamName=log_stream_name,
         logEvents=[
-            {"timestamp": 0, "message": "test"},
-            {"timestamp": 0, "message": "test 2"},
+            {"timestamp": ts_0, "message": "test"},
+            {"timestamp": ts_1, "message": "test 2"},
         ],
     )
 
@@ -260,10 +266,10 @@ def test_put_subscription_filter_with_firehose():
     log_events.should.have.length_of(2)
     log_events[0]["id"].should.be.a(int)
     log_events[0]["message"].should.equal("test")
-    log_events[0]["timestamp"].should.equal(0)
+    log_events[0]["timestamp"].should.equal(ts_0)
     log_events[1]["id"].should.be.a(int)
     log_events[1]["message"].should.equal("test 2")
-    log_events[1]["timestamp"].should.equal(0)
+    log_events[1]["timestamp"].should.equal(ts_1)
 
 
 @mock_lambda


### PR DESCRIPTION
Closes #3979 

Implements validation for:
 - log events not in chronological order
 - log events that are too old (> 2 weeks ago)
 - log events that are too recent (> 2 hours in the future)

Tests were validated against AWS