### PR TITLE
DynamoDB - fix bugfix between 0 and x

### DIFF
--- a/moto/dynamodb2/comparisons.py
+++ b/moto/dynamodb2/comparisons.py
@@ -1162,7 +1162,11 @@ class FuncBetween(Func):
         start = self.start.expr(item)
         attr = self.attr.expr(item)
         end = self.end.expr(item)
-        if start and attr and end:
+        # Need to verify whether start has a valid value
+        # Can't just check  'if start', because start could be 0, which is a valid integer
+        start_has_value = start is not None and (isinstance(start, int) or start)
+        end_has_value = end is not None and (isinstance(end, int) or end)
+        if start_has_value and attr and end_has_value:
             return start <= attr <= end
         elif start is None and attr is None:
             # None is between None and None as well as None is between None and any number

--- a/tests/test_dynamodb2/test_dynamodb.py
+++ b/tests/test_dynamodb2/test_dynamodb.py
@@ -1551,6 +1551,12 @@ def test_filter_expression():
     )
     filter_expr.expr(row1).should.be(True)
 
+    # BETWEEN integer test
+    filter_expr = moto.dynamodb2.comparisons.get_filter_expression(
+        "Id BETWEEN :v0 AND :v1", {}, {":v0": {"N": "0"}, ":v1": {"N": "10"}}
+    )
+    filter_expr.expr(row1).should.be(True)
+
     # PAREN test
     filter_expr = moto.dynamodb2.comparisons.get_filter_expression(
         "Id = :v0 AND (Subs = :v0 OR Subs = :v1)",


### PR DESCRIPTION
Bug where 'between 0 and 10' would fail, because it would interpret '0' as None