### PR TITLE
Set version_id to null without bucket versioning

### DIFF
--- a/moto/s3/models.py
+++ b/moto/s3/models.py
@@ -1595,7 +1595,7 @@ class S3Backend(BaseBackend):
             storage=storage,
             etag=etag,
             is_versioned=bucket.is_versioned,
-            version_id=str(uuid.uuid4()) if bucket.is_versioned else None,
+            version_id=str(uuid.uuid4()) if bucket.is_versioned else "null",
             multipart=multipart,
             encryption=encryption,
             kms_key_id=kms_key_id,


### PR DESCRIPTION
The real S3 API returns `"null"` for `versionId` if bucket versioning
is disabled; not `None`. Moto returns `None`.

This causes behavior for the added test case to diverge between the real
API and the mock one: if you enable bucket configuration after objects
already exist in the bucket, it becomes impossible to empty the bucket
with moto.