### PR TITLE
Update adding dns-name(public_dns) to filter_dict_attribute_mapping in utils.py

### DIFF
--- a/moto/ec2/utils.py
+++ b/moto/ec2/utils.py
@@ -477,6 +477,7 @@ filter_dict_attribute_mapping = {
     "private-dns-name": "private_dns",
     "owner-id": "owner_id",
     "subnet-id": "subnet_id",
+    "dns-name": "public_dns",
 }
 
 


### PR DESCRIPTION
#4582

The actual method uses dns-name, but moto does not support it. So I added,