### PR TITLE
Adding functionality for cognito:groups in access_token

### DIFF
--- a/moto/cognitoidp/models.py
+++ b/moto/cognitoidp/models.py
@@ -476,12 +476,11 @@ class CognitoIdpUserPool(BaseModel):
         extra_data = {}
         user = self._get_user(username)
         if len(user.groups) > 0:
-            extra_data["cognito:groups"] = [
-                group.group_name
-                for group in user.groups
-            ]
-            
-        access_token, expires_in = self.create_jwt(client_id, username, "access", extra_data=extra_data)
+            extra_data["cognito:groups"] = [group.group_name for group in user.groups]
+
+        access_token, expires_in = self.create_jwt(
+            client_id, username, "access", extra_data=extra_data
+        )
         self.access_tokens[access_token] = (client_id, username)
         return access_token, expires_in
 

--- a/moto/cognitoidp/models.py
+++ b/moto/cognitoidp/models.py
@@ -473,7 +473,15 @@ class CognitoIdpUserPool(BaseModel):
         return refresh_token
 
     def create_access_token(self, client_id, username):
-        access_token, expires_in = self.create_jwt(client_id, username, "access")
+        extra_data = {}
+        user = self._get_user(username)
+        if len(user.groups) > 0:
+            extra_data["cognito:groups"] = [
+                group.group_name
+                for group in user.groups
+            ]
+            
+        access_token, expires_in = self.create_jwt(client_id, username, "access", extra_data=extra_data)
         self.access_tokens[access_token] = (client_id, username)
         return access_token, expires_in
 


### PR DESCRIPTION
References and address #3741.

### Problem
`cognito:groups` claims in the payload are not present when using `respond_to_auth_challenge`. moto tests are unable to test or verify group based access since `cognito:groups` is not present. Referencing [Using the Access Token - AWS Docs](https://docs.aws.amazon.com/cognito/latest/developerguide/amazon-cognito-user-pools-using-the-access-token.html) `cognito:groups` claim is present when a user is in a group.

### Solution
When an access token is generated, gather extra information corresponding to the users association to a group. Pass that extra information to `CognitoIdpUserPool.create_jwt` as `kwgs: extra_data`.

### Commits
1. Original commit adds functionality for `cognito:groups` (*note*: referencing AWS documentation `cognito:roles` is not mentioned in claims in access token)
2. Fixed formatting for changes
3. Added tests

### Summary
- [x] `access_token` properly has `cognito:groups` claims
- [x] linter is happy for my lines
- [x] added tests