### PR TITLE
Route53Resolver:  Add support for filters for list_resolver_endpoints

### DIFF
--- a/moto/route53resolver/responses.py
+++ b/moto/route53resolver/responses.py
@@ -88,7 +88,7 @@ class Route53ResolverResponse(BaseResponse):
                 endpoints,
                 next_token,
             ) = self.route53resolver_backend.list_resolver_endpoints(
-                filters=filters, next_token=next_token, max_results=max_results
+                filters, next_token=next_token, max_results=max_results
             )
         except InvalidToken as exc:
             raise InvalidNextTokenException() from exc


### PR DESCRIPTION
I tried to write this so the filter validation functions can be used by the other Route53Resolver list functions.  

Note that the allowed filter names can be in the old style (all caps, snake case) or in the new style (camel case), which complicates things.  And of course, there is an exception to the filter name rules!