### PR TITLE
Rework mock_all to work as a context manager

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ SHELL := /bin/bash
 ifeq ($(TEST_SERVER_MODE), true)
 	# exclude test_kinesisvideoarchivedmedia
 	# because testing with moto_server is difficult with data-endpoint
-	TEST_EXCLUDE := -k 'not (test_kinesisvideoarchivedmedia or test_awslambda or test_batch or test_ec2 or test_sqs or test_context_manager)'
+	TEST_EXCLUDE := -k 'not (test_kinesisvideoarchivedmedia or test_awslambda or test_batch or test_ec2 or test_sqs)'
 	# Parallel tests will be run separate
 	PARALLEL_TESTS := ./tests/test_awslambda ./tests/test_batch ./tests/test_ec2 ./tests/test_sqs
 else

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ SHELL := /bin/bash
 ifeq ($(TEST_SERVER_MODE), true)
 	# exclude test_kinesisvideoarchivedmedia
 	# because testing with moto_server is difficult with data-endpoint
-	TEST_EXCLUDE := -k 'not (test_kinesisvideoarchivedmedia or test_awslambda or test_batch or test_ec2 or test_sqs)'
+	TEST_EXCLUDE := -k 'not (test_kinesisvideoarchivedmedia or test_awslambda or test_batch or test_ec2 or test_sqs or test_context_manager)'
 	# Parallel tests will be run separate
 	PARALLEL_TESTS := ./tests/test_awslambda ./tests/test_batch ./tests/test_ec2 ./tests/test_sqs
 else

--- a/moto/__init__.py
+++ b/moto/__init__.py
@@ -174,14 +174,17 @@ mock_sdb = lazy_load(".sdb", "mock_sdb", boto3_name="sdb")
 
 class mock_all(ContextDecorator):
     def __init__(self):
-        self.mocks = [
-            globals()[mock]()
-            for mock in dir(sys.modules["moto"])
-            if mock.startswith("mock_")
-            and not mock.endswith("_deprecated")
-            and not mock == "mock_all"
-            and not mock == "mock_xray_client"
-        ]
+        self.mocks = []
+        for mock in dir(sys.modules["moto"]):
+            if (
+                mock.startswith("mock_")
+                and not mock.endswith("_deprecated")
+                and not mock == ("mock_all")
+            ):
+                try:
+                    self.mocks.append(globals()[mock]())
+                except:
+                    continue
 
     def __enter__(self):
         for mock in self.mocks:

--- a/moto/__init__.py
+++ b/moto/__init__.py
@@ -172,7 +172,7 @@ mock_wafv2 = lazy_load(".wafv2", "mock_wafv2")
 mock_sdb = lazy_load(".sdb", "mock_sdb", boto3_name="sdb")
 
 
-class mock_all(ContextDecorator):
+class MockAll(ContextDecorator):
     def __init__(self):
         self.mocks = []
         for mock in dir(sys.modules["moto"]):
@@ -190,6 +190,9 @@ class mock_all(ContextDecorator):
     def __exit__(self, *exc):
         for mock in self.mocks:
             mock.stop()
+
+
+mock_all = MockAll
 
 
 # import logging

--- a/moto/__init__.py
+++ b/moto/__init__.py
@@ -183,7 +183,7 @@ class mock_all(ContextDecorator):
             ):
                 try:
                     self.mocks.append(globals()[mock]())
-                except:
+                except:  # noqa
                     continue
 
     def __enter__(self):

--- a/moto/__init__.py
+++ b/moto/__init__.py
@@ -181,10 +181,7 @@ class mock_all(ContextDecorator):
                 and not mock.endswith("_deprecated")
                 and not mock == ("mock_all")
             ):
-                try:
-                    self.mocks.append(globals()[mock]())
-                except:  # noqa
-                    continue
+                self.mocks.append(globals()[mock]())
 
     def __enter__(self):
         for mock in self.mocks:

--- a/moto/xray/__init__.py
+++ b/moto/xray/__init__.py
@@ -1,6 +1,7 @@
 from .models import xray_backends
 from ..core.models import base_decorator
-from .mock_client import mock_xray_client, XRaySegment  # noqa
+from .mock_client import MockXrayClient, XRaySegment  # noqa
 
 xray_backend = xray_backends["us-east-1"]
 mock_xray = base_decorator(xray_backends)
+mock_xray_client = MockXrayClient()

--- a/tests/test_core/test_mock_all.py
+++ b/tests/test_core/test_mock_all.py
@@ -25,7 +25,7 @@ def test_context_manager():
     rgn = "us-east-1"
 
     with mock_all():
-        sqs = boto3.Session().client("sqs", region_name=rgn)
+        sqs = boto3.client("sqs", region_name=rgn)
         r = sqs.list_queues()
         r["ResponseMetadata"]["HTTPStatusCode"].should.equal(200)
 

--- a/tests/test_core/test_mock_all.py
+++ b/tests/test_core/test_mock_all.py
@@ -22,19 +22,14 @@ def test_decorator():
 
 
 def test_context_manager():
+    rgn = "us-east-1"
+
     with mock_all():
-        rgn = "us-east-1"
-        sqs = boto3.client("sqs", region_name=rgn)
+        sqs = boto3.Session().client("sqs", region_name=rgn)
         r = sqs.list_queues()
         r["ResponseMetadata"]["HTTPStatusCode"].should.equal(200)
 
-        lmbda = boto3.client("lambda", region_name=rgn)
-        r = lmbda.list_event_source_mappings()
-        r["ResponseMetadata"]["HTTPStatusCode"].should.equal(200)
-
-        ddb = boto3.client("dynamodb", region_name=rgn)
-        r = ddb.list_tables()
-        r["ResponseMetadata"]["HTTPStatusCode"].should.equal(200)
+    unpatched_sqs = boto3.Session().client("sqs", region_name=rgn)
 
     with pytest.raises(Exception):
-        sqs.list_queues()
+        unpatched_sqs.list_queues()

--- a/tests/test_core/test_mock_all.py
+++ b/tests/test_core/test_mock_all.py
@@ -1,14 +1,15 @@
 import boto3
+import pytest
 import sure  # noqa # pylint: disable=unused-import
 
 from moto import mock_all
 
 
 @mock_all()
-def test_multiple_services():
+def test_decorator():
     rgn = "us-east-1"
     sqs = boto3.client("sqs", region_name=rgn)
-    r = sqs.list_queues()  #
+    r = sqs.list_queues()
     r["ResponseMetadata"]["HTTPStatusCode"].should.equal(200)
 
     lmbda = boto3.client("lambda", region_name=rgn)
@@ -18,3 +19,22 @@ def test_multiple_services():
     ddb = boto3.client("dynamodb", region_name=rgn)
     r = ddb.list_tables()
     r["ResponseMetadata"]["HTTPStatusCode"].should.equal(200)
+
+
+def test_context_manager():
+    with mock_all():
+        rgn = "us-east-1"
+        sqs = boto3.client("sqs", region_name=rgn)
+        r = sqs.list_queues()
+        r["ResponseMetadata"]["HTTPStatusCode"].should.equal(200)
+
+        lmbda = boto3.client("lambda", region_name=rgn)
+        r = lmbda.list_event_source_mappings()
+        r["ResponseMetadata"]["HTTPStatusCode"].should.equal(200)
+
+        ddb = boto3.client("dynamodb", region_name=rgn)
+        r = ddb.list_tables()
+        r["ResponseMetadata"]["HTTPStatusCode"].should.equal(200)
+
+    with pytest.raises(Exception):
+        sqs.list_queues()

--- a/tests/test_xray/test_xray_client.py
+++ b/tests/test_xray/test_xray_client.py
@@ -45,6 +45,37 @@ def test_xray_dynamo_request_id():
     setattr(requests.Session, "prepare_request", original_session_prep_request)
 
 
+def test_xray_dynamo_request_id_with_context_mgr():
+    with mock_xray_client():
+        with mock_dynamodb2():
+            # Could be ran in any order, so we need to tell sdk that its been unpatched
+            xray_core_patcher._PATCHED_MODULES = set()
+            xray_core.patch_all()
+
+            client = boto3.client("dynamodb", region_name="us-east-1")
+
+            with XRaySegment():
+                resp = client.list_tables()
+                resp["ResponseMetadata"].should.contain("RequestId")
+                id1 = resp["ResponseMetadata"]["RequestId"]
+
+            with XRaySegment():
+                client.list_tables()
+                resp = client.list_tables()
+                id2 = resp["ResponseMetadata"]["RequestId"]
+
+            id1.should_not.equal(id2)
+
+            setattr(
+                botocore.client.BaseClient, "_make_api_call", original_make_api_call
+            )
+            setattr(
+                botocore.endpoint.Endpoint, "_encode_headers", original_encode_headers
+            )
+            setattr(requests.Session, "request", original_session_request)
+            setattr(requests.Session, "prepare_request", original_session_prep_request)
+
+
 @mock_xray_client
 def test_xray_udp_emitter_patched():
     # Could be ran in any order, so we need to tell sdk that its been unpatched

--- a/tests/test_xray/test_xray_client.py
+++ b/tests/test_xray/test_xray_client.py
@@ -47,6 +47,7 @@ def test_xray_dynamo_request_id():
 
 def test_xray_dynamo_request_id_with_context_mgr():
     with mock_xray_client():
+        assert isinstance(xray_core.xray_recorder._emitter, MockEmitter)
         with mock_dynamodb2():
             # Could be ran in any order, so we need to tell sdk that its been unpatched
             xray_core_patcher._PATCHED_MODULES = set()
@@ -74,6 +75,9 @@ def test_xray_dynamo_request_id_with_context_mgr():
             )
             setattr(requests.Session, "request", original_session_request)
             setattr(requests.Session, "prepare_request", original_session_prep_request)
+
+    # Verify we have unmocked the xray recorder
+    assert not isinstance(xray_core.xray_recorder._emitter, MockEmitter)
 
 
 @mock_xray_client


### PR DESCRIPTION
At the moment `@mock_all` works as a decorator only, but it should also be usable as a context manager (`with mock_all():`).

In order for this to work, the `mock_xray_client` also needed to be changed to work as a context manager.

Tests have been added to verify the behaviour of both.

Based on and supercedes #4596 - does this look OK to you @jmsanders?