### PR TITLE
SQS - try circumvent test errors

### DIFF
--- a/tests/test_sqs/test_sqs.py
+++ b/tests/test_sqs/test_sqs.py
@@ -1517,9 +1517,9 @@ def test_message_becomes_inflight_when_received():
 
 @mock_sqs
 def test_message_becomes_inflight_when_received_boto3():
-    sqs = boto3.resource("sqs", region_name="us-east-1")
+    sqs = boto3.resource("sqs", region_name="eu-west-1")
     queue = sqs.create_queue(
-        QueueName=str(uuid4())[0:6], Attributes={"VisibilityTimeout ": "1"}
+        QueueName=str(uuid4())[0:6], Attributes={"VisibilityTimeout ": "2"}
     )
 
     queue.attributes["ApproximateNumberOfMessages"].should.equal("0")
@@ -1537,7 +1537,7 @@ def test_message_becomes_inflight_when_received_boto3():
     queue.attributes["ApproximateNumberOfMessages"].should.equal("0")
 
     # Wait
-    time.sleep(2)
+    time.sleep(3)
 
     queue.reload()
     queue.attributes["ApproximateNumberOfMessages"].should.equal("1")


### PR DESCRIPTION
Attempt at fixing/debugging the `test_sqs.py::test_message_becomes_inflight_when_received_boto3` test, that keeps failing in builds.

Details:

 - It fails intermittently
 - It fails on Python 3.9 only
 - It works in ServerMode
 - I can't reproduce it locally
 - I haven't seen it in builds on my own fork (recently)

Possible fixes:
 - Different region - is there a queue with the same name in the other region?
 - Sleep longer - is Py3.9 too slow, and is the message already available again by the time it gets there?