### PR TITLE
Fix incorrect DnsEntries XML for describe_vpc_endpoints

### DIFF
--- a/moto/ec2/responses/vpcs.py
+++ b/moto/ec2/responses/vpcs.py
@@ -691,13 +691,16 @@ DESCRIBE_VPC_ENDPOINT_RESPONSE = """<DescribeVpcEndpointsResponse xmlns="http://
                         {% endfor %}
                     </networkInterfaceIdSet>
                 {% endif %}
-                {% if vpc_end_point.dns_entries %}
-                    <dnsEntries>
-                        {% for dns_entry in vpc_end_point.dns_entries %}
-                            <item>{{ dns_entry }}</item>
-                        {% endfor %}
-                    </dnsEntries>
+                <dnsEntrySet>
+                {% if vpc_end_point.dns_entries  %}
+                    {% for entry in vpc_end_point.dns_entries %}
+                    <item>
+                        <hostedZoneId>{{ entry["hosted_zone_id"] }}</hostedZoneId>
+                        <dnsName>{{ entry["dns_name"] }}</dnsName>
+                    </item>
+                    {% endfor %}
                 {% endif %}
+                </dnsEntrySet>
                 {% if vpc_end_point.security_group_ids %}
                     <groupSet>
                         {% for group_id in vpc_end_point.security_group_ids %}


### PR DESCRIPTION
The XML generated for describe_vpc_endpoints did not have the expected schema for DnsEntries, so creating an interface endpoint and then describing it gave you an empty DnsEntries array.  I fixed that and I updated the tests to test both gateway and interface endpoints.