### PR TITLE
S3 - Fix corner cases multi upload

### DIFF
--- a/moto/s3/exceptions.py
+++ b/moto/s3/exceptions.py
@@ -253,6 +253,22 @@ class InvalidMaxPartArgument(S3ClientError):
         super(InvalidMaxPartArgument, self).__init__("InvalidArgument", error)
 
 
+class InvalidMaxPartNumberArgument(InvalidArgumentError):
+    code = 400
+
+    def __init__(self, value, *args, **kwargs):
+        error = "Part number must be an integer between 1 and 10000, inclusive"
+        super().__init__(message=error, name="partNumber", value=value, *args, **kwargs)
+
+
+class NotAnIntegerException(InvalidArgumentError):
+    code = 400
+
+    def __init__(self, name, value, *args, **kwargs):
+        error = f"Provided {name} not an integer or within integer range"
+        super().__init__(message=error, name=name, value=value, *args, **kwargs)
+
+
 class InvalidNotificationARN(S3ClientError):
     code = 400
 

--- a/moto/s3/models.py
+++ b/moto/s3/models.py
@@ -386,10 +386,9 @@ class FakeMultipart(BaseModel):
         return key
 
     def list_parts(self, part_number_marker, max_parts):
-        for part_id in self.partlist:
-            part = self.parts[part_id]
-            if part_number_marker <= part.name < part_number_marker + max_parts:
-                yield part
+        max_marker = part_number_marker + max_parts
+        for part_id in self.partlist[part_number_marker:max_marker]:
+            yield self.parts[part_id]
 
 
 class FakeGrantee(BaseModel):
@@ -1874,7 +1873,7 @@ class S3Backend(BaseBackend, CloudWatchMetricProvider):
 
     def is_truncated(self, bucket_name, multipart_id, next_part_number_marker):
         bucket = self.get_bucket(bucket_name)
-        return len(bucket.multiparts[multipart_id].parts) >= next_part_number_marker
+        return len(bucket.multiparts[multipart_id].parts) > next_part_number_marker
 
     def create_multipart_upload(
         self, bucket_name, key_name, metadata, storage_type, tags


### PR DESCRIPTION
Closes #4586 

Adds correct error messaging when providing too big a number when getting a multipart
Adds error when creating an upload with part > 10000
Fixes behaviour when retrieving parts where some uploaded parts are missing (i.e., only part 1, 2, and 10000 are uploaded)

All affected tests are verified against AWS