### PR TITLE
Added restore table to point in time DynamoDB method

### DIFF
--- a/docs/docs/services/dynamodb.rst
+++ b/docs/docs/services/dynamodb.rst
@@ -61,7 +61,7 @@ dynamodb
 - [X] put_item
 - [X] query
 - [X] restore_table_from_backup
-- [ ] restore_table_to_point_in_time
+- [X] restore_table_to_point_in_time
 - [X] scan
 - [X] tag_resource
 - [X] transact_get_items

--- a/moto/dynamodb2/models/__init__.py
+++ b/moto/dynamodb2/models/__init__.py
@@ -1009,6 +1009,7 @@ class RestoredTable(Table):
         }
         return result
 
+
 class RestoredPITTable(Table):
     def __init__(self, name, source):
         params = self._parse_params_from_table(source)
@@ -1025,10 +1026,10 @@ class RestoredPITTable(Table):
         params = {
             "schema": copy.deepcopy(table.schema),
             "attr": copy.deepcopy(table.attr),
-            "throughput": copy.deepcopy(table.throughput)
+            "throughput": copy.deepcopy(table.throughput),
         }
         return params
-    
+
     def describe(self, base_key="TableDescription"):
         result = super(RestoredPITTable, self).describe(base_key=base_key)
         result[base_key]["RestoreSummary"] = {
@@ -1037,6 +1038,7 @@ class RestoredPITTable(Table):
             "RestoreInProgress": False,
         }
         return result
+
 
 class Backup(object):
     def __init__(
@@ -1717,7 +1719,7 @@ class DynamoDBBackend(BaseBackend):
         new_table = RestoredTable(target_table_name, backup)
         self.tables[target_table_name] = new_table
         return new_table
-    
+
     def restore_table_to_point_in_time(self, target_table_name, source_table_name):
         source = self.get_table(source_table_name)
         if source is None:

--- a/moto/dynamodb2/models/__init__.py
+++ b/moto/dynamodb2/models/__init__.py
@@ -1724,6 +1724,7 @@ class DynamoDBBackend(BaseBackend):
     Currently this only accepts the source and target table elements, and will
     copy all items from the source without respect to other arguments.
     """
+
     def restore_table_to_point_in_time(self, target_table_name, source_table_name):
         source = self.get_table(source_table_name)
         if source is None:

--- a/moto/dynamodb2/models/__init__.py
+++ b/moto/dynamodb2/models/__init__.py
@@ -1720,6 +1720,10 @@ class DynamoDBBackend(BaseBackend):
         self.tables[target_table_name] = new_table
         return new_table
 
+    """
+    Currently this only accepts the source and target table elements, and will
+    copy all items from the source without respect to other arguments.
+    """
     def restore_table_to_point_in_time(self, target_table_name, source_table_name):
         source = self.get_table(source_table_name)
         if source is None:

--- a/moto/dynamodb2/models/__init__.py
+++ b/moto/dynamodb2/models/__init__.py
@@ -1009,6 +1009,34 @@ class RestoredTable(Table):
         }
         return result
 
+class RestoredPITTable(Table):
+    def __init__(self, name, source):
+        params = self._parse_params_from_table(source)
+        super(RestoredPITTable, self).__init__(name, **params)
+        self.indexes = copy.deepcopy(source.indexes)
+        self.global_indexes = copy.deepcopy(source.global_indexes)
+        self.items = copy.deepcopy(source.items)
+        # Restore Attrs
+        self.source_table_arn = source.table_arn
+        self.restore_date_time = self.created_at
+
+    @staticmethod
+    def _parse_params_from_table(table):
+        params = {
+            "schema": copy.deepcopy(table.schema),
+            "attr": copy.deepcopy(table.attr),
+            "throughput": copy.deepcopy(table.throughput)
+        }
+        return params
+    
+    def describe(self, base_key="TableDescription"):
+        result = super(RestoredPITTable, self).describe(base_key=base_key)
+        result[base_key]["RestoreSummary"] = {
+            "SourceTableArn": self.source_table_arn,
+            "RestoreDateTime": unix_time(self.restore_date_time),
+            "RestoreInProgress": False,
+        }
+        return result
 
 class Backup(object):
     def __init__(
@@ -1687,6 +1715,17 @@ class DynamoDBBackend(BaseBackend):
         if existing_table is not None:
             raise ValueError()
         new_table = RestoredTable(target_table_name, backup)
+        self.tables[target_table_name] = new_table
+        return new_table
+    
+    def restore_table_to_point_in_time(self, target_table_name, source_table_name):
+        source = self.get_table(source_table_name)
+        if source is None:
+            raise KeyError()
+        existing_table = self.get_table(target_table_name)
+        if existing_table is not None:
+            raise ValueError()
+        new_table = RestoredPITTable(target_table_name, source)
         self.tables[target_table_name] = new_table
         return new_table
 

--- a/moto/dynamodb2/responses.py
+++ b/moto/dynamodb2/responses.py
@@ -1203,3 +1203,19 @@ class DynamoHandler(BaseResponse):
         except ValueError:
             er = "com.amazonaws.dynamodb.v20111205#TableAlreadyExistsException"
             return self.error(er, "Table already exists: %s" % target_table_name)
+    
+    def restore_table_to_point_in_time(self):
+        body = self.body
+        target_table_name = body.get("TargetTableName")
+        source_table_name = body.get("SourceTableName")
+        try:
+            restored_table = self.dynamodb_backend.restore_table_to_point_in_time(
+                target_table_name, source_table_name
+            )
+            return dynamo_json_dump(restored_table.describe())
+        except KeyError:
+            er = "com.amazonaws.dynamodb.v20111205#SourceTableNotFoundException"
+            return self.error(er, "Sourec table not found: %s" % source_table_name)
+        except ValueError:
+            er = "com.amazonaws.dynamodb.v20111205#TableAlreadyExistsException"
+            return self.error(er, "Table already exists: %s" % target_table_name)

--- a/moto/dynamodb2/responses.py
+++ b/moto/dynamodb2/responses.py
@@ -1203,7 +1203,7 @@ class DynamoHandler(BaseResponse):
         except ValueError:
             er = "com.amazonaws.dynamodb.v20111205#TableAlreadyExistsException"
             return self.error(er, "Table already exists: %s" % target_table_name)
-    
+
     def restore_table_to_point_in_time(self):
         body = self.body
         target_table_name = body.get("TargetTableName")

--- a/moto/dynamodb2/responses.py
+++ b/moto/dynamodb2/responses.py
@@ -1215,7 +1215,7 @@ class DynamoHandler(BaseResponse):
             return dynamo_json_dump(restored_table.describe())
         except KeyError:
             er = "com.amazonaws.dynamodb.v20111205#SourceTableNotFoundException"
-            return self.error(er, "Sourec table not found: %s" % source_table_name)
+            return self.error(er, "Source table not found: %s" % source_table_name)
         except ValueError:
             er = "com.amazonaws.dynamodb.v20111205#TableAlreadyExistsException"
             return self.error(er, "Table already exists: %s" % target_table_name)


### PR DESCRIPTION
I added the `restore_table_to_point_in_time` DyanmoDB method to the library. I _think_ I got adequate coverage for the unique use case I have (which is restore a table's most recent PIT to another table), but please let me know if you think I've missed anything.

**Please note**: There are 4 failing tests when I run the tests locally, which also failed when I checked out the `master` branch. They are in code I haven't touched so either it's a local issue or something pre-existing from what I can tell.

Thanks for your consideration!