### PR TITLE
Directory Service, Route53Resolver:  Delete network interfaces created during initialization

### DIFF
--- a/moto/ds/responses.py
+++ b/moto/ds/responses.py
@@ -97,13 +97,13 @@ class DirectoryServiceResponse(BaseResponse):
         next_token = self._get_param("NextToken")
         limit = self._get_int_param("Limit")
         try:
-            (descriptions, next_token) = self.ds_backend.describe_directories(
+            (directories, next_token) = self.ds_backend.describe_directories(
                 directory_ids, next_token=next_token, limit=limit
             )
         except InvalidToken as exc:
             raise InvalidNextTokenException() from exc
 
-        response = {"DirectoryDescriptions": [x.to_json() for x in descriptions]}
+        response = {"DirectoryDescriptions": [x.to_dict() for x in directories]}
         if next_token:
             response["NextToken"] = next_token
         return json.dumps(response)

--- a/tests/test_ds/test_ds.py
+++ b/tests/test_ds/test_ds.py
@@ -36,6 +36,16 @@ def test_ds_delete_directory():
     result = client.delete_directory(DirectoryId=directory_id)
     assert result["DirectoryId"] == directory_id
 
+    # Verify there are no dictionaries, network interfaces or associated
+    # security groups.
+    result = client.describe_directories()
+    assert len(result["DirectoryDescriptions"]) == 0
+    result = ec2_client.describe_network_interfaces()
+    assert len(result["NetworkInterfaces"]) == 0
+    result = ec2_client.describe_security_groups()
+    for group in result["SecurityGroups"]:
+        assert "directory controllers" not in group["Description"]
+
     # Attempt to delete a non-existent directory.
     nonexistent_id = f"d-{get_random_hex(10)}"
     with pytest.raises(ClientError) as exc:

--- a/tests/test_ds/test_ds.py
+++ b/tests/test_ds/test_ds.py
@@ -116,6 +116,7 @@ def test_ds_describe_directories():
         assert dir_info["Type"] == "SimpleAD"
         assert dir_info["VpcSettings"]["VpcId"].startswith("vpc-")
         assert len(dir_info["VpcSettings"]["SubnetIds"]) == 2
+        assert dir_info["VpcSettings"]["SecurityGroupId"].startswith("sg-")
         assert len(dir_info["DnsIpAddrs"]) == 2
     assert "NextToken" not in result
 

--- a/tests/test_route53resolver/test_route53resolver_endpoint.py
+++ b/tests/test_route53resolver/test_route53resolver_endpoint.py
@@ -415,6 +415,12 @@ def test_route53resolver_delete_resolver_endpoint():
     assert "Deleting" in endpoint["StatusMessage"]
     assert endpoint["CreationTime"] == created_endpoint["CreationTime"]
 
+    # Verify there are no endpoints or no network interfaces.
+    response = client.list_resolver_endpoints()
+    assert len(response["ResolverEndpoints"]) == 0
+    result = ec2_client.describe_network_interfaces()
+    assert len(result["NetworkInterfaces"]) == 0
+
 
 @mock_ec2
 @mock_route53resolver


### PR DESCRIPTION
Directory Service creates a security group and network interfaces, but those weren't being deleted when a directory was deleted.  Also, the Security Group Id should be displayed in the `describe_directory` output.

Route53Resolver creates network interfaces for the endpoint and those should be deleted when the endpoint is deleted.