### PR TITLE
Validate message group ID for standard queues

### DIFF
--- a/moto/sqs/models.py
+++ b/moto/sqs/models.py
@@ -710,13 +710,6 @@ class SQSBackend(BaseBackend):
             )
             raise InvalidParameterValue(msg)
 
-        if not queue.fifo_queue and group_id is not None:
-            msg = (
-                "Value {} for parameter MessageGroupId is invalid. "
-                "Reason: The request include parameter that is not valid for this queue type."
-            ).format(group_id)
-            raise InvalidParameterValue(msg)
-
         if delay_seconds:
             delay_seconds = int(delay_seconds)
         else:
@@ -745,6 +738,12 @@ class SQSBackend(BaseBackend):
             if queue.fifo_queue:
                 raise MissingParameter("MessageGroupId")
         else:
+            if not queue.fifo_queue:
+                msg = (
+                    "Value {} for parameter MessageGroupId is invalid. "
+                    "Reason: The request include parameter that is not valid for this queue type."
+                ).format(group_id)
+                raise InvalidParameterValue(msg)
             message.group_id = group_id
 
         if message_attributes:

--- a/moto/sqs/models.py
+++ b/moto/sqs/models.py
@@ -710,6 +710,13 @@ class SQSBackend(BaseBackend):
             )
             raise InvalidParameterValue(msg)
 
+        if not queue.fifo_queue and group_id is not None:
+            msg = (
+                "Value {} for parameter MessageGroupId is invalid. "
+                "Reason: The request include parameter that is not valid for this queue type."
+            ).format(group_id)
+            raise InvalidParameterValue(msg)
+
         if delay_seconds:
             delay_seconds = int(delay_seconds)
         else:

--- a/tests/test_sqs/test_sqs.py
+++ b/tests/test_sqs/test_sqs.py
@@ -564,8 +564,7 @@ def test_send_message_with_message_group_id_standard_queue():
 
     with pytest.raises(ClientError) as ex:
         queue.send_message(
-            MessageBody="mydata",
-            MessageGroupId="group_id_1",
+            MessageBody="mydata", MessageGroupId="group_id_1",
         )
 
     err = ex.value.response["Error"]

--- a/tests/test_sqs/test_sqs.py
+++ b/tests/test_sqs/test_sqs.py
@@ -558,6 +558,25 @@ def test_send_message_with_message_group_id():
 
 
 @mock_sqs
+def test_send_message_with_message_group_id_standard_queue():
+    sqs = boto3.resource("sqs", region_name="us-east-1")
+    queue = sqs.create_queue(QueueName=str(uuid4())[0:6])
+
+    with pytest.raises(ClientError) as ex:
+        queue.send_message(
+            MessageBody="mydata",
+            MessageGroupId="group_id_1",
+        )
+
+    err = ex.value.response["Error"]
+    err["Code"].should.equal("InvalidParameterValue")
+    err["Message"].should.equal(
+        "Value group_id_1 for parameter MessageGroupId is invalid. "
+        "Reason: The request include parameter that is not valid for this queue type."
+    )
+
+
+@mock_sqs
 def test_send_message_with_unicode_characters():
     body_one = "Héllo!😀"
 

--- a/tests/test_sqs/test_sqs.py
+++ b/tests/test_sqs/test_sqs.py
@@ -2115,7 +2115,9 @@ def test_delete_message_errors():
 @mock_sqs
 def test_send_message_batch():
     client = boto3.client("sqs", region_name="us-east-1")
-    response = client.create_queue(QueueName=str(uuid4())[0:6])
+    response = client.create_queue(
+        QueueName=f"{str(uuid4())[0:6]}.fifo", Attributes={"FifoQueue": "true"},
+    )
     queue_url = response["QueueUrl"]
 
     response = client.send_message_batch(


### PR DESCRIPTION
This PR introduces the validation to prevent sending a message group ID when using a queue of standard type.

Closes #4594.