### PR TITLE
fix: STS xml was malformed

### DIFF
--- a/moto/sts/responses.py
+++ b/moto/sts/responses.py
@@ -118,8 +118,7 @@ GET_SESSION_TOKEN_RESPONSE = """<GetSessionTokenResponse xmlns="https://sts.amaz
 </GetSessionTokenResponse>"""
 
 
-GET_FEDERATION_TOKEN_RESPONSE = """<GetFederationTokenResponse xmlns="https://sts.amazonaws.com/doc/
-2011-06-15/">
+GET_FEDERATION_TOKEN_RESPONSE = """<GetFederationTokenResponse xmlns="https://sts.amazonaws.com/doc/2011-06-15/">
   <GetFederationTokenResult>
     <Credentials>
       <SessionToken>AQoDYXdzEPT//////////wEXAMPLEtc764bNrC9SAPBSM22wDOk4x4HIZ8j4FZTwdQWLWsKWHGBuFqwAeMicRXmxfpSPfIeoIYRqTflfKD8YUuwthAx7mSEI/qkPpKPi/kMcGdQrmGdeehM4IC1NtBmUpp2wUE8phUZampKsburEDy0KPkyQDYwT7WZ0wq5VSXDvp75YU9HFvlRd8Tx6q6fE8YQcHNVXAkiY9q6d+xo0rKwT38xVqr7ZD0u0iPPkUL64lIZbqBAz+scqKmlzm8FDrypNC9Yjc8fPOLn9FX9KSYvKTr4rvx3iSIlTJabIQwj2ICCR/oLxBA==</SessionToken>

--- a/tests/test_sts/test_server.py
+++ b/tests/test_sts/test_server.py
@@ -36,3 +36,15 @@ def test_sts_get_caller_identity():
     res.data.should.contain(b"Arn")
     res.data.should.contain(b"UserId")
     res.data.should.contain(b"Account")
+
+
+def test_sts_wellformed_xml():
+    backend = server.create_backend_app("sts")
+    test_client = backend.test_client()
+
+    res = test_client.get("/?Action=GetFederationToken&Name=Bob")
+    res.data.should_not.contain(b"\n")
+    res = test_client.get("/?Action=GetSessionToken")
+    res.data.should_not.contain(b"\n")
+    res = test_client.get("/?Action=GetCallerIdentity")
+    res.data.should_not.contain(b"\n")


### PR DESCRIPTION
Found from this issue in localstack https://github.com/localstack/localstack/issues/4807 we were getting \n characters in the xml for the GetFederationToken call. Thinking this will fix it