### PR TITLE
Correct status code for a versioned key search in not versioned bucket.

### DIFF
--- a/moto/s3/responses.py
+++ b/moto/s3/responses.py
@@ -1630,6 +1630,9 @@ class ResponseObject(_TemplateEnvironmentMixin, ActionAuthenticatorMixin):
 
         response_headers = {}
         version_id = query.get("versionId", [None])[0]
+        if version_id and not self.backend.get_bucket(bucket_name).is_versioned:
+            return 400, response_headers, ""
+
         part_number = query.get("partNumber", [None])[0]
         if part_number:
             part_number = int(part_number)

--- a/tests/test_s3/test_s3.py
+++ b/tests/test_s3/test_s3.py
@@ -6614,3 +6614,17 @@ def test_boto3_copy_object_with_kms_encryption():
     result = client.head_object(Bucket="blah", Key="test2")
     assert result["SSEKMSKeyId"] == kms_key
     assert result["ServerSideEncryption"] == "aws:kms"
+
+
+@mock_s3
+def test_head_versioned_key_in_not_versioned_bucket():
+    client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
+    client.create_bucket(Bucket="simple-bucked")
+
+    with pytest.raises(ClientError) as ex:
+        client.head_object(
+            Bucket="simple-bucked", Key="file.txt", VersionId="noVersion"
+        )
+
+    response = ex.value.response
+    assert response["Error"]["Code"] == "400"


### PR DESCRIPTION
This PR addresses issue localstack/localstack#4624.

Changes: 
- Before searching for a versioned key, now the S3 Backend checks if the bucket is versioned, if it isn't, it responds with the correct status code.