### PR TITLE
SQS - Align logic around receipt_handles with AWS

### DIFF
--- a/moto/sqs/exceptions.py
+++ b/moto/sqs/exceptions.py
@@ -1,11 +1,6 @@
 from moto.core.exceptions import RESTError
 
 
-class MessageNotInflight(Exception):
-    description = "The message referred to is not in flight."
-    status_code = 400
-
-
 class ReceiptHandleIsInvalid(RESTError):
     code = 400
 


### PR DESCRIPTION
Closes #3435

Supercedes #3586

Summary:
Old receipt handles should be kept, as it is possible to change message visibility or delete a message using them.
The `ReceiptHandleIsInvalid`-error is only thrown when providing a receipt handle that was never issued by AWS.

All tests have been verified against AWS.

The `MessageNotInFlight` has been removed, as I could not find a way to raise this error in AWS.
