### PR TITLE
S3 - copy ContentType and Metadata from source object

### DIFF
--- a/moto/s3/models.py
+++ b/moto/s3/models.py
@@ -2067,6 +2067,7 @@ class S3Backend(BaseBackend, CloudWatchMetricProvider):
             lock_until=key.lock_until,
         )
         self.tagger.copy_tags(key.arn, new_key.arn)
+        new_key.set_metadata(key.metadata)
 
         if acl is not None:
             new_key.set_acl(acl)

--- a/tests/test_s3/test_s3.py
+++ b/tests/test_s3/test_s3.py
@@ -1043,6 +1043,27 @@ def test_copy_key_replace_metadata():
 
 
 @mock_s3
+def test_copy_key_with_metadata_boto3():
+    s3 = boto3.resource("s3", region_name=DEFAULT_REGION_NAME)
+    client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
+    s3.create_bucket(Bucket="foobar")
+
+    key = s3.Object("foobar", "the-key")
+    metadata = {"md": "Metadatastring"}
+    content_type = "application/json"
+    initial = key.put(Body=b"{}", Metadata=metadata, ContentType=content_type)
+
+    client.copy_object(
+        Bucket="foobar", CopySource="foobar/the-key", Key="new-key",
+    )
+
+    resp = client.get_object(Bucket="foobar", Key="new-key")
+    resp["Metadata"].should.equal(metadata)
+    resp["ContentType"].should.equal(content_type)
+    resp["ETag"].should.equal(initial["ETag"])
+
+
+@mock_s3
 def test_copy_key_replace_metadata_boto3():
     s3 = boto3.resource("s3", region_name=DEFAULT_REGION_NAME)
     client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)


### PR DESCRIPTION
I have created a test case for https://github.com/localstack/localstack/issues/5068 and run it against AWS S3, `Metadata` and `ContentType` are copied over to a new object, so updating it in `moto` as well