### PR TITLE
S3 - restore_object() should error on non archived class

### DIFF
--- a/moto/s3/responses.py
+++ b/moto/s3/responses.py
@@ -2085,6 +2085,8 @@ class ResponseObject(_TemplateEnvironmentMixin, ActionAuthenticatorMixin):
             es = minidom.parseString(body).getElementsByTagName("Days")
             days = es[0].childNodes[0].wholeText
             key = self.backend.get_object(bucket_name, key_name)
+            if key.storage_class not in ["GLACIER", "DEEP_ARCHIVE"]:
+                raise InvalidObjectState(storage_class=key.storage_class)
             r = 202
             if key.expiry_date is not None:
                 r = 200

--- a/tests/test_s3/test_s3.py
+++ b/tests/test_s3/test_s3.py
@@ -1728,6 +1728,7 @@ def test_restore_key():
     bucket = conn.create_bucket("foobar")
     key = Key(bucket)
     key.key = "the-key"
+    key.storage_class = "GLACIER"
     key.set_contents_from_string("some value")
     list(bucket)[0].ongoing_restore.should.be.none
     key.restore(1)
@@ -1749,7 +1750,7 @@ def test_restore_key_boto3():
     bucket = s3.Bucket("foobar")
     bucket.create()
 
-    key = bucket.put_object(Key="the-key", Body=b"somedata")
+    key = bucket.put_object(Key="the-key", Body=b"somedata", StorageClass="GLACIER")
     key.restore.should.be.none
     key.restore_object(RestoreRequest={"Days": 1})
     if settings.TEST_SERVER_MODE:
@@ -1769,6 +1770,24 @@ def test_restore_key_boto3():
         )
 
 
+@mock_s3
+def test_cannot_restore_standard_class_object_boto3():
+    s3 = boto3.resource("s3", region_name=DEFAULT_REGION_NAME)
+    bucket = s3.Bucket("foobar")
+    bucket.create()
+
+    key = bucket.put_object(Key="the-key", Body=b"somedata")
+    with pytest.raises(Exception) as err:
+        key.restore_object(RestoreRequest={"Days": 1})
+
+    err = err.value.response["Error"]
+    err["Code"].should.equal("InvalidObjectState")
+    err["StorageClass"].should.equal("STANDARD")
+    err["Message"].should.equal(
+        "The operation is not valid for the object's storage class"
+    )
+
+
 @freeze_time("2012-01-01 12:00:00")
 @mock_s3_deprecated
 def test_restore_key_headers():
@@ -1776,6 +1795,7 @@ def test_restore_key_headers():
     bucket = conn.create_bucket("foobar")
     key = Key(bucket)
     key.key = "the-key"
+    key.storage_class = "GLACIER"
     key.set_contents_from_string("some value")
     key.restore(1, headers={"foo": "bar"})
     key = bucket.get_key("the-key")


### PR DESCRIPTION
While writing a test to restore an S3 object, I noticed that restore_object() of moto3 does not error on standard class objects.  
For example, bellow code end with InvalidObjectState error message in the case of using real S3.

```py
import boto3

BUCKET_NAME = "SOME_BUCKET"
KEY = "STANDAR_CLASS_FILE"

client = boto3.client('s3')
response = client.restore_object(Bucket=BUCKET_NAME, Key=KEY)
```

```bash
$ python restore_test.py
Traceback (most recent call last):
  File "restore_test.py", line 7, in <module>
    response = client.restore_object(Bucket=BUCKET_NAME, Key=KEY)
  File "C:\Users\TakahisaIshikawa\AppData\Local\Programs\Python\Python37\lib\site-packages\botocore\client.py", line 386, in _api_call
    return self._make_api_call(operation_name, kwargs)
  File "C:\Users\TakahisaIshikawa\AppData\Local\Programs\Python\Python37\lib\site-packages\botocore\client.py", line 705, in _make_api_call
    raise error_class(parsed_response, operation_name)
botocore.errorfactory.InvalidObjectState: An error occurred (InvalidObjectState) when calling the RestoreObject operation: Restore is not allowed for the object's current storage class
```

Although [the boto3 document](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3.html#S3.Client.restore_object) dose not say clearly, the correct behavior is to get an error when attempting to restore any class object other than Glacier or DeepArchive class.