### PR TITLE
ELBv2 - Support create_listener with ForwardConfig param

### DIFF
--- a/moto/elbv2/responses.py
+++ b/moto/elbv2/responses.py
@@ -187,7 +187,7 @@ class ELBV2Response(BaseResponse):
         healthcheck_enabled = self._get_param("HealthCheckEnabled")
         healthy_threshold_count = self._get_param("HealthyThresholdCount")
         unhealthy_threshold_count = self._get_param("UnhealthyThresholdCount")
-        matcher = self._get_param("Matcher")
+        matcher = self._get_params().get("Matcher")
         target_type = self._get_param("TargetType")
 
         target_group = self.elbv2_backend.create_target_group(

--- a/tests/test_elbv2/test_elbv2_target_groups.py
+++ b/tests/test_elbv2/test_elbv2_target_groups.py
@@ -447,10 +447,12 @@ def test_describe_target_groups_no_arguments():
         HealthCheckTimeoutSeconds=5,
         HealthyThresholdCount=5,
         UnhealthyThresholdCount=2,
-        Matcher={"HttpCode": "200"},
+        Matcher={"HttpCode": "201"},
     )
 
-    conn.describe_target_groups()["TargetGroups"].should.have.length_of(1)
+    groups = conn.describe_target_groups()["TargetGroups"]
+    groups.should.have.length_of(1)
+    groups[0].should.have.key("Matcher").equals({"HttpCode": "201"})
 
 
 @mock_elbv2
@@ -570,3 +572,123 @@ def test_delete_target_group_after_modifying_listener():
     default_actions.should.equal(
         [{"Type": "forward", "TargetGroupArn": target_group_arn2}]
     )
+
+
+@mock_elbv2
+@mock_ec2
+def test_create_listener_with_multiple_target_groups():
+    client = boto3.client("elbv2", region_name="us-east-1")
+
+    response, vpc, _, _, _, conn = create_load_balancer()
+
+    load_balancer_arn = response.get("LoadBalancers")[0].get("LoadBalancerArn")
+
+    response = client.create_target_group(
+        Name="a-target", Protocol="HTTP", Port=8080, VpcId=vpc.id,
+    )
+    target_group_arn1 = response.get("TargetGroups")[0]["TargetGroupArn"]
+
+    response = client.create_target_group(
+        Name="a-target-2", Protocol="HTTPS", Port=8081, VpcId=vpc.id,
+    )
+    target_group_arn2 = response.get("TargetGroups")[0]["TargetGroupArn"]
+
+    conn.create_listener(
+        LoadBalancerArn=load_balancer_arn,
+        Protocol="HTTP",
+        Port=80,
+        DefaultActions=[
+            {
+                "Type": "forward",
+                "ForwardConfig": {
+                    "TargetGroups": [
+                        {"TargetGroupArn": target_group_arn1, "Weight": 100},
+                        {"TargetGroupArn": target_group_arn2, "Weight": 0},
+                    ],
+                    "TargetGroupStickinessConfig": {
+                        "Enabled": False,
+                        "DurationSeconds": 300,
+                    },
+                },
+            }
+        ],
+    )
+
+    response = conn.describe_listeners(LoadBalancerArn=load_balancer_arn)
+    listener = response["Listeners"][0]
+    groups = listener["DefaultActions"][0]["ForwardConfig"]["TargetGroups"]
+    groups.should.have.length_of(2)
+    groups.should.contain({"TargetGroupArn": target_group_arn1, "Weight": 100})
+    groups.should.contain({"TargetGroupArn": target_group_arn2, "Weight": 0})
+
+
+@mock_elbv2
+@mock_ec2
+def test_create_listener_with_invalid_target_group():
+    response, _, _, _, _, conn = create_load_balancer()
+
+    load_balancer_arn = response.get("LoadBalancers")[0].get("LoadBalancerArn")
+
+    with pytest.raises(ClientError) as exc:
+        conn.create_listener(
+            LoadBalancerArn=load_balancer_arn,
+            Protocol="HTTP",
+            Port=80,
+            DefaultActions=[
+                {
+                    "Type": "forward",
+                    "ForwardConfig": {
+                        "TargetGroups": [{"TargetGroupArn": "unknown", "Weight": 100}]
+                    },
+                }
+            ],
+        )
+    err = exc.value.response["Error"]
+    err["Code"].should.equal("TargetGroupNotFound")
+    err["Message"].should.equal("Target group 'unknown' not found")
+
+
+@mock_elbv2
+@mock_ec2
+def test_delete_target_group_while_listener_still_exists():
+    client = boto3.client("elbv2", region_name="us-east-1")
+
+    response, vpc, _, _, _, conn = create_load_balancer()
+
+    load_balancer_arn = response.get("LoadBalancers")[0].get("LoadBalancerArn")
+
+    response = client.create_target_group(
+        Name="a-target", Protocol="HTTP", Port=8080, VpcId=vpc.id,
+    )
+    target_group_arn1 = response.get("TargetGroups")[0]["TargetGroupArn"]
+
+    response = conn.create_listener(
+        LoadBalancerArn=load_balancer_arn,
+        Protocol="HTTP",
+        Port=80,
+        DefaultActions=[
+            {
+                "Type": "forward",
+                "ForwardConfig": {
+                    "TargetGroups": [
+                        {"TargetGroupArn": target_group_arn1, "Weight": 100}
+                    ]
+                },
+            }
+        ],
+    )
+    listener_arn = response["Listeners"][0]["ListenerArn"]
+
+    # Deletion does not succeed if the Listener still exists
+    with pytest.raises(ClientError) as exc:
+        client.delete_target_group(TargetGroupArn=target_group_arn1)
+    err = exc.value.response["Error"]
+    err["Code"].should.equal("ResourceInUse")
+    err["Message"].should.equal(
+        f"The target group '{target_group_arn1}' is currently in use by a listener or a rule"
+    )
+
+    client.delete_listener(ListenerArn=listener_arn)
+
+    # Deletion does succeed now that the listener is deleted
+    client.delete_target_group(TargetGroupArn=target_group_arn1)


### PR DESCRIPTION
Also fixes a minor bug where the Matcher-parameter was not picked up in the `create_target` call

Fixes #4702 
Fixes #4695 