### PR TITLE
prevent a missing policy json

### DIFF
--- a/moto/sqs/models.py
+++ b/moto/sqs/models.py
@@ -338,8 +338,7 @@ class Queue(CloudFormationModel):
         if attributes.get("RedrivePolicy", None) is not None:
             self._setup_dlq(attributes["RedrivePolicy"])
 
-        if attributes.get("Policy"):
-            self.policy = attributes["Policy"]
+        self.policy = attributes.get("Policy")
 
         self.last_modified_timestamp = now
 


### PR DESCRIPTION
I am using moto with terraform. After a recent update we can no longer create SQS queues without a policy. I am not totally sure which change caused this issue but after reading through the code it appears there is a way for the `Queue` object to end up in a bad state. Based on the age of the code it seems like this potential has been there for a while but maybe something upstream is depending on the state being valid now.

If `self.policy` is called as a getter it must have `self._policy_json` defined or it will throw an error:

```python
    @property
    def policy(self):
        if self._policy_json.get("Statement"):
            return json.dumps(self._policy_json)
        else:
            return None
```

This method is called in the `attributes` method like so:

```python
        if self.policy:
            result["Policy"] = self.policy
```

To me the intent is clearly that `self.policy` should return `None` here if `self._policy_json` isn't defined it throws an exception.

At first I was going to handle this in the `policy` getter but I looked at the setter:


```python
    @policy.setter
    def policy(self, policy):
        if policy:
            self._policy_json = json.loads(policy)
        else:
            self._policy_json = {
                "Version": "2012-10-17",
                "Id": "{}/SQSDefaultPolicy".format(self.queue_arn),
                "Statement": [],
            }
```

And it should actually be able to handle a falsey `policy` argument however where it is called:

```python
        if attributes.get("Policy"):
            self.policy = attributes["Policy"]
```

It is explicitly not called if `Policy` is not included. Also, `self._policy_json` is used in other places (like lines 1021, 1049, and 1054) than the getter so it is critical that it is always set during initialization. 

I felt the best way to fix this issue was to call the setter with a possibly missing `Policy`.