### PR TITLE
Batch - ensure that logs are posted in chronological order

### DIFF
--- a/moto/batch/models.py
+++ b/moto/batch/models.py
@@ -609,7 +609,6 @@ class Job(threading.Thread, BaseModel, DockerModel):
                 logs_stdout = [x for x in logs_stdout if len(x) > 0]
                 logs_stderr = [x for x in logs_stderr if len(x) > 0]
                 logs = []
-                prev_date = None
                 for line in logs_stdout + logs_stderr:
                     date, line = line.split(" ", 1)
                     date_obj = (
@@ -618,11 +617,8 @@ class Job(threading.Thread, BaseModel, DockerModel):
                         .replace(tzinfo=None)
                     )
                     date = unix_time_millis(date_obj)
-                    # Guarantee that logs are in order
-                    if prev_date and prev_date > date:
-                        date = prev_date
-                    prev_date = date
                     logs.append({"timestamp": date, "message": line.strip()})
+                logs = sorted(logs, key=lambda l: l["timestamp"])
 
                 # Send to cloudwatch
                 log_group = "/aws/batch/job"

--- a/moto/batch/models.py
+++ b/moto/batch/models.py
@@ -609,6 +609,7 @@ class Job(threading.Thread, BaseModel, DockerModel):
                 logs_stdout = [x for x in logs_stdout if len(x) > 0]
                 logs_stderr = [x for x in logs_stderr if len(x) > 0]
                 logs = []
+                prev_date = None
                 for line in logs_stdout + logs_stderr:
                     date, line = line.split(" ", 1)
                     date_obj = (
@@ -617,8 +618,11 @@ class Job(threading.Thread, BaseModel, DockerModel):
                         .replace(tzinfo=None)
                     )
                     date = unix_time_millis(date_obj)
+                    # Guarantee that logs are in order
+                    if prev_date and prev_date > date:
+                        date = prev_date
+                    prev_date = date
                     logs.append({"timestamp": date, "message": line.strip()})
-                logs = sorted(logs, key=lambda l: l["timestamp"])
 
                 # Send to cloudwatch
                 log_group = "/aws/batch/job"

--- a/moto/batch/models.py
+++ b/moto/batch/models.py
@@ -618,6 +618,7 @@ class Job(threading.Thread, BaseModel, DockerModel):
                     )
                     date = unix_time_millis(date_obj)
                     logs.append({"timestamp": date, "message": line.strip()})
+                logs = sorted(logs, key=lambda l: l["timestamp"])
 
                 # Send to cloudwatch
                 log_group = "/aws/batch/job"


### PR DESCRIPTION
I am testing Batch jobs in moto and many of my batch jobs fail. It appears that some jobs are posting log events that are not in chronological order. I believe this is because here:

```python
                for line in logs_stdout + logs_stderr:
                    date, line = line.split(" ", 1)
                    date_obj = (
                        dateutil.parser.parse(date)
                        .astimezone(datetime.timezone.utc)
                        .replace(tzinfo=None)
                    )
                    date = unix_time_millis(date_obj)
                    logs.append({"timestamp": date, "message": line.strip()})
```

stdout and stderr are appended together but some stderr events may come before some stdout events. I considered a few things to fix this but ultimately I think sorting the logs after the fact is the best way to fix this. If the logs are out of order for any reason and you want them to stay that way this removes that.

I also considered weaving the two together and I tested this and it does fix the problem. However it makes the code a lot more complicated for minimal benefit.

I also considered adding the previous timestamp if the timestamp is earlier than the previous, though this distorts the timestamps.