### PR TITLE
admin_user_global_sign_out works only once

### DIFF
--- a/moto/cognitoidp/models.py
+++ b/moto/cognitoidp/models.py
@@ -1335,6 +1335,8 @@ class CognitoIdpBackend(BaseBackend):
         self.admin_get_user(user_pool_id, username)
 
         for token, token_tuple in list(user_pool.refresh_tokens.items()):
+            if token_tuple is None:
+                continue
             _, username = token_tuple
             if username == username:
                 user_pool.refresh_tokens[token] = None


### PR DESCRIPTION
Sign out method assigns `None` instead of tuple. But code expect exactly tuple.

Error on request:
Traceback (most recent call last):
  File "/usr/local/lib/python3.7/site-packages/werkzeug/serving.py", line 319, in run_wsgi
    execute(self.server.app)
  File "/usr/local/lib/python3.7/site-packages/werkzeug/serving.py", line 308, in execute
    application_iter = app(environ, start_response)
  File "/usr/local/lib/python3.7/site-packages/moto/server.py", line 239, in __call__
    return backend_app(environ, start_response)
  File "/usr/local/lib/python3.7/site-packages/flask/app.py", line 2091, in __call__
    return self.wsgi_app(environ, start_response)
  File "/usr/local/lib/python3.7/site-packages/flask/app.py", line 2076, in wsgi_app
    response = self.handle_exception(e)
  File "/usr/local/lib/python3.7/site-packages/flask_cors/extension.py", line 165, in wrapped_function
    return cors_after_request(app.make_response(f(*args, **kwargs)))
  File "/usr/local/lib/python3.7/site-packages/flask/app.py", line 2073, in wsgi_app
    response = self.full_dispatch_request()
  File "/usr/local/lib/python3.7/site-packages/flask/app.py", line 1518, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/usr/local/lib/python3.7/site-packages/flask_cors/extension.py", line 165, in wrapped_function
    return cors_after_request(app.make_response(f(*args, **kwargs)))
  File "/usr/local/lib/python3.7/site-packages/flask/app.py", line 1516, in full_dispatch_request
    rv = self.dispatch_request()
  File "/usr/local/lib/python3.7/site-packages/flask/app.py", line 1502, in dispatch_request
    return self.ensure_sync(self.view_functions[rule.endpoint])(**req.view_args)
  File "/usr/local/lib/python3.7/site-packages/moto/core/utils.py", line 147, in __call__
    result = self.callback(request, request.url, dict(request.headers))
  File "/usr/local/lib/python3.7/site-packages/moto/core/responses.py", line 203, in dispatch
    return cls()._dispatch(*args, **kwargs)
  File "/usr/local/lib/python3.7/site-packages/moto/core/responses.py", line 313, in _dispatch
    return self.call_action()
  File "/usr/local/lib/python3.7/site-packages/moto/core/responses.py", line 403, in call_action
    response = method()
  File "/usr/local/lib/python3.7/site-packages/moto/cognitoidp/responses.py", line 500, in admin_user_global_sign_out
    user_pool_id, username
  File "/usr/local/lib/python3.7/site-packages/moto/cognitoidp/models.py", line 1338, in admin_user_global_sign_out
    _, username = token_tuple
TypeError: cannot unpack non-iterable NoneType object