### PR TITLE
fix(s3/listparts): check parts length

### DIFF
--- a/moto/s3/responses.py
+++ b/moto/s3/responses.py
@@ -1347,7 +1347,7 @@ class ResponseObject(_TemplateEnvironmentMixin, ActionAuthenticatorMixin):
                 max_parts=max_parts,
             )
             next_part_number_marker = parts[-1].name if parts else 0
-            is_truncated = parts and self.backend.is_truncated(
+            is_truncated = len(parts) != 0 and self.backend.is_truncated(
                 bucket_name, upload_id, next_part_number_marker
             )
 

--- a/tests/test_s3/test_s3_multipart.py
+++ b/tests/test_s3/test_s3_multipart.py
@@ -108,6 +108,21 @@ def test_multipart_upload_should_return_part_10000():
 
 
 @mock_s3
+def test_multipart_upload_without_parts():
+    bucket = "dummybucket"
+    s3_client = boto3.client("s3", "us-east-1")
+
+    key = "test_file"
+    s3_client.create_bucket(Bucket=bucket)
+
+    mpu = s3_client.create_multipart_upload(Bucket=bucket, Key=key)
+    mpu_id = mpu["UploadId"]
+
+    list_parts_result = s3_client.list_parts(Bucket=bucket, Key=key, UploadId=mpu_id)
+    list_parts_result["IsTruncated"].should.equal(False)
+
+
+@mock_s3
 @pytest.mark.parametrize("part_nr", [10001, 10002, 20000])
 def test_s3_multipart_upload_cannot_upload_part_over_10000(part_nr):
     bucket = "dummy"


### PR DESCRIPTION
* With Multipart Uploads, If there is no parts yet, `is_truncated` value is set `[]`.
  * `parts and self.backend.is_truncated(...)` result is always  `[]` if `parts` is empty list.
* Check `len(parts) != 0` not `parts`.