### PR TITLE
Escape windows return character

### DIFF
--- a/moto/sqs/models.py
+++ b/moto/sqs/models.py
@@ -150,7 +150,7 @@ class Message(BaseModel):
 
     @property
     def body(self):
-        return escape(self._body)
+        return escape(self._body).replace('"', "&quot;").replace("\r", "&#xD;")
 
     def mark_sent(self, delay_seconds=None):
         self.sent_timestamp = int(unix_time_millis())

--- a/tests/test_sqs/test_sqs.py
+++ b/tests/test_sqs/test_sqs.py
@@ -3455,3 +3455,16 @@ def test_receive_message_again_preserves_attributes():
     assert len(second_messages[0]["MessageAttributes"]) == 2
     assert second_messages[0]["MessageAttributes"].get("Custom1") is not None
     assert second_messages[0]["MessageAttributes"].get("Custom2") is not None
+
+
+@mock_sqs
+def test_message_has_windows_return():
+    sqs = boto3.resource("sqs", region_name="us-east-1")
+    queue = sqs.create_queue(QueueName=f"{str(uuid4())[0:6]}")
+
+    message = "content:\rmessage_with line"
+    queue.send_message(MessageBody=message)
+
+    messages = queue.receive_messages()
+    messages.should.have.length_of(1)
+    messages[0].body.should.match(message)


### PR DESCRIPTION
This PR addresses issue localstack/localstack#5172 where is described that the SQS service removes the "\r" character from the body messages when receiving the messages from a queue.

Changes:
 - replacement of the `\r` for its unicode representation `&#xd;`. 
 - replacement of the `"` for the html entity `&quot;`. This was not necessary but it makes the responses more in pair with the AWS responses.
 - Test added to validate character is not being removed.