### PR TITLE
Pylint on D/E directories

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ init:
 lint:
 	flake8 moto
 	black --check moto/ tests/
-	pylint -j 0 moto/a* moto/b* moto/c* tests
+	pylint -j 0 moto/a* moto/b* moto/c* moto/d* moto/e* tests
 
 format:
 	black moto/ tests/


### PR DESCRIPTION
Followup from #4728, but now we actually enforce pylint