### PR TITLE
Fix : cloudwatch list metrics 

### DIFF
--- a/moto/cloudwatch/models.py
+++ b/moto/cloudwatch/models.py
@@ -220,9 +220,14 @@ class MetricDatum(BaseModel):
             return False
 
         for metric in already_present_metrics or []:
-            if self.dimensions and are_dimensions_same(
-                metric.dimensions, self.dimensions
-            ):
+            if (
+                (
+                    self.dimensions
+                    and are_dimensions_same(metric.dimensions, self.dimensions)
+                )
+                and self.name == metric.name
+                and self.namespace == metric.namespace
+            ):  # should be considered as already present only when name, namespace and dimensions all three are same
                 return False
 
         if dimensions and any(


### PR DESCRIPTION
This PR addresses issue localstack/localstack#5000 . The issue is that list-metrics does not return all the unique metrics.

The conditional logic here https://github.com/spulec/moto/blob/master/moto/cloudwatch/models.py#L197 checks only if the metrics dimension's name and value are same , to be considered as already present in the list , causing the referenced issue.

Changes

- Improved the conditional logic to check uniqueness by considering all three properties(namespace, name , dimensions)
- Added test case to validate the modified logic and only unique metrics are always returned
