### PR TITLE
Fix response data types for kinesis operations

### DIFF
--- a/moto/kinesis/models.py
+++ b/moto/kinesis/models.py
@@ -86,7 +86,7 @@ class Shard(BaseModel):
         self.records[sequence_number] = Record(
             partition_key, data, sequence_number, explicit_hash_key
         )
-        return sequence_number
+        return str(sequence_number)
 
     def get_min_sequence_number(self):
         if self.records:
@@ -121,16 +121,16 @@ class Shard(BaseModel):
                 "StartingHashKey": str(self.starting_hash),
             },
             "SequenceNumberRange": {
-                "StartingSequenceNumber": self.get_min_sequence_number(),
+                "StartingSequenceNumber": str(self.get_min_sequence_number()),
             },
             "ShardId": self.shard_id,
         }
         if self.parent:
             response["ParentShardId"] = self.parent
         if not self.is_open:
-            response["SequenceNumberRange"][
-                "EndingSequenceNumber"
-            ] = self.get_max_sequence_number()
+            response["SequenceNumberRange"]["EndingSequenceNumber"] = str(
+                self.get_max_sequence_number()
+            )
         return response
 
 

--- a/tests/test_kinesis/test_kinesis.py
+++ b/tests/test_kinesis/test_kinesis.py
@@ -226,7 +226,8 @@ def test_put_records():
         InvalidArgumentException
     )
 
-    conn.put_record(stream_name, data, partition_key)
+    response = conn.put_record(stream_name, data, partition_key)
+    response["SequenceNumber"].should.equal("1")
 
     response = conn.describe_stream(stream_name)
     shard_id = response["StreamDescription"]["Shards"][0]["ShardId"]
@@ -256,7 +257,10 @@ def test_put_records_boto3():
     data = b"hello world"
     partition_key = "1234"
 
-    client.put_record(StreamName=stream_name, Data=data, PartitionKey=partition_key)
+    response = client.put_record(
+        StreamName=stream_name, Data=data, PartitionKey=partition_key
+    )
+    response["SequenceNumber"].should.equal("1")
 
     resp = client.get_shard_iterator(
         StreamName=stream_name, ShardId=shard_id, ShardIteratorType="TRIM_HORIZON"


### PR DESCRIPTION
This PR fixes a bug in kinesis operations returning the fields `"SequenceNumber"`, `"StartingSequenceNumber"`, and `"EndingSequenceNumber"`. This includes `put_record()`, `put_records()`, and `list_shards()`.

Each of these fields now returns a string rather than an int, as per the spec:

Reference: https://docs.aws.amazon.com/kinesis/latest/APIReference/kinesis-api.pdf