### PR TITLE
Enhancement/cognitoidp add force change password challenge flow

### DIFF
--- a/moto/cognitoidp/models.py
+++ b/moto/cognitoidp/models.py
@@ -1486,6 +1486,13 @@ class CognitoIdpBackend(BaseBackend):
             session = str(uuid.uuid4())
             self.sessions[session] = user_pool
 
+            if user.status is UserStatus.FORCE_CHANGE_PASSWORD:
+                return {
+                    "ChallengeName": "NEW_PASSWORD_REQUIRED",
+                    "ChallengeParameters": {"USERNAME": user.username},
+                    "Session": session,
+                }
+
             access_token, expires_in = user_pool.create_access_token(
                 client_id, username
             )


### PR DESCRIPTION
https://github.com/spulec/moto/issues/4739
Adds the challenge `NEW_PASSWORD_REQUIRED` during a `USER_PASSWORD_AUTH` authentication when the user is in `FORCE_CHANGE_PASSWORD` status
Used [documentation](https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_RespondToAuthChallenge.html) as well as testing on an actual cognito pool to make sure the structure was correct.

- [x] Feature is added
- [x] The linter is happy
- [x] Tests are added
- [~] All tests pass, existing and new

For the tests part, I found 7 tests were failing which have nothing to do with cognitoidp:
```
tests/test_swf/responses/test_timeouts.py::test_workflow_execution_start_to_close_timeout_boto3 FAILED
tests/test_swf/responses/test_timeouts.py::test_activity_task_heartbeat_timeout_boto3 FAILED
tests/test_swf/responses/test_timeouts.py::test_decision_task_start_to_close_timeout_boto3 FAILED
tests/test_swf/responses/test_timeouts.py::test_workflow_execution_start_to_close_timeout_boto3 FAILED
tests/test_swf/responses/test_decision_tasks.py::test_respond_decision_task_completed_with_schedule_activity_task_boto3 FAILED
tests/test_s3/test_s3_acl.py::test_raise_exception_for_grant_and_acl FAILED
tests/test_s3/test_s3_auth.py::test_head_bucket_with_correct_credentials FAILED
tests/test_s3/test_s3_auth.py::test_head_bucket_with_incorrect_credentials FAILED
```
I don't really know what to do about that 