### PR TITLE
feat: add support for filtering by tags in describe_managed_prefix_lists

### DIFF
--- a/moto/ec2/models.py
+++ b/moto/ec2/models.py
@@ -5610,6 +5610,7 @@ class ManagedPrefixListBackend(object):
         result = managed_prefix_lists
         if filters:
             result = filter_resources(managed_prefix_lists, filters, attr_pairs)
+            result = describe_tag_filter(filters, managed_prefix_lists)
 
         for item in result.copy():
             if not item.delete_counter:


### PR DESCRIPTION
This PR adds support for filtering by tags (instead of ignoring the tag filter and returning all results) during calls to `describe_managed_prefix_lists` (EC2 client).

The test added in this PR doesn't pass without the associated change.

I made the minimal change that would allow me to use moto to test a project I'm working on. Please let met know if that approach is OK!