### PR TITLE
Fix interoperability with responses 0.17.x

### DIFF
--- a/moto/core/custom_responses_mock.py
+++ b/moto/core/custom_responses_mock.py
@@ -71,7 +71,7 @@ class CallbackResponse(responses.CallbackResponse):
         if not match_querystring:
             other = other.split("?", 1)[0]
 
-        if responses._is_string(url):
+        if isinstance(url, str):
             if responses._has_unicode(url):
                 url = responses._clean_unicode(url)
                 if not isinstance(other, str):


### PR DESCRIPTION
The `_is_string` method has been removed from `responses`, and will break compatibility with future releases