### PR TITLE
Improve future interoperability with responses-module

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -222,6 +222,7 @@ jobs:
     needs: lint
     strategy:
       matrix:
+        fail-fast: false
         python-version: [ 3.8 ]
         responses-version: [0.11.0, 0.12.0, 0.12.1, 0.13.0, 0.15.0, 0.17.0]
 
@@ -251,7 +252,7 @@ jobs:
           pip install "coverage<=4.5.4"
       - name: Test core-logic with responses==${{ matrix.responses-version }}
         run: |
-          pytest -sv --cov=moto --cov-report xml ./tests/test_core
+          pytest -sv --cov=moto --cov-report xml ./tests/test_core ./tests/test_apigateway/test_apigateway_integration.py
       - name: "Upload coverage to Codecov"
         if: ${{ github.repository == 'spulec/moto'}}
         uses: codecov/codecov-action@v1

--- a/moto/apigateway/models.py
+++ b/moto/apigateway/models.py
@@ -918,7 +918,6 @@ class RestAPI(CloudFormationModel):
                         method=http_method,
                         callback=self.resource_callback,
                         content_type="text/plain",
-                        match_querystring=False,
                     )
                     responses_mock.add(callback_response)
 

--- a/moto/core/custom_responses_mock.py
+++ b/moto/core/custom_responses_mock.py
@@ -13,6 +13,9 @@ except ImportError:
     from importlib_metadata import version
 
 
+RESPONSES_VERSION = version("responses")
+
+
 class CallbackResponse(responses.CallbackResponse):
     """
     Need to subclass so we can change a couple things
@@ -151,7 +154,6 @@ def get_response_mock():
     """
     responses_mock = None
 
-    RESPONSES_VERSION = version("responses")
     if LooseVersion(RESPONSES_VERSION) < LooseVersion("0.12.1"):
         responses_mock = responses.RequestsMock(assert_all_requests_are_fired=False)
         responses_mock._find_match = types.MethodType(
@@ -169,3 +171,17 @@ def get_response_mock():
 
     responses_mock.add_passthru("http")
     return responses_mock
+
+
+def reset_responses_mock(responses_mock):
+    if LooseVersion(RESPONSES_VERSION) < LooseVersion("0.12.1"):
+        responses_mock.reset()
+    elif LooseVersion(RESPONSES_VERSION) >= LooseVersion("0.17.0"):
+        from .responses_custom_registry import CustomRegistry
+
+        responses_mock.reset()
+        # No way to set the registry directly (yet..)
+        responses_mock._set_registry(CustomRegistry)
+        responses_mock.add_passthru("http")
+    else:
+        responses_mock.reset()

--- a/moto/core/custom_responses_mock.py
+++ b/moto/core/custom_responses_mock.py
@@ -71,7 +71,7 @@ class CallbackResponse(responses.CallbackResponse):
         if not match_querystring:
             other = other.split("?", 1)[0]
 
-        if responses._is_string(url):
+        if isinstance(url, str):
             if responses._has_unicode(url):
                 url = responses._clean_unicode(url)
                 if not isinstance(other, str):

--- a/moto/core/models.py
+++ b/moto/core/models.py
@@ -22,6 +22,7 @@ from .custom_responses_mock import (
     get_response_mock,
     CallbackResponse,
     not_implemented_callback,
+    reset_responses_mock,
 )
 from .utils import (
     convert_httpretty_response,
@@ -317,7 +318,7 @@ def patch_resource(resource):
 class BotocoreEventMockAWS(BaseMockAWS):
     def reset(self):
         botocore_stubber.reset()
-        responses_mock.calls.reset()
+        reset_responses_mock(responses_mock)
 
     def enable_patching(self):
         botocore_stubber.enabled = True

--- a/moto/core/models.py
+++ b/moto/core/models.py
@@ -341,7 +341,6 @@ class BotocoreEventMockAWS(BaseMockAWS):
                             method=method,
                             url=re.compile(key),
                             callback=convert_flask_to_responses_response(value),
-                            match_querystring=False,
                         )
                     )
             responses_mock.add(
@@ -349,7 +348,6 @@ class BotocoreEventMockAWS(BaseMockAWS):
                     method=method,
                     url=re.compile(r"https?://.+\.amazonaws.com/.*"),
                     callback=not_implemented_callback,
-                    match_querystring=False,
                 )
             )
             botocore_mock.add(
@@ -357,7 +355,6 @@ class BotocoreEventMockAWS(BaseMockAWS):
                     method=method,
                     url=re.compile(r"https?://.+\.amazonaws.com/.*"),
                     callback=not_implemented_callback,
-                    match_querystring=False,
                 )
             )
 


### PR DESCRIPTION
Adds more test cases with older versions of `responses`
Removes a method that will no longer exist in the next `responses`-release
Removes a parameter that throws warnings in the latest `responses`-release