### PR TITLE
docker networks support

### DIFF
--- a/moto/awslambda/models.py
+++ b/moto/awslambda/models.py
@@ -584,6 +584,8 @@ class LambdaFunction(CloudFormationModel, DockerModel):
                             "host.docker.internal": "host-gateway"
                         }
 
+                    networks = os.environ["MOTO_DOCKER_NETWORKS"].split() if "MOTO_DOCKER_NETWORKS" in os.environ else []
+
                     image_ref = "lambci/lambda:{}".format(self.run_time)
                     self.docker_client.images.pull(":".join(parse_image_ref(image_ref)))
                     container = self.docker_client.containers.run(
@@ -595,6 +597,7 @@ class LambdaFunction(CloudFormationModel, DockerModel):
                         environment=env_vars,
                         detach=True,
                         log_config=log_config,
+                        networks=networks,
                         **run_kwargs
                     )
                 finally:

--- a/moto/awslambda/models.py
+++ b/moto/awslambda/models.py
@@ -584,11 +584,8 @@ class LambdaFunction(CloudFormationModel, DockerModel):
                             "host.docker.internal": "host-gateway"
                         }
 
-                    networks = (
-                        os.environ["MOTO_DOCKER_NETWORKS"].split()
-                        if "MOTO_DOCKER_NETWORKS" in os.environ
-                        else []
-                    )
+                    if "MOTO_DOCKER_NETWORK" in os.environ:
+                        run_kwargs["network"] = os.environ["MOTO_DOCKER_NETWORK"]
 
                     image_ref = "lambci/lambda:{}".format(self.run_time)
                     self.docker_client.images.pull(":".join(parse_image_ref(image_ref)))
@@ -601,7 +598,6 @@ class LambdaFunction(CloudFormationModel, DockerModel):
                         environment=env_vars,
                         detach=True,
                         log_config=log_config,
-                        networks=networks,
                         **run_kwargs
                     )
                 finally:

--- a/moto/awslambda/models.py
+++ b/moto/awslambda/models.py
@@ -584,7 +584,11 @@ class LambdaFunction(CloudFormationModel, DockerModel):
                             "host.docker.internal": "host-gateway"
                         }
 
-                    networks = os.environ["MOTO_DOCKER_NETWORKS"].split() if "MOTO_DOCKER_NETWORKS" in os.environ else []
+                    networks = (
+                        os.environ["MOTO_DOCKER_NETWORKS"].split()
+                        if "MOTO_DOCKER_NETWORKS" in os.environ
+                        else []
+                    )
 
                     image_ref = "lambci/lambda:{}".format(self.run_time)
                     self.docker_client.images.pull(":".join(parse_image_ref(image_ref)))

--- a/moto/batch/models.py
+++ b/moto/batch/models.py
@@ -554,7 +554,11 @@ class Job(threading.Thread, BaseModel, DockerModel):
 
             self.job_started_at = datetime.datetime.now()
 
-            networks = os.environ["MOTO_DOCKER_NETWORKS"].split() if "MOTO_DOCKER_NETWORKS" in os.environ else []
+            networks = (
+                os.environ["MOTO_DOCKER_NETWORKS"].split()
+                if "MOTO_DOCKER_NETWORKS" in os.environ
+                else []
+            )
 
             log_config = docker.types.LogConfig(type=docker.types.LogConfig.types.JSON)
             self.job_state = "STARTING"

--- a/moto/batch/models.py
+++ b/moto/batch/models.py
@@ -556,7 +556,7 @@ class Job(threading.Thread, BaseModel, DockerModel):
 
             run_kwargs = {}
             if "MOTO_DOCKER_NETWORK" in os.environ:
-                kwargs["network"] = os.environ["MOTO_DOCKER_NETWORK"]
+                run_kwargs["network"] = os.environ["MOTO_DOCKER_NETWORK"]
 
             log_config = docker.types.LogConfig(type=docker.types.LogConfig.types.JSON)
             self.job_state = "STARTING"

--- a/moto/batch/models.py
+++ b/moto/batch/models.py
@@ -1,3 +1,4 @@
+import os
 import re
 from itertools import cycle
 import datetime
@@ -553,6 +554,8 @@ class Job(threading.Thread, BaseModel, DockerModel):
 
             self.job_started_at = datetime.datetime.now()
 
+            networks = os.environ["MOTO_DOCKER_NETWORKS"].split() if "MOTO_DOCKER_NETWORKS" in os.environ else []
+
             log_config = docker.types.LogConfig(type=docker.types.LogConfig.types.JSON)
             self.job_state = "STARTING"
             container = self.docker_client.containers.run(
@@ -564,6 +567,7 @@ class Job(threading.Thread, BaseModel, DockerModel):
                 environment=environment,
                 mounts=mounts,
                 privileged=privileged,
+                networks=networks,
             )
             self.job_state = "RUNNING"
             try:

--- a/moto/batch/models.py
+++ b/moto/batch/models.py
@@ -554,11 +554,9 @@ class Job(threading.Thread, BaseModel, DockerModel):
 
             self.job_started_at = datetime.datetime.now()
 
-            networks = (
-                os.environ["MOTO_DOCKER_NETWORKS"].split()
-                if "MOTO_DOCKER_NETWORKS" in os.environ
-                else []
-            )
+            run_kwargs = {}
+            if "MOTO_DOCKER_NETWORK" in os.environ:
+                kwargs["network"] = os.environ["MOTO_DOCKER_NETWORK"]
 
             log_config = docker.types.LogConfig(type=docker.types.LogConfig.types.JSON)
             self.job_state = "STARTING"
@@ -571,7 +569,7 @@ class Job(threading.Thread, BaseModel, DockerModel):
                 environment=environment,
                 mounts=mounts,
                 privileged=privileged,
-                networks=networks,
+                **run_kwargs,
             )
             self.job_state = "RUNNING"
             try:


### PR DESCRIPTION
This adds a new environment variable `MOTO_DOCKER_NETWORK` that is the name of a docker network to bind docker containers ran by moto to. This is for usage of the moto container with docker compose. By creating an overlay network in your docker compose file you can add that network name in this environment variable. This allows you to communicate with other mock services while mocking your application in docker compose.