### PR TITLE
EC2 - Cross region VPC peering bug

### DIFF
--- a/moto/ec2/models.py
+++ b/moto/ec2/models.py
@@ -3919,13 +3919,6 @@ class VPCBackend(object):
         self.vpc_refs[self.__class__].add(weakref.ref(self))
         super().__init__()
 
-    @classmethod
-    def get_vpc_refs(cls):
-        for inst_ref in cls.vpc_refs[cls]:
-            inst = inst_ref()
-            if inst is not None:
-                yield inst
-
     def create_vpc(
         self,
         cidr_block,
@@ -3974,13 +3967,6 @@ class VPCBackend(object):
         if vpc_id not in self.vpcs:
             raise InvalidVPCIdError(vpc_id)
         return self.vpcs.get(vpc_id)
-
-    # get vpc by vpc id and aws region
-    def get_cross_vpc(self, vpc_id, peer_region):
-        for vpcs in self.get_vpc_refs():
-            if vpcs.region_name == peer_region:
-                match_vpc = vpcs.get_vpc(vpc_id)
-        return match_vpc
 
     def describe_vpcs(self, vpc_ids=None, filters=None):
         matches = self.vpcs.copy().values()

--- a/moto/ec2/responses/vpc_peering_connections.py
+++ b/moto/ec2/responses/vpc_peering_connections.py
@@ -13,9 +13,9 @@ class VPCPeeringConnections(BaseResponse):
         if peer_region == self.region or peer_region is None:
             peer_vpc = self.ec2_backend.get_vpc(self._get_param("PeerVpcId"))
         else:
-            peer_vpc = self.ec2_backend.get_cross_vpc(
-                self._get_param("PeerVpcId"), peer_region
-            )
+            from moto.ec2.models import ec2_backends
+
+            peer_vpc = ec2_backends[peer_region].get_vpc(self._get_param("PeerVpcId"))
         vpc = self.ec2_backend.get_vpc(self._get_param("VpcId"))
         vpc_pcx = self.ec2_backend.create_vpc_peering_connection(vpc, peer_vpc, tags)
         template = self.response_template(CREATE_VPC_PEERING_CONNECTION_RESPONSE)


### PR DESCRIPTION
Bug where Python would throw an UnboundLocalError in the `get_cross_vpc`-method if no vpc was found in that region.

There was a test for this usecase, `test_vpc_peering_connections_cross_region_fail`. This test fails when running it on it's own, but would pass when running the entire EC2-test suite. That's why it was never discovered.

#### Solution

When a (cross-region) VPC is not found, it should throw a `VpcNotFound` error. 
The new solution simplifies this approach  - it tries to find the VPC in the other region, and the `get_vpc`-method throws the error if the VPC does not exist. 

The test now passes when running on it's own, as well as when running the entire suite.
