### PR TITLE
SQS - Improve delete_message_batch() error responses

### DIFF
--- a/moto/sqs/responses.py
+++ b/moto/sqs/responses.py
@@ -351,14 +351,26 @@ class SQSResponse(BaseResponse):
                 raise BatchEntryIdsNotDistinct(receipt_and_id["msg_user_id"])
             receipt_seen.add(receipt)
 
+        success = []
+        errors = []
         for receipt_and_id in receipts:
-            self.sqs_backend.delete_message(
-                queue_name, receipt_and_id["receipt_handle"]
-            )
+            try:
+                self.sqs_backend.delete_message(
+                    queue_name, receipt_and_id["receipt_handle"]
+                )
+                success.append(receipt_and_id["msg_user_id"])
+            except ReceiptHandleIsInvalid:
+                errors.append(
+                    {
+                        "Id": receipt_and_id["msg_user_id"],
+                        "SenderFault": "true",
+                        "Code": "ReceiptHandleIsInvalid",
+                        "Message": f'The input receipt handle "{receipt_and_id["receipt_handle"]}" is not a valid receipt handle.',
+                    }
+                )
 
-        message_ids = [r["msg_user_id"] for r in receipts]
         template = self.response_template(DELETE_MESSAGE_BATCH_RESPONSE)
-        return template.render(message_ids=message_ids)
+        return template.render(success=success, errors=errors)
 
     def purge_queue(self):
         queue_name = self._get_queue_name()
@@ -669,10 +681,18 @@ DELETE_MESSAGE_RESPONSE = """<DeleteMessageResponse>
 
 DELETE_MESSAGE_BATCH_RESPONSE = """<DeleteMessageBatchResponse>
     <DeleteMessageBatchResult>
-        {% for message_id in message_ids %}
+        {% for message_id in success %}
             <DeleteMessageBatchResultEntry>
                 <Id>{{ message_id }}</Id>
             </DeleteMessageBatchResultEntry>
+        {% endfor %}
+        {% for error_dict in errors %}
+        <BatchResultErrorEntry>
+            <Id>{{ error_dict['Id'] }}</Id>
+            <Code>{{ error_dict['Code'] }}</Code>
+            <Message>{{ error_dict['Message'] }}</Message>
+            <SenderFault>{{ error_dict['SenderFault'] }}</SenderFault>
+        </BatchResultErrorEntry>
         {% endfor %}
     </DeleteMessageBatchResult>
     <ResponseMetadata>


### PR DESCRIPTION
Currently, if the input to SQS.delete_message_batch() includes an invalid receipt handle, moto returns an error:

```
Traceback (most recent call last):
  File "test.py", line 26, in <module>
    sqs.delete_message_batch(
  File "<...>/botocore/client.py", line 391, in _api_call
    return self._make_api_call(operation_name, kwargs)
  File "<...>/botocore/client.py", line 719, in _make_api_call
    raise error_class(parsed_response, operation_name)
botocore.errorfactory.ReceiptHandleIsInvalid: An error occurred (ReceiptHandleIsInvalid) when calling the DeleteMessageBatch operation: The input receipt handle is invalid.
```

However, if the input to Amazon SQS DeleteMessageBatch API includes an invalid receipt handle, the Amazon SQS API returns the error in Failed field of an 200 OK response:

```
{
  "Successful": [...],
  "Failed": [{
    "Id": "invalid",
    "SenderFault": True,
    "Code": "ReceiptHandleIsInvalid",
    "Message": 'The input receipt handle "invalid" is not a valid receipt handle.',
  }],
  "ResponseMetadata": {...},
}
```

This commit updates moto delete_message_batch() method implementation to return ReceiptHandleIsInvalid errors in the "Failed" field of a 200 OK response instead of failing the entire request.

The implementation follows the implementation of similar functionality in the SQS change_message_visibility_batch() method. Test case added to check output in case of a partial failure.