### PR TITLE
feat: SES add (minimal) address validation

### DIFF
--- a/moto/ses/utils.py
+++ b/moto/ses/utils.py
@@ -1,5 +1,6 @@
 import random
 import string
+from email.utils import parseaddr
 
 
 def random_hex(length):
@@ -16,3 +17,11 @@ def get_random_message_id():
         random_hex(12),
         random_hex(6),
     )
+
+
+def is_valid_address(addr):
+    _, address = parseaddr(addr)
+    address = address.split("@")
+    if len(address) != 2 or not address[1]:
+        return False, "Missing domain"
+    return True, None

--- a/tests/test_ses/test_ses_utils.py
+++ b/tests/test_ses/test_ses_utils.py
@@ -1,0 +1,17 @@
+import sure  # noqa # pylint: disable=unused-import
+
+from moto.ses.utils import is_valid_address
+
+
+def test_is_valid_address():
+    valid, msg = is_valid_address("test@example.com")
+    valid.should.be.ok
+    msg.should.be.none
+
+    valid, msg = is_valid_address("test@")
+    valid.should_not.be.ok
+    msg.should.be.a(str)
+
+    valid, msg = is_valid_address("test")
+    valid.should_not.be.ok
+    msg.should.be.a(str)


### PR DESCRIPTION
Adding validation of source and destination addresses as I need a mock related to the following specification.

https://docs.aws.amazon.com/ses/latest/APIReference/API_SendRawEmail.html
> If you send a single message to more than one recipient address, and one of the recipient addresses isn't in a valid format (that is, it's not in the format UserName@[SubDomain.]Domain.TopLevelDomain), Amazon SES rejects the entire message, even if the other addresses are valid.

The validation is minimal and only checks if the domain part of the email address exists.
Full validation is not implemented because the exact specification is unknown.