### PR TITLE
Add CreatedDate and LastChangedDate in secretsmanager responses

### DIFF
--- a/moto/secretsmanager/models.py
+++ b/moto/secretsmanager/models.py
@@ -61,6 +61,8 @@ class FakeSecret:
         kms_key_id=None,
         version_id=None,
         version_stages=None,
+        last_changed_date=None,
+        created_date=None,
     ):
         self.secret_id = secret_id
         self.name = secret_id
@@ -72,14 +74,20 @@ class FakeSecret:
         self.kms_key_id = kms_key_id
         self.version_id = version_id
         self.version_stages = version_stages
+        self.last_changed_date = last_changed_date
+        self.created_date = created_date
         self.rotation_enabled = False
         self.rotation_lambda_arn = ""
         self.auto_rotate_after_days = 0
         self.deleted_date = None
 
-    def update(self, description=None, tags=None, kms_key_id=None):
+    def update(
+        self, description=None, tags=None, kms_key_id=None, last_changed_date=None
+    ):
         self.description = description
         self.tags = tags or []
+        if last_changed_date is not None:
+            self.last_changed_date = last_changed_date
 
         if kms_key_id is not None:
             self.kms_key_id = kms_key_id
@@ -134,12 +142,13 @@ class FakeSecret:
             "RotationLambdaARN": self.rotation_lambda_arn,
             "RotationRules": {"AutomaticallyAfterDays": self.auto_rotate_after_days},
             "LastRotatedDate": None,
-            "LastChangedDate": None,
+            "LastChangedDate": self.last_changed_date,
             "LastAccessedDate": None,
             "DeletedDate": self.deleted_date,
             "Tags": self.tags,
             "VersionIdsToStages": version_id_to_stages,
             "SecretVersionsToStages": version_id_to_stages,
+            "CreatedDate": self.created_date,
         }
 
     def _form_version_ids_to_stages(self):
@@ -350,10 +359,11 @@ class SecretsManagerBackend(BaseBackend):
         if secret_binary is not None:
             secret_version["secret_binary"] = secret_binary
 
+        update_time = int(time.time())
         if secret_id in self.secrets:
             secret = self.secrets[secret_id]
 
-            secret.update(description, tags, kms_key_id)
+            secret.update(description, tags, kms_key_id, last_changed_date=update_time)
 
             if "AWSPENDING" in version_stages:
                 secret.versions[version_id] = secret_version
@@ -368,6 +378,8 @@ class SecretsManagerBackend(BaseBackend):
                 description=description,
                 tags=tags,
                 kms_key_id=kms_key_id,
+                last_changed_date=update_time,
+                created_date=update_time,
             )
             secret.set_versions({version_id: secret_version})
             secret.set_default_version_id(version_id)

--- a/tests/test_secretsmanager/test_list_secrets.py
+++ b/tests/test_secretsmanager/test_list_secrets.py
@@ -1,5 +1,8 @@
 # -*- coding: utf-8 -*-
+from datetime import datetime
+
 import boto3
+from dateutil.tz import tzlocal
 
 from moto import mock_secretsmanager
 from botocore.exceptions import ClientError
@@ -41,6 +44,10 @@ def test_list_secrets():
     assert secrets["SecretList"][1]["Name"] == "test-secret-2"
     assert secrets["SecretList"][1]["Tags"] == [{"Key": "a", "Value": "1"}]
     assert secrets["SecretList"][1]["SecretVersionsToStages"] is not None
+    assert secrets["SecretList"][0]["CreatedDate"] <= datetime.now(tz=tzlocal())
+    assert secrets["SecretList"][1]["CreatedDate"] <= datetime.now(tz=tzlocal())
+    assert secrets["SecretList"][0]["LastChangedDate"] <= datetime.now(tz=tzlocal())
+    assert secrets["SecretList"][1]["LastChangedDate"] <= datetime.now(tz=tzlocal())
 
 
 @mock_secretsmanager

--- a/tests/test_secretsmanager/test_secretsmanager.py
+++ b/tests/test_secretsmanager/test_secretsmanager.py
@@ -1,3 +1,5 @@
+import os
+
 import boto3
 from dateutil.tz import tzlocal
 
@@ -993,7 +995,17 @@ def test_update_secret_updates_last_changed_dates(pass_arn):
         conn.update_secret(SecretId="test-secret", Description="new-desc")
         secret_details_2 = conn.describe_secret(SecretId=secret_id)
         assert secret_details_1["CreatedDate"] == secret_details_2["CreatedDate"]
-        assert secret_details_1["LastChangedDate"] < secret_details_2["LastChangedDate"]
+        if os.environ.get("TEST_SERVER_MODE", "false").lower() == "false":
+            assert (
+                secret_details_1["LastChangedDate"]
+                < secret_details_2["LastChangedDate"]
+            )
+        else:
+            # Can't manipulate time in server mode, so use weaker constraints here
+            assert (
+                secret_details_1["LastChangedDate"]
+                <= secret_details_2["LastChangedDate"]
+            )
 
 
 @mock_secretsmanager


### PR DESCRIPTION
Currently, these dates are missing, but should be present.

As an example, here is a request for list-secrets against AWS:
```
$ aws secretsmanager list-secrets
{
    "SecretList": [
        {
            "ARN": "arn:aws:secretsmanager:...",
            "Name": "testsecret",
            "Description": "some desc",
            "LastChangedDate": "2022-01-17T10:41:35.163000+01:00",
            "SecretVersionsToStages": {
                "e75a49b6-e07a-4bd9-acd7-510557dfc9b1": [
                    "AWSCURRENT"
                ]
            },
            "CreatedDate": "2022-01-14T19:43:03.127000+01:00"
        }
    ]
}
```

This PR introduces this behavior in moto. As their names say, CreatedDate will only be set on creation of the secret, LastChangedDate also on update operation.

The PR also includes the corresponding tests, both in existing test cases (where fitting, for additional attributes this seemed appropriate) and adds a new test specifically testing the CreatedDate / LastChangedDate behavior on object updates.