### PR TITLE
Enable testing for Py3.10

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,7 +44,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ 3.6, 3.7, 3.8, 3.9 ]
+        python-version: [ 3.6, 3.7, 3.8, 3.9, "3.10" ]
 
     steps:
       - uses: actions/checkout@v2
@@ -113,7 +113,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.6, 3.7, 3.8, 3.9, "3.10"]
 
     steps:
     - uses: actions/checkout@v2
@@ -158,7 +158,7 @@ jobs:
     needs: lint
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.6, 3.7, 3.8, 3.9, "3.10"]
 
     steps:
     - uses: actions/checkout@v2
@@ -224,7 +224,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: [ 3.8 ]
-        part: ["aa", "ab", "ac"]
+        part: ["aa", "ab", "ac", "ad"]
 
     steps:
     - uses: actions/checkout@v2
@@ -259,7 +259,7 @@ jobs:
       run: |
         cd moto-terraform-tests
         bin/list-tests -i ../tests/terraform-tests.success.txt -e ../tests/terraform-tests.failures.txt > tftestlist.txt
-        split -n l/3 tftestlist.txt tf-split-
+        split -n l/4 tftestlist.txt tf-split-
         cd ..
     - name: Run Terraform Tests
       run: |

--- a/.github/workflows/test_outdated_versions.yml
+++ b/.github/workflows/test_outdated_versions.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ "3.7", "3.9" ]
+        python-version: [ "3.7", "3.9", "3.10" ]
         responses-version: ["0.11.0", "0.12.0", "0.12.1", "0.13.0", "0.15.0", "0.17.0" ]
         mock-version: [ "3.0.5", "4.0.0", "4.0.3" ]
 

--- a/setup.py
+++ b/setup.py
@@ -135,11 +135,11 @@ setup(
     test_suite="tests",
     classifiers=[
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
         "License :: OSI Approved :: Apache Software License",
         "Topic :: Software Development :: Testing",
     ],


### PR DESCRIPTION
 - Removes support for Py3.5
 - Speed up Terraform tests, by splitting up the tests over 4 VM's (instead of 3)