### PR TITLE
Implement remove_account_from_organization, disallow organization deletion if accounts exist

### DIFF
--- a/docs/docs/services/organizations.rst
+++ b/docs/docs/services/organizations.rst
@@ -71,7 +71,7 @@ organizations
 - [X] list_targets_for_policy
 - [X] move_account
 - [X] register_delegated_administrator
-- [ ] remove_account_from_organization
+- [X] remove_account_from_organization
 - [X] tag_resource
 - [X] untag_resource
 - [X] update_organizational_unit

--- a/moto/organizations/models.py
+++ b/moto/organizations/models.py
@@ -381,6 +381,11 @@ class OrganizationsBackend(BaseBackend):
         return self.org.describe()
 
     def delete_organization(self, **kwargs):
+        if [account for account in self.accounts if account.name != "master"]:
+            raise RESTError(
+                "OrganizationNotEmptyException",
+                "To delete an organization you must first remove all member accounts (except the master).",
+            )
         self._reset()
         return {}
 
@@ -884,6 +889,12 @@ class OrganizationsBackend(BaseBackend):
                 raise AccountNotFoundException
         else:
             raise InvalidInputException("You specified an invalid value.")
+
+    def remove_account_from_organization(self, **kwargs):
+        account = self.get_account_by_id(kwargs["AccountId"])
+        for policy in account.attached_policies:
+            policy.attachments.remove(account)
+        self.accounts.remove(account)
 
 
 organizations_backend = OrganizationsBackend()

--- a/moto/organizations/responses.py
+++ b/moto/organizations/responses.py
@@ -215,3 +215,10 @@ class OrganizationsResponse(BaseResponse):
         return json.dumps(
             self.organizations_backend.detach_policy(**self.request_params)
         )
+
+    def remove_account_from_organization(self):
+        return json.dumps(
+            self.organizations_backend.remove_account_from_organization(
+                **self.request_params
+            )
+        )


### PR DESCRIPTION
As seen in the specification of DeleteOrganization (https://docs.aws.amazon.com/organizations/latest/APIReference/API_DeleteOrganization.html), organizations cannot be deleted when accounts are still assigned to it (except for the master account).
This PR implements this behavior, and implements a rudimentary remove_account_from_organization (so testing is easier).
I hope I did not miss any reference onto this account when deleting it though.

Both behaviors are tested with new test cases.