### PR TITLE
Fix : Exception type in cloudwatch get_metric_statistics

### DIFF
--- a/moto/cloudwatch/exceptions.py
+++ b/moto/cloudwatch/exceptions.py
@@ -15,6 +15,13 @@ class InvalidParameterValue(RESTError):
         super().__init__(__class__.__name__, message)
 
 
+class InvalidParameterCombination(RESTError):
+    code = 400
+
+    def __init__(self, message):
+        super().__init__(__class__.__name__, message)
+
+
 class ResourceNotFound(RESTError):
     code = 404
 

--- a/moto/cloudwatch/responses.py
+++ b/moto/cloudwatch/responses.py
@@ -5,6 +5,7 @@ from dateutil.parser import parse as dtparse
 from moto.core.responses import BaseResponse
 from moto.core.utils import amzn_request_id
 from .models import cloudwatch_backends, MetricDataQuery, MetricStat, Metric, Dimension
+from .exceptions import InvalidParameterCombination
 
 
 class CloudWatchResponse(BaseResponse):
@@ -187,9 +188,8 @@ class CloudWatchResponse(BaseResponse):
         unit = self._get_param("Unit")
         extended_statistics = self._get_param("ExtendedStatistics")
 
-        # TODO: this should instead throw InvalidParameterCombination
         if not statistics and not extended_statistics:
-            raise NotImplementedError(
+            raise InvalidParameterCombination(
                 "Must specify either Statistics or ExtendedStatistics"
             )
 


### PR DESCRIPTION
This PR addresses localstack/localstack#5134. The issue is that exception message thrown currently is bit misleading. 

Changes

1. Changed the `NotImplementedError` exception to `InvalidParameterCombination` exception.
2. Added test case to verify the behaviour.