### PR TITLE
set region before executing the script

### DIFF
--- a/docs/docs/contributing/new_feature.rst
+++ b/docs/docs/contributing/new_feature.rst
@@ -9,7 +9,7 @@ Moto has a script that can automatically provide the scaffolding for a new servi
 Please try it out by running:
 
 .. sourcecode:: bash
-
+  export AWS_DEFAULT_REGION="us-east-2"
   python scripts/scaffold.py
 
 


### PR DESCRIPTION
region must be selected or the script terminates with an error

I was unable to run the script until I set the default region. I chose us-east-1 arbitrarily. 