### PR TITLE
DynamoDb2 transact_write_items: Check multiple transacts on same item

### DIFF
--- a/moto/dynamodb2/exceptions.py
+++ b/moto/dynamodb2/exceptions.py
@@ -175,7 +175,7 @@ class TransactionCanceledException(ValueError):
 
 
 class MultipleTransactionsException(MockValidationException):
-    msg = 'Transaction request cannot include multiple operations on one item'
+    msg = "Transaction request cannot include multiple operations on one item"
 
     def __init__(self):
         super().__init__(self.msg)

--- a/moto/dynamodb2/exceptions.py
+++ b/moto/dynamodb2/exceptions.py
@@ -174,6 +174,13 @@ class TransactionCanceledException(ValueError):
         super().__init__(msg)
 
 
+class MultipleTransactionsException(MockValidationException):
+    msg = 'Transaction request cannot include multiple operations on one item'
+
+    def __init__(self):
+        super().__init__(self.msg)
+
+
 class EmptyKeyAttributeException(MockValidationException):
     empty_str_msg = "One or more parameter values were invalid: An AttributeValue may not contain an empty string"
     # AWS has a different message for empty index keys

--- a/moto/dynamodb2/models/__init__.py
+++ b/moto/dynamodb2/models/__init__.py
@@ -1569,8 +1569,7 @@ class DynamoDBBackend(BaseBackend):
         def check_unicity(table_name, key):
             item = (table_name, key)
             if item in target_items:
-                # raise MultipleTransactionsException()
-                pass
+                raise MultipleTransactionsException()
             target_items.add(item)
 
         errors = []

--- a/moto/dynamodb2/responses.py
+++ b/moto/dynamodb2/responses.py
@@ -1127,6 +1127,9 @@ class DynamoHandler(BaseResponse):
         except TransactionCanceledException as e:
             er = "com.amazonaws.dynamodb.v20111205#TransactionCanceledException"
             return self.error(er, str(e))
+        except MockValidationException as mve:
+            er = "com.amazonaws.dynamodb.v20111205#ValidationException"
+            return self.error(er, mve.exception_msg)
         response = {"ConsumedCapacity": [], "ItemCollectionMetrics": {}}
         return dynamo_json_dump(response)
 

--- a/tests/test_dynamodb2/exceptions/test_dynamodb_exceptions.py
+++ b/tests/test_dynamodb2/exceptions/test_dynamodb_exceptions.py
@@ -466,51 +466,8 @@ def test_creating_table_with_0_global_indexes():
     )
 
 
-# @mock_dynamodb2
-# def test_multiple_transactions_on_same_item():
-#     table_schema = {
-#         "KeySchema": [{"AttributeName": "id", "KeyType": "HASH"}],
-#         "AttributeDefinitions": [{"AttributeName": "id", "AttributeType": "S"},],
-#     }
-#     dynamodb = boto3.client("dynamodb", region_name="us-east-1")
-#     dynamodb.create_table(
-#         TableName="test-table", BillingMode="PAY_PER_REQUEST", **table_schema
-#     )
-#     # Insert an item
-#     dynamodb.put_item(TableName="test-table", Item={"id": {"S": "foo"}})
-
-#     def update_email_transact(email):
-#         return {"Update": {
-#                     "Key": {"id": {"S": "foo"}},
-#                     "TableName": "test-table",
-#                     "UpdateExpression": "SET #e = :v",
-#                     "ExpressionAttributeNames": {"#e": "email_address"},
-#                     "ExpressionAttributeValues": {":v": {"S": email}},
-#                 }
-#             }
-
-#     # with pytest.raises(ClientError) as exc:
-#     dynamodb.transact_write_items(
-#         TransactItems=[
-#             {"Update": {
-#                     "Key": {"id": {"S": "foo"}},
-#                     "TableName": "test-table",
-#                     "UpdateExpression": "SET #e = :v",
-#                     "ExpressionAttributeNames": {"#e": "email_address"},
-#                     "ExpressionAttributeValues": {":v": {"S": "test"}},
-#                 }
-#             }
-#             # update_email_transact("test2@moto.com"),
-#         ]
-#     )
-#     # err = exc.value.response["Error"]
-#     # err["Code"].should.equal("ValidationException")
-#     # err["Message"].should.equal(
-#     #     "Transaction request cannot include multiple operations on one item"
-#     # )
-
 @mock_dynamodb2
-def test_transact_write_items_update():
+def test_multiple_transactions_on_same_item():
     table_schema = {
         "KeySchema": [{"AttributeName": "id", "KeyType": "HASH"}],
         "AttributeDefinitions": [{"AttributeName": "id", "AttributeType": "S"},],
@@ -520,18 +477,28 @@ def test_transact_write_items_update():
         TableName="test-table", BillingMode="PAY_PER_REQUEST", **table_schema
     )
     # Insert an item
-    dynamodb.put_item(TableName="test-table", Item={"id": {"S": "foo"}, "email_address": {"S": "test"}})
-    # Update the item
-    dynamodb.transact_write_items(
-        TransactItems=[
-            {
-                "Update": {
-                    "Key": {"id": {"S": "foo"}},
-                    "TableName": "test-table",
-                    "UpdateExpression": "SET #e = :v",
-                    "ExpressionAttributeNames": {"#e": "email_address"},
-                    "ExpressionAttributeValues": {":v": {"S": "test@moto.com"}},
-                }
+    dynamodb.put_item(TableName="test-table", Item={"id": {"S": "foo"}})
+
+    def update_email_transact(email):
+        return {
+            "Update": {
+                "Key": {"id": {"S": "foo"}},
+                "TableName": "test-table",
+                "UpdateExpression": "SET #e = :v",
+                "ExpressionAttributeNames": {"#e": "email_address"},
+                "ExpressionAttributeValues": {":v": {"S": email}},
             }
-        ]
+        }
+
+    with pytest.raises(ClientError) as exc:
+        dynamodb.transact_write_items(
+            TransactItems=[
+                update_email_transact("test1@moto.com"),
+                update_email_transact("test2@moto.com"),
+            ]
+        )
+    err = exc.value.response["Error"]
+    err["Code"].should.equal("ValidationException")
+    err["Message"].should.equal(
+        "Transaction request cannot include multiple operations on one item"
     )

--- a/tests/test_dynamodb2/exceptions/test_dynamodb_exceptions.py
+++ b/tests/test_dynamodb2/exceptions/test_dynamodb_exceptions.py
@@ -1,11 +1,9 @@
 import boto3
 import pytest
 import sure  # noqa # pylint: disable=unused-import
-
-from botocore.exceptions import ClientError
 from boto3.dynamodb.conditions import Key
+from botocore.exceptions import ClientError
 from moto import mock_dynamodb2
-
 
 table_schema = {
     "KeySchema": [{"AttributeName": "partitionKey", "KeyType": "HASH"}],
@@ -465,4 +463,75 @@ def test_creating_table_with_0_global_indexes():
     err["Code"].should.equal("ValidationException")
     err["Message"].should.equal(
         "One or more parameter values were invalid: List of GlobalSecondaryIndexes is empty"
+    )
+
+
+# @mock_dynamodb2
+# def test_multiple_transactions_on_same_item():
+#     table_schema = {
+#         "KeySchema": [{"AttributeName": "id", "KeyType": "HASH"}],
+#         "AttributeDefinitions": [{"AttributeName": "id", "AttributeType": "S"},],
+#     }
+#     dynamodb = boto3.client("dynamodb", region_name="us-east-1")
+#     dynamodb.create_table(
+#         TableName="test-table", BillingMode="PAY_PER_REQUEST", **table_schema
+#     )
+#     # Insert an item
+#     dynamodb.put_item(TableName="test-table", Item={"id": {"S": "foo"}})
+
+#     def update_email_transact(email):
+#         return {"Update": {
+#                     "Key": {"id": {"S": "foo"}},
+#                     "TableName": "test-table",
+#                     "UpdateExpression": "SET #e = :v",
+#                     "ExpressionAttributeNames": {"#e": "email_address"},
+#                     "ExpressionAttributeValues": {":v": {"S": email}},
+#                 }
+#             }
+
+#     # with pytest.raises(ClientError) as exc:
+#     dynamodb.transact_write_items(
+#         TransactItems=[
+#             {"Update": {
+#                     "Key": {"id": {"S": "foo"}},
+#                     "TableName": "test-table",
+#                     "UpdateExpression": "SET #e = :v",
+#                     "ExpressionAttributeNames": {"#e": "email_address"},
+#                     "ExpressionAttributeValues": {":v": {"S": "test"}},
+#                 }
+#             }
+#             # update_email_transact("test2@moto.com"),
+#         ]
+#     )
+#     # err = exc.value.response["Error"]
+#     # err["Code"].should.equal("ValidationException")
+#     # err["Message"].should.equal(
+#     #     "Transaction request cannot include multiple operations on one item"
+#     # )
+
+@mock_dynamodb2
+def test_transact_write_items_update():
+    table_schema = {
+        "KeySchema": [{"AttributeName": "id", "KeyType": "HASH"}],
+        "AttributeDefinitions": [{"AttributeName": "id", "AttributeType": "S"},],
+    }
+    dynamodb = boto3.client("dynamodb", region_name="us-east-1")
+    dynamodb.create_table(
+        TableName="test-table", BillingMode="PAY_PER_REQUEST", **table_schema
+    )
+    # Insert an item
+    dynamodb.put_item(TableName="test-table", Item={"id": {"S": "foo"}, "email_address": {"S": "test"}})
+    # Update the item
+    dynamodb.transact_write_items(
+        TransactItems=[
+            {
+                "Update": {
+                    "Key": {"id": {"S": "foo"}},
+                    "TableName": "test-table",
+                    "UpdateExpression": "SET #e = :v",
+                    "ExpressionAttributeNames": {"#e": "email_address"},
+                    "ExpressionAttributeValues": {":v": {"S": "test@moto.com"}},
+                }
+            }
+        ]
     )


### PR DESCRIPTION
fixes #4779 

during a call of `transact_write_items`
- look for (key, table) pairs in the items
- if there is a match, throw a (newly created) `MultipleTransactionsException`