### PR TITLE
test: add missing test for delete_log_stream

### DIFF
--- a/tests/test_logs/test_logs.py
+++ b/tests/test_logs/test_logs.py
@@ -650,6 +650,18 @@ def test_put_retention_policy():
 
 
 @mock_logs
+def test_delete_log_stream():
+    logs = boto3.client("logs", TEST_REGION)
+    logs.create_log_group(logGroupName="logGroup")
+    logs.create_log_stream(logGroupName="logGroup", logStreamName="logStream")
+    resp = logs.describe_log_streams(logGroupName="logGroup")
+    assert resp["logStreams"][0]["logStreamName"] == "logStream"
+    logs.delete_log_stream(logGroupName="logGroup", logStreamName="logStream")
+    resp = logs.describe_log_streams(logGroupName="logGroup")
+    assert resp["logStreams"] == []
+
+
+@mock_logs
 def test_delete_retention_policy():
     conn = boto3.client("logs", TEST_REGION)
     log_group_name = "dummy"


### PR DESCRIPTION
This PR tests the CW logs method `delete_log_stream()` which was missing tests. This checks the happy path:

* create log group
* create log stream
* describe log streams
* assert one exists
* delete log stream
* assert zero exist
