### PR TITLE
When a timer fires, it should also schedule a decision

### DIFF
--- a/moto/swf/models/workflow_execution.py
+++ b/moto/swf/models/workflow_execution.py
@@ -726,6 +726,7 @@ class WorkflowExecution(BaseModel):
             "TimerFired", started_event_id=started_event_id, timer_id=timer_id
         )
         self._timers.pop(timer_id)
+        self._schedule_decision_task()
 
     def cancel_timer(self, event_id, timer_id):
         requested_timer = self._timers.get(timer_id)

--- a/tests/test_swf/models/test_workflow_execution.py
+++ b/tests/test_swf/models/test_workflow_execution.py
@@ -589,10 +589,12 @@ def test_start_timer_correctly_fires_timer_later():
         # Small wait to let both events populate
         sleep(0.5)
 
+        second_to_last_event = wfe.events()[-2]
         last_event = wfe.events()[-1]
-        last_event.event_type.should.equal("TimerFired")
-        last_event.event_attributes["timerId"].should.equal("abc123")
-        last_event.event_attributes["startedEventId"].should.equal(1)
+        second_to_last_event.event_type.should.equal("TimerFired")
+        second_to_last_event.event_attributes["timerId"].should.equal("abc123")
+        second_to_last_event.event_attributes["startedEventId"].should.equal(1)
+        last_event.event_type.should.equal("DecisionTaskScheduled")
 
 
 def test_start_timer_fails_if_timer_already_started():

--- a/tests/test_swf/responses/test_decision_tasks.py
+++ b/tests/test_swf/responses/test_decision_tasks.py
@@ -505,16 +505,17 @@ def test_start_and_fire_timer_decision():
             "DecisionTaskCompleted",
             "TimerStarted",
             "TimerFired",
+            "DecisionTaskScheduled",
         ]
     )
-    resp["events"][-2]["timerStartedEventAttributes"].should.equal(
+    resp["events"][-3]["timerStartedEventAttributes"].should.equal(
         {
             "decisionTaskCompletedEventId": 4,
             "startToFireTimeout": "1",
             "timerId": "timer1",
         }
     )
-    resp["events"][-1]["timerFiredEventAttributes"].should.equal(
+    resp["events"][-2]["timerFiredEventAttributes"].should.equal(
         {"startedEventId": 5, "timerId": "timer1"}
     )
 


### PR DESCRIPTION
Hello again! A bug fix for the implementation of the timers in https://github.com/spulec/moto/pull/4713

As not explicitly pointed out in the API docs, but mentioned instead [here](https://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dg-timers.html), when a timer has fired, a decision task should be scheduled. If this doesn't happen, then the workflow will not progress, as there is nothing notifying it that it should do something.