### PR TITLE
Missing VersionID for versioned buckets in API

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -60,3 +60,4 @@ Moto is written by Steve Pulec with contributions from:
 * [Kyle Jones](https://github.com/Kerl1310)
 * [Mickaël Schoentgen](https://github.com/BoboTiG)
 * [Ariel Beck](https://github.com/arielb135)
+* [Roman Rader](https://github.com/rrader/)

--- a/moto/s3/responses.py
+++ b/moto/s3/responses.py
@@ -1272,6 +1272,9 @@ class ResponseObject(_TemplateEnvironmentMixin, ActionAuthenticatorMixin):
         elif key is None:
             raise MissingVersion()
 
+        if key.version_id:
+            response_headers["x-amz-version-id"] = key.version_id
+
         if key.storage_class == "GLACIER":
             raise InvalidObjectState(storage_class="GLACIER")
         if if_unmodified_since:

--- a/tests/test_s3/test_s3.py
+++ b/tests/test_s3/test_s3.py
@@ -3562,6 +3562,7 @@ def test_boto3_put_object_tagging_on_earliest_version():
 
     # Older version has tags while the most recent does not
     resp = s3.get_object_tagging(Bucket=bucket_name, Key=key, VersionId=first_object.id)
+    resp["VersionId"].should.equal(first_object.id)
     resp["ResponseMetadata"]["HTTPStatusCode"].should.equal(200)
     sorted_tagset = sorted(resp["TagSet"], key=lambda t: t["Key"])
     sorted_tagset.should.equal(
@@ -3571,6 +3572,7 @@ def test_boto3_put_object_tagging_on_earliest_version():
     resp = s3.get_object_tagging(
         Bucket=bucket_name, Key=key, VersionId=second_object.id
     )
+    resp["VersionId"].should.equal(second_object.id)
     resp["ResponseMetadata"]["HTTPStatusCode"].should.equal(200)
     resp["TagSet"].should.equal([])
 


### PR DESCRIPTION
Regarding the API docs, https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3.html#S3.Client.get_object_tagging `get_object_tagging` method (as well as some others get_object related methods) should return `VersionId` in response.

The current implementation of moto does not return this value which makes it incompatible with real API for this use case.

This PR makes a small change by adding `x-amz-version-id` header to the response in case version exists.