### PR TITLE
Add RDS functionality: export tasks

### DIFF
--- a/IMPLEMENTATION_COVERAGE.md
+++ b/IMPLEMENTATION_COVERAGE.md
@@ -3800,7 +3800,7 @@
 
 ## rds
 <details>
-<summary>17% implemented</summary>
+<summary>19% implemented</summary>
 
 - [ ] add_role_to_db_cluster
 - [ ] add_role_to_db_instance
@@ -3809,7 +3809,7 @@
 - [ ] apply_pending_maintenance_action
 - [ ] authorize_db_security_group_ingress
 - [ ] backtrack_db_cluster
-- [ ] cancel_export_task
+- [X] cancel_export_task
 - [ ] copy_db_cluster_parameter_group
 - [ ] copy_db_cluster_snapshot
 - [ ] copy_db_parameter_group
@@ -3880,7 +3880,7 @@
 - [ ] describe_event_categories
 - [ ] describe_event_subscriptions
 - [ ] describe_events
-- [ ] describe_export_tasks
+- [X] describe_export_tasks
 - [ ] describe_global_clusters
 - [ ] describe_installation_media
 - [X] describe_option_group_options
@@ -3938,7 +3938,7 @@
 - [X] start_db_cluster
 - [ ] start_db_instance
 - [ ] start_db_instance_automated_backups_replication
-- [ ] start_export_task
+- [X] start_export_task
 - [ ] stop_activity_stream
 - [X] stop_db_cluster
 - [ ] stop_db_instance

--- a/moto/rds2/exceptions.py
+++ b/moto/rds2/exceptions.py
@@ -147,3 +147,33 @@ class DBClusterSnapshotAlreadyExistsError(RDSClientError):
                 database_snapshot_identifier
             ),
         )
+
+
+class ExportTaskAlreadyExistsError(RDSClientError):
+    def __init__(self, export_task_identifier):
+        super().__init__(
+            "ExportTaskAlreadyExistsFault",
+            "Cannot start export task because a task with the identifier {} already exists.".format(
+                export_task_identifier
+            ),
+        )
+
+
+class ExportTaskNotFoundError(RDSClientError):
+    def __init__(self, export_task_identifier):
+        super().__init__(
+            "ExportTaskNotFoundFault",
+            "Cannot cancel export task because a task with the identifier {} is not exist.".format(
+                export_task_identifier
+            ),
+        )
+
+
+class InvalidExportSourceStateError(RDSClientError):
+    def __init__(self, status):
+        super().__init__(
+            "InvalidExportSourceStateFault",
+            "Export source should be 'available' but current status is {}.".format(
+                status
+            ),
+        )

--- a/tests/test_rds2/test_rds2_export_tasks.py
+++ b/tests/test_rds2/test_rds2_export_tasks.py
@@ -1,0 +1,160 @@
+import boto3
+import pytest
+import sure  # noqa # pylint: disable=unused-import
+
+from botocore.exceptions import ClientError
+from moto import mock_rds2
+from moto.core import ACCOUNT_ID
+
+
+def _prepare_db_snapshot(client, snapshot_name="snapshot-1"):
+    client.create_db_instance(
+        DBInstanceIdentifier="db-primary-1",
+        AllocatedStorage=10,
+        Engine="postgres",
+        DBName="staging-postgres",
+        DBInstanceClass="db.m1.small",
+        MasterUsername="root",
+        MasterUserPassword="hunter2",
+        Port=1234,
+        DBSecurityGroups=["my_sg"],
+    )
+    resp = client.create_db_snapshot(
+        DBInstanceIdentifier="db-primary-1", DBSnapshotIdentifier=snapshot_name
+    )
+    return resp["DBSnapshot"]["DBSnapshotArn"]
+
+
+@mock_rds2
+def test_start_export_task_fails_unknown_snapshot():
+    client = boto3.client("rds", region_name="us-west-2")
+
+    with pytest.raises(ClientError) as ex:
+        client.start_export_task(
+            ExportTaskIdentifier="export-snapshot-1",
+            SourceArn=f"arn:aws:rds:us-west-2:{ACCOUNT_ID}:snapshot:snapshot-1",
+            S3BucketName="export-bucket",
+            IamRoleArn="",
+            KmsKeyId="",
+        )
+
+    err = ex.value.response["Error"]
+    err["Code"].should.equal("DBSnapshotNotFound")
+    err["Message"].should.equal("DBSnapshot snapshot-1 not found.")
+
+
+@mock_rds2
+def test_start_export_task():
+    client = boto3.client("rds", region_name="us-west-2")
+    source_arn = _prepare_db_snapshot(client)
+
+    export = client.start_export_task(
+        ExportTaskIdentifier="export-snapshot-1",
+        SourceArn=source_arn,
+        S3BucketName="export-bucket",
+        S3Prefix="snaps/",
+        IamRoleArn="arn:aws:iam:::role/export-role",
+        KmsKeyId="arn:aws:kms:::key/0ea3fef3-80a7-4778-9d8c-1c0c6EXAMPLE",
+        ExportOnly=["schema.table"],
+    )
+
+    export["ExportTaskIdentifier"].should.equal("export-snapshot-1")
+    export["SourceArn"].should.equal(source_arn)
+    export["S3Bucket"].should.equal("export-bucket")
+    export["S3Prefix"].should.equal("snaps/")
+    export["IamRoleArn"].should.equal("arn:aws:iam:::role/export-role")
+    export["KmsKeyId"].should.equal(
+        "arn:aws:kms:::key/0ea3fef3-80a7-4778-9d8c-1c0c6EXAMPLE"
+    )
+    export["ExportOnly"].should.equal(["schema.table"])
+
+
+@mock_rds2
+def test_start_export_task_fail_already_exists():
+    client = boto3.client("rds", region_name="us-west-2")
+    source_arn = _prepare_db_snapshot(client)
+
+    client.start_export_task(
+        ExportTaskIdentifier="export-snapshot-1",
+        SourceArn=source_arn,
+        S3BucketName="export-bucket",
+        IamRoleArn="",
+        KmsKeyId="",
+    )
+    with pytest.raises(ClientError) as ex:
+        client.start_export_task(
+            ExportTaskIdentifier="export-snapshot-1",
+            SourceArn=source_arn,
+            S3BucketName="export-bucket",
+            IamRoleArn="",
+            KmsKeyId="",
+        )
+
+    err = ex.value.response["Error"]
+    err["Code"].should.equal("ExportTaskAlreadyExistsFault")
+    err["Message"].should.equal(
+        "Cannot start export task because a task with the identifier export-snapshot-1 already exists."
+    )
+
+
+@mock_rds2
+def test_cancel_export_task_fails_unknown_task():
+    client = boto3.client("rds", region_name="us-west-2")
+    with pytest.raises(ClientError) as ex:
+        client.cancel_export_task(ExportTaskIdentifier="export-snapshot-1")
+
+    err = ex.value.response["Error"]
+    err["Code"].should.equal("ExportTaskNotFoundFault")
+    err["Message"].should.equal(
+        "Cannot cancel export task because a task with the identifier export-snapshot-1 is not exist."
+    )
+
+
+@mock_rds2
+def test_cancel_export_task():
+    client = boto3.client("rds", region_name="us-west-2")
+    source_arn = _prepare_db_snapshot(client)
+
+    client.start_export_task(
+        ExportTaskIdentifier="export-snapshot-1",
+        SourceArn=source_arn,
+        S3BucketName="export-bucket",
+        IamRoleArn="",
+        KmsKeyId="",
+    )
+
+    export = client.cancel_export_task(ExportTaskIdentifier="export-snapshot-1")
+
+    export["ExportTaskIdentifier"].should.equal("export-snapshot-1")
+    export["Status"].should.equal("canceled")
+
+
+@mock_rds2
+def test_describe_export_tasks():
+    client = boto3.client("rds", region_name="us-west-2")
+    source_arn = _prepare_db_snapshot(client)
+    client.start_export_task(
+        ExportTaskIdentifier="export-snapshot-1",
+        SourceArn=source_arn,
+        S3BucketName="export-bucket",
+        IamRoleArn="",
+        KmsKeyId="",
+    )
+
+    exports = client.describe_export_tasks().get("ExportTasks")
+
+    exports.should.have.length_of(1)
+    exports[0]["ExportTaskIdentifier"].should.equal("export-snapshot-1")
+
+
+@mock_rds2
+def test_describe_export_tasks_fails_unknown_task():
+    client = boto3.client("rds", region_name="us-west-2")
+    with pytest.raises(ClientError) as ex:
+        client.describe_export_tasks(ExportTaskIdentifier="export-snapshot-1")
+
+    err = ex.value.response["Error"]
+    err["Code"].should.equal("ExportTaskNotFoundFault")
+    err["Message"].should.equal(
+        "Cannot cancel export task because a task with the identifier export-snapshot-1 is not exist."
+    )


### PR DESCRIPTION
Hi team.
I'm implementing RDS operators for Aifrow and I'm going to use moto for testing purposes.
So I need to implement some methods for mock_rds2

* DB instance copy snapshot method: #4790
* Cluster snapshot methods: #4790
* **Export task methods (cancel_export_task, describe_export_tasks, start_export_task)**
* Event subscriptions (create_event_subscription, delete_event_subscription, describe_event_subscriptions)
