### PR TITLE
AWS Batch containerProperties.resourceRequirements as strings

### DIFF
--- a/moto/batch/models.py
+++ b/moto/batch/models.py
@@ -265,17 +265,19 @@ class JobDefinition(CloudFormationModel):
         )
 
         if required_resource:
-            return required_resource[0]["value"]
+            if req_type == "vcpus":
+                return float(required_resource[0]["value"])
+            elif req_type == "memory":
+                return int(required_resource[0]["value"])
+            else:
+                return required_resource[0]["value"]
         else:
             return self.container_properties.get(req_type, default)
 
     def _validate(self):
+        # For future use when containers arnt the only thing in batch
         if self.type not in ("container",):
             raise ClientException('type must be one of "container"')
-
-        # For future use when containers arnt the only thing in batch
-        if self.type != "container":
-            raise NotImplementedError()
 
         if not isinstance(self.parameters, dict):
             raise ClientException("parameters must be a string to string map")
@@ -292,7 +294,7 @@ class JobDefinition(CloudFormationModel):
         vcpus = self._get_resource_requirement("vcpus")
         if vcpus is None:
             raise ClientException("containerProperties must contain vcpus")
-        if vcpus < 1:
+        if vcpus <= 0:
             raise ClientException("container vcpus limit must be greater than 0")
 
     def update(

--- a/tests/test_batch/test_batch_task_definition.py
+++ b/tests/test_batch/test_batch_task_definition.py
@@ -195,25 +195,20 @@ def register_job_def(batch_client, definition_name="sleep10", use_resource_reqs=
         container_properties.update(
             {
                 "resourceRequirements": [
-                    {"value": "1", "type": "VCPU"},
-                    {"value": str(random.randint(4, 128)), "type": "MEMORY"},
+                    {"value": "0.25", "type": "VCPU"},
+                    {"value": "512", "type": "MEMORY"},
                 ]
             }
         )
     else:
         container_properties.update(
-            {"memory": random.randint(4, 128), "vcpus": 1,}
+            {"memory": 128, "vcpus": 1,}
         )
 
     return batch_client.register_job_definition(
         jobDefinitionName=definition_name,
         type="container",
-        containerProperties={
-            "image": "busybox",
-            "vcpus": 1,
-            "memory": random.randint(4, 128),
-            "command": ["sleep", "10"],
-        },
+        containerProperties=container_properties,
     )
 
 


### PR DESCRIPTION
Closes #4806

Seems like part of the cause was that the tests were building a `containerProperties` argument, but then discarding it. Maybe it was a git merge that went wrong some time in the past? Anyway, I've updated it so it actually tests what is intended - which failed as per the issue. Fixed that by coercing the fields to the appropriate types.

I've also removed the randomisation, so that the tests are deterministic and reproducible. It only covers one combination of vCPU and memory, but I think thats enough. Note that AWS Batch on Fargate uses partial vCPUs which might be a bit unexpected, so thats why it is testing 0.25 for vCPU via `resourceRequirements`.