### PR TITLE
FIX: Cognito-idp

### DIFF
--- a/moto/cognitoidp/models.py
+++ b/moto/cognitoidp/models.py
@@ -1509,7 +1509,7 @@ class CognitoIdpBackend(BaseBackend):
                     "TokenType": "Bearer",
                 }
             }
-        elif auth_flow in ["REFRESH_TOKEN", "REFRESH_TOKEN_AUTH"]:
+        elif auth_flow in ("REFRESH_TOKEN", "REFRESH_TOKEN_AUTH"):
             refresh_token = auth_parameters.get("REFRESH_TOKEN")
             if not refresh_token:
                 raise ResourceNotFoundError(refresh_token)

--- a/moto/cognitoidp/models.py
+++ b/moto/cognitoidp/models.py
@@ -1509,7 +1509,7 @@ class CognitoIdpBackend(BaseBackend):
                     "TokenType": "Bearer",
                 }
             }
-        elif auth_flow == "REFRESH_TOKEN":
+        elif auth_flow in ["REFRESH_TOKEN", "REFRESH_TOKEN_AUTH"]:
             refresh_token = auth_parameters.get("REFRESH_TOKEN")
             if not refresh_token:
                 raise ResourceNotFoundError(refresh_token)

--- a/moto/cognitoidp/models.py
+++ b/moto/cognitoidp/models.py
@@ -1106,6 +1106,7 @@ class CognitoIdpBackend(BaseBackend):
                 "AccessToken": access_token,
                 "RefreshToken": refresh_token,
                 "ExpiresIn": expires_in,
+                "TokenType": "Bearer",
             }
         }
 
@@ -1538,6 +1539,7 @@ class CognitoIdpBackend(BaseBackend):
                     "IdToken": id_token,
                     "AccessToken": access_token,
                     "ExpiresIn": expires_in,
+                    "TokenType": "Bearer",
                 }
             }
         else:

--- a/moto/cognitoidp/models.py
+++ b/moto/cognitoidp/models.py
@@ -1529,8 +1529,8 @@ class CognitoIdpBackend(BaseBackend):
                     raise NotAuthorizedError(secret_hash)
 
             (
-                id_token,
                 access_token,
+                id_token,
                 expires_in,
             ) = user_pool.create_tokens_from_refresh_token(refresh_token)
 


### PR DESCRIPTION
Minor fixes to cognito-idp:

* Added missing `TokenType` to  all `AuthenticationResults`
* `REFRESH_TOKEN_AUTH` flow is an alias for `REFRESH_TOKEN` flow, so can be handled by the same logic
* During token refresh, access_token and id_token were incorrectly switched