### PR TITLE
Addition of bucket name when creating a key object

### DIFF
--- a/moto/s3/models.py
+++ b/moto/s3/models.py
@@ -1614,6 +1614,7 @@ class S3Backend(BaseBackend, CloudWatchMetricProvider):
 
         new_key = FakeKey(
             name=key_name,
+            bucket_name=bucket_name,
             value=value,
             storage=storage,
             etag=etag,

--- a/tests/test_s3/test_s3.py
+++ b/tests/test_s3/test_s3.py
@@ -5315,3 +5315,31 @@ def test_head_versioned_key_in_not_versioned_bucket():
 
     response = ex.value.response
     assert response["Error"]["Code"] == "400"
+
+
+@mock_s3
+def test_objects_tagging_with_same_key_name():
+    s3 = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
+    key_name = "file.txt"
+
+    bucket1 = "bucket-1"
+    s3.create_bucket(Bucket=bucket1)
+    tagging = "variable=one"
+
+    s3.put_object(Bucket=bucket1, Body=b"test", Key=key_name, Tagging=tagging)
+
+    bucket2 = "bucket-2"
+    s3.create_bucket(Bucket=bucket2)
+    tagging2 = "variable=two"
+
+    s3.put_object(Bucket=bucket2, Body=b"test", Key=key_name, Tagging=tagging2)
+
+    variable1 = s3.get_object_tagging(Bucket=bucket1, Key=key_name)["TagSet"][0][
+        "Value"
+    ]
+    variable2 = s3.get_object_tagging(Bucket=bucket2, Key=key_name)["TagSet"][0][
+        "Value"
+    ]
+
+    assert variable1 == "one"
+    assert variable2 == "two"


### PR DESCRIPTION
This PR addresses issue localstack/localstack#5121 where the user describes that having the same key_name in different bucket triggers the objects to share the same tags.

Changes:
- Addition of bucket name parameter during key object creation.
- Test creation that asserts that the issue is resolved.