### PR TITLE
SES: Fix GetSendStatistics response template

### DIFF
--- a/moto/ses/responses.py
+++ b/moto/ses/responses.py
@@ -431,13 +431,13 @@ GET_SEND_STATISTICS = """<GetSendStatisticsResponse xmlns="http://ses.amazonaws.
   <GetSendStatisticsResult>
       <SendDataPoints>
         {% for statistics in all_statistics %}
-            <item>
+            <member>
                 <DeliveryAttempts>{{ statistics["DeliveryAttempts"] }}</DeliveryAttempts>
                 <Rejects>{{ statistics["Rejects"] }}</Rejects>
                 <Bounces>{{ statistics["Bounces"] }}</Bounces>
                 <Complaints>{{ statistics["Complaints"] }}</Complaints>
-                <Timestamp>{{ statistics["Timestamp"] }}</Timestamp>
-            </item>
+                <Timestamp>{{ statistics["Timestamp"].isoformat() }}</Timestamp>
+            </member>
         {% endfor %}
       </SendDataPoints>
   </GetSendStatisticsResult>

--- a/tests/test_ses/test_server.py
+++ b/tests/test_ses/test_server.py
@@ -1,3 +1,6 @@
+from datetime import datetime
+import re
+
 import sure  # noqa # pylint: disable=unused-import
 
 import moto.server as server
@@ -13,3 +16,16 @@ def test_ses_list_identities():
 
     res = test_client.get("/?Action=ListIdentities")
     res.data.should.contain(b"ListIdentitiesResponse")
+
+
+def test_ses_get_send_statistics():
+    backend = server.create_backend_app("ses")
+    test_client = backend.test_client()
+
+    res = test_client.get("/?Action=GetSendStatistics")
+    res.data.should.contain(b"GetSendStatisticsResponse")
+
+    # Timestamps must be in ISO 8601 format
+    groups = re.search("<Timestamp>(.*)</Timestamp>", res.data.decode("utf-8"))
+    timestamp = groups.groups()[0]
+    datetime.fromisoformat(timestamp)

--- a/tests/test_ses/test_server.py
+++ b/tests/test_ses/test_server.py
@@ -28,4 +28,4 @@ def test_ses_get_send_statistics():
     # Timestamps must be in ISO 8601 format
     groups = re.search("<Timestamp>(.*)</Timestamp>", res.data.decode("utf-8"))
     timestamp = groups.groups()[0]
-    datetime.fromisoformat(timestamp)
+    datetime.strptime(timestamp, "%Y-%m-%dT%H:%M:%S.%f")


### PR DESCRIPTION
This PR makes following fixes to the response for GetSendStatistics call:

- Change XML tags of statistics items to comply with upstream AWS response.
  Closes https://github.com/localstack/localstack/issues/5074
  AWS uses the XML tag `<member>` to represent each statictics object, not `<item>`

- Change timestamp representation to ISO 8601 format.
  Closes https://github.com/localstack/localstack/issues/3645.
  Currently the str representation of Python datetime is used, which causes various clients to fail timestamp parsing since they expect an ISO timestamp.