### PR TITLE
Increase Batch timeouts, in case Docker takes a while to start

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -104,7 +104,7 @@ jobs:
         pip install -r requirements-dev.txt
     - name: Lint with flake8
       run:
-        make lint
+        echo make lint
 
   test:
     name: Unit test
@@ -144,7 +144,7 @@ jobs:
         pip install "coverage<=4.5.4"
     - name: Test with pytest
       run: |
-        pytest -sv ./tests/test_batch
+        pytest -sv ./tests/test_batch --durations 10
     - name: "Upload coverage to Codecov"
       if: ${{ github.repository == 'spulec/moto'}}
       uses: codecov/codecov-action@v1
@@ -193,7 +193,7 @@ jobs:
       env:
         TEST_SERVER_MODE: ${{ true }}
       run: |
-        pytest -sv ./tests/test_batch
+        pytest -sv ./tests/test_batch --durations 10
     - name: "Upload coverage to Codecov"
       if: ${{ github.repository == 'spulec/moto'}}
       uses: codecov/codecov-action@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -144,7 +144,7 @@ jobs:
         pip install "coverage<=4.5.4"
     - name: Test with pytest
       run: |
-        pytest -sv ./tests/test_batch --durations 10
+        pytest -sv ./tests/test_batch/test_batch_jobs.py::test_terminate_job --durations 10
     - name: "Upload coverage to Codecov"
       if: ${{ github.repository == 'spulec/moto'}}
       uses: codecov/codecov-action@v1
@@ -193,7 +193,7 @@ jobs:
       env:
         TEST_SERVER_MODE: ${{ true }}
       run: |
-        pytest -sv ./tests/test_batch --durations 10
+        pytest -sv ./tests/test_batch/test_batch_jobs.py::test_terminate_job --durations 10
     - name: "Upload coverage to Codecov"
       if: ${{ github.repository == 'spulec/moto'}}
       uses: codecov/codecov-action@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -144,7 +144,7 @@ jobs:
         pip install "coverage<=4.5.4"
     - name: Test with pytest
       run: |
-        pytest -sv ./tests/test_batch/test_batch_jobs.py --durations 10
+        pytest -sv ./tests/test_batch --durations 10
     - name: "Upload coverage to Codecov"
       if: ${{ github.repository == 'spulec/moto'}}
       uses: codecov/codecov-action@v1
@@ -193,7 +193,7 @@ jobs:
       env:
         TEST_SERVER_MODE: ${{ true }}
       run: |
-        pytest -sv ./tests/test_batch/test_batch_jobs.py --durations 10
+        pytest -sv ./tests/test_batch --durations 10
     - name: "Upload coverage to Codecov"
       if: ${{ github.repository == 'spulec/moto'}}
       uses: codecov/codecov-action@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -144,7 +144,7 @@ jobs:
         pip install "coverage<=4.5.4"
     - name: Test with pytest
       run: |
-        make test-only
+        pytest -sv ./tests/test_batch
     - name: "Upload coverage to Codecov"
       if: ${{ github.repository == 'spulec/moto'}}
       uses: codecov/codecov-action@v1
@@ -193,7 +193,7 @@ jobs:
       env:
         TEST_SERVER_MODE: ${{ true }}
       run: |
-        make test-only
+        pytest -sv ./tests/test_batch
     - name: "Upload coverage to Codecov"
       if: ${{ github.repository == 'spulec/moto'}}
       uses: codecov/codecov-action@v1
@@ -217,6 +217,7 @@ jobs:
           serverlogs/*
 
   terraform:
+    if: ${{ false }}
     name: Terraform Tests
     runs-on: ubuntu-latest
     needs: terraformcache

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -104,7 +104,7 @@ jobs:
         pip install -r requirements-dev.txt
     - name: Lint with flake8
       run:
-        echo make lint
+        make lint
 
   test:
     name: Unit test
@@ -144,7 +144,7 @@ jobs:
         pip install "coverage<=4.5.4"
     - name: Test with pytest
       run: |
-        pytest -sv ./tests/test_batch --durations 10
+        make test-only
     - name: "Upload coverage to Codecov"
       if: ${{ github.repository == 'spulec/moto'}}
       uses: codecov/codecov-action@v1
@@ -193,7 +193,7 @@ jobs:
       env:
         TEST_SERVER_MODE: ${{ true }}
       run: |
-        pytest -sv ./tests/test_batch --durations 10
+        make test-only
     - name: "Upload coverage to Codecov"
       if: ${{ github.repository == 'spulec/moto'}}
       uses: codecov/codecov-action@v1
@@ -217,7 +217,6 @@ jobs:
           serverlogs/*
 
   terraform:
-    if: ${{ false }}
     name: Terraform Tests
     runs-on: ubuntu-latest
     needs: terraformcache

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -144,7 +144,7 @@ jobs:
         pip install "coverage<=4.5.4"
     - name: Test with pytest
       run: |
-        pytest -sv ./tests/test_batch/test_batch_jobs.py::test_terminate_job --durations 10
+        pytest -sv ./tests/test_batch/test_batch_jobs.py --durations 10
     - name: "Upload coverage to Codecov"
       if: ${{ github.repository == 'spulec/moto'}}
       uses: codecov/codecov-action@v1
@@ -193,7 +193,7 @@ jobs:
       env:
         TEST_SERVER_MODE: ${{ true }}
       run: |
-        pytest -sv ./tests/test_batch/test_batch_jobs.py::test_terminate_job --durations 10
+        pytest -sv ./tests/test_batch/test_batch_jobs.py --durations 10
     - name: "Upload coverage to Codecov"
       if: ${{ github.repository == 'spulec/moto'}}
       uses: codecov/codecov-action@v1

--- a/moto/batch/models.py
+++ b/moto/batch/models.py
@@ -609,8 +609,12 @@ class Job(threading.Thread, BaseModel, DockerModel):
                     )
                     print(f"Attempt duration is set. Max time = {max_time}")
 
+                print(f"Status==running: {container.status == 'running'}")
+                print(f"Self.stop: {self.stop}")
                 while container.status == "running" and not self.stop:
+                    print("Reloading container...")
                     container.reload()
+                    print("Container reloaded. Sleeping...")
                     time.sleep(0.5)
 
                     print(f"Check if {max_time} exceeds {datetime.datetime.now()}...")

--- a/moto/batch/models.py
+++ b/moto/batch/models.py
@@ -556,6 +556,7 @@ class Job(threading.Thread, BaseModel, DockerModel):
             # TODO setup ecs container instance
 
             self.job_started_at = datetime.datetime.now()
+            print(f"Step 1 at {datetime.datetime.now()}")
 
             # add host.docker.internal host on linux to emulate Mac + Windows behavior
             #   for communication with other mock AWS services running on localhost
@@ -564,20 +565,27 @@ class Job(threading.Thread, BaseModel, DockerModel):
                 if platform == "linux" or platform == "linux2"
                 else {}
             )
+            print(f"Step 2 at {datetime.datetime.now()}")
 
             environment["MOTO_HOST"] = settings.moto_server_host()
+            print(f"Step 3 at {datetime.datetime.now()}")
             environment["MOTO_PORT"] = settings.moto_server_port()
+            print(f"Step 4 at {datetime.datetime.now()}")
             environment[
                 "MOTO_HTTP_ENDPOINT"
             ] = f'{environment["MOTO_HOST"]}:{environment["MOTO_PORT"]}'
+            print(f"Step 5 at {datetime.datetime.now()}")
 
             run_kwargs = dict()
             network_name = settings.moto_network_name()
+            print(f"Step 6 at {datetime.datetime.now()}")
             network_mode = settings.moto_network_mode()
+            print(f"Step 7 at {datetime.datetime.now()}")
             if network_name:
                 run_kwargs["network"] = network_name
             elif network_mode:
                 run_kwargs["network_mode"] = network_mode
+            print(f"Step 8 at {datetime.datetime.now()}")
 
             log_config = docker.types.LogConfig(type=docker.types.LogConfig.types.JSON)
             self.job_state = "STARTING"

--- a/moto/batch/models.py
+++ b/moto/batch/models.py
@@ -595,21 +595,25 @@ class Job(threading.Thread, BaseModel, DockerModel):
                 extra_hosts=extra_hosts,
                 **run_kwargs,
             )
+            print(f"container is running: {container}")
             self.job_state = "RUNNING"
             try:
                 container.reload()
 
                 max_time = None
+                print(f"Job started at {self.job_started_at}")
                 if self._get_attempt_duration():
                     attempt_duration = self._get_attempt_duration()
                     max_time = self.job_started_at + datetime.timedelta(
                         seconds=attempt_duration
                     )
+                    print(f"Attempt duration is set. Max time = {max_time}")
 
                 while container.status == "running" and not self.stop:
                     container.reload()
                     time.sleep(0.5)
 
+                    print(f"Check if {max_time} exceeds {datetime.datetime.now()}...")
                     if max_time and datetime.datetime.now() > max_time:
                         raise Exception(
                             "Job time exceeded the configured attemptDurationSeconds"

--- a/moto/settings.py
+++ b/moto/settings.py
@@ -1,6 +1,9 @@
 import json
 import os
 
+from functools import lru_cache
+
+
 TEST_SERVER_MODE = os.environ.get("TEST_SERVER_MODE", "0").lower() == "true"
 INITIAL_NO_AUTH_ACTION_COUNT = float(
     os.environ.get("INITIAL_NO_AUTH_ACTION_COUNT", float("inf"))
@@ -55,6 +58,7 @@ def moto_server_port():
     return os.environ.get("MOTO_PORT") or "5000"
 
 
+@lru_cache()
 def moto_server_host():
     if is_docker():
         return get_docker_host()

--- a/tests/test_batch/test_batch_jobs.py
+++ b/tests/test_batch/test_batch_jobs.py
@@ -241,7 +241,7 @@ def test_cancel_pending_job():
     # We need to be able to cancel a job that has not been started yet
     # Locally, our jobs start so fast that we can't cancel them in time
     # So delay our job, by letting it depend on a slow-running job
-    commands = ["sleep", "1"]
+    commands = ["sleep", "10"]
     job_def_arn, queue_arn = prepare_job(batch_client, commands, iam_arn, "deptest")
 
     resp = batch_client.submit_job(
@@ -786,7 +786,7 @@ def test_submit_job_with_timeout_set_at_definition():
     _, _, _, iam_arn = _setup(ec2_client, iam_client)
 
     job_def_name = str(uuid4())[0:6]
-    commands = ["sleep", "3"]
+    commands = ["sleep", "30"]
     _, queue_arn = prepare_job(batch_client, commands, iam_arn, job_def_name)
     resp = batch_client.register_job_definition(
         jobDefinitionName=job_def_name,

--- a/tests/test_batch/test_batch_jobs.py
+++ b/tests/test_batch/test_batch_jobs.py
@@ -305,6 +305,7 @@ def _wait_for_job_status(client, job_id, status, seconds_to_wait=60):
         last_job_status = resp["jobs"][0]["status"]
         if last_job_status == status:
             break
+        time.sleep(0.1)
     else:
         raise RuntimeError(
             "Time out waiting for job status {status}!\n Last status: {last_status}".format(

--- a/tests/test_batch/test_batch_jobs.py
+++ b/tests/test_batch/test_batch_jobs.py
@@ -306,7 +306,6 @@ def _wait_for_job_status(client, job_id, status, seconds_to_wait=60):
         print(f"Job {job_id} has status {last_job_status}, waiting for {status}")
         if last_job_status == status:
             break
-        time.sleep(1)
     else:
         raise RuntimeError(
             "Time out waiting for job status {status}!\n Last status: {last_status}".format(

--- a/tests/test_batch/test_batch_jobs.py
+++ b/tests/test_batch/test_batch_jobs.py
@@ -300,13 +300,11 @@ def test_cancel_running_job():
 def _wait_for_job_status(client, job_id, status, seconds_to_wait=60):
     wait_time = datetime.datetime.now() + datetime.timedelta(seconds=seconds_to_wait)
     last_job_status = None
-    cnt = 0
     while datetime.datetime.now() < wait_time:
         resp = client.describe_jobs(jobs=[job_id])
+        if last_job_status != resp["jobs"][0]["status"]:
+            print(f"Describing jobs: status changed from {last_job_status} to {resp['jobs'][0]['status']} at {datetime.datetime.now()}")
         last_job_status = resp["jobs"][0]["status"]
-        if cnt % 20 == 0:
-            print(f"Job {job_id} has status {last_job_status}, waiting for {status}")
-        cnt = cnt + 1
         if last_job_status == status:
             break
     else:

--- a/tests/test_batch/test_batch_jobs.py
+++ b/tests/test_batch/test_batch_jobs.py
@@ -300,10 +300,13 @@ def test_cancel_running_job():
 def _wait_for_job_status(client, job_id, status, seconds_to_wait=60):
     wait_time = datetime.datetime.now() + datetime.timedelta(seconds=seconds_to_wait)
     last_job_status = None
+    cnt = 0
     while datetime.datetime.now() < wait_time:
         resp = client.describe_jobs(jobs=[job_id])
         last_job_status = resp["jobs"][0]["status"]
-        print(f"Job {job_id} has status {last_job_status}, waiting for {status}")
+        if cnt % 20 == 0:
+            print(f"Job {job_id} has status {last_job_status}, waiting for {status}")
+        cnt = cnt + 1
         if last_job_status == status:
             break
     else:

--- a/tests/test_batch/test_batch_jobs.py
+++ b/tests/test_batch/test_batch_jobs.py
@@ -259,7 +259,7 @@ def test_cancel_pending_job():
     job_id = resp["jobId"]
 
     batch_client.cancel_job(jobId=job_id, reason="test_cancel")
-    _wait_for_job_status(batch_client, job_id, "FAILED", seconds_to_wait=30)
+    _wait_for_job_status(batch_client, job_id, "FAILED", seconds_to_wait=60)
 
     resp = batch_client.describe_jobs(jobs=[job_id])
     resp["jobs"][0]["jobName"].should.equal("test_job_name")
@@ -290,14 +290,14 @@ def test_cancel_running_job():
 
     batch_client.cancel_job(jobId=job_id, reason="test_cancel")
     # We cancelled too late, the job was already running. Now we just wait for it to succeed
-    _wait_for_job_status(batch_client, job_id, "SUCCEEDED", seconds_to_wait=5)
+    _wait_for_job_status(batch_client, job_id, "SUCCEEDED", seconds_to_wait=60)
 
     resp = batch_client.describe_jobs(jobs=[job_id])
     resp["jobs"][0]["jobName"].should.equal("test_job_name")
     resp["jobs"][0].shouldnt.have.key("statusReason")
 
 
-def _wait_for_job_status(client, job_id, status, seconds_to_wait=30):
+def _wait_for_job_status(client, job_id, status, seconds_to_wait=60):
     wait_time = datetime.datetime.now() + datetime.timedelta(seconds=seconds_to_wait)
     last_job_status = None
     while datetime.datetime.now() < wait_time:

--- a/tests/test_batch/test_batch_jobs.py
+++ b/tests/test_batch/test_batch_jobs.py
@@ -476,7 +476,7 @@ def test_failed_dependencies():
             "image": "busybox:latest",
             "vcpus": 1,
             "memory": 128,
-            "command": ["exi1", "1"],
+            "command": ["exit", "1"],
         },
     )
     job_def_arn_failure = resp["jobDefinitionArn"]

--- a/tests/test_batch/test_batch_jobs.py
+++ b/tests/test_batch/test_batch_jobs.py
@@ -303,8 +303,10 @@ def _wait_for_job_status(client, job_id, status, seconds_to_wait=60):
     while datetime.datetime.now() < wait_time:
         resp = client.describe_jobs(jobs=[job_id])
         last_job_status = resp["jobs"][0]["status"]
+        print(f"Job {job_id} has status {last_job_status}, waiting for {status}")
         if last_job_status == status:
             break
+        time.sleep(1)
     else:
         raise RuntimeError(
             "Time out waiting for job status {status}!\n Last status: {last_status}".format(

--- a/tests/test_sqs/test_sqs_cloudformation.py
+++ b/tests/test_sqs/test_sqs_cloudformation.py
@@ -55,7 +55,7 @@ def test_describe_stack_subresources():
     template_body = simple_queue.substitute(q_name=q_name)
     cf.create_stack(StackName=stack_name, TemplateBody=template_body)
 
-    queue_urls = client.list_queues()["QueueUrls"]
+    queue_urls = client.list_queues(QueueNamePrefix=q_name)["QueueUrls"]
     assert any(["{}/{}".format(ACCOUNT_ID, q_name) in url for url in queue_urls])
 
     stack = res.Stack(stack_name)
@@ -76,7 +76,7 @@ def test_list_stack_resources():
     template_body = simple_queue.substitute(q_name=q_name)
     cf.create_stack(StackName=stack_name, TemplateBody=template_body)
 
-    queue_urls = client.list_queues()["QueueUrls"]
+    queue_urls = client.list_queues(QueueNamePrefix=q_name)["QueueUrls"]
     assert any(["{}/{}".format(ACCOUNT_ID, q_name) in url for url in queue_urls])
 
     queue = cf.list_stack_resources(StackName=stack_name)["StackResourceSummaries"][0]
@@ -98,7 +98,7 @@ def test_create_from_cloudformation_json_with_tags():
     response = cf.describe_stack_resources(StackName=stack_name)
     q_name = response["StackResources"][0]["PhysicalResourceId"]
 
-    all_urls = client.list_queues()["QueueUrls"]
+    all_urls = client.list_queues(QueueNamePrefix=q_name)["QueueUrls"]
     queue_url = [url for url in all_urls if url.endswith(q_name)][0]
 
     queue_tags = client.list_queue_tags(QueueUrl=queue_url)["Tags"]


### PR DESCRIPTION
Github Actions started failing on batch tests, exposing:
 - A timing issue where failing a job too late would not actually fail it
 - Tests that were too dependent on Docker being fast - the moment Docker start-up takes longer than the usual 0.5 seconds, tests would fail.

Playing around with the `seconds_to_wait`-parameter ensures that the tests now wait a long time, in case Docker is slow.

This also fixes some SQS tests that would fail if too many queues were created in parallel.