### PR TITLE
ec2: Add GpuInfo to describe_instance_types

### DIFF
--- a/moto/ec2/responses/instances.py
+++ b/moto/ec2/responses/instances.py
@@ -871,6 +871,23 @@ EC2_DESCRIBE_INSTANCE_TYPES = """<?xml version="1.0" encoding="UTF-8"?>
                     {% endfor %}
                 </supportedArchitectures>
             </processorInfo>
+            {% if instance_type.get('GpuInfo', {})|length > 0 %}
+            <gpuInfo>
+                <gpus>
+                    {% for gpu in instance_type.get('GpuInfo').get('Gpus') %}
+                    <item>
+                        <count>{{ gpu['Count']|int }}</count>
+                        <manufacturer>{{ gpu['Manufacturer'] }}</manufacturer>
+                        <memoryInfo>
+                            <sizeInMiB>{{ gpu['MemoryInfo']['SizeInMiB']|int }}</sizeInMiB>
+                        </memoryInfo>
+                        <name>{{ gpu['Name'] }}</name>
+                    </item>
+                    {% endfor %}
+                </gpus>
+                <totalGpuMemoryInMiB>{{ instance_type['GpuInfo']['TotalGpuMemoryInMiB']|int }}</totalGpuMemoryInMiB>
+            </gpuInfo>
+            {% endif %}
         </item>
     {% endfor %}
     </instanceTypeSet>

--- a/tests/test_ec2/test_instance_types.py
+++ b/tests/test_ec2/test_instance_types.py
@@ -38,6 +38,49 @@ def test_describe_instance_types_filter_by_type():
 
 
 @mock_ec2
+def test_describe_instance_types_gpu_instance_types():
+    client = boto3.client("ec2", "us-east-1")
+    instance_types = client.describe_instance_types(
+        InstanceTypes=["p3.2xlarge", "g4ad.8xlarge"]
+    )
+
+    instance_types.should.have.key("InstanceTypes")
+    instance_types["InstanceTypes"].should_not.be.empty
+    instance_types["InstanceTypes"].should.have.length_of(2)
+    instance_types["InstanceTypes"][0]["GpuInfo"].should_not.be.empty
+    instance_types["InstanceTypes"][1]["GpuInfo"].should_not.be.empty
+
+    instance_type_to_gpu_info = {
+        instance_info["InstanceType"]: instance_info["GpuInfo"]
+        for instance_info in instance_types["InstanceTypes"]
+    }
+    assert instance_type_to_gpu_info == {
+        "g4ad.8xlarge": {
+            "Gpus": [
+                {
+                    "Count": 2,
+                    "Manufacturer": "AMD",
+                    "MemoryInfo": {"SizeInMiB": 8192},
+                    "Name": "Radeon Pro V520",
+                }
+            ],
+            "TotalGpuMemoryInMiB": 16384,
+        },
+        "p3.2xlarge": {
+            "Gpus": [
+                {
+                    "Count": 1,
+                    "Manufacturer": "NVIDIA",
+                    "MemoryInfo": {"SizeInMiB": 16384},
+                    "Name": "V100",
+                }
+            ],
+            "TotalGpuMemoryInMiB": 16384,
+        },
+    }
+
+
+@mock_ec2
 def test_describe_instance_types_unknown_type():
     client = boto3.client("ec2", "us-east-1")
 


### PR DESCRIPTION
## Testing

I have inspected the return result and saw that the instance types that should have Gpus do have the correct values.

For example, looking at the entry for `g4ad.8xlarge`:

```
{'GpuInfo': {'Gpus': [{'Count': 2,
                       'Manufacturer': 'AMD',
                       'MemoryInfo': {'SizeInMiB': 8192},
                       'Name': 'Radeon Pro V520'}],
             'TotalGpuMemoryInMiB': 16384},
 'InstanceStorageInfo': {'TotalSizeInGB': 1200},
 'InstanceType': 'g4ad.8xlarge',
 'MemoryInfo': {'SizeInMiB': 131072},
 'ProcessorInfo': {'SupportedArchitectures': ['x86_64']},
 'VCpuInfo': {'DefaultCores': 16,
              'DefaultThreadsPerCore': 2,
              'DefaultVCpus': 32}}
```