### PR TITLE
Allow "True" in SQS Queue boolean attributes

### DIFF
--- a/moto/sqs/models.py
+++ b/moto/sqs/models.py
@@ -327,7 +327,7 @@ class Queue(CloudFormationModel):
             if key in integer_fields:
                 value = int(value)
             if key in bool_fields:
-                value = value == "true" or value == "True"
+                value = value.lower() == "true"
 
             if key in ["Policy", "RedrivePolicy"] and value is not None:
                 continue

--- a/moto/sqs/models.py
+++ b/moto/sqs/models.py
@@ -327,7 +327,7 @@ class Queue(CloudFormationModel):
             if key in integer_fields:
                 value = int(value)
             if key in bool_fields:
-                value = value.lower() == "true"
+                value = str(value).lower() == "true"
 
             if key in ["Policy", "RedrivePolicy"] and value is not None:
                 continue

--- a/moto/sqs/models.py
+++ b/moto/sqs/models.py
@@ -327,7 +327,7 @@ class Queue(CloudFormationModel):
             if key in integer_fields:
                 value = int(value)
             if key in bool_fields:
-                value = value == "true"
+                value = value == "true" or value == "True"
 
             if key in ["Policy", "RedrivePolicy"] and value is not None:
                 continue

--- a/tests/test_cloudformation/test_cloudformation_stack_crud_boto3.py
+++ b/tests/test_cloudformation/test_cloudformation_stack_crud_boto3.py
@@ -264,10 +264,7 @@ dummy_redrive_template = {
         },
         "DeadLetterQueue": {
             "Type": "AWS::SQS::Queue",
-            "Properties": {
-                "QueueName": "deadletterqueue.fifo",
-                "FifoQueue": True
-                },
+            "Properties": {"QueueName": "deadletterqueue.fifo", "FifoQueue": True},
         },
     },
 }

--- a/tests/test_cloudformation/test_cloudformation_stack_crud_boto3.py
+++ b/tests/test_cloudformation/test_cloudformation_stack_crud_boto3.py
@@ -264,8 +264,10 @@ dummy_redrive_template = {
         },
         "DeadLetterQueue": {
             "Type": "AWS::SQS::Queue",
-            "QueueName": "deadletterqueue.fifo",
-            "Properties": {"FifoQueue": True},
+            "Properties": {
+                "QueueName": "deadletterqueue.fifo",
+                "FifoQueue": True
+                },
         },
     },
 }

--- a/tests/test_cloudformation/test_cloudformation_stack_crud_boto3.py
+++ b/tests/test_cloudformation/test_cloudformation_stack_crud_boto3.py
@@ -264,6 +264,7 @@ dummy_redrive_template = {
         },
         "DeadLetterQueue": {
             "Type": "AWS::SQS::Queue",
+            "QueueName": "deadletterqueue.fifo",
             "Properties": {"FifoQueue": True},
         },
     },

--- a/tests/test_sqs/test_sqs.py
+++ b/tests/test_sqs/test_sqs.py
@@ -95,12 +95,12 @@ def test_create_queue_with_different_attributes_fail():
         raise RuntimeError("Should of raised QueueAlreadyExists Exception")
 
     q_name2 = str(uuid4())[0:6]
-    response = sqs.create_queue(QueueName=q_name2, Attributes={"FifoQueue": "True"})
+    response = sqs.create_queue(QueueName=q_name2, Attributes={"FifoQueue": "tru"})
 
     attributes = {"VisibilityTimeout": "60"}
     sqs.set_queue_attributes(QueueUrl=response.get("QueueUrl"), Attributes=attributes)
 
-    new_response = sqs.create_queue(QueueName=q_name2, Attributes={"FifoQueue": "True"})
+    new_response = sqs.create_queue(QueueName=q_name2, Attributes={"FifoQueue": "tru"})
     new_response["QueueUrl"].should.equal(response.get("QueueUrl"))
 
 


### PR DESCRIPTION
This PR addresses issue localstack/localstack#5330. CDK sends the boolean parameters with a capitalized string but the behaviour should be the same as if it send a lowercase string.