### PR TITLE
Non-unittest classes use a lowercase setup-method

### DIFF
--- a/moto/core/models.py
+++ b/moto/core/models.py
@@ -142,8 +142,10 @@ class BaseMockAWS:
         )
         # Check whether the user has overridden the setUp-method
         has_setup_method = (
-            "setUp" in supermethods and unittest.TestCase in klass.__mro__
-        ) or "setup" in supermethods
+            ("setUp" in supermethods and unittest.TestCase in klass.__mro__)
+            or "setup" in supermethods
+            or "setup_method" in supermethods
+        )
 
         for attr in itertools.chain(direct_methods, defined_classes):
             if attr.startswith("_"):

--- a/moto/core/models.py
+++ b/moto/core/models.py
@@ -137,11 +137,13 @@ class BaseMockAWS:
             c for c in klass.__mro__ if c not in [unittest.TestCase, object]
         ]
         # Get a list of all userdefined methods
-        supermethods = itertools.chain(
-            *[get_direct_methods_of(c) for c in superclasses]
+        supermethods = list(
+            itertools.chain(*[get_direct_methods_of(c) for c in superclasses])
         )
         # Check whether the user has overridden the setUp-method
-        has_setup_method = "setUp" in supermethods
+        has_setup_method = (
+            "setUp" in supermethods and unittest.TestCase in klass.__mro__
+        ) or "setup" in supermethods
 
         for attr in itertools.chain(direct_methods, defined_classes):
             if attr.startswith("_"):

--- a/tests/test_core/test_decorator_calls.py
+++ b/tests/test_core/test_decorator_calls.py
@@ -125,6 +125,22 @@ class TestWithSetup(unittest.TestCase):
 
 
 @mock_s3
+class TestWithLowercaseSetup:
+    def setup(self):
+        s3 = boto3.client("s3", region_name="us-east-1")
+        s3.create_bucket(Bucket="mybucket")
+
+    def test_should_find_bucket(self):
+        s3 = boto3.client("s3", region_name="us-east-1")
+        assert s3.head_bucket(Bucket="mybucket") is not None
+
+    def test_should_not_find_unknown_bucket(self):
+        s3 = boto3.client("s3", region_name="us-east-1")
+        with pytest.raises(ClientError):
+            s3.head_bucket(Bucket="unknown_bucket")
+
+
+@mock_s3
 class TestWithPublicMethod(unittest.TestCase):
     def ensure_bucket_exists(self):
         s3 = boto3.client("s3", region_name="us-east-1")

--- a/tests/test_core/test_decorator_calls.py
+++ b/tests/test_core/test_decorator_calls.py
@@ -109,8 +109,9 @@ class TesterWithStaticmethod(object):
 
 
 @mock_s3
-class TestWithSetup(unittest.TestCase):
+class TestWithSetup_UppercaseU(unittest.TestCase):
     def setUp(self):
+        # This method will be executed automatically, provided we extend the TestCase-class
         s3 = boto3.client("s3", region_name="us-east-1")
         s3.create_bucket(Bucket="mybucket")
 
@@ -125,8 +126,9 @@ class TestWithSetup(unittest.TestCase):
 
 
 @mock_s3
-class TestWithLowercaseSetup:
-    def setup(self):
+class TestWithSetup_LowercaseU:
+    def setup(self, *args):
+        # This method will be executed automatically using pytest
         s3 = boto3.client("s3", region_name="us-east-1")
         s3.create_bucket(Bucket="mybucket")
 
@@ -138,6 +140,36 @@ class TestWithLowercaseSetup:
         s3 = boto3.client("s3", region_name="us-east-1")
         with pytest.raises(ClientError):
             s3.head_bucket(Bucket="unknown_bucket")
+
+
+@mock_s3
+class TestWithSetupMethod:
+    def setup_method(self, *args):
+        # This method will be executed automatically using pytest
+        s3 = boto3.client("s3", region_name="us-east-1")
+        s3.create_bucket(Bucket="mybucket")
+
+    def test_should_find_bucket(self):
+        s3 = boto3.client("s3", region_name="us-east-1")
+        assert s3.head_bucket(Bucket="mybucket") is not None
+
+    def test_should_not_find_unknown_bucket(self):
+        s3 = boto3.client("s3", region_name="us-east-1")
+        with pytest.raises(ClientError):
+            s3.head_bucket(Bucket="unknown_bucket")
+
+
+@mock_s3
+class TestWithInvalidSetupMethod:
+    def setupmethod(self):
+        s3 = boto3.client("s3", region_name="us-east-1")
+        s3.create_bucket(Bucket="mybucket")
+
+    def test_should_not_find_bucket(self):
+        # Name of setupmethod is not recognized, so it will not be executed
+        s3 = boto3.client("s3", region_name="us-east-1")
+        with pytest.raises(ClientError):
+            s3.head_bucket(Bucket="mybucket")
 
 
 @mock_s3


### PR DESCRIPTION
Fixes #4831 

Classes that extend the `unittest.TestCase` can have a `setUp`-method - classes that do not use unittest will use `setup` (lowercase).

~~This PR ensures both use-cases are supported.~~

Edit: Pytest also supports a `setup_method` option, as described here: https://docs.pytest.org/en/latest/how-to/xunit_setup.html

This PR now supports everything, as far as I can tell.

---------

As of Pytest 7.x, it looks like the `setup` and `setup_method` require a `function`-argument, that will be populated with the value of the test-function executed next: `def setup(self, function)`.
Our tests all use `def setup(self, *args):` to ensure it works in both pytest 7.x and 6.x