### PR TITLE
Restrict initiate_auth and admin_initiate_auth AuthFlow

### DIFF
--- a/moto/cognitoidp/models.py
+++ b/moto/cognitoidp/models.py
@@ -1126,7 +1126,9 @@ class CognitoIdpBackend(BaseBackend):
             }
         }
 
-    def _validate_auth_flow(self, auth_flow: str, valid_flows: typing.List[AuthFlow]) -> AuthFlow:
+    def _validate_auth_flow(
+        self, auth_flow: str, valid_flows: typing.List[AuthFlow]
+    ) -> AuthFlow:
         """ validate auth_flow value and convert auth_flow to enum """
 
         try:
@@ -1139,16 +1141,20 @@ class CognitoIdpBackend(BaseBackend):
             )
 
         if auth_flow not in valid_flows:
-            raise InvalidParameterException('Initiate Auth method not supported')
+            raise InvalidParameterException("Initiate Auth method not supported")
 
         return auth_flow
 
     def admin_initiate_auth(self, user_pool_id, client_id, auth_flow, auth_parameters):
         admin_auth_flows = [
-            AuthFlow.ADMIN_NO_SRP_AUTH, AuthFlow.ADMIN_USER_PASSWORD_AUTH, AuthFlow.REFRESH_TOKEN_AUTH,
-            AuthFlow.REFRESH_TOKEN
+            AuthFlow.ADMIN_NO_SRP_AUTH,
+            AuthFlow.ADMIN_USER_PASSWORD_AUTH,
+            AuthFlow.REFRESH_TOKEN_AUTH,
+            AuthFlow.REFRESH_TOKEN,
         ]
-        auth_flow = self._validate_auth_flow(auth_flow=auth_flow, valid_flows=admin_auth_flows)
+        auth_flow = self._validate_auth_flow(
+            auth_flow=auth_flow, valid_flows=admin_auth_flows
+        )
 
         user_pool = self.describe_user_pool(user_pool_id)
 
@@ -1471,11 +1477,16 @@ class CognitoIdpBackend(BaseBackend):
 
     def initiate_auth(self, client_id, auth_flow, auth_parameters):
         user_auth_flows = [
-            AuthFlow.USER_SRP_AUTH, AuthFlow.REFRESH_TOKEN_AUTH, AuthFlow.REFRESH_TOKEN, AuthFlow.CUSTOM_AUTH,
-            AuthFlow.USER_PASSWORD_AUTH
+            AuthFlow.USER_SRP_AUTH,
+            AuthFlow.REFRESH_TOKEN_AUTH,
+            AuthFlow.REFRESH_TOKEN,
+            AuthFlow.CUSTOM_AUTH,
+            AuthFlow.USER_PASSWORD_AUTH,
         ]
 
-        auth_flow = self._validate_auth_flow(auth_flow=auth_flow, valid_flows=user_auth_flows)
+        auth_flow = self._validate_auth_flow(
+            auth_flow=auth_flow, valid_flows=user_auth_flows
+        )
 
         user_pool = None
         for p in self.user_pools.values():

--- a/tests/test_cognitoidp/test_cognitoidp.py
+++ b/tests/test_cognitoidp/test_cognitoidp.py
@@ -2471,6 +2471,7 @@ def test_authentication_flow_invalid_flow():
         "'CUSTOM_AUTH', 'USER_PASSWORD_AUTH']"
     )
 
+
 @mock_cognitoidp
 def test_authentication_flow_invalid_user_flow():
     """ Pass a user authFlow to admin_initiate_auth """
@@ -2482,6 +2483,7 @@ def test_authentication_flow_invalid_user_flow():
     err = ex.value.response["Error"]
     err["Code"].should.equal("InvalidParameterException")
     err["Message"].should.equal("Initiate Auth method not supported")
+
 
 def user_authentication_flow(conn):
     username = str(uuid.uuid4())
@@ -3396,7 +3398,10 @@ def test_initiate_auth_invalid_auth_flow():
         conn.initiate_auth(
             ClientId=result["client_id"],
             AuthFlow="NO_SUCH_FLOW",
-            AuthParameters={"USERNAME": result["username"], "PASSWORD": result["password"]},
+            AuthParameters={
+                "USERNAME": result["username"],
+                "PASSWORD": result["password"],
+            },
         )
 
     err = ex.value.response["Error"]
@@ -3420,7 +3425,10 @@ def test_initiate_auth_invalid_admin_auth_flow():
         conn.initiate_auth(
             ClientId=result["client_id"],
             AuthFlow="ADMIN_USER_PASSWORD_AUTH",
-            AuthParameters={"USERNAME": result["username"], "PASSWORD": result["password"]},
+            AuthParameters={
+                "USERNAME": result["username"],
+                "PASSWORD": result["password"],
+            },
         )
 
     err = ex.value.response["Error"]

--- a/tests/test_cognitoidp/test_cognitoidp.py
+++ b/tests/test_cognitoidp/test_cognitoidp.py
@@ -2464,8 +2464,24 @@ def test_authentication_flow_invalid_flow():
 
     err = ex.value.response["Error"]
     err["Code"].should.equal("InvalidParameterException")
-    err["Message"].should.equal("Initiate Auth method not supported")
+    err["Message"].should.equal(
+        "1 validation error detected: Value 'NO_SUCH_FLOW' at 'authFlow' failed to satisfy constraint: "
+        "Member must satisfy enum value set: "
+        "['ADMIN_NO_SRP_AUTH', 'ADMIN_USER_PASSWORD_AUTH', 'USER_SRP_AUTH', 'REFRESH_TOKEN_AUTH', 'REFRESH_TOKEN', "
+        "'CUSTOM_AUTH', 'USER_PASSWORD_AUTH']"
+    )
 
+@mock_cognitoidp
+def test_authentication_flow_invalid_user_flow():
+    """ Pass a user authFlow to admin_initiate_auth """
+    conn = boto3.client("cognito-idp", "us-west-2")
+
+    with pytest.raises(ClientError) as ex:
+        authentication_flow(conn, "USER_PASSWORD_AUTH")
+
+    err = ex.value.response["Error"]
+    err["Code"].should.equal("InvalidParameterException")
+    err["Message"].should.equal("Initiate Auth method not supported")
 
 def user_authentication_flow(conn):
     username = str(uuid.uuid4())
@@ -3377,9 +3393,33 @@ def test_initiate_auth_invalid_auth_flow():
     with pytest.raises(ClientError) as ex:
         user_authentication_flow(conn)
 
-        result = conn.initiate_auth(
+        conn.initiate_auth(
             ClientId=result["client_id"],
             AuthFlow="NO_SUCH_FLOW",
+            AuthParameters={"USERNAME": result["username"], "PASSWORD": result["password"]},
+        )
+
+    err = ex.value.response["Error"]
+    err["Code"].should.equal("InvalidParameterException")
+    err["Message"].should.equal(
+        "1 validation error detected: Value 'NO_SUCH_FLOW' at 'authFlow' failed to satisfy constraint: "
+        "Member must satisfy enum value set: ['ADMIN_NO_SRP_AUTH', 'ADMIN_USER_PASSWORD_AUTH', 'USER_SRP_AUTH', "
+        "'REFRESH_TOKEN_AUTH', 'REFRESH_TOKEN', 'CUSTOM_AUTH', 'USER_PASSWORD_AUTH']"
+    )
+
+
+@mock_cognitoidp
+def test_initiate_auth_invalid_admin_auth_flow():
+    """ Pass an admin auth_flow to the regular initiate_auth"""
+    conn = boto3.client("cognito-idp", "us-west-2")
+    result = user_authentication_flow(conn)
+
+    with pytest.raises(ClientError) as ex:
+        user_authentication_flow(conn)
+
+        conn.initiate_auth(
+            ClientId=result["client_id"],
+            AuthFlow="ADMIN_USER_PASSWORD_AUTH",
             AuthParameters={"USERNAME": result["username"], "PASSWORD": result["password"]},
         )
 


### PR DESCRIPTION
The API documentation for `initiate_auth` and `admin_initiate_auth` Cognito IDP methods are ambiguous about the supported AuthFlow parameters.

As stated in #4623, AWS have confirmed via email what the valid attributes are. I have also validated the behaviour through testing.

This PR restricts the AuthFlow parameters to the known values for initiate_auth and admin_initiate_auth methods and raises `InvalidParameterException` for invalid or inappropriate auth_flow values.

In the test case raised by #4623, moto will properly emulate AWS by raising an `InvalidParameterException('Initiate Auth method not supported')` exception to the user for using `ADMIN_USER_PASSWORD_AUTH` with the regular user `initiate_auth` endpoint.