### PR TITLE
Correctly use the filter for describe_..._prefix_lists

### DIFF
--- a/moto/ec2/models.py
+++ b/moto/ec2/models.py
@@ -5566,8 +5566,8 @@ class ManagedPrefixListBackend(object):
 
         result = managed_prefix_lists
         if filters:
-            result = filter_resources(managed_prefix_lists, filters, attr_pairs)
-            result = describe_tag_filter(filters, managed_prefix_lists)
+            result = filter_resources(result, filters, attr_pairs)
+            result = describe_tag_filter(filters, result)
 
         for item in result.copy():
             if not item.delete_counter:

--- a/tests/test_ec2/test_vpcs.py
+++ b/tests/test_ec2/test_vpcs.py
@@ -1097,3 +1097,16 @@ def test_describe_vpcs_dryrun():
     ex.value.response["Error"]["Message"].should.equal(
         "An error occurred (DryRunOperation) when calling the DescribeVpcs operation: Request would have succeeded, but DryRun flag is set"
     )
+
+
+@mock_ec2
+def test_describe_prefix_lists():
+    client = boto3.client("ec2", region_name="us-east-1")
+    result_unfiltered = client.describe_prefix_lists()
+    assert len(result_unfiltered["PrefixLists"]) > 1
+    result_filtered = client.describe_prefix_lists(
+        Filters=[
+            {"Name": "prefix-list-name", "Values": ["com.amazonaws.us-east-1.s3"]},
+        ]
+    )
+    assert len(result_filtered["PrefixLists"]) == 1


### PR DESCRIPTION
This change affects both ec2s describe_managed_prefix_lists and describe_prefix_lists, as they boil down to the same method.

As you can see, in the current filter method, the result of filter_resources is (incorrectly) discarded, and replaced by describe_tag_filter (since both operations act on copies of the original object).

This PR fixes this behavior by calculating both operations on the currently valid result (so describe_tag_filter gets the already filtered result).

Also added a test for this behavior.