### PR TITLE
bugfix: raise an error when attempting to copy s3 object to itself without any changes

### DIFF
--- a/moto/s3/exceptions.py
+++ b/moto/s3/exceptions.py
@@ -575,6 +575,16 @@ class BucketMustHaveLockeEnabled(S3ClientError):
         )
 
 
+class CopyObjectMustChangeSomething(S3ClientError):
+    code = 400
+
+    def __init__(self):
+        super().__init__(
+            "InvalidRequest",
+            "This copy request is illegal because it is trying to copy an object to itself without changing the object's metadata, storage class, website redirect location or encryption attributes.",
+        )
+
+
 class InvalidFilterRuleName(InvalidArgumentError):
     code = 400
 

--- a/moto/s3/models.py
+++ b/moto/s3/models.py
@@ -37,6 +37,7 @@ from moto.s3.exceptions import (
     AccessDeniedByLock,
     BucketAlreadyExists,
     BucketNeedsToBeNew,
+    CopyObjectMustChangeSomething,
     MissingBucket,
     InvalidBucketName,
     InvalidPart,
@@ -2016,6 +2017,16 @@ class S3Backend(BaseBackend, CloudWatchMetricProvider):
         kms_key_id=None,
         bucket_key_enabled=False,
     ):
+        if (
+            src_key.name == dest_key_name
+            and src_key.bucket_name == dest_bucket_name
+            and storage == src_key.storage_class
+            and acl == src_key.acl
+            and encryption == src_key.encryption
+            and kms_key_id == src_key.kms_key_id
+            and bucket_key_enabled == (src_key.bucket_key_enabled or False)
+        ):
+            raise CopyObjectMustChangeSomething
 
         new_key = self.put_object(
             bucket_name=dest_bucket_name,


### PR DESCRIPTION
In the real AWS S3 API, if you attempt to copy an object to itself without making any changes you get a `bad request` error.
```
 import boto3
 DEFAULT_REGION_NAME='us-east-1'
 client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
 bucket_name = "my-unique-bucket-123321"
 s3 = boto3.resource("s3", region_name=DEFAULT_REGION_NAME)
 key_name = "my_key"
 key = s3.Object(bucket_name, key_name)
 s3.create_bucket(Bucket=bucket_name)
 s3.Bucket(name='my-unique-bucket-123321')
 key.put(Body=b"some value")

# attempt to copy object to itself
 client.copy_object(
...     Bucket=bucket_name,
...     CopySource="{}/{}".format(bucket_name, key_name),
...     Key=key_name,
... )
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/local/lib/python3.9/site-packages/botocore/client.py", line 391, in _api_call
    return self._make_api_call(operation_name, kwargs)
  File "/usr/local/lib/python3.9/site-packages/botocore/client.py", line 719, in _make_api_call
    raise error_class(parsed_response, operation_name)
botocore.exceptions.ClientError: An error occurred (InvalidRequest) when calling the CopyObject operation: This copy request is illegal because it is trying to copy an object to itself without changing the object's metadata, storage class, website redirect location or encryption attributes.
```

Currently no such error occurs with moto. This PR attempts to fix that.
Please note that this is my first contribution to `moto`. I appreciate any and all feedback. This issue was originally brought to my attention via this issue in LocalStack:
https://github.com/localstack/localstack/issues/5274