### PR TITLE
[LocalStack] Fixes to secretsmanager's PutSecretValue, CreateSecret, DeleteSecret

### DIFF
--- a/moto/secretsmanager/models.py
+++ b/moto/secretsmanager/models.py
@@ -129,7 +129,7 @@ class FakeSecret:
             "VersionId": version_id,
         }
         if include_version_stages:
-            dct["VersionStages"] = self.versions[version_id]['version_stages']
+            dct["VersionStages"] = self.versions[version_id]["version_stages"]
         return json.dumps(dct)
 
     def to_dict(self):
@@ -319,7 +319,7 @@ class SecretsManagerBackend(BaseBackend):
         description=None,
         tags=None,
         kms_key_id=None,
-        client_request_token=None
+        client_request_token=None,
     ):
 
         # error if secret exists
@@ -335,7 +335,7 @@ class SecretsManagerBackend(BaseBackend):
             description=description,
             tags=tags,
             kms_key_id=kms_key_id,
-            version_id=client_request_token
+            version_id=client_request_token,
         )
 
         return secret.to_short_dict()
@@ -374,7 +374,7 @@ class SecretsManagerBackend(BaseBackend):
 
             secret.update(description, tags, kms_key_id, last_changed_date=update_time)
 
-            if 'AWSCURRENT' in version_stages:
+            if "AWSCURRENT" in version_stages:
                 secret.reset_default_version(secret_version, version_id)
             else:
                 secret.versions[version_id] = secret_version

--- a/moto/secretsmanager/models.py
+++ b/moto/secretsmanager/models.py
@@ -120,14 +120,16 @@ class FakeSecret:
     def is_deleted(self):
         return self.deleted_date is not None
 
-    def to_short_dict(self, include_version_stages=False):
+    def to_short_dict(self, include_version_stages=False, version_id=None):
+        if not version_id:
+            version_id = self.default_version_id
         dct = {
             "ARN": self.arn,
             "Name": self.name,
-            "VersionId": self.default_version_id,
+            "VersionId": version_id,
         }
         if include_version_stages:
-            dct["VersionStages"] = self.version_stages
+            dct["VersionStages"] = self.versions[version_id]['version_stages']
         return json.dumps(dct)
 
     def to_dict(self):
@@ -207,6 +209,14 @@ class SecretsManagerBackend(BaseBackend):
         if token_length < 32 or token_length > 64:
             msg = "ClientRequestToken must be 32-64 characters long."
             raise InvalidParameterException(msg)
+
+    def _from_client_request_token(self, client_request_token):
+        version_id = client_request_token
+        if version_id:
+            self._client_request_token_validator(version_id)
+        else:
+            version_id = str(uuid.uuid4())
+        return version_id
 
     def get_secret_value(self, secret_id, version_id, version_stage):
         if not self._is_valid_identifier(secret_id):
@@ -309,6 +319,7 @@ class SecretsManagerBackend(BaseBackend):
         description=None,
         tags=None,
         kms_key_id=None,
+        client_request_token=None
     ):
 
         # error if secret exists
@@ -324,6 +335,7 @@ class SecretsManagerBackend(BaseBackend):
             description=description,
             tags=tags,
             kms_key_id=kms_key_id,
+            version_id=client_request_token
         )
 
         return secret.to_short_dict()
@@ -343,10 +355,7 @@ class SecretsManagerBackend(BaseBackend):
         if version_stages is None:
             version_stages = ["AWSCURRENT"]
 
-        if version_id:
-            self._client_request_token_validator(version_id)
-        else:
-            version_id = str(uuid.uuid4())
+        version_id = self._from_client_request_token(version_id)
 
         secret_version = {
             "createdate": int(time.time()),
@@ -365,10 +374,10 @@ class SecretsManagerBackend(BaseBackend):
 
             secret.update(description, tags, kms_key_id, last_changed_date=update_time)
 
-            if "AWSPENDING" in version_stages:
-                secret.versions[version_id] = secret_version
-            else:
+            if 'AWSCURRENT' in version_stages:
                 secret.reset_default_version(secret_version, version_id)
+            else:
+                secret.versions[version_id] = secret_version
         else:
             secret = FakeSecret(
                 region_name=self.region,
@@ -403,17 +412,19 @@ class SecretsManagerBackend(BaseBackend):
             tags = secret.tags
             description = secret.description
 
+        version_id = self._from_client_request_token(client_request_token)
+
         secret = self._add_secret(
             secret_id,
             secret_string,
             secret_binary,
-            version_id=client_request_token,
+            version_id=version_id,
             description=description,
             tags=tags,
             version_stages=version_stages,
         )
 
-        return secret.to_short_dict(include_version_stages=True)
+        return secret.to_short_dict(include_version_stages=True, version_id=version_id)
 
     def describe_secret(self, secret_id):
         if not self._is_valid_identifier(secret_id):
@@ -658,21 +669,6 @@ class SecretsManagerBackend(BaseBackend):
         self, secret_id, recovery_window_in_days, force_delete_without_recovery
     ):
 
-        if not self._is_valid_identifier(secret_id):
-            raise SecretNotFoundException()
-
-        if self.secrets[secret_id].is_deleted():
-            raise InvalidRequestException(
-                "An error occurred (InvalidRequestException) when calling the DeleteSecret operation: You tried to \
-                perform the operation on a secret that's currently marked deleted."
-            )
-
-        if recovery_window_in_days and force_delete_without_recovery:
-            raise InvalidParameterException(
-                "An error occurred (InvalidParameterException) when calling the DeleteSecret operation: You can't \
-                use ForceDeleteWithoutRecovery in conjunction with RecoveryWindowInDays."
-            )
-
         if recovery_window_in_days and (
             recovery_window_in_days < 7 or recovery_window_in_days > 30
         ):
@@ -681,22 +677,44 @@ class SecretsManagerBackend(BaseBackend):
                 RecoveryWindowInDays value must be between 7 and 30 days (inclusive)."
             )
 
-        deletion_date = datetime.datetime.utcnow()
+        if recovery_window_in_days and force_delete_without_recovery:
+            raise InvalidParameterException(
+                "An error occurred (InvalidParameterException) when calling the DeleteSecret operation: You can't \
+                use ForceDeleteWithoutRecovery in conjunction with RecoveryWindowInDays."
+            )
 
-        if force_delete_without_recovery:
-            secret = self.secrets.pop(secret_id, None)
+        if not self._is_valid_identifier(secret_id):
+            if not force_delete_without_recovery:
+                raise SecretNotFoundException()
+            else:
+                secret = FakeSecret(self.region, secret_id)
+                arn = secret.arn
+                name = secret.name
+                deletion_date = datetime.datetime.utcnow()
+                return arn, name, self._unix_time_secs(deletion_date)
         else:
-            deletion_date += datetime.timedelta(days=recovery_window_in_days or 30)
-            self.secrets[secret_id].delete(self._unix_time_secs(deletion_date))
-            secret = self.secrets.get(secret_id, None)
+            if self.secrets[secret_id].is_deleted():
+                raise InvalidRequestException(
+                    "An error occurred (InvalidRequestException) when calling the DeleteSecret operation: You tried to \
+                    perform the operation on a secret that's currently marked deleted."
+                )
 
-        if not secret:
-            raise SecretNotFoundException()
+            deletion_date = datetime.datetime.utcnow()
 
-        arn = secret.arn
-        name = secret.name
+            if force_delete_without_recovery:
+                secret = self.secrets.pop(secret_id, None)
+            else:
+                deletion_date += datetime.timedelta(days=recovery_window_in_days or 30)
+                self.secrets[secret_id].delete(self._unix_time_secs(deletion_date))
+                secret = self.secrets.get(secret_id, None)
 
-        return arn, name, self._unix_time_secs(deletion_date)
+            if not secret:
+                raise SecretNotFoundException()
+
+            arn = secret.arn
+            name = secret.name
+
+            return arn, name, self._unix_time_secs(deletion_date)
 
     def restore_secret(self, secret_id):
 

--- a/moto/secretsmanager/responses.py
+++ b/moto/secretsmanager/responses.py
@@ -53,7 +53,7 @@ class SecretsManagerResponse(BaseResponse):
             description=description,
             tags=tags,
             kms_key_id=kms_key_id,
-            client_request_token=client_request_token
+            client_request_token=client_request_token,
         )
 
     def update_secret(self):

--- a/moto/secretsmanager/responses.py
+++ b/moto/secretsmanager/responses.py
@@ -45,6 +45,7 @@ class SecretsManagerResponse(BaseResponse):
         description = self._get_param("Description", if_none="")
         tags = self._get_param("Tags", if_none=[])
         kms_key_id = self._get_param("KmsKeyId", if_none=None)
+        client_request_token = self._get_param("ClientRequestToken", if_none=None)
         return secretsmanager_backends[self.region].create_secret(
             name=name,
             secret_string=secret_string,
@@ -52,6 +53,7 @@ class SecretsManagerResponse(BaseResponse):
             description=description,
             tags=tags,
             kms_key_id=kms_key_id,
+            client_request_token=client_request_token
         )
 
     def update_secret(self):

--- a/tests/test_secretsmanager/test_secretsmanager.py
+++ b/tests/test_secretsmanager/test_secretsmanager.py
@@ -30,14 +30,14 @@ def test_get_secret_value():
 def test_create_secret_with_client_request_token():
     conn = boto3.client("secretsmanager", region_name="us-west-2")
 
-    version_id = 'eb41453f-25bb-4025-b7f4-850cfca0ce71'
+    version_id = "eb41453f-25bb-4025-b7f4-850cfca0ce71"
     create_dict = conn.create_secret(
         Name=DEFAULT_SECRET_NAME,
-        SecretString='secret_string',
-        ClientRequestToken=version_id
+        SecretString="secret_string",
+        ClientRequestToken=version_id,
     )
     assert create_dict
-    assert create_dict['VersionId'] == version_id
+    assert create_dict["VersionId"] == version_id
 
 
 @mock_secretsmanager
@@ -246,9 +246,11 @@ def test_delete_secret_force():
 def test_delete_secret_force_no_such_secret():
     conn = boto3.client("secretsmanager", region_name="us-west-2")
 
-    deleted_secret = conn.delete_secret(SecretId=DEFAULT_SECRET_NAME, ForceDeleteWithoutRecovery=True)
+    deleted_secret = conn.delete_secret(
+        SecretId=DEFAULT_SECRET_NAME, ForceDeleteWithoutRecovery=True
+    )
     assert deleted_secret
-    assert deleted_secret['Name'] == DEFAULT_SECRET_NAME
+    assert deleted_secret["Name"] == DEFAULT_SECRET_NAME
 
 
 @mock_secretsmanager
@@ -319,8 +321,9 @@ def test_delete_secret_force_no_such_secret_with_invalid_recovery_window():
         conn.delete_secret(
             SecretId=DEFAULT_SECRET_NAME,
             ForceDeleteWithoutRecovery=True,
-            RecoveryWindowInDays=4
+            RecoveryWindowInDays=4,
         )
+
 
 @mock_secretsmanager
 def test_delete_secret_that_is_marked_deleted():
@@ -991,25 +994,25 @@ def test_put_secret_value_version_stages_response():
     conn = boto3.client("secretsmanager", region_name="us-west-2")
 
     # Creation.
-    first_version_id = 'eb41453f-25bb-4025-b7f4-850cfca0ce71'
+    first_version_id = "eb41453f-25bb-4025-b7f4-850cfca0ce71"
     conn.create_secret(
         Name=DEFAULT_SECRET_NAME,
-        SecretString='first_secret_string',
-        ClientRequestToken=first_version_id
+        SecretString="first_secret_string",
+        ClientRequestToken=first_version_id,
     )
 
     # Use PutSecretValue to push a new version with new version stages.
-    second_version_id = 'eb41453f-25bb-4025-b7f4-850cfca0ce72'
-    second_version_stages = ['SAMPLESTAGE1', 'SAMPLESTAGE0']
+    second_version_id = "eb41453f-25bb-4025-b7f4-850cfca0ce72"
+    second_version_stages = ["SAMPLESTAGE1", "SAMPLESTAGE0"]
     second_put_res_dict = conn.put_secret_value(
         SecretId=DEFAULT_SECRET_NAME,
-        SecretString='second_secret_string',
+        SecretString="second_secret_string",
         VersionStages=second_version_stages,
-        ClientRequestToken=second_version_id
+        ClientRequestToken=second_version_id,
     )
     assert second_put_res_dict
-    assert second_put_res_dict['VersionId'] == second_version_id
-    assert second_put_res_dict['VersionStages'] == second_version_stages
+    assert second_put_res_dict["VersionId"] == second_version_id
+    assert second_put_res_dict["VersionStages"] == second_version_stages
 
 
 @mock_secretsmanager
@@ -1017,25 +1020,25 @@ def test_put_secret_value_version_stages_pending_response():
     conn = boto3.client("secretsmanager", region_name="us-west-2")
 
     # Creation.
-    first_version_id = 'eb41453f-25bb-4025-b7f4-850cfca0ce71'
+    first_version_id = "eb41453f-25bb-4025-b7f4-850cfca0ce71"
     conn.create_secret(
         Name=DEFAULT_SECRET_NAME,
-        SecretString='first_secret_string',
-        ClientRequestToken=first_version_id
+        SecretString="first_secret_string",
+        ClientRequestToken=first_version_id,
     )
 
     # Use PutSecretValue to push a new version with new version stages.
-    second_version_id = 'eb41453f-25bb-4025-b7f4-850cfca0ce72'
-    second_version_stages = ['AWSPENDING']
+    second_version_id = "eb41453f-25bb-4025-b7f4-850cfca0ce72"
+    second_version_stages = ["AWSPENDING"]
     second_put_res_dict = conn.put_secret_value(
         SecretId=DEFAULT_SECRET_NAME,
-        SecretString='second_secret_string',
+        SecretString="second_secret_string",
         VersionStages=second_version_stages,
-        ClientRequestToken=second_version_id
+        ClientRequestToken=second_version_id,
     )
     assert second_put_res_dict
-    assert second_put_res_dict['VersionId'] == second_version_id
-    assert second_put_res_dict['VersionStages'] == second_version_stages
+    assert second_put_res_dict["VersionId"] == second_version_id
+    assert second_put_res_dict["VersionStages"] == second_version_stages
 
 
 @mock_secretsmanager
@@ -1043,29 +1046,29 @@ def test_after_put_secret_value_version_stages_can_get_current():
     conn = boto3.client("secretsmanager", region_name="us-west-2")
 
     # Creation.
-    first_version_id = 'eb41453f-25bb-4025-b7f4-850cfca0ce71'
-    first_secret_string = 'first_secret_string'
+    first_version_id = "eb41453f-25bb-4025-b7f4-850cfca0ce71"
+    first_secret_string = "first_secret_string"
     conn.create_secret(
         Name=DEFAULT_SECRET_NAME,
         SecretString=first_secret_string,
-        ClientRequestToken=first_version_id
+        ClientRequestToken=first_version_id,
     )
 
     # Use PutSecretValue to push a new version with new version stages.
-    second_version_id = 'eb41453f-25bb-4025-b7f4-850cfca0ce72'
+    second_version_id = "eb41453f-25bb-4025-b7f4-850cfca0ce72"
     conn.put_secret_value(
         SecretId=DEFAULT_SECRET_NAME,
-        SecretString='second_secret_string',
-        VersionStages=['SAMPLESTAGE1', 'SAMPLESTAGE0'],
-        ClientRequestToken=second_version_id
+        SecretString="second_secret_string",
+        VersionStages=["SAMPLESTAGE1", "SAMPLESTAGE0"],
+        ClientRequestToken=second_version_id,
     )
 
     # Get current.
     get_dict = conn.get_secret_value(SecretId=DEFAULT_SECRET_NAME)
     assert get_dict
-    assert get_dict['VersionId'] == first_version_id
-    assert get_dict['SecretString'] == first_secret_string
-    assert get_dict['VersionStages'] == ['AWSCURRENT']
+    assert get_dict["VersionId"] == first_version_id
+    assert get_dict["SecretString"] == first_secret_string
+    assert get_dict["VersionStages"] == ["AWSCURRENT"]
 
 
 @mock_secretsmanager
@@ -1073,29 +1076,29 @@ def test_after_put_secret_value_version_stages_pending_can_get_current():
     conn = boto3.client("secretsmanager", region_name="us-west-2")
 
     # Creation.
-    first_version_id = 'eb41453f-25bb-4025-b7f4-850cfca0ce71'
-    first_secret_string = 'first_secret_string'
+    first_version_id = "eb41453f-25bb-4025-b7f4-850cfca0ce71"
+    first_secret_string = "first_secret_string"
     conn.create_secret(
         Name=DEFAULT_SECRET_NAME,
         SecretString=first_secret_string,
-        ClientRequestToken=first_version_id
+        ClientRequestToken=first_version_id,
     )
 
     # Use PutSecretValue to push a new version with new version stages.
-    pending_version_id = 'eb41453f-25bb-4025-b7f4-850cfca0ce72'
+    pending_version_id = "eb41453f-25bb-4025-b7f4-850cfca0ce72"
     conn.put_secret_value(
         SecretId=DEFAULT_SECRET_NAME,
-        SecretString='second_secret_string',
-        VersionStages=['AWSPENDING'],
-        ClientRequestToken=pending_version_id
+        SecretString="second_secret_string",
+        VersionStages=["AWSPENDING"],
+        ClientRequestToken=pending_version_id,
     )
 
     # Get current.
     get_dict = conn.get_secret_value(SecretId=DEFAULT_SECRET_NAME)
     assert get_dict
-    assert get_dict['VersionId'] == first_version_id
-    assert get_dict['SecretString'] == first_secret_string
-    assert get_dict['VersionStages'] == ['AWSCURRENT']
+    assert get_dict["VersionId"] == first_version_id
+    assert get_dict["SecretString"] == first_secret_string
+    assert get_dict["VersionStages"] == ["AWSCURRENT"]
 
 
 @mock_secretsmanager

--- a/tests/test_secretsmanager/test_server.py
+++ b/tests/test_secretsmanager/test_server.py
@@ -774,6 +774,7 @@ def test_update_secret_version_stage(pass_arn):
         headers={"X-Amz-Target": "secretsmanager.PutSecretValue"},
     )
     put_secret = json.loads(put_secret.data.decode("utf-8"))
+    assert put_secret["VersionStages"] == [custom_stage]
     new_version = put_secret["VersionId"]
 
     describe_secret = test_client.post(
@@ -785,7 +786,7 @@ def test_update_secret_version_stage(pass_arn):
     json_data = json.loads(describe_secret.data.decode("utf-8"))
     stages = json_data["SecretVersionsToStages"]
     assert len(stages) == 2
-    assert stages[initial_version] == ["AWSPREVIOUS"]
+    assert stages[initial_version] == ["AWSCURRENT"]
     assert stages[new_version] == [custom_stage]
 
     test_client.post(
@@ -808,7 +809,7 @@ def test_update_secret_version_stage(pass_arn):
     json_data = json.loads(describe_secret.data.decode("utf-8"))
     stages = json_data["SecretVersionsToStages"]
     assert len(stages) == 2
-    assert stages[initial_version] == ["AWSPREVIOUS", custom_stage]
+    assert stages[initial_version] == ["AWSCURRENT", custom_stage]
     assert stages[new_version] == []
 
 


### PR DESCRIPTION
LocalStack recently received some issue reports about the handling of PutSecretValue requests to secretsmanager. After validating the behaviour of AWS's secretsmanager with respect to PutSecretValue, CreateSecret and DeleteSecret requests, I propose the following fixes.
-- Please note that all tests introduced, or updated, were verified agains AWS before the opening of the pull request.

### PutSecretValue

#### Response

I updated moto's implementation of `PutSecretValue` to return the version of the secret resulting from the execution of the request itself. This is in contrast to the original logic, which returned the current/default version of the secret.
The fix consists in handling the derivation of the secret version's `VersionId` (either from validation of the provided `ClientRequestToken` value, or generating a new one) in the `PutSecretValue` function. Hence, passing this `VersionId` to `__add_secret` (as expected), and later retrieving the version to compute the response. The response is compiled as before through the `to_short_dict` function, which now accepts an optional `version_id` parameter, defaulting to the current version if unspecified.

#### VersionStages

Moto's implementation of `PutSecretValue` to prevent setting as new default/current version of the secret the same version that resulted in the introduction of a new `VersionStages` collection. This was achieved by updating `__add_secret` function to only update its default version iff the submitted `VersionStages` contain the `AWSCURRENT` value.
This behaviour can be verified by forwarding to AWS's secretsmanager a `GetSecretValue` by `SecretId`, following any number of `PutSecretValue` requests updating the secret with any valid set of `VersionStages` not containing `AWSCURRENT` (`AWSPENDING`, in this context behaves no differently to any other valid non-current `VersionStage` value).

#### Tests

To test the two items above, I introduced the test cases: `test_put_secret_value_version_stages_response `, `test_put_secret_value_version_stages_pending_response `, `test_after_put_secret_value_version_stages_can_get_current `, and `test_after_put_secret_value_version_stages_pending_can_get_current` in `tests/test_secretsmanager/test_secretsmanager.py`.
Please note the coupling of the two fixes applied.
Updating of the server test `test_update_secret_version_stage` was also required.

### CreateSecret

#### ClientRequestToken
I updates moto's implementation of `CreateSecret` to accept the optional `ClientRequestToken` value, as AWS this is allowed by AWS itself.

#### Tests
To validate `CreateSecret`'s handing of  `ClientRequestToken` I have introduced the test case `test_create_secret_with_client_request_token` in `tests/test_secretsmanager/test_secretsmanager.py`.


### DeleteSecret

#### Force Deletion of Inexistent Secrets
I updated moto's implementation to not raise an `InvalidRequestException` exception when the deletion requests demands to delete an inexistent `SecretId` with `force_delete_without_recovery`. This behaves as if the secret was in fact deleted, matching the AWS's behaviour observed.

#### Parameters Validation Sequence
I updated moto's implementation of `DeleteSecret` to validate the parameters of the request in the same, obsoverd, order of AWS.

#### Tests
To test the two items above, I introduced the test cases: `test_delete_secret_force_no_such_secret`, `test_delete_secret_force_no_such_secret_with_invalid_recovery_window`, and updated `test_delete_secret_that_does_not_exist` to match the parameter validation sequence.

