### PR TITLE
handle 'NoDevice' parameter in BlockDeviceMappings #4852

### DIFF
--- a/moto/ec2/exceptions.py
+++ b/moto/ec2/exceptions.py
@@ -49,6 +49,11 @@ class InvalidDHCPOptionsIdError(EC2ClientError):
         )
 
 
+class InvalidRequest(EC2ClientError):
+    def __init__(self):
+        super().__init__("InvalidRequest", "The request received was invalid")
+
+
 class InvalidParameterCombination(EC2ClientError):
     def __init__(self, msg):
         super().__init__("InvalidParameterCombination", msg)

--- a/moto/ec2/models.py
+++ b/moto/ec2/models.py
@@ -1155,7 +1155,7 @@ class InstanceBackend(object):
                         "DeleteOnTermination", False
                     )
                     kms_key_id = block_device["Ebs"].get("KmsKeyId")
-                    if block_device["NoDevice"] != "":
+                    if block_device.get("NoDevice") != "":
                         new_instance.add_block_device(
                             volume_size,
                             device_name,

--- a/moto/ec2/models.py
+++ b/moto/ec2/models.py
@@ -1155,14 +1155,15 @@ class InstanceBackend(object):
                         "DeleteOnTermination", False
                     )
                     kms_key_id = block_device["Ebs"].get("KmsKeyId")
-                    new_instance.add_block_device(
-                        volume_size,
-                        device_name,
-                        snapshot_id,
-                        encrypted,
-                        delete_on_termination,
-                        kms_key_id,
-                    )
+                    if block_device["NoDevice"] != "":
+                        new_instance.add_block_device(
+                            volume_size,
+                            device_name,
+                            snapshot_id,
+                            encrypted,
+                            delete_on_termination,
+                            kms_key_id,
+                        )
             else:
                 new_instance.setup_defaults()
             if kwargs.get("instance_market_options"):

--- a/moto/ec2/responses/instances.py
+++ b/moto/ec2/responses/instances.py
@@ -320,6 +320,7 @@ class InstanceResponse(BaseResponse):
                 device_mapping.get("ebs._encrypted", False)
             )
             device_template["Ebs"]["KmsKeyId"] = device_mapping.get("ebs._kms_key_id")
+            device_template["NoDevice"] = device_mapping.get("no_device")
             mappings.append(device_template)
 
         return mappings
@@ -327,6 +328,8 @@ class InstanceResponse(BaseResponse):
     @staticmethod
     def _validate_block_device_mapping(device_mapping):
 
+        if "no_device" in device_mapping:
+            return
         if not any(mapping for mapping in device_mapping if mapping.startswith("ebs.")):
             raise MissingParameterError("ebs")
         if (
@@ -349,6 +352,7 @@ class InstanceResponse(BaseResponse):
 BLOCK_DEVICE_MAPPING_TEMPLATE = {
     "VirtualName": None,
     "DeviceName": None,
+    "NoDevice": None,
     "Ebs": {
         "SnapshotId": None,
         "VolumeSize": None,


### PR DESCRIPTION
fixes #4852 by adding support for `NoDevice` parameter in `BlockDeviceMappings`.

