### PR TITLE
EC2 performance improvements

### DIFF
--- a/moto/core/utils.py
+++ b/moto/core/utils.py
@@ -13,6 +13,7 @@ from urllib.parse import urlparse
 
 
 REQUEST_ID_LONG = string.digits + string.ascii_uppercase
+HEX_CHARS = list(range(10)) + ["a", "b", "c", "d", "e", "f"]
 
 
 def camelcase_to_underscores(argument):
@@ -73,8 +74,7 @@ def method_names_from_class(clazz):
 
 
 def get_random_hex(length=8):
-    chars = list(range(10)) + ["a", "b", "c", "d", "e", "f"]
-    return "".join(str(random.choice(chars)) for x in range(length))
+    return "".join(str(random.choice(HEX_CHARS)) for _ in range(length))
 
 
 def get_random_message_id():

--- a/moto/ec2/models.py
+++ b/moto/ec2/models.py
@@ -217,7 +217,11 @@ DEFAULT_VPC_ENDPOINT_SERVICES = []
 
 
 def utc_date_and_time():
-    return datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%S.000Z")
+    x = datetime.utcnow()
+    # Better performing alternative to x.strftime("%Y-%m-%dT%H:%M:%S.000Z")
+    return "{}-{:02d}-{:02d}T{:02d}:{:02d}:{:02d}.000Z".format(
+        x.year, x.month, x.day, x.hour, x.minute, x.second
+    )
 
 
 def validate_resource_ids(resource_ids):
@@ -5476,13 +5480,11 @@ class VPCEndPoint(TaggedEC2Resource):
         self.add_tags(tags or {})
         self.destination_prefix_list_id = destination_prefix_list_id
 
+        self.created_at = utc_date_and_time()
+
     @property
     def owner_id(self):
         return ACCOUNT_ID
-
-    @property
-    def created_at(self):
-        return utc_date_and_time()
 
 
 class ManagedPrefixList(TaggedEC2Resource):

--- a/moto/ec2/responses/instances.py
+++ b/moto/ec2/responses/instances.py
@@ -1,4 +1,3 @@
-from moto.autoscaling import autoscaling_backends
 from moto.core.responses import BaseResponse
 from moto.core.utils import camelcase_to_underscores
 from moto.ec2.exceptions import MissingParameterError, InvalidParameterCombination
@@ -6,7 +5,6 @@ from moto.ec2.utils import (
     filters_from_querystring,
     dict_from_querystring,
 )
-from moto.elbv2 import elbv2_backends
 from moto.core import ACCOUNT_ID
 
 from copy import deepcopy
@@ -91,6 +89,9 @@ class InstanceResponse(BaseResponse):
         instance_ids = self._get_multi_param("InstanceId")
         if self.is_not_dryrun("TerminateInstance"):
             instances = self.ec2_backend.terminate_instances(instance_ids)
+            from moto.autoscaling import autoscaling_backends
+            from moto.elbv2 import elbv2_backends
+
             autoscaling_backends[self.region].notify_terminate_instances(instance_ids)
             elbv2_backends[self.region].notify_terminate_instances(instance_ids)
             template = self.response_template(EC2_TERMINATE_INSTANCES)

--- a/moto/ec2/urls.py
+++ b/moto/ec2/urls.py
@@ -3,5 +3,4 @@ from .responses import EC2Response
 
 url_bases = [r"https?://ec2\.(.+)\.amazonaws\.com(|\.cn)"]
 
-response = EC2Response()
-url_paths = {"{0}/": response._dispatch}
+url_paths = {"{0}/": EC2Response.dispatch}

--- a/moto/ec2/urls.py
+++ b/moto/ec2/urls.py
@@ -3,4 +3,5 @@ from .responses import EC2Response
 
 url_bases = [r"https?://ec2\.(.+)\.amazonaws\.com(|\.cn)"]
 
-url_paths = {"{0}/": EC2Response.dispatch}
+response = EC2Response()
+url_paths = {"{0}/": response._dispatch}

--- a/moto/ec2/utils.py
+++ b/moto/ec2/utils.py
@@ -57,16 +57,15 @@ EC2_RESOURCE_TO_PREFIX = {
 
 
 EC2_PREFIX_TO_RESOURCE = dict((v, k) for (k, v) in EC2_RESOURCE_TO_PREFIX.items())
+HEX_CHARS = list(str(x) for x in range(10)) + ["a", "b", "c", "d", "e", "f"]
 
 
 def random_resource_id(size=8):
-    chars = list(range(10)) + ["a", "b", "c", "d", "e", "f"]
-    resource_id = "".join(str(random.choice(chars)) for _ in range(size))
-    return resource_id
+    return "".join(random.choice(HEX_CHARS) for _ in range(size))
 
 
 def random_id(prefix="", size=8):
-    return "{0}-{1}".format(prefix, random_resource_id(size))
+    return f"{prefix}-{random_resource_id(size)}"
 
 
 def random_ami_id():

--- a/tests/test_apigateway/test_apigateway.py
+++ b/tests/test_apigateway/test_apigateway.py
@@ -2066,9 +2066,8 @@ def test_update_usage_plan():
             {"op": "replace", "path": "/productCode", "value": "new-productionCode"},
         ],
     )
-    response["quota"]["limit"].should.equal("1000")
+    response["quota"]["limit"].should.equal(1000)
     response["quota"]["period"].should.equal("MONTH")
-    response["quota"]["limit"].should.equal("1000")
     response["name"].should.equal("new-name")
     response["description"].should.equal("new-description")
     response["productCode"].should.equal("new-productionCode")

--- a/tests/test_ec2/test_amis.py
+++ b/tests/test_ec2/test_amis.py
@@ -955,7 +955,7 @@ def test_ami_filter_wildcard():
     ec2_resource = boto3.resource("ec2", region_name="us-west-1")
     ec2_client = boto3.client("ec2", region_name="us-west-1")
 
-    image_name = str(uuid4())[0:6]
+    image_name = str(uuid4())[0:12]
 
     instance = ec2_resource.create_instances(
         ImageId=EXAMPLE_AMI_ID, MinCount=1, MaxCount=1
@@ -967,7 +967,7 @@ def test_ami_filter_wildcard():
 
     my_images = ec2_client.describe_images(
         Owners=[ACCOUNT_ID],
-        Filters=[{"Name": "name", "Values": [f"{image_name[0:4]}*"]}],
+        Filters=[{"Name": "name", "Values": [f"{image_name[0:8]}*"]}],
     )["Images"]
     my_images.should.have.length_of(1)
 


### PR DESCRIPTION
Some low-hanging fruit - these changes resulted in a 10 to 20% performance improvement

Another big improvement would be to have a global cache of templates - currently they are cached per `EC2Response()`-instance, and every request creates a new `EC2Response`

The APIGateway-test change is unrelated, but required to make the tests pass - the latest boto3 changed the format from `str` to `int`