### PR TITLE
Fix KeyError Exception on iam.delete_policy

### DIFF
--- a/moto/iam/models.py
+++ b/moto/iam/models.py
@@ -2339,7 +2339,8 @@ class IAMBackend(BaseBackend):
         user.delete_policy(policy_name)
 
     def delete_policy(self, policy_arn):
-        del self.managed_policies[policy_arn]
+        policy = self.get_policy(policy_arn)
+        del self.managed_policies[policy.arn]
 
     def create_access_key(self, user_name=None, status="Active"):
         user = self.get_user(user_name)


### PR DESCRIPTION
When attempting to delete a policy that does not exist, a `NoSuchEntity` exception is expected to be returned, as described in the [boto3 iam docs](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/iam.html#IAM.Client.delete_policy).

This change addresses the `KeyError` that is raised when attempting to delete a policy that does not exist. It follows the logic from `def delete_role()` by first getting the policy from the existing policy dictionary. If the policy does not exist, an `IAMNotFoundException` is raised by `get_policy()` method.