### PR TITLE
SNS Improvements

### DIFF
--- a/docs/docs/services/sns.rst
+++ b/docs/docs/services/sns.rst
@@ -12,6 +12,8 @@
 sns
 ===
 
+.. autoclass:: moto.sns.models.SNSBackend
+
 |start-h3| Example usage |end-h3|
 
 .. sourcecode:: python

--- a/moto/sns/exceptions.py
+++ b/moto/sns/exceptions.py
@@ -1,7 +1,13 @@
 from moto.core.exceptions import RESTError
 
 
-class SNSNotFoundError(RESTError):
+class SNSException(RESTError):
+    def __init__(self, *args, **kwargs):
+        kwargs["template"] = "wrapped_single_error"
+        super().__init__(*args, **kwargs)
+
+
+class SNSNotFoundError(SNSException):
     code = 404
 
     def __init__(self, message, **kwargs):
@@ -13,42 +19,42 @@ class TopicNotFound(SNSNotFoundError):
         super().__init__(message="Topic does not exist")
 
 
-class ResourceNotFoundError(RESTError):
+class ResourceNotFoundError(SNSException):
     code = 404
 
     def __init__(self):
         super().__init__("ResourceNotFound", "Resource does not exist")
 
 
-class DuplicateSnsEndpointError(RESTError):
+class DuplicateSnsEndpointError(SNSException):
     code = 400
 
     def __init__(self, message):
         super().__init__("DuplicateEndpoint", message)
 
 
-class SnsEndpointDisabled(RESTError):
+class SnsEndpointDisabled(SNSException):
     code = 400
 
     def __init__(self, message):
         super().__init__("EndpointDisabled", message)
 
 
-class SNSInvalidParameter(RESTError):
+class SNSInvalidParameter(SNSException):
     code = 400
 
     def __init__(self, message):
         super().__init__("InvalidParameter", message)
 
 
-class InvalidParameterValue(RESTError):
+class InvalidParameterValue(SNSException):
     code = 400
 
     def __init__(self, message):
         super().__init__("InvalidParameterValue", message)
 
 
-class TagLimitExceededError(RESTError):
+class TagLimitExceededError(SNSException):
     code = 400
 
     def __init__(self):
@@ -58,14 +64,14 @@ class TagLimitExceededError(RESTError):
         )
 
 
-class InternalError(RESTError):
+class InternalError(SNSException):
     code = 500
 
     def __init__(self, message):
         super().__init__("InternalFailure", message)
 
 
-class TooManyEntriesInBatchRequest(RESTError):
+class TooManyEntriesInBatchRequest(SNSException):
     code = 400
 
     def __init__(self):
@@ -75,7 +81,7 @@ class TooManyEntriesInBatchRequest(RESTError):
         )
 
 
-class BatchEntryIdsNotDistinct(RESTError):
+class BatchEntryIdsNotDistinct(SNSException):
     code = 400
 
     def __init__(self):

--- a/moto/sns/models.py
+++ b/moto/sns/models.py
@@ -51,6 +51,7 @@ class Topic(CloudFormationModel):
         self.subscriptions_pending = 0
         self.subscriptions_confimed = 0
         self.subscriptions_deleted = 0
+        self.sent_notifications = []
 
         self._policy_json = self._create_default_topic_policy(
             sns_backend.region_name, self.account_id, name
@@ -70,6 +71,9 @@ class Topic(CloudFormationModel):
                 message_attributes=message_attributes,
                 group_id=group_id,
             )
+        self.sent_notifications.append(
+            (message_id, message, subject, message_attributes, group_id)
+        )
         return message_id
 
     @classmethod
@@ -89,7 +93,7 @@ class Topic(CloudFormationModel):
 
     @property
     def policy(self):
-        return json.dumps(self._policy_json)
+        return json.dumps(self._policy_json, separators=(",", ":"))
 
     @policy.setter
     def policy(self, policy):
@@ -215,7 +219,7 @@ class Subscription(BaseModel):
                     if value["Type"].startswith("Binary"):
                         attr_type = "binary_value"
                     elif value["Type"].startswith("Number"):
-                        type_value = "{0:g}".format(value["Value"])
+                        type_value = str(value["Value"])
 
                     raw_message_attributes[key] = {
                         "data_type": value["Type"],
@@ -404,6 +408,19 @@ class PlatformEndpoint(BaseModel):
 
 
 class SNSBackend(BaseBackend):
+    """
+    Responsible for mocking calls to SNS. Integration with SQS/HTTP/etc is supported.
+
+    Messages published to a topic are persisted in the backend. If you need to verify that a message was published successfully, you can use the internal API to check the message was published successfully:
+
+    .. sourcecode:: python
+
+        from moto.sns import sns_backend
+        all_send_notifications = sns_backend.topics[topic_arn].sent_notifications
+
+    Note that, as this is an internal API, the exact format may differ per versions.
+    """
+
     def __init__(self, region_name):
         super().__init__()
         self.topics = OrderedDict()
@@ -880,7 +897,7 @@ class SNSBackend(BaseBackend):
                     message=entry["Message"],
                     arn=topic_arn,
                     subject=entry.get("Subject"),
-                    message_attributes=entry.get("MessageAttributes", []),
+                    message_attributes=entry.get("MessageAttributes", {}),
                     group_id=entry.get("MessageGroupId"),
                 )
                 successful.append({"MessageId": message_id, "Id": entry["Id"]})

--- a/tests/terraform-tests.success.txt
+++ b/tests/terraform-tests.success.txt
@@ -84,6 +84,7 @@ TestAccAWSProvider
 TestAccAWSRedshiftServiceAccount
 TestAccAWSRolePolicyAttachment
 TestAccAWSSNSSMSPreferences
+TestAccAWSSNSTopicPolicy
 TestAccAWSSageMakerPrebuiltECRImage
 TestAccAWSServiceDiscovery
 TestAccAWSSQSQueuePolicy

--- a/tests/test_sns/test_publish_batch.py
+++ b/tests/test_sns/test_publish_batch.py
@@ -145,10 +145,43 @@ def test_publish_batch_to_sqs():
     messages.should.contain({"Message": "1"})
     messages.should.contain({"Message": "2", "Subject": "subj2"})
     messages.should.contain(
-        {
-            "Message": "3",
-            "MessageAttributes": [
-                {"Name": "a", "Value": {"DataType": "String", "StringValue": "v"}}
-            ],
-        }
+        {"Message": "3", "MessageAttributes": {"a": {"Type": "String", "Value": "v"}}}
     )
+
+
+@mock_sqs
+@mock_sns
+def test_publish_batch_to_sqs_raw():
+    client = boto3.client("sns", region_name="us-east-1")
+    topic_arn = client.create_topic(Name="standard_topic")["TopicArn"]
+    sqs = boto3.resource("sqs", region_name="us-east-1")
+    queue = sqs.create_queue(QueueName="test-queue")
+
+    queue_url = "arn:aws:sqs:us-east-1:{}:test-queue".format(ACCOUNT_ID)
+    client.subscribe(
+        TopicArn=topic_arn,
+        Protocol="sqs",
+        Endpoint=queue_url,
+        Attributes={"RawMessageDelivery": "true"},
+    )
+
+    entries = [
+        {"Id": "1", "Message": "foo",},
+        {
+            "Id": "2",
+            "Message": "bar",
+            "MessageAttributes": {"a": {"DataType": "String", "StringValue": "v"}},
+        },
+    ]
+    resp = client.publish_batch(TopicArn=topic_arn, PublishBatchRequestEntries=entries,)
+
+    resp.should.have.key("Successful").length_of(2)
+
+    received = queue.receive_messages(
+        MaxNumberOfMessages=10, MessageAttributeNames=["All"],
+    )
+
+    messages = [(message.body, message.message_attributes) for message in received]
+
+    messages.should.contain(("foo", None))
+    messages.should.contain(("bar", {"a": {"StringValue": "v", "DataType": "String"}}))

--- a/tests/test_sns/test_topics_boto3.py
+++ b/tests/test_sns/test_topics_boto3.py
@@ -214,7 +214,7 @@ def test_topic_attributes():
     )
 
     attributes = conn.get_topic_attributes(TopicArn=topic_arn)["Attributes"]
-    attributes["Policy"].should.equal('{"foo": "bar"}')
+    attributes["Policy"].should.equal('{"foo":"bar"}')
     attributes["DisplayName"].should.equal("My display name")
     attributes["DeliveryPolicy"].should.equal(
         '{"http": {"defaultHealthyRetryPolicy": {"numRetries": 5}}}'


### PR DESCRIPTION
 - Stores any SNS Notifications that were send, so that users can use the internal API to verify the contents
 - Fixes the formatting of numbers used as message attributes
 - Fixes a bug in publish_batch where message attributes would not be processed correctly
 - Fixes the formatting of SNS Errors, so that TF understands error responses correctly

Fixes #3252
Fixes #4756 
Fixes #4757 
Fixes #4819 

Supercedes #4818 