### PR TITLE
RDS: enable add and remove tag for resources

### DIFF
--- a/moto/rds2/models.py
+++ b/moto/rds2/models.py
@@ -1971,14 +1971,16 @@ class RDS2Backend(BaseBackend):
             resource_name = arn_breakdown[len(arn_breakdown) - 1]
             if resource_type == "db":  # Database
                 if resource_name in self.databases:
-                    self.databases[resource_name].remove_tags(tag_keys)
+                    return self.databases[resource_name].remove_tags(tag_keys)
             elif resource_type == "es":  # Event Subscription
-                return None
+                if resource_name in self.event_subscriptions:
+                    return self.event_subscriptions[resource_name].remove_tags(tag_keys)
             elif resource_type == "og":  # Option Group
                 if resource_name in self.option_groups:
                     return self.option_groups[resource_name].remove_tags(tag_keys)
             elif resource_type == "pg":  # Parameter Group
-                return None
+                if resource_name in self.db_parameter_groups:
+                    return self.db_parameter_groups[resource_name].remove_tags(tag_keys)
             elif resource_type == "ri":  # Reserved DB instance
                 return None
             elif resource_type == "secgrp":  # DB security group
@@ -2007,12 +2009,14 @@ class RDS2Backend(BaseBackend):
                 if resource_name in self.databases:
                     return self.databases[resource_name].add_tags(tags)
             elif resource_type == "es":  # Event Subscription
-                return []
+                if resource_name in self.event_subscriptions:
+                    return self.event_subscriptions[resource_name].add_tags(tags)
             elif resource_type == "og":  # Option Group
                 if resource_name in self.option_groups:
                     return self.option_groups[resource_name].add_tags(tags)
             elif resource_type == "pg":  # Parameter Group
-                return []
+                if resource_name in self.db_parameter_groups:
+                    return self.db_parameter_groups[resource_name].add_tags(tags)
             elif resource_type == "ri":  # Reserved DB instance
                 return []
             elif resource_type == "secgrp":  # DB security group

--- a/tests/test_rds2/test_rds2.py
+++ b/tests/test_rds2/test_rds2.py
@@ -1568,6 +1568,32 @@ def test_list_tags_database_subnet_group():
     )
 
 
+@mock_rds2
+def test_modify_tags_parameter_group():
+    conn = boto3.client("rds", region_name="us-west-2")
+    client_tags = [{"Key": "character_set_client", "Value": "utf-8"}]
+    result = conn.create_db_parameter_group(
+        DBParameterGroupName="test-sqlserver-2017",
+        DBParameterGroupFamily="mysql5.6",
+        Description="MySQL Group",
+        Tags=client_tags,
+    )
+    resource = result["DBParameterGroup"]["DBParameterGroupArn"]
+    result = conn.list_tags_for_resource(ResourceName=resource)
+    result["TagList"].should.equal(client_tags)
+    server_tags = [{"Key": "character_set_server", "Value": "utf-8"}]
+    conn.add_tags_to_resource(ResourceName=resource, Tags=server_tags)
+    combined_tags = client_tags + server_tags
+    result = conn.list_tags_for_resource(ResourceName=resource)
+    result["TagList"].should.equal(combined_tags)
+
+    conn.remove_tags_from_resource(
+        ResourceName=resource, TagKeys=["character_set_client"]
+    )
+    result = conn.list_tags_for_resource(ResourceName=resource)
+    result["TagList"].should.equal(server_tags)
+
+
 @mock_ec2
 @mock_rds2
 def test_add_tags_database_subnet_group():


### PR DESCRIPTION
This PR enables adding and removing tags from EventSubscription and DBParameterGroup.

Added testcase where DBParameterGroup + EventSubscription tags are modified.