### PR TITLE
Fix copying S3 objects, when using MetadataDirective='REPLACE'

### DIFF
--- a/moto/s3/models.py
+++ b/moto/s3/models.py
@@ -2016,6 +2016,7 @@ class S3Backend(BaseBackend, CloudWatchMetricProvider):
         encryption=None,
         kms_key_id=None,
         bucket_key_enabled=False,
+        mdirective=None,
     ):
         if (
             src_key.name == dest_key_name
@@ -2025,6 +2026,7 @@ class S3Backend(BaseBackend, CloudWatchMetricProvider):
             and encryption == src_key.encryption
             and kms_key_id == src_key.kms_key_id
             and bucket_key_enabled == (src_key.bucket_key_enabled or False)
+            and mdirective != "REPLACE"
         ):
             raise CopyObjectMustChangeSomething
 

--- a/moto/s3/responses.py
+++ b/moto/s3/responses.py
@@ -1468,6 +1468,8 @@ class ResponseObject(_TemplateEnvironmentMixin, ActionAuthenticatorMixin):
                     == "true"
                 )
 
+                mdirective = request.headers.get("x-amz-metadata-directive")
+
                 self.backend.copy_object(
                     key,
                     bucket_name,
@@ -1477,12 +1479,12 @@ class ResponseObject(_TemplateEnvironmentMixin, ActionAuthenticatorMixin):
                     kms_key_id=kms_key_id,
                     encryption=encryption,
                     bucket_key_enabled=bucket_key_enabled,
+                    mdirective=mdirective,
                 )
             else:
                 raise MissingKey(key=src_key)
 
             new_key = self.backend.get_object(bucket_name, key_name)
-            mdirective = request.headers.get("x-amz-metadata-directive")
             if mdirective is not None and mdirective == "REPLACE":
                 metadata = metadata_from_headers(request.headers)
                 new_key.set_metadata(metadata, replace=True)

--- a/tests/test_s3/test_s3.py
+++ b/tests/test_s3/test_s3.py
@@ -704,6 +704,30 @@ def test_copy_key_without_changes_should_error_boto3():
         )
 
 
+@mock_s3
+def test_copy_key_without_changes_should_not_error_boto3():
+    client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
+    bucket_name = "my_bucket"
+    s3 = boto3.resource("s3", region_name=DEFAULT_REGION_NAME)
+    key_name = "my_key"
+    key = s3.Object(bucket_name, key_name)
+
+    s3.create_bucket(Bucket=bucket_name)
+    key.put(Body=b"some value")
+
+    client.copy_object(
+        Bucket=bucket_name,
+        CopySource="{}/{}".format(bucket_name, key_name),
+        Key=key_name,
+        Metadata={"some-key": "some-value"},
+        MetadataDirective="REPLACE",
+    )
+
+    new_object = client.get_object(Bucket=bucket_name, Key=key_name)
+
+    assert new_object["Metadata"] == {"some-key": "some-value"}
+
+
 @freeze_time("2012-01-01 12:00:00")
 @mock_s3
 def test_last_modified_boto3():


### PR DESCRIPTION
This relates to the change in https://github.com/spulec/moto/pull/4838.

When using the MetadataDirective, the copy_object call is still allowed, even if no other changes take place. The current version of moto 3.0.4 doesn't allow this.

Example using boto3:

```python
import boto3
key_name = "my_file.txt"
source_bucket = "bucket.bucket.com"

s3_client = boto3.client('s3')

# Write a file for us to use
s3 = boto3.resource("s3", region_name='eu-west-1')
key = s3.Object(source_bucket, key_name)
key.put(Body=b"some value")

# attempt to copy object to itself
# This would fail with a ClientError (Invalid Request) because the object is already in the bucket and nothing is being changed
s3_client.copy_object(
    Bucket=source_bucket,
    CopySource=f"{source_bucket}/{key_name}",
    Key=key_name,
)


# This is allowed by boto3, but fails when using moto
s3_client.copy_object(
    Bucket=source_bucket,
    CopySource=f"{source_bucket}/{key_name}",
    Key=key_name,
    MetadataDirective="REPLACE",
)
```

I'm not sure if I've done the correct thing here by adding a new property to the copy_object function in the model, so happy to receive some input on that.

Also added a test which fails on the latest `master` branch.

