### PR TITLE
Added support for custom AWS Lambda images.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,12 @@
 Moto Changelog
-===================
+==============
 
 3.0.5
 -----
 Docker Digest for 3.0.5: <autopopulateddigest>
 
-    TBD
+    Miscellaneous:
+        * AWSLambda: Made the docker image repository selectable via the `MOTO_DOCKER_LAMBDA_IMAGE` environment variable.
 
 3.0.4
 -----

--- a/moto/awslambda/models.py
+++ b/moto/awslambda/models.py
@@ -610,7 +610,8 @@ class LambdaFunction(CloudFormationModel, DockerModel):
                             "host.docker.internal": "host-gateway"
                         }
 
-                    image_ref = "lambci/lambda:{}".format(self.run_time)
+                    image_repo = settings.moto_lambda_image()
+                    image_ref = f"{image_repo}:{self.run_time}"
                     self.docker_client.images.pull(":".join(parse_image_ref(image_ref)))
                     container = self.docker_client.containers.run(
                         image_ref,
@@ -1171,6 +1172,7 @@ The following environment variables are available for fine-grained control over 
     # Note that this option will be ignored if MOTO_DOCKER_NETWORK_NAME is also set
     MOTO_DOCKER_NETWORK_MODE=host moto_server
 
+The Docker image can be overridden using an environment variable: ``MOTO_DOCKER_LAMBDA_IMAGE``.
 
 .. note:: When using the decorators, a Docker container cannot reach Moto, as it does not run as a server. Any boto3-invocations used within your Lambda will try to connect to AWS.
     """

--- a/moto/settings.py
+++ b/moto/settings.py
@@ -66,6 +66,10 @@ def moto_server_host():
         return "http://host.docker.internal"
 
 
+def moto_lambda_image():
+    return os.environ.get("MOTO_DOCKER_LAMBDA_IMAGE", "lambci/lambda")
+
+
 def moto_network_name():
     return os.environ.get("MOTO_DOCKER_NETWORK_NAME")
 


### PR DESCRIPTION
~~Also changed the default to `mlupin/docker-lambda`.~~

Currently the image used for executing Lambda functions is hardcoded:

https://github.com/spulec/moto/blob/e84cc20abe5b92e3bb77bcddd9240d4233a9524e/moto/awslambda/models.py#L613

Unfortunately it seems that development has also stalled, the last release at the time of writing being over one year ago:

- https://github.com/lambci/docker-lambda
- https://hub.docker.com/r/lambci/lambda/tags

Because of this, there is no image built for Python 3.9 which means it is not possible to use this with moto.

~~Instead, we should~~ With this change it is possible to switch to using a supported fork:

- https://github.com/mLupine/docker-lambda
- https://hub.docker.com/r/mlupin/docker-lambda/tags

~~In addition, it is now possible to set~~ This is achieved by setting the `MOTO_DOCKER_LAMBDA_IMAGE` environment variable to override this as required.