### PR TITLE
Addition of Entities Ids when listing

### DIFF
--- a/moto/iam/responses.py
+++ b/moto/iam/responses.py
@@ -129,7 +129,7 @@ class IamResponse(BaseResponse):
                 for user in users:
                     for p in user.managed_policies:
                         if p == policy_arn:
-                            entity_users.append(user.name)
+                            entity_users.append({"name": user.name, "id": user.id})
 
         if not entity or entity == "Role":
             roles, _ = iam_backend.list_roles(path_prefix, marker, max_items)
@@ -137,7 +137,7 @@ class IamResponse(BaseResponse):
                 for role in roles:
                     for p in role.managed_policies:
                         if p == policy_arn:
-                            entity_roles.append(role.name)
+                            entity_roles.append({"name": role.name, "id": role.id})
 
         if not entity or entity == "Group":
             groups = iam_backend.list_groups()
@@ -145,7 +145,7 @@ class IamResponse(BaseResponse):
                 for group in groups:
                     for p in group.managed_policies:
                         if p == policy_arn:
-                            entity_groups.append(group.name)
+                            entity_groups.append({"name": group.name, "id": group.id})
 
         if entity == "LocalManagedPolicy" or entity == "AWSManagedPolicy":
             users = iam_backend.list_users(path_prefix, marker, max_items)
@@ -153,21 +153,21 @@ class IamResponse(BaseResponse):
                 for user in users:
                     for p in user.managed_policies:
                         if p == policy_arn:
-                            entity_users.append(user.name)
+                            entity_users.append({"name": user.name, "id": user.id})
 
             roles, _ = iam_backend.list_roles(path_prefix, marker, max_items)
             if roles:
                 for role in roles:
                     for p in role.managed_policies:
                         if p == policy_arn:
-                            entity_roles.append(role.name)
+                            entity_roles.append({"name": role.name, "id": role.id})
 
             groups = iam_backend.list_groups()
             if groups:
                 for group in groups:
                     for p in group.managed_policies:
                         if p == policy_arn:
-                            entity_groups.append(group.name)
+                            entity_groups.append({"name": group.name, "id": group.id})
 
         template = self.response_template(LIST_ENTITIES_FOR_POLICY_TEMPLATE)
         return template.render(
@@ -1098,14 +1098,16 @@ LIST_ENTITIES_FOR_POLICY_TEMPLATE = """<ListEntitiesForPolicyResponse>
  <PolicyRoles>
        {% for role in roles %}
       <member>
-        <RoleName>{{ role }}</RoleName>
+        <RoleName>{{ role.name }}</RoleName>
+        <RoleId>{{ role.id }}</RoleId>
       </member>
       {% endfor %}
  </PolicyRoles>
  <PolicyGroups>
        {% for group in groups %}
       <member>
-        <GroupName>{{ group }}</GroupName>
+        <GroupName>{{ group.name }}</GroupName>
+        <GroupId>{{ group.id }}</GroupId>
       </member>
       {% endfor %}
  </PolicyGroups>
@@ -1113,7 +1115,8 @@ LIST_ENTITIES_FOR_POLICY_TEMPLATE = """<ListEntitiesForPolicyResponse>
  <PolicyUsers>
       {% for user in users %}
       <member>
-        <UserName>{{ user }}</UserName>
+        <UserName>{{ user.name }}</UserName>
+        <UserId>{{ user.id }}</UserId>
       </member>
       {% endfor %}
  </PolicyUsers>

--- a/tests/test_iam/test_iam.py
+++ b/tests/test_iam/test_iam.py
@@ -2815,7 +2815,8 @@ def test_list_entities_for_policy():
         PolicyArn="arn:aws:iam::{}:policy/testPolicy".format(ACCOUNT_ID),
         EntityFilter="Role",
     )
-    assert response["PolicyRoles"] == [{"RoleName": "my-role"}]
+    assert response["PolicyRoles"][0]["RoleName"] == "my-role"
+    response["PolicyRoles"][0].should.have.key("RoleId")
     response["PolicyGroups"].should.equal([])
     response["PolicyUsers"].should.equal([])
 
@@ -2823,7 +2824,8 @@ def test_list_entities_for_policy():
         PolicyArn="arn:aws:iam::{}:policy/testPolicy".format(ACCOUNT_ID),
         EntityFilter="User",
     )
-    assert response["PolicyUsers"] == [{"UserName": "testUser"}]
+    assert response["PolicyUsers"][0]["UserName"] == "testUser"
+    response["PolicyUsers"][0].should.have.key("UserId")
     response["PolicyGroups"].should.equal([])
     response["PolicyRoles"].should.equal([])
 
@@ -2831,7 +2833,8 @@ def test_list_entities_for_policy():
         PolicyArn="arn:aws:iam::{}:policy/testPolicy".format(ACCOUNT_ID),
         EntityFilter="Group",
     )
-    assert response["PolicyGroups"] == [{"GroupName": "testGroup"}]
+    assert response["PolicyGroups"][0]["GroupName"] == "testGroup"
+    response["PolicyGroups"][0].should.have.key("GroupId")
     response["PolicyRoles"].should.equal([])
     response["PolicyUsers"].should.equal([])
 
@@ -2839,17 +2842,25 @@ def test_list_entities_for_policy():
         PolicyArn="arn:aws:iam::{}:policy/testPolicy".format(ACCOUNT_ID),
         EntityFilter="LocalManagedPolicy",
     )
-    assert response["PolicyGroups"] == [{"GroupName": "testGroup"}]
-    assert response["PolicyUsers"] == [{"UserName": "testUser"}]
-    assert response["PolicyRoles"] == [{"RoleName": "my-role"}]
+    assert response["PolicyGroups"][0]["GroupName"] == "testGroup"
+    assert response["PolicyUsers"][0]["UserName"] == "testUser"
+    assert response["PolicyRoles"][0]["RoleName"] == "my-role"
+
+    response["PolicyGroups"][0].should.have.key("GroupId")
+    response["PolicyUsers"][0].should.have.key("UserId")
+    response["PolicyRoles"][0].should.have.key("RoleId")
 
     # Return everything when no entity is specified
     response = conn.list_entities_for_policy(
         PolicyArn="arn:aws:iam::{}:policy/testPolicy".format(ACCOUNT_ID)
     )
-    response["PolicyGroups"].should.equal([{"GroupName": "testGroup"}])
-    response["PolicyUsers"].should.equal([{"UserName": "testUser"}])
-    response["PolicyRoles"].should.equal([{"RoleName": "my-role"}])
+    response["PolicyGroups"][0]["GroupName"].should.equal("testGroup")
+    response["PolicyUsers"][0]["UserName"].should.equal("testUser")
+    response["PolicyRoles"][0]["RoleName"].should.equal("my-role")
+
+    response["PolicyGroups"][0].should.have.key("GroupId")
+    response["PolicyUsers"][0].should.have.key("UserId")
+    response["PolicyRoles"][0].should.have.key("RoleId")
 
 
 @mock_iam()

--- a/tests/test_iam/test_iam_cloudformation.py
+++ b/tests/test_iam/test_iam_cloudformation.py
@@ -473,9 +473,11 @@ Resources:
     )
 
     response = iam_client.list_entities_for_policy(PolicyArn=policy_arn)
-    response.should.have.key("PolicyGroups").equal([{"GroupName": group_name}])
     response.should.have.key("PolicyUsers").equal([])
     response.should.have.key("PolicyRoles").equal([])
+
+    response["PolicyGroups"][0]["GroupName"].should.be.equal(group_name)
+    response["PolicyGroups"][0].should.have.key("GroupId")
 
 
 @mock_iam
@@ -523,8 +525,10 @@ Resources:
 
     response = iam_client.list_entities_for_policy(PolicyArn=policy_arn)
     response.should.have.key("PolicyGroups").equal([])
-    response.should.have.key("PolicyUsers").equal([{"UserName": user_name}])
     response.should.have.key("PolicyRoles").equal([])
+
+    response["PolicyUsers"][0]["UserName"].should.be.equal(user_name)
+    response["PolicyUsers"][0].should.have.key("UserId")
 
 
 @mock_iam
@@ -573,7 +577,9 @@ Resources:
     response = iam_client.list_entities_for_policy(PolicyArn=policy_arn)
     response.should.have.key("PolicyGroups").equal([])
     response.should.have.key("PolicyUsers").equal([])
-    response.should.have.key("PolicyRoles").equal([{"RoleName": role_name}])
+
+    response["PolicyRoles"][0]["RoleName"].should.be.equal(role_name)
+    response["PolicyRoles"][0].should.have.key("RoleId")
 
 
 # AWS::IAM::Policy Tests


### PR DESCRIPTION
This PR addresses localstack/localstack#5296. where the user describes that the IAM service is missing the Resource Id (GroupId, UserId and RoleId) when calling **ListEntitiesForPolicy**. I compared the Moto response to AWS and it's true.

Changes:
- Addition of GroupId's, RoleId's and UserId's to the **ListEntitiesForPolicy** response.
- Extension of Iam tests to validate the existanse of the attribute in the response.