### PR TITLE
Unknown regions - fixes a bug in caching mechanism

### DIFF
--- a/moto/core/utils.py
+++ b/moto/core/utils.py
@@ -416,6 +416,8 @@ class BackendDict(dict):
         return item in self.regions or item in self.keys()
 
     def __getitem__(self, item):
+        if item in self.keys():
+            return super().__getitem__(item)
         # Create the backend for a specific region
         if item in self.regions and item not in self.keys():
             super().__setitem__(item, self.fn(item))

--- a/moto/s3control/urls.py
+++ b/moto/s3control/urls.py
@@ -7,8 +7,8 @@ url_bases = [
 
 
 url_paths = {
-    "{0}/v20180820/configuration/publicAccessBlock$": S3ControlResponseInstance.public_access_block,
-    "{0}/v20180820/accesspoint/(?P<name>[\w_:%-]+)$": S3ControlResponseInstance.access_point,
-    "{0}/v20180820/accesspoint/(?P<name>[\w_:%-]+)/policy$": S3ControlResponseInstance.access_point_policy,
-    "{0}/v20180820/accesspoint/(?P<name>[\w_:%-]+)/policyStatus$": S3ControlResponseInstance.access_point_policy_status,
+    r"{0}/v20180820/configuration/publicAccessBlock$": S3ControlResponseInstance.public_access_block,
+    r"{0}/v20180820/accesspoint/(?P<name>[\w_:%-]+)$": S3ControlResponseInstance.access_point,
+    r"{0}/v20180820/accesspoint/(?P<name>[\w_:%-]+)/policy$": S3ControlResponseInstance.access_point_policy,
+    r"{0}/v20180820/accesspoint/(?P<name>[\w_:%-]+)/policyStatus$": S3ControlResponseInstance.access_point_policy_status,
 }

--- a/tests/test_core/test_mock_regions.py
+++ b/tests/test_core/test_mock_regions.py
@@ -2,7 +2,7 @@ import boto3
 import mock
 import os
 import pytest
-from moto import mock_sns, settings
+from moto import mock_dynamodb2, mock_sns, settings
 from unittest import SkipTest
 
 
@@ -42,3 +42,20 @@ def test_use_unknown_region_from_env_but_allow_it():
         raise SkipTest("Cannot set environemnt variables in ServerMode")
     client = boto3.client("sns")
     client.list_platform_applications()["PlatformApplications"].should.equal([])
+
+
+@mock_dynamodb2
+@mock.patch.dict(os.environ, {"MOTO_ALLOW_NONEXISTENT_REGION": "trUe"})
+def test_use_unknown_region_from_env_but_allow_it__dynamo():
+    if settings.TEST_SERVER_MODE:
+        raise SkipTest("Cannot set environemnt variables in ServerMode")
+    dynamo_db = boto3.resource("dynamodb", region_name="test")
+    dynamo_db.create_table(
+        TableName="test_table",
+        KeySchema=[{"AttributeName": "key", "KeyType": "HASH"}],
+        AttributeDefinitions=[{"AttributeName": "key", "AttributeType": "S"}],
+        BillingMode="PAY_PER_REQUEST",
+    )
+    tables = list(dynamo_db.tables.all())
+    tables.should.have.length_of(1)
+    [table.name for table in tables].should.equal(["test_table"])


### PR DESCRIPTION
Fixes #4893 

The Backend for unknown regions would be recreated for every request, effectively resetting it every time.
This PR ensures a previously created cache entry is actually used

Also removes some unrelated warnings from S3Control