### PR TITLE
fix for duplicate tag keys in secretsmanager

### DIFF
--- a/moto/secretsmanager/models.py
+++ b/moto/secretsmanager/models.py
@@ -735,6 +735,9 @@ class SecretsManagerBackend(BaseBackend):
         old_tags = secret.tags
 
         for tag in tags:
+            existing_key_name = next((old_key for old_key in old_tags if old_key.get('Key') == tag.get('Key')), None)
+            if existing_key_name:
+                old_tags.remove(existing_key_name)
             old_tags.append(tag)
 
         return secret_id

--- a/moto/secretsmanager/models.py
+++ b/moto/secretsmanager/models.py
@@ -735,7 +735,14 @@ class SecretsManagerBackend(BaseBackend):
         old_tags = secret.tags
 
         for tag in tags:
-            existing_key_name = next((old_key for old_key in old_tags if old_key.get('Key') == tag.get('Key')), None)
+            existing_key_name = next(
+                (
+                    old_key
+                    for old_key in old_tags
+                    if old_key.get("Key") == tag.get("Key")
+                ),
+                None,
+            )
             if existing_key_name:
                 old_tags.remove(existing_key_name)
             old_tags.append(tag)

--- a/tests/test_secretsmanager/test_secretsmanager.py
+++ b/tests/test_secretsmanager/test_secretsmanager.py
@@ -1282,14 +1282,16 @@ def test_tag_resource(pass_arn):
     conn.tag_resource(
         SecretId=secret_id, Tags=[{"Key": "FirstTag", "Value": "SomeValue"},],
     )
-
+    conn.tag_resource(
+        SecretId="test-secret", Tags=[{"Key": "FirstTag", "Value": "SomeOtherValue"}, ],
+    )
     conn.tag_resource(
         SecretId=secret_id, Tags=[{"Key": "SecondTag", "Value": "AnotherValue"},],
     )
 
     secrets = conn.list_secrets()
     assert secrets["SecretList"][0].get("Tags") == [
-        {"Key": "FirstTag", "Value": "SomeValue"},
+        {"Key": "FirstTag", "Value": "SomeOtherValue"},
         {"Key": "SecondTag", "Value": "AnotherValue"},
     ]
 

--- a/tests/test_secretsmanager/test_secretsmanager.py
+++ b/tests/test_secretsmanager/test_secretsmanager.py
@@ -1283,7 +1283,7 @@ def test_tag_resource(pass_arn):
         SecretId=secret_id, Tags=[{"Key": "FirstTag", "Value": "SomeValue"},],
     )
     conn.tag_resource(
-        SecretId="test-secret", Tags=[{"Key": "FirstTag", "Value": "SomeOtherValue"}, ],
+        SecretId="test-secret", Tags=[{"Key": "FirstTag", "Value": "SomeOtherValue"},],
     )
     conn.tag_resource(
         SecretId=secret_id, Tags=[{"Key": "SecondTag", "Value": "AnotherValue"},],


### PR DESCRIPTION
This should fix issue #4899 