### PR TITLE
Admin - change XML2Dict namespace separator

### DIFF
--- a/moto/sts/models.py
+++ b/moto/sts/models.py
@@ -102,22 +102,23 @@ class STSBackend(BaseBackend):
             force_cdata=True,
             process_namespaces=True,
             namespaces=namespaces,
+            namespace_separator="|",
         )
 
-        saml_assertion_attributes = saml_assertion["samlp:Response"]["saml:Assertion"][
-            "saml:AttributeStatement"
-        ]["saml:Attribute"]
+        saml_assertion_attributes = saml_assertion["samlp|Response"]["saml|Assertion"][
+            "saml|AttributeStatement"
+        ]["saml|Attribute"]
         for attribute in saml_assertion_attributes:
             if (
                 attribute["@Name"]
                 == "https://aws.amazon.com/SAML/Attributes/RoleSessionName"
             ):
-                kwargs["role_session_name"] = attribute["saml:AttributeValue"]["#text"]
+                kwargs["role_session_name"] = attribute["saml|AttributeValue"]["#text"]
             if (
                 attribute["@Name"]
                 == "https://aws.amazon.com/SAML/Attributes/SessionDuration"
             ):
-                kwargs["duration"] = int(attribute["saml:AttributeValue"]["#text"])
+                kwargs["duration"] = int(attribute["saml|AttributeValue"]["#text"])
 
         if "duration" not in kwargs:
             kwargs["duration"] = DEFAULT_STS_SESSION_DURATION


### PR DESCRIPTION
The default separator, ':',  broke the underlying parser after a security update.

Source: https://bugs.launchpad.net/ubuntu/+source/python-xmltodict/+bug/1961800
Proposed fix to xmltodict: https://github.com/martinblech/xmltodict/pull/290

As far as I can tell, this is the only place where it affects Moto, as no other services use XML namespaces.
This PR should remove the need to wait for any upstream/downstream fixes that may or may not happen.

@thrau FYI, as it looks like were bitten by this first here: https://github.com/localstack/localstack/pull/5585