### PR TITLE
Fix deleting secrets by ARN

### DIFF
--- a/moto/secretsmanager/models.py
+++ b/moto/secretsmanager/models.py
@@ -180,6 +180,10 @@ class SecretsStore(dict):
         new_key = get_secret_name_from_arn(key)
         return dict.__contains__(self, new_key)
 
+    def get(self, key, *args, **kwargs):
+        new_key = get_secret_name_from_arn(key)
+        return super().get(new_key, *args, **kwargs)
+
     def pop(self, key, *args, **kwargs):
         new_key = get_secret_name_from_arn(key)
         return super().pop(new_key, *args, **kwargs)

--- a/tests/test_secretsmanager/test_secretsmanager.py
+++ b/tests/test_secretsmanager/test_secretsmanager.py
@@ -227,6 +227,25 @@ def test_delete_secret():
 
 
 @mock_secretsmanager
+def test_delete_secret_by_arn():
+    conn = boto3.client("secretsmanager", region_name="us-west-2")
+
+    secret = conn.create_secret(Name="test-secret", SecretString="foosecret")
+
+    deleted_secret = conn.delete_secret(SecretId=secret["ARN"])
+
+    assert deleted_secret["ARN"] == secret["ARN"]
+    assert deleted_secret["Name"] == "test-secret"
+    assert deleted_secret["DeletionDate"] > datetime.fromtimestamp(1, pytz.utc)
+
+    secret_details = conn.describe_secret(SecretId="test-secret")
+
+    assert secret_details["ARN"] == secret["ARN"]
+    assert secret_details["Name"] == "test-secret"
+    assert secret_details["DeletedDate"] > datetime.fromtimestamp(1, pytz.utc)
+
+
+@mock_secretsmanager
 def test_delete_secret_force():
     conn = boto3.client("secretsmanager", region_name="us-west-2")
 


### PR DESCRIPTION
This fixes an issue with deleting secrets in AWS Secrets Manager not
being possible when using the full ARN as secret id, because SecretsStore
didn't do resolve from ARNs to secret names when using get().

Fixes #4917