### PR TITLE
ELBv2: Fix LoadBalancerNotFound being thrown for listener rules

### DIFF
--- a/moto/elbv2/models.py
+++ b/moto/elbv2/models.py
@@ -307,6 +307,7 @@ class FakeListenerRule(CloudFormationModel):
         self.conditions = conditions
         self.actions = actions
         self.priority = priority
+        self.tags = {}
 
     @property
     def physical_resource_id(self):

--- a/tests/test_elbv2/test_elbv2_listener_rules.py
+++ b/tests/test_elbv2/test_elbv2_listener_rules.py
@@ -117,6 +117,10 @@ def test_create_rule_condition(condition):
     response = conn.describe_rules(RuleArns=[rule["RuleArn"]])
     response["Rules"].should.equal([rule])
 
+    # assert describe_tags response
+    response = conn.describe_tags(ResourceArns=[rule["RuleArn"]])
+    response["TagDescriptions"].should.have.length_of(1)
+
 
 @mock_elbv2
 @mock_ec2


### PR DESCRIPTION
### Summary

This PR fixes an incorrect error being thrown for `DescribeTags` on listener rules, even when it is valid.

```
$ awslocal elbv2 describe-tags --resource-arns arn:aws:elasticloadbalancing:us-east-1:000000000000:listener-rule/foobar/50dc6c495c0c9188/None139624438527312/bdc4f6368e71c81f

An error occurred (LoadBalancerNotFound) when calling the DescribeTags operation: The specified load balancer does not exist.
```

This is fixed to return correct error for invalid listener rules

```
$ awslocal elbv2 describe-tags --resource-arns arn:aws:elasticloadbalancing:us-east-1:000000000000:listener-rule/foobar/50dc6c495c0c9188/None139835059098528/4e5d3770330e38dc

An error occurred (RuleNotFound) when calling the DescribeTags operation: The specified rule does not exist.
```

and expected response for valid listener rules:

```
$ awslocal elbv2 describe-tags --resource-arns arn:aws:elasticloadbalancing:us-east-1:000000000000:listener-rule/foobar/50dc6c495c0c9188/None139835059098528/4e5d3770330e389c
{
    "TagDescriptions": [
        {
            "ResourceArn": "arn:aws:elasticloadbalancing:us-east-1:000000000000:listener-rule/foobar/50dc6c495c0c9188/None139835059098528/4e5d3770330e389c",
            "Tags": []
        }
    ]
}
```