### PR TITLE
ELBv2: DescribeListeners and missing ARNs

### DIFF
--- a/moto/elbv2/exceptions.py
+++ b/moto/elbv2/exceptions.py
@@ -131,7 +131,7 @@ class ActionTargetGroupNotFoundError(ELBClientError):
 
 
 class ListenerOrBalancerMissingError(ELBClientError):
-    def __init__(self, arn):
+    def __init__(self):
         super().__init__(
             "ValidationError",
             "You must specify either listener ARNs or a load balancer ARN",

--- a/tests/test_elbv2/test_elbv2.py
+++ b/tests/test_elbv2/test_elbv2.py
@@ -90,6 +90,20 @@ def test_describe_load_balancers():
 
 @mock_elbv2
 @mock_ec2
+def test_describe_listeners():
+    conn = boto3.client("elbv2", region_name="us-east-1")
+
+    with pytest.raises(ClientError) as exc:
+        conn.describe_listeners()
+    err = exc.value.response["Error"]
+    err["Code"].should.equal("ValidationError")
+    err["Message"].should.equal(
+        "You must specify either listener ARNs or a load balancer ARN"
+    )
+
+
+@mock_elbv2
+@mock_ec2
 def test_add_remove_tags():
     _, _, _, _, _, conn = create_load_balancer()
 


### PR DESCRIPTION
ELBv2 DescribeListeners requires either listener ARNs or a load balancer ARN. An exception is supposed to be thrown if these are missing.

This exception required an unused `arn` argument which was not passed, causing the following, which is fixed by this PR.

```
  File "/home/viren/repo/moto-viren-nadkarni/moto/core/utils.py", line 261, in _wrapper
    response = f(*args, **kwargs)
  File "/home/viren/repo/moto-viren-nadkarni/moto/elbv2/responses.py", line 320, in describe_listeners
    raise ListenerOrBalancerMissingError()
TypeError: __init__() missing 1 required positional argument: 'arn'
```