### PR TITLE
fixed route53 private zone value

### DIFF
--- a/moto/route53/models.py
+++ b/moto/route53/models.py
@@ -524,7 +524,7 @@ class Route53Backend(BaseBackend):
         """
         zone_list = []
         for zone in self.list_hosted_zones():
-            if zone.private_zone == "true":
+            if zone.private_zone is True:
                 this_zone = self.get_hosted_zone(zone.id)
                 if this_zone.vpcid == vpc_id:
                     this_id = f"/hostedzone/{zone.id}"

--- a/moto/route53/responses.py
+++ b/moto/route53/responses.py
@@ -40,14 +40,17 @@ class Route53(BaseResponse):
             if "HostedZoneConfig" in zone_request:
                 zone_config = zone_request["HostedZoneConfig"]
                 comment = zone_config["Comment"]
-                private_zone = zone_config.get("PrivateZone", False)
+                if zone_request["VPC"].get("VPCId", None):
+                    private_zone = True
+                else:
+                    private_zone = zone_config.get("PrivateZone", False)
             else:
                 comment = None
                 private_zone = False
 
             # It is possible to create a Private Hosted Zone without
             # associating VPC at the time of creation.
-            if private_zone == "true":
+            if private_zone == "true" or private_zone is True:
                 if zone_request.get("VPC", None) is not None:
                     vpcid = zone_request["VPC"].get("VPCId", None)
                     vpcregion = zone_request["VPC"].get("VPCRegion", None)
@@ -500,7 +503,7 @@ GET_HOSTED_ZONE_RESPONSE = """<GetHostedZoneResponse xmlns="https://route53.amaz
         {% if zone.comment %}
             <Comment>{{ zone.comment }}</Comment>
         {% endif %}
-        <PrivateZone>{{ zone.private_zone }}</PrivateZone>
+        <PrivateZone>{{ 'true' if zone.private_zone else 'false' }}</PrivateZone>
       </Config>
    </HostedZone>
    <DelegationSet>
@@ -527,7 +530,7 @@ CREATE_HOSTED_ZONE_RESPONSE = """<CreateHostedZoneResponse xmlns="https://route5
         {% if zone.comment %}
             <Comment>{{ zone.comment }}</Comment>
         {% endif %}
-        <PrivateZone>{{ zone.private_zone }}</PrivateZone>
+        <PrivateZone>{{ 'true' if zone.private_zone else 'false' }}</PrivateZone>
       </Config>
    </HostedZone>
    <DelegationSet>
@@ -552,7 +555,7 @@ LIST_HOSTED_ZONES_RESPONSE = """<ListHostedZonesResponse xmlns="https://route53.
             {% if zone.comment %}
                 <Comment>{{ zone.comment }}</Comment>
             {% endif %}
-           <PrivateZone>{{ zone.private_zone }}</PrivateZone>
+           <PrivateZone>{{ 'true' if zone.private_zone else 'false' }}</PrivateZone>
          </Config>
          <ResourceRecordSetCount>{{ zone.rrsets|count  }}</ResourceRecordSetCount>
       </HostedZone>
@@ -574,7 +577,7 @@ LIST_HOSTED_ZONES_BY_NAME_RESPONSE = """<ListHostedZonesByNameResponse xmlns="{{
             {% if zone.comment %}
                 <Comment>{{ zone.comment }}</Comment>
             {% endif %}
-           <PrivateZone>{{ zone.private_zone }}</PrivateZone>
+           <PrivateZone>{{ 'true' if zone.private_zone else 'false' }}</PrivateZone>
          </Config>
          <ResourceRecordSetCount>{{ zone.rrsets|count  }}</ResourceRecordSetCount>
       </HostedZone>

--- a/moto/route53/responses.py
+++ b/moto/route53/responses.py
@@ -26,6 +26,16 @@ def error_handler(f):
 class Route53(BaseResponse):
     """Handler for Route53 requests and responses."""
 
+    @staticmethod
+    def _convert_to_bool(bool_str):
+        if isinstance(bool_str, bool):
+            return bool_str
+
+        if isinstance(bool_str, str):
+            return str(bool_str).lower() == "true"
+
+        return False
+
     @error_handler
     def list_or_create_hostzone_response(self, request, full_url, headers):
         self.setup_class(request, full_url, headers)
@@ -40,17 +50,19 @@ class Route53(BaseResponse):
             if "HostedZoneConfig" in zone_request:
                 zone_config = zone_request["HostedZoneConfig"]
                 comment = zone_config["Comment"]
-                if zone_request["VPC"].get("VPCId", None):
+                if zone_request.get("VPC", {}).get("VPCId", None):
                     private_zone = True
                 else:
-                    private_zone = zone_config.get("PrivateZone", False)
+                    private_zone = self._convert_to_bool(
+                        zone_config.get("PrivateZone", False)
+                    )
             else:
                 comment = None
                 private_zone = False
 
             # It is possible to create a Private Hosted Zone without
             # associating VPC at the time of creation.
-            if private_zone == "true" or private_zone is True:
+            if self._convert_to_bool(private_zone):
                 if zone_request.get("VPC", None) is not None:
                     vpcid = zone_request["VPC"].get("VPCId", None)
                     vpcregion = zone_request["VPC"].get("VPCRegion", None)


### PR DESCRIPTION
## Fixed
- `PrivateZone` value type in response
- default behaviour for `PrivateZone` when `vpc` is present