### PR TITLE
Update Response for TimestreamWrite:WriteRecords

### DIFF
--- a/moto/timestreamwrite/responses.py
+++ b/moto/timestreamwrite/responses.py
@@ -85,7 +85,14 @@ class TimestreamWriteResponse(BaseResponse):
         table_name = self._get_param("TableName")
         records = self._get_param("Records")
         self.timestreamwrite_backend.write_records(database_name, table_name, records)
-        return "{}"
+        resp = {
+            "RecordsIngested": {
+                "Total": len(records),
+                "MemoryStore": len(records),
+                "MagneticStore": 0,
+            }
+        }
+        return json.dumps(resp)
 
     def describe_endpoints(self):
         resp = self.timestreamwrite_backend.describe_endpoints()


### PR DESCRIPTION
The botocore `WriteRecordsResponse` model was updated to include `RecordsIngested` a few months ago.[1]

* Include `RecordsIngested` in the `moto` response
* Use sample records from AWS documentation in `test_write_records`

[1]:https://github.com/boto/botocore/commit/4a2fc7f7c042b6f20b10b4d9c0454dae173c9969

Closes #4946 