### PR TITLE
Fix: EMR Steps should be returned in reverse order of creation

### DIFF
--- a/moto/emr/models.py
+++ b/moto/emr/models.py
@@ -560,7 +560,11 @@ class ElasticMapReduceBackend(BaseBackend):
 
     def list_steps(self, cluster_id, marker=None, step_ids=None, step_states=None):
         max_items = 50
-        steps = self.clusters[cluster_id].steps
+        steps = sorted(
+            self.clusters[cluster_id].steps,
+            key=lambda o: o.creation_datetime,
+            reverse=True,
+        )
         if step_ids:
             steps = [s for s in steps if s.id in step_ids]
         if step_states:

--- a/tests/test_emr/test_emr_boto3.py
+++ b/tests/test_emr/test_emr_boto3.py
@@ -1013,6 +1013,10 @@ def test_steps():
 
     steps = client.list_steps(ClusterId=cluster_id)["Steps"]
     steps.should.have.length_of(2)
+    # Steps should be returned in reverse order.
+    sorted(
+        steps, key=lambda o: o["Status"]["Timeline"]["CreationDateTime"], reverse=True
+    ).should.equal(steps)
     for x in steps:
         y = expected[x["Name"]]
         x["ActionOnFailure"].should.equal("TERMINATE_CLUSTER")
@@ -1044,7 +1048,7 @@ def test_steps():
         # x['Status']['Timeline']['EndDateTime'].should.be.a('datetime.datetime')
         # x['Status']['Timeline']['StartDateTime'].should.be.a('datetime.datetime')
 
-    step_id = steps[0]["Id"]
+    step_id = steps[-1]["Id"]  # Last step is first created step.
     steps = client.list_steps(ClusterId=cluster_id, StepIds=[step_id])["Steps"]
     steps.should.have.length_of(1)
     steps[0]["Id"].should.equal(step_id)


### PR DESCRIPTION
This is according to the AWS EMR documentation[1] and has been verified against a real AWS backend.

[1]:https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/emr.html#EMR.Client.list_steps

Closes #1866