### PR TITLE
Fix test failures on systems with 32-bit time_t

### DIFF
--- a/tests/test_acm/test_acm.py
+++ b/tests/test_acm/test_acm.py
@@ -160,7 +160,10 @@ def test_describe_certificate():
     client = boto3.client("acm", region_name="eu-central-1")
     arn = _import_cert(client)
 
-    resp = client.describe_certificate(CertificateArn=arn)
+    try:
+        resp = client.describe_certificate(CertificateArn=arn)
+    except OverflowError:
+        pytest.skip("This test requires 64-bit time_t")
     resp["Certificate"]["CertificateArn"].should.equal(arn)
     resp["Certificate"]["DomainName"].should.equal(SERVER_COMMON_NAME)
     resp["Certificate"]["Issuer"].should.equal("Moto")

--- a/tests/test_budgets/test_budgets.py
+++ b/tests/test_budgets/test_budgets.py
@@ -22,9 +22,12 @@ def test_create_and_describe_budget_minimal_params():
     )
     resp["ResponseMetadata"]["HTTPStatusCode"].should.equal(200)
 
-    budget = client.describe_budget(AccountId=ACCOUNT_ID, BudgetName="testbudget")[
-        "Budget"
-    ]
+    try:
+        budget = client.describe_budget(AccountId=ACCOUNT_ID, BudgetName="testbudget")[
+            "Budget"
+        ]
+    except OverflowError:
+        pytest.skip("This test requires 64-bit time_t")
     budget.should.have.key("BudgetLimit")
     budget["BudgetLimit"].should.have.key("Amount")
     budget["BudgetLimit"]["Amount"].should.equal("10")
@@ -140,7 +143,10 @@ def test_create_and_describe_all_budgets():
         },
     )
 
-    res = client.describe_budgets(AccountId=ACCOUNT_ID)
+    try:
+        res = client.describe_budgets(AccountId=ACCOUNT_ID)
+    except OverflowError:
+        pytest.skip("This test requires 64-bit time_t")
     res["Budgets"].should.have.length_of(1)
 
 


### PR DESCRIPTION
Skip tests if OverflowError is raised when boto3 is processing
timestamps.  This is a known limitation of boto3 on 32-bit platforms
(https://github.com/boto/botocore/issues/2355).

Catching OverflowError is the best option here since some 32-bit
platforms (e.g. NetBSD) use 64-bit time_t, and others are working
on providing a switch to the 64-bit type (e.g. glibc).