### PR TITLE
Return all things when using "*" query_string parameter

### DIFF
--- a/moto/iot/models.py
+++ b/moto/iot/models.py
@@ -45,6 +45,8 @@ class FakeThing(BaseModel):
         self.thing_shadow = None
 
     def matches(self, query_string):
+        if query_string == "*":
+            return True
         if query_string.startswith("thingName:"):
             qs = query_string[10:].replace("*", ".*").replace("?", ".")
             return re.search(f"^{qs}$", self.thing_name)

--- a/tests/test_iot/test_iot_search.py
+++ b/tests/test_iot/test_iot_search.py
@@ -12,6 +12,7 @@ from moto import mock_iot
         ["thingName:abc", {"abc"}],
         ["thingName:ab*", {"abc", "abd", "abcefg"}],
         ["thingName:ab?", {"abc", "abd"}],
+        ["*", {"abc", "abd", "bbe", "abcefg", "uuuabc", "bbefg"}],
     ],
 )
 def test_search_things(query_string, results):


### PR DESCRIPTION
- The current implementation of `search_index` did not support wildcard search

- From https://docs.aws.amazon.com/iot/latest/developerguide/query-syntax.html
   - "... but searching for "*" matches all things"