### PR TITLE
Added support for ListenerAddress based on srt or zixi-pull protocols.

### DIFF
--- a/moto/mediaconnect/responses.py
+++ b/moto/mediaconnect/responses.py
@@ -18,6 +18,9 @@ class MediaConnectResponse(BaseResponse):
         entitlements = self._get_param("entitlements")
         name = self._get_param("name")
         outputs = self._get_param("outputs")
+        for index, output in enumerate(outputs):
+            if output.get("protocol") in ["srt-listener", "zixi-pull"]:
+                output["listenerAddress"] = f"{index}.0.0.0"
         source = self._get_param("source")
         source_failover_config = self._get_param("sourceFailoverConfig")
         sources = self._get_param("sources")

--- a/tests/test_mediaconnect/test_mediaconnect.py
+++ b/tests/test_mediaconnect/test_mediaconnect.py
@@ -23,7 +23,9 @@ def _create_flow_config(name, **kwargs):
             }
         ],
     )
-    outputs = kwargs.get("outputs", [{"Name": "Output 1", "Protocol": "zixi-push"}])
+    outputs = kwargs.get("outputs", [{"Name": "Output 1", "Protocol": "zixi-push"},
+                                     {"Name": "Output 2", "Protocol": "zixi-pull"},
+                                     {"Name": "Output 3", "Protocol": "srt-listener"}])
     source = kwargs.get(
         "source",
         {
@@ -59,6 +61,9 @@ def test_create_flow_succeeds():
     response["Flow"]["FlowArn"][:26].should.equal("arn:aws:mediaconnect:flow:")
     response["Flow"]["Name"].should.equal("test Flow 1")
     response["Flow"]["Status"].should.equal("STANDBY")
+    response["Flow"]["Outputs"][0].should.equal({"Name": "Output 1"})
+    response["Flow"]["Outputs"][1]["ListenerAddress"].should.equal("1.0.0.0")
+    response["Flow"]["Outputs"][2]["ListenerAddress"].should.equal("2.0.0.0")
     response["Flow"]["Sources"][0][
         "SourceArn"
     ] == "arn:aws:mediaconnect:source:Source A"

--- a/tests/test_mediaconnect/test_mediaconnect.py
+++ b/tests/test_mediaconnect/test_mediaconnect.py
@@ -23,9 +23,14 @@ def _create_flow_config(name, **kwargs):
             }
         ],
     )
-    outputs = kwargs.get("outputs", [{"Name": "Output 1", "Protocol": "zixi-push"},
-                                     {"Name": "Output 2", "Protocol": "zixi-pull"},
-                                     {"Name": "Output 3", "Protocol": "srt-listener"}])
+    outputs = kwargs.get(
+        "outputs",
+        [
+            {"Name": "Output 1", "Protocol": "zixi-push"},
+            {"Name": "Output 2", "Protocol": "zixi-pull"},
+            {"Name": "Output 3", "Protocol": "srt-listener"},
+        ],
+    )
     source = kwargs.get(
         "source",
         {


### PR DESCRIPTION
Currently, we don't return a `ListenerAddress` when creating and describing flows in media connect. This PR add this field in the response for listener based protocols.