### PR TITLE
ELBv2 - improve tagging

### DIFF
--- a/moto/resourcegroupstaggingapi/models.py
+++ b/moto/resourcegroupstaggingapi/models.py
@@ -297,38 +297,30 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
 
         # TODO add these to the keys and values functions / combine functions
         # ELB, resource type elasticloadbalancing:loadbalancer
-        def get_elbv2_tags(arn):
-            result = []
-            for key, value in self.elbv2_backend.load_balancers[arn].tags.items():
-                result.append({"Key": key, "Value": value})
-            return result
-
         if (
             not resource_type_filters
             or "elasticloadbalancing" in resource_type_filters
             or "elasticloadbalancing:loadbalancer" in resource_type_filters
         ):
             for elb in self.elbv2_backend.load_balancers.values():
-                tags = get_elbv2_tags(elb.arn)
+                tags = self.elbv2_backend.tagging_service.list_tags_for_resource(
+                    elb.arn
+                )["Tags"]
                 if not tag_filter(tags):  # Skip if no tags, or invalid filter
                     continue
 
                 yield {"ResourceARN": "{0}".format(elb.arn), "Tags": tags}
 
         # ELB Target Group, resource type elasticloadbalancing:targetgroup
-        def get_target_group_tags(arn):
-            result = []
-            for key, value in self.elbv2_backend.target_groups[arn].tags.items():
-                result.append({"Key": key, "Value": value})
-            return result
-
         if (
             not resource_type_filters
             or "elasticloadbalancing" in resource_type_filters
             or "elasticloadbalancing:targetgroup" in resource_type_filters
         ):
             for target_group in self.elbv2_backend.target_groups.values():
-                tags = get_target_group_tags(target_group.arn)
+                tags = self.elbv2_backend.tagging_service.list_tags_for_resource(
+                    target_group.arn
+                )["Tags"]
                 if not tag_filter(tags):  # Skip if no tags, or invalid filter
                     continue
 

--- a/moto/utilities/tagging_service.py
+++ b/moto/utilities/tagging_service.py
@@ -45,6 +45,8 @@ class TaggingService:
 
         Note: the storage is internal to this class instance.
         """
+        if not tags:
+            return
         if arn not in self.tags:
             self.tags[arn] = {}
         for tag in tags:

--- a/tests/test_elbv2/test_elbv2_listener_rule_tags.py
+++ b/tests/test_elbv2/test_elbv2_listener_rule_tags.py
@@ -1,0 +1,93 @@
+import sure  # noqa # pylint: disable=unused-import
+
+from moto import mock_elbv2, mock_ec2
+
+from .test_elbv2 import create_load_balancer
+
+create_condition = {"Field": "host-header", "Values": ["example.com"]}
+default_action = {
+    "FixedResponseConfig": {"StatusCode": "200", "ContentType": "text/plain"},
+    "Type": "fixed-response",
+}
+
+
+@mock_elbv2
+@mock_ec2
+def test_create_listener_rule_with_tags():
+    response, _, _, _, _, elbv2 = create_load_balancer()
+
+    load_balancer_arn = response.get("LoadBalancers")[0].get("LoadBalancerArn")
+
+    listener_arn = elbv2.create_listener(
+        LoadBalancerArn=load_balancer_arn,
+        Protocol="HTTP",
+        Port=80,
+        DefaultActions=[],
+    )["Listeners"][0]["ListenerArn"]
+    rule_arn = elbv2.create_rule(
+        ListenerArn=listener_arn,
+        Priority=100,
+        Conditions=[create_condition],
+        Actions=[default_action],
+        Tags=[{"Key": "k1", "Value": "v1"}],
+    )["Rules"][0]["RuleArn"]
+
+    # Ensure the tags persisted
+    response = elbv2.describe_tags(ResourceArns=[rule_arn])
+    tags = {d["Key"]: d["Value"] for d in response["TagDescriptions"][0]["Tags"]}
+    tags.should.equal({"k1": "v1"})
+
+
+@mock_elbv2
+@mock_ec2
+def test_listener_rule_add_remove_tags():
+    response, _, _, _, _, elbv2 = create_load_balancer()
+
+    load_balancer_arn = response.get("LoadBalancers")[0].get("LoadBalancerArn")
+
+    listener_arn = elbv2.create_listener(
+        LoadBalancerArn=load_balancer_arn,
+        Protocol="HTTP",
+        Port=80,
+        DefaultActions=[],
+        Tags=[{"Key": "k1", "Value": "v1"}],
+    )["Listeners"][0]["ListenerArn"]
+    rule_arn = elbv2.create_rule(
+        ListenerArn=listener_arn,
+        Priority=100,
+        Conditions=[create_condition],
+        Actions=[default_action],
+    )["Rules"][0]["RuleArn"]
+
+    elbv2.add_tags(ResourceArns=[rule_arn], Tags=[{"Key": "a", "Value": "b"}])
+
+    tags = elbv2.describe_tags(ResourceArns=[rule_arn])["TagDescriptions"][0]["Tags"]
+    tags.should.equal([{"Key": "a", "Value": "b"}])
+
+    elbv2.add_tags(
+        ResourceArns=[rule_arn],
+        Tags=[
+            {"Key": "a", "Value": "b"},
+            {"Key": "b", "Value": "b"},
+            {"Key": "c", "Value": "b"},
+        ],
+    )
+
+    tags = elbv2.describe_tags(ResourceArns=[rule_arn])["TagDescriptions"][0]["Tags"]
+    tags.should.equal(
+        [
+            {"Key": "a", "Value": "b"},
+            {"Key": "b", "Value": "b"},
+            {"Key": "c", "Value": "b"},
+        ]
+    )
+
+    elbv2.remove_tags(ResourceArns=[rule_arn], TagKeys=["a"])
+
+    tags = elbv2.describe_tags(ResourceArns=[rule_arn])["TagDescriptions"][0]["Tags"]
+    tags.should.equal(
+        [
+            {"Key": "b", "Value": "b"},
+            {"Key": "c", "Value": "b"},
+        ]
+    )


### PR DESCRIPTION
Simplifies the tagging logic in ELBv2. This is now handled by the TaggingService, similar to how other (most?) services handle tags.

This change also fixes a bug, so that it's now possible to add and remove tags from ListenerRules