### PR TITLE
ECR - Fix bug in batch_delete where images could not be deleted

### DIFF
--- a/moto/ecr/models.py
+++ b/moto/ecr/models.py
@@ -631,24 +631,24 @@ class ECRBackend(BaseBackend):
                     else:
                         repository.images.remove(image)
 
-                if not image_found:
-                    failure_response = {
-                        "imageId": {},
-                        "failureCode": "ImageNotFound",
-                        "failureReason": "Requested image not found",
-                    }
+            if not image_found:
+                failure_response = {
+                    "imageId": {},
+                    "failureCode": "ImageNotFound",
+                    "failureReason": "Requested image not found",
+                }
 
-                    if "imageDigest" in image_id:
-                        failure_response["imageId"]["imageDigest"] = image_id.get(
-                            "imageDigest", "null"
-                        )
+                if "imageDigest" in image_id:
+                    failure_response["imageId"]["imageDigest"] = image_id.get(
+                        "imageDigest", "null"
+                    )
 
-                    if "imageTag" in image_id:
-                        failure_response["imageId"]["imageTag"] = image_id.get(
-                            "imageTag", "null"
-                        )
+                if "imageTag" in image_id:
+                    failure_response["imageId"]["imageTag"] = image_id.get(
+                        "imageTag", "null"
+                    )
 
-                    response["failures"].append(failure_response)
+                response["failures"].append(failure_response)
 
         return response
 


### PR DESCRIPTION
Closes #4941 

The `batch_delete_image` only worked in happy scenarios, where one image existed and one image was deleted.
A test was added to verify that we can now delete only a subset of the existing images.