### PR TITLE
ECS - support for CapacityProviders

### DIFF
--- a/IMPLEMENTATION_COVERAGE.md
+++ b/IMPLEMENTATION_COVERAGE.md
@@ -1995,21 +1995,21 @@
 
 ## ecs
 <details>
-<summary>73% implemented</summary>
+<summary>78% implemented</summary>
 
-- [ ] create_capacity_provider
+- [X] create_capacity_provider
 - [X] create_cluster
 - [X] create_service
 - [X] create_task_set
 - [X] delete_account_setting
 - [X] delete_attributes
-- [ ] delete_capacity_provider
+- [X] delete_capacity_provider
 - [X] delete_cluster
 - [X] delete_service
 - [X] delete_task_set
 - [X] deregister_container_instance
 - [X] deregister_task_definition
-- [ ] describe_capacity_providers
+- [X] describe_capacity_providers
 - [X] describe_clusters
 - [X] describe_container_instances
 - [X] describe_services

--- a/docs/docs/services/ecs.rst
+++ b/docs/docs/services/ecs.rst
@@ -27,13 +27,17 @@ ecs
 
 |start-h3| Implemented features for this service |end-h3|
 
-- [ ] create_capacity_provider
+- [X] create_capacity_provider
 - [X] create_cluster
+  
+        The following parameters are not yet implemented: configuration, capacityProviders, defaultCapacityProviderStrategy
+        
+
 - [X] create_service
 - [X] create_task_set
 - [X] delete_account_setting
 - [X] delete_attributes
-- [ ] delete_capacity_provider
+- [X] delete_capacity_provider
 - [X] delete_cluster
 - [X] delete_service
 - [X] delete_task_set
@@ -43,7 +47,7 @@ ecs
 
 - [X] deregister_container_instance
 - [X] deregister_task_definition
-- [ ] describe_capacity_providers
+- [X] describe_capacity_providers
 - [X] describe_clusters
   
         Only include=TAGS is currently supported.

--- a/moto/ecs/responses.py
+++ b/moto/ecs/responses.py
@@ -25,12 +25,20 @@ class EC2ContainerServiceResponse(BaseResponse):
     def _get_param(self, param_name, if_none=None):
         return self.request_params.get(param_name, if_none)
 
+    def create_capacity_provider(self):
+        name = self._get_param("name")
+        asg_provider = self._get_param("autoScalingGroupProvider")
+        tags = self._get_param("tags")
+        provider = self.ecs_backend.create_capacity_provider(name, asg_provider, tags)
+        return json.dumps({"capacityProvider": provider.response_object})
+
     def create_cluster(self):
         cluster_name = self._get_param("clusterName")
         tags = self._get_param("tags")
+        settings = self._get_param("settings")
         if cluster_name is None:
             cluster_name = "default"
-        cluster = self.ecs_backend.create_cluster(cluster_name, tags)
+        cluster = self.ecs_backend.create_cluster(cluster_name, tags, settings)
         return json.dumps({"cluster": cluster.response_object})
 
     def list_clusters(self):
@@ -39,6 +47,21 @@ class EC2ContainerServiceResponse(BaseResponse):
             {
                 "clusterArns": cluster_arns
                 #  'nextToken': str(uuid.uuid4())
+            }
+        )
+
+    def delete_capacity_provider(self):
+        name = self._get_param("capacityProvider")
+        provider = self.ecs_backend.delete_capacity_provider(name)
+        return json.dumps({"capacityProvider": provider.response_object})
+
+    def describe_capacity_providers(self):
+        names = self._get_param("capacityProviders")
+        providers, failures = self.ecs_backend.describe_capacity_providers(names)
+        return json.dumps(
+            {
+                "capacityProviders": [p.response_object for p in providers],
+                "failures": [p.response_object for p in failures],
             }
         )
 

--- a/tests/test_ecs/test_ecs_capacity_provider.py
+++ b/tests/test_ecs/test_ecs_capacity_provider.py
@@ -1,0 +1,173 @@
+import boto3
+
+from moto import mock_ecs
+from moto.core import ACCOUNT_ID
+
+
+@mock_ecs
+def test_create_capacity_provider():
+    client = boto3.client("ecs", region_name="us-west-1")
+    resp = client.create_capacity_provider(
+        name="my_provider",
+        autoScalingGroupProvider={
+            "autoScalingGroupArn": "asg:arn",
+            "managedScaling": {
+                "status": "ENABLED",
+                "targetCapacity": 5,
+                "maximumScalingStepSize": 2,
+            },
+            "managedTerminationProtection": "DISABLED",
+        },
+    )
+    resp.should.have.key("capacityProvider")
+
+    provider = resp["capacityProvider"]
+    provider.should.have.key("capacityProviderArn")
+    provider.should.have.key("name").equals("my_provider")
+    provider.should.have.key("status").equals("ACTIVE")
+    provider.should.have.key("autoScalingGroupProvider").equals(
+        {
+            "autoScalingGroupArn": "asg:arn",
+            "managedScaling": {
+                "status": "ENABLED",
+                "targetCapacity": 5,
+                "maximumScalingStepSize": 2,
+            },
+            "managedTerminationProtection": "DISABLED",
+        }
+    )
+
+
+@mock_ecs
+def test_create_capacity_provider_with_tags():
+    client = boto3.client("ecs", region_name="us-west-1")
+    resp = client.create_capacity_provider(
+        name="my_provider",
+        autoScalingGroupProvider={"autoScalingGroupArn": "asg:arn"},
+        tags=[{"key": "k1", "value": "v1"}],
+    )
+    resp.should.have.key("capacityProvider")
+
+    provider = resp["capacityProvider"]
+    provider.should.have.key("capacityProviderArn")
+    provider.should.have.key("name").equals("my_provider")
+    provider.should.have.key("tags").equals([{"key": "k1", "value": "v1"}])
+
+
+@mock_ecs
+def test_describe_capacity_provider__using_name():
+    client = boto3.client("ecs", region_name="us-west-1")
+    client.create_capacity_provider(
+        name="my_provider",
+        autoScalingGroupProvider={
+            "autoScalingGroupArn": "asg:arn",
+            "managedScaling": {
+                "status": "ENABLED",
+                "targetCapacity": 5,
+                "maximumScalingStepSize": 2,
+            },
+            "managedTerminationProtection": "DISABLED",
+        },
+    )
+
+    resp = client.describe_capacity_providers(capacityProviders=["my_provider"])
+    resp.should.have.key("capacityProviders").length_of(1)
+
+    provider = resp["capacityProviders"][0]
+    provider.should.have.key("capacityProviderArn")
+    provider.should.have.key("name").equals("my_provider")
+    provider.should.have.key("status").equals("ACTIVE")
+    provider.should.have.key("autoScalingGroupProvider").equals(
+        {
+            "autoScalingGroupArn": "asg:arn",
+            "managedScaling": {
+                "status": "ENABLED",
+                "targetCapacity": 5,
+                "maximumScalingStepSize": 2,
+            },
+            "managedTerminationProtection": "DISABLED",
+        }
+    )
+
+
+@mock_ecs
+def test_describe_capacity_provider__using_arn():
+    client = boto3.client("ecs", region_name="us-west-1")
+    provider_arn = client.create_capacity_provider(
+        name="my_provider",
+        autoScalingGroupProvider={
+            "autoScalingGroupArn": "asg:arn",
+            "managedScaling": {
+                "status": "ENABLED",
+                "targetCapacity": 5,
+                "maximumScalingStepSize": 2,
+            },
+            "managedTerminationProtection": "DISABLED",
+        },
+    )["capacityProvider"]["capacityProviderArn"]
+
+    resp = client.describe_capacity_providers(capacityProviders=[provider_arn])
+    resp.should.have.key("capacityProviders").length_of(1)
+
+    provider = resp["capacityProviders"][0]
+    provider.should.have.key("name").equals("my_provider")
+
+
+@mock_ecs
+def test_describe_capacity_provider__missing():
+    client = boto3.client("ecs", region_name="us-west-1")
+    client.create_capacity_provider(
+        name="my_provider",
+        autoScalingGroupProvider={
+            "autoScalingGroupArn": "asg:arn",
+            "managedScaling": {
+                "status": "ENABLED",
+                "targetCapacity": 5,
+                "maximumScalingStepSize": 2,
+            },
+            "managedTerminationProtection": "DISABLED",
+        },
+    )
+
+    resp = client.describe_capacity_providers(
+        capacityProviders=["my_provider", "another_provider"]
+    )
+    resp.should.have.key("capacityProviders").length_of(1)
+    resp.should.have.key("failures").length_of(1)
+    resp["failures"].should.contain(
+        {
+            "arn": f"arn:aws:ecs:us-west-1:{ACCOUNT_ID}:capacity_provider/another_provider",
+            "reason": "MISSING",
+        }
+    )
+
+
+@mock_ecs
+def test_delete_capacity_provider():
+    client = boto3.client("ecs", region_name="us-west-1")
+    client.create_capacity_provider(
+        name="my_provider", autoScalingGroupProvider={"autoScalingGroupArn": "asg:arn"}
+    )
+
+    resp = client.delete_capacity_provider(capacityProvider="my_provider")
+    resp.should.have.key("capacityProvider")
+    resp["capacityProvider"].should.have.key("name").equals("my_provider")
+
+    # We can't find either provider
+    resp = client.describe_capacity_providers(
+        capacityProviders=["my_provider", "another_provider"]
+    )
+    resp.should.have.key("capacityProviders").length_of(0)
+    resp.should.have.key("failures").length_of(2)
+    resp["failures"].should.contain(
+        {
+            "arn": f"arn:aws:ecs:us-west-1:{ACCOUNT_ID}:capacity_provider/another_provider",
+            "reason": "MISSING",
+        }
+    )
+    resp["failures"].should.contain(
+        {
+            "arn": f"arn:aws:ecs:us-west-1:{ACCOUNT_ID}:capacity_provider/my_provider",
+            "reason": "MISSING",
+        }
+    )


### PR DESCRIPTION
Adds support for:
ECS: create_capacity_provider()
ECS: delete_capacity_provider()
ECS: describe_capacity_providers()

ECS:create_cluster() now supports the parameter `settings`

ECS:delete_service() and ECS:describe_service() can now also be called using ARN's, instead of just the plain name

Closes #4858 