### PR TITLE
Remove apostrophe

### DIFF
--- a/docs/docs/contributing/development_tips/urls.rst
+++ b/docs/docs/contributing/development_tips/urls.rst
@@ -4,7 +4,7 @@
     :format: html
 
 ***********************
-Intercepting URL's
+Intercepting URLs
 ***********************
 
 


### PR DESCRIPTION
This is an example of a "greengrocers' apostrophe" https://en.wikipedia.org/wiki/Apostrophe#Greengrocers'_apostrophes and is generally considered incorrect