### PR TITLE
IOTData - use available services from 'IOT'

### DIFF
--- a/moto/iotdata/models.py
+++ b/moto/iotdata/models.py
@@ -203,4 +203,4 @@ class IoTDataPlaneBackend(BaseBackend):
         self.published_payloads.append((topic, payload))
 
 
-iotdata_backends = BackendDict(IoTDataPlaneBackend, "iot-data")
+iotdata_backends = BackendDict(IoTDataPlaneBackend, "iot")


### PR DESCRIPTION
Botocore 1.24.29 still released a list of regions in `get_available_regions`.

Botocore 1.24.30 now returns an empty list for `get_available_regions("iot-data").

`IOT` should have the same regions, so we can use that instead.

[Related issue: https://github.com/boto/botocore/issues/2631](https://github.com/aws/aws-sdk/issues/206)