### PR TITLE
IOTData - intercept new URLs in botocore 1.24.30

### DIFF
--- a/moto/backend_index.py
+++ b/moto/backend_index.py
@@ -73,6 +73,7 @@ backend_url_patterns = [
     ("iam", re.compile("https?://iam\\.(.*\\.)?amazonaws\\.com")),
     ("iot", re.compile("https?://iot\\.(.+)\\.amazonaws\\.com")),
     ("iot-data", re.compile("https?://data\\.iot\\.(.+)\\.amazonaws.com")),
+    ("iot-data", re.compile("https?://data-ats\\.iot\\.(.+)\\.amazonaws.com")),
     ("kinesis", re.compile("https?://kinesis\\.(.+)\\.amazonaws\\.com")),
     ("kinesisvideo", re.compile("https?://kinesisvideo\\.(.+)\\.amazonaws.com")),
     (

--- a/moto/iotdata/models.py
+++ b/moto/iotdata/models.py
@@ -203,4 +203,4 @@ class IoTDataPlaneBackend(BaseBackend):
         self.published_payloads.append((topic, payload))
 
 
-iotdata_backends = BackendDict(IoTDataPlaneBackend, "iot-data")
+iotdata_backends = BackendDict(IoTDataPlaneBackend, "iot")

--- a/moto/iotdata/urls.py
+++ b/moto/iotdata/urls.py
@@ -1,6 +1,9 @@
 from .responses import IoTDataPlaneResponse
 
-url_bases = [r"https?://data\.iot\.(.+)\.amazonaws.com"]
+url_bases = [
+    r"https?://data\.iot\.(.+)\.amazonaws.com",
+    r"https?://data-ats\.iot\.(.+)\.amazonaws.com",
+]
 
 
 response = IoTDataPlaneResponse()


### PR DESCRIPTION
Botocore 1.24.29 still released a list of regions in get_available_regions.

Botocore 1.24.30 now returns an empty list for `get_available_regions("iot-data").

IOT should have the same regions, so we can use that instead.

AWS also changed the IOTdata endpoint, so we now have to intercept both URL's.

https://github.com/aws/aws-sdk/issues/206