### PR TITLE
Linting

### DIFF
--- a/moto/ec2/models.py
+++ b/moto/ec2/models.py
@@ -7180,7 +7180,7 @@ class NetworkAclBackend(object):
         )
 
         subnet_id = None
-        for key, value in default_acl.associations.items():
+        for key in default_acl.associations:
             if key == association_id:
                 subnet_id = default_acl.associations[key].subnet_id
                 del default_acl.associations[key]


### PR DESCRIPTION
The latest version of pylint, `2.13.4`, (correctly) complains about `value` being unused

Previous versions of pylint had no problem with this code, but the latest release does complain about it.