### PR TITLE
Make docs on AWS_... env vars consistent, cross reference FAQ

### DIFF
--- a/docs/docs/getting_started.rst
+++ b/docs/docs/getting_started.rst
@@ -215,10 +215,13 @@ You need to ensure that the mocks are actually in place.
         export AWS_SECRET_ACCESS_KEY='testing'
         export AWS_SECURITY_TOKEN='testing'
         export AWS_SESSION_TOKEN='testing'
+        export AWS_DEFAULT_REGION='us-east-1'
 
  #. **VERY IMPORTANT**: ensure that you have your mocks set up *BEFORE* your `boto3` client is established.
     This can typically happen if you import a module that has a `boto3` client instantiated outside of a function.
     See the pesky imports section below on how to work around this.
+
+.. note:: By default, the region must be one supported by AWS, see :ref:`Can I mock the default AWS region?` for how to change this.
 
 Example on usage
 ~~~~~~~~~~~~~~~~


### PR DESCRIPTION
This applies two tweaks to the discussion of the `AWS_...` environment variables in the documentation:

- set the same variables in the first block as in the following section (about `pytest`)
- reference the FAQ entry that discusses how to use a region name that AWS doesn't support

(Thanks for moto!)