### PR TITLE
Use correct service name for "ecr" in `BackendDict`

### DIFF
--- a/moto/ecr/models.py
+++ b/moto/ecr/models.py
@@ -951,4 +951,4 @@ class ECRBackend(BaseBackend):
         }
 
 
-ecr_backends = BackendDict(ECRBackend, "ec2")
+ecr_backends = BackendDict(ECRBackend, "ecr")


### PR DESCRIPTION
I am pretty sure this should be "ecr" (the AWS name for the ECR service), not "ec2".

I presume the bug arises from a copy-paste error.

The service name appears to only be used to lookup supported regions, which is probably why this bug hasn't had any impact on users.