### PR TITLE
S3 - initial Notifications implementation

### DIFF
--- a/docs/docs/services/s3.rst
+++ b/docs/docs/services/s3.rst
@@ -105,6 +105,18 @@ s3
 - [ ] put_bucket_metrics_configuration
 - [ ] put_bucket_notification
 - [X] put_bucket_notification_configuration
+  
+        The configuration can be persisted, but at the moment we only send notifications to the following targets:
+
+         - AWSLambda
+         - SQS
+
+        For the following events:
+
+         - 's3:ObjectCreated:Copy'
+         - 's3:ObjectCreated:Put'
+        
+
 - [ ] put_bucket_ownership_controls
 - [X] put_bucket_policy
 - [X] put_bucket_replication

--- a/moto/s3/notifications.py
+++ b/moto/s3/notifications.py
@@ -1,0 +1,120 @@
+import json
+from datetime import datetime
+
+_EVENT_TIME_FORMAT = "%Y-%m-%dT%H:%M:%S.%f"
+
+S3_OBJECT_CREATE_COPY = "s3:ObjectCreated:Copy"
+S3_OBJECT_CREATE_PUT = "s3:ObjectCreated:Put"
+
+
+def _get_s3_event(event_name, bucket, key, notification_id):
+    etag = key.etag.replace('"', "")
+    # s3:ObjectCreated:Put --> ObjectCreated:Put
+    event_name = event_name[3:]
+    event_time = datetime.now().strftime(_EVENT_TIME_FORMAT)
+    return {
+        "Records": [
+            {
+                "eventVersion": "2.1",
+                "eventSource": "aws:s3",
+                "awsRegion": bucket.region_name,
+                "eventTime": event_time,
+                "eventName": event_name,
+                "s3": {
+                    "s3SchemaVersion": "1.0",
+                    "configurationId": notification_id,
+                    "bucket": {
+                        "name": bucket.name,
+                        "arn": f"arn:aws:s3:::{bucket.name}",
+                    },
+                    "object": {"key": key.name, "size": key.size, "eTag": etag},
+                },
+            }
+        ]
+    }
+
+
+def _event_matches(event_name, available_events):
+    if event_name in available_events:
+        return True
+    # s3:ObjectCreated:Put --> s3:ObjectCreated:*
+    wildcard = ":".join(event_name.rsplit(":")[0:2]) + ":*"
+    if wildcard in available_events:
+        return True
+    return False
+
+
+def _get_region_from_arn(arn):
+    return arn.split(":")[3]
+
+
+def send_event(event_name, bucket, key):
+    if bucket.notification_configuration is None:
+        return
+
+    for notification in bucket.notification_configuration.cloud_function:
+        available_events = notification.events
+        if _event_matches(event_name, available_events):
+            event_body = _get_s3_event(event_name, bucket, key, notification.id)
+            region_name = _get_region_from_arn(notification.arn)
+
+            _invoke_awslambda(event_body, notification.arn, region_name)
+
+    for notification in bucket.notification_configuration.queue:
+        available_events = notification.events
+        if _event_matches(event_name, available_events):
+            event_body = _get_s3_event(event_name, bucket, key, notification.id)
+            region_name = _get_region_from_arn(notification.arn)
+            queue_name = notification.arn.split(":")[-1]
+
+            _send_sqs_message(event_body, queue_name, region_name)
+
+
+def _send_sqs_message(event_body, queue_name, region_name):
+    try:
+        from moto.sqs.models import sqs_backends
+
+        sqs_backend = sqs_backends[region_name]
+        sqs_backend.send_message(
+            queue_name=queue_name, message_body=json.dumps(event_body)
+        )
+    except:  # noqa
+        # This is an async action in AWS.
+        # Even if this part fails, the calling function should pass, so catch all errors
+        # Possible exceptions that could be thrown:
+        # - Queue does not exist
+        pass
+
+
+def _invoke_awslambda(event_body, fn_arn, region_name):
+    try:
+        from moto.awslambda.models import lambda_backends
+
+        lambda_backend = lambda_backends[region_name]
+        func = lambda_backend.get_function(fn_arn)
+        func.invoke(json.dumps(event_body), dict(), dict())
+    except:  # noqa
+        # This is an async action in AWS.
+        # Even if this part fails, the calling function should pass, so catch all errors
+        # Possible exceptions that could be thrown:
+        # - Function does not exist
+        pass
+
+
+def _get_test_event(bucket_name):
+    event_time = datetime.now().strftime(_EVENT_TIME_FORMAT)
+    return {
+        "Service": "Amazon S3",
+        "Event": "s3:TestEvent",
+        "Time": event_time,
+        "Bucket": bucket_name,
+    }
+
+
+def send_test_event(bucket):
+    for notification in bucket.notification_configuration.queue:
+
+        region_name = _get_region_from_arn(notification.arn)
+        queue_name = notification.arn.split(":")[-1]
+        message_body = _get_test_event(bucket.name)
+        _send_sqs_message(message_body, queue_name, region_name)

--- a/tests/test_awslambda/utilities.py
+++ b/tests/test_awslambda/utilities.py
@@ -134,6 +134,16 @@ def util_function():
     return zip_output.read()
 
 
+def get_test_zip_file_print_event():
+    pfunc = """
+def lambda_handler(event, context):
+    print(event)
+    print("FINISHED_PRINTING_EVENT")
+    return event
+"""
+    return _process_lambda(pfunc)
+
+
 def create_invalid_lambda(role):
     conn = boto3.client("lambda", _lambda_region)
     zip_content = get_test_zip_file1()
@@ -166,11 +176,11 @@ def get_role_name():
             )["Role"]["Arn"]
 
 
-def wait_for_log_msg(expected_msg, log_group):
+def wait_for_log_msg(expected_msg, log_group, wait_time=30):
     logs_conn = boto3.client("logs", region_name="us-east-1")
     received_messages = []
     start = time.time()
-    while (time.time() - start) < 30:
+    while (time.time() - start) < wait_time:
         try:
             result = logs_conn.describe_log_streams(logGroupName=log_group)
             log_streams = result.get("logStreams")

--- a/tests/test_s3/test_s3_lambda_integration.py
+++ b/tests/test_s3/test_s3_lambda_integration.py
@@ -1,0 +1,211 @@
+import boto3
+import json
+import pytest
+from moto import mock_lambda, mock_logs, mock_s3, mock_sqs
+from moto.core import ACCOUNT_ID
+from tests.test_awslambda.utilities import (
+    get_test_zip_file_print_event,
+    get_role_name,
+    wait_for_log_msg,
+)
+from uuid import uuid4
+
+
+REGION_NAME = "us-east-1"
+
+
+@mock_lambda
+@mock_logs
+@mock_s3
+@pytest.mark.parametrize(
+    "match_events,actual_event",
+    [
+        (["s3:ObjectCreated:Put"], "ObjectCreated:Put"),
+        (["s3:ObjectCreated:*"], "ObjectCreated:Put"),
+        (["s3:ObjectCreated:Post"], None),
+        (["s3:ObjectCreated:Post", "s3:ObjectCreated:*"], "ObjectCreated:Put"),
+    ],
+)
+def test_objectcreated_put__invokes_lambda(match_events, actual_event):
+    s3_res = boto3.resource("s3", region_name=REGION_NAME)
+    s3_client = boto3.client("s3", region_name=REGION_NAME)
+    lambda_client = boto3.client("lambda", REGION_NAME)
+
+    # Create S3 bucket
+    bucket_name = str(uuid4())
+    s3_res.create_bucket(Bucket=bucket_name)
+
+    # Create AWSLambda function
+    function_name = str(uuid4())[0:6]
+    fn_arn = lambda_client.create_function(
+        FunctionName=function_name,
+        Runtime="python3.7",
+        Role=get_role_name(),
+        Handler="lambda_function.lambda_handler",
+        Code={"ZipFile": get_test_zip_file_print_event()},
+    )["FunctionArn"]
+
+    # Put Notification
+    s3_client.put_bucket_notification_configuration(
+        Bucket=bucket_name,
+        NotificationConfiguration={
+            "LambdaFunctionConfigurations": [
+                {
+                    "Id": "unrelated",
+                    "LambdaFunctionArn": f"arn:aws:lambda:us-east-1:{ACCOUNT_ID}:function:n/a",
+                    "Events": ["s3:ReducedRedundancyLostObject"],
+                },
+                {
+                    "Id": "s3eventtriggerslambda",
+                    "LambdaFunctionArn": fn_arn,
+                    "Events": match_events,
+                },
+            ]
+        },
+    )
+
+    # Put Object
+    s3_client.put_object(Bucket=bucket_name, Key="keyname", Body="bodyofnewobject")
+
+    # Find the output of AWSLambda
+    expected_msg = "FINISHED_PRINTING_EVENT"
+    log_group = f"/aws/lambda/{function_name}"
+    msg_showed_up, all_logs = wait_for_log_msg(expected_msg, log_group, wait_time=10)
+
+    if actual_event is None:
+        # The event should not be fired on POST, as we've only PUT an event for now
+        assert not msg_showed_up
+        return
+
+    # If we do have an actual event, verify the Lambda was invoked with the correct event
+    assert msg_showed_up, (
+        expected_msg
+        + " was not found after sending an SQS message. All logs: "
+        + str(all_logs)
+    )
+
+    records = [l for l in all_logs if l.startswith("{'Records'")][0]
+    records = json.loads(records.replace("'", '"'))["Records"]
+
+    records.should.have.length_of(1)
+    records[0].should.have.key("awsRegion").equals(REGION_NAME)
+    records[0].should.have.key("eventName").equals(actual_event)
+    records[0].should.have.key("eventSource").equals("aws:s3")
+    records[0].should.have.key("eventTime")
+    records[0].should.have.key("s3")
+    records[0]["s3"].should.have.key("bucket")
+    records[0]["s3"]["bucket"].should.have.key("arn").equals(
+        f"arn:aws:s3:::{bucket_name}"
+    )
+    records[0]["s3"]["bucket"].should.have.key("name").equals(bucket_name)
+    records[0]["s3"].should.have.key("configurationId").equals("s3eventtriggerslambda")
+    records[0]["s3"].should.have.key("object")
+    records[0]["s3"]["object"].should.have.key("eTag").equals(
+        "61ea96c3c8d2c76fc5a42bfccb6affd9"
+    )
+    records[0]["s3"]["object"].should.have.key("key").equals("keyname")
+    records[0]["s3"]["object"].should.have.key("size").equals(15)
+
+
+@mock_logs
+@mock_s3
+def test_objectcreated_put__unknown_lambda_is_handled_gracefully():
+    s3_res = boto3.resource("s3", region_name=REGION_NAME)
+    s3_client = boto3.client("s3", region_name=REGION_NAME)
+
+    # Create S3 bucket
+    bucket_name = str(uuid4())
+    s3_res.create_bucket(Bucket=bucket_name)
+
+    # Put Notification
+    s3_client.put_bucket_notification_configuration(
+        Bucket=bucket_name,
+        NotificationConfiguration={
+            "LambdaFunctionConfigurations": [
+                {
+                    "Id": "unrelated",
+                    "LambdaFunctionArn": f"arn:aws:lambda:us-east-1:{ACCOUNT_ID}:function:n/a",
+                    "Events": ["s3:ObjectCreated:Put"],
+                }
+            ]
+        },
+    )
+
+    # Put Object
+    s3_client.put_object(Bucket=bucket_name, Key="keyname", Body="bodyofnewobject")
+
+    # The object was persisted successfully
+    resp = s3_client.get_object(Bucket=bucket_name, Key="keyname")
+    resp.should.have.key("ContentLength").equal(15)
+    resp["Body"].read().should.equal(b"bodyofnewobject")
+
+
+@mock_s3
+@mock_sqs
+def test_object_copy__sends_to_queue():
+    s3_res = boto3.resource("s3", region_name=REGION_NAME)
+    s3_client = boto3.client("s3", region_name=REGION_NAME)
+    sqs_client = boto3.client("sqs", region_name=REGION_NAME)
+
+    # Create S3 bucket
+    bucket_name = str(uuid4())
+    s3_res.create_bucket(Bucket=bucket_name)
+
+    # Create SQS queue
+    queue_url = sqs_client.create_queue(QueueName=str(uuid4())[0:6])["QueueUrl"]
+    queue_arn = sqs_client.get_queue_attributes(
+        QueueUrl=queue_url, AttributeNames=["QueueArn"]
+    )["Attributes"]["QueueArn"]
+
+    # Put Notification
+    s3_client.put_bucket_notification_configuration(
+        Bucket=bucket_name,
+        NotificationConfiguration={
+            "QueueConfigurations": [
+                {
+                    "Id": "queue_config",
+                    "QueueArn": queue_arn,
+                    "Events": ["s3:ObjectCreated:Copy"],
+                }
+            ]
+        },
+    )
+
+    # We should have received a test event now
+    messages = sqs_client.receive_message(QueueUrl=queue_url)["Messages"]
+    messages.should.have.length_of(1)
+    message = json.loads(messages[0]["Body"])
+    message.should.have.key("Service").equals("Amazon S3")
+    message.should.have.key("Event").equals("s3:TestEvent")
+    message.should.have.key("Time")
+    message.should.have.key("Bucket").equals(bucket_name)
+
+    # Copy an Object
+    s3_client.put_object(Bucket=bucket_name, Key="keyname", Body="bodyofnewobject")
+    s3_client.copy_object(
+        Bucket=bucket_name, CopySource=f"{bucket_name}/keyname", Key="key2"
+    )
+
+    # Read SQS messages - we should have the Copy-event here
+    resp = sqs_client.receive_message(QueueUrl=queue_url)
+    resp.should.have.key("Messages").length_of(1)
+    records = json.loads(resp["Messages"][0]["Body"])["Records"]
+
+    records.should.have.length_of(1)
+    records[0].should.have.key("awsRegion").equals(REGION_NAME)
+    records[0].should.have.key("eventName").equals("ObjectCreated:Copy")
+    records[0].should.have.key("eventSource").equals("aws:s3")
+    records[0].should.have.key("eventTime")
+    records[0].should.have.key("s3")
+    records[0]["s3"].should.have.key("bucket")
+    records[0]["s3"]["bucket"].should.have.key("arn").equals(
+        f"arn:aws:s3:::{bucket_name}"
+    )
+    records[0]["s3"]["bucket"].should.have.key("name").equals(bucket_name)
+    records[0]["s3"].should.have.key("configurationId").equals("queue_config")
+    records[0]["s3"].should.have.key("object")
+    records[0]["s3"]["object"].should.have.key("eTag").equals(
+        "61ea96c3c8d2c76fc5a42bfccb6affd9"
+    )
+    records[0]["s3"]["object"].should.have.key("key").equals("key2")
+    records[0]["s3"]["object"].should.have.key("size").equals(15)


### PR DESCRIPTION
It was always possible to persist the configurations for bucket notications (`put_bucket_notification_configuration`) - this PR adds support to send the actual notifications.

Whenever a user creates or copies an object in S3, the configured AWSLambda functions will be invoked and a message will be send to the configured SQS queues.

(Not all events are supported yet, such as deleting objects, creating tags, etc.)