### PR TITLE
rds - support final snapshot when delete a cluster

### DIFF
--- a/moto/rds/models.py
+++ b/moto/rds/models.py
@@ -1801,12 +1801,14 @@ class RDSBackend(BaseBackend):
             raise DBClusterSnapshotNotFoundError(db_snapshot_identifier)
         return list(snapshots.values())
 
-    def delete_db_cluster(self, cluster_identifier):
+    def delete_db_cluster(self, cluster_identifier, snapshot_name=None):
         if cluster_identifier in self.clusters:
             if self.clusters[cluster_identifier].deletion_protection:
                 raise InvalidParameterValue(
                     "Can't delete Cluster with protection enabled"
                 )
+            if snapshot_name:
+                self.create_db_cluster_snapshot(cluster_identifier, snapshot_name)
             return self.clusters.pop(cluster_identifier)
         raise DBClusterNotFoundError(cluster_identifier)
 

--- a/moto/rds/responses.py
+++ b/moto/rds/responses.py
@@ -507,7 +507,10 @@ class RDSResponse(BaseResponse):
 
     def delete_db_cluster(self):
         _id = self._get_param("DBClusterIdentifier")
-        cluster = self.backend.delete_db_cluster(cluster_identifier=_id)
+        snapshot_name = self._get_param("FinalDBSnapshotIdentifier")
+        cluster = self.backend.delete_db_cluster(
+            cluster_identifier=_id, snapshot_name=snapshot_name
+        )
         template = self.response_template(DELETE_CLUSTER_TEMPLATE)
         return template.render(cluster=cluster)
 

--- a/tests/test_rds/test_rds_clusters.py
+++ b/tests/test_rds/test_rds_clusters.py
@@ -211,6 +211,25 @@ def test_delete_db_cluster():
 
 
 @mock_rds
+def test_delete_db_cluster_do_snapshot():
+    client = boto3.client("rds", region_name="eu-north-1")
+
+    client.create_db_cluster(
+        DBClusterIdentifier="cluster-id",
+        Engine="aurora",
+        MasterUsername="root",
+        MasterUserPassword="hunter2_",
+    )
+
+    client.delete_db_cluster(
+        DBClusterIdentifier="cluster-id", FinalDBSnapshotIdentifier="final-ss"
+    )
+    client.describe_db_clusters()["DBClusters"].should.have.length_of(0)
+    snapshots = client.describe_db_cluster_snapshots()["DBClusterSnapshots"]
+    snapshots[0]["DBClusterIdentifier"] == "cluster-id"
+
+
+@mock_rds
 def test_delete_db_cluster_that_is_protected():
     client = boto3.client("rds", region_name="eu-north-1")
 


### PR DESCRIPTION
create a final snapshot if FinalDBSnapshotIdentifier is given while deleting a rds cluster