### PR TITLE
rds - modify_db_instance does not support tags

### DIFF
--- a/moto/rds/responses.py
+++ b/moto/rds/responses.py
@@ -195,6 +195,8 @@ class RDSResponse(BaseResponse):
     def modify_db_instance(self):
         db_instance_identifier = self._get_param("DBInstanceIdentifier")
         db_kwargs = self._get_db_kwargs()
+        # NOTE modify_db_instance does not support tags
+        del(db_kwargs["tags"])
         new_db_instance_identifier = self._get_param("NewDBInstanceIdentifier")
         if new_db_instance_identifier:
             db_kwargs["new_db_instance_identifier"] = new_db_instance_identifier

--- a/moto/rds/responses.py
+++ b/moto/rds/responses.py
@@ -196,7 +196,7 @@ class RDSResponse(BaseResponse):
         db_instance_identifier = self._get_param("DBInstanceIdentifier")
         db_kwargs = self._get_db_kwargs()
         # NOTE modify_db_instance does not support tags
-        del(db_kwargs["tags"])
+        del db_kwargs["tags"]
         new_db_instance_identifier = self._get_param("NewDBInstanceIdentifier")
         if new_db_instance_identifier:
             db_kwargs["new_db_instance_identifier"] = new_db_instance_identifier


### PR DESCRIPTION
This pr is to remove the `tags` param in the modify_db_instance implementation as the boto3 API does not support that, otherwise, the existing tags will be cleared.

NOTE: I haven't checked other language SDKs.