### PR TITLE
ELB: Fix response templates

### DIFF
--- a/moto/elbv2/models.py
+++ b/moto/elbv2/models.py
@@ -496,9 +496,14 @@ class FakeLoadBalancer(CloudFormationModel):
         "access_logs.s3.prefix",
         "deletion_protection.enabled",
         "idle_timeout.timeout_seconds",
+        "ipv6.deny_all_igw_traffic",
         "load_balancing.cross_zone.enabled",
-        "routing.http2.enabled",
+        "routing.http.desync_mitigation_mode",
         "routing.http.drop_invalid_header_fields.enabled",
+        "routing.http.x_amzn_tls_version_and_cipher_suite.enabled",
+        "routing.http.xff_client_port.enabled",
+        "routing.http2.enabled",
+        "waf.fail_open.enabled",
     }
 
     def __init__(

--- a/moto/elbv2/responses.py
+++ b/moto/elbv2/responses.py
@@ -1430,24 +1430,85 @@ DESCRIBE_TARGET_HEALTH_TEMPLATE = """<DescribeTargetHealthResponse xmlns="http:/
 SET_RULE_PRIORITIES_TEMPLATE = """<SetRulePrioritiesResponse xmlns="http://elasticloadbalancing.amazonaws.com/doc/2015-12-01/">
   <SetRulePrioritiesResult>
     <Rules>
+      {% for rule in rules %}
       <member>
-        <IsDefault>{{ "true" if rules.is_default else "false" }}</IsDefault>
+        <IsDefault>{{ "true" if rule.is_default else "false" }}</IsDefault>
         <Conditions>
-          {% for condition in rules.conditions %}
+          {% for condition in rule.conditions %}
           <member>
-            <Field>{{ condition["field"] }}</Field>
+            <Field>{{ condition["Field"] }}</Field>
+            {% if "Values" in condition %}
             <Values>
-              {% for value in condition["values"] %}
+              {% for value in condition["Values"] %}
               <member>{{ value }}</member>
               {% endfor %}
             </Values>
+            {% endif %}
+            {% if "HttpHeaderConfig" in condition %}
+            <HttpHeaderConfig>
+              <HttpHeaderName>{{ condition["HttpHeaderConfig"]["HttpHeaderName"] }}</HttpHeaderName>
+              <Values>
+                {% for value in condition["HttpHeaderConfig"]["Values"] %}
+                <member>{{ value }}</member>
+                {% endfor %}
+              </Values>
+            </HttpHeaderConfig>
+            {% endif %}
+            {% if "HttpRequestMethodConfig" in condition %}
+            <HttpRequestMethodConfig>
+              <Values>
+                {% for value in condition["HttpRequestMethodConfig"]["Values"] %}
+                <member>{{ value }}</member>
+                {% endfor %}
+              </Values>
+            </HttpRequestMethodConfig>
+            {% endif %}
+            {% if "QueryStringConfig" in condition %}
+            <QueryStringConfig>
+              <Values>
+                {% for value in condition["QueryStringConfig"]["Values"] %}
+                <member>
+                    <Key>{{ value["Key"] }}</Key>
+                    <Value>{{ value["Value"] }}</Value>
+                </member>
+                {% endfor %}
+              </Values>
+            </QueryStringConfig>
+            {% endif %}
+            {% if "SourceIpConfig" in condition %}
+            <SourceIpConfig>
+              <Values>
+                {% for value in condition["SourceIpConfig"]["Values"] %}
+                <member>{{ value }}</member>
+                {% endfor %}
+              </Values>
+            </SourceIpConfig>
+            {% endif %}
+            {% if "PathPatternConfig" in condition %}
+            <PathPatternConfig>
+              <Values>
+                {% for value in condition["PathPatternConfig"]["Values"] %}
+                <member>{{ value }}</member>
+                {% endfor %}
+              </Values>
+            </PathPatternConfig>
+            {% endif %}
+            {% if "HostHeaderConfig" in condition %}
+            <HostHeaderConfig>
+              <Values>
+                {% for value in condition["HostHeaderConfig"]["Values"] %}
+                <member>{{ value }}</member>
+                {% endfor %}
+              </Values>
+            </HostHeaderConfig>
+            {% endif %}
           </member>
           {% endfor %}
         </Conditions>
-        <Priority>{{ rules.priority }}</Priority>
-        <RuleArn>{{ rules.arn }}</RuleArn>
+        <Priority>{{ rule.priority }}</Priority>
+        <RuleArn>{{ rule.arn }}</RuleArn>
         <Actions>
-          {% for action in rules.actions %}
+          {% for action in rule.actions %}
           <member>
             <Type>{{ action["type"] }}</Type>
             {% if action["type"] == "forward" and "forward_config" in action.data %}
@@ -1469,6 +1530,7 @@ SET_RULE_PRIORITIES_TEMPLATE = """<SetRulePrioritiesResponse xmlns="http://elast
           {% endfor %}
         </Actions>
       </member>
+      {% endfor %}
     </Rules>
   </SetRulePrioritiesResult>
   <ResponseMetadata>

--- a/tests/test_elbv2/test_elbv2.py
+++ b/tests/test_elbv2/test_elbv2.py
@@ -960,11 +960,11 @@ def test_handle_listener_rules():
     )
 
     # assert response of SetRulePriorities operation
-    updated_rule['Rules'].should.have.length_of(1)
-    updated_rule['Rules'][0]['RuleArn'].should.equal(first_rule['RuleArn'])
-    updated_rule['Rules'][0]['Priority'].should.equal(str(new_priority))
-    updated_rule['Rules'][0]['Conditions'].should.have.length_of(3)
-    updated_rule['Rules'][0]['Actions'].should.have.length_of(1)
+    updated_rule["Rules"].should.have.length_of(1)
+    updated_rule["Rules"][0]["RuleArn"].should.equal(first_rule["RuleArn"])
+    updated_rule["Rules"][0]["Priority"].should.equal(str(new_priority))
+    updated_rule["Rules"][0]["Conditions"].should.have.length_of(3)
+    updated_rule["Rules"][0]["Actions"].should.have.length_of(1)
 
     # modify forward_config rule partially rule
     new_host_2 = "new.examplewebsite.com"

--- a/tests/test_elbv2/test_elbv2.py
+++ b/tests/test_elbv2/test_elbv2.py
@@ -949,14 +949,22 @@ def test_handle_listener_rules():
     )
 
     # modify priority
-    conn.set_rule_priorities(
+    new_priority = int(first_rule["Priority"]) - 1
+    updated_rule = conn.set_rule_priorities(
         RulePriorities=[
             {
                 "RuleArn": first_rule["RuleArn"],
-                "Priority": int(first_rule["Priority"]) - 1,
+                "Priority": new_priority,
             }
         ]
     )
+
+    # assert response of SetRulePriorities operation
+    updated_rule['Rules'].should.have.length_of(1)
+    updated_rule['Rules'][0]['RuleArn'].should.equal(first_rule['RuleArn'])
+    updated_rule['Rules'][0]['Priority'].should.equal(str(new_priority))
+    updated_rule['Rules'][0]['Conditions'].should.have.length_of(3)
+    updated_rule['Rules'][0]['Actions'].should.have.length_of(1)
 
     # modify forward_config rule partially rule
     new_host_2 = "new.examplewebsite.com"


### PR DESCRIPTION
### Summary
This PR fixes response template for `SetRulePriorities` operations. The template now correctly renders the list of [Rule objects](https://docs.aws.amazon.com/elasticloadbalancing/latest/APIReference/API_SetRulePriorities.html#API_SetRulePriorities_ResponseElements).

The list of valid [Load Balancer attributes](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/application-load-balancers.html#load-balancer-attributes) is also updated.