### PR TITLE
Admin - enable more Pylint rules

### DIFF
--- a/moto/apigateway/models.py
+++ b/moto/apigateway/models.py
@@ -545,10 +545,7 @@ class Stage(BaseModel, dict):
             "caching/unauthorizedCacheControlHeaderStrategy": "unauthorizedCacheControlHeaderStrategy",
         }
 
-        if key in mappings:
-            return mappings[key]
-        else:
-            None
+        return mappings.get(key)
 
     def _str2bool(self, v):
         return v.lower() == "true"

--- a/moto/apigatewayv2/models.py
+++ b/moto/apigatewayv2/models.py
@@ -66,7 +66,7 @@ class Authorizer(BaseModel):
         if auth_result_ttl is not None:
             self.auth_result_ttl = auth_result_ttl
         if authorizer_type is not None:
-            self.authorizer_type is authorizer_type
+            self.authorizer_type = authorizer_type
         if authorizer_uri is not None:
             self.authorizer_uri = authorizer_uri
         if enable_simple_response is not None:

--- a/moto/cognitoidp/models.py
+++ b/moto/cognitoidp/models.py
@@ -1616,8 +1616,8 @@ class CognitoIdpBackend(BaseBackend):
                 self.admin_get_user(user_pool.id, username)
 
                 return {"SecretCode": str(uuid.uuid4())}
-        else:
-            raise NotAuthorizedError(access_token)
+
+        raise NotAuthorizedError(access_token)
 
     def verify_software_token(self, access_token):
         """
@@ -1631,8 +1631,8 @@ class CognitoIdpBackend(BaseBackend):
                 user.token_verified = True
 
                 return {"Status": "SUCCESS"}
-        else:
-            raise NotAuthorizedError(access_token)
+
+        raise NotAuthorizedError(access_token)
 
     def set_user_mfa_preference(
         self, access_token, software_token_mfa_settings, sms_mfa_settings
@@ -1660,8 +1660,8 @@ class CognitoIdpBackend(BaseBackend):
                     if sms_mfa_settings.get("PreferredMfa"):
                         user.preferred_mfa_setting = "SMS_MFA"
                 return None
-        else:
-            raise NotAuthorizedError(access_token)
+
+        raise NotAuthorizedError(access_token)
 
     def admin_set_user_mfa_preference(
         self, user_pool_id, username, software_token_mfa_settings, sms_mfa_settings

--- a/moto/dynamodb/parsing/ast_nodes.py
+++ b/moto/dynamodb/parsing/ast_nodes.py
@@ -367,5 +367,4 @@ class NodeDepthLeftTypeFetcher(object):
             candidate = self.queue.popleft()
             if isinstance(candidate, self.node_type):
                 return candidate
-        else:
-            raise StopIteration
+        raise StopIteration

--- a/moto/ecs/models.py
+++ b/moto/ecs/models.py
@@ -1650,14 +1650,12 @@ class EC2ContainerServiceBackend(BaseBackend):
                 for revision in task_definition.values():
                     if revision.arn == resource_arn:
                         return revision.tags
-            else:
-                raise TaskDefinitionNotFoundException()
+            raise TaskDefinitionNotFoundException()
         elif parsed_arn["service"] == "service":
             for service in self.services.values():
                 if service.arn == resource_arn:
                     return service.tags
-            else:
-                raise ServiceNotFoundException
+            raise ServiceNotFoundException
         raise NotImplementedError()
 
     def _get_last_task_definition_revision_id(self, family):
@@ -1673,8 +1671,7 @@ class EC2ContainerServiceBackend(BaseBackend):
                 if service.arn == resource_arn:
                     service.tags = self._merge_tags(service.tags, tags)
                     return {}
-            else:
-                raise ServiceNotFoundException
+            raise ServiceNotFoundException
         raise NotImplementedError()
 
     def _merge_tags(self, existing_tags, new_tags):
@@ -1699,8 +1696,7 @@ class EC2ContainerServiceBackend(BaseBackend):
                         tag for tag in service.tags if tag["key"] not in tag_keys
                     ]
                     return {}
-            else:
-                raise ServiceNotFoundException
+            raise ServiceNotFoundException
         raise NotImplementedError()
 
     def create_task_set(

--- a/moto/iam/models.py
+++ b/moto/iam/models.py
@@ -1102,10 +1102,10 @@ class User(CloudFormationModel):
         for key in self.access_keys:
             if key.access_key_id == access_key_id:
                 return key
-        else:
-            raise IAMNotFoundException(
-                "The Access Key with id {0} cannot be found".format(access_key_id)
-            )
+
+        raise IAMNotFoundException(
+            f"The Access Key with id {access_key_id} cannot be found"
+        )
 
     def has_access_key(self, access_key_id):
         return any(
@@ -1125,12 +1125,10 @@ class User(CloudFormationModel):
         for key in self.ssh_public_keys:
             if key.ssh_public_key_id == ssh_public_key_id:
                 return key
-        else:
-            raise IAMNotFoundException(
-                "The SSH Public Key with id {0} cannot be found".format(
-                    ssh_public_key_id
-                )
-            )
+
+        raise IAMNotFoundException(
+            f"The SSH Public Key with id {ssh_public_key_id} cannot be found"
+        )
 
     def get_all_ssh_public_keys(self):
         return self.ssh_public_keys
@@ -2366,10 +2364,10 @@ class IAMBackend(BaseBackend):
         for key in access_keys_list:
             if key.access_key_id == access_key_id:
                 return {"user_name": key.user_name, "last_used": key.last_used_iso_8601}
-        else:
-            raise IAMNotFoundException(
-                "The Access Key with id {0} cannot be found".format(access_key_id)
-            )
+
+        raise IAMNotFoundException(
+            f"The Access Key with id {access_key_id} cannot be found"
+        )
 
     def get_all_access_keys_for_all_users(self):
         access_keys_list = []

--- a/moto/iot/models.py
+++ b/moto/iot/models.py
@@ -211,7 +211,7 @@ class FakePolicy(BaseModel):
     def __init__(self, name, document, region_name, default_version_id="1"):
         self.name = name
         self.document = document
-        self.arn = "arn:aws:iot:%s:1:policy/%s" % (region_name, name)
+        self.arn = f"arn:aws:iot:{region_name}:{ACCOUNT_ID}:policy/{name}"
         self.default_version_id = default_version_id
         self.versions = [FakePolicyVersion(self.name, document, True, region_name)]
 
@@ -238,7 +238,7 @@ class FakePolicy(BaseModel):
 class FakePolicyVersion(object):
     def __init__(self, policy_name, document, is_default, region_name):
         self.name = policy_name
-        self.arn = "arn:aws:iot:%s:1:policy/%s" % (region_name, policy_name)
+        self.arn = f"arn:aws:iot:{region_name}:{ACCOUNT_ID}:policy/{policy_name}"
         self.document = document or {}
         self.is_default = is_default
         self.version_id = "1"

--- a/moto/ses/models.py
+++ b/moto/ses/models.py
@@ -462,8 +462,8 @@ class SESBackend(BaseBackend):
         for receipt_rule in rule_set:
             if receipt_rule["name"] == rule_name:
                 return receipt_rule
-        else:
-            raise RuleDoesNotExist("Invalid Rule Name.")
+
+        raise RuleDoesNotExist("Invalid Rule Name.")
 
     def update_receipt_rule(self, rule_set_name, rule):
         rule_set = self.receipt_rule_set.get(rule_set_name)

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,5 +17,5 @@ ignore-paths=moto/packages
 
 [pylint.'MESSAGES CONTROL']
 disable = W,C,R,E
-# future sensible checks = super-init-not-called, useless-else-on-loop, pointless-statement, redefined-outer-name, unspecified-encoding, undefined-loop-variable
-enable = arguments-renamed, dangerous-default-value, deprecated-module, function-redefined, import-self, redefined-builtin, reimported, super-with-arguments, unused-argument, unused-import, unused-variable, wildcard-import
+# future sensible checks = super-init-not-called, redefined-outer-name, unspecified-encoding, undefined-loop-variable
+enable = arguments-renamed, dangerous-default-value, deprecated-module, function-redefined, import-self, redefined-builtin, reimported, pointless-statement, super-with-arguments, unused-argument, unused-import, unused-variable, useless-else-on-loop, wildcard-import

--- a/tests/test_apigateway/test_apigateway_stage.py
+++ b/tests/test_apigateway/test_apigateway_stage.py
@@ -372,7 +372,7 @@ def test_update_stage_configuration():
     stage["cacheClusterSize"].should.equal("1.6")
     stage["variables"]["environment"].should.match("dev")
     stage["variables"].should_not.have.key("region")
-    stage["cacheClusterEnabled"].should.be.true
+    stage["cacheClusterEnabled"].should.equal(True)
     stage["deploymentId"].should.match(deployment_id)
     stage["methodSettings"].should.have.key("*/*")
     stage["methodSettings"]["*/*"].should.have.key(

--- a/tests/test_cloudformation/test_cloudformation_stack_crud_boto3.py
+++ b/tests/test_cloudformation/test_cloudformation_stack_crud_boto3.py
@@ -326,7 +326,7 @@ def test_create_stack():
 
 @mock_cloudformation
 @mock_ec2
-def test_boto3_describe_stack_instances():
+def test_describe_stack_instances():
     cf_conn = boto3.client("cloudformation", region_name="us-east-1")
     cf_conn.create_stack_set(
         StackSetName="test_stack_set", TemplateBody=dummy_template_json
@@ -362,7 +362,7 @@ def test_boto3_describe_stack_instances():
 
 
 @mock_cloudformation
-def test_boto3_list_stacksets_length():
+def test_list_stacksets_length():
     cf_conn = boto3.client("cloudformation", region_name="us-east-1")
     cf_conn.create_stack_set(
         StackSetName="test_stack_set", TemplateBody=dummy_template_json
@@ -375,7 +375,7 @@ def test_boto3_list_stacksets_length():
 
 
 @mock_cloudformation
-def test_boto3_filter_stacks():
+def test_filter_stacks():
     conn = boto3.client("cloudformation", region_name="us-east-1")
     conn.create_stack(StackName="test_stack", TemplateBody=dummy_template_json)
     conn.create_stack(StackName="test_stack2", TemplateBody=dummy_template_json)
@@ -388,7 +388,7 @@ def test_boto3_filter_stacks():
 
 
 @mock_cloudformation
-def test_boto3_list_stacksets_contents():
+def test_list_stacksets_contents():
     cf_conn = boto3.client("cloudformation", region_name="us-east-1")
     cf_conn.create_stack_set(
         StackSetName="test_stack_set", TemplateBody=dummy_template_json
@@ -401,7 +401,7 @@ def test_boto3_list_stacksets_contents():
 
 
 @mock_cloudformation
-def test_boto3_stop_stack_set_operation():
+def test_stop_stack_set_operation():
     cf_conn = boto3.client("cloudformation", region_name="us-east-1")
     cf_conn.create_stack_set(
         StackSetName="test_stack_set", TemplateBody=dummy_template_json
@@ -422,7 +422,7 @@ def test_boto3_stop_stack_set_operation():
 
 
 @mock_cloudformation
-def test_boto3_describe_stack_set_operation():
+def test_describe_stack_set_operation():
     cf_conn = boto3.client("cloudformation", region_name="us-east-1")
     cf_conn.create_stack_set(
         StackSetName="test_stack_set", TemplateBody=dummy_template_json
@@ -459,7 +459,7 @@ def test_boto3_describe_stack_set_operation():
 
 
 @mock_cloudformation
-def test_boto3_list_stack_set_operation_results():
+def test_list_stack_set_operation_results():
     cf_conn = boto3.client("cloudformation", region_name="us-east-1")
     cf_conn.create_stack_set(
         StackSetName="test_stack_set", TemplateBody=dummy_template_json
@@ -486,7 +486,7 @@ def test_boto3_list_stack_set_operation_results():
 
 
 @mock_cloudformation
-def test_boto3_update_stack_instances():
+def test_update_stack_instances():
     cf_conn = boto3.client("cloudformation", region_name="us-east-1")
     param = [
         {"ParameterKey": "SomeParam", "ParameterValue": "StackSetValue"},
@@ -554,11 +554,11 @@ def test_boto3_update_stack_instances():
         "ParameterValue"
     ].should.equal(param_overrides[1]["ParameterValue"])
 
-    use1_instance["StackInstance"]["ParameterOverrides"].should.be.empty
+    use1_instance["StackInstance"]["ParameterOverrides"].should.equal([])
 
 
 @mock_cloudformation
-def test_boto3_delete_stack_instances():
+def test_delete_stack_instances():
     cf_conn = boto3.client("cloudformation", region_name="us-east-1")
     cf_conn.create_stack_set(
         StackSetName="test_stack_set", TemplateBody=dummy_template_json
@@ -585,7 +585,7 @@ def test_boto3_delete_stack_instances():
 
 
 @mock_cloudformation
-def test_boto3_create_stack_instances():
+def test_create_stack_instances():
     cf_conn = boto3.client("cloudformation", region_name="us-east-1")
     cf_conn.create_stack_set(
         StackSetName="test_stack_set", TemplateBody=dummy_template_json
@@ -605,7 +605,7 @@ def test_boto3_create_stack_instances():
 
 
 @mock_cloudformation
-def test_boto3_create_stack_instances_with_param_overrides():
+def test_create_stack_instances_with_param_overrides():
     cf_conn = boto3.client("cloudformation", region_name="us-east-1")
     param = [
         {"ParameterKey": "TagDescription", "ParameterValue": "StackSetValue"},
@@ -721,7 +721,7 @@ def test_update_stack_set_with_previous_value():
 
 
 @mock_cloudformation
-def test_boto3_list_stack_set_operations():
+def test_list_stack_set_operations():
     cf_conn = boto3.client("cloudformation", region_name="us-east-1")
     cf_conn.create_stack_set(
         StackSetName="test_stack_set", TemplateBody=dummy_template_json
@@ -743,7 +743,7 @@ def test_boto3_list_stack_set_operations():
 
 
 @mock_cloudformation
-def test_boto3_bad_list_stack_resources():
+def test_bad_list_stack_resources():
     cf_conn = boto3.client("cloudformation", region_name="us-east-1")
 
     with pytest.raises(ClientError):
@@ -751,7 +751,7 @@ def test_boto3_bad_list_stack_resources():
 
 
 @mock_cloudformation
-def test_boto3_delete_stack_set_by_name():
+def test_delete_stack_set_by_name():
     cf_conn = boto3.client("cloudformation", region_name="us-east-1")
     cf_conn.create_stack_set(
         StackSetName="test_stack_set", TemplateBody=dummy_template_json
@@ -764,7 +764,7 @@ def test_boto3_delete_stack_set_by_name():
 
 
 @mock_cloudformation
-def test_boto3_delete_stack_set_by_id():
+def test_delete_stack_set_by_id():
     cf_conn = boto3.client("cloudformation", region_name="us-east-1")
     response = cf_conn.create_stack_set(
         StackSetName="test_stack_set", TemplateBody=dummy_template_json
@@ -778,7 +778,7 @@ def test_boto3_delete_stack_set_by_id():
 
 
 @mock_cloudformation
-def test_boto3_create_stack_set():
+def test_create_stack_set():
     cf_conn = boto3.client("cloudformation", region_name="us-east-1")
     response = cf_conn.create_stack_set(
         StackSetName="test_stack_set", TemplateBody=dummy_template_json
@@ -787,11 +787,11 @@ def test_boto3_create_stack_set():
     cf_conn.describe_stack_set(StackSetName="test_stack_set")["StackSet"][
         "TemplateBody"
     ].should.equal(dummy_template_json)
-    response["StackSetId"].should_not.be.empty
+    response["StackSetId"].should_not.equal(None)
 
 
 @mock_cloudformation
-def test_boto3_create_stack_set_with_yaml():
+def test_create_stack_set_with_yaml():
     cf_conn = boto3.client("cloudformation", region_name="us-east-1")
     cf_conn.create_stack_set(
         StackSetName="test_stack_set", TemplateBody=dummy_template_yaml
@@ -822,7 +822,7 @@ def test_create_stack_set_from_s3_url():
 
 
 @mock_cloudformation
-def test_boto3_create_stack_set_with_ref_yaml():
+def test_create_stack_set_with_ref_yaml():
     cf_conn = boto3.client("cloudformation", region_name="us-east-1")
     params = [
         {"ParameterKey": "TagDescription", "ParameterValue": "desc_ref"},
@@ -840,7 +840,7 @@ def test_boto3_create_stack_set_with_ref_yaml():
 
 
 @mock_cloudformation
-def test_boto3_describe_stack_set_params():
+def test_describe_stack_set_params():
     cf_conn = boto3.client("cloudformation", region_name="us-east-1")
     params = [
         {"ParameterKey": "TagDescription", "ParameterValue": "desc_ref"},
@@ -858,7 +858,7 @@ def test_boto3_describe_stack_set_params():
 
 
 @mock_cloudformation
-def test_boto3_describe_stack_set_by_id():
+def test_describe_stack_set_by_id():
     cf_conn = boto3.client("cloudformation", region_name="us-east-1")
     response = cf_conn.create_stack_set(
         StackSetName="test_stack", TemplateBody=dummy_template_json
@@ -871,17 +871,7 @@ def test_boto3_describe_stack_set_by_id():
 
 
 @mock_cloudformation
-def test_boto3_create_stack():
-    cf_conn = boto3.client("cloudformation", region_name="us-east-1")
-    cf_conn.create_stack(StackName="test_stack", TemplateBody=dummy_template_json)
-
-    cf_conn.get_template(StackName="test_stack")["TemplateBody"].should.equal(
-        json.loads(dummy_template_json, object_pairs_hook=OrderedDict)
-    )
-
-
-@mock_cloudformation
-def test_boto3_create_stack_fail_missing_parameter():
+def test_create_stack_fail_missing_parameter():
     cf_conn = boto3.client("cloudformation", region_name="us-east-1")
 
     with pytest.raises(ClientError, match="Missing parameter KeyName"):
@@ -892,7 +882,7 @@ def test_boto3_create_stack_fail_missing_parameter():
 
 
 @mock_cloudformation
-def test_boto3_create_stack_s3_long_name():
+def test_create_stack_s3_long_name():
     cf_conn = boto3.client("cloudformation", region_name="us-east-1")
 
     stack_name = "MyLongStackName01234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012"
@@ -917,7 +907,7 @@ def test_boto3_create_stack_s3_long_name():
 
 
 @mock_cloudformation
-def test_boto3_create_stack_with_yaml():
+def test_create_stack_with_yaml():
     cf_conn = boto3.client("cloudformation", region_name="us-east-1")
     cf_conn.create_stack(StackName="test_stack", TemplateBody=dummy_template_yaml)
 
@@ -927,7 +917,7 @@ def test_boto3_create_stack_with_yaml():
 
 
 @mock_cloudformation
-def test_boto3_create_stack_with_short_form_func_yaml():
+def test_create_stack_with_short_form_func_yaml():
     cf_conn = boto3.client("cloudformation", region_name="us-east-1")
     cf_conn.create_stack(
         StackName="test_stack", TemplateBody=dummy_template_yaml_with_short_form_func
@@ -1045,7 +1035,7 @@ def test_get_template_summary_for_template_containing_parameters():
 
 
 @mock_cloudformation
-def test_boto3_create_stack_with_ref_yaml():
+def test_create_stack_with_ref_yaml():
     cf_conn = boto3.client("cloudformation", region_name="us-east-1")
     params = [
         {"ParameterKey": "TagDescription", "ParameterValue": "desc_ref"},
@@ -1174,7 +1164,7 @@ def test_create_stack_from_s3_url():
 
 
 @mock_cloudformation
-def test_boto3_update_stack_fail_missing_new_parameter():
+def test_update_stack_fail_missing_new_parameter():
 
     name = "update_stack_fail_missing_new_parameter"
 
@@ -1190,7 +1180,7 @@ def test_boto3_update_stack_fail_missing_new_parameter():
 
 
 @mock_cloudformation
-def test_boto3_update_stack_fail_update_same_template_body():
+def test_update_stack_fail_update_same_template_body():
 
     name = "update_stack_with_previous_value"
     cf_conn = boto3.client("cloudformation", region_name="us-east-1")
@@ -1225,7 +1215,7 @@ def test_boto3_update_stack_fail_update_same_template_body():
 
 
 @mock_cloudformation
-def test_boto3_update_stack_deleted_resources_can_reference_deleted_parameters():
+def test_update_stack_deleted_resources_can_reference_deleted_parameters():
 
     name = "update_stack_deleted_resources_can_reference_deleted_parameters"
 
@@ -1256,7 +1246,7 @@ def test_boto3_update_stack_deleted_resources_can_reference_deleted_parameters()
 
 
 @mock_cloudformation
-def test_boto3_update_stack_deleted_resources_can_reference_deleted_resources():
+def test_update_stack_deleted_resources_can_reference_deleted_resources():
 
     name = "update_stack_deleted_resources_can_reference_deleted_resources"
 
@@ -1510,7 +1500,7 @@ def test_describe_stack_pagination():
     stacks = resp["Stacks"]
     stacks.should.have.length_of(50)
     next_token = resp["NextToken"]
-    next_token.should_not.be.none
+    next_token.should_not.equal(None)
     resp2 = conn.describe_stacks(NextToken=next_token)
     stacks.extend(resp2["Stacks"])
     stacks.should.have.length_of(100)
@@ -2090,7 +2080,7 @@ def test_stack_with_imports():
     output_stack.outputs.should.have.length_of(1)
     output = output_stack.outputs[0]["OutputValue"]
     queue = ec2_resource.get_queue_by_name(QueueName=output)
-    queue.should_not.be.none
+    queue.should_not.equal(None)
 
 
 @mock_sqs
@@ -2107,7 +2097,7 @@ def test_non_json_redrive_policy():
 
 
 @mock_cloudformation
-def test_boto3_create_duplicate_stack():
+def test_create_duplicate_stack():
     cf_conn = boto3.client("cloudformation", region_name="us-east-1")
     cf_conn.create_stack(StackName="test_stack", TemplateBody=dummy_template_json)
 

--- a/tests/test_cloudwatch/test_cloudwatch_boto3.py
+++ b/tests/test_cloudwatch/test_cloudwatch_boto3.py
@@ -335,7 +335,7 @@ def test_list_metrics():
     cloudwatch = boto3.client("cloudwatch", "eu-west-1")
     # Verify namespace has to exist
     res = cloudwatch.list_metrics(Namespace="unknown/")["Metrics"]
-    res.should.be.empty
+    res.should.equal([])
     # Create some metrics to filter on
     create_metrics(cloudwatch, namespace="list_test_1/", metrics=4, data_points=2)
     create_metrics(cloudwatch, namespace="list_test_2/", metrics=4, data_points=2)
@@ -358,7 +358,7 @@ def test_list_metrics():
     )
     # Verify unknown namespace still has no results
     res = cloudwatch.list_metrics(Namespace="unknown/")["Metrics"]
-    res.should.be.empty
+    res.should.equal([])
 
 
 @mock_cloudwatch
@@ -376,7 +376,7 @@ def test_list_metrics_paginated():
     create_metrics(cloudwatch, namespace="test", metrics=100, data_points=1)
     # Verify that a single page is returned until we've reached 500
     first_page = cloudwatch.list_metrics(Namespace="test")
-    first_page["Metrics"].shouldnt.be.empty
+    first_page["Metrics"].should.have.length_of(100)
 
     len(first_page["Metrics"]).should.equal(100)
     create_metrics(cloudwatch, namespace="test", metrics=200, data_points=2)
@@ -387,7 +387,7 @@ def test_list_metrics_paginated():
     create_metrics(cloudwatch, namespace="test", metrics=60, data_points=10)
     first_page = cloudwatch.list_metrics(Namespace="test")
     len(first_page["Metrics"]).should.equal(500)
-    first_page["NextToken"].shouldnt.be.empty
+    first_page["NextToken"].shouldnt.equal(None)
     # Retrieve second page - and verify there's more where that came from
     second_page = cloudwatch.list_metrics(
         Namespace="test", NextToken=first_page["NextToken"]
@@ -919,7 +919,7 @@ def test_put_metric_alarm():
     alarm["AlarmDescription"].should.equal("test alarm")
     alarm["AlarmConfigurationUpdatedTimestamp"].should.be.a(datetime)
     alarm["AlarmConfigurationUpdatedTimestamp"].tzinfo.should.equal(tzutc())
-    alarm["ActionsEnabled"].should.be.ok
+    alarm["ActionsEnabled"].should.equal(True)
     alarm["OKActions"].should.equal([sns_topic_arn])
     alarm["AlarmActions"].should.equal([sns_topic_arn])
     alarm["InsufficientDataActions"].should.equal([sns_topic_arn])
@@ -989,7 +989,7 @@ def test_put_metric_alarm_with_percentile():
     alarm["AlarmDescription"].should.equal("test alarm")
     alarm["AlarmConfigurationUpdatedTimestamp"].should.be.a(datetime)
     alarm["AlarmConfigurationUpdatedTimestamp"].tzinfo.should.equal(tzutc())
-    alarm["ActionsEnabled"].should.be.ok
+    alarm["ActionsEnabled"].should.equal(True)
     alarm["StateValue"].should.equal("OK")
     alarm["StateReason"].should.equal("Unchecked: Initial alarm creation")
     alarm["StateUpdatedTimestamp"].should.be.a(datetime)

--- a/tests/test_cloudwatch/test_cloudwatch_tags.py
+++ b/tests/test_cloudwatch/test_cloudwatch_tags.py
@@ -57,7 +57,7 @@ def test_list_tags_for_resource_with_unknown_resource():
     )
 
     # then
-    response["Tags"].should.be.empty
+    response["Tags"].should.equal([])
 
 
 @mock_cloudwatch

--- a/tests/test_cognitoidp/test_cognitoidp.py
+++ b/tests/test_cognitoidp/test_cognitoidp.py
@@ -32,7 +32,6 @@ def test_create_user_pool():
     value = str(uuid.uuid4())
     result = conn.create_user_pool(PoolName=name, LambdaConfig={"PreSignUp": value})
 
-    result["UserPool"]["Id"].should_not.be.none
     result["UserPool"]["Id"].should.match(r"[\w-]+_[0-9a-zA-Z]+")
     result["UserPool"]["Arn"].should.equal(
         "arn:aws:cognito-idp:us-west-2:{}:userpool/{}".format(
@@ -75,7 +74,7 @@ def test_create_user_pool_should_have_all_default_attributes_in_schema():
             attribute.get("NumberAttributeConstraints", None).should.equal(
                 default_attr.get("NumberAttributeConstraints", None)
             )
-            attribute["DeveloperOnlyAttribute"].should.be.false
+            attribute["DeveloperOnlyAttribute"].should.equal(False)
 
 
 @mock_cognitoidp
@@ -126,18 +125,18 @@ def test_create_user_pool_custom_attribute_defaults():
         for attr in res["UserPool"]["SchemaAttributes"]
         if attr["Name"] == "custom:string"
     )
-    string_attribute["DeveloperOnlyAttribute"].should.be.false
-    string_attribute["Mutable"].should.be.true
-    string_attribute.get("StringAttributeConstraints").should.be.none
+    string_attribute["DeveloperOnlyAttribute"].should.equal(False)
+    string_attribute["Mutable"].should.equal(True)
+    string_attribute.shouldnt.have.key("StringAttributeConstraints")
 
     number_attribute = next(
         attr
         for attr in res["UserPool"]["SchemaAttributes"]
         if attr["Name"] == "custom:number"
     )
-    number_attribute["DeveloperOnlyAttribute"].should.be.false
-    number_attribute["Mutable"].should.be.true
-    number_attribute.get("NumberAttributeConstraints").should.be.none
+    number_attribute["DeveloperOnlyAttribute"].should.equal(False)
+    number_attribute["Mutable"].should.equal(True)
+    number_attribute.shouldnt.have.key("NumberAttributeConstraints")
 
 
 @mock_cognitoidp
@@ -159,7 +158,7 @@ def test_create_user_pool_custom_attribute_developer_only():
         for attr in res["UserPool"]["SchemaAttributes"]
         if attr["Name"] == "dev:custom:banana"
     )
-    attribute["DeveloperOnlyAttribute"].should.be.true
+    attribute["DeveloperOnlyAttribute"].should.equal(True)
 
 
 @mock_cognitoidp
@@ -236,7 +235,7 @@ def test_create_user_pool_attribute_with_schema():
     string_attribute["StringAttributeConstraints"].should.equal(
         {"MinLength": "10", "MaxLength": "20"}
     )
-    string_attribute.get("NumberAttributeConstraints").should.be.none
+    string_attribute.shouldnt.have.key("NumberAttributeConstraints")
 
     number_attribute = next(
         attr
@@ -246,15 +245,15 @@ def test_create_user_pool_attribute_with_schema():
     number_attribute["NumberAttributeConstraints"].should.equal(
         {"MinValue": "10", "MaxValue": "20"}
     )
-    number_attribute.get("StringAttributeConstraints").should.be.none
+    number_attribute.shouldnt.have.key("StringAttributeConstraints")
 
     boolean_attribute = next(
         attr
         for attr in res["UserPool"]["SchemaAttributes"]
         if attr["Name"] == "custom:boolean"
     )
-    boolean_attribute.get("NumberAttributeConstraints").should.be.none
-    boolean_attribute.get("StringAttributeConstraints").should.be.none
+    boolean_attribute.shouldnt.have.key("NumberAttributeConstraints")
+    boolean_attribute.shouldnt.have.key("StringAttributeConstraints")
 
 
 @mock_cognitoidp
@@ -307,13 +306,13 @@ def test_create_user_pool_attribute_partial_schema():
     )
 
     string_no_min["StringAttributeConstraints"]["MaxLength"].should.equal("10")
-    string_no_min["StringAttributeConstraints"].get("MinLength", None).should.be.none
+    string_no_min["StringAttributeConstraints"].shouldnt.have.key("MinLength")
     string_no_max["StringAttributeConstraints"]["MinLength"].should.equal("10")
-    string_no_max["StringAttributeConstraints"].get("MaxLength", None).should.be.none
+    string_no_max["StringAttributeConstraints"].shouldnt.have.key("MaxLength")
     number_no_min["NumberAttributeConstraints"]["MaxValue"].should.equal("10")
-    number_no_min["NumberAttributeConstraints"].get("MinValue", None).should.be.none
+    number_no_min["NumberAttributeConstraints"].shouldnt.have.key("MinValue")
     number_no_max["NumberAttributeConstraints"]["MinValue"].should.equal("10")
-    number_no_max["NumberAttributeConstraints"].get("MaxValue", None).should.be.none
+    number_no_max["NumberAttributeConstraints"].shouldnt.have.key("MaxValue")
 
 
 @mock_cognitoidp
@@ -460,7 +459,7 @@ def test_add_custom_attributes():
         if attr["Name"] == "custom:banana"
     )
     # Skip verification - already covered by create_user_pool with custom attributes
-    described_attribute.should_not.be.none
+    described_attribute.should_not.equal(None)
 
 
 @mock_cognitoidp
@@ -751,7 +750,7 @@ def test_create_user_pool_domain():
     user_pool_id = conn.create_user_pool(PoolName=str(uuid.uuid4()))["UserPool"]["Id"]
     result = conn.create_user_pool_domain(UserPoolId=user_pool_id, Domain=domain)
     result["ResponseMetadata"]["HTTPStatusCode"].should.equal(200)
-    result["CloudFrontDomain"].should_not.be.none
+    result["CloudFrontDomain"].should_not.equal(None)
 
 
 @mock_cognitoidp
@@ -782,7 +781,7 @@ def test_describe_user_pool_domain():
     result = conn.describe_user_pool_domain(Domain=domain)
     result["DomainDescription"]["Domain"].should.equal(domain)
     result["DomainDescription"]["UserPoolId"].should.equal(user_pool_id)
-    result["DomainDescription"]["AWSAccountId"].should_not.be.none
+    result["DomainDescription"]["AWSAccountId"].should_not.equal(None)
 
 
 @mock_cognitoidp
@@ -856,7 +855,7 @@ def test_create_user_pool_client_returns_secret():
     result["UserPoolClient"]["UserPoolId"].should.equal(user_pool_id)
     bool(re.match(r"^[0-9a-z]{26}$", result["UserPoolClient"]["ClientId"])).should.be.ok
     result["UserPoolClient"]["ClientName"].should.equal(client_name)
-    result["UserPoolClient"]["ClientSecret"].should_not.be.none
+    result["UserPoolClient"]["ClientSecret"].should_not.equal(None)
     result["UserPoolClient"]["CallbackURLs"].should.have.length_of(1)
     result["UserPoolClient"]["CallbackURLs"][0].should.equal(value)
 
@@ -1023,16 +1022,13 @@ def test_delete_user_pool_client():
         UserPoolId=user_pool_id, ClientId=client_details["UserPoolClient"]["ClientId"]
     )
 
-    caught = False
-    try:
+    with pytest.raises(ClientError) as exc:
         conn.describe_user_pool_client(
             UserPoolId=user_pool_id,
             ClientId=client_details["UserPoolClient"]["ClientId"],
         )
-    except conn.exceptions.ResourceNotFoundException:
-        caught = True
-
-    caught.should.be.true
+    err = exc.value.response["Error"]
+    err["Code"].should.equal("ResourceNotFoundException")
 
 
 @mock_cognitoidp
@@ -1264,15 +1260,12 @@ def test_delete_identity_providers():
 
     conn.delete_identity_provider(UserPoolId=user_pool_id, ProviderName=provider_name)
 
-    caught = False
-    try:
+    with pytest.raises(ClientError) as exc:
         conn.describe_identity_provider(
             UserPoolId=user_pool_id, ProviderName=provider_name
         )
-    except conn.exceptions.ResourceNotFoundException:
-        caught = True
-
-    caught.should.be.true
+    err = exc.value.response["Error"]
+    err["Code"].should.equal("ResourceNotFoundException")
 
 
 @mock_cognitoidp
@@ -1340,7 +1333,7 @@ def test_group_in_access_token():
 
     # A newly created user is forced to set a new password
     result["ChallengeName"].should.equal("NEW_PASSWORD_REQUIRED")
-    result["Session"].should_not.be.none
+    result["Session"].should_not.equal(None)
 
     # This sets a new password and logs the user in (creates tokens)
     new_password = str(uuid.uuid4())
@@ -1784,17 +1777,14 @@ def test_admin_create_existing_user():
         UserAttributes=[{"Name": "thing", "Value": value}],
     )
 
-    caught = False
-    try:
+    with pytest.raises(ClientError) as exc:
         conn.admin_create_user(
             UserPoolId=user_pool_id,
             Username=username,
             UserAttributes=[{"Name": "thing", "Value": value}],
         )
-    except conn.exceptions.UsernameExistsException:
-        caught = True
-
-    caught.should.be.true
+    err = exc.value.response["Error"]
+    err["Code"].should.equal("UsernameExistsException")
 
 
 @mock_cognitoidp
@@ -1863,18 +1853,13 @@ def test_admin_resend_invitation_existing_user():
         UserAttributes=[{"Name": "thing", "Value": value}],
     )
 
-    caught = False
-    try:
-        conn.admin_create_user(
-            UserPoolId=user_pool_id,
-            Username=username,
-            UserAttributes=[{"Name": "thing", "Value": value}],
-            MessageAction="RESEND",
-        )
-    except conn.exceptions.UsernameExistsException:
-        caught = True
-
-    caught.should.be.false
+    # Resending this should not throw an error
+    conn.admin_create_user(
+        UserPoolId=user_pool_id,
+        Username=username,
+        UserAttributes=[{"Name": "thing", "Value": value}],
+        MessageAction="RESEND",
+    )
 
 
 @mock_cognitoidp
@@ -2420,7 +2405,7 @@ def authentication_flow(conn, auth_flow):
 
     # A newly created user is forced to set a new password
     result["ChallengeName"].should.equal("NEW_PASSWORD_REQUIRED")
-    result["Session"].should_not.be.none
+    result["Session"].should_not.equal(None)
 
     # This sets a new password and logs the user in (creates tokens)
     new_password = str(uuid.uuid4())
@@ -2431,8 +2416,8 @@ def authentication_flow(conn, auth_flow):
         ChallengeResponses={"USERNAME": username, "NEW_PASSWORD": new_password},
     )
 
-    result["AuthenticationResult"]["IdToken"].should_not.be.none
-    result["AuthenticationResult"]["AccessToken"].should_not.be.none
+    result["AuthenticationResult"]["IdToken"].should_not.equal(None)
+    result["AuthenticationResult"]["AccessToken"].should_not.equal(None)
 
     return {
         "user_pool_id": user_pool_id,
@@ -2555,8 +2540,8 @@ def user_authentication_flow(conn):
         AuthParameters={"SECRET_HASH": secret_hash, "REFRESH_TOKEN": refresh_token},
     )
 
-    result["AuthenticationResult"]["IdToken"].should_not.be.none
-    result["AuthenticationResult"]["AccessToken"].should_not.be.none
+    result["AuthenticationResult"]["IdToken"].should_not.equal(None)
+    result["AuthenticationResult"]["AccessToken"].should_not.equal(None)
     result["AuthenticationResult"]["TokenType"].should.equal("Bearer")
 
     # authenticate user once again this time with mfa token
@@ -2668,7 +2653,7 @@ def test_change_password():
             },
         )
 
-        result["AuthenticationResult"].should_not.be.none
+        result["AuthenticationResult"].should_not.equal(None)
 
 
 @mock_cognitoidp
@@ -2704,7 +2689,7 @@ def test_change_password__using_custom_user_agent_header():
             },
         )
 
-        result["AuthenticationResult"].should_not.be.none
+        result["AuthenticationResult"].should_not.equal(None)
 
 
 @mock_cognitoidp
@@ -2715,7 +2700,7 @@ def test_forgot_password():
         UserPoolId=user_pool_id, ClientName=str(uuid.uuid4())
     )["UserPoolClient"]["ClientId"]
     result = conn.forgot_password(ClientId=client_id, Username=str(uuid.uuid4()))
-    result["CodeDeliveryDetails"]["Destination"].should.not_be.none
+    result["CodeDeliveryDetails"]["Destination"].should_not.equal(None)
     result["CodeDeliveryDetails"]["DeliveryMedium"].should.equal("SMS")
     result["CodeDeliveryDetails"]["AttributeName"].should.equal("phone_number")
 
@@ -3187,8 +3172,8 @@ def test_sign_up():
     username = str(uuid.uuid4())
     password = str(uuid.uuid4())
     result = conn.sign_up(ClientId=client_id, Username=username, Password=password)
-    result["UserConfirmed"].should.be.false
-    result["UserSub"].should_not.be.none
+    result["UserConfirmed"].should.equal(False)
+    result["UserSub"].should_not.equal(None)
 
 
 @mock_cognitoidp
@@ -3204,19 +3189,19 @@ def test_sign_up_with_username_attributes():
     password = str(uuid.uuid4())
     with pytest.raises(ClientError) as err:
         # Attempt to add user again
-        result = conn.sign_up(ClientId=client_id, Username=username, Password=password)
+        conn.sign_up(ClientId=client_id, Username=username, Password=password)
     err.value.response["Error"]["Code"].should.equal("InvalidParameterException")
 
     username = "test@example.com"
     result = conn.sign_up(ClientId=client_id, Username=username, Password=password)
 
-    result["UserConfirmed"].should.be.false
-    result["UserSub"].should_not.be.none
+    result["UserConfirmed"].should.equal(False)
+    result["UserSub"].should_not.equal(None)
     username = "+123456789"
     result = conn.sign_up(ClientId=client_id, Username=username, Password=password)
 
-    result["UserConfirmed"].should.be.false
-    result["UserSub"].should_not.be.none
+    result["UserConfirmed"].should.equal(False)
+    result["UserSub"].should_not.equal(None)
 
 
 @mock_cognitoidp
@@ -3365,7 +3350,7 @@ def test_initiate_auth_REFRESH_TOKEN():
         },
     )
 
-    result["AuthenticationResult"]["AccessToken"].should_not.be.none
+    result["AuthenticationResult"]["AccessToken"].should_not.equal(None)
 
 
 @mock_cognitoidp
@@ -3378,9 +3363,9 @@ def test_initiate_auth_USER_PASSWORD_AUTH():
         AuthParameters={"USERNAME": result["username"], "PASSWORD": result["password"]},
     )
 
-    result["AuthenticationResult"]["AccessToken"].should_not.be.none
-    result["AuthenticationResult"]["IdToken"].should_not.be.none
-    result["AuthenticationResult"]["RefreshToken"].should_not.be.none
+    result["AuthenticationResult"]["AccessToken"].should_not.equal(None)
+    result["AuthenticationResult"]["IdToken"].should_not.equal(None)
+    result["AuthenticationResult"]["RefreshToken"].should_not.equal(None)
     result["AuthenticationResult"]["TokenType"].should.equal("Bearer")
 
 
@@ -3466,7 +3451,7 @@ def test_initiate_auth_USER_PASSWORD_AUTH_with_FORCE_CHANGE_PASSWORD_status():
 
     result["ChallengeName"].should.equal("NEW_PASSWORD_REQUIRED")
     result["ChallengeParameters"]["USERNAME"].should.equal(username)
-    result["Session"].should_not.be.none
+    result["Session"].should_not.equal("")
     assert result.get("AuthenticationResult") is None
 
     new_password = str(uuid.uuid4())
@@ -3480,8 +3465,8 @@ def test_initiate_auth_USER_PASSWORD_AUTH_with_FORCE_CHANGE_PASSWORD_status():
         },
     )
 
-    result["AuthenticationResult"]["IdToken"].should_not.be.none
-    result["AuthenticationResult"]["AccessToken"].should_not.be.none
+    result["AuthenticationResult"]["IdToken"].should_not.equal("")
+    result["AuthenticationResult"]["AccessToken"].should_not.equal("")
 
 
 @mock_cognitoidp
@@ -3555,8 +3540,7 @@ def test_initiate_auth_for_unconfirmed_user():
     new_digest = hmac.new(key, msg, hashlib.sha256).digest()
     secret_hash = base64.b64encode(new_digest).decode()
 
-    caught = False
-    try:
+    with pytest.raises(ClientError) as exc:
         conn.initiate_auth(
             ClientId=client_id,
             AuthFlow="USER_SRP_AUTH",
@@ -3566,10 +3550,8 @@ def test_initiate_auth_for_unconfirmed_user():
                 "SECRET_HASH": secret_hash,
             },
         )
-    except conn.exceptions.UserNotConfirmedException:
-        caught = True
-
-    caught.should.be.true
+    err = exc.value.response["Error"]
+    err["Code"].should.equal("UserNotConfirmedException")
 
 
 @mock_cognitoidp
@@ -3589,8 +3571,7 @@ def test_initiate_auth_with_invalid_secret_hash():
 
     invalid_secret_hash = str(uuid.uuid4())
 
-    caught = False
-    try:
+    with pytest.raises(ClientError) as exc:
         conn.initiate_auth(
             ClientId=client_id,
             AuthFlow="USER_SRP_AUTH",
@@ -3600,10 +3581,8 @@ def test_initiate_auth_with_invalid_secret_hash():
                 "SECRET_HASH": invalid_secret_hash,
             },
         )
-    except conn.exceptions.NotAuthorizedException:
-        caught = True
-
-    caught.should.be.true
+    err = exc.value.response["Error"]
+    err["Code"].should.equal("NotAuthorizedException")
 
 
 @mock_cognitoidp
@@ -3636,16 +3615,13 @@ def test_setting_mfa_when_token_not_verified():
         result = authentication_flow(conn, auth_flow)
         conn.associate_software_token(AccessToken=result["access_token"])
 
-        caught = False
-        try:
+        with pytest.raises(ClientError) as exc:
             conn.set_user_mfa_preference(
                 AccessToken=result["access_token"],
                 SoftwareTokenMfaSettings={"Enabled": True, "PreferredMfa": True},
             )
-        except conn.exceptions.InvalidParameterException:
-            caught = True
-
-        caught.should.be.true
+        err = exc.value.response["Error"]
+        err["Code"].should.equal("InvalidParameterException")
 
 
 @mock_cognitoidp
@@ -3715,8 +3691,7 @@ def test_respond_to_auth_challenge_with_invalid_secret_hash():
         },
     )
 
-    caught = False
-    try:
+    with pytest.raises(ClientError) as exc:
         conn.respond_to_auth_challenge(
             ClientId=result["client_id"],
             Session=challenge["Session"],
@@ -3727,10 +3702,8 @@ def test_respond_to_auth_challenge_with_invalid_secret_hash():
                 "SECRET_HASH": invalid_secret_hash,
             },
         )
-    except conn.exceptions.NotAuthorizedException:
-        caught = True
-
-    caught.should.be.true
+    err = exc.value.response["Error"]
+    err["Code"].should.equal("NotAuthorizedException")
 
 
 @mock_cognitoidp

--- a/tests/test_core/test_importorder.py
+++ b/tests/test_core/test_importorder.py
@@ -25,7 +25,7 @@ def test_mock_works_with_client_created_inside(
     client = boto3.client("s3", region_name="us-east-1")
 
     b = client.list_buckets()
-    b["Buckets"].should.be.empty
+    b["Buckets"].should.equal([])
     m.stop()
 
 
@@ -45,7 +45,7 @@ def test_mock_works_with_client_created_outside(
     patch_client(outside_client)
 
     b = outside_client.list_buckets()
-    b["Buckets"].should.be.empty
+    b["Buckets"].should.equal([])
     m.stop()
 
 
@@ -65,7 +65,7 @@ def test_mock_works_with_resource_created_outside(
     patch_resource(outside_resource)
 
     b = list(outside_resource.buckets.all())
-    b.should.be.empty
+    b.should.equal([])
     m.stop()
 
 

--- a/tests/test_datasync/test_datasync.py
+++ b/tests/test_datasync/test_datasync.py
@@ -334,11 +334,12 @@ def test_start_task_execution_twice():
     task_arn = response["TaskArn"]
 
     response = client.start_task_execution(TaskArn=task_arn)
-    assert "TaskExecutionArn" in response
-    response["TaskExecutionArn"]
+    response.should.have.key("TaskExecutionArn")
 
-    with pytest.raises(ClientError):
+    with pytest.raises(ClientError) as exc:
         client.start_task_execution(TaskArn=task_arn)
+    err = exc.value.response["Error"]
+    err["Code"].should.equal("InvalidRequestException")
 
 
 @mock_datasync

--- a/tests/test_ec2/test_amis.py
+++ b/tests/test_ec2/test_amis.py
@@ -32,7 +32,7 @@ def test_snapshots_for_initial_amis():
 
 
 @mock_ec2
-def test_ami_create_and_delete_boto3():
+def test_ami_create_and_delete():
     ec2 = boto3.client("ec2", region_name="us-east-1")
 
     reservation = ec2.run_instances(ImageId=EXAMPLE_AMI_ID, MinCount=1, MaxCount=1)
@@ -118,11 +118,11 @@ def test_ami_create_and_delete_boto3():
     ex.value.response["ResponseMetadata"]["HTTPStatusCode"].should.equal(400)
     err = ex.value.response["Error"]
     err["Code"].should.equal("InvalidAMIID.NotFound")
-    ex.value.response["ResponseMetadata"]["RequestId"].should_not.be.none
+    ex.value.response["ResponseMetadata"]["RequestId"].should_not.equal(None)
 
 
 @mock_ec2
-def test_ami_copy_boto3_dryrun():
+def test_ami_copy_dryrun():
     ec2 = boto3.client("ec2", region_name="us-west-1")
 
     reservation = ec2.run_instances(ImageId=EXAMPLE_AMI_ID, MinCount=1, MaxCount=1)
@@ -152,7 +152,7 @@ def test_ami_copy_boto3_dryrun():
 
 
 @mock_ec2
-def test_ami_copy_boto3():
+def test_ami_copy():
     ec2 = boto3.client("ec2", region_name="us-west-1")
 
     reservation = ec2.run_instances(ImageId=EXAMPLE_AMI_ID, MinCount=1, MaxCount=1)
@@ -270,7 +270,7 @@ def test_copy_image_changes_owner_id():
 
 
 @mock_ec2
-def test_ami_tagging_boto3():
+def test_ami_tagging():
     ec2 = boto3.client("ec2", region_name="us-east-1")
     res = boto3.resource("ec2", region_name="us-east-1")
     reservation = ec2.run_instances(ImageId=EXAMPLE_AMI_ID, MinCount=1, MaxCount=1)
@@ -299,7 +299,7 @@ def test_ami_tagging_boto3():
 
 
 @mock_ec2
-def test_ami_create_from_missing_instance_boto3():
+def test_ami_create_from_missing_instance():
     ec2 = boto3.client("ec2", region_name="us-east-1")
 
     with pytest.raises(ClientError) as ex:
@@ -312,7 +312,7 @@ def test_ami_create_from_missing_instance_boto3():
 
 
 @mock_ec2
-def test_ami_pulls_attributes_from_instance_boto3():
+def test_ami_pulls_attributes_from_instance():
     ec2 = boto3.client("ec2", region_name="us-east-1")
     reservation = ec2.run_instances(ImageId=EXAMPLE_AMI_ID, MinCount=1, MaxCount=1)
     instance = reservation["Instances"][0]
@@ -328,7 +328,7 @@ def test_ami_pulls_attributes_from_instance_boto3():
 
 
 @mock_ec2
-def test_ami_uses_account_id_if_valid_access_key_is_supplied_boto3():
+def test_ami_uses_account_id_if_valid_access_key_is_supplied():
     # The boto-equivalent required an access_key to be passed in, but Moto will always mock this in boto3
     # So the only thing we're testing here, really.. is whether OwnerId is equal to ACCOUNT_ID?
     # TODO: Maybe patch account_id with multiple values, and verify it always  matches with OwnerId
@@ -346,7 +346,7 @@ def test_ami_uses_account_id_if_valid_access_key_is_supplied_boto3():
 
 
 @mock_ec2
-def test_ami_filters_boto3():
+def test_ami_filters():
     image_name_A = f"test-ami-{str(uuid4())[0:6]}"
     kernel_value_A = f"k-{str(uuid4())[0:6]}"
     kernel_value_B = f"k-{str(uuid4())[0:6]}"
@@ -432,7 +432,7 @@ def test_ami_filters_boto3():
 
 
 @mock_ec2
-def test_ami_filtering_via_tag_boto3():
+def test_ami_filtering_via_tag():
     tag_value = f"value {str(uuid4())}"
     other_value = f"value {str(uuid4())}"
     ec2 = boto3.client("ec2", region_name="us-east-1")
@@ -465,7 +465,7 @@ def test_ami_filtering_via_tag_boto3():
 
 
 @mock_ec2
-def test_getting_missing_ami_boto3():
+def test_getting_missing_ami():
     ec2 = boto3.resource("ec2", region_name="us-east-1")
 
     with pytest.raises(ClientError) as ex:
@@ -476,7 +476,7 @@ def test_getting_missing_ami_boto3():
 
 
 @mock_ec2
-def test_getting_malformed_ami_boto3():
+def test_getting_malformed_ami():
     ec2 = boto3.resource("ec2", region_name="us-east-1")
 
     with pytest.raises(ClientError) as ex:
@@ -487,7 +487,7 @@ def test_getting_malformed_ami_boto3():
 
 
 @mock_ec2
-def test_ami_attribute_group_permissions_boto3():
+def test_ami_attribute_group_permissions():
     ec2 = boto3.client("ec2", region_name="us-east-1")
     reservation = ec2.run_instances(ImageId=EXAMPLE_AMI_ID, MinCount=1, MaxCount=1)
     instance = reservation["Instances"][0]
@@ -553,7 +553,7 @@ def test_ami_attribute_group_permissions_boto3():
 
 
 @mock_ec2
-def test_ami_attribute_user_permissions_boto3():
+def test_ami_attribute_user_permissions():
     ec2 = boto3.client("ec2", region_name="us-east-1")
     reservation = ec2.run_instances(ImageId=EXAMPLE_AMI_ID, MinCount=1, MaxCount=1)
     instance = reservation["Instances"][0]
@@ -737,7 +737,7 @@ def test_ami_describe_executable_users_and_filter():
 
 
 @mock_ec2
-def test_ami_attribute_user_and_group_permissions_boto3():
+def test_ami_attribute_user_and_group_permissions():
     """
     Boto supports adding/removing both users and groups at the same time.
     Just spot-check this -- input variations, idempotency, etc are validated
@@ -827,7 +827,7 @@ def test_filter_description():
 
 
 @mock_ec2
-def test_ami_attribute_error_cases_boto3():
+def test_ami_attribute_error_cases():
     ec2 = boto3.client("ec2", region_name="us-east-1")
     reservation = ec2.run_instances(ImageId=EXAMPLE_AMI_ID, MinCount=1, MaxCount=1)
     instance = reservation["Instances"][0]

--- a/tests/test_ec2/test_elastic_block_store.py
+++ b/tests/test_ec2/test_elastic_block_store.py
@@ -11,7 +11,7 @@ from uuid import uuid4
 
 
 @mock_ec2
-def test_create_and_delete_volume_boto3():
+def test_create_and_delete_volume():
     client = boto3.client("ec2", region_name="us-east-1")
     ec2 = boto3.resource("ec2", region_name="us-east-1")
     volume = ec2.create_volume(Size=80, AvailabilityZone="us-east-1a")
@@ -47,7 +47,7 @@ def test_create_and_delete_volume_boto3():
 
 
 @mock_ec2
-def test_delete_attached_volume_boto3():
+def test_delete_attached_volume():
     client = boto3.client("ec2", region_name="us-east-1")
     ec2 = boto3.resource("ec2", region_name="us-east-1")
     reservation = client.run_instances(ImageId=EXAMPLE_AMI_ID, MinCount=1, MaxCount=1)
@@ -87,7 +87,7 @@ def test_delete_attached_volume_boto3():
 
 
 @mock_ec2
-def test_create_encrypted_volume_dryrun_boto3():
+def test_create_encrypted_volume_dryrun():
     ec2 = boto3.resource("ec2", region_name="us-east-1")
     with pytest.raises(ClientError) as ex:
         ec2.create_volume(Size=80, AvailabilityZone="us-east-1a", DryRun=True)
@@ -99,7 +99,7 @@ def test_create_encrypted_volume_dryrun_boto3():
 
 
 @mock_ec2
-def test_create_encrypted_volume_boto3():
+def test_create_encrypted_volume():
     client = boto3.client("ec2", region_name="us-east-1")
     ec2 = boto3.resource("ec2", region_name="us-east-1")
     volume = ec2.create_volume(Size=80, AvailabilityZone="us-east-1a", Encrypted=True)
@@ -109,7 +109,7 @@ def test_create_encrypted_volume_boto3():
 
 
 @mock_ec2
-def test_filter_volume_by_id_boto3():
+def test_filter_volume_by_id():
     client = boto3.client("ec2", region_name="us-east-1")
     ec2 = boto3.resource("ec2", region_name="us-east-1")
     volume1 = ec2.create_volume(Size=80, AvailabilityZone="us-east-1a")
@@ -131,7 +131,7 @@ def test_filter_volume_by_id_boto3():
 
 
 @mock_ec2
-def test_volume_filters_boto3():
+def test_volume_filters():
     client = boto3.client("ec2", region_name="us-east-1")
     ec2 = boto3.resource("ec2", region_name="us-east-1")
 
@@ -254,7 +254,7 @@ def test_volume_filters_boto3():
 
 
 @mock_ec2
-def test_volume_attach_and_detach_boto3():
+def test_volume_attach_and_detach():
     client = boto3.client("ec2", region_name="us-east-1")
     ec2 = boto3.resource("ec2", region_name="us-east-1")
     reservation = client.run_instances(ImageId=EXAMPLE_AMI_ID, MinCount=1, MaxCount=1)
@@ -320,7 +320,7 @@ def test_volume_attach_and_detach_boto3():
 
 
 @mock_ec2
-def test_create_snapshot_boto3():
+def test_create_snapshot():
     client = boto3.client("ec2", region_name="us-east-1")
     ec2 = boto3.resource("ec2", region_name="us-east-1")
     volume = ec2.create_volume(Size=80, AvailabilityZone="us-east-1a")
@@ -344,7 +344,7 @@ def test_create_snapshot_boto3():
     ]
     snapshots.should.have.length_of(1)
     snapshots[0]["Description"].should.equal("a test snapshot")
-    snapshots[0]["StartTime"].should_not.be.none
+    snapshots[0]["StartTime"].shouldnt.equal(None)
     snapshots[0]["Encrypted"].should.be(False)
 
     # Create snapshot without description
@@ -365,7 +365,7 @@ def test_create_snapshot_boto3():
 
 @mock_ec2
 @pytest.mark.parametrize("encrypted", [True, False])
-def test_create_encrypted_snapshot_boto3(encrypted):
+def test_create_encrypted_snapshot(encrypted):
     client = boto3.client("ec2", region_name="us-east-1")
     ec2 = boto3.resource("ec2", region_name="us-east-1")
     volume = ec2.create_volume(
@@ -383,12 +383,12 @@ def test_create_encrypted_snapshot_boto3(encrypted):
     ]
     snapshots.should.have.length_of(1)
     snapshots[0]["Description"].should.equal("a test snapshot")
-    snapshots[0]["StartTime"].should_not.be.none
+    snapshots[0]["StartTime"].shouldnt.equal(None)
     snapshots[0]["Encrypted"].should.be(encrypted)
 
 
 @mock_ec2
-def test_filter_snapshot_by_id_boto3():
+def test_filter_snapshot_by_id():
     client = boto3.client("ec2", region_name="us-east-1")
     ec2 = boto3.resource("ec2", region_name="us-east-1")
     volume1 = ec2.create_volume(Size=36, AvailabilityZone="us-east-1a")
@@ -405,7 +405,7 @@ def test_filter_snapshot_by_id_boto3():
     ]
     snapshots2.should.have.length_of(2)
     for s in snapshots2:
-        s["StartTime"].should_not.be.none
+        s["StartTime"].shouldnt.equal(None)
         s["VolumeId"].should.be.within([volume2.id, volume3.id])
 
     with pytest.raises(ClientError) as ex:
@@ -416,7 +416,7 @@ def test_filter_snapshot_by_id_boto3():
 
 
 @mock_ec2
-def test_snapshot_filters_boto3():
+def test_snapshot_filters():
     client = boto3.client("ec2", region_name="us-east-1")
     ec2 = boto3.resource("ec2", region_name="us-east-1")
     volume1 = ec2.create_volume(Size=20, AvailabilityZone="us-east-1a", Encrypted=False)
@@ -519,7 +519,7 @@ def test_modify_snapshot_attribute():
         ec2_client.modify_snapshot_attribute(**dict(ADD_GROUP_ARGS, **{"DryRun": True}))
 
     cm.value.response["Error"]["Code"].should.equal("DryRunOperation")
-    cm.value.response["ResponseMetadata"]["RequestId"].should_not.be.none
+    cm.value.response["ResponseMetadata"]["RequestId"].shouldnt.equal(None)
     cm.value.response["ResponseMetadata"]["HTTPStatusCode"].should.equal(412)
 
     ec2_client.modify_snapshot_attribute(**ADD_GROUP_ARGS)
@@ -545,7 +545,7 @@ def test_modify_snapshot_attribute():
             **dict(REMOVE_GROUP_ARGS, **{"DryRun": True})
         )
     cm.value.response["Error"]["Code"].should.equal("DryRunOperation")
-    cm.value.response["ResponseMetadata"]["RequestId"].should_not.be.none
+    cm.value.response["ResponseMetadata"]["RequestId"].shouldnt.equal(None)
     cm.value.response["ResponseMetadata"]["HTTPStatusCode"].should.equal(412)
 
     ec2_client.modify_snapshot_attribute(**REMOVE_GROUP_ARGS)
@@ -574,7 +574,7 @@ def test_modify_snapshot_attribute():
             GroupNames=["everyone"],
         )
     cm.value.response["Error"]["Code"].should.equal("InvalidAMIAttributeItemValue")
-    cm.value.response["ResponseMetadata"]["RequestId"].should_not.be.none
+    cm.value.response["ResponseMetadata"]["RequestId"].shouldnt.equal(None)
     cm.value.response["ResponseMetadata"]["HTTPStatusCode"].should.equal(400)
 
     # Error: Add with invalid snapshot ID
@@ -586,7 +586,7 @@ def test_modify_snapshot_attribute():
             GroupNames=["all"],
         )
     cm.value.response["Error"]["Code"].should.equal("InvalidSnapshot.NotFound")
-    cm.value.response["ResponseMetadata"]["RequestId"].should_not.be.none
+    cm.value.response["ResponseMetadata"]["RequestId"].shouldnt.equal(None)
     cm.value.response["ResponseMetadata"]["HTTPStatusCode"].should.equal(400)
 
     # Error: Remove with invalid snapshot ID
@@ -598,7 +598,7 @@ def test_modify_snapshot_attribute():
             GroupNames=["all"],
         )
     cm.value.response["Error"]["Code"].should.equal("InvalidSnapshot.NotFound")
-    cm.value.response["ResponseMetadata"]["RequestId"].should_not.be.none
+    cm.value.response["ResponseMetadata"]["RequestId"].shouldnt.equal(None)
     cm.value.response["ResponseMetadata"]["HTTPStatusCode"].should.equal(400)
 
     # Test adding user id
@@ -656,7 +656,7 @@ def test_modify_snapshot_attribute():
 
 @mock_ec2
 @pytest.mark.parametrize("encrypted", [True, False])
-def test_create_volume_from_snapshot_boto3(encrypted):
+def test_create_volume_from_snapshot(encrypted):
     client = boto3.client("ec2", region_name="us-east-1")
     ec2 = boto3.resource("ec2", region_name="us-east-1")
     volume = ec2.create_volume(
@@ -675,7 +675,7 @@ def test_create_volume_from_snapshot_boto3(encrypted):
 
 
 @mock_ec2
-def test_modify_attribute_blockDeviceMapping_boto3():
+def test_modify_attribute_blockDeviceMapping():
     """
     Reproduces the missing feature explained at [0], where we want to mock a
     call to modify an instance attribute of type: blockDeviceMapping.
@@ -714,7 +714,7 @@ def test_modify_attribute_blockDeviceMapping_boto3():
 
 
 @mock_ec2
-def test_volume_tag_escaping_boto3():
+def test_volume_tag_escaping():
     client = boto3.client("ec2", region_name="us-east-1")
     ec2 = boto3.resource("ec2", region_name="us-east-1")
     volume = ec2.create_volume(Size=10, AvailabilityZone="us-east-1a")
@@ -796,7 +796,7 @@ def test_copy_snapshot():
     cm.value.response["Error"]["Message"].should.equal(
         "The volume 'vol-abcd1234' does not exist."
     )
-    cm.value.response["ResponseMetadata"]["RequestId"].should_not.be.none
+    cm.value.response["ResponseMetadata"]["RequestId"].shouldnt.equal(None)
     cm.value.response["ResponseMetadata"]["HTTPStatusCode"].should.equal(400)
 
     # Copy from non-existent source region.
@@ -806,8 +806,8 @@ def test_copy_snapshot():
             SourceRegion="eu-west-2",
         )
     cm.value.response["Error"]["Code"].should.equal("InvalidSnapshot.NotFound")
-    cm.value.response["Error"]["Message"].should.be.none
-    cm.value.response["ResponseMetadata"]["RequestId"].should_not.be.none
+    cm.value.response["Error"]["Message"].should.equal(None)
+    cm.value.response["ResponseMetadata"]["RequestId"].shouldnt.equal(None)
     cm.value.response["ResponseMetadata"]["HTTPStatusCode"].should.equal(400)
 
 
@@ -852,13 +852,13 @@ def test_create_encrypted_volume_without_kms_key_should_use_default_key():
     )
     default_ebs_key_arn = kms.describe_key(KeyId="alias/aws/ebs")["KeyMetadata"]["Arn"]
     volume.kms_key_id.should.equal(default_ebs_key_arn)
-    volume.encrypted.should.be.true
+    volume.encrypted.should.equal(True)
     # Subsequent encrypted volumes should use the now-created default key.
     volume = resource.create_volume(
         AvailabilityZone="us-east-1a", Encrypted=True, Size=10
     )
     volume.kms_key_id.should.equal(default_ebs_key_arn)
-    volume.encrypted.should.be.true
+    volume.encrypted.should.equal(True)
 
 
 @mock_ec2
@@ -868,24 +868,24 @@ def test_create_volume_with_kms_key():
         AvailabilityZone="us-east-1a", Encrypted=True, KmsKeyId="key", Size=10
     )
     volume.kms_key_id.should.equal("key")
-    volume.encrypted.should.be.true
+    volume.encrypted.should.equal(True)
 
 
 @mock_ec2
 def test_kms_key_id_property_hidden_when_volume_not_encrypted():
     client = boto3.client("ec2", region_name="us-east-1")
     resp = client.create_volume(AvailabilityZone="us-east-1a", Encrypted=False, Size=10)
-    resp["Encrypted"].should.be.false
+    resp["Encrypted"].should.equal(False)
     resp.should_not.have.key("KmsKeyId")
     resp = client.describe_volumes(VolumeIds=[resp["VolumeId"]])
-    resp["Volumes"][0]["Encrypted"].should.be.false
+    resp["Volumes"][0]["Encrypted"].should.equal(False)
     resp["Volumes"][0].should_not.have.key("KmsKeyId")
     resource = boto3.resource("ec2", region_name="us-east-1")
     volume = resource.create_volume(
         AvailabilityZone="us-east-1a", Encrypted=False, Size=10
     )
-    volume.encrypted.should.be.false
-    volume.kms_key_id.should.be.none
+    volume.encrypted.should.equal(False)
+    volume.kms_key_id.should.equal(None)
 
 
 @mock_ec2

--- a/tests/test_ec2/test_elastic_network_interfaces.py
+++ b/tests/test_ec2/test_elastic_network_interfaces.py
@@ -13,7 +13,7 @@ from uuid import uuid4
 
 
 @mock_ec2
-def test_elastic_network_interfaces_boto3():
+def test_elastic_network_interfaces():
     ec2 = boto3.resource("ec2", region_name="us-east-1")
     client = boto3.client("ec2", "us-east-1")
 
@@ -70,7 +70,7 @@ def test_elastic_network_interfaces_boto3():
 
 
 @mock_ec2
-def test_elastic_network_interfaces_subnet_validation_boto3():
+def test_elastic_network_interfaces_subnet_validation():
     client = boto3.client("ec2", "us-east-1")
 
     with pytest.raises(ClientError) as ex:
@@ -81,7 +81,7 @@ def test_elastic_network_interfaces_subnet_validation_boto3():
 
 
 @mock_ec2
-def test_elastic_network_interfaces_with_private_ip_boto3():
+def test_elastic_network_interfaces_with_private_ip():
     ec2 = boto3.resource("ec2", region_name="us-east-1")
     client = boto3.client("ec2", "us-east-1")
 
@@ -106,7 +106,7 @@ def test_elastic_network_interfaces_with_private_ip_boto3():
 
 
 @mock_ec2
-def test_elastic_network_interfaces_with_groups_boto3():
+def test_elastic_network_interfaces_with_groups():
     ec2 = boto3.resource("ec2", region_name="us-east-1")
     client = boto3.client("ec2", "us-east-1")
 
@@ -158,7 +158,7 @@ def test_elastic_network_interfaces_without_group():
 
 
 @mock_ec2
-def test_elastic_network_interfaces_modify_attribute_boto3():
+def test_elastic_network_interfaces_modify_attribute():
     ec2 = boto3.resource("ec2", region_name="us-east-1")
     client = boto3.client("ec2", "us-east-1")
 
@@ -197,7 +197,7 @@ def test_elastic_network_interfaces_modify_attribute_boto3():
 
 
 @mock_ec2
-def test_elastic_network_interfaces_filtering_boto3():
+def test_elastic_network_interfaces_filtering():
     ec2 = boto3.resource("ec2", region_name="us-east-1")
     client = boto3.client("ec2", "us-east-1")
 
@@ -1003,7 +1003,7 @@ def test_elastic_network_interfaces_describe_attachment():
         NetworkInterfaceId=eni_id, Attribute="attachment"
     ).get("Attachment")
     my_eni_attachment["InstanceId"].should.equal(instance_id)
-    my_eni_attachment["DeleteOnTermination"].should.be.false
+    my_eni_attachment["DeleteOnTermination"].should.equal(False)
 
     with pytest.raises(ClientError) as ex:
         client.describe_network_interface_attribute(

--- a/tests/test_ec2/test_general.py
+++ b/tests/test_ec2/test_general.py
@@ -9,7 +9,7 @@ from tests import EXAMPLE_AMI_ID
 
 
 @mock_ec2
-def test_console_output_boto3():
+def test_console_output():
     conn = boto3.resource("ec2", "us-east-1")
     instances = conn.create_instances(ImageId=EXAMPLE_AMI_ID, MinCount=1, MaxCount=1)
 
@@ -18,11 +18,11 @@ def test_console_output_boto3():
 
 
 @mock_ec2
-def test_console_output_without_instance_boto3():
+def test_console_output_without_instance():
     client = boto3.client("ec2", "us-east-1")
 
     with pytest.raises(ClientError) as ex:
         client.get_console_output(InstanceId="i-1234abcd")
     ex.value.response["ResponseMetadata"]["HTTPStatusCode"].should.equal(400)
-    ex.value.response["ResponseMetadata"]["RequestId"].shouldnt.be.none
+    ex.value.response["ResponseMetadata"]["RequestId"].shouldnt.equal(None)
     ex.value.response["Error"]["Code"].should.equal("InvalidInstanceID.NotFound")

--- a/tests/test_ec2/test_instance_type_offerings.py
+++ b/tests/test_ec2/test_instance_type_offerings.py
@@ -9,8 +9,8 @@ def test_describe_instance_type_offerings():
     client = boto3.client("ec2", "us-east-1")
     offerings = client.describe_instance_type_offerings()
 
-    offerings.should.have.key("InstanceTypeOfferings")
-    offerings["InstanceTypeOfferings"].should_not.be.empty
+    offerings.should.have.key("InstanceTypeOfferings").be.a(list)
+    len(offerings["InstanceTypeOfferings"]).should.be.greater_than(0)
     offerings["InstanceTypeOfferings"][0].should.have.key("InstanceType")
     offerings["InstanceTypeOfferings"][0].should.have.key("Location")
     offerings["InstanceTypeOfferings"][0].should.have.key("LocationType")
@@ -26,7 +26,6 @@ def test_describe_instance_type_offering_filter_by_type():
     )
 
     offerings.should.have.key("InstanceTypeOfferings")
-    offerings["InstanceTypeOfferings"].should_not.be.empty
     offerings = offerings["InstanceTypeOfferings"]
     offerings.should.have.length_of(1)
     offerings[0]["InstanceType"].should.equal("t2.nano")
@@ -56,7 +55,6 @@ def test_describe_instance_type_offering_filter_by_zone():
 
     offerings.should.have.key("InstanceTypeOfferings")
     offerings = offerings["InstanceTypeOfferings"]
-    offerings.should_not.be.empty
     offerings.should.have.length_of(486)
     assert all([o["LocationType"] == "availability-zone" for o in offerings])
     assert all([o["Location"] == "us-east-1c" for o in offerings])
@@ -76,7 +74,6 @@ def test_describe_instance_type_offering_filter_by_zone_id():
 
     offerings.should.have.key("InstanceTypeOfferings")
     offerings = offerings["InstanceTypeOfferings"]
-    offerings.should_not.be.empty
     offerings.should.have.length_of(1)
     offerings[0]["LocationType"].should.equal("availability-zone-id")
     offerings[0]["InstanceType"].should.equal("c5.9xlarge")

--- a/tests/test_ec2/test_instance_types.py
+++ b/tests/test_ec2/test_instance_types.py
@@ -12,8 +12,8 @@ def test_describe_instance_types():
     client = boto3.client("ec2", "us-east-1")
     instance_types = client.describe_instance_types()
 
-    instance_types.should.have.key("InstanceTypes")
-    instance_types["InstanceTypes"].should_not.be.empty
+    instance_types.should.have.key("InstanceTypes").be.a(list)
+    len(instance_types["InstanceTypes"]).should.be.greater_than(0)
     instance_types["InstanceTypes"][0].should.have.key("InstanceType")
     instance_types["InstanceTypes"][0].should.have.key("MemoryInfo")
     instance_types["InstanceTypes"][0]["MemoryInfo"].should.have.key("SizeInMiB")
@@ -27,7 +27,6 @@ def test_describe_instance_types_filter_by_type():
     )
 
     instance_types.should.have.key("InstanceTypes")
-    instance_types["InstanceTypes"].should_not.be.empty
     instance_types["InstanceTypes"].should.have.length_of(2)
     instance_types["InstanceTypes"][0]["InstanceType"].should.be.within(
         ["t1.micro", "t2.nano"]
@@ -45,10 +44,9 @@ def test_describe_instance_types_gpu_instance_types():
     )
 
     instance_types.should.have.key("InstanceTypes")
-    instance_types["InstanceTypes"].should_not.be.empty
     instance_types["InstanceTypes"].should.have.length_of(2)
-    instance_types["InstanceTypes"][0]["GpuInfo"].should_not.be.empty
-    instance_types["InstanceTypes"][1]["GpuInfo"].should_not.be.empty
+    instance_types["InstanceTypes"][0].should.have.key("GpuInfo")
+    instance_types["InstanceTypes"][1].should.have.key("GpuInfo")
 
     instance_type_to_gpu_info = {
         instance_info["InstanceType"]: instance_info["GpuInfo"]

--- a/tests/test_ec2/test_instances.py
+++ b/tests/test_ec2/test_instances.py
@@ -20,7 +20,7 @@ decode_method = base64.decodebytes
 
 
 @mock_ec2
-def test_add_servers_boto3():
+def test_add_servers():
     client = boto3.client("ec2", region_name="us-east-1")
     resp = client.run_instances(ImageId=EXAMPLE_AMI_ID, MinCount=2, MaxCount=2)
     for i in resp["Instances"]:
@@ -36,7 +36,7 @@ def test_add_servers_boto3():
 
 @freeze_time("2014-01-01 05:00:00")
 @mock_ec2
-def test_instance_launch_and_terminate_boto3():
+def test_instance_launch_and_terminate():
     client = boto3.client("ec2", region_name="us-east-1")
 
     with pytest.raises(ClientError) as ex:
@@ -174,8 +174,6 @@ def test_instance_terminate_keep_volumes_implicit():
     for volume in instance.volumes.all():
         instance_volume_ids.append(volume.volume_id)
 
-    instance_volume_ids.shouldnt.be.empty
-
     instance.terminate()
     instance.wait_until_terminated()
 
@@ -235,7 +233,7 @@ def test_instance_detach_volume_wrong_path():
 
 
 @mock_ec2
-def test_terminate_empty_instances_boto3():
+def test_terminate_empty_instances():
     client = boto3.client("ec2", region_name="us-east-1")
 
     with pytest.raises(ClientError) as ex:
@@ -247,7 +245,7 @@ def test_terminate_empty_instances_boto3():
 
 @freeze_time("2014-01-01 05:00:00")
 @mock_ec2
-def test_instance_attach_volume_boto3():
+def test_instance_attach_volume():
     client = boto3.client("ec2", region_name="us-east-1")
     ec2 = boto3.resource("ec2", region_name="us-east-1")
     reservation = client.run_instances(ImageId=EXAMPLE_AMI_ID, MinCount=1, MaxCount=1)
@@ -280,7 +278,7 @@ def test_instance_attach_volume_boto3():
 
 
 @mock_ec2
-def test_get_instances_by_id_boto3():
+def test_get_instances_by_id():
     client = boto3.client("ec2", region_name="us-east-1")
     ec2 = boto3.resource("ec2", region_name="us-east-1")
     reservation = client.run_instances(ImageId=EXAMPLE_AMI_ID, MinCount=2, MaxCount=2)
@@ -326,7 +324,7 @@ def test_get_paginated_instances():
     res1.should.have.length_of(5)
     next_token = resp1["NextToken"]
 
-    next_token.should_not.be.none
+    next_token.should_not.equal(None)
 
     resp2 = client.describe_instances(InstanceIds=instance_ids, NextToken=next_token)
     resp2["Reservations"].should.have.length_of(7)  # 12 total - 5 from the first call
@@ -392,7 +390,7 @@ def test_create_with_volume_tags():
 
 
 @mock_ec2
-def test_get_instances_filtering_by_state_boto3():
+def test_get_instances_filtering_by_state():
     ec2 = boto3.resource("ec2", "us-west-1")
     client = boto3.client("ec2", "us-west-1")
     reservation = ec2.create_instances(ImageId=EXAMPLE_AMI_ID, MinCount=3, MaxCount=3)
@@ -440,7 +438,7 @@ def test_get_instances_filtering_by_state_boto3():
 
 
 @mock_ec2
-def test_get_instances_filtering_by_instance_id_boto3():
+def test_get_instances_filtering_by_instance_id():
     ec2 = boto3.resource("ec2", "us-west-1")
     client = boto3.client("ec2", "us-west-1")
     reservation = ec2.create_instances(ImageId=EXAMPLE_AMI_ID, MinCount=3, MaxCount=3)
@@ -462,7 +460,7 @@ def test_get_instances_filtering_by_instance_id_boto3():
 
 
 @mock_ec2
-def test_get_instances_filtering_by_instance_type_boto3():
+def test_get_instances_filtering_by_instance_type():
     ec2 = boto3.resource("ec2", "us-west-1")
     client = boto3.client("ec2", "us-west-1")
     instance1 = ec2.create_instances(
@@ -503,7 +501,7 @@ def test_get_instances_filtering_by_instance_type_boto3():
 
 
 @mock_ec2
-def test_get_instances_filtering_by_reason_code_boto3():
+def test_get_instances_filtering_by_reason_code():
     ec2 = boto3.resource("ec2", "us-west-1")
     client = boto3.client("ec2", "us-west-1")
     reservation = ec2.create_instances(ImageId=EXAMPLE_AMI_ID, MinCount=3, MaxCount=3)
@@ -530,7 +528,7 @@ def test_get_instances_filtering_by_reason_code_boto3():
 
 
 @mock_ec2
-def test_get_instances_filtering_by_source_dest_check_boto3():
+def test_get_instances_filtering_by_source_dest_check():
     ec2 = boto3.resource("ec2", "us-west-1")
     client = boto3.client("ec2", "us-west-1")
     reservation = ec2.create_instances(ImageId=EXAMPLE_AMI_ID, MinCount=2, MaxCount=2)
@@ -554,7 +552,7 @@ def test_get_instances_filtering_by_source_dest_check_boto3():
 
 
 @mock_ec2
-def test_get_instances_filtering_by_vpc_id_boto3():
+def test_get_instances_filtering_by_vpc_id():
     ec2 = boto3.resource("ec2", "us-west-1")
     client = boto3.client("ec2", "us-west-1")
     vpc1 = ec2.create_vpc(CidrBlock="10.0.0.0/16")
@@ -625,7 +623,7 @@ def test_get_instances_filtering_by_dns_name():
 
 
 @mock_ec2
-def test_get_instances_filtering_by_architecture_boto3():
+def test_get_instances_filtering_by_architecture():
     ec2 = boto3.resource("ec2", region_name="us-west-1")
     client = boto3.client("ec2", region_name="us-west-1")
     ec2.create_instances(ImageId=EXAMPLE_AMI_ID, MinCount=1, MaxCount=1)
@@ -748,7 +746,7 @@ def test_get_instances_filtering_by_subnet_id():
 
 
 @mock_ec2
-def test_get_instances_filtering_by_tag_boto3():
+def test_get_instances_filtering_by_tag():
     client = boto3.client("ec2", region_name="us-east-1")
     ec2 = boto3.resource("ec2", region_name="us-east-1")
     reservation = ec2.create_instances(ImageId=EXAMPLE_AMI_ID, MinCount=3, MaxCount=3)
@@ -803,7 +801,7 @@ def test_get_instances_filtering_by_tag_boto3():
 
 
 @mock_ec2
-def test_get_instances_filtering_by_tag_value_boto3():
+def test_get_instances_filtering_by_tag_value():
     client = boto3.client("ec2", region_name="us-east-1")
     ec2 = boto3.resource("ec2", region_name="us-east-1")
     reservation = ec2.create_instances(ImageId=EXAMPLE_AMI_ID, MinCount=3, MaxCount=3)
@@ -857,7 +855,7 @@ def test_get_instances_filtering_by_tag_value_boto3():
 
 
 @mock_ec2
-def test_get_instances_filtering_by_tag_name_boto3():
+def test_get_instances_filtering_by_tag_name():
     client = boto3.client("ec2", region_name="us-east-1")
     ec2 = boto3.resource("ec2", region_name="us-east-1")
     reservation = ec2.create_instances(ImageId=EXAMPLE_AMI_ID, MinCount=3, MaxCount=3)
@@ -896,7 +894,7 @@ def test_get_instances_filtering_by_tag_name_boto3():
 
 
 @mock_ec2
-def test_instance_start_and_stop_boto3():
+def test_instance_start_and_stop():
     client = boto3.client("ec2", region_name="us-east-1")
     ec2 = boto3.resource("ec2", region_name="us-east-1")
     reservation = ec2.create_instances(ImageId=EXAMPLE_AMI_ID, MinCount=2, MaxCount=2)
@@ -944,7 +942,7 @@ def test_instance_start_and_stop_boto3():
 
 
 @mock_ec2
-def test_instance_reboot_boto3():
+def test_instance_reboot():
     ec2 = boto3.resource("ec2", region_name="us-east-1")
     response = ec2.create_instances(ImageId=EXAMPLE_AMI_ID, MinCount=1, MaxCount=1)
     instance = response[0]
@@ -967,7 +965,7 @@ def test_instance_reboot_boto3():
 
 
 @mock_ec2
-def test_instance_attribute_instance_type_boto3():
+def test_instance_attribute_instance_type():
     ec2 = boto3.resource("ec2", region_name="us-east-1")
     response = ec2.create_instances(ImageId=EXAMPLE_AMI_ID, MinCount=1, MaxCount=1)
     instance = response[0]
@@ -990,7 +988,7 @@ def test_instance_attribute_instance_type_boto3():
 
 
 @mock_ec2
-def test_modify_instance_attribute_security_groups_boto3():
+def test_modify_instance_attribute_security_groups():
     ec2 = boto3.resource("ec2", region_name="us-east-1")
     response = ec2.create_instances(ImageId=EXAMPLE_AMI_ID, MinCount=1, MaxCount=1)
     instance = response[0]
@@ -1021,7 +1019,7 @@ def test_modify_instance_attribute_security_groups_boto3():
 
 
 @mock_ec2
-def test_instance_attribute_user_data_boto3():
+def test_instance_attribute_user_data():
     ec2 = boto3.resource("ec2", region_name="us-east-1")
     res = ec2.create_instances(ImageId=EXAMPLE_AMI_ID, MinCount=1, MaxCount=1)
     instance = res[0]
@@ -1044,7 +1042,7 @@ def test_instance_attribute_user_data_boto3():
 
 
 @mock_ec2
-def test_instance_attribute_source_dest_check_boto3():
+def test_instance_attribute_source_dest_check():
     ec2 = boto3.resource("ec2", region_name="us-west-1")
     instance = ec2.create_instances(ImageId=EXAMPLE_AMI_ID, MinCount=1, MaxCount=1)[0]
 
@@ -1074,7 +1072,7 @@ def test_instance_attribute_source_dest_check_boto3():
 
 
 @mock_ec2
-def test_user_data_with_run_instance_boto3():
+def test_user_data_with_run_instance():
     user_data = b"some user data"
     ec2 = boto3.resource("ec2", region_name="us-east-1")
     instance = ec2.create_instances(
@@ -1088,7 +1086,7 @@ def test_user_data_with_run_instance_boto3():
 
 
 @mock_ec2
-def test_run_instance_with_security_group_name_boto3():
+def test_run_instance_with_security_group_name():
     ec2 = boto3.resource("ec2", region_name="us-east-1")
 
     sec_group_name = str(uuid4())[0:6]
@@ -1118,7 +1116,7 @@ def test_run_instance_with_security_group_name_boto3():
 
 
 @mock_ec2
-def test_run_instance_with_security_group_id_boto3():
+def test_run_instance_with_security_group_id():
     ec2 = boto3.resource("ec2", region_name="us-east-1")
     sec_group_name = str(uuid4())
     group = ec2.create_security_group(
@@ -1134,7 +1132,7 @@ def test_run_instance_with_security_group_id_boto3():
 
 
 @mock_ec2
-def test_run_instance_with_instance_type_boto3():
+def test_run_instance_with_instance_type():
     ec2 = boto3.resource("ec2", region_name="us-east-1")
     instance = ec2.create_instances(
         ImageId=EXAMPLE_AMI_ID, MinCount=1, MaxCount=1, InstanceType="t1.micro"
@@ -1144,7 +1142,7 @@ def test_run_instance_with_instance_type_boto3():
 
 
 @mock_ec2
-def test_run_instance_with_default_placement_boto3():
+def test_run_instance_with_default_placement():
     ec2 = boto3.resource("ec2", region_name="us-east-1")
     instance = ec2.create_instances(ImageId=EXAMPLE_AMI_ID, MinCount=1, MaxCount=1)[0]
 
@@ -1152,7 +1150,7 @@ def test_run_instance_with_default_placement_boto3():
 
 
 @mock_ec2
-def test_run_instance_with_placement_boto3():
+def test_run_instance_with_placement():
     ec2 = boto3.resource("ec2", region_name="us-east-1")
     instance = ec2.create_instances(
         ImageId=EXAMPLE_AMI_ID,
@@ -1165,7 +1163,7 @@ def test_run_instance_with_placement_boto3():
 
 
 @mock_ec2
-def test_run_instance_with_subnet_boto3():
+def test_run_instance_with_subnet():
     client = boto3.client("ec2", region_name="eu-central-1")
 
     ip_networks = [
@@ -1261,7 +1259,7 @@ def test_run_instance_mapped_public_ipv4():
 
 
 @mock_ec2
-def test_run_instance_with_nic_autocreated_boto3():
+def test_run_instance_with_nic_autocreated():
     ec2 = boto3.resource("ec2", "us-west-1")
     client = boto3.client("ec2", "us-west-1")
     vpc = ec2.create_vpc(CidrBlock="10.0.0.0/16")
@@ -1311,7 +1309,7 @@ def test_run_instance_with_nic_autocreated_boto3():
 
 
 @mock_ec2
-def test_run_instance_with_nic_preexisting_boto3():
+def test_run_instance_with_nic_preexisting():
     ec2 = boto3.resource("ec2", "us-west-1")
     client = boto3.client("ec2", "us-west-1")
     vpc = ec2.create_vpc(CidrBlock="10.0.0.0/16")
@@ -1401,7 +1399,7 @@ def test_run_instance_with_new_nic_and_security_groups():
 
 
 @mock_ec2
-def test_instance_with_nic_attach_detach_boto3():
+def test_instance_with_nic_attach_detach():
     ec2 = boto3.resource("ec2", "us-west-1")
     client = boto3.client("ec2", "us-west-1")
     vpc = ec2.create_vpc(CidrBlock="10.0.0.0/16")
@@ -1503,7 +1501,7 @@ def test_instance_with_nic_attach_detach_boto3():
 
 
 @mock_ec2
-def test_ec2_classic_has_public_ip_address_boto3():
+def test_ec2_classic_has_public_ip_address():
     ec2 = boto3.resource("ec2", region_name="us-east-1")
     instance = ec2.create_instances(ImageId=EXAMPLE_AMI_ID, MinCount=1, MaxCount=1)[0]
     instance.public_ip_address.should_not.equal(None)
@@ -1517,7 +1515,7 @@ def test_ec2_classic_has_public_ip_address_boto3():
 
 
 @mock_ec2
-def test_run_instance_with_keypair_boto3():
+def test_run_instance_with_keypair():
     ec2 = boto3.resource("ec2", region_name="us-east-1")
     instance = ec2.create_instances(
         ImageId=EXAMPLE_AMI_ID, MinCount=1, MaxCount=1, KeyName="keypair_name"
@@ -1595,7 +1593,7 @@ def test_run_instance_with_block_device_mappings_using_no_device():
     # instances["Reservations"][0]["Instances"][0].shouldnt.have.key("BlockDeviceMappings")
 
     # moto gives the key with an empty list instead of not having it at all, that's also fine
-    instances["Reservations"][0]["Instances"][0]["BlockDeviceMappings"].should.be.empty
+    instances["Reservations"][0]["Instances"][0]["BlockDeviceMappings"].should.equal([])
 
     # passing None with NoDevice should raise ParamValidationError
     kwargs["BlockDeviceMappings"][0]["NoDevice"] = None
@@ -1675,7 +1673,7 @@ def test_run_instance_with_block_device_mappings_from_snapshot():
 
 
 @mock_ec2
-def test_describe_instance_status_no_instances_boto3():
+def test_describe_instance_status_no_instances():
     if settings.TEST_SERVER_MODE:
         raise SkipTest("ServerMode is not guaranteed to be empty")
     client = boto3.client("ec2", region_name="us-east-1")
@@ -1684,7 +1682,7 @@ def test_describe_instance_status_no_instances_boto3():
 
 
 @mock_ec2
-def test_describe_instance_status_with_instances_boto3():
+def test_describe_instance_status_with_instances():
     client = boto3.client("ec2", region_name="us-east-1")
     ec2 = boto3.resource("ec2", region_name="us-east-1")
     instance = ec2.create_instances(ImageId=EXAMPLE_AMI_ID, MinCount=1, MaxCount=1)[0]
@@ -1699,7 +1697,7 @@ def test_describe_instance_status_with_instances_boto3():
 
 
 @mock_ec2
-def test_describe_instance_status_with_instance_filter_deprecated_boto3():
+def test_describe_instance_status_with_instance_filter_deprecated():
     ec2 = boto3.resource("ec2", region_name="us-east-1")
     client = boto3.client("ec2", region_name="us-east-1")
 
@@ -1822,7 +1820,7 @@ def test_describe_instance_status_with_instance_filter():
 
 
 @mock_ec2
-def test_describe_instance_status_with_non_running_instances_boto3():
+def test_describe_instance_status_with_non_running_instances():
     client = boto3.client("ec2", region_name="us-east-1")
     ec2 = boto3.resource("ec2", region_name="us-east-1")
     reservation = ec2.create_instances(ImageId=EXAMPLE_AMI_ID, MinCount=3, MaxCount=3)
@@ -1860,7 +1858,7 @@ def test_describe_instance_status_with_non_running_instances_boto3():
 
 
 @mock_ec2
-def test_get_instance_by_security_group_boto3():
+def test_get_instance_by_security_group():
     client = boto3.client("ec2", region_name="us-east-1")
     ec2 = boto3.resource("ec2", region_name="us-east-1")
 
@@ -1991,7 +1989,7 @@ def test_describe_instance_attribute():
             response["Groups"][0]["GroupId"].should.equal(security_group_id)
         elif valid_instance_attribute == "userData":
             response.should.have.key("UserData")
-            response["UserData"].should.be.empty
+            response["UserData"].should.equal({})
 
     invalid_instance_attributes = [
         "abc",

--- a/tests/test_ec2/test_network_acls.py
+++ b/tests/test_ec2/test_network_acls.py
@@ -226,7 +226,7 @@ def test_default_network_acl_default_entries():
     if not settings.TEST_SERVER_MODE:
         # Can't know whether the first ACL is the default in ServerMode
         default_network_acl = next(iter(ec2.network_acls.all()), None)
-        default_network_acl.is_default.should.be.ok
+        default_network_acl.is_default.should.equal(True)
         default_network_acl.entries.should.have.length_of(4)
 
     vpc = client.create_vpc(CidrBlock="10.0.0.0/16")
@@ -265,7 +265,7 @@ def test_delete_default_network_acl_default_entry():
         )
     ec2 = boto3.resource("ec2", region_name="us-west-1")
     default_network_acl = next(iter(ec2.network_acls.all()), None)
-    default_network_acl.is_default.should.be.ok
+    default_network_acl.is_default.should.equal(True)
 
     default_network_acl.entries.should.have.length_of(4)
     first_default_network_acl_entry = default_network_acl.entries[0]
@@ -282,7 +282,7 @@ def test_delete_default_network_acl_default_entry():
 def test_duplicate_network_acl_entry():
     ec2 = boto3.resource("ec2", region_name="us-west-1")
     default_network_acl = next(iter(ec2.network_acls.all()), None)
-    default_network_acl.is_default.should.be.ok
+    default_network_acl.is_default.should.equal(True)
 
     rule_number = randint(0, 9999)
     egress = True

--- a/tests/test_ec2/test_route_tables.py
+++ b/tests/test_ec2/test_route_tables.py
@@ -10,7 +10,7 @@ from uuid import uuid4
 
 
 @mock_ec2
-def test_route_tables_defaults_boto3():
+def test_route_tables_defaults():
     client = boto3.client("ec2", region_name="us-east-1")
     ec2 = boto3.resource("ec2", region_name="us-east-1")
     vpc = ec2.create_vpc(CidrBlock="10.0.0.0/16")
@@ -40,7 +40,7 @@ def test_route_tables_defaults_boto3():
 
 
 @mock_ec2
-def test_route_tables_additional_boto3():
+def test_route_tables_additional():
     client = boto3.client("ec2", region_name="us-east-1")
     ec2 = boto3.resource("ec2", region_name="us-east-1")
     vpc = ec2.create_vpc(CidrBlock="10.0.0.0/16")
@@ -85,7 +85,7 @@ def test_route_tables_additional_boto3():
 
 
 @mock_ec2
-def test_route_tables_filters_standard_boto3():
+def test_route_tables_filters_standard():
     client = boto3.client("ec2", region_name="us-east-1")
     ec2 = boto3.resource("ec2", region_name="us-east-1")
 
@@ -145,7 +145,7 @@ def test_route_tables_filters_standard_boto3():
 
 
 @mock_ec2
-def test_route_tables_filters_associations_boto3():
+def test_route_tables_filters_associations():
     client = boto3.client("ec2", region_name="us-east-1")
     ec2 = boto3.resource("ec2", region_name="us-east-1")
 
@@ -193,7 +193,7 @@ def test_route_tables_filters_associations_boto3():
 
 
 @mock_ec2
-def test_route_table_associations_boto3():
+def test_route_table_associations():
     client = boto3.client("ec2", region_name="us-east-1")
     ec2 = boto3.resource("ec2", region_name="us-east-1")
 
@@ -271,7 +271,7 @@ def test_route_table_associations_boto3():
 
 
 @mock_ec2
-def test_route_table_replace_route_table_association_boto3():
+def test_route_table_replace_route_table_association():
     client = boto3.client("ec2", region_name="us-east-1")
     ec2 = boto3.resource("ec2", region_name="us-east-1")
 
@@ -365,7 +365,7 @@ def test_route_table_replace_route_table_association_boto3():
 
 
 @mock_ec2
-def test_route_table_get_by_tag_boto3():
+def test_route_table_get_by_tag():
     ec2 = boto3.resource("ec2", region_name="eu-central-1")
 
     vpc = ec2.create_vpc(CidrBlock="10.0.0.0/16")
@@ -385,7 +385,7 @@ def test_route_table_get_by_tag_boto3():
 
 
 @mock_ec2
-def test_routes_additional_boto3():
+def test_routes_additional():
     client = boto3.client("ec2", region_name="us-east-1")
     ec2 = boto3.resource("ec2", region_name="us-east-1")
     vpc = ec2.create_vpc(CidrBlock="10.0.0.0/16")
@@ -410,7 +410,7 @@ def test_routes_additional_boto3():
 
     new_route = new_routes[0]
     new_route.gateway_id.should.equal(igw.id)
-    new_route.instance_id.should.be.none
+    new_route.instance_id.should.equal(None)
     new_route.state.should.equal("active")
     new_route.destination_cidr_block.should.equal(ROUTE_CIDR)
 
@@ -438,7 +438,7 @@ def test_routes_additional_boto3():
 
 
 @mock_ec2
-def test_routes_replace_boto3():
+def test_routes_replace():
     client = boto3.client("ec2", region_name="us-east-1")
     ec2 = boto3.resource("ec2", region_name="us-east-1")
     vpc = ec2.create_vpc(CidrBlock="10.0.0.0/16")
@@ -509,7 +509,7 @@ def test_routes_replace_boto3():
 
 
 @mock_ec2
-def test_routes_not_supported_boto3():
+def test_routes_not_supported():
     client = boto3.client("ec2", region_name="us-east-1")
     ec2 = boto3.resource("ec2", region_name="us-east-1")
     main_route_table_id = client.describe_route_tables()["RouteTables"][0][
@@ -550,7 +550,7 @@ def test_routes_not_supported_boto3():
 
 
 @mock_ec2
-def test_routes_vpc_peering_connection_boto3():
+def test_routes_vpc_peering_connection():
     client = boto3.client("ec2", region_name="us-east-1")
     ec2 = boto3.resource("ec2", region_name="us-east-1")
     vpc = ec2.create_vpc(CidrBlock="10.0.0.0/16")
@@ -580,15 +580,15 @@ def test_routes_vpc_peering_connection_boto3():
     new_routes.should.have.length_of(1)
 
     new_route = new_routes[0]
-    new_route.gateway_id.should.be.none
-    new_route.instance_id.should.be.none
+    new_route.gateway_id.should.equal(None)
+    new_route.instance_id.should.equal(None)
     new_route.vpc_peering_connection_id.should.equal(vpc_pcx.id)
     new_route.state.should.equal("active")
     new_route.destination_cidr_block.should.equal(ROUTE_CIDR)
 
 
 @mock_ec2
-def test_routes_vpn_gateway_boto3():
+def test_routes_vpn_gateway():
     client = boto3.client("ec2", region_name="us-east-1")
     ec2 = boto3.resource("ec2", region_name="us-east-1")
     vpc = ec2.create_vpc(CidrBlock="10.0.0.0/16")
@@ -616,12 +616,12 @@ def test_routes_vpn_gateway_boto3():
 
     new_route = new_routes[0]
     new_route.gateway_id.should.equal(vpn_gw_id)
-    new_route.instance_id.should.be.none
-    new_route.vpc_peering_connection_id.should.be.none
+    new_route.instance_id.should.equal(None)
+    new_route.vpc_peering_connection_id.should.equal(None)
 
 
 @mock_ec2
-def test_network_acl_tagging_boto3():
+def test_network_acl_tagging():
     client = boto3.client("ec2", region_name="us-east-1")
     ec2 = boto3.resource("ec2", region_name="us-east-1")
     vpc = ec2.create_vpc(CidrBlock="10.0.0.0/16")
@@ -649,7 +649,7 @@ def test_create_route_with_invalid_destination_cidr_block_parameter():
 
     vpc = ec2.create_vpc(CidrBlock="10.0.0.0/16")
     vpc.reload()
-    vpc.is_default.shouldnt.be.ok
+    vpc.is_default.should.equal(False)
 
     route_table = ec2.create_route_table(VpcId=vpc.id)
     route_table.reload()

--- a/tests/test_ec2/test_security_groups.py
+++ b/tests/test_ec2/test_security_groups.py
@@ -599,7 +599,7 @@ def test_sec_group_rule_limit(use_vpc):
     )
 
     sg.reload()
-    sg.ip_permissions.should.be.empty
+    sg.ip_permissions.should.equal([])
     # authorize a rule targeting a different sec group (because this count too)
     other_permissions = [
         {
@@ -987,7 +987,7 @@ def test_authorize_and_revoke_in_bulk():
         sorted_sg01_ip_permissions.should.contain(ip_permission)
 
     sg01.revoke_ingress(IpPermissions=ip_permissions)
-    sg01.ip_permissions.should.be.empty
+    sg01.ip_permissions.should.equal([])
     for ip_permission in expected_ip_permissions:
         sg01.ip_permissions.shouldnt.contain(ip_permission)
 

--- a/tests/test_ec2/test_subnets.py
+++ b/tests/test_ec2/test_subnets.py
@@ -12,7 +12,7 @@ from unittest import SkipTest
 
 
 @mock_ec2
-def test_subnets_boto3():
+def test_subnets():
     ec2 = boto3.resource("ec2", region_name="us-east-1")
     client = boto3.client("ec2", region_name="us-east-1")
     vpc = ec2.create_vpc(CidrBlock="10.0.0.0/16")
@@ -36,7 +36,7 @@ def test_subnets_boto3():
 
 
 @mock_ec2
-def test_subnet_create_vpc_validation_boto3():
+def test_subnet_create_vpc_validation():
     ec2 = boto3.resource("ec2", region_name="us-east-1")
 
     with pytest.raises(ClientError) as ex:
@@ -47,7 +47,7 @@ def test_subnet_create_vpc_validation_boto3():
 
 
 @mock_ec2
-def test_subnet_tagging_boto3():
+def test_subnet_tagging():
     ec2 = boto3.resource("ec2", region_name="us-east-1")
     client = boto3.client("ec2", region_name="us-east-1")
     vpc = ec2.create_vpc(CidrBlock="10.0.0.0/16")
@@ -67,7 +67,7 @@ def test_subnet_tagging_boto3():
 
 
 @mock_ec2
-def test_subnet_should_have_proper_availability_zone_set_boto3():
+def test_subnet_should_have_proper_availability_zone_set():
     ec2 = boto3.resource("ec2", region_name="us-west-1")
     vpcA = ec2.create_vpc(CidrBlock="10.0.0.0/16")
     subnetA = ec2.create_subnet(
@@ -97,29 +97,29 @@ def test_default_subnet():
     default_vpc = list(ec2.vpcs.all())[0]
     default_vpc.cidr_block.should.equal("172.31.0.0/16")
     default_vpc.reload()
-    default_vpc.is_default.should.be.ok
+    default_vpc.is_default.should.equal(True)
 
     subnet = ec2.create_subnet(
         VpcId=default_vpc.id, CidrBlock="172.31.48.0/20", AvailabilityZone="us-west-1a"
     )
     subnet.reload()
-    subnet.map_public_ip_on_launch.shouldnt.be.ok
+    subnet.map_public_ip_on_launch.should.equal(False)
 
 
 @mock_ec2
-def test_boto3_non_default_subnet():
+def test_non_default_subnet():
     ec2 = boto3.resource("ec2", region_name="us-west-1")
 
     # Create the non default VPC
     vpc = ec2.create_vpc(CidrBlock="10.0.0.0/16")
     vpc.reload()
-    vpc.is_default.shouldnt.be.ok
+    vpc.is_default.should.equal(False)
 
     subnet = ec2.create_subnet(
         VpcId=vpc.id, CidrBlock="10.0.0.0/24", AvailabilityZone="us-west-1a"
     )
     subnet.reload()
-    subnet.map_public_ip_on_launch.shouldnt.be.ok
+    subnet.map_public_ip_on_launch.should.equal(False)
 
 
 @mock_ec2
@@ -140,19 +140,19 @@ def test_modify_subnet_attribute_public_ip_on_launch():
     subnet.reload()
 
     # For non default subnet, attribute value should be 'False'
-    subnet.map_public_ip_on_launch.shouldnt.be.ok
+    subnet.map_public_ip_on_launch.should.equal(False)
 
     client.modify_subnet_attribute(
         SubnetId=subnet.id, MapPublicIpOnLaunch={"Value": False}
     )
     subnet.reload()
-    subnet.map_public_ip_on_launch.shouldnt.be.ok
+    subnet.map_public_ip_on_launch.should.equal(False)
 
     client.modify_subnet_attribute(
         SubnetId=subnet.id, MapPublicIpOnLaunch={"Value": True}
     )
     subnet.reload()
-    subnet.map_public_ip_on_launch.should.be.ok
+    subnet.map_public_ip_on_launch.should.equal(True)
 
 
 @mock_ec2
@@ -174,19 +174,19 @@ def test_modify_subnet_attribute_assign_ipv6_address_on_creation():
     client.describe_subnets()
 
     # For non default subnet, attribute value should be 'False'
-    subnet.assign_ipv6_address_on_creation.shouldnt.be.ok
+    subnet.assign_ipv6_address_on_creation.should.equal(False)
 
     client.modify_subnet_attribute(
         SubnetId=subnet.id, AssignIpv6AddressOnCreation={"Value": False}
     )
     subnet.reload()
-    subnet.assign_ipv6_address_on_creation.shouldnt.be.ok
+    subnet.assign_ipv6_address_on_creation.should.equal(False)
 
     client.modify_subnet_attribute(
         SubnetId=subnet.id, AssignIpv6AddressOnCreation={"Value": True}
     )
     subnet.reload()
-    subnet.assign_ipv6_address_on_creation.should.be.ok
+    subnet.assign_ipv6_address_on_creation.should.equal(True)
 
 
 @mock_ec2
@@ -200,7 +200,7 @@ def test_modify_subnet_attribute_validation():
 
 
 @mock_ec2
-def test_subnet_get_by_id_boto3():
+def test_subnet_get_by_id():
     ec2 = boto3.resource("ec2", region_name="us-west-1")
     client = boto3.client("ec2", region_name="us-west-1")
     vpcA = ec2.create_vpc(CidrBlock="10.0.0.0/16")
@@ -231,7 +231,7 @@ def test_subnet_get_by_id_boto3():
 
 
 @mock_ec2
-def test_get_subnets_filtering_boto3():
+def test_get_subnets_filtering():
     ec2 = boto3.resource("ec2", region_name="us-west-1")
     client = boto3.client("ec2", region_name="us-west-1")
     vpcA = ec2.create_vpc(CidrBlock="10.0.0.0/16")
@@ -428,7 +428,7 @@ def test_create_subnet_with_invalid_cidr_range():
 
     vpc = ec2.create_vpc(CidrBlock="10.0.0.0/16")
     vpc.reload()
-    vpc.is_default.shouldnt.be.ok
+    vpc.is_default.should.equal(False)
 
     subnet_cidr_block = "10.1.0.0/20"
     with pytest.raises(ClientError) as ex:
@@ -446,7 +446,7 @@ def test_create_subnet_with_invalid_cidr_range_multiple_vpc_cidr_blocks():
     vpc = ec2.create_vpc(CidrBlock="10.0.0.0/16")
     ec2.meta.client.associate_vpc_cidr_block(CidrBlock="10.1.0.0/16", VpcId=vpc.id)
     vpc.reload()
-    vpc.is_default.shouldnt.be.ok
+    vpc.is_default.should.equal(False)
 
     subnet_cidr_block = "10.2.0.0/20"
     with pytest.raises(ClientError) as ex:
@@ -463,7 +463,7 @@ def test_create_subnet_with_invalid_cidr_block_parameter():
 
     vpc = ec2.create_vpc(CidrBlock="10.0.0.0/16")
     vpc.reload()
-    vpc.is_default.shouldnt.be.ok
+    vpc.is_default.should.equal(False)
 
     subnet_cidr_block = "1000.1.0.0/20"
     with pytest.raises(ClientError) as ex:
@@ -484,7 +484,7 @@ def test_create_subnets_with_multiple_vpc_cidr_blocks():
     vpc = ec2.create_vpc(CidrBlock="10.0.0.0/16")
     ec2.meta.client.associate_vpc_cidr_block(CidrBlock="10.1.0.0/16", VpcId=vpc.id)
     vpc.reload()
-    vpc.is_default.shouldnt.be.ok
+    vpc.is_default.should.equal(False)
 
     subnet_cidr_block_primary = "10.0.0.0/24"
     subnet_primary = ec2.create_subnet(
@@ -522,7 +522,7 @@ def test_create_subnets_with_overlapping_cidr_blocks():
 
     vpc = ec2.create_vpc(CidrBlock="10.0.0.0/16")
     vpc.reload()
-    vpc.is_default.shouldnt.be.ok
+    vpc.is_default.should.equal(False)
 
     subnet_cidr_block = "10.0.0.0/24"
     with pytest.raises(ClientError) as ex:

--- a/tests/test_ec2/test_tags.py
+++ b/tests/test_ec2/test_tags.py
@@ -74,7 +74,7 @@ def test_instance_delete_tags():
 
 
 @mock_ec2
-def test_get_all_tags_with_special_characters_boto3():
+def test_get_all_tags_with_special_characters():
     ec2 = boto3.resource("ec2", region_name="us-east-1")
     client = boto3.client("ec2", region_name="us-east-1")
     instance = ec2.create_instances(ImageId=EXAMPLE_AMI_ID, MinCount=1, MaxCount=1)[0]
@@ -90,7 +90,7 @@ def test_get_all_tags_with_special_characters_boto3():
 
 
 @mock_ec2
-def test_create_tags_boto3():
+def test_create_tags():
     ec2 = boto3.resource("ec2", region_name="us-east-1")
     client = boto3.client("ec2", region_name="us-east-1")
     instance = ec2.create_instances(ImageId=EXAMPLE_AMI_ID, MinCount=1, MaxCount=1)[0]
@@ -125,7 +125,7 @@ def test_create_tags_boto3():
 
 
 @mock_ec2
-def test_tag_limit_exceeded_boto3():
+def test_tag_limit_exceeded():
     ec2 = boto3.resource("ec2", region_name="us-east-1")
     client = boto3.client("ec2", region_name="us-east-1")
     instance = ec2.create_instances(ImageId=EXAMPLE_AMI_ID, MinCount=1, MaxCount=1)[0]
@@ -155,7 +155,7 @@ def test_tag_limit_exceeded_boto3():
 
 
 @mock_ec2
-def test_invalid_id_boto3():
+def test_invalid_id():
     client = boto3.client("ec2", region_name="us-east-1")
     with pytest.raises(ClientError) as ex:
         client.create_tags(
@@ -175,7 +175,7 @@ def test_invalid_id_boto3():
 
 
 @mock_ec2
-def test_get_all_tags_resource_filter_boto3():
+def test_get_all_tags_resource_filter():
     ec2 = boto3.resource("ec2", region_name="us-east-1")
     client = boto3.client("ec2", region_name="us-east-1")
     instance = ec2.create_instances(ImageId=EXAMPLE_AMI_ID, MinCount=1, MaxCount=1)[0]
@@ -227,7 +227,7 @@ def test_get_all_tags_resource_filter_boto3():
 
 
 @mock_ec2
-def test_get_all_tags_value_filter_boto3():
+def test_get_all_tags_value_filter():
     ec2 = boto3.resource("ec2", region_name="us-east-1")
     client = boto3.client("ec2", region_name="us-east-1")
 
@@ -265,7 +265,7 @@ def test_get_all_tags_value_filter_boto3():
 
 
 @mock_ec2
-def test_retrieved_instances_must_contain_their_tags_boto3():
+def test_retrieved_instances_must_contain_their_tags():
     tag_key = "Tag name"
     tag_value = "Tag value"
     tags_to_be_set = {"Key": tag_key, "Value": tag_value}
@@ -291,7 +291,7 @@ def test_retrieved_instances_must_contain_their_tags_boto3():
 
 
 @mock_ec2
-def test_retrieved_volumes_must_contain_their_tags_boto3():
+def test_retrieved_volumes_must_contain_their_tags():
     tag_key = "Tag name"
     tag_value = "Tag value"
     tags_to_be_set = {"Key": tag_key, "Value": tag_value}
@@ -299,7 +299,7 @@ def test_retrieved_volumes_must_contain_their_tags_boto3():
     ec2 = boto3.resource("ec2", region_name="eu-west-1")
     client = boto3.client("ec2", region_name="eu-west-1")
     volume = ec2.create_volume(Size=80, AvailabilityZone="us-east-1a")
-    volume.tags.should.be.none
+    volume.tags.should.equal(None)
 
     client.create_tags(Resources=[volume.id], Tags=[tags_to_be_set])
 
@@ -308,7 +308,7 @@ def test_retrieved_volumes_must_contain_their_tags_boto3():
 
 
 @mock_ec2
-def test_retrieved_snapshots_must_contain_their_tags_boto3():
+def test_retrieved_snapshots_must_contain_their_tags():
     tag_key = "Tag name"
     tag_value = "Tag value"
     tags_to_be_set = {"Key": tag_key, "Value": tag_value}
@@ -325,7 +325,7 @@ def test_retrieved_snapshots_must_contain_their_tags_boto3():
 
 
 @mock_ec2
-def test_filter_instances_by_wildcard_tags_boto3():
+def test_filter_instances_by_wildcard_tags():
     ec2 = boto3.resource("ec2", region_name="eu-west-1")
     client = boto3.client("ec2", region_name="eu-west-1")
 

--- a/tests/test_ec2/test_vpcs.py
+++ b/tests/test_ec2/test_vpcs.py
@@ -37,7 +37,7 @@ def test_create_and_delete_vpc():
 
 
 @mock_ec2
-def test_vpc_defaults_boto3():
+def test_vpc_defaults():
     ec2 = boto3.resource("ec2", region_name="eu-north-1")
     client = boto3.client("ec2", region_name="eu-north-1")
     vpc = ec2.create_vpc(CidrBlock="10.0.0.0/16")
@@ -62,7 +62,7 @@ def test_vpc_defaults_boto3():
 
 
 @mock_ec2
-def test_vpc_isdefault_filter_boto3():
+def test_vpc_isdefault_filter():
     ec2 = boto3.resource("ec2", region_name="eu-west-1")
     client = boto3.client("ec2", region_name="eu-west-1")
     vpc = ec2.create_vpc(CidrBlock="10.0.0.0/16")
@@ -78,7 +78,7 @@ def test_vpc_isdefault_filter_boto3():
 
 
 @mock_ec2
-def test_multiple_vpcs_default_filter_boto3():
+def test_multiple_vpcs_default_filter():
     ec2 = boto3.resource("ec2", region_name="eu-west-1")
     client = boto3.client("ec2", region_name="eu-west-1")
     ec2.create_vpc(CidrBlock="10.8.0.0/16")
@@ -91,7 +91,7 @@ def test_multiple_vpcs_default_filter_boto3():
 
 
 @mock_ec2
-def test_vpc_state_available_filter_boto3():
+def test_vpc_state_available_filter():
     ec2 = boto3.resource("ec2", region_name="eu-west-1")
     client = boto3.client("ec2", region_name="eu-west-1")
     vpc1 = ec2.create_vpc(CidrBlock="10.0.0.0/16")
@@ -120,7 +120,7 @@ def retrieve_all_vpcs(client, filters=[]):  # pylint: disable=W0102
 
 
 @mock_ec2
-def test_vpc_tagging_boto3():
+def test_vpc_tagging():
     ec2 = boto3.resource("ec2", region_name="eu-west-1")
     client = boto3.client("ec2", region_name="eu-west-1")
     vpc = ec2.create_vpc(CidrBlock="10.0.0.0/16")
@@ -138,7 +138,7 @@ def test_vpc_tagging_boto3():
 
 
 @mock_ec2
-def test_vpc_get_by_id_boto3():
+def test_vpc_get_by_id():
     ec2 = boto3.resource("ec2", region_name="eu-west-1")
     client = boto3.client("ec2", region_name="eu-west-1")
     vpc1 = ec2.create_vpc(CidrBlock="10.0.0.0/16")
@@ -159,7 +159,7 @@ def test_vpc_get_by_id_boto3():
 
 
 @mock_ec2
-def test_vpc_get_by_cidr_block_boto3():
+def test_vpc_get_by_cidr_block():
     ec2 = boto3.resource("ec2", region_name="eu-west-1")
     client = boto3.client("ec2", region_name="eu-west-1")
     random_ip = ".".join(map(str, (random.randint(0, 99) for _ in range(4))))
@@ -175,7 +175,7 @@ def test_vpc_get_by_cidr_block_boto3():
 
 
 @mock_ec2
-def test_vpc_get_by_dhcp_options_id_boto3():
+def test_vpc_get_by_dhcp_options_id():
     ec2 = boto3.resource("ec2", region_name="us-east-1")
     client = boto3.client("ec2", region_name="us-east-1")
     dhcp_options = ec2.create_dhcp_options(
@@ -201,7 +201,7 @@ def test_vpc_get_by_dhcp_options_id_boto3():
 
 
 @mock_ec2
-def test_vpc_get_by_tag_boto3():
+def test_vpc_get_by_tag():
     ec2 = boto3.resource("ec2", region_name="us-east-1")
     client = boto3.client("ec2", region_name="us-east-1")
     vpc1 = ec2.create_vpc(CidrBlock="10.0.0.0/16")
@@ -221,7 +221,7 @@ def test_vpc_get_by_tag_boto3():
 
 
 @mock_ec2
-def test_vpc_get_by_tag_key_superset_boto3():
+def test_vpc_get_by_tag_key_superset():
     ec2 = boto3.resource("ec2", region_name="us-east-1")
     client = boto3.client("ec2", region_name="us-east-1")
     vpc1 = ec2.create_vpc(CidrBlock="10.0.0.0/16")
@@ -243,7 +243,7 @@ def test_vpc_get_by_tag_key_superset_boto3():
 
 
 @mock_ec2
-def test_vpc_get_by_tag_key_subset_boto3():
+def test_vpc_get_by_tag_key_subset():
     ec2 = boto3.resource("ec2", region_name="us-east-1")
     client = boto3.client("ec2", region_name="us-east-1")
     vpc1 = ec2.create_vpc(CidrBlock="10.0.0.0/16")
@@ -266,7 +266,7 @@ def test_vpc_get_by_tag_key_subset_boto3():
 
 
 @mock_ec2
-def test_vpc_get_by_tag_value_superset_boto3():
+def test_vpc_get_by_tag_value_superset():
     ec2 = boto3.resource("ec2", region_name="us-east-1")
     client = boto3.client("ec2", region_name="us-east-1")
     vpc1 = ec2.create_vpc(CidrBlock="10.0.0.0/16")
@@ -288,7 +288,7 @@ def test_vpc_get_by_tag_value_superset_boto3():
 
 
 @mock_ec2
-def test_vpc_get_by_tag_value_subset_boto3():
+def test_vpc_get_by_tag_value_subset():
     ec2 = boto3.resource("ec2", region_name="us-east-1")
     client = boto3.client("ec2", region_name="us-east-1")
     vpc1 = ec2.create_vpc(CidrBlock="10.0.0.0/16")
@@ -320,16 +320,16 @@ def test_default_vpc():
     default_vpc.cidr_block.should.equal("172.31.0.0/16")
     default_vpc.instance_tenancy.should.equal("default")
     default_vpc.reload()
-    default_vpc.is_default.should.be.ok
+    default_vpc.is_default.should.equal(True)
 
     # Test default values for VPC attributes
     response = default_vpc.describe_attribute(Attribute="enableDnsSupport")
     attr = response.get("EnableDnsSupport")
-    attr.get("Value").should.be.ok
+    attr.get("Value").should.equal(True)
 
     response = default_vpc.describe_attribute(Attribute="enableDnsHostnames")
     attr = response.get("EnableDnsHostnames")
-    attr.get("Value").should.be.ok
+    attr.get("Value").should.equal(True)
 
 
 @mock_ec2
@@ -342,7 +342,7 @@ def test_non_default_vpc():
     # Create the non default VPC
     vpc = ec2.create_vpc(CidrBlock="10.0.0.0/16")
     vpc.reload()
-    vpc.is_default.shouldnt.be.ok
+    vpc.is_default.should.equal(False)
 
     # Test default instance_tenancy
     vpc.instance_tenancy.should.equal("default")
@@ -350,11 +350,11 @@ def test_non_default_vpc():
     # Test default values for VPC attributes
     response = vpc.describe_attribute(Attribute="enableDnsSupport")
     attr = response.get("EnableDnsSupport")
-    attr.get("Value").should.be.ok
+    attr.get("Value").should.equal(True)
 
     response = vpc.describe_attribute(Attribute="enableDnsHostnames")
     attr = response.get("EnableDnsHostnames")
-    attr.get("Value").shouldnt.be.ok
+    attr.get("Value").should.equal(False)
 
     # Check Primary CIDR Block Associations
     cidr_block_association_set = next(iter(vpc.cidr_block_association_set), None)
@@ -373,7 +373,7 @@ def test_vpc_dedicated_tenancy():
     # Create the non default VPC
     vpc = ec2.create_vpc(CidrBlock="10.0.0.0/16", InstanceTenancy="dedicated")
     vpc.reload()
-    vpc.is_default.shouldnt.be.ok
+    vpc.is_default.should.equal(False)
 
     vpc.instance_tenancy.should.equal("dedicated")
 
@@ -445,7 +445,7 @@ def test_vpc_modify_enable_dns_hostnames():
 
 
 @mock_ec2
-def test_vpc_associate_dhcp_options_boto3():
+def test_vpc_associate_dhcp_options():
     ec2 = boto3.resource("ec2", region_name="us-west-1")
     client = boto3.client("ec2", region_name="us-west-1")
     dhcp_options = ec2.create_dhcp_options(
@@ -798,7 +798,7 @@ def test_enable_vpc_classic_link():
     vpc = ec2.create_vpc(CidrBlock="10.1.0.0/16")
 
     response = ec2.meta.client.enable_vpc_classic_link(VpcId=vpc.id)
-    assert response.get("Return").should.be.true
+    assert response.get("Return").should.equal(True)
 
 
 @mock_ec2
@@ -833,7 +833,7 @@ def test_describe_classic_link_enabled():
 
     ec2.meta.client.enable_vpc_classic_link(VpcId=vpc.id)
     response = ec2.meta.client.describe_vpc_classic_link(VpcIds=[vpc.id])
-    assert response.get("Vpcs")[0].get("ClassicLinkEnabled").should.be.true
+    assert response.get("Vpcs")[0].get("ClassicLinkEnabled").should.equal(True)
 
 
 @mock_ec2
@@ -876,7 +876,7 @@ def test_enable_vpc_classic_link_dns_support():
     vpc = ec2.create_vpc(CidrBlock="10.1.0.0/16")
 
     response = ec2.meta.client.enable_vpc_classic_link_dns_support(VpcId=vpc.id)
-    assert response.get("Return").should.be.true
+    assert response.get("Return").should.equal(True)
 
 
 @mock_ec2
@@ -900,7 +900,7 @@ def test_describe_classic_link_dns_support_enabled():
 
     ec2.meta.client.enable_vpc_classic_link_dns_support(VpcId=vpc.id)
     response = ec2.meta.client.describe_vpc_classic_link_dns_support(VpcIds=[vpc.id])
-    assert response.get("Vpcs")[0].get("ClassicLinkDnsSupported").should.be.true
+    assert response.get("Vpcs")[0].get("ClassicLinkDnsSupported").should.equal(True)
 
 
 @mock_ec2
@@ -954,8 +954,8 @@ def test_describe_vpc_gateway_end_points():
     all_endpoints = retrieve_all_endpoints(ec2)
     [e["VpcEndpointId"] for e in all_endpoints].should.contain(our_id)
     our_endpoint = [e for e in all_endpoints if e["VpcEndpointId"] == our_id][0]
-    vpc_end_point["PrivateDnsEnabled"].should.be.true
-    our_endpoint["PrivateDnsEnabled"].should.be.true
+    vpc_end_point["PrivateDnsEnabled"].should.equal(True)
+    our_endpoint["PrivateDnsEnabled"].should.equal(True)
 
     our_endpoint["VpcId"].should.equal(vpc["VpcId"])
     our_endpoint["RouteTableIds"].should.equal([route_table["RouteTableId"]])
@@ -1004,8 +1004,8 @@ def test_describe_vpc_interface_end_points():
     all_endpoints = retrieve_all_endpoints(ec2)
     [e["VpcEndpointId"] for e in all_endpoints].should.contain(our_id)
     our_endpoint = [e for e in all_endpoints if e["VpcEndpointId"] == our_id][0]
-    vpc_end_point["PrivateDnsEnabled"].should.be.true
-    our_endpoint["PrivateDnsEnabled"].should.be.true
+    vpc_end_point["PrivateDnsEnabled"].should.equal(True)
+    our_endpoint["PrivateDnsEnabled"].should.equal(True)
 
     our_endpoint["VpcId"].should.equal(vpc["VpcId"])
     our_endpoint.should_not.have.key("RouteTableIds")

--- a/tests/test_eks/test_eks.py
+++ b/tests/test_eks/test_eks.py
@@ -192,7 +192,7 @@ def test_list_clusters_returns_empty_by_default():
 
     result = client.list_clusters()[ResponseAttributes.CLUSTERS]
 
-    result.should.be.empty
+    result.should.equal([])
 
 
 @mock_eks
@@ -403,7 +403,7 @@ def test_list_nodegroups_returns_empty_by_default(ClusterBuilder):
         clusterName=generated_test_data.existing_cluster_name
     )[ResponseAttributes.NODEGROUPS]
 
-    result.should.be.empty
+    result.should.equal([])
 
 
 @mock_eks
@@ -851,7 +851,7 @@ def test_list_fargate_profile_returns_empty_by_default(ClusterBuilder):
         clusterName=generated_test_data.existing_cluster_name
     )[ResponseAttributes.FARGATE_PROFILE_NAMES]
 
-    result.should.be.empty
+    result.should.equal([])
 
 
 @mock_eks
@@ -1343,7 +1343,7 @@ def all_arn_values_should_be_valid(expected_arn_values, pattern, arn_under_test)
         if expected_value:
             value.should.be.within(expected_value)
         else:
-            value.should.be.truthy
+            value.shouldnt.equal(None)
     region_matches_partition(findall[1], findall[0]).should.be.true
 
 

--- a/tests/test_emrcontainers/test_server.py
+++ b/tests/test_emrcontainers/test_server.py
@@ -1,4 +1,4 @@
-"""Test different server responses."""
+import json
 import sure  # noqa # pylint: disable=unused-import
 import moto.server as server
 
@@ -13,4 +13,4 @@ def test_list_virtual_clusters():
 
     res = test_client.get("/virtualclusters")
 
-    b'{"virtualClusters": [], "nextToken": null}' in res.data
+    json.loads(res.data).should.have.key("virtualClusters")

--- a/tests/test_events/test_events.py
+++ b/tests/test_events/test_events.py
@@ -249,7 +249,7 @@ def test_enable_disable_rule():
         client.enable_rule(Name="junk")
 
     err = ex.value.response["Error"]
-    err["Code"] == "ResourceNotFoundException"
+    err["Code"].should.equal("ResourceNotFoundException")
 
 
 @mock_events
@@ -2227,14 +2227,14 @@ def test_start_replay_send_to_log_group():
     )
     event_original = json.loads(events[0]["message"])
     event_original["version"].should.equal("0")
-    event_original["id"].should_not.be.empty
+    event_original["id"].should_not.equal(None)
     event_original["detail-type"].should.equal("type")
     event_original["source"].should.equal("source")
     event_original["time"].should.equal(
         iso_8601_datetime_without_milliseconds(event_time)
     )
     event_original["region"].should.equal("eu-central-1")
-    event_original["resources"].should.be.empty
+    event_original["resources"].should.equal([])
     event_original["detail"].should.equal({"key": "value"})
     event_original.should_not.have.key("replay-name")
 
@@ -2245,7 +2245,7 @@ def test_start_replay_send_to_log_group():
     event_replay["source"].should.equal("source")
     event_replay["time"].should.equal(event_original["time"])
     event_replay["region"].should.equal("eu-central-1")
-    event_replay["resources"].should.be.empty
+    event_replay["resources"].should.equal([])
     event_replay["detail"].should.equal({"key": "value"})
     event_replay["replay-name"].should.equal("test-replay")
 

--- a/tests/test_events/test_events_integration.py
+++ b/tests/test_events/test_events_integration.py
@@ -52,19 +52,19 @@ def test_send_to_cw_log_group():
     response = client_logs.filter_log_events(logGroupName=log_group_name)
     response["events"].should.have.length_of(1)
     event = response["events"][0]
-    event["logStreamName"].should_not.be.empty
+    event["logStreamName"].should_not.equal(None)
     event["timestamp"].should.be.a(float)
     event["ingestionTime"].should.be.a(int)
-    event["eventId"].should_not.be.empty
+    event["eventId"].should_not.equal(None)
 
     message = json.loads(event["message"])
     message["version"].should.equal("0")
-    message["id"].should_not.be.empty
+    message["id"].should_not.equal(None)
     message["detail-type"].should.equal("type")
     message["source"].should.equal("source")
     message["time"].should.equal(iso_8601_datetime_without_milliseconds(event_time))
     message["region"].should.equal("eu-central-1")
-    message["resources"].should.be.empty
+    message["resources"].should.equal([])
     message["detail"].should.equal({"key": "value"})
 
 
@@ -131,21 +131,21 @@ def test_send_to_sqs_fifo_queue():
     )
     response["Messages"].should.have.length_of(1)
     message = response["Messages"][0]
-    message["MessageId"].should_not.be.empty
-    message["ReceiptHandle"].should_not.be.empty
-    message["MD5OfBody"].should_not.be.empty
+    message["MessageId"].should_not.equal(None)
+    message["ReceiptHandle"].should_not.equal(None)
+    message["MD5OfBody"].should_not.equal(None)
 
-    message["Attributes"]["MessageDeduplicationId"].should_not.be.empty
+    message["Attributes"]["MessageDeduplicationId"].should_not.equal(None)
     message["Attributes"]["MessageGroupId"].should.equal("group-id")
 
     body = json.loads(message["Body"])
     body["version"].should.equal("0")
-    body["id"].should_not.be.empty
+    body["id"].should_not.equal(None)
     body["detail-type"].should.equal("type")
     body["source"].should.equal("source")
     body["time"].should.equal(iso_8601_datetime_without_milliseconds(event_time))
     body["region"].should.equal("eu-central-1")
-    body["resources"].should.be.empty
+    body["resources"].should.equal([])
     body["detail"].should.equal({"key": "value"})
 
     # A FIFO queue without content-based deduplication enabled
@@ -191,18 +191,18 @@ def test_send_to_sqs_queue():
     response = client_sqs.receive_message(QueueUrl=queue_url)
     response["Messages"].should.have.length_of(1)
     message = response["Messages"][0]
-    message["MessageId"].should_not.be.empty
-    message["ReceiptHandle"].should_not.be.empty
-    message["MD5OfBody"].should_not.be.empty
+    message["MessageId"].should_not.equal(None)
+    message["ReceiptHandle"].should_not.equal(None)
+    message["MD5OfBody"].should_not.equal(None)
 
     body = json.loads(message["Body"])
     body["version"].should.equal("0")
-    body["id"].should_not.be.empty
+    body["id"].should_not.equal(None)
     body["detail-type"].should.equal("type")
     body["source"].should.equal("source")
     body["time"].should.equal(iso_8601_datetime_without_milliseconds(event_time))
     body["region"].should.equal("eu-central-1")
-    body["resources"].should.be.empty
+    body["resources"].should.equal([])
     body["detail"].should.equal({"key": "value"})
 
 

--- a/tests/test_forecast/test_forecast.py
+++ b/tests/test_forecast/test_forecast.py
@@ -77,7 +77,7 @@ def test_forecast_dataset_group_list_default_empty():
     client = boto3.client("forecast", region_name=region)
 
     resp = client.list_dataset_groups()
-    resp["DatasetGroups"].should.be.empty
+    resp["DatasetGroups"].should.equal([])
 
 
 @mock_forecast

--- a/tests/test_glacier/test_glacier_jobs.py
+++ b/tests/test_glacier/test_glacier_jobs.py
@@ -124,7 +124,6 @@ def test_get_job_output_boto3():
         except Exception:
             time.sleep(1)
 
-    output.shouldnt.be.none
     output.should.have.key("status").equal(200)
     output.should.have.key("contentType").equal("application/octet-stream")
     output.should.have.key("body")

--- a/tests/test_glue/test_datacatalog.py
+++ b/tests/test_glue/test_datacatalog.py
@@ -838,7 +838,7 @@ def test_delete_partition():
 
     response = client.get_partitions(DatabaseName=database_name, TableName=table_name)
     partitions = response["Partitions"]
-    partitions.should.be.empty
+    partitions.should.equal([])
 
 
 @mock_glue

--- a/tests/test_iam/test_iam.py
+++ b/tests/test_iam/test_iam.py
@@ -68,7 +68,7 @@ MOCK_POLICY_3 = """
 
 
 @mock_iam
-def test_get_role__should_throw__when_role_does_not_exist_boto3():
+def test_get_role__should_throw__when_role_does_not_exist():
     conn = boto3.client("iam", region_name="us-east-1")
     with pytest.raises(ClientError) as ex:
         conn.get_role(RoleName="unexisting_role")
@@ -78,7 +78,7 @@ def test_get_role__should_throw__when_role_does_not_exist_boto3():
 
 
 @mock_iam
-def test_get_instance_profile__should_throw__when_instance_profile_does_not_exist_boto3():
+def test_get_instance_profile__should_throw__when_instance_profile_does_not_exist():
     conn = boto3.client("iam", region_name="us-east-1")
     with pytest.raises(ClientError) as ex:
         conn.get_instance_profile(InstanceProfileName="unexisting_instance_profile")
@@ -88,7 +88,7 @@ def test_get_instance_profile__should_throw__when_instance_profile_does_not_exis
 
 
 @mock_iam
-def test_create_role_and_instance_profile_boto3():
+def test_create_role_and_instance_profile():
     conn = boto3.client("iam", region_name="us-east-1")
     conn.create_instance_profile(InstanceProfileName="my-profile", Path="my-path")
     conn.create_role(
@@ -129,7 +129,7 @@ def test_create_instance_profile_should_throw_when_name_is_not_unique():
 
 
 @mock_iam
-def test_remove_role_from_instance_profile_boto3():
+def test_remove_role_from_instance_profile():
     conn = boto3.client("iam", region_name="us-east-1")
     conn.create_instance_profile(InstanceProfileName="my-profile", Path="my-path")
     conn.create_role(
@@ -263,7 +263,7 @@ def test_delete_role():
 
 
 @mock_iam
-def test_list_instance_profiles_boto3():
+def test_list_instance_profiles():
     conn = boto3.client("iam", region_name="us-east-1")
     conn.create_instance_profile(InstanceProfileName="my-profile", Path="my-path")
     conn.create_role(
@@ -282,7 +282,7 @@ def test_list_instance_profiles_boto3():
 
 
 @mock_iam
-def test_list_instance_profiles_for_role_boto3():
+def test_list_instance_profiles_for_role():
     conn = boto3.client("iam", region_name="us-east-1")
 
     conn.create_role(
@@ -321,7 +321,7 @@ def test_list_instance_profiles_for_role_boto3():
 
 
 @mock_iam
-def test_list_role_policies_boto3():
+def test_list_role_policies():
     conn = boto3.client("iam", region_name="us-east-1")
 
     conn.create_role(
@@ -353,7 +353,7 @@ def test_list_role_policies_boto3():
 
 
 @mock_iam
-def test_put_role_policy_boto3():
+def test_put_role_policy():
     conn = boto3.client("iam", region_name="us-east-1")
     conn.create_role(
         RoleName="my-role", AssumeRolePolicyDocument="some policy", Path="my-path"
@@ -377,7 +377,7 @@ def test_get_role_policy():
 
 
 @mock_iam
-def test_update_assume_role_policy_boto3():
+def test_update_assume_role_policy():
     conn = boto3.client("iam", region_name="us-east-1")
     conn.create_role(
         RoleName="my-role", AssumeRolePolicyDocument="some policy", Path="my-path"
@@ -1269,7 +1269,7 @@ def test_create_user_boto():
 
 
 @mock_iam
-def test_get_user_boto3():
+def test_get_user():
     conn = boto3.client("iam", region_name="us-east-1")
     with pytest.raises(ClientError) as ex:
         conn.get_user(UserName="my-user")
@@ -1301,7 +1301,7 @@ def test_update_user():
 
 
 @mock_iam
-def test_get_current_user_boto3():
+def test_get_current_user():
     """If no user is specific, IAM returns the current user"""
     conn = boto3.client("iam", region_name="us-east-1")
     user = conn.get_user()["User"]
@@ -1362,19 +1362,6 @@ def test_create_login_profile_with_unknown_user():
 
 
 @mock_iam
-def test_create_login_profile_boto3():
-    conn = boto3.client("iam", region_name="us-east-1")
-    conn.create_user(UserName="my-user")
-    conn.create_login_profile(UserName="my-user", Password="my-pass")
-
-    with pytest.raises(ClientError) as ex:
-        conn.create_login_profile(UserName="my-user", Password="my-pass")
-    err = ex.value.response["Error"]
-    err["Code"].should.equal("User my-user already has password")
-    err["Message"].should.equal(None)
-
-
-@mock_iam
 def test_delete_login_profile_with_unknown_user():
     conn = boto3.client("iam", region_name="us-east-1")
     with pytest.raises(ClientError) as ex:
@@ -1396,7 +1383,7 @@ def test_delete_nonexistent_login_profile():
 
 
 @mock_iam
-def test_delete_login_profile_boto3():
+def test_delete_login_profile():
     conn = boto3.client("iam", region_name="us-east-1")
     conn.create_user(UserName="my-user")
     conn.create_login_profile(UserName="my-user", Password="my-pass")
@@ -1501,7 +1488,7 @@ def test_create_virtual_mfa_device():
         "arn:aws:iam::{}:mfa/test-device".format(ACCOUNT_ID)
     )
     device["Base32StringSeed"].decode("ascii").should.match("[A-Z234567]")
-    device["QRCodePNG"].should_not.be.empty
+    device["QRCodePNG"].should_not.equal("")
 
     response = client.create_virtual_mfa_device(
         Path="/", VirtualMFADeviceName="test-device-2"
@@ -1512,7 +1499,7 @@ def test_create_virtual_mfa_device():
         "arn:aws:iam::{}:mfa/test-device-2".format(ACCOUNT_ID)
     )
     device["Base32StringSeed"].decode("ascii").should.match("[A-Z234567]")
-    device["QRCodePNG"].should_not.be.empty
+    device["QRCodePNG"].should_not.equal("")
 
     response = client.create_virtual_mfa_device(
         Path="/test/", VirtualMFADeviceName="test-device"
@@ -1523,7 +1510,8 @@ def test_create_virtual_mfa_device():
         "arn:aws:iam::{}:mfa/test/test-device".format(ACCOUNT_ID)
     )
     device["Base32StringSeed"].decode("ascii").should.match("[A-Z234567]")
-    device["QRCodePNG"].should_not.be.empty
+    device["QRCodePNG"].should_not.equal("")
+    device["QRCodePNG"].should.be.a(bytes)
 
 
 @mock_iam
@@ -1575,7 +1563,7 @@ def test_delete_virtual_mfa_device():
     response = client.list_virtual_mfa_devices()
 
     response["VirtualMFADevices"].should.have.length_of(0)
-    response["IsTruncated"].should_not.be.ok
+    response["IsTruncated"].should.equal(False)
 
 
 @mock_iam
@@ -1607,24 +1595,24 @@ def test_list_virtual_mfa_devices():
     response["VirtualMFADevices"].should.equal(
         [{"SerialNumber": serial_number_1}, {"SerialNumber": serial_number_2}]
     )
-    response["IsTruncated"].should_not.be.ok
+    response["IsTruncated"].should.equal(False)
 
     response = client.list_virtual_mfa_devices(AssignmentStatus="Assigned")
 
     response["VirtualMFADevices"].should.have.length_of(0)
-    response["IsTruncated"].should_not.be.ok
+    response["IsTruncated"].should.equal(False)
 
     response = client.list_virtual_mfa_devices(AssignmentStatus="Unassigned")
 
     response["VirtualMFADevices"].should.equal(
         [{"SerialNumber": serial_number_1}, {"SerialNumber": serial_number_2}]
     )
-    response["IsTruncated"].should_not.be.ok
+    response["IsTruncated"].should.equal(False)
 
     response = client.list_virtual_mfa_devices(AssignmentStatus="Any", MaxItems=1)
 
     response["VirtualMFADevices"].should.equal([{"SerialNumber": serial_number_1}])
-    response["IsTruncated"].should.be.ok
+    response["IsTruncated"].should.equal(True)
     response["Marker"].should.equal("1")
 
     response = client.list_virtual_mfa_devices(
@@ -1632,7 +1620,7 @@ def test_list_virtual_mfa_devices():
     )
 
     response["VirtualMFADevices"].should.equal([{"SerialNumber": serial_number_2}])
-    response["IsTruncated"].should_not.be.ok
+    response["IsTruncated"].should.equal(False)
 
 
 @mock_iam
@@ -1663,7 +1651,7 @@ def test_enable_virtual_mfa_device():
     response = client.list_virtual_mfa_devices(AssignmentStatus="Unassigned")
 
     response["VirtualMFADevices"].should.have.length_of(0)
-    response["IsTruncated"].should_not.be.ok
+    response["IsTruncated"].should.equal(False)
 
     response = client.list_virtual_mfa_devices(AssignmentStatus="Assigned")
 
@@ -1671,26 +1659,26 @@ def test_enable_virtual_mfa_device():
     device["SerialNumber"].should.equal(serial_number)
     device["User"]["Path"].should.equal("/")
     device["User"]["UserName"].should.equal("test-user")
-    device["User"]["UserId"].should_not.be.empty
+    device["User"]["UserId"].should.match("[a-z0-9]+")
     device["User"]["Arn"].should.equal(
         "arn:aws:iam::{}:user/test-user".format(ACCOUNT_ID)
     )
     device["User"]["CreateDate"].should.be.a(datetime)
     device["User"]["Tags"].should.equal(tags)
     device["EnableDate"].should.be.a(datetime)
-    response["IsTruncated"].should_not.be.ok
+    response["IsTruncated"].should.equal(False)
 
     client.deactivate_mfa_device(UserName="test-user", SerialNumber=serial_number)
 
     response = client.list_virtual_mfa_devices(AssignmentStatus="Assigned")
 
     response["VirtualMFADevices"].should.have.length_of(0)
-    response["IsTruncated"].should_not.be.ok
+    response["IsTruncated"].should.equal(False)
 
     response = client.list_virtual_mfa_devices(AssignmentStatus="Unassigned")
 
     response["VirtualMFADevices"].should.equal([{"SerialNumber": serial_number}])
-    response["IsTruncated"].should_not.be.ok
+    response["IsTruncated"].should.equal(False)
 
 
 @mock_iam()
@@ -1733,7 +1721,7 @@ def test_delete_user():
 
 
 @mock_iam
-def test_boto3_generate_credential_report():
+def test_generate_credential_report():
     conn = boto3.client("iam", region_name="us-east-1")
     result = conn.generate_credential_report()
     result["State"].should.equal("STARTED")
@@ -1742,7 +1730,7 @@ def test_boto3_generate_credential_report():
 
 
 @mock_iam
-def test_boto3_get_credential_report():
+def test_get_credential_report():
     conn = boto3.client("iam", region_name="us-east-1")
     conn.create_user(UserName="my-user")
     with pytest.raises(ClientError):
@@ -1756,7 +1744,7 @@ def test_boto3_get_credential_report():
 
 
 @mock_iam
-def test_boto3_get_credential_report_content():
+def test_get_credential_report_content():
     conn = boto3.client("iam", region_name="us-east-1")
     username = "my-user"
     conn.create_user(UserName=username)
@@ -1823,7 +1811,7 @@ def test_get_access_key_last_used_when_used():
 
 
 @mock_iam
-def test_managed_policy_boto3():
+def test_managed_policy():
     conn = boto3.client("iam", region_name="us-west-1")
 
     conn.create_policy(
@@ -1916,17 +1904,17 @@ def test_managed_policy_boto3():
 
 
 @mock_iam
-def test_boto3_create_login_profile():
+def test_create_login_profile__duplicate():
     conn = boto3.client("iam", region_name="us-east-1")
-
-    with pytest.raises(ClientError):
-        conn.create_login_profile(UserName="my-user", Password="Password")
 
     conn.create_user(UserName="my-user")
     conn.create_login_profile(UserName="my-user", Password="Password")
 
-    with pytest.raises(ClientError):
-        conn.create_login_profile(UserName="my-user", Password="Password")
+    with pytest.raises(ClientError) as exc:
+        conn.create_login_profile(UserName="my-user", Password="my-pass")
+    err = exc.value.response["Error"]
+    err["Code"].should.equal("User my-user already has password")
+    err["Message"].should.equal(None)
 
 
 @mock_iam()
@@ -3192,17 +3180,17 @@ def test_list_user_tags():
     )
     response = conn.list_user_tags(UserName="kenny-bania")
     response["Tags"].should.have.length_of(0)
-    response["IsTruncated"].should_not.be.ok
+    response["IsTruncated"].should.equal(False)
 
     response = conn.list_user_tags(UserName="jackie-chiles")
     response["Tags"].should.equal([{"Key": "Sue-Allen", "Value": "Oh-Henry"}])
-    response["IsTruncated"].should_not.be.ok
+    response["IsTruncated"].should.equal(False)
 
     response = conn.list_user_tags(UserName="cosmo")
     response["Tags"].should.equal(
         [{"Key": "Stan", "Value": "The Caddy"}, {"Key": "like-a", "Value": "glove"}]
     )
-    response["IsTruncated"].should_not.be.ok
+    response["IsTruncated"].should.equal(False)
 
 
 @mock_iam()

--- a/tests/test_iot/test_iot_policies.py
+++ b/tests/test_iot/test_iot_policies.py
@@ -72,7 +72,7 @@ def test_list_attached_policies():
     client = boto3.client("iot", region_name="ap-northeast-1")
     cert = client.create_keys_and_certificate(setAsActive=True)
     policies = client.list_attached_policies(target=cert["certificateArn"])
-    policies["policies"].should.be.empty
+    policies["policies"].should.equal([])
 
 
 @mock_iot

--- a/tests/test_kms/test_kms_boto3.py
+++ b/tests/test_kms/test_kms_boto3.py
@@ -73,9 +73,9 @@ def test_create_key():
     key["KeyMetadata"]["CreationDate"].should.be.a(datetime)
     key["KeyMetadata"]["CustomerMasterKeySpec"].should.equal("SYMMETRIC_DEFAULT")
     key["KeyMetadata"]["Description"].should.equal("my key")
-    key["KeyMetadata"]["Enabled"].should.be.ok
+    key["KeyMetadata"]["Enabled"].should.equal(True)
     key["KeyMetadata"]["EncryptionAlgorithms"].should.equal(["SYMMETRIC_DEFAULT"])
-    key["KeyMetadata"]["KeyId"].should_not.be.empty
+    key["KeyMetadata"]["KeyId"].should.match("[-a-zA-Z0-9]+")
     key["KeyMetadata"]["KeyManager"].should.equal("CUSTOMER")
     key["KeyMetadata"]["KeyState"].should.equal("Enabled")
     key["KeyMetadata"]["KeyUsage"].should.equal("ENCRYPT_DECRYPT")
@@ -134,9 +134,9 @@ def test_describe_key(id_or_arn):
     response["KeyMetadata"]["CreationDate"].should.be.a(datetime)
     response["KeyMetadata"]["CustomerMasterKeySpec"].should.equal("SYMMETRIC_DEFAULT")
     response["KeyMetadata"]["Description"].should.equal("my key")
-    response["KeyMetadata"]["Enabled"].should.be.ok
+    response["KeyMetadata"]["Enabled"].should.equal(True)
     response["KeyMetadata"]["EncryptionAlgorithms"].should.equal(["SYMMETRIC_DEFAULT"])
-    response["KeyMetadata"]["KeyId"].should_not.be.empty
+    response["KeyMetadata"]["KeyId"].should.match("[-a-zA-Z0-9]+")
     response["KeyMetadata"]["KeyManager"].should.equal("CUSTOMER")
     response["KeyMetadata"]["KeyState"].should.equal("Enabled")
     response["KeyMetadata"]["KeyUsage"].should.equal("ENCRYPT_DECRYPT")

--- a/tests/test_mediaconnect/test_mediaconnect.py
+++ b/tests/test_mediaconnect/test_mediaconnect.py
@@ -69,9 +69,9 @@ def test_create_flow_succeeds():
     response["Flow"]["Outputs"][0].should.equal({"Name": "Output 1"})
     response["Flow"]["Outputs"][1]["ListenerAddress"].should.equal("1.0.0.0")
     response["Flow"]["Outputs"][2]["ListenerAddress"].should.equal("2.0.0.0")
-    response["Flow"]["Sources"][0][
-        "SourceArn"
-    ] == "arn:aws:mediaconnect:source:Source A"
+    response["Flow"]["Sources"][0]["SourceArn"].should.equal(
+        "arn:aws:mediaconnect:source:Source A"
+    )
 
 
 @mock_mediaconnect

--- a/tests/test_organizations/organizations_test_utils.py
+++ b/tests/test_organizations/organizations_test_utils.py
@@ -63,7 +63,7 @@ def validate_organization(response):
 
 def validate_roots(org, response):
     response.should.have.key("Roots").should.be.a(list)
-    response["Roots"].should_not.be.empty
+    response["Roots"].shouldnt.equal([])
     root = response["Roots"][0]
     root.should.have.key("Id").should.match(utils.ROOT_ID_REGEX)
     root.should.have.key("Arn").should.equal(

--- a/tests/test_organizations/test_organizations_boto3.py
+++ b/tests/test_organizations/test_organizations_boto3.py
@@ -430,7 +430,7 @@ def test_get_paginated_list_create_account_status():
     for createAccountStatus in createAccountStatuses:
         validate_create_account_status(createAccountStatus)
     next_token = response["NextToken"]
-    next_token.should_not.be.none
+    next_token.should_not.equal(None)
     response2 = client.list_create_account_status(NextToken=next_token)
     createAccountStatuses.extend(response2["CreateAccountStatuses"])
     createAccountStatuses.should.have.length_of(6)
@@ -2003,7 +2003,7 @@ def test_aiservices_opt_out_policy():
     summary["Name"].should.equal("ai-opt-out")
     summary["Description"].should.equal("Opt out of all AI services")
     summary["Type"].should.equal("AISERVICES_OPT_OUT_POLICY")
-    summary["AwsManaged"].should_not.be.ok
+    summary["AwsManaged"].should.equal(False)
     json.loads(response["Policy"]["Content"]).should.equal(ai_policy)
 
     # when

--- a/tests/test_route53/test_route53.py
+++ b/tests/test_route53/test_route53.py
@@ -10,7 +10,7 @@ from moto import mock_ec2, mock_route53
 
 
 @mock_route53
-def test_create_hosted_zone_boto3():
+def test_create_hosted_zone():
     conn = boto3.client("route53", region_name="us-east-1")
     response = conn.create_hosted_zone(
         Name="testdns.aws.com.", CallerReference=str(hash("foo"))
@@ -156,7 +156,7 @@ def test_list_resource_record_set_unknown_type():
 
 
 @mock_route53
-def test_create_health_check_boto3():
+def test_create_health_check():
     conn = boto3.client("route53", region_name="us-east-1")
 
     check = conn.create_health_check(
@@ -189,7 +189,7 @@ def test_create_health_check_boto3():
 
 
 @mock_route53
-def test_list_health_checks_boto3():
+def test_list_health_checks():
     conn = boto3.client("route53", region_name="us-east-1")
 
     conn.list_health_checks()["HealthChecks"].should.have.length_of(0)
@@ -214,7 +214,7 @@ def test_list_health_checks_boto3():
 
 
 @mock_route53
-def test_delete_health_checks_boto3():
+def test_delete_health_checks():
     conn = boto3.client("route53", region_name="us-east-1")
 
     conn.list_health_checks()["HealthChecks"].should.have.length_of(0)
@@ -240,7 +240,7 @@ def test_delete_health_checks_boto3():
 
 
 @mock_route53
-def test_use_health_check_in_resource_record_set_boto3():
+def test_use_health_check_in_resource_record_set():
     conn = boto3.client("route53", region_name="us-east-1")
 
     check = conn.create_health_check(
@@ -286,7 +286,7 @@ def test_use_health_check_in_resource_record_set_boto3():
 
 
 @mock_route53
-def test_hosted_zone_comment_preserved_boto3():
+def test_hosted_zone_comment_preserved():
     conn = boto3.client("route53", region_name="us-east-1")
 
     firstzone = conn.create_hosted_zone(
@@ -304,7 +304,7 @@ def test_hosted_zone_comment_preserved_boto3():
 
 
 @mock_route53
-def test_deleting_weighted_route_boto3():
+def test_deleting_weighted_route():
     conn = boto3.client("route53", region_name="us-east-1")
 
     zone = conn.create_hosted_zone(
@@ -360,7 +360,7 @@ def test_deleting_weighted_route_boto3():
 
 
 @mock_route53
-def test_deleting_latency_route_boto3():
+def test_deleting_latency_route():
     conn = boto3.client("route53", region_name="us-east-1")
 
     zone = conn.create_hosted_zone(
@@ -424,7 +424,7 @@ def test_deleting_latency_route_boto3():
 
 @mock_ec2
 @mock_route53
-def test_hosted_zone_private_zone_preserved_boto3():
+def test_hosted_zone_private_zone_preserved():
     # Create mock VPC so we can get a VPC ID
     region = "us-east-1"
     ec2c = boto3.client("ec2", region_name=region)
@@ -446,8 +446,8 @@ def test_hosted_zone_private_zone_preserved_boto3():
     hosted_zone["VPCs"].should.have.length_of(1)
     hosted_zone["VPCs"][0].should.have.key("VPCId")
     hosted_zone["VPCs"][0].should.have.key("VPCRegion")
-    hosted_zone["VPCs"][0]["VPCId"].should_not.be.empty
-    hosted_zone["VPCs"][0]["VPCRegion"].should_not.be.empty
+    hosted_zone["VPCs"][0]["VPCId"].should_not.equal(None)
+    hosted_zone["VPCs"][0]["VPCRegion"].should_not.equal(None)
     hosted_zone["VPCs"][0]["VPCId"].should.be.equal(vpc_id)
     hosted_zone["VPCs"][0]["VPCRegion"].should.be.equal(region)
 
@@ -474,8 +474,8 @@ def test_hosted_zone_private_zone_preserved_boto3():
     hosted_zone["VPCs"].should.have.length_of(1)
     hosted_zone["VPCs"][0].should.have.key("VPCId")
     hosted_zone["VPCs"][0].should.have.key("VPCRegion")
-    hosted_zone["VPCs"][0]["VPCId"].should.be.empty
-    hosted_zone["VPCs"][0]["VPCRegion"].should.be.empty
+    hosted_zone["VPCs"][0]["VPCId"].should.equal("")
+    hosted_zone["VPCs"][0]["VPCRegion"].should.equal("")
 
     hosted_zones = conn.list_hosted_zones()
     hosted_zones["HostedZones"].should.have.length_of(2)
@@ -511,7 +511,7 @@ def test_list_or_change_tags_for_resource_request():
     response = conn.list_tags_for_resource(
         ResourceType="healthcheck", ResourceId=healthcheck_id
     )
-    response["ResourceTagSet"]["Tags"].should.be.empty
+    response["ResourceTagSet"]["Tags"].should.equal([])
 
     tag1 = {"Key": "Deploy", "Value": "True"}
     tag2 = {"Key": "Name", "Value": "UnitTest"}
@@ -575,7 +575,7 @@ def test_list_or_change_tags_for_resource_request():
     response = conn.list_tags_for_resource(
         ResourceType="healthcheck", ResourceId=healthcheck_id
     )
-    response["ResourceTagSet"]["Tags"].should.be.empty
+    response["ResourceTagSet"]["Tags"].should.equal([])
 
 
 @mock_ec2
@@ -620,8 +620,8 @@ def test_list_hosted_zones_by_name():
     b_hz_vpcs = b_hosted_zone["VPCs"][0]
     b_hz_vpcs.should.have.key("VPCId")
     b_hz_vpcs.should.have.key("VPCRegion")
-    b_hz_vpcs["VPCId"].should_not.be.empty
-    b_hz_vpcs["VPCRegion"].should_not.be.empty
+    b_hz_vpcs["VPCId"].should_not.equal("")
+    b_hz_vpcs["VPCRegion"].should_not.equal("")
     b_hz_vpcs["VPCId"].should.be.equal(vpc_id)
     b_hz_vpcs["VPCRegion"].should.be.equal(region)
 

--- a/tests/test_s3/test_s3.py
+++ b/tests/test_s3/test_s3.py
@@ -339,9 +339,9 @@ def test_delete_versioned_objects():
     versions = s3.list_object_versions(Bucket=bucket).get("Versions")
     delete_markers = s3.list_object_versions(Bucket=bucket).get("DeleteMarkers")
 
-    objects.shouldnt.be.empty
-    versions.shouldnt.be.empty
-    delete_markers.should.be.none
+    objects.should.have.length_of(1)
+    versions.should.have.length_of(1)
+    delete_markers.should.equal(None)
 
     s3.delete_object(Bucket=bucket, Key=key)
 
@@ -349,9 +349,9 @@ def test_delete_versioned_objects():
     versions = s3.list_object_versions(Bucket=bucket).get("Versions")
     delete_markers = s3.list_object_versions(Bucket=bucket).get("DeleteMarkers")
 
-    objects.should.be.none
-    versions.shouldnt.be.empty
-    delete_markers.shouldnt.be.empty
+    objects.should.equal(None)
+    versions.should.have.length_of(1)
+    delete_markers.should.have.length_of(1)
 
     s3.delete_object(Bucket=bucket, Key=key, VersionId=versions[0].get("VersionId"))
 
@@ -359,9 +359,9 @@ def test_delete_versioned_objects():
     versions = s3.list_object_versions(Bucket=bucket).get("Versions")
     delete_markers = s3.list_object_versions(Bucket=bucket).get("DeleteMarkers")
 
-    objects.should.be.none
-    versions.should.be.none
-    delete_markers.shouldnt.be.empty
+    objects.should.equal(None)
+    versions.should.equal(None)
+    delete_markers.should.have.length_of(1)
 
     s3.delete_object(
         Bucket=bucket, Key=key, VersionId=delete_markers[0].get("VersionId")
@@ -371,9 +371,9 @@ def test_delete_versioned_objects():
     versions = s3.list_object_versions(Bucket=bucket).get("Versions")
     delete_markers = s3.list_object_versions(Bucket=bucket).get("DeleteMarkers")
 
-    objects.should.be.none
-    versions.should.be.none
-    delete_markers.should.be.none
+    objects.should.equal(None)
+    versions.should.equal(None)
+    delete_markers.should.equal(None)
 
 
 @mock_s3
@@ -512,7 +512,7 @@ def test_restore_key():
     bucket.create()
 
     key = bucket.put_object(Key="the-key", Body=b"somedata", StorageClass="GLACIER")
-    key.restore.should.be.none
+    key.restore.should.equal(None)
     key.restore_object(RestoreRequest={"Days": 1})
     if settings.TEST_SERVER_MODE:
         key.restore.should.contain('ongoing-request="false"')
@@ -556,7 +556,7 @@ def test_get_versioning_status():
     bucket.create()
 
     v = s3.BucketVersioning("foobar")
-    v.status.should.be.none
+    v.status.should.equal(None)
 
     v.enable()
     v.status.should.equal("Enabled")
@@ -1025,7 +1025,7 @@ def test_website_redirect_location():
 
     s3.put_object(Bucket="mybucket", Key="steve", Body=b"is awesome")
     resp = s3.get_object(Bucket="mybucket", Key="steve")
-    resp.get("WebsiteRedirectLocation").should.be.none
+    resp.get("WebsiteRedirectLocation").should.equal(None)
 
     url = "https://github.com/spulec/moto"
     s3.put_object(

--- a/tests/test_s3/test_s3_multipart.py
+++ b/tests/test_s3/test_s3_multipart.py
@@ -655,7 +655,7 @@ def test_multipart_version():
         },
     )
 
-    response["VersionId"].should.should_not.be.none
+    response["VersionId"].should.match("[-a-z0-9]+")
 
 
 @mock_s3

--- a/tests/test_ses/test_ses_utils.py
+++ b/tests/test_ses/test_ses_utils.py
@@ -5,13 +5,13 @@ from moto.ses.utils import is_valid_address
 
 def test_is_valid_address():
     valid, msg = is_valid_address("test@example.com")
-    valid.should.be.ok
-    msg.should.be.none
+    valid.should.equal(True)
+    msg.should.equal(None)
 
     valid, msg = is_valid_address("test@")
-    valid.should_not.be.ok
+    valid.should.equal(False)
     msg.should.be.a(str)
 
     valid, msg = is_valid_address("test")
-    valid.should_not.be.ok
+    valid.should.equal(False)
     msg.should.be.a(str)

--- a/tests/test_sqs/test_sqs.py
+++ b/tests/test_sqs/test_sqs.py
@@ -174,14 +174,11 @@ def test_create_queue():
 
     q_name = str(uuid4())[0:6]
     new_queue = sqs.create_queue(QueueName=q_name)
-    new_queue.should_not.be.none
     new_queue.should.have.property("url").should.contain(q_name)
 
     queue = sqs.get_queue_by_name(QueueName=q_name)
-    queue.attributes.get("QueueArn").should_not.be.none
     queue.attributes.get("QueueArn").split(":")[-1].should.equal(q_name)
     queue.attributes.get("QueueArn").split(":")[3].should.equal("us-east-1")
-    queue.attributes.get("VisibilityTimeout").should_not.be.none
     queue.attributes.get("VisibilityTimeout").should.equal("30")
 
 
@@ -190,14 +187,13 @@ def test_create_queue_kms():
     sqs = boto3.resource("sqs", region_name="us-east-1")
 
     q_name = str(uuid4())[0:6]
-    new_queue = sqs.create_queue(
+    sqs.create_queue(
         QueueName=q_name,
         Attributes={
             "KmsMasterKeyId": "master-key-id",
             "KmsDataKeyReusePeriodSeconds": "600",
         },
     )
-    new_queue.should_not.be.none
 
     queue = sqs.get_queue_by_name(QueueName=q_name)
 
@@ -1404,7 +1400,7 @@ def test_receive_messages_with_wait_seconds_timeout_of_zero():
 
 
 @mock_sqs
-def test_send_message_with_xml_characters_boto3():
+def test_send_message_with_xml_characters():
     sqs = boto3.resource("sqs", region_name="us-east-1")
     client = boto3.client("sqs", region_name="us-east-1")
     queue = sqs.create_queue(QueueName=str(uuid4())[0:6])
@@ -1419,7 +1415,7 @@ def test_send_message_with_xml_characters_boto3():
 
 
 @mock_sqs
-def test_send_message_with_delay_boto3():
+def test_send_message_with_delay():
     sqs = boto3.resource("sqs", region_name="us-east-1")
     queue = sqs.create_queue(QueueName=str(uuid4())[0:6])
 
@@ -1439,7 +1435,7 @@ def test_send_message_with_delay_boto3():
 
 
 @mock_sqs
-def test_send_large_message_fails_boto3():
+def test_send_large_message_fails():
     sqs = boto3.resource("sqs", region_name="us-east-1")
     queue = sqs.create_queue(QueueName=str(uuid4())[0:6])
 
@@ -1454,7 +1450,7 @@ def test_send_large_message_fails_boto3():
 
 
 @mock_sqs
-def test_message_becomes_inflight_when_received_boto3():
+def test_message_becomes_inflight_when_received():
     sqs = boto3.resource("sqs", region_name="eu-west-1")
     queue = sqs.create_queue(
         QueueName=str(uuid4())[0:6], Attributes={"VisibilityTimeout ": "2"}
@@ -1482,7 +1478,7 @@ def test_message_becomes_inflight_when_received_boto3():
 
 
 @mock_sqs
-def test_receive_message_with_explicit_visibility_timeout_boto3():
+def test_receive_message_with_explicit_visibility_timeout():
     sqs = boto3.resource("sqs", region_name="us-east-1")
     queue = sqs.create_queue(
         QueueName=str(uuid4())[0:6], Attributes={"VisibilityTimeout ": "1"}
@@ -1504,7 +1500,7 @@ def test_receive_message_with_explicit_visibility_timeout_boto3():
 
 
 @mock_sqs
-def test_change_message_visibility_boto3():
+def test_change_message_visibility():
     sqs = boto3.resource("sqs", region_name="us-east-1")
     queue = sqs.create_queue(
         QueueName=str(uuid4())[0:6], Attributes={"VisibilityTimeout ": "2"}
@@ -1561,7 +1557,7 @@ def test_change_message_visibility_on_unknown_receipt_handle():
 
 
 @mock_sqs
-def test_queue_length_boto3():
+def test_queue_length():
     sqs = boto3.resource("sqs", region_name="us-east-1")
     queue = sqs.create_queue(
         QueueName=str(uuid4())[0:6], Attributes={"VisibilityTimeout ": "2"}
@@ -1575,7 +1571,7 @@ def test_queue_length_boto3():
 
 
 @mock_sqs
-def test_delete_batch_operation_boto3():
+def test_delete_batch_operation():
     sqs = boto3.resource("sqs", region_name="us-east-1")
     queue = sqs.create_queue(
         QueueName=str(uuid4())[0:6], Attributes={"VisibilityTimeout ": "2"}
@@ -1597,7 +1593,7 @@ def test_delete_batch_operation_boto3():
 
 
 @mock_sqs
-def test_change_message_visibility_on_old_message_boto3():
+def test_change_message_visibility_on_old_message():
     sqs = boto3.resource("sqs", region_name="us-east-1")
     queue = sqs.create_queue(
         QueueName=str(uuid4())[0:6], Attributes={"VisibilityTimeout": "1"}
@@ -1636,7 +1632,7 @@ def test_change_message_visibility_on_old_message_boto3():
 
 
 @mock_sqs
-def test_change_message_visibility_on_visible_message_boto3():
+def test_change_message_visibility_on_visible_message():
     sqs = boto3.resource("sqs", region_name="us-east-1")
     queue = sqs.create_queue(
         QueueName=str(uuid4())[0:6], Attributes={"VisibilityTimeout": "1"}
@@ -1695,7 +1691,7 @@ def test_purge_queue_before_delete_message():
 
 
 @mock_sqs
-def test_delete_message_after_visibility_timeout_boto3():
+def test_delete_message_after_visibility_timeout():
     VISIBILITY_TIMEOUT = 1
     sqs = boto3.resource("sqs", region_name="us-east-1")
     queue = sqs.create_queue(

--- a/tests/test_stepfunctions/test_stepfunctions.py
+++ b/tests/test_stepfunctions/test_stepfunctions.py
@@ -188,7 +188,7 @@ def test_state_machine_list_returns_empty_list_by_default():
     client = boto3.client("stepfunctions", region_name=region)
     #
     sm_list = client.list_state_machines()
-    sm_list["stateMachines"].should.be.empty
+    sm_list["stateMachines"].should.equal([])
 
 
 @mock_stepfunctions
@@ -706,7 +706,7 @@ def test_state_machine_describe_execution_with_no_input():
     description["ResponseMetadata"]["HTTPStatusCode"].should.equal(200)
     description["executionArn"].should.equal(execution["executionArn"])
     description["input"].should.equal("{}")
-    description["name"].shouldnt.be.empty
+    description["name"].should.match("[-0-9a-z]+")
     description["startDate"].should.equal(execution["startDate"])
     description["stateMachineArn"].should.equal(sm["stateMachineArn"])
     description["status"].should.equal("RUNNING")
@@ -730,7 +730,7 @@ def test_state_machine_describe_execution_with_custom_input():
     description["ResponseMetadata"]["HTTPStatusCode"].should.equal(200)
     description["executionArn"].should.equal(execution["executionArn"])
     description["input"].should.equal(execution_input)
-    description["name"].shouldnt.be.empty
+    description["name"].should.match("[-a-z0-9]+")
     description["startDate"].should.equal(execution["startDate"])
     description["stateMachineArn"].should.equal(sm["stateMachineArn"])
     description["status"].should.equal("RUNNING")

--- a/tests/test_swf/models/test_activity_task.py
+++ b/tests/test_swf/models/test_activity_task.py
@@ -23,8 +23,8 @@ def test_activity_task_creation():
     )
     task.workflow_execution.should.equal(wfe)
     task.state.should.equal("SCHEDULED")
-    task.task_token.should_not.be.empty
-    task.started_event_id.should.be.none
+    task.task_token.should.match("[-a-z0-9]+")
+    task.started_event_id.should.equal(None)
 
     task.start(123)
     task.state.should.equal("STARTED")

--- a/tests/test_swf/models/test_decision_task.py
+++ b/tests/test_swf/models/test_decision_task.py
@@ -11,8 +11,8 @@ def test_decision_task_creation():
     dt = DecisionTask(wfe, 123)
     dt.workflow_execution.should.equal(wfe)
     dt.state.should.equal("SCHEDULED")
-    dt.task_token.should_not.be.empty
-    dt.started_event_id.should.be.none
+    dt.task_token.should.match("[-a-z0-9]+")
+    dt.started_event_id.should.equal(None)
 
 
 def test_decision_task_full_dict_representation():

--- a/tests/test_swf/models/test_timeout.py
+++ b/tests/test_swf/models/test_timeout.py
@@ -13,7 +13,7 @@ def test_timeout_creation():
     timeout = Timeout(wfe, 1420117200, "START_TO_CLOSE")
 
     with freeze_time("2015-01-01 12:00:00"):
-        timeout.reached.should.be.falsy
+        timeout.reached.should.equal(False)
 
     with freeze_time("2015-01-01 13:00:00"):
-        timeout.reached.should.be.truthy
+        timeout.reached.should.equal(True)

--- a/tests/test_swf/models/test_workflow_execution.py
+++ b/tests/test_swf/models/test_workflow_execution.py
@@ -123,7 +123,7 @@ def test_workflow_execution_medium_dict_representation():
     md["workflowType"].should.equal(wf_type.to_short_dict())
     md["startTimestamp"].should.be.a("float")
     md["executionStatus"].should.equal("OPEN")
-    md["cancelRequested"].should.be.falsy
+    md["cancelRequested"].should.equal(False)
     md.should_not.contain("tagList")
 
     wfe.tag_list = ["foo", "bar", "baz"]
@@ -209,7 +209,7 @@ def test_workflow_execution_list_dict_representation():
     ld["executionStatus"].should.equal("OPEN")
     ld["execution"]["workflowId"].should.equal("ab1234")
     ld["execution"].should.contain("runId")
-    ld["cancelRequested"].should.be.false
+    ld["cancelRequested"].should.equal(False)
     ld.should.contain("startTimestamp")
 
 
@@ -282,7 +282,7 @@ def test_workflow_execution_fail():
 @freeze_time("2015-01-01 12:00:00")
 def test_workflow_execution_schedule_activity_task():
     wfe = make_workflow_execution()
-    wfe.latest_activity_task_timestamp.should.be.none
+    wfe.latest_activity_task_timestamp.should.equal(None)
 
     wfe.schedule_activity_task(123, VALID_ACTIVITY_TASK_ATTRIBUTES)
 

--- a/tests/test_swf/responses/test_activity_tasks.py
+++ b/tests/test_swf/responses/test_activity_tasks.py
@@ -29,7 +29,7 @@ def test_poll_for_activity_task_when_one_boto3():
         identity="surprise",
     )
     resp["activityId"].should.equal("my-activity-001")
-    resp["taskToken"].should_not.be.none
+    resp["taskToken"].should.match("[-a-z0-9]+")
 
     resp = client.get_workflow_execution_history(
         domain="test-domain",


### PR DESCRIPTION
The only functional change is that IOT now uses the proper account ID in the policy ARN's, instead of a `1`