### PR TITLE
Refer to correct black version

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,7 @@ You should be able to run `make init` to install the dependencies and then `make
 
 ## Linting
 
-Ensure that the correct version of black is installed - `black==19.10b0`. (Different versions of black will return different results.)  
+Ensure that the correct version of black is installed (see `requirements-dev.txt`). Different versions of black will return different results.  
 Run `make lint` to verify whether your code confirms to the guidelines.  
 Use `make format` to automatically format your code, if it does not conform to `black`'s rules.
 

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,8 @@ lint:
 	@echo "Running flake8..."
 	flake8 moto tests
 	@echo "Running black... "
-	@echo "(Make sure you have black-22.1.0 installed, as other versions will produce different results)"
+	$(eval black_version := $(shell grep -oP "(?<=black==).*" requirements-dev.txt))
+	@echo "(Make sure you have black-$(black_version) installed, as other versions will produce different results)"
 	black --check moto/ tests/
 	@echo "Running pylint..."
 	pylint -j 0 moto tests

--- a/docs/docs/contributing/faq.rst
+++ b/docs/docs/contributing/faq.rst
@@ -16,7 +16,8 @@ When running the linter...
 Why does black give different results?
 ****************************************
 Different versions of black produce different results.
-To ensure that our CI passes, please format the code using :bash:`black==19.10b0`.
+The CI system uses the version set in `requirements-dev.txt`.
+To ensure that our CI passes, please format the code using the same version.
 
 When running a test...
 #########################


### PR DESCRIPTION
The correct black version is the one in requirements-dev.txt.

Instead of keeping the docs and Makefile in sync they now point to the source of truth.