### PR TITLE
Autoscaling - pass BlockDeviceMapping from launch_config/launch_template

### DIFF
--- a/moto/autoscaling/responses.py
+++ b/moto/autoscaling/responses.py
@@ -20,22 +20,23 @@ class AutoScalingResponse(BaseResponse):
             instance_monitoring = True
         else:
             instance_monitoring = False
+        params = self._get_params()
         self.autoscaling_backend.create_launch_configuration(
-            name=self._get_param("LaunchConfigurationName"),
-            image_id=self._get_param("ImageId"),
-            key_name=self._get_param("KeyName"),
-            ramdisk_id=self._get_param("RamdiskId"),
-            kernel_id=self._get_param("KernelId"),
+            name=params.get("LaunchConfigurationName"),
+            image_id=params.get("ImageId"),
+            key_name=params.get("KeyName"),
+            ramdisk_id=params.get("RamdiskId"),
+            kernel_id=params.get("KernelId"),
             security_groups=self._get_multi_param("SecurityGroups.member"),
-            user_data=self._get_param("UserData"),
-            instance_type=self._get_param("InstanceType"),
+            user_data=params.get("UserData"),
+            instance_type=params.get("InstanceType"),
             instance_monitoring=instance_monitoring,
-            instance_profile_name=self._get_param("IamInstanceProfile"),
-            spot_price=self._get_param("SpotPrice"),
-            ebs_optimized=self._get_param("EbsOptimized"),
-            associate_public_ip_address=self._get_param("AssociatePublicIpAddress"),
-            block_device_mappings=self._get_list_prefix("BlockDeviceMappings.member"),
-            instance_id=self._get_param("InstanceId"),
+            instance_profile_name=params.get("IamInstanceProfile"),
+            spot_price=params.get("SpotPrice"),
+            ebs_optimized=params.get("EbsOptimized"),
+            associate_public_ip_address=params.get("AssociatePublicIpAddress"),
+            block_device_mappings=params.get("BlockDeviceMappings"),
+            instance_id=params.get("InstanceId"),
         )
         template = self.response_template(CREATE_LAUNCH_CONFIGURATION_TEMPLATE)
         return template.render()

--- a/moto/packages/boto/ec2/blockdevicemapping.py
+++ b/moto/packages/boto/ec2/blockdevicemapping.py
@@ -54,6 +54,7 @@ class BlockDeviceType(object):
         self.volume_type = volume_type
         self.iops = iops
         self.encrypted = encrypted
+        self.kms_key_id = None
 
 
 # for backwards compatibility
@@ -81,3 +82,18 @@ class BlockDeviceMapping(dict):
         self.connection = connection
         self.current_name = None
         self.current_value = None
+
+    def to_source_dict(self):
+        return [
+            {
+                "DeviceName": device_name,
+                "Ebs": {
+                    "DeleteOnTermination": block.delete_on_termination,
+                    "Encrypted": block.encrypted,
+                    "VolumeType": block.volume_type,
+                    "VolumeSize": block.size,
+                },
+                "VirtualName": block.ephemeral_name,
+            }
+            for device_name, block in self.items()
+        ]


### PR DESCRIPTION
Fixes #4718 

Changes the source format of BlockDeviceMappings, so we can refer to it as a dict, instead of reading `ebs._volume_type`
Change the EC2-logic to also look for BlockDevices in launch_config/launch_template
Also parse the VolumeType in EC2, as that was missing until now