### PR TITLE
fix(setup): install wheel to avoid setup errors

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ def get_version():
 
 
 install_requires = [
+    "wheel",
     "boto3>=1.9.201",
     "botocore>=1.12.201",
     "cryptography>=3.3.1",


### PR DESCRIPTION
Setup.py tries to install the following packages by building a wheel: sure,
regex, inflection, and future. Without the wheel package installed, each
installation fails with error because the bdist_wheel command is not found.

Fixes #5036.