### PR TITLE
Autoscaling - create custom BlockDevice in addition to default image block device

### DIFF
--- a/moto/ec2/_models/instances.py
+++ b/moto/ec2/_models/instances.py
@@ -557,6 +557,8 @@ class InstanceBackend(object):
             new_reservation.instances.append(new_instance)
             new_instance.add_tags(instance_tags)
             block_device_mappings = None
+            if "block_device_mappings" not in kwargs:
+                new_instance.setup_defaults()
             if "block_device_mappings" in kwargs:
                 block_device_mappings = kwargs["block_device_mappings"]
             elif kwargs.get("launch_template"):
@@ -590,8 +592,6 @@ class InstanceBackend(object):
                             kms_key_id,
                             volume_type=volume_type,
                         )
-            else:
-                new_instance.setup_defaults()
             if kwargs.get("instance_market_options"):
                 new_instance.lifecycle = "spot"
             # Tag all created volumes.

--- a/moto/ec2/exceptions.py
+++ b/moto/ec2/exceptions.py
@@ -258,6 +258,14 @@ class InvalidAMIIdError(EC2ClientError):
         )
 
 
+class UnvailableAMIIdError(EC2ClientError):
+    def __init__(self, ami_id):
+        super().__init__(
+            "InvalidAMIID.Unavailable",
+            "The image id '[{0}]' is no longer available".format(ami_id),
+        )
+
+
 class InvalidAMIAttributeItemValueError(EC2ClientError):
     def __init__(self, attribute, value):
         super().__init__(

--- a/moto/ec2/resources/amis.json
+++ b/moto/ec2/resources/amis.json
@@ -661,5 +661,22 @@
     "root_device_type": "ebs",
     "sriov": "simple",
     "virtualization_type": "hvm"
+  },
+  {
+    "architecture": "x86_64",
+    "ami_id": "ami-04681a1dbd79675b6",
+    "image_location": "amazon/amzn2-ami-minimal-pv-2.0.20180810-x86_64-gp2",
+    "image_type": "machine",
+    "public": true,
+    "owner_id": "137112412989",
+    "platform": "Linux/UNIX",
+    "state": "available",
+    "description": "Example InstanceStore AMI used by AutoScaling tests",
+    "hypervisor": "xen",
+    "name": "amzn-ami-minimal-pv-2.0.20180810-x86_64-gp2",
+    "root_device_name": "/dev/xvda",
+    "root_device_type": "instance-store",
+    "sriov": "simple",
+    "virtualization_type": "hvm"
   }
 ]

--- a/tests/terraformtests/terraform-tests.success.txt
+++ b/tests/terraformtests/terraform-tests.success.txt
@@ -8,8 +8,11 @@ apigatewayv2:
   - TestAccAPIGatewayV2RouteResponse
   - TestAccAPIGatewayV2VPCLink
 autoscaling:
-  - TestAccAutoScalingGroupDataSource
   - TestAccAutoScalingAttachment
+  - TestAccAutoScalingGroupDataSource
+  - TestAccAutoScalingGroupTag
+  - TestAccAutoScalingLaunchConfigurationDataSource
+  - TestAccAutoScalingLaunchConfiguration_
 batch:
   - TestAccBatchJobDefinition
 cloudtrail:

--- a/tests/test_autoscaling/test_autoscaling.py
+++ b/tests/test_autoscaling/test_autoscaling.py
@@ -2810,5 +2810,9 @@ def test_create_template_with_block_device():
     )
     ec2_client = boto3.client("ec2", region_name="ap-southeast-2")
     volumes = ec2_client.describe_volumes()["Volumes"]
-    volumes[0]["VolumeType"].should.equal("gp3")
-    volumes[0]["Size"].should.equal(20)
+    # The standard root volume
+    volumes[0]["VolumeType"].should.equal("gp2")
+    volumes[0]["Size"].should.equal(8)
+    # Our Ebs-volume
+    volumes[1]["VolumeType"].should.equal("gp3")
+    volumes[1]["Size"].should.equal(20)


### PR DESCRIPTION
 - BlockDeviceMappings defined in a launch config/launch template should be created in addition to the default block device that will be created for an instance.
   (This is a follow-up to #5044, where the user-defined mappings replaces the default device)
 - Adds the parameters ClassicLinkVPCId, ClassicLinkVPCSecurityGroups, MetadataOptions to the `create_launch_configuration` method
 - Fix the ARN creation for launch configurations
 - Persist the Throughput/Encrypted/NoDevice parameters when configuring BlockDeviceMappings

EC2 improvements:
 - Don't throw an error when describing an image that has been deleted recently (behaviour confirmed against AWS)
 - Deregistering the same image twice throws a custom error (behaviour confirmed against AWS)