### PR TITLE
events: delete_rule implementation update

### DIFF
--- a/moto/events/models.py
+++ b/moto/events/models.py
@@ -1045,7 +1045,11 @@ class EventsBackend(BaseBackend):
         return rule
 
     def delete_rule(self, name):
-        arn = self.rules.get(name).arn
+        rule = self.rules.get(name)
+        if len(rule.targets) > 0:
+            raise ValidationException("Rule can't be deleted since it has targets.")
+
+        arn = rule.arn
         if self.tagger.has_tags(arn):
             self.tagger.delete_all_tags_for_resource(arn)
         return self.rules.pop(name) is not None

--- a/tests/test_events/test_events.py
+++ b/tests/test_events/test_events.py
@@ -305,6 +305,7 @@ def test_delete_rule():
     rules = client.list_rules()
     assert len(rules["Rules"]) == len(RULES) - 1
 
+
 @mock_events
 def test_delete_rule_with_targets():
     # given

--- a/tests/test_events/test_events.py
+++ b/tests/test_events/test_events.py
@@ -299,13 +299,11 @@ def test_list_rule_names_by_target_using_limit():
 
 @mock_events
 def test_delete_rule():
-    client = boto3.client("events", "us-west-2")
-    client.put_rule(Name="test1", ScheduleExpression="rate(5 minutes)", EventPattern="")
+    client = generate_environment(add_targets=False)
 
-    client.delete_rule(Name="test1")
+    client.delete_rule(Name=RULES[0]["Name"])
     rules = client.list_rules()
-    assert len(rules["Rules"]) == 0
-
+    assert len(rules["Rules"]) == len(RULES) - 1
 
 @mock_events
 def test_delete_rule_with_targets():

--- a/tests/test_events/test_events.py
+++ b/tests/test_events/test_events.py
@@ -62,7 +62,7 @@ def get_random_rule():
     return RULES[random.randint(0, len(RULES) - 1)]
 
 
-def generate_environment():
+def generate_environment(add_targets=True):
     client = boto3.client("events", "us-west-2")
 
     for rule in RULES:
@@ -73,12 +73,13 @@ def generate_environment():
             Tags=rule.get("Tags", []),
         )
 
-        targets = []
-        for target in TARGETS:
-            if rule["Name"] in TARGETS[target].get("Rules"):
-                targets.append({"Id": target, "Arn": TARGETS[target]["Arn"]})
+        if add_targets:
+            targets = []
+            for target in TARGETS:
+                if rule["Name"] in TARGETS[target].get("Rules"):
+                    targets.append({"Id": target, "Arn": TARGETS[target]["Arn"]})
 
-        client.put_targets(Rule=rule["Name"], Targets=targets)
+            client.put_targets(Rule=rule["Name"], Targets=targets)
 
     return client
 
@@ -298,11 +299,31 @@ def test_list_rule_names_by_target_using_limit():
 
 @mock_events
 def test_delete_rule():
+    client = boto3.client("events", "us-west-2")
+    client.put_rule(Name="test1", ScheduleExpression="rate(5 minutes)", EventPattern="")
+
+    client.delete_rule(Name="test1")
+    rules = client.list_rules()
+    assert len(rules["Rules"]) == 0
+
+
+@mock_events
+def test_delete_rule_with_targets():
+    # given
     client = generate_environment()
 
-    client.delete_rule(Name=RULES[0]["Name"])
-    rules = client.list_rules()
-    assert len(rules["Rules"]) == len(RULES) - 1
+    # when
+    with pytest.raises(ClientError) as e:
+        client.delete_rule(Name=RULES[0]["Name"])
+
+    # then
+    ex = e.value
+    ex.operation_name.should.equal("DeleteRule")
+    ex.response["ResponseMetadata"]["HTTPStatusCode"].should.equal(400)
+    ex.response["Error"]["Code"].should.contain("ValidationException")
+    ex.response["Error"]["Message"].should.equal(
+        "Rule can't be deleted since it has targets."
+    )
 
 
 @mock_events
@@ -940,7 +961,7 @@ def test_create_rule_with_tags():
 
 @mock_events
 def test_delete_rule_with_tags():
-    client = generate_environment()
+    client = generate_environment(add_targets=False)
     rule_name = "test2"
     rule_arn = client.describe_rule(Name=rule_name).get("Arn")
     client.delete_rule(Name=rule_name)


### PR DESCRIPTION
events, delete_rule should throw a ValidationException when attempting to delete a rule which has targets. This PR adds an additional logic, one test case, and modifies two others tests.

The boto3 docs don't really outline this specific `ValidationException`, but they say "Before you can delete the rule, you must remove all targets, using RemoveTargets."

Through testing using my live account I found that it the API does raise a ValidationException with the string "Rule can't be deleted since it has targets."
