### PR TITLE
SQS - Accept queue-names as QueueUrl-parameter

### DIFF
--- a/moto/sqs/exceptions.py
+++ b/moto/sqs/exceptions.py
@@ -128,13 +128,3 @@ class OverLimit(RESTError):
         super().__init__(
             "OverLimit", "{} Actions were found, maximum allowed is 7.".format(count)
         )
-
-
-class InvalidAddress(RESTError):
-    code = 400
-
-    def __init__(self, address):
-        super().__init__(
-            "InvalidAddress",
-            "The address {} is not valid for this endpoint.".format(address),
-        )

--- a/moto/sqs/responses.py
+++ b/moto/sqs/responses.py
@@ -12,7 +12,6 @@ from urllib.parse import urlparse
 
 from .exceptions import (
     EmptyBatchRequest,
-    InvalidAddress,
     InvalidAttributeName,
     ReceiptHandleIsInvalid,
     BatchEntryIdsNotDistinct,
@@ -53,7 +52,8 @@ class SQSResponse(BaseResponse):
             if queue_url.startswith("http://") or queue_url.startswith("https://"):
                 return queue_url.split("/")[-1]
             else:
-                raise InvalidAddress(queue_url)
+                # The parameter could be the name itself, which AWS also accepts
+                return queue_url
         except TypeError:
             # Fallback to reading from the URL for botocore
             return self.path.split("/")[-1]

--- a/tests/test_sqs/test_sqs.py
+++ b/tests/test_sqs/test_sqs.py
@@ -3018,7 +3018,7 @@ def test_fifo_send_message_when_same_group_id_is_in_dlq():
 
 
 @mock_sqs
-def test_receive_message_should_not_accept_invalid_urls():
+def test_receive_message_using_name__should_return_name_as_url():
     sqs = boto3.resource("sqs", region_name="us-east-1")
     conn = boto3.client("sqs", region_name="us-east-1")
     name = str(uuid4())[0:6]
@@ -3029,17 +3029,10 @@ def test_receive_message_should_not_accept_invalid_urls():
     working_url.should.match(f"/{ACCOUNT_ID}/{name}")
 
     queue = sqs.Queue(name)
-    with pytest.raises(ClientError) as e:
-        queue.send_message(MessageBody="this is a test message")
-    err = e.value.response["Error"]
-    err["Code"].should.equal("InvalidAddress")
-    err["Message"].should.equal(f"The address {name} is not valid for this endpoint.")
+    queue.send_message(MessageBody="this is a test message")
 
-    with pytest.raises(ClientError) as e:
-        conn.receive_message(QueueUrl=name)
-    err = e.value.response["Error"]
-    err["Code"].should.equal("InvalidAddress")
-    err["Message"].should.equal(f"The address {name} is not valid for this endpoint.")
+    resp = queue.receive_messages()
+    resp[0].queue_url.should.equal(name)
 
 
 @mock_sqs


### PR DESCRIPTION
The validation that a queue name cannot be used for the QueueUrl-parameter was originally introduced in #3657.

As @paulmdavies correctly noticed, this validation does not (anymore?) appear in AWS, so this PR essentially reverts the behaviour.

Closes #5064 