### PR TITLE
upgrade black and unpin click

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,6 +3,7 @@
 
 black==22.3.0
 flake8==4.0.1
+click
 inflection
 lxml
 packaging

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,10 +1,8 @@
 -e .[all,server]
 -r requirements-tests.txt
 
-black==22.1.0
+black==22.3.0
 flake8==4.0.1
-# https://github.com/pallets/click/issues/2232
-click<8.1.0
 inflection
 lxml
 packaging


### PR DESCRIPTION
The upstream issue <https://github.com/pallets/click/issues/2232> has been solved.

We can upgrade `black` to the latest version and do not need to pin `click`'s version.