### PR TITLE
Support SES get_identity_verification_attributes

### DIFF
--- a/moto/ses/models.py
+++ b/moto/ses/models.py
@@ -523,5 +523,16 @@ class SESBackend(BaseBackend):
 
         return attributes_by_identity
 
+    def get_identity_verification_attributes(self, identities=None):
+        if identities is None:
+            identities = []
+
+        attributes_by_identity = {}
+        for identity in identities:
+            if identity in (self.domains + self.addresses):
+                attributes_by_identity[identity] = "Success"
+
+        return attributes_by_identity
+
 
 ses_backend = SESBackend()

--- a/moto/ses/responses.py
+++ b/moto/ses/responses.py
@@ -298,6 +298,16 @@ class EmailResponse(BaseResponse):
 
         return template.render(identities=identities)
 
+    def get_identity_verification_attributes(self):
+        params = self._get_params()
+        identities = params.get("Identities")
+        verification_attributes = ses_backend.get_identity_verification_attributes(
+            identities=identities,
+        )
+
+        template = self.response_template(GET_IDENTITY_VERIFICATION_ATTRIBUTES_TEMPLATE)
+        return template.render(verification_attributes=verification_attributes)
+
 
 VERIFY_EMAIL_IDENTITY = """<VerifyEmailIdentityResponse xmlns="http://ses.amazonaws.com/doc/2010-12-01/">
   <VerifyEmailIdentityResult/>
@@ -685,3 +695,22 @@ GET_IDENTITY_MAIL_FROM_DOMAIN_ATTRIBUTES = """<GetIdentityMailFromDomainAttribut
     <RequestId>47e0ef1a-9bf2-11e1-9279-0100e8cf109a</RequestId>
   </ResponseMetadata>
 </GetIdentityMailFromDomainAttributesResponse>"""
+
+GET_IDENTITY_VERIFICATION_ATTRIBUTES_TEMPLATE = """<GetIdentityVerificationAttributesResponse xmlns="http://ses.amazonaws.com/doc/2010-12-01/">
+  <GetIdentityVerificationAttributesResult>
+    <VerificationAttributes>
+      {% for name, value in verification_attributes.items() %}
+      <entry>
+        <key>{{ name }}</key>
+        <value>
+          <VerificationStatus>{{ value }}</VerificationStatus>
+          <VerificationToken>ILQMESfEW0p6i6gIJcEWvO65TP5hg6B99hGFZ2lxrIs=</VerificationToken>
+        </value>
+      </entry>
+      {% endfor %}
+    </VerificationAttributes>
+  </GetIdentityVerificationAttributesResult>
+  <ResponseMetadata>
+    <RequestId>d435c1b8-a225-4b89-acff-81fcf7ef9236</RequestId>
+  </ResponseMetadata>
+</GetIdentityVerificationAttributesResponse>"""

--- a/tests/test_ses/test_ses_boto3.py
+++ b/tests/test_ses/test_ses_boto3.py
@@ -1343,3 +1343,23 @@ def test_get_identity_mail_from_domain_attributes():
     attributes["MailFromDomainAttributes"].should.have.length_of(2)
     attributes["MailFromDomainAttributes"]["bar@foo.com"].should.have.length_of(1)
     attributes["MailFromDomainAttributes"]["lorem.com"].should.have.length_of(1)
+
+
+@mock_ses
+def test_get_identity_verification_attributes():
+    conn = boto3.client("ses", region_name="eu-central-1")
+
+    conn.verify_email_identity(EmailAddress="foo@bar.com")
+    conn.verify_domain_identity(Domain="foo.com")
+
+    attributes = conn.get_identity_verification_attributes(
+        Identities=["foo.com", "foo@bar.com", "bar@bar.com"]
+    )
+
+    attributes["VerificationAttributes"].should.have.length_of(2)
+    attributes["VerificationAttributes"]["foo.com"]["VerificationStatus"].should.equal(
+        "Success"
+    )
+    attributes["VerificationAttributes"]["foo@bar.com"][
+        "VerificationStatus"
+    ].should.equal("Success")


### PR DESCRIPTION
Adds the get_identity_verification_attributes API

I used the scripts to generate the code, the took the XML from a debug output of awscli.

I'm not too sure if this is all correct, however the test passes. 
I wasn't sure if there was a way of setting a status _other_ than Success, although I feel that might mean we would need to explicitly record/track other status separately from the core boto3 API?