### PR TITLE
EC2 SpotFleetRequests - support LaunchTemplates

### DIFF
--- a/moto/ec2/responses/elastic_block_store.py
+++ b/moto/ec2/responses/elastic_block_store.py
@@ -17,7 +17,7 @@ class ElasticBlockStore(EC2BaseResponse):
         source_snapshot_id = self._get_param("SourceSnapshotId")
         source_region = self._get_param("SourceRegion")
         description = self._get_param("Description")
-        tags = self._parse_tag_specification("TagSpecification")
+        tags = self._parse_tag_specification()
         snapshot_tags = tags.get("snapshot", {})
         if self.is_not_dryrun("CopySnapshot"):
             snapshot = self.ec2_backend.copy_snapshot(
@@ -30,7 +30,7 @@ class ElasticBlockStore(EC2BaseResponse):
     def create_snapshot(self):
         volume_id = self._get_param("VolumeId")
         description = self._get_param("Description")
-        tags = self._parse_tag_specification("TagSpecification")
+        tags = self._parse_tag_specification()
         snapshot_tags = tags.get("snapshot", {})
         if self.is_not_dryrun("CreateSnapshot"):
             snapshot = self.ec2_backend.create_snapshot(volume_id, description)
@@ -42,7 +42,7 @@ class ElasticBlockStore(EC2BaseResponse):
         params = self._get_params()
         instance_spec = params.get("InstanceSpecification")
         description = params.get("Description", "")
-        tags = self._parse_tag_specification("TagSpecification")
+        tags = self._parse_tag_specification()
         snapshot_tags = tags.get("snapshot", {})
 
         if self.is_not_dryrun("CreateSnapshots"):
@@ -57,7 +57,7 @@ class ElasticBlockStore(EC2BaseResponse):
         zone = self._get_param("AvailabilityZone")
         snapshot_id = self._get_param("SnapshotId")
         volume_type = self._get_param("VolumeType")
-        tags = self._parse_tag_specification("TagSpecification")
+        tags = self._parse_tag_specification()
         volume_tags = tags.get("volume", {})
         encrypted = self._get_bool_param("Encrypted", if_none=False)
         kms_key_id = self._get_param("KmsKeyId")

--- a/moto/ec2/responses/flow_logs.py
+++ b/moto/ec2/responses/flow_logs.py
@@ -15,7 +15,7 @@ class FlowLogs(EC2BaseResponse):
         max_aggregation_interval = self._get_param("MaxAggregationInterval")
         validate_resource_ids(resource_ids)
 
-        tags = self._parse_tag_specification("TagSpecification")
+        tags = self._parse_tag_specification()
         tags = tags.get("vpc-flow-log", {})
         if self.is_not_dryrun("CreateFlowLogs"):
             flow_logs, errors = self.ec2_backend.create_flow_logs(

--- a/moto/ec2/responses/instances.py
+++ b/moto/ec2/responses/instances.py
@@ -58,7 +58,7 @@ class InstanceResponse(EC2BaseResponse):
             "nics": self._get_multi_param("NetworkInterface."),
             "private_ip": self._get_param("PrivateIpAddress"),
             "associate_public_ip": self._get_param("AssociatePublicIpAddress"),
-            "tags": self._parse_tag_specification("TagSpecification"),
+            "tags": self._parse_tag_specification(),
             "ebs_optimized": self._get_param("EbsOptimized") or False,
             "instance_market_options": self._get_param(
                 "InstanceMarketOptions.MarketType"

--- a/moto/ec2/responses/launch_templates.py
+++ b/moto/ec2/responses/launch_templates.py
@@ -94,7 +94,7 @@ class LaunchTemplates(EC2BaseResponse):
     def create_launch_template(self):
         name = self._get_param("LaunchTemplateName")
         version_description = self._get_param("VersionDescription")
-        tag_spec = self._parse_tag_specification("TagSpecification")
+        tag_spec = self._parse_tag_specification()
 
         raw_template_data = self._get_dict_param("LaunchTemplateData.")
         parsed_template_data = parse_object(raw_template_data)

--- a/moto/ec2/responses/spot_fleets.py
+++ b/moto/ec2/responses/spot_fleets.py
@@ -42,14 +42,18 @@ class SpotFleets(BaseResponse):
         return template.render(successful=successful)
 
     def request_spot_fleet(self):
-        spot_config = self._get_dict_param("SpotFleetRequestConfig.")
-        spot_price = spot_config.get("spot_price")
-        target_capacity = spot_config["target_capacity"]
-        iam_fleet_role = spot_config["iam_fleet_role"]
-        allocation_strategy = spot_config["allocation_strategy"]
+        spot_config = self._get_multi_param_dict("SpotFleetRequestConfig")
+        spot_price = spot_config.get("SpotPrice")
+        target_capacity = spot_config["TargetCapacity"]
+        iam_fleet_role = spot_config["IamFleetRole"]
+        allocation_strategy = spot_config["AllocationStrategy"]
 
-        launch_specs = self._get_list_prefix(
-            "SpotFleetRequestConfig.LaunchSpecifications"
+        launch_specs = spot_config.get("LaunchSpecifications")
+        launch_template_config = list(
+            self._get_params()
+            .get("SpotFleetRequestConfig", {})
+            .get("LaunchTemplateConfigs", {})
+            .values()
         )
 
         request = self.ec2_backend.request_spot_fleet(
@@ -58,6 +62,7 @@ class SpotFleets(BaseResponse):
             iam_fleet_role=iam_fleet_role,
             allocation_strategy=allocation_strategy,
             launch_specs=launch_specs,
+            launch_template_config=launch_template_config,
         )
 
         template = self.response_template(REQUEST_SPOT_FLEET_TEMPLATE)


### PR DESCRIPTION
Supports the `LaunchTemplateConfigs`-parameter in EC2:request_spot_fleet

Also refactors and simplifies the Tag-extraction across EC2 to make it more readable, but without any functional changes.

Closes #4746 