### PR TITLE
EC2 - Spot Requests improvements

### DIFF
--- a/moto/ec2/_models/instances.py
+++ b/moto/ec2/_models/instances.py
@@ -99,8 +99,8 @@ class Instance(TaggedEC2Resource, BotoInstance, CloudFormationModel):
         self.launch_time = utc_date_and_time()
         self.ami_launch_index = kwargs.get("ami_launch_index", 0)
         self.disable_api_termination = kwargs.get("disable_api_termination", False)
-        self.instance_initiated_shutdown_behavior = kwargs.get(
-            "instance_initiated_shutdown_behavior", "stop"
+        self.instance_initiated_shutdown_behavior = (
+            kwargs.get("instance_initiated_shutdown_behavior") or "stop"
         )
         self.sriov_net_support = "simple"
         self._spot_fleet_id = kwargs.get("spot_fleet_id", None)

--- a/moto/ec2/responses/spot_fleets.py
+++ b/moto/ec2/responses/spot_fleets.py
@@ -47,6 +47,9 @@ class SpotFleets(BaseResponse):
         target_capacity = spot_config["TargetCapacity"]
         iam_fleet_role = spot_config["IamFleetRole"]
         allocation_strategy = spot_config["AllocationStrategy"]
+        instance_interruption_behaviour = spot_config.get(
+            "InstanceInterruptionBehavior"
+        )
 
         launch_specs = spot_config.get("LaunchSpecifications")
         launch_template_config = list(
@@ -63,6 +66,7 @@ class SpotFleets(BaseResponse):
             allocation_strategy=allocation_strategy,
             launch_specs=launch_specs,
             launch_template_config=launch_template_config,
+            instance_interruption_behaviour=instance_interruption_behaviour,
         )
 
         template = self.response_template(REQUEST_SPOT_FLEET_TEMPLATE)

--- a/tests/terraformtests/etc/0002-EC2-reduce-wait-times.patch
+++ b/tests/terraformtests/etc/0002-EC2-reduce-wait-times.patch
@@ -342,7 +342,7 @@ index 49e4909b3a..731a37f253 100644
  		Timeouts: &schema.ResourceTimeout{
 -			Create: schema.DefaultTimeout(10 * time.Minute),
 -			Delete: schema.DefaultTimeout(15 * time.Minute),
-+			Create: schema.DefaultTimeout(10 * time.Second),
++			Create: schema.DefaultTimeout(20 * time.Second),
 +			Delete: schema.DefaultTimeout(15 * time.Second),
  		},
  
@@ -366,7 +366,7 @@ index e054f82987..08aeb6cf70 100644
  		Timeouts: &schema.ResourceTimeout{
 -			Create: schema.DefaultTimeout(10 * time.Minute),
 -			Delete: schema.DefaultTimeout(20 * time.Minute),
-+			Create: schema.DefaultTimeout(10 * time.Second),
++			Create: schema.DefaultTimeout(20 * time.Second),
 +			Delete: schema.DefaultTimeout(20 * time.Second),
  		},
  

--- a/tests/terraformtests/terraform-tests.success.txt
+++ b/tests/terraformtests/terraform-tests.success.txt
@@ -39,6 +39,8 @@ ec2:
   - TestAccEC2InternetGateway_
   - TestAccEC2NATGateway_
   - TestAccEC2RouteTableAssociation_
+  - TestAccEC2SpotInstanceRequest_disappears
+  - TestAccEC2SpotInstanceRequest_interruptUpdate
   - TestAccEC2VPCEndpointService_
   - TestAccEC2VPNGateway_
   - TestAccEC2VPNGatewayAttachment_


### PR DESCRIPTION
EC2:request_spot_fleet now supports the InstanceInterruptionBehavior-parameter
EC2:request_spot_instances now supports the InstanceInterruptionBehavior-parameter
EC2:request_spot_fleet now properly formats the spot price to 6 digits
The status of a spot instances request now automatically transitions to 'active/fulfilled'

All behaviour has been verified against Terraform tests

Closes #2625