### PR TITLE
Bugfix/mediaconnect create flow include source ingest ip

### DIFF
--- a/moto/mediaconnect/models.py
+++ b/moto/mediaconnect/models.py
@@ -78,6 +78,15 @@ class MediaConnectBackend(BaseBackend):
         self._flows = OrderedDict()
         self._resources = OrderedDict()
 
+    def _add_source_details(self, source, flow_id):
+        source_name = source.get("name")
+        if isinstance(source, dict) and source_name:
+            source[
+                "sourceArn"
+            ] = f"arn:aws:mediaconnect:{self.region_name}:{ACCOUNT_ID}:source:{flow_id}:{source_name}"
+            if not source.get("EntitlementArn"):
+                source["IngestIp"] = "127.0.0.1"
+
     def reset(self):
         region_name = self.region_name
         self.__dict__ = {}
@@ -95,11 +104,9 @@ class MediaConnectBackend(BaseBackend):
         vpc_interfaces,
     ):
         flow_id = uuid4().hex
-        source_name = source.get("name")
-        if isinstance(source, dict) and source_name:
-            source[
-                "sourceArn"
-            ] = f"arn:aws:mediaconnect:{self.region_name}:{ACCOUNT_ID}:source:{flow_id}:{source_name}"
+        self._add_source_details(source, flow_id)
+        for _source in sources:
+            self._add_source_details(_source, flow_id)
         flow = Flow(
             availability_zone=availability_zone,
             entitlements=entitlements,

--- a/moto/mediaconnect/models.py
+++ b/moto/mediaconnect/models.py
@@ -78,14 +78,28 @@ class MediaConnectBackend(BaseBackend):
         self._flows = OrderedDict()
         self._resources = OrderedDict()
 
-    def _add_source_details(self, source, flow_id):
-        source_name = source.get("name")
-        if isinstance(source, dict) and source_name:
-            source[
-                "sourceArn"
-            ] = f"arn:aws:mediaconnect:{self.region_name}:{ACCOUNT_ID}:source:{flow_id}:{source_name}"
-            if not source.get("EntitlementArn"):
-                source["IngestIp"] = "127.0.0.1"
+    def _add_source_details(self, source, flow_id, ingest_ip="127.0.0.1"):
+        if source:
+            source["sourceArn"] = (
+                f"arn:aws:mediaconnect:{self.region_name}:{ACCOUNT_ID}:source"
+                f":{flow_id}:{source['name']}"
+            )
+            if not source.get("entitlementArn"):
+                source["ingestIp"] = ingest_ip
+
+    def _create_flow_add_details(self, flow):
+        flow_id = uuid4().hex
+
+        flow.description = "A Moto test flow"
+        flow.egress_ip = "127.0.0.1"
+        flow.flow_arn = f"arn:aws:mediaconnect:{self.region_name}:{ACCOUNT_ID}:flow:{flow_id}:{flow.name}"
+
+        for index, _source in enumerate(flow.sources):
+            self._add_source_details(_source, flow_id, f"127.0.0.{index}")
+
+        for index, output in enumerate(flow.outputs):
+            if output.get("protocol") in ["srt-listener", "zixi-pull"]:
+                output["listenerAddress"] = f"{index}.0.0.0"
 
     def reset(self):
         region_name = self.region_name
@@ -103,10 +117,6 @@ class MediaConnectBackend(BaseBackend):
         sources,
         vpc_interfaces,
     ):
-        flow_id = uuid4().hex
-        self._add_source_details(source, flow_id)
-        for _source in sources:
-            self._add_source_details(_source, flow_id)
         flow = Flow(
             availability_zone=availability_zone,
             entitlements=entitlements,
@@ -117,9 +127,7 @@ class MediaConnectBackend(BaseBackend):
             sources=sources,
             vpc_interfaces=vpc_interfaces,
         )
-        flow.description = "A Moto test flow"
-        flow.egress_ip = "127.0.0.1"
-        flow.flow_arn = f"arn:aws:mediaconnect:{self.region_name}:{ACCOUNT_ID}:flow:{flow_id}:{name}"
+        self._create_flow_add_details(flow)
         self._flows[flow.flow_arn] = flow
         return flow
 

--- a/moto/mediaconnect/responses.py
+++ b/moto/mediaconnect/responses.py
@@ -18,9 +18,6 @@ class MediaConnectResponse(BaseResponse):
         entitlements = self._get_param("entitlements")
         name = self._get_param("name")
         outputs = self._get_param("outputs")
-        for index, output in enumerate(outputs):
-            if output.get("protocol") in ["srt-listener", "zixi-pull"]:
-                output["listenerAddress"] = f"{index}.0.0.0"
         source = self._get_param("source")
         source_failover_config = self._get_param("sourceFailoverConfig")
         sources = self._get_param("sources")

--- a/tests/test_mediaconnect/test_mediaconnect.py
+++ b/tests/test_mediaconnect/test_mediaconnect.py
@@ -223,7 +223,9 @@ def test_add_flow_vpc_interfaces_fails():
         client.add_flow_vpc_interfaces(FlowArn=flow_arn, VpcInterfaces=[])
     err = err.value.response["Error"]
     err["Code"].should.equal("NotFoundException")
-    err["Message"].should.equal("flow with arn=unknown-flow not found")
+    err["Message"].should.equal(
+        "flow with arn=unknown-flow not found".format(str(flow_arn))
+    )
 
 
 @mock_mediaconnect
@@ -268,7 +270,9 @@ def test_remove_flow_vpc_interface_fails():
         )
     err = err.value.response["Error"]
     err["Code"].should.equal("NotFoundException")
-    err["Message"].should.equal("flow with arn=unknown-flow not found")
+    err["Message"].should.equal(
+        "flow with arn=unknown-flow not found".format(str(flow_arn))
+    )
 
 
 @mock_mediaconnect
@@ -303,7 +307,9 @@ def test_add_flow_outputs_fails():
         client.add_flow_outputs(FlowArn=flow_arn, Outputs=[])
     err = err.value.response["Error"]
     err["Code"].should.equal("NotFoundException")
-    err["Message"].should.equal("flow with arn=unknown-flow not found")
+    err["Message"].should.equal(
+        "flow with arn=unknown-flow not found".format(str(flow_arn))
+    )
 
 
 @mock_mediaconnect
@@ -315,7 +321,9 @@ def test_remove_flow_output_fails():
         client.remove_flow_output(FlowArn=flow_arn, OutputArn=output_arn)
     err = err.value.response["Error"]
     err["Code"].should.equal("NotFoundException")
-    err["Message"].should.equal("flow with arn=unknown-flow not found")
+    err["Message"].should.equal(
+        "flow with arn=unknown-flow not found".format(str(flow_arn))
+    )
 
 
 @mock_mediaconnect

--- a/tests/test_mediaconnect/test_mediaconnect.py
+++ b/tests/test_mediaconnect/test_mediaconnect.py
@@ -223,9 +223,7 @@ def test_add_flow_vpc_interfaces_fails():
         client.add_flow_vpc_interfaces(FlowArn=flow_arn, VpcInterfaces=[])
     err = err.value.response["Error"]
     err["Code"].should.equal("NotFoundException")
-    err["Message"].should.equal(
-        "flow with arn=unknown-flow not found".format(str(flow_arn))
-    )
+    err["Message"].should.equal("flow with arn=unknown-flow not found")
 
 
 @mock_mediaconnect
@@ -270,9 +268,7 @@ def test_remove_flow_vpc_interface_fails():
         )
     err = err.value.response["Error"]
     err["Code"].should.equal("NotFoundException")
-    err["Message"].should.equal(
-        "flow with arn=unknown-flow not found".format(str(flow_arn))
-    )
+    err["Message"].should.equal("flow with arn=unknown-flow not found")
 
 
 @mock_mediaconnect
@@ -307,9 +303,7 @@ def test_add_flow_outputs_fails():
         client.add_flow_outputs(FlowArn=flow_arn, Outputs=[])
     err = err.value.response["Error"]
     err["Code"].should.equal("NotFoundException")
-    err["Message"].should.equal(
-        "flow with arn=unknown-flow not found".format(str(flow_arn))
-    )
+    err["Message"].should.equal("flow with arn=unknown-flow not found")
 
 
 @mock_mediaconnect
@@ -321,9 +315,7 @@ def test_remove_flow_output_fails():
         client.remove_flow_output(FlowArn=flow_arn, OutputArn=output_arn)
     err = err.value.response["Error"]
     err["Code"].should.equal("NotFoundException")
-    err["Message"].should.equal(
-        "flow with arn=unknown-flow not found".format(str(flow_arn))
-    )
+    err["Message"].should.equal("flow with arn=unknown-flow not found")
 
 
 @mock_mediaconnect


### PR DESCRIPTION
mediaconnect:
- Adding "ingestIp" to non entitlement flow sources on "create_flow"
- moving flow outputs "listenerAddress" update so that it doesn't error when "outputs" argument isn't passed to "create_flow" method
- moving all "create_flow" flow updates to their own function to keep them all in one place