### PR TITLE
Databrew: add recipe version support

### DIFF
--- a/IMPLEMENTATION_COVERAGE.md
+++ b/IMPLEMENTATION_COVERAGE.md
@@ -1069,7 +1069,7 @@
 
 ## databrew
 <details>
-<summary>15% implemented</summary>
+<summary>22% implemented</summary>
 
 - [ ] batch_delete_recipe_version
 - [ ] create_dataset
@@ -1082,26 +1082,26 @@
 - [ ] delete_dataset
 - [ ] delete_job
 - [ ] delete_project
-- [ ] delete_recipe_version
+- [X] delete_recipe_version
 - [X] delete_ruleset
 - [ ] delete_schedule
 - [ ] describe_dataset
 - [ ] describe_job
 - [ ] describe_job_run
 - [ ] describe_project
-- [ ] describe_recipe
+- [X] describe_recipe
 - [ ] describe_ruleset
 - [ ] describe_schedule
 - [ ] list_datasets
 - [ ] list_job_runs
 - [ ] list_jobs
 - [ ] list_projects
-- [ ] list_recipe_versions
+- [X] list_recipe_versions
 - [X] list_recipes
 - [X] list_rulesets
 - [ ] list_schedules
 - [ ] list_tags_for_resource
-- [ ] publish_recipe
+- [X] publish_recipe
 - [ ] send_project_session_action
 - [ ] start_job_run
 - [ ] start_project_session

--- a/docs/docs/services/databrew.rst
+++ b/docs/docs/services/databrew.rst
@@ -36,26 +36,26 @@ databrew
 - [ ] delete_dataset
 - [ ] delete_job
 - [ ] delete_project
-- [ ] delete_recipe_version
+- [X] delete_recipe_version
 - [X] delete_ruleset
 - [ ] delete_schedule
 - [ ] describe_dataset
 - [ ] describe_job
 - [ ] describe_job_run
 - [ ] describe_project
-- [ ] describe_recipe
+- [X] describe_recipe
 - [ ] describe_ruleset
 - [ ] describe_schedule
 - [ ] list_datasets
 - [ ] list_job_runs
 - [ ] list_jobs
 - [ ] list_projects
-- [ ] list_recipe_versions
+- [X] list_recipe_versions
 - [X] list_recipes
 - [X] list_rulesets
 - [ ] list_schedules
 - [ ] list_tags_for_resource
-- [ ] publish_recipe
+- [X] publish_recipe
 - [ ] send_project_session_action
 - [ ] start_job_run
 - [ ] start_project_session

--- a/moto/databrew/exceptions.py
+++ b/moto/databrew/exceptions.py
@@ -18,7 +18,6 @@ class ConflictException(DataBrewClientError):
 
 
 class ValidationException(DataBrewClientError):
-
     def __init__(self, message, **kwargs):
         super().__init__("ValidationException", message, **kwargs)
 

--- a/moto/databrew/exceptions.py
+++ b/moto/databrew/exceptions.py
@@ -22,6 +22,7 @@ class ValidationException(DataBrewClientError):
     def __init__(self, message, **kwargs):
         super().__init__("ValidationException", message, **kwargs)
 
+
 class RulesetAlreadyExistsException(AlreadyExistsException):
     def __init__(self):
         super().__init__("Ruleset")
@@ -35,7 +36,7 @@ class EntityNotFoundException(DataBrewClientError):
 class ResourceNotFoundException(DataBrewClientError):
     code = 404
 
-    def __init__(self, message):
+    def __init__(self, message, **kwargs):
         super().__init__("ResourceNotFoundException", message, **kwargs)
 
 

--- a/moto/databrew/exceptions.py
+++ b/moto/databrew/exceptions.py
@@ -10,10 +10,17 @@ class AlreadyExistsException(DataBrewClientError):
         super().__init__("AlreadyExistsException", "%s already exists." % (typ))
 
 
-class RecipeAlreadyExistsException(AlreadyExistsException):
-    def __init__(self):
-        super().__init__("Recipe")
+class ConflictException(DataBrewClientError):
+    code = 409
 
+    def __init__(self, message, **kwargs):
+        super().__init__("ConflictException", message, **kwargs)
+
+
+class ValidationException(DataBrewClientError):
+
+    def __init__(self, message, **kwargs):
+        super().__init__("ValidationException", message, **kwargs)
 
 class RulesetAlreadyExistsException(AlreadyExistsException):
     def __init__(self):
@@ -25,9 +32,11 @@ class EntityNotFoundException(DataBrewClientError):
         super().__init__("EntityNotFoundException", msg)
 
 
-class RecipeNotFoundException(EntityNotFoundException):
-    def __init__(self, recipe_name):
-        super().__init__("Recipe %s not found." % recipe_name)
+class ResourceNotFoundException(DataBrewClientError):
+    code = 404
+
+    def __init__(self, message):
+        super().__init__("ResourceNotFoundException", message, **kwargs)
 
 
 class RulesetNotFoundException(EntityNotFoundException):

--- a/moto/databrew/models.py
+++ b/moto/databrew/models.py
@@ -133,14 +133,11 @@ class DataBrewBackend(BaseBackend):
 
         latest_working = recipe.latest_working
 
-        recipe_versions = (
-            [
-                recipe_version if recipe_version is not latest_working else None
-                for recipe_version in recipe.versions.values()
-            ]
-            if recipe
-            else []
-        )
+        recipe_versions = [
+            recipe_version
+            for recipe_version in recipe.versions.values()
+            if recipe_version is not latest_working
+        ]
         return [r for r in recipe_versions if r is not None]
 
     def get_recipe(self, recipe_name, recipe_version=None):

--- a/moto/databrew/responses.py
+++ b/moto/databrew/responses.py
@@ -104,6 +104,7 @@ class DataBrewResponse(BaseResponse):
         return 200, {}, json.dumps({"Name": recipe_name})
 
     def get_recipe_response(self, recipe_name):
+        # https://docs.aws.amazon.com/databrew/latest/dg/API_DescribeRecipe.html
         recipe_version = self._get_param("RecipeVersion", self._get_param("recipeVersion"))
         recipe = self.databrew_backend.get_recipe(recipe_name, recipe_version=recipe_version)
         return 200, {}, json.dumps(recipe.as_dict())

--- a/moto/databrew/responses.py
+++ b/moto/databrew/responses.py
@@ -32,16 +32,29 @@ class DataBrewResponse(BaseResponse):
         )
 
     @amzn_request_id
+    def delete_recipe_version(self, request, full_url, headers):
+        self.setup_class(request, full_url, headers)
+        # https://docs.aws.amazon.com/databrew/latest/dg/API_DeleteRecipeVersion.html
+        if request.method == "DELETE":
+            parsed_url = urlparse(full_url)
+            split_path = parsed_url.path.strip("/").split("/")
+            recipe_name = split_path[1]
+            recipe_version = split_path[3]
+            self.databrew_backend.delete_recipe_version(recipe_name, recipe_version)
+            return 200, {}, json.dumps({"Name": recipe_name, "RecipeVersion": recipe_version})
+
+    @amzn_request_id
     def list_recipes(self):
         # https://docs.aws.amazon.com/databrew/latest/dg/API_ListRecipes.html
         next_token = self._get_param("NextToken", self._get_param("nextToken"))
         max_results = self._get_int_param(
             "MaxResults", self._get_int_param("maxResults")
         )
+        recipe_version = self._get_param("RecipeVersion", self._get_param("recipeVersion"))
 
         # pylint: disable=unexpected-keyword-arg, unbalanced-tuple-unpacking
         recipe_list, next_token = self.databrew_backend.list_recipes(
-            next_token=next_token, max_results=max_results
+            next_token=next_token, max_results=max_results, recipe_version=recipe_version
         )
         return json.dumps(
             {
@@ -50,19 +63,50 @@ class DataBrewResponse(BaseResponse):
             }
         )
 
+    @amzn_request_id
+    def list_recipe_versions(self):
+        # https://docs.aws.amazon.com/databrew/latest/dg/API_ListRecipeVersions.html
+        recipe_name = self._get_param("Name")
+        next_token = self._get_param("NextToken", self._get_param("nextToken"))
+        max_results = self._get_int_param(
+            "MaxResults", self._get_int_param("maxResults")
+        )
+
+        # pylint: disable=unexpected-keyword-arg, unbalanced-tuple-unpacking
+        recipe_list, next_token = self.databrew_backend.list_recipe_versions(
+            recipe_name=recipe_name, next_token=next_token, max_results=max_results
+        )
+        return json.dumps(
+            {
+                "Recipes": [recipe.as_dict() for recipe in recipe_list],
+                "NextToken": next_token,
+            }
+        )
+
+    @amzn_request_id
+    def publish_recipe(self, request, full_url, headers):
+        self.setup_class(request, full_url, headers)
+        if request.method == "POST":
+            parsed_url = urlparse(full_url)
+            recipe_name = parsed_url.path.strip("/").split("/", 2)[1]
+            recipe_description = self.parameters.get("Description")
+            self.databrew_backend.publish_recipe(recipe_name, recipe_description)
+            return 200, {}, json.dumps({"Name": recipe_name})
+
     def put_recipe_response(self, recipe_name):
         recipe_description = self.parameters.get("Description")
         recipe_steps = self.parameters.get("Steps")
         tags = self.parameters.get("Tags")
 
-        recipe = self.databrew_backend.update_recipe(
+        self.databrew_backend.update_recipe(
             recipe_name, recipe_description, recipe_steps, tags
         )
-        return 200, {}, json.dumps(recipe.as_dict())
+        return 200, {}, json.dumps({"Name": recipe_name})
 
     def get_recipe_response(self, recipe_name):
-        recipe = self.databrew_backend.get_recipe(recipe_name)
-        return 201, {}, json.dumps(recipe.as_dict())
+        recipe_version = self._get_param("RecipeVersion", self._get_param("recipeVersion"))
+        recipe = self.databrew_backend.get_recipe(recipe_name, recipe_version=recipe_version)
+        return 200, {}, json.dumps(recipe.as_dict())
 
     @amzn_request_id
     def recipe_response(self, request, full_url, headers):

--- a/moto/databrew/responses.py
+++ b/moto/databrew/responses.py
@@ -41,7 +41,11 @@ class DataBrewResponse(BaseResponse):
             recipe_name = split_path[1]
             recipe_version = split_path[3]
             self.databrew_backend.delete_recipe_version(recipe_name, recipe_version)
-            return 200, {}, json.dumps({"Name": recipe_name, "RecipeVersion": recipe_version})
+            return (
+                200,
+                {},
+                json.dumps({"Name": recipe_name, "RecipeVersion": recipe_version}),
+            )
 
     @amzn_request_id
     def list_recipes(self):
@@ -50,11 +54,15 @@ class DataBrewResponse(BaseResponse):
         max_results = self._get_int_param(
             "MaxResults", self._get_int_param("maxResults")
         )
-        recipe_version = self._get_param("RecipeVersion", self._get_param("recipeVersion"))
+        recipe_version = self._get_param(
+            "RecipeVersion", self._get_param("recipeVersion")
+        )
 
         # pylint: disable=unexpected-keyword-arg, unbalanced-tuple-unpacking
         recipe_list, next_token = self.databrew_backend.list_recipes(
-            next_token=next_token, max_results=max_results, recipe_version=recipe_version
+            next_token=next_token,
+            max_results=max_results,
+            recipe_version=recipe_version,
         )
         return json.dumps(
             {
@@ -105,8 +113,12 @@ class DataBrewResponse(BaseResponse):
 
     def get_recipe_response(self, recipe_name):
         # https://docs.aws.amazon.com/databrew/latest/dg/API_DescribeRecipe.html
-        recipe_version = self._get_param("RecipeVersion", self._get_param("recipeVersion"))
-        recipe = self.databrew_backend.get_recipe(recipe_name, recipe_version=recipe_version)
+        recipe_version = self._get_param(
+            "RecipeVersion", self._get_param("recipeVersion")
+        )
+        recipe = self.databrew_backend.get_recipe(
+            recipe_name, recipe_version=recipe_version
+        )
         return 200, {}, json.dumps(recipe.as_dict())
 
     @amzn_request_id

--- a/moto/databrew/responses.py
+++ b/moto/databrew/responses.py
@@ -64,9 +64,10 @@ class DataBrewResponse(BaseResponse):
         )
 
     @amzn_request_id
-    def list_recipe_versions(self):
+    def list_recipe_versions(self, request, full_url, headers):
         # https://docs.aws.amazon.com/databrew/latest/dg/API_ListRecipeVersions.html
-        recipe_name = self._get_param("Name")
+        self.setup_class(request, full_url, headers)
+        recipe_name = self._get_param("Name", self._get_param("name"))
         next_token = self._get_param("NextToken", self._get_param("nextToken"))
         max_results = self._get_int_param(
             "MaxResults", self._get_int_param("maxResults")
@@ -96,10 +97,9 @@ class DataBrewResponse(BaseResponse):
     def put_recipe_response(self, recipe_name):
         recipe_description = self.parameters.get("Description")
         recipe_steps = self.parameters.get("Steps")
-        tags = self.parameters.get("Tags")
 
         self.databrew_backend.update_recipe(
-            recipe_name, recipe_description, recipe_steps, tags
+            recipe_name, recipe_description, recipe_steps
         )
         return 200, {}, json.dumps({"Name": recipe_name})
 

--- a/moto/databrew/urls.py
+++ b/moto/databrew/urls.py
@@ -3,8 +3,11 @@ from .responses import DataBrewResponse
 url_bases = [r"https?://databrew\.(.+)\.amazonaws.com"]
 
 url_paths = {
+    "{0}/recipeVersions$": DataBrewResponse().list_recipe_versions,
     "{0}/recipes$": DataBrewResponse.dispatch,
     "{0}/recipes/(?P<recipe_name>[^/]+)$": DataBrewResponse().recipe_response,
+    "{0}/recipes/(?P<recipe_name>[^/]+)/recipeVersion/(?P<recipe_version>[^/]+)": DataBrewResponse().delete_recipe_version,
+    "{0}/recipes/(?P<recipe_name>[^/]+)/publishRecipe$": DataBrewResponse().publish_recipe,
     "{0}/rulesets$": DataBrewResponse.dispatch,
     "{0}/rulesets/(?P<ruleset_name>[^/]+)$": DataBrewResponse().ruleset_response,
 }

--- a/tests/test_databrew/test_databrew_recipes.py
+++ b/tests/test_databrew/test_databrew_recipes.py
@@ -63,7 +63,7 @@ def test_list_recipes_with_max_results():
     client = _create_databrew_client()
 
     _create_test_recipes(client, 4)
-    response = client.list_recipes(MaxResults=2)
+    response = client.list_recipes(MaxResults=2, RecipeVersion='LATEST_WORKING')
     response["Recipes"].should.have.length_of(2)
     response.should.have.key("NextToken")
 
@@ -72,8 +72,8 @@ def test_list_recipes_with_max_results():
 def test_list_recipes_from_next_token():
     client = _create_databrew_client()
     _create_test_recipes(client, 10)
-    first_response = client.list_recipes(MaxResults=3)
-    response = client.list_recipes(NextToken=first_response["NextToken"])
+    first_response = client.list_recipes(MaxResults=3, RecipeVersion='LATEST_WORKING')
+    response = client.list_recipes(NextToken=first_response["NextToken"], RecipeVersion='LATEST_WORKING')
     response["Recipes"].should.have.length_of(7)
 
 
@@ -81,7 +81,7 @@ def test_list_recipes_from_next_token():
 def test_list_recipes_with_max_results_greater_than_actual_results():
     client = _create_databrew_client()
     _create_test_recipes(client, 4)
-    response = client.list_recipes(MaxResults=10)
+    response = client.list_recipes(MaxResults=10, RecipeVersion='LATEST_WORKING')
     response["Recipes"].should.have.length_of(4)
 
 
@@ -90,7 +90,7 @@ def test_describe_recipe():
     client = _create_databrew_client()
     response = _create_test_recipe(client)
 
-    recipe = client.describe_recipe(Name=response["Name"])
+    recipe = client.describe_recipe(Name=response["Name"], RecipeVersion='LATEST_WORKING')
 
     recipe["Name"].should.equal(response["Name"])
     recipe["Steps"].should.have.length_of(1)
@@ -130,7 +130,7 @@ def test_update_recipe():
     recipe["Name"].should.equal(response["Name"])
 
     # Describe the recipe and change the changes
-    recipe = client.describe_recipe(Name=response["Name"])
+    recipe = client.describe_recipe(Name=response["Name"], RecipeVersion='LATEST_WORKING')
     recipe["Name"].should.equal(response["Name"])
     recipe["Steps"].should.have.length_of(1)
     recipe["Steps"][0]["Action"]["Parameters"]["removeCustomValue"].should.equal("true")
@@ -152,9 +152,31 @@ def test_create_recipe_that_already_exists():
     client = _create_databrew_client()
 
     response = _create_test_recipe(client)
-
+    recipe_name = response['Name']
     with pytest.raises(ClientError) as exc:
         _create_test_recipe(client, recipe_name=response["Name"])
     err = exc.value.response["Error"]
-    err["Code"].should.equal("AlreadyExistsException")
-    err["Message"].should.equal("Recipe already exists.")
+    err["Code"].should.equal("ConflictException")
+    err["Message"].should.equal(f"The recipe {recipe_name} already exists")
+
+
+@mock_databrew
+def test_publish_recipe():
+    client = _create_databrew_client()
+
+    response = _create_test_recipe(client)
+    recipe_name = response['Name']
+
+    publish_response = client.publish_recipe(Name=recipe_name, Description="test desc")
+    publish_response["Name"].should.equal(recipe_name)
+
+    recipe = client.describe_recipe(Name=recipe_name)
+    recipe['Description'].should.equal("test desc")
+    recipe['RecipeVersion'].should.equal("1.0")
+
+    publish_response = client.publish_recipe(Name=recipe_name, Description="test desc")
+    publish_response["Name"].should.equal(recipe_name)
+
+    recipe = client.describe_recipe(Name=recipe_name)
+    recipe['Description'].should.equal("test desc")
+    recipe['RecipeVersion'].should.equal("2.0")

--- a/tests/test_databrew/test_databrew_recipes.py
+++ b/tests/test_databrew/test_databrew_recipes.py
@@ -246,6 +246,19 @@ def test_describe_recipe_with_long_version():
 
 
 @mock_databrew
+def test_describe_recipe_with_invalid_version():
+    client = _create_databrew_client()
+    name = "AnyName"
+    version = "invalid"
+    with pytest.raises(ClientError) as exc:
+        client.describe_recipe(Name=name, RecipeVersion=version)
+    err = exc.value.response["Error"]
+    err["Code"].should.equal("ValidationException")
+    err["Message"].should.equal(f"Recipe {name} version {version} isn't valid.")
+    exc.value.response["ResponseMetadata"]["HTTPStatusCode"].should.equal(400)
+
+
+@mock_databrew
 def test_update_recipe():
     client = _create_databrew_client()
     response = _create_test_recipe(client)

--- a/tests/test_databrew/test_databrew_recipes.py
+++ b/tests/test_databrew/test_databrew_recipes.py
@@ -63,13 +63,15 @@ def test_recipe_list_when_empty():
 def test_recipe_list_with_invalid_version():
     client = _create_databrew_client()
 
-    recipe_version='1.1'
+    recipe_version = "1.1"
     with pytest.raises(ClientError) as exc:
         client.list_recipes(RecipeVersion=recipe_version)
     err = exc.value.response["Error"]
     err["Code"].should.equal("ValidationException")
-    err["Message"].should.equal(f"Invalid version {recipe_version}. "
-                                "Valid versions are LATEST_PUBLISHED and LATEST_WORKING.")
+    err["Message"].should.equal(
+        f"Invalid version {recipe_version}. "
+        "Valid versions are LATEST_PUBLISHED and LATEST_WORKING."
+    )
     exc.value.response["ResponseMetadata"]["HTTPStatusCode"].should.equal(400)
     err = exc.value.response["Error"]
     err["Code"].should.equal("ValidationException")
@@ -80,7 +82,7 @@ def test_list_recipes_with_max_results():
     client = _create_databrew_client()
 
     _create_test_recipes(client, 4)
-    response = client.list_recipes(MaxResults=2, RecipeVersion='LATEST_WORKING')
+    response = client.list_recipes(MaxResults=2, RecipeVersion="LATEST_WORKING")
     response["Recipes"].should.have.length_of(2)
     response.should.have.key("NextToken")
 
@@ -89,8 +91,10 @@ def test_list_recipes_with_max_results():
 def test_list_recipes_from_next_token():
     client = _create_databrew_client()
     _create_test_recipes(client, 10)
-    first_response = client.list_recipes(MaxResults=3, RecipeVersion='LATEST_WORKING')
-    response = client.list_recipes(NextToken=first_response["NextToken"], RecipeVersion='LATEST_WORKING')
+    first_response = client.list_recipes(MaxResults=3, RecipeVersion="LATEST_WORKING")
+    response = client.list_recipes(
+        NextToken=first_response["NextToken"], RecipeVersion="LATEST_WORKING"
+    )
     response["Recipes"].should.have.length_of(7)
 
 
@@ -98,7 +102,7 @@ def test_list_recipes_from_next_token():
 def test_list_recipes_with_max_results_greater_than_actual_results():
     client = _create_databrew_client()
     _create_test_recipes(client, 4)
-    response = client.list_recipes(MaxResults=10, RecipeVersion='LATEST_WORKING')
+    response = client.list_recipes(MaxResults=10, RecipeVersion="LATEST_WORKING")
     response["Recipes"].should.have.length_of(4)
 
 
@@ -148,7 +152,9 @@ def test_describe_recipe_latest_working():
     client = _create_databrew_client()
     response = _create_test_recipe(client)
 
-    recipe = client.describe_recipe(Name=response["Name"], RecipeVersion='LATEST_WORKING')
+    recipe = client.describe_recipe(
+        Name=response["Name"], RecipeVersion="LATEST_WORKING"
+    )
 
     recipe["Name"].should.equal(response["Name"])
     recipe["Steps"].should.have.length_of(1)
@@ -160,7 +166,7 @@ def test_describe_recipe_with_version():
     client = _create_databrew_client()
     response = _create_test_recipe(client)
 
-    recipe = client.describe_recipe(Name=response["Name"], RecipeVersion='0.1')
+    recipe = client.describe_recipe(Name=response["Name"], RecipeVersion="0.1")
 
     recipe["Name"].should.equal(response["Name"])
     recipe["Steps"].should.have.length_of(1)
@@ -173,7 +179,9 @@ def test_describe_recipe_latest_published():
     response = _create_test_recipe(client)
 
     client.publish_recipe(Name=response["Name"])
-    recipe = client.describe_recipe(Name=response["Name"], RecipeVersion='LATEST_PUBLISHED')
+    recipe = client.describe_recipe(
+        Name=response["Name"], RecipeVersion="LATEST_PUBLISHED"
+    )
 
     recipe["Name"].should.equal(response["Name"])
     recipe["Steps"].should.have.length_of(1)
@@ -192,6 +200,7 @@ def test_describe_recipe_implicit_latest_published():
     recipe["Steps"].should.have.length_of(1)
     recipe["RecipeVersion"].should.equal("1.0")
 
+
 @mock_databrew
 def test_describe_recipe_that_does_not_exist():
     client = _create_databrew_client()
@@ -200,33 +209,39 @@ def test_describe_recipe_that_does_not_exist():
         client.describe_recipe(Name="DoseNotExist")
     err = exc.value.response["Error"]
     err["Code"].should.equal("ResourceNotFoundException")
-    err["Message"].should.equal("The recipe DoseNotExist for version LATEST_PUBLISHED wasn't found.")
+    err["Message"].should.equal(
+        "The recipe DoseNotExist for version LATEST_PUBLISHED wasn't found."
+    )
     exc.value.response["ResponseMetadata"]["HTTPStatusCode"].should.equal(404)
 
 
 @mock_databrew
 def test_describe_recipe_with_long_name():
     client = _create_databrew_client()
-    name = "a"*256
+    name = "a" * 256
     with pytest.raises(ClientError) as exc:
         client.describe_recipe(Name=name)
     err = exc.value.response["Error"]
     err["Code"].should.equal("ValidationException")
-    err["Message"].should.equal(f"1 validation error detected: Value '{name}' at 'name' failed to satisfy constraint: "
-                                f"Member must have length less than or equal to 255")
+    err["Message"].should.equal(
+        f"1 validation error detected: Value '{name}' at 'name' failed to satisfy constraint: "
+        f"Member must have length less than or equal to 255"
+    )
     exc.value.response["ResponseMetadata"]["HTTPStatusCode"].should.equal(400)
 
 
 @mock_databrew
 def test_describe_recipe_with_long_version():
     client = _create_databrew_client()
-    version = "1"*17
+    version = "1" * 17
     with pytest.raises(ClientError) as exc:
         client.describe_recipe(Name="AnyName", RecipeVersion=version)
     err = exc.value.response["Error"]
     err["Code"].should.equal("ValidationException")
-    err["Message"].should.equal(f"1 validation error detected: Value '{version}' at 'recipeVersion' failed to satisfy constraint: "
-                                f"Member must have length less than or equal to 16")
+    err["Message"].should.equal(
+        f"1 validation error detected: Value '{version}' at 'recipeVersion' failed to satisfy constraint: "
+        f"Member must have length less than or equal to 16"
+    )
     exc.value.response["ResponseMetadata"]["HTTPStatusCode"].should.equal(400)
 
 
@@ -264,7 +279,9 @@ def test_update_recipe():
     recipe["Name"].should.equal(response["Name"])
 
     # Describe the recipe and check the changes
-    recipe = client.describe_recipe(Name=response["Name"], RecipeVersion='LATEST_WORKING')
+    recipe = client.describe_recipe(
+        Name=response["Name"], RecipeVersion="LATEST_WORKING"
+    )
     recipe["Name"].should.equal(response["Name"])
     recipe["Steps"].should.have.length_of(1)
     recipe["Steps"][0]["Action"]["Parameters"]["removeCustomValue"].should.equal("true")
@@ -277,15 +294,15 @@ def test_update_recipe_description():
 
     description = "NewDescription"
     recipe = client.update_recipe(
-        Name=response["Name"],
-        Steps=[],
-        Description=description
+        Name=response["Name"], Steps=[], Description=description
     )
 
     recipe["Name"].should.equal(response["Name"])
 
     # Describe the recipe and check the changes
-    recipe = client.describe_recipe(Name=response["Name"], RecipeVersion='LATEST_WORKING')
+    recipe = client.describe_recipe(
+        Name=response["Name"], RecipeVersion="LATEST_WORKING"
+    )
     recipe["Name"].should.equal(response["Name"])
     recipe["Description"].should.equal(description)
 
@@ -294,9 +311,9 @@ def test_update_recipe_description():
 def test_update_recipe_invalid():
     client = _create_databrew_client()
 
-    recipe_name = 'NotFound'
+    recipe_name = "NotFound"
     with pytest.raises(ClientError) as exc:
-        recipe = client.update_recipe(Name=recipe_name)
+        client.update_recipe(Name=recipe_name)
     err = exc.value.response["Error"]
     err["Code"].should.equal("ResourceNotFoundException")
     err["Message"].should.equal(f"The recipe {recipe_name} wasn't found")
@@ -308,7 +325,7 @@ def test_create_recipe_that_already_exists():
     client = _create_databrew_client()
 
     response = _create_test_recipe(client)
-    recipe_name = response['Name']
+    recipe_name = response["Name"]
     with pytest.raises(ClientError) as exc:
         _create_test_recipe(client, recipe_name=response["Name"])
     err = exc.value.response["Error"]
@@ -322,7 +339,7 @@ def test_publish_recipe():
     client = _create_databrew_client()
 
     response = _create_test_recipe(client)
-    recipe_name = response['Name']
+    recipe_name = response["Name"]
 
     # Before a recipe is published, we should not be able to retrieve a published version
     with pytest.raises(ClientError) as exc:
@@ -338,19 +355,19 @@ def test_publish_recipe():
 
     # Recipe is now published, so check we can retrieve the published version
     recipe = client.describe_recipe(Name=recipe_name)
-    recipe['Description'].should.equal("1st desc")
-    recipe['RecipeVersion'].should.equal("1.0")
-    recipe['PublishedDate'].should.be.greater_than(dt_before_publish)
-    first_published_date = recipe['PublishedDate']
+    recipe["Description"].should.equal("1st desc")
+    recipe["RecipeVersion"].should.equal("1.0")
+    recipe["PublishedDate"].should.be.greater_than(dt_before_publish)
+    first_published_date = recipe["PublishedDate"]
 
     # Publish the recipe a 2nd time
     publish_response = client.publish_recipe(Name=recipe_name, Description="2nd desc")
     publish_response["Name"].should.equal(recipe_name)
 
     recipe = client.describe_recipe(Name=recipe_name)
-    recipe['Description'].should.equal("2nd desc")
-    recipe['RecipeVersion'].should.equal("2.0")
-    recipe['PublishedDate'].should.be.greater_than(first_published_date)
+    recipe["Description"].should.equal("2nd desc")
+    recipe["RecipeVersion"].should.equal("2.0")
+    recipe["PublishedDate"].should.be.greater_than(first_published_date)
 
 
 @mock_databrew
@@ -366,13 +383,15 @@ def test_publish_recipe_that_does_not_exist():
 @mock_databrew
 def test_publish_long_recipe_name():
     client = _create_databrew_client()
-    name = "a"*256
+    name = "a" * 256
     with pytest.raises(ClientError) as exc:
         client.publish_recipe(Name=name)
     err = exc.value.response["Error"]
     err["Code"].should.equal("ValidationException")
-    err["Message"].should.equal(f"1 validation error detected: Value '{name}' at 'name' failed to satisfy constraint: "
-                                f"Member must have length less than or equal to 255")
+    err["Message"].should.equal(
+        f"1 validation error detected: Value '{name}' at 'name' failed to satisfy constraint: "
+        f"Member must have length less than or equal to 255"
+    )
     exc.value.response["ResponseMetadata"]["HTTPStatusCode"].should.equal(400)
     err = exc.value.response["Error"]
     err["Code"].should.equal("ValidationException")
@@ -382,8 +401,8 @@ def test_publish_long_recipe_name():
 def test_delete_recipe_version():
     client = _create_databrew_client()
     response = _create_test_recipe(client)
-    recipe_name = response['Name']
-    client.delete_recipe_version(Name=recipe_name, RecipeVersion='LATEST_WORKING')
+    recipe_name = response["Name"]
+    client.delete_recipe_version(Name=recipe_name, RecipeVersion="LATEST_WORKING")
     with pytest.raises(ClientError) as exc:
         client.describe_recipe(Name=recipe_name)
     err = exc.value.response["Error"]
@@ -395,15 +414,15 @@ def test_delete_recipe_version():
 def test_delete_recipe_version_published():
     client = _create_databrew_client()
     response = _create_test_recipe(client)
-    recipe_name = response['Name']
+    recipe_name = response["Name"]
     client.publish_recipe(Name=recipe_name)
-    client.delete_recipe_version(Name=recipe_name, RecipeVersion='1.0')
+    client.delete_recipe_version(Name=recipe_name, RecipeVersion="1.0")
     with pytest.raises(ClientError) as exc:
         client.describe_recipe(Name=recipe_name)
     err = exc.value.response["Error"]
     err["Code"].should.equal("ResourceNotFoundException")
     exc.value.response["ResponseMetadata"]["HTTPStatusCode"].should.equal(404)
-    recipe = client.describe_recipe(Name=recipe_name, RecipeVersion='1.1')
+    recipe = client.describe_recipe(Name=recipe_name, RecipeVersion="1.1")
     recipe["RecipeVersion"].should.equal("1.1")
 
 
@@ -411,13 +430,15 @@ def test_delete_recipe_version_published():
 def test_delete_recipe_version_latest_working_after_publish():
     client = _create_databrew_client()
     response = _create_test_recipe(client)
-    recipe_name = response['Name']
+    recipe_name = response["Name"]
     client.publish_recipe(Name=recipe_name)
     with pytest.raises(ClientError) as exc:
-        client.delete_recipe_version(Name=recipe_name, RecipeVersion='LATEST_WORKING')
+        client.delete_recipe_version(Name=recipe_name, RecipeVersion="LATEST_WORKING")
     err = exc.value.response["Error"]
     err["Code"].should.equal("ValidationException")
-    err["Message"].should.equal("Recipe version LATEST_WORKING is not allowed to be deleted")
+    err["Message"].should.equal(
+        "Recipe version LATEST_WORKING is not allowed to be deleted"
+    )
     exc.value.response["ResponseMetadata"]["HTTPStatusCode"].should.equal(400)
 
 
@@ -425,10 +446,10 @@ def test_delete_recipe_version_latest_working_after_publish():
 def test_delete_recipe_version_latest_working_numeric_after_publish():
     client = _create_databrew_client()
     response = _create_test_recipe(client)
-    recipe_name = response['Name']
+    recipe_name = response["Name"]
     client.publish_recipe(Name=recipe_name)
     with pytest.raises(ClientError) as exc:
-        client.delete_recipe_version(Name=recipe_name, RecipeVersion='1.1')
+        client.delete_recipe_version(Name=recipe_name, RecipeVersion="1.1")
     err = exc.value.response["Error"]
     err["Code"].should.equal("ValidationException")
     err["Message"].should.equal("Recipe version 1.1 is not allowed to be deleted")
@@ -439,14 +460,16 @@ def test_delete_recipe_version_latest_working_numeric_after_publish():
 def test_delete_recipe_version_invalid_version_string():
     client = _create_databrew_client()
     response = _create_test_recipe(client)
-    recipe_name = response['Name']
-    recipe_version = 'NotValid'
+    recipe_name = response["Name"]
+    recipe_version = "NotValid"
     client.publish_recipe(Name=recipe_name)
     with pytest.raises(ClientError) as exc:
         client.delete_recipe_version(Name=recipe_name, RecipeVersion=recipe_version)
     err = exc.value.response["Error"]
     err["Code"].should.equal("ValidationException")
-    err["Message"].should.equal(f"Recipe {recipe_name} version {recipe_version} is invalid.")
+    err["Message"].should.equal(
+        f"Recipe {recipe_name} version {recipe_version} is invalid."
+    )
     exc.value.response["ResponseMetadata"]["HTTPStatusCode"].should.equal(400)
 
 
@@ -454,23 +477,25 @@ def test_delete_recipe_version_invalid_version_string():
 def test_delete_recipe_version_invalid_version_length():
     client = _create_databrew_client()
     response = _create_test_recipe(client)
-    recipe_name = response['Name']
-    recipe_version = '1'*17
+    recipe_name = response["Name"]
+    recipe_version = "1" * 17
     client.publish_recipe(Name=recipe_name)
     with pytest.raises(ClientError) as exc:
         client.delete_recipe_version(Name=recipe_name, RecipeVersion=recipe_version)
     err = exc.value.response["Error"]
     err["Code"].should.equal("ValidationException")
-    err["Message"].should.equal(f"Recipe {recipe_name} version {recipe_version} is invalid.")
+    err["Message"].should.equal(
+        f"Recipe {recipe_name} version {recipe_version} is invalid."
+    )
     exc.value.response["ResponseMetadata"]["HTTPStatusCode"].should.equal(400)
 
 
 @mock_databrew
 def test_delete_recipe_version_unknown_recipe():
     client = _create_databrew_client()
-    recipe_name = 'Unknown'
+    recipe_name = "Unknown"
     with pytest.raises(ClientError) as exc:
-        client.delete_recipe_version(Name=recipe_name, RecipeVersion='1.1')
+        client.delete_recipe_version(Name=recipe_name, RecipeVersion="1.1")
     err = exc.value.response["Error"]
     err["Code"].should.equal("ResourceNotFoundException")
     err["Message"].should.equal(f"The recipe {recipe_name} wasn't found")
@@ -481,11 +506,13 @@ def test_delete_recipe_version_unknown_recipe():
 def test_delete_recipe_version_unknown_version():
     client = _create_databrew_client()
     response = _create_test_recipe(client)
-    recipe_name = response['Name']
-    recipe_version = '1.1'
+    recipe_name = response["Name"]
+    recipe_version = "1.1"
     with pytest.raises(ClientError) as exc:
         client.delete_recipe_version(Name=recipe_name, RecipeVersion=recipe_version)
     err = exc.value.response["Error"]
     err["Code"].should.equal("ResourceNotFoundException")
-    err["Message"].should.equal(f"The recipe {recipe_name} version {recipe_version} wasn't found.")
+    err["Message"].should.equal(
+        f"The recipe {recipe_name} version {recipe_version} wasn't found."
+    )
     exc.value.response["ResponseMetadata"]["HTTPStatusCode"].should.equal(404)


### PR DESCRIPTION
Adds recipe versioning to the databrew support.

This includes these additional methods:
* delete_recipe_version()
* list_recipe_versions()
* publish_recipe()

Also fixed exceptions raised by existing for recipe-related methods to match those in AWS documentation:
* RecipeAlreadyExistsException -> ConflictException
* RecipeNotFoundException -> ResourceNotFoundException