### PR TITLE
mediaconnect: fix, actually fixing create_flow to allow no outputs

### DIFF
--- a/moto/mediaconnect/models.py
+++ b/moto/mediaconnect/models.py
@@ -97,7 +97,7 @@ class MediaConnectBackend(BaseBackend):
         for index, _source in enumerate(flow.sources):
             self._add_source_details(_source, flow_id, f"127.0.0.{index}")
 
-        for index, output in enumerate(flow.outputs):
+        for index, output in enumerate(flow.outputs or []):
             if output.get("protocol") in ["srt-listener", "zixi-pull"]:
                 output["listenerAddress"] = f"{index}.0.0.0"
 

--- a/tests/test_mediaconnect/test_mediaconnect.py
+++ b/tests/test_mediaconnect/test_mediaconnect.py
@@ -108,6 +108,7 @@ def test_create_flow_alternative_succeeds():
             "SourcePriority": {"PrimarySource": "Source-B"},
             "State": "ENABLED",
         },
+        outputs=None,
     )
 
     response = client.create_flow(**channel_config)


### PR DESCRIPTION
Sorry, I intended to fix this in my previous PR but I failed

I've noticed there's a quite a few mismatches between the moto create_flow response and the expected boto3 response (see https://youtype.github.io/boto3_stubs_docs/mypy_boto3_mediaconnect/type_defs/#flowtypedef). I'll try to do a bigger PR in the future to make it a closer match to that

For now this PR at least makes create_flow more usable