### PR TITLE
Fix dashboard not to show JSON as '[object Object]'

### DIFF
--- a/moto/moto_server/templates/dashboard.html
+++ b/moto/moto_server/templates/dashboard.html
@@ -89,7 +89,7 @@
                     {{#each this}}
                     <tr>
                         {{#each this}}
-                        <td>{{@key}}: {{this}}</td>
+                        <td>{{@key}}: {{{json this}}}</td>
                         {{/each}}
                     </tr>
                     {{else}}
@@ -152,7 +152,9 @@
         }
 
         $(document).ready(function (){
-
+            Handlebars.registerHelper("json", function (context) {
+              return JSON.stringify(context);
+            });
             $.getJSON("/moto-api/data.json", function(data) {
                 var source = $('#template').html();
                 var template = Handlebars.compile(source);


### PR DESCRIPTION
Original dashboard can't show JSON (it results `[object Object]`). My fix shows JSON content.

Before 
<img width="1255" alt="スクリーンショット 2022-05-12 10 30 37" src="https://user-images.githubusercontent.com/564612/168143077-d1e5bbd5-39e3-4272-b7b6-6eb0f7cf30c9.png">

After
<img width="1198" alt="スクリーンショット 2022-05-12 23 58 14" src="https://user-images.githubusercontent.com/564612/168143129-9a949f1a-ecb6-4d5e-8535-05abd82edb60.png">

