### PR TITLE
Add `Ipv6Native` field to ec2:Subnet response templates

### DIFF
--- a/moto/ec2/models/subnets.py
+++ b/moto/ec2/models/subnets.py
@@ -59,6 +59,9 @@ class Subnet(TaggedEC2Resource, CloudFormationModel):
         self._subnet_ips = {}  # has IP: instance
         self.state = "available"
 
+        # Placeholder for response templates until Ipv6 support implemented.
+        self.ipv6_native = False
+
     @property
     def owner_id(self):
         return get_account_id()

--- a/moto/ec2/responses/subnets.py
+++ b/moto/ec2/responses/subnets.py
@@ -105,6 +105,7 @@ CREATE_SUBNET_RESPONSE = """
     {% endif %}
     {% endfor %}
     </ipv6CidrBlockAssociationSet>
+    <ipv6Native>{{ 'false' if not subnet.ipv6_native else 'true' }}</ipv6Native>
     <subnetArn>arn:aws:ec2:{{ subnet._availability_zone.name[0:-1] }}:{{ subnet.owner_id }}:subnet/{{ subnet.id }}</subnetArn>
     <tagSet>
         {% for tag in subnet.get_tags() %}
@@ -156,6 +157,7 @@ DESCRIBE_SUBNETS_RESPONSE = """
         {% endfor %}
         </ipv6CidrBlockAssociationSet>
         <subnetArn>arn:aws:ec2:{{ subnet._availability_zone.name[0:-1] }}:{{ subnet.owner_id }}:subnet/{{ subnet.id }}</subnetArn>
+        <ipv6Native>{{ 'false' if not subnet.ipv6_native else 'true' }}</ipv6Native>
         {% if subnet.get_tags() %}
           <tagSet>
             {% for tag in subnet.get_tags() %}

--- a/tests/test_ec2/test_subnets.py
+++ b/tests/test_ec2/test_subnets.py
@@ -354,6 +354,7 @@ def test_create_subnet_response_fields():
     subnet.should.have.key("MapPublicIpOnLaunch").which.should.equal(False)
     subnet.should.have.key("OwnerId")
     subnet.should.have.key("AssignIpv6AddressOnCreation").which.should.equal(False)
+    subnet.should.have.key("Ipv6Native").which.should.equal(False)
 
     subnet_arn = "arn:aws:ec2:{region}:{owner_id}:subnet/{subnet_id}".format(
         region=subnet["AvailabilityZone"][0:-1],
@@ -390,6 +391,7 @@ def test_describe_subnet_response_fields():
     subnet.should.have.key("MapPublicIpOnLaunch").which.should.equal(False)
     subnet.should.have.key("OwnerId")
     subnet.should.have.key("AssignIpv6AddressOnCreation").which.should.equal(False)
+    subnet.should.have.key("Ipv6Native").which.should.equal(False)
 
     subnet_arn = "arn:aws:ec2:{region}:{owner_id}:subnet/{subnet_id}".format(
         region=subnet["AvailabilityZone"][0:-1],


### PR DESCRIPTION
This is currently just a placeholder because Moto does not yet fully support
Ipv6 subnets, but it is included in the Ipv4 subnet responses (set to `False`).

Closes #5021 