### PR TITLE
Add ability to list ECS services by launch type

### DIFF
--- a/moto/ecs/models.py
+++ b/moto/ecs/models.py
@@ -1278,16 +1278,23 @@ class EC2ContainerServiceBackend(BaseBackend):
 
         return service
 
-    def list_services(self, cluster_str, scheduling_strategy=None):
+    def list_services(self, cluster_str, scheduling_strategy=None, launch_type=None):
         cluster_name = cluster_str.split("/")[-1]
         service_arns = []
         for key, service in self.services.items():
-            if cluster_name + ":" in key:
-                if (
-                    scheduling_strategy is None
-                    or service.scheduling_strategy == scheduling_strategy
-                ):
-                    service_arns.append(service.arn)
+            if cluster_name + ":" not in key:
+                continue
+
+            if (
+                scheduling_strategy is not None
+                and service.scheduling_strategy != scheduling_strategy
+            ):
+                continue
+
+            if launch_type is not None and service.launch_type != launch_type:
+                continue
+
+            service_arns.append(service.arn)
 
         return sorted(service_arns)
 

--- a/moto/ecs/responses.py
+++ b/moto/ecs/responses.py
@@ -228,7 +228,10 @@ class EC2ContainerServiceResponse(BaseResponse):
     def list_services(self):
         cluster_str = self._get_param("cluster", "default")
         scheduling_strategy = self._get_param("schedulingStrategy")
-        service_arns = self.ecs_backend.list_services(cluster_str, scheduling_strategy)
+        launch_type = self._get_param("launchType")
+        service_arns = self.ecs_backend.list_services(
+            cluster_str, scheduling_strategy, launch_type=launch_type
+        )
         return json.dumps(
             {
                 "serviceArns": service_arns

--- a/tests/test_ecs/test_ecs_boto3.py
+++ b/tests/test_ecs/test_ecs_boto3.py
@@ -641,7 +641,8 @@ def test_create_service_scheduling_strategy():
 @mock_ecs
 def test_list_services():
     client = boto3.client("ecs", region_name="us-east-1")
-    _ = client.create_cluster(clusterName="test_ecs_cluster")
+    _ = client.create_cluster(clusterName="test_ecs_cluster1")
+    _ = client.create_cluster(clusterName="test_ecs_cluster2")
     _ = client.register_task_definition(
         family="test_ecs_task",
         containerDefinitions=[
@@ -659,41 +660,53 @@ def test_list_services():
         ],
     )
     _ = client.create_service(
-        cluster="test_ecs_cluster",
+        cluster="test_ecs_cluster1",
         serviceName="test_ecs_service1",
         taskDefinition="test_ecs_task",
         schedulingStrategy="REPLICA",
+        launchType="EC2",
         desiredCount=2,
     )
     _ = client.create_service(
-        cluster="test_ecs_cluster",
+        cluster="test_ecs_cluster1",
         serviceName="test_ecs_service2",
         taskDefinition="test_ecs_task",
         schedulingStrategy="DAEMON",
+        launchType="FARGATE",
         desiredCount=2,
     )
-    unfiltered_response = client.list_services(cluster="test_ecs_cluster")
-    len(unfiltered_response["serviceArns"]).should.equal(2)
-    unfiltered_response["serviceArns"][0].should.equal(
-        "arn:aws:ecs:us-east-1:{}:service/test_ecs_cluster/test_ecs_service1".format(
-            ACCOUNT_ID
-        )
-    )
-    unfiltered_response["serviceArns"][1].should.equal(
-        "arn:aws:ecs:us-east-1:{}:service/test_ecs_cluster/test_ecs_service2".format(
-            ACCOUNT_ID
-        )
+    _ = client.create_service(
+        cluster="test_ecs_cluster2",
+        serviceName="test_ecs_service3",
+        taskDefinition="test_ecs_task",
+        schedulingStrategy="DAEMON",
+        launchType="FARGATE",
+        desiredCount=2,
     )
 
-    filtered_response = client.list_services(
-        cluster="test_ecs_cluster", schedulingStrategy="REPLICA"
+    test_ecs_service1_arn = "arn:aws:ecs:us-east-1:{}:service/test_ecs_cluster1/test_ecs_service1".format(
+        ACCOUNT_ID
     )
-    len(filtered_response["serviceArns"]).should.equal(1)
-    filtered_response["serviceArns"][0].should.equal(
-        "arn:aws:ecs:us-east-1:{}:service/test_ecs_cluster/test_ecs_service1".format(
-            ACCOUNT_ID
-        )
+    test_ecs_service2_arn = "arn:aws:ecs:us-east-1:{}:service/test_ecs_cluster1/test_ecs_service2".format(
+        ACCOUNT_ID
     )
+
+    cluster1_services = client.list_services(cluster="test_ecs_cluster1")
+    len(cluster1_services["serviceArns"]).should.equal(2)
+    cluster1_services["serviceArns"][0].should.equal(test_ecs_service1_arn)
+    cluster1_services["serviceArns"][1].should.equal(test_ecs_service2_arn)
+
+    cluster1_replica_services = client.list_services(
+        cluster="test_ecs_cluster1", schedulingStrategy="REPLICA"
+    )
+    len(cluster1_replica_services["serviceArns"]).should.equal(1)
+    cluster1_replica_services["serviceArns"][0].should.equal(test_ecs_service1_arn)
+
+    cluster1_fargate_services = client.list_services(
+        cluster="test_ecs_cluster1", launchType="FARGATE"
+    )
+    len(cluster1_fargate_services["serviceArns"]).should.equal(1)
+    cluster1_fargate_services["serviceArns"][0].should.equal(test_ecs_service2_arn)
 
 
 @mock_ecs

--- a/tests/test_ecs/test_ecs_boto3.py
+++ b/tests/test_ecs/test_ecs_boto3.py
@@ -679,16 +679,20 @@ def test_list_services():
         cluster="test_ecs_cluster2",
         serviceName="test_ecs_service3",
         taskDefinition="test_ecs_task",
-        schedulingStrategy="DAEMON",
+        schedulingStrategy="REPLICA",
         launchType="FARGATE",
         desiredCount=2,
     )
 
-    test_ecs_service1_arn = "arn:aws:ecs:us-east-1:{}:service/test_ecs_cluster1/test_ecs_service1".format(
-        ACCOUNT_ID
+    test_ecs_service1_arn = (
+        "arn:aws:ecs:us-east-1:{}:service/test_ecs_cluster1/test_ecs_service1".format(
+            ACCOUNT_ID
+        )
     )
-    test_ecs_service2_arn = "arn:aws:ecs:us-east-1:{}:service/test_ecs_cluster1/test_ecs_service2".format(
-        ACCOUNT_ID
+    test_ecs_service2_arn = (
+        "arn:aws:ecs:us-east-1:{}:service/test_ecs_cluster1/test_ecs_service2".format(
+            ACCOUNT_ID
+        )
     )
 
     cluster1_services = client.list_services(cluster="test_ecs_cluster1")


### PR DESCRIPTION
Add optional `launchType` parameter to the ECS service according to the latest [boto3](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/ecs.html#ECS.Client.list_services) version and AWS API