### PR TITLE
add passthroughBehaviour to the integration

### DIFF
--- a/moto/apigateway/models.py
+++ b/moto/apigateway/models.py
@@ -126,6 +126,8 @@ class Integration(BaseModel, dict):
         uri,
         http_method,
         request_templates=None,
+        passthrough_behavior="WHEN_NO_MATCH",
+        cache_key_parameters=None,
         tls_config=None,
         cache_namespace=None,
         timeout_in_millis=None,
@@ -133,7 +135,9 @@ class Integration(BaseModel, dict):
         super().__init__()
         self["type"] = integration_type
         self["uri"] = uri
-        self["httpMethod"] = http_method
+        self["httpMethod"] = http_method if integration_type != "MOCK" else None
+        self["passthroughBehavior"] = passthrough_behavior
+        self["cacheKeyParameters"] = cache_key_parameters or []
         self["requestTemplates"] = request_templates
         # self["integrationResponses"] = {"200": IntegrationResponse(200)}  # commented out (tf-compat)
         self[
@@ -369,6 +373,7 @@ class Resource(CloudFormationModel):
         integration_type,
         uri,
         request_templates=None,
+        passthrough_behavior=None,
         integration_method=None,
         tls_config=None,
         cache_namespace=None,
@@ -380,6 +385,7 @@ class Resource(CloudFormationModel):
             uri,
             integration_method,
             request_templates=request_templates,
+            passthrough_behavior=passthrough_behavior,
             tls_config=tls_config,
             cache_namespace=cache_namespace,
             timeout_in_millis=timeout_in_millis,
@@ -1564,6 +1570,7 @@ class APIGatewayBackend(BaseBackend):
         integration_method=None,
         credentials=None,
         request_templates=None,
+        passthrough_behavior=None,
         tls_config=None,
         cache_namespace=None,
         timeout_in_millis=None,
@@ -1604,6 +1611,7 @@ class APIGatewayBackend(BaseBackend):
             uri,
             integration_method=integration_method,
             request_templates=request_templates,
+            passthrough_behavior=passthrough_behavior,
             tls_config=tls_config,
             cache_namespace=cache_namespace,
             timeout_in_millis=timeout_in_millis,

--- a/moto/apigateway/responses.py
+++ b/moto/apigateway/responses.py
@@ -442,6 +442,7 @@ class APIGatewayResponse(BaseResponse):
             uri = self._get_param("uri")
             credentials = self._get_param("credentials")
             request_templates = self._get_param("requestTemplates")
+            passthrough_behavior = self._get_param("passthroughBehavior")
             tls_config = self._get_param("tlsConfig")
             cache_namespace = self._get_param("cacheNamespace")
             timeout_in_millis = self._get_param("timeoutInMillis")
@@ -460,6 +461,7 @@ class APIGatewayResponse(BaseResponse):
                 credentials=credentials,
                 integration_method=integration_http_method,
                 request_templates=request_templates,
+                passthrough_behavior=passthrough_behavior,
                 tls_config=tls_config,
                 cache_namespace=cache_namespace,
                 timeout_in_millis=timeout_in_millis,

--- a/tests/test_apigateway/test_apigateway.py
+++ b/tests/test_apigateway/test_apigateway.py
@@ -531,6 +531,7 @@ def test_integrations():
             "type": "HTTP",
             "uri": "http://httpbin.org/robots.txt",
             "passthroughBehavior": "WHEN_NO_TEMPLATES",
+            "cacheKeyParameters": [],
         }
     )
 
@@ -547,6 +548,7 @@ def test_integrations():
             "type": "HTTP",
             "uri": "http://httpbin.org/robots.txt",
             "passthroughBehavior": "WHEN_NO_TEMPLATES",
+            "cacheKeyParameters": [],
         }
     )
 
@@ -557,7 +559,13 @@ def test_integrations():
     response["resourceMethods"]["GET"]["httpMethod"].should.equal("GET")
     response["resourceMethods"]["GET"]["authorizationType"].should.equal("none")
     response["resourceMethods"]["GET"]["methodIntegration"].should.equal(
-        {"httpMethod": "POST", "type": "HTTP", "uri": "http://httpbin.org/robots.txt"}
+        {
+            "httpMethod": "POST",
+            "type": "HTTP",
+            "uri": "http://httpbin.org/robots.txt",
+            "cacheKeyParameters": [],
+            "passthroughBehavior": "WHEN_NO_TEMPLATES",
+        }
     )
 
     client.delete_integration(restApiId=api_id, resourceId=root_id, httpMethod="GET")

--- a/tests/test_apigateway/test_apigateway.py
+++ b/tests/test_apigateway/test_apigateway.py
@@ -517,6 +517,7 @@ def test_integrations():
         resourceId=root_id,
         httpMethod="GET",
         type="HTTP",
+        passthroughBehavior="WHEN_NO_TEMPLATES",
         uri="http://httpbin.org/robots.txt",
         integrationHttpMethod="POST",
     )
@@ -529,6 +530,7 @@ def test_integrations():
             "httpMethod": "POST",
             "type": "HTTP",
             "uri": "http://httpbin.org/robots.txt",
+            "passthroughBehavior": "WHEN_NO_TEMPLATES"
         }
     )
 
@@ -544,6 +546,7 @@ def test_integrations():
             "httpMethod": "POST",
             "type": "HTTP",
             "uri": "http://httpbin.org/robots.txt",
+            "passthroughBehavior": "WHEN_NO_TEMPLATES"
         }
     )
 
@@ -584,6 +587,7 @@ def test_integrations():
         type="HTTP",
         uri=test_uri,
         requestTemplates=templates,
+        passthroughBehavior="WHEN_NO_MATCH",
         integrationHttpMethod="POST",
         timeoutInMillis=29000,
     )
@@ -593,6 +597,7 @@ def test_integrations():
     )
     response["uri"].should.equal(test_uri)
     response["requestTemplates"].should.equal(templates)
+    response["passthroughBehavior"].should.equal("WHEN_NO_MATCH")
     response.should.have.key("timeoutInMillis").equals(29000)
 
 

--- a/tests/test_apigateway/test_apigateway.py
+++ b/tests/test_apigateway/test_apigateway.py
@@ -530,7 +530,7 @@ def test_integrations():
             "httpMethod": "POST",
             "type": "HTTP",
             "uri": "http://httpbin.org/robots.txt",
-            "passthroughBehavior": "WHEN_NO_TEMPLATES"
+            "passthroughBehavior": "WHEN_NO_TEMPLATES",
         }
     )
 
@@ -546,7 +546,7 @@ def test_integrations():
             "httpMethod": "POST",
             "type": "HTTP",
             "uri": "http://httpbin.org/robots.txt",
-            "passthroughBehavior": "WHEN_NO_TEMPLATES"
+            "passthroughBehavior": "WHEN_NO_TEMPLATES",
         }
     )
 


### PR DESCRIPTION
Minor addition to the integration model object. The property `passthroughBehavior` is used in the template logic.