### PR TITLE
fix template variable typo

### DIFF
--- a/moto/elbv2/responses.py
+++ b/moto/elbv2/responses.py
@@ -804,7 +804,7 @@ CREATE_TARGET_GROUP_TEMPLATE = """<CreateTargetGroupResponse xmlns="http://elast
         {% if target_group.vpc_id %}
         <VpcId>{{ target_group.vpc_id }}</VpcId>
         {% endif %}
-        <HealthCheckProtocol>{{ target_group.health_check_protocol }}</HealthCheckProtocol>
+        <HealthCheckProtocol>{{ target_group.healthcheck_protocol }}</HealthCheckProtocol>
         {% if target_group.healthcheck_port %}<HealthCheckPort>{{ target_group.healthcheck_port }}</HealthCheckPort>{% endif %}
         <HealthCheckPath>{{ target_group.healthcheck_path or '' }}</HealthCheckPath>
         <HealthCheckIntervalSeconds>{{ target_group.healthcheck_interval_seconds }}</HealthCheckIntervalSeconds>

--- a/tests/test_elbv2/test_elbv2_target_groups.py
+++ b/tests/test_elbv2/test_elbv2_target_groups.py
@@ -96,13 +96,13 @@ def test_create_target_group_and_listeners():
         UnhealthyThresholdCount=2,
         Matcher={"HttpCode": "200"},
     )
-    target_group_arn = response.get("TargetGroups")[0]["TargetGroupArn"]
+    target_group = response.get("TargetGroups")[0]
+    target_group_arn = target_group.get("TargetGroupArn")
+    target_group.get("HealthCheckProtocol").should.equal("HTTP")
 
     # Check it's in the describe_target_groups response
     response = conn.describe_target_groups()
     response.get("TargetGroups").should.have.length_of(1)
-    target_group = response.get("TargetGroups")[0]
-    target_group.get("HealthCheckProtocol").should.equal("HTTP")
 
     # Plain HTTP listener
     response = conn.create_listener(

--- a/tests/test_elbv2/test_elbv2_target_groups.py
+++ b/tests/test_elbv2/test_elbv2_target_groups.py
@@ -101,6 +101,8 @@ def test_create_target_group_and_listeners():
     # Check it's in the describe_target_groups response
     response = conn.describe_target_groups()
     response.get("TargetGroups").should.have.length_of(1)
+    target_group = response.get("TargetGroups")[0]
+    target_group.get("HealthCheckProtocol").should.equal("HTTP")
 
     # Plain HTTP listener
     response = conn.create_listener(


### PR DESCRIPTION
The template variable name for the elbv2 healthcheck protocol is incorrect, which causes the healthcheck protocol in any api call response to always be an empty string.