### PR TITLE
Referring to the environment variable MOTO_ACCOUNT_ID directly in get_account_id()

### DIFF
--- a/moto/core/models.py
+++ b/moto/core/models.py
@@ -26,15 +26,10 @@ from .utils import convert_flask_to_responses_response
 ACCOUNT_ID = os.environ.get("MOTO_ACCOUNT_ID", "123456789012")
 
 
-def _get_default_account_id():
-    return ACCOUNT_ID
-
-
-account_id_resolver = _get_default_account_id
-
-
 def get_account_id():
-    return account_id_resolver()
+    # Those referring to the global var ACCOUNT_ID directly can continue to do so, but this will support the cases when
+    # an environment variable is overridden after moto is loaded/imported
+    return os.environ.get("MOTO_ACCOUNT_ID", "123456789012")
 
 
 class BaseMockAWS:

--- a/tests/test_sts/test_sts.py
+++ b/tests/test_sts/test_sts.py
@@ -1,5 +1,6 @@
 from base64 import b64encode
 import json
+import os
 
 import boto3
 from botocore.client import ClientError
@@ -767,3 +768,14 @@ def test_sts_regions(region):
     client = boto3.client("sts", region_name=region)
     resp = client.get_caller_identity()
     resp["ResponseMetadata"]["HTTPStatusCode"].should.equal(200)
+
+
+@mock_sts
+def test_sts_account_override(monkeypatch):
+    dummy_account_id = "MEMEMEMEME"
+    monkeypatch.setenv("MOTO_ACCOUNT_ID", dummy_account_id)
+    os_account_id = os.environ.get("MOTO_ACCOUNT_ID")
+    os_account_id.should.equal(dummy_account_id)
+    client = boto3.client("sts", region_name="us-west-2")
+    resp = client.get_caller_identity()
+    resp["Account"].should.equal(dummy_account_id)


### PR DESCRIPTION
Resolves #5027.

Test case taken from #5028 