### PR TITLE
CloudFormation - specify all dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -89,7 +89,6 @@ extras_per_service.update(
         "appsync": [_dep_graphql],
         "awslambda": [_dep_docker],
         "batch": [_dep_docker],
-        "cloudformation": [_dep_docker, _dep_PyYAML, _dep_cfn_lint],
         "cognitoidp": [_dep_python_jose, _dep_python_jose_ecdsa_pin],
         "ec2": [_dep_sshpubkeys],
         "glue": [_dep_pyparsing],
@@ -117,6 +116,8 @@ extras_per_service["efs"] = extras_per_service["ec2"]
 # DirectoryService needs EC2 to verify VPCs and subnets.
 extras_per_service["ds"] = extras_per_service["ec2"]
 extras_per_service["route53resolver"] = extras_per_service["ec2"]
+# CloudFormation imports everything, so install everything
+extras_per_service["cloudformation"] = all_extra_deps
 extras_require = {
     "all": all_extra_deps,
     "server": all_server_deps,


### PR DESCRIPTION
Closes #5162 

CloudFormation loads all modules, to retrieve the full list of CloudFormationModels that it knows about, so it should also install all dependencies.