### PR TITLE
add kafka broker-storage VolumeSize to application autoscaling dimensions

### DIFF
--- a/moto/applicationautoscaling/models.py
+++ b/moto/applicationautoscaling/models.py
@@ -11,6 +11,8 @@ import uuid
 @unique
 class ResourceTypeExceptionValueSet(Enum):
     RESOURCE_TYPE = "ResourceType"
+    # MSK currently only has the "broker-storage" resource type which is not part of the resource_id
+    KAFKA_BROKER_STORAGE = "broker-storage"
 
 
 @unique
@@ -26,6 +28,7 @@ class ServiceNamespaceValueSet(Enum):
     COMPREHEND = "comprehend"
     ECS = "ecs"
     SAGEMAKER = "sagemaker"
+    KAFKA = "kafka"
 
 
 @unique
@@ -56,6 +59,7 @@ class ScalableDimensionValueSet(Enum):
     SAGEMAKER_VARIANT_DESIRED_INSTANCE_COUNT = "sagemaker:variant:DesiredInstanceCount"
     EC2_SPOT_FLEET_REQUEST_TARGET_CAPACITY = "ec2:spot-fleet-request:TargetCapacity"
     ECS_SERVICE_DESIRED_COUNT = "ecs:service:DesiredCount"
+    KAFKA_BROKER_STORAGE_VOLUME_SIZE = "kafka:broker-storage:VolumeSize"
 
 
 class ApplicationAutoscalingBackend(BaseBackend):
@@ -424,8 +428,12 @@ class FakeApplicationAutoscalingPolicy(BaseModel):
         self.policy_name = policy_name
         self.policy_type = policy_type
         self._guid = uuid.uuid4()
-        self.policy_arn = "arn:aws:autoscaling:{}:scalingPolicy:{}:resource/sagemaker/{}:policyName/{}".format(
-            region_name, self._guid, self.resource_id, self.policy_name
+        self.policy_arn = "arn:aws:autoscaling:{}:scalingPolicy:{}:resource/{}/{}:policyName/{}".format(
+            region_name,
+            self._guid,
+            self.service_namespace,
+            self.resource_id,
+            self.policy_name,
         )
         self.creation_time = time.time()
 


### PR DESCRIPTION
This PR adds an application-autoscaling dimension for MSK. Currently `broker-storage`is the only resource dimension for Kafka: https://docs.aws.amazon.com/autoscaling/application/APIReference/API_ScalableTarget.html


This example request was taken from the docs here: https://docs.aws.amazon.com/autoscaling/application/userguide/services-that-can-integrate-msk.html

```sh
aws application-autoscaling register-scalable-target \
   --service-namespace kafka \
   --scalable-dimension kafka:broker-storage:VolumeSize \
   --resource-id arn:aws:kafka:us-east-1:123456789012:cluster/demo-cluster-1/6357e0b2-0e6a-4b86-a0b4-70df934c2e31-5 \
   --min-capacity 100 \
   --max-capacity 800
```

I know that moto does not have MSK support yet, so I cannot add a proper test for it. I tested it against LocalStack.
