### PR TITLE
add ec2 network-acl egress filter

### DIFF
--- a/moto/ec2/models/network_acls.py
+++ b/moto/ec2/models/network_acls.py
@@ -238,6 +238,8 @@ class NetworkAcl(TaggedEC2Resource):
             return [entry.rule_number for entry in self.network_acl_entries]
         elif filter_name == "entry.rule-action":
             return [entry.rule_action for entry in self.network_acl_entries]
+        elif filter_name == "entry.egress":
+            return [entry.egress for entry in self.network_acl_entries]
         elif filter_name == "owner-id":
             return self.owner_id
         else:

--- a/tests/test_ec2/test_network_acls.py
+++ b/tests/test_ec2/test_network_acls.py
@@ -389,13 +389,13 @@ def test_describe_network_acls():
     resp4 = conn.describe_network_acls(
         Filters=[{"Name": "entry.egress", "Values": ["false"]}]
     )
-    resp4["NetworkAcls"].should.have.length_of(3)
+    [entry["NetworkAclId"] for entry in resp4["NetworkAcls"]].should.contain(
+        network_acl_id
+    )
     # the ACL with network_acl_id contains no entries with Egress=True
-    resp4["NetworkAcls"][2]["NetworkAclId"].should.equal(network_acl_id)
     resp4 = conn.describe_network_acls(
         Filters=[{"Name": "entry.egress", "Values": ["true"]}]
     )
-    resp4["NetworkAcls"].should.have.length_of(2)
     [entry["NetworkAclId"] for entry in resp4["NetworkAcls"]].shouldnt.contain(
         network_acl_id
     )

--- a/tests/test_ec2/test_network_acls.py
+++ b/tests/test_ec2/test_network_acls.py
@@ -385,6 +385,21 @@ def test_describe_network_acls():
     )
     resp4["NetworkAcls"].should.have.length_of(0)
 
+    # Ensure filtering by egress flag
+    resp4 = conn.describe_network_acls(
+        Filters=[{"Name": "entry.egress", "Values": ["false"]}]
+    )
+    resp4["NetworkAcls"].should.have.length_of(3)
+    # the ACL with network_acl_id contains no entries with Egress=True
+    resp4["NetworkAcls"][2]["NetworkAclId"].should.equal(network_acl_id)
+    resp4 = conn.describe_network_acls(
+        Filters=[{"Name": "entry.egress", "Values": ["true"]}]
+    )
+    resp4["NetworkAcls"].should.have.length_of(2)
+    [entry["NetworkAclId"] for entry in resp4["NetworkAcls"]].shouldnt.contain(
+        network_acl_id
+    )
+
     # Ensure filtering by rule action
     resp4 = conn.describe_network_acls(
         Filters=[


### PR DESCRIPTION
This PR adds the EC2 Network ACL filter for the `egress` flag. 

This is not in the [official documentation](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeNetworkAcls.html#API_DescribeNetworkAcls_RequestParameters
), for network acl filters, but AWS allows it (and it is sometimes queried by Terraform)
```
% aws ec2 describe-network-acls --filters Name=entry.egress,Values=false 
{
    "NetworkAcls": [
        {
            "Associations": [
                {
                    "NetworkAclAssociationId": "aclassoc-bc6a1111",
                    ...
```