### PR TITLE
Pin versions of werkzeug

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -61,3 +61,4 @@ Moto is written by Steve Pulec with contributions from:
 * [Mickaël Schoentgen](https://github.com/BoboTiG)
 * [Ariel Beck](https://github.com/arielb135)
 * [Roman Rader](https://github.com/rrader/)
+* [Bryan Chen](https://github.com/bchen1116)

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ install_requires = [
     "cryptography>=3.3.1",
     "requests>=2.5",
     "xmltodict",
-    "werkzeug",
+    "werkzeug>=0.5",
     "pytz",
     "python-dateutil<3.0.0,>=2.1",
     "responses>=0.9.0",


### PR DESCRIPTION
`Werkzeug<0.5` fails installation on Moto with py38. Pinning to `>=0.5` allows the install to successfully happen.

(installing `werkzeug==0.4` after `moto`)
<img width="1713" alt="image" src="https://user-images.githubusercontent.com/22552445/170768061-ef93bfe5-6c4b-4bc8-9f82-9f794756341c.png">

(installing `werkzeug==0.5` after `moto`)
<img width="1271" alt="image" src="https://user-images.githubusercontent.com/22552445/170768113-021084ce-b8b3-455c-b9fc-bc74ef40cbac.png">
