### PR TITLE
Bug fix for selecting KMS key via alias ARN

### DIFF
--- a/moto/kms/models.py
+++ b/moto/kms/models.py
@@ -308,7 +308,7 @@ class KmsBackend(BaseBackend):
     def get_alias_name(alias_name):
         # Allow use of ARN as well as alias name
         if alias_name.startswith("arn:") and ":alias/" in alias_name:
-            return alias_name.split(":alias/")[1]
+            return "alias/" + alias_name.split(":alias/")[1]
 
         return alias_name
 

--- a/tests/test_kms/test_kms_boto3.py
+++ b/tests/test_kms/test_kms_boto3.py
@@ -648,7 +648,7 @@ def test_generate_data_key_all_valid_key_ids(prefix, append_key_id):
     if append_key_id:
         target_id += key_id
 
-    client.generate_data_key(KeyId=key_id, NumberOfBytes=32)
+    client.generate_data_key(KeyId=target_id, NumberOfBytes=32)
 
 
 @mock_kms

--- a/tests/test_kms/test_model.py
+++ b/tests/test_kms/test_model.py
@@ -1,70 +1,52 @@
+import pytest
 import sure  # noqa # pylint: disable=unused-import
 
 from moto.kms.models import KmsBackend
 
+PLAINTEXT = b"text"
+REGION = "us-east-1"
 
-def test_encrypt_key_id():
-    region = "us-east-1"
-    backend = KmsBackend(region)
-    # Create key
-    key = backend.create_key(
-        None, "ENCRYPT_DECRYPT", "SYMMETRIC_DEFAULT", "Test key", None, region
+
+@pytest.fixture
+def backend():
+    return KmsBackend(REGION)
+
+
+@pytest.fixture
+def key(backend):
+    return backend.create_key(
+        None, "ENCRYPT_DECRYPT", "SYMMETRIC_DEFAULT", "Test key", None, REGION
     )
-    # Create alias
-    backend.add_alias(key.id, "alias/test/test")
 
-    # Test encryption
-    ciphertext, arn = backend.encrypt(key.id, b"text", {})
+
+def test_encrypt_key_id(backend, key):
+    ciphertext, arn = backend.encrypt(key.id, PLAINTEXT, {})
 
     ciphertext.shouldnt.be.none
     arn.shouldnt.be.none
 
 
-def test_encrypt_key_arn():
-    region = "us-east-1"
-    backend = KmsBackend(region)
-    # Create key
-    key = backend.create_key(
-        None, "ENCRYPT_DECRYPT", "SYMMETRIC_DEFAULT", "Test key", None, region
-    )
-
-    # Test encryption
-    ciphertext, arn = backend.encrypt(key.arn, b"text", {})
+def test_encrypt_key_arn(backend, key):
+    ciphertext, arn = backend.encrypt(key.arn, PLAINTEXT, {})
 
     ciphertext.shouldnt.be.none
     arn.shouldnt.be.none
 
 
-def test_encrypt_alias_name():
-    region = "us-east-1"
-    backend = KmsBackend(region)
-    # Create key
-    key = backend.create_key(
-        None, "ENCRYPT_DECRYPT", "SYMMETRIC_DEFAULT", "Test key", None, region
-    )
-    # Create alias
+def test_encrypt_alias_name(backend, key):
     backend.add_alias(key.id, "alias/test/test")
 
-    # Test encryption
-    ciphertext, arn = backend.encrypt("alias/test/test", b"text", {})
+    ciphertext, arn = backend.encrypt("alias/test/test", PLAINTEXT, {})
 
     ciphertext.shouldnt.be.none
     arn.shouldnt.be.none
 
 
-def test_encrypt_alias_arn():
-    region = "us-east-1"
-    backend = KmsBackend(region)
-    # Create key
-    key = backend.create_key(
-        None, "ENCRYPT_DECRYPT", "SYMMETRIC_DEFAULT", "Test key", None, region
-    )
-    # Create alias
+def test_encrypt_alias_arn(backend, key):
     backend.add_alias(key.id, "alias/test/test")
 
-    # Test encryption
     ciphertext, arn = backend.encrypt(
-        "arn:aws:kms::000000000000:alias/test/test", b"text", {}
+        "arn:aws:kms::000000000000:alias/test/test", PLAINTEXT, {}
     )
 
     ciphertext.shouldnt.be.none

--- a/tests/test_kms/test_model.py
+++ b/tests/test_kms/test_model.py
@@ -46,7 +46,7 @@ def test_encrypt_alias_arn(backend, key):
     backend.add_alias(key.id, "alias/test/test")
 
     ciphertext, arn = backend.encrypt(
-        "arn:aws:kms::000000000000:alias/test/test", PLAINTEXT, {}
+        "arn:aws:kms:us-east-1:000000000000:alias/test/test", PLAINTEXT, {}
     )
 
     ciphertext.shouldnt.be.none

--- a/tests/test_kms/test_model.py
+++ b/tests/test_kms/test_model.py
@@ -1,0 +1,71 @@
+import sure  # noqa # pylint: disable=unused-import
+
+from moto.kms.models import KmsBackend
+
+
+def test_encrypt_key_id():
+    region = "us-east-1"
+    backend = KmsBackend(region)
+    # Create key
+    key = backend.create_key(
+        None, "ENCRYPT_DECRYPT", "SYMMETRIC_DEFAULT", "Test key", None, region
+    )
+    # Create alias
+    backend.add_alias(key.id, "alias/test/test")
+
+    # Test encryption
+    ciphertext, arn = backend.encrypt(key.id, b"text", {})
+
+    ciphertext.shouldnt.be.none
+    arn.shouldnt.be.none
+
+
+def test_encrypt_key_arn():
+    region = "us-east-1"
+    backend = KmsBackend(region)
+    # Create key
+    key = backend.create_key(
+        None, "ENCRYPT_DECRYPT", "SYMMETRIC_DEFAULT", "Test key", None, region
+    )
+
+    # Test encryption
+    ciphertext, arn = backend.encrypt(key.arn, b"text", {})
+
+    ciphertext.shouldnt.be.none
+    arn.shouldnt.be.none
+
+
+def test_encrypt_alias_name():
+    region = "us-east-1"
+    backend = KmsBackend(region)
+    # Create key
+    key = backend.create_key(
+        None, "ENCRYPT_DECRYPT", "SYMMETRIC_DEFAULT", "Test key", None, region
+    )
+    # Create alias
+    backend.add_alias(key.id, "alias/test/test")
+
+    # Test encryption
+    ciphertext, arn = backend.encrypt("alias/test/test", b"text", {})
+
+    ciphertext.shouldnt.be.none
+    arn.shouldnt.be.none
+
+
+def test_encrypt_alias_arn():
+    region = "us-east-1"
+    backend = KmsBackend(region)
+    # Create key
+    key = backend.create_key(
+        None, "ENCRYPT_DECRYPT", "SYMMETRIC_DEFAULT", "Test key", None, region
+    )
+    # Create alias
+    backend.add_alias(key.id, "alias/test/test")
+
+    # Test encryption
+    ciphertext, arn = backend.encrypt(
+        "arn:aws:kms::000000000000:alias/test/test", b"text", {}
+    )
+
+    ciphertext.shouldnt.be.none
+    arn.shouldnt.be.none

--- a/tests/test_kms/test_model.py
+++ b/tests/test_kms/test_model.py
@@ -22,14 +22,14 @@ def test_encrypt_key_id(backend, key):
     ciphertext, arn = backend.encrypt(key.id, PLAINTEXT, {})
 
     assert ciphertext is not None
-    assert arn is not None
+    assert arn == key.arn
 
 
 def test_encrypt_key_arn(backend, key):
     ciphertext, arn = backend.encrypt(key.arn, PLAINTEXT, {})
 
     assert ciphertext is not None
-    assert arn is not None
+    assert arn == key.arn
 
 
 def test_encrypt_alias_name(backend, key):
@@ -38,15 +38,15 @@ def test_encrypt_alias_name(backend, key):
     ciphertext, arn = backend.encrypt("alias/test/test", PLAINTEXT, {})
 
     assert ciphertext is not None
-    assert arn is not None
+    assert arn == key.arn
 
 
 def test_encrypt_alias_arn(backend, key):
     backend.add_alias(key.id, "alias/test/test")
 
     ciphertext, arn = backend.encrypt(
-        "arn:aws:kms:us-east-1:000000000000:alias/test/test", PLAINTEXT, {}
+        f"arn:aws:kms:{REGION}:{key.account_id}:alias/test/test", PLAINTEXT, {}
     )
 
     assert ciphertext is not None
-    assert arn is not None
+    assert arn == key.arn

--- a/tests/test_kms/test_model.py
+++ b/tests/test_kms/test_model.py
@@ -1,5 +1,4 @@
 import pytest
-import sure  # noqa # pylint: disable=unused-import
 
 from moto.kms.models import KmsBackend
 
@@ -22,15 +21,15 @@ def key(backend):
 def test_encrypt_key_id(backend, key):
     ciphertext, arn = backend.encrypt(key.id, PLAINTEXT, {})
 
-    ciphertext.shouldnt.be.none
-    arn.shouldnt.be.none
+    assert ciphertext is not None
+    assert arn is not None
 
 
 def test_encrypt_key_arn(backend, key):
     ciphertext, arn = backend.encrypt(key.arn, PLAINTEXT, {})
 
-    ciphertext.shouldnt.be.none
-    arn.shouldnt.be.none
+    assert ciphertext is not None
+    assert arn is not None
 
 
 def test_encrypt_alias_name(backend, key):
@@ -38,8 +37,8 @@ def test_encrypt_alias_name(backend, key):
 
     ciphertext, arn = backend.encrypt("alias/test/test", PLAINTEXT, {})
 
-    ciphertext.shouldnt.be.none
-    arn.shouldnt.be.none
+    assert ciphertext is not None
+    assert arn is not None
 
 
 def test_encrypt_alias_arn(backend, key):
@@ -49,5 +48,5 @@ def test_encrypt_alias_arn(backend, key):
         "arn:aws:kms:us-east-1:000000000000:alias/test/test", PLAINTEXT, {}
     )
 
-    ciphertext.shouldnt.be.none
-    arn.shouldnt.be.none
+    assert ciphertext is not None
+    assert arn is not None


### PR DESCRIPTION
When using Localstack with moto as the KMS provider, I encountered issues with selecting a key via the alias ARN. I believe this change fixes the issue by ensuring the `alias/` prefix is included when the name is extracted from the ARN. I've added tests to the KMS model to verify that, and that encryption works via all the other supported mechanisms