### PR TITLE
Quicksight url pattern matching modified 

### DIFF
--- a/moto/quicksight/urls.py
+++ b/moto/quicksight/urls.py
@@ -12,10 +12,10 @@ response = QuickSightResponse()
 url_paths = {
     r"{0}/accounts/(?P<account_id>[\d]+)/data-sets$": response.dataset,
     r"{0}/accounts/(?P<account_id>[\d]+)/data-sets/(?P<datasetid>[^/.]+)/ingestions/(?P<ingestionid>[^/.]+)$": response.ingestion,
-    r"{0}/accounts/(?P<account_id>[\d]+)/namespaces/(?P<namespace>[^/.]+)/groups$": response.groups,
-    r"{0}/accounts/(?P<account_id>[\d]+)/namespaces/(?P<namespace>[^/.]+)/groups/(?P<groupname>[^/.]+)$": response.group,
-    r"{0}/accounts/(?P<account_id>[\d]+)/namespaces/(?P<namespace>[^/.]+)/groups/(?P<groupname>[^/.]+)/members$": response.group_members,
-    r"{0}/accounts/(?P<account_id>[\d]+)/namespaces/(?P<namespace>[^/.]+)/groups/(?P<groupname>[^/.]+)/members/(?P<username>[^/.]+)$": response.group_member,
-    r"{0}/accounts/(?P<account_id>[\d]+)/namespaces/(?P<namespace>[^/.]+)/users$": response.users,
-    r"{0}/accounts/(?P<account_id>[\d]+)/namespaces/(?P<namespace>[^/.]+)/users/(?P<username>[^/.]+)$": response.user,
+    r"{0}/accounts/(?P<account_id>[\d]+)/namespaces/(?P<namespace>[a-zA-Z0-9._-]+)/groups$": response.groups,
+    r"{0}/accounts/(?P<account_id>[\d]+)/namespaces/(?P<namespace>[a-zA-Z0-9._-]+)/groups/(?P<groupname>[^/]+)$": response.group,
+    r"{0}/accounts/(?P<account_id>[\d]+)/namespaces/(?P<namespace>[a-zA-Z0-9._-]+)/groups/(?P<groupname>[^/]+)/members$": response.group_members,
+    r"{0}/accounts/(?P<account_id>[\d]+)/namespaces/(?P<namespace>[a-zA-Z0-9._-]+)/groups/(?P<groupname>[^/]+)/members/(?P<username>[^/]+)$": response.group_member,
+    r"{0}/accounts/(?P<account_id>[\d]+)/namespaces/(?P<namespace>[a-zA-Z0-9._-]+)/users$": response.users,
+    r"{0}/accounts/(?P<account_id>[\d]+)/namespaces/(?P<namespace>[a-zA-Z0-9._-]+)/users/(?P<username>[^/]+)$": response.user,
 }

--- a/tests/test_quicksight/test_quicksight_users.py
+++ b/tests/test_quicksight/test_quicksight_users.py
@@ -146,7 +146,7 @@ def test_create_group_membership():
         Namespace="default",
         Email="fakeemail@example.com",
         IdentityType="QUICKSIGHT",
-        UserName="user1",
+        UserName="user.1",
         UserRole="READER",
     )
     client.create_group(
@@ -154,7 +154,7 @@ def test_create_group_membership():
     )
 
     resp = client.create_group_membership(
-        MemberName="user1",
+        MemberName="user.1",
         GroupName="group1",
         AwsAccountId=ACCOUNT_ID,
         Namespace="default",
@@ -162,8 +162,8 @@ def test_create_group_membership():
 
     resp.should.have.key("GroupMember").equals(
         {
-            "Arn": f"arn:aws:quicksight:us-east-2:{ACCOUNT_ID}:group/default/group1/user1",
-            "MemberName": "user1",
+            "Arn": f"arn:aws:quicksight:us-east-2:{ACCOUNT_ID}:group/default/group1/user.1",
+            "MemberName": "user.1",
         }
     )
     resp.should.have.key("Status").equals(200)


### PR DESCRIPTION
Fixes https://github.com/spulec/moto/issues/5183

* `[a-zA-Z0-9._-]+` for namespaces according to [aws docs ](https://docs.aws.amazon.com/quicksight/latest/APIReference/API_CreateGroup.html)
* `[^/]+` - for username and groups. Unfortunately. I was not able to add handling for `/`. Url resolver acts weird. Omitting `/` makes the solution more stable.