### PR TITLE
Stable cognito user pool

### DIFF
--- a/docs/docs/services/cognito-idp.rst
+++ b/docs/docs/services/cognito-idp.rst
@@ -145,3 +145,10 @@ cognito-idp
 
 - [ ] verify_user_attribute
 
+
+|start-h3| Stable Cognito User Pool Id |end-h3|
+
+In some cases, you need to have reproducible IDs for the user pool.
+For example, a single initialization before the start of integration tests.
+
+This behavior can be enabled by passing the environment variable: MOTO_COGNITO_IDP_USER_POOL_ID_STRATEGY=HASH.

--- a/moto/cognitoidp/models.py
+++ b/moto/cognitoidp/models.py
@@ -24,6 +24,7 @@ from .exceptions import (
 from .utils import (
     create_id,
     check_secret_hash,
+    generate_id,
     validate_username_format,
     flatten_attrs,
     expand_attrs,
@@ -31,6 +32,7 @@ from .utils import (
 )
 from moto.utilities.paginator import paginate
 from moto.utilities.utils import md5_hash
+from ..settings import get_cognito_idp_user_pool_id_strategy
 
 
 class UserStatus(str, enum.Enum):
@@ -366,12 +368,20 @@ DEFAULT_USER_POOL_CONFIG = {
 
 
 class CognitoIdpUserPool(BaseModel):
+
+    MAX_ID_LENGTH = 56
+
     def __init__(self, region, name, extended_config):
         self.region = region
-        self.id = "{}_{}".format(self.region, str(uuid.uuid4().hex))
+
+        user_pool_id = generate_id(
+            get_cognito_idp_user_pool_id_strategy(), region, name, extended_config
+        )
+        self.id = "{}_{}".format(self.region, user_pool_id)[: self.MAX_ID_LENGTH]
         self.arn = "arn:aws:cognito-idp:{}:{}:userpool/{}".format(
             self.region, get_account_id(), self.id
         )
+
         self.name = name
         self.status = None
 

--- a/moto/cognitoidp/utils.py
+++ b/moto/cognitoidp/utils.py
@@ -4,6 +4,7 @@ import hashlib
 import hmac
 import base64
 import re
+import uuid
 
 FORMATS = {
     "email": r"\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}\b",
@@ -66,3 +67,26 @@ def flatten_attrs(attrs):
 
 def expand_attrs(attrs):
     return [{"Name": k, "Value": v} for k, v in attrs.items()]
+
+
+ID_HASH_STRATEGY = "HASH"
+
+
+def generate_id(strategy, *args):
+    if strategy == ID_HASH_STRATEGY:
+        return _generate_id_hash(args)
+    else:
+        return _generate_id_uuid()
+
+
+def _generate_id_uuid():
+    return uuid.uuid4().hex
+
+
+def _generate_id_hash(args):
+    hasher = hashlib.sha256()
+
+    for arg in args:
+        hasher.update(str(arg).encode())
+
+    return hasher.hexdigest()

--- a/moto/settings.py
+++ b/moto/settings.py
@@ -125,3 +125,7 @@ def get_docker_host():
         )
         print(f"{type(e)}::{e}")
         return "http://host.docker.internal"
+
+
+def get_cognito_idp_user_pool_id_strategy():
+    return os.environ.get("MOTO_COGNITO_IDP_USER_POOL_ID_STRATEGY")


### PR DESCRIPTION
Hi!

We create a Cogito UserPool before running integration tests, and random IDs complicate the process of finding a pool.

I added an environment variable `MOTO_COGNITO_IDP_USER_POOL_ID_STRATEGY=HASH`, setting which makes the ID of Cognito Userpool reproducible. I think this change will be useful to other moto users as well.