### PR TITLE
fixed route53 rrset terraform suit

### DIFF
--- a/moto/route53/exceptions.py
+++ b/moto/route53/exceptions.py
@@ -65,6 +65,17 @@ class NoSuchHostedZone(Route53ClientError):
         self.content_type = "text/xml"
 
 
+class NoSuchHealthCheck(Route53ClientError):
+    """HealthCheck does not exist."""
+
+    code = 404
+
+    def __init__(self, health_check_id):
+        message = f"A health check with id {health_check_id} does not exist."
+        super().__init__("NoSuchHealthCheck", message)
+        self.content_type = "text/xml"
+
+
 class HostedZoneNotEmpty(Route53ClientError):
     """HostedZone does not exist."""
 

--- a/moto/route53/exceptions.py
+++ b/moto/route53/exceptions.py
@@ -6,7 +6,7 @@ class Route53ClientError(RESTError):
     """Base class for Route53 errors."""
 
     def __init__(self, *args, **kwargs):
-        kwargs.setdefault("template", "single_error")
+        kwargs.setdefault("template", "wrapped_single_error")
         super().__init__(*args, **kwargs)
 
 
@@ -62,6 +62,19 @@ class NoSuchHostedZone(Route53ClientError):
     def __init__(self, host_zone_id):
         message = f"No hosted zone found with ID: {host_zone_id}"
         super().__init__("NoSuchHostedZone", message)
+        self.content_type = "text/xml"
+
+
+class HostedZoneNotEmpty(Route53ClientError):
+    """HostedZone does not exist."""
+
+    code = 400
+
+    def __init__(self):
+        message = (
+            "The hosted zone contains resource records that are not SOA or NS records."
+        )
+        super().__init__("HostedZoneNotEmpty", message)
         self.content_type = "text/xml"
 
 

--- a/moto/route53/models.py
+++ b/moto/route53/models.py
@@ -9,6 +9,7 @@ import uuid
 from jinja2 import Template
 
 from moto.route53.exceptions import (
+    HostedZoneNotEmpty,
     InvalidInput,
     NoSuchCloudWatchLogsLogGroup,
     NoSuchDelegationSet,
@@ -153,9 +154,9 @@ class RecordSet(CloudFormationModel):
         self.health_check = kwargs.get("HealthCheckId")
         self.hosted_zone_name = kwargs.get("HostedZoneName")
         self.hosted_zone_id = kwargs.get("HostedZoneId")
-        self.alias_target = kwargs.get("AliasTarget")
-        self.failover = kwargs.get("Failover")
-        self.geo_location = kwargs.get("GeoLocation")
+        self.alias_target = kwargs.get("AliasTarget", [])
+        self.failover = kwargs.get("Failover", [])
+        self.geo_location = kwargs.get("GeoLocation", [])
 
     @staticmethod
     def cloudformation_name_type():
@@ -411,6 +412,9 @@ class Route53Backend(BaseBackend):
         delegation_set = self.create_reusable_delegation_set(
             caller_reference=f"DelSet_{name}", delegation_set_id=delegation_set_id
         )
+        # default delegation set does not contains id
+        if not delegation_set_id:
+            delegation_set.id = ""
         new_zone = FakeZone(
             name,
             new_id,
@@ -420,8 +424,20 @@ class Route53Backend(BaseBackend):
             comment=comment,
             delegation_set=delegation_set,
         )
+        # default nameservers are also part of rrset
+        record_set = {
+            "Name": name,
+            "ResourceRecords": delegation_set.name_servers,
+            "TTL": "172800",
+            "Type": "NS",
+        }
+        new_zone.add_rrset(record_set)
         self.zones[new_id] = new_zone
         return new_zone
+
+    def get_dnssec(self, zone_id):
+        # check if hosted zone exists
+        self.get_hosted_zone(zone_id)
 
     def change_tags_for_resource(self, resource_id, tags):
         if "Tag" in tags:
@@ -557,7 +573,11 @@ class Route53Backend(BaseBackend):
 
     def delete_hosted_zone(self, id_):
         # Verify it exists
-        self.get_hosted_zone(id_)
+        zone = self.get_hosted_zone(id_)
+        if len(zone.rrsets) > 0:
+            for rrset in zone.rrsets:
+                if rrset.type_ != "NS" and rrset.type_ != "SOA":
+                    raise HostedZoneNotEmpty()
         return self.zones.pop(id_.replace("/hostedzone/", ""), None)
 
     def create_health_check(self, caller_reference, health_check_args):

--- a/moto/route53/models.py
+++ b/moto/route53/models.py
@@ -13,6 +13,7 @@ from moto.route53.exceptions import (
     InvalidInput,
     NoSuchCloudWatchLogsLogGroup,
     NoSuchDelegationSet,
+    NoSuchHealthCheck,
     NoSuchHostedZone,
     NoSuchQueryLoggingConfig,
     QueryLoggingConfigAlreadyExists,
@@ -591,6 +592,12 @@ class Route53Backend(BaseBackend):
 
     def delete_health_check(self, health_check_id):
         return self.health_checks.pop(health_check_id, None)
+
+    def get_health_check(self, health_check_id):
+        health_check = self.health_checks.get(health_check_id)
+        if not health_check:
+            raise NoSuchHealthCheck(health_check_id)
+        return health_check
 
     @staticmethod
     def _validate_arn(region, arn):

--- a/moto/route53/responses.py
+++ b/moto/route53/responses.py
@@ -259,6 +259,11 @@ class Route53(BaseResponse):
             health_check = route53_backend.get_health_check(health_check_id)
             template = Template(GET_HEALTH_CHECK_RESPONSE)
             return 200, headers, template.render(health_check=health_check)
+        elif method == "DELETE":
+            health_check_id = parsed_url.path.split("/")[-1]
+            route53_backend.delete_health_check(health_check_id)
+            template = Template(DELETE_HEALTH_CHECK_RESPONSE)
+            return 200, headers, template.render(xmlns=XMLNS)
 
     def not_implemented_response(self, request, full_url, headers):
         self.setup_class(request, full_url, headers)

--- a/moto/route53/urls.py
+++ b/moto/route53/urls.py
@@ -21,7 +21,7 @@ url_paths = {
     r"{0}/(?P<api_version>[\d_-]+)/hostedzonesbyvpc": Route53().list_hosted_zones_by_vpc_response,
     r"{0}/(?P<api_version>[\d_-]+)/hostedzonecount": Route53().get_hosted_zone_count_response,
     r"{0}/(?P<api_version>[\d_-]+)/healthcheck": Route53().health_check_response,
-    r"{0}/(?P<api_version>[\d_-]+)/healthcheck/(?P<health_check_id>[^/]+)$": Route53().health_check_response,
+    r"{0}/(?P<api_version>[\d_-]+)/healthcheck/(?P<health_check_id>[^/]+)$": Route53().get_or_delete_health_check_response,
     r"{0}/(?P<api_version>[\d_-]+)/tags/healthcheck/(?P<zone_id>[^/]+)$": tag_response1,
     r"{0}/(?P<api_version>[\d_-]+)/tags/hostedzone/(?P<zone_id>[^/]+)$": tag_response2,
     r"{0}/(?P<api_version>[\d_-]+)/trafficpolicyinstances/*": Route53().not_implemented_response,

--- a/moto/route53/urls.py
+++ b/moto/route53/urls.py
@@ -16,6 +16,7 @@ url_paths = {
     r"{0}/(?P<api_version>[\d_-]+)/hostedzone$": Route53().list_or_create_hostzone_response,
     r"{0}/(?P<api_version>[\d_-]+)/hostedzone/(?P<zone_id>[^/]+)$": Route53().get_or_delete_hostzone_response,
     r"{0}/(?P<api_version>[\d_-]+)/hostedzone/(?P<zone_id>[^/]+)/rrset/?$": Route53().rrset_response,
+    r"{0}/(?P<api_version>[\d_-]+)/hostedzone/(?P<zone_id>[^/]+)/dnssec/?$": Route53().get_dnssec_response,
     r"{0}/(?P<api_version>[\d_-]+)/hostedzonesbyname": Route53().list_hosted_zones_by_name_response,
     r"{0}/(?P<api_version>[\d_-]+)/hostedzonesbyvpc": Route53().list_hosted_zones_by_vpc_response,
     r"{0}/(?P<api_version>[\d_-]+)/hostedzonecount": Route53().get_hosted_zone_count_response,

--- a/tests/terraformtests/terraform-tests.success.txt
+++ b/tests/terraformtests/terraform-tests.success.txt
@@ -135,6 +135,34 @@ quicksight:
   - TestAccQuickSightUser
 redshift:
   - TestAccRedshiftServiceAccountDataSource
+route53:
+  - TestAccRoute53Record_basic
+  - TestAccRoute53Record_underscored
+  - TestAccRoute53Record_disappears
+  - TestAccRoute53Record_Disappears_multipleRecords
+  - TestAccRoute53Record_Basic_fqdn
+  - TestAccRoute53Record_Basic_trailingPeriodAndZoneID
+  - TestAccRoute53Record_txtSupport
+  - TestAccRoute53Record_spfSupport
+  - TestAccRoute53Record_caaSupport
+  - TestAccRoute53Record_dsSupport
+  - TestAccRoute53Record_generatesSuffix
+  - TestAccRoute53Record_wildcard
+  - TestAccRoute53Record_failover
+  - TestAccRoute53Record_Weighted_basic
+  - TestAccRoute53Record_WeightedToSimple_basic
+  - TestAccRoute53Record_Alias_s3
+  - TestAccRoute53Record_Geolocation_basic
+  - TestAccRoute53Record_HealthCheckID_setIdentifierChange
+  - TestAccRoute53Record_HealthCheckID_typeChange
+  - TestAccRoute53Record_Latency_basic
+  - TestAccRoute53Record_typeChange
+  - TestAccRoute53Record_nameChange
+  - TestAccRoute53Record_setIdentifierChange
+  - TestAccRoute53Record_empty
+  - TestAccRoute53Record_longTXTrecord
+  - TestAccRoute53Record_doNotAllowOverwrite
+  - TestAccRoute53Record_allowOverwrite
 s3:
   - TestAccS3BucketPolicy
   - TestAccS3BucketPublicAccessBlock

--- a/tests/test_route53/test_route53.py
+++ b/tests/test_route53/test_route53.py
@@ -395,7 +395,9 @@ def test_deleting_latency_route():
     )["ResourceRecordSets"]
     cnames.should.have.length_of(3)
     foo_cname = [
-        cname for cname in cnames if cname.get("SetIdentifier") and cname["SetIdentifier"] == "success-test-foo"
+        cname
+        for cname in cnames
+        if cname.get("SetIdentifier") and cname["SetIdentifier"] == "success-test-foo"
     ][0]
     foo_cname["Region"].should.equal("us-west-2")
 

--- a/tests/test_route53/test_route53.py
+++ b/tests/test_route53/test_route53.py
@@ -19,7 +19,7 @@ def test_create_hosted_zone():
     firstzone.should.have.key("Id").match(r"/hostedzone/[A-Z0-9]+")
     firstzone.should.have.key("Name").equal("testdns.aws.com.")
     firstzone.should.have.key("Config").equal({"PrivateZone": False})
-    firstzone.should.have.key("ResourceRecordSetCount").equal(0)
+    firstzone.should.have.key("ResourceRecordSetCount").equal(1)
 
     delegation = response["DelegationSet"]
     delegation.should.have.key("NameServers").length_of(4)
@@ -281,8 +281,8 @@ def test_use_health_check_in_resource_record_set():
     record_sets = conn.list_resource_record_sets(HostedZoneId=zone_id)[
         "ResourceRecordSets"
     ]
-    record_sets[0]["Name"].should.equal("foo.bar.testdns.aws.com.")
-    record_sets[0]["HealthCheckId"].should.equal(check_id)
+    record_sets[1]["Name"].should.equal("foo.bar.testdns.aws.com.")
+    record_sets[1]["HealthCheckId"].should.equal(check_id)
 
 
 @mock_route53
@@ -333,7 +333,7 @@ def test_deleting_weighted_route():
     cnames = conn.list_resource_record_sets(
         HostedZoneId=zone_id, StartRecordName="cname", StartRecordType="CNAME"
     )["ResourceRecordSets"]
-    cnames.should.have.length_of(2)
+    cnames.should.have.length_of(3)
 
     conn.change_resource_record_sets(
         HostedZoneId=zone_id,
@@ -354,9 +354,9 @@ def test_deleting_weighted_route():
     cnames = conn.list_resource_record_sets(
         HostedZoneId=zone_id, StartRecordName="cname", StartRecordType="CNAME"
     )["ResourceRecordSets"]
-    cnames.should.have.length_of(1)
-    cnames[0]["Name"].should.equal("cname.testdns.aws.com.")
-    cnames[0]["SetIdentifier"].should.equal("success-test-bar")
+    cnames.should.have.length_of(2)
+    cnames[1]["Name"].should.equal("cname.testdns.aws.com.")
+    cnames[1]["SetIdentifier"].should.equal("success-test-bar")
 
 
 @mock_route53
@@ -393,9 +393,9 @@ def test_deleting_latency_route():
     cnames = conn.list_resource_record_sets(
         HostedZoneId=zone_id, StartRecordName="cname", StartRecordType="CNAME"
     )["ResourceRecordSets"]
-    cnames.should.have.length_of(2)
+    cnames.should.have.length_of(3)
     foo_cname = [
-        cname for cname in cnames if cname["SetIdentifier"] == "success-test-foo"
+        cname for cname in cnames if cname.get("SetIdentifier") and cname["SetIdentifier"] == "success-test-foo"
     ][0]
     foo_cname["Region"].should.equal("us-west-2")
 
@@ -417,9 +417,9 @@ def test_deleting_latency_route():
     cnames = conn.list_resource_record_sets(
         HostedZoneId=zone_id, StartRecordName="cname", StartRecordType="CNAME"
     )["ResourceRecordSets"]
-    cnames.should.have.length_of(1)
-    cnames[0]["SetIdentifier"].should.equal("success-test-bar")
-    cnames[0]["Region"].should.equal("us-west-1")
+    cnames.should.have.length_of(2)
+    cnames[1]["SetIdentifier"].should.equal("success-test-bar")
+    cnames[1]["Region"].should.equal("us-west-1")
 
 
 @mock_ec2
@@ -801,8 +801,8 @@ def test_change_resource_record_sets_crud_valid():
     )
 
     response = conn.list_resource_record_sets(HostedZoneId=hosted_zone_id)
-    len(response["ResourceRecordSets"]).should.equal(1)
-    a_record_detail = response["ResourceRecordSets"][0]
+    len(response["ResourceRecordSets"]).should.equal(2)
+    a_record_detail = response["ResourceRecordSets"][1]
     a_record_detail["Name"].should.equal("prod.redis.db.")
     a_record_detail["Type"].should.equal("A")
     a_record_detail["TTL"].should.equal(10)
@@ -828,8 +828,8 @@ def test_change_resource_record_sets_crud_valid():
     )
 
     response = conn.list_resource_record_sets(HostedZoneId=hosted_zone_id)
-    len(response["ResourceRecordSets"]).should.equal(1)
-    cname_record_detail = response["ResourceRecordSets"][0]
+    len(response["ResourceRecordSets"]).should.equal(2)
+    cname_record_detail = response["ResourceRecordSets"][1]
     cname_record_detail["Name"].should.equal("prod.redis.db.")
     cname_record_detail["Type"].should.equal("A")
     cname_record_detail["TTL"].should.equal(60)
@@ -859,7 +859,7 @@ def test_change_resource_record_sets_crud_valid():
     )
 
     response = conn.list_resource_record_sets(HostedZoneId=hosted_zone_id)
-    cname_alias_record_detail = response["ResourceRecordSets"][0]
+    cname_alias_record_detail = response["ResourceRecordSets"][1]
     cname_alias_record_detail["Name"].should.equal("prod.redis.db.")
     cname_alias_record_detail["Type"].should.equal("A")
     cname_alias_record_detail["TTL"].should.equal(60)
@@ -886,7 +886,7 @@ def test_change_resource_record_sets_crud_valid():
         HostedZoneId=hosted_zone_id, ChangeBatch=delete_payload
     )
     response = conn.list_resource_record_sets(HostedZoneId=hosted_zone_id)
-    len(response["ResourceRecordSets"]).should.equal(1)
+    len(response["ResourceRecordSets"]).should.equal(2)
 
     # Delete record.
     delete_payload = {
@@ -902,7 +902,7 @@ def test_change_resource_record_sets_crud_valid():
         HostedZoneId=hosted_zone_id, ChangeBatch=delete_payload
     )
     response = conn.list_resource_record_sets(HostedZoneId=hosted_zone_id)
-    len(response["ResourceRecordSets"]).should.equal(0)
+    len(response["ResourceRecordSets"]).should.equal(1)
 
 
 @mock_route53
@@ -939,8 +939,8 @@ def test_change_resource_record_sets_crud_valid_with_special_xml_chars():
     )
 
     response = conn.list_resource_record_sets(HostedZoneId=hosted_zone_id)
-    len(response["ResourceRecordSets"]).should.equal(1)
-    a_record_detail = response["ResourceRecordSets"][0]
+    len(response["ResourceRecordSets"]).should.equal(2)
+    a_record_detail = response["ResourceRecordSets"][1]
     a_record_detail["Name"].should.equal("prod.redis.db.")
     a_record_detail["Type"].should.equal("TXT")
     a_record_detail["TTL"].should.equal(10)
@@ -967,8 +967,8 @@ def test_change_resource_record_sets_crud_valid_with_special_xml_chars():
     )
 
     response = conn.list_resource_record_sets(HostedZoneId=hosted_zone_id)
-    len(response["ResourceRecordSets"]).should.equal(1)
-    cname_record_detail = response["ResourceRecordSets"][0]
+    len(response["ResourceRecordSets"]).should.equal(2)
+    cname_record_detail = response["ResourceRecordSets"][1]
     cname_record_detail["Name"].should.equal("prod.redis.db.")
     cname_record_detail["Type"].should.equal("TXT")
     cname_record_detail["TTL"].should.equal(60)
@@ -990,7 +990,7 @@ def test_change_resource_record_sets_crud_valid_with_special_xml_chars():
         HostedZoneId=hosted_zone_id, ChangeBatch=delete_payload
     )
     response = conn.list_resource_record_sets(HostedZoneId=hosted_zone_id)
-    len(response["ResourceRecordSets"]).should.equal(0)
+    len(response["ResourceRecordSets"]).should.equal(1)
 
 
 @mock_route53
@@ -1096,10 +1096,11 @@ def test_change_weighted_resource_record_sets():
 
     response = conn.list_resource_record_sets(HostedZoneId=hosted_zone_id)
     for record in response["ResourceRecordSets"]:
-        if record["SetIdentifier"] == "test1":
-            record["Weight"].should.equal(90)
-        if record["SetIdentifier"] == "test2":
-            record["Weight"].should.equal(10)
+        if record.get("SetIdentifier"):
+            if record["SetIdentifier"] == "test1":
+                record["Weight"].should.equal(90)
+            if record["SetIdentifier"] == "test2":
+                record["Weight"].should.equal(10)
 
 
 @mock_route53
@@ -1129,7 +1130,7 @@ def test_failover_record_sets():
     )
 
     response = conn.list_resource_record_sets(HostedZoneId=hosted_zone_id)
-    record = response["ResourceRecordSets"][0]
+    record = response["ResourceRecordSets"][1]
     record["Failover"].should.equal("PRIMARY")
 
 
@@ -1171,8 +1172,8 @@ def test_geolocation_record_sets():
 
     response = conn.list_resource_record_sets(HostedZoneId=hosted_zone_id)
     rrs = response["ResourceRecordSets"]
-    rrs[0]["GeoLocation"].should.equal({"ContinentCode": "EU"})
-    rrs[1]["GeoLocation"].should.equal({"CountryCode": "US", "SubdivisionCode": "NY"})
+    rrs[1]["GeoLocation"].should.equal({"ContinentCode": "EU"})
+    rrs[2]["GeoLocation"].should.equal({"CountryCode": "US", "SubdivisionCode": "NY"})
 
 
 @mock_route53
@@ -1210,7 +1211,7 @@ def test_change_resource_record_invalid():
         )
 
     response = conn.list_resource_record_sets(HostedZoneId=hosted_zone_id)
-    len(response["ResourceRecordSets"]).should.equal(0)
+    len(response["ResourceRecordSets"]).should.equal(1)
 
     invalid_cname_record_payload = {
         "Comment": "this should also fail",
@@ -1233,7 +1234,7 @@ def test_change_resource_record_invalid():
         )
 
     response = conn.list_resource_record_sets(HostedZoneId=hosted_zone_id)
-    len(response["ResourceRecordSets"]).should.equal(0)
+    len(response["ResourceRecordSets"]).should.equal(1)
 
 
 @mock_route53
@@ -1465,7 +1466,7 @@ def test_list_resource_recordset_pagination():
     response.should.have.key("ResourceRecordSets").length_of(100)
     response.should.have.key("IsTruncated").equals(True)
     response.should.have.key("MaxItems").equals("100")
-    response.should.have.key("NextRecordName").equals("env189.redis.db.")
+    response.should.have.key("NextRecordName").equals("env188.redis.db.")
     response.should.have.key("NextRecordType").equals("A")
 
     response = conn.list_resource_record_sets(
@@ -1476,7 +1477,7 @@ def test_list_resource_recordset_pagination():
     response.should.have.key("ResourceRecordSets").length_of(300)
     response.should.have.key("IsTruncated").equals(True)
     response.should.have.key("MaxItems").equals("300")
-    response.should.have.key("NextRecordName").equals("env459.redis.db.")
+    response.should.have.key("NextRecordName").equals("env458.redis.db.")
     response.should.have.key("NextRecordType").equals("A")
 
     response = conn.list_resource_record_sets(
@@ -1484,7 +1485,7 @@ def test_list_resource_recordset_pagination():
         StartRecordName=response["NextRecordName"],
         StartRecordType=response["NextRecordType"],
     )
-    response.should.have.key("ResourceRecordSets").length_of(100)
+    response.should.have.key("ResourceRecordSets").length_of(101)
     response.should.have.key("IsTruncated").equals(False)
     response.should.have.key("MaxItems").equals("300")
     response.shouldnt.have.key("NextRecordName")

--- a/tests/test_route53/test_route53_cloudformation.py
+++ b/tests/test_route53/test_route53_cloudformation.py
@@ -56,7 +56,7 @@ def test_create_stack_hosted_zone_by_id():
     # then a hosted zone should exist
     zone = conn.list_hosted_zones()["HostedZones"][0]
     zone.should.have.key("Name").equal("foo.bar.baz")
-    zone.should.have.key("ResourceRecordSetCount").equal(0)
+    zone.should.have.key("ResourceRecordSetCount").equal(1)
 
     # when adding a record set to this zone
     cf_conn.create_stack(
@@ -69,7 +69,7 @@ def test_create_stack_hosted_zone_by_id():
     updated_zone = conn.list_hosted_zones()["HostedZones"][0]
     updated_zone.should.have.key("Id").equal(zone["Id"])
     updated_zone.should.have.key("Name").equal("foo.bar.baz")
-    updated_zone.should.have.key("ResourceRecordSetCount").equal(1)
+    updated_zone.should.have.key("ResourceRecordSetCount").equal(2)
 
 
 @mock_cloudformation
@@ -88,8 +88,8 @@ def test_route53_roundrobin():
     rrsets = route53.list_resource_record_sets(HostedZoneId=zone_id)[
         "ResourceRecordSets"
     ]
-    rrsets.should.have.length_of(2)
-    record_set1 = rrsets[0]
+    rrsets.should.have.length_of(3)
+    record_set1 = rrsets[1]
     record_set1["Name"].should.equal("test_stack.us-west-1.my_zone.")
     record_set1["SetIdentifier"].should.equal("test_stack AWS")
     record_set1["Type"].should.equal("CNAME")
@@ -97,7 +97,7 @@ def test_route53_roundrobin():
     record_set1["Weight"].should.equal(3)
     record_set1["ResourceRecords"][0]["Value"].should.equal("aws.amazon.com")
 
-    record_set2 = rrsets[1]
+    record_set2 = rrsets[2]
     record_set2["Name"].should.equal("test_stack.us-west-1.my_zone.")
     record_set2["SetIdentifier"].should.equal("test_stack Amazon")
     record_set2["Type"].should.equal("CNAME")
@@ -135,9 +135,9 @@ def test_route53_ec2_instance_with_public_ip():
     rrsets = route53.list_resource_record_sets(HostedZoneId=zone_id)[
         "ResourceRecordSets"
     ]
-    rrsets.should.have.length_of(1)
+    rrsets.should.have.length_of(2)
 
-    record_set = rrsets[0]
+    record_set = rrsets[1]
     record_set["Name"].should.equal("{0}.us-west-1.my_zone.".format(instance_id))
     record_set.shouldnt.have.key("SetIdentifier")
     record_set["Type"].should.equal("A")
@@ -174,7 +174,7 @@ def test_route53_associate_health_check():
     rrsets = route53.list_resource_record_sets(HostedZoneId=zone_id)[
         "ResourceRecordSets"
     ]
-    rrsets.should.have.length_of(1)
+    rrsets.should.have.length_of(2)
     record_set = rrsets[0]
     record_set["HealthCheckId"].should.equal(health_check_id)
 
@@ -197,22 +197,22 @@ def test_route53_with_update():
     rrsets = route53.list_resource_record_sets(HostedZoneId=zone_id)[
         "ResourceRecordSets"
     ]
-    rrsets.should.have.length_of(1)
+    rrsets.should.have.length_of(2)
 
     record_set = rrsets[0]
     record_set["ResourceRecords"][0]["Value"].should.equal("my.example.com")
 
-    # given
+    # # given
     template = deepcopy(route53_health_check.template)
     template["Resources"]["myDNSRecord"]["Properties"]["ResourceRecords"] = [
         "my_other.example.com"
     ]
     template_json = json.dumps(template)
 
-    # when
+    # # when
     cf.update_stack(StackName="test_stack", TemplateBody=template_json)
 
-    # then
+    # # then
     zones = route53.list_hosted_zones()["HostedZones"]
     zones.should.have.length_of(1)
     zone_id = zones[0]["Id"].split("/")[2]
@@ -220,7 +220,7 @@ def test_route53_with_update():
     rrsets = route53.list_resource_record_sets(HostedZoneId=zone_id)[
         "ResourceRecordSets"
     ]
-    rrsets.should.have.length_of(1)
+    rrsets.should.have.length_of(2)
 
     record_set = rrsets[0]
     record_set["ResourceRecords"][0]["Value"].should.equal("my_other.example.com")


### PR DESCRIPTION
## Fixed TF Test
- TestAccRoute53Record_basiac
- TestAccRoute53Record_underscored
- TestAccRoute53Record_disappears
- TestAccRoute53Record_Disappears_multipleRecords
- TestAccRoute53Record_Basic_fqdn
- TestAccRoute53Record_Basic_trailingPeriodAndZoneID
- TestAccRoute53Record_txtSupport
- TestAccRoute53Record_spfSupport
- TestAccRoute53Record_caaSupport
- TestAccRoute53Record_dsSupport
- TestAccRoute53Record_generatesSuffix
- TestAccRoute53Record_wildcard
- TestAccRoute53Record_failover
- TestAccRoute53Record_Weighted_basic
- TestAccRoute53Record_WeightedToSimple_basic
- TestAccRoute53Record_Alias_s3
- TestAccRoute53Record_Geolocation_basic
- TestAccRoute53Record_HealthCheckID_setIdentifierChange
- TestAccRoute53Record_HealthCheckID_typeChange
- TestAccRoute53Record_Latency_basic
- TestAccRoute53Record_typeChange
- TestAccRoute53Record_nameChange
- TestAccRoute53Record_setIdentifierChange
- TestAccRoute53Record_empty
- TestAccRoute53Record_longTXTrecord
- TestAccRoute53Record_doNotAllowOverwrite
- TestAccRoute53Record_allowOverwrite

## Fixes
- Added static getdnssec response
- updated error from `single_error` to `wrapped_error`
- added exception `HostedZoneNotEmpty` when trying to delete hosted zone with record
- updated response templates to be more inclined with AWS