### PR TITLE
create_vpc should never create a default vpc

### DIFF
--- a/moto/ec2/models/vpcs.py
+++ b/moto/ec2/models/vpcs.py
@@ -335,6 +335,7 @@ class VPCBackend:
     def create_vpc(
         self,
         cidr_block,
+        is_default=False,
         instance_tenancy="default",
         amazon_provided_ipv6_cidr_block=False,
         tags=None,
@@ -350,7 +351,7 @@ class VPCBackend:
             self,
             vpc_id,
             cidr_block,
-            len(self.vpcs) == 0,
+            is_default,
             instance_tenancy,
             amazon_provided_ipv6_cidr_block,
         )

--- a/moto/ec2/models/vpcs.py
+++ b/moto/ec2/models/vpcs.py
@@ -335,7 +335,6 @@ class VPCBackend:
     def create_vpc(
         self,
         cidr_block,
-        is_default=False,
         instance_tenancy="default",
         amazon_provided_ipv6_cidr_block=False,
         tags=None,
@@ -351,7 +350,7 @@ class VPCBackend:
             self,
             vpc_id,
             cidr_block,
-            is_default,
+            False,
             instance_tenancy,
             amazon_provided_ipv6_cidr_block,
         )


### PR DESCRIPTION
The create_vpc call never creates a default VPC in AWS - there is a
separate create_default_vpc call. This removes a behavior by which
previously moto would create a default vpc if no other vpcs exist.