### PR TITLE
Fix InvalidObjectState HTTP status code

### DIFF
--- a/moto/s3/exceptions.py
+++ b/moto/s3/exceptions.py
@@ -524,7 +524,7 @@ class InvalidContinuationToken(S3ClientError):
 
 
 class InvalidObjectState(BucketError):
-    code = 400
+    code = 403
 
     def __init__(self, storage_class, **kwargs):
         kwargs.setdefault("template", "storage_error")


### PR DESCRIPTION
Hello!

This PR fixes the HTTP status code for the InvalidObjectState error.

The expected HTTP code ([AWS docs](https://docs.aws.amazon.com/AmazonS3/latest/API/ErrorResponses.html)) is 403.