### PR TITLE
fixed tf suite: Route53HostedZone

### DIFF
--- a/moto/route53/exceptions.py
+++ b/moto/route53/exceptions.py
@@ -89,6 +89,28 @@ class HostedZoneNotEmpty(Route53ClientError):
         self.content_type = "text/xml"
 
 
+class PublicZoneVPCAssociation(Route53ClientError):
+    """Public hosted zone can't be associated."""
+
+    code = 400
+
+    def __init__(self):
+        message = "You're trying to associate a VPC with a public hosted zone. Amazon Route 53 doesn't support associating a VPC with a public hosted zone."
+        super().__init__("PublicZoneVPCAssociation", message)
+        self.content_type = "text/xml"
+
+
+class LastVPCAssociation(Route53ClientError):
+    """Last VPC can't be disassociate."""
+
+    code = 400
+
+    def __init__(self):
+        message = "The VPC that you're trying to disassociate from the private hosted zone is the last VPC that is associated with the hosted zone. Amazon Route 53 doesn't support disassociating the last VPC from a hosted zone."
+        super().__init__("LastVPCAssociation", message)
+        self.content_type = "text/xml"
+
+
 class NoSuchQueryLoggingConfig(Route53ClientError):
     """Query log config does not exist."""
 

--- a/moto/route53/urls.py
+++ b/moto/route53/urls.py
@@ -17,6 +17,8 @@ url_paths = {
     r"{0}/(?P<api_version>[\d_-]+)/hostedzone/(?P<zone_id>[^/]+)$": Route53().get_or_delete_hostzone_response,
     r"{0}/(?P<api_version>[\d_-]+)/hostedzone/(?P<zone_id>[^/]+)/rrset/?$": Route53().rrset_response,
     r"{0}/(?P<api_version>[\d_-]+)/hostedzone/(?P<zone_id>[^/]+)/dnssec/?$": Route53().get_dnssec_response,
+    r"{0}/(?P<api_version>[\d_-]+)/hostedzone/(?P<zone_id>[^/]+)/associatevpc/?$": Route53().associate_vpc_response,
+    r"{0}/(?P<api_version>[\d_-]+)/hostedzone/(?P<zone_id>[^/]+)/disassociatevpc/?$": Route53().disassociate_vpc_response,
     r"{0}/(?P<api_version>[\d_-]+)/hostedzonesbyname": Route53().list_hosted_zones_by_name_response,
     r"{0}/(?P<api_version>[\d_-]+)/hostedzonesbyvpc": Route53().list_hosted_zones_by_vpc_response,
     r"{0}/(?P<api_version>[\d_-]+)/hostedzonecount": Route53().get_hosted_zone_count_response,

--- a/tests/terraformtests/terraform-tests.success.txt
+++ b/tests/terraformtests/terraform-tests.success.txt
@@ -163,6 +163,17 @@ route53:
   - TestAccRoute53Record_longTXTrecord
   - TestAccRoute53Record_doNotAllowOverwrite
   - TestAccRoute53Record_allowOverwrite
+  - TestAccRoute53Zone_basic
+  - TestAccRoute53Zone_disappears
+  - TestAccRoute53Zone_multiple
+  - TestAccRoute53Zone_comment
+  - TestAccRoute53Zone_delegationSetID
+  - TestAccRoute53Zone_forceDestroy
+  - TestAccRoute53Zone_ForceDestroy_trailingPeriod
+  - TestAccRoute53Zone_tags
+  - TestAccRoute53Zone_VPC_single
+  - TestAccRoute53Zone_VPC_multiple
+  - TestAccRoute53Zone_VPC_updates
 s3:
   - TestAccS3BucketPolicy
   - TestAccS3BucketPublicAccessBlock

--- a/tests/test_route53/test_route53.py
+++ b/tests/test_route53/test_route53.py
@@ -506,11 +506,7 @@ def test_hosted_zone_private_zone_preserved():
     hosted_zone = conn.get_hosted_zone(Id=zone_id)
     hosted_zone["HostedZone"]["Config"]["PrivateZone"].should.equal(True)
     hosted_zone.should.have.key("VPCs")
-    hosted_zone["VPCs"].should.have.length_of(1)
-    hosted_zone["VPCs"][0].should.have.key("VPCId")
-    hosted_zone["VPCs"][0].should.have.key("VPCRegion")
-    hosted_zone["VPCs"][0]["VPCId"].should.equal("")
-    hosted_zone["VPCs"][0]["VPCRegion"].should.equal("")
+    hosted_zone["VPCs"].should.have.length_of(0)
 
     hosted_zones = conn.list_hosted_zones()
     hosted_zones["HostedZones"].should.have.length_of(2)


### PR DESCRIPTION
## Added
**APIs**
- associate_vpc
- disassociate_vpc

## Updated
- Mechanism to store VPC in FakeZone

## TF Tests
- TestAccRoute53Zone_basic
- TestAccRoute53Zone_disappears
- TestAccRoute53Zone_multiple
- TestAccRoute53Zone_comment
- TestAccRoute53Zone_delegationSetID
- TestAccRoute53Zone_forceDestroy
- TestAccRoute53Zone_ForceDestroy_trailingPeriod
- TestAccRoute53Zone_tags
- TestAccRoute53Zone_VPC_single
- TestAccRoute53Zone_VPC_multiple
- TestAccRoute53Zone_VPC_updates

Note:
- The test `test_hosted_zone_private_zone_preserved` was expecting to create a vpc without having to add VPC info. In `create_hosted_zone` response VPCs section was having one entry with empty string so it was expecting len(vpc) == 1. (Which was changed to contain empty vpc list::: len(vpc) == 0)
- Future Work: Need to make sure we can create a vpc with params as : `private_zone = True` and without `VPC` config