### PR TITLE
Databrew: support for returning ResourceArn in databrew datasets

### DIFF
--- a/moto/databrew/models.py
+++ b/moto/databrew/models.py
@@ -240,6 +240,7 @@ class DataBrewBackend(BaseBackend):
 
         dataset = FakeDataset(
             self.region_name,
+            self.account_id,
             dataset_name,
             dataset_format,
             dataset_format_options,
@@ -432,6 +433,7 @@ class FakeDataset(BaseModel):
     def __init__(
         self,
         region_name,
+        account_id,
         dataset_name,
         dataset_format,
         dataset_format_options,
@@ -440,6 +442,7 @@ class FakeDataset(BaseModel):
         tags,
     ):
         self.region_name = region_name
+        self.account_id = account_id
         self.name = dataset_name
         self.format = dataset_format
         self.format_options = dataset_format_options
@@ -447,6 +450,12 @@ class FakeDataset(BaseModel):
         self.path_options = dataset_path_options
         self.created_time = datetime.now()
         self.tags = tags
+
+    @property
+    def resource_arn(self):
+        return (
+            f"arn:aws:databrew:{self.region_name}:{self.account_id}:dataset/{self.name}"
+        )
 
     def as_dict(self):
         return {
@@ -457,6 +466,7 @@ class FakeDataset(BaseModel):
             "PathOptions": self.path_options,
             "CreateTime": self.created_time.isoformat(),
             "Tags": self.tags or dict(),
+            "ResourceArn": self.resource_arn,
         }
 
 

--- a/tests/test_databrew/test_databrew_datasets.py
+++ b/tests/test_databrew/test_databrew_datasets.py
@@ -5,6 +5,7 @@ import pytest
 from botocore.exceptions import ClientError
 
 from moto import mock_databrew
+from moto.core import ACCOUNT_ID
 
 
 def _create_databrew_client():
@@ -109,6 +110,7 @@ def test_list_datasets_with_max_results():
     _create_test_datasets(client, 4)
     response = client.list_datasets(MaxResults=2)
     response["Datasets"].should.have.length_of(2)
+    response["Datasets"][0].should.have.key("ResourceArn")
     response.should.have.key("NextToken")
 
 
@@ -137,6 +139,9 @@ def test_describe_dataset():
     response = _create_test_dataset(client)
     dataset = client.describe_dataset(Name=response["Name"])
     dataset["Name"].should.equal(response["Name"])
+    dataset.should.have.key("ResourceArn").equal(
+        f"arn:aws:databrew:us-west-1:{ACCOUNT_ID}:dataset/{response['Name']}"
+    )
     # endregion
 
     # region JSON test

--- a/tests/test_databrew/test_databrew_datasets.py
+++ b/tests/test_databrew/test_databrew_datasets.py
@@ -237,6 +237,9 @@ def test_update_dataset():
     dataset = client.describe_dataset(Name=response["Name"])
     dataset["Name"].should.equal(response["Name"])
     dataset["Format"].should.equal("TEST")
+    dataset.should.have.key("ResourceArn").equal(
+        f"arn:aws:databrew:us-west-1:{ACCOUNT_ID}:dataset/{response['Name']}"
+    )
 
 
 @mock_databrew


### PR DESCRIPTION
This adds support for including a ResourceArn as part of the dataset(s) returned by `list_datasets()`, `describe_dataset()` and `update_dataset()`.