### PR TITLE
Fix encoding for prefix and commonPrefixes

### DIFF
--- a/moto/s3/responses.py
+++ b/moto/s3/responses.py
@@ -3,6 +3,8 @@ import os
 import re
 from typing import List, Union
 
+import urllib.parse
+
 from moto import settings
 from moto.core.utils import (
     amzn_request_id,
@@ -632,6 +634,12 @@ class S3Response(BaseResponse):
         result_keys, result_folders = self._split_truncated_keys(truncated_keys)
 
         key_count = len(result_keys) + len(result_folders)
+
+        if encoding_type == "url":
+            prefix = urllib.parse.quote(prefix) if prefix else ""
+            result_folders = list(
+                map(lambda folder: urllib.parse.quote(folder), result_folders)
+            )
 
         return template.render(
             bucket=bucket,


### PR DESCRIPTION
This pr addresses issue #5228. Now that the list_objects_v2 response has the `EncodingType` attribute, Boto3 tries to decode the attributes `Prefix` and the `CommonPrefixes` like with the name of a Key Object. 

Changes: 
- Encoding of Prefix and CommonPrefixes if necessary.
- The added test groups the multiple reproducers provided in the issue.