### PR TITLE
Add KMS Sign/Verify

### DIFF
--- a/IMPLEMENTATION_COVERAGE.md
+++ b/IMPLEMENTATION_COVERAGE.md
@@ -3559,14 +3559,14 @@
 - [X] retire_grant
 - [X] revoke_grant
 - [X] schedule_key_deletion
-- [ ] sign
+- [X] sign
 - [X] tag_resource
 - [X] untag_resource
 - [ ] update_alias
 - [ ] update_custom_key_store
 - [X] update_key_description
 - [ ] update_primary_region
-- [ ] verify
+- [X] verify
 - [ ] verify_mac
 </details>
 

--- a/moto/dynamodb/models/__init__.py
+++ b/moto/dynamodb/models/__init__.py
@@ -482,7 +482,7 @@ class Table(CloudFormationModel):
             key = kms.create_key(
                 policy="",
                 key_usage="ENCRYPT_DECRYPT",
-                customer_master_key_spec="SYMMETRIC_DEFAULT",
+                key_spec="SYMMETRIC_DEFAULT",
                 description="Default master key that protects my DynamoDB table storage",
                 tags=None,
                 region=region,

--- a/moto/ec2/models/elastic_block_store.py
+++ b/moto/ec2/models/elastic_block_store.py
@@ -410,7 +410,7 @@ class EBSBackend:
             key = kms.create_key(
                 policy="",
                 key_usage="ENCRYPT_DECRYPT",
-                customer_master_key_spec="SYMMETRIC_DEFAULT",
+                key_spec="SYMMETRIC_DEFAULT",
                 description="Default master key that protects my EBS volumes when no other key is defined",
                 tags=None,
                 region=self.region_name,

--- a/moto/kms/models.py
+++ b/moto/kms/models.py
@@ -520,7 +520,7 @@ class KmsBackend(BaseBackend):
             key = self.describe_key(key_id)
             key.retire_grant(grant_id)
 
-    def __ensure_valid_sing_and_verify_key(self, key: Key):
+    def __ensure_valid_sign_and_verify_key(self, key: Key):
         if key.key_usage != "SIGN_VERIFY":
             raise ValidationException(
                 (
@@ -552,7 +552,7 @@ class KmsBackend(BaseBackend):
         """
         key = self.describe_key(key_id)
 
-        self.__ensure_valid_sing_and_verify_key(key)
+        self.__ensure_valid_sign_and_verify_key(key)
         self.__ensure_valid_signing_augorithm(key, signing_algorithm)
 
         # TODO: support more than one hardcoded algorithm based on KeySpec
@@ -576,7 +576,7 @@ class KmsBackend(BaseBackend):
         """
         key = self.describe_key(key_id)
 
-        self.__ensure_valid_sing_and_verify_key(key)
+        self.__ensure_valid_sign_and_verify_key(key)
         self.__ensure_valid_signing_augorithm(key, signing_algorithm)
 
         if signing_algorithm not in key.signing_algorithms:

--- a/moto/kms/models.py
+++ b/moto/kms/models.py
@@ -542,21 +542,16 @@ class KmsBackend(BaseBackend):
                 )
             )
 
-    def __ensure_implemented_sign_and_verify_args(self, grant_tokens, message_type):
-        if grant_tokens:
-            raise NotImplementedError(
-                "GrantTokens not supported by kms_verify mock yet"
-            )
-
-        if message_type == "DIGEST":
-            raise NotImplementedError(
-                "MessageType DIGEST not supported by kms_verify mock yet"
-            )
-
     def sign(self, key_id, message, message_type, grant_tokens, signing_algorithm):
+        """Sign message using generated private key.
+
+        NOTES:
+        - signing_algorithm is ignored and hardcoded to RSASSA_PSS_SHA_256
+        - message_type DIGEST is not implemented
+        - grant_tokens are not implemented
+        """
         key = self.describe_key(key_id)
 
-        self.__ensure_implemented_sign_and_verify_args(grant_tokens, message_type)
         self.__ensure_valid_sing_and_verify_key(key)
         self.__ensure_valid_signing_augorithm(key, signing_algorithm)
 
@@ -574,9 +569,15 @@ class KmsBackend(BaseBackend):
     def verify(
         self, key_id, message, message_type, signature, signing_algorithm, grant_tokens
     ):
+        """Verify message using public key from generated private key.
+
+        NOTES:
+        - signing_algorithm is ignored and hardcoded to RSASSA_PSS_SHA_256
+        - message_type DIGEST is not implemented
+        - grant_tokens are not implemented
+        """
         key = self.describe_key(key_id)
 
-        self.__ensure_implemented_sign_and_verify_args(grant_tokens, message_type)
         self.__ensure_valid_sing_and_verify_key(key)
         self.__ensure_valid_signing_augorithm(key, signing_algorithm)
 

--- a/moto/kms/models.py
+++ b/moto/kms/models.py
@@ -542,7 +542,7 @@ class KmsBackend(BaseBackend):
                 )
             )
 
-    def sign(self, key_id, message, message_type, grant_tokens, signing_algorithm):
+    def sign(self, key_id, message, signing_algorithm):
         """Sign message using generated private key.
 
         NOTES:
@@ -566,9 +566,7 @@ class KmsBackend(BaseBackend):
 
         return key.arn, signature, signing_algorithm
 
-    def verify(
-        self, key_id, message, message_type, signature, signing_algorithm, grant_tokens
-    ):
+    def verify(self, key_id, message, signature, signing_algorithm):
         """Verify message using public key from generated private key.
 
         NOTES:

--- a/moto/kms/responses.py
+++ b/moto/kms/responses.py
@@ -641,8 +641,6 @@ class KmsResponse(BaseResponse):
         key_id, signature, signing_algorithm = self.kms_backend.sign(
             key_id=key_id,
             message=message,
-            message_type=message_type,
-            grant_tokens=grant_tokens,
             signing_algorithm=signing_algorithm,
         )
 
@@ -681,6 +679,7 @@ class KmsResponse(BaseResponse):
             warnings.warn(
                 "The SigningAlgorithm-parameter is ignored hardcoded to RSASSA_PSS_SHA_256 for client.verify()"
             )
+
         if not message_type:
             message_type = "RAW"
 
@@ -704,10 +703,8 @@ class KmsResponse(BaseResponse):
         key_arn, signature_valid, signing_algorithm = self.kms_backend.verify(
             key_id=key_id,
             message=message,
-            message_type=message_type,
             signature=signature,
             signing_algorithm=signing_algorithm,
-            grant_tokens=grant_tokens,
         )
 
         return json.dumps(

--- a/moto/kms/responses.py
+++ b/moto/kms/responses.py
@@ -2,6 +2,7 @@ import base64
 import json
 import os
 import re
+import warnings
 
 from moto.core import get_account_id
 from moto.core.responses import BaseResponse
@@ -611,6 +612,21 @@ class KmsResponse(BaseResponse):
 
         self._validate_key_id(key_id)
 
+        if grant_tokens:
+            warnings.warn(
+                "The GrantTokens-parameter is not yet implemented for client.sign()"
+            )
+
+        if message_type == "DIGEST":
+            warnings.warn(
+                "The MessageType-parameter DIGEST is not yet implemented for client.sign()"
+            )
+
+        if signing_algorithm != "RSASSA_PSS_SHA_256":
+            warnings.warn(
+                "The SigningAlgorithm-parameter is ignored hardcoded to RSASSA_PSS_SHA_256 for client.sign()"
+            )
+
         if isinstance(message, str):
             message = message.encode("utf-8")
 
@@ -651,6 +667,20 @@ class KmsResponse(BaseResponse):
 
         self._validate_key_id(key_id)
 
+        if grant_tokens:
+            warnings.warn(
+                "The GrantTokens-parameter is not yet implemented for client.verify()"
+            )
+
+        if message_type == "DIGEST":
+            warnings.warn(
+                "The MessageType-parameter DIGEST is not yet implemented for client.verify()"
+            )
+
+        if signing_algorithm != "RSASSA_PSS_SHA_256":
+            warnings.warn(
+                "The SigningAlgorithm-parameter is ignored hardcoded to RSASSA_PSS_SHA_256 for client.verify()"
+            )
         if not message_type:
             message_type = "RAW"
 

--- a/moto/kms/responses.py
+++ b/moto/kms/responses.py
@@ -108,12 +108,14 @@ class KmsResponse(BaseResponse):
         """https://docs.aws.amazon.com/kms/latest/APIReference/API_CreateKey.html"""
         policy = self.parameters.get("Policy")
         key_usage = self.parameters.get("KeyUsage")
-        customer_master_key_spec = self.parameters.get("CustomerMasterKeySpec")
+        key_spec = self.parameters.get("KeySpec") or self.parameters.get(
+            "CustomerMasterKeySpec"
+        )
         description = self.parameters.get("Description")
         tags = self.parameters.get("Tags")
 
         key = self.kms_backend.create_key(
-            policy, key_usage, customer_master_key_spec, description, tags, self.region
+            policy, key_usage, key_spec, description, tags, self.region
         )
         return json.dumps(key.to_dict())
 

--- a/moto/kms/utils.py
+++ b/moto/kms/utils.py
@@ -60,7 +60,11 @@ def generate_master_key():
 
 
 def generate_private_key():
-    """Generate a private key to be used on asymmetric sign/verify."""
+    """Generate a private key to be used on asymmetric sign/verify.
+
+    NOTE: KeySpec is not taken into consideration and the key is always RSA_2048
+    this could be improved to support multiple key types
+    """
     return rsa.generate_private_key(
         public_exponent=65537,
         key_size=2048,

--- a/moto/kms/utils.py
+++ b/moto/kms/utils.py
@@ -6,6 +6,7 @@ import uuid
 
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives.ciphers import algorithms, Cipher, modes
+from cryptography.hazmat.primitives.asymmetric import rsa
 
 from .exceptions import (
     InvalidCiphertextException,
@@ -56,6 +57,14 @@ def generate_data_key(number_of_bytes):
 def generate_master_key():
     """Generate a master key."""
     return generate_data_key(MASTER_KEY_LEN)
+
+
+def generate_private_key():
+    """Generate a private key to be used on asymmetric sign/verify."""
+    return rsa.generate_private_key(
+        public_exponent=65537,
+        key_size=2048,
+    )
 
 
 def _serialize_ciphertext_blob(ciphertext):

--- a/tests/test_kms/test_kms_boto3.py
+++ b/tests/test_kms/test_kms_boto3.py
@@ -71,6 +71,7 @@ def test_create_key():
     key["KeyMetadata"]["AWSAccountId"].should.equal(ACCOUNT_ID)
     key["KeyMetadata"]["CreationDate"].should.be.a(datetime)
     key["KeyMetadata"]["CustomerMasterKeySpec"].should.equal("SYMMETRIC_DEFAULT")
+    key["KeyMetadata"]["KeySpec"].should.equal("SYMMETRIC_DEFAULT")
     key["KeyMetadata"]["Description"].should.equal("my key")
     key["KeyMetadata"]["Enabled"].should.equal(True)
     key["KeyMetadata"]["EncryptionAlgorithms"].should.equal(["SYMMETRIC_DEFAULT"])
@@ -81,14 +82,14 @@ def test_create_key():
     key["KeyMetadata"]["Origin"].should.equal("AWS_KMS")
     key["KeyMetadata"].should_not.have.key("SigningAlgorithms")
 
-    key = conn.create_key(KeyUsage="ENCRYPT_DECRYPT", CustomerMasterKeySpec="RSA_2048")
+    key = conn.create_key(KeyUsage="ENCRYPT_DECRYPT", KeySpec="RSA_2048")
 
     sorted(key["KeyMetadata"]["EncryptionAlgorithms"]).should.equal(
         ["RSAES_OAEP_SHA_1", "RSAES_OAEP_SHA_256"]
     )
     key["KeyMetadata"].should_not.have.key("SigningAlgorithms")
 
-    key = conn.create_key(KeyUsage="SIGN_VERIFY", CustomerMasterKeySpec="RSA_2048")
+    key = conn.create_key(KeyUsage="SIGN_VERIFY", KeySpec="RSA_2048")
 
     key["KeyMetadata"].should_not.have.key("EncryptionAlgorithms")
     sorted(key["KeyMetadata"]["SigningAlgorithms"]).should.equal(
@@ -102,22 +103,31 @@ def test_create_key():
         ]
     )
 
-    key = conn.create_key(
-        KeyUsage="SIGN_VERIFY", CustomerMasterKeySpec="ECC_SECG_P256K1"
-    )
+    key = conn.create_key(KeyUsage="SIGN_VERIFY", KeySpec="ECC_SECG_P256K1")
 
     key["KeyMetadata"].should_not.have.key("EncryptionAlgorithms")
     key["KeyMetadata"]["SigningAlgorithms"].should.equal(["ECDSA_SHA_256"])
 
-    key = conn.create_key(KeyUsage="SIGN_VERIFY", CustomerMasterKeySpec="ECC_NIST_P384")
+    key = conn.create_key(KeyUsage="SIGN_VERIFY", KeySpec="ECC_NIST_P384")
 
     key["KeyMetadata"].should_not.have.key("EncryptionAlgorithms")
     key["KeyMetadata"]["SigningAlgorithms"].should.equal(["ECDSA_SHA_384"])
 
+    key = conn.create_key(KeyUsage="SIGN_VERIFY", KeySpec="ECC_NIST_P521")
+
+    key["KeyMetadata"].should_not.have.key("EncryptionAlgorithms")
+    key["KeyMetadata"]["SigningAlgorithms"].should.equal(["ECDSA_SHA_512"])
+
+
+def test_create_key_deprecated_master_custom_key_spec():
+    conn = boto3.client("kms", region_name="us-east-1")
     key = conn.create_key(KeyUsage="SIGN_VERIFY", CustomerMasterKeySpec="ECC_NIST_P521")
 
     key["KeyMetadata"].should_not.have.key("EncryptionAlgorithms")
     key["KeyMetadata"]["SigningAlgorithms"].should.equal(["ECDSA_SHA_512"])
+
+    key["KeyMetadata"]["CustomerMasterKeySpec"].should.equal("ECC_NIST_P521")
+    key["KeyMetadata"]["KeySpec"].should.equal("ECC_NIST_P521")
 
 
 @pytest.mark.parametrize("id_or_arn", ["KeyId", "Arn"])
@@ -132,6 +142,7 @@ def test_describe_key(id_or_arn):
     response["KeyMetadata"]["AWSAccountId"].should.equal("123456789012")
     response["KeyMetadata"]["CreationDate"].should.be.a(datetime)
     response["KeyMetadata"]["CustomerMasterKeySpec"].should.equal("SYMMETRIC_DEFAULT")
+    response["KeyMetadata"]["KeySpec"].should.equal("SYMMETRIC_DEFAULT")
     response["KeyMetadata"]["Description"].should.equal("my key")
     response["KeyMetadata"]["Enabled"].should.equal(True)
     response["KeyMetadata"]["EncryptionAlgorithms"].should.equal(["SYMMETRIC_DEFAULT"])

--- a/tests/test_kms/test_kms_boto3.py
+++ b/tests/test_kms/test_kms_boto3.py
@@ -119,6 +119,7 @@ def test_create_key():
     key["KeyMetadata"]["SigningAlgorithms"].should.equal(["ECDSA_SHA_512"])
 
 
+@mock_kms
 def test_create_key_deprecated_master_custom_key_spec():
     conn = boto3.client("kms", region_name="us-east-1")
     key = conn.create_key(KeyUsage="SIGN_VERIFY", CustomerMasterKeySpec="ECC_NIST_P521")

--- a/tests/test_kms/test_kms_boto3.py
+++ b/tests/test_kms/test_kms_boto3.py
@@ -1148,8 +1148,13 @@ def test_sign_invalid_signing_algorithm():
     message = "My message"
     signing_algorithm = "INVALID"
 
-    with pytest.raises(ClientError):
+    with pytest.raises(ClientError) as ex:
         client.sign(KeyId=key_id, Message=message, SigningAlgorithm=signing_algorithm)
+    err = ex.value.response["Error"]
+    err["Code"].should.equal("ValidationException")
+    err["Message"].should.equal(
+        "1 validation error detected: Value 'INVALID' at 'SigningAlgorithm' failed to satisfy constraint: Member must satisfy enum value set: ['RSASSA_PKCS1_V1_5_SHA_256', 'RSASSA_PKCS1_V1_5_SHA_384', 'RSASSA_PKCS1_V1_5_SHA_512', 'RSASSA_PSS_SHA_256', 'RSASSA_PSS_SHA_384', 'RSASSA_PSS_SHA_512']"
+    )
 
 
 @mock_kms
@@ -1162,8 +1167,13 @@ def test_sign_invalid_key_usage():
     message = "My message"
     signing_algorithm = "RSASSA_PSS_SHA_256"
 
-    with pytest.raises(ClientError):
+    with pytest.raises(ClientError) as ex:
         client.sign(KeyId=key_id, Message=message, SigningAlgorithm=signing_algorithm)
+    err = ex.value.response["Error"]
+    err["Code"].should.equal("ValidationException")
+    err["Message"].should.equal(
+        f"1 validation error detected: Value '{key_id}' at 'KeyId' failed to satisfy constraint: Member must point to a key with usage: 'SIGN_VERIFY'"
+    )
 
 
 @mock_kms
@@ -1176,8 +1186,13 @@ def test_sign_invalid_message():
     message = ""
     signing_algorithm = "RSASSA_PSS_SHA_256"
 
-    with pytest.raises(ClientError):
+    with pytest.raises(ClientError) as ex:
         client.sign(KeyId=key_id, Message=message, SigningAlgorithm=signing_algorithm)
+    err = ex.value.response["Error"]
+    err["Code"].should.equal("ValidationException")
+    err["Message"].should.equal(
+        "1 validation error detected: Value at 'Message' failed to satisfy constraint: Member must have length greater than or equal to 1"
+    )
 
 
 @pytest.mark.parametrize("plaintext", PLAINTEXT_VECTORS)

--- a/tests/test_kms/test_kms_boto3.py
+++ b/tests/test_kms/test_kms_boto3.py
@@ -1148,11 +1148,8 @@ def test_sign_invalid_signing_algorithm():
     message = "My message"
     signing_algorithm = "INVALID"
 
-    try:
+    with pytest.raises(ClientError):
         client.sign(KeyId=key_id, Message=message, SigningAlgorithm=signing_algorithm)
-        assert False
-    except ClientError:
-        assert True
 
 
 @mock_kms
@@ -1165,11 +1162,8 @@ def test_sign_invalid_key_usage():
     message = "My message"
     signing_algorithm = "RSASSA_PSS_SHA_256"
 
-    try:
+    with pytest.raises(ClientError):
         client.sign(KeyId=key_id, Message=message, SigningAlgorithm=signing_algorithm)
-        assert False
-    except ClientError:
-        assert True
 
 
 @mock_kms
@@ -1182,11 +1176,8 @@ def test_sign_invalid_message():
     message = ""
     signing_algorithm = "RSASSA_PSS_SHA_256"
 
-    try:
+    with pytest.raises(ClientError):
         client.sign(KeyId=key_id, Message=message, SigningAlgorithm=signing_algorithm)
-        assert False
-    except ClientError:
-        assert True
 
 
 @pytest.mark.parametrize("plaintext", PLAINTEXT_VECTORS)


### PR DESCRIPTION
This is adding support for KMS [sign](https://docs.aws.amazon.com/kms/latest/APIReference/API_Sign.html) and [verify](https://docs.aws.amazon.com/kms/latest/APIReference/API_Sign.html).

I added support for `KeySpec`  keeping support for the deprecated deprecated `CustomerMasterKeySpec`. I can move that change to another PR if it makes things easier.

This is not the full implementation for sign and verify, as the algorithm and private key type are hardcoded. But it's enough to use `sign` and `verify` within the application. Would that be enough for now? It is good enough for our use case.

`GrantTokens` and `MessageType` `DIGEST` are not supported as well.