### PR TITLE
add createtime to glue table response

### DIFF
--- a/moto/glue/models.py
+++ b/moto/glue/models.py
@@ -275,6 +275,7 @@ class FakeTable(BaseModel):
         self.database_name = database_name
         self.name = table_name
         self.partitions = OrderedDict()
+        self.created_time = datetime.utcnow()
         self.versions = []
         self.update(table_input)
 
@@ -295,7 +296,11 @@ class FakeTable(BaseModel):
             raise VersionNotFoundException()
 
     def as_dict(self, version=-1):
-        obj = {"DatabaseName": self.database_name, "Name": self.name}
+        obj = {
+            "DatabaseName": self.database_name,
+            "Name": self.name,
+            "CreateTime": self.created_time.isoformat(),
+        }
         obj.update(self.get_version(version))
         return obj
 

--- a/tests/test_glue/test_datacatalog.py
+++ b/tests/test_glue/test_datacatalog.py
@@ -118,6 +118,7 @@ def test_delete_unknown_database():
 
 
 @mock_glue
+@freeze_time(FROZEN_CREATE_TIME)
 def test_create_table():
     client = boto3.client("glue", region_name="us-east-1")
     database_name = "myspecialdatabase"
@@ -129,6 +130,9 @@ def test_create_table():
 
     response = helpers.get_table(client, database_name, table_name)
     table = response["Table"]
+
+    if not settings.TEST_SERVER_MODE:
+        table["CreateTime"].should.equal(FROZEN_CREATE_TIME)
 
     table["Name"].should.equal(table_input["Name"])
     table["StorageDescriptor"].should.equal(table_input["StorageDescriptor"])


### PR DESCRIPTION
Added a CreateTime key to the Glue get_table response to match the boto3 functionality here:
https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/glue.html#Glue.Client.get_table

Implemented just like the glue database CreateTime.

Really enjoying the library! Let me know of any edits you'd like to see.