### PR TITLE
fixed route53 resolver endpoint creation without ip address

### DIFF
--- a/moto/route53resolver/models.py
+++ b/moto/route53resolver/models.py
@@ -445,6 +445,13 @@ class Route53ResolverBackend(BaseBackend):
                 f"Account '{get_account_id()}' has exceeded 'max-endpoints'"
             )
 
+        for x in ip_addresses:
+            if not x.get("Ip"):
+                subnet_info = ec2_backends[region].get_all_subnets(
+                    subnet_ids=[x["SubnetId"]]
+                )[0]
+                x["Ip"] = subnet_info.get_available_subnet_ip(self)
+
         self._verify_subnet_ips(region, ip_addresses)
         self._verify_security_group_ids(region, security_group_ids)
         if creator_request_id in [

--- a/tests/terraformtests/terraform-tests.success.txt
+++ b/tests/terraformtests/terraform-tests.success.txt
@@ -189,6 +189,7 @@ route53:
   - TestAccRoute53HealthCheck_withSNI
   - TestAccRoute53HealthCheck_disabled
   - TestAccRoute53HealthCheck_disappears
+  - TestAccRoute53ResolverEndpoint_basicInbound
 s3:
   - TestAccS3BucketPolicy
   - TestAccS3BucketPublicAccessBlock


### PR DESCRIPTION
## TF Test
- TestAccRoute53ResolverEndpoint_basicInbound

## Fixed
- while using `create_resolver_endpoint` - SubnetID is required field and IP address is optional. If we dont provide IP address it should automatically assign ip from subnet cidr.