### PR TITLE
Deletion of endpoints after platform app

### DIFF
--- a/moto/sns/models.py
+++ b/moto/sns/models.py
@@ -662,6 +662,9 @@ class SNSBackend(BaseBackend):
 
     def delete_platform_application(self, platform_arn):
         self.applications.pop(platform_arn)
+        endpoints = self.list_endpoints_by_platform_application(platform_arn)
+        for endpoint in endpoints:
+            self.platform_endpoints.pop(endpoint.arn)
 
     def create_platform_endpoint(
         self, region, application, custom_user_data, token, attributes


### PR DESCRIPTION
While making some changes for localstack/localstack#6256 in came to light that AWS deletes the endpoints of a deleted platform application.

Changes:
- deletion of endpoints when deleting the platform app.
- test  that validates that the endpoint doesn't exist after it's app was deleted.

Note: in AWS it takes like 5 seconds to delete the endpoint after the deletion of the app.