### PR TITLE
Improve test coverage of KMS sign and verify

### DIFF
--- a/moto/kms/models.py
+++ b/moto/kms/models.py
@@ -547,7 +547,6 @@ class KmsBackend(BaseBackend):
 
         NOTES:
         - signing_algorithm is ignored and hardcoded to RSASSA_PSS_SHA_256
-        - message_type DIGEST is not implemented
         - grant_tokens are not implemented
         """
         key = self.describe_key(key_id)
@@ -571,7 +570,6 @@ class KmsBackend(BaseBackend):
 
         NOTES:
         - signing_algorithm is ignored and hardcoded to RSASSA_PSS_SHA_256
-        - message_type DIGEST is not implemented
         - grant_tokens are not implemented
         """
         key = self.describe_key(key_id)

--- a/moto/kms/responses.py
+++ b/moto/kms/responses.py
@@ -617,11 +617,6 @@ class KmsResponse(BaseResponse):
                 "The GrantTokens-parameter is not yet implemented for client.sign()"
             )
 
-        if message_type == "DIGEST":
-            warnings.warn(
-                "The MessageType-parameter DIGEST is not yet implemented for client.sign()"
-            )
-
         if signing_algorithm != "RSASSA_PSS_SHA_256":
             warnings.warn(
                 "The SigningAlgorithm-parameter is ignored hardcoded to RSASSA_PSS_SHA_256 for client.sign()"


### PR DESCRIPTION
The deploy step is complaining about test coverage so I added more tests to
fix it. https://codecov.io/gh/spulec/moto/commit/25aad70481d2b99b80b1a89c90ad21c20628c2a2

<img width="1337" alt="Screen Shot 2022-06-22 at 11 42 31 AM" src="https://user-images.githubusercontent.com/1987013/174914223-a8591e6a-3774-4eea-b3d6-26bbcf79f63b.png">

By adding this coverage, I tested sending hash digests to sign and verify and they seem to be working fine, so I removed the warning.