### PR TITLE
EC2: create_customer_gateway - support PublicIp and IpAddress

### DIFF
--- a/moto/ec2/responses/customer_gateways.py
+++ b/moto/ec2/responses/customer_gateways.py
@@ -3,9 +3,8 @@ from ._base_response import EC2BaseResponse
 
 class CustomerGateways(EC2BaseResponse):
     def create_customer_gateway(self):
-        # raise NotImplementedError('CustomerGateways(AmazonVPC).create_customer_gateway is not yet implemented')
         gateway_type = self._get_param("Type")
-        ip_address = self._get_param("IpAddress")
+        ip_address = self._get_param("IpAddress") or self._get_param("PublicIp")
         bgp_asn = self._get_param("BgpAsn")
         tags = self._get_multi_param("TagSpecification")
         tags = tags[0] if isinstance(tags, list) and len(tags) == 1 else tags


### PR DESCRIPTION
The EC2 API was changed on 21st of June - see https://github.com/boto/botocore/commit/86202c8698cf77fb6ecccfdbc05bbc218e861d14#diff-c51449716bfc26c1eac92ec403b470827d2dcba1126cf303567074b872d5c592.