### PR TITLE
IOT - allow attaching policies to ThingGroups

### DIFF
--- a/moto/iot/models.py
+++ b/moto/iot/models.py
@@ -1103,6 +1103,13 @@ class IoTBackend(BaseBackend):
                 raise ResourceNotFoundException()
             principal = certs[0]
             return principal
+        if ":thinggroup/" in principal_arn:
+            try:
+                return self.thing_groups[principal_arn]
+            except KeyError:
+                raise ResourceNotFoundException(
+                    f"No thing group with ARN {principal_arn} exists"
+                )
         from moto.cognitoidentity import cognitoidentity_backends
 
         cognito = cognitoidentity_backends[self.region_name]


### PR DESCRIPTION
According to the [AWS documentation here](https://docs.aws.amazon.com/iot/latest/developerguide/thing-groups.html#group-attach-policy) the `target` can be one of these three:
- thing group ARN **(this PR)**
- certificate ARN _(already implemented)_
- Amazon Cognito Identity _(already implemented)_

I've add two tests and refactored the other tests in `test_iot_policies.py` to reduce duplication a bit.
If that is unwanted I'll be happy to revert the state of the tests.

Feedback greatly appreciated!

Thanks for all the work on this very helpful library and kind regards.