### PR TITLE
Fix: S3 Key safe_name should avoid encoding "/"

### DIFF
--- a/moto/s3/models.py
+++ b/moto/s3/models.py
@@ -163,7 +163,7 @@ class FakeKey(BaseModel, ManagedState):
 
     def safe_name(self, encoding_type=None):
         if encoding_type == "url":
-            return urllib.parse.quote(self.name, safe="")
+            return urllib.parse.quote(self.name)
         return self.name
 
     @property

--- a/tests/test_s3/test_s3.py
+++ b/tests/test_s3/test_s3.py
@@ -152,6 +152,14 @@ def test_key_name_encoding_in_listing():
     key_received = client.list_objects_v2(Bucket="foobar")["Contents"][0]["Key"]
     key_received.should.equal(name)
 
+    name = "example/file.text"
+    client.put_object(Bucket="foobar", Key=name, Body=b"")
+
+    key_received = client.list_objects(
+        Bucket="foobar", Prefix="example/", Delimiter="/", MaxKeys=1, EncodingType="url"
+    )["Contents"][0]["Key"]
+    key_received.should.equal(name)
+
 
 @mock_s3
 def test_empty_key_set_on_existing_key():


### PR DESCRIPTION
This is another fix for another issue that came from encoding the key's name. Mentioned in localstack/localstack#6323