### PR TITLE
fix increment policy version ids

### DIFF
--- a/moto/iot/models.py
+++ b/moto/iot/models.py
@@ -1047,7 +1047,8 @@ class IoTBackend(BaseBackend):
             policy_name, policy_document, set_as_default, self.region_name
         )
         policy.versions.append(version)
-        version.version_id = "{0}".format(len(policy.versions))
+        max_version_id = max(v.version_id for v in policy.versions)
+        version.version_id = "{0}".format(int(max_version_id) + 1)
         if set_as_default:
             self.set_default_policy_version(policy_name, version.version_id)
         return version

--- a/moto/iot/models.py
+++ b/moto/iot/models.py
@@ -216,6 +216,7 @@ class FakePolicy(BaseModel):
         self.arn = f"arn:aws:iot:{region_name}:{get_account_id()}:policy/{name}"
         self.default_version_id = default_version_id
         self.versions = [FakePolicyVersion(self.name, document, True, region_name)]
+        self.max_version_id = self.versions[0].version_id
 
     def to_get_dict(self):
         return {
@@ -1047,8 +1048,8 @@ class IoTBackend(BaseBackend):
             policy_name, policy_document, set_as_default, self.region_name
         )
         policy.versions.append(version)
-        max_version_id = max(v.version_id for v in policy.versions)
-        version.version_id = "{0}".format(int(max_version_id) + 1)
+        version.version_id = "{0}".format(int(policy.max_version_id) + 1)
+        policy.max_version_id = version.version_id
         if set_as_default:
             self.set_default_policy_version(policy_name, version.version_id)
         return version

--- a/tests/test_iot/test_iot_policies.py
+++ b/tests/test_iot/test_iot_policies.py
@@ -261,6 +261,7 @@ def test_policy_versions_increment_beyond_5(iot_client, policy):
             policyName=policy_name, policyVersionId=str(v - 1)
         )
 
+
 def test_policy_versions_increment_even_after_version_delete(iot_client, policy):
     """Version ids increment even if the max version was deleted."""
 
@@ -271,9 +272,7 @@ def test_policy_versions_increment_even_after_version_delete(iot_client, policy)
         policyDocument=json.dumps({"version": "version_2"}),
     )
     new_version.should.have.key("policyVersionId").which.should.equal("2")
-    iot_client.delete_policy_version(
-        policyName=policy_name, policyVersionId="2"
-    )
+    iot_client.delete_policy_version(policyName=policy_name, policyVersionId="2")
     third_version = iot_client.create_policy_version(
         policyName=policy_name,
         policyDocument=json.dumps({"version": "version_3"}),

--- a/tests/test_iot/test_iot_policies.py
+++ b/tests/test_iot/test_iot_policies.py
@@ -261,6 +261,25 @@ def test_policy_versions_increment_beyond_5(iot_client, policy):
             policyName=policy_name, policyVersionId=str(v - 1)
         )
 
+def test_policy_versions_increment_even_after_version_delete(iot_client, policy):
+    """Version ids increment even if the max version was deleted."""
+
+    policy_name = policy["policyName"]
+
+    new_version = iot_client.create_policy_version(
+        policyName=policy_name,
+        policyDocument=json.dumps({"version": "version_2"}),
+    )
+    new_version.should.have.key("policyVersionId").which.should.equal("2")
+    iot_client.delete_policy_version(
+        policyName=policy_name, policyVersionId="2"
+    )
+    third_version = iot_client.create_policy_version(
+        policyName=policy_name,
+        policyDocument=json.dumps({"version": "version_3"}),
+    )
+    third_version.should.have.key("policyVersionId").which.should.equal("3")
+
 
 def test_delete_policy_validation(iot_client):
     doc = """{

--- a/tests/test_iot/test_iot_policies.py
+++ b/tests/test_iot/test_iot_policies.py
@@ -241,6 +241,27 @@ def test_policy_versions(iot_client):
     err["Message"].should.equal("Cannot delete the default version of a policy")
 
 
+def test_policy_versions_increment_beyond_5(iot_client, policy):
+    """
+    Version ids increment by one each time.
+
+    Previously there was a bug where the version id was not incremented beyond 5.
+    This prevents a regression.
+    """
+    policy_name = policy["policyName"]
+
+    for v in range(2, 11):
+        new_version = iot_client.create_policy_version(
+            policyName=policy_name,
+            policyDocument=json.dumps({"version": f"version_{v}"}),
+            setAsDefault=True,
+        )
+        new_version.should.have.key("policyVersionId").which.should.equal(str(v))
+        iot_client.delete_policy_version(
+            policyName=policy_name, policyVersionId=str(v - 1)
+        )
+
+
 def test_delete_policy_validation(iot_client):
     doc = """{
     "Version": "2012-10-17",


### PR DESCRIPTION
The current implementation will not increment beyond 5 and will create duplicate version ids.

This fixes that by finding the current max version and incrementing that by one for the newly created one.