### PR TITLE
check for non-default policy versions before deleting

### DIFF
--- a/moto/iot/models.py
+++ b/moto/iot/models.py
@@ -1024,7 +1024,6 @@ class IoTBackend(BaseBackend):
         return policies[0]
 
     def delete_policy(self, policy_name):
-
         policies = [
             k[1] for k, v in self.principal_policies.items() if k[1] == policy_name
         ]
@@ -1035,6 +1034,11 @@ class IoTBackend(BaseBackend):
             )
 
         policy = self.get_policy(policy_name)
+        if len(policy.versions) > 1:
+            raise DeleteConflictException(
+                "Cannot delete the policy because it has one or more policy versions attached to it (name=%s)"
+                % policy_name
+            )
         del self.policies[policy.name]
 
     def create_policy_version(self, policy_name, policy_document, set_as_default):

--- a/tests/test_iot/test_iot_policies.py
+++ b/tests/test_iot/test_iot_policies.py
@@ -324,3 +324,17 @@ def test_attach_policy_to_non_existant_thing_group_raises_ResourceNotFoundExcept
 
     with pytest.raises(ClientError, match=thing_group_arn):
         iot_client.attach_policy(policyName=policy_name, target=thing_group_arn)
+
+
+def test_policy_delete_fails_when_versions_exist(iot_client, policy):
+    policy_name = policy["policyName"]
+    iot_client.create_policy_version(
+        policyName=policy_name,
+        policyDocument=policy["policyDocument"],
+        setAsDefault=True,
+    )
+    with pytest.raises(ClientError) as e:
+        iot_client.delete_policy(policyName=policy_name)
+    e.value.response["Error"]["Message"].should.contain(
+        "Cannot delete the policy because it has one or more policy versions attached to it"
+    )


### PR DESCRIPTION
According [to the docs](https://docs.aws.amazon.com/iot/latest/apireference/API_DeletePolicy.html) all non-default policy versions have to be deleted before deleting a policy itself.