### PR TITLE
Allow subscription role attribute to SNS.Subscription

### DIFF
--- a/moto/sns/models.py
+++ b/moto/sns/models.py
@@ -727,6 +727,7 @@ class SNSBackend(BaseBackend):
             "DeliveryPolicy",
             "FilterPolicy",
             "RedrivePolicy",
+            "SubscriptionRoleArn",
         ]:
             raise SNSInvalidParameter("AttributeName")
 

--- a/tests/test_sns/test_subscriptions_boto3.py
+++ b/tests/test_sns/test_subscriptions_boto3.py
@@ -258,6 +258,8 @@ def test_creating_subscription_with_attributes():
         }
     )
 
+    subscription_role_arn = "arn:aws:iam:000000000:role/test-role"
+
     conn.subscribe(
         TopicArn=topic_arn,
         Protocol="http",
@@ -266,6 +268,7 @@ def test_creating_subscription_with_attributes():
             "RawMessageDelivery": "true",
             "DeliveryPolicy": delivery_policy,
             "FilterPolicy": filter_policy,
+            "SubscriptionRoleArn": subscription_role_arn,
         },
     )
 
@@ -284,6 +287,7 @@ def test_creating_subscription_with_attributes():
     attrs["Attributes"]["RawMessageDelivery"].should.equal("true")
     attrs["Attributes"]["DeliveryPolicy"].should.equal(delivery_policy)
     attrs["Attributes"]["FilterPolicy"].should.equal(filter_policy)
+    attrs["Attributes"]["SubscriptionRoleArn"].should.equal(subscription_role_arn)
 
     # Now unsubscribe the subscription
     conn.unsubscribe(SubscriptionArn=subscription["SubscriptionArn"])


### PR DESCRIPTION
With this PR it is now possible to set the attribute SubscriptionRoleArn for a Subscription. Related to localstack/localstack#6426