### PR TITLE
Add extra keys to EC2 `describe-addresses` operation

### DIFF
--- a/moto/ec2/models/elastic_ip_addresses.py
+++ b/moto/ec2/models/elastic_ip_addresses.py
@@ -37,7 +37,7 @@ class ElasticAddress(TaggedEC2Resource, CloudFormationModel):
 
     @staticmethod
     def cloudformation_type():
-        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-eip.html
+        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-eip.html
         return "AWS::EC2::EIP"
 
     @classmethod

--- a/moto/ec2/responses/elastic_ip_addresses.py
+++ b/moto/ec2/responses/elastic_ip_addresses.py
@@ -145,6 +145,7 @@ DESCRIBE_ADDRESS_RESPONSE = """<DescribeAddressesResponse xmlns="http://ec2.amaz
           {% endif %}
           {% if address.eni %}
             <networkInterfaceId>{{ address.eni.id }}</networkInterfaceId>
+            <privateIpAddress>{{ address.eni.private_ip_address}}</privateIpAddress>
           {% else %}
             <networkInterfaceId/>
           {% endif %}

--- a/moto/ec2/responses/elastic_ip_addresses.py
+++ b/moto/ec2/responses/elastic_ip_addresses.py
@@ -145,7 +145,8 @@ DESCRIBE_ADDRESS_RESPONSE = """<DescribeAddressesResponse xmlns="http://ec2.amaz
           {% endif %}
           {% if address.eni %}
             <networkInterfaceId>{{ address.eni.id }}</networkInterfaceId>
-            <privateIpAddress>{{ address.eni.private_ip_address}}</privateIpAddress>
+            <privateIpAddress>{{ address.eni.private_ip_address }}</privateIpAddress>
+            <networkInterfaceOwnerId>{{ address.eni.owner_id }}</networkInterfaceOwnerId>
           {% else %}
             <networkInterfaceId/>
           {% endif %}

--- a/tests/test_ec2/test_elastic_ip_addresses.py
+++ b/tests/test_ec2/test_elastic_ip_addresses.py
@@ -699,3 +699,4 @@ def test_describe_addresses_with_vpc_associated_eni():
     address["NetworkInterfaceId"].should.be.equal(eni.id)
     address["PrivateIpAddress"].should.be.equal(eni.private_ip_address)
     address["AssociationId"].should.be.equal(association_id)
+    address["NetworkInterfaceOwnerId"].should.be.equal(eni.owner_id)

--- a/tests/test_ec2/test_elastic_ip_addresses.py
+++ b/tests/test_ec2/test_elastic_ip_addresses.py
@@ -672,3 +672,30 @@ def test_describe_addresses_tags():
     assert addresses_with_tags.get("Addresses")[0].get("Tags") == [
         {"Key": "ManagedBy", "Value": "MyCode"}
     ]
+
+
+@mock_ec2
+def test_describe_addresses_with_vpc_associated_eni():
+    """Extra attributes for EIP associated with a ENI inside a VPC"""
+    client = boto3.client("ec2", region_name="us-east-1")
+    ec2 = boto3.resource("ec2", region_name="us-east-1")
+
+    vpc = ec2.create_vpc(CidrBlock="10.0.0.0/16")
+    subnet = ec2.create_subnet(VpcId=vpc.id, CidrBlock="10.0.0.0/18")
+    eni = ec2.create_network_interface(SubnetId=subnet.id)
+
+    eip = client.allocate_address(Domain="vpc")
+    association_id = client.associate_address(
+        NetworkInterfaceId=eni.id, PublicIp=eip["PublicIp"]
+    )["AssociationId"]
+
+    result = client.describe_addresses()
+
+    result["ResponseMetadata"]["HTTPStatusCode"].should.equal(200)
+    result["Addresses"].should.have.length_of(1)
+
+    address = result["Addresses"][0]
+
+    address["NetworkInterfaceId"].should.be.equal(eni.id)
+    address["PrivateIpAddress"].should.be.equal(eni.private_ip_address)
+    address["AssociationId"].should.be.equal(association_id)

--- a/tests/test_ec2/test_elastic_ip_addresses.py
+++ b/tests/test_ec2/test_elastic_ip_addresses.py
@@ -689,7 +689,9 @@ def test_describe_addresses_with_vpc_associated_eni():
         NetworkInterfaceId=eni.id, PublicIp=eip["PublicIp"]
     )["AssociationId"]
 
-    result = client.describe_addresses()
+    result = client.describe_addresses(
+        Filters=[{"Name": "association-id", "Values": [association_id]}]
+    )
 
     result["ResponseMetadata"]["HTTPStatusCode"].should.equal(200)
     result["Addresses"].should.have.length_of(1)


### PR DESCRIPTION
### Description

Added two new keys for the `describe-addresses` response:
1. `PrivateIPAddress`; 
2. `NetworkInterfaceOwnerId`.

Updated comment with outdated cloudformation link.

closes #4088.