### PR TITLE
Cache Jinja environment by response type

### DIFF
--- a/tests/test_core/test_responses.py
+++ b/tests/test_core/test_responses.py
@@ -163,3 +163,41 @@ def test_get_dict_list_params():
     result = subject._get_multi_param_dict("VpcSecurityGroupIds")
 
     result.should.equal({"VpcSecurityGroupId": ["sg-123", "sg-456", "sg-789"]})
+
+
+def test_response_environment_preserved_by_type():
+    """Ensure Jinja environment is cached by response type."""
+
+    class ResponseA(BaseResponse):
+        pass
+
+    class ResponseB(BaseResponse):
+        pass
+
+    resp_a = ResponseA()
+    another_resp_a = ResponseA()
+    resp_b = ResponseB()
+
+    assert resp_a.environment is another_resp_a.environment
+    assert resp_b.environment is not resp_a.environment
+
+    source_1 = "template"
+    source_2 = "amother template"
+
+    assert not resp_a.contains_template(id(source_1))
+    resp_a.response_template(source_1)
+    assert resp_a.contains_template(id(source_1))
+
+    assert not resp_a.contains_template(id(source_2))
+    resp_a.response_template(source_2)
+    assert resp_a.contains_template(id(source_2))
+
+    assert not resp_b.contains_template(id(source_1))
+    assert not resp_b.contains_template(id(source_2))
+
+    assert another_resp_a.contains_template(id(source_1))
+    assert another_resp_a.contains_template(id(source_2))
+
+    resp_a_new_instance = ResponseA()
+    assert resp_a_new_instance.contains_template(id(source_1))
+    assert resp_a_new_instance.contains_template(id(source_2))


### PR DESCRIPTION
`DynamicDictLoader` supports caching but the loader and the environment would be created on each construction, rather than shared, enabling caching. Here we cache the Jinja environment (and loader) by response type.

In terms of real performance, this gives is a couple of ms (measurements made with the motoserver):

After this change:
```
In [106]: timeit for i in range(10): sqs_client.create_queue(QueueName=str(i))
85.5 ms ± 3.21 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

In [107]: timeit for i in range(10): sqs_client.create_queue(QueueName=str(i))
68.3 ms ± 3.32 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)
```

Master:
```
In [108]: timeit for i in range(10): sqs_client.create_queue(QueueName=str(i))
99.9 ms ± 3.78 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

In [109]: timeit for i in range(10): sqs_client.create_queue(QueueName=str(i))
80.5 ms ± 2.98 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)
```