### PR TITLE
check for existing thing group when creating

### DIFF
--- a/moto/iot/models.py
+++ b/moto/iot/models.py
@@ -1212,7 +1212,21 @@ class IoTBackend(BaseBackend):
             self.region_name,
             self.thing_groups,
         )
-        self.thing_groups[thing_group.arn] = thing_group
+        # this behavior is not documented, but AWS does it like that
+        # if a thing group with the same name exists, it's properties are compared
+        # if they differ, an error is returned.
+        # Otherwise, the old thing group is returned
+        if thing_group.arn in self.thing_groups:
+            current_thing_group = self.thing_groups[thing_group.arn]
+            if current_thing_group.thing_group_properties != thing_group_properties:
+                raise ResourceAlreadyExistsException(
+                    msg=f"Thing Group {thing_group_name} already exists in current account with different properties",
+                    resource_arn=thing_group.arn,
+                    resource_id=current_thing_group.thing_group_id,
+                )
+            thing_group = current_thing_group
+        else:
+            self.thing_groups[thing_group.arn] = thing_group
         return thing_group.thing_group_name, thing_group.arn, thing_group.thing_group_id
 
     def delete_thing_group(self, thing_group_name):

--- a/tests/test_iot/test_iot_thing_groups.py
+++ b/tests/test_iot/test_iot_thing_groups.py
@@ -563,3 +563,34 @@ def test_thing_group_relations():
     things = client.list_things_in_thing_group(thingGroupName=group_name)
     things.should.have.key("things")
     things["things"].should.have.length_of(0)
+
+
+@mock_iot
+def test_thing_group_already_exists_with_different_properties_raises():
+    client = boto3.client("iot", region_name="ap-northeast-1")
+    thing_group_name = "my-group-name"
+    client.create_thing_group(
+        thingGroupName=thing_group_name,
+        thingGroupProperties={"thingGroupDescription": "Current description"},
+    )
+
+    with pytest.raises(
+        client.exceptions.ResourceAlreadyExistsException,
+        match=f"Thing Group {thing_group_name} already exists in current account with different properties",
+    ):
+        client.create_thing_group(thingGroupName=thing_group_name)
+
+
+@mock_iot
+def test_thing_group_already_exists_with_same_properties_returned():
+    client = boto3.client("iot", region_name="ap-northeast-1")
+    thing_group_name = "my-group-name"
+    thing_group_properties = {"thingGroupDescription": "Current description"}
+    current_thing_group = client.create_thing_group(
+        thingGroupName=thing_group_name, thingGroupProperties=thing_group_properties
+    )
+
+    thing_group = client.create_thing_group(
+        thingGroupName=thing_group_name, thingGroupProperties=thing_group_properties
+    )
+    assert thing_group == current_thing_group


### PR DESCRIPTION
The current behaviour is incomplete.
See this usage of the cli and notice that the `thingGroupId` is equal in the last call:

```
❯ aws iot create-thing-group --thing-group-name example --thing-group-properties '{"thingGroupDescription": "example"}'
{
    "thingGroupName": "example",
    "thingGroupArn": "arn:aws:iot:eu-central-1:123456789012:thinggroup/example",
    "thingGroupId": "e57b175c-87ed-41c9-99ae-bf505bedff0e"
}


❯ aws iot create-thing-group --thing-group-name example --thing-group-properties '{"thingGroupDescription": "another one"}'

An error occurred (ResourceAlreadyExistsException) when calling the CreateThingGroup operation: Thing Group example already exists in current account with different properties


❯ aws iot create-thing-group --thing-group-name example --thing-group-properties '{"thingGroupDescription": "example"}'
{
    "thingGroupName": "example",
    "thingGroupArn": "arn:aws:iot:eu-central-1:123456789012:thinggroup/example",
    "thingGroupId": "e57b175c-87ed-41c9-99ae-bf505bedff0e"
}
```