### PR TITLE
Fix iam check for codepipeline where codepipeline is not first trusted service

### DIFF
--- a/tests/test_codepipeline/test_codepipeline.py
+++ b/tests/test_codepipeline/test_codepipeline.py
@@ -648,8 +648,8 @@ def test_untag_resource_errors():
         "The account with id '123456789012' does not include a pipeline with the name 'not-existing'"
     )
 
-    
-simple_trust_policy =  {
+
+simple_trust_policy = {
     "Version": "2012-10-17",
     "Statement": [
         {
@@ -660,8 +660,9 @@ simple_trust_policy =  {
     ],
 }
 
+
 @mock_iam
-def get_role_arn(name = "test-role", trust_policy = None):
+def get_role_arn(name="test-role", trust_policy=None):
     client = boto3.client("iam", region_name="us-east-1")
     try:
         return client.get_role(name)["Role"]["Arn"]
@@ -724,7 +725,7 @@ def create_basic_codepipeline(client, name, role_arn=None):
         tags=[{"key": "key", "value": "value"}],
     )
 
-extended_trust_policy =  {
+extended_trust_policy = {
     "Version": "2012-10-17",
     "Statement": [
         {
@@ -744,7 +745,7 @@ extended_trust_policy =  {
 
 
 @mock_codepipeline
-def test_create_pipeline():
+def test_create_pipeline_with_extended_trust_policy():
     client = boto3.client("codepipeline", region_name="us-east-1")
 
     role_arn = get_role_arn(name="test-role-extended", trust_policy=extended_trust_policy)
@@ -752,6 +753,6 @@ def test_create_pipeline():
     basic_role_arn = get_role_arn()
 
     extended_pipeline_details = expected_pipeline_details.replace(basic_role_arn, role_arn)
-    
+
     response["pipeline"].should.equal(extended_pipeline_details)
     response["tags"].should.equal([{"key": "key", "value": "value"}])

--- a/tests/test_codepipeline/test_codepipeline.py
+++ b/tests/test_codepipeline/test_codepipeline.py
@@ -9,64 +9,65 @@ import pytest
 from moto import mock_codepipeline, mock_iam
 
 
+expected_pipeline_details = {
+    "name": "test-pipeline",
+    "roleArn": "arn:aws:iam::123456789012:role/test-role",
+    "artifactStore": {
+        "type": "S3",
+        "location": "codepipeline-us-east-1-123456789012",
+    },
+    "stages": [
+        {
+            "name": "Stage-1",
+            "actions": [
+                {
+                    "name": "Action-1",
+                    "actionTypeId": {
+                        "category": "Source",
+                        "owner": "AWS",
+                        "provider": "S3",
+                        "version": "1",
+                    },
+                    "runOrder": 1,
+                    "configuration": {
+                        "S3Bucket": "test-bucket",
+                        "S3ObjectKey": "test-object",
+                    },
+                    "outputArtifacts": [{"name": "artifact"}],
+                    "inputArtifacts": [],
+                }
+            ],
+        },
+        {
+            "name": "Stage-2",
+            "actions": [
+                {
+                    "name": "Action-1",
+                    "actionTypeId": {
+                        "category": "Approval",
+                        "owner": "AWS",
+                        "provider": "Manual",
+                        "version": "1",
+                    },
+                    "runOrder": 1,
+                    "configuration": {},
+                    "outputArtifacts": [],
+                    "inputArtifacts": [],
+                }
+            ],
+        },
+    ],
+    "version": 1,
+}
+
+
 @mock_codepipeline
 def test_create_pipeline():
     client = boto3.client("codepipeline", region_name="us-east-1")
 
     response = create_basic_codepipeline(client, "test-pipeline")
 
-    response["pipeline"].should.equal(
-        {
-            "name": "test-pipeline",
-            "roleArn": "arn:aws:iam::123456789012:role/test-role",
-            "artifactStore": {
-                "type": "S3",
-                "location": "codepipeline-us-east-1-123456789012",
-            },
-            "stages": [
-                {
-                    "name": "Stage-1",
-                    "actions": [
-                        {
-                            "name": "Action-1",
-                            "actionTypeId": {
-                                "category": "Source",
-                                "owner": "AWS",
-                                "provider": "S3",
-                                "version": "1",
-                            },
-                            "runOrder": 1,
-                            "configuration": {
-                                "S3Bucket": "test-bucket",
-                                "S3ObjectKey": "test-object",
-                            },
-                            "outputArtifacts": [{"name": "artifact"}],
-                            "inputArtifacts": [],
-                        }
-                    ],
-                },
-                {
-                    "name": "Stage-2",
-                    "actions": [
-                        {
-                            "name": "Action-1",
-                            "actionTypeId": {
-                                "category": "Approval",
-                                "owner": "AWS",
-                                "provider": "Manual",
-                                "version": "1",
-                            },
-                            "runOrder": 1,
-                            "configuration": {},
-                            "outputArtifacts": [],
-                            "inputArtifacts": [],
-                        }
-                    ],
-                },
-            ],
-            "version": 1,
-        }
-    )
+    response["pipeline"].should.equal(expected_pipeline_details)
     response["tags"].should.equal([{"key": "key", "value": "value"}])
 
 
@@ -647,35 +648,39 @@ def test_untag_resource_errors():
         "The account with id '123456789012' does not include a pipeline with the name 'not-existing'"
     )
 
+    
+simple_trust_policy =  {
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Principal": {"Service": "codepipeline.amazonaws.com"},
+            "Action": "sts:AssumeRole",
+        }
+    ],
+}
 
 @mock_iam
-def get_role_arn():
+def get_role_arn(name = "test-role", trust_policy = None):
     client = boto3.client("iam", region_name="us-east-1")
     try:
-        return client.get_role(RoleName="test-role")["Role"]["Arn"]
+        return client.get_role(name)["Role"]["Arn"]
     except ClientError:
+        if trust_policy is None:
+            trust_policy = simple_trust_policy
         return client.create_role(
-            RoleName="test-role",
-            AssumeRolePolicyDocument=json.dumps(
-                {
-                    "Version": "2012-10-17",
-                    "Statement": [
-                        {
-                            "Effect": "Allow",
-                            "Principal": {"Service": "codepipeline.amazonaws.com"},
-                            "Action": "sts:AssumeRole",
-                        }
-                    ],
-                }
-            ),
+            RoleName=name,
+            AssumeRolePolicyDocument=json.dumps(trust_policy),
         )["Role"]["Arn"]
 
 
-def create_basic_codepipeline(client, name):
+def create_basic_codepipeline(client, name, role_arn=None):
+    if role_arn is None:
+        role_arn = get_role_arn()
     return client.create_pipeline(
         pipeline={
             "name": name,
-            "roleArn": get_role_arn(),
+            "roleArn": role_arn,
             "artifactStore": {
                 "type": "S3",
                 "location": "codepipeline-us-east-1-123456789012",
@@ -718,3 +723,35 @@ def create_basic_codepipeline(client, name):
         },
         tags=[{"key": "key", "value": "value"}],
     )
+
+extended_trust_policy =  {
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Principal": {
+                "Service": "codebuild.amazonaws.com"
+            },
+            "Action": "sts:AssumeRole"
+        },
+        {
+            "Effect": "Allow",
+            "Principal": {"Service": "codepipeline.amazonaws.com"},
+            "Action": "sts:AssumeRole",
+        }
+    ],
+}
+
+
+@mock_codepipeline
+def test_create_pipeline():
+    client = boto3.client("codepipeline", region_name="us-east-1")
+
+    role_arn = get_role_arn(name="test-role-extended", trust_policy=extended_trust_policy)
+    response = create_basic_codepipeline(client, "test-pipeline", role_arn=role_arn)
+    basic_role_arn = get_role_arn()
+
+    extended_pipeline_details = expected_pipeline_details.replace(basic_role_arn, role_arn)
+    
+    response["pipeline"].should.equal(extended_pipeline_details)
+    response["tags"].should.equal([{"key": "key", "value": "value"}])


### PR DESCRIPTION
Add a test where a valid trust policy is provided but where tests will fail.
Fix will be added shortly but first want to see tests highlight the bug.