### PR TITLE
Fix KeyError on describe_db_clusters for non-existent cluster

### DIFF
--- a/moto/rds/models.py
+++ b/moto/rds/models.py
@@ -1796,6 +1796,8 @@ class RDSBackend(BaseBackend):
 
     def describe_db_clusters(self, cluster_identifier):
         if cluster_identifier:
+            if cluster_identifier not in self.clusters:
+                raise DBClusterNotFoundError(cluster_identifier)
             return [self.clusters[cluster_identifier]]
         return self.clusters.values()
 

--- a/tests/test_rds/test_rds_clusters.py
+++ b/tests/test_rds/test_rds_clusters.py
@@ -16,6 +16,19 @@ def test_describe_db_cluster_initial():
 
 
 @mock_rds
+def test_describe_db_cluster_fails_for_non_existent_cluster():
+    client = boto3.client("rds", region_name="eu-north-1")
+
+    resp = client.describe_db_clusters()
+    resp.should.have.key("DBClusters").should.have.length_of(0)
+    with pytest.raises(ClientError) as ex:
+        client.describe_db_clusters(DBClusterIdentifier="cluster-id")
+    err = ex.value.response["Error"]
+    err["Code"].should.equal("DBClusterNotFoundFault")
+    err["Message"].should.equal("DBCluster cluster-id not found.")
+
+
+@mock_rds
 def test_create_db_cluster_needs_master_username():
     client = boto3.client("rds", region_name="eu-north-1")
 


### PR DESCRIPTION
Throw the correct exception if the requested cluster does not exist. Fixes #5320