### PR TITLE
Support CatalogId in create_database

### DIFF
--- a/moto/glue/responses.py
+++ b/moto/glue/responses.py
@@ -21,6 +21,8 @@ class GlueResponse(BaseResponse):
     def create_database(self):
         database_input = self.parameters.get("DatabaseInput")
         database_name = database_input.get("Name")
+        if "CatalogId" in self.parameters:
+            database_input["CatalogId"] = self.parameters.get("CatalogId")
         self.glue_backend.create_database(database_name, database_input)
         return ""
 

--- a/tests/test_glue/helpers.py
+++ b/tests/test_glue/helpers.py
@@ -12,10 +12,14 @@ def create_database_input(database_name):
     return database_input
 
 
-def create_database(client, database_name, database_input=None):
+def create_database(client, database_name, database_input=None, catalog_id=None):
     if database_input is None:
         database_input = create_database_input(database_name)
-    return client.create_database(DatabaseInput=database_input)
+
+    database_kwargs = {"DatabaseInput": database_input}
+    if catalog_id is not None:
+        database_kwargs["CatalogId"] = catalog_id
+    return client.create_database(**database_kwargs)
 
 
 def get_database(client, database_name):

--- a/tests/test_glue/test_datacatalog.py
+++ b/tests/test_glue/test_datacatalog.py
@@ -11,6 +11,7 @@ import pytz
 from freezegun import freeze_time
 
 from moto import mock_glue, settings
+from moto.core import ACCOUNT_ID
 from . import helpers
 
 
@@ -22,8 +23,9 @@ FROZEN_CREATE_TIME = datetime(2015, 1, 1, 0, 0, 0)
 def test_create_database():
     client = boto3.client("glue", region_name="us-east-1")
     database_name = "myspecialdatabase"
+    database_catalog_id = ACCOUNT_ID
     database_input = helpers.create_database_input(database_name)
-    helpers.create_database(client, database_name, database_input)
+    helpers.create_database(client, database_name, database_input, database_catalog_id)
 
     response = helpers.get_database(client, database_name)
     database = response["Database"]
@@ -38,7 +40,7 @@ def test_create_database():
         database_input.get("CreateTableDefaultPermissions")
     )
     database.get("TargetDatabase").should.equal(database_input.get("TargetDatabase"))
-    database.get("CatalogId").should.equal(database_input.get("CatalogId"))
+    database.get("CatalogId").should.equal(database_catalog_id)
 
 
 @mock_glue


### PR DESCRIPTION
Related issue: https://github.com/spulec/moto/issues/3571

> This is still not fully solved, the CatalogId is not correctly handled. As seen in the Boto3 docs for [create_database](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/glue.html#Glue.Client.create_database) the call is made with CatalogId and DatabaseInput.
> 
> This means that in the [glue/responses.py](https://github.com/spulec/moto/blob/004c971a27d00b7a76b42f88cf3b095f672fff17/moto/glue/responses.py#L21) the CatalagId should be placed in the DatabaseInput or handled like database_name.
> 
> My suggestion would be the following:
> 
> ```python
>     def create_database(self):
>         database_input = self.parameters.get("DatabaseInput")
>         database_name = database_input.get("Name")
>         if 'CatalogId' in self.parameters:
>             database_input["CatalogId"] = self.parameters.get("CatalogId")
>         self.glue_backend.create_database(database_name, database_input)
>         return ""
> ```

