### PR TITLE
Fix: `KeyName` should not be in `ec2:DescribeInstances` response if value is `None`

### DIFF
--- a/moto/ec2/responses/instances.py
+++ b/moto/ec2/responses/instances.py
@@ -406,7 +406,9 @@ EC2_RUN_INSTANCES = (
           <publicDnsName>{{ instance.public_dns }}</publicDnsName>
           <dnsName>{{ instance.public_dns }}</dnsName>
           <reason/>
-          <keyName>{{ instance.key_name }}</keyName>
+          {% if instance.key_name is not none %}
+             <keyName>{{ instance.key_name }}</keyName>
+          {% endif %}
           <ebsOptimized>{{ instance.ebs_optimized }}</ebsOptimized>
           <amiLaunchIndex>{{ instance.ami_launch_index }}</amiLaunchIndex>
           <instanceType>{{ instance.instance_type }}</instanceType>
@@ -559,7 +561,9 @@ EC2_DESCRIBE_INSTANCES = (
                     <publicDnsName>{{ instance.public_dns }}</publicDnsName>
                     <dnsName>{{ instance.public_dns }}</dnsName>
                     <reason>{{ instance._reason }}</reason>
-                    <keyName>{{ instance.key_name }}</keyName>
+                    {% if instance.key_name is not none %}
+                        <keyName>{{ instance.key_name }}</keyName>
+                    {% endif %}
                     <ebsOptimized>{{ instance.ebs_optimized }}</ebsOptimized>
                     <amiLaunchIndex>{{ instance.ami_launch_index }}</amiLaunchIndex>
                     <productCodes/>

--- a/tests/test_ec2/test_instances.py
+++ b/tests/test_ec2/test_instances.py
@@ -1991,6 +1991,22 @@ def test_modify_delete_on_termination():
 
 
 @mock_ec2
+def test_create_instance_with_default_options():
+    client = boto3.client("ec2", region_name="eu-west-1")
+
+    def assert_instance(instance):
+        # TODO: Add additional asserts for default instance response
+        assert instance["ImageId"] == EXAMPLE_AMI_ID
+        assert "KeyName" not in instance
+
+    resp = client.run_instances(ImageId=EXAMPLE_AMI_ID, MaxCount=1, MinCount=1)
+    assert_instance(resp["Instances"][0])
+
+    resp = client.describe_instances(InstanceIds=[resp["Instances"][0]["InstanceId"]])
+    assert_instance(resp["Reservations"][0]["Instances"][0])
+
+
+@mock_ec2
 def test_create_instance_ebs_optimized():
     ec2_resource = boto3.resource("ec2", region_name="eu-west-1")
 


### PR DESCRIPTION
AWS does not serialize NULL values.

Closes #5346