### PR TITLE
DynamoDB: add check for empty key when getting an item (fix #5345)

### DIFF
--- a/moto/dynamodb/responses.py
+++ b/moto/dynamodb/responses.py
@@ -434,6 +434,12 @@ class DynamoHandler(BaseResponse):
         name = self.body["TableName"]
         self.dynamodb_backend.get_table(name)
         key = self.body["Key"]
+        empty_keys = [k for k, v in key.items() if not next(iter(v.values()))]
+        if empty_keys:
+            raise MockValidationException(
+                "One or more parameter values are not valid. The AttributeValue for a key attribute cannot contain an "
+                "empty string value. Key: " + empty_keys[0]
+            )
         projection_expression = self.body.get("ProjectionExpression")
         expression_attribute_names = self.body.get("ExpressionAttributeNames")
         if expression_attribute_names == {}:

--- a/moto/dynamodb/responses.py
+++ b/moto/dynamodb/responses.py
@@ -438,7 +438,7 @@ class DynamoHandler(BaseResponse):
         if empty_keys:
             raise MockValidationException(
                 "One or more parameter values are not valid. The AttributeValue for a key attribute cannot contain an "
-                "empty string value. Key: " + empty_keys[0]
+                f"empty string value. Key: {empty_keys[0]}"
             )
         projection_expression = self.body.get("ProjectionExpression")
         expression_attribute_names = self.body.get("ExpressionAttributeNames")

--- a/moto/dynamodb/responses.py
+++ b/moto/dynamodb/responses.py
@@ -704,7 +704,7 @@ class DynamoHandler(BaseResponse):
             expr_names=expression_attribute_names,
             expr_values=expression_attribute_values,
             filter_expression=filter_expression,
-            **filter_kwargs
+            **filter_kwargs,
         )
 
         result = {

--- a/tests/test_dynamodb/exceptions/test_key_length_exceptions.py
+++ b/tests/test_dynamodb/exceptions/test_key_length_exceptions.py
@@ -310,15 +310,13 @@ def test_item_add_empty_key_exception():
     )
 
     with pytest.raises(ClientError) as ex:
-        conn.put_item(
+        conn.get_item(
             TableName=name,
-            Item={
-                "forum_name": {"S": ""},
-                "subject": {"S": "Check this out!"},
-            },
+            Key={"forum_name": {"S": ""}},
         )
     ex.value.response["Error"]["Code"].should.equal("ValidationException")
     ex.value.response["ResponseMetadata"]["HTTPStatusCode"].should.equal(400)
     ex.value.response["Error"]["Message"].should.equal(
-        "One or more parameter values were invalid: An AttributeValue may not contain an empty string"
+        "One or more parameter values are not valid. The AttributeValue for a key attribute "
+        "cannot contain an empty string value. Key: forum_name"
     )

--- a/tests/test_dynamodb/exceptions/test_key_length_exceptions.py
+++ b/tests/test_dynamodb/exceptions/test_key_length_exceptions.py
@@ -296,3 +296,29 @@ def test_update_item_with_long_string_range_key_exception():
     ex.value.response["Error"]["Message"].should.equal(
         "One or more parameter values were invalid: Aggregated size of all range keys has exceeded the size limit of 1024 bytes"
     )
+
+
+@mock_dynamodb
+def test_item_add_empty_key_exception():
+    name = "TestTable"
+    conn = boto3.client("dynamodb", region_name="us-west-2")
+    conn.create_table(
+        TableName=name,
+        KeySchema=[{"AttributeName": "forum_name", "KeyType": "HASH"}],
+        AttributeDefinitions=[{"AttributeName": "forum_name", "AttributeType": "S"}],
+        BillingMode="PAY_PER_REQUEST",
+    )
+
+    with pytest.raises(ClientError) as ex:
+        conn.put_item(
+            TableName=name,
+            Item={
+                "forum_name": {"S": ""},
+                "subject": {"S": "Check this out!"},
+            },
+        )
+    ex.value.response["Error"]["Code"].should.equal("ValidationException")
+    ex.value.response["ResponseMetadata"]["HTTPStatusCode"].should.equal(400)
+    ex.value.response["Error"]["Message"].should.equal(
+        "One or more parameter values were invalid: An AttributeValue may not contain an empty string"
+    )


### PR DESCRIPTION
fix #5345 by making sure an exception is raised if a user is trying to get an item but providing an empty key