### PR TITLE
check if policy name already taken

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -62,3 +62,4 @@ Moto is written by Steve Pulec with contributions from:
 * [Ariel Beck](https://github.com/arielb135)
 * [Roman Rader](https://github.com/rrader/)
 * [Bryan Chen](https://github.com/bchen1116)
+* [Jonas Bulik](https://github.com/MrGreenTea)

--- a/moto/iot/models.py
+++ b/moto/iot/models.py
@@ -992,6 +992,13 @@ class IoTBackend(BaseBackend):
         cert.status = new_status
 
     def create_policy(self, policy_name, policy_document):
+        if policy_name in self.policies:
+            current_policy = self.policies[policy_name]
+            raise ResourceAlreadyExistsException(
+                f"Policy cannot be created - name already exists (name={policy_name})",
+                current_policy.name,
+                current_policy.arn,
+            )
         policy = FakePolicy(policy_name, policy_document, self.region_name)
         self.policies[policy.name] = policy
         return policy


### PR DESCRIPTION
```
❯ aws iot create-policy --policy-name example --policy-document '{"Version": "2012-10-17", "Statement": [{"Effect": "Allow", "Acti
on": "*", "Resource": "*"}]}'

An error occurred (ResourceAlreadyExistsException) when calling the CreatePolicy operation: Policy cannot be created - name already exists (name=example)
```

Right now the policy is just overwritten in `moto`