### PR TITLE
TF - split long-running tests

### DIFF
--- a/.github/workflows/test_terraform.yml
+++ b/.github/workflows/test_terraform.yml
@@ -45,7 +45,10 @@ jobs:
           ${{ runner.os }}-go-${{ matrix.go-version }}-2-
     - name: Get list of tests for  this service
       id: get-list
-      run: echo "::set-output name=testlist::$(python tests/terraformtests/get_tf_tests.py ${{ matrix.service }})"
+      run: echo "::set-output name=testlist::$(python tests/terraformtests/get_tf_tests.py '${{ matrix.service }}')"
+    - name: Get original AWS service name
+      id: get-service-name
+      run: echo "::set-output name=servicename::$(python -c "print('${{ matrix.service }}'[:'${{ matrix.service }}'.index('|') if '|' in '${{ matrix.service }}' else len('${{ matrix.service }}')])")"
     - name: Execute tests
       run: |
-        make terraformtests SERVICE_NAME=${{ matrix.service }} TEST_NAMES=${{ steps.get-list.outputs.testlist }}
+        make terraformtests SERVICE_NAME=${{ steps.get-service-name.outputs.servicename }} TEST_NAMES=${{ steps.get-list.outputs.testlist }}

--- a/tests/terraformtests/terraform-tests.success.txt
+++ b/tests/terraformtests/terraform-tests.success.txt
@@ -142,7 +142,7 @@ quicksight:
   - TestAccQuickSightUser
 redshift:
   - TestAccRedshiftServiceAccountDataSource
-route53:
+route53|1:
   - TestAccRoute53Record_basic
   - TestAccRoute53Record_underscored
   - TestAccRoute53Record_disappears
@@ -170,6 +170,7 @@ route53:
   - TestAccRoute53Record_longTXTrecord
   - TestAccRoute53Record_doNotAllowOverwrite
   - TestAccRoute53Record_allowOverwrite
+route53|2:
   - TestAccRoute53Zone_basic
   - TestAccRoute53Zone_disappears
   - TestAccRoute53Zone_multiple


### PR DESCRIPTION
Should half the run-time.

Only Route53 is split for now, as that is the only service that takes 40+ minutes - others may get the same treatment in the future.