### PR TITLE
fix(ec2): handle non-existent template for describe-launch-templates

### DIFF
--- a/moto/ec2/exceptions.py
+++ b/moto/ec2/exceptions.py
@@ -702,11 +702,19 @@ class OperationNotPermitted4(EC2ClientError):
         )
 
 
-class InvalidLaunchTemplateNameError(EC2ClientError):
+class InvalidLaunchTemplateNameAlreadyExistsError(EC2ClientError):
     def __init__(self):
         super().__init__(
             "InvalidLaunchTemplateName.AlreadyExistsException",
             "Launch template name already in use.",
+        )
+
+
+class InvalidLaunchTemplateNameNotFoundError(EC2ClientError):
+    def __init__(self):
+        super().__init__(
+            "InvalidLaunchTemplateName.NotFoundException",
+            "At least one of the launch templates specified in the request does not exist.",
         )
 
 

--- a/moto/ec2/models/launch_templates.py
+++ b/moto/ec2/models/launch_templates.py
@@ -1,7 +1,10 @@
 from collections import OrderedDict
 from .core import TaggedEC2Resource
 from ..utils import generic_filter, random_launch_template_id, utc_date_and_time
-from ..exceptions import InvalidLaunchTemplateNameError
+from ..exceptions import (
+    InvalidLaunchTemplateNameAlreadyExistsError,
+    InvalidLaunchTemplateNameNotFoundError,
+)
 
 
 class LaunchTemplateVersion(object):
@@ -81,7 +84,7 @@ class LaunchTemplateBackend:
 
     def create_launch_template(self, name, description, template_data):
         if name in self.launch_template_name_to_ids:
-            raise InvalidLaunchTemplateNameError()
+            raise InvalidLaunchTemplateNameAlreadyExistsError()
         template = LaunchTemplate(self, name, template_data, description)
         self.launch_templates[template.id] = template
         self.launch_template_name_to_ids[template.name] = template.id
@@ -105,6 +108,8 @@ class LaunchTemplateBackend:
         if template_names and not template_ids:
             template_ids = []
             for name in template_names:
+                if name not in self.launch_template_name_to_ids:
+                    raise InvalidLaunchTemplateNameNotFoundError()
                 template_ids.append(self.launch_template_name_to_ids[name])
 
         if template_ids:

--- a/tests/test_ec2/test_launch_templates.py
+++ b/tests/test_ec2/test_launch_templates.py
@@ -305,6 +305,20 @@ def test_describe_launch_template_versions_with_min_and_max():
 
 
 @mock_ec2
+def test_describe_launch_templates_with_non_existent_name():
+    cli = boto3.client("ec2", region_name="us-east-1")
+
+    template_name = str(uuid4())
+
+    with pytest.raises(ClientError) as ex:
+        cli.describe_launch_templates(LaunchTemplateNames=[template_name])
+
+    str(ex.value).should.equal(
+        "An error occurred (InvalidLaunchTemplateName.NotFoundException) when calling the DescribeLaunchTemplates operation: At least one of the launch templates specified in the request does not exist."
+    )
+
+
+@mock_ec2
 def test_describe_launch_templates():
     cli = boto3.client("ec2", region_name="us-east-1")
 


### PR DESCRIPTION
Currently, when calling `ec2 describe-launch-templates` with a template name
that does not (yet) exist, an unhandled exception occurs and HTTP 500 is
returned.

This commit adds a check for the existence of the passed launch template name.
If a template by this name does not exist, an `InvalidLaunchTemplateNameNotFoundError` is raised.
It also renames the current `InvalidLaunchTemplateNameError` to `InvalidLaunchTemplateNameAlreadyExistsError`,
so that both cases are representable.