### PR TITLE
Regenerated instance types

### DIFF
--- a/moto/ec2/resources/instance_types.json
+++ b/moto/ec2/resources/instance_types.json
@@ -30,7 +30,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 15,
    "Ipv6AddressesPerInterface": 15,
    "Ipv6Supported": true,
@@ -58,9 +57,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.3
   },
-  "SupportedBootModes": [
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -108,7 +104,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 30,
    "Ipv6AddressesPerInterface": 30,
    "Ipv6Supported": true,
@@ -136,9 +131,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.3
   },
-  "SupportedBootModes": [
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -186,7 +178,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 10,
    "Ipv6AddressesPerInterface": 10,
    "Ipv6Supported": true,
@@ -214,9 +205,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.3
   },
-  "SupportedBootModes": [
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -264,7 +252,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 4,
    "Ipv6AddressesPerInterface": 4,
    "Ipv6Supported": true,
@@ -292,9 +279,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.3
   },
-  "SupportedBootModes": [
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -341,7 +325,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 30,
    "Ipv6AddressesPerInterface": 30,
    "Ipv6Supported": true,
@@ -369,9 +352,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.3
   },
-  "SupportedBootModes": [
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -419,7 +399,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 15,
    "Ipv6AddressesPerInterface": 15,
    "Ipv6Supported": true,
@@ -447,9 +426,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.3
   },
-  "SupportedBootModes": [
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -474,7 +450,7 @@
   "DedicatedHostsSupported": false,
   "EbsInfo": {
    "EbsOptimizedSupport": "unsupported",
-   "EncryptionSupport": "unsupported",
+   "EncryptionSupport": "supported",
    "NvmeSupport": "unsupported"
   },
   "FreeTierEligible": false,
@@ -488,7 +464,6 @@
      "Type": "hdd"
     }
    ],
-   "EncryptionSupport": "unsupported",
    "NvmeSupport": "unsupported",
    "TotalSizeInGB": 350
   },
@@ -501,7 +476,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "unsupported",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 6,
    "Ipv6AddressesPerInterface": 0,
    "Ipv6Supported": false,
@@ -528,9 +502,6 @@
     "x86_64"
    ]
   },
-  "SupportedBootModes": [
-   "legacy-bios"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs",
    "instance-store"
@@ -565,7 +536,7 @@
     "MaximumThroughputInMBps": 125.0
    },
    "EbsOptimizedSupport": "supported",
-   "EncryptionSupport": "unsupported",
+   "EncryptionSupport": "supported",
    "NvmeSupport": "unsupported"
   },
   "FreeTierEligible": false,
@@ -579,7 +550,6 @@
      "Type": "hdd"
     }
    ],
-   "EncryptionSupport": "unsupported",
    "NvmeSupport": "unsupported",
    "TotalSizeInGB": 1680
   },
@@ -592,7 +562,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "unsupported",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 15,
    "Ipv6AddressesPerInterface": 0,
    "Ipv6Supported": false,
@@ -618,9 +587,6 @@
     "x86_64"
    ]
   },
-  "SupportedBootModes": [
-   "legacy-bios"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs",
    "instance-store"
@@ -669,7 +635,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "unsupported",
    "NvmeSupport": "unsupported",
    "TotalSizeInGB": 160
   },
@@ -682,7 +647,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "unsupported",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 15,
    "Ipv6AddressesPerInterface": 15,
    "Ipv6Supported": true,
@@ -710,9 +674,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.8
   },
-  "SupportedBootModes": [
-   "legacy-bios"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs",
    "instance-store"
@@ -771,7 +732,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "unsupported",
    "NvmeSupport": "unsupported",
    "TotalSizeInGB": 320
   },
@@ -784,7 +744,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "unsupported",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 30,
    "Ipv6AddressesPerInterface": 30,
    "Ipv6Supported": true,
@@ -812,9 +771,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.8
   },
-  "SupportedBootModes": [
-   "legacy-bios"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs",
    "instance-store"
@@ -869,7 +825,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "unsupported",
    "NvmeSupport": "unsupported",
    "TotalSizeInGB": 640
   },
@@ -882,7 +837,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "unsupported",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 30,
    "Ipv6AddressesPerInterface": 30,
    "Ipv6Supported": true,
@@ -910,9 +864,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.8
   },
-  "SupportedBootModes": [
-   "legacy-bios"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs",
    "instance-store"
@@ -967,7 +918,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "unsupported",
    "NvmeSupport": "unsupported",
    "TotalSizeInGB": 32
   },
@@ -980,7 +930,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "unsupported",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 10,
    "Ipv6AddressesPerInterface": 10,
    "Ipv6Supported": true,
@@ -1009,9 +958,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.8
   },
-  "SupportedBootModes": [
-   "legacy-bios"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs",
    "instance-store"
@@ -1067,7 +1013,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "unsupported",
    "NvmeSupport": "unsupported",
    "TotalSizeInGB": 80
   },
@@ -1080,7 +1025,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "unsupported",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 15,
    "Ipv6AddressesPerInterface": 15,
    "Ipv6Supported": true,
@@ -1108,9 +1052,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.8
   },
-  "SupportedBootModes": [
-   "legacy-bios"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs",
    "instance-store"
@@ -1168,7 +1109,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "unsupported",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 15,
    "Ipv6AddressesPerInterface": 15,
    "Ipv6Supported": true,
@@ -1196,9 +1136,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.9
   },
-  "SupportedBootModes": [
-   "legacy-bios"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -1256,7 +1193,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "unsupported",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 30,
    "Ipv6AddressesPerInterface": 30,
    "Ipv6Supported": true,
@@ -1284,9 +1220,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.9
   },
-  "SupportedBootModes": [
-   "legacy-bios"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -1348,7 +1281,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "unsupported",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 30,
    "Ipv6AddressesPerInterface": 30,
    "Ipv6Supported": true,
@@ -1376,9 +1308,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.9
   },
-  "SupportedBootModes": [
-   "legacy-bios"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -1441,7 +1370,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "unsupported",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 10,
    "Ipv6AddressesPerInterface": 10,
    "Ipv6Supported": true,
@@ -1469,9 +1397,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.9
   },
-  "SupportedBootModes": [
-   "legacy-bios"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -1526,7 +1451,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "unsupported",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 15,
    "Ipv6AddressesPerInterface": 15,
    "Ipv6Supported": true,
@@ -1554,9 +1478,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.9
   },
-  "SupportedBootModes": [
-   "legacy-bios"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -1612,7 +1533,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 30,
    "Ipv6AddressesPerInterface": 30,
    "Ipv6Supported": true,
@@ -1640,10 +1560,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.6
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -1709,7 +1625,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 50,
    "Ipv6AddressesPerInterface": 50,
    "Ipv6Supported": true,
@@ -1737,10 +1652,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.4
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -1811,7 +1722,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 50,
    "Ipv6AddressesPerInterface": 50,
    "Ipv6Supported": true,
@@ -1839,10 +1749,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.6
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -1920,7 +1826,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 15,
    "Ipv6AddressesPerInterface": 15,
    "Ipv6Supported": true,
@@ -1948,10 +1853,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.4
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -2007,7 +1908,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 30,
    "Ipv6AddressesPerInterface": 30,
    "Ipv6Supported": true,
@@ -2035,10 +1935,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.4
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -2096,7 +1992,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 30,
    "Ipv6AddressesPerInterface": 30,
    "Ipv6Supported": true,
@@ -2124,10 +2019,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.4
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -2190,7 +2081,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 10,
    "Ipv6AddressesPerInterface": 10,
    "Ipv6Supported": true,
@@ -2218,10 +2108,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.4
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -2275,7 +2161,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 50,
    "Ipv6AddressesPerInterface": 50,
    "Ipv6Supported": true,
@@ -2303,9 +2188,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.6
   },
-  "SupportedBootModes": [
-   "legacy-bios"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -2353,7 +2235,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 15,
    "Ipv6AddressesPerInterface": 15,
    "Ipv6Supported": true,
@@ -2381,10 +2262,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.4
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -2439,7 +2316,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": true,
    "Ipv4AddressesPerInterface": 30,
    "Ipv6AddressesPerInterface": 30,
    "Ipv6Supported": true,
@@ -2467,10 +2343,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.3
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -2533,7 +2405,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": true,
    "Ipv4AddressesPerInterface": 50,
    "Ipv6AddressesPerInterface": 50,
    "Ipv6Supported": true,
@@ -2561,10 +2432,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.3
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -2629,7 +2496,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": true,
    "Ipv4AddressesPerInterface": 50,
    "Ipv6AddressesPerInterface": 50,
    "Ipv6Supported": true,
@@ -2657,10 +2523,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.3
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -2729,7 +2591,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": true,
    "Ipv4AddressesPerInterface": 15,
    "Ipv6AddressesPerInterface": 15,
    "Ipv6Supported": true,
@@ -2757,10 +2618,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.3
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -2818,7 +2675,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": true,
    "Ipv4AddressesPerInterface": 30,
    "Ipv6AddressesPerInterface": 30,
    "Ipv6Supported": true,
@@ -2846,10 +2702,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.3
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -2908,7 +2760,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": true,
    "Ipv4AddressesPerInterface": 30,
    "Ipv6AddressesPerInterface": 30,
    "Ipv6Supported": true,
@@ -2936,10 +2787,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.3
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -3000,7 +2847,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": true,
    "Ipv4AddressesPerInterface": 10,
    "Ipv6AddressesPerInterface": 10,
    "Ipv6Supported": true,
@@ -3028,10 +2874,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.3
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -3086,7 +2928,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": true,
    "Ipv4AddressesPerInterface": 15,
    "Ipv6AddressesPerInterface": 15,
    "Ipv6Supported": true,
@@ -3114,10 +2955,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.3
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -3172,7 +3009,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "required",
    "NvmeSupport": "required",
    "TotalSizeInGB": 1800
   },
@@ -3185,7 +3021,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": true,
    "Ipv4AddressesPerInterface": 30,
    "Ipv6AddressesPerInterface": 30,
    "Ipv6Supported": true,
@@ -3213,10 +3048,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.3
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -3278,7 +3109,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "required",
    "NvmeSupport": "required",
    "TotalSizeInGB": 2400
   },
@@ -3291,7 +3121,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": true,
    "Ipv4AddressesPerInterface": 50,
    "Ipv6AddressesPerInterface": 50,
    "Ipv6Supported": true,
@@ -3319,10 +3148,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.3
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -3386,7 +3211,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "required",
    "NvmeSupport": "required",
    "TotalSizeInGB": 3800
   },
@@ -3399,7 +3223,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": true,
    "Ipv4AddressesPerInterface": 50,
    "Ipv6AddressesPerInterface": 50,
    "Ipv6Supported": true,
@@ -3427,10 +3250,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.3
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -3498,7 +3317,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "required",
    "NvmeSupport": "required",
    "TotalSizeInGB": 300
   },
@@ -3511,7 +3329,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": true,
    "Ipv4AddressesPerInterface": 15,
    "Ipv6AddressesPerInterface": 15,
    "Ipv6Supported": true,
@@ -3539,10 +3356,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.3
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -3599,7 +3412,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "required",
    "NvmeSupport": "required",
    "TotalSizeInGB": 600
   },
@@ -3612,7 +3424,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": true,
    "Ipv4AddressesPerInterface": 30,
    "Ipv6AddressesPerInterface": 30,
    "Ipv6Supported": true,
@@ -3640,10 +3451,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.3
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -3701,7 +3508,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "required",
    "NvmeSupport": "required",
    "TotalSizeInGB": 1200
   },
@@ -3714,7 +3520,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": true,
    "Ipv4AddressesPerInterface": 30,
    "Ipv6AddressesPerInterface": 30,
    "Ipv6Supported": true,
@@ -3742,10 +3547,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.3
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -3805,7 +3606,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "required",
    "NvmeSupport": "required",
    "TotalSizeInGB": 75
   },
@@ -3818,7 +3618,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": true,
    "Ipv4AddressesPerInterface": 10,
    "Ipv6AddressesPerInterface": 10,
    "Ipv6Supported": true,
@@ -3846,10 +3645,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.3
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -3903,7 +3698,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "required",
    "NvmeSupport": "required",
    "TotalSizeInGB": 150
   },
@@ -3916,7 +3710,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": true,
    "Ipv4AddressesPerInterface": 15,
    "Ipv6AddressesPerInterface": 15,
    "Ipv6Supported": true,
@@ -3944,10 +3737,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.3
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -4002,7 +3791,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "required",
    "NvmeSupport": "required",
    "TotalSizeInGB": 1800
   },
@@ -4015,7 +3803,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 30,
    "Ipv6AddressesPerInterface": 30,
    "Ipv6Supported": true,
@@ -4043,10 +3830,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.6
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -4111,7 +3894,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "required",
    "NvmeSupport": "required",
    "TotalSizeInGB": 1800
   },
@@ -4124,7 +3906,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 50,
    "Ipv6AddressesPerInterface": 50,
    "Ipv6Supported": true,
@@ -4152,10 +3933,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.4
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -4225,7 +4002,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "required",
    "NvmeSupport": "required",
    "TotalSizeInGB": 3600
   },
@@ -4238,7 +4014,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 50,
    "Ipv6AddressesPerInterface": 50,
    "Ipv6Supported": true,
@@ -4266,10 +4041,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.6
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -4346,7 +4117,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "required",
    "NvmeSupport": "required",
    "TotalSizeInGB": 200
   },
@@ -4359,7 +4129,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 15,
    "Ipv6AddressesPerInterface": 15,
    "Ipv6Supported": true,
@@ -4387,10 +4156,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.4
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -4445,7 +4210,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "required",
    "NvmeSupport": "required",
    "TotalSizeInGB": 400
   },
@@ -4458,7 +4222,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 30,
    "Ipv6AddressesPerInterface": 30,
    "Ipv6Supported": true,
@@ -4486,10 +4249,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.4
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -4546,7 +4305,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "required",
    "NvmeSupport": "required",
    "TotalSizeInGB": 900
   },
@@ -4559,7 +4317,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 30,
    "Ipv6AddressesPerInterface": 30,
    "Ipv6Supported": true,
@@ -4587,10 +4344,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.4
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -4652,7 +4405,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "required",
    "NvmeSupport": "required",
    "TotalSizeInGB": 50
   },
@@ -4665,7 +4417,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 10,
    "Ipv6AddressesPerInterface": 10,
    "Ipv6Supported": true,
@@ -4693,10 +4444,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.4
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -4749,7 +4496,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "required",
    "NvmeSupport": "required",
    "TotalSizeInGB": 3600
   },
@@ -4762,7 +4508,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 50,
    "Ipv6AddressesPerInterface": 50,
    "Ipv6Supported": true,
@@ -4790,9 +4535,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.6
   },
-  "SupportedBootModes": [
-   "legacy-bios"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -4839,7 +4581,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "required",
    "NvmeSupport": "required",
    "TotalSizeInGB": 100
   },
@@ -4852,7 +4593,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 15,
    "Ipv6AddressesPerInterface": 15,
    "Ipv6Supported": true,
@@ -4880,10 +4620,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.4
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -4936,12 +4672,8 @@
   },
   "NetworkInfo": {
    "DefaultNetworkCardIndex": 0,
-   "EfaInfo": {
-    "MaximumEfaInterfaces": 1
-   },
    "EfaSupported": true,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": true,
    "Ipv4AddressesPerInterface": 50,
    "Ipv6AddressesPerInterface": 50,
    "Ipv6Supported": true,
@@ -4969,10 +4701,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.4
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -5043,7 +4771,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": true,
    "Ipv4AddressesPerInterface": 15,
    "Ipv6AddressesPerInterface": 15,
    "Ipv6Supported": true,
@@ -5071,10 +4798,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.4
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -5130,7 +4853,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": true,
    "Ipv4AddressesPerInterface": 30,
    "Ipv6AddressesPerInterface": 30,
    "Ipv6Supported": true,
@@ -5158,10 +4880,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.4
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -5217,12 +4935,8 @@
   },
   "NetworkInfo": {
    "DefaultNetworkCardIndex": 0,
-   "EfaInfo": {
-    "MaximumEfaInterfaces": 1
-   },
    "EfaSupported": true,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": true,
    "Ipv4AddressesPerInterface": 30,
    "Ipv6AddressesPerInterface": 30,
    "Ipv6Supported": true,
@@ -5250,10 +4964,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.4
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -5316,7 +5026,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": true,
    "Ipv4AddressesPerInterface": 10,
    "Ipv6AddressesPerInterface": 10,
    "Ipv6Supported": true,
@@ -5344,10 +5053,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.4
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -5399,12 +5104,8 @@
   },
   "NetworkInfo": {
    "DefaultNetworkCardIndex": 0,
-   "EfaInfo": {
-    "MaximumEfaInterfaces": 1
-   },
    "EfaSupported": true,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": true,
    "Ipv4AddressesPerInterface": 50,
    "Ipv6AddressesPerInterface": 50,
    "Ipv6Supported": true,
@@ -5432,9 +5133,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.4
   },
-  "SupportedBootModes": [
-   "legacy-bios"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -5482,7 +5180,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": true,
    "Ipv4AddressesPerInterface": 15,
    "Ipv6AddressesPerInterface": 15,
    "Ipv6Supported": true,
@@ -5510,10 +5207,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.4
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -5529,6 +5222,951 @@
    "DefaultThreadsPerCore": 2,
    "DefaultVCpus": 4,
    "ValidCores": [
+    2
+   ],
+   "ValidThreadsPerCore": [
+    1,
+    2
+   ]
+  }
+ },
+ "c6a.12xlarge": {
+  "AutoRecoverySupported": true,
+  "BareMetal": false,
+  "BurstablePerformanceSupported": false,
+  "CurrentGeneration": true,
+  "DedicatedHostsSupported": true,
+  "EbsInfo": {
+   "EbsOptimizedInfo": {
+    "BaselineBandwidthInMbps": 10000,
+    "BaselineIops": 40000,
+    "BaselineThroughputInMBps": 1250.0,
+    "MaximumBandwidthInMbps": 10000,
+    "MaximumIops": 40000,
+    "MaximumThroughputInMBps": 1250.0
+   },
+   "EbsOptimizedSupport": "default",
+   "EncryptionSupport": "supported",
+   "NvmeSupport": "required"
+  },
+  "FreeTierEligible": false,
+  "HibernationSupported": false,
+  "Hypervisor": "nitro",
+  "InstanceStorageSupported": false,
+  "InstanceType": "c6a.12xlarge",
+  "MemoryInfo": {
+   "SizeInMiB": 98304
+  },
+  "NetworkInfo": {
+   "DefaultNetworkCardIndex": 0,
+   "EfaSupported": false,
+   "EnaSupport": "required",
+   "Ipv4AddressesPerInterface": 30,
+   "Ipv6AddressesPerInterface": 30,
+   "Ipv6Supported": true,
+   "MaximumNetworkCards": 1,
+   "MaximumNetworkInterfaces": 8,
+   "NetworkCards": [
+    {
+     "MaximumNetworkInterfaces": 8,
+     "NetworkCardIndex": 0,
+     "NetworkPerformance": "18.75 Gigabit"
+    }
+   ],
+   "NetworkPerformance": "18.75 Gigabit"
+  },
+  "PlacementGroupInfo": {
+   "SupportedStrategies": [
+    "cluster",
+    "partition",
+    "spread"
+   ]
+  },
+  "ProcessorInfo": {
+   "SupportedArchitectures": [
+    "x86_64"
+   ],
+   "SustainedClockSpeedInGhz": 3.6
+  },
+  "SupportedRootDeviceTypes": [
+   "ebs"
+  ],
+  "SupportedUsageClasses": [
+   "on-demand",
+   "spot"
+  ],
+  "SupportedVirtualizationTypes": [
+   "hvm"
+  ],
+  "VCpuInfo": {
+   "DefaultCores": 24,
+   "DefaultThreadsPerCore": 2,
+   "DefaultVCpus": 48,
+   "ValidCores": [
+    1,
+    2,
+    3,
+    4,
+    5,
+    6,
+    7,
+    8,
+    16,
+    24
+   ],
+   "ValidThreadsPerCore": [
+    1,
+    2
+   ]
+  }
+ },
+ "c6a.16xlarge": {
+  "AutoRecoverySupported": true,
+  "BareMetal": false,
+  "BurstablePerformanceSupported": false,
+  "CurrentGeneration": true,
+  "DedicatedHostsSupported": true,
+  "EbsInfo": {
+   "EbsOptimizedInfo": {
+    "BaselineBandwidthInMbps": 13300,
+    "BaselineIops": 53333,
+    "BaselineThroughputInMBps": 1662.5,
+    "MaximumBandwidthInMbps": 13300,
+    "MaximumIops": 53333,
+    "MaximumThroughputInMBps": 1662.5
+   },
+   "EbsOptimizedSupport": "default",
+   "EncryptionSupport": "supported",
+   "NvmeSupport": "required"
+  },
+  "FreeTierEligible": false,
+  "HibernationSupported": false,
+  "Hypervisor": "nitro",
+  "InstanceStorageSupported": false,
+  "InstanceType": "c6a.16xlarge",
+  "MemoryInfo": {
+   "SizeInMiB": 131072
+  },
+  "NetworkInfo": {
+   "DefaultNetworkCardIndex": 0,
+   "EfaSupported": false,
+   "EnaSupport": "required",
+   "Ipv4AddressesPerInterface": 50,
+   "Ipv6AddressesPerInterface": 50,
+   "Ipv6Supported": true,
+   "MaximumNetworkCards": 1,
+   "MaximumNetworkInterfaces": 15,
+   "NetworkCards": [
+    {
+     "MaximumNetworkInterfaces": 15,
+     "NetworkCardIndex": 0,
+     "NetworkPerformance": "25 Gigabit"
+    }
+   ],
+   "NetworkPerformance": "25 Gigabit"
+  },
+  "PlacementGroupInfo": {
+   "SupportedStrategies": [
+    "cluster",
+    "partition",
+    "spread"
+   ]
+  },
+  "ProcessorInfo": {
+   "SupportedArchitectures": [
+    "x86_64"
+   ],
+   "SustainedClockSpeedInGhz": 3.6
+  },
+  "SupportedRootDeviceTypes": [
+   "ebs"
+  ],
+  "SupportedUsageClasses": [
+   "on-demand",
+   "spot"
+  ],
+  "SupportedVirtualizationTypes": [
+   "hvm"
+  ],
+  "VCpuInfo": {
+   "DefaultCores": 32,
+   "DefaultThreadsPerCore": 2,
+   "DefaultVCpus": 64,
+   "ValidCores": [
+    2,
+    4,
+    6,
+    8,
+    10,
+    12,
+    14,
+    16,
+    32
+   ],
+   "ValidThreadsPerCore": [
+    1,
+    2
+   ]
+  }
+ },
+ "c6a.24xlarge": {
+  "AutoRecoverySupported": true,
+  "BareMetal": false,
+  "BurstablePerformanceSupported": false,
+  "CurrentGeneration": true,
+  "DedicatedHostsSupported": true,
+  "EbsInfo": {
+   "EbsOptimizedInfo": {
+    "BaselineBandwidthInMbps": 20000,
+    "BaselineIops": 80000,
+    "BaselineThroughputInMBps": 2500.0,
+    "MaximumBandwidthInMbps": 20000,
+    "MaximumIops": 80000,
+    "MaximumThroughputInMBps": 2500.0
+   },
+   "EbsOptimizedSupport": "default",
+   "EncryptionSupport": "supported",
+   "NvmeSupport": "required"
+  },
+  "FreeTierEligible": false,
+  "HibernationSupported": false,
+  "Hypervisor": "nitro",
+  "InstanceStorageSupported": false,
+  "InstanceType": "c6a.24xlarge",
+  "MemoryInfo": {
+   "SizeInMiB": 196608
+  },
+  "NetworkInfo": {
+   "DefaultNetworkCardIndex": 0,
+   "EfaSupported": false,
+   "EnaSupport": "required",
+   "Ipv4AddressesPerInterface": 50,
+   "Ipv6AddressesPerInterface": 50,
+   "Ipv6Supported": true,
+   "MaximumNetworkCards": 1,
+   "MaximumNetworkInterfaces": 15,
+   "NetworkCards": [
+    {
+     "MaximumNetworkInterfaces": 15,
+     "NetworkCardIndex": 0,
+     "NetworkPerformance": "37.5 Gigabit"
+    }
+   ],
+   "NetworkPerformance": "37.5 Gigabit"
+  },
+  "PlacementGroupInfo": {
+   "SupportedStrategies": [
+    "cluster",
+    "partition",
+    "spread"
+   ]
+  },
+  "ProcessorInfo": {
+   "SupportedArchitectures": [
+    "x86_64"
+   ],
+   "SustainedClockSpeedInGhz": 3.6
+  },
+  "SupportedRootDeviceTypes": [
+   "ebs"
+  ],
+  "SupportedUsageClasses": [
+   "on-demand",
+   "spot"
+  ],
+  "SupportedVirtualizationTypes": [
+   "hvm"
+  ],
+  "VCpuInfo": {
+   "DefaultCores": 48,
+   "DefaultThreadsPerCore": 2,
+   "DefaultVCpus": 96,
+   "ValidCores": [
+    2,
+    4,
+    6,
+    8,
+    10,
+    12,
+    14,
+    16,
+    32,
+    48
+   ],
+   "ValidThreadsPerCore": [
+    1,
+    2
+   ]
+  }
+ },
+ "c6a.2xlarge": {
+  "AutoRecoverySupported": true,
+  "BareMetal": false,
+  "BurstablePerformanceSupported": false,
+  "CurrentGeneration": true,
+  "DedicatedHostsSupported": true,
+  "EbsInfo": {
+   "EbsOptimizedInfo": {
+    "BaselineBandwidthInMbps": 2122,
+    "BaselineIops": 8333,
+    "BaselineThroughputInMBps": 265.25,
+    "MaximumBandwidthInMbps": 6666,
+    "MaximumIops": 26667,
+    "MaximumThroughputInMBps": 833.333333
+   },
+   "EbsOptimizedSupport": "default",
+   "EncryptionSupport": "supported",
+   "NvmeSupport": "required"
+  },
+  "FreeTierEligible": false,
+  "HibernationSupported": false,
+  "Hypervisor": "nitro",
+  "InstanceStorageSupported": false,
+  "InstanceType": "c6a.2xlarge",
+  "MemoryInfo": {
+   "SizeInMiB": 16384
+  },
+  "NetworkInfo": {
+   "DefaultNetworkCardIndex": 0,
+   "EfaSupported": false,
+   "EnaSupport": "required",
+   "Ipv4AddressesPerInterface": 15,
+   "Ipv6AddressesPerInterface": 15,
+   "Ipv6Supported": true,
+   "MaximumNetworkCards": 1,
+   "MaximumNetworkInterfaces": 4,
+   "NetworkCards": [
+    {
+     "MaximumNetworkInterfaces": 4,
+     "NetworkCardIndex": 0,
+     "NetworkPerformance": "Up to 12.5 Gigabit"
+    }
+   ],
+   "NetworkPerformance": "Up to 12.5 Gigabit"
+  },
+  "PlacementGroupInfo": {
+   "SupportedStrategies": [
+    "cluster",
+    "partition",
+    "spread"
+   ]
+  },
+  "ProcessorInfo": {
+   "SupportedArchitectures": [
+    "x86_64"
+   ],
+   "SustainedClockSpeedInGhz": 3.6
+  },
+  "SupportedRootDeviceTypes": [
+   "ebs"
+  ],
+  "SupportedUsageClasses": [
+   "on-demand",
+   "spot"
+  ],
+  "SupportedVirtualizationTypes": [
+   "hvm"
+  ],
+  "VCpuInfo": {
+   "DefaultCores": 4,
+   "DefaultThreadsPerCore": 2,
+   "DefaultVCpus": 8,
+   "ValidCores": [
+    1,
+    2,
+    3,
+    4
+   ],
+   "ValidThreadsPerCore": [
+    1,
+    2
+   ]
+  }
+ },
+ "c6a.32xlarge": {
+  "AutoRecoverySupported": true,
+  "BareMetal": false,
+  "BurstablePerformanceSupported": false,
+  "CurrentGeneration": true,
+  "DedicatedHostsSupported": true,
+  "EbsInfo": {
+   "EbsOptimizedInfo": {
+    "BaselineBandwidthInMbps": 26666,
+    "BaselineIops": 100000,
+    "BaselineThroughputInMBps": 3333.333333,
+    "MaximumBandwidthInMbps": 26666,
+    "MaximumIops": 100000,
+    "MaximumThroughputInMBps": 3333.333333
+   },
+   "EbsOptimizedSupport": "default",
+   "EncryptionSupport": "supported",
+   "NvmeSupport": "required"
+  },
+  "FreeTierEligible": false,
+  "HibernationSupported": false,
+  "Hypervisor": "nitro",
+  "InstanceStorageSupported": false,
+  "InstanceType": "c6a.32xlarge",
+  "MemoryInfo": {
+   "SizeInMiB": 262144
+  },
+  "NetworkInfo": {
+   "DefaultNetworkCardIndex": 0,
+   "EfaSupported": true,
+   "EnaSupport": "required",
+   "Ipv4AddressesPerInterface": 50,
+   "Ipv6AddressesPerInterface": 50,
+   "Ipv6Supported": true,
+   "MaximumNetworkCards": 1,
+   "MaximumNetworkInterfaces": 15,
+   "NetworkCards": [
+    {
+     "MaximumNetworkInterfaces": 15,
+     "NetworkCardIndex": 0,
+     "NetworkPerformance": "50 Gigabit"
+    }
+   ],
+   "NetworkPerformance": "50 Gigabit"
+  },
+  "PlacementGroupInfo": {
+   "SupportedStrategies": [
+    "cluster",
+    "partition",
+    "spread"
+   ]
+  },
+  "ProcessorInfo": {
+   "SupportedArchitectures": [
+    "x86_64"
+   ],
+   "SustainedClockSpeedInGhz": 3.6
+  },
+  "SupportedRootDeviceTypes": [
+   "ebs"
+  ],
+  "SupportedUsageClasses": [
+   "on-demand",
+   "spot"
+  ],
+  "SupportedVirtualizationTypes": [
+   "hvm"
+  ],
+  "VCpuInfo": {
+   "DefaultCores": 64,
+   "DefaultThreadsPerCore": 2,
+   "DefaultVCpus": 128,
+   "ValidCores": [
+    4,
+    8,
+    12,
+    16,
+    20,
+    24,
+    28,
+    32,
+    64
+   ],
+   "ValidThreadsPerCore": [
+    1,
+    2
+   ]
+  }
+ },
+ "c6a.48xlarge": {
+  "AutoRecoverySupported": true,
+  "BareMetal": false,
+  "BurstablePerformanceSupported": false,
+  "CurrentGeneration": true,
+  "DedicatedHostsSupported": true,
+  "EbsInfo": {
+   "EbsOptimizedInfo": {
+    "BaselineBandwidthInMbps": 40000,
+    "BaselineIops": 160000,
+    "BaselineThroughputInMBps": 5000.0,
+    "MaximumBandwidthInMbps": 40000,
+    "MaximumIops": 160000,
+    "MaximumThroughputInMBps": 5000.0
+   },
+   "EbsOptimizedSupport": "default",
+   "EncryptionSupport": "supported",
+   "NvmeSupport": "required"
+  },
+  "FreeTierEligible": false,
+  "HibernationSupported": false,
+  "Hypervisor": "nitro",
+  "InstanceStorageSupported": false,
+  "InstanceType": "c6a.48xlarge",
+  "MemoryInfo": {
+   "SizeInMiB": 393216
+  },
+  "NetworkInfo": {
+   "DefaultNetworkCardIndex": 0,
+   "EfaSupported": true,
+   "EnaSupport": "required",
+   "Ipv4AddressesPerInterface": 50,
+   "Ipv6AddressesPerInterface": 50,
+   "Ipv6Supported": true,
+   "MaximumNetworkCards": 1,
+   "MaximumNetworkInterfaces": 15,
+   "NetworkCards": [
+    {
+     "MaximumNetworkInterfaces": 15,
+     "NetworkCardIndex": 0,
+     "NetworkPerformance": "50 Gigabit"
+    }
+   ],
+   "NetworkPerformance": "50 Gigabit"
+  },
+  "PlacementGroupInfo": {
+   "SupportedStrategies": [
+    "cluster",
+    "partition",
+    "spread"
+   ]
+  },
+  "ProcessorInfo": {
+   "SupportedArchitectures": [
+    "x86_64"
+   ],
+   "SustainedClockSpeedInGhz": 3.6
+  },
+  "SupportedRootDeviceTypes": [
+   "ebs"
+  ],
+  "SupportedUsageClasses": [
+   "on-demand",
+   "spot"
+  ],
+  "SupportedVirtualizationTypes": [
+   "hvm"
+  ],
+  "VCpuInfo": {
+   "DefaultCores": 96,
+   "DefaultThreadsPerCore": 2,
+   "DefaultVCpus": 192,
+   "ValidCores": [
+    4,
+    8,
+    12,
+    16,
+    20,
+    24,
+    28,
+    32,
+    64,
+    96
+   ],
+   "ValidThreadsPerCore": [
+    1,
+    2
+   ]
+  }
+ },
+ "c6a.4xlarge": {
+  "AutoRecoverySupported": true,
+  "BareMetal": false,
+  "BurstablePerformanceSupported": false,
+  "CurrentGeneration": true,
+  "DedicatedHostsSupported": true,
+  "EbsInfo": {
+   "EbsOptimizedInfo": {
+    "BaselineBandwidthInMbps": 4245,
+    "BaselineIops": 16000,
+    "BaselineThroughputInMBps": 530.625,
+    "MaximumBandwidthInMbps": 6666,
+    "MaximumIops": 26667,
+    "MaximumThroughputInMBps": 833.333333
+   },
+   "EbsOptimizedSupport": "default",
+   "EncryptionSupport": "supported",
+   "NvmeSupport": "required"
+  },
+  "FreeTierEligible": false,
+  "HibernationSupported": false,
+  "Hypervisor": "nitro",
+  "InstanceStorageSupported": false,
+  "InstanceType": "c6a.4xlarge",
+  "MemoryInfo": {
+   "SizeInMiB": 32768
+  },
+  "NetworkInfo": {
+   "DefaultNetworkCardIndex": 0,
+   "EfaSupported": false,
+   "EnaSupport": "required",
+   "Ipv4AddressesPerInterface": 30,
+   "Ipv6AddressesPerInterface": 30,
+   "Ipv6Supported": true,
+   "MaximumNetworkCards": 1,
+   "MaximumNetworkInterfaces": 8,
+   "NetworkCards": [
+    {
+     "MaximumNetworkInterfaces": 8,
+     "NetworkCardIndex": 0,
+     "NetworkPerformance": "Up to 12.5 Gigabit"
+    }
+   ],
+   "NetworkPerformance": "Up to 12.5 Gigabit"
+  },
+  "PlacementGroupInfo": {
+   "SupportedStrategies": [
+    "cluster",
+    "partition",
+    "spread"
+   ]
+  },
+  "ProcessorInfo": {
+   "SupportedArchitectures": [
+    "x86_64"
+   ],
+   "SustainedClockSpeedInGhz": 3.6
+  },
+  "SupportedRootDeviceTypes": [
+   "ebs"
+  ],
+  "SupportedUsageClasses": [
+   "on-demand",
+   "spot"
+  ],
+  "SupportedVirtualizationTypes": [
+   "hvm"
+  ],
+  "VCpuInfo": {
+   "DefaultCores": 8,
+   "DefaultThreadsPerCore": 2,
+   "DefaultVCpus": 16,
+   "ValidCores": [
+    1,
+    2,
+    3,
+    4,
+    5,
+    6,
+    7,
+    8
+   ],
+   "ValidThreadsPerCore": [
+    1,
+    2
+   ]
+  }
+ },
+ "c6a.8xlarge": {
+  "AutoRecoverySupported": true,
+  "BareMetal": false,
+  "BurstablePerformanceSupported": false,
+  "CurrentGeneration": true,
+  "DedicatedHostsSupported": true,
+  "EbsInfo": {
+   "EbsOptimizedInfo": {
+    "BaselineBandwidthInMbps": 6666,
+    "BaselineIops": 26667,
+    "BaselineThroughputInMBps": 833.333333,
+    "MaximumBandwidthInMbps": 6666,
+    "MaximumIops": 26667,
+    "MaximumThroughputInMBps": 833.333333
+   },
+   "EbsOptimizedSupport": "default",
+   "EncryptionSupport": "supported",
+   "NvmeSupport": "required"
+  },
+  "FreeTierEligible": false,
+  "HibernationSupported": false,
+  "Hypervisor": "nitro",
+  "InstanceStorageSupported": false,
+  "InstanceType": "c6a.8xlarge",
+  "MemoryInfo": {
+   "SizeInMiB": 65536
+  },
+  "NetworkInfo": {
+   "DefaultNetworkCardIndex": 0,
+   "EfaSupported": false,
+   "EnaSupport": "required",
+   "Ipv4AddressesPerInterface": 30,
+   "Ipv6AddressesPerInterface": 30,
+   "Ipv6Supported": true,
+   "MaximumNetworkCards": 1,
+   "MaximumNetworkInterfaces": 8,
+   "NetworkCards": [
+    {
+     "MaximumNetworkInterfaces": 8,
+     "NetworkCardIndex": 0,
+     "NetworkPerformance": "12.5 Gigabit"
+    }
+   ],
+   "NetworkPerformance": "12.5 Gigabit"
+  },
+  "PlacementGroupInfo": {
+   "SupportedStrategies": [
+    "cluster",
+    "partition",
+    "spread"
+   ]
+  },
+  "ProcessorInfo": {
+   "SupportedArchitectures": [
+    "x86_64"
+   ],
+   "SustainedClockSpeedInGhz": 3.6
+  },
+  "SupportedRootDeviceTypes": [
+   "ebs"
+  ],
+  "SupportedUsageClasses": [
+   "on-demand",
+   "spot"
+  ],
+  "SupportedVirtualizationTypes": [
+   "hvm"
+  ],
+  "VCpuInfo": {
+   "DefaultCores": 16,
+   "DefaultThreadsPerCore": 2,
+   "DefaultVCpus": 32,
+   "ValidCores": [
+    1,
+    2,
+    3,
+    4,
+    5,
+    6,
+    7,
+    8,
+    16
+   ],
+   "ValidThreadsPerCore": [
+    1,
+    2
+   ]
+  }
+ },
+ "c6a.large": {
+  "AutoRecoverySupported": true,
+  "BareMetal": false,
+  "BurstablePerformanceSupported": false,
+  "CurrentGeneration": true,
+  "DedicatedHostsSupported": true,
+  "EbsInfo": {
+   "EbsOptimizedInfo": {
+    "BaselineBandwidthInMbps": 531,
+    "BaselineIops": 3600,
+    "BaselineThroughputInMBps": 66.375,
+    "MaximumBandwidthInMbps": 6666,
+    "MaximumIops": 26667,
+    "MaximumThroughputInMBps": 833.333333
+   },
+   "EbsOptimizedSupport": "default",
+   "EncryptionSupport": "supported",
+   "NvmeSupport": "required"
+  },
+  "FreeTierEligible": false,
+  "HibernationSupported": false,
+  "Hypervisor": "nitro",
+  "InstanceStorageSupported": false,
+  "InstanceType": "c6a.large",
+  "MemoryInfo": {
+   "SizeInMiB": 4096
+  },
+  "NetworkInfo": {
+   "DefaultNetworkCardIndex": 0,
+   "EfaSupported": false,
+   "EnaSupport": "required",
+   "Ipv4AddressesPerInterface": 10,
+   "Ipv6AddressesPerInterface": 10,
+   "Ipv6Supported": true,
+   "MaximumNetworkCards": 1,
+   "MaximumNetworkInterfaces": 3,
+   "NetworkCards": [
+    {
+     "MaximumNetworkInterfaces": 3,
+     "NetworkCardIndex": 0,
+     "NetworkPerformance": "Up to 12.5 Gigabit"
+    }
+   ],
+   "NetworkPerformance": "Up to 12.5 Gigabit"
+  },
+  "PlacementGroupInfo": {
+   "SupportedStrategies": [
+    "cluster",
+    "partition",
+    "spread"
+   ]
+  },
+  "ProcessorInfo": {
+   "SupportedArchitectures": [
+    "x86_64"
+   ],
+   "SustainedClockSpeedInGhz": 3.6
+  },
+  "SupportedRootDeviceTypes": [
+   "ebs"
+  ],
+  "SupportedUsageClasses": [
+   "on-demand",
+   "spot"
+  ],
+  "SupportedVirtualizationTypes": [
+   "hvm"
+  ],
+  "VCpuInfo": {
+   "DefaultCores": 1,
+   "DefaultThreadsPerCore": 2,
+   "DefaultVCpus": 2,
+   "ValidCores": [
+    1
+   ],
+   "ValidThreadsPerCore": [
+    1,
+    2
+   ]
+  }
+ },
+ "c6a.metal": {
+  "AutoRecoverySupported": true,
+  "BareMetal": true,
+  "BurstablePerformanceSupported": false,
+  "CurrentGeneration": true,
+  "DedicatedHostsSupported": true,
+  "EbsInfo": {
+   "EbsOptimizedInfo": {
+    "BaselineBandwidthInMbps": 40000,
+    "BaselineIops": 160000,
+    "BaselineThroughputInMBps": 5000.0,
+    "MaximumBandwidthInMbps": 40000,
+    "MaximumIops": 160000,
+    "MaximumThroughputInMBps": 5000.0
+   },
+   "EbsOptimizedSupport": "default",
+   "EncryptionSupport": "supported",
+   "NvmeSupport": "required"
+  },
+  "FreeTierEligible": false,
+  "HibernationSupported": false,
+  "InstanceStorageSupported": false,
+  "InstanceType": "c6a.metal",
+  "MemoryInfo": {
+   "SizeInMiB": 393216
+  },
+  "NetworkInfo": {
+   "DefaultNetworkCardIndex": 0,
+   "EfaSupported": true,
+   "EnaSupport": "required",
+   "Ipv4AddressesPerInterface": 50,
+   "Ipv6AddressesPerInterface": 50,
+   "Ipv6Supported": true,
+   "MaximumNetworkCards": 1,
+   "MaximumNetworkInterfaces": 15,
+   "NetworkCards": [
+    {
+     "MaximumNetworkInterfaces": 15,
+     "NetworkCardIndex": 0,
+     "NetworkPerformance": "50 Gigabit"
+    }
+   ],
+   "NetworkPerformance": "50 Gigabit"
+  },
+  "PlacementGroupInfo": {
+   "SupportedStrategies": [
+    "cluster",
+    "partition",
+    "spread"
+   ]
+  },
+  "ProcessorInfo": {
+   "SupportedArchitectures": [
+    "x86_64"
+   ],
+   "SustainedClockSpeedInGhz": 3.6
+  },
+  "SupportedRootDeviceTypes": [
+   "ebs"
+  ],
+  "SupportedUsageClasses": [
+   "on-demand",
+   "spot"
+  ],
+  "SupportedVirtualizationTypes": [
+   "hvm"
+  ],
+  "VCpuInfo": {
+   "DefaultCores": 96,
+   "DefaultThreadsPerCore": 2,
+   "DefaultVCpus": 192
+  }
+ },
+ "c6a.xlarge": {
+  "AutoRecoverySupported": true,
+  "BareMetal": false,
+  "BurstablePerformanceSupported": false,
+  "CurrentGeneration": true,
+  "DedicatedHostsSupported": true,
+  "EbsInfo": {
+   "EbsOptimizedInfo": {
+    "BaselineBandwidthInMbps": 1061,
+    "BaselineIops": 6000,
+    "BaselineThroughputInMBps": 132.625,
+    "MaximumBandwidthInMbps": 6666,
+    "MaximumIops": 26667,
+    "MaximumThroughputInMBps": 833.333333
+   },
+   "EbsOptimizedSupport": "default",
+   "EncryptionSupport": "supported",
+   "NvmeSupport": "required"
+  },
+  "FreeTierEligible": false,
+  "HibernationSupported": false,
+  "Hypervisor": "nitro",
+  "InstanceStorageSupported": false,
+  "InstanceType": "c6a.xlarge",
+  "MemoryInfo": {
+   "SizeInMiB": 8192
+  },
+  "NetworkInfo": {
+   "DefaultNetworkCardIndex": 0,
+   "EfaSupported": false,
+   "EnaSupport": "required",
+   "Ipv4AddressesPerInterface": 15,
+   "Ipv6AddressesPerInterface": 15,
+   "Ipv6Supported": true,
+   "MaximumNetworkCards": 1,
+   "MaximumNetworkInterfaces": 4,
+   "NetworkCards": [
+    {
+     "MaximumNetworkInterfaces": 4,
+     "NetworkCardIndex": 0,
+     "NetworkPerformance": "Up to 12.5 Gigabit"
+    }
+   ],
+   "NetworkPerformance": "Up to 12.5 Gigabit"
+  },
+  "PlacementGroupInfo": {
+   "SupportedStrategies": [
+    "cluster",
+    "partition",
+    "spread"
+   ]
+  },
+  "ProcessorInfo": {
+   "SupportedArchitectures": [
+    "x86_64"
+   ],
+   "SustainedClockSpeedInGhz": 3.6
+  },
+  "SupportedRootDeviceTypes": [
+   "ebs"
+  ],
+  "SupportedUsageClasses": [
+   "on-demand",
+   "spot"
+  ],
+  "SupportedVirtualizationTypes": [
+   "hvm"
+  ],
+  "VCpuInfo": {
+   "DefaultCores": 2,
+   "DefaultThreadsPerCore": 2,
+   "DefaultVCpus": 4,
+   "ValidCores": [
+    1,
     2
    ],
    "ValidThreadsPerCore": [
@@ -5568,7 +6206,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 30,
    "Ipv6AddressesPerInterface": 30,
    "Ipv6Supported": true,
@@ -5596,9 +6233,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.5
   },
-  "SupportedBootModes": [
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -5699,7 +6333,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 50,
    "Ipv6AddressesPerInterface": 50,
    "Ipv6Supported": true,
@@ -5727,9 +6360,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.5
   },
-  "SupportedBootModes": [
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -5846,7 +6476,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 15,
    "Ipv6AddressesPerInterface": 15,
    "Ipv6Supported": true,
@@ -5874,9 +6503,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.5
   },
-  "SupportedBootModes": [
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -5937,7 +6563,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 30,
    "Ipv6AddressesPerInterface": 30,
    "Ipv6Supported": true,
@@ -5965,9 +6590,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.5
   },
-  "SupportedBootModes": [
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -6036,7 +6658,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 30,
    "Ipv6AddressesPerInterface": 30,
    "Ipv6Supported": true,
@@ -6064,9 +6685,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.5
   },
-  "SupportedBootModes": [
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -6151,7 +6769,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 10,
    "Ipv6AddressesPerInterface": 10,
    "Ipv6Supported": true,
@@ -6179,9 +6796,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.5
   },
-  "SupportedBootModes": [
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -6236,7 +6850,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 4,
    "Ipv6AddressesPerInterface": 4,
    "Ipv6Supported": true,
@@ -6264,9 +6877,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.5
   },
-  "SupportedBootModes": [
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -6313,7 +6923,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 50,
    "Ipv6AddressesPerInterface": 50,
    "Ipv6Supported": true,
@@ -6341,9 +6950,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.5
   },
-  "SupportedBootModes": [
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -6391,7 +6997,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 15,
    "Ipv6AddressesPerInterface": 15,
    "Ipv6Supported": true,
@@ -6419,9 +7024,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.5
   },
-  "SupportedBootModes": [
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -6477,7 +7079,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "required",
    "NvmeSupport": "required",
    "TotalSizeInGB": 2850
   },
@@ -6490,7 +7091,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 30,
    "Ipv6AddressesPerInterface": 30,
    "Ipv6Supported": true,
@@ -6518,9 +7118,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.5
   },
-  "SupportedBootModes": [
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -6620,7 +7217,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "required",
    "NvmeSupport": "required",
    "TotalSizeInGB": 3800
   },
@@ -6633,7 +7229,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 50,
    "Ipv6AddressesPerInterface": 50,
    "Ipv6Supported": true,
@@ -6661,9 +7256,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.5
   },
-  "SupportedBootModes": [
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -6779,7 +7371,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "required",
    "NvmeSupport": "required",
    "TotalSizeInGB": 474
   },
@@ -6792,7 +7383,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 15,
    "Ipv6AddressesPerInterface": 15,
    "Ipv6Supported": true,
@@ -6820,9 +7410,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.5
   },
-  "SupportedBootModes": [
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -6882,7 +7469,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "required",
    "NvmeSupport": "required",
    "TotalSizeInGB": 950
   },
@@ -6895,7 +7481,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 30,
    "Ipv6AddressesPerInterface": 30,
    "Ipv6Supported": true,
@@ -6923,9 +7508,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.5
   },
-  "SupportedBootModes": [
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -6993,7 +7575,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "required",
    "NvmeSupport": "required",
    "TotalSizeInGB": 1900
   },
@@ -7006,7 +7587,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 30,
    "Ipv6AddressesPerInterface": 30,
    "Ipv6Supported": true,
@@ -7034,9 +7614,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.5
   },
-  "SupportedBootModes": [
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -7120,7 +7697,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "required",
    "NvmeSupport": "required",
    "TotalSizeInGB": 118
   },
@@ -7133,7 +7709,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 10,
    "Ipv6AddressesPerInterface": 10,
    "Ipv6Supported": true,
@@ -7161,9 +7736,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.5
   },
-  "SupportedBootModes": [
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -7217,7 +7789,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "required",
    "NvmeSupport": "required",
    "TotalSizeInGB": 59
   },
@@ -7230,7 +7801,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 4,
    "Ipv6AddressesPerInterface": 4,
    "Ipv6Supported": true,
@@ -7258,9 +7828,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.5
   },
-  "SupportedBootModes": [
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -7306,7 +7873,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "required",
    "NvmeSupport": "required",
    "TotalSizeInGB": 3800
   },
@@ -7319,7 +7885,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 50,
    "Ipv6AddressesPerInterface": 50,
    "Ipv6Supported": true,
@@ -7347,9 +7912,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.5
   },
-  "SupportedBootModes": [
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -7396,7 +7958,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "required",
    "NvmeSupport": "required",
    "TotalSizeInGB": 237
   },
@@ -7409,7 +7970,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 15,
    "Ipv6AddressesPerInterface": 15,
    "Ipv6Supported": true,
@@ -7437,9 +7997,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.5
   },
-  "SupportedBootModes": [
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -7496,7 +8053,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": true,
    "Ipv4AddressesPerInterface": 30,
    "Ipv6AddressesPerInterface": 30,
    "Ipv6Supported": true,
@@ -7524,9 +8080,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.5
   },
-  "SupportedBootModes": [
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -7625,12 +8178,8 @@
   },
   "NetworkInfo": {
    "DefaultNetworkCardIndex": 0,
-   "EfaInfo": {
-    "MaximumEfaInterfaces": 1
-   },
    "EfaSupported": true,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": true,
    "Ipv4AddressesPerInterface": 50,
    "Ipv6AddressesPerInterface": 50,
    "Ipv6Supported": true,
@@ -7658,9 +8207,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.5
   },
-  "SupportedBootModes": [
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -7777,7 +8323,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": true,
    "Ipv4AddressesPerInterface": 15,
    "Ipv6AddressesPerInterface": 15,
    "Ipv6Supported": true,
@@ -7805,9 +8350,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.5
   },
-  "SupportedBootModes": [
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -7868,7 +8410,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": true,
    "Ipv4AddressesPerInterface": 30,
    "Ipv6AddressesPerInterface": 30,
    "Ipv6Supported": true,
@@ -7896,9 +8437,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.5
   },
-  "SupportedBootModes": [
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -7967,7 +8505,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": true,
    "Ipv4AddressesPerInterface": 30,
    "Ipv6AddressesPerInterface": 30,
    "Ipv6Supported": true,
@@ -7995,9 +8532,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.5
   },
-  "SupportedBootModes": [
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -8082,7 +8616,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": true,
    "Ipv4AddressesPerInterface": 10,
    "Ipv6AddressesPerInterface": 10,
    "Ipv6Supported": true,
@@ -8110,9 +8643,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.5
   },
-  "SupportedBootModes": [
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -8167,7 +8697,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": true,
    "Ipv4AddressesPerInterface": 4,
    "Ipv6AddressesPerInterface": 4,
    "Ipv6Supported": true,
@@ -8195,9 +8724,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.5
   },
-  "SupportedBootModes": [
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -8251,7 +8777,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": true,
    "Ipv4AddressesPerInterface": 15,
    "Ipv6AddressesPerInterface": 15,
    "Ipv6Supported": true,
@@ -8279,9 +8804,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.5
   },
-  "SupportedBootModes": [
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -8338,7 +8860,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": true,
    "Ipv4AddressesPerInterface": 30,
    "Ipv6AddressesPerInterface": 30,
    "Ipv6Supported": true,
@@ -8366,10 +8887,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.5
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -8435,7 +8952,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": true,
    "Ipv4AddressesPerInterface": 50,
    "Ipv6AddressesPerInterface": 50,
    "Ipv6Supported": true,
@@ -8463,10 +8979,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.5
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -8536,7 +9048,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": true,
    "Ipv4AddressesPerInterface": 50,
    "Ipv6AddressesPerInterface": 50,
    "Ipv6Supported": true,
@@ -8564,10 +9075,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.5
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -8645,7 +9152,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": true,
    "Ipv4AddressesPerInterface": 15,
    "Ipv6AddressesPerInterface": 15,
    "Ipv6Supported": true,
@@ -8673,10 +9179,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.5
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -8730,12 +9232,8 @@
   },
   "NetworkInfo": {
    "DefaultNetworkCardIndex": 0,
-   "EfaInfo": {
-    "MaximumEfaInterfaces": 1
-   },
    "EfaSupported": true,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": true,
    "Ipv4AddressesPerInterface": 50,
    "Ipv6AddressesPerInterface": 50,
    "Ipv6Supported": true,
@@ -8763,10 +9261,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.5
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -8852,7 +9346,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": true,
    "Ipv4AddressesPerInterface": 30,
    "Ipv6AddressesPerInterface": 30,
    "Ipv6Supported": true,
@@ -8880,10 +9373,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.5
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -8941,7 +9430,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": true,
    "Ipv4AddressesPerInterface": 30,
    "Ipv6AddressesPerInterface": 30,
    "Ipv6Supported": true,
@@ -8969,10 +9457,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.5
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -9034,7 +9518,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": true,
    "Ipv4AddressesPerInterface": 10,
    "Ipv6AddressesPerInterface": 10,
    "Ipv6Supported": true,
@@ -9062,10 +9545,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.5
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -9117,12 +9596,8 @@
   },
   "NetworkInfo": {
    "DefaultNetworkCardIndex": 0,
-   "EfaInfo": {
-    "MaximumEfaInterfaces": 1
-   },
    "EfaSupported": true,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": true,
    "Ipv4AddressesPerInterface": 50,
    "Ipv6AddressesPerInterface": 50,
    "Ipv6Supported": true,
@@ -9150,9 +9625,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.5
   },
-  "SupportedBootModes": [
-   "legacy-bios"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -9200,7 +9672,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": true,
    "Ipv4AddressesPerInterface": 15,
    "Ipv6AddressesPerInterface": 15,
    "Ipv6Supported": true,
@@ -9228,10 +9699,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.5
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -9256,6 +9723,1811 @@
    ]
   }
  },
+ "c6id.12xlarge": {
+  "AutoRecoverySupported": false,
+  "BareMetal": false,
+  "BurstablePerformanceSupported": false,
+  "CurrentGeneration": true,
+  "DedicatedHostsSupported": true,
+  "EbsInfo": {
+   "EbsOptimizedInfo": {
+    "BaselineBandwidthInMbps": 15000,
+    "BaselineIops": 60000,
+    "BaselineThroughputInMBps": 1875.0,
+    "MaximumBandwidthInMbps": 15000,
+    "MaximumIops": 60000,
+    "MaximumThroughputInMBps": 1875.0
+   },
+   "EbsOptimizedSupport": "default",
+   "EncryptionSupport": "supported",
+   "NvmeSupport": "required"
+  },
+  "FreeTierEligible": false,
+  "HibernationSupported": false,
+  "Hypervisor": "nitro",
+  "InstanceStorageInfo": {
+   "Disks": [
+    {
+     "Count": 2,
+     "SizeInGB": 1425,
+     "Type": "ssd"
+    }
+   ],
+   "NvmeSupport": "required",
+   "TotalSizeInGB": 2850
+  },
+  "InstanceStorageSupported": true,
+  "InstanceType": "c6id.12xlarge",
+  "MemoryInfo": {
+   "SizeInMiB": 98304
+  },
+  "NetworkInfo": {
+   "DefaultNetworkCardIndex": 0,
+   "EfaSupported": false,
+   "EnaSupport": "required",
+   "Ipv4AddressesPerInterface": 30,
+   "Ipv6AddressesPerInterface": 30,
+   "Ipv6Supported": true,
+   "MaximumNetworkCards": 1,
+   "MaximumNetworkInterfaces": 8,
+   "NetworkCards": [
+    {
+     "MaximumNetworkInterfaces": 8,
+     "NetworkCardIndex": 0,
+     "NetworkPerformance": "18.75 Gigabit"
+    }
+   ],
+   "NetworkPerformance": "18.75 Gigabit"
+  },
+  "PlacementGroupInfo": {
+   "SupportedStrategies": [
+    "cluster",
+    "partition",
+    "spread"
+   ]
+  },
+  "ProcessorInfo": {
+   "SupportedArchitectures": [
+    "x86_64"
+   ],
+   "SustainedClockSpeedInGhz": 3.5
+  },
+  "SupportedRootDeviceTypes": [
+   "ebs"
+  ],
+  "SupportedUsageClasses": [
+   "on-demand",
+   "spot"
+  ],
+  "SupportedVirtualizationTypes": [
+   "hvm"
+  ],
+  "VCpuInfo": {
+   "DefaultCores": 24,
+   "DefaultThreadsPerCore": 2,
+   "DefaultVCpus": 48,
+   "ValidCores": [
+    2,
+    4,
+    6,
+    8,
+    10,
+    12,
+    14,
+    16,
+    18,
+    20,
+    22,
+    24
+   ],
+   "ValidThreadsPerCore": [
+    1,
+    2
+   ]
+  }
+ },
+ "c6id.16xlarge": {
+  "AutoRecoverySupported": false,
+  "BareMetal": false,
+  "BurstablePerformanceSupported": false,
+  "CurrentGeneration": true,
+  "DedicatedHostsSupported": true,
+  "EbsInfo": {
+   "EbsOptimizedInfo": {
+    "BaselineBandwidthInMbps": 20000,
+    "BaselineIops": 80000,
+    "BaselineThroughputInMBps": 2500.0,
+    "MaximumBandwidthInMbps": 20000,
+    "MaximumIops": 80000,
+    "MaximumThroughputInMBps": 2500.0
+   },
+   "EbsOptimizedSupport": "default",
+   "EncryptionSupport": "supported",
+   "NvmeSupport": "required"
+  },
+  "FreeTierEligible": false,
+  "HibernationSupported": false,
+  "Hypervisor": "nitro",
+  "InstanceStorageInfo": {
+   "Disks": [
+    {
+     "Count": 2,
+     "SizeInGB": 1900,
+     "Type": "ssd"
+    }
+   ],
+   "NvmeSupport": "required",
+   "TotalSizeInGB": 3800
+  },
+  "InstanceStorageSupported": true,
+  "InstanceType": "c6id.16xlarge",
+  "MemoryInfo": {
+   "SizeInMiB": 131072
+  },
+  "NetworkInfo": {
+   "DefaultNetworkCardIndex": 0,
+   "EfaSupported": false,
+   "EnaSupport": "required",
+   "Ipv4AddressesPerInterface": 50,
+   "Ipv6AddressesPerInterface": 50,
+   "Ipv6Supported": true,
+   "MaximumNetworkCards": 1,
+   "MaximumNetworkInterfaces": 15,
+   "NetworkCards": [
+    {
+     "MaximumNetworkInterfaces": 15,
+     "NetworkCardIndex": 0,
+     "NetworkPerformance": "25 Gigabit"
+    }
+   ],
+   "NetworkPerformance": "25 Gigabit"
+  },
+  "PlacementGroupInfo": {
+   "SupportedStrategies": [
+    "cluster",
+    "partition",
+    "spread"
+   ]
+  },
+  "ProcessorInfo": {
+   "SupportedArchitectures": [
+    "x86_64"
+   ],
+   "SustainedClockSpeedInGhz": 3.5
+  },
+  "SupportedRootDeviceTypes": [
+   "ebs"
+  ],
+  "SupportedUsageClasses": [
+   "on-demand",
+   "spot"
+  ],
+  "SupportedVirtualizationTypes": [
+   "hvm"
+  ],
+  "VCpuInfo": {
+   "DefaultCores": 32,
+   "DefaultThreadsPerCore": 2,
+   "DefaultVCpus": 64,
+   "ValidCores": [
+    2,
+    4,
+    6,
+    8,
+    10,
+    12,
+    14,
+    16,
+    18,
+    20,
+    22,
+    24,
+    26,
+    28,
+    30,
+    32
+   ],
+   "ValidThreadsPerCore": [
+    1,
+    2
+   ]
+  }
+ },
+ "c6id.24xlarge": {
+  "AutoRecoverySupported": false,
+  "BareMetal": false,
+  "BurstablePerformanceSupported": false,
+  "CurrentGeneration": true,
+  "DedicatedHostsSupported": true,
+  "EbsInfo": {
+   "EbsOptimizedInfo": {
+    "BaselineBandwidthInMbps": 30000,
+    "BaselineIops": 120000,
+    "BaselineThroughputInMBps": 3750.0,
+    "MaximumBandwidthInMbps": 30000,
+    "MaximumIops": 120000,
+    "MaximumThroughputInMBps": 3750.0
+   },
+   "EbsOptimizedSupport": "default",
+   "EncryptionSupport": "supported",
+   "NvmeSupport": "required"
+  },
+  "FreeTierEligible": false,
+  "HibernationSupported": false,
+  "Hypervisor": "nitro",
+  "InstanceStorageInfo": {
+   "Disks": [
+    {
+     "Count": 4,
+     "SizeInGB": 1425,
+     "Type": "ssd"
+    }
+   ],
+   "NvmeSupport": "required",
+   "TotalSizeInGB": 5700
+  },
+  "InstanceStorageSupported": true,
+  "InstanceType": "c6id.24xlarge",
+  "MemoryInfo": {
+   "SizeInMiB": 196608
+  },
+  "NetworkInfo": {
+   "DefaultNetworkCardIndex": 0,
+   "EfaSupported": false,
+   "EnaSupport": "required",
+   "Ipv4AddressesPerInterface": 50,
+   "Ipv6AddressesPerInterface": 50,
+   "Ipv6Supported": true,
+   "MaximumNetworkCards": 1,
+   "MaximumNetworkInterfaces": 15,
+   "NetworkCards": [
+    {
+     "MaximumNetworkInterfaces": 15,
+     "NetworkCardIndex": 0,
+     "NetworkPerformance": "37.5 Gigabit"
+    }
+   ],
+   "NetworkPerformance": "37.5 Gigabit"
+  },
+  "PlacementGroupInfo": {
+   "SupportedStrategies": [
+    "cluster",
+    "partition",
+    "spread"
+   ]
+  },
+  "ProcessorInfo": {
+   "SupportedArchitectures": [
+    "x86_64"
+   ],
+   "SustainedClockSpeedInGhz": 3.5
+  },
+  "SupportedRootDeviceTypes": [
+   "ebs"
+  ],
+  "SupportedUsageClasses": [
+   "on-demand",
+   "spot"
+  ],
+  "SupportedVirtualizationTypes": [
+   "hvm"
+  ],
+  "VCpuInfo": {
+   "DefaultCores": 48,
+   "DefaultThreadsPerCore": 2,
+   "DefaultVCpus": 96,
+   "ValidCores": [
+    2,
+    4,
+    6,
+    8,
+    10,
+    12,
+    14,
+    16,
+    18,
+    20,
+    22,
+    24,
+    26,
+    28,
+    30,
+    32,
+    34,
+    36,
+    38,
+    40,
+    42,
+    44,
+    46,
+    48
+   ],
+   "ValidThreadsPerCore": [
+    1,
+    2
+   ]
+  }
+ },
+ "c6id.2xlarge": {
+  "AutoRecoverySupported": false,
+  "BareMetal": false,
+  "BurstablePerformanceSupported": false,
+  "CurrentGeneration": true,
+  "DedicatedHostsSupported": true,
+  "EbsInfo": {
+   "EbsOptimizedInfo": {
+    "BaselineBandwidthInMbps": 2500,
+    "BaselineIops": 12000,
+    "BaselineThroughputInMBps": 312.5,
+    "MaximumBandwidthInMbps": 10000,
+    "MaximumIops": 40000,
+    "MaximumThroughputInMBps": 1250.0
+   },
+   "EbsOptimizedSupport": "default",
+   "EncryptionSupport": "supported",
+   "NvmeSupport": "required"
+  },
+  "FreeTierEligible": false,
+  "HibernationSupported": false,
+  "Hypervisor": "nitro",
+  "InstanceStorageInfo": {
+   "Disks": [
+    {
+     "Count": 1,
+     "SizeInGB": 474,
+     "Type": "ssd"
+    }
+   ],
+   "NvmeSupport": "required",
+   "TotalSizeInGB": 474
+  },
+  "InstanceStorageSupported": true,
+  "InstanceType": "c6id.2xlarge",
+  "MemoryInfo": {
+   "SizeInMiB": 16384
+  },
+  "NetworkInfo": {
+   "DefaultNetworkCardIndex": 0,
+   "EfaSupported": false,
+   "EnaSupport": "required",
+   "Ipv4AddressesPerInterface": 15,
+   "Ipv6AddressesPerInterface": 15,
+   "Ipv6Supported": true,
+   "MaximumNetworkCards": 1,
+   "MaximumNetworkInterfaces": 4,
+   "NetworkCards": [
+    {
+     "MaximumNetworkInterfaces": 4,
+     "NetworkCardIndex": 0,
+     "NetworkPerformance": "Up to 12.5 Gigabit"
+    }
+   ],
+   "NetworkPerformance": "Up to 12.5 Gigabit"
+  },
+  "PlacementGroupInfo": {
+   "SupportedStrategies": [
+    "cluster",
+    "partition",
+    "spread"
+   ]
+  },
+  "ProcessorInfo": {
+   "SupportedArchitectures": [
+    "x86_64"
+   ],
+   "SustainedClockSpeedInGhz": 3.5
+  },
+  "SupportedRootDeviceTypes": [
+   "ebs"
+  ],
+  "SupportedUsageClasses": [
+   "on-demand",
+   "spot"
+  ],
+  "SupportedVirtualizationTypes": [
+   "hvm"
+  ],
+  "VCpuInfo": {
+   "DefaultCores": 4,
+   "DefaultThreadsPerCore": 2,
+   "DefaultVCpus": 8,
+   "ValidCores": [
+    2,
+    4
+   ],
+   "ValidThreadsPerCore": [
+    1,
+    2
+   ]
+  }
+ },
+ "c6id.32xlarge": {
+  "AutoRecoverySupported": false,
+  "BareMetal": false,
+  "BurstablePerformanceSupported": false,
+  "CurrentGeneration": true,
+  "DedicatedHostsSupported": true,
+  "EbsInfo": {
+   "EbsOptimizedInfo": {
+    "BaselineBandwidthInMbps": 40000,
+    "BaselineIops": 160000,
+    "BaselineThroughputInMBps": 5000.0,
+    "MaximumBandwidthInMbps": 40000,
+    "MaximumIops": 160000,
+    "MaximumThroughputInMBps": 5000.0
+   },
+   "EbsOptimizedSupport": "default",
+   "EncryptionSupport": "supported",
+   "NvmeSupport": "required"
+  },
+  "FreeTierEligible": false,
+  "HibernationSupported": false,
+  "Hypervisor": "nitro",
+  "InstanceStorageInfo": {
+   "Disks": [
+    {
+     "Count": 4,
+     "SizeInGB": 1900,
+     "Type": "ssd"
+    }
+   ],
+   "NvmeSupport": "required",
+   "TotalSizeInGB": 7600
+  },
+  "InstanceStorageSupported": true,
+  "InstanceType": "c6id.32xlarge",
+  "MemoryInfo": {
+   "SizeInMiB": 262144
+  },
+  "NetworkInfo": {
+   "DefaultNetworkCardIndex": 0,
+   "EfaSupported": true,
+   "EnaSupport": "required",
+   "Ipv4AddressesPerInterface": 50,
+   "Ipv6AddressesPerInterface": 50,
+   "Ipv6Supported": true,
+   "MaximumNetworkCards": 1,
+   "MaximumNetworkInterfaces": 15,
+   "NetworkCards": [
+    {
+     "MaximumNetworkInterfaces": 15,
+     "NetworkCardIndex": 0,
+     "NetworkPerformance": "50 Gigabit"
+    }
+   ],
+   "NetworkPerformance": "50 Gigabit"
+  },
+  "PlacementGroupInfo": {
+   "SupportedStrategies": [
+    "cluster",
+    "partition",
+    "spread"
+   ]
+  },
+  "ProcessorInfo": {
+   "SupportedArchitectures": [
+    "x86_64"
+   ],
+   "SustainedClockSpeedInGhz": 3.5
+  },
+  "SupportedRootDeviceTypes": [
+   "ebs"
+  ],
+  "SupportedUsageClasses": [
+   "on-demand",
+   "spot"
+  ],
+  "SupportedVirtualizationTypes": [
+   "hvm"
+  ],
+  "VCpuInfo": {
+   "DefaultCores": 64,
+   "DefaultThreadsPerCore": 2,
+   "DefaultVCpus": 128,
+   "ValidCores": [
+    2,
+    4,
+    6,
+    8,
+    10,
+    12,
+    14,
+    16,
+    18,
+    20,
+    22,
+    24,
+    26,
+    28,
+    30,
+    32,
+    34,
+    36,
+    38,
+    40,
+    42,
+    44,
+    46,
+    48,
+    50,
+    52,
+    54,
+    56,
+    58,
+    60,
+    62,
+    64
+   ],
+   "ValidThreadsPerCore": [
+    1,
+    2
+   ]
+  }
+ },
+ "c6id.4xlarge": {
+  "AutoRecoverySupported": false,
+  "BareMetal": false,
+  "BurstablePerformanceSupported": false,
+  "CurrentGeneration": true,
+  "DedicatedHostsSupported": true,
+  "EbsInfo": {
+   "EbsOptimizedInfo": {
+    "BaselineBandwidthInMbps": 5000,
+    "BaselineIops": 20000,
+    "BaselineThroughputInMBps": 625.0,
+    "MaximumBandwidthInMbps": 10000,
+    "MaximumIops": 40000,
+    "MaximumThroughputInMBps": 1250.0
+   },
+   "EbsOptimizedSupport": "default",
+   "EncryptionSupport": "supported",
+   "NvmeSupport": "required"
+  },
+  "FreeTierEligible": false,
+  "HibernationSupported": false,
+  "Hypervisor": "nitro",
+  "InstanceStorageInfo": {
+   "Disks": [
+    {
+     "Count": 1,
+     "SizeInGB": 950,
+     "Type": "ssd"
+    }
+   ],
+   "NvmeSupport": "required",
+   "TotalSizeInGB": 950
+  },
+  "InstanceStorageSupported": true,
+  "InstanceType": "c6id.4xlarge",
+  "MemoryInfo": {
+   "SizeInMiB": 32768
+  },
+  "NetworkInfo": {
+   "DefaultNetworkCardIndex": 0,
+   "EfaSupported": false,
+   "EnaSupport": "required",
+   "Ipv4AddressesPerInterface": 30,
+   "Ipv6AddressesPerInterface": 30,
+   "Ipv6Supported": true,
+   "MaximumNetworkCards": 1,
+   "MaximumNetworkInterfaces": 8,
+   "NetworkCards": [
+    {
+     "MaximumNetworkInterfaces": 8,
+     "NetworkCardIndex": 0,
+     "NetworkPerformance": "Up to 12.5 Gigabit"
+    }
+   ],
+   "NetworkPerformance": "Up to 12.5 Gigabit"
+  },
+  "PlacementGroupInfo": {
+   "SupportedStrategies": [
+    "cluster",
+    "partition",
+    "spread"
+   ]
+  },
+  "ProcessorInfo": {
+   "SupportedArchitectures": [
+    "x86_64"
+   ],
+   "SustainedClockSpeedInGhz": 3.5
+  },
+  "SupportedRootDeviceTypes": [
+   "ebs"
+  ],
+  "SupportedUsageClasses": [
+   "on-demand",
+   "spot"
+  ],
+  "SupportedVirtualizationTypes": [
+   "hvm"
+  ],
+  "VCpuInfo": {
+   "DefaultCores": 8,
+   "DefaultThreadsPerCore": 2,
+   "DefaultVCpus": 16,
+   "ValidCores": [
+    2,
+    4,
+    6,
+    8
+   ],
+   "ValidThreadsPerCore": [
+    1,
+    2
+   ]
+  }
+ },
+ "c6id.8xlarge": {
+  "AutoRecoverySupported": false,
+  "BareMetal": false,
+  "BurstablePerformanceSupported": false,
+  "CurrentGeneration": true,
+  "DedicatedHostsSupported": true,
+  "EbsInfo": {
+   "EbsOptimizedInfo": {
+    "BaselineBandwidthInMbps": 10000,
+    "BaselineIops": 40000,
+    "BaselineThroughputInMBps": 1250.0,
+    "MaximumBandwidthInMbps": 10000,
+    "MaximumIops": 40000,
+    "MaximumThroughputInMBps": 1250.0
+   },
+   "EbsOptimizedSupport": "default",
+   "EncryptionSupport": "supported",
+   "NvmeSupport": "required"
+  },
+  "FreeTierEligible": false,
+  "HibernationSupported": false,
+  "Hypervisor": "nitro",
+  "InstanceStorageInfo": {
+   "Disks": [
+    {
+     "Count": 1,
+     "SizeInGB": 1900,
+     "Type": "ssd"
+    }
+   ],
+   "NvmeSupport": "required",
+   "TotalSizeInGB": 1900
+  },
+  "InstanceStorageSupported": true,
+  "InstanceType": "c6id.8xlarge",
+  "MemoryInfo": {
+   "SizeInMiB": 65536
+  },
+  "NetworkInfo": {
+   "DefaultNetworkCardIndex": 0,
+   "EfaSupported": false,
+   "EnaSupport": "required",
+   "Ipv4AddressesPerInterface": 30,
+   "Ipv6AddressesPerInterface": 30,
+   "Ipv6Supported": true,
+   "MaximumNetworkCards": 1,
+   "MaximumNetworkInterfaces": 8,
+   "NetworkCards": [
+    {
+     "MaximumNetworkInterfaces": 8,
+     "NetworkCardIndex": 0,
+     "NetworkPerformance": "12.5 Gigabit"
+    }
+   ],
+   "NetworkPerformance": "12.5 Gigabit"
+  },
+  "PlacementGroupInfo": {
+   "SupportedStrategies": [
+    "cluster",
+    "partition",
+    "spread"
+   ]
+  },
+  "ProcessorInfo": {
+   "SupportedArchitectures": [
+    "x86_64"
+   ],
+   "SustainedClockSpeedInGhz": 3.5
+  },
+  "SupportedRootDeviceTypes": [
+   "ebs"
+  ],
+  "SupportedUsageClasses": [
+   "on-demand",
+   "spot"
+  ],
+  "SupportedVirtualizationTypes": [
+   "hvm"
+  ],
+  "VCpuInfo": {
+   "DefaultCores": 16,
+   "DefaultThreadsPerCore": 2,
+   "DefaultVCpus": 32,
+   "ValidCores": [
+    2,
+    4,
+    6,
+    8,
+    10,
+    12,
+    14,
+    16
+   ],
+   "ValidThreadsPerCore": [
+    1,
+    2
+   ]
+  }
+ },
+ "c6id.large": {
+  "AutoRecoverySupported": false,
+  "BareMetal": false,
+  "BurstablePerformanceSupported": false,
+  "CurrentGeneration": true,
+  "DedicatedHostsSupported": true,
+  "EbsInfo": {
+   "EbsOptimizedInfo": {
+    "BaselineBandwidthInMbps": 650,
+    "BaselineIops": 3600,
+    "BaselineThroughputInMBps": 81.25,
+    "MaximumBandwidthInMbps": 10000,
+    "MaximumIops": 40000,
+    "MaximumThroughputInMBps": 1250.0
+   },
+   "EbsOptimizedSupport": "default",
+   "EncryptionSupport": "supported",
+   "NvmeSupport": "required"
+  },
+  "FreeTierEligible": false,
+  "HibernationSupported": false,
+  "Hypervisor": "nitro",
+  "InstanceStorageInfo": {
+   "Disks": [
+    {
+     "Count": 1,
+     "SizeInGB": 118,
+     "Type": "ssd"
+    }
+   ],
+   "NvmeSupport": "required",
+   "TotalSizeInGB": 118
+  },
+  "InstanceStorageSupported": true,
+  "InstanceType": "c6id.large",
+  "MemoryInfo": {
+   "SizeInMiB": 4096
+  },
+  "NetworkInfo": {
+   "DefaultNetworkCardIndex": 0,
+   "EfaSupported": false,
+   "EnaSupport": "required",
+   "Ipv4AddressesPerInterface": 10,
+   "Ipv6AddressesPerInterface": 10,
+   "Ipv6Supported": true,
+   "MaximumNetworkCards": 1,
+   "MaximumNetworkInterfaces": 3,
+   "NetworkCards": [
+    {
+     "MaximumNetworkInterfaces": 3,
+     "NetworkCardIndex": 0,
+     "NetworkPerformance": "Up to 12.5 Gigabit"
+    }
+   ],
+   "NetworkPerformance": "Up to 12.5 Gigabit"
+  },
+  "PlacementGroupInfo": {
+   "SupportedStrategies": [
+    "cluster",
+    "partition",
+    "spread"
+   ]
+  },
+  "ProcessorInfo": {
+   "SupportedArchitectures": [
+    "x86_64"
+   ],
+   "SustainedClockSpeedInGhz": 3.5
+  },
+  "SupportedRootDeviceTypes": [
+   "ebs"
+  ],
+  "SupportedUsageClasses": [
+   "on-demand",
+   "spot"
+  ],
+  "SupportedVirtualizationTypes": [
+   "hvm"
+  ],
+  "VCpuInfo": {
+   "DefaultCores": 1,
+   "DefaultThreadsPerCore": 2,
+   "DefaultVCpus": 2,
+   "ValidCores": [
+    1
+   ],
+   "ValidThreadsPerCore": [
+    1,
+    2
+   ]
+  }
+ },
+ "c6id.metal": {
+  "AutoRecoverySupported": false,
+  "BareMetal": true,
+  "BurstablePerformanceSupported": false,
+  "CurrentGeneration": true,
+  "DedicatedHostsSupported": true,
+  "EbsInfo": {
+   "EbsOptimizedInfo": {
+    "BaselineBandwidthInMbps": 40000,
+    "BaselineIops": 160000,
+    "BaselineThroughputInMBps": 5000.0,
+    "MaximumBandwidthInMbps": 40000,
+    "MaximumIops": 160000,
+    "MaximumThroughputInMBps": 5000.0
+   },
+   "EbsOptimizedSupport": "default",
+   "EncryptionSupport": "supported",
+   "NvmeSupport": "required"
+  },
+  "FreeTierEligible": false,
+  "HibernationSupported": false,
+  "InstanceStorageInfo": {
+   "Disks": [
+    {
+     "Count": 4,
+     "SizeInGB": 1900,
+     "Type": "ssd"
+    }
+   ],
+   "NvmeSupport": "required",
+   "TotalSizeInGB": 7600
+  },
+  "InstanceStorageSupported": true,
+  "InstanceType": "c6id.metal",
+  "MemoryInfo": {
+   "SizeInMiB": 262144
+  },
+  "NetworkInfo": {
+   "DefaultNetworkCardIndex": 0,
+   "EfaSupported": true,
+   "EnaSupport": "required",
+   "Ipv4AddressesPerInterface": 50,
+   "Ipv6AddressesPerInterface": 50,
+   "Ipv6Supported": true,
+   "MaximumNetworkCards": 1,
+   "MaximumNetworkInterfaces": 15,
+   "NetworkCards": [
+    {
+     "MaximumNetworkInterfaces": 15,
+     "NetworkCardIndex": 0,
+     "NetworkPerformance": "50 Gigabit"
+    }
+   ],
+   "NetworkPerformance": "50 Gigabit"
+  },
+  "PlacementGroupInfo": {
+   "SupportedStrategies": [
+    "cluster",
+    "partition",
+    "spread"
+   ]
+  },
+  "ProcessorInfo": {
+   "SupportedArchitectures": [
+    "x86_64"
+   ],
+   "SustainedClockSpeedInGhz": 3.5
+  },
+  "SupportedRootDeviceTypes": [
+   "ebs"
+  ],
+  "SupportedUsageClasses": [
+   "on-demand",
+   "spot"
+  ],
+  "SupportedVirtualizationTypes": [
+   "hvm"
+  ],
+  "VCpuInfo": {
+   "DefaultCores": 64,
+   "DefaultThreadsPerCore": 2,
+   "DefaultVCpus": 128
+  }
+ },
+ "c6id.xlarge": {
+  "AutoRecoverySupported": false,
+  "BareMetal": false,
+  "BurstablePerformanceSupported": false,
+  "CurrentGeneration": true,
+  "DedicatedHostsSupported": true,
+  "EbsInfo": {
+   "EbsOptimizedInfo": {
+    "BaselineBandwidthInMbps": 1250,
+    "BaselineIops": 6000,
+    "BaselineThroughputInMBps": 156.25,
+    "MaximumBandwidthInMbps": 10000,
+    "MaximumIops": 40000,
+    "MaximumThroughputInMBps": 1250.0
+   },
+   "EbsOptimizedSupport": "default",
+   "EncryptionSupport": "supported",
+   "NvmeSupport": "required"
+  },
+  "FreeTierEligible": false,
+  "HibernationSupported": false,
+  "Hypervisor": "nitro",
+  "InstanceStorageInfo": {
+   "Disks": [
+    {
+     "Count": 1,
+     "SizeInGB": 237,
+     "Type": "ssd"
+    }
+   ],
+   "NvmeSupport": "required",
+   "TotalSizeInGB": 237
+  },
+  "InstanceStorageSupported": true,
+  "InstanceType": "c6id.xlarge",
+  "MemoryInfo": {
+   "SizeInMiB": 8192
+  },
+  "NetworkInfo": {
+   "DefaultNetworkCardIndex": 0,
+   "EfaSupported": false,
+   "EnaSupport": "required",
+   "Ipv4AddressesPerInterface": 15,
+   "Ipv6AddressesPerInterface": 15,
+   "Ipv6Supported": true,
+   "MaximumNetworkCards": 1,
+   "MaximumNetworkInterfaces": 4,
+   "NetworkCards": [
+    {
+     "MaximumNetworkInterfaces": 4,
+     "NetworkCardIndex": 0,
+     "NetworkPerformance": "Up to 12.5 Gigabit"
+    }
+   ],
+   "NetworkPerformance": "Up to 12.5 Gigabit"
+  },
+  "PlacementGroupInfo": {
+   "SupportedStrategies": [
+    "cluster",
+    "partition",
+    "spread"
+   ]
+  },
+  "ProcessorInfo": {
+   "SupportedArchitectures": [
+    "x86_64"
+   ],
+   "SustainedClockSpeedInGhz": 3.5
+  },
+  "SupportedRootDeviceTypes": [
+   "ebs"
+  ],
+  "SupportedUsageClasses": [
+   "on-demand",
+   "spot"
+  ],
+  "SupportedVirtualizationTypes": [
+   "hvm"
+  ],
+  "VCpuInfo": {
+   "DefaultCores": 2,
+   "DefaultThreadsPerCore": 2,
+   "DefaultVCpus": 4,
+   "ValidCores": [
+    1,
+    2
+   ],
+   "ValidThreadsPerCore": [
+    1,
+    2
+   ]
+  }
+ },
+ "c7g.12xlarge": {
+  "AutoRecoverySupported": true,
+  "BareMetal": false,
+  "BurstablePerformanceSupported": false,
+  "CurrentGeneration": true,
+  "DedicatedHostsSupported": true,
+  "EbsInfo": {
+   "EbsOptimizedInfo": {
+    "BaselineBandwidthInMbps": 15000,
+    "BaselineIops": 60000,
+    "BaselineThroughputInMBps": 1875.0,
+    "MaximumBandwidthInMbps": 15000,
+    "MaximumIops": 60000,
+    "MaximumThroughputInMBps": 1875.0
+   },
+   "EbsOptimizedSupport": "default",
+   "EncryptionSupport": "supported",
+   "NvmeSupport": "required"
+  },
+  "FreeTierEligible": false,
+  "HibernationSupported": false,
+  "Hypervisor": "nitro",
+  "InstanceStorageSupported": false,
+  "InstanceType": "c7g.12xlarge",
+  "MemoryInfo": {
+   "SizeInMiB": 98304
+  },
+  "NetworkInfo": {
+   "DefaultNetworkCardIndex": 0,
+   "EfaSupported": false,
+   "EnaSupport": "required",
+   "Ipv4AddressesPerInterface": 30,
+   "Ipv6AddressesPerInterface": 30,
+   "Ipv6Supported": true,
+   "MaximumNetworkCards": 1,
+   "MaximumNetworkInterfaces": 8,
+   "NetworkCards": [
+    {
+     "MaximumNetworkInterfaces": 8,
+     "NetworkCardIndex": 0,
+     "NetworkPerformance": "22.5 Gigabit"
+    }
+   ],
+   "NetworkPerformance": "22.5 Gigabit"
+  },
+  "PlacementGroupInfo": {
+   "SupportedStrategies": [
+    "cluster",
+    "partition",
+    "spread"
+   ]
+  },
+  "ProcessorInfo": {
+   "SupportedArchitectures": [
+    "arm64"
+   ],
+   "SustainedClockSpeedInGhz": 2.6
+  },
+  "SupportedRootDeviceTypes": [
+   "ebs"
+  ],
+  "SupportedUsageClasses": [
+   "on-demand",
+   "spot"
+  ],
+  "SupportedVirtualizationTypes": [
+   "hvm"
+  ],
+  "VCpuInfo": {
+   "DefaultCores": 48,
+   "DefaultThreadsPerCore": 1,
+   "DefaultVCpus": 48,
+   "ValidCores": [
+    1,
+    2,
+    3,
+    4,
+    5,
+    6,
+    7,
+    8,
+    9,
+    10,
+    11,
+    12,
+    13,
+    14,
+    15,
+    16,
+    17,
+    18,
+    19,
+    20,
+    21,
+    22,
+    23,
+    24,
+    25,
+    26,
+    27,
+    28,
+    29,
+    30,
+    31,
+    32,
+    33,
+    34,
+    35,
+    36,
+    37,
+    38,
+    39,
+    40,
+    41,
+    42,
+    43,
+    44,
+    45,
+    46,
+    47,
+    48
+   ],
+   "ValidThreadsPerCore": [
+    1
+   ]
+  }
+ },
+ "c7g.16xlarge": {
+  "AutoRecoverySupported": true,
+  "BareMetal": false,
+  "BurstablePerformanceSupported": false,
+  "CurrentGeneration": true,
+  "DedicatedHostsSupported": true,
+  "EbsInfo": {
+   "EbsOptimizedInfo": {
+    "BaselineBandwidthInMbps": 20000,
+    "BaselineIops": 80000,
+    "BaselineThroughputInMBps": 2500.0,
+    "MaximumBandwidthInMbps": 20000,
+    "MaximumIops": 80000,
+    "MaximumThroughputInMBps": 2500.0
+   },
+   "EbsOptimizedSupport": "default",
+   "EncryptionSupport": "supported",
+   "NvmeSupport": "required"
+  },
+  "FreeTierEligible": false,
+  "HibernationSupported": false,
+  "Hypervisor": "nitro",
+  "InstanceStorageSupported": false,
+  "InstanceType": "c7g.16xlarge",
+  "MemoryInfo": {
+   "SizeInMiB": 131072
+  },
+  "NetworkInfo": {
+   "DefaultNetworkCardIndex": 0,
+   "EfaSupported": true,
+   "EnaSupport": "required",
+   "Ipv4AddressesPerInterface": 50,
+   "Ipv6AddressesPerInterface": 50,
+   "Ipv6Supported": true,
+   "MaximumNetworkCards": 1,
+   "MaximumNetworkInterfaces": 15,
+   "NetworkCards": [
+    {
+     "MaximumNetworkInterfaces": 15,
+     "NetworkCardIndex": 0,
+     "NetworkPerformance": "30 Gigabit"
+    }
+   ],
+   "NetworkPerformance": "30 Gigabit"
+  },
+  "PlacementGroupInfo": {
+   "SupportedStrategies": [
+    "cluster",
+    "partition",
+    "spread"
+   ]
+  },
+  "ProcessorInfo": {
+   "SupportedArchitectures": [
+    "arm64"
+   ],
+   "SustainedClockSpeedInGhz": 2.6
+  },
+  "SupportedRootDeviceTypes": [
+   "ebs"
+  ],
+  "SupportedUsageClasses": [
+   "on-demand",
+   "spot"
+  ],
+  "SupportedVirtualizationTypes": [
+   "hvm"
+  ],
+  "VCpuInfo": {
+   "DefaultCores": 64,
+   "DefaultThreadsPerCore": 1,
+   "DefaultVCpus": 64,
+   "ValidCores": [
+    1,
+    2,
+    3,
+    4,
+    5,
+    6,
+    7,
+    8,
+    9,
+    10,
+    11,
+    12,
+    13,
+    14,
+    15,
+    16,
+    17,
+    18,
+    19,
+    20,
+    21,
+    22,
+    23,
+    24,
+    25,
+    26,
+    27,
+    28,
+    29,
+    30,
+    31,
+    32,
+    33,
+    34,
+    35,
+    36,
+    37,
+    38,
+    39,
+    40,
+    41,
+    42,
+    43,
+    44,
+    45,
+    46,
+    47,
+    48,
+    49,
+    50,
+    51,
+    52,
+    53,
+    54,
+    55,
+    56,
+    57,
+    58,
+    59,
+    60,
+    61,
+    62,
+    63,
+    64
+   ],
+   "ValidThreadsPerCore": [
+    1
+   ]
+  }
+ },
+ "c7g.2xlarge": {
+  "AutoRecoverySupported": true,
+  "BareMetal": false,
+  "BurstablePerformanceSupported": false,
+  "CurrentGeneration": true,
+  "DedicatedHostsSupported": true,
+  "EbsInfo": {
+   "EbsOptimizedInfo": {
+    "BaselineBandwidthInMbps": 2500,
+    "BaselineIops": 12000,
+    "BaselineThroughputInMBps": 312.5,
+    "MaximumBandwidthInMbps": 10000,
+    "MaximumIops": 40000,
+    "MaximumThroughputInMBps": 1250.0
+   },
+   "EbsOptimizedSupport": "default",
+   "EncryptionSupport": "supported",
+   "NvmeSupport": "required"
+  },
+  "FreeTierEligible": false,
+  "HibernationSupported": false,
+  "Hypervisor": "nitro",
+  "InstanceStorageSupported": false,
+  "InstanceType": "c7g.2xlarge",
+  "MemoryInfo": {
+   "SizeInMiB": 16384
+  },
+  "NetworkInfo": {
+   "DefaultNetworkCardIndex": 0,
+   "EfaSupported": false,
+   "EnaSupport": "required",
+   "Ipv4AddressesPerInterface": 15,
+   "Ipv6AddressesPerInterface": 15,
+   "Ipv6Supported": true,
+   "MaximumNetworkCards": 1,
+   "MaximumNetworkInterfaces": 4,
+   "NetworkCards": [
+    {
+     "MaximumNetworkInterfaces": 4,
+     "NetworkCardIndex": 0,
+     "NetworkPerformance": "Up to 15 Gigabit"
+    }
+   ],
+   "NetworkPerformance": "Up to 15 Gigabit"
+  },
+  "PlacementGroupInfo": {
+   "SupportedStrategies": [
+    "cluster",
+    "partition",
+    "spread"
+   ]
+  },
+  "ProcessorInfo": {
+   "SupportedArchitectures": [
+    "arm64"
+   ],
+   "SustainedClockSpeedInGhz": 2.6
+  },
+  "SupportedRootDeviceTypes": [
+   "ebs"
+  ],
+  "SupportedUsageClasses": [
+   "on-demand",
+   "spot"
+  ],
+  "SupportedVirtualizationTypes": [
+   "hvm"
+  ],
+  "VCpuInfo": {
+   "DefaultCores": 8,
+   "DefaultThreadsPerCore": 1,
+   "DefaultVCpus": 8,
+   "ValidCores": [
+    1,
+    2,
+    3,
+    4,
+    5,
+    6,
+    7,
+    8
+   ],
+   "ValidThreadsPerCore": [
+    1
+   ]
+  }
+ },
+ "c7g.4xlarge": {
+  "AutoRecoverySupported": true,
+  "BareMetal": false,
+  "BurstablePerformanceSupported": false,
+  "CurrentGeneration": true,
+  "DedicatedHostsSupported": true,
+  "EbsInfo": {
+   "EbsOptimizedInfo": {
+    "BaselineBandwidthInMbps": 5000,
+    "BaselineIops": 20000,
+    "BaselineThroughputInMBps": 625.0,
+    "MaximumBandwidthInMbps": 10000,
+    "MaximumIops": 40000,
+    "MaximumThroughputInMBps": 1250.0
+   },
+   "EbsOptimizedSupport": "default",
+   "EncryptionSupport": "supported",
+   "NvmeSupport": "required"
+  },
+  "FreeTierEligible": false,
+  "HibernationSupported": false,
+  "Hypervisor": "nitro",
+  "InstanceStorageSupported": false,
+  "InstanceType": "c7g.4xlarge",
+  "MemoryInfo": {
+   "SizeInMiB": 32768
+  },
+  "NetworkInfo": {
+   "DefaultNetworkCardIndex": 0,
+   "EfaSupported": false,
+   "EnaSupport": "required",
+   "Ipv4AddressesPerInterface": 30,
+   "Ipv6AddressesPerInterface": 30,
+   "Ipv6Supported": true,
+   "MaximumNetworkCards": 1,
+   "MaximumNetworkInterfaces": 8,
+   "NetworkCards": [
+    {
+     "MaximumNetworkInterfaces": 8,
+     "NetworkCardIndex": 0,
+     "NetworkPerformance": "Up to 15 Gigabit"
+    }
+   ],
+   "NetworkPerformance": "Up to 15 Gigabit"
+  },
+  "PlacementGroupInfo": {
+   "SupportedStrategies": [
+    "cluster",
+    "partition",
+    "spread"
+   ]
+  },
+  "ProcessorInfo": {
+   "SupportedArchitectures": [
+    "arm64"
+   ],
+   "SustainedClockSpeedInGhz": 2.6
+  },
+  "SupportedRootDeviceTypes": [
+   "ebs"
+  ],
+  "SupportedUsageClasses": [
+   "on-demand",
+   "spot"
+  ],
+  "SupportedVirtualizationTypes": [
+   "hvm"
+  ],
+  "VCpuInfo": {
+   "DefaultCores": 16,
+   "DefaultThreadsPerCore": 1,
+   "DefaultVCpus": 16,
+   "ValidCores": [
+    1,
+    2,
+    3,
+    4,
+    5,
+    6,
+    7,
+    8,
+    9,
+    10,
+    11,
+    12,
+    13,
+    14,
+    15,
+    16
+   ],
+   "ValidThreadsPerCore": [
+    1
+   ]
+  }
+ },
+ "c7g.8xlarge": {
+  "AutoRecoverySupported": true,
+  "BareMetal": false,
+  "BurstablePerformanceSupported": false,
+  "CurrentGeneration": true,
+  "DedicatedHostsSupported": true,
+  "EbsInfo": {
+   "EbsOptimizedInfo": {
+    "BaselineBandwidthInMbps": 10000,
+    "BaselineIops": 40000,
+    "BaselineThroughputInMBps": 1250.0,
+    "MaximumBandwidthInMbps": 10000,
+    "MaximumIops": 40000,
+    "MaximumThroughputInMBps": 1250.0
+   },
+   "EbsOptimizedSupport": "default",
+   "EncryptionSupport": "supported",
+   "NvmeSupport": "required"
+  },
+  "FreeTierEligible": false,
+  "HibernationSupported": false,
+  "Hypervisor": "nitro",
+  "InstanceStorageSupported": false,
+  "InstanceType": "c7g.8xlarge",
+  "MemoryInfo": {
+   "SizeInMiB": 65536
+  },
+  "NetworkInfo": {
+   "DefaultNetworkCardIndex": 0,
+   "EfaSupported": false,
+   "EnaSupport": "required",
+   "Ipv4AddressesPerInterface": 30,
+   "Ipv6AddressesPerInterface": 30,
+   "Ipv6Supported": true,
+   "MaximumNetworkCards": 1,
+   "MaximumNetworkInterfaces": 8,
+   "NetworkCards": [
+    {
+     "MaximumNetworkInterfaces": 8,
+     "NetworkCardIndex": 0,
+     "NetworkPerformance": "15 Gigabit"
+    }
+   ],
+   "NetworkPerformance": "15 Gigabit"
+  },
+  "PlacementGroupInfo": {
+   "SupportedStrategies": [
+    "cluster",
+    "partition",
+    "spread"
+   ]
+  },
+  "ProcessorInfo": {
+   "SupportedArchitectures": [
+    "arm64"
+   ],
+   "SustainedClockSpeedInGhz": 2.6
+  },
+  "SupportedRootDeviceTypes": [
+   "ebs"
+  ],
+  "SupportedUsageClasses": [
+   "on-demand",
+   "spot"
+  ],
+  "SupportedVirtualizationTypes": [
+   "hvm"
+  ],
+  "VCpuInfo": {
+   "DefaultCores": 32,
+   "DefaultThreadsPerCore": 1,
+   "DefaultVCpus": 32,
+   "ValidCores": [
+    1,
+    2,
+    3,
+    4,
+    5,
+    6,
+    7,
+    8,
+    9,
+    10,
+    11,
+    12,
+    13,
+    14,
+    15,
+    16,
+    17,
+    18,
+    19,
+    20,
+    21,
+    22,
+    23,
+    24,
+    25,
+    26,
+    27,
+    28,
+    29,
+    30,
+    31,
+    32
+   ],
+   "ValidThreadsPerCore": [
+    1
+   ]
+  }
+ },
+ "c7g.large": {
+  "AutoRecoverySupported": true,
+  "BareMetal": false,
+  "BurstablePerformanceSupported": false,
+  "CurrentGeneration": true,
+  "DedicatedHostsSupported": true,
+  "EbsInfo": {
+   "EbsOptimizedInfo": {
+    "BaselineBandwidthInMbps": 630,
+    "BaselineIops": 3600,
+    "BaselineThroughputInMBps": 78.75,
+    "MaximumBandwidthInMbps": 10000,
+    "MaximumIops": 40000,
+    "MaximumThroughputInMBps": 1250.0
+   },
+   "EbsOptimizedSupport": "default",
+   "EncryptionSupport": "supported",
+   "NvmeSupport": "required"
+  },
+  "FreeTierEligible": false,
+  "HibernationSupported": false,
+  "Hypervisor": "nitro",
+  "InstanceStorageSupported": false,
+  "InstanceType": "c7g.large",
+  "MemoryInfo": {
+   "SizeInMiB": 4096
+  },
+  "NetworkInfo": {
+   "DefaultNetworkCardIndex": 0,
+   "EfaSupported": false,
+   "EnaSupport": "required",
+   "Ipv4AddressesPerInterface": 10,
+   "Ipv6AddressesPerInterface": 10,
+   "Ipv6Supported": true,
+   "MaximumNetworkCards": 1,
+   "MaximumNetworkInterfaces": 3,
+   "NetworkCards": [
+    {
+     "MaximumNetworkInterfaces": 3,
+     "NetworkCardIndex": 0,
+     "NetworkPerformance": "Up to 12.5 Gigabit"
+    }
+   ],
+   "NetworkPerformance": "Up to 12.5 Gigabit"
+  },
+  "PlacementGroupInfo": {
+   "SupportedStrategies": [
+    "cluster",
+    "partition",
+    "spread"
+   ]
+  },
+  "ProcessorInfo": {
+   "SupportedArchitectures": [
+    "arm64"
+   ],
+   "SustainedClockSpeedInGhz": 2.6
+  },
+  "SupportedRootDeviceTypes": [
+   "ebs"
+  ],
+  "SupportedUsageClasses": [
+   "on-demand",
+   "spot"
+  ],
+  "SupportedVirtualizationTypes": [
+   "hvm"
+  ],
+  "VCpuInfo": {
+   "DefaultCores": 2,
+   "DefaultThreadsPerCore": 1,
+   "DefaultVCpus": 2,
+   "ValidCores": [
+    1,
+    2
+   ],
+   "ValidThreadsPerCore": [
+    1
+   ]
+  }
+ },
+ "c7g.medium": {
+  "AutoRecoverySupported": true,
+  "BareMetal": false,
+  "BurstablePerformanceSupported": false,
+  "CurrentGeneration": true,
+  "DedicatedHostsSupported": true,
+  "EbsInfo": {
+   "EbsOptimizedInfo": {
+    "BaselineBandwidthInMbps": 315,
+    "BaselineIops": 2500,
+    "BaselineThroughputInMBps": 39.375,
+    "MaximumBandwidthInMbps": 10000,
+    "MaximumIops": 40000,
+    "MaximumThroughputInMBps": 1250.0
+   },
+   "EbsOptimizedSupport": "default",
+   "EncryptionSupport": "supported",
+   "NvmeSupport": "required"
+  },
+  "FreeTierEligible": false,
+  "HibernationSupported": false,
+  "Hypervisor": "nitro",
+  "InstanceStorageSupported": false,
+  "InstanceType": "c7g.medium",
+  "MemoryInfo": {
+   "SizeInMiB": 2048
+  },
+  "NetworkInfo": {
+   "DefaultNetworkCardIndex": 0,
+   "EfaSupported": false,
+   "EnaSupport": "required",
+   "Ipv4AddressesPerInterface": 4,
+   "Ipv6AddressesPerInterface": 4,
+   "Ipv6Supported": true,
+   "MaximumNetworkCards": 1,
+   "MaximumNetworkInterfaces": 2,
+   "NetworkCards": [
+    {
+     "MaximumNetworkInterfaces": 2,
+     "NetworkCardIndex": 0,
+     "NetworkPerformance": "Up to 12.5 Gigabit"
+    }
+   ],
+   "NetworkPerformance": "Up to 12.5 Gigabit"
+  },
+  "PlacementGroupInfo": {
+   "SupportedStrategies": [
+    "cluster",
+    "partition",
+    "spread"
+   ]
+  },
+  "ProcessorInfo": {
+   "SupportedArchitectures": [
+    "arm64"
+   ],
+   "SustainedClockSpeedInGhz": 2.6
+  },
+  "SupportedRootDeviceTypes": [
+   "ebs"
+  ],
+  "SupportedUsageClasses": [
+   "on-demand",
+   "spot"
+  ],
+  "SupportedVirtualizationTypes": [
+   "hvm"
+  ],
+  "VCpuInfo": {
+   "DefaultCores": 1,
+   "DefaultThreadsPerCore": 1,
+   "DefaultVCpus": 1
+  }
+ },
+ "c7g.xlarge": {
+  "AutoRecoverySupported": true,
+  "BareMetal": false,
+  "BurstablePerformanceSupported": false,
+  "CurrentGeneration": true,
+  "DedicatedHostsSupported": true,
+  "EbsInfo": {
+   "EbsOptimizedInfo": {
+    "BaselineBandwidthInMbps": 1250,
+    "BaselineIops": 6000,
+    "BaselineThroughputInMBps": 156.25039999999998,
+    "MaximumBandwidthInMbps": 10000,
+    "MaximumIops": 40000,
+    "MaximumThroughputInMBps": 1250.0
+   },
+   "EbsOptimizedSupport": "default",
+   "EncryptionSupport": "supported",
+   "NvmeSupport": "required"
+  },
+  "FreeTierEligible": false,
+  "HibernationSupported": false,
+  "Hypervisor": "nitro",
+  "InstanceStorageSupported": false,
+  "InstanceType": "c7g.xlarge",
+  "MemoryInfo": {
+   "SizeInMiB": 8192
+  },
+  "NetworkInfo": {
+   "DefaultNetworkCardIndex": 0,
+   "EfaSupported": false,
+   "EnaSupport": "required",
+   "Ipv4AddressesPerInterface": 15,
+   "Ipv6AddressesPerInterface": 15,
+   "Ipv6Supported": true,
+   "MaximumNetworkCards": 1,
+   "MaximumNetworkInterfaces": 4,
+   "NetworkCards": [
+    {
+     "MaximumNetworkInterfaces": 4,
+     "NetworkCardIndex": 0,
+     "NetworkPerformance": "Up to 12.5 Gigabit"
+    }
+   ],
+   "NetworkPerformance": "Up to 12.5 Gigabit"
+  },
+  "PlacementGroupInfo": {
+   "SupportedStrategies": [
+    "cluster",
+    "partition",
+    "spread"
+   ]
+  },
+  "ProcessorInfo": {
+   "SupportedArchitectures": [
+    "arm64"
+   ],
+   "SustainedClockSpeedInGhz": 2.6
+  },
+  "SupportedRootDeviceTypes": [
+   "ebs"
+  ],
+  "SupportedUsageClasses": [
+   "on-demand",
+   "spot"
+  ],
+  "SupportedVirtualizationTypes": [
+   "hvm"
+  ],
+  "VCpuInfo": {
+   "DefaultCores": 4,
+   "DefaultThreadsPerCore": 1,
+   "DefaultVCpus": 4,
+   "ValidCores": [
+    1,
+    2,
+    3,
+    4
+   ],
+   "ValidThreadsPerCore": [
+    1
+   ]
+  }
+ },
  "cc2.8xlarge": {
   "AutoRecoverySupported": false,
   "BareMetal": false,
@@ -9264,7 +11536,7 @@
   "DedicatedHostsSupported": false,
   "EbsInfo": {
    "EbsOptimizedSupport": "unsupported",
-   "EncryptionSupport": "unsupported",
+   "EncryptionSupport": "supported",
    "NvmeSupport": "unsupported"
   },
   "FreeTierEligible": false,
@@ -9278,7 +11550,6 @@
      "Type": "hdd"
     }
    ],
-   "EncryptionSupport": "unsupported",
    "NvmeSupport": "unsupported",
    "TotalSizeInGB": 3360
   },
@@ -9291,7 +11562,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "unsupported",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 30,
    "Ipv6AddressesPerInterface": 0,
    "Ipv6Supported": false,
@@ -9319,9 +11589,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.6
   },
-  "SupportedBootModes": [
-   "legacy-bios"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs",
    "instance-store"
@@ -9368,7 +11635,6 @@
      "Type": "hdd"
     }
    ],
-   "EncryptionSupport": "unsupported",
    "NvmeSupport": "unsupported",
    "TotalSizeInGB": 12288
   },
@@ -9381,7 +11647,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "unsupported",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 15,
    "Ipv6AddressesPerInterface": 15,
    "Ipv6Supported": true,
@@ -9409,9 +11674,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.4
   },
-  "SupportedBootModes": [
-   "legacy-bios"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs",
    "instance-store"
@@ -9469,7 +11731,6 @@
      "Type": "hdd"
     }
    ],
-   "EncryptionSupport": "unsupported",
    "NvmeSupport": "unsupported",
    "TotalSizeInGB": 24576
   },
@@ -9482,7 +11743,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "unsupported",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 30,
    "Ipv6AddressesPerInterface": 30,
    "Ipv6Supported": true,
@@ -9510,9 +11770,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.4
   },
-  "SupportedBootModes": [
-   "legacy-bios"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs",
    "instance-store"
@@ -9574,7 +11831,6 @@
      "Type": "hdd"
     }
    ],
-   "EncryptionSupport": "unsupported",
    "NvmeSupport": "unsupported",
    "TotalSizeInGB": 49152
   },
@@ -9587,7 +11843,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "unsupported",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 30,
    "Ipv6AddressesPerInterface": 30,
    "Ipv6Supported": true,
@@ -9615,9 +11870,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.4
   },
-  "SupportedBootModes": [
-   "legacy-bios"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs",
    "instance-store"
@@ -9680,7 +11932,6 @@
      "Type": "hdd"
     }
    ],
-   "EncryptionSupport": "unsupported",
    "NvmeSupport": "unsupported",
    "TotalSizeInGB": 6144
   },
@@ -9693,7 +11944,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "unsupported",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 15,
    "Ipv6AddressesPerInterface": 15,
    "Ipv6Supported": true,
@@ -9721,9 +11971,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.4
   },
-  "SupportedBootModes": [
-   "legacy-bios"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs",
    "instance-store"
@@ -9779,7 +12026,6 @@
      "Type": "hdd"
     }
    ],
-   "EncryptionSupport": "required",
    "NvmeSupport": "required",
    "TotalSizeInGB": 11880
   },
@@ -9792,7 +12038,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": true,
    "Ipv4AddressesPerInterface": 5,
    "Ipv6AddressesPerInterface": 5,
    "Ipv6Supported": true,
@@ -9820,10 +12065,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.1
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -9878,7 +12119,6 @@
      "Type": "hdd"
     }
    ],
-   "EncryptionSupport": "required",
    "NvmeSupport": "required",
    "TotalSizeInGB": 23760
   },
@@ -9891,7 +12131,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": true,
    "Ipv4AddressesPerInterface": 10,
    "Ipv6AddressesPerInterface": 10,
    "Ipv6Supported": true,
@@ -9919,10 +12158,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.1
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -9979,7 +12214,6 @@
      "Type": "hdd"
     }
    ],
-   "EncryptionSupport": "required",
    "NvmeSupport": "required",
    "TotalSizeInGB": 47520
   },
@@ -9992,7 +12226,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": true,
    "Ipv4AddressesPerInterface": 20,
    "Ipv6AddressesPerInterface": 20,
    "Ipv6Supported": true,
@@ -10020,10 +12253,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.1
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -10084,7 +12313,6 @@
      "Type": "hdd"
     }
    ],
-   "EncryptionSupport": "required",
    "NvmeSupport": "required",
    "TotalSizeInGB": 5940
   },
@@ -10097,7 +12325,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": true,
    "Ipv4AddressesPerInterface": 3,
    "Ipv6AddressesPerInterface": 3,
    "Ipv6Supported": true,
@@ -10125,10 +12352,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.1
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -10183,7 +12406,6 @@
      "Type": "hdd"
     }
    ],
-   "EncryptionSupport": "required",
    "NvmeSupport": "required",
    "TotalSizeInGB": 335520
   },
@@ -10196,7 +12418,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": true,
    "Ipv4AddressesPerInterface": 30,
    "Ipv6AddressesPerInterface": 30,
    "Ipv6Supported": true,
@@ -10224,10 +12445,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.1
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -10292,7 +12509,6 @@
      "Type": "hdd"
     }
    ],
-   "EncryptionSupport": "required",
    "NvmeSupport": "required",
    "TotalSizeInGB": 55920
   },
@@ -10305,7 +12521,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": true,
    "Ipv4AddressesPerInterface": 5,
    "Ipv6AddressesPerInterface": 5,
    "Ipv6Supported": true,
@@ -10333,10 +12548,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.1
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -10391,7 +12602,6 @@
      "Type": "hdd"
     }
    ],
-   "EncryptionSupport": "required",
    "NvmeSupport": "required",
    "TotalSizeInGB": 111840
   },
@@ -10404,7 +12614,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": true,
    "Ipv4AddressesPerInterface": 10,
    "Ipv6AddressesPerInterface": 10,
    "Ipv6Supported": true,
@@ -10432,10 +12641,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.1
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -10492,7 +12697,6 @@
      "Type": "hdd"
     }
    ],
-   "EncryptionSupport": "required",
    "NvmeSupport": "required",
    "TotalSizeInGB": 167760
   },
@@ -10505,7 +12709,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": true,
    "Ipv4AddressesPerInterface": 15,
    "Ipv6AddressesPerInterface": 15,
    "Ipv6Supported": true,
@@ -10533,10 +12736,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.1
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -10595,7 +12794,6 @@
      "Type": "hdd"
     }
    ],
-   "EncryptionSupport": "required",
    "NvmeSupport": "required",
    "TotalSizeInGB": 223680
   },
@@ -10608,7 +12806,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": true,
    "Ipv4AddressesPerInterface": 20,
    "Ipv6AddressesPerInterface": 20,
    "Ipv6Supported": true,
@@ -10636,10 +12833,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.1
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -10700,7 +12893,6 @@
      "Type": "hdd"
     }
    ],
-   "EncryptionSupport": "required",
    "NvmeSupport": "required",
    "TotalSizeInGB": 27960
   },
@@ -10713,7 +12905,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": true,
    "Ipv4AddressesPerInterface": 3,
    "Ipv6AddressesPerInterface": 3,
    "Ipv6Supported": true,
@@ -10741,10 +12932,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.1
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -10770,7 +12957,7 @@
   }
  },
  "dl1.24xlarge": {
-  "AutoRecoverySupported": true,
+  "AutoRecoverySupported": false,
   "BareMetal": false,
   "BurstablePerformanceSupported": false,
   "CurrentGeneration": true,
@@ -10812,7 +12999,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "required",
    "NvmeSupport": "required",
    "TotalSizeInGB": 4000
   },
@@ -10823,12 +13009,8 @@
   },
   "NetworkInfo": {
    "DefaultNetworkCardIndex": 0,
-   "EfaInfo": {
-    "MaximumEfaInterfaces": 4
-   },
    "EfaSupported": true,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": true,
    "Ipv4AddressesPerInterface": 50,
    "Ipv6AddressesPerInterface": 50,
    "Ipv6Supported": true,
@@ -10871,9 +13053,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.0
   },
-  "SupportedBootModes": [
-   "legacy-bios"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -10963,7 +13142,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "required",
    "NvmeSupport": "required",
    "TotalSizeInGB": 3760
   },
@@ -10976,7 +13154,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "unsupported",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 50,
    "Ipv6AddressesPerInterface": 50,
    "Ipv6Supported": true,
@@ -11004,9 +13181,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.3
   },
-  "SupportedBootModes": [
-   "legacy-bios"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -11088,7 +13262,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "required",
    "NvmeSupport": "required",
    "TotalSizeInGB": 470
   },
@@ -11101,7 +13274,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "unsupported",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 15,
    "Ipv6AddressesPerInterface": 15,
    "Ipv6Supported": true,
@@ -11129,9 +13301,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.3
   },
-  "SupportedBootModes": [
-   "legacy-bios"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -11201,7 +13370,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "required",
    "NvmeSupport": "required",
    "TotalSizeInGB": 940
   },
@@ -11214,7 +13382,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "unsupported",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 30,
    "Ipv6AddressesPerInterface": 30,
    "Ipv6Supported": true,
@@ -11242,9 +13409,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.3
   },
-  "SupportedBootModes": [
-   "legacy-bios"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -11318,7 +13482,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "unsupported",
    "NvmeSupport": "unsupported",
    "TotalSizeInGB": 60
   },
@@ -11331,7 +13494,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "unsupported",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 15,
    "Ipv6AddressesPerInterface": 0,
    "Ipv6Supported": false,
@@ -11359,9 +13521,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.6
   },
-  "SupportedBootModes": [
-   "legacy-bios"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs",
    "instance-store"
@@ -11424,7 +13583,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "unsupported",
    "NvmeSupport": "unsupported",
    "TotalSizeInGB": 240
   },
@@ -11437,7 +13595,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "unsupported",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 30,
    "Ipv6AddressesPerInterface": 0,
    "Ipv6Supported": false,
@@ -11465,9 +13622,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.6
   },
-  "SupportedBootModes": [
-   "legacy-bios"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs",
    "instance-store"
@@ -11500,7 +13654,7 @@
   }
  },
  "g3.16xlarge": {
-  "AutoRecoverySupported": false,
+  "AutoRecoverySupported": true,
   "BareMetal": false,
   "BurstablePerformanceSupported": false,
   "CurrentGeneration": true,
@@ -11543,7 +13697,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "supported",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 50,
    "Ipv6AddressesPerInterface": 50,
    "Ipv6Supported": true,
@@ -11571,9 +13724,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.3
   },
-  "SupportedBootModes": [
-   "legacy-bios"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -11613,7 +13763,7 @@
   }
  },
  "g3.4xlarge": {
-  "AutoRecoverySupported": false,
+  "AutoRecoverySupported": true,
   "BareMetal": false,
   "BurstablePerformanceSupported": false,
   "CurrentGeneration": true,
@@ -11656,7 +13806,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "supported",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 30,
    "Ipv6AddressesPerInterface": 30,
    "Ipv6Supported": true,
@@ -11684,9 +13833,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.7
   },
-  "SupportedBootModes": [
-   "legacy-bios"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -11718,7 +13864,7 @@
   }
  },
  "g3.8xlarge": {
-  "AutoRecoverySupported": false,
+  "AutoRecoverySupported": true,
   "BareMetal": false,
   "BurstablePerformanceSupported": false,
   "CurrentGeneration": true,
@@ -11761,7 +13907,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "supported",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 30,
    "Ipv6AddressesPerInterface": 30,
    "Ipv6Supported": true,
@@ -11789,9 +13934,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.7
   },
-  "SupportedBootModes": [
-   "legacy-bios"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -11831,7 +13973,7 @@
   }
  },
  "g3s.xlarge": {
-  "AutoRecoverySupported": false,
+  "AutoRecoverySupported": true,
   "BareMetal": false,
   "BurstablePerformanceSupported": false,
   "CurrentGeneration": true,
@@ -11874,7 +14016,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 15,
    "Ipv6AddressesPerInterface": 15,
    "Ipv6Supported": true,
@@ -11902,9 +14043,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.7
   },
-  "SupportedBootModes": [
-   "legacy-bios"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -11972,7 +14110,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "required",
    "NvmeSupport": "required",
    "TotalSizeInGB": 2400
   },
@@ -11985,7 +14122,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": true,
    "Ipv4AddressesPerInterface": 30,
    "Ipv6AddressesPerInterface": 30,
    "Ipv6Supported": true,
@@ -12013,10 +14149,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.0
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -12087,7 +14219,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "required",
    "NvmeSupport": "required",
    "TotalSizeInGB": 300
   },
@@ -12100,7 +14231,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": true,
    "Ipv4AddressesPerInterface": 4,
    "Ipv6AddressesPerInterface": 4,
    "Ipv6Supported": true,
@@ -12128,10 +14258,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.0
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -12199,7 +14325,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "required",
    "NvmeSupport": "required",
    "TotalSizeInGB": 600
   },
@@ -12212,7 +14337,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": true,
    "Ipv4AddressesPerInterface": 10,
    "Ipv6AddressesPerInterface": 10,
    "Ipv6Supported": true,
@@ -12240,10 +14364,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.0
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -12312,7 +14432,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "required",
    "NvmeSupport": "required",
    "TotalSizeInGB": 1200
   },
@@ -12325,7 +14444,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": true,
    "Ipv4AddressesPerInterface": 15,
    "Ipv6AddressesPerInterface": 15,
    "Ipv6Supported": true,
@@ -12353,10 +14471,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.0
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -12426,7 +14540,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "required",
    "NvmeSupport": "required",
    "TotalSizeInGB": 150
   },
@@ -12439,7 +14552,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": true,
    "Ipv4AddressesPerInterface": 4,
    "Ipv6AddressesPerInterface": 4,
    "Ipv6Supported": true,
@@ -12467,10 +14579,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.0
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -12537,7 +14645,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "required",
    "NvmeSupport": "required",
    "TotalSizeInGB": 900
   },
@@ -12548,12 +14655,8 @@
   },
   "NetworkInfo": {
    "DefaultNetworkCardIndex": 0,
-   "EfaInfo": {
-    "MaximumEfaInterfaces": 1
-   },
    "EfaSupported": true,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": true,
    "Ipv4AddressesPerInterface": 30,
    "Ipv6AddressesPerInterface": 30,
    "Ipv6Supported": true,
@@ -12581,10 +14684,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.5
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -12662,7 +14761,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "required",
    "NvmeSupport": "required",
    "TotalSizeInGB": 900
   },
@@ -12675,7 +14773,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": true,
    "Ipv4AddressesPerInterface": 15,
    "Ipv6AddressesPerInterface": 15,
    "Ipv6Supported": true,
@@ -12703,10 +14800,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.5
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -12788,7 +14881,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "required",
    "NvmeSupport": "required",
    "TotalSizeInGB": 225
   },
@@ -12801,7 +14893,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": true,
    "Ipv4AddressesPerInterface": 10,
    "Ipv6AddressesPerInterface": 10,
    "Ipv6Supported": true,
@@ -12829,10 +14920,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.5
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -12900,7 +14987,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "required",
    "NvmeSupport": "required",
    "TotalSizeInGB": 225
   },
@@ -12913,7 +14999,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": true,
    "Ipv4AddressesPerInterface": 10,
    "Ipv6AddressesPerInterface": 10,
    "Ipv6Supported": true,
@@ -12941,10 +15026,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.5
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -13014,7 +15095,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "required",
    "NvmeSupport": "required",
    "TotalSizeInGB": 900
   },
@@ -13025,12 +15105,8 @@
   },
   "NetworkInfo": {
    "DefaultNetworkCardIndex": 0,
-   "EfaInfo": {
-    "MaximumEfaInterfaces": 1
-   },
    "EfaSupported": true,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": true,
    "Ipv4AddressesPerInterface": 15,
    "Ipv6AddressesPerInterface": 15,
    "Ipv6Supported": true,
@@ -13058,10 +15134,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.5
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -13134,7 +15206,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "required",
    "NvmeSupport": "required",
    "TotalSizeInGB": 1800
   },
@@ -13145,12 +15216,8 @@
   },
   "NetworkInfo": {
    "DefaultNetworkCardIndex": 0,
-   "EfaInfo": {
-    "MaximumEfaInterfaces": 1
-   },
    "EfaSupported": true,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": true,
    "Ipv4AddressesPerInterface": 50,
    "Ipv6AddressesPerInterface": 50,
    "Ipv6Supported": true,
@@ -13178,9 +15245,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.5
   },
-  "SupportedBootModes": [
-   "legacy-bios"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -13240,7 +15304,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "required",
    "NvmeSupport": "required",
    "TotalSizeInGB": 125
   },
@@ -13253,7 +15316,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": true,
    "Ipv4AddressesPerInterface": 10,
    "Ipv6AddressesPerInterface": 10,
    "Ipv6Supported": true,
@@ -13281,10 +15343,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.5
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -13309,7 +15367,7 @@
   }
  },
  "g5.12xlarge": {
-  "AutoRecoverySupported": true,
+  "AutoRecoverySupported": false,
   "BareMetal": false,
   "BurstablePerformanceSupported": false,
   "CurrentGeneration": true,
@@ -13351,7 +15409,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "required",
    "NvmeSupport": "required",
    "TotalSizeInGB": 3800
   },
@@ -13364,7 +15421,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": true,
    "Ipv4AddressesPerInterface": 50,
    "Ipv6AddressesPerInterface": 50,
    "Ipv6Supported": true,
@@ -13392,10 +15448,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.3
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -13413,7 +15465,7 @@
   }
  },
  "g5.16xlarge": {
-  "AutoRecoverySupported": true,
+  "AutoRecoverySupported": false,
   "BareMetal": false,
   "BurstablePerformanceSupported": false,
   "CurrentGeneration": true,
@@ -13455,7 +15507,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "required",
    "NvmeSupport": "required",
    "TotalSizeInGB": 1900
   },
@@ -13468,7 +15519,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": true,
    "Ipv4AddressesPerInterface": 30,
    "Ipv6AddressesPerInterface": 30,
    "Ipv6Supported": true,
@@ -13496,10 +15546,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.3
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -13517,7 +15563,7 @@
   }
  },
  "g5.24xlarge": {
-  "AutoRecoverySupported": true,
+  "AutoRecoverySupported": false,
   "BareMetal": false,
   "BurstablePerformanceSupported": false,
   "CurrentGeneration": true,
@@ -13559,7 +15605,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "required",
    "NvmeSupport": "required",
    "TotalSizeInGB": 3800
   },
@@ -13572,7 +15617,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": true,
    "Ipv4AddressesPerInterface": 50,
    "Ipv6AddressesPerInterface": 50,
    "Ipv6Supported": true,
@@ -13600,10 +15644,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.3
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -13621,7 +15661,7 @@
   }
  },
  "g5.2xlarge": {
-  "AutoRecoverySupported": true,
+  "AutoRecoverySupported": false,
   "BareMetal": false,
   "BurstablePerformanceSupported": false,
   "CurrentGeneration": true,
@@ -13663,7 +15703,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "required",
    "NvmeSupport": "required",
    "TotalSizeInGB": 450
   },
@@ -13676,7 +15715,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": true,
    "Ipv4AddressesPerInterface": 15,
    "Ipv6AddressesPerInterface": 15,
    "Ipv6Supported": true,
@@ -13704,10 +15742,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.3
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -13725,7 +15759,7 @@
   }
  },
  "g5.48xlarge": {
-  "AutoRecoverySupported": true,
+  "AutoRecoverySupported": false,
   "BareMetal": false,
   "BurstablePerformanceSupported": false,
   "CurrentGeneration": true,
@@ -13767,7 +15801,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "required",
    "NvmeSupport": "required",
    "TotalSizeInGB": 7600
   },
@@ -13778,12 +15811,8 @@
   },
   "NetworkInfo": {
    "DefaultNetworkCardIndex": 0,
-   "EfaInfo": {
-    "MaximumEfaInterfaces": 1
-   },
    "EfaSupported": true,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": true,
    "Ipv4AddressesPerInterface": 50,
    "Ipv6AddressesPerInterface": 50,
    "Ipv6Supported": true,
@@ -13811,10 +15840,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.3
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -13832,7 +15857,7 @@
   }
  },
  "g5.4xlarge": {
-  "AutoRecoverySupported": true,
+  "AutoRecoverySupported": false,
   "BareMetal": false,
   "BurstablePerformanceSupported": false,
   "CurrentGeneration": true,
@@ -13874,7 +15899,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "required",
    "NvmeSupport": "required",
    "TotalSizeInGB": 600
   },
@@ -13887,7 +15911,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": true,
    "Ipv4AddressesPerInterface": 30,
    "Ipv6AddressesPerInterface": 30,
    "Ipv6Supported": true,
@@ -13915,10 +15938,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.3
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -13936,7 +15955,7 @@
   }
  },
  "g5.8xlarge": {
-  "AutoRecoverySupported": true,
+  "AutoRecoverySupported": false,
   "BareMetal": false,
   "BurstablePerformanceSupported": false,
   "CurrentGeneration": true,
@@ -13978,7 +15997,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "required",
    "NvmeSupport": "required",
    "TotalSizeInGB": 900
   },
@@ -13991,7 +16009,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": true,
    "Ipv4AddressesPerInterface": 30,
    "Ipv6AddressesPerInterface": 30,
    "Ipv6Supported": true,
@@ -14019,10 +16036,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.3
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -14040,7 +16053,7 @@
   }
  },
  "g5.xlarge": {
-  "AutoRecoverySupported": true,
+  "AutoRecoverySupported": false,
   "BareMetal": false,
   "BurstablePerformanceSupported": false,
   "CurrentGeneration": true,
@@ -14082,7 +16095,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "required",
    "NvmeSupport": "required",
    "TotalSizeInGB": 250
   },
@@ -14095,7 +16107,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": true,
    "Ipv4AddressesPerInterface": 15,
    "Ipv6AddressesPerInterface": 15,
    "Ipv6Supported": true,
@@ -14123,10 +16134,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.3
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -14187,7 +16194,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 50,
    "Ipv6AddressesPerInterface": 50,
    "Ipv6Supported": true,
@@ -14215,9 +16221,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.5
   },
-  "SupportedBootModes": [
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -14347,7 +16350,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 15,
    "Ipv6AddressesPerInterface": 15,
    "Ipv6Supported": true,
@@ -14375,9 +16377,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.5
   },
-  "SupportedBootModes": [
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -14451,7 +16450,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 30,
    "Ipv6AddressesPerInterface": 30,
    "Ipv6Supported": true,
@@ -14479,9 +16477,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.5
   },
-  "SupportedBootModes": [
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -14563,7 +16558,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 30,
    "Ipv6AddressesPerInterface": 30,
    "Ipv6Supported": true,
@@ -14591,9 +16585,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.5
   },
-  "SupportedBootModes": [
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -14648,7 +16639,7 @@
   }
  },
  "g5g.metal": {
-  "AutoRecoverySupported": true,
+  "AutoRecoverySupported": false,
   "BareMetal": true,
   "BurstablePerformanceSupported": false,
   "CurrentGeneration": true,
@@ -14690,7 +16681,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 50,
    "Ipv6AddressesPerInterface": 50,
    "Ipv6Supported": true,
@@ -14718,9 +16708,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.5
   },
-  "SupportedBootModes": [
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -14781,7 +16768,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 15,
    "Ipv6AddressesPerInterface": 15,
    "Ipv6Supported": true,
@@ -14809,9 +16795,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.5
   },
-  "SupportedBootModes": [
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -14867,7 +16850,6 @@
      "Type": "hdd"
     }
    ],
-   "EncryptionSupport": "required",
    "NvmeSupport": "unsupported",
    "TotalSizeInGB": 16000
   },
@@ -14880,7 +16862,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "supported",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 50,
    "Ipv6AddressesPerInterface": 50,
    "Ipv6Supported": true,
@@ -14908,9 +16889,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.3
   },
-  "SupportedBootModes": [
-   "legacy-bios"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -14979,7 +16957,6 @@
      "Type": "hdd"
     }
    ],
-   "EncryptionSupport": "required",
    "NvmeSupport": "unsupported",
    "TotalSizeInGB": 2000
   },
@@ -14992,7 +16969,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "supported",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 15,
    "Ipv6AddressesPerInterface": 15,
    "Ipv6Supported": true,
@@ -15020,9 +16996,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.3
   },
-  "SupportedBootModes": [
-   "legacy-bios"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -15079,7 +17052,6 @@
      "Type": "hdd"
     }
    ],
-   "EncryptionSupport": "required",
    "NvmeSupport": "unsupported",
    "TotalSizeInGB": 4000
   },
@@ -15092,7 +17064,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "supported",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 30,
    "Ipv6AddressesPerInterface": 30,
    "Ipv6Supported": true,
@@ -15120,9 +17091,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.3
   },
-  "SupportedBootModes": [
-   "legacy-bios"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -15183,7 +17151,6 @@
      "Type": "hdd"
     }
    ],
-   "EncryptionSupport": "required",
    "NvmeSupport": "unsupported",
    "TotalSizeInGB": 8000
   },
@@ -15196,7 +17163,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "supported",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 30,
    "Ipv6AddressesPerInterface": 30,
    "Ipv6Supported": true,
@@ -15224,9 +17190,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.3
   },
-  "SupportedBootModes": [
-   "legacy-bios"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -15294,12 +17257,8 @@
   },
   "NetworkInfo": {
    "DefaultNetworkCardIndex": 0,
-   "EfaInfo": {
-    "MaximumEfaInterfaces": 1
-   },
    "EfaSupported": true,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": true,
    "Ipv4AddressesPerInterface": 50,
    "Ipv6AddressesPerInterface": 50,
    "Ipv6Supported": true,
@@ -15327,10 +17286,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.6
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -15376,7 +17331,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "unsupported",
    "NvmeSupport": "unsupported",
    "TotalSizeInGB": 1600
   },
@@ -15389,7 +17343,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "unsupported",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 15,
    "Ipv6AddressesPerInterface": 15,
    "Ipv6Supported": true,
@@ -15417,9 +17370,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.5
   },
-  "SupportedBootModes": [
-   "legacy-bios"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs",
    "instance-store"
@@ -15477,7 +17427,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "unsupported",
    "NvmeSupport": "unsupported",
    "TotalSizeInGB": 3200
   },
@@ -15490,7 +17439,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "unsupported",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 30,
    "Ipv6AddressesPerInterface": 30,
    "Ipv6Supported": true,
@@ -15518,9 +17466,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.5
   },
-  "SupportedBootModes": [
-   "legacy-bios"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs",
    "instance-store"
@@ -15574,7 +17519,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "unsupported",
    "NvmeSupport": "unsupported",
    "TotalSizeInGB": 6400
   },
@@ -15587,7 +17531,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "unsupported",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 30,
    "Ipv6AddressesPerInterface": 30,
    "Ipv6Supported": true,
@@ -15615,9 +17558,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.5
   },
-  "SupportedBootModes": [
-   "legacy-bios"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs",
    "instance-store"
@@ -15679,7 +17619,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "unsupported",
    "NvmeSupport": "unsupported",
    "TotalSizeInGB": 800
   },
@@ -15692,7 +17631,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "unsupported",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 15,
    "Ipv6AddressesPerInterface": 15,
    "Ipv6Supported": true,
@@ -15720,9 +17658,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.5
   },
-  "SupportedBootModes": [
-   "legacy-bios"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs",
    "instance-store"
@@ -15778,7 +17713,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "required",
    "NvmeSupport": "required",
    "TotalSizeInGB": 15200
   },
@@ -15791,7 +17725,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "supported",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 50,
    "Ipv6AddressesPerInterface": 50,
    "Ipv6Supported": true,
@@ -15819,9 +17752,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.3
   },
-  "SupportedBootModes": [
-   "legacy-bios"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -15890,7 +17820,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "required",
    "NvmeSupport": "required",
    "TotalSizeInGB": 1900
   },
@@ -15903,7 +17832,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "supported",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 15,
    "Ipv6AddressesPerInterface": 15,
    "Ipv6Supported": true,
@@ -15931,9 +17859,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.3
   },
-  "SupportedBootModes": [
-   "legacy-bios"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -15990,7 +17915,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "required",
    "NvmeSupport": "required",
    "TotalSizeInGB": 3800
   },
@@ -16003,7 +17927,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "supported",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 30,
    "Ipv6AddressesPerInterface": 30,
    "Ipv6Supported": true,
@@ -16031,9 +17954,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.3
   },
-  "SupportedBootModes": [
-   "legacy-bios"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -16094,7 +18014,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "required",
    "NvmeSupport": "required",
    "TotalSizeInGB": 7600
   },
@@ -16107,7 +18026,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "supported",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 30,
    "Ipv6AddressesPerInterface": 30,
    "Ipv6Supported": true,
@@ -16135,9 +18053,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.3
   },
-  "SupportedBootModes": [
-   "legacy-bios"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -16206,7 +18121,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "required",
    "NvmeSupport": "required",
    "TotalSizeInGB": 475
   },
@@ -16219,7 +18133,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "supported",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 10,
    "Ipv6AddressesPerInterface": 10,
    "Ipv6Supported": true,
@@ -16247,9 +18160,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.3
   },
-  "SupportedBootModes": [
-   "legacy-bios"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -16302,7 +18212,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "required",
    "NvmeSupport": "required",
    "TotalSizeInGB": 15200
   },
@@ -16315,7 +18224,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 50,
    "Ipv6AddressesPerInterface": 50,
    "Ipv6Supported": true,
@@ -16343,9 +18251,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.3
   },
-  "SupportedBootModes": [
-   "legacy-bios"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -16392,7 +18297,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "required",
    "NvmeSupport": "required",
    "TotalSizeInGB": 950
   },
@@ -16405,7 +18309,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "supported",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 15,
    "Ipv6AddressesPerInterface": 15,
    "Ipv6Supported": true,
@@ -16433,9 +18336,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.3
   },
-  "SupportedBootModes": [
-   "legacy-bios"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -16490,7 +18390,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "required",
    "NvmeSupport": "required",
    "TotalSizeInGB": 30000
   },
@@ -16501,12 +18400,8 @@
   },
   "NetworkInfo": {
    "DefaultNetworkCardIndex": 0,
-   "EfaInfo": {
-    "MaximumEfaInterfaces": 1
-   },
    "EfaSupported": true,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": true,
    "Ipv4AddressesPerInterface": 30,
    "Ipv6AddressesPerInterface": 30,
    "Ipv6Supported": true,
@@ -16534,10 +18429,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.1
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -16602,7 +18493,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "required",
    "NvmeSupport": "required",
    "TotalSizeInGB": 60000
   },
@@ -16613,12 +18503,8 @@
   },
   "NetworkInfo": {
    "DefaultNetworkCardIndex": 0,
-   "EfaInfo": {
-    "MaximumEfaInterfaces": 1
-   },
    "EfaSupported": true,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": true,
    "Ipv4AddressesPerInterface": 50,
    "Ipv6AddressesPerInterface": 50,
    "Ipv6Supported": true,
@@ -16646,10 +18532,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.1
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -16726,7 +18608,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "required",
    "NvmeSupport": "required",
    "TotalSizeInGB": 5000
   },
@@ -16739,7 +18620,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": true,
    "Ipv4AddressesPerInterface": 15,
    "Ipv6AddressesPerInterface": 15,
    "Ipv6Supported": true,
@@ -16767,10 +18647,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.1
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -16825,7 +18701,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "required",
    "NvmeSupport": "required",
    "TotalSizeInGB": 7500
   },
@@ -16838,7 +18713,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": true,
    "Ipv4AddressesPerInterface": 15,
    "Ipv6AddressesPerInterface": 15,
    "Ipv6Supported": true,
@@ -16866,10 +18740,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.1
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -16925,7 +18795,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "required",
    "NvmeSupport": "required",
    "TotalSizeInGB": 15000
   },
@@ -16938,7 +18807,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": true,
    "Ipv4AddressesPerInterface": 30,
    "Ipv6AddressesPerInterface": 30,
    "Ipv6Supported": true,
@@ -16966,10 +18834,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.1
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -17028,7 +18892,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "required",
    "NvmeSupport": "required",
    "TotalSizeInGB": 1250
   },
@@ -17041,7 +18904,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": true,
    "Ipv4AddressesPerInterface": 10,
    "Ipv6AddressesPerInterface": 10,
    "Ipv6Supported": true,
@@ -17069,10 +18931,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.1
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -17125,7 +18983,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "required",
    "NvmeSupport": "required",
    "TotalSizeInGB": 60000
   },
@@ -17136,12 +18993,8 @@
   },
   "NetworkInfo": {
    "DefaultNetworkCardIndex": 0,
-   "EfaInfo": {
-    "MaximumEfaInterfaces": 1
-   },
    "EfaSupported": true,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": true,
    "Ipv4AddressesPerInterface": 50,
    "Ipv6AddressesPerInterface": 50,
    "Ipv6Supported": true,
@@ -17169,9 +19022,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.1
   },
-  "SupportedBootModes": [
-   "legacy-bios"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -17218,7 +19068,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "required",
    "NvmeSupport": "required",
    "TotalSizeInGB": 2500
   },
@@ -17231,7 +19080,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": true,
    "Ipv4AddressesPerInterface": 15,
    "Ipv6AddressesPerInterface": 15,
    "Ipv6Supported": true,
@@ -17259,10 +19107,806 @@
    ],
    "SustainedClockSpeedInGhz": 3.1
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
+  "SupportedRootDeviceTypes": [
+   "ebs"
   ],
+  "SupportedUsageClasses": [
+   "on-demand",
+   "spot"
+  ],
+  "SupportedVirtualizationTypes": [
+   "hvm"
+  ],
+  "VCpuInfo": {
+   "DefaultCores": 2,
+   "DefaultThreadsPerCore": 2,
+   "DefaultVCpus": 4,
+   "ValidCores": [
+    1,
+    2
+   ],
+   "ValidThreadsPerCore": [
+    1,
+    2
+   ]
+  }
+ },
+ "i4i.16xlarge": {
+  "AutoRecoverySupported": true,
+  "BareMetal": false,
+  "BurstablePerformanceSupported": false,
+  "CurrentGeneration": true,
+  "DedicatedHostsSupported": true,
+  "EbsInfo": {
+   "EbsOptimizedInfo": {
+    "BaselineBandwidthInMbps": 20000,
+    "BaselineIops": 80000,
+    "BaselineThroughputInMBps": 2500.0,
+    "MaximumBandwidthInMbps": 20000,
+    "MaximumIops": 80000,
+    "MaximumThroughputInMBps": 2500.0
+   },
+   "EbsOptimizedSupport": "default",
+   "EncryptionSupport": "supported",
+   "NvmeSupport": "required"
+  },
+  "FreeTierEligible": false,
+  "HibernationSupported": false,
+  "Hypervisor": "nitro",
+  "InstanceStorageInfo": {
+   "Disks": [
+    {
+     "Count": 4,
+     "SizeInGB": 3750,
+     "Type": "ssd"
+    }
+   ],
+   "NvmeSupport": "required",
+   "TotalSizeInGB": 15000
+  },
+  "InstanceStorageSupported": true,
+  "InstanceType": "i4i.16xlarge",
+  "MemoryInfo": {
+   "SizeInMiB": 524288
+  },
+  "NetworkInfo": {
+   "DefaultNetworkCardIndex": 0,
+   "EfaSupported": false,
+   "EnaSupport": "required",
+   "Ipv4AddressesPerInterface": 50,
+   "Ipv6AddressesPerInterface": 50,
+   "Ipv6Supported": true,
+   "MaximumNetworkCards": 1,
+   "MaximumNetworkInterfaces": 15,
+   "NetworkCards": [
+    {
+     "MaximumNetworkInterfaces": 8,
+     "NetworkCardIndex": 0,
+     "NetworkPerformance": "37.5 Gigabit"
+    }
+   ],
+   "NetworkPerformance": "37.5 Gigabit"
+  },
+  "PlacementGroupInfo": {
+   "SupportedStrategies": [
+    "cluster",
+    "partition",
+    "spread"
+   ]
+  },
+  "ProcessorInfo": {
+   "SupportedArchitectures": [
+    "x86_64"
+   ],
+   "SustainedClockSpeedInGhz": 3.5
+  },
+  "SupportedRootDeviceTypes": [
+   "ebs"
+  ],
+  "SupportedUsageClasses": [
+   "on-demand",
+   "spot"
+  ],
+  "SupportedVirtualizationTypes": [
+   "hvm"
+  ],
+  "VCpuInfo": {
+   "DefaultCores": 32,
+   "DefaultThreadsPerCore": 2,
+   "DefaultVCpus": 64,
+   "ValidCores": [
+    2,
+    4,
+    6,
+    8,
+    10,
+    12,
+    14,
+    16,
+    18,
+    20,
+    22,
+    24,
+    26,
+    28,
+    30,
+    32
+   ],
+   "ValidThreadsPerCore": [
+    1,
+    2
+   ]
+  }
+ },
+ "i4i.2xlarge": {
+  "AutoRecoverySupported": true,
+  "BareMetal": false,
+  "BurstablePerformanceSupported": false,
+  "CurrentGeneration": true,
+  "DedicatedHostsSupported": true,
+  "EbsInfo": {
+   "EbsOptimizedInfo": {
+    "BaselineBandwidthInMbps": 2500,
+    "BaselineIops": 10000,
+    "BaselineThroughputInMBps": 312.5,
+    "MaximumBandwidthInMbps": 10000,
+    "MaximumIops": 40000,
+    "MaximumThroughputInMBps": 1250.0
+   },
+   "EbsOptimizedSupport": "default",
+   "EncryptionSupport": "supported",
+   "NvmeSupport": "required"
+  },
+  "FreeTierEligible": false,
+  "HibernationSupported": false,
+  "Hypervisor": "nitro",
+  "InstanceStorageInfo": {
+   "Disks": [
+    {
+     "Count": 1,
+     "SizeInGB": 1875,
+     "Type": "ssd"
+    }
+   ],
+   "NvmeSupport": "required",
+   "TotalSizeInGB": 1875
+  },
+  "InstanceStorageSupported": true,
+  "InstanceType": "i4i.2xlarge",
+  "MemoryInfo": {
+   "SizeInMiB": 65536
+  },
+  "NetworkInfo": {
+   "DefaultNetworkCardIndex": 0,
+   "EfaSupported": false,
+   "EnaSupport": "required",
+   "Ipv4AddressesPerInterface": 15,
+   "Ipv6AddressesPerInterface": 15,
+   "Ipv6Supported": true,
+   "MaximumNetworkCards": 1,
+   "MaximumNetworkInterfaces": 4,
+   "NetworkCards": [
+    {
+     "MaximumNetworkInterfaces": 4,
+     "NetworkCardIndex": 0,
+     "NetworkPerformance": "Up to 12 Gigabit"
+    }
+   ],
+   "NetworkPerformance": "Up to 12 Gigabit"
+  },
+  "PlacementGroupInfo": {
+   "SupportedStrategies": [
+    "cluster",
+    "partition",
+    "spread"
+   ]
+  },
+  "ProcessorInfo": {
+   "SupportedArchitectures": [
+    "x86_64"
+   ],
+   "SustainedClockSpeedInGhz": 3.5
+  },
+  "SupportedRootDeviceTypes": [
+   "ebs"
+  ],
+  "SupportedUsageClasses": [
+   "on-demand",
+   "spot"
+  ],
+  "SupportedVirtualizationTypes": [
+   "hvm"
+  ],
+  "VCpuInfo": {
+   "DefaultCores": 4,
+   "DefaultThreadsPerCore": 2,
+   "DefaultVCpus": 8,
+   "ValidCores": [
+    1,
+    2,
+    3,
+    4
+   ],
+   "ValidThreadsPerCore": [
+    1,
+    2
+   ]
+  }
+ },
+ "i4i.32xlarge": {
+  "AutoRecoverySupported": true,
+  "BareMetal": false,
+  "BurstablePerformanceSupported": false,
+  "CurrentGeneration": true,
+  "DedicatedHostsSupported": true,
+  "EbsInfo": {
+   "EbsOptimizedInfo": {
+    "BaselineBandwidthInMbps": 40000,
+    "BaselineIops": 160000,
+    "BaselineThroughputInMBps": 5000.0,
+    "MaximumBandwidthInMbps": 40000,
+    "MaximumIops": 160000,
+    "MaximumThroughputInMBps": 5000.0
+   },
+   "EbsOptimizedSupport": "default",
+   "EncryptionSupport": "supported",
+   "NvmeSupport": "required"
+  },
+  "FreeTierEligible": false,
+  "HibernationSupported": false,
+  "Hypervisor": "nitro",
+  "InstanceStorageInfo": {
+   "Disks": [
+    {
+     "Count": 8,
+     "SizeInGB": 3750,
+     "Type": "ssd"
+    }
+   ],
+   "NvmeSupport": "required",
+   "TotalSizeInGB": 30000
+  },
+  "InstanceStorageSupported": true,
+  "InstanceType": "i4i.32xlarge",
+  "MemoryInfo": {
+   "SizeInMiB": 1048576
+  },
+  "NetworkInfo": {
+   "DefaultNetworkCardIndex": 0,
+   "EfaSupported": true,
+   "EnaSupport": "required",
+   "Ipv4AddressesPerInterface": 50,
+   "Ipv6AddressesPerInterface": 50,
+   "Ipv6Supported": true,
+   "MaximumNetworkCards": 1,
+   "MaximumNetworkInterfaces": 15,
+   "NetworkCards": [
+    {
+     "MaximumNetworkInterfaces": 15,
+     "NetworkCardIndex": 0,
+     "NetworkPerformance": "75 Gigabit"
+    }
+   ],
+   "NetworkPerformance": "75 Gigabit"
+  },
+  "PlacementGroupInfo": {
+   "SupportedStrategies": [
+    "cluster",
+    "partition",
+    "spread"
+   ]
+  },
+  "ProcessorInfo": {
+   "SupportedArchitectures": [
+    "x86_64"
+   ],
+   "SustainedClockSpeedInGhz": 3.5
+  },
+  "SupportedRootDeviceTypes": [
+   "ebs"
+  ],
+  "SupportedUsageClasses": [
+   "on-demand",
+   "spot"
+  ],
+  "SupportedVirtualizationTypes": [
+   "hvm"
+  ],
+  "VCpuInfo": {
+   "DefaultCores": 64,
+   "DefaultThreadsPerCore": 2,
+   "DefaultVCpus": 128,
+   "ValidCores": [
+    2,
+    4,
+    6,
+    8,
+    10,
+    12,
+    14,
+    16,
+    18,
+    20,
+    22,
+    24,
+    26,
+    28,
+    30,
+    32,
+    34,
+    36,
+    38,
+    40,
+    42,
+    44,
+    46,
+    48,
+    50,
+    52,
+    54,
+    56,
+    58,
+    60,
+    62,
+    64
+   ],
+   "ValidThreadsPerCore": [
+    1,
+    2
+   ]
+  }
+ },
+ "i4i.4xlarge": {
+  "AutoRecoverySupported": true,
+  "BareMetal": false,
+  "BurstablePerformanceSupported": false,
+  "CurrentGeneration": true,
+  "DedicatedHostsSupported": true,
+  "EbsInfo": {
+   "EbsOptimizedInfo": {
+    "BaselineBandwidthInMbps": 5000,
+    "BaselineIops": 20000,
+    "BaselineThroughputInMBps": 625.0,
+    "MaximumBandwidthInMbps": 10000,
+    "MaximumIops": 40000,
+    "MaximumThroughputInMBps": 1250.0
+   },
+   "EbsOptimizedSupport": "default",
+   "EncryptionSupport": "supported",
+   "NvmeSupport": "required"
+  },
+  "FreeTierEligible": false,
+  "HibernationSupported": false,
+  "Hypervisor": "nitro",
+  "InstanceStorageInfo": {
+   "Disks": [
+    {
+     "Count": 1,
+     "SizeInGB": 3750,
+     "Type": "ssd"
+    }
+   ],
+   "NvmeSupport": "required",
+   "TotalSizeInGB": 3750
+  },
+  "InstanceStorageSupported": true,
+  "InstanceType": "i4i.4xlarge",
+  "MemoryInfo": {
+   "SizeInMiB": 131072
+  },
+  "NetworkInfo": {
+   "DefaultNetworkCardIndex": 0,
+   "EfaSupported": false,
+   "EnaSupport": "required",
+   "Ipv4AddressesPerInterface": 30,
+   "Ipv6AddressesPerInterface": 30,
+   "Ipv6Supported": true,
+   "MaximumNetworkCards": 1,
+   "MaximumNetworkInterfaces": 8,
+   "NetworkCards": [
+    {
+     "MaximumNetworkInterfaces": 8,
+     "NetworkCardIndex": 0,
+     "NetworkPerformance": "Up to 25 Gigabit"
+    }
+   ],
+   "NetworkPerformance": "Up to 25 Gigabit"
+  },
+  "PlacementGroupInfo": {
+   "SupportedStrategies": [
+    "cluster",
+    "partition",
+    "spread"
+   ]
+  },
+  "ProcessorInfo": {
+   "SupportedArchitectures": [
+    "x86_64"
+   ],
+   "SustainedClockSpeedInGhz": 3.5
+  },
+  "SupportedRootDeviceTypes": [
+   "ebs"
+  ],
+  "SupportedUsageClasses": [
+   "on-demand",
+   "spot"
+  ],
+  "SupportedVirtualizationTypes": [
+   "hvm"
+  ],
+  "VCpuInfo": {
+   "DefaultCores": 8,
+   "DefaultThreadsPerCore": 2,
+   "DefaultVCpus": 16,
+   "ValidCores": [
+    1,
+    2,
+    3,
+    4,
+    5,
+    6,
+    7,
+    8
+   ],
+   "ValidThreadsPerCore": [
+    1,
+    2
+   ]
+  }
+ },
+ "i4i.8xlarge": {
+  "AutoRecoverySupported": true,
+  "BareMetal": false,
+  "BurstablePerformanceSupported": false,
+  "CurrentGeneration": true,
+  "DedicatedHostsSupported": true,
+  "EbsInfo": {
+   "EbsOptimizedInfo": {
+    "BaselineBandwidthInMbps": 10000,
+    "BaselineIops": 40000,
+    "BaselineThroughputInMBps": 1250.0,
+    "MaximumBandwidthInMbps": 10000,
+    "MaximumIops": 40000,
+    "MaximumThroughputInMBps": 1250.0
+   },
+   "EbsOptimizedSupport": "default",
+   "EncryptionSupport": "supported",
+   "NvmeSupport": "required"
+  },
+  "FreeTierEligible": false,
+  "HibernationSupported": false,
+  "Hypervisor": "nitro",
+  "InstanceStorageInfo": {
+   "Disks": [
+    {
+     "Count": 2,
+     "SizeInGB": 3750,
+     "Type": "ssd"
+    }
+   ],
+   "NvmeSupport": "required",
+   "TotalSizeInGB": 7500
+  },
+  "InstanceStorageSupported": true,
+  "InstanceType": "i4i.8xlarge",
+  "MemoryInfo": {
+   "SizeInMiB": 262144
+  },
+  "NetworkInfo": {
+   "DefaultNetworkCardIndex": 0,
+   "EfaSupported": false,
+   "EnaSupport": "required",
+   "Ipv4AddressesPerInterface": 30,
+   "Ipv6AddressesPerInterface": 30,
+   "Ipv6Supported": true,
+   "MaximumNetworkCards": 1,
+   "MaximumNetworkInterfaces": 8,
+   "NetworkCards": [
+    {
+     "MaximumNetworkInterfaces": 8,
+     "NetworkCardIndex": 0,
+     "NetworkPerformance": "18.75 Gigabit"
+    }
+   ],
+   "NetworkPerformance": "18.75 Gigabit"
+  },
+  "PlacementGroupInfo": {
+   "SupportedStrategies": [
+    "cluster",
+    "partition",
+    "spread"
+   ]
+  },
+  "ProcessorInfo": {
+   "SupportedArchitectures": [
+    "x86_64"
+   ],
+   "SustainedClockSpeedInGhz": 3.5
+  },
+  "SupportedRootDeviceTypes": [
+   "ebs"
+  ],
+  "SupportedUsageClasses": [
+   "on-demand",
+   "spot"
+  ],
+  "SupportedVirtualizationTypes": [
+   "hvm"
+  ],
+  "VCpuInfo": {
+   "DefaultCores": 16,
+   "DefaultThreadsPerCore": 2,
+   "DefaultVCpus": 32,
+   "ValidCores": [
+    1,
+    2,
+    3,
+    4,
+    5,
+    6,
+    7,
+    8,
+    9,
+    10,
+    11,
+    12,
+    13,
+    14,
+    15,
+    16
+   ],
+   "ValidThreadsPerCore": [
+    1,
+    2
+   ]
+  }
+ },
+ "i4i.large": {
+  "AutoRecoverySupported": true,
+  "BareMetal": false,
+  "BurstablePerformanceSupported": false,
+  "CurrentGeneration": true,
+  "DedicatedHostsSupported": true,
+  "EbsInfo": {
+   "EbsOptimizedInfo": {
+    "BaselineBandwidthInMbps": 625,
+    "BaselineIops": 2500,
+    "BaselineThroughputInMBps": 78.125,
+    "MaximumBandwidthInMbps": 10000,
+    "MaximumIops": 40000,
+    "MaximumThroughputInMBps": 1250.0
+   },
+   "EbsOptimizedSupport": "default",
+   "EncryptionSupport": "supported",
+   "NvmeSupport": "required"
+  },
+  "FreeTierEligible": false,
+  "HibernationSupported": false,
+  "Hypervisor": "nitro",
+  "InstanceStorageInfo": {
+   "Disks": [
+    {
+     "Count": 1,
+     "SizeInGB": 468,
+     "Type": "ssd"
+    }
+   ],
+   "NvmeSupport": "required",
+   "TotalSizeInGB": 468
+  },
+  "InstanceStorageSupported": true,
+  "InstanceType": "i4i.large",
+  "MemoryInfo": {
+   "SizeInMiB": 16384
+  },
+  "NetworkInfo": {
+   "DefaultNetworkCardIndex": 0,
+   "EfaSupported": false,
+   "EnaSupport": "required",
+   "Ipv4AddressesPerInterface": 10,
+   "Ipv6AddressesPerInterface": 10,
+   "Ipv6Supported": true,
+   "MaximumNetworkCards": 1,
+   "MaximumNetworkInterfaces": 3,
+   "NetworkCards": [
+    {
+     "MaximumNetworkInterfaces": 3,
+     "NetworkCardIndex": 0,
+     "NetworkPerformance": "Up to 10 Gigabit"
+    }
+   ],
+   "NetworkPerformance": "Up to 10 Gigabit"
+  },
+  "PlacementGroupInfo": {
+   "SupportedStrategies": [
+    "cluster",
+    "partition",
+    "spread"
+   ]
+  },
+  "ProcessorInfo": {
+   "SupportedArchitectures": [
+    "x86_64"
+   ],
+   "SustainedClockSpeedInGhz": 3.5
+  },
+  "SupportedRootDeviceTypes": [
+   "ebs"
+  ],
+  "SupportedUsageClasses": [
+   "on-demand",
+   "spot"
+  ],
+  "SupportedVirtualizationTypes": [
+   "hvm"
+  ],
+  "VCpuInfo": {
+   "DefaultCores": 1,
+   "DefaultThreadsPerCore": 2,
+   "DefaultVCpus": 2,
+   "ValidCores": [
+    1
+   ],
+   "ValidThreadsPerCore": [
+    1,
+    2
+   ]
+  }
+ },
+ "i4i.metal": {
+  "AutoRecoverySupported": true,
+  "BareMetal": true,
+  "BurstablePerformanceSupported": false,
+  "CurrentGeneration": true,
+  "DedicatedHostsSupported": true,
+  "EbsInfo": {
+   "EbsOptimizedInfo": {
+    "BaselineBandwidthInMbps": 40000,
+    "BaselineIops": 160000,
+    "BaselineThroughputInMBps": 5000.0,
+    "MaximumBandwidthInMbps": 40000,
+    "MaximumIops": 160000,
+    "MaximumThroughputInMBps": 5000.0
+   },
+   "EbsOptimizedSupport": "default",
+   "EncryptionSupport": "supported",
+   "NvmeSupport": "required"
+  },
+  "FreeTierEligible": false,
+  "HibernationSupported": false,
+  "InstanceStorageInfo": {
+   "Disks": [
+    {
+     "Count": 8,
+     "SizeInGB": 3750,
+     "Type": "ssd"
+    }
+   ],
+   "NvmeSupport": "required",
+   "TotalSizeInGB": 30000
+  },
+  "InstanceStorageSupported": true,
+  "InstanceType": "i4i.metal",
+  "MemoryInfo": {
+   "SizeInMiB": 1048576
+  },
+  "NetworkInfo": {
+   "DefaultNetworkCardIndex": 0,
+   "EfaSupported": true,
+   "EnaSupport": "required",
+   "Ipv4AddressesPerInterface": 50,
+   "Ipv6AddressesPerInterface": 50,
+   "Ipv6Supported": true,
+   "MaximumNetworkCards": 1,
+   "MaximumNetworkInterfaces": 15,
+   "NetworkCards": [
+    {
+     "MaximumNetworkInterfaces": 15,
+     "NetworkCardIndex": 0,
+     "NetworkPerformance": "75 Gigabit"
+    }
+   ],
+   "NetworkPerformance": "75 Gigabit"
+  },
+  "PlacementGroupInfo": {
+   "SupportedStrategies": [
+    "cluster",
+    "partition",
+    "spread"
+   ]
+  },
+  "ProcessorInfo": {
+   "SupportedArchitectures": [
+    "x86_64"
+   ],
+   "SustainedClockSpeedInGhz": 3.5
+  },
+  "SupportedRootDeviceTypes": [
+   "ebs"
+  ],
+  "SupportedUsageClasses": [
+   "on-demand",
+   "spot"
+  ],
+  "SupportedVirtualizationTypes": [
+   "hvm"
+  ],
+  "VCpuInfo": {
+   "DefaultCores": 64,
+   "DefaultThreadsPerCore": 2,
+   "DefaultVCpus": 128
+  }
+ },
+ "i4i.xlarge": {
+  "AutoRecoverySupported": true,
+  "BareMetal": false,
+  "BurstablePerformanceSupported": false,
+  "CurrentGeneration": true,
+  "DedicatedHostsSupported": true,
+  "EbsInfo": {
+   "EbsOptimizedInfo": {
+    "BaselineBandwidthInMbps": 1250,
+    "BaselineIops": 5000,
+    "BaselineThroughputInMBps": 156.25,
+    "MaximumBandwidthInMbps": 10000,
+    "MaximumIops": 40000,
+    "MaximumThroughputInMBps": 1250.0
+   },
+   "EbsOptimizedSupport": "default",
+   "EncryptionSupport": "supported",
+   "NvmeSupport": "required"
+  },
+  "FreeTierEligible": false,
+  "HibernationSupported": false,
+  "Hypervisor": "nitro",
+  "InstanceStorageInfo": {
+   "Disks": [
+    {
+     "Count": 1,
+     "SizeInGB": 937,
+     "Type": "ssd"
+    }
+   ],
+   "NvmeSupport": "required",
+   "TotalSizeInGB": 937
+  },
+  "InstanceStorageSupported": true,
+  "InstanceType": "i4i.xlarge",
+  "MemoryInfo": {
+   "SizeInMiB": 32768
+  },
+  "NetworkInfo": {
+   "DefaultNetworkCardIndex": 0,
+   "EfaSupported": false,
+   "EnaSupport": "required",
+   "Ipv4AddressesPerInterface": 15,
+   "Ipv6AddressesPerInterface": 15,
+   "Ipv6Supported": true,
+   "MaximumNetworkCards": 1,
+   "MaximumNetworkInterfaces": 4,
+   "NetworkCards": [
+    {
+     "MaximumNetworkInterfaces": 4,
+     "NetworkCardIndex": 0,
+     "NetworkPerformance": "Up to 10 Gigabit"
+    }
+   ],
+   "NetworkPerformance": "Up to 10 Gigabit"
+  },
+  "PlacementGroupInfo": {
+   "SupportedStrategies": [
+    "cluster",
+    "partition",
+    "spread"
+   ]
+  },
+  "ProcessorInfo": {
+   "SupportedArchitectures": [
+    "x86_64"
+   ],
+   "SustainedClockSpeedInGhz": 3.5
+  },
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -17317,7 +19961,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "required",
    "NvmeSupport": "required",
    "TotalSizeInGB": 30000
   },
@@ -17328,12 +19971,8 @@
   },
   "NetworkInfo": {
    "DefaultNetworkCardIndex": 0,
-   "EfaInfo": {
-    "MaximumEfaInterfaces": 1
-   },
    "EfaSupported": true,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": true,
    "Ipv4AddressesPerInterface": 50,
    "Ipv6AddressesPerInterface": 50,
    "Ipv6Supported": true,
@@ -17361,9 +20000,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.5
   },
-  "SupportedBootModes": [
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -17479,7 +20115,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "required",
    "NvmeSupport": "required",
    "TotalSizeInGB": 3750
   },
@@ -17492,7 +20127,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": true,
    "Ipv4AddressesPerInterface": 15,
    "Ipv6AddressesPerInterface": 15,
    "Ipv6Supported": true,
@@ -17520,9 +20154,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.5
   },
-  "SupportedBootModes": [
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -17582,7 +20213,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "required",
    "NvmeSupport": "required",
    "TotalSizeInGB": 7500
   },
@@ -17595,7 +20225,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": true,
    "Ipv4AddressesPerInterface": 30,
    "Ipv6AddressesPerInterface": 30,
    "Ipv6Supported": true,
@@ -17623,9 +20252,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.5
   },
-  "SupportedBootModes": [
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -17693,7 +20319,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "required",
    "NvmeSupport": "required",
    "TotalSizeInGB": 15000
   },
@@ -17706,7 +20331,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": true,
    "Ipv4AddressesPerInterface": 30,
    "Ipv6AddressesPerInterface": 30,
    "Ipv6Supported": true,
@@ -17734,9 +20358,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.5
   },
-  "SupportedBootModes": [
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -17820,7 +20441,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "required",
    "NvmeSupport": "required",
    "TotalSizeInGB": 937
   },
@@ -17833,7 +20453,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": true,
    "Ipv4AddressesPerInterface": 10,
    "Ipv6AddressesPerInterface": 10,
    "Ipv6Supported": true,
@@ -17861,9 +20480,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.5
   },
-  "SupportedBootModes": [
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -17917,7 +20533,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "required",
    "NvmeSupport": "required",
    "TotalSizeInGB": 1875
   },
@@ -17930,7 +20545,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": true,
    "Ipv4AddressesPerInterface": 15,
    "Ipv6AddressesPerInterface": 15,
    "Ipv6Supported": true,
@@ -17958,9 +20572,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.5
   },
-  "SupportedBootModes": [
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -17987,7 +20598,7 @@
   }
  },
  "inf1.24xlarge": {
-  "AutoRecoverySupported": false,
+  "AutoRecoverySupported": true,
   "BareMetal": false,
   "BurstablePerformanceSupported": false,
   "CurrentGeneration": true,
@@ -18024,12 +20635,8 @@
   },
   "NetworkInfo": {
    "DefaultNetworkCardIndex": 0,
-   "EfaInfo": {
-    "MaximumEfaInterfaces": 1
-   },
    "EfaSupported": true,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": true,
    "Ipv4AddressesPerInterface": 30,
    "Ipv6AddressesPerInterface": 30,
    "Ipv6Supported": true,
@@ -18057,10 +20664,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.5
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -18108,7 +20711,7 @@
   }
  },
  "inf1.2xlarge": {
-  "AutoRecoverySupported": false,
+  "AutoRecoverySupported": true,
   "BareMetal": false,
   "BurstablePerformanceSupported": false,
   "CurrentGeneration": true,
@@ -18147,7 +20750,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": true,
    "Ipv4AddressesPerInterface": 10,
    "Ipv6AddressesPerInterface": 10,
    "Ipv6Supported": true,
@@ -18175,10 +20777,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.5
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -18204,7 +20802,7 @@
   }
  },
  "inf1.6xlarge": {
-  "AutoRecoverySupported": false,
+  "AutoRecoverySupported": true,
   "BareMetal": false,
   "BurstablePerformanceSupported": false,
   "CurrentGeneration": true,
@@ -18243,7 +20841,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": true,
    "Ipv4AddressesPerInterface": 30,
    "Ipv6AddressesPerInterface": 30,
    "Ipv6Supported": true,
@@ -18271,10 +20868,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.5
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -18304,7 +20897,7 @@
   }
  },
  "inf1.xlarge": {
-  "AutoRecoverySupported": false,
+  "AutoRecoverySupported": true,
   "BareMetal": false,
   "BurstablePerformanceSupported": false,
   "CurrentGeneration": true,
@@ -18343,7 +20936,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": true,
    "Ipv4AddressesPerInterface": 10,
    "Ipv6AddressesPerInterface": 10,
    "Ipv6Supported": true,
@@ -18371,10 +20963,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.5
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -18428,7 +21016,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "required",
    "NvmeSupport": "required",
    "TotalSizeInGB": 7500
   },
@@ -18441,7 +21028,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": true,
    "Ipv4AddressesPerInterface": 15,
    "Ipv6AddressesPerInterface": 15,
    "Ipv6Supported": true,
@@ -18469,9 +21055,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.5
   },
-  "SupportedBootModes": [
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -18531,7 +21114,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "required",
    "NvmeSupport": "required",
    "TotalSizeInGB": 15000
   },
@@ -18544,7 +21126,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": true,
    "Ipv4AddressesPerInterface": 30,
    "Ipv6AddressesPerInterface": 30,
    "Ipv6Supported": true,
@@ -18572,9 +21153,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.5
   },
-  "SupportedBootModes": [
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -18642,7 +21220,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "required",
    "NvmeSupport": "required",
    "TotalSizeInGB": 30000
   },
@@ -18655,7 +21232,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": true,
    "Ipv4AddressesPerInterface": 30,
    "Ipv6AddressesPerInterface": 30,
    "Ipv6Supported": true,
@@ -18683,9 +21259,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.5
   },
-  "SupportedBootModes": [
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -18769,7 +21342,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "required",
    "NvmeSupport": "required",
    "TotalSizeInGB": 1875
   },
@@ -18782,7 +21354,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": true,
    "Ipv4AddressesPerInterface": 10,
    "Ipv6AddressesPerInterface": 10,
    "Ipv6Supported": true,
@@ -18810,9 +21381,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.5
   },
-  "SupportedBootModes": [
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -18866,7 +21434,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "required",
    "NvmeSupport": "required",
    "TotalSizeInGB": 937
   },
@@ -18879,7 +21446,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": true,
    "Ipv4AddressesPerInterface": 4,
    "Ipv6AddressesPerInterface": 4,
    "Ipv6Supported": true,
@@ -18907,9 +21473,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.5
   },
-  "SupportedBootModes": [
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -18962,7 +21525,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "required",
    "NvmeSupport": "required",
    "TotalSizeInGB": 3750
   },
@@ -18975,7 +21537,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": true,
    "Ipv4AddressesPerInterface": 15,
    "Ipv6AddressesPerInterface": 15,
    "Ipv6Supported": true,
@@ -19003,9 +21564,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.5
   },
-  "SupportedBootModes": [
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -19047,7 +21605,7 @@
     "MaximumThroughputInMBps": 62.5
    },
    "EbsOptimizedSupport": "supported",
-   "EncryptionSupport": "unsupported",
+   "EncryptionSupport": "supported",
    "NvmeSupport": "unsupported"
   },
   "FreeTierEligible": false,
@@ -19061,7 +21619,6 @@
      "Type": "hdd"
     }
    ],
-   "EncryptionSupport": "unsupported",
    "NvmeSupport": "unsupported",
    "TotalSizeInGB": 840
   },
@@ -19074,7 +21631,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "unsupported",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 10,
    "Ipv6AddressesPerInterface": 0,
    "Ipv6Supported": false,
@@ -19100,9 +21656,6 @@
     "x86_64"
    ]
   },
-  "SupportedBootModes": [
-   "legacy-bios"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs",
    "instance-store"
@@ -19129,7 +21682,7 @@
   "DedicatedHostsSupported": false,
   "EbsInfo": {
    "EbsOptimizedSupport": "unsupported",
-   "EncryptionSupport": "unsupported",
+   "EncryptionSupport": "supported",
    "NvmeSupport": "unsupported"
   },
   "FreeTierEligible": false,
@@ -19143,7 +21696,6 @@
      "Type": "hdd"
     }
    ],
-   "EncryptionSupport": "unsupported",
    "NvmeSupport": "unsupported",
    "TotalSizeInGB": 410
   },
@@ -19156,7 +21708,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "unsupported",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 6,
    "Ipv6AddressesPerInterface": 0,
    "Ipv6Supported": false,
@@ -19183,9 +21734,6 @@
     "x86_64"
    ]
   },
-  "SupportedBootModes": [
-   "legacy-bios"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs",
    "instance-store"
@@ -19212,7 +21760,7 @@
   "DedicatedHostsSupported": false,
   "EbsInfo": {
    "EbsOptimizedSupport": "unsupported",
-   "EncryptionSupport": "unsupported",
+   "EncryptionSupport": "supported",
    "NvmeSupport": "unsupported"
   },
   "FreeTierEligible": false,
@@ -19226,7 +21774,6 @@
      "Type": "hdd"
     }
    ],
-   "EncryptionSupport": "unsupported",
    "NvmeSupport": "unsupported",
    "TotalSizeInGB": 160
   },
@@ -19239,7 +21786,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "unsupported",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 4,
    "Ipv6AddressesPerInterface": 0,
    "Ipv6Supported": false,
@@ -19266,9 +21812,6 @@
     "x86_64"
    ]
   },
-  "SupportedBootModes": [
-   "legacy-bios"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs",
    "instance-store"
@@ -19303,7 +21846,7 @@
     "MaximumThroughputInMBps": 125.0
    },
    "EbsOptimizedSupport": "supported",
-   "EncryptionSupport": "unsupported",
+   "EncryptionSupport": "supported",
    "NvmeSupport": "unsupported"
   },
   "FreeTierEligible": false,
@@ -19317,7 +21860,6 @@
      "Type": "hdd"
     }
    ],
-   "EncryptionSupport": "unsupported",
    "NvmeSupport": "unsupported",
    "TotalSizeInGB": 1680
   },
@@ -19330,7 +21872,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "unsupported",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 15,
    "Ipv6AddressesPerInterface": 0,
    "Ipv6Supported": false,
@@ -19356,9 +21897,6 @@
     "x86_64"
    ]
   },
-  "SupportedBootModes": [
-   "legacy-bios"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs",
    "instance-store"
@@ -19393,7 +21931,7 @@
     "MaximumThroughputInMBps": 62.5
    },
    "EbsOptimizedSupport": "supported",
-   "EncryptionSupport": "unsupported",
+   "EncryptionSupport": "supported",
    "NvmeSupport": "unsupported"
   },
   "FreeTierEligible": false,
@@ -19407,7 +21945,6 @@
      "Type": "hdd"
     }
    ],
-   "EncryptionSupport": "unsupported",
    "NvmeSupport": "unsupported",
    "TotalSizeInGB": 850
   },
@@ -19420,7 +21957,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "unsupported",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 30,
    "Ipv6AddressesPerInterface": 0,
    "Ipv6Supported": false,
@@ -19446,9 +21982,6 @@
     "x86_64"
    ]
   },
-  "SupportedBootModes": [
-   "legacy-bios"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs",
    "instance-store"
@@ -19492,7 +22025,7 @@
     "MaximumThroughputInMBps": 125.0
    },
    "EbsOptimizedSupport": "supported",
-   "EncryptionSupport": "unsupported",
+   "EncryptionSupport": "supported",
    "NvmeSupport": "unsupported"
   },
   "FreeTierEligible": false,
@@ -19506,7 +22039,6 @@
      "Type": "hdd"
     }
    ],
-   "EncryptionSupport": "unsupported",
    "NvmeSupport": "unsupported",
    "TotalSizeInGB": 1680
   },
@@ -19519,7 +22051,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "unsupported",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 30,
    "Ipv6AddressesPerInterface": 0,
    "Ipv6Supported": false,
@@ -19545,9 +22076,6 @@
     "x86_64"
    ]
   },
-  "SupportedBootModes": [
-   "legacy-bios"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs",
    "instance-store"
@@ -19587,7 +22115,7 @@
   "DedicatedHostsSupported": false,
   "EbsInfo": {
    "EbsOptimizedSupport": "unsupported",
-   "EncryptionSupport": "unsupported",
+   "EncryptionSupport": "supported",
    "NvmeSupport": "unsupported"
   },
   "FreeTierEligible": false,
@@ -19601,7 +22129,6 @@
      "Type": "hdd"
     }
    ],
-   "EncryptionSupport": "unsupported",
    "NvmeSupport": "unsupported",
    "TotalSizeInGB": 420
   },
@@ -19614,7 +22141,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "unsupported",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 15,
    "Ipv6AddressesPerInterface": 0,
    "Ipv6Supported": false,
@@ -19640,9 +22166,6 @@
     "x86_64"
    ]
   },
-  "SupportedBootModes": [
-   "legacy-bios"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs",
    "instance-store"
@@ -19698,7 +22221,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "unsupported",
    "NvmeSupport": "unsupported",
    "TotalSizeInGB": 160
   },
@@ -19711,7 +22233,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "unsupported",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 30,
    "Ipv6AddressesPerInterface": 0,
    "Ipv6Supported": false,
@@ -19738,9 +22259,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.5
   },
-  "SupportedBootModes": [
-   "legacy-bios"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs",
    "instance-store"
@@ -19791,7 +22309,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "unsupported",
    "NvmeSupport": "unsupported",
    "TotalSizeInGB": 32
   },
@@ -19804,7 +22321,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "unsupported",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 10,
    "Ipv6AddressesPerInterface": 0,
    "Ipv6Supported": false,
@@ -19831,9 +22347,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.5
   },
-  "SupportedBootModes": [
-   "legacy-bios"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs",
    "instance-store"
@@ -19881,7 +22394,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "unsupported",
    "NvmeSupport": "unsupported",
    "TotalSizeInGB": 4
   },
@@ -19894,7 +22406,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "unsupported",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 6,
    "Ipv6AddressesPerInterface": 0,
    "Ipv6Supported": false,
@@ -19921,9 +22432,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.5
   },
-  "SupportedBootModes": [
-   "legacy-bios"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs",
    "instance-store"
@@ -19972,7 +22480,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "unsupported",
    "NvmeSupport": "unsupported",
    "TotalSizeInGB": 80
   },
@@ -19985,7 +22492,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "unsupported",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 15,
    "Ipv6AddressesPerInterface": 0,
    "Ipv6Supported": false,
@@ -20012,9 +22518,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.5
   },
-  "SupportedBootModes": [
-   "legacy-bios"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs",
    "instance-store"
@@ -20073,7 +22576,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "unsupported",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 30,
    "Ipv6AddressesPerInterface": 30,
    "Ipv6Supported": true,
@@ -20101,9 +22603,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.4
   },
-  "SupportedBootModes": [
-   "legacy-bios"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -20167,7 +22666,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "supported",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 30,
    "Ipv6AddressesPerInterface": 30,
    "Ipv6Supported": true,
@@ -20195,9 +22693,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.3
   },
-  "SupportedBootModes": [
-   "legacy-bios"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -20267,7 +22762,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "unsupported",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 15,
    "Ipv6AddressesPerInterface": 15,
    "Ipv6Supported": true,
@@ -20295,9 +22789,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.4
   },
-  "SupportedBootModes": [
-   "legacy-bios"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -20355,7 +22846,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "unsupported",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 30,
    "Ipv6AddressesPerInterface": 30,
    "Ipv6Supported": true,
@@ -20383,9 +22873,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.4
   },
-  "SupportedBootModes": [
-   "legacy-bios"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -20447,7 +22934,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "unsupported",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 10,
    "Ipv6AddressesPerInterface": 10,
    "Ipv6Supported": true,
@@ -20475,9 +22961,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.4
   },
-  "SupportedBootModes": [
-   "legacy-bios"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -20532,7 +23015,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "unsupported",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 15,
    "Ipv6AddressesPerInterface": 15,
    "Ipv6Supported": true,
@@ -20560,9 +23042,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.4
   },
-  "SupportedBootModes": [
-   "legacy-bios"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -20618,7 +23097,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 30,
    "Ipv6AddressesPerInterface": 30,
    "Ipv6Supported": true,
@@ -20646,10 +23124,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.1
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -20715,7 +23189,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 50,
    "Ipv6AddressesPerInterface": 50,
    "Ipv6Supported": true,
@@ -20743,10 +23216,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.1
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -20816,7 +23285,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 50,
    "Ipv6AddressesPerInterface": 50,
    "Ipv6Supported": true,
@@ -20844,10 +23312,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.1
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -20924,7 +23388,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 15,
    "Ipv6AddressesPerInterface": 15,
    "Ipv6Supported": true,
@@ -20952,10 +23415,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.1
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -21011,7 +23470,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 30,
    "Ipv6AddressesPerInterface": 30,
    "Ipv6Supported": true,
@@ -21039,10 +23497,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.1
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -21100,7 +23554,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 30,
    "Ipv6AddressesPerInterface": 30,
    "Ipv6Supported": true,
@@ -21128,10 +23581,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.1
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -21193,7 +23642,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 10,
    "Ipv6AddressesPerInterface": 10,
    "Ipv6Supported": true,
@@ -21221,10 +23669,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.1
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -21278,7 +23722,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 50,
    "Ipv6AddressesPerInterface": 50,
    "Ipv6Supported": true,
@@ -21306,9 +23749,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.1
   },
-  "SupportedBootModes": [
-   "legacy-bios"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -21356,7 +23796,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 15,
    "Ipv6AddressesPerInterface": 15,
    "Ipv6Supported": true,
@@ -21384,10 +23823,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.1
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -21442,7 +23877,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 30,
    "Ipv6AddressesPerInterface": 30,
    "Ipv6Supported": true,
@@ -21470,10 +23904,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.5
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -21531,7 +23961,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 50,
    "Ipv6AddressesPerInterface": 50,
    "Ipv6Supported": true,
@@ -21559,10 +23988,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.5
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -21629,7 +24054,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 50,
    "Ipv6AddressesPerInterface": 50,
    "Ipv6Supported": true,
@@ -21657,10 +24081,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.5
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -21719,7 +24139,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 15,
    "Ipv6AddressesPerInterface": 15,
    "Ipv6Supported": true,
@@ -21747,10 +24166,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.5
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -21806,7 +24221,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 30,
    "Ipv6AddressesPerInterface": 30,
    "Ipv6Supported": true,
@@ -21834,10 +24248,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.5
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -21895,7 +24305,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 30,
    "Ipv6AddressesPerInterface": 30,
    "Ipv6Supported": true,
@@ -21923,10 +24332,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.5
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -21987,7 +24392,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 10,
    "Ipv6AddressesPerInterface": 10,
    "Ipv6Supported": true,
@@ -22015,10 +24419,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.5
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -22073,7 +24473,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 15,
    "Ipv6AddressesPerInterface": 15,
    "Ipv6Supported": true,
@@ -22101,10 +24500,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.5
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -22158,7 +24553,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "required",
    "NvmeSupport": "required",
    "TotalSizeInGB": 1800
   },
@@ -22171,7 +24565,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 30,
    "Ipv6AddressesPerInterface": 30,
    "Ipv6Supported": true,
@@ -22199,10 +24592,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.2
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -22259,7 +24648,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "required",
    "NvmeSupport": "required",
    "TotalSizeInGB": 2400
   },
@@ -22272,7 +24660,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 50,
    "Ipv6AddressesPerInterface": 50,
    "Ipv6Supported": true,
@@ -22300,10 +24687,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.5
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -22369,7 +24752,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "required",
    "NvmeSupport": "required",
    "TotalSizeInGB": 3600
   },
@@ -22382,7 +24764,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 50,
    "Ipv6AddressesPerInterface": 50,
    "Ipv6Supported": true,
@@ -22410,10 +24791,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.2
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -22471,7 +24848,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "required",
    "NvmeSupport": "required",
    "TotalSizeInGB": 300
   },
@@ -22484,7 +24860,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 15,
    "Ipv6AddressesPerInterface": 15,
    "Ipv6Supported": true,
@@ -22512,10 +24887,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.2
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -22570,7 +24941,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "required",
    "NvmeSupport": "required",
    "TotalSizeInGB": 600
   },
@@ -22583,7 +24953,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 30,
    "Ipv6AddressesPerInterface": 30,
    "Ipv6Supported": true,
@@ -22611,10 +24980,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.2
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -22671,7 +25036,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "required",
    "NvmeSupport": "required",
    "TotalSizeInGB": 1200
   },
@@ -22684,7 +25048,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 30,
    "Ipv6AddressesPerInterface": 30,
    "Ipv6Supported": true,
@@ -22712,10 +25075,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.5
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -22775,7 +25134,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "required",
    "NvmeSupport": "required",
    "TotalSizeInGB": 75
   },
@@ -22788,7 +25146,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 10,
    "Ipv6AddressesPerInterface": 10,
    "Ipv6Supported": true,
@@ -22816,10 +25173,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.2
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -22873,7 +25226,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "required",
    "NvmeSupport": "required",
    "TotalSizeInGB": 150
   },
@@ -22886,7 +25238,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 15,
    "Ipv6AddressesPerInterface": 15,
    "Ipv6Supported": true,
@@ -22914,10 +25265,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.2
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -22971,7 +25318,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "required",
    "NvmeSupport": "required",
    "TotalSizeInGB": 1800
   },
@@ -22984,7 +25330,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 30,
    "Ipv6AddressesPerInterface": 30,
    "Ipv6Supported": true,
@@ -23012,10 +25357,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.1
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -23080,7 +25421,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "required",
    "NvmeSupport": "required",
    "TotalSizeInGB": 2400
   },
@@ -23093,7 +25433,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 50,
    "Ipv6AddressesPerInterface": 50,
    "Ipv6Supported": true,
@@ -23121,10 +25460,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.1
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -23193,7 +25528,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "required",
    "NvmeSupport": "required",
    "TotalSizeInGB": 3600
   },
@@ -23206,7 +25540,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 50,
    "Ipv6AddressesPerInterface": 50,
    "Ipv6Supported": true,
@@ -23234,10 +25567,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.1
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -23313,7 +25642,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "required",
    "NvmeSupport": "required",
    "TotalSizeInGB": 300
   },
@@ -23326,7 +25654,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 15,
    "Ipv6AddressesPerInterface": 15,
    "Ipv6Supported": true,
@@ -23354,10 +25681,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.1
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -23412,7 +25735,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "required",
    "NvmeSupport": "required",
    "TotalSizeInGB": 600
   },
@@ -23425,7 +25747,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 30,
    "Ipv6AddressesPerInterface": 30,
    "Ipv6Supported": true,
@@ -23453,10 +25774,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.1
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -23513,7 +25830,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "required",
    "NvmeSupport": "required",
    "TotalSizeInGB": 1200
   },
@@ -23526,7 +25842,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 30,
    "Ipv6AddressesPerInterface": 30,
    "Ipv6Supported": true,
@@ -23554,10 +25869,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.1
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -23618,7 +25929,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "required",
    "NvmeSupport": "required",
    "TotalSizeInGB": 75
   },
@@ -23631,7 +25941,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 10,
    "Ipv6AddressesPerInterface": 10,
    "Ipv6Supported": true,
@@ -23659,10 +25968,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.1
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -23715,7 +26020,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "required",
    "NvmeSupport": "required",
    "TotalSizeInGB": 3600
   },
@@ -23728,7 +26032,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 50,
    "Ipv6AddressesPerInterface": 50,
    "Ipv6Supported": true,
@@ -23756,9 +26059,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.1
   },
-  "SupportedBootModes": [
-   "legacy-bios"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -23805,7 +26105,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "required",
    "NvmeSupport": "required",
    "TotalSizeInGB": 150
   },
@@ -23818,7 +26117,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 15,
    "Ipv6AddressesPerInterface": 15,
    "Ipv6Supported": true,
@@ -23846,10 +26144,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.1
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -23903,7 +26197,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "required",
    "NvmeSupport": "required",
    "TotalSizeInGB": 1800
   },
@@ -23916,7 +26209,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": true,
    "Ipv4AddressesPerInterface": 30,
    "Ipv6AddressesPerInterface": 30,
    "Ipv6Supported": true,
@@ -23944,10 +26236,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.1
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -24012,7 +26300,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "required",
    "NvmeSupport": "required",
    "TotalSizeInGB": 2400
   },
@@ -24025,7 +26312,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": true,
    "Ipv4AddressesPerInterface": 50,
    "Ipv6AddressesPerInterface": 50,
    "Ipv6Supported": true,
@@ -24053,10 +26339,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.1
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -24125,7 +26407,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "required",
    "NvmeSupport": "required",
    "TotalSizeInGB": 3600
   },
@@ -24136,12 +26417,8 @@
   },
   "NetworkInfo": {
    "DefaultNetworkCardIndex": 0,
-   "EfaInfo": {
-    "MaximumEfaInterfaces": 1
-   },
    "EfaSupported": true,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": true,
    "Ipv4AddressesPerInterface": 50,
    "Ipv6AddressesPerInterface": 50,
    "Ipv6Supported": true,
@@ -24169,10 +26446,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.1
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -24231,7 +26504,7 @@
     "BaselineIops": 12000,
     "BaselineThroughputInMBps": 287.5,
     "MaximumBandwidthInMbps": 4750,
-    "MaximumIops": 15000,
+    "MaximumIops": 18750,
     "MaximumThroughputInMBps": 593.75
    },
    "EbsOptimizedSupport": "default",
@@ -24249,7 +26522,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "required",
    "NvmeSupport": "required",
    "TotalSizeInGB": 300
   },
@@ -24262,7 +26534,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": true,
    "Ipv4AddressesPerInterface": 15,
    "Ipv6AddressesPerInterface": 15,
    "Ipv6Supported": true,
@@ -24290,10 +26561,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.1
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -24327,10 +26594,10 @@
   "EbsInfo": {
    "EbsOptimizedInfo": {
     "BaselineBandwidthInMbps": 4750,
-    "BaselineIops": 15000,
+    "BaselineIops": 18750,
     "BaselineThroughputInMBps": 593.75,
     "MaximumBandwidthInMbps": 4750,
-    "MaximumIops": 15000,
+    "MaximumIops": 18750,
     "MaximumThroughputInMBps": 593.75
    },
    "EbsOptimizedSupport": "default",
@@ -24348,7 +26615,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "required",
    "NvmeSupport": "required",
    "TotalSizeInGB": 600
   },
@@ -24361,7 +26627,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": true,
    "Ipv4AddressesPerInterface": 30,
    "Ipv6AddressesPerInterface": 30,
    "Ipv6Supported": true,
@@ -24389,10 +26654,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.1
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -24449,7 +26710,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "required",
    "NvmeSupport": "required",
    "TotalSizeInGB": 1200
   },
@@ -24462,7 +26722,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": true,
    "Ipv4AddressesPerInterface": 30,
    "Ipv6AddressesPerInterface": 30,
    "Ipv6Supported": true,
@@ -24490,10 +26749,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.1
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -24533,10 +26788,10 @@
   "EbsInfo": {
    "EbsOptimizedInfo": {
     "BaselineBandwidthInMbps": 650,
-    "BaselineIops": 3000,
+    "BaselineIops": 3600,
     "BaselineThroughputInMBps": 81.25,
     "MaximumBandwidthInMbps": 4750,
-    "MaximumIops": 15000,
+    "MaximumIops": 18750,
     "MaximumThroughputInMBps": 593.75
    },
    "EbsOptimizedSupport": "default",
@@ -24554,7 +26809,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "required",
    "NvmeSupport": "required",
    "TotalSizeInGB": 75
   },
@@ -24567,7 +26821,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": true,
    "Ipv4AddressesPerInterface": 10,
    "Ipv6AddressesPerInterface": 10,
    "Ipv6Supported": true,
@@ -24595,10 +26848,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.1
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -24651,7 +26900,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "required",
    "NvmeSupport": "required",
    "TotalSizeInGB": 3600
   },
@@ -24662,12 +26910,8 @@
   },
   "NetworkInfo": {
    "DefaultNetworkCardIndex": 0,
-   "EfaInfo": {
-    "MaximumEfaInterfaces": 1
-   },
    "EfaSupported": true,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": true,
    "Ipv4AddressesPerInterface": 50,
    "Ipv6AddressesPerInterface": 50,
    "Ipv6Supported": true,
@@ -24695,9 +26939,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.1
   },
-  "SupportedBootModes": [
-   "legacy-bios"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -24726,7 +26967,7 @@
     "BaselineIops": 6000,
     "BaselineThroughputInMBps": 143.75,
     "MaximumBandwidthInMbps": 4750,
-    "MaximumIops": 15000,
+    "MaximumIops": 18750,
     "MaximumThroughputInMBps": 593.75
    },
    "EbsOptimizedSupport": "default",
@@ -24744,7 +26985,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "required",
    "NvmeSupport": "required",
    "TotalSizeInGB": 150
   },
@@ -24757,7 +26997,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": true,
    "Ipv4AddressesPerInterface": 15,
    "Ipv6AddressesPerInterface": 15,
    "Ipv6Supported": true,
@@ -24785,10 +27024,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.1
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -24844,7 +27079,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": true,
    "Ipv4AddressesPerInterface": 30,
    "Ipv6AddressesPerInterface": 30,
    "Ipv6Supported": true,
@@ -24872,10 +27106,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.1
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -24941,7 +27171,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": true,
    "Ipv4AddressesPerInterface": 50,
    "Ipv6AddressesPerInterface": 50,
    "Ipv6Supported": true,
@@ -24969,10 +27198,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.1
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -25040,12 +27265,8 @@
   },
   "NetworkInfo": {
    "DefaultNetworkCardIndex": 0,
-   "EfaInfo": {
-    "MaximumEfaInterfaces": 1
-   },
    "EfaSupported": true,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": true,
    "Ipv4AddressesPerInterface": 50,
    "Ipv6AddressesPerInterface": 50,
    "Ipv6Supported": true,
@@ -25073,10 +27294,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.1
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -25135,7 +27352,7 @@
     "BaselineIops": 12000,
     "BaselineThroughputInMBps": 287.5,
     "MaximumBandwidthInMbps": 4750,
-    "MaximumIops": 15000,
+    "MaximumIops": 18750,
     "MaximumThroughputInMBps": 593.75
    },
    "EbsOptimizedSupport": "default",
@@ -25154,7 +27371,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": true,
    "Ipv4AddressesPerInterface": 15,
    "Ipv6AddressesPerInterface": 15,
    "Ipv6Supported": true,
@@ -25182,10 +27398,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.1
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -25219,10 +27431,10 @@
   "EbsInfo": {
    "EbsOptimizedInfo": {
     "BaselineBandwidthInMbps": 4750,
-    "BaselineIops": 15000,
+    "BaselineIops": 18750,
     "BaselineThroughputInMBps": 593.75,
     "MaximumBandwidthInMbps": 4750,
-    "MaximumIops": 15000,
+    "MaximumIops": 18750,
     "MaximumThroughputInMBps": 593.75
    },
    "EbsOptimizedSupport": "default",
@@ -25241,7 +27453,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": true,
    "Ipv4AddressesPerInterface": 30,
    "Ipv6AddressesPerInterface": 30,
    "Ipv6Supported": true,
@@ -25269,10 +27480,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.1
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -25330,7 +27537,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": true,
    "Ipv4AddressesPerInterface": 30,
    "Ipv6AddressesPerInterface": 30,
    "Ipv6Supported": true,
@@ -25358,10 +27564,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.1
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -25401,10 +27603,10 @@
   "EbsInfo": {
    "EbsOptimizedInfo": {
     "BaselineBandwidthInMbps": 650,
-    "BaselineIops": 3000,
+    "BaselineIops": 3600,
     "BaselineThroughputInMBps": 81.25,
     "MaximumBandwidthInMbps": 4750,
-    "MaximumIops": 15000,
+    "MaximumIops": 18750,
     "MaximumThroughputInMBps": 593.75
    },
    "EbsOptimizedSupport": "default",
@@ -25423,7 +27625,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": true,
    "Ipv4AddressesPerInterface": 10,
    "Ipv6AddressesPerInterface": 10,
    "Ipv6Supported": true,
@@ -25451,10 +27652,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.1
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -25506,12 +27703,8 @@
   },
   "NetworkInfo": {
    "DefaultNetworkCardIndex": 0,
-   "EfaInfo": {
-    "MaximumEfaInterfaces": 1
-   },
    "EfaSupported": true,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": true,
    "Ipv4AddressesPerInterface": 50,
    "Ipv6AddressesPerInterface": 50,
    "Ipv6Supported": true,
@@ -25539,9 +27732,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.1
   },
-  "SupportedBootModes": [
-   "legacy-bios"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -25570,7 +27760,7 @@
     "BaselineIops": 6000,
     "BaselineThroughputInMBps": 143.75,
     "MaximumBandwidthInMbps": 4750,
-    "MaximumIops": 15000,
+    "MaximumIops": 18750,
     "MaximumThroughputInMBps": 593.75
    },
    "EbsOptimizedSupport": "default",
@@ -25589,7 +27779,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": true,
    "Ipv4AddressesPerInterface": 15,
    "Ipv6AddressesPerInterface": 15,
    "Ipv6Supported": true,
@@ -25617,10 +27806,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.1
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -25646,7 +27831,7 @@
   }
  },
  "m5zn.12xlarge": {
-  "AutoRecoverySupported": false,
+  "AutoRecoverySupported": true,
   "BareMetal": false,
   "BurstablePerformanceSupported": false,
   "CurrentGeneration": true,
@@ -25674,12 +27859,8 @@
   },
   "NetworkInfo": {
    "DefaultNetworkCardIndex": 0,
-   "EfaInfo": {
-    "MaximumEfaInterfaces": 1
-   },
    "EfaSupported": true,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": true,
    "Ipv4AddressesPerInterface": 50,
    "Ipv6AddressesPerInterface": 50,
    "Ipv6Supported": true,
@@ -25707,10 +27888,6 @@
    ],
    "SustainedClockSpeedInGhz": 4.5
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -25746,7 +27923,7 @@
   }
  },
  "m5zn.2xlarge": {
-  "AutoRecoverySupported": false,
+  "AutoRecoverySupported": true,
   "BareMetal": false,
   "BurstablePerformanceSupported": false,
   "CurrentGeneration": true,
@@ -25776,7 +27953,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": true,
    "Ipv4AddressesPerInterface": 15,
    "Ipv6AddressesPerInterface": 15,
    "Ipv6Supported": true,
@@ -25804,10 +27980,6 @@
    ],
    "SustainedClockSpeedInGhz": 4.5
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -25833,7 +28005,7 @@
   }
  },
  "m5zn.3xlarge": {
-  "AutoRecoverySupported": false,
+  "AutoRecoverySupported": true,
   "BareMetal": false,
   "BurstablePerformanceSupported": false,
   "CurrentGeneration": true,
@@ -25863,7 +28035,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": true,
    "Ipv4AddressesPerInterface": 30,
    "Ipv6AddressesPerInterface": 30,
    "Ipv6Supported": true,
@@ -25891,10 +28062,6 @@
    ],
    "SustainedClockSpeedInGhz": 4.5
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -25921,7 +28088,7 @@
   }
  },
  "m5zn.6xlarge": {
-  "AutoRecoverySupported": false,
+  "AutoRecoverySupported": true,
   "BareMetal": false,
   "BurstablePerformanceSupported": false,
   "CurrentGeneration": true,
@@ -25951,7 +28118,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": true,
    "Ipv4AddressesPerInterface": 30,
    "Ipv6AddressesPerInterface": 30,
    "Ipv6Supported": true,
@@ -25979,10 +28145,6 @@
    ],
    "SustainedClockSpeedInGhz": 4.5
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -26012,7 +28174,7 @@
   }
  },
  "m5zn.large": {
-  "AutoRecoverySupported": false,
+  "AutoRecoverySupported": true,
   "BareMetal": false,
   "BurstablePerformanceSupported": false,
   "CurrentGeneration": true,
@@ -26042,7 +28204,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": true,
    "Ipv4AddressesPerInterface": 10,
    "Ipv6AddressesPerInterface": 10,
    "Ipv6Supported": true,
@@ -26070,10 +28231,6 @@
    ],
    "SustainedClockSpeedInGhz": 4.5
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -26098,7 +28255,7 @@
   }
  },
  "m5zn.metal": {
-  "AutoRecoverySupported": false,
+  "AutoRecoverySupported": true,
   "BareMetal": true,
   "BurstablePerformanceSupported": false,
   "CurrentGeneration": true,
@@ -26125,12 +28282,8 @@
   },
   "NetworkInfo": {
    "DefaultNetworkCardIndex": 0,
-   "EfaInfo": {
-    "MaximumEfaInterfaces": 1
-   },
    "EfaSupported": true,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": true,
    "Ipv4AddressesPerInterface": 50,
    "Ipv6AddressesPerInterface": 50,
    "Ipv6Supported": true,
@@ -26158,9 +28311,6 @@
    ],
    "SustainedClockSpeedInGhz": 4.5
   },
-  "SupportedBootModes": [
-   "legacy-bios"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -26178,7 +28328,7 @@
   }
  },
  "m5zn.xlarge": {
-  "AutoRecoverySupported": false,
+  "AutoRecoverySupported": true,
   "BareMetal": false,
   "BurstablePerformanceSupported": false,
   "CurrentGeneration": true,
@@ -26208,7 +28358,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": true,
    "Ipv4AddressesPerInterface": 15,
    "Ipv6AddressesPerInterface": 15,
    "Ipv6Supported": true,
@@ -26236,10 +28385,6 @@
    ],
    "SustainedClockSpeedInGhz": 4.5
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -26295,7 +28440,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": true,
    "Ipv4AddressesPerInterface": 30,
    "Ipv6AddressesPerInterface": 30,
    "Ipv6Supported": true,
@@ -26323,10 +28467,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.6
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -26390,7 +28530,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": true,
    "Ipv4AddressesPerInterface": 50,
    "Ipv6AddressesPerInterface": 50,
    "Ipv6Supported": true,
@@ -26418,10 +28557,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.6
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -26484,7 +28619,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": true,
    "Ipv4AddressesPerInterface": 50,
    "Ipv6AddressesPerInterface": 50,
    "Ipv6Supported": true,
@@ -26512,10 +28646,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.6
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -26579,7 +28709,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": true,
    "Ipv4AddressesPerInterface": 15,
    "Ipv6AddressesPerInterface": 15,
    "Ipv6Supported": true,
@@ -26607,10 +28736,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.6
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -26666,12 +28791,8 @@
   },
   "NetworkInfo": {
    "DefaultNetworkCardIndex": 0,
-   "EfaInfo": {
-    "MaximumEfaInterfaces": 1
-   },
    "EfaSupported": true,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": true,
    "Ipv4AddressesPerInterface": 50,
    "Ipv6AddressesPerInterface": 50,
    "Ipv6Supported": true,
@@ -26699,10 +28820,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.6
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -26763,12 +28880,8 @@
   },
   "NetworkInfo": {
    "DefaultNetworkCardIndex": 0,
-   "EfaInfo": {
-    "MaximumEfaInterfaces": 1
-   },
    "EfaSupported": true,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": true,
    "Ipv4AddressesPerInterface": 50,
    "Ipv6AddressesPerInterface": 50,
    "Ipv6Supported": true,
@@ -26796,10 +28909,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.6
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -26863,7 +28972,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": true,
    "Ipv4AddressesPerInterface": 30,
    "Ipv6AddressesPerInterface": 30,
    "Ipv6Supported": true,
@@ -26891,10 +28999,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.6
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -26956,7 +29060,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": true,
    "Ipv4AddressesPerInterface": 30,
    "Ipv6AddressesPerInterface": 30,
    "Ipv6Supported": true,
@@ -26984,10 +29087,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.6
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -27050,7 +29149,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": true,
    "Ipv4AddressesPerInterface": 10,
    "Ipv6AddressesPerInterface": 10,
    "Ipv6Supported": true,
@@ -27078,10 +29176,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.6
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -27103,6 +29197,79 @@
     1,
     2
    ]
+  }
+ },
+ "m6a.metal": {
+  "AutoRecoverySupported": true,
+  "BareMetal": true,
+  "BurstablePerformanceSupported": false,
+  "CurrentGeneration": true,
+  "DedicatedHostsSupported": true,
+  "EbsInfo": {
+   "EbsOptimizedInfo": {
+    "BaselineBandwidthInMbps": 40000,
+    "BaselineIops": 160000,
+    "BaselineThroughputInMBps": 5000.0,
+    "MaximumBandwidthInMbps": 40000,
+    "MaximumIops": 160000,
+    "MaximumThroughputInMBps": 5000.0
+   },
+   "EbsOptimizedSupport": "default",
+   "EncryptionSupport": "supported",
+   "NvmeSupport": "required"
+  },
+  "FreeTierEligible": false,
+  "HibernationSupported": false,
+  "InstanceStorageSupported": false,
+  "InstanceType": "m6a.metal",
+  "MemoryInfo": {
+   "SizeInMiB": 786432
+  },
+  "NetworkInfo": {
+   "DefaultNetworkCardIndex": 0,
+   "EfaSupported": true,
+   "EnaSupport": "required",
+   "Ipv4AddressesPerInterface": 50,
+   "Ipv6AddressesPerInterface": 50,
+   "Ipv6Supported": true,
+   "MaximumNetworkCards": 1,
+   "MaximumNetworkInterfaces": 15,
+   "NetworkCards": [
+    {
+     "MaximumNetworkInterfaces": 15,
+     "NetworkCardIndex": 0,
+     "NetworkPerformance": "50 Gigabit"
+    }
+   ],
+   "NetworkPerformance": "50 Gigabit"
+  },
+  "PlacementGroupInfo": {
+   "SupportedStrategies": [
+    "cluster",
+    "partition",
+    "spread"
+   ]
+  },
+  "ProcessorInfo": {
+   "SupportedArchitectures": [
+    "x86_64"
+   ],
+   "SustainedClockSpeedInGhz": 3.6
+  },
+  "SupportedRootDeviceTypes": [
+   "ebs"
+  ],
+  "SupportedUsageClasses": [
+   "on-demand",
+   "spot"
+  ],
+  "SupportedVirtualizationTypes": [
+   "hvm"
+  ],
+  "VCpuInfo": {
+   "DefaultCores": 96,
+   "DefaultThreadsPerCore": 2,
+   "DefaultVCpus": 192
   }
  },
  "m6a.xlarge": {
@@ -27136,7 +29303,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": true,
    "Ipv4AddressesPerInterface": 15,
    "Ipv6AddressesPerInterface": 15,
    "Ipv6Supported": true,
@@ -27164,10 +29330,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.6
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -27223,7 +29385,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 30,
    "Ipv6AddressesPerInterface": 30,
    "Ipv6Supported": true,
@@ -27251,9 +29412,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.5
   },
-  "SupportedBootModes": [
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -27354,7 +29512,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 50,
    "Ipv6AddressesPerInterface": 50,
    "Ipv6Supported": true,
@@ -27382,9 +29539,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.5
   },
-  "SupportedBootModes": [
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -27501,7 +29655,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 15,
    "Ipv6AddressesPerInterface": 15,
    "Ipv6Supported": true,
@@ -27529,9 +29682,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.5
   },
-  "SupportedBootModes": [
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -27592,7 +29742,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 30,
    "Ipv6AddressesPerInterface": 30,
    "Ipv6Supported": true,
@@ -27620,9 +29769,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.5
   },
-  "SupportedBootModes": [
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -27691,7 +29837,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 30,
    "Ipv6AddressesPerInterface": 30,
    "Ipv6Supported": true,
@@ -27719,9 +29864,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.5
   },
-  "SupportedBootModes": [
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -27806,7 +29948,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 10,
    "Ipv6AddressesPerInterface": 10,
    "Ipv6Supported": true,
@@ -27834,9 +29975,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.5
   },
-  "SupportedBootModes": [
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -27891,7 +30029,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 4,
    "Ipv6AddressesPerInterface": 4,
    "Ipv6Supported": true,
@@ -27919,9 +30056,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.5
   },
-  "SupportedBootModes": [
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -27968,7 +30102,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 50,
    "Ipv6AddressesPerInterface": 50,
    "Ipv6Supported": true,
@@ -27996,9 +30129,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.5
   },
-  "SupportedBootModes": [
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -28046,7 +30176,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 15,
    "Ipv6AddressesPerInterface": 15,
    "Ipv6Supported": true,
@@ -28074,9 +30203,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.5
   },
-  "SupportedBootModes": [
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -28132,7 +30258,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "required",
    "NvmeSupport": "required",
    "TotalSizeInGB": 2850
   },
@@ -28145,7 +30270,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 30,
    "Ipv6AddressesPerInterface": 30,
    "Ipv6Supported": true,
@@ -28173,9 +30297,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.5
   },
-  "SupportedBootModes": [
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -28275,7 +30396,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "required",
    "NvmeSupport": "required",
    "TotalSizeInGB": 3800
   },
@@ -28288,7 +30408,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 50,
    "Ipv6AddressesPerInterface": 50,
    "Ipv6Supported": true,
@@ -28316,9 +30435,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.5
   },
-  "SupportedBootModes": [
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -28434,7 +30550,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "required",
    "NvmeSupport": "required",
    "TotalSizeInGB": 474
   },
@@ -28447,7 +30562,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 15,
    "Ipv6AddressesPerInterface": 15,
    "Ipv6Supported": true,
@@ -28475,9 +30589,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.5
   },
-  "SupportedBootModes": [
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -28537,7 +30648,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "required",
    "NvmeSupport": "required",
    "TotalSizeInGB": 950
   },
@@ -28550,7 +30660,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 30,
    "Ipv6AddressesPerInterface": 30,
    "Ipv6Supported": true,
@@ -28578,9 +30687,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.5
   },
-  "SupportedBootModes": [
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -28648,7 +30754,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "required",
    "NvmeSupport": "required",
    "TotalSizeInGB": 1900
   },
@@ -28661,7 +30766,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 30,
    "Ipv6AddressesPerInterface": 30,
    "Ipv6Supported": true,
@@ -28689,9 +30793,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.5
   },
-  "SupportedBootModes": [
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -28775,7 +30876,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "required",
    "NvmeSupport": "required",
    "TotalSizeInGB": 118
   },
@@ -28788,7 +30888,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 10,
    "Ipv6AddressesPerInterface": 10,
    "Ipv6Supported": true,
@@ -28816,9 +30915,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.5
   },
-  "SupportedBootModes": [
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -28872,7 +30968,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "required",
    "NvmeSupport": "required",
    "TotalSizeInGB": 59
   },
@@ -28885,7 +30980,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 4,
    "Ipv6AddressesPerInterface": 4,
    "Ipv6Supported": true,
@@ -28913,9 +31007,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.5
   },
-  "SupportedBootModes": [
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -28961,7 +31052,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "required",
    "NvmeSupport": "required",
    "TotalSizeInGB": 3800
   },
@@ -28974,7 +31064,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 50,
    "Ipv6AddressesPerInterface": 50,
    "Ipv6Supported": true,
@@ -29002,9 +31091,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.5
   },
-  "SupportedBootModes": [
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -29051,7 +31137,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "required",
    "NvmeSupport": "required",
    "TotalSizeInGB": 237
   },
@@ -29064,7 +31149,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 15,
    "Ipv6AddressesPerInterface": 15,
    "Ipv6Supported": true,
@@ -29092,9 +31176,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.5
   },
-  "SupportedBootModes": [
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -29151,7 +31232,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": true,
    "Ipv4AddressesPerInterface": 30,
    "Ipv6AddressesPerInterface": 30,
    "Ipv6Supported": true,
@@ -29179,10 +31259,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.5
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -29248,7 +31324,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": true,
    "Ipv4AddressesPerInterface": 50,
    "Ipv6AddressesPerInterface": 50,
    "Ipv6Supported": true,
@@ -29276,10 +31351,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.5
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -29349,7 +31420,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": true,
    "Ipv4AddressesPerInterface": 50,
    "Ipv6AddressesPerInterface": 50,
    "Ipv6Supported": true,
@@ -29377,10 +31447,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.5
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -29458,7 +31524,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": true,
    "Ipv4AddressesPerInterface": 15,
    "Ipv6AddressesPerInterface": 15,
    "Ipv6Supported": true,
@@ -29486,10 +31551,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.5
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -29543,12 +31604,8 @@
   },
   "NetworkInfo": {
    "DefaultNetworkCardIndex": 0,
-   "EfaInfo": {
-    "MaximumEfaInterfaces": 1
-   },
    "EfaSupported": true,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": true,
    "Ipv4AddressesPerInterface": 50,
    "Ipv6AddressesPerInterface": 50,
    "Ipv6Supported": true,
@@ -29576,10 +31633,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.5
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -29665,7 +31718,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": true,
    "Ipv4AddressesPerInterface": 30,
    "Ipv6AddressesPerInterface": 30,
    "Ipv6Supported": true,
@@ -29693,10 +31745,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.5
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -29754,7 +31802,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": true,
    "Ipv4AddressesPerInterface": 30,
    "Ipv6AddressesPerInterface": 30,
    "Ipv6Supported": true,
@@ -29782,10 +31829,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.5
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -29847,7 +31890,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": true,
    "Ipv4AddressesPerInterface": 10,
    "Ipv6AddressesPerInterface": 10,
    "Ipv6Supported": true,
@@ -29875,10 +31917,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.5
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -29930,12 +31968,8 @@
   },
   "NetworkInfo": {
    "DefaultNetworkCardIndex": 0,
-   "EfaInfo": {
-    "MaximumEfaInterfaces": 1
-   },
    "EfaSupported": true,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": true,
    "Ipv4AddressesPerInterface": 50,
    "Ipv6AddressesPerInterface": 50,
    "Ipv6Supported": true,
@@ -29963,9 +31997,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.5
   },
-  "SupportedBootModes": [
-   "legacy-bios"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -30013,7 +32044,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": true,
    "Ipv4AddressesPerInterface": 15,
    "Ipv6AddressesPerInterface": 15,
    "Ipv6Supported": true,
@@ -30041,10 +32071,1010 @@
    ],
    "SustainedClockSpeedInGhz": 3.5
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
+  "SupportedRootDeviceTypes": [
+   "ebs"
   ],
+  "SupportedUsageClasses": [
+   "on-demand",
+   "spot"
+  ],
+  "SupportedVirtualizationTypes": [
+   "hvm"
+  ],
+  "VCpuInfo": {
+   "DefaultCores": 2,
+   "DefaultThreadsPerCore": 2,
+   "DefaultVCpus": 4,
+   "ValidCores": [
+    1,
+    2
+   ],
+   "ValidThreadsPerCore": [
+    1,
+    2
+   ]
+  }
+ },
+ "m6id.12xlarge": {
+  "AutoRecoverySupported": false,
+  "BareMetal": false,
+  "BurstablePerformanceSupported": false,
+  "CurrentGeneration": true,
+  "DedicatedHostsSupported": true,
+  "EbsInfo": {
+   "EbsOptimizedInfo": {
+    "BaselineBandwidthInMbps": 15000,
+    "BaselineIops": 60000,
+    "BaselineThroughputInMBps": 1875.0,
+    "MaximumBandwidthInMbps": 15000,
+    "MaximumIops": 60000,
+    "MaximumThroughputInMBps": 1875.0
+   },
+   "EbsOptimizedSupport": "default",
+   "EncryptionSupport": "supported",
+   "NvmeSupport": "required"
+  },
+  "FreeTierEligible": false,
+  "HibernationSupported": false,
+  "Hypervisor": "nitro",
+  "InstanceStorageInfo": {
+   "Disks": [
+    {
+     "Count": 2,
+     "SizeInGB": 1425,
+     "Type": "ssd"
+    }
+   ],
+   "NvmeSupport": "required",
+   "TotalSizeInGB": 2850
+  },
+  "InstanceStorageSupported": true,
+  "InstanceType": "m6id.12xlarge",
+  "MemoryInfo": {
+   "SizeInMiB": 196608
+  },
+  "NetworkInfo": {
+   "DefaultNetworkCardIndex": 0,
+   "EfaSupported": false,
+   "EnaSupport": "required",
+   "Ipv4AddressesPerInterface": 30,
+   "Ipv6AddressesPerInterface": 30,
+   "Ipv6Supported": true,
+   "MaximumNetworkCards": 1,
+   "MaximumNetworkInterfaces": 8,
+   "NetworkCards": [
+    {
+     "MaximumNetworkInterfaces": 8,
+     "NetworkCardIndex": 0,
+     "NetworkPerformance": "18.75 Gigabit"
+    }
+   ],
+   "NetworkPerformance": "18.75 Gigabit"
+  },
+  "PlacementGroupInfo": {
+   "SupportedStrategies": [
+    "cluster",
+    "partition",
+    "spread"
+   ]
+  },
+  "ProcessorInfo": {
+   "SupportedArchitectures": [
+    "x86_64"
+   ],
+   "SustainedClockSpeedInGhz": 3.5
+  },
+  "SupportedRootDeviceTypes": [
+   "ebs"
+  ],
+  "SupportedUsageClasses": [
+   "on-demand",
+   "spot"
+  ],
+  "SupportedVirtualizationTypes": [
+   "hvm"
+  ],
+  "VCpuInfo": {
+   "DefaultCores": 24,
+   "DefaultThreadsPerCore": 2,
+   "DefaultVCpus": 48,
+   "ValidCores": [
+    2,
+    4,
+    6,
+    8,
+    10,
+    12,
+    14,
+    16,
+    18,
+    20,
+    22,
+    24
+   ],
+   "ValidThreadsPerCore": [
+    1,
+    2
+   ]
+  }
+ },
+ "m6id.16xlarge": {
+  "AutoRecoverySupported": false,
+  "BareMetal": false,
+  "BurstablePerformanceSupported": false,
+  "CurrentGeneration": true,
+  "DedicatedHostsSupported": true,
+  "EbsInfo": {
+   "EbsOptimizedInfo": {
+    "BaselineBandwidthInMbps": 20000,
+    "BaselineIops": 80000,
+    "BaselineThroughputInMBps": 2500.0,
+    "MaximumBandwidthInMbps": 20000,
+    "MaximumIops": 80000,
+    "MaximumThroughputInMBps": 2500.0
+   },
+   "EbsOptimizedSupport": "default",
+   "EncryptionSupport": "supported",
+   "NvmeSupport": "required"
+  },
+  "FreeTierEligible": false,
+  "HibernationSupported": false,
+  "Hypervisor": "nitro",
+  "InstanceStorageInfo": {
+   "Disks": [
+    {
+     "Count": 2,
+     "SizeInGB": 1900,
+     "Type": "ssd"
+    }
+   ],
+   "NvmeSupport": "required",
+   "TotalSizeInGB": 3800
+  },
+  "InstanceStorageSupported": true,
+  "InstanceType": "m6id.16xlarge",
+  "MemoryInfo": {
+   "SizeInMiB": 262144
+  },
+  "NetworkInfo": {
+   "DefaultNetworkCardIndex": 0,
+   "EfaSupported": false,
+   "EnaSupport": "required",
+   "Ipv4AddressesPerInterface": 50,
+   "Ipv6AddressesPerInterface": 50,
+   "Ipv6Supported": true,
+   "MaximumNetworkCards": 1,
+   "MaximumNetworkInterfaces": 15,
+   "NetworkCards": [
+    {
+     "MaximumNetworkInterfaces": 15,
+     "NetworkCardIndex": 0,
+     "NetworkPerformance": "25 Gigabit"
+    }
+   ],
+   "NetworkPerformance": "25 Gigabit"
+  },
+  "PlacementGroupInfo": {
+   "SupportedStrategies": [
+    "cluster",
+    "partition",
+    "spread"
+   ]
+  },
+  "ProcessorInfo": {
+   "SupportedArchitectures": [
+    "x86_64"
+   ],
+   "SustainedClockSpeedInGhz": 3.5
+  },
+  "SupportedRootDeviceTypes": [
+   "ebs"
+  ],
+  "SupportedUsageClasses": [
+   "on-demand",
+   "spot"
+  ],
+  "SupportedVirtualizationTypes": [
+   "hvm"
+  ],
+  "VCpuInfo": {
+   "DefaultCores": 32,
+   "DefaultThreadsPerCore": 2,
+   "DefaultVCpus": 64,
+   "ValidCores": [
+    2,
+    4,
+    6,
+    8,
+    10,
+    12,
+    14,
+    16,
+    18,
+    20,
+    22,
+    24,
+    26,
+    28,
+    30,
+    32
+   ],
+   "ValidThreadsPerCore": [
+    1,
+    2
+   ]
+  }
+ },
+ "m6id.24xlarge": {
+  "AutoRecoverySupported": false,
+  "BareMetal": false,
+  "BurstablePerformanceSupported": false,
+  "CurrentGeneration": true,
+  "DedicatedHostsSupported": true,
+  "EbsInfo": {
+   "EbsOptimizedInfo": {
+    "BaselineBandwidthInMbps": 30000,
+    "BaselineIops": 120000,
+    "BaselineThroughputInMBps": 3750.0,
+    "MaximumBandwidthInMbps": 30000,
+    "MaximumIops": 120000,
+    "MaximumThroughputInMBps": 3750.0
+   },
+   "EbsOptimizedSupport": "default",
+   "EncryptionSupport": "supported",
+   "NvmeSupport": "required"
+  },
+  "FreeTierEligible": false,
+  "HibernationSupported": false,
+  "Hypervisor": "nitro",
+  "InstanceStorageInfo": {
+   "Disks": [
+    {
+     "Count": 4,
+     "SizeInGB": 1425,
+     "Type": "ssd"
+    }
+   ],
+   "NvmeSupport": "required",
+   "TotalSizeInGB": 5700
+  },
+  "InstanceStorageSupported": true,
+  "InstanceType": "m6id.24xlarge",
+  "MemoryInfo": {
+   "SizeInMiB": 393216
+  },
+  "NetworkInfo": {
+   "DefaultNetworkCardIndex": 0,
+   "EfaSupported": false,
+   "EnaSupport": "required",
+   "Ipv4AddressesPerInterface": 50,
+   "Ipv6AddressesPerInterface": 50,
+   "Ipv6Supported": true,
+   "MaximumNetworkCards": 1,
+   "MaximumNetworkInterfaces": 15,
+   "NetworkCards": [
+    {
+     "MaximumNetworkInterfaces": 15,
+     "NetworkCardIndex": 0,
+     "NetworkPerformance": "37.5 Gigabit"
+    }
+   ],
+   "NetworkPerformance": "37.5 Gigabit"
+  },
+  "PlacementGroupInfo": {
+   "SupportedStrategies": [
+    "cluster",
+    "partition",
+    "spread"
+   ]
+  },
+  "ProcessorInfo": {
+   "SupportedArchitectures": [
+    "x86_64"
+   ],
+   "SustainedClockSpeedInGhz": 3.5
+  },
+  "SupportedRootDeviceTypes": [
+   "ebs"
+  ],
+  "SupportedUsageClasses": [
+   "on-demand",
+   "spot"
+  ],
+  "SupportedVirtualizationTypes": [
+   "hvm"
+  ],
+  "VCpuInfo": {
+   "DefaultCores": 48,
+   "DefaultThreadsPerCore": 2,
+   "DefaultVCpus": 96,
+   "ValidCores": [
+    2,
+    4,
+    6,
+    8,
+    10,
+    12,
+    14,
+    16,
+    18,
+    20,
+    22,
+    24,
+    26,
+    28,
+    30,
+    32,
+    34,
+    36,
+    38,
+    40,
+    42,
+    44,
+    46,
+    48
+   ],
+   "ValidThreadsPerCore": [
+    1,
+    2
+   ]
+  }
+ },
+ "m6id.2xlarge": {
+  "AutoRecoverySupported": false,
+  "BareMetal": false,
+  "BurstablePerformanceSupported": false,
+  "CurrentGeneration": true,
+  "DedicatedHostsSupported": true,
+  "EbsInfo": {
+   "EbsOptimizedInfo": {
+    "BaselineBandwidthInMbps": 2500,
+    "BaselineIops": 12000,
+    "BaselineThroughputInMBps": 312.5,
+    "MaximumBandwidthInMbps": 10000,
+    "MaximumIops": 40000,
+    "MaximumThroughputInMBps": 1250.0
+   },
+   "EbsOptimizedSupport": "default",
+   "EncryptionSupport": "supported",
+   "NvmeSupport": "required"
+  },
+  "FreeTierEligible": false,
+  "HibernationSupported": false,
+  "Hypervisor": "nitro",
+  "InstanceStorageInfo": {
+   "Disks": [
+    {
+     "Count": 1,
+     "SizeInGB": 474,
+     "Type": "ssd"
+    }
+   ],
+   "NvmeSupport": "required",
+   "TotalSizeInGB": 474
+  },
+  "InstanceStorageSupported": true,
+  "InstanceType": "m6id.2xlarge",
+  "MemoryInfo": {
+   "SizeInMiB": 32768
+  },
+  "NetworkInfo": {
+   "DefaultNetworkCardIndex": 0,
+   "EfaSupported": false,
+   "EnaSupport": "required",
+   "Ipv4AddressesPerInterface": 15,
+   "Ipv6AddressesPerInterface": 15,
+   "Ipv6Supported": true,
+   "MaximumNetworkCards": 1,
+   "MaximumNetworkInterfaces": 4,
+   "NetworkCards": [
+    {
+     "MaximumNetworkInterfaces": 4,
+     "NetworkCardIndex": 0,
+     "NetworkPerformance": "Up to 12.5 Gigabit"
+    }
+   ],
+   "NetworkPerformance": "Up to 12.5 Gigabit"
+  },
+  "PlacementGroupInfo": {
+   "SupportedStrategies": [
+    "cluster",
+    "partition",
+    "spread"
+   ]
+  },
+  "ProcessorInfo": {
+   "SupportedArchitectures": [
+    "x86_64"
+   ],
+   "SustainedClockSpeedInGhz": 3.5
+  },
+  "SupportedRootDeviceTypes": [
+   "ebs"
+  ],
+  "SupportedUsageClasses": [
+   "on-demand",
+   "spot"
+  ],
+  "SupportedVirtualizationTypes": [
+   "hvm"
+  ],
+  "VCpuInfo": {
+   "DefaultCores": 4,
+   "DefaultThreadsPerCore": 2,
+   "DefaultVCpus": 8,
+   "ValidCores": [
+    2,
+    4
+   ],
+   "ValidThreadsPerCore": [
+    1,
+    2
+   ]
+  }
+ },
+ "m6id.32xlarge": {
+  "AutoRecoverySupported": false,
+  "BareMetal": false,
+  "BurstablePerformanceSupported": false,
+  "CurrentGeneration": true,
+  "DedicatedHostsSupported": true,
+  "EbsInfo": {
+   "EbsOptimizedInfo": {
+    "BaselineBandwidthInMbps": 40000,
+    "BaselineIops": 160000,
+    "BaselineThroughputInMBps": 5000.0,
+    "MaximumBandwidthInMbps": 40000,
+    "MaximumIops": 160000,
+    "MaximumThroughputInMBps": 5000.0
+   },
+   "EbsOptimizedSupport": "default",
+   "EncryptionSupport": "supported",
+   "NvmeSupport": "required"
+  },
+  "FreeTierEligible": false,
+  "HibernationSupported": false,
+  "Hypervisor": "nitro",
+  "InstanceStorageInfo": {
+   "Disks": [
+    {
+     "Count": 4,
+     "SizeInGB": 1900,
+     "Type": "ssd"
+    }
+   ],
+   "NvmeSupport": "required",
+   "TotalSizeInGB": 7600
+  },
+  "InstanceStorageSupported": true,
+  "InstanceType": "m6id.32xlarge",
+  "MemoryInfo": {
+   "SizeInMiB": 524288
+  },
+  "NetworkInfo": {
+   "DefaultNetworkCardIndex": 0,
+   "EfaSupported": true,
+   "EnaSupport": "required",
+   "Ipv4AddressesPerInterface": 50,
+   "Ipv6AddressesPerInterface": 50,
+   "Ipv6Supported": true,
+   "MaximumNetworkCards": 1,
+   "MaximumNetworkInterfaces": 15,
+   "NetworkCards": [
+    {
+     "MaximumNetworkInterfaces": 15,
+     "NetworkCardIndex": 0,
+     "NetworkPerformance": "50 Gigabit"
+    }
+   ],
+   "NetworkPerformance": "50 Gigabit"
+  },
+  "PlacementGroupInfo": {
+   "SupportedStrategies": [
+    "cluster",
+    "partition",
+    "spread"
+   ]
+  },
+  "ProcessorInfo": {
+   "SupportedArchitectures": [
+    "x86_64"
+   ],
+   "SustainedClockSpeedInGhz": 3.5
+  },
+  "SupportedRootDeviceTypes": [
+   "ebs"
+  ],
+  "SupportedUsageClasses": [
+   "on-demand",
+   "spot"
+  ],
+  "SupportedVirtualizationTypes": [
+   "hvm"
+  ],
+  "VCpuInfo": {
+   "DefaultCores": 64,
+   "DefaultThreadsPerCore": 2,
+   "DefaultVCpus": 128,
+   "ValidCores": [
+    2,
+    4,
+    6,
+    8,
+    10,
+    12,
+    14,
+    16,
+    18,
+    20,
+    22,
+    24,
+    26,
+    28,
+    30,
+    32,
+    34,
+    36,
+    38,
+    40,
+    42,
+    44,
+    46,
+    48,
+    50,
+    52,
+    54,
+    56,
+    58,
+    60,
+    62,
+    64
+   ],
+   "ValidThreadsPerCore": [
+    1,
+    2
+   ]
+  }
+ },
+ "m6id.4xlarge": {
+  "AutoRecoverySupported": false,
+  "BareMetal": false,
+  "BurstablePerformanceSupported": false,
+  "CurrentGeneration": true,
+  "DedicatedHostsSupported": true,
+  "EbsInfo": {
+   "EbsOptimizedInfo": {
+    "BaselineBandwidthInMbps": 5000,
+    "BaselineIops": 20000,
+    "BaselineThroughputInMBps": 625.0,
+    "MaximumBandwidthInMbps": 10000,
+    "MaximumIops": 40000,
+    "MaximumThroughputInMBps": 1250.0
+   },
+   "EbsOptimizedSupport": "default",
+   "EncryptionSupport": "supported",
+   "NvmeSupport": "required"
+  },
+  "FreeTierEligible": false,
+  "HibernationSupported": false,
+  "Hypervisor": "nitro",
+  "InstanceStorageInfo": {
+   "Disks": [
+    {
+     "Count": 1,
+     "SizeInGB": 950,
+     "Type": "ssd"
+    }
+   ],
+   "NvmeSupport": "required",
+   "TotalSizeInGB": 950
+  },
+  "InstanceStorageSupported": true,
+  "InstanceType": "m6id.4xlarge",
+  "MemoryInfo": {
+   "SizeInMiB": 65536
+  },
+  "NetworkInfo": {
+   "DefaultNetworkCardIndex": 0,
+   "EfaSupported": false,
+   "EnaSupport": "required",
+   "Ipv4AddressesPerInterface": 30,
+   "Ipv6AddressesPerInterface": 30,
+   "Ipv6Supported": true,
+   "MaximumNetworkCards": 1,
+   "MaximumNetworkInterfaces": 8,
+   "NetworkCards": [
+    {
+     "MaximumNetworkInterfaces": 8,
+     "NetworkCardIndex": 0,
+     "NetworkPerformance": "Up to 12.5 Gigabit"
+    }
+   ],
+   "NetworkPerformance": "Up to 12.5 Gigabit"
+  },
+  "PlacementGroupInfo": {
+   "SupportedStrategies": [
+    "cluster",
+    "partition",
+    "spread"
+   ]
+  },
+  "ProcessorInfo": {
+   "SupportedArchitectures": [
+    "x86_64"
+   ],
+   "SustainedClockSpeedInGhz": 3.5
+  },
+  "SupportedRootDeviceTypes": [
+   "ebs"
+  ],
+  "SupportedUsageClasses": [
+   "on-demand",
+   "spot"
+  ],
+  "SupportedVirtualizationTypes": [
+   "hvm"
+  ],
+  "VCpuInfo": {
+   "DefaultCores": 8,
+   "DefaultThreadsPerCore": 2,
+   "DefaultVCpus": 16,
+   "ValidCores": [
+    2,
+    4,
+    6,
+    8
+   ],
+   "ValidThreadsPerCore": [
+    1,
+    2
+   ]
+  }
+ },
+ "m6id.8xlarge": {
+  "AutoRecoverySupported": false,
+  "BareMetal": false,
+  "BurstablePerformanceSupported": false,
+  "CurrentGeneration": true,
+  "DedicatedHostsSupported": true,
+  "EbsInfo": {
+   "EbsOptimizedInfo": {
+    "BaselineBandwidthInMbps": 10000,
+    "BaselineIops": 40000,
+    "BaselineThroughputInMBps": 1250.0,
+    "MaximumBandwidthInMbps": 10000,
+    "MaximumIops": 40000,
+    "MaximumThroughputInMBps": 1250.0
+   },
+   "EbsOptimizedSupport": "default",
+   "EncryptionSupport": "supported",
+   "NvmeSupport": "required"
+  },
+  "FreeTierEligible": false,
+  "HibernationSupported": false,
+  "Hypervisor": "nitro",
+  "InstanceStorageInfo": {
+   "Disks": [
+    {
+     "Count": 1,
+     "SizeInGB": 1900,
+     "Type": "ssd"
+    }
+   ],
+   "NvmeSupport": "required",
+   "TotalSizeInGB": 1900
+  },
+  "InstanceStorageSupported": true,
+  "InstanceType": "m6id.8xlarge",
+  "MemoryInfo": {
+   "SizeInMiB": 131072
+  },
+  "NetworkInfo": {
+   "DefaultNetworkCardIndex": 0,
+   "EfaSupported": false,
+   "EnaSupport": "required",
+   "Ipv4AddressesPerInterface": 30,
+   "Ipv6AddressesPerInterface": 30,
+   "Ipv6Supported": true,
+   "MaximumNetworkCards": 1,
+   "MaximumNetworkInterfaces": 8,
+   "NetworkCards": [
+    {
+     "MaximumNetworkInterfaces": 8,
+     "NetworkCardIndex": 0,
+     "NetworkPerformance": "12.5 Gigabit"
+    }
+   ],
+   "NetworkPerformance": "12.5 Gigabit"
+  },
+  "PlacementGroupInfo": {
+   "SupportedStrategies": [
+    "cluster",
+    "partition",
+    "spread"
+   ]
+  },
+  "ProcessorInfo": {
+   "SupportedArchitectures": [
+    "x86_64"
+   ],
+   "SustainedClockSpeedInGhz": 3.5
+  },
+  "SupportedRootDeviceTypes": [
+   "ebs"
+  ],
+  "SupportedUsageClasses": [
+   "on-demand",
+   "spot"
+  ],
+  "SupportedVirtualizationTypes": [
+   "hvm"
+  ],
+  "VCpuInfo": {
+   "DefaultCores": 16,
+   "DefaultThreadsPerCore": 2,
+   "DefaultVCpus": 32,
+   "ValidCores": [
+    2,
+    4,
+    6,
+    8,
+    10,
+    12,
+    14,
+    16
+   ],
+   "ValidThreadsPerCore": [
+    1,
+    2
+   ]
+  }
+ },
+ "m6id.large": {
+  "AutoRecoverySupported": false,
+  "BareMetal": false,
+  "BurstablePerformanceSupported": false,
+  "CurrentGeneration": true,
+  "DedicatedHostsSupported": true,
+  "EbsInfo": {
+   "EbsOptimizedInfo": {
+    "BaselineBandwidthInMbps": 650,
+    "BaselineIops": 3600,
+    "BaselineThroughputInMBps": 81.25,
+    "MaximumBandwidthInMbps": 10000,
+    "MaximumIops": 40000,
+    "MaximumThroughputInMBps": 1250.0
+   },
+   "EbsOptimizedSupport": "default",
+   "EncryptionSupport": "supported",
+   "NvmeSupport": "required"
+  },
+  "FreeTierEligible": false,
+  "HibernationSupported": false,
+  "Hypervisor": "nitro",
+  "InstanceStorageInfo": {
+   "Disks": [
+    {
+     "Count": 1,
+     "SizeInGB": 118,
+     "Type": "ssd"
+    }
+   ],
+   "NvmeSupport": "required",
+   "TotalSizeInGB": 118
+  },
+  "InstanceStorageSupported": true,
+  "InstanceType": "m6id.large",
+  "MemoryInfo": {
+   "SizeInMiB": 8192
+  },
+  "NetworkInfo": {
+   "DefaultNetworkCardIndex": 0,
+   "EfaSupported": false,
+   "EnaSupport": "required",
+   "Ipv4AddressesPerInterface": 10,
+   "Ipv6AddressesPerInterface": 10,
+   "Ipv6Supported": true,
+   "MaximumNetworkCards": 1,
+   "MaximumNetworkInterfaces": 3,
+   "NetworkCards": [
+    {
+     "MaximumNetworkInterfaces": 3,
+     "NetworkCardIndex": 0,
+     "NetworkPerformance": "Up to 12.5 Gigabit"
+    }
+   ],
+   "NetworkPerformance": "Up to 12.5 Gigabit"
+  },
+  "PlacementGroupInfo": {
+   "SupportedStrategies": [
+    "cluster",
+    "partition",
+    "spread"
+   ]
+  },
+  "ProcessorInfo": {
+   "SupportedArchitectures": [
+    "x86_64"
+   ],
+   "SustainedClockSpeedInGhz": 3.5
+  },
+  "SupportedRootDeviceTypes": [
+   "ebs"
+  ],
+  "SupportedUsageClasses": [
+   "on-demand",
+   "spot"
+  ],
+  "SupportedVirtualizationTypes": [
+   "hvm"
+  ],
+  "VCpuInfo": {
+   "DefaultCores": 1,
+   "DefaultThreadsPerCore": 2,
+   "DefaultVCpus": 2,
+   "ValidCores": [
+    1
+   ],
+   "ValidThreadsPerCore": [
+    1,
+    2
+   ]
+  }
+ },
+ "m6id.metal": {
+  "AutoRecoverySupported": false,
+  "BareMetal": true,
+  "BurstablePerformanceSupported": false,
+  "CurrentGeneration": true,
+  "DedicatedHostsSupported": true,
+  "EbsInfo": {
+   "EbsOptimizedInfo": {
+    "BaselineBandwidthInMbps": 40000,
+    "BaselineIops": 160000,
+    "BaselineThroughputInMBps": 5000.0,
+    "MaximumBandwidthInMbps": 40000,
+    "MaximumIops": 160000,
+    "MaximumThroughputInMBps": 5000.0
+   },
+   "EbsOptimizedSupport": "default",
+   "EncryptionSupport": "supported",
+   "NvmeSupport": "required"
+  },
+  "FreeTierEligible": false,
+  "HibernationSupported": false,
+  "InstanceStorageInfo": {
+   "Disks": [
+    {
+     "Count": 4,
+     "SizeInGB": 1900,
+     "Type": "ssd"
+    }
+   ],
+   "NvmeSupport": "required",
+   "TotalSizeInGB": 7600
+  },
+  "InstanceStorageSupported": true,
+  "InstanceType": "m6id.metal",
+  "MemoryInfo": {
+   "SizeInMiB": 524288
+  },
+  "NetworkInfo": {
+   "DefaultNetworkCardIndex": 0,
+   "EfaSupported": true,
+   "EnaSupport": "required",
+   "Ipv4AddressesPerInterface": 50,
+   "Ipv6AddressesPerInterface": 50,
+   "Ipv6Supported": true,
+   "MaximumNetworkCards": 1,
+   "MaximumNetworkInterfaces": 15,
+   "NetworkCards": [
+    {
+     "MaximumNetworkInterfaces": 15,
+     "NetworkCardIndex": 0,
+     "NetworkPerformance": "50 Gigabit"
+    }
+   ],
+   "NetworkPerformance": "50 Gigabit"
+  },
+  "PlacementGroupInfo": {
+   "SupportedStrategies": [
+    "cluster",
+    "partition",
+    "spread"
+   ]
+  },
+  "ProcessorInfo": {
+   "SupportedArchitectures": [
+    "x86_64"
+   ],
+   "SustainedClockSpeedInGhz": 3.5
+  },
+  "SupportedRootDeviceTypes": [
+   "ebs"
+  ],
+  "SupportedUsageClasses": [
+   "on-demand",
+   "spot"
+  ],
+  "SupportedVirtualizationTypes": [
+   "hvm"
+  ],
+  "VCpuInfo": {
+   "DefaultCores": 64,
+   "DefaultThreadsPerCore": 2,
+   "DefaultVCpus": 128
+  }
+ },
+ "m6id.xlarge": {
+  "AutoRecoverySupported": false,
+  "BareMetal": false,
+  "BurstablePerformanceSupported": false,
+  "CurrentGeneration": true,
+  "DedicatedHostsSupported": true,
+  "EbsInfo": {
+   "EbsOptimizedInfo": {
+    "BaselineBandwidthInMbps": 1250,
+    "BaselineIops": 6000,
+    "BaselineThroughputInMBps": 156.25,
+    "MaximumBandwidthInMbps": 10000,
+    "MaximumIops": 40000,
+    "MaximumThroughputInMBps": 1250.0
+   },
+   "EbsOptimizedSupport": "default",
+   "EncryptionSupport": "supported",
+   "NvmeSupport": "required"
+  },
+  "FreeTierEligible": false,
+  "HibernationSupported": false,
+  "Hypervisor": "nitro",
+  "InstanceStorageInfo": {
+   "Disks": [
+    {
+     "Count": 1,
+     "SizeInGB": 237,
+     "Type": "ssd"
+    }
+   ],
+   "NvmeSupport": "required",
+   "TotalSizeInGB": 237
+  },
+  "InstanceStorageSupported": true,
+  "InstanceType": "m6id.xlarge",
+  "MemoryInfo": {
+   "SizeInMiB": 16384
+  },
+  "NetworkInfo": {
+   "DefaultNetworkCardIndex": 0,
+   "EfaSupported": false,
+   "EnaSupport": "required",
+   "Ipv4AddressesPerInterface": 15,
+   "Ipv6AddressesPerInterface": 15,
+   "Ipv6Supported": true,
+   "MaximumNetworkCards": 1,
+   "MaximumNetworkInterfaces": 4,
+   "NetworkCards": [
+    {
+     "MaximumNetworkInterfaces": 4,
+     "NetworkCardIndex": 0,
+     "NetworkPerformance": "Up to 12.5 Gigabit"
+    }
+   ],
+   "NetworkPerformance": "Up to 12.5 Gigabit"
+  },
+  "PlacementGroupInfo": {
+   "SupportedStrategies": [
+    "cluster",
+    "partition",
+    "spread"
+   ]
+  },
+  "ProcessorInfo": {
+   "SupportedArchitectures": [
+    "x86_64"
+   ],
+   "SustainedClockSpeedInGhz": 3.5
+  },
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -30070,7 +33100,7 @@
   }
  },
  "mac1.metal": {
-  "AutoRecoverySupported": true,
+  "AutoRecoverySupported": false,
   "BareMetal": true,
   "BurstablePerformanceSupported": false,
   "CurrentGeneration": true,
@@ -30099,7 +33129,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 30,
    "Ipv6AddressesPerInterface": 30,
    "Ipv6Supported": true,
@@ -30116,7 +33145,6 @@
   },
   "PlacementGroupInfo": {
    "SupportedStrategies": [
-    "cluster",
     "partition",
     "spread"
    ]
@@ -30127,9 +33155,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.2
   },
-  "SupportedBootModes": [
-   "legacy-bios"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -30143,6 +33168,77 @@
    "DefaultCores": 6,
    "DefaultThreadsPerCore": 2,
    "DefaultVCpus": 12
+  }
+ },
+ "mac2.metal": {
+  "AutoRecoverySupported": false,
+  "BareMetal": true,
+  "BurstablePerformanceSupported": false,
+  "CurrentGeneration": true,
+  "DedicatedHostsSupported": true,
+  "EbsInfo": {
+   "EbsOptimizedInfo": {
+    "BaselineBandwidthInMbps": 10000,
+    "BaselineIops": 55000,
+    "BaselineThroughputInMBps": 1250.0,
+    "MaximumBandwidthInMbps": 10000,
+    "MaximumIops": 55000,
+    "MaximumThroughputInMBps": 1250.0
+   },
+   "EbsOptimizedSupport": "default",
+   "EncryptionSupport": "supported",
+   "NvmeSupport": "required"
+  },
+  "FreeTierEligible": false,
+  "HibernationSupported": false,
+  "InstanceStorageSupported": false,
+  "InstanceType": "mac2.metal",
+  "MemoryInfo": {
+   "SizeInMiB": 16384
+  },
+  "NetworkInfo": {
+   "DefaultNetworkCardIndex": 0,
+   "EfaSupported": false,
+   "EnaSupport": "required",
+   "Ipv4AddressesPerInterface": 30,
+   "Ipv6AddressesPerInterface": 30,
+   "Ipv6Supported": true,
+   "MaximumNetworkCards": 1,
+   "MaximumNetworkInterfaces": 8,
+   "NetworkCards": [
+    {
+     "MaximumNetworkInterfaces": 8,
+     "NetworkCardIndex": 0,
+     "NetworkPerformance": "10 Gigabit"
+    }
+   ],
+   "NetworkPerformance": "10 Gigabit"
+  },
+  "PlacementGroupInfo": {
+   "SupportedStrategies": [
+    "partition",
+    "spread"
+   ]
+  },
+  "ProcessorInfo": {
+   "SupportedArchitectures": [
+    "arm64_mac"
+   ],
+   "SustainedClockSpeedInGhz": 3.2
+  },
+  "SupportedRootDeviceTypes": [
+   "ebs"
+  ],
+  "SupportedUsageClasses": [
+   "on-demand"
+  ],
+  "SupportedVirtualizationTypes": [
+   "hvm"
+  ],
+  "VCpuInfo": {
+   "DefaultCores": 4,
+   "DefaultThreadsPerCore": 2,
+   "DefaultVCpus": 8
   }
  },
  "p2.16xlarge": {
@@ -30189,7 +33285,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "supported",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 30,
    "Ipv6AddressesPerInterface": 30,
    "Ipv6Supported": true,
@@ -30217,9 +33312,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.3
   },
-  "SupportedBootModes": [
-   "legacy-bios"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -30302,7 +33394,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "supported",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 30,
    "Ipv6AddressesPerInterface": 30,
    "Ipv6Supported": true,
@@ -30330,9 +33421,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.7
   },
-  "SupportedBootModes": [
-   "legacy-bios"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -30415,7 +33503,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "supported",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 15,
    "Ipv6AddressesPerInterface": 15,
    "Ipv6Supported": true,
@@ -30443,9 +33530,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.7
   },
-  "SupportedBootModes": [
-   "legacy-bios"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -30514,7 +33598,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "supported",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 30,
    "Ipv6AddressesPerInterface": 30,
    "Ipv6Supported": true,
@@ -30542,9 +33625,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.7
   },
-  "SupportedBootModes": [
-   "legacy-bios"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -30627,7 +33707,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "supported",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 15,
    "Ipv6AddressesPerInterface": 15,
    "Ipv6Supported": true,
@@ -30655,9 +33734,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.7
   },
-  "SupportedBootModes": [
-   "legacy-bios"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -30728,7 +33804,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "supported",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 30,
    "Ipv6AddressesPerInterface": 30,
    "Ipv6Supported": true,
@@ -30756,9 +33831,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.7
   },
-  "SupportedBootModes": [
-   "legacy-bios"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -30840,7 +33912,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "required",
    "NvmeSupport": "required",
    "TotalSizeInGB": 1800
   },
@@ -30851,12 +33922,8 @@
   },
   "NetworkInfo": {
    "DefaultNetworkCardIndex": 0,
-   "EfaInfo": {
-    "MaximumEfaInterfaces": 1
-   },
    "EfaSupported": true,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": true,
    "Ipv4AddressesPerInterface": 50,
    "Ipv6AddressesPerInterface": 50,
    "Ipv6Supported": true,
@@ -30884,10 +33951,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.5
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -30976,7 +34039,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "required",
    "NvmeSupport": "required",
    "TotalSizeInGB": 8000
   },
@@ -30987,12 +34049,8 @@
   },
   "NetworkInfo": {
    "DefaultNetworkCardIndex": 0,
-   "EfaInfo": {
-    "MaximumEfaInterfaces": 4
-   },
    "EfaSupported": true,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": true,
    "Ipv4AddressesPerInterface": 50,
    "Ipv6AddressesPerInterface": 50,
    "Ipv6Supported": true,
@@ -31035,9 +34093,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.0
   },
-  "SupportedBootModes": [
-   "legacy-bios"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -31114,7 +34169,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "unsupported",
    "NvmeSupport": "unsupported",
    "TotalSizeInGB": 160
   },
@@ -31127,7 +34181,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "unsupported",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 15,
    "Ipv6AddressesPerInterface": 15,
    "Ipv6Supported": true,
@@ -31155,9 +34208,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.5
   },
-  "SupportedBootModes": [
-   "legacy-bios"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs",
    "instance-store"
@@ -31215,7 +34265,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "unsupported",
    "NvmeSupport": "unsupported",
    "TotalSizeInGB": 320
   },
@@ -31228,7 +34277,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "unsupported",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 30,
    "Ipv6AddressesPerInterface": 30,
    "Ipv6Supported": true,
@@ -31256,9 +34304,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.5
   },
-  "SupportedBootModes": [
-   "legacy-bios"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs",
    "instance-store"
@@ -31312,7 +34357,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "unsupported",
    "NvmeSupport": "unsupported",
    "TotalSizeInGB": 640
   },
@@ -31325,7 +34369,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "unsupported",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 30,
    "Ipv6AddressesPerInterface": 30,
    "Ipv6Supported": true,
@@ -31353,9 +34396,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.5
   },
-  "SupportedBootModes": [
-   "legacy-bios"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs",
    "instance-store"
@@ -31409,7 +34449,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "unsupported",
    "NvmeSupport": "unsupported",
    "TotalSizeInGB": 32
   },
@@ -31422,7 +34461,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "unsupported",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 10,
    "Ipv6AddressesPerInterface": 10,
    "Ipv6Supported": true,
@@ -31450,9 +34488,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.5
   },
-  "SupportedBootModes": [
-   "legacy-bios"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs",
    "instance-store"
@@ -31507,7 +34542,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "unsupported",
    "NvmeSupport": "unsupported",
    "TotalSizeInGB": 80
   },
@@ -31520,7 +34554,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "unsupported",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 15,
    "Ipv6AddressesPerInterface": 15,
    "Ipv6Supported": true,
@@ -31548,9 +34581,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.5
   },
-  "SupportedBootModes": [
-   "legacy-bios"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs",
    "instance-store"
@@ -31607,7 +34637,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "supported",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 50,
    "Ipv6AddressesPerInterface": 50,
    "Ipv6Supported": true,
@@ -31635,9 +34664,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.3
   },
-  "SupportedBootModes": [
-   "legacy-bios"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -31707,7 +34733,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "supported",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 15,
    "Ipv6AddressesPerInterface": 15,
    "Ipv6Supported": true,
@@ -31735,9 +34760,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.3
   },
-  "SupportedBootModes": [
-   "legacy-bios"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -31795,7 +34817,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "supported",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 30,
    "Ipv6AddressesPerInterface": 30,
    "Ipv6Supported": true,
@@ -31823,9 +34844,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.3
   },
-  "SupportedBootModes": [
-   "legacy-bios"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -31887,7 +34905,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "supported",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 30,
    "Ipv6AddressesPerInterface": 30,
    "Ipv6Supported": true,
@@ -31915,9 +34932,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.3
   },
-  "SupportedBootModes": [
-   "legacy-bios"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -31987,7 +35001,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "supported",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 10,
    "Ipv6AddressesPerInterface": 10,
    "Ipv6Supported": true,
@@ -32015,9 +35028,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.3
   },
-  "SupportedBootModes": [
-   "legacy-bios"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -32072,7 +35082,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "supported",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 15,
    "Ipv6AddressesPerInterface": 15,
    "Ipv6Supported": true,
@@ -32100,9 +35109,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.3
   },
-  "SupportedBootModes": [
-   "legacy-bios"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -32158,7 +35164,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 30,
    "Ipv6AddressesPerInterface": 30,
    "Ipv6Supported": true,
@@ -32186,10 +35191,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.1
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -32255,7 +35256,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 50,
    "Ipv6AddressesPerInterface": 50,
    "Ipv6Supported": true,
@@ -32283,10 +35283,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.1
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -32356,7 +35352,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 50,
    "Ipv6AddressesPerInterface": 50,
    "Ipv6Supported": true,
@@ -32384,10 +35379,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.1
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -32464,7 +35455,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 15,
    "Ipv6AddressesPerInterface": 15,
    "Ipv6Supported": true,
@@ -32492,10 +35482,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.1
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -32551,7 +35537,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 30,
    "Ipv6AddressesPerInterface": 30,
    "Ipv6Supported": true,
@@ -32579,10 +35564,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.1
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -32640,7 +35621,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 30,
    "Ipv6AddressesPerInterface": 30,
    "Ipv6Supported": true,
@@ -32668,10 +35648,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.1
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -32733,7 +35709,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 10,
    "Ipv6AddressesPerInterface": 10,
    "Ipv6Supported": true,
@@ -32761,10 +35736,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.1
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -32818,7 +35789,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 50,
    "Ipv6AddressesPerInterface": 50,
    "Ipv6Supported": true,
@@ -32846,9 +35816,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.1
   },
-  "SupportedBootModes": [
-   "legacy-bios"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -32896,7 +35863,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 15,
    "Ipv6AddressesPerInterface": 15,
    "Ipv6Supported": true,
@@ -32924,10 +35890,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.1
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -32982,7 +35944,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 30,
    "Ipv6AddressesPerInterface": 30,
    "Ipv6Supported": true,
@@ -33010,10 +35971,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.5
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -33071,7 +36028,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 50,
    "Ipv6AddressesPerInterface": 50,
    "Ipv6Supported": true,
@@ -33099,10 +36055,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.5
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -33169,7 +36121,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 50,
    "Ipv6AddressesPerInterface": 50,
    "Ipv6Supported": true,
@@ -33197,10 +36148,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.5
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -33259,7 +36206,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 15,
    "Ipv6AddressesPerInterface": 15,
    "Ipv6Supported": true,
@@ -33287,10 +36233,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.5
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -33346,7 +36288,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 30,
    "Ipv6AddressesPerInterface": 30,
    "Ipv6Supported": true,
@@ -33374,10 +36315,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.5
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -33435,7 +36372,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 30,
    "Ipv6AddressesPerInterface": 30,
    "Ipv6Supported": true,
@@ -33463,10 +36399,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.5
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -33527,7 +36459,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 10,
    "Ipv6AddressesPerInterface": 10,
    "Ipv6Supported": true,
@@ -33555,10 +36486,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.5
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -33613,7 +36540,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 15,
    "Ipv6AddressesPerInterface": 15,
    "Ipv6Supported": true,
@@ -33641,10 +36567,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.5
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -33698,7 +36620,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "required",
    "NvmeSupport": "required",
    "TotalSizeInGB": 1800
   },
@@ -33711,7 +36632,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 30,
    "Ipv6AddressesPerInterface": 30,
    "Ipv6Supported": true,
@@ -33739,10 +36659,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.2
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -33799,7 +36715,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "required",
    "NvmeSupport": "required",
    "TotalSizeInGB": 2400
   },
@@ -33812,7 +36727,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 50,
    "Ipv6AddressesPerInterface": 50,
    "Ipv6Supported": true,
@@ -33840,10 +36754,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.5
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -33909,7 +36819,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "required",
    "NvmeSupport": "required",
    "TotalSizeInGB": 3600
   },
@@ -33922,7 +36831,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 50,
    "Ipv6AddressesPerInterface": 50,
    "Ipv6Supported": true,
@@ -33950,10 +36858,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.2
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -34011,7 +36915,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "required",
    "NvmeSupport": "required",
    "TotalSizeInGB": 300
   },
@@ -34024,7 +36927,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 15,
    "Ipv6AddressesPerInterface": 15,
    "Ipv6Supported": true,
@@ -34052,10 +36954,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.2
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -34110,7 +37008,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "required",
    "NvmeSupport": "required",
    "TotalSizeInGB": 600
   },
@@ -34123,7 +37020,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 30,
    "Ipv6AddressesPerInterface": 30,
    "Ipv6Supported": true,
@@ -34151,10 +37047,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.2
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -34211,7 +37103,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "required",
    "NvmeSupport": "required",
    "TotalSizeInGB": 1200
   },
@@ -34224,7 +37115,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 30,
    "Ipv6AddressesPerInterface": 30,
    "Ipv6Supported": true,
@@ -34252,10 +37142,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.5
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -34315,7 +37201,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "required",
    "NvmeSupport": "required",
    "TotalSizeInGB": 75
   },
@@ -34328,7 +37213,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 10,
    "Ipv6AddressesPerInterface": 10,
    "Ipv6Supported": true,
@@ -34356,10 +37240,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.2
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -34413,7 +37293,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "required",
    "NvmeSupport": "required",
    "TotalSizeInGB": 150
   },
@@ -34426,7 +37305,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 15,
    "Ipv6AddressesPerInterface": 15,
    "Ipv6Supported": true,
@@ -34454,10 +37332,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.2
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -34482,7 +37356,7 @@
   }
  },
  "r5b.12xlarge": {
-  "AutoRecoverySupported": false,
+  "AutoRecoverySupported": true,
   "BareMetal": false,
   "BurstablePerformanceSupported": false,
   "CurrentGeneration": true,
@@ -34512,7 +37386,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 30,
    "Ipv6AddressesPerInterface": 30,
    "Ipv6Supported": true,
@@ -34540,10 +37413,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.1
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -34579,7 +37448,7 @@
   }
  },
  "r5b.16xlarge": {
-  "AutoRecoverySupported": false,
+  "AutoRecoverySupported": true,
   "BareMetal": false,
   "BurstablePerformanceSupported": false,
   "CurrentGeneration": true,
@@ -34609,7 +37478,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 50,
    "Ipv6AddressesPerInterface": 50,
    "Ipv6Supported": true,
@@ -34637,10 +37505,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.1
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -34680,7 +37544,7 @@
   }
  },
  "r5b.24xlarge": {
-  "AutoRecoverySupported": false,
+  "AutoRecoverySupported": true,
   "BareMetal": false,
   "BurstablePerformanceSupported": false,
   "CurrentGeneration": true,
@@ -34710,7 +37574,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 50,
    "Ipv6AddressesPerInterface": 50,
    "Ipv6Supported": true,
@@ -34738,10 +37601,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.1
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -34789,7 +37648,7 @@
   }
  },
  "r5b.2xlarge": {
-  "AutoRecoverySupported": false,
+  "AutoRecoverySupported": true,
   "BareMetal": false,
   "BurstablePerformanceSupported": false,
   "CurrentGeneration": true,
@@ -34819,7 +37678,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 15,
    "Ipv6AddressesPerInterface": 15,
    "Ipv6Supported": true,
@@ -34847,10 +37705,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.1
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -34876,7 +37730,7 @@
   }
  },
  "r5b.4xlarge": {
-  "AutoRecoverySupported": false,
+  "AutoRecoverySupported": true,
   "BareMetal": false,
   "BurstablePerformanceSupported": false,
   "CurrentGeneration": true,
@@ -34906,7 +37760,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 30,
    "Ipv6AddressesPerInterface": 30,
    "Ipv6Supported": true,
@@ -34934,10 +37787,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.1
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -34965,7 +37814,7 @@
   }
  },
  "r5b.8xlarge": {
-  "AutoRecoverySupported": false,
+  "AutoRecoverySupported": true,
   "BareMetal": false,
   "BurstablePerformanceSupported": false,
   "CurrentGeneration": true,
@@ -34995,7 +37844,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 30,
    "Ipv6AddressesPerInterface": 30,
    "Ipv6Supported": true,
@@ -35023,10 +37871,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.1
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -35058,7 +37902,7 @@
   }
  },
  "r5b.large": {
-  "AutoRecoverySupported": false,
+  "AutoRecoverySupported": true,
   "BareMetal": false,
   "BurstablePerformanceSupported": false,
   "CurrentGeneration": true,
@@ -35088,7 +37932,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 10,
    "Ipv6AddressesPerInterface": 10,
    "Ipv6Supported": true,
@@ -35116,10 +37959,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.1
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -35144,7 +37983,7 @@
   }
  },
  "r5b.metal": {
-  "AutoRecoverySupported": false,
+  "AutoRecoverySupported": true,
   "BareMetal": true,
   "BurstablePerformanceSupported": false,
   "CurrentGeneration": true,
@@ -35173,7 +38012,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 50,
    "Ipv6AddressesPerInterface": 50,
    "Ipv6Supported": true,
@@ -35201,9 +38039,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.1
   },
-  "SupportedBootModes": [
-   "legacy-bios"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -35221,7 +38056,7 @@
   }
  },
  "r5b.xlarge": {
-  "AutoRecoverySupported": false,
+  "AutoRecoverySupported": true,
   "BareMetal": false,
   "BurstablePerformanceSupported": false,
   "CurrentGeneration": true,
@@ -35251,7 +38086,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 15,
    "Ipv6AddressesPerInterface": 15,
    "Ipv6Supported": true,
@@ -35279,10 +38113,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.1
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -35337,7 +38167,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "required",
    "NvmeSupport": "required",
    "TotalSizeInGB": 1800
   },
@@ -35350,7 +38179,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 30,
    "Ipv6AddressesPerInterface": 30,
    "Ipv6Supported": true,
@@ -35378,10 +38206,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.1
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -35446,7 +38270,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "required",
    "NvmeSupport": "required",
    "TotalSizeInGB": 2400
   },
@@ -35459,7 +38282,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 50,
    "Ipv6AddressesPerInterface": 50,
    "Ipv6Supported": true,
@@ -35487,10 +38309,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.1
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -35559,7 +38377,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "required",
    "NvmeSupport": "required",
    "TotalSizeInGB": 3600
   },
@@ -35572,7 +38389,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 50,
    "Ipv6AddressesPerInterface": 50,
    "Ipv6Supported": true,
@@ -35600,10 +38416,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.1
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -35679,7 +38491,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "required",
    "NvmeSupport": "required",
    "TotalSizeInGB": 300
   },
@@ -35692,7 +38503,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 15,
    "Ipv6AddressesPerInterface": 15,
    "Ipv6Supported": true,
@@ -35720,10 +38530,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.1
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -35778,7 +38584,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "required",
    "NvmeSupport": "required",
    "TotalSizeInGB": 600
   },
@@ -35791,7 +38596,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 30,
    "Ipv6AddressesPerInterface": 30,
    "Ipv6Supported": true,
@@ -35819,10 +38623,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.1
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -35879,7 +38679,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "required",
    "NvmeSupport": "required",
    "TotalSizeInGB": 1200
   },
@@ -35892,7 +38691,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 30,
    "Ipv6AddressesPerInterface": 30,
    "Ipv6Supported": true,
@@ -35920,10 +38718,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.1
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -35984,7 +38778,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "required",
    "NvmeSupport": "required",
    "TotalSizeInGB": 75
   },
@@ -35997,7 +38790,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 10,
    "Ipv6AddressesPerInterface": 10,
    "Ipv6Supported": true,
@@ -36025,10 +38817,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.1
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -36081,7 +38869,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "required",
    "NvmeSupport": "required",
    "TotalSizeInGB": 3600
   },
@@ -36094,7 +38881,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 50,
    "Ipv6AddressesPerInterface": 50,
    "Ipv6Supported": true,
@@ -36122,9 +38908,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.1
   },
-  "SupportedBootModes": [
-   "legacy-bios"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -36171,7 +38954,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "required",
    "NvmeSupport": "required",
    "TotalSizeInGB": 150
   },
@@ -36184,7 +38966,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 15,
    "Ipv6AddressesPerInterface": 15,
    "Ipv6Supported": true,
@@ -36212,10 +38993,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.1
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -36269,7 +39046,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "required",
    "NvmeSupport": "required",
    "TotalSizeInGB": 1800
   },
@@ -36282,7 +39058,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": true,
    "Ipv4AddressesPerInterface": 30,
    "Ipv6AddressesPerInterface": 30,
    "Ipv6Supported": true,
@@ -36310,10 +39085,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.1
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -36378,7 +39149,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "required",
    "NvmeSupport": "required",
    "TotalSizeInGB": 2400
   },
@@ -36391,7 +39161,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": true,
    "Ipv4AddressesPerInterface": 50,
    "Ipv6AddressesPerInterface": 50,
    "Ipv6Supported": true,
@@ -36419,10 +39188,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.1
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -36491,7 +39256,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "required",
    "NvmeSupport": "required",
    "TotalSizeInGB": 3600
   },
@@ -36502,12 +39266,8 @@
   },
   "NetworkInfo": {
    "DefaultNetworkCardIndex": 0,
-   "EfaInfo": {
-    "MaximumEfaInterfaces": 1
-   },
    "EfaSupported": true,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": true,
    "Ipv4AddressesPerInterface": 50,
    "Ipv6AddressesPerInterface": 50,
    "Ipv6Supported": true,
@@ -36535,10 +39295,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.1
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -36597,7 +39353,7 @@
     "BaselineIops": 12000,
     "BaselineThroughputInMBps": 287.5,
     "MaximumBandwidthInMbps": 4750,
-    "MaximumIops": 15000,
+    "MaximumIops": 18750,
     "MaximumThroughputInMBps": 593.75
    },
    "EbsOptimizedSupport": "default",
@@ -36615,7 +39371,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "required",
    "NvmeSupport": "required",
    "TotalSizeInGB": 300
   },
@@ -36628,7 +39383,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": true,
    "Ipv4AddressesPerInterface": 15,
    "Ipv6AddressesPerInterface": 15,
    "Ipv6Supported": true,
@@ -36656,10 +39410,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.1
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -36693,10 +39443,10 @@
   "EbsInfo": {
    "EbsOptimizedInfo": {
     "BaselineBandwidthInMbps": 4750,
-    "BaselineIops": 15000,
+    "BaselineIops": 18750,
     "BaselineThroughputInMBps": 593.75,
     "MaximumBandwidthInMbps": 4750,
-    "MaximumIops": 15000,
+    "MaximumIops": 18750,
     "MaximumThroughputInMBps": 593.75
    },
    "EbsOptimizedSupport": "default",
@@ -36714,7 +39464,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "required",
    "NvmeSupport": "required",
    "TotalSizeInGB": 600
   },
@@ -36727,7 +39476,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": true,
    "Ipv4AddressesPerInterface": 30,
    "Ipv6AddressesPerInterface": 30,
    "Ipv6Supported": true,
@@ -36755,10 +39503,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.1
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -36815,7 +39559,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "required",
    "NvmeSupport": "required",
    "TotalSizeInGB": 1200
   },
@@ -36828,7 +39571,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": true,
    "Ipv4AddressesPerInterface": 30,
    "Ipv6AddressesPerInterface": 30,
    "Ipv6Supported": true,
@@ -36856,10 +39598,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.1
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -36899,10 +39637,10 @@
   "EbsInfo": {
    "EbsOptimizedInfo": {
     "BaselineBandwidthInMbps": 650,
-    "BaselineIops": 3000,
+    "BaselineIops": 3600,
     "BaselineThroughputInMBps": 81.25,
     "MaximumBandwidthInMbps": 4750,
-    "MaximumIops": 15000,
+    "MaximumIops": 18750,
     "MaximumThroughputInMBps": 593.75
    },
    "EbsOptimizedSupport": "default",
@@ -36920,7 +39658,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "required",
    "NvmeSupport": "required",
    "TotalSizeInGB": 75
   },
@@ -36933,7 +39670,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": true,
    "Ipv4AddressesPerInterface": 10,
    "Ipv6AddressesPerInterface": 10,
    "Ipv6Supported": true,
@@ -36961,10 +39697,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.1
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -37017,7 +39749,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "required",
    "NvmeSupport": "required",
    "TotalSizeInGB": 3600
   },
@@ -37028,12 +39759,8 @@
   },
   "NetworkInfo": {
    "DefaultNetworkCardIndex": 0,
-   "EfaInfo": {
-    "MaximumEfaInterfaces": 1
-   },
    "EfaSupported": true,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": true,
    "Ipv4AddressesPerInterface": 50,
    "Ipv6AddressesPerInterface": 50,
    "Ipv6Supported": true,
@@ -37061,9 +39788,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.1
   },
-  "SupportedBootModes": [
-   "legacy-bios"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -37092,7 +39816,7 @@
     "BaselineIops": 6000,
     "BaselineThroughputInMBps": 143.75,
     "MaximumBandwidthInMbps": 4750,
-    "MaximumIops": 15000,
+    "MaximumIops": 18750,
     "MaximumThroughputInMBps": 593.75
    },
    "EbsOptimizedSupport": "default",
@@ -37110,7 +39834,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "required",
    "NvmeSupport": "required",
    "TotalSizeInGB": 150
   },
@@ -37123,7 +39846,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": true,
    "Ipv4AddressesPerInterface": 15,
    "Ipv6AddressesPerInterface": 15,
    "Ipv6Supported": true,
@@ -37151,10 +39873,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.1
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -37210,7 +39928,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": true,
    "Ipv4AddressesPerInterface": 30,
    "Ipv6AddressesPerInterface": 30,
    "Ipv6Supported": true,
@@ -37238,10 +39955,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.1
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -37307,7 +40020,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": true,
    "Ipv4AddressesPerInterface": 50,
    "Ipv6AddressesPerInterface": 50,
    "Ipv6Supported": true,
@@ -37335,10 +40047,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.1
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -37406,12 +40114,8 @@
   },
   "NetworkInfo": {
    "DefaultNetworkCardIndex": 0,
-   "EfaInfo": {
-    "MaximumEfaInterfaces": 1
-   },
    "EfaSupported": true,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": true,
    "Ipv4AddressesPerInterface": 50,
    "Ipv6AddressesPerInterface": 50,
    "Ipv6Supported": true,
@@ -37439,10 +40143,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.1
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -37501,7 +40201,7 @@
     "BaselineIops": 12000,
     "BaselineThroughputInMBps": 287.5,
     "MaximumBandwidthInMbps": 4750,
-    "MaximumIops": 15000,
+    "MaximumIops": 18750,
     "MaximumThroughputInMBps": 593.75
    },
    "EbsOptimizedSupport": "default",
@@ -37520,7 +40220,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": true,
    "Ipv4AddressesPerInterface": 15,
    "Ipv6AddressesPerInterface": 15,
    "Ipv6Supported": true,
@@ -37548,10 +40247,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.1
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -37585,10 +40280,10 @@
   "EbsInfo": {
    "EbsOptimizedInfo": {
     "BaselineBandwidthInMbps": 4750,
-    "BaselineIops": 15000,
+    "BaselineIops": 18750,
     "BaselineThroughputInMBps": 593.75,
     "MaximumBandwidthInMbps": 4750,
-    "MaximumIops": 15000,
+    "MaximumIops": 18750,
     "MaximumThroughputInMBps": 593.75
    },
    "EbsOptimizedSupport": "default",
@@ -37607,7 +40302,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": true,
    "Ipv4AddressesPerInterface": 30,
    "Ipv6AddressesPerInterface": 30,
    "Ipv6Supported": true,
@@ -37635,10 +40329,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.1
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -37696,7 +40386,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": true,
    "Ipv4AddressesPerInterface": 30,
    "Ipv6AddressesPerInterface": 30,
    "Ipv6Supported": true,
@@ -37724,10 +40413,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.1
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -37767,10 +40452,10 @@
   "EbsInfo": {
    "EbsOptimizedInfo": {
     "BaselineBandwidthInMbps": 650,
-    "BaselineIops": 3000,
+    "BaselineIops": 3600,
     "BaselineThroughputInMBps": 81.25,
     "MaximumBandwidthInMbps": 4750,
-    "MaximumIops": 15000,
+    "MaximumIops": 18750,
     "MaximumThroughputInMBps": 593.75
    },
    "EbsOptimizedSupport": "default",
@@ -37789,7 +40474,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": true,
    "Ipv4AddressesPerInterface": 10,
    "Ipv6AddressesPerInterface": 10,
    "Ipv6Supported": true,
@@ -37817,10 +40501,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.1
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -37872,12 +40552,8 @@
   },
   "NetworkInfo": {
    "DefaultNetworkCardIndex": 0,
-   "EfaInfo": {
-    "MaximumEfaInterfaces": 1
-   },
    "EfaSupported": true,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": true,
    "Ipv4AddressesPerInterface": 50,
    "Ipv6AddressesPerInterface": 50,
    "Ipv6Supported": true,
@@ -37905,9 +40581,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.1
   },
-  "SupportedBootModes": [
-   "legacy-bios"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -37936,7 +40609,7 @@
     "BaselineIops": 6000,
     "BaselineThroughputInMBps": 143.75,
     "MaximumBandwidthInMbps": 4750,
-    "MaximumIops": 15000,
+    "MaximumIops": 18750,
     "MaximumThroughputInMBps": 593.75
    },
    "EbsOptimizedSupport": "default",
@@ -37955,7 +40628,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": true,
    "Ipv4AddressesPerInterface": 15,
    "Ipv6AddressesPerInterface": 15,
    "Ipv6Supported": true,
@@ -37983,10 +40655,951 @@
    ],
    "SustainedClockSpeedInGhz": 3.1
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
+  "SupportedRootDeviceTypes": [
+   "ebs"
   ],
+  "SupportedUsageClasses": [
+   "on-demand",
+   "spot"
+  ],
+  "SupportedVirtualizationTypes": [
+   "hvm"
+  ],
+  "VCpuInfo": {
+   "DefaultCores": 2,
+   "DefaultThreadsPerCore": 2,
+   "DefaultVCpus": 4,
+   "ValidCores": [
+    1,
+    2
+   ],
+   "ValidThreadsPerCore": [
+    1,
+    2
+   ]
+  }
+ },
+ "r6a.12xlarge": {
+  "AutoRecoverySupported": true,
+  "BareMetal": false,
+  "BurstablePerformanceSupported": false,
+  "CurrentGeneration": true,
+  "DedicatedHostsSupported": true,
+  "EbsInfo": {
+   "EbsOptimizedInfo": {
+    "BaselineBandwidthInMbps": 10000,
+    "BaselineIops": 40000,
+    "BaselineThroughputInMBps": 1250.0,
+    "MaximumBandwidthInMbps": 10000,
+    "MaximumIops": 40000,
+    "MaximumThroughputInMBps": 1250.0
+   },
+   "EbsOptimizedSupport": "default",
+   "EncryptionSupport": "supported",
+   "NvmeSupport": "required"
+  },
+  "FreeTierEligible": false,
+  "HibernationSupported": false,
+  "Hypervisor": "nitro",
+  "InstanceStorageSupported": false,
+  "InstanceType": "r6a.12xlarge",
+  "MemoryInfo": {
+   "SizeInMiB": 393216
+  },
+  "NetworkInfo": {
+   "DefaultNetworkCardIndex": 0,
+   "EfaSupported": false,
+   "EnaSupport": "required",
+   "Ipv4AddressesPerInterface": 30,
+   "Ipv6AddressesPerInterface": 30,
+   "Ipv6Supported": true,
+   "MaximumNetworkCards": 1,
+   "MaximumNetworkInterfaces": 8,
+   "NetworkCards": [
+    {
+     "MaximumNetworkInterfaces": 8,
+     "NetworkCardIndex": 0,
+     "NetworkPerformance": "18.75 Gigabit"
+    }
+   ],
+   "NetworkPerformance": "18.75 Gigabit"
+  },
+  "PlacementGroupInfo": {
+   "SupportedStrategies": [
+    "cluster",
+    "partition",
+    "spread"
+   ]
+  },
+  "ProcessorInfo": {
+   "SupportedArchitectures": [
+    "x86_64"
+   ],
+   "SustainedClockSpeedInGhz": 3.6
+  },
+  "SupportedRootDeviceTypes": [
+   "ebs"
+  ],
+  "SupportedUsageClasses": [
+   "on-demand",
+   "spot"
+  ],
+  "SupportedVirtualizationTypes": [
+   "hvm"
+  ],
+  "VCpuInfo": {
+   "DefaultCores": 24,
+   "DefaultThreadsPerCore": 2,
+   "DefaultVCpus": 48,
+   "ValidCores": [
+    1,
+    2,
+    3,
+    4,
+    5,
+    6,
+    7,
+    8,
+    16,
+    24
+   ],
+   "ValidThreadsPerCore": [
+    1,
+    2
+   ]
+  }
+ },
+ "r6a.16xlarge": {
+  "AutoRecoverySupported": true,
+  "BareMetal": false,
+  "BurstablePerformanceSupported": false,
+  "CurrentGeneration": true,
+  "DedicatedHostsSupported": true,
+  "EbsInfo": {
+   "EbsOptimizedInfo": {
+    "BaselineBandwidthInMbps": 13300,
+    "BaselineIops": 53333,
+    "BaselineThroughputInMBps": 1662.5,
+    "MaximumBandwidthInMbps": 13300,
+    "MaximumIops": 53333,
+    "MaximumThroughputInMBps": 1662.5
+   },
+   "EbsOptimizedSupport": "default",
+   "EncryptionSupport": "supported",
+   "NvmeSupport": "required"
+  },
+  "FreeTierEligible": false,
+  "HibernationSupported": false,
+  "Hypervisor": "nitro",
+  "InstanceStorageSupported": false,
+  "InstanceType": "r6a.16xlarge",
+  "MemoryInfo": {
+   "SizeInMiB": 524288
+  },
+  "NetworkInfo": {
+   "DefaultNetworkCardIndex": 0,
+   "EfaSupported": false,
+   "EnaSupport": "required",
+   "Ipv4AddressesPerInterface": 50,
+   "Ipv6AddressesPerInterface": 50,
+   "Ipv6Supported": true,
+   "MaximumNetworkCards": 1,
+   "MaximumNetworkInterfaces": 15,
+   "NetworkCards": [
+    {
+     "MaximumNetworkInterfaces": 15,
+     "NetworkCardIndex": 0,
+     "NetworkPerformance": "25 Gigabit"
+    }
+   ],
+   "NetworkPerformance": "25 Gigabit"
+  },
+  "PlacementGroupInfo": {
+   "SupportedStrategies": [
+    "cluster",
+    "partition",
+    "spread"
+   ]
+  },
+  "ProcessorInfo": {
+   "SupportedArchitectures": [
+    "x86_64"
+   ],
+   "SustainedClockSpeedInGhz": 3.6
+  },
+  "SupportedRootDeviceTypes": [
+   "ebs"
+  ],
+  "SupportedUsageClasses": [
+   "on-demand",
+   "spot"
+  ],
+  "SupportedVirtualizationTypes": [
+   "hvm"
+  ],
+  "VCpuInfo": {
+   "DefaultCores": 32,
+   "DefaultThreadsPerCore": 2,
+   "DefaultVCpus": 64,
+   "ValidCores": [
+    2,
+    4,
+    6,
+    8,
+    10,
+    12,
+    14,
+    16,
+    32
+   ],
+   "ValidThreadsPerCore": [
+    1,
+    2
+   ]
+  }
+ },
+ "r6a.24xlarge": {
+  "AutoRecoverySupported": true,
+  "BareMetal": false,
+  "BurstablePerformanceSupported": false,
+  "CurrentGeneration": true,
+  "DedicatedHostsSupported": true,
+  "EbsInfo": {
+   "EbsOptimizedInfo": {
+    "BaselineBandwidthInMbps": 20000,
+    "BaselineIops": 80000,
+    "BaselineThroughputInMBps": 2500.0,
+    "MaximumBandwidthInMbps": 20000,
+    "MaximumIops": 80000,
+    "MaximumThroughputInMBps": 2500.0
+   },
+   "EbsOptimizedSupport": "default",
+   "EncryptionSupport": "supported",
+   "NvmeSupport": "required"
+  },
+  "FreeTierEligible": false,
+  "HibernationSupported": false,
+  "Hypervisor": "nitro",
+  "InstanceStorageSupported": false,
+  "InstanceType": "r6a.24xlarge",
+  "MemoryInfo": {
+   "SizeInMiB": 786432
+  },
+  "NetworkInfo": {
+   "DefaultNetworkCardIndex": 0,
+   "EfaSupported": false,
+   "EnaSupport": "required",
+   "Ipv4AddressesPerInterface": 50,
+   "Ipv6AddressesPerInterface": 50,
+   "Ipv6Supported": true,
+   "MaximumNetworkCards": 1,
+   "MaximumNetworkInterfaces": 15,
+   "NetworkCards": [
+    {
+     "MaximumNetworkInterfaces": 15,
+     "NetworkCardIndex": 0,
+     "NetworkPerformance": "37.5 Gigabit"
+    }
+   ],
+   "NetworkPerformance": "37.5 Gigabit"
+  },
+  "PlacementGroupInfo": {
+   "SupportedStrategies": [
+    "cluster",
+    "partition",
+    "spread"
+   ]
+  },
+  "ProcessorInfo": {
+   "SupportedArchitectures": [
+    "x86_64"
+   ],
+   "SustainedClockSpeedInGhz": 3.6
+  },
+  "SupportedRootDeviceTypes": [
+   "ebs"
+  ],
+  "SupportedUsageClasses": [
+   "on-demand",
+   "spot"
+  ],
+  "SupportedVirtualizationTypes": [
+   "hvm"
+  ],
+  "VCpuInfo": {
+   "DefaultCores": 48,
+   "DefaultThreadsPerCore": 2,
+   "DefaultVCpus": 96,
+   "ValidCores": [
+    2,
+    4,
+    6,
+    8,
+    10,
+    12,
+    14,
+    16,
+    32,
+    48
+   ],
+   "ValidThreadsPerCore": [
+    1,
+    2
+   ]
+  }
+ },
+ "r6a.2xlarge": {
+  "AutoRecoverySupported": true,
+  "BareMetal": false,
+  "BurstablePerformanceSupported": false,
+  "CurrentGeneration": true,
+  "DedicatedHostsSupported": true,
+  "EbsInfo": {
+   "EbsOptimizedInfo": {
+    "BaselineBandwidthInMbps": 2122,
+    "BaselineIops": 8333,
+    "BaselineThroughputInMBps": 265.25,
+    "MaximumBandwidthInMbps": 6666,
+    "MaximumIops": 26667,
+    "MaximumThroughputInMBps": 833.333333
+   },
+   "EbsOptimizedSupport": "default",
+   "EncryptionSupport": "supported",
+   "NvmeSupport": "required"
+  },
+  "FreeTierEligible": false,
+  "HibernationSupported": false,
+  "Hypervisor": "nitro",
+  "InstanceStorageSupported": false,
+  "InstanceType": "r6a.2xlarge",
+  "MemoryInfo": {
+   "SizeInMiB": 65536
+  },
+  "NetworkInfo": {
+   "DefaultNetworkCardIndex": 0,
+   "EfaSupported": false,
+   "EnaSupport": "required",
+   "Ipv4AddressesPerInterface": 15,
+   "Ipv6AddressesPerInterface": 15,
+   "Ipv6Supported": true,
+   "MaximumNetworkCards": 1,
+   "MaximumNetworkInterfaces": 4,
+   "NetworkCards": [
+    {
+     "MaximumNetworkInterfaces": 4,
+     "NetworkCardIndex": 0,
+     "NetworkPerformance": "Up to 12.5 Gigabit"
+    }
+   ],
+   "NetworkPerformance": "Up to 12.5 Gigabit"
+  },
+  "PlacementGroupInfo": {
+   "SupportedStrategies": [
+    "cluster",
+    "partition",
+    "spread"
+   ]
+  },
+  "ProcessorInfo": {
+   "SupportedArchitectures": [
+    "x86_64"
+   ],
+   "SustainedClockSpeedInGhz": 3.6
+  },
+  "SupportedRootDeviceTypes": [
+   "ebs"
+  ],
+  "SupportedUsageClasses": [
+   "on-demand",
+   "spot"
+  ],
+  "SupportedVirtualizationTypes": [
+   "hvm"
+  ],
+  "VCpuInfo": {
+   "DefaultCores": 4,
+   "DefaultThreadsPerCore": 2,
+   "DefaultVCpus": 8,
+   "ValidCores": [
+    1,
+    2,
+    3,
+    4
+   ],
+   "ValidThreadsPerCore": [
+    1,
+    2
+   ]
+  }
+ },
+ "r6a.32xlarge": {
+  "AutoRecoverySupported": true,
+  "BareMetal": false,
+  "BurstablePerformanceSupported": false,
+  "CurrentGeneration": true,
+  "DedicatedHostsSupported": true,
+  "EbsInfo": {
+   "EbsOptimizedInfo": {
+    "BaselineBandwidthInMbps": 26666,
+    "BaselineIops": 100000,
+    "BaselineThroughputInMBps": 3333.333333,
+    "MaximumBandwidthInMbps": 26666,
+    "MaximumIops": 100000,
+    "MaximumThroughputInMBps": 3333.333333
+   },
+   "EbsOptimizedSupport": "default",
+   "EncryptionSupport": "supported",
+   "NvmeSupport": "required"
+  },
+  "FreeTierEligible": false,
+  "HibernationSupported": false,
+  "Hypervisor": "nitro",
+  "InstanceStorageSupported": false,
+  "InstanceType": "r6a.32xlarge",
+  "MemoryInfo": {
+   "SizeInMiB": 1048576
+  },
+  "NetworkInfo": {
+   "DefaultNetworkCardIndex": 0,
+   "EfaSupported": true,
+   "EnaSupport": "required",
+   "Ipv4AddressesPerInterface": 50,
+   "Ipv6AddressesPerInterface": 50,
+   "Ipv6Supported": true,
+   "MaximumNetworkCards": 1,
+   "MaximumNetworkInterfaces": 15,
+   "NetworkCards": [
+    {
+     "MaximumNetworkInterfaces": 15,
+     "NetworkCardIndex": 0,
+     "NetworkPerformance": "50 Gigabit"
+    }
+   ],
+   "NetworkPerformance": "50 Gigabit"
+  },
+  "PlacementGroupInfo": {
+   "SupportedStrategies": [
+    "cluster",
+    "partition",
+    "spread"
+   ]
+  },
+  "ProcessorInfo": {
+   "SupportedArchitectures": [
+    "x86_64"
+   ],
+   "SustainedClockSpeedInGhz": 3.6
+  },
+  "SupportedRootDeviceTypes": [
+   "ebs"
+  ],
+  "SupportedUsageClasses": [
+   "on-demand",
+   "spot"
+  ],
+  "SupportedVirtualizationTypes": [
+   "hvm"
+  ],
+  "VCpuInfo": {
+   "DefaultCores": 64,
+   "DefaultThreadsPerCore": 2,
+   "DefaultVCpus": 128,
+   "ValidCores": [
+    4,
+    8,
+    12,
+    16,
+    20,
+    24,
+    28,
+    32,
+    64
+   ],
+   "ValidThreadsPerCore": [
+    1,
+    2
+   ]
+  }
+ },
+ "r6a.48xlarge": {
+  "AutoRecoverySupported": true,
+  "BareMetal": false,
+  "BurstablePerformanceSupported": false,
+  "CurrentGeneration": true,
+  "DedicatedHostsSupported": true,
+  "EbsInfo": {
+   "EbsOptimizedInfo": {
+    "BaselineBandwidthInMbps": 40000,
+    "BaselineIops": 160000,
+    "BaselineThroughputInMBps": 5000.0,
+    "MaximumBandwidthInMbps": 40000,
+    "MaximumIops": 160000,
+    "MaximumThroughputInMBps": 5000.0
+   },
+   "EbsOptimizedSupport": "default",
+   "EncryptionSupport": "supported",
+   "NvmeSupport": "required"
+  },
+  "FreeTierEligible": false,
+  "HibernationSupported": false,
+  "Hypervisor": "nitro",
+  "InstanceStorageSupported": false,
+  "InstanceType": "r6a.48xlarge",
+  "MemoryInfo": {
+   "SizeInMiB": 1572864
+  },
+  "NetworkInfo": {
+   "DefaultNetworkCardIndex": 0,
+   "EfaSupported": true,
+   "EnaSupport": "required",
+   "Ipv4AddressesPerInterface": 50,
+   "Ipv6AddressesPerInterface": 50,
+   "Ipv6Supported": true,
+   "MaximumNetworkCards": 1,
+   "MaximumNetworkInterfaces": 15,
+   "NetworkCards": [
+    {
+     "MaximumNetworkInterfaces": 15,
+     "NetworkCardIndex": 0,
+     "NetworkPerformance": "50 Gigabit"
+    }
+   ],
+   "NetworkPerformance": "50 Gigabit"
+  },
+  "PlacementGroupInfo": {
+   "SupportedStrategies": [
+    "cluster",
+    "partition",
+    "spread"
+   ]
+  },
+  "ProcessorInfo": {
+   "SupportedArchitectures": [
+    "x86_64"
+   ],
+   "SustainedClockSpeedInGhz": 3.6
+  },
+  "SupportedRootDeviceTypes": [
+   "ebs"
+  ],
+  "SupportedUsageClasses": [
+   "on-demand",
+   "spot"
+  ],
+  "SupportedVirtualizationTypes": [
+   "hvm"
+  ],
+  "VCpuInfo": {
+   "DefaultCores": 96,
+   "DefaultThreadsPerCore": 2,
+   "DefaultVCpus": 192,
+   "ValidCores": [
+    4,
+    8,
+    12,
+    16,
+    20,
+    24,
+    28,
+    32,
+    64,
+    96
+   ],
+   "ValidThreadsPerCore": [
+    1,
+    2
+   ]
+  }
+ },
+ "r6a.4xlarge": {
+  "AutoRecoverySupported": true,
+  "BareMetal": false,
+  "BurstablePerformanceSupported": false,
+  "CurrentGeneration": true,
+  "DedicatedHostsSupported": true,
+  "EbsInfo": {
+   "EbsOptimizedInfo": {
+    "BaselineBandwidthInMbps": 4245,
+    "BaselineIops": 16000,
+    "BaselineThroughputInMBps": 530.625,
+    "MaximumBandwidthInMbps": 6666,
+    "MaximumIops": 26667,
+    "MaximumThroughputInMBps": 833.333333
+   },
+   "EbsOptimizedSupport": "default",
+   "EncryptionSupport": "supported",
+   "NvmeSupport": "required"
+  },
+  "FreeTierEligible": false,
+  "HibernationSupported": false,
+  "Hypervisor": "nitro",
+  "InstanceStorageSupported": false,
+  "InstanceType": "r6a.4xlarge",
+  "MemoryInfo": {
+   "SizeInMiB": 131072
+  },
+  "NetworkInfo": {
+   "DefaultNetworkCardIndex": 0,
+   "EfaSupported": false,
+   "EnaSupport": "required",
+   "Ipv4AddressesPerInterface": 30,
+   "Ipv6AddressesPerInterface": 30,
+   "Ipv6Supported": true,
+   "MaximumNetworkCards": 1,
+   "MaximumNetworkInterfaces": 8,
+   "NetworkCards": [
+    {
+     "MaximumNetworkInterfaces": 8,
+     "NetworkCardIndex": 0,
+     "NetworkPerformance": "Up to 12.5 Gigabit"
+    }
+   ],
+   "NetworkPerformance": "Up to 12.5 Gigabit"
+  },
+  "PlacementGroupInfo": {
+   "SupportedStrategies": [
+    "cluster",
+    "partition",
+    "spread"
+   ]
+  },
+  "ProcessorInfo": {
+   "SupportedArchitectures": [
+    "x86_64"
+   ],
+   "SustainedClockSpeedInGhz": 3.6
+  },
+  "SupportedRootDeviceTypes": [
+   "ebs"
+  ],
+  "SupportedUsageClasses": [
+   "on-demand",
+   "spot"
+  ],
+  "SupportedVirtualizationTypes": [
+   "hvm"
+  ],
+  "VCpuInfo": {
+   "DefaultCores": 8,
+   "DefaultThreadsPerCore": 2,
+   "DefaultVCpus": 16,
+   "ValidCores": [
+    1,
+    2,
+    3,
+    4,
+    5,
+    6,
+    7,
+    8
+   ],
+   "ValidThreadsPerCore": [
+    1,
+    2
+   ]
+  }
+ },
+ "r6a.8xlarge": {
+  "AutoRecoverySupported": true,
+  "BareMetal": false,
+  "BurstablePerformanceSupported": false,
+  "CurrentGeneration": true,
+  "DedicatedHostsSupported": true,
+  "EbsInfo": {
+   "EbsOptimizedInfo": {
+    "BaselineBandwidthInMbps": 6666,
+    "BaselineIops": 26667,
+    "BaselineThroughputInMBps": 833.333333,
+    "MaximumBandwidthInMbps": 6666,
+    "MaximumIops": 26667,
+    "MaximumThroughputInMBps": 833.333333
+   },
+   "EbsOptimizedSupport": "default",
+   "EncryptionSupport": "supported",
+   "NvmeSupport": "required"
+  },
+  "FreeTierEligible": false,
+  "HibernationSupported": false,
+  "Hypervisor": "nitro",
+  "InstanceStorageSupported": false,
+  "InstanceType": "r6a.8xlarge",
+  "MemoryInfo": {
+   "SizeInMiB": 262144
+  },
+  "NetworkInfo": {
+   "DefaultNetworkCardIndex": 0,
+   "EfaSupported": false,
+   "EnaSupport": "required",
+   "Ipv4AddressesPerInterface": 30,
+   "Ipv6AddressesPerInterface": 30,
+   "Ipv6Supported": true,
+   "MaximumNetworkCards": 1,
+   "MaximumNetworkInterfaces": 8,
+   "NetworkCards": [
+    {
+     "MaximumNetworkInterfaces": 8,
+     "NetworkCardIndex": 0,
+     "NetworkPerformance": "12.5 Gigabit"
+    }
+   ],
+   "NetworkPerformance": "12.5 Gigabit"
+  },
+  "PlacementGroupInfo": {
+   "SupportedStrategies": [
+    "cluster",
+    "partition",
+    "spread"
+   ]
+  },
+  "ProcessorInfo": {
+   "SupportedArchitectures": [
+    "x86_64"
+   ],
+   "SustainedClockSpeedInGhz": 3.6
+  },
+  "SupportedRootDeviceTypes": [
+   "ebs"
+  ],
+  "SupportedUsageClasses": [
+   "on-demand",
+   "spot"
+  ],
+  "SupportedVirtualizationTypes": [
+   "hvm"
+  ],
+  "VCpuInfo": {
+   "DefaultCores": 16,
+   "DefaultThreadsPerCore": 2,
+   "DefaultVCpus": 32,
+   "ValidCores": [
+    1,
+    2,
+    3,
+    4,
+    5,
+    6,
+    7,
+    8,
+    16
+   ],
+   "ValidThreadsPerCore": [
+    1,
+    2
+   ]
+  }
+ },
+ "r6a.large": {
+  "AutoRecoverySupported": true,
+  "BareMetal": false,
+  "BurstablePerformanceSupported": false,
+  "CurrentGeneration": true,
+  "DedicatedHostsSupported": true,
+  "EbsInfo": {
+   "EbsOptimizedInfo": {
+    "BaselineBandwidthInMbps": 531,
+    "BaselineIops": 3600,
+    "BaselineThroughputInMBps": 66.375,
+    "MaximumBandwidthInMbps": 6666,
+    "MaximumIops": 26667,
+    "MaximumThroughputInMBps": 833.333333
+   },
+   "EbsOptimizedSupport": "default",
+   "EncryptionSupport": "supported",
+   "NvmeSupport": "required"
+  },
+  "FreeTierEligible": false,
+  "HibernationSupported": false,
+  "Hypervisor": "nitro",
+  "InstanceStorageSupported": false,
+  "InstanceType": "r6a.large",
+  "MemoryInfo": {
+   "SizeInMiB": 16384
+  },
+  "NetworkInfo": {
+   "DefaultNetworkCardIndex": 0,
+   "EfaSupported": false,
+   "EnaSupport": "required",
+   "Ipv4AddressesPerInterface": 10,
+   "Ipv6AddressesPerInterface": 10,
+   "Ipv6Supported": true,
+   "MaximumNetworkCards": 1,
+   "MaximumNetworkInterfaces": 3,
+   "NetworkCards": [
+    {
+     "MaximumNetworkInterfaces": 3,
+     "NetworkCardIndex": 0,
+     "NetworkPerformance": "Up to 12.5 Gigabit"
+    }
+   ],
+   "NetworkPerformance": "Up to 12.5 Gigabit"
+  },
+  "PlacementGroupInfo": {
+   "SupportedStrategies": [
+    "cluster",
+    "partition",
+    "spread"
+   ]
+  },
+  "ProcessorInfo": {
+   "SupportedArchitectures": [
+    "x86_64"
+   ],
+   "SustainedClockSpeedInGhz": 3.6
+  },
+  "SupportedRootDeviceTypes": [
+   "ebs"
+  ],
+  "SupportedUsageClasses": [
+   "on-demand",
+   "spot"
+  ],
+  "SupportedVirtualizationTypes": [
+   "hvm"
+  ],
+  "VCpuInfo": {
+   "DefaultCores": 1,
+   "DefaultThreadsPerCore": 2,
+   "DefaultVCpus": 2,
+   "ValidCores": [
+    1
+   ],
+   "ValidThreadsPerCore": [
+    1,
+    2
+   ]
+  }
+ },
+ "r6a.metal": {
+  "AutoRecoverySupported": true,
+  "BareMetal": true,
+  "BurstablePerformanceSupported": false,
+  "CurrentGeneration": true,
+  "DedicatedHostsSupported": true,
+  "EbsInfo": {
+   "EbsOptimizedInfo": {
+    "BaselineBandwidthInMbps": 40000,
+    "BaselineIops": 160000,
+    "BaselineThroughputInMBps": 5000.0,
+    "MaximumBandwidthInMbps": 40000,
+    "MaximumIops": 160000,
+    "MaximumThroughputInMBps": 5000.0
+   },
+   "EbsOptimizedSupport": "default",
+   "EncryptionSupport": "supported",
+   "NvmeSupport": "required"
+  },
+  "FreeTierEligible": false,
+  "HibernationSupported": false,
+  "InstanceStorageSupported": false,
+  "InstanceType": "r6a.metal",
+  "MemoryInfo": {
+   "SizeInMiB": 1572864
+  },
+  "NetworkInfo": {
+   "DefaultNetworkCardIndex": 0,
+   "EfaSupported": true,
+   "EnaSupport": "required",
+   "Ipv4AddressesPerInterface": 50,
+   "Ipv6AddressesPerInterface": 50,
+   "Ipv6Supported": true,
+   "MaximumNetworkCards": 1,
+   "MaximumNetworkInterfaces": 15,
+   "NetworkCards": [
+    {
+     "MaximumNetworkInterfaces": 15,
+     "NetworkCardIndex": 0,
+     "NetworkPerformance": "50 Gigabit"
+    }
+   ],
+   "NetworkPerformance": "50 Gigabit"
+  },
+  "PlacementGroupInfo": {
+   "SupportedStrategies": [
+    "cluster",
+    "partition",
+    "spread"
+   ]
+  },
+  "ProcessorInfo": {
+   "SupportedArchitectures": [
+    "x86_64"
+   ],
+   "SustainedClockSpeedInGhz": 3.6
+  },
+  "SupportedRootDeviceTypes": [
+   "ebs"
+  ],
+  "SupportedUsageClasses": [
+   "on-demand",
+   "spot"
+  ],
+  "SupportedVirtualizationTypes": [
+   "hvm"
+  ],
+  "VCpuInfo": {
+   "DefaultCores": 96,
+   "DefaultThreadsPerCore": 2,
+   "DefaultVCpus": 192
+  }
+ },
+ "r6a.xlarge": {
+  "AutoRecoverySupported": true,
+  "BareMetal": false,
+  "BurstablePerformanceSupported": false,
+  "CurrentGeneration": true,
+  "DedicatedHostsSupported": true,
+  "EbsInfo": {
+   "EbsOptimizedInfo": {
+    "BaselineBandwidthInMbps": 1061,
+    "BaselineIops": 6000,
+    "BaselineThroughputInMBps": 132.625,
+    "MaximumBandwidthInMbps": 6666,
+    "MaximumIops": 26667,
+    "MaximumThroughputInMBps": 833.333333
+   },
+   "EbsOptimizedSupport": "default",
+   "EncryptionSupport": "supported",
+   "NvmeSupport": "required"
+  },
+  "FreeTierEligible": false,
+  "HibernationSupported": false,
+  "Hypervisor": "nitro",
+  "InstanceStorageSupported": false,
+  "InstanceType": "r6a.xlarge",
+  "MemoryInfo": {
+   "SizeInMiB": 32768
+  },
+  "NetworkInfo": {
+   "DefaultNetworkCardIndex": 0,
+   "EfaSupported": false,
+   "EnaSupport": "required",
+   "Ipv4AddressesPerInterface": 15,
+   "Ipv6AddressesPerInterface": 15,
+   "Ipv6Supported": true,
+   "MaximumNetworkCards": 1,
+   "MaximumNetworkInterfaces": 4,
+   "NetworkCards": [
+    {
+     "MaximumNetworkInterfaces": 4,
+     "NetworkCardIndex": 0,
+     "NetworkPerformance": "Up to 12.5 Gigabit"
+    }
+   ],
+   "NetworkPerformance": "Up to 12.5 Gigabit"
+  },
+  "PlacementGroupInfo": {
+   "SupportedStrategies": [
+    "cluster",
+    "partition",
+    "spread"
+   ]
+  },
+  "ProcessorInfo": {
+   "SupportedArchitectures": [
+    "x86_64"
+   ],
+   "SustainedClockSpeedInGhz": 3.6
+  },
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -38042,7 +41655,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 30,
    "Ipv6AddressesPerInterface": 30,
    "Ipv6Supported": true,
@@ -38070,9 +41682,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.5
   },
-  "SupportedBootModes": [
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -38173,7 +41782,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 50,
    "Ipv6AddressesPerInterface": 50,
    "Ipv6Supported": true,
@@ -38201,9 +41809,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.5
   },
-  "SupportedBootModes": [
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -38320,7 +41925,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 15,
    "Ipv6AddressesPerInterface": 15,
    "Ipv6Supported": true,
@@ -38348,9 +41952,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.5
   },
-  "SupportedBootModes": [
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -38411,7 +42012,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 30,
    "Ipv6AddressesPerInterface": 30,
    "Ipv6Supported": true,
@@ -38439,9 +42039,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.5
   },
-  "SupportedBootModes": [
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -38510,7 +42107,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 30,
    "Ipv6AddressesPerInterface": 30,
    "Ipv6Supported": true,
@@ -38538,9 +42134,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.5
   },
-  "SupportedBootModes": [
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -38625,7 +42218,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 10,
    "Ipv6AddressesPerInterface": 10,
    "Ipv6Supported": true,
@@ -38653,9 +42245,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.5
   },
-  "SupportedBootModes": [
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -38710,7 +42299,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 4,
    "Ipv6AddressesPerInterface": 4,
    "Ipv6Supported": true,
@@ -38738,9 +42326,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.5
   },
-  "SupportedBootModes": [
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -38787,7 +42372,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 50,
    "Ipv6AddressesPerInterface": 50,
    "Ipv6Supported": true,
@@ -38815,9 +42399,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.5
   },
-  "SupportedBootModes": [
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -38865,7 +42446,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 15,
    "Ipv6AddressesPerInterface": 15,
    "Ipv6Supported": true,
@@ -38893,9 +42473,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.5
   },
-  "SupportedBootModes": [
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -38951,7 +42528,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "required",
    "NvmeSupport": "required",
    "TotalSizeInGB": 2850
   },
@@ -38964,7 +42540,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 30,
    "Ipv6AddressesPerInterface": 30,
    "Ipv6Supported": true,
@@ -38992,9 +42567,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.5
   },
-  "SupportedBootModes": [
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -39094,7 +42666,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "required",
    "NvmeSupport": "required",
    "TotalSizeInGB": 3800
   },
@@ -39107,7 +42678,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 50,
    "Ipv6AddressesPerInterface": 50,
    "Ipv6Supported": true,
@@ -39135,9 +42705,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.5
   },
-  "SupportedBootModes": [
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -39253,7 +42820,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "required",
    "NvmeSupport": "required",
    "TotalSizeInGB": 474
   },
@@ -39266,7 +42832,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 15,
    "Ipv6AddressesPerInterface": 15,
    "Ipv6Supported": true,
@@ -39294,9 +42859,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.5
   },
-  "SupportedBootModes": [
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -39356,7 +42918,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "required",
    "NvmeSupport": "required",
    "TotalSizeInGB": 950
   },
@@ -39369,7 +42930,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 30,
    "Ipv6AddressesPerInterface": 30,
    "Ipv6Supported": true,
@@ -39397,9 +42957,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.5
   },
-  "SupportedBootModes": [
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -39467,7 +43024,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "required",
    "NvmeSupport": "required",
    "TotalSizeInGB": 1900
   },
@@ -39480,7 +43036,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 30,
    "Ipv6AddressesPerInterface": 30,
    "Ipv6Supported": true,
@@ -39508,9 +43063,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.5
   },
-  "SupportedBootModes": [
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -39594,7 +43146,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "required",
    "NvmeSupport": "required",
    "TotalSizeInGB": 118
   },
@@ -39607,7 +43158,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 10,
    "Ipv6AddressesPerInterface": 10,
    "Ipv6Supported": true,
@@ -39635,9 +43185,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.5
   },
-  "SupportedBootModes": [
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -39691,7 +43238,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "required",
    "NvmeSupport": "required",
    "TotalSizeInGB": 59
   },
@@ -39704,7 +43250,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 4,
    "Ipv6AddressesPerInterface": 4,
    "Ipv6Supported": true,
@@ -39732,9 +43277,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.5
   },
-  "SupportedBootModes": [
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -39780,7 +43322,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "required",
    "NvmeSupport": "required",
    "TotalSizeInGB": 3800
   },
@@ -39793,7 +43334,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 50,
    "Ipv6AddressesPerInterface": 50,
    "Ipv6Supported": true,
@@ -39821,9 +43361,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.5
   },
-  "SupportedBootModes": [
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -39870,7 +43407,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "required",
    "NvmeSupport": "required",
    "TotalSizeInGB": 237
   },
@@ -39883,7 +43419,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 15,
    "Ipv6AddressesPerInterface": 15,
    "Ipv6Supported": true,
@@ -39911,9 +43446,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.5
   },
-  "SupportedBootModes": [
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -39970,7 +43502,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": true,
    "Ipv4AddressesPerInterface": 30,
    "Ipv6AddressesPerInterface": 30,
    "Ipv6Supported": true,
@@ -39998,10 +43529,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.5
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -40067,7 +43594,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": true,
    "Ipv4AddressesPerInterface": 50,
    "Ipv6AddressesPerInterface": 50,
    "Ipv6Supported": true,
@@ -40095,10 +43621,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.5
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -40168,7 +43690,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": true,
    "Ipv4AddressesPerInterface": 50,
    "Ipv6AddressesPerInterface": 50,
    "Ipv6Supported": true,
@@ -40196,10 +43717,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.5
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -40277,7 +43794,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": true,
    "Ipv4AddressesPerInterface": 15,
    "Ipv6AddressesPerInterface": 15,
    "Ipv6Supported": true,
@@ -40305,10 +43821,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.5
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -40362,12 +43874,8 @@
   },
   "NetworkInfo": {
    "DefaultNetworkCardIndex": 0,
-   "EfaInfo": {
-    "MaximumEfaInterfaces": 1
-   },
    "EfaSupported": true,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": true,
    "Ipv4AddressesPerInterface": 50,
    "Ipv6AddressesPerInterface": 50,
    "Ipv6Supported": true,
@@ -40395,10 +43903,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.5
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -40484,7 +43988,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": true,
    "Ipv4AddressesPerInterface": 30,
    "Ipv6AddressesPerInterface": 30,
    "Ipv6Supported": true,
@@ -40512,10 +44015,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.5
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -40573,7 +44072,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": true,
    "Ipv4AddressesPerInterface": 30,
    "Ipv6AddressesPerInterface": 30,
    "Ipv6Supported": true,
@@ -40601,10 +44099,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.5
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -40666,7 +44160,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": true,
    "Ipv4AddressesPerInterface": 10,
    "Ipv6AddressesPerInterface": 10,
    "Ipv6Supported": true,
@@ -40694,10 +44187,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.5
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -40749,12 +44238,8 @@
   },
   "NetworkInfo": {
    "DefaultNetworkCardIndex": 0,
-   "EfaInfo": {
-    "MaximumEfaInterfaces": 1
-   },
    "EfaSupported": true,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": true,
    "Ipv4AddressesPerInterface": 50,
    "Ipv6AddressesPerInterface": 50,
    "Ipv6Supported": true,
@@ -40782,9 +44267,6 @@
    ],
    "SustainedClockSpeedInGhz": 3.5
   },
-  "SupportedBootModes": [
-   "legacy-bios"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -40832,7 +44314,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": true,
    "Ipv4AddressesPerInterface": 15,
    "Ipv6AddressesPerInterface": 15,
    "Ipv6Supported": true,
@@ -40860,10 +44341,1010 @@
    ],
    "SustainedClockSpeedInGhz": 3.5
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
+  "SupportedRootDeviceTypes": [
+   "ebs"
   ],
+  "SupportedUsageClasses": [
+   "on-demand",
+   "spot"
+  ],
+  "SupportedVirtualizationTypes": [
+   "hvm"
+  ],
+  "VCpuInfo": {
+   "DefaultCores": 2,
+   "DefaultThreadsPerCore": 2,
+   "DefaultVCpus": 4,
+   "ValidCores": [
+    1,
+    2
+   ],
+   "ValidThreadsPerCore": [
+    1,
+    2
+   ]
+  }
+ },
+ "r6id.12xlarge": {
+  "AutoRecoverySupported": false,
+  "BareMetal": false,
+  "BurstablePerformanceSupported": false,
+  "CurrentGeneration": true,
+  "DedicatedHostsSupported": true,
+  "EbsInfo": {
+   "EbsOptimizedInfo": {
+    "BaselineBandwidthInMbps": 15000,
+    "BaselineIops": 60000,
+    "BaselineThroughputInMBps": 1875.0,
+    "MaximumBandwidthInMbps": 15000,
+    "MaximumIops": 60000,
+    "MaximumThroughputInMBps": 1875.0
+   },
+   "EbsOptimizedSupport": "default",
+   "EncryptionSupport": "supported",
+   "NvmeSupport": "required"
+  },
+  "FreeTierEligible": false,
+  "HibernationSupported": false,
+  "Hypervisor": "nitro",
+  "InstanceStorageInfo": {
+   "Disks": [
+    {
+     "Count": 2,
+     "SizeInGB": 1425,
+     "Type": "ssd"
+    }
+   ],
+   "NvmeSupport": "required",
+   "TotalSizeInGB": 2850
+  },
+  "InstanceStorageSupported": true,
+  "InstanceType": "r6id.12xlarge",
+  "MemoryInfo": {
+   "SizeInMiB": 393216
+  },
+  "NetworkInfo": {
+   "DefaultNetworkCardIndex": 0,
+   "EfaSupported": false,
+   "EnaSupport": "required",
+   "Ipv4AddressesPerInterface": 30,
+   "Ipv6AddressesPerInterface": 30,
+   "Ipv6Supported": true,
+   "MaximumNetworkCards": 1,
+   "MaximumNetworkInterfaces": 8,
+   "NetworkCards": [
+    {
+     "MaximumNetworkInterfaces": 8,
+     "NetworkCardIndex": 0,
+     "NetworkPerformance": "18.75 Gigabit"
+    }
+   ],
+   "NetworkPerformance": "18.75 Gigabit"
+  },
+  "PlacementGroupInfo": {
+   "SupportedStrategies": [
+    "cluster",
+    "partition",
+    "spread"
+   ]
+  },
+  "ProcessorInfo": {
+   "SupportedArchitectures": [
+    "x86_64"
+   ],
+   "SustainedClockSpeedInGhz": 3.5
+  },
+  "SupportedRootDeviceTypes": [
+   "ebs"
+  ],
+  "SupportedUsageClasses": [
+   "on-demand",
+   "spot"
+  ],
+  "SupportedVirtualizationTypes": [
+   "hvm"
+  ],
+  "VCpuInfo": {
+   "DefaultCores": 24,
+   "DefaultThreadsPerCore": 2,
+   "DefaultVCpus": 48,
+   "ValidCores": [
+    2,
+    4,
+    6,
+    8,
+    10,
+    12,
+    14,
+    16,
+    18,
+    20,
+    22,
+    24
+   ],
+   "ValidThreadsPerCore": [
+    1,
+    2
+   ]
+  }
+ },
+ "r6id.16xlarge": {
+  "AutoRecoverySupported": false,
+  "BareMetal": false,
+  "BurstablePerformanceSupported": false,
+  "CurrentGeneration": true,
+  "DedicatedHostsSupported": true,
+  "EbsInfo": {
+   "EbsOptimizedInfo": {
+    "BaselineBandwidthInMbps": 20000,
+    "BaselineIops": 80000,
+    "BaselineThroughputInMBps": 2500.0,
+    "MaximumBandwidthInMbps": 20000,
+    "MaximumIops": 80000,
+    "MaximumThroughputInMBps": 2500.0
+   },
+   "EbsOptimizedSupport": "default",
+   "EncryptionSupport": "supported",
+   "NvmeSupport": "required"
+  },
+  "FreeTierEligible": false,
+  "HibernationSupported": false,
+  "Hypervisor": "nitro",
+  "InstanceStorageInfo": {
+   "Disks": [
+    {
+     "Count": 2,
+     "SizeInGB": 1900,
+     "Type": "ssd"
+    }
+   ],
+   "NvmeSupport": "required",
+   "TotalSizeInGB": 3800
+  },
+  "InstanceStorageSupported": true,
+  "InstanceType": "r6id.16xlarge",
+  "MemoryInfo": {
+   "SizeInMiB": 524288
+  },
+  "NetworkInfo": {
+   "DefaultNetworkCardIndex": 0,
+   "EfaSupported": false,
+   "EnaSupport": "required",
+   "Ipv4AddressesPerInterface": 50,
+   "Ipv6AddressesPerInterface": 50,
+   "Ipv6Supported": true,
+   "MaximumNetworkCards": 1,
+   "MaximumNetworkInterfaces": 15,
+   "NetworkCards": [
+    {
+     "MaximumNetworkInterfaces": 15,
+     "NetworkCardIndex": 0,
+     "NetworkPerformance": "25 Gigabit"
+    }
+   ],
+   "NetworkPerformance": "25 Gigabit"
+  },
+  "PlacementGroupInfo": {
+   "SupportedStrategies": [
+    "cluster",
+    "partition",
+    "spread"
+   ]
+  },
+  "ProcessorInfo": {
+   "SupportedArchitectures": [
+    "x86_64"
+   ],
+   "SustainedClockSpeedInGhz": 3.5
+  },
+  "SupportedRootDeviceTypes": [
+   "ebs"
+  ],
+  "SupportedUsageClasses": [
+   "on-demand",
+   "spot"
+  ],
+  "SupportedVirtualizationTypes": [
+   "hvm"
+  ],
+  "VCpuInfo": {
+   "DefaultCores": 32,
+   "DefaultThreadsPerCore": 2,
+   "DefaultVCpus": 64,
+   "ValidCores": [
+    2,
+    4,
+    6,
+    8,
+    10,
+    12,
+    14,
+    16,
+    18,
+    20,
+    22,
+    24,
+    26,
+    28,
+    30,
+    32
+   ],
+   "ValidThreadsPerCore": [
+    1,
+    2
+   ]
+  }
+ },
+ "r6id.24xlarge": {
+  "AutoRecoverySupported": false,
+  "BareMetal": false,
+  "BurstablePerformanceSupported": false,
+  "CurrentGeneration": true,
+  "DedicatedHostsSupported": true,
+  "EbsInfo": {
+   "EbsOptimizedInfo": {
+    "BaselineBandwidthInMbps": 30000,
+    "BaselineIops": 120000,
+    "BaselineThroughputInMBps": 3750.0,
+    "MaximumBandwidthInMbps": 30000,
+    "MaximumIops": 120000,
+    "MaximumThroughputInMBps": 3750.0
+   },
+   "EbsOptimizedSupport": "default",
+   "EncryptionSupport": "supported",
+   "NvmeSupport": "required"
+  },
+  "FreeTierEligible": false,
+  "HibernationSupported": false,
+  "Hypervisor": "nitro",
+  "InstanceStorageInfo": {
+   "Disks": [
+    {
+     "Count": 4,
+     "SizeInGB": 1425,
+     "Type": "ssd"
+    }
+   ],
+   "NvmeSupport": "required",
+   "TotalSizeInGB": 5700
+  },
+  "InstanceStorageSupported": true,
+  "InstanceType": "r6id.24xlarge",
+  "MemoryInfo": {
+   "SizeInMiB": 786432
+  },
+  "NetworkInfo": {
+   "DefaultNetworkCardIndex": 0,
+   "EfaSupported": false,
+   "EnaSupport": "required",
+   "Ipv4AddressesPerInterface": 50,
+   "Ipv6AddressesPerInterface": 50,
+   "Ipv6Supported": true,
+   "MaximumNetworkCards": 1,
+   "MaximumNetworkInterfaces": 15,
+   "NetworkCards": [
+    {
+     "MaximumNetworkInterfaces": 15,
+     "NetworkCardIndex": 0,
+     "NetworkPerformance": "37.5 Gigabit"
+    }
+   ],
+   "NetworkPerformance": "37.5 Gigabit"
+  },
+  "PlacementGroupInfo": {
+   "SupportedStrategies": [
+    "cluster",
+    "partition",
+    "spread"
+   ]
+  },
+  "ProcessorInfo": {
+   "SupportedArchitectures": [
+    "x86_64"
+   ],
+   "SustainedClockSpeedInGhz": 3.5
+  },
+  "SupportedRootDeviceTypes": [
+   "ebs"
+  ],
+  "SupportedUsageClasses": [
+   "on-demand",
+   "spot"
+  ],
+  "SupportedVirtualizationTypes": [
+   "hvm"
+  ],
+  "VCpuInfo": {
+   "DefaultCores": 48,
+   "DefaultThreadsPerCore": 2,
+   "DefaultVCpus": 96,
+   "ValidCores": [
+    2,
+    4,
+    6,
+    8,
+    10,
+    12,
+    14,
+    16,
+    18,
+    20,
+    22,
+    24,
+    26,
+    28,
+    30,
+    32,
+    34,
+    36,
+    38,
+    40,
+    42,
+    44,
+    46,
+    48
+   ],
+   "ValidThreadsPerCore": [
+    1,
+    2
+   ]
+  }
+ },
+ "r6id.2xlarge": {
+  "AutoRecoverySupported": false,
+  "BareMetal": false,
+  "BurstablePerformanceSupported": false,
+  "CurrentGeneration": true,
+  "DedicatedHostsSupported": true,
+  "EbsInfo": {
+   "EbsOptimizedInfo": {
+    "BaselineBandwidthInMbps": 2500,
+    "BaselineIops": 12000,
+    "BaselineThroughputInMBps": 312.5,
+    "MaximumBandwidthInMbps": 10000,
+    "MaximumIops": 40000,
+    "MaximumThroughputInMBps": 1250.0
+   },
+   "EbsOptimizedSupport": "default",
+   "EncryptionSupport": "supported",
+   "NvmeSupport": "required"
+  },
+  "FreeTierEligible": false,
+  "HibernationSupported": false,
+  "Hypervisor": "nitro",
+  "InstanceStorageInfo": {
+   "Disks": [
+    {
+     "Count": 1,
+     "SizeInGB": 474,
+     "Type": "ssd"
+    }
+   ],
+   "NvmeSupport": "required",
+   "TotalSizeInGB": 474
+  },
+  "InstanceStorageSupported": true,
+  "InstanceType": "r6id.2xlarge",
+  "MemoryInfo": {
+   "SizeInMiB": 65536
+  },
+  "NetworkInfo": {
+   "DefaultNetworkCardIndex": 0,
+   "EfaSupported": false,
+   "EnaSupport": "required",
+   "Ipv4AddressesPerInterface": 15,
+   "Ipv6AddressesPerInterface": 15,
+   "Ipv6Supported": true,
+   "MaximumNetworkCards": 1,
+   "MaximumNetworkInterfaces": 4,
+   "NetworkCards": [
+    {
+     "MaximumNetworkInterfaces": 4,
+     "NetworkCardIndex": 0,
+     "NetworkPerformance": "Up to 12.5 Gigabit"
+    }
+   ],
+   "NetworkPerformance": "Up to 12.5 Gigabit"
+  },
+  "PlacementGroupInfo": {
+   "SupportedStrategies": [
+    "cluster",
+    "partition",
+    "spread"
+   ]
+  },
+  "ProcessorInfo": {
+   "SupportedArchitectures": [
+    "x86_64"
+   ],
+   "SustainedClockSpeedInGhz": 3.5
+  },
+  "SupportedRootDeviceTypes": [
+   "ebs"
+  ],
+  "SupportedUsageClasses": [
+   "on-demand",
+   "spot"
+  ],
+  "SupportedVirtualizationTypes": [
+   "hvm"
+  ],
+  "VCpuInfo": {
+   "DefaultCores": 4,
+   "DefaultThreadsPerCore": 2,
+   "DefaultVCpus": 8,
+   "ValidCores": [
+    2,
+    4
+   ],
+   "ValidThreadsPerCore": [
+    1,
+    2
+   ]
+  }
+ },
+ "r6id.32xlarge": {
+  "AutoRecoverySupported": false,
+  "BareMetal": false,
+  "BurstablePerformanceSupported": false,
+  "CurrentGeneration": true,
+  "DedicatedHostsSupported": true,
+  "EbsInfo": {
+   "EbsOptimizedInfo": {
+    "BaselineBandwidthInMbps": 40000,
+    "BaselineIops": 160000,
+    "BaselineThroughputInMBps": 5000.0,
+    "MaximumBandwidthInMbps": 40000,
+    "MaximumIops": 160000,
+    "MaximumThroughputInMBps": 5000.0
+   },
+   "EbsOptimizedSupport": "default",
+   "EncryptionSupport": "supported",
+   "NvmeSupport": "required"
+  },
+  "FreeTierEligible": false,
+  "HibernationSupported": false,
+  "Hypervisor": "nitro",
+  "InstanceStorageInfo": {
+   "Disks": [
+    {
+     "Count": 4,
+     "SizeInGB": 1900,
+     "Type": "ssd"
+    }
+   ],
+   "NvmeSupport": "required",
+   "TotalSizeInGB": 7600
+  },
+  "InstanceStorageSupported": true,
+  "InstanceType": "r6id.32xlarge",
+  "MemoryInfo": {
+   "SizeInMiB": 1048576
+  },
+  "NetworkInfo": {
+   "DefaultNetworkCardIndex": 0,
+   "EfaSupported": true,
+   "EnaSupport": "required",
+   "Ipv4AddressesPerInterface": 50,
+   "Ipv6AddressesPerInterface": 50,
+   "Ipv6Supported": true,
+   "MaximumNetworkCards": 1,
+   "MaximumNetworkInterfaces": 15,
+   "NetworkCards": [
+    {
+     "MaximumNetworkInterfaces": 15,
+     "NetworkCardIndex": 0,
+     "NetworkPerformance": "50 Gigabit"
+    }
+   ],
+   "NetworkPerformance": "50 Gigabit"
+  },
+  "PlacementGroupInfo": {
+   "SupportedStrategies": [
+    "cluster",
+    "partition",
+    "spread"
+   ]
+  },
+  "ProcessorInfo": {
+   "SupportedArchitectures": [
+    "x86_64"
+   ],
+   "SustainedClockSpeedInGhz": 3.5
+  },
+  "SupportedRootDeviceTypes": [
+   "ebs"
+  ],
+  "SupportedUsageClasses": [
+   "on-demand",
+   "spot"
+  ],
+  "SupportedVirtualizationTypes": [
+   "hvm"
+  ],
+  "VCpuInfo": {
+   "DefaultCores": 64,
+   "DefaultThreadsPerCore": 2,
+   "DefaultVCpus": 128,
+   "ValidCores": [
+    2,
+    4,
+    6,
+    8,
+    10,
+    12,
+    14,
+    16,
+    18,
+    20,
+    22,
+    24,
+    26,
+    28,
+    30,
+    32,
+    34,
+    36,
+    38,
+    40,
+    42,
+    44,
+    46,
+    48,
+    50,
+    52,
+    54,
+    56,
+    58,
+    60,
+    62,
+    64
+   ],
+   "ValidThreadsPerCore": [
+    1,
+    2
+   ]
+  }
+ },
+ "r6id.4xlarge": {
+  "AutoRecoverySupported": false,
+  "BareMetal": false,
+  "BurstablePerformanceSupported": false,
+  "CurrentGeneration": true,
+  "DedicatedHostsSupported": true,
+  "EbsInfo": {
+   "EbsOptimizedInfo": {
+    "BaselineBandwidthInMbps": 5000,
+    "BaselineIops": 20000,
+    "BaselineThroughputInMBps": 625.0,
+    "MaximumBandwidthInMbps": 10000,
+    "MaximumIops": 40000,
+    "MaximumThroughputInMBps": 1250.0
+   },
+   "EbsOptimizedSupport": "default",
+   "EncryptionSupport": "supported",
+   "NvmeSupport": "required"
+  },
+  "FreeTierEligible": false,
+  "HibernationSupported": false,
+  "Hypervisor": "nitro",
+  "InstanceStorageInfo": {
+   "Disks": [
+    {
+     "Count": 1,
+     "SizeInGB": 950,
+     "Type": "ssd"
+    }
+   ],
+   "NvmeSupport": "required",
+   "TotalSizeInGB": 950
+  },
+  "InstanceStorageSupported": true,
+  "InstanceType": "r6id.4xlarge",
+  "MemoryInfo": {
+   "SizeInMiB": 131072
+  },
+  "NetworkInfo": {
+   "DefaultNetworkCardIndex": 0,
+   "EfaSupported": false,
+   "EnaSupport": "required",
+   "Ipv4AddressesPerInterface": 30,
+   "Ipv6AddressesPerInterface": 30,
+   "Ipv6Supported": true,
+   "MaximumNetworkCards": 1,
+   "MaximumNetworkInterfaces": 8,
+   "NetworkCards": [
+    {
+     "MaximumNetworkInterfaces": 8,
+     "NetworkCardIndex": 0,
+     "NetworkPerformance": "Up to 12.5 Gigabit"
+    }
+   ],
+   "NetworkPerformance": "Up to 12.5 Gigabit"
+  },
+  "PlacementGroupInfo": {
+   "SupportedStrategies": [
+    "cluster",
+    "partition",
+    "spread"
+   ]
+  },
+  "ProcessorInfo": {
+   "SupportedArchitectures": [
+    "x86_64"
+   ],
+   "SustainedClockSpeedInGhz": 3.5
+  },
+  "SupportedRootDeviceTypes": [
+   "ebs"
+  ],
+  "SupportedUsageClasses": [
+   "on-demand",
+   "spot"
+  ],
+  "SupportedVirtualizationTypes": [
+   "hvm"
+  ],
+  "VCpuInfo": {
+   "DefaultCores": 8,
+   "DefaultThreadsPerCore": 2,
+   "DefaultVCpus": 16,
+   "ValidCores": [
+    2,
+    4,
+    6,
+    8
+   ],
+   "ValidThreadsPerCore": [
+    1,
+    2
+   ]
+  }
+ },
+ "r6id.8xlarge": {
+  "AutoRecoverySupported": false,
+  "BareMetal": false,
+  "BurstablePerformanceSupported": false,
+  "CurrentGeneration": true,
+  "DedicatedHostsSupported": true,
+  "EbsInfo": {
+   "EbsOptimizedInfo": {
+    "BaselineBandwidthInMbps": 10000,
+    "BaselineIops": 40000,
+    "BaselineThroughputInMBps": 1250.0,
+    "MaximumBandwidthInMbps": 10000,
+    "MaximumIops": 40000,
+    "MaximumThroughputInMBps": 1250.0
+   },
+   "EbsOptimizedSupport": "default",
+   "EncryptionSupport": "supported",
+   "NvmeSupport": "required"
+  },
+  "FreeTierEligible": false,
+  "HibernationSupported": false,
+  "Hypervisor": "nitro",
+  "InstanceStorageInfo": {
+   "Disks": [
+    {
+     "Count": 1,
+     "SizeInGB": 1900,
+     "Type": "ssd"
+    }
+   ],
+   "NvmeSupport": "required",
+   "TotalSizeInGB": 1900
+  },
+  "InstanceStorageSupported": true,
+  "InstanceType": "r6id.8xlarge",
+  "MemoryInfo": {
+   "SizeInMiB": 262144
+  },
+  "NetworkInfo": {
+   "DefaultNetworkCardIndex": 0,
+   "EfaSupported": false,
+   "EnaSupport": "required",
+   "Ipv4AddressesPerInterface": 30,
+   "Ipv6AddressesPerInterface": 30,
+   "Ipv6Supported": true,
+   "MaximumNetworkCards": 1,
+   "MaximumNetworkInterfaces": 8,
+   "NetworkCards": [
+    {
+     "MaximumNetworkInterfaces": 8,
+     "NetworkCardIndex": 0,
+     "NetworkPerformance": "12.5 Gigabit"
+    }
+   ],
+   "NetworkPerformance": "12.5 Gigabit"
+  },
+  "PlacementGroupInfo": {
+   "SupportedStrategies": [
+    "cluster",
+    "partition",
+    "spread"
+   ]
+  },
+  "ProcessorInfo": {
+   "SupportedArchitectures": [
+    "x86_64"
+   ],
+   "SustainedClockSpeedInGhz": 3.5
+  },
+  "SupportedRootDeviceTypes": [
+   "ebs"
+  ],
+  "SupportedUsageClasses": [
+   "on-demand",
+   "spot"
+  ],
+  "SupportedVirtualizationTypes": [
+   "hvm"
+  ],
+  "VCpuInfo": {
+   "DefaultCores": 16,
+   "DefaultThreadsPerCore": 2,
+   "DefaultVCpus": 32,
+   "ValidCores": [
+    2,
+    4,
+    6,
+    8,
+    10,
+    12,
+    14,
+    16
+   ],
+   "ValidThreadsPerCore": [
+    1,
+    2
+   ]
+  }
+ },
+ "r6id.large": {
+  "AutoRecoverySupported": false,
+  "BareMetal": false,
+  "BurstablePerformanceSupported": false,
+  "CurrentGeneration": true,
+  "DedicatedHostsSupported": true,
+  "EbsInfo": {
+   "EbsOptimizedInfo": {
+    "BaselineBandwidthInMbps": 650,
+    "BaselineIops": 3600,
+    "BaselineThroughputInMBps": 81.25,
+    "MaximumBandwidthInMbps": 10000,
+    "MaximumIops": 40000,
+    "MaximumThroughputInMBps": 1250.0
+   },
+   "EbsOptimizedSupport": "default",
+   "EncryptionSupport": "supported",
+   "NvmeSupport": "required"
+  },
+  "FreeTierEligible": false,
+  "HibernationSupported": false,
+  "Hypervisor": "nitro",
+  "InstanceStorageInfo": {
+   "Disks": [
+    {
+     "Count": 1,
+     "SizeInGB": 118,
+     "Type": "ssd"
+    }
+   ],
+   "NvmeSupport": "required",
+   "TotalSizeInGB": 118
+  },
+  "InstanceStorageSupported": true,
+  "InstanceType": "r6id.large",
+  "MemoryInfo": {
+   "SizeInMiB": 16384
+  },
+  "NetworkInfo": {
+   "DefaultNetworkCardIndex": 0,
+   "EfaSupported": false,
+   "EnaSupport": "required",
+   "Ipv4AddressesPerInterface": 10,
+   "Ipv6AddressesPerInterface": 10,
+   "Ipv6Supported": true,
+   "MaximumNetworkCards": 1,
+   "MaximumNetworkInterfaces": 3,
+   "NetworkCards": [
+    {
+     "MaximumNetworkInterfaces": 3,
+     "NetworkCardIndex": 0,
+     "NetworkPerformance": "Up to 12.5 Gigabit"
+    }
+   ],
+   "NetworkPerformance": "Up to 12.5 Gigabit"
+  },
+  "PlacementGroupInfo": {
+   "SupportedStrategies": [
+    "cluster",
+    "partition",
+    "spread"
+   ]
+  },
+  "ProcessorInfo": {
+   "SupportedArchitectures": [
+    "x86_64"
+   ],
+   "SustainedClockSpeedInGhz": 3.5
+  },
+  "SupportedRootDeviceTypes": [
+   "ebs"
+  ],
+  "SupportedUsageClasses": [
+   "on-demand",
+   "spot"
+  ],
+  "SupportedVirtualizationTypes": [
+   "hvm"
+  ],
+  "VCpuInfo": {
+   "DefaultCores": 1,
+   "DefaultThreadsPerCore": 2,
+   "DefaultVCpus": 2,
+   "ValidCores": [
+    1
+   ],
+   "ValidThreadsPerCore": [
+    1,
+    2
+   ]
+  }
+ },
+ "r6id.metal": {
+  "AutoRecoverySupported": false,
+  "BareMetal": true,
+  "BurstablePerformanceSupported": false,
+  "CurrentGeneration": true,
+  "DedicatedHostsSupported": true,
+  "EbsInfo": {
+   "EbsOptimizedInfo": {
+    "BaselineBandwidthInMbps": 40000,
+    "BaselineIops": 160000,
+    "BaselineThroughputInMBps": 5000.0,
+    "MaximumBandwidthInMbps": 40000,
+    "MaximumIops": 160000,
+    "MaximumThroughputInMBps": 5000.0
+   },
+   "EbsOptimizedSupport": "default",
+   "EncryptionSupport": "supported",
+   "NvmeSupport": "required"
+  },
+  "FreeTierEligible": false,
+  "HibernationSupported": false,
+  "InstanceStorageInfo": {
+   "Disks": [
+    {
+     "Count": 4,
+     "SizeInGB": 1900,
+     "Type": "ssd"
+    }
+   ],
+   "NvmeSupport": "required",
+   "TotalSizeInGB": 7600
+  },
+  "InstanceStorageSupported": true,
+  "InstanceType": "r6id.metal",
+  "MemoryInfo": {
+   "SizeInMiB": 1048576
+  },
+  "NetworkInfo": {
+   "DefaultNetworkCardIndex": 0,
+   "EfaSupported": true,
+   "EnaSupport": "required",
+   "Ipv4AddressesPerInterface": 50,
+   "Ipv6AddressesPerInterface": 50,
+   "Ipv6Supported": true,
+   "MaximumNetworkCards": 1,
+   "MaximumNetworkInterfaces": 15,
+   "NetworkCards": [
+    {
+     "MaximumNetworkInterfaces": 15,
+     "NetworkCardIndex": 0,
+     "NetworkPerformance": "50 Gigabit"
+    }
+   ],
+   "NetworkPerformance": "50 Gigabit"
+  },
+  "PlacementGroupInfo": {
+   "SupportedStrategies": [
+    "cluster",
+    "partition",
+    "spread"
+   ]
+  },
+  "ProcessorInfo": {
+   "SupportedArchitectures": [
+    "x86_64"
+   ],
+   "SustainedClockSpeedInGhz": 3.5
+  },
+  "SupportedRootDeviceTypes": [
+   "ebs"
+  ],
+  "SupportedUsageClasses": [
+   "on-demand",
+   "spot"
+  ],
+  "SupportedVirtualizationTypes": [
+   "hvm"
+  ],
+  "VCpuInfo": {
+   "DefaultCores": 64,
+   "DefaultThreadsPerCore": 2,
+   "DefaultVCpus": 128
+  }
+ },
+ "r6id.xlarge": {
+  "AutoRecoverySupported": false,
+  "BareMetal": false,
+  "BurstablePerformanceSupported": false,
+  "CurrentGeneration": true,
+  "DedicatedHostsSupported": true,
+  "EbsInfo": {
+   "EbsOptimizedInfo": {
+    "BaselineBandwidthInMbps": 1250,
+    "BaselineIops": 6000,
+    "BaselineThroughputInMBps": 156.25,
+    "MaximumBandwidthInMbps": 10000,
+    "MaximumIops": 40000,
+    "MaximumThroughputInMBps": 1250.0
+   },
+   "EbsOptimizedSupport": "default",
+   "EncryptionSupport": "supported",
+   "NvmeSupport": "required"
+  },
+  "FreeTierEligible": false,
+  "HibernationSupported": false,
+  "Hypervisor": "nitro",
+  "InstanceStorageInfo": {
+   "Disks": [
+    {
+     "Count": 1,
+     "SizeInGB": 237,
+     "Type": "ssd"
+    }
+   ],
+   "NvmeSupport": "required",
+   "TotalSizeInGB": 237
+  },
+  "InstanceStorageSupported": true,
+  "InstanceType": "r6id.xlarge",
+  "MemoryInfo": {
+   "SizeInMiB": 32768
+  },
+  "NetworkInfo": {
+   "DefaultNetworkCardIndex": 0,
+   "EfaSupported": false,
+   "EnaSupport": "required",
+   "Ipv4AddressesPerInterface": 15,
+   "Ipv6AddressesPerInterface": 15,
+   "Ipv6Supported": true,
+   "MaximumNetworkCards": 1,
+   "MaximumNetworkInterfaces": 4,
+   "NetworkCards": [
+    {
+     "MaximumNetworkInterfaces": 4,
+     "NetworkCardIndex": 0,
+     "NetworkPerformance": "Up to 12.5 Gigabit"
+    }
+   ],
+   "NetworkPerformance": "Up to 12.5 Gigabit"
+  },
+  "PlacementGroupInfo": {
+   "SupportedStrategies": [
+    "cluster",
+    "partition",
+    "spread"
+   ]
+  },
+  "ProcessorInfo": {
+   "SupportedArchitectures": [
+    "x86_64"
+   ],
+   "SustainedClockSpeedInGhz": 3.5
+  },
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -40889,14 +45370,14 @@
   }
  },
  "t1.micro": {
-  "AutoRecoverySupported": false,
+  "AutoRecoverySupported": true,
   "BareMetal": false,
   "BurstablePerformanceSupported": false,
   "CurrentGeneration": false,
   "DedicatedHostsSupported": false,
   "EbsInfo": {
    "EbsOptimizedSupport": "unsupported",
-   "EncryptionSupport": "unsupported",
+   "EncryptionSupport": "supported",
    "NvmeSupport": "unsupported"
   },
   "FreeTierEligible": true,
@@ -40911,7 +45392,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "unsupported",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 2,
    "Ipv6AddressesPerInterface": 0,
    "Ipv6Supported": false,
@@ -40938,9 +45418,6 @@
     "x86_64"
    ]
   },
-  "SupportedBootModes": [
-   "legacy-bios"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -40981,7 +45458,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "unsupported",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 15,
    "Ipv6AddressesPerInterface": 15,
    "Ipv6Supported": true,
@@ -41008,9 +45484,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.3
   },
-  "SupportedBootModes": [
-   "legacy-bios"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -41050,7 +45523,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "unsupported",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 12,
    "Ipv6AddressesPerInterface": 12,
    "Ipv6Supported": true,
@@ -41077,9 +45549,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.3
   },
-  "SupportedBootModes": [
-   "legacy-bios"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -41119,7 +45588,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "unsupported",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 6,
    "Ipv6AddressesPerInterface": 6,
    "Ipv6Supported": true,
@@ -41147,9 +45615,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.3
   },
-  "SupportedBootModes": [
-   "legacy-bios"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -41189,7 +45654,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "unsupported",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 2,
    "Ipv6AddressesPerInterface": 2,
    "Ipv6Supported": true,
@@ -41217,9 +45681,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.5
   },
-  "SupportedBootModes": [
-   "legacy-bios"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -41259,7 +45720,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "unsupported",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 2,
    "Ipv6AddressesPerInterface": 2,
    "Ipv6Supported": true,
@@ -41287,9 +45747,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.4
   },
-  "SupportedBootModes": [
-   "legacy-bios"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -41328,7 +45785,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "unsupported",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 4,
    "Ipv6AddressesPerInterface": 4,
    "Ipv6Supported": true,
@@ -41356,9 +45812,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.5
   },
-  "SupportedBootModes": [
-   "legacy-bios"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -41398,7 +45851,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "unsupported",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 15,
    "Ipv6AddressesPerInterface": 15,
    "Ipv6Supported": true,
@@ -41425,9 +45877,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.3
   },
-  "SupportedBootModes": [
-   "legacy-bios"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -41475,7 +45924,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 15,
    "Ipv6AddressesPerInterface": 15,
    "Ipv6Supported": true,
@@ -41502,10 +45950,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.5
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -41561,7 +46005,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 12,
    "Ipv6AddressesPerInterface": 12,
    "Ipv6Supported": true,
@@ -41588,10 +46031,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.5
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -41646,7 +46085,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 6,
    "Ipv6AddressesPerInterface": 6,
    "Ipv6Supported": true,
@@ -41673,10 +46111,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.5
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -41731,7 +46165,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 2,
    "Ipv6AddressesPerInterface": 2,
    "Ipv6Supported": true,
@@ -41758,10 +46191,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.5
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -41816,7 +46245,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 2,
    "Ipv6AddressesPerInterface": 2,
    "Ipv6Supported": true,
@@ -41843,10 +46271,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.5
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -41901,7 +46325,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 4,
    "Ipv6AddressesPerInterface": 4,
    "Ipv6Supported": true,
@@ -41928,10 +46351,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.5
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -41986,7 +46405,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 15,
    "Ipv6AddressesPerInterface": 15,
    "Ipv6Supported": true,
@@ -42013,10 +46431,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.5
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -42071,7 +46485,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 15,
    "Ipv6AddressesPerInterface": 15,
    "Ipv6Supported": true,
@@ -42098,10 +46511,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.2
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -42157,7 +46566,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 12,
    "Ipv6AddressesPerInterface": 12,
    "Ipv6Supported": true,
@@ -42184,10 +46592,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.2
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -42242,7 +46646,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 6,
    "Ipv6AddressesPerInterface": 6,
    "Ipv6Supported": true,
@@ -42269,10 +46672,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.2
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -42327,7 +46726,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 2,
    "Ipv6AddressesPerInterface": 2,
    "Ipv6Supported": true,
@@ -42354,10 +46752,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.2
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -42412,7 +46806,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 2,
    "Ipv6AddressesPerInterface": 2,
    "Ipv6Supported": true,
@@ -42439,10 +46832,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.2
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -42497,7 +46886,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 4,
    "Ipv6AddressesPerInterface": 4,
    "Ipv6Supported": true,
@@ -42524,10 +46912,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.2
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -42582,7 +46966,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 15,
    "Ipv6AddressesPerInterface": 15,
    "Ipv6Supported": true,
@@ -42609,10 +46992,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.2
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -42637,7 +47016,7 @@
   }
  },
  "t4g.2xlarge": {
-  "AutoRecoverySupported": false,
+  "AutoRecoverySupported": true,
   "BareMetal": false,
   "BurstablePerformanceSupported": true,
   "CurrentGeneration": true,
@@ -42667,7 +47046,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 15,
    "Ipv6AddressesPerInterface": 15,
    "Ipv6Supported": true,
@@ -42694,9 +47072,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.5
   },
-  "SupportedBootModes": [
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -42727,7 +47102,7 @@
   }
  },
  "t4g.large": {
-  "AutoRecoverySupported": false,
+  "AutoRecoverySupported": true,
   "BareMetal": false,
   "BurstablePerformanceSupported": true,
   "CurrentGeneration": true,
@@ -42757,7 +47132,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 12,
    "Ipv6AddressesPerInterface": 12,
    "Ipv6Supported": true,
@@ -42784,9 +47158,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.5
   },
-  "SupportedBootModes": [
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -42811,7 +47182,7 @@
   }
  },
  "t4g.medium": {
-  "AutoRecoverySupported": false,
+  "AutoRecoverySupported": true,
   "BareMetal": false,
   "BurstablePerformanceSupported": true,
   "CurrentGeneration": true,
@@ -42841,7 +47212,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 6,
    "Ipv6AddressesPerInterface": 6,
    "Ipv6Supported": true,
@@ -42868,9 +47238,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.5
   },
-  "SupportedBootModes": [
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -42895,7 +47262,7 @@
   }
  },
  "t4g.micro": {
-  "AutoRecoverySupported": false,
+  "AutoRecoverySupported": true,
   "BareMetal": false,
   "BurstablePerformanceSupported": true,
   "CurrentGeneration": true,
@@ -42925,7 +47292,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 2,
    "Ipv6AddressesPerInterface": 2,
    "Ipv6Supported": true,
@@ -42952,9 +47318,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.5
   },
-  "SupportedBootModes": [
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -42979,7 +47342,7 @@
   }
  },
  "t4g.nano": {
-  "AutoRecoverySupported": false,
+  "AutoRecoverySupported": true,
   "BareMetal": false,
   "BurstablePerformanceSupported": true,
   "CurrentGeneration": true,
@@ -43009,7 +47372,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 2,
    "Ipv6AddressesPerInterface": 2,
    "Ipv6Supported": true,
@@ -43036,9 +47398,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.5
   },
-  "SupportedBootModes": [
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -43063,7 +47422,7 @@
   }
  },
  "t4g.small": {
-  "AutoRecoverySupported": false,
+  "AutoRecoverySupported": true,
   "BareMetal": false,
   "BurstablePerformanceSupported": true,
   "CurrentGeneration": true,
@@ -43093,7 +47452,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 4,
    "Ipv6AddressesPerInterface": 4,
    "Ipv6Supported": true,
@@ -43120,9 +47478,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.5
   },
-  "SupportedBootModes": [
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -43147,7 +47502,7 @@
   }
  },
  "t4g.xlarge": {
-  "AutoRecoverySupported": false,
+  "AutoRecoverySupported": true,
   "BareMetal": false,
   "BurstablePerformanceSupported": true,
   "CurrentGeneration": true,
@@ -43177,7 +47532,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 15,
    "Ipv6AddressesPerInterface": 15,
    "Ipv6Supported": true,
@@ -43204,9 +47558,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.5
   },
-  "SupportedBootModes": [
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -43263,7 +47614,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": true,
    "Ipv4AddressesPerInterface": 50,
    "Ipv6AddressesPerInterface": 50,
    "Ipv6Supported": true,
@@ -43291,10 +47641,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.1
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -43344,6 +47690,113 @@
    ]
   }
  },
+ "u-3tb1.56xlarge": {
+  "AutoRecoverySupported": true,
+  "BareMetal": false,
+  "BurstablePerformanceSupported": false,
+  "CurrentGeneration": true,
+  "DedicatedHostsSupported": false,
+  "EbsInfo": {
+   "EbsOptimizedInfo": {
+    "BaselineBandwidthInMbps": 19000,
+    "BaselineIops": 80000,
+    "BaselineThroughputInMBps": 2375.0,
+    "MaximumBandwidthInMbps": 19000,
+    "MaximumIops": 80000,
+    "MaximumThroughputInMBps": 2375.0
+   },
+   "EbsOptimizedSupport": "default",
+   "EncryptionSupport": "supported",
+   "NvmeSupport": "required"
+  },
+  "FreeTierEligible": false,
+  "HibernationSupported": false,
+  "Hypervisor": "nitro",
+  "InstanceStorageSupported": false,
+  "InstanceType": "u-3tb1.56xlarge",
+  "MemoryInfo": {
+   "SizeInMiB": 3145728
+  },
+  "NetworkInfo": {
+   "DefaultNetworkCardIndex": 0,
+   "EfaSupported": false,
+   "EnaSupport": "required",
+   "Ipv4AddressesPerInterface": 30,
+   "Ipv6AddressesPerInterface": 30,
+   "Ipv6Supported": true,
+   "MaximumNetworkCards": 1,
+   "MaximumNetworkInterfaces": 8,
+   "NetworkCards": [
+    {
+     "MaximumNetworkInterfaces": 8,
+     "NetworkCardIndex": 0,
+     "NetworkPerformance": "50 Gigabit"
+    }
+   ],
+   "NetworkPerformance": "50 Gigabit"
+  },
+  "PlacementGroupInfo": {
+   "SupportedStrategies": [
+    "cluster",
+    "partition",
+    "spread"
+   ]
+  },
+  "ProcessorInfo": {
+   "SupportedArchitectures": [
+    "x86_64"
+   ],
+   "SustainedClockSpeedInGhz": 2.1
+  },
+  "SupportedRootDeviceTypes": [
+   "ebs"
+  ],
+  "SupportedUsageClasses": [
+   "on-demand"
+  ],
+  "SupportedVirtualizationTypes": [
+   "hvm"
+  ],
+  "VCpuInfo": {
+   "DefaultCores": 112,
+   "DefaultThreadsPerCore": 2,
+   "DefaultVCpus": 224,
+   "ValidCores": [
+    4,
+    8,
+    12,
+    16,
+    20,
+    24,
+    28,
+    32,
+    36,
+    40,
+    44,
+    48,
+    52,
+    56,
+    60,
+    64,
+    68,
+    72,
+    76,
+    80,
+    84,
+    88,
+    92,
+    96,
+    100,
+    104,
+    108,
+    112
+   ],
+   "ValidThreadsPerCore": [
+    1,
+    2
+   ]
+  }
+ },
  "u-6tb1.112xlarge": {
   "AutoRecoverySupported": true,
   "BareMetal": false,
@@ -43375,7 +47828,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": true,
    "Ipv4AddressesPerInterface": 50,
    "Ipv6AddressesPerInterface": 50,
    "Ipv6Supported": true,
@@ -43403,10 +47855,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.1
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -43487,7 +47935,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": true,
    "Ipv4AddressesPerInterface": 50,
    "Ipv6AddressesPerInterface": 50,
    "Ipv6Supported": true,
@@ -43515,10 +47962,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.1
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -43598,7 +48041,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": true,
    "Ipv4AddressesPerInterface": 50,
    "Ipv6AddressesPerInterface": 50,
    "Ipv6Supported": true,
@@ -43626,10 +48068,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.1
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -43680,7 +48118,7 @@
   }
  },
  "vt1.24xlarge": {
-  "AutoRecoverySupported": false,
+  "AutoRecoverySupported": true,
   "BareMetal": false,
   "BurstablePerformanceSupported": false,
   "CurrentGeneration": true,
@@ -43708,12 +48146,8 @@
   },
   "NetworkInfo": {
    "DefaultNetworkCardIndex": 0,
-   "EfaInfo": {
-    "MaximumEfaInterfaces": 1
-   },
    "EfaSupported": true,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": true,
    "Ipv4AddressesPerInterface": 50,
    "Ipv6AddressesPerInterface": 50,
    "Ipv6Supported": true,
@@ -43740,9 +48174,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.5
   },
-  "SupportedBootModes": [
-   "legacy-bios"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -43769,7 +48200,7 @@
   }
  },
  "vt1.3xlarge": {
-  "AutoRecoverySupported": false,
+  "AutoRecoverySupported": true,
   "BareMetal": false,
   "BurstablePerformanceSupported": false,
   "CurrentGeneration": true,
@@ -43799,7 +48230,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": true,
    "Ipv4AddressesPerInterface": 15,
    "Ipv6AddressesPerInterface": 15,
    "Ipv6Supported": true,
@@ -43826,9 +48256,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.5
   },
-  "SupportedBootModes": [
-   "legacy-bios"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -43853,7 +48280,7 @@
   }
  },
  "vt1.6xlarge": {
-  "AutoRecoverySupported": false,
+  "AutoRecoverySupported": true,
   "BareMetal": false,
   "BurstablePerformanceSupported": false,
   "CurrentGeneration": true,
@@ -43883,7 +48310,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": true,
    "Ipv4AddressesPerInterface": 30,
    "Ipv6AddressesPerInterface": 30,
    "Ipv6Supported": true,
@@ -43910,9 +48336,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.5
   },
-  "SupportedBootModes": [
-   "legacy-bios"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -43967,7 +48390,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "unsupported",
    "NvmeSupport": "unsupported",
    "TotalSizeInGB": 1920
   },
@@ -43980,7 +48402,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "supported",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 30,
    "Ipv6AddressesPerInterface": 30,
    "Ipv6Supported": true,
@@ -44008,9 +48429,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.3
   },
-  "SupportedBootModes": [
-   "legacy-bios"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs",
    "instance-store"
@@ -44080,7 +48498,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "unsupported",
    "NvmeSupport": "unsupported",
    "TotalSizeInGB": 3840
   },
@@ -44093,7 +48510,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "supported",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 30,
    "Ipv6AddressesPerInterface": 30,
    "Ipv6Supported": true,
@@ -44121,9 +48537,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.3
   },
-  "SupportedBootModes": [
-   "legacy-bios"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs",
    "instance-store"
@@ -44193,7 +48606,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "unsupported",
    "NvmeSupport": "unsupported",
    "TotalSizeInGB": 1920
   },
@@ -44206,7 +48618,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "supported",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 30,
    "Ipv6AddressesPerInterface": 30,
    "Ipv6Supported": true,
@@ -44234,9 +48645,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.3
   },
-  "SupportedBootModes": [
-   "legacy-bios"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -44305,7 +48713,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "unsupported",
    "NvmeSupport": "unsupported",
    "TotalSizeInGB": 240
   },
@@ -44318,7 +48725,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "supported",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 15,
    "Ipv6AddressesPerInterface": 15,
    "Ipv6Supported": true,
@@ -44346,9 +48752,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.3
   },
-  "SupportedBootModes": [
-   "legacy-bios"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -44405,7 +48808,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "unsupported",
    "NvmeSupport": "unsupported",
    "TotalSizeInGB": 3840
   },
@@ -44418,7 +48820,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "supported",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 30,
    "Ipv6AddressesPerInterface": 30,
    "Ipv6Supported": true,
@@ -44446,9 +48847,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.3
   },
-  "SupportedBootModes": [
-   "legacy-bios"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -44517,7 +48915,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "unsupported",
    "NvmeSupport": "unsupported",
    "TotalSizeInGB": 480
   },
@@ -44530,7 +48927,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "supported",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 15,
    "Ipv6AddressesPerInterface": 15,
    "Ipv6Supported": true,
@@ -44558,9 +48954,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.3
   },
-  "SupportedBootModes": [
-   "legacy-bios"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -44621,7 +49014,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "unsupported",
    "NvmeSupport": "unsupported",
    "TotalSizeInGB": 960
   },
@@ -44634,7 +49026,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "supported",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 15,
    "Ipv6AddressesPerInterface": 15,
    "Ipv6Supported": true,
@@ -44662,9 +49053,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.3
   },
-  "SupportedBootModes": [
-   "legacy-bios"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -44733,7 +49121,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "unsupported",
    "NvmeSupport": "unsupported",
    "TotalSizeInGB": 120
   },
@@ -44746,7 +49133,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "supported",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 10,
    "Ipv6AddressesPerInterface": 10,
    "Ipv6Supported": true,
@@ -44774,9 +49160,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.3
   },
-  "SupportedBootModes": [
-   "legacy-bios"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -44831,7 +49214,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "required",
    "NvmeSupport": "required",
    "TotalSizeInGB": 2850
   },
@@ -44844,7 +49226,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 30,
    "Ipv6AddressesPerInterface": 30,
    "Ipv6Supported": true,
@@ -44872,9 +49253,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.5
   },
-  "SupportedBootModes": [
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -44974,7 +49352,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "required",
    "NvmeSupport": "required",
    "TotalSizeInGB": 3800
   },
@@ -44987,7 +49364,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 50,
    "Ipv6AddressesPerInterface": 50,
    "Ipv6Supported": true,
@@ -45015,9 +49391,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.5
   },
-  "SupportedBootModes": [
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -45133,7 +49506,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "required",
    "NvmeSupport": "required",
    "TotalSizeInGB": 475
   },
@@ -45146,7 +49518,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 15,
    "Ipv6AddressesPerInterface": 15,
    "Ipv6Supported": true,
@@ -45174,9 +49545,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.5
   },
-  "SupportedBootModes": [
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -45236,7 +49604,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "required",
    "NvmeSupport": "required",
    "TotalSizeInGB": 950
   },
@@ -45249,7 +49616,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 30,
    "Ipv6AddressesPerInterface": 30,
    "Ipv6Supported": true,
@@ -45277,9 +49643,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.5
   },
-  "SupportedBootModes": [
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -45347,7 +49710,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "required",
    "NvmeSupport": "required",
    "TotalSizeInGB": 1900
   },
@@ -45360,7 +49722,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 30,
    "Ipv6AddressesPerInterface": 30,
    "Ipv6Supported": true,
@@ -45388,9 +49749,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.5
   },
-  "SupportedBootModes": [
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -45474,7 +49832,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "required",
    "NvmeSupport": "required",
    "TotalSizeInGB": 118
   },
@@ -45487,7 +49844,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 10,
    "Ipv6AddressesPerInterface": 10,
    "Ipv6Supported": true,
@@ -45515,9 +49871,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.5
   },
-  "SupportedBootModes": [
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -45571,7 +49924,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "required",
    "NvmeSupport": "required",
    "TotalSizeInGB": 59
   },
@@ -45584,7 +49936,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 4,
    "Ipv6AddressesPerInterface": 4,
    "Ipv6Supported": true,
@@ -45612,9 +49963,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.5
   },
-  "SupportedBootModes": [
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -45660,7 +50008,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "required",
    "NvmeSupport": "required",
    "TotalSizeInGB": 3800
   },
@@ -45673,7 +50020,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 50,
    "Ipv6AddressesPerInterface": 50,
    "Ipv6Supported": true,
@@ -45701,9 +50047,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.5
   },
-  "SupportedBootModes": [
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -45750,7 +50093,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "required",
    "NvmeSupport": "required",
    "TotalSizeInGB": 237
   },
@@ -45763,7 +50105,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 15,
    "Ipv6AddressesPerInterface": 15,
    "Ipv6Supported": true,
@@ -45791,9 +50132,6 @@
    ],
    "SustainedClockSpeedInGhz": 2.5
   },
-  "SupportedBootModes": [
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -45817,6 +50155,1749 @@
    "ValidThreadsPerCore": [
     1
    ]
+  }
+ },
+ "x2idn.16xlarge": {
+  "AutoRecoverySupported": true,
+  "BareMetal": false,
+  "BurstablePerformanceSupported": false,
+  "CurrentGeneration": true,
+  "DedicatedHostsSupported": true,
+  "EbsInfo": {
+   "EbsOptimizedInfo": {
+    "BaselineBandwidthInMbps": 40000,
+    "BaselineIops": 173333,
+    "BaselineThroughputInMBps": 5000.0,
+    "MaximumBandwidthInMbps": 40000,
+    "MaximumIops": 173333,
+    "MaximumThroughputInMBps": 5000.0
+   },
+   "EbsOptimizedSupport": "default",
+   "EncryptionSupport": "supported",
+   "NvmeSupport": "required"
+  },
+  "FreeTierEligible": false,
+  "HibernationSupported": false,
+  "Hypervisor": "nitro",
+  "InstanceStorageInfo": {
+   "Disks": [
+    {
+     "Count": 1,
+     "SizeInGB": 1900,
+     "Type": "ssd"
+    }
+   ],
+   "NvmeSupport": "required",
+   "TotalSizeInGB": 1900
+  },
+  "InstanceStorageSupported": true,
+  "InstanceType": "x2idn.16xlarge",
+  "MemoryInfo": {
+   "SizeInMiB": 1048576
+  },
+  "NetworkInfo": {
+   "DefaultNetworkCardIndex": 0,
+   "EfaSupported": false,
+   "EnaSupport": "required",
+   "Ipv4AddressesPerInterface": 50,
+   "Ipv6AddressesPerInterface": 50,
+   "Ipv6Supported": true,
+   "MaximumNetworkCards": 1,
+   "MaximumNetworkInterfaces": 15,
+   "NetworkCards": [
+    {
+     "MaximumNetworkInterfaces": 15,
+     "NetworkCardIndex": 0,
+     "NetworkPerformance": "50 Gigabit"
+    }
+   ],
+   "NetworkPerformance": "50 Gigabit"
+  },
+  "PlacementGroupInfo": {
+   "SupportedStrategies": [
+    "cluster",
+    "partition",
+    "spread"
+   ]
+  },
+  "ProcessorInfo": {
+   "SupportedArchitectures": [
+    "x86_64"
+   ],
+   "SustainedClockSpeedInGhz": 3.5
+  },
+  "SupportedRootDeviceTypes": [
+   "ebs"
+  ],
+  "SupportedUsageClasses": [
+   "on-demand",
+   "spot"
+  ],
+  "SupportedVirtualizationTypes": [
+   "hvm"
+  ],
+  "VCpuInfo": {
+   "DefaultCores": 32,
+   "DefaultThreadsPerCore": 2,
+   "DefaultVCpus": 64,
+   "ValidCores": [
+    2,
+    4,
+    6,
+    8,
+    10,
+    12,
+    14,
+    16,
+    18,
+    20,
+    22,
+    24,
+    26,
+    28,
+    30,
+    32
+   ],
+   "ValidThreadsPerCore": [
+    1,
+    2
+   ]
+  }
+ },
+ "x2idn.24xlarge": {
+  "AutoRecoverySupported": true,
+  "BareMetal": false,
+  "BurstablePerformanceSupported": false,
+  "CurrentGeneration": true,
+  "DedicatedHostsSupported": true,
+  "EbsInfo": {
+   "EbsOptimizedInfo": {
+    "BaselineBandwidthInMbps": 60000,
+    "BaselineIops": 260000,
+    "BaselineThroughputInMBps": 7500.0,
+    "MaximumBandwidthInMbps": 60000,
+    "MaximumIops": 260000,
+    "MaximumThroughputInMBps": 7500.0
+   },
+   "EbsOptimizedSupport": "default",
+   "EncryptionSupport": "supported",
+   "NvmeSupport": "required"
+  },
+  "FreeTierEligible": false,
+  "HibernationSupported": false,
+  "Hypervisor": "nitro",
+  "InstanceStorageInfo": {
+   "Disks": [
+    {
+     "Count": 2,
+     "SizeInGB": 1425,
+     "Type": "ssd"
+    }
+   ],
+   "NvmeSupport": "required",
+   "TotalSizeInGB": 2850
+  },
+  "InstanceStorageSupported": true,
+  "InstanceType": "x2idn.24xlarge",
+  "MemoryInfo": {
+   "SizeInMiB": 1572864
+  },
+  "NetworkInfo": {
+   "DefaultNetworkCardIndex": 0,
+   "EfaSupported": false,
+   "EnaSupport": "required",
+   "Ipv4AddressesPerInterface": 50,
+   "Ipv6AddressesPerInterface": 50,
+   "Ipv6Supported": true,
+   "MaximumNetworkCards": 1,
+   "MaximumNetworkInterfaces": 15,
+   "NetworkCards": [
+    {
+     "MaximumNetworkInterfaces": 15,
+     "NetworkCardIndex": 0,
+     "NetworkPerformance": "75 Gigabit"
+    }
+   ],
+   "NetworkPerformance": "75 Gigabit"
+  },
+  "PlacementGroupInfo": {
+   "SupportedStrategies": [
+    "cluster",
+    "partition",
+    "spread"
+   ]
+  },
+  "ProcessorInfo": {
+   "SupportedArchitectures": [
+    "x86_64"
+   ],
+   "SustainedClockSpeedInGhz": 3.5
+  },
+  "SupportedRootDeviceTypes": [
+   "ebs"
+  ],
+  "SupportedUsageClasses": [
+   "on-demand",
+   "spot"
+  ],
+  "SupportedVirtualizationTypes": [
+   "hvm"
+  ],
+  "VCpuInfo": {
+   "DefaultCores": 48,
+   "DefaultThreadsPerCore": 2,
+   "DefaultVCpus": 96,
+   "ValidCores": [
+    2,
+    4,
+    6,
+    8,
+    10,
+    12,
+    14,
+    16,
+    18,
+    20,
+    22,
+    24,
+    26,
+    28,
+    30,
+    32,
+    34,
+    36,
+    38,
+    40,
+    42,
+    44,
+    46,
+    48
+   ],
+   "ValidThreadsPerCore": [
+    1,
+    2
+   ]
+  }
+ },
+ "x2idn.32xlarge": {
+  "AutoRecoverySupported": true,
+  "BareMetal": false,
+  "BurstablePerformanceSupported": false,
+  "CurrentGeneration": true,
+  "DedicatedHostsSupported": true,
+  "EbsInfo": {
+   "EbsOptimizedInfo": {
+    "BaselineBandwidthInMbps": 80000,
+    "BaselineIops": 260000,
+    "BaselineThroughputInMBps": 10000.0,
+    "MaximumBandwidthInMbps": 80000,
+    "MaximumIops": 260000,
+    "MaximumThroughputInMBps": 10000.0
+   },
+   "EbsOptimizedSupport": "default",
+   "EncryptionSupport": "supported",
+   "NvmeSupport": "required"
+  },
+  "FreeTierEligible": false,
+  "HibernationSupported": false,
+  "Hypervisor": "nitro",
+  "InstanceStorageInfo": {
+   "Disks": [
+    {
+     "Count": 2,
+     "SizeInGB": 1900,
+     "Type": "ssd"
+    }
+   ],
+   "NvmeSupport": "required",
+   "TotalSizeInGB": 3800
+  },
+  "InstanceStorageSupported": true,
+  "InstanceType": "x2idn.32xlarge",
+  "MemoryInfo": {
+   "SizeInMiB": 2097152
+  },
+  "NetworkInfo": {
+   "DefaultNetworkCardIndex": 0,
+   "EfaSupported": true,
+   "EnaSupport": "required",
+   "Ipv4AddressesPerInterface": 50,
+   "Ipv6AddressesPerInterface": 50,
+   "Ipv6Supported": true,
+   "MaximumNetworkCards": 1,
+   "MaximumNetworkInterfaces": 15,
+   "NetworkCards": [
+    {
+     "MaximumNetworkInterfaces": 15,
+     "NetworkCardIndex": 0,
+     "NetworkPerformance": "100 Gigabit"
+    }
+   ],
+   "NetworkPerformance": "100 Gigabit"
+  },
+  "PlacementGroupInfo": {
+   "SupportedStrategies": [
+    "cluster",
+    "partition",
+    "spread"
+   ]
+  },
+  "ProcessorInfo": {
+   "SupportedArchitectures": [
+    "x86_64"
+   ],
+   "SustainedClockSpeedInGhz": 3.5
+  },
+  "SupportedRootDeviceTypes": [
+   "ebs"
+  ],
+  "SupportedUsageClasses": [
+   "on-demand",
+   "spot"
+  ],
+  "SupportedVirtualizationTypes": [
+   "hvm"
+  ],
+  "VCpuInfo": {
+   "DefaultCores": 64,
+   "DefaultThreadsPerCore": 2,
+   "DefaultVCpus": 128,
+   "ValidCores": [
+    2,
+    4,
+    6,
+    8,
+    10,
+    12,
+    14,
+    16,
+    18,
+    20,
+    22,
+    24,
+    26,
+    28,
+    30,
+    32,
+    34,
+    36,
+    38,
+    40,
+    42,
+    44,
+    46,
+    48,
+    50,
+    52,
+    54,
+    56,
+    58,
+    60,
+    62,
+    64
+   ],
+   "ValidThreadsPerCore": [
+    1,
+    2
+   ]
+  }
+ },
+ "x2idn.metal": {
+  "AutoRecoverySupported": true,
+  "BareMetal": true,
+  "BurstablePerformanceSupported": false,
+  "CurrentGeneration": true,
+  "DedicatedHostsSupported": true,
+  "EbsInfo": {
+   "EbsOptimizedInfo": {
+    "BaselineBandwidthInMbps": 80000,
+    "BaselineIops": 260000,
+    "BaselineThroughputInMBps": 10000.0,
+    "MaximumBandwidthInMbps": 80000,
+    "MaximumIops": 260000,
+    "MaximumThroughputInMBps": 10000.0
+   },
+   "EbsOptimizedSupport": "default",
+   "EncryptionSupport": "supported",
+   "NvmeSupport": "required"
+  },
+  "FreeTierEligible": false,
+  "HibernationSupported": false,
+  "InstanceStorageInfo": {
+   "Disks": [
+    {
+     "Count": 2,
+     "SizeInGB": 1900,
+     "Type": "ssd"
+    }
+   ],
+   "NvmeSupport": "required",
+   "TotalSizeInGB": 3800
+  },
+  "InstanceStorageSupported": true,
+  "InstanceType": "x2idn.metal",
+  "MemoryInfo": {
+   "SizeInMiB": 2097152
+  },
+  "NetworkInfo": {
+   "DefaultNetworkCardIndex": 0,
+   "EfaSupported": true,
+   "EnaSupport": "required",
+   "Ipv4AddressesPerInterface": 50,
+   "Ipv6AddressesPerInterface": 50,
+   "Ipv6Supported": true,
+   "MaximumNetworkCards": 1,
+   "MaximumNetworkInterfaces": 15,
+   "NetworkCards": [
+    {
+     "MaximumNetworkInterfaces": 15,
+     "NetworkCardIndex": 0,
+     "NetworkPerformance": "100 Gigabit"
+    }
+   ],
+   "NetworkPerformance": "100 Gigabit"
+  },
+  "PlacementGroupInfo": {
+   "SupportedStrategies": [
+    "cluster",
+    "partition",
+    "spread"
+   ]
+  },
+  "ProcessorInfo": {
+   "SupportedArchitectures": [
+    "x86_64"
+   ],
+   "SustainedClockSpeedInGhz": 3.5
+  },
+  "SupportedRootDeviceTypes": [
+   "ebs"
+  ],
+  "SupportedUsageClasses": [
+   "on-demand",
+   "spot"
+  ],
+  "SupportedVirtualizationTypes": [
+   "hvm"
+  ],
+  "VCpuInfo": {
+   "DefaultCores": 64,
+   "DefaultThreadsPerCore": 2,
+   "DefaultVCpus": 128
+  }
+ },
+ "x2iedn.16xlarge": {
+  "AutoRecoverySupported": true,
+  "BareMetal": false,
+  "BurstablePerformanceSupported": false,
+  "CurrentGeneration": true,
+  "DedicatedHostsSupported": true,
+  "EbsInfo": {
+   "EbsOptimizedInfo": {
+    "BaselineBandwidthInMbps": 40000,
+    "BaselineIops": 130000,
+    "BaselineThroughputInMBps": 5000.0,
+    "MaximumBandwidthInMbps": 40000,
+    "MaximumIops": 130000,
+    "MaximumThroughputInMBps": 5000.0
+   },
+   "EbsOptimizedSupport": "default",
+   "EncryptionSupport": "supported",
+   "NvmeSupport": "required"
+  },
+  "FreeTierEligible": false,
+  "HibernationSupported": false,
+  "Hypervisor": "nitro",
+  "InstanceStorageInfo": {
+   "Disks": [
+    {
+     "Count": 1,
+     "SizeInGB": 1900,
+     "Type": "ssd"
+    }
+   ],
+   "NvmeSupport": "required",
+   "TotalSizeInGB": 1900
+  },
+  "InstanceStorageSupported": true,
+  "InstanceType": "x2iedn.16xlarge",
+  "MemoryInfo": {
+   "SizeInMiB": 2097152
+  },
+  "NetworkInfo": {
+   "DefaultNetworkCardIndex": 0,
+   "EfaSupported": false,
+   "EnaSupport": "required",
+   "Ipv4AddressesPerInterface": 50,
+   "Ipv6AddressesPerInterface": 50,
+   "Ipv6Supported": true,
+   "MaximumNetworkCards": 1,
+   "MaximumNetworkInterfaces": 15,
+   "NetworkCards": [
+    {
+     "MaximumNetworkInterfaces": 15,
+     "NetworkCardIndex": 0,
+     "NetworkPerformance": "50 Gigabit"
+    }
+   ],
+   "NetworkPerformance": "50 Gigabit"
+  },
+  "PlacementGroupInfo": {
+   "SupportedStrategies": [
+    "cluster",
+    "partition",
+    "spread"
+   ]
+  },
+  "ProcessorInfo": {
+   "SupportedArchitectures": [
+    "x86_64"
+   ],
+   "SustainedClockSpeedInGhz": 3.5
+  },
+  "SupportedRootDeviceTypes": [
+   "ebs"
+  ],
+  "SupportedUsageClasses": [
+   "on-demand",
+   "spot"
+  ],
+  "SupportedVirtualizationTypes": [
+   "hvm"
+  ],
+  "VCpuInfo": {
+   "DefaultCores": 32,
+   "DefaultThreadsPerCore": 2,
+   "DefaultVCpus": 64,
+   "ValidCores": [
+    2,
+    4,
+    6,
+    8,
+    10,
+    12,
+    14,
+    16,
+    18,
+    20,
+    22,
+    24,
+    26,
+    28,
+    30,
+    32
+   ],
+   "ValidThreadsPerCore": [
+    1,
+    2
+   ]
+  }
+ },
+ "x2iedn.24xlarge": {
+  "AutoRecoverySupported": true,
+  "BareMetal": false,
+  "BurstablePerformanceSupported": false,
+  "CurrentGeneration": true,
+  "DedicatedHostsSupported": true,
+  "EbsInfo": {
+   "EbsOptimizedInfo": {
+    "BaselineBandwidthInMbps": 60000,
+    "BaselineIops": 195000,
+    "BaselineThroughputInMBps": 7500.0,
+    "MaximumBandwidthInMbps": 60000,
+    "MaximumIops": 195000,
+    "MaximumThroughputInMBps": 7500.0
+   },
+   "EbsOptimizedSupport": "default",
+   "EncryptionSupport": "supported",
+   "NvmeSupport": "required"
+  },
+  "FreeTierEligible": false,
+  "HibernationSupported": false,
+  "Hypervisor": "nitro",
+  "InstanceStorageInfo": {
+   "Disks": [
+    {
+     "Count": 2,
+     "SizeInGB": 1425,
+     "Type": "ssd"
+    }
+   ],
+   "NvmeSupport": "required",
+   "TotalSizeInGB": 2850
+  },
+  "InstanceStorageSupported": true,
+  "InstanceType": "x2iedn.24xlarge",
+  "MemoryInfo": {
+   "SizeInMiB": 3145728
+  },
+  "NetworkInfo": {
+   "DefaultNetworkCardIndex": 0,
+   "EfaSupported": false,
+   "EnaSupport": "required",
+   "Ipv4AddressesPerInterface": 50,
+   "Ipv6AddressesPerInterface": 50,
+   "Ipv6Supported": true,
+   "MaximumNetworkCards": 1,
+   "MaximumNetworkInterfaces": 15,
+   "NetworkCards": [
+    {
+     "MaximumNetworkInterfaces": 15,
+     "NetworkCardIndex": 0,
+     "NetworkPerformance": "75 Gigabit"
+    }
+   ],
+   "NetworkPerformance": "75 Gigabit"
+  },
+  "PlacementGroupInfo": {
+   "SupportedStrategies": [
+    "cluster",
+    "partition",
+    "spread"
+   ]
+  },
+  "ProcessorInfo": {
+   "SupportedArchitectures": [
+    "x86_64"
+   ],
+   "SustainedClockSpeedInGhz": 3.5
+  },
+  "SupportedRootDeviceTypes": [
+   "ebs"
+  ],
+  "SupportedUsageClasses": [
+   "on-demand",
+   "spot"
+  ],
+  "SupportedVirtualizationTypes": [
+   "hvm"
+  ],
+  "VCpuInfo": {
+   "DefaultCores": 48,
+   "DefaultThreadsPerCore": 2,
+   "DefaultVCpus": 96,
+   "ValidCores": [
+    2,
+    4,
+    6,
+    8,
+    10,
+    12,
+    14,
+    16,
+    18,
+    20,
+    22,
+    24,
+    26,
+    28,
+    30,
+    32,
+    34,
+    36,
+    38,
+    40,
+    42,
+    44,
+    46,
+    48
+   ],
+   "ValidThreadsPerCore": [
+    1,
+    2
+   ]
+  }
+ },
+ "x2iedn.2xlarge": {
+  "AutoRecoverySupported": true,
+  "BareMetal": false,
+  "BurstablePerformanceSupported": false,
+  "CurrentGeneration": true,
+  "DedicatedHostsSupported": true,
+  "EbsInfo": {
+   "EbsOptimizedInfo": {
+    "BaselineBandwidthInMbps": 5000,
+    "BaselineIops": 16250,
+    "BaselineThroughputInMBps": 625.0,
+    "MaximumBandwidthInMbps": 20000,
+    "MaximumIops": 65000,
+    "MaximumThroughputInMBps": 2500.0
+   },
+   "EbsOptimizedSupport": "default",
+   "EncryptionSupport": "supported",
+   "NvmeSupport": "required"
+  },
+  "FreeTierEligible": false,
+  "HibernationSupported": false,
+  "Hypervisor": "nitro",
+  "InstanceStorageInfo": {
+   "Disks": [
+    {
+     "Count": 1,
+     "SizeInGB": 237,
+     "Type": "ssd"
+    }
+   ],
+   "NvmeSupport": "required",
+   "TotalSizeInGB": 237
+  },
+  "InstanceStorageSupported": true,
+  "InstanceType": "x2iedn.2xlarge",
+  "MemoryInfo": {
+   "SizeInMiB": 262144
+  },
+  "NetworkInfo": {
+   "DefaultNetworkCardIndex": 0,
+   "EfaSupported": false,
+   "EnaSupport": "required",
+   "Ipv4AddressesPerInterface": 15,
+   "Ipv6AddressesPerInterface": 15,
+   "Ipv6Supported": true,
+   "MaximumNetworkCards": 1,
+   "MaximumNetworkInterfaces": 4,
+   "NetworkCards": [
+    {
+     "MaximumNetworkInterfaces": 4,
+     "NetworkCardIndex": 0,
+     "NetworkPerformance": "Up to 25 Gigabit"
+    }
+   ],
+   "NetworkPerformance": "Up to 25 Gigabit"
+  },
+  "PlacementGroupInfo": {
+   "SupportedStrategies": [
+    "cluster",
+    "partition",
+    "spread"
+   ]
+  },
+  "ProcessorInfo": {
+   "SupportedArchitectures": [
+    "x86_64"
+   ],
+   "SustainedClockSpeedInGhz": 3.5
+  },
+  "SupportedRootDeviceTypes": [
+   "ebs"
+  ],
+  "SupportedUsageClasses": [
+   "on-demand",
+   "spot"
+  ],
+  "SupportedVirtualizationTypes": [
+   "hvm"
+  ],
+  "VCpuInfo": {
+   "DefaultCores": 4,
+   "DefaultThreadsPerCore": 2,
+   "DefaultVCpus": 8,
+   "ValidCores": [
+    2,
+    4
+   ],
+   "ValidThreadsPerCore": [
+    1,
+    2
+   ]
+  }
+ },
+ "x2iedn.32xlarge": {
+  "AutoRecoverySupported": true,
+  "BareMetal": false,
+  "BurstablePerformanceSupported": false,
+  "CurrentGeneration": true,
+  "DedicatedHostsSupported": true,
+  "EbsInfo": {
+   "EbsOptimizedInfo": {
+    "BaselineBandwidthInMbps": 80000,
+    "BaselineIops": 260000,
+    "BaselineThroughputInMBps": 10000.0,
+    "MaximumBandwidthInMbps": 80000,
+    "MaximumIops": 260000,
+    "MaximumThroughputInMBps": 10000.0
+   },
+   "EbsOptimizedSupport": "default",
+   "EncryptionSupport": "supported",
+   "NvmeSupport": "required"
+  },
+  "FreeTierEligible": false,
+  "HibernationSupported": false,
+  "Hypervisor": "nitro",
+  "InstanceStorageInfo": {
+   "Disks": [
+    {
+     "Count": 2,
+     "SizeInGB": 1900,
+     "Type": "ssd"
+    }
+   ],
+   "NvmeSupport": "required",
+   "TotalSizeInGB": 3800
+  },
+  "InstanceStorageSupported": true,
+  "InstanceType": "x2iedn.32xlarge",
+  "MemoryInfo": {
+   "SizeInMiB": 4194304
+  },
+  "NetworkInfo": {
+   "DefaultNetworkCardIndex": 0,
+   "EfaSupported": true,
+   "EnaSupport": "required",
+   "Ipv4AddressesPerInterface": 50,
+   "Ipv6AddressesPerInterface": 50,
+   "Ipv6Supported": true,
+   "MaximumNetworkCards": 1,
+   "MaximumNetworkInterfaces": 15,
+   "NetworkCards": [
+    {
+     "MaximumNetworkInterfaces": 15,
+     "NetworkCardIndex": 0,
+     "NetworkPerformance": "100 Gigabit"
+    }
+   ],
+   "NetworkPerformance": "100 Gigabit"
+  },
+  "PlacementGroupInfo": {
+   "SupportedStrategies": [
+    "cluster",
+    "partition",
+    "spread"
+   ]
+  },
+  "ProcessorInfo": {
+   "SupportedArchitectures": [
+    "x86_64"
+   ],
+   "SustainedClockSpeedInGhz": 3.5
+  },
+  "SupportedRootDeviceTypes": [
+   "ebs"
+  ],
+  "SupportedUsageClasses": [
+   "on-demand",
+   "spot"
+  ],
+  "SupportedVirtualizationTypes": [
+   "hvm"
+  ],
+  "VCpuInfo": {
+   "DefaultCores": 64,
+   "DefaultThreadsPerCore": 2,
+   "DefaultVCpus": 128,
+   "ValidCores": [
+    2,
+    4,
+    6,
+    8,
+    10,
+    12,
+    14,
+    16,
+    18,
+    20,
+    22,
+    24,
+    26,
+    28,
+    30,
+    32,
+    34,
+    36,
+    38,
+    40,
+    42,
+    44,
+    46,
+    48,
+    50,
+    52,
+    54,
+    56,
+    58,
+    60,
+    62,
+    64
+   ],
+   "ValidThreadsPerCore": [
+    1,
+    2
+   ]
+  }
+ },
+ "x2iedn.4xlarge": {
+  "AutoRecoverySupported": true,
+  "BareMetal": false,
+  "BurstablePerformanceSupported": false,
+  "CurrentGeneration": true,
+  "DedicatedHostsSupported": true,
+  "EbsInfo": {
+   "EbsOptimizedInfo": {
+    "BaselineBandwidthInMbps": 10000,
+    "BaselineIops": 32500,
+    "BaselineThroughputInMBps": 1250.0,
+    "MaximumBandwidthInMbps": 20000,
+    "MaximumIops": 65000,
+    "MaximumThroughputInMBps": 2500.0
+   },
+   "EbsOptimizedSupport": "default",
+   "EncryptionSupport": "supported",
+   "NvmeSupport": "required"
+  },
+  "FreeTierEligible": false,
+  "HibernationSupported": false,
+  "Hypervisor": "nitro",
+  "InstanceStorageInfo": {
+   "Disks": [
+    {
+     "Count": 1,
+     "SizeInGB": 475,
+     "Type": "ssd"
+    }
+   ],
+   "NvmeSupport": "required",
+   "TotalSizeInGB": 475
+  },
+  "InstanceStorageSupported": true,
+  "InstanceType": "x2iedn.4xlarge",
+  "MemoryInfo": {
+   "SizeInMiB": 524288
+  },
+  "NetworkInfo": {
+   "DefaultNetworkCardIndex": 0,
+   "EfaSupported": false,
+   "EnaSupport": "required",
+   "Ipv4AddressesPerInterface": 30,
+   "Ipv6AddressesPerInterface": 30,
+   "Ipv6Supported": true,
+   "MaximumNetworkCards": 1,
+   "MaximumNetworkInterfaces": 8,
+   "NetworkCards": [
+    {
+     "MaximumNetworkInterfaces": 8,
+     "NetworkCardIndex": 0,
+     "NetworkPerformance": "Up to 25 Gigabit"
+    }
+   ],
+   "NetworkPerformance": "Up to 25 Gigabit"
+  },
+  "PlacementGroupInfo": {
+   "SupportedStrategies": [
+    "cluster",
+    "partition",
+    "spread"
+   ]
+  },
+  "ProcessorInfo": {
+   "SupportedArchitectures": [
+    "x86_64"
+   ],
+   "SustainedClockSpeedInGhz": 3.5
+  },
+  "SupportedRootDeviceTypes": [
+   "ebs"
+  ],
+  "SupportedUsageClasses": [
+   "on-demand",
+   "spot"
+  ],
+  "SupportedVirtualizationTypes": [
+   "hvm"
+  ],
+  "VCpuInfo": {
+   "DefaultCores": 8,
+   "DefaultThreadsPerCore": 2,
+   "DefaultVCpus": 16,
+   "ValidCores": [
+    2,
+    4,
+    6,
+    8
+   ],
+   "ValidThreadsPerCore": [
+    1,
+    2
+   ]
+  }
+ },
+ "x2iedn.8xlarge": {
+  "AutoRecoverySupported": true,
+  "BareMetal": false,
+  "BurstablePerformanceSupported": false,
+  "CurrentGeneration": true,
+  "DedicatedHostsSupported": true,
+  "EbsInfo": {
+   "EbsOptimizedInfo": {
+    "BaselineBandwidthInMbps": 20000,
+    "BaselineIops": 65000,
+    "BaselineThroughputInMBps": 2500.0,
+    "MaximumBandwidthInMbps": 20000,
+    "MaximumIops": 65000,
+    "MaximumThroughputInMBps": 2500.0
+   },
+   "EbsOptimizedSupport": "default",
+   "EncryptionSupport": "supported",
+   "NvmeSupport": "required"
+  },
+  "FreeTierEligible": false,
+  "HibernationSupported": false,
+  "Hypervisor": "nitro",
+  "InstanceStorageInfo": {
+   "Disks": [
+    {
+     "Count": 1,
+     "SizeInGB": 950,
+     "Type": "ssd"
+    }
+   ],
+   "NvmeSupport": "required",
+   "TotalSizeInGB": 950
+  },
+  "InstanceStorageSupported": true,
+  "InstanceType": "x2iedn.8xlarge",
+  "MemoryInfo": {
+   "SizeInMiB": 1048576
+  },
+  "NetworkInfo": {
+   "DefaultNetworkCardIndex": 0,
+   "EfaSupported": false,
+   "EnaSupport": "required",
+   "Ipv4AddressesPerInterface": 30,
+   "Ipv6AddressesPerInterface": 30,
+   "Ipv6Supported": true,
+   "MaximumNetworkCards": 1,
+   "MaximumNetworkInterfaces": 8,
+   "NetworkCards": [
+    {
+     "MaximumNetworkInterfaces": 8,
+     "NetworkCardIndex": 0,
+     "NetworkPerformance": "25 Gigabit"
+    }
+   ],
+   "NetworkPerformance": "25 Gigabit"
+  },
+  "PlacementGroupInfo": {
+   "SupportedStrategies": [
+    "cluster",
+    "partition",
+    "spread"
+   ]
+  },
+  "ProcessorInfo": {
+   "SupportedArchitectures": [
+    "x86_64"
+   ],
+   "SustainedClockSpeedInGhz": 3.5
+  },
+  "SupportedRootDeviceTypes": [
+   "ebs"
+  ],
+  "SupportedUsageClasses": [
+   "on-demand",
+   "spot"
+  ],
+  "SupportedVirtualizationTypes": [
+   "hvm"
+  ],
+  "VCpuInfo": {
+   "DefaultCores": 16,
+   "DefaultThreadsPerCore": 2,
+   "DefaultVCpus": 32,
+   "ValidCores": [
+    2,
+    4,
+    6,
+    8,
+    10,
+    12,
+    14,
+    16
+   ],
+   "ValidThreadsPerCore": [
+    1,
+    2
+   ]
+  }
+ },
+ "x2iedn.metal": {
+  "AutoRecoverySupported": true,
+  "BareMetal": true,
+  "BurstablePerformanceSupported": false,
+  "CurrentGeneration": true,
+  "DedicatedHostsSupported": true,
+  "EbsInfo": {
+   "EbsOptimizedInfo": {
+    "BaselineBandwidthInMbps": 80000,
+    "BaselineIops": 260000,
+    "BaselineThroughputInMBps": 10000.0,
+    "MaximumBandwidthInMbps": 80000,
+    "MaximumIops": 260000,
+    "MaximumThroughputInMBps": 10000.0
+   },
+   "EbsOptimizedSupport": "default",
+   "EncryptionSupport": "supported",
+   "NvmeSupport": "required"
+  },
+  "FreeTierEligible": false,
+  "HibernationSupported": false,
+  "InstanceStorageInfo": {
+   "Disks": [
+    {
+     "Count": 2,
+     "SizeInGB": 1900,
+     "Type": "ssd"
+    }
+   ],
+   "NvmeSupport": "required",
+   "TotalSizeInGB": 3800
+  },
+  "InstanceStorageSupported": true,
+  "InstanceType": "x2iedn.metal",
+  "MemoryInfo": {
+   "SizeInMiB": 4194304
+  },
+  "NetworkInfo": {
+   "DefaultNetworkCardIndex": 0,
+   "EfaSupported": true,
+   "EnaSupport": "required",
+   "Ipv4AddressesPerInterface": 50,
+   "Ipv6AddressesPerInterface": 50,
+   "Ipv6Supported": true,
+   "MaximumNetworkCards": 1,
+   "MaximumNetworkInterfaces": 15,
+   "NetworkCards": [
+    {
+     "MaximumNetworkInterfaces": 15,
+     "NetworkCardIndex": 0,
+     "NetworkPerformance": "100 Gigabit"
+    }
+   ],
+   "NetworkPerformance": "100 Gigabit"
+  },
+  "PlacementGroupInfo": {
+   "SupportedStrategies": [
+    "cluster",
+    "partition",
+    "spread"
+   ]
+  },
+  "ProcessorInfo": {
+   "SupportedArchitectures": [
+    "x86_64"
+   ],
+   "SustainedClockSpeedInGhz": 3.5
+  },
+  "SupportedRootDeviceTypes": [
+   "ebs"
+  ],
+  "SupportedUsageClasses": [
+   "on-demand",
+   "spot"
+  ],
+  "SupportedVirtualizationTypes": [
+   "hvm"
+  ],
+  "VCpuInfo": {
+   "DefaultCores": 64,
+   "DefaultThreadsPerCore": 2,
+   "DefaultVCpus": 128
+  }
+ },
+ "x2iedn.xlarge": {
+  "AutoRecoverySupported": true,
+  "BareMetal": false,
+  "BurstablePerformanceSupported": false,
+  "CurrentGeneration": true,
+  "DedicatedHostsSupported": true,
+  "EbsInfo": {
+   "EbsOptimizedInfo": {
+    "BaselineBandwidthInMbps": 2500,
+    "BaselineIops": 8125,
+    "BaselineThroughputInMBps": 312.5,
+    "MaximumBandwidthInMbps": 20000,
+    "MaximumIops": 65000,
+    "MaximumThroughputInMBps": 2500.0
+   },
+   "EbsOptimizedSupport": "default",
+   "EncryptionSupport": "supported",
+   "NvmeSupport": "required"
+  },
+  "FreeTierEligible": false,
+  "HibernationSupported": false,
+  "Hypervisor": "nitro",
+  "InstanceStorageInfo": {
+   "Disks": [
+    {
+     "Count": 1,
+     "SizeInGB": 118,
+     "Type": "ssd"
+    }
+   ],
+   "NvmeSupport": "required",
+   "TotalSizeInGB": 118
+  },
+  "InstanceStorageSupported": true,
+  "InstanceType": "x2iedn.xlarge",
+  "MemoryInfo": {
+   "SizeInMiB": 131072
+  },
+  "NetworkInfo": {
+   "DefaultNetworkCardIndex": 0,
+   "EfaSupported": false,
+   "EnaSupport": "required",
+   "Ipv4AddressesPerInterface": 15,
+   "Ipv6AddressesPerInterface": 15,
+   "Ipv6Supported": true,
+   "MaximumNetworkCards": 1,
+   "MaximumNetworkInterfaces": 4,
+   "NetworkCards": [
+    {
+     "MaximumNetworkInterfaces": 4,
+     "NetworkCardIndex": 0,
+     "NetworkPerformance": "Up to 25 Gigabit"
+    }
+   ],
+   "NetworkPerformance": "Up to 25 Gigabit"
+  },
+  "PlacementGroupInfo": {
+   "SupportedStrategies": [
+    "cluster",
+    "partition",
+    "spread"
+   ]
+  },
+  "ProcessorInfo": {
+   "SupportedArchitectures": [
+    "x86_64"
+   ],
+   "SustainedClockSpeedInGhz": 3.5
+  },
+  "SupportedRootDeviceTypes": [
+   "ebs"
+  ],
+  "SupportedUsageClasses": [
+   "on-demand",
+   "spot"
+  ],
+  "SupportedVirtualizationTypes": [
+   "hvm"
+  ],
+  "VCpuInfo": {
+   "DefaultCores": 2,
+   "DefaultThreadsPerCore": 2,
+   "DefaultVCpus": 4,
+   "ValidCores": [
+    1,
+    2
+   ],
+   "ValidThreadsPerCore": [
+    1,
+    2
+   ]
+  }
+ },
+ "x2iezn.12xlarge": {
+  "AutoRecoverySupported": true,
+  "BareMetal": false,
+  "BurstablePerformanceSupported": false,
+  "CurrentGeneration": true,
+  "DedicatedHostsSupported": true,
+  "EbsInfo": {
+   "EbsOptimizedInfo": {
+    "BaselineBandwidthInMbps": 19000,
+    "BaselineIops": 80000,
+    "BaselineThroughputInMBps": 2375.0,
+    "MaximumBandwidthInMbps": 19000,
+    "MaximumIops": 80000,
+    "MaximumThroughputInMBps": 2375.0
+   },
+   "EbsOptimizedSupport": "default",
+   "EncryptionSupport": "supported",
+   "NvmeSupport": "required"
+  },
+  "FreeTierEligible": false,
+  "HibernationSupported": false,
+  "Hypervisor": "nitro",
+  "InstanceStorageSupported": false,
+  "InstanceType": "x2iezn.12xlarge",
+  "MemoryInfo": {
+   "SizeInMiB": 1572864
+  },
+  "NetworkInfo": {
+   "DefaultNetworkCardIndex": 0,
+   "EfaSupported": true,
+   "EnaSupport": "required",
+   "Ipv4AddressesPerInterface": 50,
+   "Ipv6AddressesPerInterface": 50,
+   "Ipv6Supported": true,
+   "MaximumNetworkCards": 1,
+   "MaximumNetworkInterfaces": 15,
+   "NetworkCards": [
+    {
+     "MaximumNetworkInterfaces": 15,
+     "NetworkCardIndex": 0,
+     "NetworkPerformance": "100 Gigabit"
+    }
+   ],
+   "NetworkPerformance": "100 Gigabit"
+  },
+  "PlacementGroupInfo": {
+   "SupportedStrategies": [
+    "cluster",
+    "partition",
+    "spread"
+   ]
+  },
+  "ProcessorInfo": {
+   "SupportedArchitectures": [
+    "x86_64"
+   ],
+   "SustainedClockSpeedInGhz": 4.5
+  },
+  "SupportedRootDeviceTypes": [
+   "ebs"
+  ],
+  "SupportedUsageClasses": [
+   "on-demand",
+   "spot"
+  ],
+  "SupportedVirtualizationTypes": [
+   "hvm"
+  ],
+  "VCpuInfo": {
+   "DefaultCores": 24,
+   "DefaultThreadsPerCore": 2,
+   "DefaultVCpus": 48,
+   "ValidCores": [
+    2,
+    4,
+    6,
+    8,
+    10,
+    12,
+    14,
+    16,
+    18,
+    20,
+    22,
+    24
+   ],
+   "ValidThreadsPerCore": [
+    1,
+    2
+   ]
+  }
+ },
+ "x2iezn.2xlarge": {
+  "AutoRecoverySupported": true,
+  "BareMetal": false,
+  "BurstablePerformanceSupported": false,
+  "CurrentGeneration": true,
+  "DedicatedHostsSupported": true,
+  "EbsInfo": {
+   "EbsOptimizedInfo": {
+    "BaselineBandwidthInMbps": 3170,
+    "BaselineIops": 13333,
+    "BaselineThroughputInMBps": 396.25,
+    "MaximumBandwidthInMbps": 3170,
+    "MaximumIops": 13333,
+    "MaximumThroughputInMBps": 396.25
+   },
+   "EbsOptimizedSupport": "default",
+   "EncryptionSupport": "supported",
+   "NvmeSupport": "required"
+  },
+  "FreeTierEligible": false,
+  "HibernationSupported": false,
+  "Hypervisor": "nitro",
+  "InstanceStorageSupported": false,
+  "InstanceType": "x2iezn.2xlarge",
+  "MemoryInfo": {
+   "SizeInMiB": 262144
+  },
+  "NetworkInfo": {
+   "DefaultNetworkCardIndex": 0,
+   "EfaSupported": false,
+   "EnaSupport": "required",
+   "Ipv4AddressesPerInterface": 15,
+   "Ipv6AddressesPerInterface": 15,
+   "Ipv6Supported": true,
+   "MaximumNetworkCards": 1,
+   "MaximumNetworkInterfaces": 4,
+   "NetworkCards": [
+    {
+     "MaximumNetworkInterfaces": 4,
+     "NetworkCardIndex": 0,
+     "NetworkPerformance": "Up to 25 Gigabit"
+    }
+   ],
+   "NetworkPerformance": "Up to 25 Gigabit"
+  },
+  "PlacementGroupInfo": {
+   "SupportedStrategies": [
+    "cluster",
+    "partition",
+    "spread"
+   ]
+  },
+  "ProcessorInfo": {
+   "SupportedArchitectures": [
+    "x86_64"
+   ],
+   "SustainedClockSpeedInGhz": 4.5
+  },
+  "SupportedRootDeviceTypes": [
+   "ebs"
+  ],
+  "SupportedUsageClasses": [
+   "on-demand",
+   "spot"
+  ],
+  "SupportedVirtualizationTypes": [
+   "hvm"
+  ],
+  "VCpuInfo": {
+   "DefaultCores": 4,
+   "DefaultThreadsPerCore": 2,
+   "DefaultVCpus": 8,
+   "ValidCores": [
+    2,
+    4
+   ],
+   "ValidThreadsPerCore": [
+    1,
+    2
+   ]
+  }
+ },
+ "x2iezn.4xlarge": {
+  "AutoRecoverySupported": true,
+  "BareMetal": false,
+  "BurstablePerformanceSupported": false,
+  "CurrentGeneration": true,
+  "DedicatedHostsSupported": true,
+  "EbsInfo": {
+   "EbsOptimizedInfo": {
+    "BaselineBandwidthInMbps": 4750,
+    "BaselineIops": 20000,
+    "BaselineThroughputInMBps": 593.75,
+    "MaximumBandwidthInMbps": 4750,
+    "MaximumIops": 20000,
+    "MaximumThroughputInMBps": 593.75
+   },
+   "EbsOptimizedSupport": "default",
+   "EncryptionSupport": "supported",
+   "NvmeSupport": "required"
+  },
+  "FreeTierEligible": false,
+  "HibernationSupported": false,
+  "Hypervisor": "nitro",
+  "InstanceStorageSupported": false,
+  "InstanceType": "x2iezn.4xlarge",
+  "MemoryInfo": {
+   "SizeInMiB": 524288
+  },
+  "NetworkInfo": {
+   "DefaultNetworkCardIndex": 0,
+   "EfaSupported": false,
+   "EnaSupport": "required",
+   "Ipv4AddressesPerInterface": 30,
+   "Ipv6AddressesPerInterface": 30,
+   "Ipv6Supported": true,
+   "MaximumNetworkCards": 1,
+   "MaximumNetworkInterfaces": 8,
+   "NetworkCards": [
+    {
+     "MaximumNetworkInterfaces": 8,
+     "NetworkCardIndex": 0,
+     "NetworkPerformance": "Up to 25 Gigabit"
+    }
+   ],
+   "NetworkPerformance": "Up to 25 Gigabit"
+  },
+  "PlacementGroupInfo": {
+   "SupportedStrategies": [
+    "cluster",
+    "partition",
+    "spread"
+   ]
+  },
+  "ProcessorInfo": {
+   "SupportedArchitectures": [
+    "x86_64"
+   ],
+   "SustainedClockSpeedInGhz": 4.5
+  },
+  "SupportedRootDeviceTypes": [
+   "ebs"
+  ],
+  "SupportedUsageClasses": [
+   "on-demand",
+   "spot"
+  ],
+  "SupportedVirtualizationTypes": [
+   "hvm"
+  ],
+  "VCpuInfo": {
+   "DefaultCores": 8,
+   "DefaultThreadsPerCore": 2,
+   "DefaultVCpus": 16,
+   "ValidCores": [
+    2,
+    4,
+    6,
+    8
+   ],
+   "ValidThreadsPerCore": [
+    1,
+    2
+   ]
+  }
+ },
+ "x2iezn.6xlarge": {
+  "AutoRecoverySupported": true,
+  "BareMetal": false,
+  "BurstablePerformanceSupported": false,
+  "CurrentGeneration": true,
+  "DedicatedHostsSupported": true,
+  "EbsInfo": {
+   "EbsOptimizedInfo": {
+    "BaselineBandwidthInMbps": 9500,
+    "BaselineIops": 40000,
+    "BaselineThroughputInMBps": 1187.5,
+    "MaximumBandwidthInMbps": 9500,
+    "MaximumIops": 40000,
+    "MaximumThroughputInMBps": 1187.5
+   },
+   "EbsOptimizedSupport": "default",
+   "EncryptionSupport": "supported",
+   "NvmeSupport": "required"
+  },
+  "FreeTierEligible": false,
+  "HibernationSupported": false,
+  "Hypervisor": "nitro",
+  "InstanceStorageSupported": false,
+  "InstanceType": "x2iezn.6xlarge",
+  "MemoryInfo": {
+   "SizeInMiB": 786432
+  },
+  "NetworkInfo": {
+   "DefaultNetworkCardIndex": 0,
+   "EfaSupported": false,
+   "EnaSupport": "required",
+   "Ipv4AddressesPerInterface": 30,
+   "Ipv6AddressesPerInterface": 30,
+   "Ipv6Supported": true,
+   "MaximumNetworkCards": 1,
+   "MaximumNetworkInterfaces": 8,
+   "NetworkCards": [
+    {
+     "MaximumNetworkInterfaces": 8,
+     "NetworkCardIndex": 0,
+     "NetworkPerformance": "50 Gigabit"
+    }
+   ],
+   "NetworkPerformance": "50 Gigabit"
+  },
+  "PlacementGroupInfo": {
+   "SupportedStrategies": [
+    "cluster",
+    "partition",
+    "spread"
+   ]
+  },
+  "ProcessorInfo": {
+   "SupportedArchitectures": [
+    "x86_64"
+   ],
+   "SustainedClockSpeedInGhz": 4.5
+  },
+  "SupportedRootDeviceTypes": [
+   "ebs"
+  ],
+  "SupportedUsageClasses": [
+   "on-demand",
+   "spot"
+  ],
+  "SupportedVirtualizationTypes": [
+   "hvm"
+  ],
+  "VCpuInfo": {
+   "DefaultCores": 12,
+   "DefaultThreadsPerCore": 2,
+   "DefaultVCpus": 24,
+   "ValidCores": [
+    2,
+    4,
+    6,
+    8,
+    10,
+    12
+   ],
+   "ValidThreadsPerCore": [
+    1,
+    2
+   ]
+  }
+ },
+ "x2iezn.8xlarge": {
+  "AutoRecoverySupported": true,
+  "BareMetal": false,
+  "BurstablePerformanceSupported": false,
+  "CurrentGeneration": true,
+  "DedicatedHostsSupported": true,
+  "EbsInfo": {
+   "EbsOptimizedInfo": {
+    "BaselineBandwidthInMbps": 12000,
+    "BaselineIops": 55000,
+    "BaselineThroughputInMBps": 1500.0,
+    "MaximumBandwidthInMbps": 12000,
+    "MaximumIops": 55000,
+    "MaximumThroughputInMBps": 1500.0
+   },
+   "EbsOptimizedSupport": "default",
+   "EncryptionSupport": "supported",
+   "NvmeSupport": "required"
+  },
+  "FreeTierEligible": false,
+  "HibernationSupported": false,
+  "Hypervisor": "nitro",
+  "InstanceStorageSupported": false,
+  "InstanceType": "x2iezn.8xlarge",
+  "MemoryInfo": {
+   "SizeInMiB": 1048576
+  },
+  "NetworkInfo": {
+   "DefaultNetworkCardIndex": 0,
+   "EfaSupported": false,
+   "EnaSupport": "required",
+   "Ipv4AddressesPerInterface": 30,
+   "Ipv6AddressesPerInterface": 30,
+   "Ipv6Supported": true,
+   "MaximumNetworkCards": 1,
+   "MaximumNetworkInterfaces": 8,
+   "NetworkCards": [
+    {
+     "MaximumNetworkInterfaces": 8,
+     "NetworkCardIndex": 0,
+     "NetworkPerformance": "75 Gigabit"
+    }
+   ],
+   "NetworkPerformance": "75 Gigabit"
+  },
+  "PlacementGroupInfo": {
+   "SupportedStrategies": [
+    "cluster",
+    "partition",
+    "spread"
+   ]
+  },
+  "ProcessorInfo": {
+   "SupportedArchitectures": [
+    "x86_64"
+   ],
+   "SustainedClockSpeedInGhz": 4.5
+  },
+  "SupportedRootDeviceTypes": [
+   "ebs"
+  ],
+  "SupportedUsageClasses": [
+   "on-demand",
+   "spot"
+  ],
+  "SupportedVirtualizationTypes": [
+   "hvm"
+  ],
+  "VCpuInfo": {
+   "DefaultCores": 16,
+   "DefaultThreadsPerCore": 2,
+   "DefaultVCpus": 32,
+   "ValidCores": [
+    2,
+    4,
+    6,
+    8,
+    10,
+    12,
+    14,
+    16
+   ],
+   "ValidThreadsPerCore": [
+    1,
+    2
+   ]
+  }
+ },
+ "x2iezn.metal": {
+  "AutoRecoverySupported": true,
+  "BareMetal": true,
+  "BurstablePerformanceSupported": false,
+  "CurrentGeneration": true,
+  "DedicatedHostsSupported": true,
+  "EbsInfo": {
+   "EbsOptimizedInfo": {
+    "BaselineBandwidthInMbps": 19000,
+    "BaselineIops": 80000,
+    "BaselineThroughputInMBps": 2375.0,
+    "MaximumBandwidthInMbps": 19000,
+    "MaximumIops": 80000,
+    "MaximumThroughputInMBps": 2375.0
+   },
+   "EbsOptimizedSupport": "default",
+   "EncryptionSupport": "supported",
+   "NvmeSupport": "required"
+  },
+  "FreeTierEligible": false,
+  "HibernationSupported": false,
+  "InstanceStorageSupported": false,
+  "InstanceType": "x2iezn.metal",
+  "MemoryInfo": {
+   "SizeInMiB": 1572864
+  },
+  "NetworkInfo": {
+   "DefaultNetworkCardIndex": 0,
+   "EfaSupported": true,
+   "EnaSupport": "required",
+   "Ipv4AddressesPerInterface": 50,
+   "Ipv6AddressesPerInterface": 50,
+   "Ipv6Supported": true,
+   "MaximumNetworkCards": 1,
+   "MaximumNetworkInterfaces": 15,
+   "NetworkCards": [
+    {
+     "MaximumNetworkInterfaces": 15,
+     "NetworkCardIndex": 0,
+     "NetworkPerformance": "100 Gigabit"
+    }
+   ],
+   "NetworkPerformance": "100 Gigabit"
+  },
+  "PlacementGroupInfo": {
+   "SupportedStrategies": [
+    "cluster",
+    "partition",
+    "spread"
+   ]
+  },
+  "ProcessorInfo": {
+   "SupportedArchitectures": [
+    "x86_64"
+   ],
+   "SustainedClockSpeedInGhz": 4.5
+  },
+  "SupportedRootDeviceTypes": [
+   "ebs"
+  ],
+  "SupportedUsageClasses": [
+   "on-demand",
+   "spot"
+  ],
+  "SupportedVirtualizationTypes": [
+   "hvm"
+  ],
+  "VCpuInfo": {
+   "DefaultCores": 24,
+   "DefaultThreadsPerCore": 2,
+   "DefaultVCpus": 48
   }
  },
  "z1d.12xlarge": {
@@ -45849,7 +51930,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "required",
    "NvmeSupport": "required",
    "TotalSizeInGB": 1800
   },
@@ -45862,7 +51942,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 50,
    "Ipv6AddressesPerInterface": 50,
    "Ipv6Supported": true,
@@ -45890,10 +51969,6 @@
    ],
    "SustainedClockSpeedInGhz": 4.0
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -45957,7 +52032,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "required",
    "NvmeSupport": "required",
    "TotalSizeInGB": 300
   },
@@ -45970,7 +52044,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 15,
    "Ipv6AddressesPerInterface": 15,
    "Ipv6Supported": true,
@@ -45998,10 +52071,6 @@
    ],
    "SustainedClockSpeedInGhz": 4.0
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -46056,7 +52125,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "required",
    "NvmeSupport": "required",
    "TotalSizeInGB": 450
   },
@@ -46069,7 +52137,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 30,
    "Ipv6AddressesPerInterface": 30,
    "Ipv6Supported": true,
@@ -46097,10 +52164,6 @@
    ],
    "SustainedClockSpeedInGhz": 4.0
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -46156,7 +52219,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "required",
    "NvmeSupport": "required",
    "TotalSizeInGB": 900
   },
@@ -46169,7 +52231,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 30,
    "Ipv6AddressesPerInterface": 30,
    "Ipv6Supported": true,
@@ -46197,10 +52258,6 @@
    ],
    "SustainedClockSpeedInGhz": 4.0
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -46259,7 +52316,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "required",
    "NvmeSupport": "required",
    "TotalSizeInGB": 75
   },
@@ -46272,7 +52328,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 10,
    "Ipv6AddressesPerInterface": 10,
    "Ipv6Supported": true,
@@ -46300,10 +52355,6 @@
    ],
    "SustainedClockSpeedInGhz": 4.0
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -46356,7 +52407,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "required",
    "NvmeSupport": "required",
    "TotalSizeInGB": 1800
   },
@@ -46369,7 +52419,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 50,
    "Ipv6AddressesPerInterface": 50,
    "Ipv6Supported": true,
@@ -46397,9 +52446,6 @@
    ],
    "SustainedClockSpeedInGhz": 4.0
   },
-  "SupportedBootModes": [
-   "legacy-bios"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],
@@ -46446,7 +52492,6 @@
      "Type": "ssd"
     }
    ],
-   "EncryptionSupport": "required",
    "NvmeSupport": "required",
    "TotalSizeInGB": 150
   },
@@ -46459,7 +52504,6 @@
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
    "EnaSupport": "required",
-   "EncryptionInTransitSupported": false,
    "Ipv4AddressesPerInterface": 15,
    "Ipv6AddressesPerInterface": 15,
    "Ipv6Supported": true,
@@ -46487,10 +52531,6 @@
    ],
    "SustainedClockSpeedInGhz": 4.0
   },
-  "SupportedBootModes": [
-   "legacy-bios",
-   "uefi"
-  ],
   "SupportedRootDeviceTypes": [
    "ebs"
   ],


### PR DESCRIPTION
This PR regenerates the instance_types.json file.
This is because some the instance types listed in instance type offerings, were not listed in instance_types.json
e.g.
```
botocore.exceptions.ClientError: An error occurred (InvalidInstanceType.NotFound) when calling the DescribeInstanceTypes operation: The instance type '{'c6a.2xlarge', 'c6a.large', 'c6a.24xlarge', 'c6a.xlarge', 'c6a.8xlarge', 'c6a.12xlarge', 'c6a.48xlarge', 'c6a.32xlarge', 'c6a.4xlarge', 'c6a.16xlarge'}' does not exist
```