### PR TITLE
Add AvailabilityZone to describe_db_instances

### DIFF
--- a/moto/rds/models.py
+++ b/moto/rds/models.py
@@ -387,6 +387,8 @@ class Database(CloudFormationModel):
         if self.backup_retention_period is None:
             self.backup_retention_period = 1
         self.availability_zone = kwargs.get("availability_zone")
+        if not self.availability_zone:
+            self.availability_zone = f"{self.region_name}a"
         self.multi_az = kwargs.get("multi_az")
         self.db_subnet_group_name = kwargs.get("db_subnet_group_name")
         if self.db_subnet_group_name:

--- a/moto/rds/models.py
+++ b/moto/rds/models.py
@@ -495,6 +495,7 @@ class Database(CloudFormationModel):
     def to_xml(self):
         template = Template(
             """<DBInstance>
+              <AvailabilityZone>{{ database.availability_zone }}</AvailabilityZone>
               <BackupRetentionPeriod>{{ database.backup_retention_period }}</BackupRetentionPeriod>
               <DBInstanceStatus>{{ database.status }}</DBInstanceStatus>
               {% if database.db_name %}<DBName>{{ database.db_name }}</DBName>{% endif %}

--- a/tests/test_rds/test_rds.py
+++ b/tests/test_rds/test_rds.py
@@ -2019,3 +2019,39 @@ def test_create_db_instance_with_tags():
 
     resp = client.describe_db_instances(DBInstanceIdentifier=db_instance_identifier)
     resp["DBInstances"][0]["TagList"].should.equal(tags)
+
+
+@mock_rds
+def test_create_db_instance_without_availability_zone():
+    region = "us-east-1"
+    client = boto3.client("rds", region_name=region)
+    db_instance_identifier = "test-db-instance"
+    resp = client.create_db_instance(
+        DBInstanceIdentifier=db_instance_identifier,
+        Engine="postgres",
+        DBName="staging-postgres",
+        DBInstanceClass="db.m1.small",
+    )
+    resp["DBInstance"]["AvailabilityZone"].should.contain(region)
+
+    resp = client.describe_db_instances(DBInstanceIdentifier=db_instance_identifier)
+    resp["DBInstances"][0]["AvailabilityZone"].should.contain(region)
+
+
+@mock_rds
+def test_create_db_instance_with_availability_zone():
+    region = "us-east-1"
+    availability_zone = f"{region}c"
+    client = boto3.client("rds", region_name=region)
+    db_instance_identifier = "test-db-instance"
+    resp = client.create_db_instance(
+        DBInstanceIdentifier=db_instance_identifier,
+        Engine="postgres",
+        DBName="staging-postgres",
+        DBInstanceClass="db.m1.small",
+        AvailabilityZone=availability_zone,
+    )
+    resp["DBInstance"]["AvailabilityZone"].should.equal(availability_zone)
+
+    resp = client.describe_db_instances(DBInstanceIdentifier=db_instance_identifier)
+    resp["DBInstances"][0]["AvailabilityZone"].should.equal(availability_zone)


### PR DESCRIPTION
AvailabilityZone information was not printed in create/describe calls for regular RDS.

Resolves #5371