### PR TITLE
fix: Error listing Lambda layers after layer deletion

### DIFF
--- a/moto/awslambda/models.py
+++ b/moto/awslambda/models.py
@@ -364,11 +364,15 @@ class Layer(object):
         self.layer_versions.pop(str(layer_version), None)
 
     def to_dict(self):
+        if not self.layer_versions:
+            return {}
+            
+        last_key = sorted(self.layer_versions.keys(), key=lambda version: int(version))[-1]
         return {
             "LayerName": self.name,
             "LayerArn": self.layer_arn,
             "LatestMatchingVersion": self.layer_versions[
-                str(self._latest_version)
+                last_key
             ].get_layer_version(),
         }
 
@@ -1242,7 +1246,7 @@ class LayerStorage(object):
         self._layers[layer_version.name].attach_version(layer_version)
 
     def list_layers(self):
-        return [layer.to_dict() for layer in self._layers.values()]
+        return [layer.to_dict() for layer in self._layers.values() if layer.layer_versions]
 
     def delete_layer_version(self, layer_name, layer_version):
         self._layers[layer_name].delete_version(layer_version)

--- a/moto/awslambda/models.py
+++ b/moto/awslambda/models.py
@@ -366,14 +366,14 @@ class Layer(object):
     def to_dict(self):
         if not self.layer_versions:
             return {}
-            
-        last_key = sorted(self.layer_versions.keys(), key=lambda version: int(version))[-1]
+
+        last_key = sorted(self.layer_versions.keys(), key=lambda version: int(version))[
+            -1
+        ]
         return {
             "LayerName": self.name,
             "LayerArn": self.layer_arn,
-            "LatestMatchingVersion": self.layer_versions[
-                last_key
-            ].get_layer_version(),
+            "LatestMatchingVersion": self.layer_versions[last_key].get_layer_version(),
         }
 
 
@@ -1246,7 +1246,9 @@ class LayerStorage(object):
         self._layers[layer_version.name].attach_version(layer_version)
 
     def list_layers(self):
-        return [layer.to_dict() for layer in self._layers.values() if layer.layer_versions]
+        return [
+            layer.to_dict() for layer in self._layers.values() if layer.layer_versions
+        ]
 
     def delete_layer_version(self, layer_name, layer_version):
         self._layers[layer_name].delete_version(layer_version)

--- a/tests/test_awslambda/test_lambda_layers.py
+++ b/tests/test_awslambda/test_lambda_layers.py
@@ -230,3 +230,42 @@ def test_delete_layer_version():
 
     result = conn.list_layer_versions(LayerName=layer_name)["LayerVersions"]
     result.should.equal([])
+
+
+@mock_lambda
+@mock_s3
+def test_get_layer_with_no_layer_versions():
+    conn = boto3.client("lambda", _lambda_region)
+    layer_name = str(uuid4())[0:6]
+
+    # Publish a new Layer and assert Layer exists and only version 1 is there
+    conn.publish_layer_version(
+        LayerName=layer_name,
+        Content={"ZipFile": get_test_zip_file1()},
+    )
+    assert len(conn.list_layers()["Layers"]) == 1
+    assert conn.list_layers()["Layers"][0]["LatestMatchingVersion"]["Version"] == 1
+
+    # Add a new version of that Layer then delete that version
+    conn.publish_layer_version(
+        LayerName=layer_name,
+        Content={"ZipFile": get_test_zip_file1()},
+    )
+    assert len(conn.list_layers()["Layers"]) == 1
+    assert conn.list_layers()["Layers"][0]["LatestMatchingVersion"]["Version"] == 2
+
+    conn.delete_layer_version(LayerName=layer_name, VersionNumber=2)
+    assert len(conn.list_layers()["Layers"]) == 1
+    assert conn.list_layers()["Layers"][0]["LatestMatchingVersion"]["Version"] == 1
+
+    # Delete the last layer_version and check that the Layer is still in the LayerStorage
+    conn.delete_layer_version(LayerName=layer_name, VersionNumber=1)
+    assert len(conn.list_layers()["Layers"]) == 0
+
+    # Assert _latest_version didn't decrement
+    conn.publish_layer_version(
+        LayerName=layer_name,
+        Content={"ZipFile": get_test_zip_file1()},
+    )
+    assert len(conn.list_layers()["Layers"]) == 1
+    assert conn.list_layers()["Layers"][0]["LatestMatchingVersion"]["Version"] == 3

--- a/tests/test_awslambda/test_lambda_layers.py
+++ b/tests/test_awslambda/test_lambda_layers.py
@@ -235,6 +235,12 @@ def test_delete_layer_version():
 @mock_lambda
 @mock_s3
 def test_get_layer_with_no_layer_versions():
+    def get_layer_by_layer_name_from_list_of_layer_dicts(layer_name, layer_list):
+        for layer in layer_list:
+            if layer["LayerName"] == layer_name:
+                return layer
+        return None
+
     conn = boto3.client("lambda", _lambda_region)
     layer_name = str(uuid4())[0:6]
 
@@ -243,29 +249,50 @@ def test_get_layer_with_no_layer_versions():
         LayerName=layer_name,
         Content={"ZipFile": get_test_zip_file1()},
     )
-    assert len(conn.list_layers()["Layers"]) == 1
-    assert conn.list_layers()["Layers"][0]["LatestMatchingVersion"]["Version"] == 1
+    assert (
+        get_layer_by_layer_name_from_list_of_layer_dicts(
+            layer_name, conn.list_layers()["Layers"]
+        )["LatestMatchingVersion"]["Version"]
+        == 1
+    )
 
     # Add a new version of that Layer then delete that version
     conn.publish_layer_version(
         LayerName=layer_name,
         Content={"ZipFile": get_test_zip_file1()},
     )
-    assert len(conn.list_layers()["Layers"]) == 1
-    assert conn.list_layers()["Layers"][0]["LatestMatchingVersion"]["Version"] == 2
+    assert (
+        get_layer_by_layer_name_from_list_of_layer_dicts(
+            layer_name, conn.list_layers()["Layers"]
+        )["LatestMatchingVersion"]["Version"]
+        == 2
+    )
 
     conn.delete_layer_version(LayerName=layer_name, VersionNumber=2)
-    assert len(conn.list_layers()["Layers"]) == 1
-    assert conn.list_layers()["Layers"][0]["LatestMatchingVersion"]["Version"] == 1
+    assert (
+        get_layer_by_layer_name_from_list_of_layer_dicts(
+            layer_name, conn.list_layers()["Layers"]
+        )["LatestMatchingVersion"]["Version"]
+        == 1
+    )
 
     # Delete the last layer_version and check that the Layer is still in the LayerStorage
     conn.delete_layer_version(LayerName=layer_name, VersionNumber=1)
-    assert len(conn.list_layers()["Layers"]) == 0
+    assert (
+        get_layer_by_layer_name_from_list_of_layer_dicts(
+            layer_name, conn.list_layers()["Layers"]
+        )
+        is None
+    )
 
     # Assert _latest_version didn't decrement
     conn.publish_layer_version(
         LayerName=layer_name,
         Content={"ZipFile": get_test_zip_file1()},
     )
-    assert len(conn.list_layers()["Layers"]) == 1
-    assert conn.list_layers()["Layers"][0]["LatestMatchingVersion"]["Version"] == 3
+    assert (
+        get_layer_by_layer_name_from_list_of_layer_dicts(
+            layer_name, conn.list_layers()["Layers"]
+        )["LatestMatchingVersion"]["Version"]
+        == 3
+    )


### PR DESCRIPTION
- [ ] #5356

After reading the ticket above, I decided to try and fix the bug 😄 

## Context

The bug happened when a user created a layer, which resulted in a new layer version, and then deleted that same layer.

The issue here is that at first, there is no layer. When we create one, we add a new `Layer` to the `LayerStorage._layers`. Now, that same `Layer` we are going to add to its dict attribute `layer_versions` the first version. 

So now, `Layer` has `_latest_version = 1` and `layer_versions = {'1': layer_v1}`

Now when we delete that layer version, we don't reset `_latest_version` since we want to keep track of our versions, but we do remove element in the dictionary. I think _that's bug number one_

We also keep the layer instance in the Layer storage, and we retrieve all Layers, we used to retrieve all even the ones that have no versions in store. I think _that's bug number two_

## Fix

For _bug number one_, we can query for the latest version instead of using the `_latest_version` attribute since we can only increment it.

``` python
    def to_dict(self):
        if not self.layer_versions:
            return {}

        last_key = sorted(self.layer_versions.keys(), key=lambda version: int(version))[-1]
        return {
            "LayerName": self.name,
            "LayerArn": self.layer_arn,
            "LatestMatchingVersion": self.layer_versions[
                last_key
            ].get_layer_version(),
        }
```

For _bug number two_, we can get only Layers that have available version from the Layer storage.

``` python
    def list_layers(self):
        return [layer.to_dict() for layer in self._layers.values() if layer.layer_versions]
```

## Conclusion

This is actually my first PR ever in an open source project! So thank you!
Can't wait for the feedback 😄 