### PR TITLE
Fix/launch template tags

### DIFF
--- a/moto/ec2/models/launch_templates.py
+++ b/moto/ec2/models/launch_templates.py
@@ -33,11 +33,14 @@ class LaunchTemplateVersion(object):
 
 
 class LaunchTemplate(TaggedEC2Resource):
-    def __init__(self, backend, name, template_data, version_description):
+    def __init__(self, backend, name, template_data, version_description, tag_spec):
         self.ec2_backend = backend
         self.name = name
         self.id = random_launch_template_id()
         self.create_time = utc_date_and_time()
+        tag_map = tag_spec.get("launch-template", {})
+        self.add_tags(tag_map)
+        self.tags = self.get_tags()
 
         self.versions = []
         self.create_version(template_data, version_description)
@@ -82,10 +85,10 @@ class LaunchTemplateBackend:
         self.launch_templates = OrderedDict()
         self.launch_template_insert_order = []
 
-    def create_launch_template(self, name, description, template_data):
+    def create_launch_template(self, name, description, template_data, tag_spec):
         if name in self.launch_template_name_to_ids:
             raise InvalidLaunchTemplateNameAlreadyExistsError()
-        template = LaunchTemplate(self, name, template_data, description)
+        template = LaunchTemplate(self, name, template_data, description, tag_spec)
         self.launch_templates[template.id] = template
         self.launch_template_name_to_ids[template.name] = template.id
         self.launch_template_insert_order.append(template.id)

--- a/moto/ec2/responses/launch_templates.py
+++ b/moto/ec2/responses/launch_templates.py
@@ -118,7 +118,7 @@ class LaunchTemplates(EC2BaseResponse):
                 parsed_template_data["TagSpecifications"].extend(converted_tag_spec)
 
             template = self.ec2_backend.create_launch_template(
-                name, version_description, parsed_template_data
+                name, version_description, parsed_template_data, tag_spec
             )
             version = template.default_version()
 
@@ -298,6 +298,7 @@ class LaunchTemplates(EC2BaseResponse):
                         "latestVersionNumber": template.latest_version_number,
                         "launchTemplateId": template.id,
                         "launchTemplateName": template.name,
+                        "tags": template.tags,
                     },
                 )
 

--- a/moto/ec2/responses/launch_templates.py
+++ b/moto/ec2/responses/launch_templates.py
@@ -135,6 +135,7 @@ class LaunchTemplates(EC2BaseResponse):
                     "latestVersionNumber": version.number,
                     "launchTemplateId": template.id,
                     "launchTemplateName": template.name,
+                    "tags": template.tags,
                 },
             )
 

--- a/tests/test_ec2/test_launch_templates.py
+++ b/tests/test_ec2/test_launch_templates.py
@@ -501,3 +501,71 @@ def retrieve_all_templates(client, filters=[]):  # pylint: disable=W0102
         all_templates.extend(resp["LaunchTemplates"])
         next_token = resp.get("NextToken")
     return all_templates
+
+
+@mock_ec2
+def test_launch_template_create_with_tags():
+    cli = boto3.client("ec2", region_name="us-east-1")
+
+    template_name = str(uuid4())
+    resp = cli.create_launch_template(
+        LaunchTemplateName=template_name,
+        # the absolute minimum needed to create a template without other resources
+        LaunchTemplateData={
+            "TagSpecifications": [
+                {
+                    "ResourceType": "instance",
+                    "Tags": [{"Key": "test", "Value": "value"}],
+                }
+            ]
+        },
+        TagSpecifications=[
+            {
+                "ResourceType": "launch-template",
+                "Tags": [{"Key": "test1", "Value": "value1"}],
+            }
+        ],
+    )
+
+    resp.should.have.key("LaunchTemplate")
+    lt = resp["LaunchTemplate"]
+    lt["LaunchTemplateName"].should.equal(template_name)
+    lt["DefaultVersionNumber"].should.equal(1)
+    lt["LatestVersionNumber"].should.equal(1)
+    lt["Tags"].should.have.length_of(1)
+    lt["Tags"][0].should.equal({"Key": "test1", "Value": "value1"})
+
+
+@mock_ec2
+def test_launch_template_describe_with_tags():
+    cli = boto3.client("ec2", region_name="us-east-1")
+
+    template_name = str(uuid4())
+    resp = cli.create_launch_template(
+        LaunchTemplateName=template_name,
+        # the absolute minimum needed to create a template without other resources
+        LaunchTemplateData={
+            "TagSpecifications": [
+                {
+                    "ResourceType": "instance",
+                    "Tags": [{"Key": "test", "Value": "value"}],
+                }
+            ]
+        },
+        TagSpecifications=[
+            {
+                "ResourceType": "launch-template",
+                "Tags": [{"Key": "test1", "Value": "value1"}],
+            }
+        ],
+    )
+
+    lt = cli.describe_launch_templates(LaunchTemplateNames=[template_name])[
+        "LaunchTemplates"
+    ][0]
+
+    lt["LaunchTemplateName"].should.equal(template_name)
+    lt["DefaultVersionNumber"].should.equal(1)
+    lt["LatestVersionNumber"].should.equal(1)
+    lt["Tags"].should.have.length_of(1)
+    lt["Tags"][0].should.equal({"Key": "test1", "Value": "value1"})

--- a/tests/test_ec2/test_launch_templates.py
+++ b/tests/test_ec2/test_launch_templates.py
@@ -541,7 +541,7 @@ def test_launch_template_describe_with_tags():
     cli = boto3.client("ec2", region_name="us-east-1")
 
     template_name = str(uuid4())
-    resp = cli.create_launch_template(
+    cli.create_launch_template(
         LaunchTemplateName=template_name,
         # the absolute minimum needed to create a template without other resources
         LaunchTemplateData={


### PR DESCRIPTION
Currently, launch templates in moto only support TagSpecifications from inside the LaunchTemplateData (for tagging instances and volumes). This MR adds support for tagging of the launch-template resource itself.