### PR TITLE
MotoAPI - do not blow up on uninitialized objects

### DIFF
--- a/moto/moto_api/_internal/responses.py
+++ b/moto/moto_api/_internal/responses.py
@@ -54,7 +54,7 @@ class MotoAPIResponse(BaseResponse):
                         if not attr.startswith("_"):
                             try:
                                 json.dumps(getattr(instance, attr))
-                            except TypeError:
+                            except (TypeError, AttributeError):
                                 pass
                             else:
                                 inst_result[attr] = getattr(instance, attr)


### PR DESCRIPTION
Fixes #5326 


When calling `BaseModel.__new__`, created instances are stored in `model_data`
We then try and initialize the instance by calling `__init__`

However, initialization may fail, and if that happens none of the regular attributes will be set.
This PR ensures that we can still print/__repr__ the uninitialized instance, despite the fact that no attributes have been set