### PR TITLE
TechDebt - remove support for old Jinja2+Responses

### DIFF
--- a/.github/workflows/test_outdated_versions.yml
+++ b/.github/workflows/test_outdated_versions.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: [ "3.10" ]
-        responses-version: ["0.11.0", "0.12.0", "0.13.0", "0.15.0", "0.17.0", "0.19.0" ]
+        responses-version: ["0.13.0", "0.15.0", "0.17.0", "0.19.0", "0.20.0" ]
         mock-version: [ "3.0.5", "4.0.0", "4.0.3" ]
         werkzeug-version: ["2.0.1", "2.1.1"]
 

--- a/moto/core/custom_responses_mock.py
+++ b/moto/core/custom_responses_mock.py
@@ -99,25 +99,9 @@ def not_implemented_callback(request):  # pylint: disable=unused-argument
 #  - First request matches on the appropriate S3 URL
 #  - Same request, executed again, will be matched on the subsequent match, which happens to be the catch-all, not-yet-implemented, callback
 # Fix: Always return the first match
-def _find_first_match_legacy(self, request):
-    all_possibles = self._matches + responses._default_mock._matches
-    matches = [match for match in all_possibles if match.matches(request)]
-
-    # Look for implemented callbacks first
-    implemented_matches = [
-        m
-        for m in matches
-        if type(m) is not CallbackResponse or m.callback != not_implemented_callback
-    ]
-    if implemented_matches:
-        return implemented_matches[0]
-    elif matches:
-        # We had matches, but all were of type not_implemented_callback
-        return matches[0]
-    return None
-
-
-# Internal API changed: this method should be used for Responses 0.12.1 < .. < 0.17.0
+#
+# Note that, due to an outdated API we no longer support Responses <= 0.12.1
+# This method should be used for Responses 0.12.1 < .. < 0.17.0
 def _find_first_match(self, request):
     matches = []
     match_failed_reasons = []
@@ -156,12 +140,7 @@ def get_response_mock():
     """
     responses_mock = None
 
-    if LooseVersion(RESPONSES_VERSION) < LooseVersion("0.12.1"):
-        responses_mock = responses.RequestsMock(assert_all_requests_are_fired=False)
-        responses_mock._find_match = types.MethodType(
-            _find_first_match_legacy, responses_mock
-        )
-    elif LooseVersion(RESPONSES_VERSION) >= LooseVersion("0.17.0"):
+    if LooseVersion(RESPONSES_VERSION) >= LooseVersion("0.17.0"):
         from .responses_custom_registry import CustomRegistry
 
         responses_mock = responses.RequestsMock(
@@ -176,9 +155,7 @@ def get_response_mock():
 
 
 def reset_responses_mock(responses_mock):
-    if LooseVersion(RESPONSES_VERSION) < LooseVersion("0.12.1"):
-        responses_mock.reset()
-    elif LooseVersion(RESPONSES_VERSION) >= LooseVersion("0.17.0"):
+    if LooseVersion(RESPONSES_VERSION) >= LooseVersion("0.17.0"):
         from .responses_custom_registry import CustomRegistry
 
         responses_mock.reset()

--- a/moto/core/responses.py
+++ b/moto/core/responses.py
@@ -61,7 +61,6 @@ def _decode_dict(d):
 
 
 class DynamicDictLoader(DictLoader):
-
     def update(self, mapping):
         self.mapping.update(mapping)
 

--- a/moto/core/responses.py
+++ b/moto/core/responses.py
@@ -11,7 +11,7 @@ import pytz
 
 from moto.core.exceptions import DryRunClientError
 
-from jinja2 import Environment, DictLoader, TemplateNotFound
+from jinja2 import Environment, DictLoader
 
 from urllib.parse import parse_qs, parse_qsl, urlparse
 
@@ -61,17 +61,6 @@ def _decode_dict(d):
 
 
 class DynamicDictLoader(DictLoader):
-    """
-    Note: There's a bug in jinja2 pre-2.7.3 DictLoader where caching does not work.
-      Including the fixed (current) method version here to ensure performance benefit
-      even for those using older jinja versions.
-    """
-
-    def get_source(self, environment, template):
-        if template in self.mapping:
-            source = self.mapping[template]
-            return source, None, lambda: source == self.mapping.get(template)
-        raise TemplateNotFound(template)
 
     def update(self, mapping):
         self.mapping.update(mapping)

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ install_requires = [
     "werkzeug>=0.5,<2.2.0",
     "pytz",
     "python-dateutil<3.0.0,>=2.1",
-    "responses>=0.9.0",
+    "responses>=0.13.0",
     "MarkupSafe!=2.0.0a1",  # This is a Jinja2 dependency, 2.0.0a1 currently seems broken
     "Jinja2>=2.10.1",
     "importlib_metadata ; python_version < '3.8'",


### PR DESCRIPTION
Removes support for responses <= 0.12.1

Also removes an old workaround for older versions of Jinja2. We only support `Jinja2>=2.10.1` anyway, so overriding `DictLoader.get_source` is pointless.