### PR TITLE
Store and return ServerSideEncryption and KMS Key Id for S3 Multiparts

### DIFF
--- a/moto/s3/responses.py
+++ b/moto/s3/responses.py
@@ -1919,20 +1919,38 @@ class S3Response(BaseResponse):
         self._set_action("KEY", "POST", query)
         self._authenticate_and_authorize_s3_action()
 
+        encryption = request.headers.get("x-amz-server-side-encryption")
+        kms_key_id = request.headers.get("x-amz-server-side-encryption-aws-kms-key-id")
+
         if body == b"" and "uploads" in query:
+            response_headers = {}
             metadata = metadata_from_headers(request.headers)
             tagging = self._tagging_from_headers(request.headers)
             storage_type = request.headers.get("x-amz-storage-class", "STANDARD")
             acl = self._acl_from_headers(request.headers)
+
             multipart_id = self.backend.create_multipart_upload(
-                bucket_name, key_name, metadata, storage_type, tagging, acl
+                bucket_name,
+                key_name,
+                metadata,
+                storage_type,
+                tagging,
+                acl,
+                encryption,
+                kms_key_id,
             )
+            if encryption:
+                response_headers["x-amz-server-side-encryption"] = encryption
+            if kms_key_id:
+                response_headers[
+                    "x-amz-server-side-encryption-aws-kms-key-id"
+                ] = kms_key_id
 
             template = self.response_template(S3_MULTIPART_INITIATE_RESPONSE)
             response = template.render(
                 bucket_name=bucket_name, key_name=key_name, upload_id=multipart_id
             )
-            return 200, {}, response
+            return 200, response_headers, response
 
         if query.get("uploadId"):
             body = self._complete_multipart_body(body)
@@ -1951,6 +1969,8 @@ class S3Response(BaseResponse):
                 storage=multipart.storage,
                 etag=etag,
                 multipart=multipart,
+                encryption=multipart.sse_encryption,
+                kms_key_id=multipart.kms_key_id,
             )
             key.set_metadata(multipart.metadata)
             self.backend.set_key_tags(key, multipart.tags)
@@ -1960,6 +1980,13 @@ class S3Response(BaseResponse):
             headers = {}
             if key.version_id:
                 headers["x-amz-version-id"] = key.version_id
+
+            if key.encryption:
+                headers["x-amz-server-side-encryption"] = key.encryption
+
+            if key.kms_key_id:
+                headers["x-amz-server-side-encryption-aws-kms-key-id"] = key.kms_key_id
+
             return (
                 200,
                 headers,

--- a/tests/test_s3/test_s3_multipart.py
+++ b/tests/test_s3/test_s3_multipart.py
@@ -10,7 +10,7 @@ from io import BytesIO
 from moto.s3.responses import DEFAULT_REGION_NAME
 
 
-from moto import settings, mock_s3
+from moto import settings, mock_s3, mock_kms
 import moto.s3.models as s3model
 from moto.settings import get_s3_default_key_buffer_size, S3_UPLOAD_PART_MIN_SIZE
 
@@ -885,3 +885,45 @@ def test_complete_multipart_with_empty_partlist():
     err["Message"].should.equal(
         "The XML you provided was not well-formed or did not validate against our published schema"
     )
+
+
+@mock_s3
+@mock_kms
+def test_ssm_key_headers_in_create_multipart():
+    s3_client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
+    kms_client = boto3.client("kms", region_name=DEFAULT_REGION_NAME)
+
+    bucket_name = "ssm-headers-bucket"
+    s3_client.create_bucket(Bucket=bucket_name)
+
+    kms_key = kms_client.create_key()["KeyMetadata"]
+    key_name = "test-file.txt"
+
+    create_multipart_response = s3_client.create_multipart_upload(
+        Bucket=bucket_name,
+        Key=key_name,
+        ServerSideEncryption="aws:kms",
+        SSEKMSKeyId=kms_key["KeyId"],
+    )
+    assert create_multipart_response["ServerSideEncryption"] == "aws:kms"
+    assert create_multipart_response["SSEKMSKeyId"] == kms_key["KeyId"]
+
+    upload_part_response = s3_client.upload_part(
+        Body=b"bytes",
+        Bucket=bucket_name,
+        Key=key_name,
+        PartNumber=1,
+        UploadId=create_multipart_response["UploadId"],
+    )
+    assert upload_part_response["ServerSideEncryption"] == "aws:kms"
+    assert upload_part_response["SSEKMSKeyId"] == kms_key["KeyId"]
+
+    parts = {"Parts": [{"PartNumber": 1, "ETag": upload_part_response["ETag"]}]}
+    complete_multipart_response = s3_client.complete_multipart_upload(
+        Bucket=bucket_name,
+        Key=key_name,
+        UploadId=create_multipart_response["UploadId"],
+        MultipartUpload=parts,
+    )
+    assert complete_multipart_response["ServerSideEncryption"] == "aws:kms"
+    assert complete_multipart_response["SSEKMSKeyId"] == kms_key["KeyId"]


### PR DESCRIPTION
This PR addresses localstack/localstack#6604. Now the S3 Multipart stores the 'SSE' and `KmsKeyId` values and uses them when creating the key parts and the complete key.