### PR TITLE
Dynamodb - ensure getItem does not use both expression and non-expression

### DIFF
--- a/moto/dynamodb/responses.py
+++ b/moto/dynamodb/responses.py
@@ -459,7 +459,14 @@ class DynamoHandler(BaseResponse):
                 "One or more parameter values are not valid. The AttributeValue for a key attribute cannot contain an "
                 f"empty string value. Key: {empty_keys[0]}"
             )
+
         projection_expression = self.body.get("ProjectionExpression")
+        attributes_to_get = self.body.get("AttributesToGet")
+        if projection_expression and attributes_to_get:
+            raise MockValidationException(
+                "Can not use both expression and non-expression parameters in the same request: Non-expression parameters: {AttributesToGet} Expression parameters: {ProjectionExpression}"
+            )
+
         expression_attribute_names = self.body.get("ExpressionAttributeNames")
         if expression_attribute_names == {}:
             if projection_expression is None:

--- a/tests/test_dynamodb/test_dynamodb.py
+++ b/tests/test_dynamodb/test_dynamodb.py
@@ -412,6 +412,7 @@ def test_put_item_with_streams():
 @mock_dynamodb
 def test_basic_projection_expression_using_get_item():
     dynamodb = boto3.resource("dynamodb", region_name="us-east-1")
+    client = boto3.client("dynamodb", region_name="us-east-1")
 
     # Create the DynamoDB table.
     table = dynamodb.create_table(
@@ -452,6 +453,17 @@ def test_basic_projection_expression_using_get_item():
     result["Item"].should.be.equal(
         {"forum_name": "the-key", "subject": "123", "body": "some test message"}
     )
+
+    # Running this against AWS DDB gives an exception so make sure it also fails.:
+    with pytest.raises(client.exceptions.ClientError):
+        # botocore.exceptions.ClientError: An error occurred (ValidationException) when calling the GetItem
+        # operation: "Can not use both expression and non-expression parameters in the same request:
+        #  Non-expression parameters: {AttributesToGet} Expression parameters: {ProjectionExpression}"
+        table.get_item(
+            Key={"forum_name": "the-key", "subject": "123"},
+            ProjectionExpression="body",
+            AttributesToGet=["body"],
+        )
 
 
 @mock_dynamodb


### PR DESCRIPTION
Addresses #5354 by raising an exception.