### PR TITLE
Fix bug. route53 backend should be global

### DIFF
--- a/moto/route53/models.py
+++ b/moto/route53/models.py
@@ -249,7 +249,7 @@ class RecordSet(CloudFormationModel):
 
     def delete(self, account_id, region):  # pylint: disable=unused-argument
         """Not exposed as part of the Route 53 API - used for CloudFormation"""
-        backend = route53_backends[account_id][region]
+        backend = route53_backends[account_id]["global"]
         hosted_zone = backend.get_hosted_zone_by_name(self.hosted_zone_name)
         if not hosted_zone:
             hosted_zone = backend.get_hosted_zone(self.hosted_zone_id)

--- a/tests/test_route53/test_route53_cloudformation.py
+++ b/tests/test_route53/test_route53_cloudformation.py
@@ -224,3 +224,22 @@ def test_route53_with_update():
 
     record_set = rrsets[0]
     record_set["ResourceRecords"][0]["Value"].should.equal("my_other.example.com")
+
+
+@mock_cloudformation
+@mock_route53
+def test_delete_route53_recordset():
+
+    route53 = boto3.client("route53", region_name="us-west-1")
+    cf = boto3.client("cloudformation", region_name="us-west-1")
+
+    # given a stack with a record set
+    stack_name = "test_stack_recordset_delete"
+    template_json = json.dumps(route53_health_check.template)
+
+    cf.create_stack(StackName=stack_name, TemplateBody=template_json)
+
+    # when the stack is deleted
+    cf.delete_stack(StackName=stack_name)
+
+    # then it should not error

--- a/tests/test_route53/test_route53_cloudformation.py
+++ b/tests/test_route53/test_route53_cloudformation.py
@@ -230,7 +230,6 @@ def test_route53_with_update():
 @mock_route53
 def test_delete_route53_recordset():
 
-    route53 = boto3.client("route53", region_name="us-west-1")
     cf = boto3.client("cloudformation", region_name="us-west-1")
 
     # given a stack with a record set


### PR DESCRIPTION
There is [exactly one backend defined for route53](https://github.com/spulec/moto/blob/master/moto/route53/models.py#L815), and it is the "global" one:

```python
route53_backends = BackendDict(
    Route53Backend, "route53", use_boto3_regions=False, additional_regions=["global"]
)
```

But, this one method is using the given region, presumably the one of the containing CloudFormation stack?

I am pretty sure this was just an oversight in https://github.com/spulec/moto/pull/5192. The right region is used [15 or so lines above](https://github.com/spulec/moto/blob/master/moto/route53/models.py#L235):

```python
        backend = route53_backends[account_id]["global"]
```