### PR TITLE
add guard against no integration when adding a new response

### DIFF
--- a/moto/apigateway/models.py
+++ b/moto/apigateway/models.py
@@ -1641,7 +1641,8 @@ class APIGatewayBackend(BaseBackend):
         response_templates,
         content_handling,
     ):
-        if integration := self.get_integration(function_id, resource_id, method_type):
+        integration = self.get_integration(function_id, resource_id, method_type)
+        if integration:
             return integration.create_integration_response(
                 status_code, selection_pattern, response_templates, content_handling
             )

--- a/moto/apigateway/models.py
+++ b/moto/apigateway/models.py
@@ -1381,8 +1381,7 @@ class APIGatewayBackend(BaseBackend):
         api = self.get_rest_api(function_id)
         if resource_id not in api.resources:
             raise ResourceIdNotFoundException
-        resource = api.resources[resource_id]
-        return resource
+        return api.resources[resource_id]
 
     def create_resource(self, function_id, parent_resource_id, path_part):
         api = self.get_rest_api(function_id)
@@ -1643,6 +1642,8 @@ class APIGatewayBackend(BaseBackend):
         content_handling,
     ):
         integration = self.get_integration(function_id, resource_id, method_type)
+        if not integration:
+            raise NoIntegrationResponseDefined()
         integration_response = integration.create_integration_response(
             status_code, selection_pattern, response_templates, content_handling
         )

--- a/moto/apigateway/models.py
+++ b/moto/apigateway/models.py
@@ -1645,7 +1645,7 @@ class APIGatewayBackend(BaseBackend):
             return integration.create_integration_response(
                 status_code, selection_pattern, response_templates, content_handling
             )
-        raise NoIntegrationDefined()
+        raise NoIntegrationResponseDefined()
 
     def get_integration_response(
         self, function_id, resource_id, method_type, status_code

--- a/moto/apigateway/models.py
+++ b/moto/apigateway/models.py
@@ -1641,13 +1641,11 @@ class APIGatewayBackend(BaseBackend):
         response_templates,
         content_handling,
     ):
-        integration = self.get_integration(function_id, resource_id, method_type)
-        if not integration:
-            raise NoIntegrationResponseDefined()
-        integration_response = integration.create_integration_response(
-            status_code, selection_pattern, response_templates, content_handling
-        )
-        return integration_response
+        if integration := self.get_integration(function_id, resource_id, method_type):
+            return integration.create_integration_response(
+                status_code, selection_pattern, response_templates, content_handling
+            )
+        raise NoIntegrationDefined()
 
     def get_integration_response(
         self, function_id, resource_id, method_type, status_code


### PR DESCRIPTION
This PR adds a guard to cases where moto tries to add an integration response when there is no integration (yet).

The result is this exception.
```
File ".venv/lib/python3.10/site-packages/moto/apigateway/responses.py", line 497, in integration_responses
    integration_response = self.backend.put_integration_response(
  File ".venv/lib/python3.10/site-packages/moto/apigateway/models.py", line 1640, in put_integration_response
    integration_response = integration.create_integration_response(
AttributeError: 'NoneType' object has no attribute 'create_integration_response'
```