### PR TITLE
Tech Debt: Skip some tests in Py3.6, as we do not have access to all regions

### DIFF
--- a/tests/test_iam/test_iam.py
+++ b/tests/test_iam/test_iam.py
@@ -1,4 +1,5 @@
 import json
+import sys
 
 import boto3
 import csv
@@ -15,6 +16,7 @@ import pytest
 from datetime import datetime
 from uuid import uuid4
 from urllib import parse
+from unittest import SkipTest
 
 from moto.s3.responses import DEFAULT_REGION_NAME
 
@@ -3728,6 +3730,10 @@ def test_role_config_dict():
 @mock_iam
 @mock_config
 def test_role_config_client():
+    if sys.version_info < (3, 7):
+        raise SkipTest(
+            "Cannot test this in Py3.6; outdated botocore dependencies do not have all regions"
+        )
     from moto.iam.utils import random_resource_id
 
     CONFIG_REGIONS = boto3.Session().get_available_regions("config")
@@ -4172,6 +4178,10 @@ def test_policy_config_dict():
 @mock_iam
 @mock_config
 def test_policy_config_client():
+    if sys.version_info < (3, 7):
+        raise SkipTest(
+            "Cannot test this in Py3.6; outdated botocore dependencies do not have all regions"
+        )
     from moto.iam.utils import random_policy_id
 
     CONFIG_REGIONS = boto3.Session().get_available_regions("config")


### PR DESCRIPTION
New regions (such as me-central-1) do not show up in `boto3.Session().get_available_regions`.
Moto does return it, so we must know about it, but we don't know it exists afterwards in the test. Just skipping the test in 3.6 is the easiest workaround - we'll EOL 3.6 soon-ish anyway