### PR TITLE
Fix `openapi-spec-validator` import error

### DIFF
--- a/.github/workflows/test_outdated_versions.yml
+++ b/.github/workflows/test_outdated_versions.yml
@@ -17,6 +17,7 @@ jobs:
         responses-version: ["0.13.0", "0.15.0", "0.17.0", "0.19.0", "0.20.0" ]
         mock-version: [ "3.0.5", "4.0.0", "4.0.3" ]
         werkzeug-version: ["2.0.1", "2.1.1"]
+        openapi-spec-validator-version: ["0.4.0", "0.5.0"]
 
     steps:
     - name: Checkout repository
@@ -37,6 +38,7 @@ jobs:
         pip install responses==${{ matrix.responses-version }}
         pip install mock==${{ matrix.mock-version }}
         pip install werkzeug==${{ matrix.werkzeug-version }}
+        pip install openapi-spec-validator==${{ matrix.openapi-spec-validator-version }}
 
     - name: Run tests
       run: |

--- a/moto/apigateway/models.py
+++ b/moto/apigateway/models.py
@@ -12,7 +12,11 @@ import time
 from urllib.parse import urlparse
 import responses
 
-from openapi_spec_validator.exceptions import OpenAPIValidationError
+try:
+    from openapi_spec_validator.validation.exceptions import OpenAPIValidationError
+except ImportError:
+    # OpenAPI Spec Validator < 0.5.0
+    from openapi_spec_validator.exceptions import OpenAPIValidationError
 from moto.core import BaseBackend, BaseModel, CloudFormationModel
 from .utils import create_id, to_path
 from moto.core.utils import path_url, BackendDict


### PR DESCRIPTION
This package recently moved some files around in a backwards-incompatible way as part of a refactor.

Ref: https://github.com/p1c2u/openapi-spec-validator/commit/70325f638001c615909978381bb48ad3d924dafd

Closes #5457 