### PR TITLE
add rds enable_http_endpoint attribute

### DIFF
--- a/moto/rds/models.py
+++ b/moto/rds/models.py
@@ -1751,7 +1751,6 @@ class RDSBackend(BaseBackend):
     def create_db_cluster(self, kwargs):
         cluster_id = kwargs["db_cluster_identifier"]
         kwargs["account_id"] = self.account_id
-        print(kwargs)
         cluster = Cluster(**kwargs)
         self.clusters[cluster_id] = cluster
         initial_state = copy.deepcopy(cluster)  # Return status=creating

--- a/moto/rds/models.py
+++ b/moto/rds/models.py
@@ -116,7 +116,7 @@ class Cluster:
         )
         self.enable_http_endpoint = False
         # instead of raising an error on aws rds create-db-cluster commands with
-        # incompatible configurations with enable_http_endpoint 
+        # incompatible configurations with enable_http_endpoint
         # (e.g. engine_mode is not set to "serverless"), the API
         # automatically sets the enable_http_endpoint parameter to False
         if kwargs.get("enable_http_endpoint"):

--- a/moto/rds/models.py
+++ b/moto/rds/models.py
@@ -121,10 +121,24 @@ class Cluster:
         # automatically sets the enable_http_endpoint parameter to False
         if kwargs.get("enable_http_endpoint"):
             if self.engine_mode == "serverless":
-                if self.engine == "aurora-mysql" and self.engine_version in ["5.6.10a", "5.6.1", "2.07.1", "5.7.2"]:
-                    self.enable_http_endpoint = kwargs.get("enable_http_endpoint", False)
-                elif self.engine == "aurora-postgresql" and self.engine_version in ["10.12", "10.14", "10.18", "11.13"]:
-                    self.enable_http_endpoint = kwargs.get("enable_http_endpoint", False)
+                if self.engine == "aurora-mysql" and self.engine_version in [
+                    "5.6.10a",
+                    "5.6.1",
+                    "2.07.1",
+                    "5.7.2",
+                ]:
+                    self.enable_http_endpoint = kwargs.get(
+                        "enable_http_endpoint", False
+                    )
+                elif self.engine == "aurora-postgresql" and self.engine_version in [
+                    "10.12",
+                    "10.14",
+                    "10.18",
+                    "11.13",
+                ]:
+                    self.enable_http_endpoint = kwargs.get(
+                        "enable_http_endpoint", False
+                    )
 
     @property
     def db_cluster_arn(self):

--- a/moto/rds/models.py
+++ b/moto/rds/models.py
@@ -121,7 +121,7 @@ class Cluster:
         # automatically sets the enable_http_endpoint parameter to False
         if kwargs.get("enable_http_endpoint"):
             if self.engine_mode == "serverless":
-                if self.engine == "aurora-sql" and self.engine_version in ["5.6.10a", "5.6.1", "2.07.1", "5.7.2"]:
+                if self.engine == "aurora-mysql" and self.engine_version in ["5.6.10a", "5.6.1", "2.07.1", "5.7.2"]:
                     self.enable_http_endpoint = kwargs.get("enable_http_endpoint", False)
                 elif self.engine == "aurora-postgresql" and self.engine_version in ["10.12", "10.14", "10.18", "11.13"]:
                     self.enable_http_endpoint = kwargs.get("enable_http_endpoint", False)
@@ -1751,6 +1751,7 @@ class RDSBackend(BaseBackend):
     def create_db_cluster(self, kwargs):
         cluster_id = kwargs["db_cluster_identifier"]
         kwargs["account_id"] = self.account_id
+        print(kwargs)
         cluster = Cluster(**kwargs)
         self.clusters[cluster_id] = cluster
         initial_state = copy.deepcopy(cluster)  # Return status=creating

--- a/moto/rds/responses.py
+++ b/moto/rds/responses.py
@@ -117,6 +117,7 @@ class RDSResponse(BaseResponse):
             "parameter_group": self._get_param("DBClusterParameterGroup"),
             "region": self.region,
             "db_cluster_instance_class": self._get_param("DBClusterInstanceClass"),
+            "enable_http_endpoint": self._get_param("EnableHttpEndpoint"),
             "copy_tags_to_snapshot": self._get_param("CopyTagsToSnapshot"),
             "tags": self.unpack_complex_list_params("Tags.Tag", ("Key", "Value")),
         }

--- a/tests/test_rds/test_rds_clusters.py
+++ b/tests/test_rds/test_rds_clusters.py
@@ -716,3 +716,39 @@ def test_add_tags_to_cluster_snapshot():
 
     tags = conn.list_tags_for_resource(ResourceName=snapshot_arn)["TagList"]
     tags.should.equal([{"Key": "k2", "Value": "v2"}])
+
+
+@mock_rds
+def test_create_db_cluster_with_enable_http_endpoint_valid():
+    client = boto3.client("rds", region_name="eu-north-1")
+
+    resp = client.create_db_cluster(
+        DBClusterIdentifier="cluster-id",
+        DatabaseName="users",
+        Engine="aurora-mysql",
+        EngineMode="serverless",
+        EngineVersion="5.6.10a",
+        MasterUsername="root",
+        MasterUserPassword="hunter2_",
+        EnableHttpEndpoint=True,
+    )
+    cluster = resp["DBCluster"]
+    cluster.should.have.key("HttpEndpointEnabled").equal(True)
+
+
+@mock_rds
+def test_create_db_cluster_with_enable_http_endpoint_invalid():
+    client = boto3.client("rds", region_name="eu-north-1")
+
+    resp = client.create_db_cluster(
+        DBClusterIdentifier="cluster-id",
+        DatabaseName="users",
+        Engine="aurora-mysql",
+        EngineMode="serverless",
+        EngineVersion="5.7.0",
+        MasterUsername="root",
+        MasterUserPassword="hunter2_",
+        EnableHttpEndpoint=True,
+    )
+    cluster = resp["DBCluster"]
+    cluster.should.have.key("HttpEndpointEnabled").equal(False)


### PR DESCRIPTION
The current implementation of mocking the  RDS `CreateDBCluster` sets HttpEndpointEnabled to False by default without regard to an enable_http_endpoint parameter value. 

The PR introduces a `self.enable_http_endpoint` attribute within the `Cluster` class and simulates the AWS API's conditional constraints for enabling HTTP endpoints within serverless V1 clusters. Specifically, the conditions relate to the desired engine, engine version, and engine_mode configurations for the cluster to be created.