### PR TITLE
APIGatewayV2: create_authorizer() now validates the AuthorizerPayloadFormatVersion

### DIFF
--- a/moto/apigatewayv2/models.py
+++ b/moto/apigatewayv2/models.py
@@ -1023,7 +1023,7 @@ class ApiGatewayV2Backend(BaseBackend):
     def delete_api(self, api_id):
         self.apis.pop(api_id, None)
 
-    def get_api(self, api_id):
+    def get_api(self, api_id) -> Api:
         if api_id not in self.apis:
             raise ApiNotFound(api_id)
         return self.apis[api_id]
@@ -1089,6 +1089,16 @@ class ApiGatewayV2Backend(BaseBackend):
         name,
     ):
         api = self.get_api(api_id)
+
+        if (
+            api.protocol_type == "HTTP"
+            and authorizer_type == "REQUEST"
+            and not auth_payload_format_version
+        ):
+            raise BadRequestException(
+                "AuthorizerPayloadFormatVersion is a required parameter for REQUEST authorizer"
+            )
+
         authorizer = api.create_authorizer(
             auth_creds_arn=auth_creds_arn,
             auth_payload_format_version=auth_payload_format_version,

--- a/moto/apigatewayv2/responses.py
+++ b/moto/apigatewayv2/responses.py
@@ -264,9 +264,7 @@ class ApiGatewayV2Response(BaseResponse):
         params = json.loads(self.body)
 
         auth_creds_arn = params.get("authorizerCredentialsArn")
-        auth_payload_format_version = (
-            params.get("authorizerPayloadFormatVersion") or "2.0"
-        )
+        auth_payload_format_version = params.get("authorizerPayloadFormatVersion")
         auth_result_ttl = params.get("authorizerResultTtlInSeconds")
         authorizer_type = params.get("authorizerType")
         authorizer_uri = params.get("authorizerUri")

--- a/tests/terraformtests/terraform-tests.failures.txt
+++ b/tests/terraformtests/terraform-tests.failures.txt
@@ -1,8 +1,6 @@
 # The Tests in this file worked against an older version of Terraform
 # Either they do not work anymore, or have not been verified to work yet
 
-TestAccAPIGatewayV2Authorizer
-TestAccAPIGatewayV2Route
 TestAccAppsyncApiKey
 TestAccAppsyncGraphqlApi
 TestAccAutoscalingPolicy

--- a/tests/terraformtests/terraform-tests.success.txt
+++ b/tests/terraformtests/terraform-tests.success.txt
@@ -21,9 +21,10 @@ apigateway:
   - TestAccAPIGatewayStage_tags
   - TestAccAPIGatewayStage_accessLogSettings
 apigatewayv2:
+  - TestAccAPIGatewayV2Authorizer
   - TestAccAPIGatewayV2IntegrationResponse
   - TestAccAPIGatewayV2Model
-  - TestAccAPIGatewayV2RouteResponse
+  - TestAccAPIGatewayV2Route
   - TestAccAPIGatewayV2VPCLink
 autoscaling:
   - TestAccAutoScalingAttachment

--- a/tests/test_apigatewayv2/test_apigatewayv2_authorizers.py
+++ b/tests/test_apigatewayv2/test_apigatewayv2_authorizers.py
@@ -11,7 +11,11 @@ def test_create_authorizer_minimum():
     api_id = client.create_api(Name="test-api", ProtocolType="HTTP")["ApiId"]
 
     resp = client.create_authorizer(
-        ApiId=api_id, AuthorizerType="REQUEST", IdentitySource=[], Name="auth1"
+        ApiId=api_id,
+        AuthorizerType="REQUEST",
+        IdentitySource=[],
+        Name="auth1",
+        AuthorizerPayloadFormatVersion="2.0",
     )
 
     resp.should.have.key("AuthorizerId")
@@ -55,12 +59,37 @@ def test_create_authorizer():
 
 
 @mock_apigatewayv2
+def test_create_authorizer_without_payloadformatversion():
+    client = boto3.client("apigatewayv2", region_name="eu-west-1")
+    api_id = client.create_api(Name="test-api", ProtocolType="HTTP")["ApiId"]
+
+    with pytest.raises(ClientError) as exc:
+        client.create_authorizer(
+            ApiId=api_id,
+            AuthorizerType="REQUEST",
+            AuthorizerUri="auth_uri",
+            IdentitySource=[""],
+            Name="auth1",
+        )
+
+    err = exc.value.response["Error"]
+    err["Code"].should.equal("BadRequestException")
+    err["Message"].should.equal(
+        "AuthorizerPayloadFormatVersion is a required parameter for REQUEST authorizer"
+    )
+
+
+@mock_apigatewayv2
 def test_get_authorizer():
     client = boto3.client("apigatewayv2", region_name="eu-west-1")
     api_id = client.create_api(Name="test-api", ProtocolType="HTTP")["ApiId"]
 
     authorizer_id = client.create_authorizer(
-        ApiId=api_id, AuthorizerType="REQUEST", IdentitySource=[], Name="auth1"
+        ApiId=api_id,
+        AuthorizerType="REQUEST",
+        IdentitySource=[],
+        Name="auth1",
+        AuthorizerPayloadFormatVersion="2.0",
     )["AuthorizerId"]
 
     resp = client.get_authorizer(ApiId=api_id, AuthorizerId=authorizer_id)
@@ -74,7 +103,7 @@ def test_get_authorizer():
 @mock_apigatewayv2
 def test_delete_authorizer():
     client = boto3.client("apigatewayv2", region_name="eu-west-1")
-    api_id = client.create_api(Name="test-api", ProtocolType="HTTP")["ApiId"]
+    api_id = client.create_api(Name="test-api", ProtocolType="WEBSOCKET")["ApiId"]
 
     authorizer_id = client.create_authorizer(
         ApiId=api_id, AuthorizerType="REQUEST", IdentitySource=[], Name="auth1"
@@ -143,7 +172,11 @@ def test_update_authorizer_all_attributes():
     api_id = client.create_api(Name="test-api", ProtocolType="HTTP")["ApiId"]
 
     auth_id = client.create_authorizer(
-        ApiId=api_id, AuthorizerType="REQUEST", IdentitySource=[], Name="auth1"
+        ApiId=api_id,
+        AuthorizerType="REQUEST",
+        IdentitySource=[],
+        Name="auth1",
+        AuthorizerPayloadFormatVersion="2.0",
     )["AuthorizerId"]
 
     auth_id = client.update_authorizer(


### PR DESCRIPTION


See #5144 

FYI @calvernaz - I've tested all combinations against AWS, and this is the correct behaviour as far as I can see