### PR TITLE
S3:get_object() - Simple BucketPolicy validation

### DIFF
--- a/moto/moto_server/threaded_moto_server.py
+++ b/moto/moto_server/threaded_moto_server.py
@@ -31,7 +31,7 @@ class ThreadedMotoServer:
         self._thread = Thread(target=self._server_entry, daemon=True)
         self._thread.start()
         while not self._server_ready:
-            time.sleep(0.5)
+            time.sleep(0.1)
 
     def stop(self):
         self._server_ready = False

--- a/tests/test_s3/test_s3_bucket_policy.py
+++ b/tests/test_s3/test_s3_bucket_policy.py
@@ -1,133 +1,62 @@
 import boto3
 import json
 import requests
+import pytest
+import sure  # noqa # pylint: disable=unused-import
 
 from moto.moto_server.threaded_moto_server import ThreadedMotoServer
-from unittest import TestCase
 
 
-class TestBucketPolicy(TestCase):
-    def setUpClass() -> None:
-        TestBucketPolicy.server = ThreadedMotoServer(
-            ip_address="127.0.0.1", port="6000", verbose=False
-        )
-        TestBucketPolicy.server.start()
+class TestBucketPolicy:
+    @staticmethod
+    def setup_class(cls):
+        cls.server = ThreadedMotoServer(port="6000", verbose=False)
+        cls.server.start()
 
-    def setUp(self) -> None:
+    def setup(self) -> None:
         self.client = boto3.client(
             "s3", region_name="us-east-1", endpoint_url="http://localhost:6000"
         )
         self.client.create_bucket(Bucket="mybucket")
         self.client.put_object(Bucket="mybucket", Key="test_txt", Body=b"mybytes")
+        self.key_name = "http://localhost:6000/mybucket/test_txt"
 
-    def tearDown(self) -> None:
+    def teardown(self) -> None:
         self.client.delete_object(Bucket="mybucket", Key="test_txt")
         self.client.delete_bucket(Bucket="mybucket")
 
-    def tearDownClass() -> None:
-        TestBucketPolicy.server.stop()
+    @staticmethod
+    def teardown_class(cls):
+        cls.server.stop()
 
-    def test_policy_allow_all(self):
+    @pytest.mark.parametrize(
+        "kwargs,status",
+        [
+            ({}, 200),
+            ({"resource": "arn:aws:s3:::mybucket/test_txt"}, 200),
+            ({"resource": "arn:aws:s3:::notmybucket/*"}, 403),
+            ({"resource": "arn:aws:s3:::mybucket/other*"}, 403),
+            ({"actions": ["s3:PutObject"]}, 403),
+            ({"effect": "Deny"}, 403),
+        ],
+    )
+    def test_policy_allow_all(self, kwargs, status):
+        self._put_policy(**kwargs)
+
+        requests.get(self.key_name).status_code.should.equal(status)
+
+    def _put_policy(
+        self, resource="arn:aws:s3:::mybucket/*", effect="Allow", actions=None
+    ):
         policy = {
             "Version": "2012-10-17",
             "Statement": [
                 {
-                    "Effect": "Allow",
+                    "Effect": effect,
                     "Principal": "*",
-                    "Action": ["s3:GetObject"],
-                    "Resource": "arn:aws:s3:::mybucket/*",
+                    "Action": actions or ["s3:GetObject"],
+                    "Resource": resource,
                 }
             ],
         }
-        self._put_policy(policy)
-
-        r = requests.get("http://localhost:6000/mybucket/test_txt")
-        assert r.status_code == 200
-
-    def test_policy_allow_different_action(self):
-        policy = {
-            "Version": "2012-10-17",
-            "Statement": [
-                {
-                    "Effect": "Allow",
-                    "Principal": "*",
-                    "Action": ["s3:PutObject"],
-                    "Resource": "arn:aws:s3:::mybucket/*",
-                }
-            ],
-        }
-        self._put_policy(policy)
-
-        r = requests.get("http://localhost:6000/mybucket/test_txt")
-        assert r.status_code == 403
-
-    def test_policy_allow_different_bucket(self):
-        policy = {
-            "Version": "2012-10-17",
-            "Statement": [
-                {
-                    "Effect": "Allow",
-                    "Principal": "*",
-                    "Action": ["s3:GetObject"],
-                    "Resource": "arn:aws:s3:::notmybucket/*",
-                }
-            ],
-        }
-        self._put_policy(policy)
-
-        r = requests.get("http://localhost:6000/mybucket/test_txt")
-        assert r.status_code == 403
-
-    def test_policy_allow_different_resource(self):
-        policy = {
-            "Version": "2012-10-17",
-            "Statement": [
-                {
-                    "Effect": "Allow",
-                    "Principal": "*",
-                    "Action": ["s3:GetObject"],
-                    "Resource": "arn:aws:s3:::mybucket/other*",
-                }
-            ],
-        }
-        self._put_policy(policy)
-
-        r = requests.get("http://localhost:6000/mybucket/test_txt")
-        assert r.status_code == 403
-
-    def test_policy_allow_exact_resource(self):
-        policy = {
-            "Version": "2012-10-17",
-            "Statement": [
-                {
-                    "Effect": "Allow",
-                    "Principal": "*",
-                    "Action": ["s3:GetObject"],
-                    "Resource": "arn:aws:s3:::mybucket/test_txt",
-                }
-            ],
-        }
-        self._put_policy(policy)
-
-        r = requests.get("http://localhost:6000/mybucket/test_txt")
-        assert r.status_code == 200
-
-    def test_policy_deny(self):
-        policy = {
-            "Version": "2012-10-17",
-            "Statement": [
-                {
-                    "Effect": "Deny",
-                    "Principal": "*",
-                    "Action": ["s3:GetObject"],
-                    "Resource": "arn:aws:s3:::mybucket/*",
-                }
-            ],
-        }
-        self._put_policy(policy)
-
-        r = requests.get("http://localhost:6000/mybucket/test_txt")
-        assert r.status_code == 403
-
-    def _put_policy(self, policy):
         self.client.put_bucket_policy(Bucket="mybucket", Policy=json.dumps(policy))

--- a/tests/test_s3/test_s3_bucket_policy.py
+++ b/tests/test_s3/test_s3_bucket_policy.py
@@ -1,0 +1,133 @@
+import boto3
+import json
+import requests
+
+from moto.moto_server.threaded_moto_server import ThreadedMotoServer
+from unittest import TestCase
+
+
+class TestBucketPolicy(TestCase):
+    def setUpClass() -> None:
+        TestBucketPolicy.server = ThreadedMotoServer(
+            ip_address="127.0.0.1", port="6000", verbose=False
+        )
+        TestBucketPolicy.server.start()
+
+    def setUp(self) -> None:
+        self.client = boto3.client(
+            "s3", region_name="us-east-1", endpoint_url="http://localhost:6000"
+        )
+        self.client.create_bucket(Bucket="mybucket")
+        self.client.put_object(Bucket="mybucket", Key="test_txt", Body=b"mybytes")
+
+    def tearDown(self) -> None:
+        self.client.delete_object(Bucket="mybucket", Key="test_txt")
+        self.client.delete_bucket(Bucket="mybucket")
+
+    def tearDownClass() -> None:
+        TestBucketPolicy.server.stop()
+
+    def test_policy_allow_all(self):
+        policy = {
+            "Version": "2012-10-17",
+            "Statement": [
+                {
+                    "Effect": "Allow",
+                    "Principal": "*",
+                    "Action": ["s3:GetObject"],
+                    "Resource": "arn:aws:s3:::mybucket/*",
+                }
+            ],
+        }
+        self._put_policy(policy)
+
+        r = requests.get("http://localhost:6000/mybucket/test_txt")
+        assert r.status_code == 200
+
+    def test_policy_allow_different_action(self):
+        policy = {
+            "Version": "2012-10-17",
+            "Statement": [
+                {
+                    "Effect": "Allow",
+                    "Principal": "*",
+                    "Action": ["s3:PutObject"],
+                    "Resource": "arn:aws:s3:::mybucket/*",
+                }
+            ],
+        }
+        self._put_policy(policy)
+
+        r = requests.get("http://localhost:6000/mybucket/test_txt")
+        assert r.status_code == 403
+
+    def test_policy_allow_different_bucket(self):
+        policy = {
+            "Version": "2012-10-17",
+            "Statement": [
+                {
+                    "Effect": "Allow",
+                    "Principal": "*",
+                    "Action": ["s3:GetObject"],
+                    "Resource": "arn:aws:s3:::notmybucket/*",
+                }
+            ],
+        }
+        self._put_policy(policy)
+
+        r = requests.get("http://localhost:6000/mybucket/test_txt")
+        assert r.status_code == 403
+
+    def test_policy_allow_different_resource(self):
+        policy = {
+            "Version": "2012-10-17",
+            "Statement": [
+                {
+                    "Effect": "Allow",
+                    "Principal": "*",
+                    "Action": ["s3:GetObject"],
+                    "Resource": "arn:aws:s3:::mybucket/other*",
+                }
+            ],
+        }
+        self._put_policy(policy)
+
+        r = requests.get("http://localhost:6000/mybucket/test_txt")
+        assert r.status_code == 403
+
+    def test_policy_allow_exact_resource(self):
+        policy = {
+            "Version": "2012-10-17",
+            "Statement": [
+                {
+                    "Effect": "Allow",
+                    "Principal": "*",
+                    "Action": ["s3:GetObject"],
+                    "Resource": "arn:aws:s3:::mybucket/test_txt",
+                }
+            ],
+        }
+        self._put_policy(policy)
+
+        r = requests.get("http://localhost:6000/mybucket/test_txt")
+        assert r.status_code == 200
+
+    def test_policy_deny(self):
+        policy = {
+            "Version": "2012-10-17",
+            "Statement": [
+                {
+                    "Effect": "Deny",
+                    "Principal": "*",
+                    "Action": ["s3:GetObject"],
+                    "Resource": "arn:aws:s3:::mybucket/*",
+                }
+            ],
+        }
+        self._put_policy(policy)
+
+        r = requests.get("http://localhost:6000/mybucket/test_txt")
+        assert r.status_code == 403
+
+    def _put_policy(self, policy):
+        self.client.put_bucket_policy(Bucket="mybucket", Policy=json.dumps(policy))


### PR DESCRIPTION
Ideally we extend this to all actions (Get/Put/Etc), and move validation to a single place - for now we'll just validate GetObject to verify it works as expected.

Fixes #2892