### PR TITLE
Add CloudFormation support to EC2 Launch Templates

### DIFF
--- a/moto/ec2/exceptions.py
+++ b/moto/ec2/exceptions.py
@@ -718,6 +718,14 @@ class InvalidLaunchTemplateNameNotFoundError(EC2ClientError):
         )
 
 
+class InvalidLaunchTemplateNameNotFoundWithNameError(EC2ClientError):
+    def __init__(self, name):
+        super().__init__(
+            "InvalidLaunchTemplateName.NotFoundException",
+            f"The specified launch template, with template name {name}, does not exist",
+        )
+
+
 class InvalidParameterDependency(EC2ClientError):
     def __init__(self, param, param_needed):
         super().__init__(

--- a/moto/ec2/models/launch_templates.py
+++ b/moto/ec2/models/launch_templates.py
@@ -11,6 +11,7 @@ from ..utils import (
 from ..exceptions import (
     InvalidLaunchTemplateNameAlreadyExistsError,
     InvalidLaunchTemplateNameNotFoundError,
+    InvalidLaunchTemplateNameNotFoundWithNameError,
 )
 
 
@@ -179,13 +180,11 @@ class LaunchTemplateBackend:
         return template
 
     def get_launch_template(self, template_id):
-        if template_id not in self.launch_templates:
-            raise InvalidLaunchTemplateNameNotFoundError()
         return self.launch_templates[template_id]
 
     def get_launch_template_by_name(self, name):
         if name not in self.launch_template_name_to_ids:
-            raise InvalidLaunchTemplateNameNotFoundError()
+            raise InvalidLaunchTemplateNameNotFoundWithNameError(name)
         return self.get_launch_template(self.launch_template_name_to_ids[name])
 
     def delete_launch_template(self, name, tid):

--- a/moto/ec2/models/launch_templates.py
+++ b/moto/ec2/models/launch_templates.py
@@ -111,7 +111,7 @@ class LaunchTemplate(TaggedEC2Resource, CloudFormationModel):
         name = properties.get("LaunchTemplateName")
         data = properties.get("LaunchTemplateData")
         description = properties.get("VersionDescription")
-        tag_spec = convert_tag_spec(properties.get("TagSpecifications"), tag_key="Tags")
+        tag_spec = convert_tag_spec(properties.get("TagSpecifications", {}), tag_key="Tags")
 
         launch_template = backend.create_launch_template(
             name, description, data, tag_spec
@@ -139,9 +139,11 @@ class LaunchTemplate(TaggedEC2Resource, CloudFormationModel):
         data = properties.get("LaunchTemplateData")
         description = properties.get("VersionDescription")
 
-        launch_template = backend.get_launch_template(name, None)
+        launch_template = backend.get_launch_template_by_name(name)
 
         launch_template.create_version(data, description)
+
+        return launch_template
 
     @classmethod
     def delete_from_cloudformation_json(

--- a/moto/ec2/models/launch_templates.py
+++ b/moto/ec2/models/launch_templates.py
@@ -111,7 +111,9 @@ class LaunchTemplate(TaggedEC2Resource, CloudFormationModel):
         name = properties.get("LaunchTemplateName")
         data = properties.get("LaunchTemplateData")
         description = properties.get("VersionDescription")
-        tag_spec = convert_tag_spec(properties.get("TagSpecifications", {}), tag_key="Tags")
+        tag_spec = convert_tag_spec(
+            properties.get("TagSpecifications", {}), tag_key="Tags"
+        )
 
         launch_template = backend.create_launch_template(
             name, description, data, tag_spec
@@ -177,9 +179,13 @@ class LaunchTemplateBackend:
         return template
 
     def get_launch_template(self, template_id):
+        if template_id not in self.launch_templates:
+            raise InvalidLaunchTemplateNameNotFoundError()
         return self.launch_templates[template_id]
 
     def get_launch_template_by_name(self, name):
+        if name not in self.launch_template_name_to_ids:
+            raise InvalidLaunchTemplateNameNotFoundError()
         return self.get_launch_template(self.launch_template_name_to_ids[name])
 
     def delete_launch_template(self, name, tid):

--- a/moto/ec2/utils.py
+++ b/moto/ec2/utils.py
@@ -787,14 +787,15 @@ def gen_moto_amis(described_images, drop_images_missing_keys=True):
     return result
 
 
-def convert_tag_spec(tag_spec_set):
-    # IN:  [{"ResourceType": _type, "Tag": [{"Key": k, "Value": v}, ..]}]
-    # OUT: {_type: {k: v, ..}}
+def convert_tag_spec(tag_spec_set, tag_key="Tag"):
+    # IN:   [{"ResourceType": _type, "Tag": [{"Key": k, "Value": v}, ..]}]
+    #  (or) [{"ResourceType": _type, "Tags": [{"Key": k, "Value": v}, ..]}] <-- special cfn case
+    # OUT:  {_type: {k: v, ..}}
     tags = {}
     for tag_spec in tag_spec_set:
         if tag_spec["ResourceType"] not in tags:
             tags[tag_spec["ResourceType"]] = {}
         tags[tag_spec["ResourceType"]].update(
-            {tag["Key"]: tag["Value"] for tag in tag_spec["Tag"]}
+            {tag["Key"]: tag["Value"] for tag in tag_spec[tag_key]}
         )
     return tags

--- a/tests/test_ec2/test_launch_templates.py
+++ b/tests/test_ec2/test_launch_templates.py
@@ -96,7 +96,7 @@ def test_describe_launch_template_versions_by_name_when_absent():
     with pytest.raises(
         ClientError,
         match=f"The specified launch template, with template name {template_name}, does not exist",
-    ) as ex:
+    ):
 
         cli.describe_launch_template_versions(LaunchTemplateName=template_name)
 

--- a/tests/test_ec2/test_launch_templates.py
+++ b/tests/test_ec2/test_launch_templates.py
@@ -87,6 +87,28 @@ def test_describe_launch_template_versions():
 
 
 @mock_ec2
+def test_describe_launch_template_versions_when_absent():
+    cli = boto3.client("ec2", region_name="us-east-1")
+
+    template_name = str(uuid4())
+
+    # test using name
+    resp = cli.describe_launch_template_versions(
+        LaunchTemplateName=template_name, Versions=["1"]
+    )
+
+    resp["LaunchTemplateVersions"].should.have.length_of(0)
+
+    # test using id
+    resp = cli.describe_launch_template_versions(
+        LaunchTemplateId='foo',
+        Versions=["1"],
+    )
+
+    resp["LaunchTemplateVersions"].should.have.length_of(0)
+
+
+@mock_ec2
 def test_create_launch_template_version():
     cli = boto3.client("ec2", region_name="us-east-1")
 

--- a/tests/test_ec2/test_launch_templates.py
+++ b/tests/test_ec2/test_launch_templates.py
@@ -87,25 +87,18 @@ def test_describe_launch_template_versions():
 
 
 @mock_ec2
-def test_describe_launch_template_versions_when_absent():
+def test_describe_launch_template_versions_by_name_when_absent():
     cli = boto3.client("ec2", region_name="us-east-1")
 
-    template_name = str(uuid4())
+    template_name = "foo"
 
     # test using name
-    resp = cli.describe_launch_template_versions(
-        LaunchTemplateName=template_name, Versions=["1"]
-    )
+    with pytest.raises(
+        ClientError,
+        match=f"The specified launch template, with template name {template_name}, does not exist",
+    ) as ex:
 
-    resp["LaunchTemplateVersions"].should.have.length_of(0)
-
-    # test using id
-    resp = cli.describe_launch_template_versions(
-        LaunchTemplateId='foo',
-        Versions=["1"],
-    )
-
-    resp["LaunchTemplateVersions"].should.have.length_of(0)
+        cli.describe_launch_template_versions(LaunchTemplateName=template_name)
 
 
 @mock_ec2


### PR DESCRIPTION
## Purpose

* Implement CloudFormation CRUD model for EC2 LaunchTemplate resources.
* Fix a bug (discovered while writing unit tests) in `describe-launch-template-versions`: an error should be raised when the specified template does not exist:

> aws ec2 describe-launch-template-versions --launch-template-name timski
> An error occurred (InvalidLaunchTemplateName.NotFoundException) when calling the DescribeLaunchTemplateVersions operation: The specified launch template, with template name timski, does not exist.

