### PR TITLE
Add `DbInstancePort` to RDS Responses

### DIFF
--- a/moto/rds/models.py
+++ b/moto/rds/models.py
@@ -598,6 +598,7 @@ class Database(CloudFormationModel):
                 <Address>{{ database.address }}</Address>
                 <Port>{{ database.port }}</Port>
               </Endpoint>
+              <DbInstancePort>{{ database.port }}</DbInstancePort>
               <DBInstanceArn>{{ database.db_instance_arn }}</DBInstanceArn>
               <TagList>
               {%- for tag in database.tags -%}

--- a/tests/test_rds/test_rds.py
+++ b/tests/test_rds/test_rds.py
@@ -42,6 +42,8 @@ def test_create_database():
     db_instance["VpcSecurityGroups"][0]["VpcSecurityGroupId"].should.equal("sg-123456")
     db_instance["DeletionProtection"].should.equal(False)
     db_instance["EnabledCloudwatchLogsExports"].should.equal(["audit", "error"])
+    db_instance["Endpoint"]["Port"].should.equal(1234)
+    db_instance["DbInstancePort"].should.equal(1234)
 
 
 @mock_rds
@@ -336,6 +338,8 @@ def test_get_databases():
 
     instances = conn.describe_db_instances(DBInstanceIdentifier="db-master-2")
     instances["DBInstances"][0]["DeletionProtection"].should.equal(True)
+    instances["DBInstances"][0]["Endpoint"]["Port"].should.equal(1234)
+    instances["DBInstances"][0]["DbInstancePort"].should.equal(1234)
 
 
 @mock_rds


### PR DESCRIPTION
Explicit test coverage added for the following responses:

CreateDBInstanceResponse
DescribeDBInstancesResponse

Closes #5473 