### PR TITLE
Amending documentation link

### DIFF
--- a/docs/docs/iam.rst
+++ b/docs/docs/iam.rst
@@ -4,7 +4,7 @@
 IAM-like Access Control
 =======================
 
-Moto also has the ability to authenticate and authorize actions, just like it's done by IAM in AWS. This functionality can be enabled by either setting the `INITIAL_NO_AUTH_ACTION_COUNT` environment variable or using the `set_initial_no_auth_action_count` decorator. Note that the current implementation is very basic, see `the source code <https://github.com/spulec/moto/blob/master/moto/core/access_control.py>`_ for more information.
+Moto also has the ability to authenticate and authorize actions, just like it's done by IAM in AWS. This functionality can be enabled by either setting the `INITIAL_NO_AUTH_ACTION_COUNT` environment variable or using the `set_initial_no_auth_action_count` decorator. Note that the current implementation is very basic, see `the source code <https://github.com/spulec/moto/blob/master/moto/iam/access_control.py>`_ for more information.
 
 `INITIAL_NO_AUTH_ACTION_COUNT`
 ------------------------------


### PR DESCRIPTION
Updating documentation with the current `access_control.py` link.