### PR TITLE
Add expression param to existing get_tables glue api

### DIFF
--- a/IMPLEMENTATION_COVERAGE.md
+++ b/IMPLEMENTATION_COVERAGE.md
@@ -2875,13 +2875,13 @@
 
 ## glue
 <details>
-<summary>17% implemented</summary>
+<summary>20% implemented</summary>
 
-- [ ] batch_create_partition
-- [ ] batch_delete_connection
-- [ ] batch_delete_partition
-- [ ] batch_delete_table
-- [ ] batch_delete_table_version
+- [X] batch_create_partition
+- [X] batch_delete_connection
+- [X] batch_delete_partition
+- [X] batch_delete_table
+- [X] batch_delete_table_version
 - [ ] batch_get_blueprints
 - [ ] batch_get_crawlers
 - [ ] batch_get_custom_entity_types

--- a/docs/docs/services/glue.rst
+++ b/docs/docs/services/glue.rst
@@ -25,11 +25,11 @@ glue
 
 |start-h3| Implemented features for this service |end-h3|
 
-- [ ] batch_create_partition
-- [ ] batch_delete_connection
-- [ ] batch_delete_partition
-- [ ] batch_delete_table
-- [ ] batch_delete_table_version
+- [X] batch_create_partition
+- [X] batch_delete_connection
+- [X] batch_delete_partition
+- [X] batch_delete_table
+- [X] batch_delete_table_version
 - [ ] batch_get_blueprints
 - [ ] batch_get_crawlers
 - [ ] batch_get_custom_entity_types

--- a/moto/glue/models.py
+++ b/moto/glue/models.py
@@ -139,11 +139,14 @@ class GlueBackend(BaseBackend):
 
     def get_tables(self, database_name, expression):
         database = self.get_database(database_name)
-        return [
-            table
-            for table_name, table in database.tables.items()
-            if bool(re.match(expression, table_name))
-        ]
+        if expression:
+            return [
+                table
+                for table_name, table in database.tables.items()
+                if re.match(expression, table_name)
+            ]
+        else:
+            return [table for table_name, table in database.tables.items()]
 
     def delete_table(self, database_name, table_name):
         database = self.get_database(database_name)

--- a/moto/glue/models.py
+++ b/moto/glue/models.py
@@ -137,7 +137,7 @@ class GlueBackend(BaseBackend):
         except KeyError:
             raise TableNotFoundException(table_name)
 
-    def get_tables(self, database_name, expression=""):
+    def get_tables(self, database_name, expression):
         database = self.get_database(database_name)
         return [
             table

--- a/moto/glue/models.py
+++ b/moto/glue/models.py
@@ -1,6 +1,7 @@
 import time
 from collections import OrderedDict
 from datetime import datetime
+import re
 from typing import List
 from uuid import uuid4
 
@@ -136,9 +137,13 @@ class GlueBackend(BaseBackend):
         except KeyError:
             raise TableNotFoundException(table_name)
 
-    def get_tables(self, database_name):
+    def get_tables(self, database_name, expression=""):
         database = self.get_database(database_name)
-        return [table for table_name, table in database.tables.items()]
+        return [
+            table
+            for table_name, table in database.tables.items()
+            if bool(re.match(expression, table_name))
+        ]
 
     def delete_table(self, database_name, table_name):
         database = self.get_database(database_name)

--- a/moto/glue/responses.py
+++ b/moto/glue/responses.py
@@ -106,7 +106,8 @@ class GlueResponse(BaseResponse):
 
     def get_tables(self):
         database_name = self.parameters.get("DatabaseName")
-        tables = self.glue_backend.get_tables(database_name)
+        expression = self.parameters.get("Expression")
+        tables = self.glue_backend.get_tables(database_name, expression)
         return json.dumps({"TableList": [table.as_dict() for table in tables]})
 
     def delete_table(self):

--- a/tests/test_glue/helpers.py
+++ b/tests/test_glue/helpers.py
@@ -66,8 +66,11 @@ def get_table(client, database_name, table_name):
     return client.get_table(DatabaseName=database_name, Name=table_name)
 
 
-def get_tables(client, database_name, expression=""):
-    return client.get_tables(DatabaseName=database_name, Expression=expression)
+def get_tables(client, database_name, expression=None):
+    if expression:
+        return client.get_tables(DatabaseName=database_name, Expression=expression)
+    else:
+        return client.get_tables(DatabaseName=database_name)
 
 
 def get_table_versions(client, database_name, table_name):

--- a/tests/test_glue/helpers.py
+++ b/tests/test_glue/helpers.py
@@ -66,8 +66,8 @@ def get_table(client, database_name, table_name):
     return client.get_table(DatabaseName=database_name, Name=table_name)
 
 
-def get_tables(client, database_name):
-    return client.get_tables(DatabaseName=database_name)
+def get_tables(client, database_name, expression=""):
+    return client.get_tables(DatabaseName=database_name, Expression=expression)
 
 
 def get_table_versions(client, database_name, table_name):

--- a/tests/test_glue/test_datacatalog.py
+++ b/tests/test_glue/test_datacatalog.py
@@ -199,7 +199,7 @@ def test_create_table_already_exists():
 
 
 @mock_glue
-def test_get_tables_no_expression():
+def test_get_tables():
     client = boto3.client("glue", region_name="us-east-1")
     database_name = "myspecialdatabase"
     helpers.create_database(client, database_name)


### PR DESCRIPTION
Currently [boto3 implements](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/glue.html#Glue.Client.get_tables) `glue.get_tables` with additional `Expression` parameter:

> Expression (string) -- A regular expression pattern. If present, only those tables whose names match the pattern are returned.

This is the implementation.