### PR TITLE
setting default FeatureSet to ALL in create_organization

### DIFF
--- a/moto/organizations/models.py
+++ b/moto/organizations/models.py
@@ -355,7 +355,7 @@ class OrganizationsBackend(BaseBackend):
         return root
 
     def create_organization(self, **kwargs):
-        self.org = FakeOrganization(self.account_id, kwargs["FeatureSet"])
+        self.org = FakeOrganization(self.account_id, kwargs.get("FeatureSet") or "ALL")
         root_ou = FakeRoot(self.org)
         self.ou.append(root_ou)
         master_account = FakeAccount(

--- a/tests/test_organizations/test_organizations_boto3.py
+++ b/tests/test_organizations/test_organizations_boto3.py
@@ -58,6 +58,15 @@ def test_create_organization():
 
 
 @mock_organizations
+def test_create_organization_without_feature_set():
+    client = boto3.client("organizations", region_name="us-east-1")
+    client.create_organization()
+    response = client.describe_organization()
+    validate_organization(response)
+    response["Organization"]["FeatureSet"].should.equal("ALL")
+
+
+@mock_organizations
 def test_describe_organization():
     client = boto3.client("organizations", region_name="us-east-1")
     client.create_organization(FeatureSet="ALL")


### PR DESCRIPTION
### Issue
Within the service `Organizations` for the operation `create_organization`, the docs ([doc1](https://docs.aws.amazon.com/cli/latest/reference/organizations/create-organization.html) and [doc2](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/organizations.html#Organizations.Client.create_organization)) state the following: 
> By default (or if you set the FeatureSet parameter to ALL ), the new organization is created with all features enabled and service control policies automatically enabled in the root.  

As of now, not setting the FeatureSet, and therefore relying on the default value, results in a KeyError.  

### Summary

This PR solves this issue by setting "ALL" as the default if none is present.