### PR TITLE
Make assumed role user ids dependent on role

### DIFF
--- a/moto/iam/utils.py
+++ b/moto/iam/utils.py
@@ -1,5 +1,39 @@
 from moto.moto_api._internal import mock_random as random
 import string
+import base64
+
+AWS_ROLE_ALPHABET = "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567"
+ACCOUNT_OFFSET = 549755813888  # int.from_bytes(base64.b32decode(b"QAAAAAAA"), byteorder="big"), start value
+
+
+def _random_uppercase_or_digit_sequence(length):
+    return "".join(str(random.choice(AWS_ROLE_ALPHABET)) for _ in range(length))
+
+
+def generate_access_key_id_from_account_id(
+    account_id: str, prefix: str, total_length: int = 20
+):
+    """
+    Generates a key id (e.g. access key id) for the given account id and prefix
+
+    :param account_id: Account id this key id should belong to
+    :param prefix: Prefix, e.g. ASIA for temp credentials or AROA for roles
+    :param total_length: Total length of the access key (e.g. 20 for temp access keys, 21 for role ids)
+    :return: Generated id
+    """
+    account_id = int(account_id)
+    id_with_offset = account_id // 2 + ACCOUNT_OFFSET
+    account_bytes = int.to_bytes(id_with_offset, byteorder="big", length=5)
+    account_part = base64.b32encode(account_bytes).decode("utf-8")
+    middle_char = (
+        random.choice(AWS_ROLE_ALPHABET[16:])
+        if account_id % 2
+        else random.choice(AWS_ROLE_ALPHABET[:16])
+    )
+    semi_fixed_part = prefix + account_part + middle_char
+    return semi_fixed_part + _random_uppercase_or_digit_sequence(
+        total_length - len(semi_fixed_part)
+    )
 
 
 def random_alphanumeric(length):
@@ -13,6 +47,12 @@ def random_resource_id(size=20):
     chars = list(range(10)) + list(string.ascii_lowercase)
 
     return "".join(str(random.choice(chars)) for x in range(size))
+
+
+def random_role_id(account_id: str) -> str:
+    return generate_access_key_id_from_account_id(
+        account_id=account_id, prefix="AROA", total_length=21
+    )
 
 
 def random_access_key():

--- a/tests/test_iam/test_iam.py
+++ b/tests/test_iam/test_iam.py
@@ -2525,7 +2525,7 @@ def test_create_role_defaults():
 
     # Get role:
     role = conn.get_role(RoleName="my-role")["Role"]
-
+    assert role["RoleId"].startswith("AROA")
     assert role["MaxSessionDuration"] == 3600
     assert role.get("Description") is None
 

--- a/tests/test_iam/test_iam.py
+++ b/tests/test_iam/test_iam.py
@@ -3455,7 +3455,7 @@ def test_role_list_config_discovered_resources():
 @mock_iam
 def test_role_config_dict():
     from moto.iam.config import role_config_query, policy_config_query
-    from moto.iam.utils import random_resource_id, random_policy_id
+    from moto.iam.utils import random_role_id, random_policy_id
 
     # Without any roles
     assert not role_config_query.get_config_resource(DEFAULT_ACCOUNT_ID, "something")
@@ -3511,7 +3511,7 @@ def test_role_config_dict():
         DEFAULT_ACCOUNT_ID, None, None, 100, None
     )[0][0]
     assert plain_role is not None
-    assert len(plain_role["id"]) == len(random_resource_id())
+    assert len(plain_role["id"]) == len(random_role_id(DEFAULT_ACCOUNT_ID))
 
     role_config_query.backends[DEFAULT_ACCOUNT_ID]["global"].create_role(
         role_name="assume_role",
@@ -3531,7 +3531,7 @@ def test_role_config_dict():
         if role["id"] not in [plain_role["id"]]
     )
     assert assume_role is not None
-    assert len(assume_role["id"]) == len(random_resource_id())
+    assert len(assume_role["id"]) == len(random_role_id(DEFAULT_ACCOUNT_ID))
     assert assume_role["id"] is not plain_role["id"]
 
     role_config_query.backends[DEFAULT_ACCOUNT_ID]["global"].create_role(
@@ -3552,7 +3552,9 @@ def test_role_config_dict():
         if role["id"] not in [plain_role["id"], assume_role["id"]]
     )
     assert assume_and_permission_boundary_role is not None
-    assert len(assume_and_permission_boundary_role["id"]) == len(random_resource_id())
+    assert len(assume_and_permission_boundary_role["id"]) == len(
+        random_role_id(DEFAULT_ACCOUNT_ID)
+    )
     assert assume_and_permission_boundary_role["id"] is not plain_role["id"]
     assert assume_and_permission_boundary_role["id"] is not assume_role["id"]
 
@@ -3581,7 +3583,9 @@ def test_role_config_dict():
         ]
     )
     assert role_with_attached_policy is not None
-    assert len(role_with_attached_policy["id"]) == len(random_resource_id())
+    assert len(role_with_attached_policy["id"]) == len(
+        random_role_id(DEFAULT_ACCOUNT_ID)
+    )
     assert role_with_attached_policy["id"] is not plain_role["id"]
     assert role_with_attached_policy["id"] is not assume_role["id"]
     assert (
@@ -3615,7 +3619,7 @@ def test_role_config_dict():
         ]
     )
     assert role_with_inline_policy is not None
-    assert len(role_with_inline_policy["id"]) == len(random_resource_id())
+    assert len(role_with_inline_policy["id"]) == len(random_role_id(DEFAULT_ACCOUNT_ID))
     assert role_with_inline_policy["id"] is not plain_role["id"]
     assert role_with_inline_policy["id"] is not assume_role["id"]
     assert (
@@ -3734,7 +3738,7 @@ def test_role_config_client():
         raise SkipTest(
             "Cannot test this in Py3.6; outdated botocore dependencies do not have all regions"
         )
-    from moto.iam.utils import random_resource_id
+    from moto.iam.utils import random_role_id
 
     CONFIG_REGIONS = boto3.Session().get_available_regions("config")
 
@@ -3789,7 +3793,7 @@ def test_role_config_client():
     )
     first_result = result["resourceIdentifiers"][0]["resourceId"]
     assert result["resourceIdentifiers"][0]["resourceType"] == "AWS::IAM::Role"
-    assert len(first_result) == len(random_resource_id())
+    assert len(first_result) == len(random_role_id(DEFAULT_ACCOUNT_ID))
 
     # Test non-aggregated pagination
     assert (

--- a/tests/test_sts/test_sts.py
+++ b/tests/test_sts/test_sts.py
@@ -61,8 +61,10 @@ def test_get_federation_token_boto3():
 
 @freeze_time("2012-01-01 12:00:00")
 @mock_sts
+@mock_iam
 def test_assume_role():
     client = boto3.client("sts", region_name="us-east-1")
+    iam_client = boto3.client("iam", region_name="us-east-1")
 
     session_name = "session-name"
     policy = json.dumps(
@@ -77,12 +79,24 @@ def test_assume_role():
             ]
         }
     )
+    trust_policy_document = {
+        "Version": "2012-10-17",
+        "Statement": {
+            "Effect": "Allow",
+            "Principal": {
+                "AWS": "arn:aws:iam::{account_id}:root".format(account_id=ACCOUNT_ID)
+            },
+            "Action": "sts:AssumeRole",
+        },
+    }
     role_name = "test-role"
-    s3_role = "arn:aws:iam::{account_id}:role/{role_name}".format(
-        account_id=ACCOUNT_ID, role_name=role_name
-    )
+    role = iam_client.create_role(
+        RoleName="test-role", AssumeRolePolicyDocument=json.dumps(trust_policy_document)
+    )["Role"]
+    role_id = role["RoleId"]
+    role_arn = role["Arn"]
     assume_role_response = client.assume_role(
-        RoleArn=s3_role,
+        RoleArn=role_arn,
         RoleSessionName=session_name,
         Policy=policy,
         DurationSeconds=900,
@@ -103,6 +117,10 @@ def test_assume_role():
         )
     )
     assert assume_role_response["AssumedRoleUser"]["AssumedRoleId"].startswith("AROA")
+    assert (
+        assume_role_response["AssumedRoleUser"]["AssumedRoleId"].rpartition(":")[0]
+        == role_id
+    )
     assert assume_role_response["AssumedRoleUser"]["AssumedRoleId"].endswith(
         ":" + session_name
     )


### PR DESCRIPTION
## Problem description
Currently, when assuming roles, the User Id returned (and also returned by sts get-caller-identity) is not identical to the supposed format `role_id:session_name`, but regenerated freshly every time.

## Solution in this PR
* if a matching role exists, it will take the role id of that role. If not, the behavior will be unchanged (to prevent breaking behavior)
* Both access-key-ids and role ids are now, in accordance with AWS behavior, based on the account id. Basically, the first 9 characters after the 4 char prefix are (more or less) dependent on the account id. This generation is based on the blog post https://awsteele.com/blog/2020/09/26/aws-access-key-format.html, and is verified using `aws sts get-access-key-info --access-key-id ...`. The code is basically shifting the account id by an offset, and base32 encoding the big endian byte representation, with the next char after the 8 digit base32 being dependent on the LSB of the account id.