### PR TITLE
EC2 availability zones in us-west-1: use A and B

### DIFF
--- a/moto/ec2/models/availability_zones_and_regions.py
+++ b/moto/ec2/models/availability_zones_and_regions.py
@@ -238,8 +238,8 @@ class RegionsAndZonesBackend:
             Zone(region_name="us-east-2", name="us-east-2c", zone_id="use2-az3"),
         ],
         "us-west-1": [
-            Zone(region_name="us-west-1", name="us-west-1b", zone_id="usw1-az3"),
-            Zone(region_name="us-west-1", name="us-west-1c", zone_id="usw1-az1"),
+            Zone(region_name="us-west-1", name="us-west-1a", zone_id="usw1-az3"),
+            Zone(region_name="us-west-1", name="us-west-1b", zone_id="usw1-az1"),
         ],
         "us-west-2": [
             Zone(region_name="us-west-2", name="us-west-2a", zone_id="usw2-az2"),

--- a/moto/ec2/models/instances.py
+++ b/moto/ec2/models/instances.py
@@ -96,7 +96,7 @@ class Instance(TaggedEC2Resource, BotoInstance, CloudFormationModel):
         self.user_data = user_data
         self.security_groups = security_groups
         self.instance_type = kwargs.get("instance_type", "m1.small")
-        self.region_name = kwargs.get("region_name", ec2_backend.region_name)
+        self.region_name = kwargs.get("region_name", "us-east-1")
         placement = kwargs.get("placement", None)
         self.subnet_id = kwargs.get("subnet_id")
         if not self.subnet_id:
@@ -157,7 +157,7 @@ class Instance(TaggedEC2Resource, BotoInstance, CloudFormationModel):
         elif placement:
             self._placement.zone = placement
         else:
-            self._placement.zone = ec2_backend.zones[self.region_name][0].name
+            self._placement.zone = ec2_backend.region_name + "a"
 
         self.block_device_mapping = BlockDeviceMapping()
 

--- a/moto/ec2/resources/instance_type_offerings/availability-zone/us-west-1.json
+++ b/moto/ec2/resources/instance_type_offerings/availability-zone/us-west-1.json
@@ -1,2658 +1,2658 @@
 [
  {
   "InstanceType": "c1.medium",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "c1.xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "c3.2xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "c3.4xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "c3.8xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "c3.large",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "c3.xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "c4.2xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "c4.4xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "c4.8xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "c4.large",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "c4.xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "c5.12xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "c5.18xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "c5.24xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "c5.2xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "c5.4xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "c5.9xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "c5.large",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "c5.metal",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "c5.xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "c5a.12xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "c5a.16xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "c5a.24xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "c5a.2xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "c5a.4xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "c5a.8xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "c5a.large",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "c5a.xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "c5d.12xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "c5d.18xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "c5d.24xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "c5d.2xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "c5d.4xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "c5d.9xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "c5d.large",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "c5d.metal",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "c5d.xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "c5n.18xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "c5n.2xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "c5n.4xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "c5n.9xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "c5n.large",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "c5n.metal",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "c5n.xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "c6g.12xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "c6g.16xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "c6g.2xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "c6g.4xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "c6g.8xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "c6g.large",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "c6g.medium",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "c6g.metal",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "c6g.xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "c6gd.12xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "c6gd.16xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "c6gd.2xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "c6gd.4xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "c6gd.8xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "c6gd.large",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "c6gd.medium",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "c6gd.metal",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "c6gd.xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "c6gn.12xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "c6gn.16xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "c6gn.2xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "c6gn.4xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "c6gn.8xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "c6gn.large",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "c6gn.medium",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "c6gn.xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "c6i.12xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "c6i.16xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "c6i.24xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "c6i.2xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "c6i.32xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "c6i.4xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "c6i.8xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "c6i.large",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "c6i.metal",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "c6i.xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "d2.2xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "d2.4xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "d2.8xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "d2.xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "g2.2xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "g2.8xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "g3.16xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "g3.4xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "g3.8xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "g4dn.12xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "g4dn.16xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "g4dn.2xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "g4dn.4xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "g4dn.8xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "g4dn.metal",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "g4dn.xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "i2.2xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "i2.4xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "i2.8xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "i2.xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "i3.16xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "i3.2xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "i3.4xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "i3.8xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "i3.large",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "i3.metal",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "i3.xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "i3en.12xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "i3en.24xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "i3en.2xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "i3en.3xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "i3en.6xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "i3en.large",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "i3en.metal",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "i3en.xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "i4i.16xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "i4i.2xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "i4i.32xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "i4i.4xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "i4i.8xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "i4i.large",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "i4i.metal",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "i4i.xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "inf1.24xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "inf1.2xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "inf1.6xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "inf1.xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "m1.large",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "m1.medium",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "m1.small",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "m1.xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "m2.2xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "m2.4xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "m2.xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "m3.2xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "m3.large",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "m3.medium",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "m3.xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "m4.10xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "m4.16xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "m4.2xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "m4.4xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "m4.large",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "m4.xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "m5.12xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "m5.16xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "m5.24xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "m5.2xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "m5.4xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "m5.8xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "m5.large",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "m5.metal",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "m5.xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "m5a.12xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "m5a.16xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "m5a.24xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "m5a.2xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "m5a.4xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "m5a.8xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "m5a.large",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "m5a.xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "m5ad.12xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "m5ad.16xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "m5ad.24xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "m5ad.2xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "m5ad.4xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "m5ad.8xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "m5ad.large",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "m5ad.xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "m5d.12xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "m5d.16xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "m5d.24xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "m5d.2xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "m5d.4xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "m5d.8xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "m5d.large",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "m5d.metal",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "m5d.xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "m5zn.12xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "m5zn.2xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "m5zn.3xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "m5zn.6xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "m5zn.large",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "m5zn.metal",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "m5zn.xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "m6g.12xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "m6g.16xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "m6g.2xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "m6g.4xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "m6g.8xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "m6g.large",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "m6g.medium",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "m6g.metal",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "m6g.xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "m6gd.12xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "m6gd.16xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "m6gd.2xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "m6gd.4xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "m6gd.8xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "m6gd.large",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "m6gd.medium",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "m6gd.metal",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "m6gd.xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "m6i.12xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "m6i.16xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "m6i.24xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "m6i.2xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "m6i.32xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "m6i.4xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "m6i.8xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "m6i.large",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "m6i.metal",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "m6i.xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "r3.2xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "r3.4xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "r3.8xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "r3.large",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "r3.xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "r4.16xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "r4.2xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "r4.4xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "r4.8xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "r4.large",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "r4.xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "r5.12xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "r5.16xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "r5.24xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "r5.2xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "r5.4xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "r5.8xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "r5.large",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "r5.metal",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "r5.xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "r5a.12xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "r5a.16xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "r5a.24xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "r5a.2xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "r5a.4xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "r5a.8xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "r5a.large",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "r5a.xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "r5ad.12xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "r5ad.16xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "r5ad.24xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "r5ad.2xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "r5ad.4xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "r5ad.8xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "r5ad.large",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "r5ad.xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "r5d.12xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "r5d.16xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "r5d.24xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "r5d.2xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "r5d.4xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "r5d.8xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "r5d.large",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "r5d.metal",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "r5d.xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "r5n.12xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "r5n.16xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "r5n.24xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "r5n.2xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "r5n.4xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "r5n.8xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "r5n.large",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "r5n.metal",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "r5n.xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "r6g.12xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "r6g.16xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "r6g.2xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "r6g.4xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "r6g.8xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "r6g.large",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "r6g.medium",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "r6g.metal",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "r6g.xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "r6gd.12xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "r6gd.16xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "r6gd.2xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "r6gd.4xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "r6gd.8xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "r6gd.large",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "r6gd.medium",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "r6gd.metal",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "r6gd.xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "r6i.12xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "r6i.16xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "r6i.24xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "r6i.2xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "r6i.32xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "r6i.4xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "r6i.8xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "r6i.large",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "r6i.metal",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "r6i.xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "t1.micro",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "t2.2xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "t2.large",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "t2.medium",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "t2.micro",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "t2.nano",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "t2.small",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "t2.xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "t3.2xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "t3.large",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "t3.medium",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "t3.micro",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "t3.nano",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "t3.small",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "t3.xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "t3a.2xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "t3a.large",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "t3a.medium",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "t3a.micro",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "t3a.nano",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "t3a.small",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "t3a.xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "t4g.2xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "t4g.large",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "t4g.medium",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "t4g.micro",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "t4g.nano",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "t4g.small",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "t4g.xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "z1d.12xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "z1d.2xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "z1d.3xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "z1d.6xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "z1d.large",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "z1d.metal",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "z1d.xlarge",
-  "Location": "us-west-1b"
+  "Location": "us-west-1a"
  },
  {
   "InstanceType": "c1.medium",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "c1.xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "c3.2xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "c3.4xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "c3.8xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "c3.large",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "c3.xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "c4.2xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "c4.4xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "c4.8xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "c4.large",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "c4.xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "c5.12xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "c5.18xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "c5.24xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "c5.2xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "c5.4xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "c5.9xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "c5.large",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "c5.metal",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "c5.xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "c5a.12xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "c5a.16xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "c5a.24xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "c5a.2xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "c5a.4xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "c5a.8xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "c5a.large",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "c5a.xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "c5d.12xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "c5d.18xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "c5d.24xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "c5d.2xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "c5d.4xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "c5d.9xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "c5d.large",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "c5d.metal",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "c5d.xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "c5n.18xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "c5n.2xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "c5n.4xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "c5n.9xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "c5n.large",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "c5n.metal",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "c5n.xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "c6g.12xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "c6g.16xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "c6g.2xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "c6g.4xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "c6g.8xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "c6g.large",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "c6g.medium",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "c6g.metal",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "c6g.xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "c6gd.12xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "c6gd.16xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "c6gd.2xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "c6gd.4xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "c6gd.8xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "c6gd.large",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "c6gd.medium",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "c6gd.metal",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "c6gd.xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "c6gn.12xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "c6gn.16xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "c6gn.2xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "c6gn.4xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "c6gn.8xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "c6gn.large",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "c6gn.medium",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "c6gn.xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "c6i.12xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "c6i.16xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "c6i.24xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "c6i.2xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "c6i.32xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "c6i.4xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "c6i.8xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "c6i.large",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "c6i.metal",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "c6i.xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "d2.2xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "d2.4xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "d2.8xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "d2.xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "g2.2xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "g2.8xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "g3.16xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "g3.4xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "g3.8xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "g4dn.12xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "g4dn.16xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "g4dn.2xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "g4dn.4xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "g4dn.8xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "g4dn.metal",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "g4dn.xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "i2.2xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "i2.4xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "i2.8xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "i2.xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "i3.16xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "i3.2xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "i3.4xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "i3.8xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "i3.large",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "i3.metal",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "i3.xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "i3en.12xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "i3en.24xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "i3en.2xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "i3en.3xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "i3en.6xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "i3en.large",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "i3en.metal",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "i3en.xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "i4i.16xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "i4i.2xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "i4i.32xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "i4i.4xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "i4i.8xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "i4i.large",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "i4i.metal",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "i4i.xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "inf1.24xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "inf1.2xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "inf1.6xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "inf1.xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "m1.large",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "m1.medium",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "m1.small",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "m1.xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "m2.2xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "m2.4xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "m2.xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "m3.2xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "m3.large",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "m3.medium",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "m3.xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "m4.10xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "m4.16xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "m4.2xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "m4.4xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "m4.large",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "m4.xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "m5.12xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "m5.16xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "m5.24xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "m5.2xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "m5.4xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "m5.8xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "m5.large",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "m5.metal",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "m5.xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "m5a.12xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "m5a.16xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "m5a.24xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "m5a.2xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "m5a.4xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "m5a.8xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "m5a.large",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "m5a.xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "m5ad.12xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "m5ad.16xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "m5ad.24xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "m5ad.2xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "m5ad.4xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "m5ad.8xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "m5ad.large",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "m5ad.xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "m5d.12xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "m5d.16xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "m5d.24xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "m5d.2xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "m5d.4xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "m5d.8xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "m5d.large",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "m5d.metal",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "m5d.xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "m5zn.12xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "m5zn.2xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "m5zn.3xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "m5zn.6xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "m5zn.large",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "m5zn.metal",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "m5zn.xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "m6g.12xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "m6g.16xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "m6g.2xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "m6g.4xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "m6g.8xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "m6g.large",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "m6g.medium",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "m6g.metal",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "m6g.xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "m6gd.12xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "m6gd.16xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "m6gd.2xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "m6gd.4xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "m6gd.8xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "m6gd.large",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "m6gd.medium",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "m6gd.metal",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "m6gd.xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "m6i.12xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "m6i.16xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "m6i.24xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "m6i.2xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "m6i.32xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "m6i.4xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "m6i.8xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "m6i.large",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "m6i.metal",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "m6i.xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "r3.2xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "r3.4xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "r3.8xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "r3.large",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "r3.xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "r4.16xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "r4.2xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "r4.4xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "r4.8xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "r4.large",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "r4.xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "r5.12xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "r5.16xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "r5.24xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "r5.2xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "r5.4xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "r5.8xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "r5.large",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "r5.metal",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "r5.xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "r5a.12xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "r5a.16xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "r5a.24xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "r5a.2xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "r5a.4xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "r5a.8xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "r5a.large",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "r5a.xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "r5ad.12xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "r5ad.16xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "r5ad.24xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "r5ad.2xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "r5ad.4xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "r5ad.8xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "r5ad.large",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "r5ad.xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "r5d.12xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "r5d.16xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "r5d.24xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "r5d.2xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "r5d.4xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "r5d.8xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "r5d.large",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "r5d.metal",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "r5d.xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "r5n.12xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "r5n.16xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "r5n.24xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "r5n.2xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "r5n.4xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "r5n.8xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "r5n.large",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "r5n.metal",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "r5n.xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "r6g.12xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "r6g.16xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "r6g.2xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "r6g.4xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "r6g.8xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "r6g.large",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "r6g.medium",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "r6g.metal",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "r6g.xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "r6gd.12xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "r6gd.16xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "r6gd.2xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "r6gd.4xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "r6gd.8xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "r6gd.large",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "r6gd.medium",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "r6gd.metal",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "r6gd.xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "r6i.12xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "r6i.16xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "r6i.24xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "r6i.2xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "r6i.32xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "r6i.4xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "r6i.8xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "r6i.large",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "r6i.metal",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "r6i.xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "t1.micro",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "t2.2xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "t2.large",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "t2.medium",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "t2.micro",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "t2.nano",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "t2.small",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "t2.xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "t3.2xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "t3.large",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "t3.medium",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "t3.micro",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "t3.nano",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "t3.small",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "t3.xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "t3a.2xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "t3a.large",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "t3a.medium",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "t3a.micro",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "t3a.nano",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "t3a.small",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "t3a.xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "t4g.2xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "t4g.large",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "t4g.medium",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "t4g.micro",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "t4g.nano",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "t4g.small",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "t4g.xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "z1d.12xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "z1d.2xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "z1d.3xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "z1d.6xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "z1d.large",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "z1d.metal",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  },
  {
   "InstanceType": "z1d.xlarge",
-  "Location": "us-west-1c"
+  "Location": "us-west-1b"
  }
 ]

--- a/tests/test_autoscaling/test_autoscaling.py
+++ b/tests/test_autoscaling/test_autoscaling.py
@@ -148,7 +148,7 @@ def test_create_auto_scaling_from_template_version__latest():
             "LaunchTemplateName": launch_template_name,
             "Version": "$Latest",
         },
-        AvailabilityZones=["us-west-1b"],
+        AvailabilityZones=["us-west-1a"],
     )
 
     response = asg_client.describe_auto_scaling_groups(AutoScalingGroupNames=["name"])[
@@ -185,7 +185,7 @@ def test_create_auto_scaling_from_template_version__default():
             "LaunchTemplateName": launch_template_name,
             "Version": "$Default",
         },
-        AvailabilityZones=["us-west-1b"],
+        AvailabilityZones=["us-west-1a"],
     )
 
     response = asg_client.describe_auto_scaling_groups(AutoScalingGroupNames=["name"])[
@@ -214,7 +214,7 @@ def test_create_auto_scaling_from_template_version__no_version():
         MinSize=1,
         MaxSize=1,
         LaunchTemplate={"LaunchTemplateName": launch_template_name},
-        AvailabilityZones=["us-west-1b"],
+        AvailabilityZones=["us-west-1a"],
     )
 
     response = asg_client.describe_auto_scaling_groups(AutoScalingGroupNames=["name"])[
@@ -715,8 +715,8 @@ def test_autoscaling_describe_policies():
 @mock_autoscaling
 @mock_ec2
 def test_create_autoscaling_policy_with_policytype__targettrackingscaling():
-    mocked_networking = setup_networking(region_name="us-east-1")
-    client = boto3.client("autoscaling", region_name="us-east-1")
+    mocked_networking = setup_networking(region_name="us-west-1")
+    client = boto3.client("autoscaling", region_name="us-west-1")
     configuration_name = "test"
     asg_name = "asg_test"
 
@@ -750,7 +750,7 @@ def test_create_autoscaling_policy_with_policytype__targettrackingscaling():
     policy = resp["ScalingPolicies"][0]
     policy.should.have.key("PolicyName").equals(configuration_name)
     policy.should.have.key("PolicyARN").equals(
-        f"arn:aws:autoscaling:us-east-1:{ACCOUNT_ID}:scalingPolicy:c322761b-3172-4d56-9a21-0ed9d6161d67:autoScalingGroupName/{asg_name}:policyName/{configuration_name}"
+        f"arn:aws:autoscaling:us-west-1:{ACCOUNT_ID}:scalingPolicy:c322761b-3172-4d56-9a21-0ed9d6161d67:autoScalingGroupName/{asg_name}:policyName/{configuration_name}"
     )
     policy.should.have.key("PolicyType").equals("TargetTrackingScaling")
     policy.should.have.key("TargetTrackingConfiguration").should.equal(

--- a/tests/test_autoscaling/test_autoscaling_cloudformation.py
+++ b/tests/test_autoscaling/test_autoscaling_cloudformation.py
@@ -416,7 +416,7 @@ def test_autoscaling_group_update():
             "my-as-group": {
                 "Type": "AWS::AutoScaling::AutoScalingGroup",
                 "Properties": {
-                    "AvailabilityZones": ["us-west-1b"],
+                    "AvailabilityZones": ["us-west-1a"],
                     "LaunchConfigurationName": {"Ref": "my-launch-config"},
                     "MinSize": "2",
                     "MaxSize": "2",

--- a/tests/test_ec2/test_ec2_cloudformation.py
+++ b/tests/test_ec2/test_ec2_cloudformation.py
@@ -703,7 +703,7 @@ def test_vpc_endpoint_creation():
     ec2_client = boto3.client("ec2", region_name="us-west-1")
     vpc = ec2.create_vpc(CidrBlock="10.0.0.0/16")
     subnet1 = ec2.create_subnet(
-        VpcId=vpc.id, CidrBlock="10.0.0.0/24", AvailabilityZone="us-west-1b"
+        VpcId=vpc.id, CidrBlock="10.0.0.0/24", AvailabilityZone="us-west-1a"
     )
 
     subnet_template = {

--- a/tests/test_ec2/test_regions.py
+++ b/tests/test_ec2/test_regions.py
@@ -136,24 +136,3 @@ def test_describe_regions_dryrun():
     ex.value.response["Error"]["Message"].should.equal(
         "An error occurred (DryRunOperation) when calling the DescribeRegions operation: Request would have succeeded, but DryRun flag is set"
     )
-
-
-@mock_ec2
-@pytest.mark.parametrize(
-    "region_name", ["us-east-1", "us-east-2", "us-west-1", "us-west-2"]
-)
-def test_describe_zones_and_get_instance_types(region_name):
-    """
-    Verify that instance types exist in all exposed Availability Zones
-    https://github.com/spulec/moto/issues/5494
-    """
-    client = boto3.client("ec2", region_name=region_name)
-    zones = client.describe_availability_zones()["AvailabilityZones"]
-    zone_names = [z["ZoneName"] for z in zones]
-
-    for zone in zone_names:
-        offerings = client.describe_instance_type_offerings(
-            LocationType="availability-zone",
-            Filters=[{"Name": "location", "Values": [zone]}],
-        )["InstanceTypeOfferings"]
-        assert len(offerings) > 0

--- a/tests/test_ec2/test_subnets.py
+++ b/tests/test_ec2/test_subnets.py
@@ -100,7 +100,7 @@ def test_default_subnet():
     default_vpc.is_default.should.equal(True)
 
     subnet = ec2.create_subnet(
-        VpcId=default_vpc.id, CidrBlock="172.31.48.0/20", AvailabilityZone="us-west-1b"
+        VpcId=default_vpc.id, CidrBlock="172.31.48.0/20", AvailabilityZone="us-west-1a"
     )
     subnet.reload()
     subnet.map_public_ip_on_launch.should.equal(False)
@@ -116,7 +116,7 @@ def test_non_default_subnet():
     vpc.is_default.should.equal(False)
 
     subnet = ec2.create_subnet(
-        VpcId=vpc.id, CidrBlock="10.0.0.0/24", AvailabilityZone="us-west-1b"
+        VpcId=vpc.id, CidrBlock="10.0.0.0/24", AvailabilityZone="us-west-1a"
     )
     subnet.reload()
     subnet.map_public_ip_on_launch.should.equal(False)
@@ -133,7 +133,7 @@ def test_modify_subnet_attribute_public_ip_on_launch():
     random_subnet_cidr = f"{random_ip}/20"  # Same block as the VPC
 
     subnet = ec2.create_subnet(
-        VpcId=vpc.id, CidrBlock=random_subnet_cidr, AvailabilityZone="us-west-1b"
+        VpcId=vpc.id, CidrBlock=random_subnet_cidr, AvailabilityZone="us-west-1a"
     )
 
     # 'map_public_ip_on_launch' is set when calling 'DescribeSubnets' action
@@ -166,7 +166,7 @@ def test_modify_subnet_attribute_assign_ipv6_address_on_creation():
     random_subnet_cidr = f"{random_ip}/20"  # Same block as the VPC
 
     subnet = ec2.create_subnet(
-        VpcId=vpc.id, CidrBlock=random_subnet_cidr, AvailabilityZone="us-west-1b"
+        VpcId=vpc.id, CidrBlock=random_subnet_cidr, AvailabilityZone="us-west-1a"
     )
 
     # 'map_public_ip_on_launch' is set when calling 'DescribeSubnets' action
@@ -195,7 +195,7 @@ def test_modify_subnet_attribute_validation():
     ec2 = boto3.resource("ec2", region_name="us-west-1")
     vpc = ec2.create_vpc(CidrBlock="10.0.0.0/16")
     ec2.create_subnet(
-        VpcId=vpc.id, CidrBlock="10.0.0.0/24", AvailabilityZone="us-west-1b"
+        VpcId=vpc.id, CidrBlock="10.0.0.0/24", AvailabilityZone="us-west-1a"
     )
 
 
@@ -205,14 +205,14 @@ def test_subnet_get_by_id():
     client = boto3.client("ec2", region_name="us-west-1")
     vpcA = ec2.create_vpc(CidrBlock="10.0.0.0/16")
     subnetA = ec2.create_subnet(
-        VpcId=vpcA.id, CidrBlock="10.0.0.0/24", AvailabilityZone="us-west-1b"
+        VpcId=vpcA.id, CidrBlock="10.0.0.0/24", AvailabilityZone="us-west-1a"
     )
     vpcB = ec2.create_vpc(CidrBlock="10.0.0.0/16")
     subnetB1 = ec2.create_subnet(
-        VpcId=vpcB.id, CidrBlock="10.0.0.0/24", AvailabilityZone="us-west-1b"
+        VpcId=vpcB.id, CidrBlock="10.0.0.0/24", AvailabilityZone="us-west-1a"
     )
     ec2.create_subnet(
-        VpcId=vpcB.id, CidrBlock="10.0.1.0/24", AvailabilityZone="us-west-1c"
+        VpcId=vpcB.id, CidrBlock="10.0.1.0/24", AvailabilityZone="us-west-1b"
     )
 
     subnets_by_id = client.describe_subnets(SubnetIds=[subnetA.id, subnetB1.id])[
@@ -236,14 +236,14 @@ def test_get_subnets_filtering():
     client = boto3.client("ec2", region_name="us-west-1")
     vpcA = ec2.create_vpc(CidrBlock="10.0.0.0/16")
     subnetA = ec2.create_subnet(
-        VpcId=vpcA.id, CidrBlock="10.0.0.0/24", AvailabilityZone="us-west-1b"
+        VpcId=vpcA.id, CidrBlock="10.0.0.0/24", AvailabilityZone="us-west-1a"
     )
     vpcB = ec2.create_vpc(CidrBlock="10.0.0.0/16")
     subnetB1 = ec2.create_subnet(
-        VpcId=vpcB.id, CidrBlock="10.0.0.0/24", AvailabilityZone="us-west-1b"
+        VpcId=vpcB.id, CidrBlock="10.0.0.0/24", AvailabilityZone="us-west-1a"
     )
     subnetB2 = ec2.create_subnet(
-        VpcId=vpcB.id, CidrBlock="10.0.1.0/24", AvailabilityZone="us-west-1c"
+        VpcId=vpcB.id, CidrBlock="10.0.1.0/24", AvailabilityZone="us-west-1b"
     )
 
     nr_of_a_zones = len(client.describe_availability_zones()["AvailabilityZones"])
@@ -311,7 +311,7 @@ def test_get_subnets_filtering():
     # Filter by availabilityZone
     subnets_by_az = client.describe_subnets(
         Filters=[
-            {"Name": "availabilityZone", "Values": ["us-west-1b"]},
+            {"Name": "availabilityZone", "Values": ["us-west-1a"]},
             {"Name": "vpc-id", "Values": [vpcB.id]},
         ]
     )["Subnets"]
@@ -339,7 +339,7 @@ def test_create_subnet_response_fields():
 
     vpc = ec2.create_vpc(CidrBlock="10.0.0.0/16")
     subnet = client.create_subnet(
-        VpcId=vpc.id, CidrBlock="10.0.0.0/24", AvailabilityZone="us-west-1b"
+        VpcId=vpc.id, CidrBlock="10.0.0.0/24", AvailabilityZone="us-west-1a"
     )["Subnet"]
 
     subnet.should.have.key("AvailabilityZone")
@@ -372,7 +372,7 @@ def test_describe_subnet_response_fields():
 
     vpc = ec2.create_vpc(CidrBlock="10.0.0.0/16")
     subnet_object = ec2.create_subnet(
-        VpcId=vpc.id, CidrBlock="10.0.0.0/24", AvailabilityZone="us-west-1b"
+        VpcId=vpc.id, CidrBlock="10.0.0.0/24", AvailabilityZone="us-west-1a"
     )
 
     subnets = client.describe_subnets(SubnetIds=[subnet_object.id])["Subnets"]
@@ -734,11 +734,11 @@ def test_describe_subnets_by_vpc_id():
 
     vpc1 = ec2.create_vpc(CidrBlock="10.0.0.0/16")
     subnet1 = ec2.create_subnet(
-        VpcId=vpc1.id, CidrBlock="10.0.0.0/24", AvailabilityZone="us-west-1b"
+        VpcId=vpc1.id, CidrBlock="10.0.0.0/24", AvailabilityZone="us-west-1a"
     )
     vpc2 = ec2.create_vpc(CidrBlock="172.31.0.0/16")
     subnet2 = ec2.create_subnet(
-        VpcId=vpc2.id, CidrBlock="172.31.48.0/20", AvailabilityZone="us-west-1c"
+        VpcId=vpc2.id, CidrBlock="172.31.48.0/20", AvailabilityZone="us-west-1b"
     )
 
     subnets = client.describe_subnets(
@@ -773,7 +773,7 @@ def test_describe_subnets_by_state():
 
     vpc = ec2.create_vpc(CidrBlock="10.0.0.0/16")
     ec2.create_subnet(
-        VpcId=vpc.id, CidrBlock="10.0.0.0/24", AvailabilityZone="us-west-1b"
+        VpcId=vpc.id, CidrBlock="10.0.0.0/24", AvailabilityZone="us-west-1a"
     )
 
     subnets = client.describe_subnets(
@@ -790,7 +790,7 @@ def test_associate_subnet_cidr_block():
 
     vpc = ec2.create_vpc(CidrBlock="10.0.0.0/16")
     subnet_object = ec2.create_subnet(
-        VpcId=vpc.id, CidrBlock="10.0.0.0/24", AvailabilityZone="us-west-1b"
+        VpcId=vpc.id, CidrBlock="10.0.0.0/24", AvailabilityZone="us-west-1a"
     )
 
     subnets = client.describe_subnets(SubnetIds=[subnet_object.id])["Subnets"]
@@ -822,7 +822,7 @@ def test_disassociate_subnet_cidr_block():
 
     vpc = ec2.create_vpc(CidrBlock="10.0.0.0/16")
     subnet_object = ec2.create_subnet(
-        VpcId=vpc.id, CidrBlock="10.0.0.0/24", AvailabilityZone="us-west-1b"
+        VpcId=vpc.id, CidrBlock="10.0.0.0/24", AvailabilityZone="us-west-1a"
     )
 
     client.associate_subnet_cidr_block(

--- a/tests/test_ec2/test_vpc_endpoint_services_integration.py
+++ b/tests/test_ec2/test_vpc_endpoint_services_integration.py
@@ -251,7 +251,7 @@ def test_describe_vpc_default_endpoint_services():
     )
     details = config_service["ServiceDetails"][0]
     assert details["AcceptanceRequired"] is False
-    assert details["AvailabilityZones"] == ["us-west-1b", "us-west-1c"]
+    assert details["AvailabilityZones"] == ["us-west-1a", "us-west-1b"]
     assert details["BaseEndpointDnsNames"] == ["config.us-west-1.vpce.amazonaws.com"]
     assert details["ManagesVpcEndpoints"] is False
     assert details["Owner"] == "amazon"

--- a/tests/test_elb/test_elb_cloudformation.py
+++ b/tests/test_elb/test_elb_cloudformation.py
@@ -18,7 +18,7 @@ def test_stack_elb_integration_with_attached_ec2_instances():
                 "Properties": {
                     "Instances": [{"Ref": "Ec2Instance1"}],
                     "LoadBalancerName": "test-elb",
-                    "AvailabilityZones": ["us-west-1b"],
+                    "AvailabilityZones": ["us-west-1a"],
                     "Listeners": [
                         {
                             "InstancePort": "80",
@@ -47,7 +47,7 @@ def test_stack_elb_integration_with_attached_ec2_instances():
     ec2_instance = reservations["Instances"][0]
 
     load_balancer["Instances"][0]["InstanceId"].should.equal(ec2_instance["InstanceId"])
-    load_balancer["AvailabilityZones"].should.equal(["us-west-1b"])
+    load_balancer["AvailabilityZones"].should.equal(["us-west-1a"])
 
 
 @mock_elb
@@ -105,7 +105,7 @@ def test_stack_elb_integration_with_update():
                 "Type": "AWS::ElasticLoadBalancing::LoadBalancer",
                 "Properties": {
                     "LoadBalancerName": "test-elb",
-                    "AvailabilityZones": ["us-west-1c"],
+                    "AvailabilityZones": ["us-west-1a"],
                     "Listeners": [
                         {
                             "InstancePort": "80",
@@ -127,7 +127,7 @@ def test_stack_elb_integration_with_update():
     # then
     elb = boto3.client("elb", region_name="us-west-1")
     load_balancer = elb.describe_load_balancers()["LoadBalancerDescriptions"][0]
-    load_balancer["AvailabilityZones"].should.equal(["us-west-1c"])
+    load_balancer["AvailabilityZones"].should.equal(["us-west-1a"])
 
     # when
     elb_template["Resources"]["MyELB"]["Properties"]["AvailabilityZones"] = [

--- a/tests/test_elbv2/test_elbv2.py
+++ b/tests/test_elbv2/test_elbv2.py
@@ -76,10 +76,10 @@ def test_create_elb_using_subnetmapping():
     )
     vpc = ec2.create_vpc(CidrBlock="172.28.7.0/24", InstanceTenancy="default")
     subnet1 = ec2.create_subnet(
-        VpcId=vpc.id, CidrBlock="172.28.7.0/26", AvailabilityZone=region + "b"
+        VpcId=vpc.id, CidrBlock="172.28.7.0/26", AvailabilityZone=region + "a"
     )
     subnet2 = ec2.create_subnet(
-        VpcId=vpc.id, CidrBlock="172.28.7.192/26", AvailabilityZone=region + "c"
+        VpcId=vpc.id, CidrBlock="172.28.7.192/26", AvailabilityZone=region + "b"
     )
 
     conn.create_load_balancer(
@@ -93,10 +93,10 @@ def test_create_elb_using_subnetmapping():
     lb = conn.describe_load_balancers()["LoadBalancers"][0]
     lb.should.have.key("AvailabilityZones").length_of(2)
     lb["AvailabilityZones"].should.contain(
-        {"ZoneName": "us-west-1b", "SubnetId": subnet1.id}
+        {"ZoneName": "us-west-1a", "SubnetId": subnet1.id}
     )
     lb["AvailabilityZones"].should.contain(
-        {"ZoneName": "us-west-1c", "SubnetId": subnet2.id}
+        {"ZoneName": "us-west-1b", "SubnetId": subnet2.id}
     )
 
 
@@ -240,10 +240,10 @@ def test_create_elb_in_multiple_region():
         )
         vpc = ec2.create_vpc(CidrBlock="172.28.7.0/24", InstanceTenancy="default")
         subnet1 = ec2.create_subnet(
-            VpcId=vpc.id, CidrBlock="172.28.7.0/26", AvailabilityZone=region + "b"
+            VpcId=vpc.id, CidrBlock="172.28.7.0/26", AvailabilityZone=region + "a"
         )
         subnet2 = ec2.create_subnet(
-            VpcId=vpc.id, CidrBlock="172.28.7.192/26", AvailabilityZone=region + "c"
+            VpcId=vpc.id, CidrBlock="172.28.7.192/26", AvailabilityZone=region + "b"
         )
 
         conn.create_load_balancer(


### PR DESCRIPTION
Fixes #5494 
Reverts #5513 

The availability zones that we expose are `us-west-1a` and `us-west-1b`. It is more consistent to ensure that the instance types we pull down from AWS also use `a` and `b`.
(As opposed to changing the zones that we expose to `b` and `c`, and introducing a potentially breaking change for everyone, which is what I originally did in #5513).