### PR TITLE
pin terraform version to 1.2.9 in terraform tests

### DIFF
--- a/.github/workflows/test_terraform.yml
+++ b/.github/workflows/test_terraform.yml
@@ -29,6 +29,12 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: "3.8"
+    # FIXME: pinned because of https://github.com/hashicorp/terraform-provider-aws/issues/27049
+    - name: Install terraform
+      uses: hashicorp/setup-terraform@v2
+      with:
+        terraform_version: "1.2.9"
+        terraform_wrapper: "false"
     - name: Start MotoServer
       run: |
         pip install PyYAML


### PR DESCRIPTION
This PR is a workaround for the currently failing terraform tests.

See https://github.com/localstack/localstack/pull/6962 for an explanation.