### PR TITLE
More portable grep invocation in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ lint:
 	@echo "Running flake8..."
 	flake8 moto tests
 	@echo "Running black... "
-	$(eval black_version := $(shell grep -oP "(?<=black==).*" requirements-dev.txt))
+	$(eval black_version := $(shell grep "^black==" requirements-dev.txt | sed "s/black==//"))
 	@echo "(Make sure you have black-$(black_version) installed, as other versions will produce different results)"
 	black --check moto/ tests/
 	@echo "Running pylint..."


### PR DESCRIPTION
The Makefile is using grep -oP. However, the -P flag to grep (for "use Perl regex syntax") is GNU-specific and does not exist in BSD grep (e.g., on MacOS).

We can use sed to accomplish the same thing in a way that will work on any POSIX-compliant system.