### PR TITLE
Fix invalid escape sequence, enable pylint check

### DIFF
--- a/moto/s3/responses.py
+++ b/moto/s3/responses.py
@@ -1394,7 +1394,7 @@ class S3Response(BaseResponse):
         checksum_value = request.headers.get(checksum_header)
         if not checksum_value and checksum_algorithm:
             # Extract the checksum-value from the body first
-            search = re.search(b"x-amz-checksum-\w+:(\w+={1,2})", body)
+            search = re.search(rb"x-amz-checksum-\w+:(\w+={1,2})", body)
             checksum_value = search.group(1) if search else None
 
         if checksum_value:

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,4 +15,4 @@ ignore-paths=moto/packages
 [pylint.'MESSAGES CONTROL']
 disable = W,C,R,E
 # future sensible checks = super-init-not-called, unspecified-encoding, undefined-loop-variable
-enable = arguments-renamed, dangerous-default-value, deprecated-module, function-redefined, import-self, redefined-builtin, redefined-outer-name, reimported, pointless-statement, super-with-arguments, unused-argument, unused-import, unused-variable, useless-else-on-loop, wildcard-import
+enable = anomalous-backslash-in-string, arguments-renamed, dangerous-default-value, deprecated-module, function-redefined, import-self, redefined-builtin, redefined-outer-name, reimported, pointless-statement, super-with-arguments, unused-argument, unused-import, unused-variable, useless-else-on-loop, wildcard-import


### PR DESCRIPTION
In commit c4626888460, `r"x-amz-checksum-\w+:(\w+={1,2})"` was changed to  `b"x-amz-checksum-\w+:(\w+={1,2})"` (same content, different prefix). In addition to changing the type from to str to bytes (which was the intention), this lost the 'r' prefix which means that `\w` is now treated as an escape sequence.

Since it isn't actually a valid escape sequence, Python falls back to assuming it's not an escape sequence at all and the backslash is literal. This is correct and gets the same result as the "raw" version would, but generates `DeprecationWarning: invalid escape sequence \w`

This PR re-adds the `r` prefix as well as enabling the pylint check that would have caught this.