### PR TITLE
Fix glue expression

### DIFF
--- a/moto/glue/models.py
+++ b/moto/glue/models.py
@@ -143,7 +143,10 @@ class GlueBackend(BaseBackend):
             # sanitise expression, * is treated as a glob like wildcard
             # so we make it a valid regex
             if "*" in expression:
-                expression = expression.replace("*", ".*")
+                if expression.endswith(".*"):
+                    expression = f"{expression[:-2].replace('*', '.*')}\\{expression[-2:]}"
+                else:
+                    expression = expression.replace("*", ".*")
             return [
                 table
                 for table_name, table in database.tables.items()

--- a/moto/glue/models.py
+++ b/moto/glue/models.py
@@ -140,6 +140,10 @@ class GlueBackend(BaseBackend):
     def get_tables(self, database_name, expression):
         database = self.get_database(database_name)
         if expression:
+            # sanitise expression, * is treated as a glob like wildcard
+            # so we make it a valid regex
+            if "*" in expression:
+                expression = expression.replace("*", ".*")
             return [
                 table
                 for table_name, table in database.tables.items()

--- a/moto/glue/models.py
+++ b/moto/glue/models.py
@@ -140,11 +140,13 @@ class GlueBackend(BaseBackend):
     def get_tables(self, database_name, expression):
         database = self.get_database(database_name)
         if expression:
-            # sanitise expression, * is treated as a glob like wildcard
+            # sanitise expression, * is treated as a glob-like wildcard
             # so we make it a valid regex
             if "*" in expression:
                 if expression.endswith(".*"):
-                    expression = f"{expression[:-2].replace('*', '.*')}\\{expression[-2:]}"
+                    expression = (
+                        f"{expression[:-2].replace('*', '.*')}{expression[-2:]}"
+                    )
                 else:
                     expression = expression.replace("*", ".*")
             return [

--- a/tests/test_glue/test_datacatalog.py
+++ b/tests/test_glue/test_datacatalog.py
@@ -254,25 +254,35 @@ def test_get_tables_expression():
     postfix_expression = "\\w+_mytablepostfix"
     string_expression = "\\w+catchthis\\w+"
 
-    # even though * is an invalid regex, sadly glue api treats it as a glob like wildcard
+    # even though * is an invalid regex, sadly glue api treats it as a glob-like wildcard
     star_expression1 = "*"
     star_expression2 = "mytable*"
     star_expression3 = "*table*"
     star_expression4 = "*catch*is*"
     star_expression5 = ".*catch*is*"
-
-    # sadly glue api treats an expression with a trailing .* as a regex equivalent of \.*
     star_expression6 = "trailing*.*"
 
     response_prefix = helpers.get_tables(client, database_name, prefix_expression)
     response_postfix = helpers.get_tables(client, database_name, postfix_expression)
     response_string_match = helpers.get_tables(client, database_name, string_expression)
-    response_star_expression1 = helpers.get_tables(client, database_name, star_expression1)
-    response_star_expression2 = helpers.get_tables(client, database_name, star_expression2)
-    response_star_expression3 = helpers.get_tables(client, database_name, star_expression3)
-    response_star_expression4 = helpers.get_tables(client, database_name, star_expression4)
-    response_star_expression5 = helpers.get_tables(client, database_name, star_expression5)
-    response_star_expression6 = helpers.get_tables(client, database_name, star_expression6)
+    response_star_expression1 = helpers.get_tables(
+        client, database_name, star_expression1
+    )
+    response_star_expression2 = helpers.get_tables(
+        client, database_name, star_expression2
+    )
+    response_star_expression3 = helpers.get_tables(
+        client, database_name, star_expression3
+    )
+    response_star_expression4 = helpers.get_tables(
+        client, database_name, star_expression4
+    )
+    response_star_expression5 = helpers.get_tables(
+        client, database_name, star_expression5
+    )
+    response_star_expression6 = helpers.get_tables(
+        client, database_name, star_expression6
+    )
 
     tables_prefix = response_prefix["TableList"]
     tables_postfix = response_postfix["TableList"]

--- a/tests/test_glue/test_datacatalog.py
+++ b/tests/test_glue/test_datacatalog.py
@@ -240,6 +240,8 @@ def test_get_tables_expression():
         "test_catchthis123_test",
         "asduas6781catchthisasdas",
         "fakecatchthisfake",
+        "trailingtest.",
+        "trailingtest...",
     ]
     table_inputs = {}
 
@@ -252,11 +254,15 @@ def test_get_tables_expression():
     postfix_expression = "\\w+_mytablepostfix"
     string_expression = "\\w+catchthis\\w+"
 
-    # even though * is an invalid regex, glue api treats it as a glob like wildcard
+    # even though * is an invalid regex, sadly glue api treats it as a glob like wildcard
     star_expression1 = "*"
     star_expression2 = "mytable*"
     star_expression3 = "*table*"
     star_expression4 = "*catch*is*"
+    star_expression5 = ".*catch*is*"
+
+    # sadly glue api treats an expression with a trailing .* as a regex equivalent of \.*
+    star_expression6 = "trailing*.*"
 
     response_prefix = helpers.get_tables(client, database_name, prefix_expression)
     response_postfix = helpers.get_tables(client, database_name, postfix_expression)
@@ -265,6 +271,8 @@ def test_get_tables_expression():
     response_star_expression2 = helpers.get_tables(client, database_name, star_expression2)
     response_star_expression3 = helpers.get_tables(client, database_name, star_expression3)
     response_star_expression4 = helpers.get_tables(client, database_name, star_expression4)
+    response_star_expression5 = helpers.get_tables(client, database_name, star_expression5)
+    response_star_expression6 = helpers.get_tables(client, database_name, star_expression6)
 
     tables_prefix = response_prefix["TableList"]
     tables_postfix = response_postfix["TableList"]
@@ -273,14 +281,18 @@ def test_get_tables_expression():
     tables_star_expression2 = response_star_expression2["TableList"]
     tables_star_expression3 = response_star_expression3["TableList"]
     tables_star_expression4 = response_star_expression4["TableList"]
+    tables_star_expression5 = response_star_expression5["TableList"]
+    tables_star_expression6 = response_star_expression6["TableList"]
 
     tables_prefix.should.have.length_of(2)
     tables_postfix.should.have.length_of(1)
     tables_string_match.should.have.length_of(3)
-    tables_star_expression1.should.have.length_of(6)
+    tables_star_expression1.should.have.length_of(8)
     tables_star_expression2.should.have.length_of(2)
     tables_star_expression3.should.have.length_of(3)
     tables_star_expression4.should.have.length_of(3)
+    tables_star_expression5.should.have.length_of(3)
+    tables_star_expression6.should.have.length_of(2)
 
 
 @mock_glue

--- a/tests/test_glue/test_datacatalog.py
+++ b/tests/test_glue/test_datacatalog.py
@@ -252,17 +252,35 @@ def test_get_tables_expression():
     postfix_expression = "\\w+_mytablepostfix"
     string_expression = "\\w+catchthis\\w+"
 
+    # even though * is an invalid regex, glue api treats it as a glob like wildcard
+    star_expression1 = "*"
+    star_expression2 = "mytable*"
+    star_expression3 = "*table*"
+    star_expression4 = "*catch*is*"
+
     response_prefix = helpers.get_tables(client, database_name, prefix_expression)
     response_postfix = helpers.get_tables(client, database_name, postfix_expression)
     response_string_match = helpers.get_tables(client, database_name, string_expression)
+    response_star_expression1 = helpers.get_tables(client, database_name, star_expression1)
+    response_star_expression2 = helpers.get_tables(client, database_name, star_expression2)
+    response_star_expression3 = helpers.get_tables(client, database_name, star_expression3)
+    response_star_expression4 = helpers.get_tables(client, database_name, star_expression4)
 
     tables_prefix = response_prefix["TableList"]
     tables_postfix = response_postfix["TableList"]
     tables_string_match = response_string_match["TableList"]
+    tables_star_expression1 = response_star_expression1["TableList"]
+    tables_star_expression2 = response_star_expression2["TableList"]
+    tables_star_expression3 = response_star_expression3["TableList"]
+    tables_star_expression4 = response_star_expression4["TableList"]
 
     tables_prefix.should.have.length_of(2)
     tables_postfix.should.have.length_of(1)
     tables_string_match.should.have.length_of(3)
+    tables_star_expression1.should.have.length_of(6)
+    tables_star_expression2.should.have.length_of(2)
+    tables_star_expression3.should.have.length_of(3)
+    tables_star_expression4.should.have.length_of(3)
 
 
 @mock_glue


### PR DESCRIPTION
Fix for issue discussed in PR conversation on https://github.com/spulec/moto/pull/5495

Glue `get_tables` treats expressions with `*` as a glob-like wildcard.

FYI @robert-schmidtke 