### PR TITLE
Create multiplatform docker image that also runs on m1 macbooks

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,6 +51,8 @@ jobs:
         docker build -t motoserver/moto . --tag moto:${{ env.VERSION }}
     # Required to get the correct Digest
     # See https://github.com/docker/build-push-action/issues/461
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v2
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v2
     - name: Login to DockerHub
@@ -62,6 +64,7 @@ jobs:
       name: Build and push
       uses: docker/build-push-action@v2
       with:
+        platforms: linux/amd64,linux/arm64
         push: true
         tags: motoserver/moto:${{ env.VERSION }}
     - name: Increase patch version number


### PR DESCRIPTION
I noticed that the docker image of motoserver is not a multi platform build.  Therefore it creates some troubles when I try to run it with docker swarm locally on an M1 Macbook pro for my tests. I just added the needed steps to create a multi platform docker image, according to this [guide](https://github.com/docker/build-push-action/blob/master/docs/advanced/multi-platform.md).