### PR TITLE
S3:list_object_versions(): Fix delimiter to take prefix into account

### DIFF
--- a/moto/s3/models.py
+++ b/moto/s3/models.py
@@ -1601,10 +1601,12 @@ class S3Backend(BaseBackend, CloudWatchMetricProvider):
             # Filter for keys that start with prefix
             if not name.startswith(prefix):
                 continue
-            # separate out all keys that contain delimiter
-            if delimiter and delimiter in name:
-                index = name.index(delimiter) + len(delimiter)
-                prefix_including_delimiter = name[0:index]
+            # separate keys that contain the same string between the prefix and the first occurrence of the delimiter
+            if delimiter and delimiter in name[len(prefix) :]:
+                end_of_delimiter = (
+                    len(prefix) + name[len(prefix) :].index(delimiter) + len(delimiter)
+                )
+                prefix_including_delimiter = name[0:end_of_delimiter]
                 common_prefixes.append(prefix_including_delimiter)
                 continue
 

--- a/tests/test_s3/test_s3.py
+++ b/tests/test_s3/test_s3.py
@@ -2463,6 +2463,20 @@ def test_list_object_versions_with_delimiter():
         {"key11-without-data", "key12-without-data", "key13-without-data"}
     )
 
+    # Delimiter with Prefix being the entire key
+    response = s3.list_object_versions(
+        Bucket=bucket_name, Prefix="key1-with-data", Delimiter="-"
+    )
+    response.should.have.key("Versions").length_of(3)
+    response.shouldnt.have.key("CommonPrefixes")
+
+    # Delimiter without prefix
+    response = s3.list_object_versions(Bucket=bucket_name, Delimiter="-with-")
+    response["CommonPrefixes"].should.have.length_of(8)
+    response["CommonPrefixes"].should.contain({"Prefix": "key1-with-"})
+    # Should return all keys -without-data
+    response.should.have.key("Versions").length_of(24)
+
 
 @mock_s3
 def test_list_object_versions_with_delimiter_for_deleted_objects():


### PR DESCRIPTION
Fixes #5561 

From the docs:
Delimiter (string) -- A delimiter is a character that you specify to group keys. All keys that contain the same string **between the prefix and the first occurrence of the delimiter** are grouped under a single result element in CommonPrefixes. These groups are counted as one result against the max-keys limitation. These keys are not returned elsewhere in the response.

Emphasis mine. The current implementation was much too broad, and included keys that contained the delimiter regardless of the prefix specified.