### PR TITLE
Techdebt - Simplify some exceptions

### DIFF
--- a/moto/athena/exceptions.py
+++ b/moto/athena/exceptions.py
@@ -1,10 +1,10 @@
 import json
-from werkzeug.exceptions import BadRequest
+from moto.core.exceptions import JsonRESTError
 
 
-class AthenaClientError(BadRequest):
+class AthenaClientError(JsonRESTError):
     def __init__(self, code, message):
-        super().__init__()
+        super().__init__(error_type="InvalidRequestException", message=message)
         self.description = json.dumps(
             {
                 "Error": {

--- a/moto/cloudformation/exceptions.py
+++ b/moto/cloudformation/exceptions.py
@@ -1,4 +1,4 @@
-from werkzeug.exceptions import BadRequest
+from moto.core.exceptions import RESTError
 from jinja2 import Template
 
 
@@ -9,36 +9,32 @@ class UnformattedGetAttTemplateException(Exception):
     status_code = 400
 
 
-class ValidationError(BadRequest):
+class ValidationError(RESTError):
     def __init__(self, name_or_id=None, message=None):
         if message is None:
             message = "Stack with id {0} does not exist".format(name_or_id)
 
         template = Template(ERROR_RESPONSE)
-        super().__init__()
+        super().__init__(error_type="ValidationError", message=message)
         self.description = template.render(code="ValidationError", message=message)
 
 
-class MissingParameterError(BadRequest):
+class MissingParameterError(RESTError):
     def __init__(self, parameter_name):
         template = Template(ERROR_RESPONSE)
-        super().__init__()
-        self.description = template.render(
-            code="Missing Parameter",
-            message="Missing parameter {0}".format(parameter_name),
-        )
+        message = "Missing parameter {0}".format(parameter_name)
+        super().__init__(error_type="ValidationError", message=message)
+        self.description = template.render(code="Missing Parameter", message=message)
 
 
-class ExportNotFound(BadRequest):
+class ExportNotFound(RESTError):
     """Exception to raise if a template tries to import a non-existent export"""
 
     def __init__(self, export_name):
         template = Template(ERROR_RESPONSE)
-        super().__init__()
-        self.description = template.render(
-            code="ExportNotFound",
-            message="No export named {0} found.".format(export_name),
-        )
+        message = "No export named {0} found.".format(export_name)
+        super().__init__(error_type="ExportNotFound", message=message)
+        self.description = template.render(code="ExportNotFound", message=message)
 
 
 class UnsupportedAttribute(ValidationError):

--- a/moto/cognitoidentity/exceptions.py
+++ b/moto/cognitoidentity/exceptions.py
@@ -1,25 +1,15 @@
-import json
-
-from werkzeug.exceptions import BadRequest
+from moto.core.exceptions import JsonRESTError
 
 
-class ResourceNotFoundError(BadRequest):
+class ResourceNotFoundError(JsonRESTError):
     def __init__(self, message):
-        super().__init__()
-        self.description = json.dumps(
-            {"message": message, "__type": "ResourceNotFoundException"}
-        )
+        super().__init__(error_type="ResourceNotFoundException", message=message)
 
 
-class InvalidNameException(BadRequest):
+class InvalidNameException(JsonRESTError):
 
     message = "1 validation error detected: Value '{}' at 'identityPoolName' failed to satisfy constraint: Member must satisfy regular expression pattern: [\\w\\s+=,.@-]+"
 
     def __init__(self, name):
-        super().__init__()
-        self.description = json.dumps(
-            {
-                "message": InvalidNameException.message.format(name),
-                "__type": "ValidationException",
-            }
-        )
+        msg = InvalidNameException.message.format(name)
+        super().__init__(error_type="ValidationException", message=msg)

--- a/moto/cognitoidp/exceptions.py
+++ b/moto/cognitoidp/exceptions.py
@@ -1,62 +1,39 @@
-import json
-from werkzeug.exceptions import BadRequest
 from moto.core.exceptions import JsonRESTError
 
 
-class ResourceNotFoundError(BadRequest):
+class ResourceNotFoundError(JsonRESTError):
     def __init__(self, message):
-        super().__init__()
-        self.description = json.dumps(
-            {"message": message, "__type": "ResourceNotFoundException"}
-        )
+        super().__init__(error_type="ResourceNotFoundException", message=message)
 
 
-class UserNotFoundError(BadRequest):
+class UserNotFoundError(JsonRESTError):
     def __init__(self, message):
-        super().__init__()
-        self.description = json.dumps(
-            {"message": message, "__type": "UserNotFoundException"}
-        )
+        super().__init__(error_type="UserNotFoundException", message=message)
 
 
-class UsernameExistsException(BadRequest):
+class UsernameExistsException(JsonRESTError):
     def __init__(self, message):
-        super().__init__()
-        self.description = json.dumps(
-            {"message": message, "__type": "UsernameExistsException"}
-        )
+        super().__init__(error_type="UsernameExistsException", message=message)
 
 
-class GroupExistsException(BadRequest):
+class GroupExistsException(JsonRESTError):
     def __init__(self, message):
-        super().__init__()
-        self.description = json.dumps(
-            {"message": message, "__type": "GroupExistsException"}
-        )
+        super().__init__(error_type="GroupExistsException", message=message)
 
 
-class NotAuthorizedError(BadRequest):
+class NotAuthorizedError(JsonRESTError):
     def __init__(self, message):
-        super().__init__()
-        self.description = json.dumps(
-            {"message": message, "__type": "NotAuthorizedException"}
-        )
+        super().__init__(error_type="NotAuthorizedException", message=message)
 
 
-class UserNotConfirmedException(BadRequest):
+class UserNotConfirmedException(JsonRESTError):
     def __init__(self, message):
-        super().__init__()
-        self.description = json.dumps(
-            {"message": message, "__type": "UserNotConfirmedException"}
-        )
+        super().__init__(error_type="UserNotConfirmedException", message=message)
 
 
-class ExpiredCodeException(BadRequest):
+class ExpiredCodeException(JsonRESTError):
     def __init__(self, message):
-        super().__init__()
-        self.description = json.dumps(
-            {"message": message, "__type": "ExpiredCodeException"}
-        )
+        super().__init__(error_type="ExpiredCodeException", message=message)
 
 
 class InvalidParameterException(JsonRESTError):

--- a/moto/kinesis/exceptions.py
+++ b/moto/kinesis/exceptions.py
@@ -1,21 +1,14 @@
-import json
-from werkzeug.exceptions import BadRequest
+from moto.core.exceptions import JsonRESTError
 
 
-class ResourceNotFoundError(BadRequest):
+class ResourceNotFoundError(JsonRESTError):
     def __init__(self, message):
-        super().__init__()
-        self.description = json.dumps(
-            {"message": message, "__type": "ResourceNotFoundException"}
-        )
+        super().__init__(error_type="ResourceNotFoundException", message=message)
 
 
-class ResourceInUseError(BadRequest):
+class ResourceInUseError(JsonRESTError):
     def __init__(self, message):
-        super().__init__()
-        self.description = json.dumps(
-            {"message": message, "__type": "ResourceInUseException"}
-        )
+        super().__init__(error_type="ResourceInUseException", message=message)
 
 
 class StreamNotFoundError(ResourceNotFoundError):
@@ -23,13 +16,10 @@ class StreamNotFoundError(ResourceNotFoundError):
         super().__init__(f"Stream {stream_name} under account {account_id} not found.")
 
 
-class StreamCannotBeUpdatedError(BadRequest):
+class StreamCannotBeUpdatedError(JsonRESTError):
     def __init__(self, stream_name, account_id):
-        super().__init__()
         message = f"Request is invalid. Stream {stream_name} under account {account_id} is in On-Demand mode."
-        self.description = json.dumps(
-            {"message": message, "__type": "ValidationException"}
-        )
+        super().__init__(error_type="ValidationException", message=message)
 
 
 class ShardNotFoundError(ResourceNotFoundError):
@@ -44,12 +34,9 @@ class ConsumerNotFound(ResourceNotFoundError):
         super().__init__(f"Consumer {consumer}, account {account_id} not found.")
 
 
-class InvalidArgumentError(BadRequest):
+class InvalidArgumentError(JsonRESTError):
     def __init__(self, message):
-        super().__init__()
-        self.description = json.dumps(
-            {"message": message, "__type": "InvalidArgumentException"}
-        )
+        super().__init__(error_type="InvalidArgumentException", message=message)
 
 
 class InvalidRetentionPeriod(InvalidArgumentError):
@@ -73,45 +60,27 @@ class InvalidIncreaseRetention(InvalidArgumentError):
         super().__init__(msg)
 
 
-class ValidationException(BadRequest):
+class ValidationException(JsonRESTError):
     def __init__(self, value, position, regex_to_match):
-        super().__init__()
-        self.description = json.dumps(
-            {
-                "message": f"1 validation error detected: Value '{value}' at '{position}' failed to satisfy constraint: Member must satisfy regular expression pattern: {regex_to_match}",
-                "__type": "ValidationException",
-            }
-        )
+        msg = f"1 validation error detected: Value '{value}' at '{position}' failed to satisfy constraint: Member must satisfy regular expression pattern: {regex_to_match}"
+        super().__init__(error_type="ValidationException", message=msg)
 
 
-class RecordSizeExceedsLimit(BadRequest):
+class RecordSizeExceedsLimit(JsonRESTError):
     def __init__(self, position):
-        super().__init__()
-        self.description = json.dumps(
-            {
-                "message": f"1 validation error detected: Value at 'records.{position}.member.data' failed to satisfy constraint: Member must have length less than or equal to 1048576",
-                "__type": "ValidationException",
-            }
-        )
+        msg = f"1 validation error detected: Value at 'records.{position}.member.data' failed to satisfy constraint: Member must have length less than or equal to 1048576"
+        super().__init__(error_type="ValidationException", message=msg)
 
 
-class TotalRecordsSizeExceedsLimit(BadRequest):
+class TotalRecordsSizeExceedsLimit(JsonRESTError):
     def __init__(self):
-        super().__init__()
-        self.description = json.dumps(
-            {
-                "message": "Records size exceeds 5 MB limit",
-                "__type": "InvalidArgumentException",
-            }
+        super().__init__(
+            error_type="InvalidArgumentException",
+            message="Records size exceeds 5 MB limit",
         )
 
 
-class TooManyRecords(BadRequest):
+class TooManyRecords(JsonRESTError):
     def __init__(self):
-        super().__init__()
-        self.description = json.dumps(
-            {
-                "message": "1 validation error detected: Value at 'records' failed to satisfy constraint: Member must have length less than or equal to 500",
-                "__type": "ValidationException",
-            }
-        )
+        msg = "1 validation error detected: Value at 'records' failed to satisfy constraint: Member must have length less than or equal to 500"
+        super().__init__(error_type="ValidationException", message=msg)

--- a/moto/managedblockchain/exceptions.py
+++ b/moto/managedblockchain/exceptions.py
@@ -1,6 +1,6 @@
 import json
+from moto.core.exceptions import JsonRESTError
 from functools import wraps
-from werkzeug.exceptions import HTTPException
 
 
 def exception_handler(f):
@@ -14,10 +14,9 @@ def exception_handler(f):
     return _wrapper
 
 
-class ManagedBlockchainClientError(HTTPException):
-    code = 400
-
+class ManagedBlockchainClientError(JsonRESTError):
     def __init__(self, error_type, message):
+        super().__init__(error_type=error_type, message=message)
         self.error_type = error_type
         self.message = message
         self.description = json.dumps({"message": self.message})
@@ -27,10 +26,6 @@ class ManagedBlockchainClientError(HTTPException):
             ("Content-Type", "application/json"),
             ("x-amzn-ErrorType", self.error_type),
         ]
-
-    @property
-    def response(self):
-        return self.get_body()
 
     def get_body(self, *args, **kwargs):  # pylint: disable=unused-argument
         return self.description

--- a/moto/meteringmarketplace/exceptions.py
+++ b/moto/meteringmarketplace/exceptions.py
@@ -1,60 +1,38 @@
-from __future__ import unicode_literals
-
-import json
-from werkzeug.exceptions import BadRequest
+from moto.core.exceptions import JsonRESTError
 
 
-class DisabledApiException(BadRequest):
+class DisabledApiException(JsonRESTError):
     def __init__(self, message):
-        super().__init__()
-        self.description = json.dumps(
-            {"message": message, "__type": "DisabledApiException"}
+        super().__init__(error_type="DisabledApiException", message=message)
+
+
+class InternalServiceErrorException(JsonRESTError):
+    def __init__(self, message):
+        super().__init__(error_type="InternalServiceErrorException", message=message)
+
+
+class InvalidCustomerIdentifierException(JsonRESTError):
+    def __init__(self, message):
+        super().__init__(
+            error_type="InvalidCustomerIdentifierException", message=message
         )
 
 
-class InternalServiceErrorException(BadRequest):
+class InvalidProductCodeException(JsonRESTError):
     def __init__(self, message):
-        super().__init__()
-        self.description = json.dumps(
-            {"message": message, "__type": "InternalServiceErrorException"}
-        )
+        super().__init__(error_type="InvalidProductCodeException", message=message)
 
 
-class InvalidCustomerIdentifierException(BadRequest):
+class InvalidUsageDimensionException(JsonRESTError):
     def __init__(self, message):
-        super().__init__()
-        self.description = json.dumps(
-            {"message": message, "__type": "InvalidCustomerIdentifierException"}
-        )
+        super().__init__(error_type="InvalidUsageDimensionException", message=message)
 
 
-class InvalidProductCodeException(BadRequest):
+class ThrottlingException(JsonRESTError):
     def __init__(self, message):
-        super().__init__()
-        self.description = json.dumps(
-            {"message": message, "__type": "InvalidProductCodeException"}
-        )
+        super().__init__(error_type="ThrottlingException", message=message)
 
 
-class InvalidUsageDimensionException(BadRequest):
+class TimestampOutOfBoundsException(JsonRESTError):
     def __init__(self, message):
-        super().__init__()
-        self.description = json.dumps(
-            {"message": message, "__type": "InvalidUsageDimensionException"}
-        )
-
-
-class ThrottlingException(BadRequest):
-    def __init__(self, message):
-        super().__init__()
-        self.description = json.dumps(
-            {"message": message, "__type": "ThrottlingException"}
-        )
-
-
-class TimestampOutOfBoundsException(BadRequest):
-    def __init__(self, message):
-        super().__init__()
-        self.description = json.dumps(
-            {"message": message, "__type": "TimestampOutOfBoundsException"}
-        )
+        super().__init__(error_type="TimestampOutOfBoundsException", message=message)

--- a/moto/opsworks/exceptions.py
+++ b/moto/opsworks/exceptions.py
@@ -1,18 +1,11 @@
-import json
-from werkzeug.exceptions import BadRequest
+from moto.core.exceptions import JsonRESTError
 
 
-class ResourceNotFoundException(BadRequest):
+class ResourceNotFoundException(JsonRESTError):
     def __init__(self, message):
-        super().__init__()
-        self.description = json.dumps(
-            {"message": message, "__type": "ResourceNotFoundException"}
-        )
+        super().__init__(error_type="ResourceNotFoundException", message=message)
 
 
-class ValidationException(BadRequest):
+class ValidationException(JsonRESTError):
     def __init__(self, message):
-        super().__init__()
-        self.description = json.dumps(
-            {"message": message, "__type": "ResourceNotFoundException"}
-        )
+        super().__init__(error_type="ResourceNotFoundException", message=message)

--- a/moto/rds/exceptions.py
+++ b/moto/rds/exceptions.py
@@ -1,10 +1,10 @@
 from jinja2 import Template
-from werkzeug.exceptions import BadRequest
+from moto.core.exceptions import RESTError
 
 
-class RDSClientError(BadRequest):
+class RDSClientError(RESTError):
     def __init__(self, code, message):
-        super().__init__()
+        super().__init__(error_type=code, message=message)
         template = Template(
             """
         <ErrorResponse>

--- a/moto/redshift/exceptions.py
+++ b/moto/redshift/exceptions.py
@@ -1,10 +1,10 @@
 import json
-from werkzeug.exceptions import BadRequest
+from moto.core.exceptions import JsonRESTError
 
 
-class RedshiftClientError(BadRequest):
+class RedshiftClientError(JsonRESTError):
     def __init__(self, code, message):
-        super().__init__()
+        super().__init__(error_type=code, message=message)
         self.description = json.dumps(
             {
                 "Error": {"Code": code, "Message": message, "Type": "Sender"},

--- a/moto/resourcegroups/exceptions.py
+++ b/moto/resourcegroups/exceptions.py
@@ -1,13 +1,8 @@
-import json
-
-from werkzeug.exceptions import HTTPException
+from moto.core.exceptions import JsonRESTError
 
 
-class BadRequestException(HTTPException):
+class BadRequestException(JsonRESTError):
     code = 400
 
     def __init__(self, message, **kwargs):
-        super().__init__(
-            description=json.dumps({"Message": message, "Code": "BadRequestException"}),
-            **kwargs
-        )
+        super().__init__(error_type="BadRequestException", message=message)


### PR DESCRIPTION
Simplifies and streamlines some exceptions by extending our custom Exception-object, instead of werkzeug's HttpException.

The format that AWS uses for it's exceptions, `"{'__type': .., 'message': ..}"` should now only be present in our overarching JsonRestError.