### PR TITLE
S3: Close filehandle of versioned keys

### DIFF
--- a/moto/s3/models.py
+++ b/moto/s3/models.py
@@ -1455,12 +1455,10 @@ class S3Backend(BaseBackend, CloudWatchMetricProvider):
     def reset(self):
         # For every key and multipart, Moto opens a TemporaryFile to write the value of those keys
         # Ensure that these TemporaryFile-objects are closed, and leave no filehandles open
-        for bucket in self.buckets.values():
-            for key in bucket.keys.values():
-                if isinstance(key, FakeKey):
-                    key.dispose()
-            for mp in bucket.multiparts.values():
-                mp.dispose()
+        for mp in FakeMultipart.instances:
+            mp.dispose()
+        for key in FakeKey.instances:
+            key.dispose()
         super().reset()
 
     @property

--- a/tests/test_s3/test_s3_file_handles.py
+++ b/tests/test_s3/test_s3_file_handles.py
@@ -57,6 +57,11 @@ class TestS3FileHandleClosures(TestCase):
         self.s3.put_object("my-bucket", "my-key", "b" * 10_000_000)
 
     @verify_zero_warnings
+    def test_versioned_file(self):
+        self.s3.put_bucket_versioning("my-bucket", "Enabled")
+        self.s3.put_object("my-bucket", "my-key", "b" * 10_000_000)
+
+    @verify_zero_warnings
     def test_copy_object(self):
         key = self.s3.get_object("my-bucket", "my-key")
         self.s3.copy_object(


### PR DESCRIPTION
Closes #5584 

Instead of having to list all buckets, and all keys inside buckets, we can  just use the builtin `instances` which will contain a list of all instances ever created.