### PR TITLE
fix(describe_trails): trail not multiregion case

### DIFF
--- a/moto/cloudtrail/models.py
+++ b/moto/cloudtrail/models.py
@@ -318,7 +318,9 @@ class CloudTrailBackend(BaseBackend):
         if include_shadow_trails:
             current_account = cloudtrail_backends[self.account_id]
             for backend in current_account.values():
-                all_trails.extend(backend.trails.values())
+                for trail in backend.trails.values():
+                    if trail.is_multi_region == True or trail.region_name == backend.region_name:
+                        all_trails.extend(backend.trails.values())
         else:
             all_trails.extend(self.trails.values())
         return all_trails

--- a/moto/cloudtrail/models.py
+++ b/moto/cloudtrail/models.py
@@ -319,10 +319,7 @@ class CloudTrailBackend(BaseBackend):
             current_account = cloudtrail_backends[self.account_id]
             for backend in current_account.values():
                 for trail in backend.trails.values():
-                    if (
-                        trail.is_multi_region
-                        or trail.region_name == self.region_name
-                    ):
+                    if trail.is_multi_region or trail.region_name == self.region_name:
                         all_trails.append(trail)
         else:
             all_trails.extend(self.trails.values())

--- a/moto/cloudtrail/models.py
+++ b/moto/cloudtrail/models.py
@@ -321,7 +321,7 @@ class CloudTrailBackend(BaseBackend):
                 for trail in backend.trails.values():
                     if (
                         trail.is_multi_region
-                        or trail.region_name == backend.region_name
+                        or trail.region_name == self.region_name
                     ):
                         all_trails.append(trail)
         else:

--- a/moto/cloudtrail/models.py
+++ b/moto/cloudtrail/models.py
@@ -319,7 +319,7 @@ class CloudTrailBackend(BaseBackend):
             current_account = cloudtrail_backends[self.account_id]
             for backend in current_account.values():
                 for trail in backend.trails.values():
-                    if trail.is_multi_region == True or trail.region_name == backend.region_name:
+                    if trail.is_multi_region or trail.region_name == backend.region_name:
                         all_trails.extend(backend.trails.values())
         else:
             all_trails.extend(self.trails.values())

--- a/moto/cloudtrail/models.py
+++ b/moto/cloudtrail/models.py
@@ -319,7 +319,10 @@ class CloudTrailBackend(BaseBackend):
             current_account = cloudtrail_backends[self.account_id]
             for backend in current_account.values():
                 for trail in backend.trails.values():
-                    if trail.is_multi_region or trail.region_name == backend.region_name:
+                    if (
+                        trail.is_multi_region
+                        or trail.region_name == backend.region_name
+                    ):
                         all_trails.extend(backend.trails.values())
         else:
             all_trails.extend(self.trails.values())

--- a/moto/cloudtrail/models.py
+++ b/moto/cloudtrail/models.py
@@ -323,7 +323,7 @@ class CloudTrailBackend(BaseBackend):
                         trail.is_multi_region
                         or trail.region_name == backend.region_name
                     ):
-                        all_trails.extend(backend.trails.values())
+                        all_trails.append(trail)
         else:
             all_trails.extend(self.trails.values())
         return all_trails

--- a/tests/test_cloudtrail/test_cloudtrail.py
+++ b/tests/test_cloudtrail/test_cloudtrail.py
@@ -330,9 +330,9 @@ def test_get_trail_status_after_starting_and_stopping():
 def test_list_trails_different_home_region_one_multiregion():
     client = boto3.client("cloudtrail", region_name="eu-west-3")
 
-    _, trail1, _ = create_trail_simple()
+    create_trail_simple()
     _, trail2, _, _ = create_trail_advanced(region_name="ap-southeast-2")
-    _, trail3, _ = create_trail_simple(region_name="eu-west-1")
+    create_trail_simple(region_name="eu-west-1")
 
     all_trails = client.list_trails()["Trails"]
     all_trails.should.have.length_of(1)
@@ -345,6 +345,7 @@ def test_list_trails_different_home_region_one_multiregion():
             "HomeRegion": "ap-southeast-2",
         }
     )
+
 
 @mock_cloudtrail
 @mock_s3


### PR DESCRIPTION
From https://github.com/spulec/moto/issues/5604 we have realised that there is a missing condition when listing the trails from `describe_trail`.

If we don't include the condition:
```
if trail.is_multi_region or trail.region_name == backend.region_name:
```
Single multiregion trails will be shown in another regions when launching `describe_trail`

To test its effect please refer to the script included into the issue description