### PR TITLE
S3: Simplify detection of delete-flag

### DIFF
--- a/moto/s3bucket_path/utils.py
+++ b/moto/s3bucket_path/utils.py
@@ -12,15 +12,3 @@ def bucket_name_from_url(url):
 
 def parse_key_name(path):
     return "/".join(path.split("/")[2:])
-
-
-def is_delete_keys(request, path, bucket_name):
-    return (
-        path == "/" + bucket_name + "/?delete"
-        or path == "/" + bucket_name + "?delete"
-        or path == "/" + bucket_name + "?delete="
-        or (
-            path == "/" + bucket_name
-            and getattr(request, "query_string", "") == "delete"
-        )
-    )


### PR DESCRIPTION
Fixes #5610 

When detecting whether the current request is a `DeleteObjectsRequest`, we want to know whether there is a querystring-parameter called delete.

There's really no need to verify the entire path, and/or verify the exact format of the url/path.