### PR TITLE
AWSLambda - Do not pickle reproducible Docker-client

### DIFF
--- a/moto/awslambda/models.py
+++ b/moto/awslambda/models.py
@@ -1222,13 +1222,15 @@ class LambdaStorage(object):
 
         return self._get_version(name, qualifier)
 
-    def list_versions_by_function(self, name: str) -> Iterable[LambdaFunction]:
+    def list_versions_by_function(self, name: str) -> Iterable[Dict[str, Any]]:
         if name not in self._functions:
             return []
 
-        latest = copy.copy(self._functions[name]["latest"])
-        latest.function_arn += ":$LATEST"
-        return [latest] + self._functions[name]["versions"]
+        # No point in copying the entire function-object - copying the configuration only is much quicker
+        latest = copy.copy(self._functions[name]["latest"].get_configuration())
+        latest["FunctionArn"] = latest["FunctionArn"] + ":$LATEST"
+        others = [f.get_configuration() for f in self._functions[name]["versions"]]
+        return [latest] + others
 
     def get_arn(self, arn: str) -> Optional[LambdaFunction]:
         # Function ARN may contain an alias
@@ -1332,15 +1334,16 @@ class LambdaStorage(object):
                 ):
                     del self._functions[name]
 
-    def all(self) -> Iterable[LambdaFunction]:
+    def all(self) -> Iterable[Dict[str, Any]]:
         result = []
 
         for function_group in self._functions.values():
-            latest = copy.deepcopy(function_group["latest"])
-            latest.function_arn = "{}:$LATEST".format(latest.function_arn)
+            latest = copy.deepcopy(function_group["latest"].get_configuration())
+            latest["FunctionArn"] = latest["FunctionArn"] + ":$LATEST"
             result.append(latest)
 
-            result.extend(function_group["versions"])
+            others = [fn.get_configuration() for fn in function_group["versions"]]
+            result.extend(others)
 
         return result
 
@@ -1645,7 +1648,7 @@ class LambdaBackend(BaseBackend):
             function_name_or_arn, qualifier
         )
 
-    def list_versions_by_function(self, function_name: str) -> Iterable[LambdaFunction]:
+    def list_versions_by_function(self, function_name: str) -> Iterable[Dict[str, Any]]:
         return self._lambdas.list_versions_by_function(function_name)
 
     def get_event_source_mapping(self, uuid: str) -> Optional[EventSourceMapping]:
@@ -1693,10 +1696,10 @@ class LambdaBackend(BaseBackend):
 
     def list_functions(
         self, func_version: Optional[str] = None
-    ) -> Iterable[LambdaFunction]:
+    ) -> Iterable[Dict[str, Any]]:
         if func_version == "ALL":
             return self._lambdas.all()
-        return self._lambdas.latest()
+        return [fn.get_configuration() for fn in self._lambdas.latest()]
 
     def send_sqs_batch(self, function_arn: str, messages: Any, queue_arn: str) -> bool:
         success = True

--- a/moto/awslambda/models.py
+++ b/moto/awslambda/models.py
@@ -494,6 +494,13 @@ class LambdaFunction(CloudFormationModel, DockerModel):
 
         self._aliases: Dict[str, LambdaAlias] = dict()
 
+    def __getstate__(self) -> Dict[str, Any]:
+        return {
+            k: v
+            for (k, v) in self.__dict__.items()
+            if k != "_DockerModel__docker_client"
+        }
+
     def set_version(self, version: int) -> None:
         self.function_arn = make_function_ver_arn(
             self.region, self.account_id, self.function_name, version

--- a/moto/awslambda/responses.py
+++ b/moto/awslambda/responses.py
@@ -1,6 +1,6 @@
 import json
 import sys
-from typing import Any, Dict, List, Tuple, Union
+from typing import Any, Dict, Tuple, Union
 from urllib.parse import unquote
 
 from moto.core.utils import path_url
@@ -276,21 +276,14 @@ class LambdaResponse(BaseResponse):
     def _list_functions(self) -> TYPE_RESPONSE:
         querystring = self.querystring
         func_version = querystring.get("FunctionVersion", [None])[0]
-        result: Dict[str, List[Dict[str, Any]]] = {"Functions": []}
-
-        for fn in self.backend.list_functions(func_version):
-            json_data = fn.get_configuration()
-            result["Functions"].append(json_data)
+        result = {"Functions": self.backend.list_functions(func_version)}
 
         return 200, {}, json.dumps(result)
 
     def _list_versions_by_function(self, function_name: str) -> TYPE_RESPONSE:
-        result: Dict[str, Any] = {"Versions": []}
 
-        functions = self.backend.list_versions_by_function(function_name)
-        for fn in functions:
-            json_data = fn.get_configuration()
-            result["Versions"].append(json_data)
+        function_configs = self.backend.list_versions_by_function(function_name)
+        result: Dict[str, Any] = {"Versions": function_configs}
 
         return 200, {}, json.dumps(result)
 

--- a/moto/awslambda/responses.py
+++ b/moto/awslambda/responses.py
@@ -1,6 +1,6 @@
 import json
 import sys
-from typing import Any, Dict, Tuple, Union
+from typing import Any, Dict, List, Tuple, Union
 from urllib.parse import unquote
 
 from moto.core.utils import path_url
@@ -276,14 +276,21 @@ class LambdaResponse(BaseResponse):
     def _list_functions(self) -> TYPE_RESPONSE:
         querystring = self.querystring
         func_version = querystring.get("FunctionVersion", [None])[0]
-        result = {"Functions": self.backend.list_functions(func_version)}
+        result: Dict[str, List[Dict[str, Any]]] = {"Functions": []}
+
+        for fn in self.backend.list_functions(func_version):
+            json_data = fn.get_configuration()
+            result["Functions"].append(json_data)
 
         return 200, {}, json.dumps(result)
 
     def _list_versions_by_function(self, function_name: str) -> TYPE_RESPONSE:
+        result: Dict[str, Any] = {"Versions": []}
 
-        function_configs = self.backend.list_versions_by_function(function_name)
-        result: Dict[str, Any] = {"Versions": function_configs}
+        functions = self.backend.list_versions_by_function(function_name)
+        for fn in functions:
+            json_data = fn.get_configuration()
+            result["Versions"].append(json_data)
 
         return 200, {}, json.dumps(result)
 


### PR DESCRIPTION
When listing functions by versions, we need to return a custom ARN for the latest function. The easiest way is to create a copy of the function, but (in multithreaded applications) this operation occasionally fails with `TypeError: Cannot serialize socket object`. 

This PR fixes this by ensuring that the Docket-client (and  underlying socket) are not included in any copy-operations. This is not a problem, because Moto will always recreate the client if it doesn't exist anymore.

This should fix the current build failures.

Note: This may have been introduced with #5586? Not sure how, but I've only seen the build failures appear after this PR was merged.