### PR TITLE
Add EnableNetworkAddressUsageMetrics to VPC attribute

### DIFF
--- a/moto/ec2/responses/vpcs.py
+++ b/moto/ec2/responses/vpcs.py
@@ -137,8 +137,7 @@ class VPCs(EC2BaseResponse):
 
     def modify_vpc_attribute(self):
         vpc_id = self._get_param("VpcId")
-
-        for attribute in ("EnableDnsSupport", "EnableDnsHostnames"):
+        for attribute in ("EnableDnsSupport", "EnableDnsHostnames", "EnableNetworkAddressUsageMetrics"):
             if self.querystring.get("%s.Value" % attribute):
                 attr_name = camelcase_to_underscores(attribute)
                 attr_value = self.querystring.get("%s.Value" % attribute)[0]

--- a/moto/ec2/responses/vpcs.py
+++ b/moto/ec2/responses/vpcs.py
@@ -137,7 +137,11 @@ class VPCs(EC2BaseResponse):
 
     def modify_vpc_attribute(self):
         vpc_id = self._get_param("VpcId")
-        for attribute in ("EnableDnsSupport", "EnableDnsHostnames", "EnableNetworkAddressUsageMetrics"):
+        for attribute in (
+            "EnableDnsSupport",
+            "EnableDnsHostnames",
+            "EnableNetworkAddressUsageMetrics",
+        ):
             if self.querystring.get("%s.Value" % attribute):
                 attr_name = camelcase_to_underscores(attribute)
                 attr_value = self.querystring.get("%s.Value" % attribute)[0]

--- a/tests/test_ec2/test_vpcs.py
+++ b/tests/test_ec2/test_vpcs.py
@@ -378,6 +378,10 @@ def test_default_vpc():
     attr = response.get("EnableDnsHostnames")
     attr.get("Value").should.equal(True)
 
+    response = default_vpc.describe_attribute(Attribute="enableNetworkAddressUsageMetrics")
+    attr = response.get("EnableNetworkAddressUsageMetrics")
+    attr.get("Value").should.equal(False)
+
 
 @mock_ec2
 def test_non_default_vpc():
@@ -401,6 +405,10 @@ def test_non_default_vpc():
 
     response = vpc.describe_attribute(Attribute="enableDnsHostnames")
     attr = response.get("EnableDnsHostnames")
+    attr.get("Value").should.equal(False)
+
+    response = vpc.describe_attribute(Attribute="enableNetworkAddressUsageMetrics")
+    attr = response.get("EnableNetworkAddressUsageMetrics")
     attr.get("Value").should.equal(False)
 
     # Check Primary CIDR Block Associations
@@ -489,6 +497,26 @@ def test_vpc_modify_enable_dns_hostnames():
     response = vpc.describe_attribute(Attribute="enableDnsHostnames")
     attr = response.get("EnableDnsHostnames")
     attr.get("Value").should.be.ok
+
+
+@mock_ec2
+def test_vpc_modify_enable_network_address_usage_metrics():
+    ec2 = boto3.resource("ec2", region_name="us-west-1")
+
+    # Create the default VPC
+    ec2.create_vpc(CidrBlock="172.31.0.0/16")
+
+    vpc = ec2.create_vpc(CidrBlock="10.0.0.0/16")
+    # Test default values for VPC attributes
+    response = vpc.describe_attribute(Attribute="enableNetworkAddressUsageMetrics")
+    attr = response.get("EnableNetworkAddressUsageMetrics")
+    attr.get("Value").shouldnt.be.ok
+
+    vpc.modify_attribute(EnableNetworkAddressUsageMetrics={"Value": True})
+
+    response = vpc.describe_attribute(Attribute="enableNetworkAddressUsageMetrics")
+    attr = response.get("EnableNetworkAddressUsageMetrics")
+    attr.get("Value").should.equal(True)
 
 
 @mock_ec2

--- a/tests/test_ec2/test_vpcs.py
+++ b/tests/test_ec2/test_vpcs.py
@@ -378,7 +378,9 @@ def test_default_vpc():
     attr = response.get("EnableDnsHostnames")
     attr.get("Value").should.equal(True)
 
-    response = default_vpc.describe_attribute(Attribute="enableNetworkAddressUsageMetrics")
+    response = default_vpc.describe_attribute(
+        Attribute="enableNetworkAddressUsageMetrics"
+    )
     attr = response.get("EnableNetworkAddressUsageMetrics")
     attr.get("Value").should.equal(False)
 

--- a/tests/test_ec2/test_vpcs.py
+++ b/tests/test_ec2/test_vpcs.py
@@ -5,6 +5,7 @@ import boto3
 
 import sure  # noqa # pylint: disable=unused-import
 import random
+import sys
 
 from moto import mock_ec2, settings
 from unittest import SkipTest
@@ -360,6 +361,10 @@ def test_vpc_get_by_tag_value_subset():
 
 @mock_ec2
 def test_default_vpc():
+    if sys.version_info < (3, 7):
+        raise SkipTest(
+            "Cannot test this in Py3.6; outdated botocore dependencies do not have all regions"
+        )
     ec2 = boto3.resource("ec2", region_name="us-west-1")
 
     # Create the default VPC
@@ -387,6 +392,10 @@ def test_default_vpc():
 
 @mock_ec2
 def test_non_default_vpc():
+    if sys.version_info < (3, 7):
+        raise SkipTest(
+            "Cannot test this in Py3.6; outdated botocore dependencies do not have all regions"
+        )
     ec2 = boto3.resource("ec2", region_name="us-west-1")
 
     # Create the default VPC - this already exists when backend instantiated!
@@ -503,6 +512,10 @@ def test_vpc_modify_enable_dns_hostnames():
 
 @mock_ec2
 def test_vpc_modify_enable_network_address_usage_metrics():
+    if sys.version_info < (3, 7):
+        raise SkipTest(
+            "Cannot test this in Py3.6; outdated botocore dependencies do not have all regions"
+        )
     ec2 = boto3.resource("ec2", region_name="us-west-1")
 
     # Create the default VPC


### PR DESCRIPTION
Adds support for `enableNetworkAddressUsageMetrics` to be used in `modify_vpc_attribute()` and `describe_attribute()` calls to the Ec2 service.