### PR TITLE
TechDebt - Unpin coverage-dependency to speed up Py3.11

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -104,8 +104,6 @@ jobs:
         pip install -r requirements-dev.txt
         pip install pytest-cov
         pip install pytest-github-actions-annotate-failures
-        # https://github.com/aws/aws-xray-sdk-python/issues/196
-        pip install "coverage<=4.5.4"
     - name: Test with pytest
       run: |
         make test-only
@@ -153,7 +151,6 @@ jobs:
     - name: Install project dependencies
       run: |
         pip install -r requirements-dev.txt
-        pip install "coverage<=4.5.4"
     - name: Test ServerMode/Coverage
       env:
         TEST_SERVER_MODE: ${{ true }}

--- a/Makefile
+++ b/Makefile
@@ -6,11 +6,11 @@ TEST_NAMES = "*"
 ifeq ($(TEST_SERVER_MODE), true)
 	# exclude test_kinesisvideoarchivedmedia
 	# because testing with moto_server is difficult with data-endpoint
-	TEST_EXCLUDE := --ignore tests/test_kinesisvideoarchivedmedia --ignore tests/test_awslambda --ignore tests/test_batch --ignore tests/test_ec2 --ignore tests/test_sqs --ignore tests/test_xray
+	TEST_EXCLUDE := --ignore tests/test_kinesisvideoarchivedmedia --ignore tests/test_awslambda --ignore tests/test_batch --ignore tests/test_ec2 --ignore tests/test_sqs
 	# Parallel tests will be run separate
 	PARALLEL_TESTS := ./tests/test_awslambda ./tests/test_batch ./tests/test_ec2 ./tests/test_sqs
 else
-	TEST_EXCLUDE := --ignore tests/test_batch --ignore tests/test_ec2 --ignore tests/test_sqs --ignore tests/test_xray
+	TEST_EXCLUDE := --ignore tests/test_batch --ignore tests/test_ec2 --ignore tests/test_sqs
 	PARALLEL_TESTS := ./tests/test_batch ./tests/test_ec2 ./tests/test_sqs
 endif
 
@@ -37,7 +37,7 @@ test-only:
 	rm -f .coverage
 	rm -rf cover
 	pytest -sv --cov=moto --cov-report xml ./tests/ $(TEST_EXCLUDE)
-	# https://github.com/aws/aws-xray-sdk-python/issues/196
+	# https://github.com/aws/aws-xray-sdk-python/issues/196 - Run these tests separately without Coverage enabled
 	pytest -sv ./tests/test_xray
 	MOTO_CALL_RESET_API=false pytest --cov=moto --cov-report xml --cov-append -n 4 $(PARALLEL_TESTS)
 

--- a/Makefile
+++ b/Makefile
@@ -6,11 +6,11 @@ TEST_NAMES = "*"
 ifeq ($(TEST_SERVER_MODE), true)
 	# exclude test_kinesisvideoarchivedmedia
 	# because testing with moto_server is difficult with data-endpoint
-	TEST_EXCLUDE := --ignore tests/test_kinesisvideoarchivedmedia --ignore tests/test_awslambda --ignore tests/test_batch --ignore tests/test_ec2 --ignore tests/test_sqs
+	TEST_EXCLUDE := --ignore tests/test_kinesisvideoarchivedmedia --ignore tests/test_awslambda --ignore tests/test_batch --ignore tests/test_ec2 --ignore tests/test_sqs --ignore tests/test_xray
 	# Parallel tests will be run separate
 	PARALLEL_TESTS := ./tests/test_awslambda ./tests/test_batch ./tests/test_ec2 ./tests/test_sqs
 else
-	TEST_EXCLUDE := --ignore tests/test_batch --ignore tests/test_ec2 --ignore tests/test_sqs
+	TEST_EXCLUDE := --ignore tests/test_batch --ignore tests/test_ec2 --ignore tests/test_sqs --ignore tests/test_xray
 	PARALLEL_TESTS := ./tests/test_batch ./tests/test_ec2 ./tests/test_sqs
 endif
 
@@ -37,6 +37,8 @@ test-only:
 	rm -f .coverage
 	rm -rf cover
 	pytest -sv --cov=moto --cov-report xml ./tests/ $(TEST_EXCLUDE)
+	# https://github.com/aws/aws-xray-sdk-python/issues/196
+	pytest -sv ./tests/test_xray
 	MOTO_CALL_RESET_API=false pytest --cov=moto --cov-report xml --cov-append -n 4 $(PARALLEL_TESTS)
 
 test: lint test-only

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -1,3 +1,4 @@
+coverage
 pytest
 pytest-cov
 pytest-xdist

--- a/tests/test_xray/test_xray_client.py
+++ b/tests/test_xray/test_xray_client.py
@@ -1,6 +1,11 @@
+import os
+
 from moto import mock_xray_client, XRaySegment, mock_dynamodb
+from moto.utilities.distutils_version import LooseVersion
+from unittest import SkipTest
 import sure  # noqa # pylint: disable=unused-import
 import boto3
+import sys
 
 from moto.xray.mock_client import MockEmitter
 import aws_xray_sdk.core as xray_core
@@ -18,9 +23,27 @@ original_session_request = requests.Session.request
 original_session_prep_request = requests.Session.prepare_request
 
 
+def check_coverage_status():
+    # If the wrong version of the coverage module is loaded, skip this test
+    coverage_module = sys.modules.get("coverage")
+    # If Coverage is not installed, we're fine
+    if not coverage_module:
+        return
+    coverage_version = LooseVersion(coverage_module.__version__)
+    # If we have an old version of Coverage installed, we're fine
+    if coverage_version < LooseVersion("5.0.0"):
+        return
+    # If Coverage is not enabled in this test run, we're fine
+    if "COV_CORE_SOURCE" not in os.environ:
+        return
+    raise SkipTest("Can't run this test with Coverage 5.x")
+
+
 @mock_xray_client
 @mock_dynamodb
 def test_xray_dynamo_request_id():
+    check_coverage_status()
+
     # Could be ran in any order, so we need to tell sdk that its been unpatched
     xray_core_patcher._PATCHED_MODULES = set()
     xray_core.patch_all()
@@ -46,6 +69,8 @@ def test_xray_dynamo_request_id():
 
 
 def test_xray_dynamo_request_id_with_context_mgr():
+    check_coverage_status()
+
     with mock_xray_client():
         assert isinstance(xray_core.xray_recorder._emitter, MockEmitter)
         with mock_dynamodb():
@@ -82,6 +107,8 @@ def test_xray_dynamo_request_id_with_context_mgr():
 
 @mock_xray_client
 def test_xray_udp_emitter_patched():
+    check_coverage_status()
+
     # Could be ran in any order, so we need to tell sdk that its been unpatched
     xray_core_patcher._PATCHED_MODULES = set()
     xray_core.patch_all()
@@ -96,6 +123,8 @@ def test_xray_udp_emitter_patched():
 
 @mock_xray_client
 def test_xray_context_patched():
+    check_coverage_status()
+
     # Could be ran in any order, so we need to tell sdk that its been unpatched
     xray_core_patcher._PATCHED_MODULES = set()
     xray_core.patch_all()


### PR DESCRIPTION
Unpins `coverage`-dependency. This was pinned int he first place due to a incompatibility with the XRay SDK - see https://github.com/aws/aws-xray-sdk-python/issues/196.

This means that the XRay tests have to be run separately, without the coverage enabled.

