### PR TITLE
Add organizations delete_organizational_unit

### DIFF
--- a/moto/organizations/models.py
+++ b/moto/organizations/models.py
@@ -405,6 +405,13 @@ class OrganizationsBackend(BaseBackend):
         self.attach_policy(PolicyId=utils.DEFAULT_POLICY_ID, TargetId=new_ou.id)
         return new_ou.describe()
 
+    def delete_organizational_unit(self, **kwargs):
+        ou_to_delete = self.get_organizational_unit_by_id(
+            kwargs["OrganizationalUnitId"]
+        )
+        self.ou.remove(ou_to_delete)
+        return {}
+
     def update_organizational_unit(self, **kwargs):
         for ou in self.ou:
             if ou.name == kwargs["Name"]:

--- a/moto/organizations/responses.py
+++ b/moto/organizations/responses.py
@@ -41,6 +41,11 @@ class OrganizationsResponse(BaseResponse):
             self.organizations_backend.create_organizational_unit(**self.request_params)
         )
 
+    def delete_organizational_unit(self):
+        return json.dumps(
+            self.organizations_backend.delete_organizational_unit(**self.request_params)
+        )
+
     def update_organizational_unit(self):
         return json.dumps(
             self.organizations_backend.update_organizational_unit(**self.request_params)

--- a/tests/test_organizations/test_organizations_boto3.py
+++ b/tests/test_organizations/test_organizations_boto3.py
@@ -111,6 +111,20 @@ def test_create_organizational_unit():
 
 
 @mock_organizations
+def test_delete_organizational_unit():
+    client = boto3.client("organizations", region_name="us-east-1")
+    org = client.create_organization(FeatureSet="ALL")["Organization"]
+    root_id = client.list_roots()["Roots"][0]["Id"]
+    ou_name = "ou01"
+    response = client.create_organizational_unit(ParentId=root_id, Name=ou_name)
+    validate_organizational_unit(org, response)
+    response = client.delete_organizational_unit(
+        OrganizationalUnitId=response["OrganizationalUnit"]["Id"]
+    )
+    response["ResponseMetadata"]["HTTPStatusCode"].should.equal(200)
+
+
+@mock_organizations
 def test_describe_organizational_unit():
     client = boto3.client("organizations", region_name="us-east-1")
     org = client.create_organization(FeatureSet="ALL")["Organization"]

--- a/tests/test_organizations/test_organizations_boto3.py
+++ b/tests/test_organizations/test_organizations_boto3.py
@@ -118,10 +118,21 @@ def test_delete_organizational_unit():
     ou_name = "ou01"
     response = client.create_organizational_unit(ParentId=root_id, Name=ou_name)
     validate_organizational_unit(org, response)
-    response = client.delete_organizational_unit(
-        OrganizationalUnitId=response["OrganizationalUnit"]["Id"]
-    )
+
+    # delete organizational unit
+    ou_id = response["OrganizationalUnit"]["Id"]
+    response = client.delete_organizational_unit(OrganizationalUnitId=ou_id)
     response["ResponseMetadata"]["HTTPStatusCode"].should.equal(200)
+
+    # verify the deletion
+    with pytest.raises(ClientError) as e:
+        client.describe_organizational_unit(OrganizationalUnitId=ou_id)
+    ex = e.value
+    ex.operation_name.should.equal("DescribeOrganizationalUnit")
+    ex.response["Error"]["Code"].should.equal("400")
+    ex.response["Error"]["Message"].should.contain(
+        "OrganizationalUnitNotFoundException"
+    )
 
 
 @mock_organizations


### PR DESCRIPTION
This PR adds the endpoint [delete_organizational_unit](https://docs.aws.amazon.com/organizations/latest/APIReference/API_DeleteOrganizationalUnit.html) within Organizations.

Happy to adjust it, it's my first time adding functionality to moto.. 