### PR TITLE
Fix Race Condition in Parallel AWS Lambda Server Mode Tests

### DIFF
--- a/tests/test_awslambda/utilities.py
+++ b/tests/test_awslambda/utilities.py
@@ -166,14 +166,18 @@ def create_invalid_lambda(role):
 def get_role_name():
     with mock_iam():
         iam = boto3.client("iam", region_name=_lambda_region)
-        try:
-            return iam.get_role(RoleName="my-role")["Role"]["Arn"]
-        except ClientError:
-            return iam.create_role(
-                RoleName="my-role",
-                AssumeRolePolicyDocument="some policy",
-                Path="/my-path/",
-            )["Role"]["Arn"]
+        while True:
+            try:
+                return iam.get_role(RoleName="my-role")["Role"]["Arn"]
+            except ClientError:
+                try:
+                    return iam.create_role(
+                        RoleName="my-role",
+                        AssumeRolePolicyDocument="some policy",
+                        Path="/my-path/",
+                    )["Role"]["Arn"]
+                except ClientError:
+                    pass
 
 
 def wait_for_log_msg(expected_msg, log_group, wait_time=30):


### PR DESCRIPTION
When the Server Mode tests are run in parallel, it's possible for multiple tests to call `get_role_name` at approximately the same time.  When this happens at the beginning of a test run--before `my-role` has been created--the call to `iam.get_role` can fail for more than one caller, all of whom then attempt to execute `iam.create_role`.  The first call to `iam.create_role` will succeed, but all others will result in an `EntityAlreadyExistsException`, which was not handled by the original code and would result in the test failing.

This updated code wraps the entire process in an infinite loop and adds an exception clause for the `iam.create_role` call, which simply passes, allowing the loop to attempt the `iam.get_role` call again.

An explicit test case has been added, which was failing 100% of the time prior to the included `get_role_name` code changes.  Unfortunately, neither the `boto3` client nor our own `IAMBackend` class are thread-safe, so the test itself also includes an infinite retry loop in order to be deterministic and avoid creating another flaky test that fails intermittently.

Note: Normally, infinite loops like this would be a Bad Idea, but this code is only run as part of the test suite (and not `moto` itself) and I simply encountered too many multithreading edge cases to find a suitable alternative. 

Closes #5642 