### PR TITLE
Update pytest and pytest-xdist to the latest versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ def get_version():
 install_requires = [
     "boto3>=1.9.201",
     "botocore>=1.12.201",
-    "cryptography>=3.3.1",
+    "cryptography>=38.0.3",
     "requests>=2.5",
     "xmltodict",
     "werkzeug>=0.5,!=2.2.0,!=2.2.1",


### PR DESCRIPTION
# Overview

This work updates the cryptography module to the latest version in the setup.py file. The current version was set to be >=3.3.1 and the latest is 38.0.3. In Sept 2021, the cryptography releases went from 3.4.8 to 35.0.0 which is why the version bump seems so huge.

# Rationale

The service I'm working on at work uses moto. The version of cryptography that gets installed triggers a dependabot warning: Vulnerable OpenSSL included in cryptography wheels. I noticed that the version in use in the moto dependencies was a ways off from the unaffected version, so I decided to make this PR to update it.
