### PR TITLE
Replace email with username in cogntio JWT tokens

### DIFF
--- a/moto/cognitoidp/models.py
+++ b/moto/cognitoidp/models.py
@@ -539,7 +539,7 @@ class CognitoIdpUserPool(BaseModel):
             "token_use": token_use,
             "auth_time": now,
             "exp": now + expires_in,
-            "email": flatten_attrs(self._get_user(username).attributes).get("email"),
+            "username": username,
         }
         payload.update(extra_data or {})
         headers = {"kid": "dummy"}  # KID as present in jwks-public.json

--- a/tests/test_cognitoidp/test_cognitoidp.py
+++ b/tests/test_cognitoidp/test_cognitoidp.py
@@ -2838,6 +2838,7 @@ def test_token_legitimacy():
         id_token = outputs["id_token"]
         access_token = outputs["access_token"]
         client_id = outputs["client_id"]
+        username = outputs["username"]
         issuer = "https://cognito-idp.us-west-2.amazonaws.com/{}".format(
             outputs["user_pool_id"]
         )
@@ -2851,6 +2852,7 @@ def test_token_legitimacy():
         access_claims["iss"].should.equal(issuer)
         access_claims["aud"].should.equal(client_id)
         access_claims["token_use"].should.equal("access")
+        access_claims["username"].should.equal(username)
 
 
 @mock_cognitoidp


### PR DESCRIPTION
According to [documentation](https://docs.aws.amazon.com/cognito/latest/developerguide/amazon-cognito-user-pools-using-the-access-token.html) JWT token must contain "username" and not `email`. In edge case, `username` can contain `sub` as value, but implementation of this package does not support that situation, so simply `email` was replaced with `username`.