### PR TITLE
Events: delete_rule() with unknown name should fail silently

### DIFF
--- a/moto/events/models.py
+++ b/moto/events/models.py
@@ -1068,15 +1068,17 @@ class EventsBackend(BaseBackend):
 
         return rule
 
-    def delete_rule(self, name):
+    def delete_rule(self, name: str) -> None:
         rule = self.rules.get(name)
+        if not rule:
+            return
         if len(rule.targets) > 0:
             raise ValidationException("Rule can't be deleted since it has targets.")
 
         arn = rule.arn
         if self.tagger.has_tags(arn):
             self.tagger.delete_all_tags_for_resource(arn)
-        return self.rules.pop(name) is not None
+        self.rules.pop(name)
 
     def describe_rule(self, name):
         rule = self.rules.get(name)

--- a/tests/test_events/test_events.py
+++ b/tests/test_events/test_events.py
@@ -325,6 +325,15 @@ def test_delete_rule_with_targets():
 
 
 @mock_events
+def test_delete_unknown_rule():
+    client = boto3.client("events", "us-west-1")
+    resp = client.delete_rule(Name="unknown")
+
+    # this fails silently - it just returns an empty 200. Verified against AWS.
+    resp["ResponseMetadata"].should.have.key("HTTPStatusCode").equals(200)
+
+
+@mock_events
 def test_list_targets_by_rule():
     rule_name = get_random_rule()["Name"]
     client = generate_environment()


### PR DESCRIPTION
See #5631 