### PR TITLE
[SWF] runId should be optional

### DIFF
--- a/moto/swf/responses.py
+++ b/moto/swf/responses.py
@@ -542,7 +542,7 @@ class SWFResponse(BaseResponse):
         signal_name = self._params["signalName"]
         workflow_id = self._params["workflowId"]
         _input = self._params["input"]
-        run_id = self._params["runId"]
+        run_id = self._params.get("runId")
 
         self._check_string(domain_name)
         self._check_string(signal_name)

--- a/tests/test_swf/responses/test_workflow_executions.py
+++ b/tests/test_swf/responses/test_workflow_executions.py
@@ -70,6 +70,31 @@ def test_signal_workflow_execution_boto3():
 
 
 @mock_swf
+def test_signal_workflow_execution_without_runId():
+    conn = setup_swf_environment_boto3()
+    hsh = conn.start_workflow_execution(
+        domain="test-domain",
+        workflowId="uid-abcd1234",
+        workflowType={"name": "test-workflow", "version": "v1.0"},
+    )
+    run_id = hsh["runId"]
+
+    wfe = conn.signal_workflow_execution(
+        domain="test-domain",
+        signalName="my_signal",
+        workflowId="uid-abcd1234",
+        input="my_input",
+    )
+
+    resp = conn.get_workflow_execution_history(
+        domain="test-domain", execution={"runId": run_id, "workflowId": "uid-abcd1234"}
+    )
+
+    types = [evt["eventType"] for evt in resp["events"]]
+    types.should.contain("WorkflowExecutionSignaled")
+
+
+@mock_swf
 def test_start_already_started_workflow_execution_boto3():
     client = setup_swf_environment_boto3()
     client.start_workflow_execution(

--- a/tests/test_swf/responses/test_workflow_executions.py
+++ b/tests/test_swf/responses/test_workflow_executions.py
@@ -79,7 +79,7 @@ def test_signal_workflow_execution_without_runId():
     )
     run_id = hsh["runId"]
 
-    wfe = conn.signal_workflow_execution(
+    conn.signal_workflow_execution(
         domain="test-domain",
         signalName="my_signal",
         workflowId="uid-abcd1234",


### PR DESCRIPTION
> If a runId isn't specified, then the WorkflowExecutionSignaled event is recorded in the history of the current open workflow with the matching workflowId in the domain.

See https://docs.aws.amazon.com/amazonswf/latest/apireference/API_SignalWorkflowExecution.html