### PR TITLE
[SWF] Schedule a single task if another is started

### DIFF
--- a/tests/test_swf/models/test_workflow_execution.py
+++ b/tests/test_swf/models/test_workflow_execution.py
@@ -220,6 +220,33 @@ def test_workflow_execution_schedule_decision_task():
     wfe.open_counts["openDecisionTasks"].should.equal(1)
 
 
+def test_workflow_execution_dont_schedule_decision_if_existing_started_and_other_scheduled():
+    wfe = make_workflow_execution()
+    wfe.open_counts["openDecisionTasks"].should.equal(0)
+
+    wfe.schedule_decision_task()
+    wfe.open_counts["openDecisionTasks"].should.equal(1)
+
+    wfe.decision_tasks[0].start("evt_id")
+
+    wfe.schedule_decision_task()
+    wfe.schedule_decision_task()
+    wfe.open_counts["openDecisionTasks"].should.equal(2)
+
+
+def test_workflow_execution_schedule_decision_if_existing_started_and_no_other_scheduled():
+    wfe = make_workflow_execution()
+    wfe.open_counts["openDecisionTasks"].should.equal(0)
+
+    wfe.schedule_decision_task()
+    wfe.open_counts["openDecisionTasks"].should.equal(1)
+
+    wfe.decision_tasks[0].start("evt_id")
+
+    wfe.schedule_decision_task()
+    wfe.open_counts["openDecisionTasks"].should.equal(2)
+
+
 def test_workflow_execution_start_decision_task():
     wfe = make_workflow_execution()
     wfe.schedule_decision_task()


### PR DESCRIPTION
> If something occurs that generates a decision task while a decider is processing another decision task, Amazon SWF queues the new task until the current task completes. After the current task completes, Amazon SWF makes the new decision task available. Also, decision tasks are batched in the sense that, if multiple activities complete while a decider is processing a decision task, Amazon SWF will create only a single new decision task to account for the multiple task completions. However, each task completion will receive an individual event in the workflow execution history.

See https://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dg-dev-deciders.html#swf-dg-deciders-launch