### PR TITLE
fix(add-secret): SecretString can be None

### DIFF
--- a/moto/secretsmanager/models.py
+++ b/moto/secretsmanager/models.py
@@ -522,9 +522,14 @@ class SecretsManagerBackend(BaseBackend):
         # We add the new secret version as "pending". The previous version remains
         # as "current" for now. Once we've passed the new secret through the lambda
         # rotation function (if provided) we can then update the status to "current".
+        old_secret_version_secret_string = (
+            old_secret_version["secret_string"]
+            if "secret_string" in old_secret_version
+            else None
+        )
         self._add_secret(
             secret_id,
-            old_secret_version["secret_string"],
+            old_secret_version_secret_string,
             description=secret.description,
             tags=secret.tags,
             version_id=new_version_id,

--- a/tests/test_secretsmanager/test_secretsmanager.py
+++ b/tests/test_secretsmanager/test_secretsmanager.py
@@ -647,6 +647,22 @@ def test_rotate_secret():
 
 
 @mock_secretsmanager
+def test_rotate_secret_without_secretstring():
+    conn = boto3.client("secretsmanager", region_name="us-west-2")
+    conn.create_secret(Name=DEFAULT_SECRET_NAME, Description="foodescription")
+
+    rotated_secret = conn.rotate_secret(SecretId=DEFAULT_SECRET_NAME)
+
+    assert rotated_secret
+    assert rotated_secret["ARN"] == rotated_secret["ARN"]
+    assert rotated_secret["Name"] == DEFAULT_SECRET_NAME
+    assert rotated_secret["VersionId"] == rotated_secret["VersionId"]
+
+    describe_secret = conn.describe_secret(SecretId=DEFAULT_SECRET_NAME)
+    assert describe_secret["Description"] == "foodescription"
+
+
+@mock_secretsmanager
 def test_rotate_secret_enable_rotation():
     conn = boto3.client("secretsmanager", region_name="us-west-2")
     conn.create_secret(Name=DEFAULT_SECRET_NAME, SecretString="foosecret")


### PR DESCRIPTION
#### Description

As per Boto3 documentation the `SecretString` `create_secret` API parameter is not required. 

So if you try to enable rotation in a previously created secret without a `SecretString`, the moto `rotate_secret` fails with a `KeyError` due to the inexistence of `old_secret_version["secret_string"]`


```python
@mock_secretsmanager
    def test_create_and_rotate_secret(self):
        secretsmanager_client = client("secretsmanager", region_name="eu-west-1")
        # Create Secret
        resp = secretsmanager_client.create_secret(
            Name="test-secret"
        )
        secret_arn = resp["ARN"]
        secret_name = resp["Name"]
        # Enable Rotation
        secretsmanager_client.rotate_secret( # <-- this call fails with a KeyError
            SecretId=secret_arn,
        ) 
```