### PR TITLE
Fix IfModifiedSince handling in S3 get_object/head_object

### DIFF
--- a/moto/s3/responses.py
+++ b/moto/s3/responses.py
@@ -1285,14 +1285,14 @@ class S3Response(BaseResponse):
             raise InvalidObjectState(storage_class="GLACIER")
         if if_unmodified_since:
             if_unmodified_since = str_to_rfc_1123_datetime(if_unmodified_since)
-            if key.last_modified > if_unmodified_since:
+            if key.last_modified.replace(microsecond=0) > if_unmodified_since:
                 raise PreconditionFailed("If-Unmodified-Since")
         if if_match and key.etag not in [if_match, '"{0}"'.format(if_match)]:
             raise PreconditionFailed("If-Match")
 
         if if_modified_since:
             if_modified_since = str_to_rfc_1123_datetime(if_modified_since)
-            if key.last_modified < if_modified_since:
+            if key.last_modified.replace(microsecond=0) <= if_modified_since:
                 return 304, response_headers, "Not Modified"
         if if_none_match and key.etag == if_none_match:
             return 304, response_headers, "Not Modified"
@@ -1575,14 +1575,14 @@ class S3Response(BaseResponse):
 
             if if_unmodified_since:
                 if_unmodified_since = str_to_rfc_1123_datetime(if_unmodified_since)
-                if key.last_modified > if_unmodified_since:
+                if key.last_modified.replace(microsecond=0) > if_unmodified_since:
                     return 412, response_headers, ""
             if if_match and key.etag != if_match:
                 return 412, response_headers, ""
 
             if if_modified_since:
                 if_modified_since = str_to_rfc_1123_datetime(if_modified_since)
-                if key.last_modified < if_modified_since:
+                if key.last_modified.replace(microsecond=0) <= if_modified_since:
                     return 304, response_headers, "Not Modified"
             if if_none_match and key.etag == if_none_match:
                 return 304, response_headers, "Not Modified"

--- a/tests/test_s3/test_s3.py
+++ b/tests/test_s3/test_s3.py
@@ -1633,7 +1633,7 @@ def test_get_object_if_modified_since_refresh():
         s3.get_object(
             Bucket=bucket_name,
             Key=key,
-            IfModifiedSince=response['LastModified'],
+            IfModifiedSince=response["LastModified"],
         )
     e = err.value
     e.response["Error"].should.equal({"Code": "304", "Message": "Not Modified"})
@@ -1749,7 +1749,7 @@ def test_head_object_if_modified_since_refresh():
         s3.head_object(
             Bucket=bucket_name,
             Key=key,
-            IfModifiedSince=response['LastModified'],
+            IfModifiedSince=response["LastModified"],
         )
     e = err.value
     e.response["Error"].should.equal({"Code": "304", "Message": "Not Modified"})

--- a/tests/test_s3/test_s3.py
+++ b/tests/test_s3/test_s3.py
@@ -1734,6 +1734,28 @@ def test_head_object_if_modified_since():
 
 
 @mock_s3
+def test_head_object_if_modified_since_refresh():
+    s3 = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
+    bucket_name = "blah"
+    s3.create_bucket(Bucket=bucket_name)
+
+    key = "hello.txt"
+
+    s3.put_object(Bucket=bucket_name, Key=key, Body="test")
+
+    response = s3.head_object(Bucket=bucket_name, Key=key)
+
+    with pytest.raises(botocore.exceptions.ClientError) as err:
+        s3.head_object(
+            Bucket=bucket_name,
+            Key=key,
+            IfModifiedSince=response['LastModified'],
+        )
+    e = err.value
+    e.response["Error"].should.equal({"Code": "304", "Message": "Not Modified"})
+
+
+@mock_s3
 def test_head_object_if_unmodified_since():
     s3 = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
     bucket_name = "blah"


### PR DESCRIPTION
I think the most common use case for IfModifiedSince is:

1. Call get_object
2. Remember the LastModified date
3. Call get_object again with IfModifiedSince=LastModified to only get the object if it has changed

The implementation in moto currently doesn't work for two reasons:

1. The check for returning 'NotModified should include the case when LastModified == IfModifiedSince.
2. The returned timestamps are truncated to seconds, but the internally stored ones include microseconds, so the directly comparing them doesn't work. I initially wanted to truncate the internal datetimes, but that changes a very large number of tests, because some hashes change.