### PR TITLE
Timestreamwrite: Add regions

### DIFF
--- a/moto/timestreamwrite/models.py
+++ b/moto/timestreamwrite/models.py
@@ -217,5 +217,7 @@ timestreamwrite_backends = BackendDict(
         "us-west-2",
         "eu-central-1",
         "eu-west-1",
+        "ap-southeast-2",
+        "ap-northeast-1",
     ],
 )


### PR DESCRIPTION
Timestream is available in these regions.
-  Asia Pacific (Sydney) | ap-southeast-2
-  Asia Pacific (Tokyo) | ap-northeast-1


