### PR TITLE
WIP fix: Add support for `ReturnValuesOnConditionCheckFailure=ALL_OLD`

### DIFF
--- a/moto/dynamodb/models/__init__.py
+++ b/moto/dynamodb/models/__init__.py
@@ -1701,6 +1701,17 @@ class DynamoDBBackend(BaseBackend):
                     expression_attribute_values = item.get(
                         "ExpressionAttributeValues", None
                     )
+
+                    return_values_on_condition_check_failure = item.get(
+                        "ReturnValuesOnConditionCheckFailure", None
+                    )
+                    current = self.get_item(table_name, attrs)
+                    if (
+                        return_values_on_condition_check_failure == "ALL_OLD"
+                        and current
+                    ):
+                        item["Item"] = current.to_json()["Attributes"]
+
                     self.put_item(
                         table_name,
                         attrs,


### PR DESCRIPTION
`ReturnValuesOnConditionCheckFailure` supports `ALL_OLD` which returns the existing item.

The fix for `https://github.com/spulec/moto/pull/5482` goes some of the way!

Please excuse my code, I haven't edited this repository before - feel free to change my commit, or suggest edits.

AWS documentation is here:
https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_ConditionCheck.html#DDB-Type-ConditionCheck-ReturnValuesOnConditionCheckFailure