### PR TITLE
Fix: RDS server test should use Query protocol

### DIFF
--- a/tests/test_rds/test_server.py
+++ b/tests/test_rds/test_server.py
@@ -1,4 +1,4 @@
-import json
+from urllib.parse import urlencode
 import moto.server as server
 import sure  # noqa # pylint: disable=unused-import
 
@@ -16,18 +16,20 @@ def test_create_db_instance():
     backend = server.create_backend_app("rds")
     test_client = backend.test_client()
 
-    body = {
+    params = {
+        "Action": "CreateDBInstance",
         "DBInstanceIdentifier": "hi",
         "DBInstanceClass": "db.m4.large",
         "Engine": "aurora",
         "StorageType": "standard",
         "Port": 3306,
     }
-    res = test_client.post("/?Action=CreateDBInstance", data=json.dumps(body))
+    qs = urlencode(params)
+    resp = test_client.post(f"/?{qs}")
 
-    response = res.data.decode("utf-8")
+    response = resp.data.decode("utf-8")
     response.shouldnt.contain("<DBClusterIdentifier>")
-
+    response.should.contain("<DBInstanceIdentifier>hi</DBInstanceIdentifier")
     # We do not pass these values - they should default to false
     response.should.contain("<MultiAZ>false</MultiAZ>")
     response.should.contain(


### PR DESCRIPTION
Test was incorrectly using JSON encoding in the body of the request, but RDS uses the Query protocol, which requires querystring-encoded parameters.

Note: This test has been passing because moto is extremely liberal when parsing incoming data, but it was fundamentally incorrect behavior and could break in the future if `moto` ever adheres more strictly to the AWS wire protocols when handling incoming requests.