### PR TITLE
Let `create_function` reference ECR via ImageUri

### DIFF
--- a/moto/awslambda/models.py
+++ b/moto/awslambda/models.py
@@ -483,24 +483,29 @@ class LambdaFunction(CloudFormationModel, DockerModel):
                 self.code_size = 0
                 self.code_sha_256 = ""
         elif "ImageUri" in self.code:
-            uri, tag = self.code["ImageUri"].split(":")
-            repo_name = uri.split("/")[-1]
-            image_id = {"imageTag": tag}
-
-            ecr_backend = ecr_backends[self.account_id][self.region]
-            registry_id = ecr_backend.describe_registry()["registryId"]
-
-            images = ecr_backend.batch_get_image(
-                repository_name=repo_name, image_ids=[image_id]
-            )["images"]
-
-            if len(images) == 0:
-                raise ImageNotFoundException(image_id, repo_name, registry_id)  # type: ignore
-            else:
-                self.code_sha_256 = images[0]["imageId"]["imageDigest"].replace(
-                    "sha256:", ""
-                )
+            if settings.lambda_stub_ecr():
+                self.code_sha_256 = hashlib.sha256(
+                    self.code["ImageUri"].encode("utf-8")
+                ).hexdigest()
                 self.code_size = 0
+            else:
+                uri, tag = self.code["ImageUri"].split(":")
+                repo_name = uri.split("/")[-1]
+                image_id = {"imageTag": tag}
+                ecr_backend = ecr_backends[self.account_id][self.region]
+                registry_id = ecr_backend.describe_registry()["registryId"]
+                images = ecr_backend.batch_get_image(
+                    repository_name=repo_name, image_ids=[image_id]
+                )["images"]
+
+                if len(images) == 0:
+                    raise ImageNotFoundException(image_id, repo_name, registry_id)  # type: ignore
+                else:
+                    manifest = json.loads(images[0]["imageManifest"])
+                    self.code_sha_256 = images[0]["imageId"]["imageDigest"].replace(
+                        "sha256:", ""
+                    )
+                    self.code_size = manifest["config"]["size"]
 
         self.function_arn = make_function_arn(
             self.region, self.account_id, self.function_name

--- a/moto/awslambda/models.py
+++ b/moto/awslambda/models.py
@@ -497,7 +497,9 @@ class LambdaFunction(CloudFormationModel, DockerModel):
             if len(images) == 0:
                 raise ImageNotFoundException(image_id, repo_name, registry_id)  # type: ignore
             else:
-                self.code_sha_256 = images[0]["imageId"]["imageDigest"]
+                self.code_sha_256 = images[0]["imageId"]["imageDigest"].replace(
+                    "sha256:", ""
+                )
                 self.code_size = 0
 
         self.function_arn = make_function_arn(

--- a/moto/awslambda/models.py
+++ b/moto/awslambda/models.py
@@ -28,9 +28,11 @@ from moto.core.exceptions import RESTError
 from moto.core.utils import unix_time_millis
 from moto.iam.models import iam_backends
 from moto.iam.exceptions import IAMNotFoundException
+from moto.ecr.exceptions import ImageNotFoundException
 from moto.logs.models import logs_backends
 from moto.moto_api._internal import mock_random as random
 from moto.s3.models import s3_backends, FakeKey
+from moto.ecr.models import ecr_backends
 from moto.s3.exceptions import MissingBucket, MissingKey
 from moto import settings
 from .exceptions import (
@@ -481,10 +483,22 @@ class LambdaFunction(CloudFormationModel, DockerModel):
                 self.code_size = 0
                 self.code_sha_256 = ""
         elif "ImageUri" in self.code:
-            self.code_sha_256 = hashlib.sha256(
-                self.code["ImageUri"].encode("utf-8")
-            ).hexdigest()
-            self.code_size = 0
+            uri, tag = self.code["ImageUri"].split(":")
+            repo_name = uri.split("/")[-1]
+            image_id = {"imageTag": tag}
+
+            ecr_backend = ecr_backends[self.account_id][self.region]
+            registry_id = ecr_backend.describe_registry()["registryId"]
+
+            images = ecr_backend.batch_get_image(
+                repository_name=repo_name, image_ids=[image_id]
+            )["images"]
+
+            if len(images) == 0:
+                raise ImageNotFoundException(image_id, repo_name, registry_id)  # type: ignore
+            else:
+                self.code_sha_256 = images[0]["imageId"]["imageDigest"]
+                self.code_size = 0
 
         self.function_arn = make_function_arn(
             self.region, self.account_id, self.function_name

--- a/moto/ecr/models.py
+++ b/moto/ecr/models.py
@@ -249,9 +249,11 @@ class Image(BaseObject):
         self.last_scan = None
 
     def _create_digest(self):
-        image_contents = f"docker_image{int(random.random() * 10**6)}"
+        image_manifest = json.loads(self.image_manifest)
+        layer_digests = [layer["digest"] for layer in image_manifest["layers"]]
         self.image_digest = (
-            "sha256:" + hashlib.sha256(image_contents.encode("utf-8")).hexdigest()
+            "sha256:"
+            + hashlib.sha256("".join(layer_digests).encode("utf-8")).hexdigest()
         )
 
     def get_image_digest(self):

--- a/moto/settings.py
+++ b/moto/settings.py
@@ -73,7 +73,7 @@ def lambda_stub_ecr() -> bool:
     # Whether to stub or mock ecr backend when deploying image based lambdas.
     # True => don't requiring image presence in moto ecr backend for `create_function`.
     # False => require image presence in moto ecr backend for `create_function`
-    return os.environ.get("LAMBDA_STUB_ECR", "TRUE").lower() != "false"
+    return os.environ.get("MOTO_LAMBDA_STUB_ECR", "TRUE").lower() != "false"
 
 
 def moto_server_port() -> str:

--- a/moto/settings.py
+++ b/moto/settings.py
@@ -69,6 +69,13 @@ def allow_unknown_region() -> bool:
     return os.environ.get("MOTO_ALLOW_NONEXISTENT_REGION", "false").lower() == "true"
 
 
+def lambda_stub_ecr() -> bool:
+    # Whether to stub or mock ecr backend when deploying image based lambdas.
+    # True => don't requiring image presence in moto ecr backend for `create_function`.
+    # False => require image presence in moto ecr backend for `create_function`
+    return os.environ.get("LAMBDA_STUB_ECR", "TRUE").lower() != "false"
+
+
 def moto_server_port() -> str:
     return os.environ.get("MOTO_PORT") or "5000"
 

--- a/tests/test_awslambda/test_lambda.py
+++ b/tests/test_awslambda/test_lambda.py
@@ -207,20 +207,26 @@ def test_create_function__with_tracingmode(tracing_mode):
     result.should.have.key("TracingConfig").should.equal({"Mode": output})
 
 
-@mock_ecr
+@pytest.fixture(name="with_ecr")
+def ecr_repo_fixture():
+    with mock_ecr():
+        ecr_client = ecr_client = boto3.client("ecr", "us-east-1")
+        ecr_client.create_repository(repositoryName="testlambdaecr")
+        ecr_client.put_image(
+            repositoryName="testlambdaecr",
+            imageManifest=json.dumps(_create_image_manifest()),
+            imageTag="latest",
+        )
+        yield
+        ecr_client.delete_repository(repositoryName="testlambdaecr", force=True)
+
+
 @mock_lambda
-def test_create_function_from_image():
+def test_create_function_from_image(with_ecr):
     lambda_client = boto3.client("lambda", "us-east-1")
-    ecr_client = boto3.client("ecr", "us-east-1")
-    ecr_client.create_repository(repositoryName="testlambda")
-    ecr_client.put_image(
-        repositoryName="testlambda",
-        imageManifest=json.dumps(_create_image_manifest()),
-        imageTag="latest",
-    )
 
     fn_name = str(uuid4())[0:6]
-    image_uri = f"{ACCOUNT_ID}.dkr.ecr.us-east-1.amazonaws.com/testlambda:latest"
+    image_uri = f"{ACCOUNT_ID}.dkr.ecr.us-east-1.amazonaws.com/testlambdaecr:latest"
 
     dic = {
         "FunctionName": fn_name,
@@ -248,15 +254,12 @@ def test_create_function_from_image():
     code.should.have.key("ResolvedImageUri").equals(resolved_image_uri)
 
 
-@mock_ecr
 @mock_lambda
-def test_create_function_from_missing_image():
+def test_create_function_from_missing_image(with_ecr):
     lambda_client = boto3.client("lambda", "us-east-1")
-    ecr_client = boto3.client("ecr", "us-east-1")
-    ecr_client.create_repository(repositoryName="testlambda")
 
     fn_name = str(uuid4())[0:6]
-    image_uri = f"{ACCOUNT_ID}.dkr.ecr.us-east-1.amazonaws.com/testlambda:dne"
+    image_uri = f"{ACCOUNT_ID}.dkr.ecr.us-east-1.amazonaws.com/testlambdaecr:dne"
 
     dic = {
         "FunctionName": fn_name,
@@ -272,7 +275,7 @@ def test_create_function_from_missing_image():
     err = exc.value.response["Error"]
     err["Code"].should.equal("ImageNotFoundException")
     err["Message"].should.equal(
-        "The image with imageId {'imageTag': 'dne'} does not exist within the repository with name 'testlambda' in the registry with id '123456789012'"
+        "The image with imageId {'imageTag': 'dne'} does not exist within the repository with name 'testlambdaecr' in the registry with id '123456789012'"
     )
 
 

--- a/tests/test_awslambda/test_lambda.py
+++ b/tests/test_awslambda/test_lambda.py
@@ -222,7 +222,7 @@ def ecr_repo_fixture():
 
 
 @mock_lambda
-def test_create_function_from_image(with_ecr):
+def test_create_function_from_image(with_ecr):  # pylint: disable=unused-argument
     lambda_client = boto3.client("lambda", "us-east-1")
 
     fn_name = str(uuid4())[0:6]
@@ -255,7 +255,9 @@ def test_create_function_from_image(with_ecr):
 
 
 @mock_lambda
-def test_create_function_from_missing_image(with_ecr):
+def test_create_function_from_missing_image(
+    with_ecr,
+):  # pylint: disable=unused-argument
     lambda_client = boto3.client("lambda", "us-east-1")
 
     fn_name = str(uuid4())[0:6]

--- a/tests/test_ecr/test_ecr_helpers.py
+++ b/tests/test_ecr/test_ecr_helpers.py
@@ -33,7 +33,7 @@ def _create_image_manifest(image_digest=None):
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "config": {
             "mediaType": "application/vnd.docker.container.image.v1+json",
-            "size": 7023,
+            "size": sum([layer["size"] for layer in layers]),
             "digest": image_digest,
         },
         "layers": layers,

--- a/tests/test_ecr/test_ecr_helpers.py
+++ b/tests/test_ecr/test_ecr_helpers.py
@@ -1,0 +1,40 @@
+import hashlib
+import random
+
+
+def _generate_random_sha():
+    return hashlib.sha256(f"{random.randint(0,100)}".encode("utf-8")).hexdigest()
+
+
+def _create_image_layers(n):
+    layers = []
+    for _ in range(n):
+        layers.append(
+            {
+                "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
+                "size": random.randint(100, 1000),
+                "digest": f"sha256:{_generate_random_sha()}",
+            }
+        )
+    return layers
+
+
+def _create_image_digest(layers):
+    layer_digests = "".join([layer["digest"] for layer in layers])
+    return hashlib.sha256(f"{layer_digests}".encode("utf-8")).hexdigest()
+
+
+def _create_image_manifest(image_digest=None):
+    layers = _create_image_layers(5)
+    if image_digest is None:
+        image_digest = _create_image_digest(layers)
+    return {
+        "schemaVersion": 2,
+        "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+        "config": {
+            "mediaType": "application/vnd.docker.container.image.v1+json",
+            "size": 7023,
+            "digest": image_digest,
+        },
+        "layers": layers,
+    }


### PR DESCRIPTION
# tl;dr
The core of this PR is to allow the `create_function` method of lambda to reference the mocked ECR backend to find images. Most notably it leads to "image not found" behavior when trying to deploy with an `imageUri` which does not exist within the mocked ECR backend. It also leads to the correct retrieval of attributes such as `CodeSha256` for the `list_functions` pathways.

# Why?
While using moto to test configuration flow of lambda deployments via ECR images I noticed two things:
1. Image digests are being created non-deterministically.
2. The lambda deployment is mocking out the CodeSha256 response parameter arbitrarily by hashing the imageUri.
This is all fine and good while interacting with each service independently, but I wanted to be able to populate the ECR repo with images via `put_image` and subsequently mock deploy said images.

# What?
## Image Manifests
I added a some helper functions to a `test_ecr/test_ecr_helpers.py` file. These implement a methodology that _attempts_ to better replicate the behavior of the Registry V2 in that a manifest with all the same layers as another manifest will generate the same imageDigest. This is rather approximate. But moves things in a more same-same direction with ECR (I believe). 

I went down this road due to the original reason I was making this PR: namely to wire up the image digest parameter so I could control the image digest via the boto3 request. I still may add this back in. But for the sake of what I was trying to accomplish I realized that I needed to have the `create_function` method on the lambda side of things operate more closely to AWS.

## `create_function`
I removed the arbitrary population of the codesha256 parameter and friends, and replaced it with a call to the `ecr_backend`. Now, when `create_function` is called, and the `imageUri` case is hit, the uri is used to call the ECR backend to go find the image, which ought to be mocked there before deployment of said image.

# Considerations
This may be a breaking change for some, as it completes the mock behavior between Lambda and ECR when deploying from images. I lean towards this being a change for the good, as a mocked lambda deployment with no ECR image present in the ECR mock presents a potentially caught failure.