### PR TITLE
Don't add empty Items to list_invalidations

### DIFF
--- a/moto/cloudfront/responses.py
+++ b/moto/cloudfront/responses.py
@@ -622,6 +622,7 @@ CREATE_INVALIDATION_TEMPLATE = """<?xml version="1.0"?>
 INVALIDATIONS_TEMPLATE = """<?xml version="1.0" encoding="UTF-8"?>
 <InvalidationList>
    <IsTruncated>false</IsTruncated>
+   {% if invalidations %}
    <Items>
       {% for invalidation in invalidations %}
       <InvalidationSummary>
@@ -631,6 +632,7 @@ INVALIDATIONS_TEMPLATE = """<?xml version="1.0" encoding="UTF-8"?>
       </InvalidationSummary>
       {% endfor %}
    </Items>
+   {% endif %}
    <Marker></Marker>
    <MaxItems>100</MaxItems>
    <Quantity>{{ invalidations|length }}</Quantity>

--- a/tests/test_cloudfront/test_cloudfront_invalidation.py
+++ b/tests/test_cloudfront/test_cloudfront_invalidation.py
@@ -76,4 +76,4 @@ def test_list_invalidations__no_entries():
     resp["InvalidationList"].should.have.key("MaxItems").equal(100)
     resp["InvalidationList"].should.have.key("IsTruncated").equal(False)
     resp["InvalidationList"].should.have.key("Quantity").equal(0)
-    resp["InvalidationList"].should.have.key("Items").equals([])
+    resp["InvalidationList"].shouldnt.have.key("Items")


### PR DESCRIPTION
The mock_cloudfront behaved differently to the real boto3 implementation. This makes it the same.
Fixes #5698