### PR TITLE
Add "client_id" claim to payload

### DIFF
--- a/moto/cognitoidp/models.py
+++ b/moto/cognitoidp/models.py
@@ -533,6 +533,7 @@ class CognitoIdpUserPool(BaseModel):
             "iss": f"https://cognito-idp.{self.region}.amazonaws.com/{self.id}",
             "sub": self._get_user(username).id,
             "aud": client_id,
+            "client_id": client_id,
             "token_use": token_use,
             "auth_time": now,
             "exp": now + expires_in,


### PR DESCRIPTION
As AWS Cognito no longer uses "aud" claim, it has been changed to use "client_id" instead. Keep "aud" claim for backward compatibility.

https://docs.aws.amazon.com/cognito/latest/developerguide/amazon-cognito-user-pools-using-the-access-token.html#user-pool-access-token-payload