### PR TITLE
Cognito payload - Switch key name of "client_id"

### DIFF
--- a/moto/cognitoidp/models.py
+++ b/moto/cognitoidp/models.py
@@ -532,7 +532,7 @@ class CognitoIdpUserPool(BaseModel):
         payload = {
             "iss": f"https://cognito-idp.{self.region}.amazonaws.com/{self.id}",
             "sub": self._get_user(username).id,
-            "aud": client_id,
+            "client_id" if token_use == "access" else "aud": client_id,
             "token_use": token_use,
             "auth_time": now,
             "exp": now + expires_in,

--- a/tests/test_cognitoidp/test_cognitoidp.py
+++ b/tests/test_cognitoidp/test_cognitoidp.py
@@ -2844,7 +2844,7 @@ def test_token_legitimacy():
             id_claims[k].should.equal(v)
         access_claims = json.loads(jws.verify(access_token, json_web_key, "RS256"))
         access_claims["iss"].should.equal(issuer)
-        access_claims["aud"].should.equal(client_id)
+        access_claims["client_id"].should.equal(client_id)
         access_claims["token_use"].should.equal("access")
         access_claims["username"].should.equal(username)
 


### PR DESCRIPTION
Switch between "aud" and "client_id" name of "client_id" key in JWT payload, since AWS Cognito uses "aud" claim in ID token and "client_id" claim in access token.

https://docs.aws.amazon.com/cognito/latest/developerguide/amazon-cognito-user-pools-using-tokens-verifying-a-jwt.html#amazon-cognito-user-pools-using-tokens-step-3