### PR TITLE
Fix  #5704: Moto isn't checking validity of the Batch job names

### DIFF
--- a/moto/batch/models.py
+++ b/moto/batch/models.py
@@ -39,6 +39,7 @@ logger = logging.getLogger(__name__)
 COMPUTE_ENVIRONMENT_NAME_REGEX = re.compile(
     r"^[A-Za-z0-9][A-Za-z0-9_-]{1,126}[A-Za-z0-9]$"
 )
+JOB_NAME_REGEX = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_-]{1,127}$")
 
 
 def datetime2int_milliseconds(date: datetime.datetime) -> int:
@@ -1550,6 +1551,9 @@ class BatchBackend(BaseBackend):
         """
         Parameters RetryStrategy and Parameters are not yet implemented.
         """
+        if JOB_NAME_REGEX.match(job_name) is None:
+            raise ClientException("Job name should match valid pattern")
+
         # Look for job definition
         job_def = self.get_job_definition(job_def_id)
         if job_def is None:

--- a/tests/test_batch/test_batch_jobs.py
+++ b/tests/test_batch/test_batch_jobs.py
@@ -886,3 +886,33 @@ def test_submit_job_with_timeout_set_at_definition():
 
     # This should fail, as the job-duration is longer than the attemptDurationSeconds
     _wait_for_job_status(batch_client, job_id, "FAILED")
+
+
+@mock_batch
+def test_submit_job_invalid_name():
+    """
+    Test verifies that a `ClientException` is raised if `jobName` isn't valid
+    """
+    _, _, _, _, batch_client = _get_clients()
+    with pytest.raises(botocore.exceptions.ClientError) as exc:
+        batch_client.submit_job(
+            jobName="containsinvalidcharacter.",
+            jobQueue="arn",
+            jobDefinition="job_def_name",
+        )
+    assert exc.match("ClientException")
+
+    with pytest.raises(botocore.exceptions.ClientError) as exc:
+        batch_client.submit_job(
+            jobName="-startswithinvalidcharacter",
+            jobQueue="arn",
+            jobDefinition="job_def_name",
+        )
+    assert exc.match("ClientException")
+
+    with pytest.raises(botocore.exceptions.ClientError) as exc:
+        too_long_job_name = "a" * 129
+        batch_client.submit_job(
+            jobName=too_long_job_name, jobQueue="arn", jobDefinition="job_def_name"
+        )
+    assert exc.match("ClientException")


### PR DESCRIPTION
Fix  #5704: Moto isn't checking validity of the Batch job names

Add a regex to valid the job name when submitting a job to raise a ClientException

        [] Feature is added
        [x] The linter is happy
        [x] Tests are added
        [x] All tests pass, existing and new