### PR TITLE
EC2: fix launch template names not being reusable after delete

### DIFF
--- a/moto/ec2/models/launch_templates.py
+++ b/moto/ec2/models/launch_templates.py
@@ -11,7 +11,7 @@ from ..utils import (
 from ..exceptions import (
     InvalidLaunchTemplateNameAlreadyExistsError,
     InvalidLaunchTemplateNameNotFoundError,
-    InvalidLaunchTemplateNameNotFoundWithNameError,
+    InvalidLaunchTemplateNameNotFoundWithNameError, MissingParameterError,
 )
 
 
@@ -189,8 +189,14 @@ class LaunchTemplateBackend:
 
     def delete_launch_template(self, name, tid):
         if name:
-            tid = self.launch_template_name_to_ids[name]
-        return self.launch_templates.pop(tid)
+            tid = self.launch_template_name_to_ids.get(name)
+        if tid is None:
+            raise MissingParameterError("launch template ID or launch template name")
+        if tid not in self.launch_templates:
+            raise InvalidLaunchTemplateNameNotFoundError()
+        template = self.launch_templates.pop(tid)
+        self.launch_template_name_to_ids.pop(template.name, None)
+        return template
 
     def describe_launch_templates(
         self, template_names=None, template_ids=None, filters=None

--- a/moto/ec2/models/launch_templates.py
+++ b/moto/ec2/models/launch_templates.py
@@ -11,7 +11,8 @@ from ..utils import (
 from ..exceptions import (
     InvalidLaunchTemplateNameAlreadyExistsError,
     InvalidLaunchTemplateNameNotFoundError,
-    InvalidLaunchTemplateNameNotFoundWithNameError, MissingParameterError,
+    InvalidLaunchTemplateNameNotFoundWithNameError,
+    MissingParameterError,
 )
 
 

--- a/tests/test_ec2/test_ec2_cloudformation.py
+++ b/tests/test_ec2/test_ec2_cloudformation.py
@@ -938,6 +938,10 @@ def test_launch_template_delete():
 
     cf.delete_stack(StackName=stack_name)
 
-    ec2.describe_launch_templates(LaunchTemplateNames=[launch_template_name])[
-        "LaunchTemplates"
-    ].should.have.length_of(0)
+    with pytest.raises(ClientError) as exc:
+        ec2.describe_launch_templates(LaunchTemplateNames=[launch_template_name])
+    err = exc.value.response["Error"]
+    err.should.have.key("Code").equals("InvalidLaunchTemplateName.NotFoundException")
+    err.should.have.key("Message").equals(
+        "At least one of the launch templates specified in the request does not exist."
+    )

--- a/tests/test_ec2/test_launch_templates.py
+++ b/tests/test_ec2/test_launch_templates.py
@@ -488,7 +488,9 @@ def test_delete_launch_template__by_name():
         ]
     err = exc.value.response["Error"]
     err.should.have.key("Code").equals("InvalidLaunchTemplateName.NotFoundException")
-    err.should.have.key("Message").equals("At least one of the launch templates specified in the request does not exist.")
+    err.should.have.key("Message").equals(
+        "At least one of the launch templates specified in the request does not exist."
+    )
 
     # Ensure deleted template name can be reused
     cli.create_launch_template(
@@ -507,7 +509,9 @@ def test_delete_launch_template__by_id():
         cli.delete_launch_template()
     err = exc.value.response["Error"]
     err.should.have.key("Code").equals("MissingParameter")
-    err.should.have.key("Message").equals("The request must contain the parameter launch template ID or launch template name")
+    err.should.have.key("Message").equals(
+        "The request must contain the parameter launch template ID or launch template name"
+    )
 
     template_id = cli.create_launch_template(
         LaunchTemplateName=template_name, LaunchTemplateData={"ImageId": "ami-abc123"}
@@ -525,7 +529,9 @@ def test_delete_launch_template__by_id():
         ]
     err = exc.value.response["Error"]
     err.should.have.key("Code").equals("InvalidLaunchTemplateName.NotFoundException")
-    err.should.have.key("Message").equals("At least one of the launch templates specified in the request does not exist.")
+    err.should.have.key("Message").equals(
+        "At least one of the launch templates specified in the request does not exist."
+    )
 
     # Ensure deleted template name can be reused
     cli.create_launch_template(


### PR DESCRIPTION
This PR:
1. Fixes an issue with EC2 launch templates API which prevented template names from being reused after they were deleted.
1. Raise the correct exception if template name or ID is not specified in the request

Steps to reproduce the (1) bug:
```
$ awslocal ec2 create-launch-template \
    --launch-template-name sample \
    --launch-template-data '{}'
{
    "LaunchTemplate": {
        "LaunchTemplateId": "lt-b5a04f8e468f70f4e",
        "LaunchTemplateName": "sample",
        "CreateTime": "2022-12-01T10:08:43+00:00",
        "CreatedBy": "arn:aws:iam::000000000000:root",
        "DefaultVersionNumber": 1,
        "LatestVersionNumber": 1,
        "Tags": []
    }
}

$ awslocal ec2 delete-launch-template --launch-template-name sample
{
    "LaunchTemplate": {
        "LaunchTemplateId": "lt-b5a04f8e468f70f4e",
        "LaunchTemplateName": "sample",
        "DefaultVersionNumber": 1
    }
}

$ awslocal ec2 describe-launch-templates
{
    "LaunchTemplates": []
}

$ awslocal ec2 create-launch-template \
    --launch-template-name sample \
    --launch-template-data '{}'
An error occurred (InvalidLaunchTemplateName.AlreadyExistsException) when calling the CreateLaunchTemplate operation: Launch template name already in use.
```