### PR TITLE
EC2: AllocateAddress fallback domain

### DIFF
--- a/moto/ec2/exceptions.py
+++ b/moto/ec2/exceptions.py
@@ -333,13 +333,6 @@ class VolumeInUseError(EC2ClientError):
         )
 
 
-class InvalidDomainError(EC2ClientError):
-    def __init__(self, domain):
-        super().__init__(
-            "InvalidParameterValue", f"Invalid value '{domain}' for domain."
-        )
-
-
 class InvalidAddressError(EC2ClientError):
     def __init__(self, ip):
         super().__init__("InvalidAddress.NotFound", f"Address '{ip}' not found.")

--- a/moto/ec2/models/elastic_ip_addresses.py
+++ b/moto/ec2/models/elastic_ip_addresses.py
@@ -2,7 +2,6 @@ from moto.core import CloudFormationModel
 from .core import TaggedEC2Resource
 from ..exceptions import (
     FilterNotImplementedError,
-    InvalidDomainError,
     InvalidAddressError,
     InvalidAllocationIdError,
     ResourceAlreadyAssociatedError,
@@ -113,7 +112,7 @@ class ElasticAddressBackend:
 
     def allocate_address(self, domain, address=None, tags=None):
         if domain not in ["standard", "vpc"]:
-            raise InvalidDomainError(domain)
+            domain = "vpc"
         if address:
             address = ElasticAddress(self, domain=domain, address=address, tags=tags)
         else:

--- a/moto/ec2/responses/elastic_ip_addresses.py
+++ b/moto/ec2/responses/elastic_ip_addresses.py
@@ -4,7 +4,7 @@ from ._base_response import EC2BaseResponse
 
 class ElasticIPAddresses(EC2BaseResponse):
     def allocate_address(self):
-        domain = self._get_param("Domain", if_none="standard")
+        domain = self._get_param("Domain", if_none=None)
         reallocate_address = self._get_param("Address", if_none=None)
         tags = self._get_multi_param("TagSpecification")
         tags = add_tag_specification(tags)

--- a/tests/test_ec2/test_elastic_ip_addresses.py
+++ b/tests/test_ec2/test_elastic_ip_addresses.py
@@ -78,12 +78,22 @@ def test_eip_allocate_vpc():
     vpc.should.have.key("AllocationId")
     vpc.should.have.key("Domain").equal("vpc")
 
+    # Ensure that correct fallback is used for the optional attribute `Domain` contains an empty or invalid value
+    vpc2 = client.allocate_address(Domain="")
+    vpc3 = client.allocate_address(Domain="xyz")
+
+    vpc2.should.have.key("Domain").equal("vpc")
+    vpc3.should.have.key("Domain").equal("vpc")
+
     allocation_id = vpc["AllocationId"]
+    allocation_id2 = vpc["AllocationId"]
+    allocation_id3 = vpc["AllocationId"]
 
     all_addresses = client.describe_addresses()["Addresses"]
-    [a["AllocationId"] for a in all_addresses if "AllocationId" in a].should.contain(
-        allocation_id
-    )
+    allocation_ids = [a["AllocationId"] for a in all_addresses if "AllocationId" in a]
+    allocation_ids.should.contain(allocation_id)
+    allocation_ids.should.contain(allocation_id2)
+    allocation_ids.should.contain(allocation_id3)
 
     vpc = ec2.VpcAddress(allocation_id)
     vpc.release()


### PR DESCRIPTION
The [EC2 AllocateAddress](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_AllocateAddress.html) operation takes an optional `domain` parameter. Valid values for this parameter are `standard`|`vpc`. AWS accepts invalid values for this field (eg. `''` or `'xyz'`) and falls back to the default, `vpc`. Also, Pulumi seems to send `''`.

This PR corrects the behaviour such that in case of missing or invalid value, `vpc` is used instead of raising an exception. Furthermore, since the exception (`InvalidDomainError`) is not defined in AWS, it has been removed.

Tested against AWS:

```
$ aws ec2 allocate-address --domain ""
{
    "PublicIp": "3.74.120.XXX",
    "AllocationId": "eipalloc-06f0e8671db58XXXX",
    "PublicIpv4Pool": "amazon",
    "NetworkBorderGroup": "eu-central-1",
    "Domain": "vpc"
}

$ aws ec2 allocate-address --domain "xyz"
{
    "PublicIp": "3.123.242.XXX",
    "AllocationId": "eipalloc-05814a850338dXXXX",
    "PublicIpv4Pool": "amazon",
    "NetworkBorderGroup": "eu-central-1",
    "Domain": "vpc"
}
```

See https://github.com/localstack/localstack/issues/7058