### PR TITLE
CloudFormation: Improve behaviour of StackInstances

### DIFF
--- a/IMPLEMENTATION_COVERAGE.md
+++ b/IMPLEMENTATION_COVERAGE.md
@@ -565,7 +565,7 @@
 
 ## cloudformation
 <details>
-<summary>31% implemented</summary>
+<summary>34% implemented</summary>
 
 - [ ] activate_type
 - [ ] batch_describe_type_configurations
@@ -587,7 +587,7 @@
 - [ ] describe_publisher
 - [ ] describe_stack_drift_detection_status
 - [ ] describe_stack_events
-- [ ] describe_stack_instance
+- [X] describe_stack_instance
 - [ ] describe_stack_resource
 - [ ] describe_stack_resource_drifts
 - [ ] describe_stack_resources
@@ -608,7 +608,7 @@
 - [X] list_change_sets
 - [X] list_exports
 - [ ] list_imports
-- [ ] list_stack_instances
+- [X] list_stack_instances
 - [X] list_stack_resources
 - [ ] list_stack_set_operation_results
 - [ ] list_stack_set_operations

--- a/docs/docs/services/cloudformation.rst
+++ b/docs/docs/services/cloudformation.rst
@@ -38,11 +38,23 @@ cloudformation
         
 
 - [X] create_stack_instances
+  
+        The following parameters are not yet implemented: DeploymentTargets.AccountFilterType, DeploymentTargets.AccountsUrl, OperationPreferences, CallAs
+        
+
 - [X] create_stack_set
+  
+        The following parameters are not yet implemented: StackId, AdministrationRoleARN, AutoDeployment, ExecutionRoleName, CallAs, ClientRequestToken, ManagedExecution
+        
+
 - [ ] deactivate_type
 - [X] delete_change_set
 - [X] delete_stack
 - [X] delete_stack_instances
+  
+        The following parameters are not  yet implemented: DeploymentTargets, OperationPreferences, RetainStacks, OperationId, CallAs
+        
+
 - [X] delete_stack_set
 - [ ] deregister_type
 - [ ] describe_account_limits
@@ -51,7 +63,7 @@ cloudformation
 - [ ] describe_publisher
 - [ ] describe_stack_drift_detection_status
 - [ ] describe_stack_events
-- [ ] describe_stack_instance
+- [X] describe_stack_instance
 - [ ] describe_stack_resource
 - [ ] describe_stack_resource_drifts
 - [ ] describe_stack_resources
@@ -72,7 +84,12 @@ cloudformation
 - [X] list_change_sets
 - [X] list_exports
 - [ ] list_imports
-- [ ] list_stack_instances
+- [X] list_stack_instances
+  
+        Pagination is not yet implemented.
+        The parameters StackInstanceAccount/StackInstanceRegion are not yet implemented.
+        
+
 - [X] list_stack_resources
 - [ ] list_stack_set_operation_results
 - [ ] list_stack_set_operations
@@ -98,6 +115,10 @@ cloudformation
 - [ ] test_type
 - [X] update_stack
 - [X] update_stack_instances
+  
+        Calling this will update the parameters, but the actual resources are not updated
+        
+
 - [X] update_stack_set
 - [ ] update_termination_protection
 - [X] validate_template

--- a/moto/cloudformation/exceptions.py
+++ b/moto/cloudformation/exceptions.py
@@ -38,6 +38,16 @@ class ExportNotFound(RESTError):
         self.description = template.render(code="ExportNotFound", message=message)
 
 
+class StackSetNotEmpty(RESTError):
+    def __init__(self) -> None:
+        template = Template(ERROR_RESPONSE)
+        message = "StackSet is not empty"
+        super().__init__(error_type="StackSetNotEmptyException", message=message)
+        self.description = template.render(
+            code="StackSetNotEmptyException", message=message
+        )
+
+
 class UnsupportedAttribute(ValidationError):
     def __init__(self, resource: str, attr: str):
         template = Template(ERROR_RESPONSE)

--- a/moto/cloudformation/models.py
+++ b/moto/cloudformation/models.py
@@ -14,6 +14,7 @@ from moto.core.utils import (
 )
 from moto.moto_api._internal import mock_random
 from moto.sns.models import sns_backends
+from moto.organizations.models import organizations_backends, OrganizationsBackend
 
 from .custom_model import CustomModel
 from .parsing import ResourceMap, Output, OutputMap, Export
@@ -25,7 +26,7 @@ from .utils import (
     yaml_tag_constructor,
     validate_template_cfn_lint,
 )
-from .exceptions import ValidationError
+from .exceptions import ValidationError, StackSetNotEmpty
 
 
 class FakeStackSet(BaseModel):
@@ -38,6 +39,7 @@ class FakeStackSet(BaseModel):
         region: str,
         description: Optional[str],
         parameters: Dict[str, str],
+        permission_model: str,
         tags: Optional[Dict[str, str]] = None,
         admin_role: str = "AWSCloudFormationStackSetAdministrationRole",
         execution_role: str = "AWSCloudFormationStackSetExecutionRole",
@@ -53,9 +55,12 @@ class FakeStackSet(BaseModel):
         self.admin_role_arn = f"arn:aws:iam::{account_id}:role/{self.admin_role}"
         self.execution_role = execution_role
         self.status = "ACTIVE"
-        self.instances = FakeStackInstances(parameters, self.id, self.name)
+        self.instances = FakeStackInstances(
+            account_id, template, parameters, self.id, self.name
+        )
         self.stack_instances = self.instances.stack_instances
         self.operations: List[Dict[str, Any]] = []
+        self.permission_model = permission_model or "SELF_MANAGED"
 
     def _create_operation(
         self,
@@ -128,13 +133,35 @@ class FakeStackSet(BaseModel):
         return operation
 
     def create_stack_instances(
-        self, accounts: List[str], regions: List[str], parameters: List[Dict[str, Any]]
-    ) -> None:
+        self,
+        accounts: List[str],
+        regions: List[str],
+        deployment_targets: Optional[Dict[str, Any]],
+        parameters: List[Dict[str, Any]],
+    ) -> str:
+        if self.permission_model == "SERVICE_MANAGED":
+            if not deployment_targets:
+                raise ValidationError(
+                    message="StackSets with SERVICE_MANAGED permission model can only have OrganizationalUnit as target"
+                )
+            elif "OrganizationalUnitIds" not in deployment_targets:
+                raise ValidationError(message="OrganizationalUnitIds are required")
+        if self.permission_model == "SELF_MANAGED":
+            if deployment_targets and "OrganizationalUnitIds" in deployment_targets:
+                raise ValidationError(
+                    message="StackSets with SELF_MANAGED permission model can only have accounts as target"
+                )
         operation_id = str(mock_random.uuid4())
         if not parameters:
             parameters = self.parameters  # type: ignore[assignment]
 
-        self.instances.create_instances(accounts, regions, parameters)
+        self.instances.create_instances(
+            accounts,
+            regions,
+            parameters,  # type: ignore[arg-type]
+            deployment_targets or {},
+            permission_model=self.permission_model,
+        )
         self._create_operation(
             operation_id=operation_id,
             action="CREATE",
@@ -142,6 +169,7 @@ class FakeStackSet(BaseModel):
             accounts=accounts,
             regions=regions,
         )
+        return operation_id
 
     def delete_stack_instances(self, accounts: List[str], regions: List[str]) -> None:
         operation_id = str(mock_random.uuid4())
@@ -172,36 +200,136 @@ class FakeStackSet(BaseModel):
         return operation
 
 
+class FakeStackInstance(BaseModel):
+    def __init__(
+        self,
+        account_id: str,
+        region_name: str,
+        stackset_id: str,
+        stack_name: str,
+        name: str,
+        template: str,
+        parameters: Optional[List[Dict[str, Any]]],
+        permission_model: str,
+    ):
+        self.account_id = account_id
+        self.region_name = region_name
+        self.stackset_id = stackset_id
+        self.stack_name = stack_name
+        self.name = name
+        self.template = template
+        self.parameters = parameters or []
+        self.permission_model = permission_model
+
+        # Incoming parameters can be in two formats: {key: value} or [{"": key, "": value}, ..]
+        if isinstance(parameters, dict):
+            params = parameters
+        elif isinstance(parameters, list):
+            params = {p["ParameterKey"]: p["ParameterValue"] for p in parameters}
+
+        if permission_model == "SELF_MANAGED":
+            self.stack = cloudformation_backends[account_id][region_name].create_stack(
+                name=f"StackSet:{name}", template=template, parameters=params
+            )
+        else:
+            stack_id = generate_stack_id(
+                "hiddenstackfor" + self.name, self.region_name, self.account_id
+            )
+            self.stack = FakeStack(
+                stack_id=stack_id,
+                name=self.name,
+                template=self.template,
+                parameters=params,
+                account_id=self.account_id,
+                region_name=self.region_name,
+                notification_arns=[],
+                tags=None,
+                role_arn=None,
+                cross_stack_resources={},
+                enable_termination_protection=False,
+            )
+            self.stack.create_resources()
+
+    def delete(self) -> None:
+        if self.permission_model == "SELF_MANAGED":
+            cloudformation_backends[self.account_id][self.region_name].delete_stack(
+                self.stack.name
+            )
+        else:
+            # Our stack is hidden - we have to delete it manually
+            self.stack.delete()
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "StackId": generate_stack_id(
+                self.stack_name, self.region_name, self.account_id
+            ),
+            "StackSetId": self.stackset_id,
+            "Region": self.region_name,
+            "Account": self.account_id,
+            "Status": "CURRENT",
+            "ParameterOverrides": self.parameters,
+        }
+
+
 class FakeStackInstances(BaseModel):
     def __init__(
-        self, parameters: Dict[str, str], stackset_id: str, stackset_name: str
+        self,
+        account_id: str,
+        template: str,
+        parameters: Dict[str, str],
+        stackset_id: str,
+        stackset_name: str,
     ):
+        self.account_id = account_id
+        self.template = template
         self.parameters = parameters or {}
         self.stackset_id = stackset_id
         self.stack_name = f"StackSet-{stackset_id}"
         self.stackset_name = stackset_name
-        self.stack_instances: List[Dict[str, Any]] = []
+        self.stack_instances: List[FakeStackInstance] = []
+
+    @property
+    def org_backend(self) -> OrganizationsBackend:
+        return organizations_backends[self.account_id]["global"]
 
     def create_instances(
         self,
         accounts: List[str],
         regions: List[str],
         parameters: Optional[List[Dict[str, Any]]],
+        deployment_targets: Dict[str, Any],
+        permission_model: str,
     ) -> List[Dict[str, Any]]:
-        new_instances = []
+        targets: List[Tuple[str, str]] = []
+        all_accounts = self.org_backend.accounts
+        requested_ous = deployment_targets.get("OrganizationalUnitIds", [])
+        child_ous = [
+            ou.id for ou in self.org_backend.ou if ou.parent_id in requested_ous
+        ]
         for region in regions:
             for account in accounts:
-                instance = {
-                    "StackId": generate_stack_id(self.stack_name, region, account),
-                    "StackSetId": self.stackset_id,
-                    "Region": region,
-                    "Account": account,
-                    "Status": "CURRENT",
-                    "ParameterOverrides": parameters or [],
-                }
-                new_instances.append(instance)
+                targets.append((region, account))
+            for ou_id in requested_ous + child_ous:
+                for acnt in all_accounts:
+                    if acnt.parent_id == ou_id:
+                        targets.append((region, acnt.id))
+
+        new_instances = []
+        for region, account in targets:
+            instance = FakeStackInstance(
+                account_id=account,
+                region_name=region,
+                stackset_id=self.stackset_id,
+                stack_name=self.stack_name,
+                name=self.stackset_name,
+                template=self.template,
+                parameters=parameters,
+                permission_model=permission_model,
+            )
+            new_instances.append(instance)
         self.stack_instances += new_instances
-        return new_instances
+        return [i.to_dict() for i in new_instances]
 
     def update(
         self,
@@ -212,19 +340,17 @@ class FakeStackInstances(BaseModel):
         for account in accounts:
             for region in regions:
                 instance = self.get_instance(account, region)
-                if parameters:
-                    instance["ParameterOverrides"] = parameters
-                else:
-                    instance["ParameterOverrides"] = []
+                instance.parameters = parameters or []
 
     def delete(self, accounts: List[str], regions: List[str]) -> None:
         for i, instance in enumerate(self.stack_instances):
-            if instance["Region"] in regions and instance["Account"] in accounts:
+            if instance.region_name in regions and instance.account_id in accounts:
+                instance.delete()
                 self.stack_instances.pop(i)
 
-    def get_instance(self, account: str, region: str) -> Dict[str, Any]:  # type: ignore[return]
+    def get_instance(self, account: str, region: str) -> FakeStackInstance:  # type: ignore[return]
         for i, instance in enumerate(self.stack_instances):
-            if instance["Region"] == region and instance["Account"] == account:
+            if instance.region_name == region and instance.account_id == account:
                 return self.stack_instances[i]
 
 
@@ -589,7 +715,11 @@ class CloudFormationBackend(BaseBackend):
         template: str,
         parameters: Dict[str, str],
         tags: Dict[str, str],
+        permission_model: str,
     ) -> FakeStackSet:
+        """
+        The following parameters are not yet implemented: StackId, AdministrationRoleARN, AutoDeployment, ExecutionRoleName, CallAs, ClientRequestToken, ManagedExecution
+        """
         stackset_id = generate_stackset_id(name)
         new_stackset = FakeStackSet(
             stackset_id=stackset_id,
@@ -600,6 +730,7 @@ class CloudFormationBackend(BaseBackend):
             parameters=parameters,
             description=None,
             tags=tags,
+            permission_model=permission_model,
         )
         self.stacksets[stackset_id] = new_stackset
         return new_stackset
@@ -614,12 +745,17 @@ class CloudFormationBackend(BaseBackend):
         raise ValidationError(name)
 
     def delete_stack_set(self, name: str) -> None:
-        stacksets = self.stacksets.keys()
-        if name in stacksets:
-            self.stacksets[name].delete()
-        for stackset in stacksets:
-            if self.stacksets[stackset].name == name:
-                self.stacksets[stackset].delete()
+        stackset_to_delete: Optional[FakeStackSet] = None
+        if name in self.stacksets:
+            stackset_to_delete = self.stacksets[name]
+        for stackset in self.stacksets.values():
+            if stackset.name == name:
+                stackset_to_delete = stackset
+
+        if stackset_to_delete is not None:
+            if stackset_to_delete.stack_instances:
+                raise StackSetNotEmpty()
+            stackset_to_delete.delete()
 
     def create_stack_instances(
         self,
@@ -627,15 +763,20 @@ class CloudFormationBackend(BaseBackend):
         accounts: List[str],
         regions: List[str],
         parameters: List[Dict[str, str]],
-    ) -> FakeStackSet:
+        deployment_targets: Optional[Dict[str, Any]],
+    ) -> str:
+        """
+        The following parameters are not yet implemented: DeploymentTargets.AccountFilterType, DeploymentTargets.AccountsUrl, OperationPreferences, CallAs
+        """
         stackset = self.get_stack_set(stackset_name)
 
-        stackset.create_stack_instances(
+        operation_id = stackset.create_stack_instances(
             accounts=accounts,
             regions=regions,
+            deployment_targets=deployment_targets,
             parameters=parameters,
         )
-        return stackset
+        return operation_id
 
     def update_stack_instances(
         self,
@@ -644,6 +785,9 @@ class CloudFormationBackend(BaseBackend):
         regions: List[str],
         parameters: List[Dict[str, Any]],
     ) -> Dict[str, Any]:
+        """
+        Calling this will update the parameters, but the actual resources are not updated
+        """
         stack_set = self.get_stack_set(stackset_name)
         return stack_set.update_instances(accounts, regions, parameters)
 
@@ -680,6 +824,9 @@ class CloudFormationBackend(BaseBackend):
     def delete_stack_instances(
         self, stackset_name: str, accounts: List[str], regions: List[str]
     ) -> FakeStackSet:
+        """
+        The following parameters are not  yet implemented: DeploymentTargets, OperationPreferences, RetainStacks, OperationId, CallAs
+        """
         stackset = self.get_stack_set(stackset_name)
         stackset.delete_stack_instances(accounts, regions)
         return stackset
@@ -861,6 +1008,20 @@ class CloudFormationBackend(BaseBackend):
             raise ValidationError(name_or_stack_id)
         else:
             return list(stacks)
+
+    def describe_stack_instance(
+        self, stack_set_name: str, account_id: str, region: str
+    ) -> Dict[str, Any]:
+        stack_set = self.get_stack_set(stack_set_name)
+        return stack_set.instances.get_instance(account_id, region).to_dict()
+
+    def list_stack_instances(self, stackset_name: str) -> List[Dict[str, Any]]:
+        """
+        Pagination is not yet implemented.
+        The parameters StackInstanceAccount/StackInstanceRegion are not yet implemented.
+        """
+        stack_set = self.get_stack_set(stackset_name)
+        return [i.to_dict() for i in stack_set.instances.stack_instances]
 
     def list_change_sets(self) -> Iterable[FakeChangeSet]:
         return self.change_sets.values()

--- a/tests/test_cloudformation/test_cloudformation_multi_accounts.py
+++ b/tests/test_cloudformation/test_cloudformation_multi_accounts.py
@@ -1,0 +1,294 @@
+import boto3
+import json
+import pytest
+from botocore.exceptions import ClientError
+from moto import mock_cloudformation, mock_organizations, mock_sqs, settings
+from moto.core import DEFAULT_ACCOUNT_ID
+from moto.cloudformation import cloudformation_backends as cf_backends
+from moto.sqs import sqs_backends
+from unittest import SkipTest, TestCase
+from uuid import uuid4
+
+
+TEMPLATE_DCT = {
+    "AWSTemplateFormatVersion": "2010-09-09",
+    "Description": "Template creating one queue",
+    "Resources": {
+        "MyQueue": {"Type": "AWS::SQS::Queue", "Properties": {"QueueName": "testqueue"}}
+    },
+}
+
+
+class TestStackSetMultipleAccounts(TestCase):
+    def setUp(self) -> None:
+        # Set up multiple organizations/accounts
+        # Our tests will create resources within these orgs/accounts
+        #
+        #               |   ROOT   |
+        #              /            \
+        #             /              \
+        #          [ou01]            [ou02]
+        #            |            /    |   \
+        #            |           / [acct02] \
+        #         [acct01]      /            \
+        #                     [ou21]       [ou22]
+        #                       |            |
+        #                     [acct21]      [acct22]
+        #
+        if settings.TEST_SERVER_MODE:
+            raise SkipTest(
+                "These tests directly access the backend, which is not possible in ServerMode"
+            )
+        mockname = "mock-account"
+        mockdomain = "moto-example.org"
+        mockemail = "@".join([mockname, mockdomain])
+
+        self.org = boto3.client("organizations", region_name="us-east-1")
+        self.org.create_organization(FeatureSet="ALL")
+        self.acct01 = self.org.create_account(AccountName=mockname, Email=mockemail)[
+            "CreateAccountStatus"
+        ]["AccountId"]
+        self.acct02 = self.org.create_account(AccountName=mockname, Email=mockemail)[
+            "CreateAccountStatus"
+        ]["AccountId"]
+        self.acct21 = self.org.create_account(AccountName=mockname, Email=mockemail)[
+            "CreateAccountStatus"
+        ]["AccountId"]
+        self.acct22 = self.org.create_account(AccountName=mockname, Email=mockemail)[
+            "CreateAccountStatus"
+        ]["AccountId"]
+
+        root_id = self.org.list_roots()["Roots"][0]["Id"]
+
+        self.ou01 = self.org.create_organizational_unit(ParentId=root_id, Name="ou1")[
+            "OrganizationalUnit"
+        ]["Id"]
+        self.ou02 = self.org.create_organizational_unit(ParentId=root_id, Name="ou2")[
+            "OrganizationalUnit"
+        ]["Id"]
+        self.ou21 = self.org.create_organizational_unit(
+            ParentId=self.ou02, Name="ou021"
+        )["OrganizationalUnit"]["Id"]
+        self.ou22 = self.org.create_organizational_unit(
+            ParentId=self.ou02, Name="ou022"
+        )["OrganizationalUnit"]["Id"]
+        self.org.move_account(
+            AccountId=self.acct01, SourceParentId=root_id, DestinationParentId=self.ou01
+        )
+        self.org.move_account(
+            AccountId=self.acct02, SourceParentId=root_id, DestinationParentId=self.ou02
+        )
+        self.org.move_account(
+            AccountId=self.acct21, SourceParentId=root_id, DestinationParentId=self.ou21
+        )
+        self.org.move_account(
+            AccountId=self.acct22, SourceParentId=root_id, DestinationParentId=self.ou22
+        )
+
+        self.name = "a" + str(uuid4())[0:6]
+        self.client = boto3.client("cloudformation", region_name="us-east-1")
+
+    def _verify_stack_instance(self, accnt, region=None):
+        resp = self.client.describe_stack_instance(
+            StackSetName=self.name,
+            StackInstanceAccount=accnt,
+            StackInstanceRegion=region or "us-east-1",
+        )["StackInstance"]
+        resp.should.have.key("Account").equals(accnt)
+
+    def _verify_queues(self, accnt, expected, region=None):
+        list(sqs_backends[accnt][region or "us-east-1"].queues.keys()).should.equal(
+            expected
+        )
+
+
+@mock_cloudformation
+@mock_organizations
+@mock_sqs
+class TestServiceManagedStacks(TestStackSetMultipleAccounts):
+    def setUp(self) -> None:
+        super().setUp()
+        self.client.create_stack_set(
+            StackSetName=self.name,
+            Description="test creating stack set in multiple accounts",
+            TemplateBody=json.dumps(TEMPLATE_DCT),
+            PermissionModel="SERVICE_MANAGED",
+            AutoDeployment={"Enabled": False},
+        )
+
+    def test_create_instances__specifying_accounts(self):
+        with pytest.raises(ClientError) as exc:
+            self.client.create_stack_instances(
+                StackSetName=self.name, Accounts=["888781156701"], Regions=["us-east-1"]
+            )
+        err = exc.value.response["Error"]
+        err["Code"].should.equal("ValidationError")
+        err["Message"].should.equal(
+            "StackSets with SERVICE_MANAGED permission model can only have OrganizationalUnit as target"
+        )
+
+    def test_create_instances__specifying_only_accounts_in_deployment_targets(self):
+        with pytest.raises(ClientError) as exc:
+            self.client.create_stack_instances(
+                StackSetName=self.name,
+                DeploymentTargets={
+                    "Accounts": ["888781156701"],
+                },
+                Regions=["us-east-1"],
+            )
+        err = exc.value.response["Error"]
+        err["Code"].should.equal("ValidationError")
+        err["Message"].should.equal("OrganizationalUnitIds are required")
+
+    def test_create_instances___with_invalid_ou(self):
+        with pytest.raises(ClientError) as exc:
+            self.client.create_stack_instances(
+                StackSetName=self.name,
+                DeploymentTargets={"OrganizationalUnitIds": ["unknown"]},
+                Regions=["us-east-1"],
+            )
+        err = exc.value.response["Error"]
+        err["Code"].should.equal("ValidationError")
+        err["Message"].should.equal(
+            "1 validation error detected: Value '[unknown]' at 'deploymentTargets.organizationalUnitIds' failed to satisfy constraint: Member must satisfy constraint: [Member must have length less than or equal to 68, Member must have length greater than or equal to 6, Member must satisfy regular expression pattern: ^(ou-[a-z0-9]{4,32}-[a-z0-9]{8,32}|r-[a-z0-9]{4,32})$]"
+        )
+
+    def test_create_instances__single_ou(self):
+        self.client.create_stack_instances(
+            StackSetName=self.name,
+            DeploymentTargets={"OrganizationalUnitIds": [self.ou01]},
+            Regions=["us-east-1"],
+        )
+        self._verify_stack_instance(self.acct01)
+
+        # We have a queue in our account connected to OU-01
+        self._verify_queues(self.acct01, ["testqueue"])
+        # No queue has been created in our main account, or unrelated accounts
+        self._verify_queues(DEFAULT_ACCOUNT_ID, [])
+        self._verify_queues(self.acct02, [])
+        self._verify_queues(self.acct21, [])
+        self._verify_queues(self.acct22, [])
+
+    def test_create_instances__ou_with_kiddos(self):
+        self.client.create_stack_instances(
+            StackSetName=self.name,
+            DeploymentTargets={"OrganizationalUnitIds": [self.ou02]},
+            Regions=["us-east-1"],
+        )
+        self._verify_stack_instance(self.acct02)
+        self._verify_stack_instance(self.acct21)
+        self._verify_stack_instance(self.acct22)
+
+        # No queue has been created in our main account
+        self._verify_queues(DEFAULT_ACCOUNT_ID, expected=[])
+        self._verify_queues(self.acct01, expected=[])
+        # But we do have a queue in our (child)-accounts of OU-02
+        self._verify_queues(self.acct02, ["testqueue"])
+        self._verify_queues(self.acct21, ["testqueue"])
+        self._verify_queues(self.acct22, ["testqueue"])
+
+
+@mock_cloudformation
+@mock_organizations
+@mock_sqs
+class TestSelfManagedStacks(TestStackSetMultipleAccounts):
+    def setUp(self) -> None:
+        super().setUp()
+        # Assumptions: All the necessary IAM roles are created
+        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/stacksets-prereqs-self-managed.html
+        self.client.create_stack_set(
+            StackSetName=self.name,
+            Description="test creating stack set in multiple accounts",
+            TemplateBody=json.dumps(TEMPLATE_DCT),
+        )
+
+    def test_create_instances__specifying_accounts(self):
+        self.client.create_stack_instances(
+            StackSetName=self.name, Accounts=[self.acct01], Regions=["us-east-2"]
+        )
+
+        self._verify_stack_instance(self.acct01, region="us-east-2")
+
+        # acct01 has a Stack
+        cf_backends[self.acct01]["us-east-2"].stacks.should.have.length_of(1)
+        # Other acounts do not
+        cf_backends[self.acct02]["us-east-2"].stacks.should.have.length_of(0)
+        cf_backends[self.acct21]["us-east-2"].stacks.should.have.length_of(0)
+        cf_backends[self.acct22]["us-east-2"].stacks.should.have.length_of(0)
+        cf_backends[DEFAULT_ACCOUNT_ID]["us-east-2"].stacks.should.have.length_of(0)
+
+        # acct01 has a queue
+        self._verify_queues(self.acct01, ["testqueue"], region="us-east-2")
+        # other accounts are empty
+        self._verify_queues(self.acct02, [], region="us-east-2")
+        self._verify_queues(self.acct21, [], region="us-east-2")
+        self._verify_queues(self.acct22, [], region="us-east-2")
+        self._verify_queues(DEFAULT_ACCOUNT_ID, [], region="us-east-2")
+
+    def test_create_instances__multiple_accounts(self):
+        self.client.create_stack_instances(
+            StackSetName=self.name,
+            Accounts=[self.acct01, self.acct02],
+            Regions=["us-east-2"],
+        )
+
+        # acct01 and 02 have a Stack
+        cf_backends[self.acct01]["us-east-2"].stacks.should.have.length_of(1)
+        cf_backends[self.acct02]["us-east-2"].stacks.should.have.length_of(1)
+        # Other acounts do not
+        cf_backends[self.acct21]["us-east-2"].stacks.should.have.length_of(0)
+        cf_backends[self.acct22]["us-east-2"].stacks.should.have.length_of(0)
+        cf_backends[DEFAULT_ACCOUNT_ID]["us-east-2"].stacks.should.have.length_of(0)
+
+        # acct01 and 02 have the queue
+        self._verify_queues(self.acct01, ["testqueue"], region="us-east-2")
+        self._verify_queues(self.acct02, ["testqueue"], region="us-east-2")
+        # other accounts are empty
+        self._verify_queues(self.acct21, [], region="us-east-2")
+        self._verify_queues(self.acct22, [], region="us-east-2")
+        self._verify_queues(DEFAULT_ACCOUNT_ID, [], region="us-east-2")
+
+    def test_delete_instances(self):
+        # Create two stack instances
+        self.client.create_stack_instances(
+            StackSetName=self.name,
+            Accounts=[self.acct01, self.acct02],
+            Regions=["us-east-2"],
+        )
+
+        # Delete one
+        self.client.delete_stack_instances(
+            StackSetName=self.name,
+            Accounts=[self.acct01],
+            Regions=["us-east-2"],
+            RetainStacks=False,
+        )
+
+        # Act02 still has it's stack
+        cf_backends[self.acct02]["us-east-2"].stacks.should.have.length_of(1)
+        # Other Stacks are removed
+        cf_backends[self.acct01]["us-east-2"].stacks.should.have.length_of(0)
+        cf_backends[self.acct21]["us-east-2"].stacks.should.have.length_of(0)
+        cf_backends[self.acct22]["us-east-2"].stacks.should.have.length_of(0)
+        cf_backends[DEFAULT_ACCOUNT_ID]["us-east-2"].stacks.should.have.length_of(0)
+
+        # Acct02 still has it's queue as well
+        self._verify_queues(self.acct02, ["testqueue"], region="us-east-2")
+        # Other queues are removed
+        self._verify_queues(self.acct01, [], region="us-east-2")
+        self._verify_queues(self.acct21, [], region="us-east-2")
+        self._verify_queues(self.acct22, [], region="us-east-2")
+        self._verify_queues(DEFAULT_ACCOUNT_ID, [], region="us-east-2")
+
+    def test_create_instances__single_ou(self):
+        with pytest.raises(ClientError) as exc:
+            self.client.create_stack_instances(
+                StackSetName=self.name,
+                DeploymentTargets={"OrganizationalUnitIds": [self.ou01]},
+                Regions=["us-east-1"],
+            )
+        err = exc.value.response["Error"]
+        err["Code"].should.equal("ValidationError")
+        err["Message"].should.equal(
+            "StackSets with SELF_MANAGED permission model can only have accounts as target"
+        )


### PR DESCRIPTION
Fixes #3425

create_stack_instances() now returns the actual OperationId
create_stack_set() now validates the provided name
create_stack_set() now supports the DeploymentTargets-parameter
create_stack_set() now actually creates the provided resources
delete_stack_set() now validates that no instances are present before deleting the set