### PR TITLE
Cloudformation: Various improvements

### DIFF
--- a/IMPLEMENTATION_COVERAGE.md
+++ b/IMPLEMENTATION_COVERAGE.md
@@ -565,7 +565,7 @@
 
 ## cloudformation
 <details>
-<summary>34% implemented</summary>
+<summary>50% implemented</summary>
 
 - [ ] activate_type
 - [ ] batch_describe_type_configurations
@@ -586,13 +586,13 @@
 - [ ] describe_change_set_hooks
 - [ ] describe_publisher
 - [ ] describe_stack_drift_detection_status
-- [ ] describe_stack_events
+- [X] describe_stack_events
 - [X] describe_stack_instance
-- [ ] describe_stack_resource
+- [X] describe_stack_resource
 - [ ] describe_stack_resource_drifts
-- [ ] describe_stack_resources
-- [ ] describe_stack_set
-- [ ] describe_stack_set_operation
+- [X] describe_stack_resources
+- [X] describe_stack_set
+- [X] describe_stack_set_operation
 - [X] describe_stacks
 - [ ] describe_type
 - [ ] describe_type_registration
@@ -602,7 +602,7 @@
 - [ ] estimate_template_cost
 - [X] execute_change_set
 - [X] get_stack_policy
-- [ ] get_template
+- [X] get_template
 - [ ] get_template_summary
 - [ ] import_stacks_to_stack_set
 - [X] list_change_sets
@@ -610,9 +610,9 @@
 - [ ] list_imports
 - [X] list_stack_instances
 - [X] list_stack_resources
-- [ ] list_stack_set_operation_results
-- [ ] list_stack_set_operations
-- [ ] list_stack_sets
+- [X] list_stack_set_operation_results
+- [X] list_stack_set_operations
+- [X] list_stack_sets
 - [X] list_stacks
 - [ ] list_type_registrations
 - [ ] list_type_versions
@@ -626,7 +626,7 @@
 - [ ] set_type_configuration
 - [ ] set_type_default_version
 - [ ] signal_resource
-- [ ] stop_stack_set_operation
+- [X] stop_stack_set_operation
 - [ ] test_type
 - [X] update_stack
 - [X] update_stack_instances

--- a/docs/docs/services/cloudformation.rst
+++ b/docs/docs/services/cloudformation.rst
@@ -62,13 +62,13 @@ cloudformation
 - [ ] describe_change_set_hooks
 - [ ] describe_publisher
 - [ ] describe_stack_drift_detection_status
-- [ ] describe_stack_events
+- [X] describe_stack_events
 - [X] describe_stack_instance
-- [ ] describe_stack_resource
+- [X] describe_stack_resource
 - [ ] describe_stack_resource_drifts
-- [ ] describe_stack_resources
-- [ ] describe_stack_set
-- [ ] describe_stack_set_operation
+- [X] describe_stack_resources
+- [X] describe_stack_set
+- [X] describe_stack_set_operation
 - [X] describe_stacks
 - [ ] describe_type
 - [ ] describe_type_registration
@@ -78,7 +78,7 @@ cloudformation
 - [ ] estimate_template_cost
 - [X] execute_change_set
 - [X] get_stack_policy
-- [ ] get_template
+- [X] get_template
 - [ ] get_template_summary
 - [ ] import_stacks_to_stack_set
 - [X] list_change_sets
@@ -91,9 +91,9 @@ cloudformation
         
 
 - [X] list_stack_resources
-- [ ] list_stack_set_operation_results
-- [ ] list_stack_set_operations
-- [ ] list_stack_sets
+- [X] list_stack_set_operation_results
+- [X] list_stack_set_operations
+- [X] list_stack_sets
 - [X] list_stacks
 - [ ] list_type_registrations
 - [ ] list_type_versions
@@ -111,7 +111,7 @@ cloudformation
 - [ ] set_type_configuration
 - [ ] set_type_default_version
 - [ ] signal_resource
-- [ ] stop_stack_set_operation
+- [X] stop_stack_set_operation
 - [ ] test_type
 - [X] update_stack
 - [X] update_stack_instances

--- a/moto/cloudformation/exceptions.py
+++ b/moto/cloudformation/exceptions.py
@@ -48,6 +48,16 @@ class StackSetNotEmpty(RESTError):
         )
 
 
+class StackSetNotFoundException(RESTError):
+    def __init__(self, name: str):
+        template = Template(ERROR_RESPONSE)
+        message = f"StackSet {name} not found"
+        super().__init__(error_type="StackSetNotFoundException", message=message)
+        self.description = template.render(
+            code="StackSetNotFoundException", message=message
+        )
+
+
 class UnsupportedAttribute(ValidationError):
     def __init__(self, resource: str, attr: str):
         template = Template(ERROR_RESPONSE)

--- a/tests/terraformtests/terraform-tests.success.txt
+++ b/tests/terraformtests/terraform-tests.success.txt
@@ -61,6 +61,24 @@ batch:
   - TestAccBatchJobQueue_ComputeEnvironments_externalOrderUpdate
 ce:
   - TestAccCECostCategory
+cloudformation:
+  - TestAccCloudFormationExportDataSource
+  - TestAccCloudFormationStackDataSource_DataSource
+  - TestAccCloudFormationStackSet_basic
+  - TestAccCloudFormationStackSet_templateBody
+  - TestAccCloudFormationStackSet_templateURL
+  - TestAccCloudFormationStackSet_description
+  - TestAccCloudFormationStackSet_operationPreferences
+  - TestAccCloudFormationStackSet_name
+  - TestAccCloudFormationStackSet_executionRoleName
+  - TestAccCloudFormationStackSet_disappears
+  - TestAccCloudFormationStack_basic
+  - TestAccCloudFormationStack_disappears
+  - TestAccCloudFormationStack_onFailure
+  - TestAccCloudFormationStack_yaml
+  - TestAccCloudFormationStack_withTransform
+  - TestAccCloudFormationStack_WithURLWithParams_withYAML
+  - TestAccCloudFormationStack_WithURL_withParams
 cloudfront:
   - TestAccCloudFrontDistributionDataSource_basic
   - TestAccCloudFrontDistribution_isIPV6Enabled

--- a/tests/test_cloudformation/test_cloudformation_stack_policies.py
+++ b/tests/test_cloudformation/test_cloudformation_stack_policies.py
@@ -72,6 +72,19 @@ def test_set_stack_policy_with_body():
 
 
 @mock_cloudformation
+def test_set_stack_policy_on_create():
+    cf_conn = boto3.client("cloudformation", region_name="us-east-1")
+    cf_conn.create_stack(
+        StackName="test_stack",
+        TemplateBody=dummy_template_json,
+        StackPolicyBody="stack_policy_body",
+    )
+
+    resp = cf_conn.get_stack_policy(StackName="test_stack")
+    resp.should.have.key("StackPolicyBody").equals("stack_policy_body")
+
+
+@mock_cloudformation
 @mock_s3
 def test_set_stack_policy_with_url():
     cf_conn = boto3.client("cloudformation", region_name="us-east-1")


### PR DESCRIPTION
describe_stack_set_operations(): Fixed the format of CreationTimestamp and EndTimestamp
create_stack(): Now propagates parameters StackPolicyBody and TimeoutInMinutes
create_stack_set(): Now propagates parameters AdministrationRoleARN and ExecutionRoleName
describe_stack_set(): Now returns the attributes Description, PermissionModel

Various methods have been moved to `models.py` to ensure they are picked up by the ImplementationCoverage-script