### PR TITLE
Fix: SQS fails to get newly-visible messages when long polling

### DIFF
--- a/moto/sqs/models.py
+++ b/moto/sqs/models.py
@@ -949,7 +949,7 @@ class SQSBackend(BaseBackend):
                     # so break to avoid an infinite loop.
                     break
 
-                queue.wait_for_messages(wait_seconds_timeout)
+                queue.wait_for_messages(1)
                 continue
 
             previous_result_count = len(result)

--- a/tests/test_sqs/test_sqs.py
+++ b/tests/test_sqs/test_sqs.py
@@ -3184,7 +3184,7 @@ def test_message_delay_is_more_than_15_minutes():
 
 @mock_sqs
 def test_receive_message_that_becomes_visible_while_long_polling():
-    sqs = boto3.resource("sqs")
+    sqs = boto3.resource("sqs", region_name="us-east-1")
     queue = sqs.create_queue(QueueName="test-queue")
     msg_body = str(uuid4())
     queue.send_message(MessageBody=msg_body)


### PR DESCRIPTION
The [original commit to remove the `sleep` call][1] only considered newly-arriving messages, but didn't take into account that existing messages could become visible in a much shorter time duration than the wait timeout.  This commit addresses this by checking for newly-visible messages at the visibility timeout granularity (seconds), which is still a major improvement over the original 10 millisecond polling.

Fixes #5710 

[1]: <https://github.com/spulec/moto/commit/d560ff002d6a188ceba295a012ef47415896c753> "Remove Sleep Call"