### PR TITLE
Add RDS promote_read_replica

### DIFF
--- a/moto/rds/models.py
+++ b/moto/rds/models.py
@@ -1385,6 +1385,15 @@ class RDSBackend(BaseBackend):
 
         return self.database_snapshots.pop(db_snapshot_identifier)
 
+    def promote_read_replica(self, db_kwargs):
+        database_id = db_kwargs["db_instance_identifier"]
+        database = self.databases.get(database_id)
+        if database.is_replica:
+            database.is_replica = False
+            database.update(db_kwargs)
+
+        return database
+
     def create_db_instance_read_replica(self, db_kwargs):
         database_id = db_kwargs["db_instance_identifier"]
         source_database_id = db_kwargs["source_db_identifier"]

--- a/moto/rds/responses.py
+++ b/moto/rds/responses.py
@@ -295,6 +295,14 @@ class RDSResponse(BaseResponse):
         template = self.response_template(DESCRIBE_SNAPSHOTS_TEMPLATE)
         return template.render(snapshots=snapshots)
 
+    def promote_read_replica(self):
+        db_instance_identifier = self._get_param("DBInstanceIdentifier")
+        db_kwargs = self._get_db_kwargs()
+        database = self.backend.promote_read_replica(db_kwargs)
+        database = self.backend.modify_db_instance(db_instance_identifier, db_kwargs)
+        template = self.response_template(PROMOTE_REPLICA_TEMPLATE)
+        return template.render(database=database)
+
     def delete_db_snapshot(self):
         db_snapshot_identifier = self._get_param("DBSnapshotIdentifier")
         snapshot = self.backend.delete_db_snapshot(db_snapshot_identifier)
@@ -703,6 +711,15 @@ MODIFY_DATABASE_TEMPLATE = """<ModifyDBInstanceResponse xmlns="http://rds.amazon
     <RequestId>bb58476c-a1a8-11e4-99cf-55e92d4bbada</RequestId>
   </ResponseMetadata>
 </ModifyDBInstanceResponse>"""
+
+PROMOTE_REPLICA_TEMPLATE = """<PromoteReadReplicaResponse xmlns="http://rds.amazonaws.com/doc/2014-09-01/">
+  <PromoteReadReplicaResult>
+  {{ database.to_xml() }}
+  </PromoteReadReplicaResult>
+  <ResponseMetadata>
+    <RequestId>8e8c0d64-be21-11d3-a71c-13dc2f771e41</RequestId>
+  </ResponseMetadata>
+</PromoteReadReplicaResponse>"""
 
 REBOOT_DATABASE_TEMPLATE = """<RebootDBInstanceResponse xmlns="http://rds.amazonaws.com/doc/2014-09-01/">
   <RebootDBInstanceResult>

--- a/tests/test_rds/test_rds.py
+++ b/tests/test_rds/test_rds.py
@@ -673,15 +673,15 @@ def test_promote_read_replica():
 
     conn.create_db_instance_read_replica(
         DBInstanceIdentifier="db-replica-1",
-        SourceDBInstanceIdentifier="db-master-1",
+        SourceDBInstanceIdentifier="db-primary-1",
         DBInstanceClass="db.m1.small",
     )
     conn.promote_read_replica(DBInstanceIdentifier="db-replica-1")
 
-    replicas = conn.describe_db_instance(DBInstanceIdentifier="db-primary-1").get(
+    replicas = conn.describe_db_instances(DBInstanceIdentifier="db-primary-1").get(
         "ReadReplicaDBInstanceIdentifiers"
     )
-    replicas.should.have.length_of(0)
+    assert replicas is None
 
 
 @mock_rds

--- a/tests/test_rds/test_rds.py
+++ b/tests/test_rds/test_rds.py
@@ -657,6 +657,34 @@ def test_describe_db_snapshots():
 
 
 @mock_rds
+def test_promote_read_replica():
+    conn = boto3.client("rds", region_name="us-west-2")
+    conn.create_db_instance(
+        DBInstanceIdentifier="db-primary-1",
+        AllocatedStorage=10,
+        Engine="postgres",
+        DBName="staging-postgres",
+        DBInstanceClass="db.m1.small",
+        MasterUsername="root",
+        MasterUserPassword="hunter2",
+        Port=1234,
+        DBSecurityGroups=["my_sg"],
+    )
+
+    conn.create_db_instance_read_replica(
+        DBInstanceIdentifier="db-replica-1",
+        SourceDBInstanceIdentifier="db-master-1",
+        DBInstanceClass="db.m1.small",
+    )
+    conn.promote_read_replica(DBInstanceIdentifier="db-replica-1")
+
+    replicas = conn.describe_db_instance(DBInstanceIdentifier="db-primary-1").get(
+        "ReadReplicaDBInstanceIdentifiers"
+    )
+    replicas.should.have.length_of(0)
+
+
+@mock_rds
 def test_delete_db_snapshot():
     conn = boto3.client("rds", region_name="us-west-2")
     conn.create_db_instance(


### PR DESCRIPTION
Currently moto/mock_rds doesn't support promote_read_replica(). This PR is to address that.

```shell

make lint
Running flake8...
flake8 moto tests
Running black...
(Make sure you have black-22.3.0 installed, as other versions will produce different results)
black --check moto/ tests/
All done! ✨ 🍰 ✨
1479 files would be left unchanged.
Running pylint...
pylint -j 0 moto tests

--------------------------------------------------------------------
Your code has been rated at 10.00/10 (previous run: 10.00/10, +0.00)

Running MyPy...
mypy --install-types --non-interactive
Success: no issues found in 171 source files

```