### PR TITLE
S3: Fix deadlock in list_object_versions after multipart upload

### DIFF
--- a/moto/s3/models.py
+++ b/moto/s3/models.py
@@ -161,12 +161,11 @@ class FakeKey(BaseModel, ManagedState):
 
     @property
     def value(self):
-        self.lock.acquire()
-        self._value_buffer.seek(0)
-        r = self._value_buffer.read()
-        r = copy.copy(r)
-        self.lock.release()
-        return r
+        with self.lock:
+            self._value_buffer.seek(0)
+            r = self._value_buffer.read()
+            r = copy.copy(r)
+            return r
 
     @property
     def arn(self):


### PR DESCRIPTION
After a completed multipart upload, the final FakeKey object contains a reference to the FakeMultipart object, which in turn contains references to the FakeKey objects used to represent each uploaded part. The FakeMultipart object, and its FakeKey objects, will have been disposed when the uploaded completed.

In list_object_versions, meanwhile, all FakeKey objects are deep copied, which results in copying and reading the values of the disposed FakeKey objects referenced by FakeMultipart objects.

Ultimately, this causes an exception in FakeKey.value(), since it's trying to read the value from a file that was closed when it was disposed. The exception is raised with a lock acquired, which results in a deadlock the next time the value is read.