### PR TITLE
Route53: Record overwrites

### DIFF
--- a/moto/route53/exceptions.py
+++ b/moto/route53/exceptions.py
@@ -177,5 +177,8 @@ class DnsNameInvalidForZone(Route53ClientError):
 class ChangeSetAlreadyExists(Route53ClientError):
     code = 400
 
-    def __init__(self):
-        super().__init__("InvalidChangeBatch", "Provided Change is a duplicate")
+    def __init__(self, action: str, name: str, _type: str):
+        super().__init__(
+            "InvalidChangeBatch",
+            f"Tried to {action.lower()} resource record set [name='{name}', type='{_type}'] but it already exists",
+        )

--- a/moto/route53/models.py
+++ b/moto/route53/models.py
@@ -532,8 +532,13 @@ class Route53Backend(BaseBackend):
     def change_resource_record_sets(self, zoneid, change_list) -> None:
         the_zone = self.get_hosted_zone(zoneid)
 
-        if any([rr for rr in change_list if rr in the_zone.rr_changes]):
-            raise ChangeSetAlreadyExists
+        for rr in change_list:
+            if rr in the_zone.rr_changes:
+                name = rr["ResourceRecordSet"]["Name"] + "."
+                _type = rr["ResourceRecordSet"]["Type"]
+                raise ChangeSetAlreadyExists(
+                    action=rr["Action"], name=name, _type=_type
+                )
 
         for value in change_list:
             original_change = copy.deepcopy(value)

--- a/tests/terraformtests/terraform-tests.success.txt
+++ b/tests/terraformtests/terraform-tests.success.txt
@@ -290,8 +290,8 @@ route53|1:
   - TestAccRoute53Record_setIdentifierChange
   - TestAccRoute53Record_empty
   - TestAccRoute53Record_longTXTrecord
-  - TestAccRoute53Record_doNotAllowOverwrite
-  - TestAccRoute53Record_allowOverwrite
+  - TestAccRoute53Record_Allow_doNotOverwrite
+  - TestAccRoute53Record_Allow_overwrite
 route53|2:
   - TestAccRoute53Zone_
   - TestAccRoute53ZoneAssociation


### PR DESCRIPTION
Changes introduced in #5725 were not tested properly because of wrong Terraform test-case names.

This PR corrects the test case names. 

Source: https://github.com/hashicorp/terraform-provider-aws/blob/163210e073650650adba645b636128fbc19244f4/internal/service/route53/record_test.go#L1322

This needs to be accompanied with the fix. @bblommers would you be able to take this over?