### PR TITLE
ECR Manifest List Support

### DIFF
--- a/moto/awslambda/models.py
+++ b/moto/awslambda/models.py
@@ -489,9 +489,16 @@ class LambdaFunction(CloudFormationModel, DockerModel):
                 ).hexdigest()
                 self.code_size = 0
             else:
-                uri, tag = self.code["ImageUri"].split(":")
+                if "@" in self.code["ImageUri"]:
+                    # deploying via digest
+                    uri, digest = self.code["ImageUri"].split("@")
+                    image_id = { "imageDigest": digest }
+                else:
+                    # deploying via tag
+                    uri, tag = self.code["ImageUri"].split(":")
+                    image_id = {"imageTag": tag}
+
                 repo_name = uri.split("/")[-1]
-                image_id = {"imageTag": tag}
                 ecr_backend = ecr_backends[self.account_id][self.region]
                 registry_id = ecr_backend.describe_registry()["registryId"]
                 images = ecr_backend.batch_get_image(

--- a/moto/awslambda/models.py
+++ b/moto/awslambda/models.py
@@ -492,7 +492,7 @@ class LambdaFunction(CloudFormationModel, DockerModel):
                 if "@" in self.code["ImageUri"]:
                     # deploying via digest
                     uri, digest = self.code["ImageUri"].split("@")
-                    image_id = { "imageDigest": digest }
+                    image_id = {"imageDigest": digest}
                 else:
                     # deploying via tag
                     uri, tag = self.code["ImageUri"].split(":")

--- a/moto/ecr/models.py
+++ b/moto/ecr/models.py
@@ -236,12 +236,12 @@ class Repository(BaseObject, CloudFormationModel):
 
 class Image(BaseObject):
     def __init__(
-        self, account_id, tag, manifest, repository, digest=None, registry_id=None
+        self, account_id, tag, manifest, repository, image_manifest_mediatype=None, digest=None, registry_id=None
     ):
         self.image_tag = tag
         self.image_tags = [tag] if tag is not None else []
         self.image_manifest = manifest
-        self.image_size_in_bytes = 50 * 1024 * 1024
+        self.image_manifest_mediatype = image_manifest_mediatype
         self.repository = repository
         self.registry_id = registry_id or account_id
         self.image_digest = digest
@@ -250,16 +250,30 @@ class Image(BaseObject):
 
     def _create_digest(self):
         image_manifest = json.loads(self.image_manifest)
-        layer_digests = [layer["digest"] for layer in image_manifest["layers"]]
-        self.image_digest = (
-            "sha256:"
-            + hashlib.sha256("".join(layer_digests).encode("utf-8")).hexdigest()
-        )
+        if "layers" in image_manifest: 
+            layer_digests = [layer["digest"] for layer in image_manifest["layers"]]
+            self.image_digest = (
+                "sha256:"
+                + hashlib.sha256("".join(layer_digests).encode("utf-8")).hexdigest()
+            )
+        else:
+            random_sha = hashlib.sha256(f"{random.randint(0,100)}".encode("utf-8")).hexdigest()
+            self.image_digest = f"sha256:{random_sha}"
 
     def get_image_digest(self):
         if not self.image_digest:
             self._create_digest()
         return self.image_digest
+
+    def get_image_size_in_bytes(self):
+        image_manifest = json.loads(self.image_manifest)
+        if "layers" in image_manifest:
+            try:
+                return image_manifest['config']['size']
+            except KeyError:
+                return 50 * 1024 * 1024
+        else:
+            return None
 
     def get_image_manifest(self):
         return self.image_manifest
@@ -303,9 +317,10 @@ class Image(BaseObject):
         response_object["imageTags"] = self.image_tags
         response_object["imageDigest"] = self.get_image_digest()
         response_object["imageManifest"] = self.image_manifest
+        response_object["imageManifestMediaType"] = self.image_manifest_mediatype
         response_object["repositoryName"] = self.repository
         response_object["registryId"] = self.registry_id
-        response_object["imageSizeInBytes"] = self.image_size_in_bytes
+        response_object["imageSizeInBytes"] = self.get_image_size_in_bytes()
         response_object["imagePushedAt"] = self.image_pushed_at
         return {k: v for k, v in response_object.items() if v is not None and v != []}
 
@@ -486,11 +501,25 @@ class ECRBackend(BaseBackend):
 
         return response
 
-    def put_image(self, repository_name, image_manifest, image_tag):
+    def put_image(self, repository_name, image_manifest, image_tag, image_manifest_mediatype=None):
         if repository_name in self.repositories:
             repository = self.repositories[repository_name]
         else:
             raise Exception(f"{repository_name} is not a repository")
+
+        try:
+            parsed_image_manifest = json.loads(image_manifest)
+        except:
+            raise Exception(f"Invalid parameter at 'ImageManifest' failed to satisfy constraint: 'Invalid JSON syntax'")
+
+        if image_manifest_mediatype:
+            parsed_image_manifest['imageManifest'] = image_manifest_mediatype
+        else:
+            if 'mediaType' not in parsed_image_manifest:
+                raise Exception("image manifest mediatype not provided in manifest or parameter")
+            else:
+                image_manifest_mediatype = parsed_image_manifest['mediaType']
+
 
         # Tags are unique, so delete any existing image with this tag first
         self.batch_delete_image(
@@ -503,9 +532,10 @@ class ECRBackend(BaseBackend):
                 repository.images,
             )
         )
+
         if not existing_images:
             # this image is not in ECR yet
-            image = Image(self.account_id, image_tag, image_manifest, repository_name)
+            image = Image(self.account_id, image_tag, image_manifest, repository_name, image_manifest_mediatype)
             repository.images.append(image)
             return image
         else:

--- a/tests/test_ecr/test_ecr_boto3.py
+++ b/tests/test_ecr/test_ecr_boto3.py
@@ -17,7 +17,10 @@ from unittest import SkipTest
 
 from moto.core import DEFAULT_ACCOUNT_ID as ACCOUNT_ID
 
-from tests.test_ecr.test_ecr_helpers import _create_image_manifest, _create_image_manifest_list, _generate_random_sha
+from tests.test_ecr.test_ecr_helpers import (
+    _create_image_manifest,
+    _create_image_manifest_list,
+)
 
 
 @mock_ecr
@@ -346,13 +349,14 @@ def test_put_image():
     response["image"]["repositoryName"].should.equal("test_repository")
     response["image"]["registryId"].should.equal(ACCOUNT_ID)
 
+
 @mock_ecr()
 def test_put_manifest_list():
     client = boto3.client("ecr", region_name="us-east-1")
     _ = client.create_repository(repositoryName="test_repository")
 
     manifest_list = _create_image_manifest_list()
-    for image_manifest in manifest_list['image_manifests']:
+    for image_manifest in manifest_list["image_manifests"]:
         _ = client.put_image(
             repositoryName="test_repository",
             imageManifest=json.dumps(image_manifest),
@@ -360,8 +364,8 @@ def test_put_manifest_list():
 
     response = client.put_image(
         repositoryName="test_repository",
-        imageManifest=json.dumps(manifest_list['manifest_list']),
-        imageTag="multiArch"
+        imageManifest=json.dumps(manifest_list["manifest_list"]),
+        imageTag="multiArch",
     )
 
     response["image"]["imageId"]["imageTag"].should.equal("multiArch")
@@ -369,7 +373,7 @@ def test_put_manifest_list():
     response["image"]["repositoryName"].should.equal("test_repository")
     response["image"]["registryId"].should.equal(ACCOUNT_ID)
     response["image"].should.have.key("imageManifest")
-    image_manifest = json.loads(response['image']["imageManifest"])
+    image_manifest = json.loads(response["image"]["imageManifest"])
     image_manifest.should.have.key("mediaType")
     image_manifest.should.have.key("manifests")
 
@@ -599,7 +603,7 @@ def test_describe_images():
     )
 
     manifest_list = _create_image_manifest_list()
-    for image_manifest in manifest_list['image_manifests']:
+    for image_manifest in manifest_list["image_manifests"]:
         _ = client.put_image(
             repositoryName="test_repository",
             imageManifest=json.dumps(image_manifest),
@@ -607,21 +611,35 @@ def test_describe_images():
 
     _ = client.put_image(
         repositoryName="test_repository",
-        imageManifest=json.dumps(manifest_list['manifest_list']),
-        imageTag="multiArch"
+        imageManifest=json.dumps(manifest_list["manifest_list"]),
+        imageTag="multiArch",
     )
 
     response = client.describe_images(repositoryName="test_repository")
     type(response["imageDetails"]).should.be(list)
     len(response["imageDetails"]).should.be(7)
-    
-    response["imageDetails"][0]["imageManifestMediaType"].should.contain("distribution.manifest.v2+json")
-    response["imageDetails"][1]["imageManifestMediaType"].should.contain("distribution.manifest.v2+json")
-    response["imageDetails"][2]["imageManifestMediaType"].should.contain("distribution.manifest.v2+json")
-    response["imageDetails"][3]["imageManifestMediaType"].should.contain("distribution.manifest.v2+json")
-    response["imageDetails"][4]["imageManifestMediaType"].should.contain("distribution.manifest.v2+json")
-    response["imageDetails"][5]["imageManifestMediaType"].should.contain("distribution.manifest.v2+json")
-    response["imageDetails"][6]["imageManifestMediaType"].should.contain("distribution.manifest.list.v2+json")
+
+    response["imageDetails"][0]["imageManifestMediaType"].should.contain(
+        "distribution.manifest.v2+json"
+    )
+    response["imageDetails"][1]["imageManifestMediaType"].should.contain(
+        "distribution.manifest.v2+json"
+    )
+    response["imageDetails"][2]["imageManifestMediaType"].should.contain(
+        "distribution.manifest.v2+json"
+    )
+    response["imageDetails"][3]["imageManifestMediaType"].should.contain(
+        "distribution.manifest.v2+json"
+    )
+    response["imageDetails"][4]["imageManifestMediaType"].should.contain(
+        "distribution.manifest.v2+json"
+    )
+    response["imageDetails"][5]["imageManifestMediaType"].should.contain(
+        "distribution.manifest.v2+json"
+    )
+    response["imageDetails"][6]["imageManifestMediaType"].should.contain(
+        "distribution.manifest.list.v2+json"
+    )
 
     response["imageDetails"][0]["imageDigest"].should.contain("sha")
     response["imageDetails"][1]["imageDigest"].should.contain("sha")
@@ -672,8 +690,8 @@ def test_describe_images():
     response["imageDetails"][2]["imageSizeInBytes"].should.be.greater_than(0)
     response["imageDetails"][3]["imageSizeInBytes"].should.be.greater_than(0)
     response["imageDetails"][4]["imageSizeInBytes"].should.be.greater_than(0)
-    response["imageDetails"][5]["imageSizeInBytes"].should.be.greater_than(0)    
-    
+    response["imageDetails"][5]["imageSizeInBytes"].should.be.greater_than(0)
+
 
 @mock_ecr
 def test_describe_images_by_tag():

--- a/tests/test_ecr/test_ecr_helpers.py
+++ b/tests/test_ecr/test_ecr_helpers.py
@@ -1,11 +1,11 @@
 import hashlib
 import random
-from typing import Dict
 
 
 def _generate_random_sha():
     random_sha = hashlib.sha256(f"{random.randint(0,100)}".encode("utf-8")).hexdigest()
     return f"sha256:{random_sha}"
+
 
 def _create_image_layers(n):
     layers = []
@@ -18,6 +18,7 @@ def _create_image_layers(n):
             }
         )
     return layers
+
 
 def _create_image_digest(layers):
     layer_digests = "".join([layer["digest"] for layer in layers])
@@ -39,37 +40,38 @@ def _create_image_manifest(image_digest=None):
         "layers": layers,
     }
 
-def _create_manifest_list_distribution(image_manifest: dict, architecture: str = "amd64", os: str = "linux"):
+
+def _create_manifest_list_distribution(
+    image_manifest: dict, architecture: str = "amd64", os: str = "linux"
+):
     return {
-        'mediaType': image_manifest['config']['mediaType'], 
-        'digest': image_manifest['config']['digest'], 
-        'size': image_manifest['config']['size'], 
-        'platform': {
-            'architecture': architecture, 
-            'os': os
-            }
+        "mediaType": image_manifest["config"]["mediaType"],
+        "digest": image_manifest["config"]["digest"],
+        "size": image_manifest["config"]["size"],
+        "platform": {"architecture": architecture, "os": os},
     }
+
 
 def _create_image_manifest_list():
     arm_image_manifest = _create_image_manifest()
     amd_image_manifest = _create_image_manifest()
-    arm_distribution = _create_manifest_list_distribution(arm_image_manifest, architecture="arm64")
-    amd_distribution = _create_manifest_list_distribution(amd_image_manifest, architecture="amd64")
+    arm_distribution = _create_manifest_list_distribution(
+        arm_image_manifest, architecture="arm64"
+    )
+    amd_distribution = _create_manifest_list_distribution(
+        amd_image_manifest, architecture="amd64"
+    )
     manifest_list = {
-            'mediaType': 'application/vnd.docker.distribution.manifest.list.v2+json',
-            'schemaVersion': 2,
-            'manifests': [
-                arm_distribution,
-                amd_distribution
-            ]
-        }
+        "mediaType": "application/vnd.docker.distribution.manifest.list.v2+json",
+        "schemaVersion": 2,
+        "manifests": [arm_distribution, amd_distribution],
+    }
 
     return {
-        'image_manifests': [arm_image_manifest, amd_image_manifest],
-        'manifest_list': manifest_list
+        "image_manifests": [arm_image_manifest, amd_image_manifest],
+        "manifest_list": manifest_list,
     }
-    
-    
+
 
 # {
 #             'registryId': '677771948337',

--- a/tests/test_ecr/test_ecr_helpers.py
+++ b/tests/test_ecr/test_ecr_helpers.py
@@ -1,6 +1,7 @@
 import hashlib
 import random
 
+# Manifests Spec: https://docs.docker.com/registry/spec/manifest-v2-2/
 
 def _generate_random_sha():
     random_sha = hashlib.sha256(f"{random.randint(0,100)}".encode("utf-8")).hexdigest()
@@ -22,7 +23,8 @@ def _create_image_layers(n):
 
 def _create_image_digest(layers):
     layer_digests = "".join([layer["digest"] for layer in layers])
-    return hashlib.sha256(f"{layer_digests}".encode("utf-8")).hexdigest()
+    summed_digest = hashlib.sha256(f"{layer_digests}".encode("utf-8")).hexdigest()
+    return f"sha256:{summed_digest}"
 
 
 def _create_image_manifest(image_digest=None):
@@ -35,7 +37,7 @@ def _create_image_manifest(image_digest=None):
         "config": {
             "mediaType": "application/vnd.docker.container.image.v1+json",
             "size": sum([layer["size"] for layer in layers]),
-            "digest": f"sha256:{image_digest}",
+            "digest": image_digest,
         },
         "layers": layers,
     }

--- a/tests/test_ecr/test_ecr_helpers.py
+++ b/tests/test_ecr/test_ecr_helpers.py
@@ -3,6 +3,7 @@ import random
 
 # Manifests Spec: https://docs.docker.com/registry/spec/manifest-v2-2/
 
+
 def _generate_random_sha():
     random_sha = hashlib.sha256(f"{random.randint(0,100)}".encode("utf-8")).hexdigest()
     return f"sha256:{random_sha}"

--- a/tests/test_ecr/test_ecr_helpers.py
+++ b/tests/test_ecr/test_ecr_helpers.py
@@ -1,10 +1,11 @@
 import hashlib
 import random
+from typing import Dict
 
 
 def _generate_random_sha():
-    return hashlib.sha256(f"{random.randint(0,100)}".encode("utf-8")).hexdigest()
-
+    random_sha = hashlib.sha256(f"{random.randint(0,100)}".encode("utf-8")).hexdigest()
+    return f"sha256:{random_sha}"
 
 def _create_image_layers(n):
     layers = []
@@ -13,11 +14,10 @@ def _create_image_layers(n):
             {
                 "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
                 "size": random.randint(100, 1000),
-                "digest": f"sha256:{_generate_random_sha()}",
+                "digest": _generate_random_sha(),
             }
         )
     return layers
-
 
 def _create_image_digest(layers):
     layer_digests = "".join([layer["digest"] for layer in layers])
@@ -34,7 +34,51 @@ def _create_image_manifest(image_digest=None):
         "config": {
             "mediaType": "application/vnd.docker.container.image.v1+json",
             "size": sum([layer["size"] for layer in layers]),
-            "digest": image_digest,
+            "digest": f"sha256:{image_digest}",
         },
         "layers": layers,
     }
+
+def _create_manifest_list_distribution(image_manifest: dict, architecture: str = "amd64", os: str = "linux"):
+    return {
+        'mediaType': image_manifest['config']['mediaType'], 
+        'digest': image_manifest['config']['digest'], 
+        'size': image_manifest['config']['size'], 
+        'platform': {
+            'architecture': architecture, 
+            'os': os
+            }
+    }
+
+def _create_image_manifest_list():
+    arm_image_manifest = _create_image_manifest()
+    amd_image_manifest = _create_image_manifest()
+    arm_distribution = _create_manifest_list_distribution(arm_image_manifest, architecture="arm64")
+    amd_distribution = _create_manifest_list_distribution(amd_image_manifest, architecture="amd64")
+    manifest_list = {
+            'mediaType': 'application/vnd.docker.distribution.manifest.list.v2+json',
+            'schemaVersion': 2,
+            'manifests': [
+                arm_distribution,
+                amd_distribution
+            ]
+        }
+
+    return {
+        'image_manifests': [arm_image_manifest, amd_image_manifest],
+        'manifest_list': manifest_list
+    }
+    
+    
+
+# {
+#             'registryId': '677771948337',
+#             'repositoryName': 'kaixo',
+#             'imageDigest': 'sha256:1b9176ea7c94fb3adf5b75770201d07c9f3c4659d745c53bd4b4f6090de2df85',
+#             'imageTags': ['0.0.1'],
+#             'imageSizeInBytes': 180225217,
+#             'imagePushedAt': datetime.datetime(2022, 12, 9, 10, 24, 12, tzinfo=tzlocal()),
+#             'imageManifestMediaType': 'application/vnd.docker.distribution.manifest.v2+json',
+#             'artifactMediaType': 'application/vnd.docker.container.image.v1+json',
+#             'lastRecordedPullTime': datetime.datetime(2022, 12, 9, 10, 24, 22, 519000, tzinfo=tzlocal())
+#         },

--- a/tests/test_ecr/test_ecr_helpers.py
+++ b/tests/test_ecr/test_ecr_helpers.py
@@ -71,16 +71,3 @@ def _create_image_manifest_list():
         "image_manifests": [arm_image_manifest, amd_image_manifest],
         "manifest_list": manifest_list,
     }
-
-
-# {
-#             'registryId': '677771948337',
-#             'repositoryName': 'kaixo',
-#             'imageDigest': 'sha256:1b9176ea7c94fb3adf5b75770201d07c9f3c4659d745c53bd4b4f6090de2df85',
-#             'imageTags': ['0.0.1'],
-#             'imageSizeInBytes': 180225217,
-#             'imagePushedAt': datetime.datetime(2022, 12, 9, 10, 24, 12, tzinfo=tzlocal()),
-#             'imageManifestMediaType': 'application/vnd.docker.distribution.manifest.v2+json',
-#             'artifactMediaType': 'application/vnd.docker.container.image.v1+json',
-#             'lastRecordedPullTime': datetime.datetime(2022, 12, 9, 10, 24, 22, 519000, tzinfo=tzlocal())
-#         },


### PR DESCRIPTION
# What?
- `imageManifestMediaType` now present in `describe_image()` response model.
- Deployment of lambdas using `{imageUri}@{digest}` now supported.
- Multi-arch manifest lists now supported.
- `imageByteSize` now attempts to present manifest information, if not present, defaults to previous static value. It also returns `None` in the case it's a manifest list, as manifest lists do not have this in their response model.

Largely this PR is to support that which is captured in this screenshot:

![image](https://user-images.githubusercontent.com/5049114/206874158-9557dd1f-67a7-4692-ad33-0fc5ac12ea09.png)

The above shows 3 image manifests, and one manifest list. The `0.0.1` image manifest stands on it's own. The `0.0.2` image manifest list represents the metadata which describes the untagged image manifests as being either `arm64` or `amd64`. `docker pull {uri}:0.0.2` traverses this to pull the correct image for your local machine arch. 