### PR TITLE
Create SOA in create_hosted_zone

### DIFF
--- a/moto/batch/models.py
+++ b/moto/batch/models.py
@@ -726,7 +726,7 @@ class Job(threading.Thread, BaseModel, DockerModel, ManagedState):
                     )
                     date = unix_time_millis(date_obj)
                     logs.append({"timestamp": date, "message": line.strip()})
-                logs = sorted(logs, key=lambda l: l["timestamp"])
+                logs = sorted(logs, key=lambda log: log["timestamp"])
 
                 # Send to cloudwatch
                 log_group = "/aws/batch/job"

--- a/moto/route53/models.py
+++ b/moto/route53/models.py
@@ -480,14 +480,28 @@ class Route53Backend(BaseBackend):
             comment=comment,
             delegation_set=delegation_set,
         )
+        # For each public hosted zone that you create, Amazon Route 53 automatically creates a name server (NS) record
+        # and a start of authority (SOA) record.
+        # https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/SOA-NSrecords.html
+        soa_record_set = {
+            "Name": f"{name}.",
+            "Type": "SOA",
+            "TTL": 900,
+            "ResourceRecords": [
+                {
+                    "Value": f"{delegation_set.name_servers[0]}. hostmaster.example.com. 1 7200 900 1209600 86400"
+                }
+            ],
+        }
         # default nameservers are also part of rrset
-        record_set = {
+        ns_record_set = {
             "Name": name,
             "ResourceRecords": delegation_set.name_servers,
             "TTL": "172800",
             "Type": "NS",
         }
-        new_zone.add_rrset(record_set)
+        new_zone.add_rrset(ns_record_set)
+        new_zone.add_rrset(soa_record_set)
         new_zone.add_vpc(vpcid, vpcregion)
         self.zones[new_id] = new_zone
         return new_zone

--- a/moto/route53/models.py
+++ b/moto/route53/models.py
@@ -484,7 +484,7 @@ class Route53Backend(BaseBackend):
         # and a start of authority (SOA) record.
         # https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/SOA-NSrecords.html
         soa_record_set = {
-            "Name": f"{name}.",
+            "Name": f"{name}" + ("" if name.endswith(".") else "."),
             "Type": "SOA",
             "TTL": 900,
             "ResourceRecords": [

--- a/tests/test_route53/test_route53.py
+++ b/tests/test_route53/test_route53.py
@@ -296,7 +296,7 @@ def test_deleting_weighted_route():
     cnames = conn.list_resource_record_sets(
         HostedZoneId=zone_id, StartRecordName="cname", StartRecordType="CNAME"
     )["ResourceRecordSets"]
-    cnames.should.have.length_of(3)
+    cnames.should.have.length_of(4)
 
     conn.change_resource_record_sets(
         HostedZoneId=zone_id,
@@ -318,9 +318,9 @@ def test_deleting_weighted_route():
     cnames = conn.list_resource_record_sets(
         HostedZoneId=zone_id, StartRecordName="cname", StartRecordType="CNAME"
     )["ResourceRecordSets"]
-    cnames.should.have.length_of(2)
-    cnames[1]["Name"].should.equal("cname.testdns.aws.com.")
-    cnames[1]["SetIdentifier"].should.equal("success-test-bar")
+    cnames.should.have.length_of(3)
+    cnames[-1]["Name"].should.equal("cname.testdns.aws.com.")
+    cnames[-1]["SetIdentifier"].should.equal("success-test-bar")
 
 
 @mock_route53
@@ -357,7 +357,7 @@ def test_deleting_latency_route():
     cnames = conn.list_resource_record_sets(
         HostedZoneId=zone_id, StartRecordName="cname", StartRecordType="CNAME"
     )["ResourceRecordSets"]
-    cnames.should.have.length_of(3)
+    cnames.should.have.length_of(4)
     foo_cname = [
         cname
         for cname in cnames
@@ -385,9 +385,9 @@ def test_deleting_latency_route():
     cnames = conn.list_resource_record_sets(
         HostedZoneId=zone_id, StartRecordName="cname", StartRecordType="CNAME"
     )["ResourceRecordSets"]
-    cnames.should.have.length_of(2)
-    cnames[1]["SetIdentifier"].should.equal("success-test-bar")
-    cnames[1]["Region"].should.equal("us-west-1")
+    cnames.should.have.length_of(3)
+    cnames[-1]["SetIdentifier"].should.equal("success-test-bar")
+    cnames[-1]["Region"].should.equal("us-west-1")
 
 
 @mock_route53
@@ -925,8 +925,10 @@ def test_change_weighted_resource_record_sets():
         },
     )
 
-    response = conn.list_resource_record_sets(HostedZoneId=hosted_zone_id)
-    record = response["ResourceRecordSets"][1]
+    rr_sets = conn.list_resource_record_sets(HostedZoneId=hosted_zone_id)[
+        "ResourceRecordSets"
+    ]
+    record = [r for r in rr_sets if r["Type"] == "A"][0]
     # Update the first record to have a weight of 90
     conn.change_resource_record_sets(
         HostedZoneId=hosted_zone_id,
@@ -952,7 +954,7 @@ def test_change_weighted_resource_record_sets():
         },
     )
 
-    record = response["ResourceRecordSets"][2]
+    record = [r for r in rr_sets if r["Type"] == "A"][1]
     # Update the second record to have a weight of 10
     conn.change_resource_record_sets(
         HostedZoneId=hosted_zone_id,

--- a/tests/test_route53/test_route53.py
+++ b/tests/test_route53/test_route53.py
@@ -19,7 +19,7 @@ def test_create_hosted_zone():
     firstzone.should.have.key("Id").match(r"/hostedzone/[A-Z0-9]+")
     firstzone.should.have.key("Name").equal("testdns.aws.com.")
     firstzone.should.have.key("Config").equal({"PrivateZone": False})
-    firstzone.should.have.key("ResourceRecordSetCount").equal(1)
+    firstzone.should.have.key("ResourceRecordSetCount").equal(2)
 
     delegation = response["DelegationSet"]
     delegation.should.have.key("NameServers").length_of(4)
@@ -244,8 +244,8 @@ def test_use_health_check_in_resource_record_set():
     record_sets = conn.list_resource_record_sets(HostedZoneId=zone_id)[
         "ResourceRecordSets"
     ]
-    record_sets[1]["Name"].should.equal("foo.bar.testdns.aws.com.")
-    record_sets[1]["HealthCheckId"].should.equal(check_id)
+    record_sets[2]["Name"].should.equal("foo.bar.testdns.aws.com.")
+    record_sets[2]["HealthCheckId"].should.equal(check_id)
 
 
 @mock_route53
@@ -640,8 +640,8 @@ def test_change_resource_record_sets_crud_valid():
     )
 
     response = conn.list_resource_record_sets(HostedZoneId=hosted_zone_id)
-    len(response["ResourceRecordSets"]).should.equal(2)
-    a_record_detail = response["ResourceRecordSets"][1]
+    len(response["ResourceRecordSets"]).should.equal(3)
+    a_record_detail = response["ResourceRecordSets"][2]
     a_record_detail["Name"].should.equal("prod.redis.db.")
     a_record_detail["Type"].should.equal("A")
     a_record_detail["TTL"].should.equal(10)
@@ -667,8 +667,8 @@ def test_change_resource_record_sets_crud_valid():
     )
 
     response = conn.list_resource_record_sets(HostedZoneId=hosted_zone_id)
-    len(response["ResourceRecordSets"]).should.equal(2)
-    cname_record_detail = response["ResourceRecordSets"][1]
+    len(response["ResourceRecordSets"]).should.equal(3)
+    cname_record_detail = response["ResourceRecordSets"][2]
     cname_record_detail["Name"].should.equal("prod.redis.db.")
     cname_record_detail["Type"].should.equal("A")
     cname_record_detail["TTL"].should.equal(60)
@@ -698,7 +698,7 @@ def test_change_resource_record_sets_crud_valid():
     )
 
     response = conn.list_resource_record_sets(HostedZoneId=hosted_zone_id)
-    cname_alias_record_detail = response["ResourceRecordSets"][1]
+    cname_alias_record_detail = response["ResourceRecordSets"][2]
     cname_alias_record_detail["Name"].should.equal("prod.redis.db.")
     cname_alias_record_detail["Type"].should.equal("A")
     cname_alias_record_detail["TTL"].should.equal(60)
@@ -730,7 +730,7 @@ def test_change_resource_record_sets_crud_valid():
         HostedZoneId=hosted_zone_id, ChangeBatch=delete_payload
     )
     response = conn.list_resource_record_sets(HostedZoneId=hosted_zone_id)
-    len(response["ResourceRecordSets"]).should.equal(1)
+    len(response["ResourceRecordSets"]).should.equal(2)
 
 
 @mock_route53
@@ -767,8 +767,8 @@ def test_change_resource_record_sets_crud_valid_with_special_xml_chars():
     )
 
     response = conn.list_resource_record_sets(HostedZoneId=hosted_zone_id)
-    len(response["ResourceRecordSets"]).should.equal(2)
-    a_record_detail = response["ResourceRecordSets"][1]
+    len(response["ResourceRecordSets"]).should.equal(3)
+    a_record_detail = response["ResourceRecordSets"][2]
     a_record_detail["Name"].should.equal("prod.redis.db.")
     a_record_detail["Type"].should.equal("TXT")
     a_record_detail["TTL"].should.equal(10)
@@ -795,8 +795,8 @@ def test_change_resource_record_sets_crud_valid_with_special_xml_chars():
     )
 
     response = conn.list_resource_record_sets(HostedZoneId=hosted_zone_id)
-    len(response["ResourceRecordSets"]).should.equal(2)
-    cname_record_detail = response["ResourceRecordSets"][1]
+    len(response["ResourceRecordSets"]).should.equal(3)
+    cname_record_detail = response["ResourceRecordSets"][2]
     cname_record_detail["Name"].should.equal("prod.redis.db.")
     cname_record_detail["Type"].should.equal("TXT")
     cname_record_detail["TTL"].should.equal(60)
@@ -823,7 +823,7 @@ def test_change_resource_record_sets_crud_valid_with_special_xml_chars():
         HostedZoneId=hosted_zone_id, ChangeBatch=delete_payload
     )
     response = conn.list_resource_record_sets(HostedZoneId=hosted_zone_id)
-    len(response["ResourceRecordSets"]).should.equal(1)
+    len(response["ResourceRecordSets"]).should.equal(2)
 
 
 @mock_route53
@@ -926,7 +926,7 @@ def test_change_weighted_resource_record_sets():
     )
 
     response = conn.list_resource_record_sets(HostedZoneId=hosted_zone_id)
-    record = response["ResourceRecordSets"][0]
+    record = response["ResourceRecordSets"][1]
     # Update the first record to have a weight of 90
     conn.change_resource_record_sets(
         HostedZoneId=hosted_zone_id,
@@ -952,7 +952,7 @@ def test_change_weighted_resource_record_sets():
         },
     )
 
-    record = response["ResourceRecordSets"][1]
+    record = response["ResourceRecordSets"][2]
     # Update the second record to have a weight of 10
     conn.change_resource_record_sets(
         HostedZoneId=hosted_zone_id,
@@ -1014,7 +1014,7 @@ def test_failover_record_sets():
     )
 
     response = conn.list_resource_record_sets(HostedZoneId=hosted_zone_id)
-    record = response["ResourceRecordSets"][1]
+    record = response["ResourceRecordSets"][2]
     record["Failover"].should.equal("PRIMARY")
 
 
@@ -1056,8 +1056,8 @@ def test_geolocation_record_sets():
 
     response = conn.list_resource_record_sets(HostedZoneId=hosted_zone_id)
     rrs = response["ResourceRecordSets"]
-    rrs[1]["GeoLocation"].should.equal({"ContinentCode": "EU"})
-    rrs[2]["GeoLocation"].should.equal({"CountryCode": "US", "SubdivisionCode": "NY"})
+    rrs[2]["GeoLocation"].should.equal({"ContinentCode": "EU"})
+    rrs[3]["GeoLocation"].should.equal({"CountryCode": "US", "SubdivisionCode": "NY"})
 
 
 @mock_route53
@@ -1095,7 +1095,7 @@ def test_change_resource_record_invalid():
         )
 
     response = conn.list_resource_record_sets(HostedZoneId=hosted_zone_id)
-    len(response["ResourceRecordSets"]).should.equal(1)
+    len(response["ResourceRecordSets"]).should.equal(2)
 
     invalid_cname_record_payload = {
         "Comment": "this should also fail",
@@ -1118,7 +1118,7 @@ def test_change_resource_record_invalid():
         )
 
     response = conn.list_resource_record_sets(HostedZoneId=hosted_zone_id)
-    len(response["ResourceRecordSets"]).should.equal(1)
+    len(response["ResourceRecordSets"]).should.equal(2)
 
 
 @mock_route53
@@ -1163,7 +1163,7 @@ def test_change_resource_record_invalid_action_value():
     )
 
     response = conn.list_resource_record_sets(HostedZoneId=hosted_zone_id)
-    len(response["ResourceRecordSets"]).should.equal(1)
+    len(response["ResourceRecordSets"]).should.equal(2)
 
 
 @mock_route53
@@ -1426,7 +1426,7 @@ def test_list_resource_recordset_pagination():
     response.should.have.key("ResourceRecordSets").length_of(100)
     response.should.have.key("IsTruncated").equals(True)
     response.should.have.key("MaxItems").equals("100")
-    response.should.have.key("NextRecordName").equals("env188.redis.db.")
+    response.should.have.key("NextRecordName").equals("env187.redis.db.")
     response.should.have.key("NextRecordType").equals("A")
 
     response = conn.list_resource_record_sets(
@@ -1437,7 +1437,7 @@ def test_list_resource_recordset_pagination():
     response.should.have.key("ResourceRecordSets").length_of(300)
     response.should.have.key("IsTruncated").equals(True)
     response.should.have.key("MaxItems").equals("300")
-    response.should.have.key("NextRecordName").equals("env458.redis.db.")
+    response.should.have.key("NextRecordName").equals("env457.redis.db.")
     response.should.have.key("NextRecordType").equals("A")
 
     response = conn.list_resource_record_sets(
@@ -1445,7 +1445,7 @@ def test_list_resource_recordset_pagination():
         StartRecordName=response["NextRecordName"],
         StartRecordType=response["NextRecordType"],
     )
-    response.should.have.key("ResourceRecordSets").length_of(101)
+    response.should.have.key("ResourceRecordSets").length_of(102)
     response.should.have.key("IsTruncated").equals(False)
     response.should.have.key("MaxItems").equals("300")
     response.shouldnt.have.key("NextRecordName")

--- a/tests/test_route53/test_route53_cloudformation.py
+++ b/tests/test_route53/test_route53_cloudformation.py
@@ -56,7 +56,7 @@ def test_create_stack_hosted_zone_by_id():
     # then a hosted zone should exist
     zone = conn.list_hosted_zones()["HostedZones"][0]
     zone.should.have.key("Name").equal("foo.bar.baz")
-    zone.should.have.key("ResourceRecordSetCount").equal(1)
+    zone.should.have.key("ResourceRecordSetCount").equal(2)
 
     # when adding a record set to this zone
     cf_conn.create_stack(
@@ -69,7 +69,7 @@ def test_create_stack_hosted_zone_by_id():
     updated_zone = conn.list_hosted_zones()["HostedZones"][0]
     updated_zone.should.have.key("Id").equal(zone["Id"])
     updated_zone.should.have.key("Name").equal("foo.bar.baz")
-    updated_zone.should.have.key("ResourceRecordSetCount").equal(2)
+    updated_zone.should.have.key("ResourceRecordSetCount").equal(3)
 
 
 @mock_cloudformation
@@ -88,8 +88,8 @@ def test_route53_roundrobin():
     rrsets = route53.list_resource_record_sets(HostedZoneId=zone_id)[
         "ResourceRecordSets"
     ]
-    rrsets.should.have.length_of(3)
-    record_set1 = rrsets[1]
+    rrsets.should.have.length_of(4)
+    record_set1 = rrsets[2]
     record_set1["Name"].should.equal("test_stack.us-west-1.my_zone.")
     record_set1["SetIdentifier"].should.equal("test_stack AWS")
     record_set1["Type"].should.equal("CNAME")
@@ -97,7 +97,7 @@ def test_route53_roundrobin():
     record_set1["Weight"].should.equal(3)
     record_set1["ResourceRecords"][0]["Value"].should.equal("aws.amazon.com")
 
-    record_set2 = rrsets[2]
+    record_set2 = rrsets[3]
     record_set2["Name"].should.equal("test_stack.us-west-1.my_zone.")
     record_set2["SetIdentifier"].should.equal("test_stack Amazon")
     record_set2["Type"].should.equal("CNAME")
@@ -133,9 +133,9 @@ def test_route53_ec2_instance_with_public_ip():
     rrsets = route53.list_resource_record_sets(HostedZoneId=zone_id)[
         "ResourceRecordSets"
     ]
-    rrsets.should.have.length_of(2)
+    rrsets.should.have.length_of(3)
 
-    record_set = rrsets[1]
+    record_set = rrsets[2]
     record_set["Name"].should.equal(f"{instance_id}.us-west-1.my_zone.")
     record_set.shouldnt.have.key("SetIdentifier")
     record_set["Type"].should.equal("A")
@@ -172,7 +172,7 @@ def test_route53_associate_health_check():
     rrsets = route53.list_resource_record_sets(HostedZoneId=zone_id)[
         "ResourceRecordSets"
     ]
-    rrsets.should.have.length_of(2)
+    rrsets.should.have.length_of(3)
     record_set = rrsets[0]
     record_set["HealthCheckId"].should.equal(health_check_id)
 
@@ -195,7 +195,7 @@ def test_route53_with_update():
     rrsets = route53.list_resource_record_sets(HostedZoneId=zone_id)[
         "ResourceRecordSets"
     ]
-    rrsets.should.have.length_of(2)
+    rrsets.should.have.length_of(3)
 
     record_set = rrsets[0]
     record_set["ResourceRecords"][0]["Value"].should.equal("my.example.com")
@@ -218,7 +218,7 @@ def test_route53_with_update():
     rrsets = route53.list_resource_record_sets(HostedZoneId=zone_id)[
         "ResourceRecordSets"
     ]
-    rrsets.should.have.length_of(2)
+    rrsets.should.have.length_of(3)
 
     record_set = rrsets[0]
     record_set["ResourceRecords"][0]["Value"].should.equal("my_other.example.com")


### PR DESCRIPTION
According to AWS Route 53 docs, an SOA record will be automatically added to any hosted zone created with create_hosted_zone.

https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/SOA-NSrecords.html

See issue #5762