### PR TITLE
S3: Return checksum header only if set

### DIFF
--- a/moto/s3/responses.py
+++ b/moto/s3/responses.py
@@ -1556,7 +1556,8 @@ class S3Response(BaseResponse):
         new_key.website_redirect_location = request.headers.get(
             "x-amz-website-redirect-location"
         )
-        new_key.checksum_algorithm = checksum_algorithm
+        if checksum_algorithm:
+            new_key.checksum_algorithm = checksum_algorithm
         self.backend.set_key_tags(new_key, tagging)
 
         response_headers.update(new_key.response_dict)

--- a/tests/test_s3/test_s3.py
+++ b/tests/test_s3/test_s3.py
@@ -1401,6 +1401,11 @@ def test_list_objects_v2_checksum_algo():
     s3 = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
     s3.create_bucket(Bucket="mybucket")
     resp = s3.put_object(
+        Bucket="mybucket", Key="0", Body="a"
+    )
+    resp.should_not.have.key("ChecksumCRC32")
+    resp["ResponseMetadata"]["HTTPHeaders"].should_not.have.key("x-amz-sdk-checksum-algorithm")
+    resp = s3.put_object(
         Bucket="mybucket", Key="1", Body="a", ChecksumAlgorithm="CRC32"
     )
     resp.should.have.key("ChecksumCRC32")
@@ -1416,8 +1421,9 @@ def test_list_objects_v2_checksum_algo():
     ].should.equal("SHA256")
 
     resp = s3.list_objects_v2(Bucket="mybucket")["Contents"]
-    resp[0].should.have.key("ChecksumAlgorithm").equals(["CRC32"])
-    resp[1].should.have.key("ChecksumAlgorithm").equals(["SHA256"])
+    resp[0].should_not.have.key("ChecksumAlgorithm")
+    resp[1].should.have.key("ChecksumAlgorithm").equals(["CRC32"])
+    resp[2].should.have.key("ChecksumAlgorithm").equals(["SHA256"])
 
 
 @mock_s3

--- a/tests/test_s3/test_s3.py
+++ b/tests/test_s3/test_s3.py
@@ -1400,11 +1400,11 @@ def test_list_objects_v2_truncate_combined_keys_and_folders():
 def test_list_objects_v2_checksum_algo():
     s3 = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
     s3.create_bucket(Bucket="mybucket")
-    resp = s3.put_object(
-        Bucket="mybucket", Key="0", Body="a"
-    )
+    resp = s3.put_object(Bucket="mybucket", Key="0", Body="a")
     resp.should_not.have.key("ChecksumCRC32")
-    resp["ResponseMetadata"]["HTTPHeaders"].should_not.have.key("x-amz-sdk-checksum-algorithm")
+    resp["ResponseMetadata"]["HTTPHeaders"].should_not.have.key(
+        "x-amz-sdk-checksum-algorithm"
+    )
     resp = s3.put_object(
         Bucket="mybucket", Key="1", Body="a", ChecksumAlgorithm="CRC32"
     )


### PR DESCRIPTION
### Summary

The `x-amz-sdk-checksum-algorithm` header was being returned with an empty `''` value.

This PR includes a fix so that it is only returned if also set in the request.

### Related

Regression of #5735