### PR TITLE
SQS: Align receive_message() response with AWS

### DIFF
--- a/moto/sqs/responses.py
+++ b/moto/sqs/responses.py
@@ -583,7 +583,8 @@ SEND_MESSAGE_RESPONSE = """<SendMessageResponse>
     </ResponseMetadata>
 </SendMessageResponse>"""
 
-RECEIVE_MESSAGE_RESPONSE = """<ReceiveMessageResponse>
+RECEIVE_MESSAGE_RESPONSE = """<?xml version="1.0"?>
+<ReceiveMessageResponse  xmlns="http://queue.amazonaws.com/doc/2012-11-05/">
   <ReceiveMessageResult>
     {% for message in messages %}
         <Message>
@@ -650,7 +651,7 @@ RECEIVE_MESSAGE_RESPONSE = """<ReceiveMessageResponse>
                 {% if 'Binary' in value.data_type %}
                 <BinaryValue>{{ value.binary_value }}</BinaryValue>
                 {% else %}
-                <StringValue><![CDATA[{{ value.string_value }}]]></StringValue>
+                <StringValue>{{ value.string_value|e }}</StringValue>
                 {% endif %}
               </Value>
             </MessageAttribute>
@@ -659,7 +660,7 @@ RECEIVE_MESSAGE_RESPONSE = """<ReceiveMessageResponse>
     {% endfor %}
   </ReceiveMessageResult>
   <ResponseMetadata>
-    <RequestId></RequestId>
+    <RequestId>5bdc09f4-0a03-5425-8468-55e04a092ed8</RequestId>
   </ResponseMetadata>
 </ReceiveMessageResponse>"""
 


### PR DESCRIPTION
Potential fix for #5769 

`{{ value.string_value|e }}` results in HTML-encoded output: `StringValue>&lt;att1&gt;</StringValue>`, which is equivalent to what AWS sends.

Incidentally, this changes the computation of `MD5OfMessageAttributes`, which computes the wrong value when the `StringValue` has the additional `CDATA`-stuff. 
I presume this is what trips up the C#-SDK, as reported in the linked issue - the MD5 computation.

(The other changes - adding `<?xml..>` and the RequestID - are just for sake of completeness. I don't imagine C# cares much, but you never know.)