### PR TITLE
Techdebt: replace mock with unittest.mock

### DIFF
--- a/tests/test_cognitoidentity/test_cognitoidentity.py
+++ b/tests/test_cognitoidentity/test_cognitoidentity.py
@@ -1,5 +1,5 @@
 import boto3
-import mock
+from unittest import mock
 import sure  # noqa # pylint: disable=unused-import
 from botocore.exceptions import ClientError
 from datetime import datetime

--- a/tests/test_cognitoidp/test_cognitoidp.py
+++ b/tests/test_cognitoidp/test_cognitoidp.py
@@ -5,7 +5,7 @@ import os
 import random
 import re
 
-import mock
+from unittest import mock
 import moto.cognitoidp.models
 import requests
 import hmac

--- a/tests/test_core/test_mock_regions.py
+++ b/tests/test_core/test_mock_regions.py
@@ -1,5 +1,5 @@
 import boto3
-import mock
+from unittest import mock
 import os
 import pytest
 from moto import mock_dynamodb, mock_sns, settings

--- a/tests/test_core/test_settings.py
+++ b/tests/test_core/test_settings.py
@@ -1,5 +1,5 @@
 import os
-import mock
+from unittest import mock
 import pytest
 import sure  # noqa # pylint: disable=unused-import
 

--- a/tests/test_ecs/test_ecs_boto3.py
+++ b/tests/test_ecs/test_ecs_boto3.py
@@ -2,7 +2,7 @@ from datetime import datetime
 
 from botocore.exceptions import ClientError
 import boto3
-import mock
+from unittest import mock
 import sure  # noqa # pylint: disable=unused-import
 import json
 import os

--- a/tests/test_eks/test_eks.py
+++ b/tests/test_eks/test_eks.py
@@ -2,7 +2,7 @@ from copy import deepcopy
 from unittest import SkipTest
 
 import boto3
-import mock
+from unittest import mock
 import pytest
 import sure  # noqa # pylint: disable=unused-import
 from botocore.exceptions import ClientError


### PR DESCRIPTION
From https://pypi.org/project/mock/,

> mock is now part of the Python standard library, available as
> unittest.mock in Python 3.3 onwards.
>
> This package contains a rolling backport of the standard library mock
> code compatible with Python 3.6 and up.

As moto already requires Python >= 3.6 [1], usage of the backport library is not necessary and can be replaced with the one from the standard library.

[1] https://github.com/spulec/moto/blob/4.0.11/setup.py#L141

---

This is part of efforts on dropping python-mock package in Arch Linux: https://archlinux.org/todo/drop-python-mock-checkdepends/