### PR TITLE
Kinesis: Support new endpoint for botocore 1.29.31

### DIFF
--- a/moto/kinesis/urls.py
+++ b/moto/kinesis/urls.py
@@ -3,6 +3,9 @@ from .responses import KinesisResponse
 url_bases = [
     # Need to avoid conflicting with kinesisvideo
     r"https?://kinesis\.(.+)\.amazonaws\.com",
+    # Somewhere around boto3-1.26.31 botocore-1.29.31, AWS started using a new endpoint:
+    # 	111122223333.control-kinesis.us-east-1.amazonaws.com
+    r"https?://(.+)\.control-kinesis\.(.+)\.amazonaws\.com",
 ]
 
 url_paths = {"{0}/$": KinesisResponse.dispatch}

--- a/tests/test_kinesis/test_kinesis_stream_consumers.py
+++ b/tests/test_kinesis/test_kinesis_stream_consumers.py
@@ -98,11 +98,14 @@ def test_describe_stream_consumer_unknown():
     client = boto3.client("kinesis", region_name="us-east-2")
     create_stream(client)
 
+    unknown_arn = f"arn:aws:kinesis:us-east-2:{ACCOUNT_ID}:stream/unknown"
     with pytest.raises(ClientError) as exc:
-        client.describe_stream_consumer(ConsumerARN="unknown")
+        client.describe_stream_consumer(ConsumerARN=unknown_arn)
     err = exc.value.response["Error"]
     err["Code"].should.equal("ResourceNotFoundException")
-    err["Message"].should.equal(f"Consumer unknown, account {ACCOUNT_ID} not found.")
+    err["Message"].should.equal(
+        f"Consumer {unknown_arn}, account {ACCOUNT_ID} not found."
+    )
 
 
 @mock_kinesis


### PR DESCRIPTION
Somewhere around boto3-1.26.31 botocore-1.29.31, AWS started using a new endpoint:
{ACCOUNT_ID}.control-kinesis.us-east-1.amazonaws.com

Boto3 also added some ARN validation, so the provided parameter now has to look like an ARN before it makes a request to AWS/Moto.

These changes should fix the build.