### PR TITLE
Add sagemaker mock call: delete_pipeline

### DIFF
--- a/docs/docs/services/sagemaker.rst
+++ b/docs/docs/services/sagemaker.rst
@@ -108,7 +108,7 @@ sagemaker
 - [ ] delete_monitoring_schedule
 - [X] delete_notebook_instance
 - [X] delete_notebook_instance_lifecycle_config
-- [ ] delete_pipeline
+- [X] delete_pipeline
 - [ ] delete_project
 - [ ] delete_studio_lifecycle_config
 - [X] delete_tags

--- a/moto/sagemaker/models.py
+++ b/moto/sagemaker/models.py
@@ -1774,6 +1774,21 @@ class SageMakerModelBackend(BaseBackend):
         self.pipelines[pipeline_name] = pipeline
         return pipeline
 
+    def delete_pipeline(
+        self,
+        pipeline_name,
+    ):
+        for ix, pipeline in enumerate(self.pipelines):
+            if pipeline.pipeline_name == pipeline_name:
+                pipeline_arn = pipeline.pipeline_arn
+                self.pipelines.pop(ix)
+        try:
+            return {"PipelineArn": pipeline_arn}
+        except NameError:
+            raise ValidationError(
+                message=f"Could not find pipeline with name {pipeline_name}."
+            )
+
     def list_pipelines(
         self,
         pipeline_name_prefix,

--- a/moto/sagemaker/models.py
+++ b/moto/sagemaker/models.py
@@ -1778,16 +1778,14 @@ class SageMakerModelBackend(BaseBackend):
         self,
         pipeline_name,
     ):
-        for ix, pipeline in enumerate(self.pipelines):
-            if pipeline.pipeline_name == pipeline_name:
-                pipeline_arn = pipeline.pipeline_arn
-                self.pipelines.pop(ix)
         try:
-            return {"PipelineArn": pipeline_arn}
-        except NameError:
+            pipeline_arn = self.pipelines[pipeline_name].pipeline_arn
+        except KeyError:
             raise ValidationError(
                 message=f"Could not find pipeline with name {pipeline_name}."
             )
+        del self.pipelines[pipeline_name]
+        return pipeline_arn
 
     def list_pipelines(
         self,

--- a/moto/sagemaker/responses.py
+++ b/moto/sagemaker/responses.py
@@ -486,6 +486,14 @@ class SageMakerResponse(BaseResponse):
         return 200, {}, json.dumps(response)
 
     @amzn_request_id
+    def delete_pipeline(self):
+        pipeline_arn = self.sagemaker_backend.delete_pipeline(
+            pipeline_name=self._get_param("PipelineName"),
+        )
+        response = {"PipelineArn": pipeline_arn}
+        return 200, {}, json.dumps(response)
+
+    @amzn_request_id
     def list_pipelines(self):
         max_results_range = range(1, 101)
         allowed_sort_by = ("Name", "CreationTime")

--- a/tests/test_sagemaker/test_sagemaker_pipeline.py
+++ b/tests/test_sagemaker/test_sagemaker_pipeline.py
@@ -183,12 +183,22 @@ def test_list_pipelines_invalid_values(sagemaker_client, list_pipelines_kwargs):
 def test_delete_pipeline_exists(sagemaker_client):
     fake_pipeline_names = ["APipelineName", "BPipelineName", "CPipelineName"]
     _ = create_sagemaker_pipelines(sagemaker_client, fake_pipeline_names, 0.0)
-    to_be_deleted = fake_pipeline_names[0]
-    response = sagemaker_client.delete_pipeline(PipelineName=to_be_deleted)
-    assert response["PipelineArn"].endswith(to_be_deleted)
+    pipeline_name_delete, pipeline_names_remain = (
+        fake_pipeline_names[0],
+        fake_pipeline_names[1:],
+    )
 
-    response = sagemaker_client.list_pipelines(PipelineNamePrefix=to_be_deleted)
+    response = sagemaker_client.delete_pipeline(PipelineName=pipeline_name_delete)
+    assert response["PipelineArn"].endswith(pipeline_name_delete)
+
+    response = sagemaker_client.list_pipelines(PipelineNamePrefix=pipeline_name_delete)
     assert response["PipelineSummaries"].should.be.empty
+
+    response = sagemaker_client.list_pipelines()
+    pipeline_names_exist = [
+        pipeline["PipelineName"] for pipeline in response["PipelineSummaries"]
+    ]
+    assert pipeline_names_remain == pipeline_names_exist
 
 
 def test_delete_pipeline_not_exists(sagemaker_client):

--- a/tests/test_sagemaker/test_sagemaker_pipeline.py
+++ b/tests/test_sagemaker/test_sagemaker_pipeline.py
@@ -178,3 +178,19 @@ def test_list_pipelines_created_before(sagemaker_client):
 def test_list_pipelines_invalid_values(sagemaker_client, list_pipelines_kwargs):
     with pytest.raises(botocore.exceptions.ClientError):
         _ = sagemaker_client.list_pipelines(**list_pipelines_kwargs)
+
+
+def test_delete_pipeline_exists(sagemaker_client):
+    fake_pipeline_names = ["APipelineName", "BPipelineName", "CPipelineName"]
+    _ = create_sagemaker_pipelines(sagemaker_client, fake_pipeline_names, 0.0)
+    to_be_deleted = fake_pipeline_names[0]
+    response = sagemaker_client.delete_pipeline(PipelineName=to_be_deleted)
+    assert response["PipelineArn"].endswith(to_be_deleted)
+
+    response = sagemaker_client.list_pipelines(PipelineNamePrefix=to_be_deleted)
+    assert response["PipelineSummaries"].should.be.empty
+
+
+def test_delete_pipeline_not_exists(sagemaker_client):
+    with pytest.raises(botocore.exceptions.ClientError):
+        _ = sagemaker_client.delete_pipeline(PipelineName="some-pipeline-name")


### PR DESCRIPTION
Adding sagemaker mock call `delete_pipeline`

`boto3.client("sagemaker").delete_pipeline`
https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/sagemaker.html#SageMaker.Client.delete_pipeline