### PR TITLE
fix(route53): Allow upsert for resource records that already exist.

### DIFF
--- a/moto/route53/exceptions.py
+++ b/moto/route53/exceptions.py
@@ -174,11 +174,11 @@ class DnsNameInvalidForZone(Route53ClientError):
         super().__init__("InvalidChangeBatch", error_msg)
 
 
-class ChangeSetAlreadyExists(Route53ClientError):
+class ResourceRecordAlreadyExists(Route53ClientError):
     code = 400
 
-    def __init__(self, action: str, name: str, _type: str):
+    def __init__(self, name: str, _type: str):
         super().__init__(
             "InvalidChangeBatch",
-            f"Tried to {action.lower()} resource record set [name='{name}', type='{_type}'] but it already exists",
+            f"Tried to create resource record set [name='{name}', type='{_type}'] but it already exists",
         )


### PR DESCRIPTION
From [AWS API Reference](https://docs.aws.amazon.com/Route53/latest/APIReference/API_ChangeResourceRecordSets.html) about the UPSERT action:

> `UPSERT`: If a resource set exists Route 53 updates it with the values in the request.

Thus, providing a resource record set that already exist to the UPSERT
action should succeed.

Additional changes in tests:
- Add check for error message in the existing unit test.
- Add unit test for creating a resource record with an UPSERT.