### PR TITLE
Add sagemaker mock call: describe_pipeline

### DIFF
--- a/docs/docs/services/sagemaker.rst
+++ b/docs/docs/services/sagemaker.rst
@@ -170,7 +170,7 @@ sagemaker
 - [ ] describe_monitoring_schedule
 - [ ] describe_notebook_instance
 - [X] describe_notebook_instance_lifecycle_config
-- [ ] describe_pipeline
+- [X] describe_pipeline
 - [ ] describe_pipeline_definition_for_execution
 - [ ] describe_pipeline_execution
 - [X] describe_processing_job

--- a/moto/sagemaker/models.py
+++ b/moto/sagemaker/models.py
@@ -92,7 +92,7 @@ class FakePipeline(BaseObject):
         self.pipeline_arn = arn_formatter(
             "pipeline", pipeline_name, account_id, region_name
         )
-        self.pipeline_display_name = pipeline_display_name
+        self.pipeline_display_name = pipeline_display_name or pipeline_name
         self.pipeline_definition = pipeline_definition
         self.pipeline_description = pipeline_description
         self.role_arn = role_arn
@@ -103,7 +103,27 @@ class FakePipeline(BaseObject):
         now_string = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
         self.creation_time = now_string
         self.last_modified_time = now_string
-        self.last_execution_time = now_string
+        self.last_execution_time = None
+
+        self.pipeline_status = "Active"
+        fake_user_profile_name = "fake-user-profile-name"
+        fake_domain_id = "fake-domain-id"
+        fake_user_profile_arn = arn_formatter(
+            "user-profile",
+            f"{fake_domain_id}/{fake_user_profile_name}",
+            account_id,
+            region_name,
+        )
+        self.created_by = {
+            "UserProfileArn": fake_user_profile_arn,
+            "UserProfileName": fake_user_profile_name,
+            "DomainId": fake_domain_id,
+        }
+        self.last_modified_by = {
+            "UserProfileArn": fake_user_profile_arn,
+            "UserProfileName": fake_user_profile_name,
+            "DomainId": fake_domain_id,
+        }
 
 
 class FakeProcessingJob(BaseObject):
@@ -1758,6 +1778,11 @@ class SageMakerModelBackend(BaseBackend):
         tags,
         parallelism_configuration,
     ):
+        if not any([pipeline_definition, pipeline_definition_s3_location]):
+            raise ValidationError(
+                "An error occurred (ValidationException) when calling the CreatePipeline operation: Either "
+                "Pipeline Definition or Pipeline Definition S3 location should be provided"
+            )
         pipeline = FakePipeline(
             pipeline_name,
             pipeline_display_name,
@@ -1820,6 +1845,35 @@ class SageMakerModelBackend(BaseBackend):
                 setattr(self.pipelines[pipeline_name], attr_key, attr_value)
 
         return pipeline_arn
+
+    def describe_pipeline(
+        self,
+        pipeline_name,
+    ):
+        try:
+            pipeline = self.pipelines[pipeline_name]
+        except KeyError:
+            raise ValidationError(
+                message=f"Could not find pipeline with name {pipeline_name}."
+            )
+
+        response = {
+            "PipelineArn": pipeline.pipeline_arn,
+            "PipelineName": pipeline.pipeline_name,
+            "PipelineDisplayName": pipeline.pipeline_display_name,
+            "PipelineDescription": pipeline.pipeline_description,
+            "PipelineDefinition": pipeline.pipeline_definition,
+            "RoleArn": pipeline.role_arn,
+            "PipelineStatus": pipeline.pipeline_status,
+            "CreationTime": pipeline.creation_time,
+            "LastModifiedTime": pipeline.last_modified_time,
+            "LastRunTime": pipeline.last_execution_time,
+            "CreatedBy": pipeline.created_by,
+            "LastModifiedBy": pipeline.last_modified_by,
+            "ParallelismConfiguration": pipeline.parallelism_configuration,
+        }
+
+        return response
 
     def list_pipelines(
         self,

--- a/moto/sagemaker/models.py
+++ b/moto/sagemaker/models.py
@@ -1778,10 +1778,16 @@ class SageMakerModelBackend(BaseBackend):
         tags,
         parallelism_configuration,
     ):
-        if not any([pipeline_definition, pipeline_definition_s3_location]):
+        if pipeline_definition_s3_location:
+            raise NotImplementedError(
+                "Loading a Pipeline Definition from a mocked S3 bucket via "
+                "PipelineDefinitionS3Location is not implemented yet. Please, directly "
+                "pass a PipelineDefinition."
+            )
+        if not pipeline_definition:
             raise ValidationError(
-                "An error occurred (ValidationException) when calling the CreatePipeline operation: Either "
-                "Pipeline Definition or Pipeline Definition S3 location should be provided"
+                "An error occurred (ValidationException) when calling the CreatePipeline operation: "
+                "Pipeline Definition must be provided"
             )
         pipeline = FakePipeline(
             pipeline_name,

--- a/moto/sagemaker/responses.py
+++ b/moto/sagemaker/responses.py
@@ -466,6 +466,13 @@ class SageMakerResponse(BaseResponse):
         return 200, {}, json.dumps(response)
 
     @amzn_request_id
+    def describe_pipeline(self):
+        response = self.sagemaker_backend.describe_pipeline(
+            self._get_param("PipelineName")
+        )
+        return 200, {}, json.dumps(response)
+
+    @amzn_request_id
     def create_pipeline(self):
         pipeline = self.sagemaker_backend.create_pipeline(
             pipeline_name=self._get_param("PipelineName"),

--- a/moto/sagemaker/utils.py
+++ b/moto/sagemaker/utils.py
@@ -1,0 +1,12 @@
+import boto3
+import json
+
+
+def load_pipeline_definition_from_s3(pipeline_definition_s3_location):
+    client = boto3.client("s3")
+    result = client.get_object(
+        Bucket=pipeline_definition_s3_location["Bucket"],
+        Key=pipeline_definition_s3_location["ObjectKey"],
+    )
+    pipeline_definition = json.loads(result["Body"].read())
+    return pipeline_definition

--- a/tests/test_sagemaker/test_sagemaker_pipeline.py
+++ b/tests/test_sagemaker/test_sagemaker_pipeline.py
@@ -21,13 +21,10 @@ def fixture_sagemaker_client():
         yield boto3.client("sagemaker", region_name=TEST_REGION_NAME)
 
 
-def create_sagemaker_pipelines(sagemaker_client, pipeline_names, wait_seconds=0.0):
+def create_sagemaker_pipelines(sagemaker_client, pipelines, wait_seconds=0.0):
     responses = []
-    for pipeline_name in pipeline_names:
-        responses += sagemaker_client.create_pipeline(
-            PipelineName=pipeline_name,
-            RoleArn=FAKE_ROLE_ARN,
-        )
+    for pipeline in pipelines:
+        responses += sagemaker_client.create_pipeline(**pipeline)
         sleep(wait_seconds)
     return responses
 
@@ -37,11 +34,34 @@ def test_create_pipeline(sagemaker_client):
     response = sagemaker_client.create_pipeline(
         PipelineName=fake_pipeline_name,
         RoleArn=FAKE_ROLE_ARN,
+        PipelineDefinition=" ",
     )
     assert isinstance(response, dict)
     response["PipelineArn"].should.equal(
         arn_formatter("pipeline", fake_pipeline_name, ACCOUNT_ID, TEST_REGION_NAME)
     )
+
+
+@pytest.mark.parametrize(
+    "create_pipeline_kwargs",
+    [
+        {"PipelineName": "MyPipelineName", "RoleArn": FAKE_ROLE_ARN},
+        {"RoleArn": FAKE_ROLE_ARN, "PipelineDefinition": " "},
+        {"PipelineName": "MyPipelineName", "PipelineDefinition": " "},
+    ],
+)
+def test_create_pipeline_missing_required_kwargs(
+    sagemaker_client, create_pipeline_kwargs
+):
+    with pytest.raises(
+        (
+            botocore.exceptions.ParamValidationError,
+            botocore.exceptions.ClientError,
+        )
+    ):
+        _ = sagemaker_client.create_pipeline(
+            **create_pipeline_kwargs,
+        )
 
 
 def test_list_pipelines_none(sagemaker_client):
@@ -52,7 +72,15 @@ def test_list_pipelines_none(sagemaker_client):
 
 def test_list_pipelines_single(sagemaker_client):
     fake_pipeline_names = ["APipelineName"]
-    _ = create_sagemaker_pipelines(sagemaker_client, fake_pipeline_names)
+    pipelines = [
+        {
+            "PipelineName": fake_pipeline_names[0],
+            "RoleArn": FAKE_ROLE_ARN,
+            "PipelineDefinition": " ",
+        },
+    ]
+    _ = create_sagemaker_pipelines(sagemaker_client, pipelines)
+
     response = sagemaker_client.list_pipelines()
     response["PipelineSummaries"].should.have.length_of(1)
     response["PipelineSummaries"][0]["PipelineArn"].should.equal(
@@ -62,7 +90,16 @@ def test_list_pipelines_single(sagemaker_client):
 
 def test_list_pipelines_multiple(sagemaker_client):
     fake_pipeline_names = ["APipelineName", "BPipelineName"]
-    _ = create_sagemaker_pipelines(sagemaker_client, fake_pipeline_names)
+    pipelines = [
+        {
+            "PipelineName": fake_pipeline_name,
+            "RoleArn": FAKE_ROLE_ARN,
+            "PipelineDefinition": " ",
+        }
+        for fake_pipeline_name in fake_pipeline_names
+    ]
+    _ = create_sagemaker_pipelines(sagemaker_client, pipelines)
+
     response = sagemaker_client.list_pipelines(
         SortBy="Name",
         SortOrder="Ascending",
@@ -72,7 +109,16 @@ def test_list_pipelines_multiple(sagemaker_client):
 
 def test_list_pipelines_sort_name_ascending(sagemaker_client):
     fake_pipeline_names = ["APipelineName", "BPipelineName", "CPipelineName"]
-    _ = create_sagemaker_pipelines(sagemaker_client, fake_pipeline_names)
+    pipelines = [
+        {
+            "PipelineName": fake_pipeline_name,
+            "RoleArn": FAKE_ROLE_ARN,
+            "PipelineDefinition": " ",
+        }
+        for fake_pipeline_name in fake_pipeline_names
+    ]
+    _ = create_sagemaker_pipelines(sagemaker_client, pipelines)
+
     response = sagemaker_client.list_pipelines(
         SortBy="Name",
         SortOrder="Ascending",
@@ -90,7 +136,16 @@ def test_list_pipelines_sort_name_ascending(sagemaker_client):
 
 def test_list_pipelines_sort_creation_time_descending(sagemaker_client):
     fake_pipeline_names = ["APipelineName", "BPipelineName", "CPipelineName"]
-    _ = create_sagemaker_pipelines(sagemaker_client, fake_pipeline_names, 1)
+    pipelines = [
+        {
+            "PipelineName": fake_pipeline_name,
+            "RoleArn": FAKE_ROLE_ARN,
+            "PipelineDefinition": " ",
+        }
+        for fake_pipeline_name in fake_pipeline_names
+    ]
+    _ = create_sagemaker_pipelines(sagemaker_client, pipelines, 1.0)
+
     response = sagemaker_client.list_pipelines(
         SortBy="CreationTime",
         SortOrder="Descending",
@@ -108,14 +163,30 @@ def test_list_pipelines_sort_creation_time_descending(sagemaker_client):
 
 def test_list_pipelines_max_results(sagemaker_client):
     fake_pipeline_names = ["APipelineName", "BPipelineName", "CPipelineName"]
-    _ = create_sagemaker_pipelines(sagemaker_client, fake_pipeline_names, 0.0)
+    pipelines = [
+        {
+            "PipelineName": fake_pipeline_name,
+            "RoleArn": FAKE_ROLE_ARN,
+            "PipelineDefinition": " ",
+        }
+        for fake_pipeline_name in fake_pipeline_names
+    ]
+    _ = create_sagemaker_pipelines(sagemaker_client, pipelines)
+
     response = sagemaker_client.list_pipelines(MaxResults=2)
     response["PipelineSummaries"].should.have.length_of(2)
 
 
 def test_list_pipelines_next_token(sagemaker_client):
     fake_pipeline_names = ["APipelineName"]
-    _ = create_sagemaker_pipelines(sagemaker_client, fake_pipeline_names, 0.0)
+    pipelines = [
+        {
+            "PipelineName": fake_pipeline_names[0],
+            "RoleArn": FAKE_ROLE_ARN,
+            "PipelineDefinition": " ",
+        },
+    ]
+    _ = create_sagemaker_pipelines(sagemaker_client, pipelines)
 
     response = sagemaker_client.list_pipelines(NextToken="0")
     response["PipelineSummaries"].should.have.length_of(1)
@@ -123,7 +194,16 @@ def test_list_pipelines_next_token(sagemaker_client):
 
 def test_list_pipelines_pipeline_name_prefix(sagemaker_client):
     fake_pipeline_names = ["APipelineName", "BPipelineName", "CPipelineName"]
-    _ = create_sagemaker_pipelines(sagemaker_client, fake_pipeline_names, 0.0)
+    pipelines = [
+        {
+            "PipelineName": fake_pipeline_name,
+            "RoleArn": FAKE_ROLE_ARN,
+            "PipelineDefinition": " ",
+        }
+        for fake_pipeline_name in fake_pipeline_names
+    ]
+    _ = create_sagemaker_pipelines(sagemaker_client, pipelines)
+
     response = sagemaker_client.list_pipelines(PipelineNamePrefix="APipe")
     response["PipelineSummaries"].should.have.length_of(1)
     response["PipelineSummaries"][0]["PipelineName"].should.equal("APipelineName")
@@ -134,7 +214,15 @@ def test_list_pipelines_pipeline_name_prefix(sagemaker_client):
 
 def test_list_pipelines_created_after(sagemaker_client):
     fake_pipeline_names = ["APipelineName", "BPipelineName", "CPipelineName"]
-    _ = create_sagemaker_pipelines(sagemaker_client, fake_pipeline_names, 0.0)
+    pipelines = [
+        {
+            "PipelineName": fake_pipeline_name,
+            "RoleArn": FAKE_ROLE_ARN,
+            "PipelineDefinition": " ",
+        }
+        for fake_pipeline_name in fake_pipeline_names
+    ]
+    _ = create_sagemaker_pipelines(sagemaker_client, pipelines)
 
     created_after_str = "2099-12-31 23:59:59"
     response = sagemaker_client.list_pipelines(CreatedAfter=created_after_str)
@@ -151,7 +239,15 @@ def test_list_pipelines_created_after(sagemaker_client):
 
 def test_list_pipelines_created_before(sagemaker_client):
     fake_pipeline_names = ["APipelineName", "BPipelineName", "CPipelineName"]
-    _ = create_sagemaker_pipelines(sagemaker_client, fake_pipeline_names, 0.0)
+    pipelines = [
+        {
+            "PipelineName": fake_pipeline_name,
+            "RoleArn": FAKE_ROLE_ARN,
+            "PipelineDefinition": " ",
+        }
+        for fake_pipeline_name in fake_pipeline_names
+    ]
+    _ = create_sagemaker_pipelines(sagemaker_client, pipelines)
 
     created_before_str = "2000-12-31 23:59:59"
     response = sagemaker_client.list_pipelines(CreatedBefore=created_before_str)
@@ -182,7 +278,15 @@ def test_list_pipelines_invalid_values(sagemaker_client, list_pipelines_kwargs):
 
 def test_delete_pipeline_exists(sagemaker_client):
     fake_pipeline_names = ["APipelineName", "BPipelineName", "CPipelineName"]
-    _ = create_sagemaker_pipelines(sagemaker_client, fake_pipeline_names, 0.0)
+    pipelines = [
+        {
+            "PipelineName": fake_pipeline_name,
+            "RoleArn": FAKE_ROLE_ARN,
+            "PipelineDefinition": " ",
+        }
+        for fake_pipeline_name in fake_pipeline_names
+    ]
+    _ = create_sagemaker_pipelines(sagemaker_client, pipelines)
     pipeline_name_delete, pipeline_names_remain = (
         fake_pipeline_names[0],
         fake_pipeline_names[1:],
@@ -213,7 +317,13 @@ def test_update_pipeline(sagemaker_client):
 
 def test_update_pipeline_no_update(sagemaker_client):
     pipeline_name = "APipelineName"
-    _ = create_sagemaker_pipelines(sagemaker_client, [pipeline_name])
+    pipeline = {
+        "PipelineName": pipeline_name,
+        "RoleArn": FAKE_ROLE_ARN,
+        "PipelineDefinition": " ",
+    }
+    _ = create_sagemaker_pipelines(sagemaker_client, [pipeline])
+
     response = sagemaker_client.update_pipeline(PipelineName=pipeline_name)
     response["PipelineArn"].should.equal(
         arn_formatter("pipeline", pipeline_name, ACCOUNT_ID, TEST_REGION_NAME)
@@ -226,9 +336,14 @@ def test_update_pipeline_add_attribute(sagemaker_client):
     pipeline_name = "APipelineName"
     pipeline_display_name_update = "APipelineDisplayName"
 
-    _ = create_sagemaker_pipelines(sagemaker_client, [pipeline_name])
+    pipeline = {
+        "PipelineName": pipeline_name,
+        "RoleArn": FAKE_ROLE_ARN,
+        "PipelineDefinition": " ",
+    }
+    _ = create_sagemaker_pipelines(sagemaker_client, [pipeline])
     response = sagemaker_client.list_pipelines()
-    assert "PipelineDisplayName" not in response["PipelineSummaries"][0]
+    response["PipelineSummaries"][0]["PipelineDisplayName"].should.equal(pipeline_name)
 
     _ = sagemaker_client.update_pipeline(
         PipelineName=pipeline_name,
@@ -238,14 +353,19 @@ def test_update_pipeline_add_attribute(sagemaker_client):
     response["PipelineSummaries"][0]["PipelineDisplayName"].should.equal(
         pipeline_display_name_update
     )
-    response["PipelineSummaries"][0].should.have.length_of(7)
+    response["PipelineSummaries"][0].should.have.length_of(6)
 
 
 def test_update_pipeline_update_change_attribute(sagemaker_client):
     pipeline_name = "APipelineName"
+    pipeline = {
+        "PipelineName": pipeline_name,
+        "RoleArn": FAKE_ROLE_ARN,
+        "PipelineDefinition": " ",
+    }
     role_arn_update = f"{FAKE_ROLE_ARN}Test"
 
-    _ = create_sagemaker_pipelines(sagemaker_client, [pipeline_name])
+    _ = create_sagemaker_pipelines(sagemaker_client, [pipeline])
     _ = sagemaker_client.update_pipeline(
         PipelineName=pipeline_name,
         RoleArn=role_arn_update,
@@ -253,3 +373,36 @@ def test_update_pipeline_update_change_attribute(sagemaker_client):
     response = sagemaker_client.list_pipelines()
     response["PipelineSummaries"][0]["RoleArn"].should.equal(role_arn_update)
     response["PipelineSummaries"][0].should.have.length_of(6)
+
+
+def test_describe_pipeline_not_exists(sagemaker_client):
+    with pytest.raises(botocore.exceptions.ClientError):
+        _ = sagemaker_client.describe_pipeline(PipelineName="some-pipeline-name")
+
+
+@pytest.mark.parametrize(
+    "pipeline,expected_response_length",
+    [
+        (
+            {
+                "PipelineName": "APipelineName",
+                "RoleArn": FAKE_ROLE_ARN,
+                "PipelineDefinition": " ",
+            },
+            11,
+        ),
+        (
+            {
+                "PipelineName": "BPipelineName",
+                "RoleArn": FAKE_ROLE_ARN,
+                "PipelineDefinition": " ",
+                "PipelineDescription": "some pipeline description",
+            },
+            12,
+        ),
+    ],
+)
+def test_describe_pipeline_exists(sagemaker_client, pipeline, expected_response_length):
+    _ = create_sagemaker_pipelines(sagemaker_client, [pipeline])
+    response = sagemaker_client.describe_pipeline(PipelineName=pipeline["PipelineName"])
+    response.should.have.length_of(expected_response_length)


### PR DESCRIPTION
- Adding sagemaker mock call `describe_pipeline`. It's the only remaining API call directly related to a SageMaker Pipeline (`PipelineExecution` and related mocks are then still missing).
`boto3.client("sagemaker").describe_pipeline`
https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/sagemaker.html#SageMaker.Client.describe_pipeline

- Adding check that `PipelineDefinition` OR `PipelineDefinitionS3Location` is passed to `create_pipeline`. Although the docs do not say so, it is actually a mandatory parameter (one of `{PipelineDefinition, PipelineDefinitionS3Location}` is mandatory).
- Adding support for `PipelineDefinitionS3Location` and additional tests covering this case