### PR TITLE
changing error message to match aws api (stack update attempt with no updates)

### DIFF
--- a/moto/cloudformation/responses.py
+++ b/moto/cloudformation/responses.py
@@ -367,7 +367,7 @@ class CloudFormationResponse(BaseResponse):
             new_params = self._get_param_values(incoming_params, old_stack.parameters)
             if old_stack.template == stack_body and old_stack.parameters == new_params:
                 raise ValidationError(
-                    old_stack.name, message=f"Stack [{old_stack.name}] already exists"
+                    old_stack.name, message="No updates are to be performed."
                 )
 
     def _validate_status(self, stack: FakeStack) -> None:

--- a/tests/test_cloudformation/test_cloudformation_stack_crud_boto3.py
+++ b/tests/test_cloudformation/test_cloudformation_stack_crud_boto3.py
@@ -1258,7 +1258,7 @@ def test_update_stack_fail_update_same_template_body():
     exp_metadata = exp.value.response.get("ResponseMetadata")
 
     exp_err.get("Code").should.equal("ValidationError")
-    exp_err.get("Message").should.equal(f"Stack [{name}] already exists")
+    exp_err.get("Message").should.equal("No updates are to be performed.")
     exp_metadata.get("HTTPStatusCode").should.equal(400)
 
     cf_conn.update_stack(


### PR DESCRIPTION
When a stack exists and an update is attempted with the same parameters and template body the AWS api responds with a specific message which is injected into the `ClientError` generated by boto.

To reduce complexity we make some of our processes ignorant of whether an update constitutes changes to a stack by checking if this exact message is returned as part of a `ClientError`. Reflecting this message in moto will allow us test the components that use this in their processes while preserving the the updates provided in https://github.com/spulec/moto/pull/4351.