### PR TITLE
chore(readme): Align code snippets formatting with project's rules.

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,14 +27,15 @@ Imagine you have the following python code that you want to test:
 ```python
 import boto3
 
-class MyModel(object):
+
+class MyModel:
     def __init__(self, name, value):
         self.name = name
         self.value = value
 
     def save(self):
-        s3 = boto3.client('s3', region_name='us-east-1')
-        s3.put_object(Bucket='mybucket', Key=self.name, Body=self.value)
+        s3 = boto3.client("s3", region_name="us-east-1")
+        s3.put_object(Bucket="mybucket", Key=self.name, Body=self.value)
 ```
 
 Take a minute to think how you would have tested that in the past.
@@ -46,15 +47,16 @@ import boto3
 from moto import mock_s3
 from mymodule import MyModel
 
+
 @mock_s3
 def test_my_model_save():
-    conn = boto3.resource('s3', region_name='us-east-1')
+    conn = boto3.resource("s3", region_name="us-east-1")
     # We need to create the bucket since this is all in Moto's 'virtual' AWS account
-    conn.create_bucket(Bucket='mybucket')
-    model_instance = MyModel('steve', 'is awesome')
+    conn.create_bucket(Bucket="mybucket")
+    model_instance = MyModel("steve", "is awesome")
     model_instance.save()
-    body = conn.Object('mybucket', 'steve').get()['Body'].read().decode("utf-8")
-    assert body == 'is awesome'
+    body = conn.Object("mybucket", "steve").get()["Body"].read().decode("utf-8")
+    assert body == "is awesome"
 ```
 
 With the decorator wrapping the test, all the calls to s3 are automatically mocked out. The mock keeps the state of the buckets and keys.


### PR DESCRIPTION
- Use black formatting
- Since Python 2.* is no longer supported, don't inherit from `object`