### PR TITLE
Add tags for users in the get-account-authorization-details response

### DIFF
--- a/moto/iam/responses.py
+++ b/moto/iam/responses.py
@@ -849,6 +849,7 @@ class IamResponse(BaseResponse):
             groups=account_details["groups"],
             roles=account_details["roles"],
             get_groups_for_user=self.backend.get_groups_for_user,
+            list_tags_for_user=self.backend.list_user_tags,
         )
 
     def create_saml_provider(self):
@@ -2279,6 +2280,14 @@ GET_ACCOUNT_AUTHORIZATION_DETAILS_TEMPLATE = """<GetAccountAuthorizationDetailsR
         {% endfor %}
         </UserPolicyList>
         {% endif %}
+        <Tags>
+        {% for tag in list_tags_for_user(user.name).get("Tags", []) %}
+        <member>
+            <Key>{{ tag['Key'] }}</Key>
+            <Value>{{ tag['Value'] }}</Value>
+        </member>
+        {% endfor %}
+        </Tags>
       </member>
     {% endfor %}
     </UserDetailList>

--- a/tests/test_iam/test_iam.py
+++ b/tests/test_iam/test_iam.py
@@ -2339,6 +2339,14 @@ def test_get_account_authorization_details():
         RoleName="my-role",
         PolicyArn=f"arn:aws:iam::{ACCOUNT_ID}:policy/testPolicy",
     )
+    # add tags to the user
+    conn.tag_user(
+        UserName="testUser",
+        Tags=[
+            {"Key": "somekey", "Value": "somevalue"},
+            {"Key": "someotherkey", "Value": "someothervalue"},
+        ],
+    )
 
     result = conn.get_account_authorization_details(Filter=["Role"])
     assert len(result["RoleDetailList"]) == 1
@@ -2377,6 +2385,7 @@ def test_get_account_authorization_details():
     assert len(result["UserDetailList"][0]["GroupList"]) == 1
     assert len(result["UserDetailList"][0]["UserPolicyList"]) == 1
     assert len(result["UserDetailList"][0]["AttachedManagedPolicies"]) == 1
+    assert len(result["UserDetailList"][0]["Tags"]) == 2
     assert len(result["GroupDetailList"]) == 0
     assert len(result["Policies"]) == 0
     assert (


### PR DESCRIPTION
## Problem

Currently the tags are missing for users, when running get-account-authorization-details.
It is present for roles, however.

Related localstack/localstack/issues/5230

## Solution
* Add tags to response
* Test tags in response

## Additional comments
It seems fine that an empty array is indeed returned without tags, as it is in parity with aws.
AWS response:
```
        {
            "Path": "/",
            "UserName": "test-user",
            "UserId": "AIDAXXXX",
            "Arn": "arn:aws:iam::XXXXXXXXXXXX:user/test-user",
            "CreateDate": "2022-12-22T16:30:32+00:00",
            "GroupList": [],
            "AttachedManagedPolicies": [],
            "Tags": []
        }
```