### PR TITLE
Update server_mode.rst with shell usage example

### DIFF
--- a/docs/docs/server_mode.rst
+++ b/docs/docs/server_mode.rst
@@ -119,6 +119,12 @@ Example Usage
 
 To use Moto in your tests, pass the `endpoint_url`-parameter to the SDK of your choice.
 
+In shell:
+
+.. code-block:: bash
+
+   alias aws='aws --endpoint-url http://localhost:5000'
+
 In Python:
 
 .. code-block:: python


### PR DESCRIPTION
Suggest to create a `aws` alias which contains the `--endpoint-url http://localhost:5000` command-line option