### PR TITLE
Add basic addition support to cloudwatch.get_metric_data expressions

### DIFF
--- a/moto/cloudwatch/metric_data_expression_parser.py
+++ b/moto/cloudwatch/metric_data_expression_parser.py
@@ -1,13 +1,54 @@
 from typing import Any, Dict, List, SupportsFloat, Tuple
 
+from .exceptions import ValidationError
+
 
 def parse_expression(
     expression: str, results: List[Dict[str, Any]]
 ) -> Tuple[List[SupportsFloat], List[str]]:
     values: List[SupportsFloat] = []
     timestamps: List[str] = []
+
+    if "+" in expression:
+        expression = expression.replace(" ", "")
+        plus_splits = expression.split("+")
+        if len(plus_splits) != 2:
+            raise ValidationError(
+                "Metric math expressions only support adding two values together"
+            )
+
+        by_timestamp = results_by_timestamp(results)
+        for timestamp, vals in by_timestamp.items():
+            first = vals.get(plus_splits[0], 0.0)
+            second = vals.get(plus_splits[1], 0.0)
+
+            values.append(first + second)
+            timestamps.append(timestamp)
+
     for result in results:
         if result.get("id") == expression:
             values.extend(result["vals"])
             timestamps.extend(result["timestamps"])
     return values, timestamps
+
+
+def results_by_timestamp(
+    results: List[Dict[str, Any]],
+) -> Dict[str, Dict[str, float]]:
+    out: Dict[str, Dict[str, float]] = {}
+
+    for result in results:
+        this_id = result.get("id")
+        if not this_id:
+            continue
+
+        for i in range(0, len(result["vals"])):
+            timestamp = result["timestamps"][i]
+            value = result["vals"][i]
+
+            if timestamp not in out:
+                out[timestamp] = {}
+
+            out[timestamp][this_id] = value
+
+    return out

--- a/tests/test_cloudwatch/test_cloudwatch_expression_parser.py
+++ b/tests/test_cloudwatch/test_cloudwatch_expression_parser.py
@@ -1,3 +1,5 @@
+import datetime
+
 from moto.cloudwatch.metric_data_expression_parser import parse_expression
 
 
@@ -38,3 +40,26 @@ def test_complex_expression():
     ]
     res = parse_expression("totalBytes/10", result_from_previous_queries)
     assert res == ([], [])
+
+
+def test_addition_expression():
+    t3 = datetime.datetime.now(datetime.timezone.utc)
+    t2 = t3 - datetime.timedelta(minutes=1)
+    t1 = t2 - datetime.timedelta(minutes=1)
+
+    results_from_previous_queries = [
+        {
+            "id": "first",
+            "label": "first",
+            "vals": [10.0, 15.0, 30.0],
+            "timestamps": [t1, t2, t3],
+        },
+        {
+            "id": "second",
+            "label": "second",
+            "vals": [25.0, 5.0, 3.0],
+            "timestamps": [t1, t2, t3],
+        },
+    ]
+    res = parse_expression("first + second", results_from_previous_queries)
+    assert res == ([35.0, 20.0, 33.0], [t1, t2, t3])


### PR DESCRIPTION
I am writing some code that uses the Cloudwatch `GetMetricData` API's math expression feature, specifically in trying to add two metrics together.

This PR adds support for adding two metrics together using the expression feature.

There are some additional features and validation I would like to add to this (specifically, checking that there aren't any other special characters, so that `m1 + m2 - m3` would fail, and the ability to add more than two metrics together, ex `m1 + m2 + m3`), but I wanted to open the PR at this point to see if this feature would be considered useful and check if this seems like a reasonable approach to the problem.