### PR TITLE
DynamoDB: return ConsumedCapacity on delete_item

### DIFF
--- a/moto/dynamodb/responses.py
+++ b/moto/dynamodb/responses.py
@@ -879,6 +879,7 @@ class DynamoHandler(BaseResponse):
             result["LastEvaluatedKey"] = last_evaluated_key
         return dynamo_json_dump(result)
 
+    @include_consumed_capacity()
     def delete_item(self) -> str:
         name = self.body["TableName"]
         key = self.body["Key"]


### PR DESCRIPTION
Extends the changes from https://github.com/getmoto/moto/pull/4241 to the DDB DeleteItem endpoint.

DeleteItem-Responses should include an ConsumedCapacity element in the same way as Scan-, Query-, GetItem- and PutItem-Responses already do: https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_DeleteItem.html#DDB-DeleteItem-response-ConsumedCapacity