### PR TITLE
[Lex] Lexv2 tagging fix

### DIFF
--- a/moto/resourcegroupstaggingapi/models.py
+++ b/moto/resourcegroupstaggingapi/models.py
@@ -535,7 +535,11 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
                     or resource_type in resource_type_filters
                 ):
                     for resource in resource_source.values():
-                        tags = format_tags(resource.tags)
+                        bot_tags = self.lexv2_backend.list_tags_for_resource(
+                            resource.arn
+                        )
+
+                        tags = format_tags(bot_tags)
                         if not tags or not tag_filter(tags):
                             continue
                         yield {

--- a/tests/test_resourcegroupstaggingapi/test_resourcegroupstaggingapi.py
+++ b/tests/test_resourcegroupstaggingapi/test_resourcegroupstaggingapi.py
@@ -520,6 +520,50 @@ def test_get_tag_values_cloudfront():
 
 
 @mock_aws
+def test_get_tag_values_lexv2_models():
+    client = boto3.client("lexv2-models", "us-east-1")
+    # Create a bot
+    bot = client.create_bot(
+        botName="TestBot",
+        description="A test bot",
+        roleArn="arn:aws:iam::123456789012:role/service-role/AmazonLexV2BotRole",
+        dataPrivacy={"childDirected": False},
+        idleSessionTTLInSeconds=300,
+        botTags={"Test": "Test1"},
+    )
+    bot_id = bot["botId"]
+    # Create a bot alias with tags
+    client.create_bot_alias(
+        botAliasName="TestBotAlias",
+        botId=bot_id,
+        description="A test bot alias",
+        tags={"Test": "Test2"},
+    )
+
+    rtapi = boto3.client("resourcegroupstaggingapi", "us-east-1")
+
+    # Test bot tag filtering
+    resp = rtapi.get_resources(
+        ResourceTypeFilters=["lexv2:bot"],
+        TagFilters=[{"Key": "Test", "Values": ["Test1"]}],
+    )
+    assert len(resp["ResourceTagMappingList"]) == 1
+    assert {"Key": "Test", "Value": "Test1"} in resp["ResourceTagMappingList"][0][
+        "Tags"
+    ]
+
+    # Test bot-alias tag filtering
+    resp = rtapi.get_resources(
+        ResourceTypeFilters=["lexv2:bot-alias"],
+        TagFilters=[{"Key": "Test", "Values": ["Test2"]}],
+    )
+    assert len(resp["ResourceTagMappingList"]) == 1
+    assert {"Key": "Test", "Value": "Test2"} in resp["ResourceTagMappingList"][0][
+        "Tags"
+    ]
+
+
+@mock_aws
 def test_get_many_resources():
     elbv2 = boto3.client("elbv2", region_name="us-east-1")
     ec2 = boto3.resource("ec2", region_name="us-east-1")


### PR DESCRIPTION
Adding list_tags_for_resource call to get the tags. 

Original `tags = format_tags(resource.tags)` error "resource" object does not have a "tags" attribute.

Added unit test function.