### PR TITLE
[Lex] resourceArn fix for resource policies

### DIFF
--- a/moto/lexv2models/responses.py
+++ b/moto/lexv2models/responses.py
@@ -178,7 +178,7 @@ class LexModelsV2Response(BaseResponse):
         )
 
     def create_resource_policy(self) -> str:
-        resource_arn = self._get_param("resourceArn")
+        resource_arn = unquote(self._get_param("resourceArn"))
         policy = self._get_param("policy")
         resource_arn, revision_id = self.lexv2models_backend.create_resource_policy(
             resource_arn=resource_arn,
@@ -187,7 +187,7 @@ class LexModelsV2Response(BaseResponse):
         return json.dumps(dict(resourceArn=resource_arn, revisionId=revision_id))
 
     def describe_resource_policy(self) -> str:
-        resource_arn = self._get_param("resourceArn")
+        resource_arn = unquote(self._get_param("resourceArn"))
         resource_arn, policy, revision_id = (
             self.lexv2models_backend.describe_resource_policy(
                 resource_arn=resource_arn,
@@ -198,7 +198,7 @@ class LexModelsV2Response(BaseResponse):
         )
 
     def update_resource_policy(self) -> str:
-        resource_arn = self._get_param("resourceArn")
+        resource_arn = unquote(self._get_param("resourceArn"))
         policy = self._get_param("policy")
         expected_revision_id = self._get_param("expectedRevisionId")
         resource_arn, revision_id = self.lexv2models_backend.update_resource_policy(
@@ -209,7 +209,7 @@ class LexModelsV2Response(BaseResponse):
         return json.dumps(dict(resourceArn=resource_arn, revisionId=revision_id))
 
     def delete_resource_policy(self) -> str:
-        resource_arn = self._get_param("resourceArn")
+        resource_arn = unquote(self._get_param("resourceArn"))
         expected_revision_id = self._get_param("expectedRevisionId")
         resource_arn, revision_id = self.lexv2models_backend.delete_resource_policy(
             resource_arn=resource_arn,

--- a/moto/lexv2models/urls.py
+++ b/moto/lexv2models/urls.py
@@ -12,7 +12,7 @@ url_paths = {
     "{0}/bots/(?P<botId>[^/]+)/$": LexModelsV2Response.dispatch,
     "{0}/bots/(?P<botId>[^/]+)/botaliases/$": LexModelsV2Response.dispatch,
     "{0}/bots/(?P<botId>[^/]+)/botaliases/(?P<botAliasId>[^/]+)/$": LexModelsV2Response.dispatch,
-    "{0}/policy/(?P<resourceArn>[^/]+)/$": LexModelsV2Response.dispatch,
+    "{0}/policy/(?P<resourceArn>.+)/$": LexModelsV2Response.dispatch,
     "{0}/tags/(?P<resourceARN>[^/]+)$": LexModelsV2Response.dispatch,
     "{0}/tags/(?P<arn_prefix>[^/]+)/(?P<bot_id>[^/]+)$": LexModelsV2Response.dispatch,
 }

--- a/tests/test_lexv2models/test_lexv2models.py
+++ b/tests/test_lexv2models/test_lexv2models.py
@@ -346,34 +346,33 @@ def test_bot_alias():
 @mock_aws
 def test_resource_policy():
     client = boto3.client("lexv2-models", region_name="eu-west-1")
+    arn = "arn:aws:lex:us-east-1:123456789012:bot/MyLexBot/ABCDEF123456"
     resp = client.create_resource_policy(
-        resourceArn="test_resource_arn",
+        resourceArn=arn,
         policy="test_resource_policy",
     )
-    assert resp["resourceArn"] == "test_resource_arn"
+    assert resp["resourceArn"] == arn
     assert resp.get("revisionId")
 
-    desc_resp = client.describe_resource_policy(
-        resourceArn="test_resource_arn",
-    )
-    assert desc_resp["resourceArn"] == "test_resource_arn"
+    desc_resp = client.describe_resource_policy(resourceArn=arn)
+    assert desc_resp["resourceArn"] == arn
     assert desc_resp["policy"] == "test_resource_policy"
     assert desc_resp.get("revisionId")
 
     update_resp = client.update_resource_policy(
-        resourceArn="test_resource_arn",
+        resourceArn=arn,
         policy="test_resource_policy_updated",
         expectedRevisionId=resp["revisionId"],
     )
 
-    assert update_resp["resourceArn"] == "test_resource_arn"
+    assert update_resp["resourceArn"] == arn
     assert update_resp["revisionId"] != resp["revisionId"]
 
     delete_resp = client.delete_resource_policy(
-        resourceArn="test_resource_arn",
+        resourceArn=arn,
         expectedRevisionId=update_resp["revisionId"],
     )
-    assert delete_resp["resourceArn"] == "test_resource_arn"
+    assert delete_resp["resourceArn"] == arn
 
 
 @mock_aws

--- a/tests/test_lexv2models/test_lexv2models.py
+++ b/tests/test_lexv2models/test_lexv2models.py
@@ -346,11 +346,14 @@ def test_bot_alias():
 @mock_aws
 def test_resource_policy():
     client = boto3.client("lexv2-models", region_name="eu-west-1")
-    arn = "arn:aws:lex:us-east-1:123456789012:bot/MyLexBot/ABCDEF123456"
+
+    arn = "arn:aws:lex:eu-west-1:123456789012:bot/MyLexBot"
+
     resp = client.create_resource_policy(
         resourceArn=arn,
         policy="test_resource_policy",
     )
+
     assert resp["resourceArn"] == arn
     assert resp.get("revisionId")
 
@@ -377,7 +380,7 @@ def test_resource_policy():
 
 @mock_aws
 def test_tag_resource():
-    sts = boto3.client("sts")
+    sts = boto3.client("sts", "eu-west-1")
     account_id = sts.get_caller_identity()["Account"]
     region_name = "eu-west-1"
 


### PR DESCRIPTION
Fixes #8803 

The returned resourceArn param comes encoded, so adding unquote calls to get the parameter format correctly.

Linted, formatted, and tested.