### PR TITLE
[Cloudfront] Add TrustedSigners Class

### DIFF
--- a/moto/cloudfront/models.py
+++ b/moto/cloudfront/models.py
@@ -65,6 +65,14 @@ class ForwardedValues:
         self.cookies: List[Dict[str, Any]] = config.get("Cookies") or []
 
 
+class TrustedSigners:
+    def __init__(self, config: Dict[str, Any]):
+        items = config.get("Items") or {}
+        self.acct_nums = items.get("AwsAccountNumber") or []
+        if isinstance(self.acct_nums, str):
+            self.acct_nums = [self.acct_nums]
+
+
 class TrustedKeyGroups:
     def __init__(self, config: Dict[str, Any]):
         items = config.get("Items") or {}
@@ -77,7 +85,7 @@ class DefaultCacheBehaviour:
     def __init__(self, config: Dict[str, Any]):
         self.target_origin_id = config["TargetOriginId"]
         self.trusted_signers_enabled = False
-        self.trusted_signers: List[Any] = []
+        self.trusted_signers = TrustedSigners(config.get("TrustedSigners") or {})
         self.trusted_key_groups = TrustedKeyGroups(config.get("TrustedKeyGroups") or {})
         self.viewer_protocol_policy = config["ViewerProtocolPolicy"]
         methods = config.get("AllowedMethods", {})

--- a/moto/cloudfront/responses.py
+++ b/moto/cloudfront/responses.py
@@ -325,10 +325,10 @@ DIST_CONFIG_TEMPLATE = """
       <DefaultCacheBehavior>
         <TargetOriginId>{{ distribution.distribution_config.default_cache_behavior.target_origin_id }}</TargetOriginId>
         <TrustedSigners>
-          <Enabled>{{ distribution.distribution_config.default_cache_behavior.trusted_signers_enabled }}</Enabled>
-          <Quantity>{{ distribution.distribution_config.default_cache_behavior.trusted_signers|length }}</Quantity>
+          <Enabled>{{ 'true' if distribution.distribution_config.default_cache_behavior.trusted_signers.acct_nums|length > 0 else 'false' }}</Enabled>          
+          <Quantity>{{ distribution.distribution_config.default_cache_behavior.trusted_signers.acct_nums|length }}</Quantity>
           <Items>
-            {% for aws_account_number  in distribution.distribution_config.default_cache_behavior.trusted_signers %}
+            {% for aws_account_number  in distribution.distribution_config.default_cache_behavior.trusted_signers.acct_nums %}
               <AwsAccountNumber>{{ aws_account_number }}</AwsAccountNumber>
             {% endfor %}
           </Items>
@@ -432,10 +432,10 @@ DIST_CONFIG_TEMPLATE = """
                 <PathPattern>{{ behaviour.path_pattern }}</PathPattern>
                 <TargetOriginId>{{ behaviour.target_origin_id }}</TargetOriginId>
                 <TrustedSigners>
-                  <Enabled>{{ behaviour.trusted_signers.enabled }}</Enabled>
-                  <Quantity>{{ behaviour.trusted_signers | length }}</Quantity>
+                  <Enabled>{{ 'true' if behaviour.trusted_signers.acct_nums|length > 0 else 'false' }}</Enabled>
+                  <Quantity>{{ behaviour.trusted_signers.acct_nums | length }}</Quantity>
                   <Items>
-                    {% for account_nr  in behaviour.trusted_signers %}
+                    {% for account_nr  in behaviour.trusted_signers.acct_nums %}
                       <AwsAccountNumber>{{ account_nr }}</AwsAccountNumber>
                     {% endfor %}
                   </Items>

--- a/tests/test_cloudfront/test_cloudfront.py
+++ b/tests/test_cloudfront/test_cloudfront.py
@@ -234,3 +234,49 @@ def test_update_distribution_applies_changes():
         "DistributionConfig"
     ]
     assert actual_dist_config["Enabled"]
+
+
+@mock_aws
+def test_update_distribution_trusted_signers():
+    client = boto3.client("cloudfront", region_name="us-east-1")
+
+    # Create standard distribution
+    config = scaffold.example_distribution_config(ref="ref")
+
+    dist = client.create_distribution(DistributionConfig=config)
+    dist_id = dist["Distribution"]["Id"]
+
+    # Assert that default TrustedSigners 'Enabled' value is false
+    actual_dist_config = client.get_distribution(Id=dist_id)["Distribution"][
+        "DistributionConfig"
+    ]
+    assert (
+        actual_dist_config["DefaultCacheBehavior"]["TrustedSigners"]["Enabled"] is False
+    )
+
+    # Add an item to TrustedSigners
+    get_config_response = client.get_distribution_config(Id=dist_id)
+    actual_dist_config = get_config_response["DistributionConfig"]
+    etag = get_config_response["ETag"]
+    actual_dist_config["DefaultCacheBehavior"]["TrustedSigners"]["Items"] = [
+        "AwsAccountNumber123"
+    ]
+
+    client.update_distribution(
+        DistributionConfig=actual_dist_config, Id=dist_id, IfMatch=etag
+    )
+
+    # Assert that all TrustedSigners fields updated
+    updated_dist_config = client.get_distribution(Id=dist_id)["Distribution"][
+        "DistributionConfig"
+    ]
+    assert (
+        updated_dist_config["DefaultCacheBehavior"]["TrustedSigners"]["Quantity"] == 1
+    )
+    assert (
+        updated_dist_config["DefaultCacheBehavior"]["TrustedSigners"]["Enabled"] == True
+    )
+    assert (
+        "AwsAccountNumber123"
+        in updated_dist_config["DefaultCacheBehavior"]["TrustedSigners"]["Items"]
+    )

--- a/tests/test_cloudfront/test_cloudfront.py
+++ b/tests/test_cloudfront/test_cloudfront.py
@@ -273,9 +273,7 @@ def test_update_distribution_trusted_signers():
     assert (
         updated_dist_config["DefaultCacheBehavior"]["TrustedSigners"]["Quantity"] == 1
     )
-    assert (
-        updated_dist_config["DefaultCacheBehavior"]["TrustedSigners"]["Enabled"] == True
-    )
+    assert updated_dist_config["DefaultCacheBehavior"]["TrustedSigners"]["Enabled"]
     assert (
         "AwsAccountNumber123"
         in updated_dist_config["DefaultCacheBehavior"]["TrustedSigners"]["Items"]


### PR DESCRIPTION
TrustedSigners class added. This allows users to add an AWSAccountNumber to a CacheBehavior/DefaultCacheBehavior and it will auto update the enabled/qty field. Similar to TrustedKeyGroups functionally.

Added a test to support. Format/Checked, tested local and on server.