### PR TITLE
[EC2] Update iam_instance_profile attribute after dissociation

### DIFF
--- a/moto/ec2/models/iam_instance_profile.py
+++ b/moto/ec2/models/iam_instance_profile.py
@@ -114,6 +114,11 @@ class IamInstanceProfileAssociationBackend:
                 )
                 del self.iam_instance_profile_associations[association_key]
                 # Deleting once and avoiding `RuntimeError: dictionary changed size during iteration`
+
+                self.modify_instance_attribute(
+                    association_key, "iam_instance_profile", None
+                )
+
                 break
 
         if not iam_instance_profile_association:

--- a/moto/ec2/models/iam_instance_profile.py
+++ b/moto/ec2/models/iam_instance_profile.py
@@ -115,7 +115,7 @@ class IamInstanceProfileAssociationBackend:
                 del self.iam_instance_profile_associations[association_key]
                 # Deleting once and avoiding `RuntimeError: dictionary changed size during iteration`
 
-                self.modify_instance_attribute(
+                iam_instance_profile_association.ec2_backend.modify_instance_attribute(
                     association_key, "iam_instance_profile", None
                 )
 

--- a/tests/test_ec2/test_iam_integration.py
+++ b/tests/test_ec2/test_iam_integration.py
@@ -272,6 +272,13 @@ def test_disassociate():
         a["IamInstanceProfile"]["Arn"] for a in associations
     ]
 
+    ec2_instances = [
+        instance
+        for reservation in client.describe_instances()["Reservations"]
+        for instance in reservation["Instances"]
+    ]
+    assert "IamInstanceProfile" in ec2_instances[0]
+
     disassociation = client.disassociate_iam_instance_profile(
         AssociationId=association["IamInstanceProfileAssociation"]["AssociationId"]
     )
@@ -288,6 +295,12 @@ def test_disassociate():
         a["IamInstanceProfile"]["Arn"] for a in associations
     ]
 
+    ec2_instances = [
+        instance
+        for reservation in client.describe_instances()["Reservations"]
+        for instance in reservation["Instances"]
+    ]
+    assert "IamInstanceProfile" not in ec2_instances[0]
 
 @mock_aws
 def test_invalid_disassociate():

--- a/tests/test_ec2/test_iam_integration.py
+++ b/tests/test_ec2/test_iam_integration.py
@@ -302,6 +302,7 @@ def test_disassociate():
     ]
     assert "IamInstanceProfile" not in ec2_instances[0]
 
+
 @mock_aws
 def test_invalid_disassociate():
     client = boto3.client("ec2", region_name="us-east-1")

--- a/tests/test_ec2/test_iam_integration.py
+++ b/tests/test_ec2/test_iam_integration.py
@@ -272,12 +272,10 @@ def test_disassociate():
         a["IamInstanceProfile"]["Arn"] for a in associations
     ]
 
-    ec2_instances = [
-        instance
-        for reservation in client.describe_instances()["Reservations"]
-        for instance in reservation["Instances"]
-    ]
-    assert "IamInstanceProfile" in ec2_instances[0]
+    reservations = client.describe_instances(InstanceIds=[instance_id])["Reservations"]
+    instances = reservations[0]["Instances"]
+
+    assert "IamInstanceProfile" in instances[0]
 
     disassociation = client.disassociate_iam_instance_profile(
         AssociationId=association["IamInstanceProfileAssociation"]["AssociationId"]
@@ -295,12 +293,10 @@ def test_disassociate():
         a["IamInstanceProfile"]["Arn"] for a in associations
     ]
 
-    ec2_instances = [
-        instance
-        for reservation in client.describe_instances()["Reservations"]
-        for instance in reservation["Instances"]
-    ]
-    assert "IamInstanceProfile" not in ec2_instances[0]
+    reservations = client.describe_instances(InstanceIds=[instance_id])["Reservations"]
+    instances = reservations[0]["Instances"]
+
+    assert "IamInstanceProfile" not in instances[0]
 
 
 @mock_aws


### PR DESCRIPTION
Test updated. Tests ran local/server. Ruff format/lint.

The logic added manually updates the backend object attribute and sets it to None after the iam_instance_profile_associations item is deleted.

Fixes #8562 