### PR TITLE
EventBridge: Allow Transformed messages to be send to a LogGroup

### DIFF
--- a/moto/events/models.py
+++ b/moto/events/models.py
@@ -201,9 +201,10 @@ class Rule(CloudFormationModel):
     def _send_to_cw_log_group(self, name: str, event: Dict[str, Any]) -> None:
         from moto.logs import logs_backends
 
-        event["time"] = iso_8601_datetime_without_milliseconds(
-            utcfromtimestamp(event["time"])  # type: ignore[arg-type]
-        )
+        if "time" in event:
+            event["time"] = iso_8601_datetime_without_milliseconds(
+                utcfromtimestamp(event["time"])
+            )
 
         log_stream_name = str(random.uuid4())
         log_events = [{"timestamp": unix_time_millis(), "message": json.dumps(event)}]


### PR DESCRIPTION
Fixes #8963 

We have a fairly comprehensive implementation for the `InputTransformer`, but almost no tests around it - leading to `KeyError` bugs like this.

There are a lot more tests necessary to determine the rules around InputTransformers, and how simple they are allowed to be - but with this PR we at least no longer break the entire workflow.