### PR TITLE
set correct value type for Logs.GetQueryResults

### DIFF
--- a/moto/logs/models.py
+++ b/moto/logs/models.py
@@ -88,7 +88,7 @@ class LogQuery(BaseModel):
     def to_result_json(self) -> Dict[str, Any]:
         return {
             "results": [
-                [{"field": key, "value": val} for key, val in result.items()]
+                [{"field": key, "value": str(val)} for key, val in result.items()]
                 for result in self.results
             ],
             "status": self.status,

--- a/tests/test_logs/test_logs_query/test_boto3.py
+++ b/tests/test_logs/test_logs_query/test_boto3.py
@@ -61,7 +61,7 @@ def test_get_query_results():
     )
 
     query_id = client.start_query(
-        logGroupName="test",
+        logGroupName=log_group_name,
         startTime=int(unix_time(utcnow() - timedelta(minutes=10))),
         endTime=int(unix_time(utcnow() + timedelta(minutes=10))),
         queryString="fields @message",
@@ -90,7 +90,7 @@ def test_get_query_results():
 
     # Only find events from last 2 minutes
     query_id = client.start_query(
-        logGroupName="test",
+        logGroupName=log_group_name,
         startTime=int(unix_time(utcnow() - timedelta(minutes=2, seconds=1))),
         endTime=int(unix_time(utcnow() - timedelta(seconds=1))),
         queryString="fields @message",
@@ -98,6 +98,7 @@ def test_get_query_results():
 
     resp = client.get_query_results(queryId=query_id)
     assert len(resp["results"]) == 2
+    assert isinstance(resp["results"][0][0]["value"], str)
 
     messages = [
         row["value"]


### PR DESCRIPTION
## Motivation
According to the [Boto3 operation docs](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/logs/client/get_query_results.html) and the [Go SDK documentation](https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs@v1.50.3/types#ResultField), the value field must always be a string.


## Changes
- Ensure the value attribute is always a string

## Testing
- Extended an existing test to assert the type
- Manually verified the behavior against AWS