### PR TITLE
fix: Cloudformation allow changeset updates

### DIFF
--- a/moto/cloudformation/responses.py
+++ b/moto/cloudformation/responses.py
@@ -193,10 +193,11 @@ class CloudFormationResponse(BaseResponse):
             for item in self._get_list_prefix("Tags.member")
         )
         parameters = {
-            param["parameter_key"]: stack.parameters[param["parameter_key"]]
-            if param.get("use_previous_value", "").lower() == "true"
-            and use_previous_template
-            else param["parameter_value"]
+            param["parameter_key"]: (
+                stack.stack_parameters[param["parameter_key"]]
+                if param.get("use_previous_value", "").lower() == "true"
+                else param["parameter_value"]
+            )
             for param in parameters_list
         }
         if update_or_create == "UPDATE":
@@ -373,8 +374,13 @@ class CloudFormationResponse(BaseResponse):
         old_stack: FakeStack,
     ) -> None:
         if incoming_params and stack_body:
-            new_params = self._get_param_values(incoming_params, old_stack.parameters)
-            if old_stack.template == stack_body and old_stack.parameters == new_params:
+            new_params = self._get_param_values(
+                incoming_params, old_stack.stack_parameters
+            )
+            if (
+                old_stack.template == stack_body
+                and old_stack.stack_parameters == new_params
+            ):
                 raise ValidationError(
                     old_stack.name, message="No updates are to be performed."
                 )


### PR DESCRIPTION
This commit fixes two issues with Cloudformation change set updates.

Firstly, `moto` returns an exception: `KeyError: 'parameter_value'` for existing parameters if the change set is created without the `UsePreviousTemplate` argument.

This was fixed by removing the condition for `UsePreviousTemplate` in the parameter list generation.

The second issue was default values defined in the Parameter section in the Cloudformation template are not included in the parameter arguments to `CloudFormationBackend.create_change_set` when the change set is being parsed/validated.

This results in a change set creation failing due to missing Parameter values.

The second issue was fixed by replacing references to `FakeStack.parameters` with `FakeStack.stack_parameters` which returns the resource parameters vs just the parameters provided to Cloudformation create/update stack operations.