### PR TITLE
[Cloud HSMv2] Format Create Cluster Response

### DIFF
--- a/moto/cloudhsmv2/models.py
+++ b/moto/cloudhsmv2/models.py
@@ -31,7 +31,7 @@ class Cluster:
         self.source_backup_id = source_backup_id
         self.state = "ACTIVE"
         self.state_message = "The cluster is ready for use."
-        self.subnet_mapping = {subnet_id: region_name for subnet_id in subnet_ids}
+        self.subnet_mapping = {region_name: subnet_id for subnet_id in subnet_ids}
         self.vpc_id = "vpc-" + str(uuid.uuid4())[:8]
         self.network_type = network_type
         self.certificates = {

--- a/tests/test_cloudhsmv2/test_cloudhsmv2.py
+++ b/tests/test_cloudhsmv2/test_cloudhsmv2.py
@@ -116,7 +116,7 @@ def test_create_cluster():
     assert isinstance(cluster["CreateTimestamp"], datetime)
     assert cluster["HsmType"] == "hsm1.medium"
     assert cluster["State"] == "ACTIVE"
-    assert cluster["SubnetMapping"] == {"subnet-12345678": "us-east-1"}
+    assert cluster["SubnetMapping"] == {"us-east-1": "subnet-12345678"}
     assert cluster["TagList"] == [{"Key": "Environment", "Value": "Production"}]
     assert "VpcId" in cluster
 


### PR DESCRIPTION
To maintainers and reviewers, @bblommers and @bpandola. This PR fixes #9091. It inverts the map from availability zone to the cluster’s subnet in that availability zone, according to the [boto3 api docs.](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/cloudhsmv2/client/create_cluster.html). Tests were re-run for compliance and to ensure properly functioning of endpoint.