### PR TITLE
[S3 Control] Enhance get_storage_lens_config() response

### DIFF
--- a/moto/s3control/responses.py
+++ b/moto/s3control/responses.py
@@ -301,6 +301,39 @@ GET_STORAGE_LENS_CONFIGURATION_TEMPLATE = """
    </DataExport>
    {% endif %}
    <IsEnabled>{{config["IsEnabled"]}}</IsEnabled>
+   <AccountLevel>
+        <ActivityMetrics>
+            <IsEnabled>{{config["AccountLevel"]["ActivityMetrics"]["IsEnabled"]}}</IsEnabled>
+        </ActivityMetrics>
+        <BucketLevel>
+            <ActivityMetrics>
+                <IsEnabled>{{config["AccountLevel"]["BucketLevel"]["ActivityMetrics"]["IsEnabled"]}}</IsEnabled>
+            </ActivityMetrics>
+            <PrefixLevel>
+                <StorageMetrics>
+                    <IsEnabled>{{config["AccountLevel"]["BucketLevel"]["PrefixLevel"]["StorageMetrics"]["IsEnabled"]}}</IsEnabled>
+                    <SelectionCriteria>
+                        <Delimiter>{{config["AccountLevel"]["BucketLevel"]["PrefixLevel"]["StorageMetrics"]["SelectionCriteria"]["Delimiter"]}}</Delimiter>
+                        <MaxDepth>{{config["AccountLevel"]["BucketLevel"]["PrefixLevel"]["StorageMetrics"]["SelectionCriteria"]["MaxDepth"]}}</MaxDepth>
+                        <MinStorageBytesPercentage>{{config["AccountLevel"]["BucketLevel"]["PrefixLevel"]["StorageMetrics"]["SelectionCriteria"]["MinStorageBytesPercentage"]}}</MinStorageBytesPercentage>
+                    </SelectionCriteria>
+                </StorageMetrics>
+            </PrefixLevel>
+            <DetailedStatusCodesMetrics>
+                <IsEnabled>{{config["AccountLevel"]["BucketLevel"]["DetailedStatusCodesMetrics"]["IsEnabled"]}}</IsEnabled>
+            </DetailedStatusCodesMetrics>
+        </BucketLevel>
+        <AdvancedDataProtectionMetrics>
+            <IsEnabled>{{config["AccountLevel"]["AdvancedDataProtectionMetrics"]["IsEnabled"]}}</IsEnabled>
+        </AdvancedDataProtectionMetrics>
+        <DetailedStatusCodesMetrics>
+            <IsEnabled>{{config["AccountLevel"]["DetailedStatusCodesMetrics"]["IsEnabled"]}}</IsEnabled>
+        </DetailedStatusCodesMetrics>
+   </AccountLevel>
+   <AwsOrg>
+        <Arn>{{config.get("AwsOrg", {}).get("Arn", "")}}</Arn>
+    </AwsOrg>
+    <StorageLensArn>{{config.get("StorageLensArn")}}</StorageLensArn>
 </StorageLensConfiguration>
 """
 

--- a/tests/test_s3control/test_s3control.py
+++ b/tests/test_s3control/test_s3control.py
@@ -176,6 +176,10 @@ def test_storage_lens_configuration():
     assert s3_dest["Arn"] == "arn:aws:s3:::bucket_name"
     assert "Encryption" in s3_dest
     assert s3_dest["Encryption"]["SSES3"] == {}
+    assert resp["StorageLensConfiguration"]["AccountLevel"]["ActivityMetrics"] == {
+        "IsEnabled": True
+    }
+    assert resp["StorageLensConfiguration"]["AwsOrg"]["Arn"] == "string"
 
     # List the configurations
     resp = client.list_storage_lens_configurations(AccountId=ACCOUNT_ID)
@@ -184,6 +188,11 @@ def test_storage_lens_configuration():
     # but the ID from the config itself
     assert resp["StorageLensConfigurationList"][0]["Id"] == "id-test"
     assert "StorageLensArn" in resp["StorageLensConfigurationList"][0]
+    assert resp["StorageLensConfigurationList"][0]["IsEnabled"] is True
+    assert (
+        resp["StorageLensConfigurationList"][0]["StorageLensArn"]
+        == "arn:aws:s3:us-east-1:123456789012:storage-lens/my-test-config-id"
+    )
     assert resp["StorageLensConfigurationList"][0]["IsEnabled"] is True
 
 


### PR DESCRIPTION
To reviewers and maintainers @bblommers  and @bpandola. This PR fixes #9196 and adds response  data to `GET_STORAGE_LENS_CONFIGURATION_TEMPLATE`. This adds storage lense arn in compliance with [aws docs.](https://docs.aws.amazon.com/AmazonS3/latest/API/API_control_GetStorageLensConfiguration.html)