### PR TITLE
CloudFormation: rename `resource_type` attribute to avoid clashes

### DIFF
--- a/moto/cloudformation/parsing.py
+++ b/moto/cloudformation/parsing.py
@@ -398,7 +398,7 @@ def parse_and_create_resource(
     resource = resource_class.create_from_cloudformation_json(
         resource_physical_name, resource_json, account_id, region_name, **kwargs
     )
-    resource.resource_type = resource_type
+    resource.cf_resource_type = resource_type
     resource.logical_resource_id = logical_id
     return resource
 
@@ -427,7 +427,7 @@ def parse_and_update_resource(
             account_id=account_id,
             region_name=region_name,
         )
-        new_resource.resource_type = resource_json["Type"]
+        new_resource.cf_resource_type = resource_json["Type"]
         new_resource.logical_resource_id = logical_id
         return new_resource
     else:

--- a/moto/cloudformation/responses.py
+++ b/moto/cloudformation/responses.py
@@ -28,7 +28,7 @@ class StackResourceDTO:
         # FIXME: None of these attributes are part of CloudFormationModel interface...
         self.logical_resource_id = getattr(resource, "logical_resource_id", None)
         self.physical_resource_id = getattr(resource, "physical_resource_id", None)
-        self.resource_type = getattr(resource, "resource_type", None)
+        self.resource_type = getattr(resource, "cf_resource_type", None)
         self.stack_status = stack.status
         self.creation_time = stack.creation_time
         self.timestamp = "2010-07-27T22:27:28Z"  # Hardcoded in original XML template.
@@ -366,7 +366,7 @@ class CloudFormationResponse(BaseResponse):
                     "LogicalResourceId": getattr(resource, "logical_resource_id", ""),
                     "LastUpdateTimestamp": "2011-06-21T20:15:58Z",
                     "PhysicalResourceId": getattr(resource, "physical_resource_id", ""),
-                    "ResourceType": getattr(resource, "resource_type", ""),
+                    "ResourceType": getattr(resource, "cf_resource_type", ""),
                 }
                 for resource in resources
             ]

--- a/tests/test_rds/test_rds_cloudformation.py
+++ b/tests/test_rds/test_rds_cloudformation.py
@@ -3,6 +3,7 @@ import json
 import boto3
 
 from moto import mock_aws
+from tests import DEFAULT_ACCOUNT_ID
 from tests.test_cloudformation.fixtures import (
     rds_mysql_with_db_parameter_group,
     rds_mysql_with_read_replica,
@@ -43,6 +44,10 @@ def test_create_subnetgroup_via_cf():
     assert created_subnet["DBSubnetGroupName"] == "subnetgroupname"
     assert created_subnet["DBSubnetGroupDescription"] == "subnetgroupdesc"
     assert created_subnet["VpcId"] == vpc["VpcId"]
+    assert (
+        created_subnet["DBSubnetGroupArn"]
+        == f"arn:aws:rds:us-west-2:{DEFAULT_ACCOUNT_ID}:subgrp:subnetgroupname"
+    )
 
 
 @mock_aws
@@ -87,6 +92,10 @@ def test_create_dbinstance_via_cf():
     assert created["DBInstanceIdentifier"] == db_instance_identifier
     assert created["Engine"] == "mysql"
     assert created["DBInstanceStatus"] == "available"
+    assert (
+        created["DBInstanceArn"]
+        == f"arn:aws:rds:us-west-2:{DEFAULT_ACCOUNT_ID}:db:{db_instance_identifier}"
+    )
 
     # Verify the stack outputs are correct
     o = _get_stack_outputs(cf, stack_name="test_stack")


### PR DESCRIPTION
The attribute renaming done in #9088 removed some name clashes but introduced others...

Hopefully this new name is safe.  The whole logic here needs to be removed/refactored, but it's non-trivial.

Closes #9205 