### PR TITLE
S3: complete_multipart_upload() should respect IfNoneMatch for existiing MultiPart object

### DIFF
--- a/moto/s3/responses.py
+++ b/moto/s3/responses.py
@@ -2606,11 +2606,6 @@ class S3Response(BaseResponse):
         if query.get("uploadId"):
             existing = self.backend.get_object(self.bucket_name, key_name)
 
-            if_none_match = self.headers.get("If-None-Match")
-            if if_none_match == "*":
-                if existing is not None and existing.multipart is None:
-                    raise PreconditionFailed("If-None-Match")
-
             multipart_id = query["uploadId"][0]
 
             if (
@@ -2621,6 +2616,9 @@ class S3Response(BaseResponse):
                 # Operation is idempotent
                 key: Optional[FakeKey] = existing
             else:
+                if self.headers.get("If-None-Match") == "*" and existing is not None:
+                    raise PreconditionFailed("If-None-Match")
+
                 key = self.backend.complete_multipart_upload(
                     bucket_name, multipart_id, self._complete_multipart_body(body)
                 )


### PR DESCRIPTION
Fixes #9028 

Originally introduced in https://github.com/getmoto/moto/pull/8380

The earlier PR only checked idempotent requests, where we try to complete an MultiPart upload that was already completed:
```python
client.create_multipart_upload(..)
client.upload_part(..)
client.complete_multipart_upload(..)
# This succeeds with the same parameters..
client.complete_multipart_upload(.., IfNoneMatch="*")
```

This PR fixes the scenario where we try to start a completely new upload process:

```python
client.create_multipart_upload(..)
client.upload_part(..)
client.complete_multipart_upload(..)

# Upload Number 2
client.create_multipart_upload(..)
client.upload_part(..)

# This part fails
client.complete_multipart_upload(.., IfNoneMatch="*")
```