### PR TITLE
Support specifying CertificateChain for IAM server certificates

### DIFF
--- a/moto/iam/responses.py
+++ b/moto/iam/responses.py
@@ -465,7 +465,7 @@ class IamResponse(BaseResponse):
         cert_body = self._get_param("CertificateBody")
         path = self._get_param("Path")
         private_key = self._get_param("PrivateKey")
-        cert_chain = self._get_param("CertificateName")
+        cert_chain = self._get_param("CertificateChain")
 
         cert = self.backend.upload_server_certificate(
             cert_name, cert_body, private_key, cert_chain=cert_chain, path=path
@@ -503,19 +503,20 @@ class IamResponse(BaseResponse):
     def get_server_certificate(self) -> ActionResult:
         cert_name = self._get_param("ServerCertificateName")
         cert = self.backend.get_server_certificate(cert_name)
-        result = {
-            "ServerCertificate": {
-                "ServerCertificateMetadata": {
-                    "ServerCertificateName": cert.cert_name,
-                    "Path": cert.path,
-                    "Arn": cert.arn,
-                    "UploadDate": "2010-05-08T01:02:03.004Z",
-                    "ServerCertificateId": "ASCACKCEVSQ6C2EXAMPLE",
-                    "Expiration": "2012-05-08T01:02:03.004Z",
-                },
-                "CertificateBody": cert.cert_body,
-            }
+        server_cert = {
+            "ServerCertificateMetadata": {
+                "ServerCertificateName": cert.cert_name,
+                "Path": cert.path,
+                "Arn": cert.arn,
+                "UploadDate": "2010-05-08T01:02:03.004Z",
+                "ServerCertificateId": "ASCACKCEVSQ6C2EXAMPLE",
+                "Expiration": "2012-05-08T01:02:03.004Z",
+            },
+            "CertificateBody": cert.cert_body,
         }
+        if cert.cert_chain:
+            server_cert["CertificateChain"] = cert.cert_chain
+        result = {"ServerCertificate": server_cert}
         return ActionResult(result)
 
     def delete_server_certificate(self) -> ActionResult:

--- a/tests/test_iam/test_iam_server_certificates.py
+++ b/tests/test_iam/test_iam_server_certificates.py
@@ -94,3 +94,28 @@ def test_delete_unknown_server_cert():
     assert (
         err["Message"] == "The Server Certificate with name certname cannot be found."
     )
+
+
+@mock_aws
+def test_get_server_cert_with_certificate_chain():
+    conn = boto3.client("iam", region_name="us-east-1")
+
+    conn.upload_server_certificate(
+        ServerCertificateName="certname",
+        CertificateBody="certbody",
+        PrivateKey="privatekey",
+        CertificateChain="certchain",
+    )
+    cert = conn.get_server_certificate(ServerCertificateName="certname")[
+        "ServerCertificate"
+    ]
+    assert cert["CertificateBody"] == "certbody"
+    assert cert["CertificateChain"] == "certchain"
+    assert "Tags" not in cert
+    metadata = cert["ServerCertificateMetadata"]
+    assert metadata["Path"] == "/"
+    assert metadata["ServerCertificateName"] == "certname"
+    assert metadata["Arn"] == f"arn:aws:iam::{ACCOUNT_ID}:server-certificate/certname"
+    assert "ServerCertificateId" in metadata
+    assert isinstance(metadata["UploadDate"], datetime)
+    assert isinstance(metadata["Expiration"], datetime)


### PR DESCRIPTION
This allows callers to specify a CertificateChain when uploading IAM server certificates and receive that CertificateChain back in responses when getting IAM server certificates.