### PR TITLE
Athena: Executions can now be delayed using state transitions

### DIFF
--- a/docs/docs/configuration/state_transition/models.rst
+++ b/docs/docs/configuration/state_transition/models.rst
@@ -8,6 +8,20 @@ Supported Models for State Transitions
 ============================================
 
 
+Service: Athena
+-----------------
+
+**Model**: `athena::execution`  :raw-html:`<br />`
+Available States:  :raw-html:`<br />`
+
+    "QUEUED" --> "RUNNING" --> "SUCCEEDED"
+
+Transition type: `immediate`  :raw-html:`<br />`
+Advancement:
+
+    Call `boto3.client("athena").get_query_execution(..)` to advance the status of a single execution.
+
+
 Service: Batch
 -----------------
 

--- a/moto/athena/exceptions.py
+++ b/moto/athena/exceptions.py
@@ -1,4 +1,5 @@
 import json
+from typing import Optional
 
 from moto.core.exceptions import JsonRESTError
 
@@ -25,3 +26,9 @@ class InvalidArgumentException(JsonRESTError):
 
     def __init__(self, message: str):
         super().__init__("InvalidArgumentException", message)
+
+
+class QueryStillRunning(JsonRESTError):
+    def __init__(self, current_status: Optional[str]):
+        msg = f"Query has not yet finished. Current state: {current_status}"
+        super().__init__("InvalidRequestException", msg)

--- a/moto/athena/models.py
+++ b/moto/athena/models.py
@@ -2,10 +2,11 @@ import time
 from datetime import datetime
 from typing import Any, Dict, List, Optional
 
-from moto.athena.exceptions import InvalidArgumentException
+from moto.athena.exceptions import InvalidArgumentException, QueryStillRunning
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
 from moto.moto_api._internal import mock_random
+from moto.moto_api._internal.managed_state_model import ManagedState
 from moto.s3.models import s3_backends
 from moto.s3.utils import bucket_and_name_from_url
 from moto.utilities.paginator import paginate
@@ -103,7 +104,7 @@ class DataCatalog(TaggableResourceMixin, BaseModel):
         self.parameters = parameters
 
 
-class Execution(BaseModel):
+class Execution(ManagedState):
     def __init__(
         self,
         query: str,
@@ -112,6 +113,11 @@ class Execution(BaseModel):
         workgroup: Optional[WorkGroup],
         execution_parameters: Optional[List[str]],
     ):
+        ManagedState.__init__(
+            self,
+            model_name="athena::execution",
+            transitions=[("QUEUED", "RUNNING"), ("RUNNING", "SUCCEEDED")],
+        )
         self.id = str(mock_random.uuid4())
         self.query = query
         self.context = context
@@ -120,7 +126,6 @@ class Execution(BaseModel):
         self.execution_parameters = execution_parameters
         self.start_time = time.time()
         self.end_time = time.time()
-        self.status = "SUCCEEDED"
 
         if self.config is not None and "OutputLocation" in self.config:
             if not self.config["OutputLocation"].endswith("/"):
@@ -297,9 +302,14 @@ class AthenaBackend(BaseBackend):
             self._store_query_result_in_s3(exec_id)
 
     def get_query_execution(self, exec_id: str) -> Execution:
-        return self.executions[exec_id]
+        execution = self.executions[exec_id]
+        execution.advance()
+        return execution
 
     def list_query_executions(self, workgroup: Optional[str]) -> Dict[str, Execution]:
+        # Note: We do not advance the execution status here, only in `get_query_execution`
+        # This method simply returns the QueryExecutionIds to the user
+        # They will always have to call `get_query_execution` to get the status
         if workgroup is not None:
             return {
                 exec_id: execution
@@ -356,6 +366,9 @@ class AthenaBackend(BaseBackend):
         Query results will also be stored in the S3 output location (in CSV format).
 
         """
+        if (exctn := self.executions.get(exec_id)) and exctn.status != "SUCCEEDED":
+            raise QueryStillRunning(current_status=exctn.status)
+
         self._store_predefined_query_results(exec_id)
 
         results = (

--- a/moto/moto_api/__init__.py
+++ b/moto/moto_api/__init__.py
@@ -10,6 +10,9 @@ state_manager = _internal.state_manager.StateManager()
 Default transitions across Moto
 """
 state_manager.register_default_transition(
+    model_name="athena::execution", transition={"progression": "immediate"}
+)
+state_manager.register_default_transition(
     "batch::job", transition={"progression": "manual", "times": 1}
 )
 state_manager.register_default_transition(

--- a/tests/test_athena/test_athena_execution_state.py
+++ b/tests/test_athena/test_athena_execution_state.py
@@ -1,0 +1,85 @@
+from unittest import SkipTest
+
+import boto3
+import pytest
+from botocore.exceptions import ClientError
+
+from moto import mock_aws, settings
+from moto.moto_api import state_manager
+
+
+@pytest.fixture(scope="function")
+def execution_state_transition():
+    state_manager.set_transition(
+        model_name="athena::execution", transition={"progression": "manual", "times": 2}
+    )
+    yield
+    # Reset to default - we don't want to affect other tests
+    state_manager.set_transition(
+        model_name="athena::execution", transition={"progression": "immediate"}
+    )
+
+
+@mock_aws
+def test_execution_with_manual_transition(execution_state_transition):
+    if not settings.TEST_DECORATOR_MODE:
+        # We already test the state transitions in ServerMode in other tests
+        raise SkipTest(
+            "NO point in verifying state transitions when not using the decorator"
+        )
+
+    client = boto3.client("athena", region_name="eu-west-1")
+    exex_id = client.start_query_execution(
+        QueryString="SELECT stuff FROM mytable",
+        QueryExecutionContext={"Database": "default", "Catalog": "awsdatacatalog"},
+        ResultConfiguration={"OutputLocation": "s3://qwerasdfq3451345254"},
+    )["QueryExecutionId"]
+    #
+    # First state is QUEUED
+    assert get_state(client, exex_id) == "QUEUED"
+
+    # Unable to retrieve query results
+    with pytest.raises(ClientError) as exc:
+        client.get_query_results(QueryExecutionId=exex_id)
+    err = exc.value.response["Error"]
+    assert err["Code"] == "InvalidRequestException"
+    assert err["Message"] == "Query has not yet finished. Current state: QUEUED"
+
+    # Next state is RUNNING
+    assert get_state(client, exex_id) == "RUNNING"
+    assert get_state(client, exex_id) == "RUNNING"
+
+    # Unable to retrieve query results
+    with pytest.raises(ClientError) as exc:
+        client.get_query_results(QueryExecutionId=exex_id)
+    err = exc.value.response["Error"]
+    assert err["Code"] == "InvalidRequestException"
+    assert err["Message"] == "Query has not yet finished. Current state: RUNNING"
+
+    # Next state is SUCCEEDED
+    assert get_state(client, exex_id) == "SUCCEEDED"
+
+    # Now we can get the results
+    assert client.get_query_results(QueryExecutionId=exex_id)["ResultSet"]["Rows"] == []
+
+
+def get_state(client, exex_id):
+    return client.get_query_execution(QueryExecutionId=exex_id)["QueryExecution"][
+        "Status"
+    ]["State"]
+
+
+@mock_aws
+def test_get_query_results_without_transition():
+    """
+    Default state transition is 'immediate', meaning that the query results should be ready immediately
+    """
+
+    client = boto3.client("athena", region_name="eu-west-1")
+    exex_id = client.start_query_execution(
+        QueryString="SELECT stuff FROM mytable",
+        QueryExecutionContext={"Database": "default", "Catalog": "awsdatacatalog"},
+        ResultConfiguration={"OutputLocation": "s3://qwerasdfq3451345254"},
+    )["QueryExecutionId"]
+
+    assert client.get_query_results(QueryExecutionId=exex_id)["ResultSet"]["Rows"] == []


### PR DESCRIPTION
Fixes #9200 

Background info around state transitions:

https://docs.getmoto.org/en/latest/docs/configuration/state_transition/index.html