### PR TITLE
Lambda: list_layer_versions() ordering

### DIFF
--- a/moto/awslambda/responses.py
+++ b/moto/awslambda/responses.py
@@ -363,6 +363,7 @@ class LambdaResponse(BaseResponse):
     def list_layer_versions(self) -> str:
         layer_name = self.path.rsplit("/", 2)[-2]
         layer_versions = self.backend.list_layer_versions(layer_name)
+        layer_versions = sorted(layer_versions, key=lambda lv: lv.version, reverse=True)
         return json.dumps(
             {"LayerVersions": [lv.get_layer_version() for lv in layer_versions]}
         )

--- a/tests/test_awslambda/__init__.py
+++ b/tests/test_awslambda/__init__.py
@@ -114,3 +114,12 @@ def lambda_aws_verified(func):
         )
 
     return pagination_wrapper
+
+
+def delete_all_layer_versions(client, layer_name: str):
+    versions = client.list_layer_versions(LayerName=layer_name)["LayerVersions"]
+    for version in versions:
+        client.delete_layer_version(
+            LayerName=layer_name,
+            VersionNumber=version["Version"],
+        )

--- a/tests/test_cloudformation/test_cloudformation_stack_integration.py
+++ b/tests/test_cloudformation/test_cloudformation_stack_integration.py
@@ -11,7 +11,6 @@ from botocore.exceptions import ClientError
 
 from moto import mock_aws
 from moto.core import DEFAULT_ACCOUNT_ID as ACCOUNT_ID
-from moto.utilities.distutils_version import LooseVersion
 from tests import EXAMPLE_AMI_ID, EXAMPLE_AMI_ID2
 from tests.markers import requires_docker
 from tests.test_cloudformation.fixtures import fn_join, single_instance_with_ebs_volume
@@ -288,9 +287,6 @@ def lambda_handler(event, context):
     assert lv["CompatibleRuntimes"] == ["python2.7", "python3.6"]
     assert lv["Description"] == "Test Layer"
     assert lv["LicenseInfo"] == "MIT"
-    if LooseVersion(boto3_version) > LooseVersion("1.29.0"):
-        # "Parameters only available in newer versions"
-        assert lv["CompatibleArchitectures"] == []
 
 
 @mock_aws


### PR DESCRIPTION
Fixes #9262 

## Changes
 - LayerVersions are now returned by version number, latest version first (used by to be in insertion order, so essentially first version first)
 - CreatedDate has been adjusted to follow the same format that AWS uses

This PR also splits up one massive test into 4 separate tests. That is done as a separate commit, so I'll merge this PR to keep the commit history (instead of the usual squash)