### PR TITLE
EC2: create_subnet() now supports the Ipv6Native-parameter

### DIFF
--- a/moto/ec2/models/subnets.py
+++ b/moto/ec2/models/subnets.py
@@ -15,7 +15,6 @@ from moto.ec2.models.availability_zones_and_regions import Zone
 from ..exceptions import (
     DefaultSubnetAlreadyExistsInAvailabilityZoneError,
     DefaultVpcDoesNotExistError,
-    GenericInvalidParameterValueError,
     InvalidAvailabilityZoneError,
     InvalidCIDRBlockParameterError,
     InvalidParameterValueError,
@@ -44,18 +43,22 @@ class Subnet(TaggedEC2Resource, CloudFormationModel):
         availability_zone: Zone,
         default_for_az: str,
         map_public_ip_on_launch: str,
-        assign_ipv6_address_on_creation: bool = False,
+        ipv6_native: bool = False,
     ):
         self.ec2_backend = ec2_backend
         self.id = subnet_id
         self.vpc_id = vpc_id
         self.cidr_block = cidr_block
-        self.cidr = ipaddress.IPv4Network(str(self.cidr_block), strict=False)
+        self.cidr = (
+            ipaddress.IPv4Network(str(self.cidr_block), strict=False)
+            if self.cidr_block
+            else ipaddress.IPv6Network(ipv6_cidr_block)
+        )
         self._available_ip_addresses = self.cidr.num_addresses - 5
         self._availability_zone = availability_zone
         self.default_for_az = default_for_az
         self.map_public_ip_on_launch = map_public_ip_on_launch
-        self.assign_ipv6_address_on_creation = assign_ipv6_address_on_creation
+        self.assign_ipv6_address_on_creation = ipv6_native
         self.ipv6_cidr_block_associations: Dict[str, Dict[str, Any]] = {}
         if ipv6_cidr_block:
             self.attach_ipv6_cidr_block_associations(ipv6_cidr_block)
@@ -72,7 +75,7 @@ class Subnet(TaggedEC2Resource, CloudFormationModel):
         self.state = "available"
 
         # Placeholder for response templates until Ipv6 support implemented.
-        self.ipv6_native = False
+        self.ipv6_native = ipv6_native
 
     @property
     def arn(self) -> str:
@@ -363,42 +366,40 @@ class SubnetBackend:
         ipv6_cidr_block: Optional[str] = None,
         availability_zone: Optional[str] = None,
         availability_zone_id: Optional[str] = None,
+        ipv6_native: bool = False,
         tags: Optional[Dict[str, Dict[str, str]]] = None,
     ) -> Subnet:
         subnet_id = random_subnet_id()
         # Validate VPC exists and the supplied CIDR block is a subnet of the VPC's
         vpc = self.get_vpc(vpc_id)  # type: ignore[attr-defined]
-        vpc_cidr_blocks = [
-            ipaddress.IPv4Network(
-                str(cidr_block_association["cidr_block"]), strict=False
-            )
-            for cidr_block_association in vpc.get_cidr_block_association_set()
-        ]
-        try:
-            subnet_cidr_block = ipaddress.IPv4Network(str(cidr_block), strict=False)
-        except ValueError:
-            raise InvalidCIDRBlockParameterError(cidr_block)
+        if cidr_block:
+            vpc_cidr_blocks = [
+                ipaddress.IPv4Network(
+                    str(cidr_block_association["cidr_block"]), strict=False
+                )
+                for cidr_block_association in vpc.get_cidr_block_association_set()
+            ]
+            try:
+                subnet_cidr_block = ipaddress.IPv4Network(str(cidr_block), strict=False)
+            except ValueError:
+                raise InvalidCIDRBlockParameterError(cidr_block)
 
-        subnet_in_vpc_cidr_range = False
-        for vpc_cidr_block in vpc_cidr_blocks:
-            if (
-                vpc_cidr_block.network_address <= subnet_cidr_block.network_address
-                and vpc_cidr_block.broadcast_address
-                >= subnet_cidr_block.broadcast_address
-            ):
-                subnet_in_vpc_cidr_range = True
-                break
+            subnet_in_vpc_cidr_range = False
+            for vpc_cidr_block in vpc_cidr_blocks:
+                if (
+                    vpc_cidr_block.network_address <= subnet_cidr_block.network_address
+                    and vpc_cidr_block.broadcast_address
+                    >= subnet_cidr_block.broadcast_address
+                ):
+                    subnet_in_vpc_cidr_range = True
+                    break
 
-        if not subnet_in_vpc_cidr_range:
-            raise InvalidSubnetRangeError(cidr_block)
+            if not subnet_in_vpc_cidr_range:
+                raise InvalidSubnetRangeError(cidr_block)
 
-        # The subnet size must use a /64 prefix length.
-        if ipv6_cidr_block and "::/64" not in ipv6_cidr_block:
-            raise GenericInvalidParameterValueError("ipv6-cidr-block", ipv6_cidr_block)
-
-        for subnet in self.describe_subnets(filters={"vpc-id": vpc_id}):
-            if subnet.cidr.overlaps(subnet_cidr_block):
-                raise InvalidSubnetConflictError(cidr_block)
+            for subnet in self.describe_subnets(filters={"vpc-id": vpc_id}):
+                if subnet.cidr.overlaps(subnet_cidr_block):
+                    raise InvalidSubnetConflictError(cidr_block)
 
         # if this is the first subnet for an availability zone,
         # consider it the default
@@ -443,7 +444,7 @@ class SubnetBackend:
             availability_zone_data,
             default_for_az,
             map_public_ip_on_launch,
-            assign_ipv6_address_on_creation=False,
+            ipv6_native=ipv6_native,
         )
 
         for k, v in tags.get("subnet", {}).items() if tags else []:

--- a/tests/test_ec2/__init__.py
+++ b/tests/test_ec2/__init__.py
@@ -177,6 +177,17 @@ def wait_for_vpn_connections(ec2_client, vpn_connection_id):
         sleep(5 * idx)
 
 
+def wait_for_ipv6_cidr_block_associations(ec2_client, vpc_id):
+    for idx in range(10):
+        vpcs = ec2_client.describe_vpcs(VpcIds=[vpc_id])["Vpcs"]
+        if (
+            vpcs[0]["Ipv6CidrBlockAssociationSet"][0]["Ipv6CidrBlockState"]["State"]
+            == "associated"
+        ):
+            return vpcs[0]["Ipv6CidrBlockAssociationSet"][0]
+        sleep(5 * idx)
+
+
 def delete_transit_gateway_dependencies(ec2_client, tg_id):
     delete_tg_attachments(ec2_client, tg_id)
 

--- a/tests/test_ec2/test_subnets.py
+++ b/tests/test_ec2/test_subnets.py
@@ -8,6 +8,7 @@ from botocore.exceptions import ClientError
 
 from moto import mock_aws, settings
 from tests import DEFAULT_ACCOUNT_ID, EXAMPLE_AMI_ID
+from tests.test_ec2 import ec2_aws_verified, wait_for_ipv6_cidr_block_associations
 
 
 @mock_aws
@@ -932,3 +933,78 @@ def test_describe_subnets_dryrun():
         ex.value.response["Error"]["Message"]
         == "An error occurred (DryRunOperation) when calling the DescribeSubnets operation: Request would have succeeded, but DryRun flag is set"
     )
+
+
+@pytest.mark.aws_verified
+@ec2_aws_verified(create_vpc=True)
+def test_create_ipv6native_subnet_without_cidr(
+    account_id, ec2_client=None, vpc_id=None
+):
+    with pytest.raises(ClientError) as exc:
+        ec2_client.create_subnet(VpcId=vpc_id, Ipv6Native=True)
+    err = exc.value.response["Error"]
+    assert err["Code"] == "MissingParameter"
+    assert (
+        err["Message"]
+        == "Either 'ipv6CidrBlock' or 'ipv6IpamPoolId' should be provided."
+    )
+
+
+@pytest.mark.aws_verified
+@ec2_aws_verified(create_vpc=True)
+def test_create_ipv6native_subnet_with_ipv4_cidr(
+    account_id, ec2_client=None, vpc_id=None
+):
+    with pytest.raises(ClientError) as exc:
+        ec2_client.create_subnet(VpcId=vpc_id, Ipv6Native=True, CidrBlock="10.0.0.0/24")
+    err = exc.value.response["Error"]
+    assert err["Code"] == "MissingParameter"
+    assert (
+        err["Message"]
+        == "Either 'ipv6CidrBlock' or 'ipv6IpamPoolId' should be provided."
+    )
+
+
+@pytest.mark.aws_verified
+@ec2_aws_verified(create_vpc=True)
+def test_create_ipv6native_subnet_with_ipv4_and_ipv6_cidr(
+    account_id, ec2_client=None, vpc_id=None
+):
+    with pytest.raises(ClientError) as exc:
+        ec2_client.create_subnet(
+            VpcId=vpc_id,
+            Ipv6Native=True,
+            CidrBlock="10.0.0.0/24",
+            Ipv6CidrBlock="1080::1:200C:417A/112",
+        )
+    err = exc.value.response["Error"]
+    assert err["Code"] == "InvalidParameterCombination"
+    assert (
+        err["Message"]
+        == "When specifying ipv4 parameters, cidrBlock or ipv4IpamPoolId, you cannot set ipv6Native to true."
+    )
+
+
+@pytest.mark.aws_verified
+@ec2_aws_verified(create_vpc=True)
+def test_create_ipv6native_subnet(account_id, ec2_client=None, vpc_id=None):
+    subnet = None
+    try:
+        ec2_client.associate_vpc_cidr_block(
+            VpcId=vpc_id, AmazonProvidedIpv6CidrBlock=True
+        )["Ipv6CidrBlockAssociation"]
+        assoc = wait_for_ipv6_cidr_block_associations(ec2_client, vpc_id=vpc_id)
+
+        subnet = ec2_client.create_subnet(
+            VpcId=vpc_id, Ipv6Native=True, Ipv6CidrBlock=assoc["Ipv6CidrBlock"]
+        )["Subnet"]
+        assert subnet["AssignIpv6AddressOnCreation"] is True
+        assert subnet["Ipv6Native"] is True
+        assert subnet["State"] == "available"
+        assert (
+            subnet["Ipv6CidrBlockAssociationSet"][0]["Ipv6CidrBlock"]
+            == assoc["Ipv6CidrBlock"]
+        )
+    finally:
+        if subnet:
+            ec2_client.delete_subnet(SubnetId=subnet["SubnetId"])


### PR DESCRIPTION
Part of the changes required for #9065. This is currently only validated when using a VPC with `AmazonProvidedIpv6CidrBlock` - additional testing/implementation is still required when creating a VPC with a custom IPv6 address.

## Changes
 - Adds support for the `Ipv6Native` parameter
 - Moves `cidr_block` validation so that it is only validated when actually provided
 - Removes a check that `ipv6_cidr_block` must end in `::64`. This was introduced in #4242, but tests against AWS show that the cidr block can also end in other values (e.g. `::56`)
 - Adds validation to `create_subnet` when supplying both Ipv4 and Ipv6 parameters
 - Adds AWS-verified tests for these scenarios