### PR TITLE
Core: Rework MOTO_ROOT to use a local variable

### DIFF
--- a/moto/__init__.py
+++ b/moto/__init__.py
@@ -1,8 +1,4 @@
-import os
+from moto.core.decorator import mock_aws as mock_aws  # noqa: E402
 
 __title__ = "moto"
 __version__ = "5.1.15.dev"
-
-MOTO_ROOT = os.path.dirname(os.path.abspath(__file__))
-
-from moto.core.decorator import mock_aws as mock_aws  # noqa: E402

--- a/moto/core/loaders.py
+++ b/moto/core/loaders.py
@@ -16,9 +16,13 @@ service model by supplying additional error shapes or default input
 values for use by Moto.
 """
 
+import os
+
 from botocore.loaders import Loader as BotocoreLoader
 
-from moto import MOTO_ROOT
+import moto
+
+moto_root = os.path.dirname(os.path.abspath(moto.__file__))
 
 
 class Loader(BotocoreLoader):
@@ -26,4 +30,4 @@ class Loader(BotocoreLoader):
 
 
 def create_loader() -> Loader:
-    return Loader(extra_search_paths=[MOTO_ROOT])
+    return Loader(extra_search_paths=[moto_root])


### PR DESCRIPTION
This variable was introduced in #9358, but made it part of the public API (by adding it to `moto/__init__.py`.

This PR changes to a local import, removing it from the public API.