### PR TITLE
Tests: Harden AWS checks to allow for slow/async/parallel tests

### DIFF
--- a/.github/workflows/tests_real_aws.yml
+++ b/.github/workflows/tests_real_aws.yml
@@ -45,4 +45,4 @@ jobs:
       env:
         MOTO_TEST_ALLOW_AWS_REQUEST: ${{ true }}
       run: |
-        pytest -sv -n auto --dist loadfile tests/test_applicationautoscaling/ tests/test_athena/ tests/test_cloudformation/ tests/test_dynamodb/ tests/test_ec2/ tests/test_events/ tests/test_iam/ tests/test_iot/ tests/test_lakeformation/ tests/test_logs/ tests/test_rds/ tests/test_sqs/ tests/test_ses/ tests/test_s3* tests/test_stepfunctions/ tests/test_sns/ tests/test_timestreamwrite/ -m aws_verified
+        pytest -sv -n auto --dist loadfile tests -m aws_verified --durations 100

--- a/tests/test_dynamodb/exceptions/test_dynamodb_exceptions.py
+++ b/tests/test_dynamodb/exceptions/test_dynamodb_exceptions.py
@@ -591,10 +591,14 @@ def test_query_unused_attribute_name(table_name=None):
         )
     err = exc.value.response["Error"]
     assert err["Code"] == "ValidationException"
-    assert (
-        err["Message"]
-        == "Value provided in ExpressionAttributeNames unused in expressions: keys: {#count}"
-    )
+    # Moto will always complain about the fact that #count is unused
+    # AWS will usually complain about that
+    # Sometimes (1 in 10 times, maybe?) it will complain about multiple attribute names are used in one condition
+    # Which is interesting, as there is obviously some async error handling going on. Whichever error is found first, 'wins'
+    assert err["Message"] in [
+        "Value provided in ExpressionAttributeNames unused in expressions: keys: {#count}",
+        "Invalid KeyConditionExpression: Invalid condition in KeyConditionExpression: Multiple attribute names used in one condition",
+    ]
 
 
 @pytest.mark.aws_verified

--- a/tests/test_events/test_events.py
+++ b/tests/test_events/test_events.py
@@ -2499,15 +2499,14 @@ def test_kms_key_is_created(auth_type, auth_parameters, with_headers):
 
         secret_deleted = False
         attempts = 0
-        while not secret_deleted and attempts < 5:
+        while not secret_deleted and attempts < 10:
             try:
                 attempts += 1
                 secrets.describe_secret(SecretId=secret_arn)
                 sleep(1)
-            except ClientError as e:
-                secret_deleted = (
-                    e.response["Error"]["Code"] == "ResourceNotFoundException"
-                )
+            except ClientError as exc:
+                err = exc.response["Error"]
+                secret_deleted = err["Code"] == "ResourceNotFoundException"
 
         if not secret_deleted:
             assert False, f"Should have automatically deleted secret {secret_arn}"

--- a/tests/test_sns/test_publishing_boto3.py
+++ b/tests/test_sns/test_publishing_boto3.py
@@ -38,7 +38,8 @@ def test_publish_to_sqs(
     published_message_id = published_message["MessageId"]
 
     queue = sqs_conn.get_queue_by_name(QueueName=queue_name)
-    messages = queue.receive_messages(MaxNumberOfMessages=1)
+    # Long polling - make sure we wait until the message has arrived
+    messages = queue.receive_messages(MaxNumberOfMessages=1, WaitTimeSeconds=20)
     acquired_message = json.loads(messages[0].body)
 
     assert acquired_message["Message"] == "my message"


### PR DESCRIPTION
All these tests failed in the [last parity run against AWS](https://github.com/getmoto/moto/actions/runs/18440022181/job/52539108628).

The failures are all flaky - hopefully this will stabilize the tests a bit.

This PR also updates the CI action so that we:
 - run all the tests, not just the ones in specific folders
 - show the duration, to have some idea how long they all take