### PR TITLE
Tests: Fix aws_verified tests

### DIFF
--- a/tests/test_core/test_mypy.py
+++ b/tests/test_core/test_mypy.py
@@ -35,8 +35,9 @@ def test_manual() -> None:
     m.stop()
 
 
-x: int = method_with_parentheses()
-assert x == 456
+def test_mock_aws_decorator_return_types() -> None:
+    x: int = method_with_parentheses()
+    assert x == 456
 
-y: int = method_without_parentheses()
-assert y == 123
+    y: int = method_without_parentheses()
+    assert y == 123

--- a/tests/test_ec2/__init__.py
+++ b/tests/test_ec2/__init__.py
@@ -71,9 +71,10 @@ def _invoke_func(
         kwargs["vpc_id"] = vpc_id
 
         if create_subnet:
-            subnet_id = ec2_client.create_subnet(VpcId=vpc_id, CidrBlock="10.0.0.0/24")[
-                "Subnet"
-            ]["SubnetId"]
+            subnet = ec2_client.create_subnet(
+                VpcId=vpc_id, CidrBlock="10.0.0.0/24", AvailabilityZone="us-east-1a"
+            )
+            subnet_id = subnet["Subnet"]["SubnetId"]
             kwargs["subnet_id"] = subnet_id
 
     if create_sg:

--- a/tests/test_rds/test_rds.py
+++ b/tests/test_rds/test_rds.py
@@ -1551,9 +1551,11 @@ def test_modify_non_existent_option_group(client):
     )
 
 
-@pytest.mark.aws_verified
 @mock_aws
 def test_delete_database_with_protection(client):
+    # This has been verified against AWS
+    # We're not going to mark it with @pytest.mark.aws_verified though, as we cannot run this against AWS yet
+    # Not without additional work to ensure we properly create and teardown any resources
     create_db_instance(DBInstanceIdentifier="db-primary-1", DeletionProtection=True)
 
     with pytest.raises(ClientError) as exc:

--- a/tests/test_timestreamwrite/test_timestreamwrite_table.py
+++ b/tests/test_timestreamwrite/test_timestreamwrite_table.py
@@ -10,7 +10,10 @@ from moto.core import DEFAULT_ACCOUNT_ID as ACCOUNT_ID
 from tests import aws_verified
 
 
-@pytest.mark.aws_verified
+# @pytest.mark.aws_verified
+# This works in some accounts, but in other accounts there is a KMS error:
+#    The KMS key [.. arn of AWS-managed key..] doesn't exist, is disabled or you don't have sufficient permission to use it
+# Need to figure out what's going on
 @aws_verified
 def test_create_table():
     ts = boto3.client("timestream-write", region_name="us-east-1")


### PR DESCRIPTION
#9365 enabled additional `aws_verified` tests - that promptly failed.

 - **All tests** failed because of Authentication errors. This was due to the fact that the `method_without_parentheses()` in `test_mypy.py` was run during collection time, already invoking the `mock_aws` decorator and caching a boto3 Session with fake credentials.

Now that these invocations are inside a test-method, they are no longer invoked, and there is no cached boto3 Session anymore.

 - **ELBv2**: AWS does not like the fact that we try to create an ec2 Instance using a fake KMS key (called `test2`).

Fixing this test involved:
1. Removing the KMS key
2. Using the existing `ec2_aws_verified` decorator to automatically create/destroy the VPN/subnet

 - **RDS**: a test was marked as `aws_verified`, but wasn't actually ready to be run
 - **TimestreamWrite**: The test passes locally when running it against AWS, but fails in GithubActions (which uses a different account). This test needs some additional TLC to see what's going on.