### PR TITLE
ElastiCache: Enable IPv6 test

### DIFF
--- a/tests/test_elasticache/test_elasticache.py
+++ b/tests/test_elasticache/test_elasticache.py
@@ -1,5 +1,3 @@
-from unittest import SkipTest
-
 import boto3
 import pytest
 from botocore.exceptions import ClientError
@@ -978,11 +976,8 @@ def test_cache_subnet_group_with_ipv4_and_ipv6_subnets():
     assert "dual_stack" in resp["CacheSubnetGroup"]["SupportedNetworkTypes"]
 
 
-# The following test will be skipped until the create_subnet moto feature
-# adds support for the Ipv6Native parameter.
 @mock_aws
 def test_cache_subnet_group_with_ipv6_native_subnets():
-    raise SkipTest("create_subnet() does not support Ipv6Native-parameter yet")
     client = boto3.client("elasticache", region_name="us-east-2")
     ec2_client = boto3.client("ec2", region_name="us-east-2")
 
@@ -996,13 +991,13 @@ def test_cache_subnet_group_with_ipv6_native_subnets():
         VpcId=vpc_id,
         Ipv6CidrBlock="2600:1f16:1cb1:6b00::/60",
         Ipv6Native=True,
-    )
-    subnet_ipv6_0_id = subnet_ipv6_0.get("SubnetId")
+    )["Subnet"]
+    subnet_ipv6_0_id = subnet_ipv6_0["SubnetId"]
 
     subnet_ipv6_1 = ec2_client.create_subnet(
         VpcId=vpc_id, Ipv6CidrBlock="2600:1f16:1cb1:6b10::/60", Ipv6Native=True
-    )
-    subnet_ipv6_1_id = subnet_ipv6_1.get("SubnetId")
+    )["Subnet"]
+    subnet_ipv6_1_id = subnet_ipv6_1["SubnetId"]
 
     resp = client.create_cache_subnet_group(
         CacheSubnetGroupName="test-subnet-group",


### PR DESCRIPTION
Fixes #9065 

With #9359 in, this test now passes. I'm sure there are other IPv6 scenarios that are still not implemented though - please let us know if you (still) run into issues.