### PR TITLE
IdentityStore: Add implementation for get-user-id

### DIFF
--- a/moto/identitystore/responses.py
+++ b/moto/identitystore/responses.py
@@ -75,6 +75,15 @@ class IdentityStoreResponse(BaseResponse):
         )
         return json.dumps(dict(GroupId=group_id, IdentityStoreId=identity_store_id))
 
+    def get_user_id(self) -> str:
+        identity_store_id = self._get_param("IdentityStoreId")
+        alternate_identifier = self._get_param("AlternateIdentifier")
+        user_id, identity_store_id = self.identitystore_backend.get_user_id(
+            identity_store_id=identity_store_id,
+            alternate_identifier=alternate_identifier,
+        )
+        return json.dumps(dict(UserId=user_id, IdentityStoreId=identity_store_id))
+
     def describe_user(self) -> str:
         identity_store_id = self._get_param("IdentityStoreId")
         user_id = self._get_param("UserId")


### PR DESCRIPTION
This PR adds support for the `get_user_id` operation in the IdentityStore service. This allows retrieving a user's UserId by alternate identifiers such as username or email address.

From AWS document for `list-users`: https://docs.aws.amazon.com/cli/latest/reference/identitystore/list-users.html#description
>  Filtering for a User by the UserName attribute is deprecated. Instead, use the GetUserId API action.

ExternalId alternate identifier is not yet implemented (consistent with `get_group_id`).

