### PR TITLE
Tests: Verify CDK tests for S3+EventBridge

### DIFF
--- a/.github/workflows/tests_cdk.yml
+++ b/.github/workflows/tests_cdk.yml
@@ -43,3 +43,53 @@ jobs:
         cd cdk_example_app
         source .venv/bin/activate
         cdk bootstrap -v
+
+  find-jobs:
+    runs-on: ubuntu-latest
+    needs: cdk_start
+    name: Find Jobs
+    outputs:
+      folders: ${{ steps.set-folders.outputs.folders }}
+    steps:
+      - uses: actions/checkout@v5
+      - id: set-folders
+        name: Get CDK Examples
+        shell: bash
+        run: |
+          cd other_langs/tests_cdk/
+          folders=$(tree -J -d -L 1 | jq -c '.[0].contents | map(.name)')
+          echo $folders
+          echo "folders=$folders" >> $GITHUB_OUTPUT
+
+  test:
+    runs-on: ubuntu-latest
+    needs: find-jobs
+    strategy:
+      fail-fast: false
+      matrix:
+        service: ${{ fromJson(needs.find-jobs.outputs.folders )}}
+
+    steps:
+    - uses: actions/checkout@v5
+    - name: Set up Python 3.12
+      uses: actions/setup-python@v6
+      with:
+        python-version: "3.12"
+    - name: Start MotoServer
+      run: |
+        pip install build
+        python -m build
+        docker run --rm -t --name motoserver -e TEST_SERVER_MODE=true -e AWS_SECRET_ACCESS_KEY=server_secret -e AWS_ACCESS_KEY_ID=server_key -v `pwd`:/moto -p 5000:5000 -v /var/run/docker.sock:/var/run/docker.sock python:3.10-slim /moto/scripts/ci_moto_server.sh &
+        python scripts/ci_wait_for_server.py
+    - name: Install Dependencies
+      run: |
+        pip install -r other_langs/tests_cdk/${{ matrix.service }}/requirements.txt
+    - name: Deploy Service ${{ matrix.service }}
+      env:
+        AWS_ENDPOINT_URL: "http://localhost:5000"
+      run: |
+        mkdir ~/.aws && touch ~/.aws/credentials && echo -e "[default]\naws_access_key_id = test\naws_secret_access_key = test" > ~/.aws/credentials
+        npm install -g aws-cdk
+        cd other_langs/tests_cdk/${{ matrix.service }}
+        cdk bootstrap
+        cdk deploy --require-approval never

--- a/moto/cloudformation/parsing.py
+++ b/moto/cloudformation/parsing.py
@@ -847,8 +847,14 @@ class ResourceMap(collections_abc.Mapping):  # type: ignore[type-arg]
             for logical_name in resource_names_by_action["Remove"].copy():
                 resource_json = self._resource_json_map[logical_name]
                 try:
-                    resource = self._parsed_resources[logical_name]
-                    self._delete_resource(resource, resource_json)
+                    if logical_name in self._parsed_resources:
+                        resource = self._parsed_resources[logical_name]
+                        self._delete_resource(resource, resource_json)
+                    else:
+                        # Resource wasn't created in the first place
+                        warnings.warn(
+                            f"Unable to delete {logical_name}, as it was never created"
+                        )
                 except Exception as e:
                     # skip over dependency violations, and try again in another pass
                     last_exception = e

--- a/moto/s3/models.py
+++ b/moto/s3/models.py
@@ -301,9 +301,9 @@ class FakeKey(BaseModel, ManagedState):
             if self.encryption == "aws:kms" and self.kms_key_id is not None:
                 res["x-amz-server-side-encryption-aws-kms-key-id"] = self.kms_key_id
         if self.encryption == "aws:kms" and self.bucket_key_enabled is not None:
-            res["x-amz-server-side-encryption-bucket-key-enabled"] = (
+            res["x-amz-server-side-encryption-bucket-key-enabled"] = str(
                 self.bucket_key_enabled
-            )
+            ).lower()
         if self._storage_class != "STANDARD":
             res["x-amz-storage-class"] = self._storage_class
         if self._expiry is not None:

--- a/other_langs/tests_cdk/s3_eventbridge/app.py
+++ b/other_langs/tests_cdk/s3_eventbridge/app.py
@@ -1,0 +1,44 @@
+import aws_cdk as cdk
+from aws_cdk import Stack
+from aws_cdk import aws_events as events
+from aws_cdk import aws_events_targets as targets
+from aws_cdk import aws_s3 as s3
+from aws_cdk import aws_sqs as sqs
+from constructs import Construct
+
+
+class S3EventbridgeStack(Stack):
+    def __init__(self, scope: Construct, construct_id: str, **kwargs) -> None:
+        super().__init__(scope, construct_id, **kwargs)
+
+        s3_bucket = s3.Bucket(
+            self,
+            "bucket",
+            access_control=s3.BucketAccessControl.PRIVATE,
+            encryption=s3.BucketEncryption.S3_MANAGED,
+            versioned=False,
+            block_public_access=s3.BlockPublicAccess.BLOCK_ALL,
+        )
+        # allow s3 bucket to send notification to eventbridge
+        s3_bucket.enable_event_bridge_notification()
+
+        # Queue to send events to
+        event_queue = sqs.Queue(self, id="sample_queue_id")
+
+        # eventbridge rule to trigger when objects gets added or deleted in s3 bucket
+        self.event_rule = events.Rule(
+            self,
+            "queueRule",
+            description="Rule to trigger Queue Message",
+            event_pattern=events.EventPattern(
+                source=["aws.s3"],
+                detail={"bucket": {"name": [s3_bucket.bucket_name]}},
+            ),
+        )
+        self.event_rule.add_target(targets.SqsQueue(queue=event_queue))
+
+
+app = cdk.App()
+S3EventbridgeStack(app, "s3-eventbridge-queue")
+
+app.synth()

--- a/other_langs/tests_cdk/s3_eventbridge/cdk.json
+++ b/other_langs/tests_cdk/s3_eventbridge/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "python3 app.py"
+}

--- a/other_langs/tests_cdk/s3_eventbridge/requirements.txt
+++ b/other_langs/tests_cdk/s3_eventbridge/requirements.txt
@@ -1,0 +1,2 @@
+aws-cdk-lib==2.89.0
+constructs>=10.0.0,<11.0.0


### PR DESCRIPTION
I've been doing some testing with the AWS CDK, specifically to see if we can simplify the creation of `aws_parity` tests. 

We're not there yet, but this is a first step into integrating support for the CDK into our pipeline:
 - Extend the CI action to automatically run all CDK samples
 - Add a CDK sample for S3 and EventBridge integration
 - Some minor fixes to S3 and CF to increase parity (and not break the CDK)

The S3 header needs to be a lowercase string, as the CDK does not understand the value `False`.

CF needs to be able to handle deletion of unknown resources. The CDK tries to create quite a few resources that aren't supported yet (like `AWS::SQS::QueuePolicy` and `AWS::S3::BucketPolicy`), so it's nice to be able to delete the stack without running into errors.