### PR TITLE
CI: Use separate action to build Docker image once and reuse it

### DIFF
--- a/.github/actions/run_moto_server/action.yml
+++ b/.github/actions/run_moto_server/action.yml
@@ -1,0 +1,25 @@
+name: run_moto_server
+author: bblommers
+description: run_moto_server
+runs:
+  using: "composite"
+  steps:
+    - name: Download artifact
+      uses: actions/download-artifact@v5
+      with:
+        name: localimage
+        path: /tmp
+    - name: Load Docker image
+      shell: bash
+      run: |
+        docker load --input /tmp/localimage.tar
+        docker image ls -a
+    - name: Run MotoServer
+      shell: bash
+      env:
+        TEST_SERVER_MODE: true
+        MOTO_EC2_LOAD_DEFAULT_AMIS: false
+        AWS_SECRET_ACCESS_KEY: server_secret
+        AWS_ACCESS_KEY_ID: server_key
+      run: |
+        docker run --rm -t --name motoserver -v `pwd`:/moto -p 5000:5000 -v /var/run/docker.sock:/var/run/docker.sock motoserver/moto:local &

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,12 +72,45 @@ jobs:
         mkdir .mypy_cache
         make lint
 
-  clitest:
+  buildserver:
     needs: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python-version }}
+      # Retrieve the previously cached dependencies
+      - name: Get pip cache dir
+        id: pip-cache
+        run: |
+          echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
+      - name: pip cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.pip-cache.outputs.dir }}
+          key: pip-${{ matrix.python-version }}-${{ hashFiles('**/setup.cfg') }}
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Build Docker Image
+        uses: docker/build-push-action@v6
+        with:
+          tags: motoserver/moto:local
+          outputs: type=docker,dest=/tmp/localimage.tar
+          push: false
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: localimage
+          path: /tmp/localimage.tar
+
+  clitest:
+    needs: buildserver
     uses: ./.github/workflows/tests_cli.yml
 
   cpptest:
-    needs: lint
+    needs: buildserver
     uses: ./.github/workflows/tests_sdk_cpp.yml
 
   sagemaker_client_test:
@@ -85,27 +118,27 @@ jobs:
     uses: ./.github/workflows/tests_sdk_sagemaker.yml
 
   javatest:
-    needs: lint
+    needs: buildserver
     uses: ./.github/workflows/tests_sdk_java.yml
 
   jstest:
-    needs: lint
+    needs: buildserver
     uses: ./.github/workflows/tests_sdk_js.yml
 
   dotnettest:
-    needs: lint
+    needs: buildserver
     uses: ./.github/workflows/tests_sdk_dotnet.yml
 
   rubytest:
-    needs: lint
+    needs: buildserver
     uses: ./.github/workflows/tests_sdk_ruby.yml
 
   gotest:
-    needs: lint
+    needs: buildserver
     uses: ./.github/workflows/tests_sdk_go.yml
 
   terraformexamplestest:
-    needs: lint
+    needs: buildserver
     uses: ./.github/workflows/tests_terraform_examples.yml
 
   test:
@@ -126,6 +159,6 @@ jobs:
     uses: ./.github/workflows/tests_proxymode.yml
 
   testcdk:
-    needs: [lint]
+    needs: [buildserver]
     if: "!contains(github.event.pull_request.labels.*.name, 'java')"
     uses: ./.github/workflows/tests_cdk.yml

--- a/.github/workflows/tests_cdk.yml
+++ b/.github/workflows/tests_cdk.yml
@@ -16,11 +16,7 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - name: Start MotoServer
-      run: |
-        pip install build
-        python -m build
-        docker run --rm -t --name motoserver -e TEST_SERVER_MODE=true -e MOTO_EC2_LOAD_DEFAULT_AMIS=false -e AWS_SECRET_ACCESS_KEY=server_secret -e AWS_ACCESS_KEY_ID=server_key -v `pwd`:/moto -p 5000:5000 -v /var/run/docker.sock:/var/run/docker.sock python:${{ matrix.python-version }}-slim /moto/scripts/ci_moto_server.sh &
-        python scripts/ci_wait_for_server.py
+      uses: ./.github/actions/run_moto_server
     - name: Install CDK
       id: install-cdk
       run: |
@@ -76,11 +72,7 @@ jobs:
       with:
         python-version: "3.12"
     - name: Start MotoServer
-      run: |
-        pip install build
-        python -m build
-        docker run --rm -t --name motoserver -e TEST_SERVER_MODE=true -e AWS_SECRET_ACCESS_KEY=server_secret -e AWS_ACCESS_KEY_ID=server_key -v `pwd`:/moto -p 5000:5000 -v /var/run/docker.sock:/var/run/docker.sock python:3.10-slim /moto/scripts/ci_moto_server.sh &
-        python scripts/ci_wait_for_server.py
+      uses: ./.github/actions/run_moto_server
     - name: Install Dependencies
       run: |
         pip install -r other_langs/tests_cdk/${{ matrix.service }}/requirements.txt

--- a/.github/workflows/tests_cli.yml
+++ b/.github/workflows/tests_cli.yml
@@ -14,11 +14,7 @@ jobs:
       with:
         python-version: "3.12"
     - name: Start MotoServer
-      run: |
-        pip install build
-        python -m build
-        docker run --rm -t --name motoserver -e TEST_SERVER_MODE=true -e AWS_SECRET_ACCESS_KEY=server_secret -e AWS_ACCESS_KEY_ID=server_key -v `pwd`:/moto -p 5000:5000 -v /var/run/docker.sock:/var/run/docker.sock python:3.10-slim /moto/scripts/ci_moto_server.sh &
-        python scripts/ci_wait_for_server.py
+      uses: ./.github/actions/run_moto_server
     - name: Install BATS
       run: sudo apt-get install bats -y
     - name: Run tests

--- a/.github/workflows/tests_sdk_cpp.yml
+++ b/.github/workflows/tests_sdk_cpp.yml
@@ -14,11 +14,7 @@ jobs:
       with:
         python-version: "3.12"
     - name: Start MotoServer
-      run: |
-        pip install build
-        python -m build
-        docker run --rm -t --name motoserver -e TEST_SERVER_MODE=true -e AWS_SECRET_ACCESS_KEY=server_secret -e AWS_ACCESS_KEY_ID=server_key -v `pwd`:/moto -p 5000:5000 -v /var/run/docker.sock:/var/run/docker.sock python:3.10-slim /moto/scripts/ci_moto_server.sh &
-        python scripts/ci_wait_for_server.py
+      uses: ./.github/actions/run_moto_server
 
     - name: Check build cache
       id: build-cache

--- a/.github/workflows/tests_sdk_dotnet.yml
+++ b/.github/workflows/tests_sdk_dotnet.yml
@@ -14,11 +14,7 @@ jobs:
       with:
         python-version: "3.12"
     - name: Start MotoServer
-      run: |
-        pip install build
-        python -m build
-        docker run --rm -t --name motoserver -e TEST_SERVER_MODE=true -e AWS_SECRET_ACCESS_KEY=server_secret -e AWS_ACCESS_KEY_ID=server_key -v `pwd`:/moto -p 5000:5000 -v /var/run/docker.sock:/var/run/docker.sock python:3.10-slim /moto/scripts/ci_moto_server.sh &
-        python scripts/ci_wait_for_server.py
+      uses: ./.github/actions/run_moto_server
     - uses: actions/setup-dotnet@v5
     - uses: actions/cache@v4
       with:

--- a/.github/workflows/tests_sdk_go.yml
+++ b/.github/workflows/tests_sdk_go.yml
@@ -15,11 +15,7 @@ jobs:
       with:
           go-version: '1.24.x'
     - name: Start MotoServer
-      run: |
-        pip install build
-        python -m build
-        docker run --rm -t --name motoserver -e TEST_SERVER_MODE=true -e AWS_SECRET_ACCESS_KEY=server_secret -e AWS_ACCESS_KEY_ID=server_key -v `pwd`:/moto -p 5000:5000 -v /var/run/docker.sock:/var/run/docker.sock python:3.10-slim /moto/scripts/ci_moto_server.sh &
-        python scripts/ci_wait_for_server.py
+      uses: ./.github/actions/run_moto_server
     - name: Install Dependencies
       run: cd other_langs/tests_go && go get -t .
     - name: Run Tests

--- a/.github/workflows/tests_sdk_java.yml
+++ b/.github/workflows/tests_sdk_java.yml
@@ -14,11 +14,7 @@ jobs:
       with:
         python-version: "3.12"
     - name: Start MotoServer
-      run: |
-        pip install build
-        python -m build
-        docker run --rm -t --name motoserver -e TEST_SERVER_MODE=true -e AWS_SECRET_ACCESS_KEY=server_secret -e AWS_ACCESS_KEY_ID=server_key -v `pwd`:/moto -p 5000:5000 -v /var/run/docker.sock:/var/run/docker.sock python:3.10-slim /moto/scripts/ci_moto_server.sh &
-        python scripts/ci_wait_for_server.py
+      uses: ./.github/actions/run_moto_server
     - uses: actions/setup-java@v5
       with:
         distribution: 'temurin'

--- a/.github/workflows/tests_sdk_js.yml
+++ b/.github/workflows/tests_sdk_js.yml
@@ -14,11 +14,7 @@ jobs:
       with:
         python-version: "3.11"
     - name: Start MotoServer
-      run: |
-        pip install build
-        python -m build
-        docker run --rm -t --name motoserver -e TEST_SERVER_MODE=true -e AWS_SECRET_ACCESS_KEY=server_secret -e AWS_ACCESS_KEY_ID=server_key -v `pwd`:/moto -p 5000:5000 -v /var/run/docker.sock:/var/run/docker.sock python:3.11-slim /moto/scripts/ci_moto_server.sh &
-        python scripts/ci_wait_for_server.py
+      uses: ./.github/actions/run_moto_server
     - uses: actions/setup-node@v5
     - name: Install dependencies
       run: |

--- a/.github/workflows/tests_sdk_ruby.yml
+++ b/.github/workflows/tests_sdk_ruby.yml
@@ -21,11 +21,7 @@ jobs:
         with:
           python-version: "3.12"
       - name: Start MotoServer
-        run: |
-          pip install build
-          python -m build
-          docker run --rm -t --name motoserver -e TEST_SERVER_MODE=true -e AWS_SECRET_ACCESS_KEY=server_secret -e AWS_ACCESS_KEY_ID=server_key -v `pwd`:/moto -p 5000:5000 -v /var/run/docker.sock:/var/run/docker.sock python:3.10-slim /moto/scripts/ci_moto_server.sh &
-          python scripts/ci_wait_for_server.py
+        uses: ./.github/actions/run_moto_server
       - name: Install dependencies
         run: cd other_langs/tests_ruby && bundle install
       - name: Run tests

--- a/.github/workflows/tests_terraform_examples.yml
+++ b/.github/workflows/tests_terraform_examples.yml
@@ -32,18 +32,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v5
-      with:
-        fetch-depth: 0
-    - name: Set up Python 3.12
-      uses: actions/setup-python@v6
-      with:
-        python-version: "3.12"
     - name: Start MotoServer
-      run: |
-        pip install build
-        python -m build
-        docker run --rm -t --name motoserver -e TEST_SERVER_MODE=true -e AWS_SECRET_ACCESS_KEY=server_secret -e AWS_ACCESS_KEY_ID=server_key -v `pwd`:/moto -p 5000:5000 -v /var/run/docker.sock:/var/run/docker.sock python:3.10-slim /moto/scripts/ci_moto_server.sh &
-        python scripts/ci_wait_for_server.py
+      uses: ./.github/actions/run_moto_server
     - name: Set up Terraform
       uses: hashicorp/setup-terraform@v3
     - name: Run tests


### PR DESCRIPTION
We are building a Docker image in our CI tests quite often, at least once for all the non-python SDK's:  Java, Golang, JS, CLI, SDK, DotNet, not to mention 15 Terraform tests for different services.

All of these SDK's build their own Docker image, redownloading the base Docker image + Python dependencies every time. This adds between 1 min to 1 min 20 secs to every step.

This PR changes the workflow to only build the image once, and cache it. The SDK workflows then load the image from cache and run it. This step now only takes 20 seconds, and greatly reduces the number of CPU cycles and IO traffic.

Note 1: The standard MotoServer still build their own image, just because they all need to be build using a specific Python version.

Note 2: This doesn't reduce the overall runtime of the CI, because all workflows are run in parallel - we're still upper bound by the longest running workflow (the python tests).