### PR TITLE
Serialization: better matching of Exception to Error model

### DIFF
--- a/moto/core/serialize.py
+++ b/moto/core/serialize.py
@@ -262,7 +262,7 @@ class ResponseSerializer:
         resp: ResponseDict,
         error: Exception,
     ) -> ResponseDict:
-        error_shape = get_error_model(error)
+        error_shape = get_error_model(error, self.service_model)
         serialized_error = self.MAP_TYPE()
         self._serialize_error_metadata(serialized_error, error, error_shape)
         return self._serialized_error_to_response(


### PR DESCRIPTION
The serializer was making the assumption that any exceptions raised were from the same service model as the invoked operation, which isn't always true.  Here is what happens when an exception from the IAM backend is raised during an EC2 operation:
```
=============================== warnings summary ===============================
tests/test_ec2/test_instances.py::test_instance_iam_instance_profile
tests/test_ec2/test_iam_integration.py::test_invalid_associate
tests/test_ec2/test_iam_integration.py::test_invalid_replace
  /home/runner/work/moto/moto/moto/core/errors.py:66: UserWarning: EC2 service model does not contain an error shape that matches code NoSuchEntity from Exception(NotFoundException)
    warn(warning)
```
This PR fixes the warning, and addresses the issue generally.  It's not the most elegant code--so I might revisit it at some point--but it gets the job done and is fully isolated in the `core/errors.py` module.