### PR TITLE
Add instance variable annotations for SES models

### DIFF
--- a/moto/core/base_backend.py
+++ b/moto/core/base_backend.py
@@ -43,6 +43,10 @@ class InstanceTrackerMeta(type):
 
 
 class BaseBackend:
+    region_name: str
+    account_id: str
+    partition: str
+
     def __init__(self, region_name: str, account_id: str):
         self.region_name = region_name
         self.account_id = account_id

--- a/moto/sesv2/models.py
+++ b/moto/sesv2/models.py
@@ -115,7 +115,7 @@ class SESV2Backend(BaseBackend):
         self,
         email_identity: str,
         tags: Optional[Dict[str, str]],
-        dkim_signing_attributes: Optional[object],
+        dkim_signing_attributes: Optional[Dict[str, Any]],
         configuration_set_name: Optional[str],
     ) -> EmailIdentity:
         return self.core_backend.create_email_identity_v2(


### PR DESCRIPTION
This PR reworks the annotation for SES, as suggested in https://github.com/getmoto/moto/issues/9389.

In a few instances, a proper type annotation would require the introduction of new types mapping specific AWS data types. A case would be having a type for [`dkim_attributes`](https://github.com/giograno/moto/blob/7edd15802815da40165faac4df6c6f16c70c3711/moto/ses/models.py#L348) that implements the proper AWS type ([`DkimAttributes`](https://docs.aws.amazon.com/ses/latest/APIReference-V2/API_DkimAttributes.html)). Instead of introducing a new type, I left a generic `typing.Any`.
