### PR TITLE
apigatewayv2: support url enconded stages

### DIFF
--- a/moto/apigatewayv2/responses.py
+++ b/moto/apigatewayv2/responses.py
@@ -681,13 +681,13 @@ class ApiGatewayV2Response(BaseResponse):
 
     def get_stage(self) -> TYPE_RESPONSE:
         api_id = self.path.split("/")[-3]
-        stage_name = self.path.split("/")[-1]
+        stage_name = unquote(self.path.split("/")[-1])
         stage = self.apigatewayv2_backend.get_stage(api_id, stage_name)
         return 200, {}, json.dumps(stage.to_json())
 
     def delete_stage(self) -> TYPE_RESPONSE:
         api_id = self.path.split("/")[-3]
-        stage_name = self.path.split("/")[-1]
+        stage_name = unquote(self.path.split("/")[-1])
         self.apigatewayv2_backend.delete_stage(api_id, stage_name)
         return 200, {}, "{}"
 


### PR DESCRIPTION
The AWS CLI sends stages with url encoding which isn't properly parsed in moto. I noticed this when trying to use terraform with moto proxy. The "$default" stage is sent over the url as "%24default" and therefore doesn't get stored with the right name, causing a discrepancy. This is true even for the get-stage operation with stage names that have invalid characters such as "%test" which gets sent as "%25test" showing url encoding is automatic here.

https://docs.aws.amazon.com/apigatewayv2/latest/api-reference/apis-apiid-stages-stagename.html