### PR TITLE
SSM: get_parameters_by_path() - Introduce maxResult validation

### DIFF
--- a/moto/ssm/models.py
+++ b/moto/ssm/models.py
@@ -207,6 +207,7 @@ class ParameterDict(DefaultDict[str, List["Parameter"]]):
 
 PARAMETER_VERSION_LIMIT = 100
 PARAMETER_HISTORY_MAX_RESULTS = 50
+PARAMETER_BY_PATH_MAX_RESULTS = 10
 
 
 class Parameter(CloudFormationModel):
@@ -1822,6 +1823,12 @@ class SimpleSystemManagerBackend(BaseBackend):
         max_results: int = 10,
     ) -> Tuple[List[Parameter], Optional[str]]:
         """Implement the get-parameters-by-path-API in the backend."""
+        if max_results > PARAMETER_BY_PATH_MAX_RESULTS:
+            raise ValidationException(
+                "1 validation error detected: "
+                f"Value {max_results} at 'maxResults' failed to satisfy constraint: "
+                f"Member must have value less than or equal to {PARAMETER_BY_PATH_MAX_RESULTS}"
+            )
 
         self._validate_parameter_filters(filters, by_path=True)
 

--- a/tests/test_ssm/test_ssm_boto3.py
+++ b/tests/test_ssm/test_ssm_boto3.py
@@ -10,7 +10,11 @@ from botocore.exceptions import ClientError
 
 from moto import mock_aws
 from moto.core import DEFAULT_ACCOUNT_ID as ACCOUNT_ID
-from moto.ssm.models import PARAMETER_HISTORY_MAX_RESULTS, PARAMETER_VERSION_LIMIT
+from moto.ssm.models import (
+    PARAMETER_BY_PATH_MAX_RESULTS,
+    PARAMETER_HISTORY_MAX_RESULTS,
+    PARAMETER_VERSION_LIMIT,
+)
 from tests import EXAMPLE_AMI_ID, aws_verified
 
 SSM_REGION = "us-east-1"
@@ -202,6 +206,15 @@ def test_get_parameters_by_path():
     assert client_err.value.response["Error"]["Message"] == (
         "The following filter key is not valid: Tier. "
         "Valid filter keys include: [Type, KeyId]."
+    )
+
+    max_result_value = 23
+    with pytest.raises(ClientError) as client_err:
+        client.get_parameters_by_path(Path="/", MaxResults=max_result_value)
+    assert client_err.value.response["Error"]["Message"] == (
+        "1 validation error detected: "
+        f"Value {max_result_value} at 'maxResults' failed to satisfy constraint: "
+        f"Member must have value less than or equal to {PARAMETER_BY_PATH_MAX_RESULTS}"
     )
 
     # Label filter in get_parameters_by_path


### PR DESCRIPTION
Enforce `maxResults` limit for `get_parameters_by_path` API and add corresponding test for ssm service.

related [AWS docs](https://docs.aws.amazon.com/systems-manager/latest/APIReference/API_GetParametersByPath.html#API_GetParametersByPath_RequestSyntax), desribing that max value is 10.

I have found this issue on [localstack issue](https://github.com/localstack/localstack/issues/13278) page ad decided to fix it at source.