### PR TITLE
EC2: Add support for modifying all volume params

### DIFF
--- a/moto/ec2/models/elastic_block_store.py
+++ b/moto/ec2/models/elastic_block_store.py
@@ -53,18 +53,28 @@ class VolumeModification:
             )
 
         self.volume = volume
-        self.original_size = volume.size
-        self.original_volume_type = volume.volume_type
-        self.original_iops = volume.iops
-        self.original_throughput = volume.throughput
-        self.original_multi_attach_enabled = volume.multi_attach_enabled
-        self.target_size = target_size or volume.size
-        self.target_volume_type = target_volume_type or volume.volume_type
-        self.target_iops = volume.iops = target_iops or volume.iops
-        self.target_throughput = target_throughput or volume.throughput
-        self.target_multi_attach_enabled = (
-            target_multi_attach_enabled or volume.multi_attach_enabled
-        )
+
+        if target_size:
+            self.original_size = volume.size
+            self.target_size = target_size or volume.size
+
+        if target_volume_type:
+            self.original_volume_type = volume.volume_type
+            self.target_volume_type = target_volume_type or volume.volume_type
+
+        if target_iops:
+            self.original_iops = volume.iops
+            self.target_iops = volume.iops = target_iops or volume.iops
+
+        if target_throughput:
+            self.original_throughput = volume.throughput
+            self.target_throughput = target_throughput or volume.throughput
+
+        if target_multi_attach_enabled:
+            self.original_multi_attach_enabled = volume.multi_attach_enabled or False
+            self.target_multi_attach_enabled = (
+                target_multi_attach_enabled or volume.multi_attach_enabled
+            )
 
         self.start_time = utc_date_and_time()
         self.end_time = utc_date_and_time()
@@ -171,11 +181,16 @@ class Volume(TaggedEC2Resource, CloudFormationModel):
         )
         self.modifications.append(modification)
 
-        self.size = modification.target_size
-        self.volume_type = modification.target_volume_type
-        self.iops = modification.target_iops
-        self.throughput = modification.target_throughput
-        self.multi_attach_enabled = modification.target_multi_attach_enabled
+        if target_size:
+            self.size = modification.target_size
+        if target_volume_type:
+            self.volume_type = modification.target_volume_type
+        if target_iops:
+            self.iops = modification.target_iops
+        if target_throughput:
+            self.throughput = modification.target_throughput
+        if target_multi_attach_enabled:
+            self.multi_attach_enabled = modification.target_multi_attach_enabled
 
     @staticmethod
     def cloudformation_name_type() -> str:
@@ -330,6 +345,8 @@ class EBSBackend:
             raise InvalidParameterDependency("VolumeType", "Iops")
         if volume_type not in THROUGHPUT_SUPPORTED_VOLUME_TYPES and throughput:
             raise InvalidParameterDependency("VolumeType", "Throughput")
+        if multi_attach_enabled and volume_type not in IOPS_REQUIRED_VOLUME_TYPES:
+            raise InvalidParameterDependency("MultiAttachEnabled", "VolumeType")
 
         volume_id = random_volume_id()
         zone = self.get_zone_by_name(zone_name)  # type: ignore[attr-defined]

--- a/moto/ec2/responses/elastic_block_store.py
+++ b/moto/ec2/responses/elastic_block_store.py
@@ -274,6 +274,9 @@ CREATE_VOLUME_RESPONSE = """<CreateVolumeResponse xmlns="http://ec2.amazonaws.co
   {% if volume.throughput %}
     <throughput>{{ volume.throughput }}</throughput>
   {% endif %}
+  {% if volume.multi_attach_enabled %}
+    <multiAttachEnabled>{{ volume.multi_attach_enabled }}</multiAttachEnabled>
+  {% endif %}
 </CreateVolumeResponse>"""
 
 DESCRIBE_VOLUMES_RESPONSE = """<DescribeVolumesResponse xmlns="http://ec2.amazonaws.com/doc/2013-10-15/">
@@ -329,7 +332,6 @@ DESCRIBE_VOLUMES_RESPONSE = """<DescribeVolumesResponse xmlns="http://ec2.amazon
              {% if volume.multi_attach_enabled %}
                <multiAttachEnabled>{{ volume.multi_attach_enabled }}</multiAttachEnabled>
              {% endif %}
-
           </item>
       {% endfor %}
    </volumeSet>
@@ -478,21 +480,29 @@ MODIFY_VOLUME_RESPONSE = """<?xml version="1.0" encoding="UTF-8"?>
     <volumeModification>
         {% set volume_modification = volume.modifications[-1] %}
         <modificationState>modifying</modificationState>
+        {% if volume_modification.original_size %}
         <originalSize>{{ volume_modification.original_size }}</originalSize>
-        <originalVolumeType>{{ volume_modification.original_volume_type }}</originalVolumeType>
+        {% endif %}
+        {% if volume_modification.original_volume_type %}
+            <originalVolumeType>{{ volume_modification.original_volume_type }}</originalVolumeType>
+        {% endif %}
         {% if volume_modification.original_iops %}
             <originalIops>{{ volume_modification.original_iops }}</originalIops>
         {% endif %}
         {% if volume_modification.original_throughput %}
             <originalThroughput>{{ volume_modification.original_throughput }}</originalThroughput>
         {% endif %}
-        {% if volume_modification.original_multi_attach_enabled %}
+        {% if volume_modification.original_multi_attach_enabled is not none %}
             <originalMultiAttachEnabled>{{ volume_modification.original_multi_attach_enabled }}</originalMultiAttachEnabled>
         {% endif %}
         <progress>0</progress>
         <startTime>{{ volume_modification.start_time }}</startTime>
-        <targetSize>{{ volume_modification.target_size }}</targetSize>
-        <targetVolumeType>{{ volume_modification.target_volume_type }}</targetVolumeType>
+        {% if volume_modification.target_size %}
+            <targetSize>{{ volume_modification.target_size }}</targetSize>
+        {% endif %}
+        {% if volume_modification.target_volume_type %}
+            <targetVolumeType>{{ volume_modification.target_volume_type }}</targetVolumeType>
+        {% endif %}
         {% if volume_modification.target_iops %}
             <targetIops>{{ volume_modification.target_iops }}</targetIops>
         {% endif %}
@@ -515,8 +525,12 @@ DESCRIBE_VOLUMES_MODIFICATIONS_RESPONSE = """
         <item>
             <endTime>{{ modification.end_time }}</endTime>
             <modificationState>completed</modificationState>
-            <originalSize>{{ modification.original_size }}</originalSize>
-            <originalVolumeType>{{ modification.original_volume_type }}</originalVolumeType>
+            {% if modification.original_size %}
+                <originalSize>{{ modification.original_size }}</originalSize>
+            {% endif %}
+            {% if modification.original_volume_type %}
+                <originalVolumeType>{{ modification.original_volume_type }}</originalVolumeType>
+            {% endif %}
             {% if modification.original_iops %}
                 <originalIops>{{ modification.original_iops }}</originalIops>
             {% endif %}
@@ -528,8 +542,12 @@ DESCRIBE_VOLUMES_MODIFICATIONS_RESPONSE = """
             {% endif %}
             <progress>100</progress>
             <startTime>{{ modification.start_time }}</startTime>
-            <targetSize>{{ modification.target_size }}</targetSize>
-            <targetVolumeType>{{ modification.target_volume_type }}</targetVolumeType>
+            {% if modification.target_size %}
+                <targetSize>{{ modification.target_size }}</targetSize>
+            {% endif %}
+            {% if modification.target_volume_type %}
+                <targetVolumeType>{{ modification.target_volume_type }}</targetVolumeType>
+            {% endif %}
             {% if modification.target_iops %}
                 <targetIops>{{ modification.target_iops }}</targetIops>
             {% endif %}


### PR DESCRIPTION
**Summary**

This PR adds missing parameters to the modify_volume implementation in the EC2 service to align it with the official [Boto3 modify_volume API](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/ec2/client/modify_volume.html#)
.
**Changes**

Added support to modify all volume parameters.
Updated internal volume model and response serialization to handle these new attributes.
Extended tests to verify that modified parameters persist correctly and match expected API behavior.

**Questions**

Do we need to have validation in modify_volume method like in create_volume?
There are some conditions that we can verify, but it seems that they are documented across various pages in AWS docs.