### PR TITLE
Admin: Enable Ruff's UP rules

### DIFF
--- a/moto/acm/models.py
+++ b/moto/acm/models.py
@@ -2,7 +2,8 @@ import base64
 import datetime
 import ipaddress
 import re
-from typing import Any, Dict, Iterable, List, Optional, Set, Tuple
+from collections.abc import Iterable
+from typing import Any, Optional
 
 import cryptography.hazmat.primitives.asymmetric.rsa
 import cryptography.x509
@@ -59,7 +60,7 @@ def datetime_to_epoch(date: datetime.datetime) -> float:
     return date.timestamp()
 
 
-class TagHolder(Dict[str, Optional[str]]):
+class TagHolder(dict[str, Optional[str]]):
     MAX_TAG_COUNT = 50
     MAX_KEY_LENGTH = 128
     MAX_VALUE_LENGTH = 256
@@ -67,21 +68,18 @@ class TagHolder(Dict[str, Optional[str]]):
     def _validate_kv(self, key: str, value: Optional[str], index: int) -> None:
         if len(key) > self.MAX_KEY_LENGTH:
             raise AWSValidationException(
-                "Value '%s' at 'tags.%d.member.key' failed to satisfy constraint: Member must have length less than or equal to %s"
-                % (key, index, self.MAX_KEY_LENGTH)
+                f"Value '{key}' at 'tags.{index}.member.key' failed to satisfy constraint: Member must have length less than or equal to {self.MAX_KEY_LENGTH}"
             )
         if value and len(value) > self.MAX_VALUE_LENGTH:
             raise AWSValidationException(
-                "Value '%s' at 'tags.%d.member.value' failed to satisfy constraint: Member must have length less than or equal to %s"
-                % (value, index, self.MAX_VALUE_LENGTH)
+                f"Value '{value}' at 'tags.{index}.member.value' failed to satisfy constraint: Member must have length less than or equal to {self.MAX_VALUE_LENGTH}"
             )
         if key.startswith("aws:"):
             raise AWSValidationException(
-                'Invalid Tag Key: "%s". AWS internal tags cannot be changed with this API'
-                % key
+                f'Invalid Tag Key: "{key}". AWS internal tags cannot be changed with this API'
             )
 
-    def add(self, tags: List[Dict[str, str]]) -> None:
+    def add(self, tags: list[dict[str, str]]) -> None:
         tags_copy = self.copy()
         for i, tag in enumerate(tags):
             key = tag["Key"]
@@ -90,14 +88,16 @@ class TagHolder(Dict[str, Optional[str]]):
 
             tags_copy[key] = value
         if len(tags_copy) > self.MAX_TAG_COUNT:
+            tags_as_string = ", ".join(
+                k + "=" + str(v or "") for k, v in tags_copy.items()
+            )
             raise AWSTooManyTagsException(
-                "the TagSet: '{%s}' contains too many Tags"
-                % ", ".join(k + "=" + str(v or "") for k, v in tags_copy.items())
+                f"the TagSet: '{{{tags_as_string}}}' contains too many Tags"
             )
 
         self.update(tags_copy)
 
-    def remove(self, tags: List[Dict[str, str]]) -> None:
+    def remove(self, tags: list[dict[str, str]]) -> None:
         for i, tag in enumerate(tags):
             key = tag["Key"]
             value = tag.get("Value")
@@ -112,7 +112,7 @@ class TagHolder(Dict[str, Optional[str]]):
             except KeyError:
                 pass
 
-    def equals(self, tags: List[Dict[str, str]]) -> bool:
+    def equals(self, tags: list[dict[str, str]]) -> bool:
         flat_tags = {t["Key"]: t.get("Value") for t in tags} if tags else {}
         return self == flat_tags
 
@@ -129,7 +129,7 @@ class CertBundle(BaseModel):
         cert_type: str = "IMPORTED",
         cert_status: str = "ISSUED",
         cert_authority_arn: Optional[str] = None,
-        cert_options: Optional[Dict[str, Any]] = None,
+        cert_options: Optional[dict[str, Any]] = None,
     ):
         self.created_at = utcnow()
         self.cert = certificate
@@ -140,7 +140,7 @@ class CertBundle(BaseModel):
         self.type = cert_type  # Should really be an enum
         self.status = cert_status  # Should really be an enum
         self.cert_authority_arn = cert_authority_arn
-        self.in_use_by: List[str] = []
+        self.in_use_by: list[str] = []
         self.cert_options = cert_options or {
             "CertificateTransparencyLoggingPreference": "ENABLED",
             "Export": "DISABLED",
@@ -169,10 +169,10 @@ class CertBundle(BaseModel):
         domain_name: str,
         account_id: str,
         region: str,
-        sans: Optional[List[str]] = None,
+        sans: Optional[list[str]] = None,
         cert_authority_arn: Optional[str] = None,
     ) -> "CertBundle":
-        unique_sans: Set[str] = set(sans) if sans else set()
+        unique_sans: set[str] = set(sans) if sans else set()
 
         unique_sans.add(domain_name)
         # SSL treats IP addresses differently from regular host names
@@ -341,7 +341,7 @@ class CertBundle(BaseModel):
         ):
             self.status = "ISSUED"
 
-    def describe(self) -> Dict[str, Any]:
+    def describe(self) -> dict[str, Any]:
         # 'RenewalSummary': {},  # Only when cert is amazon issued
         if self._key.key_size == 1024:
             key_algo = "RSA_1024"
@@ -361,7 +361,7 @@ class CertBundle(BaseModel):
         if san_obj is not None:
             sans = [str(item.value) for item in san_obj.value]
 
-        result: Dict[str, Any] = {
+        result: dict[str, Any] = {
             "Certificate": {
                 "CertificateArn": self.arn,
                 "DomainName": self.common_name,
@@ -453,8 +453,8 @@ class AWSCertificateManagerBackend(BaseBackend):
 
     def __init__(self, region_name: str, account_id: str):
         super().__init__(region_name, account_id)
-        self._certificates: Dict[str, CertBundle] = {}
-        self._idempotency_tokens: Dict[str, Any] = {}
+        self._certificates: dict[str, CertBundle] = {}
+        self._idempotency_tokens: dict[str, Any] = {}
         self._account_config = AccountConfiguration()
 
     def set_certificate_in_use_by(self, arn: str, load_balancer_name: str) -> None:
@@ -499,7 +499,7 @@ class AWSCertificateManagerBackend(BaseBackend):
         private_key: bytes,
         chain: Optional[bytes],
         arn: Optional[str],
-        tags: List[Dict[str, str]],
+        tags: list[dict[str, str]],
     ) -> str:
         if arn is not None:
             if arn not in self._certificates:
@@ -532,7 +532,7 @@ class AWSCertificateManagerBackend(BaseBackend):
         return bundle.arn
 
     def list_certificates(
-        self, statuses: List[str], includes: Dict[str, Any]
+        self, statuses: list[str], includes: dict[str, Any]
     ) -> Iterable[CertBundle]:
         for arn in self._certificates.keys():
             cert = self.get_certificate(arn)
@@ -565,10 +565,10 @@ class AWSCertificateManagerBackend(BaseBackend):
         self,
         domain_name: str,
         idempotency_token: str,
-        subject_alt_names: List[str],
-        tags: List[Dict[str, str]],
+        subject_alt_names: list[str],
+        tags: list[dict[str, str]],
         cert_authority_arn: Optional[str] = None,
-        cert_options: Optional[Dict[str, Any]] = None,
+        cert_options: Optional[dict[str, Any]] = None,
     ) -> str:
         """
         The parameter DomainValidationOptions has not yet been implemented
@@ -597,13 +597,13 @@ class AWSCertificateManagerBackend(BaseBackend):
 
         return cert.arn
 
-    def add_tags_to_certificate(self, arn: str, tags: List[Dict[str, str]]) -> None:
+    def add_tags_to_certificate(self, arn: str, tags: list[dict[str, str]]) -> None:
         # get_cert does arn check
         cert_bundle = self.get_certificate(arn)
         cert_bundle.tags.add(tags)
 
     def remove_tags_from_certificate(
-        self, arn: str, tags: List[Dict[str, str]]
+        self, arn: str, tags: list[dict[str, str]]
     ) -> None:
         # get_cert does arn check
         cert_bundle = self.get_certificate(arn)
@@ -611,11 +611,10 @@ class AWSCertificateManagerBackend(BaseBackend):
 
     def export_certificate(
         self, certificate_arn: str, passphrase: str
-    ) -> Tuple[str, str, str]:
+    ) -> tuple[str, str, str]:
         if len(passphrase) < self.MIN_PASSPHRASE_LEN:
             raise AWSValidationException(
-                "Value at 'passphrase' failed to satisfy constraint: Member must have length greater than or equal to %s"
-                % (self.MIN_PASSPHRASE_LEN)
+                f"Value at 'passphrase' failed to satisfy constraint: Member must have length greater than or equal to {self.MIN_PASSPHRASE_LEN}"
             )
         passphrase_bytes = base64.standard_b64decode(passphrase)
         cert_bundle = self.get_certificate(certificate_arn)
@@ -623,7 +622,7 @@ class AWSCertificateManagerBackend(BaseBackend):
             cert_bundle.cert_options["Export"] != "ENABLED"
         ):
             raise AWSValidationException(
-                "Certificate ARN: %s is not a private certificate" % (certificate_arn)
+                f"Certificate ARN: {certificate_arn} is not a private certificate"
             )
         certificate = cert_bundle.cert.decode()
         certificate_chain = cert_bundle.chain.decode()
@@ -631,7 +630,7 @@ class AWSCertificateManagerBackend(BaseBackend):
 
         return certificate, certificate_chain, private_key
 
-    def get_account_configuration(self) -> Dict[str, Any]:
+    def get_account_configuration(self) -> dict[str, Any]:
         return self._account_config.to_dict()  # type: ignore
 
     def put_account_configuration(

--- a/moto/acm/responses.py
+++ b/moto/acm/responses.py
@@ -1,13 +1,13 @@
 import base64
 import json
-from typing import Dict, List, Tuple, Union
+from typing import Union
 
 from moto.core.responses import BaseResponse
 
 from .exceptions import AWSValidationException
 from .models import AWSCertificateManagerBackend, acm_backends
 
-GENERIC_RESPONSE_TYPE = Union[str, Tuple[str, Dict[str, int]]]
+GENERIC_RESPONSE_TYPE = Union[str, tuple[str, dict[str, int]]]
 
 
 class AWSCertificateManagerResponse(BaseResponse):
@@ -151,7 +151,7 @@ class AWSCertificateManagerResponse(BaseResponse):
 
         cert_bundle = self.acm_backend.get_certificate(arn)
 
-        result: Dict[str, List[Dict[str, str]]] = {"Tags": []}
+        result: dict[str, list[dict[str, str]]] = {"Tags": []}
         # Tag "objects" can not contain the Value part
         for key, value in cert_bundle.tags.items():
             tag_dict = {"Key": key}

--- a/moto/acmpca/models.py
+++ b/moto/acmpca/models.py
@@ -3,7 +3,7 @@
 import base64
 import contextlib
 import datetime
-from typing import Any, Dict, List, Optional, Tuple, cast
+from typing import Any, Optional, cast
 
 from cryptography import x509
 from cryptography.hazmat.backends import default_backend
@@ -31,9 +31,9 @@ class CertificateAuthority(BaseModel):
         self,
         region: str,
         account_id: str,
-        certificate_authority_configuration: Dict[str, Any],
+        certificate_authority_configuration: dict[str, Any],
         certificate_authority_type: str,
-        revocation_configuration: Dict[str, Any],
+        revocation_configuration: dict[str, Any],
         security_standard: Optional[str],
     ):
         self.id = mock_random.uuid4()
@@ -42,7 +42,7 @@ class CertificateAuthority(BaseModel):
         self.region_name = region
         self.certificate_authority_configuration = certificate_authority_configuration
         self.certificate_authority_type = certificate_authority_type
-        self.revocation_configuration: Dict[str, Any] = {
+        self.revocation_configuration: dict[str, Any] = {
             "CrlConfiguration": {"Enabled": False}
         }
         self.set_revocation_configuration(revocation_configuration)
@@ -64,7 +64,7 @@ class CertificateAuthority(BaseModel):
 
         self.certificate_bytes: bytes = b""
         self.certificate_chain: Optional[bytes] = None
-        self.issued_certificates: Dict[str, bytes] = dict()
+        self.issued_certificates: dict[str, bytes] = dict()
 
         self.subject = self.certificate_authority_configuration.get("Subject", {})
 
@@ -72,7 +72,7 @@ class CertificateAuthority(BaseModel):
         self,
         subject: x509.Name,
         public_key: rsa.RSAPublicKey,
-        extensions: List[Tuple[x509.ExtensionType, bool]],
+        extensions: list[tuple[x509.ExtensionType, bool]],
     ) -> bytes:
         builder = (
             x509.CertificateBuilder()
@@ -166,7 +166,7 @@ class CertificateAuthority(BaseModel):
 
     def _x509_extensions(
         self, csr: x509.CertificateSigningRequest, template_arn: Optional[str]
-    ) -> List[Tuple[x509.ExtensionType, bool]]:
+    ) -> list[tuple[x509.ExtensionType, bool]]:
         """
         Uses a PCA certificate template ARN to return a list of X.509 extensions.
         These extensions are part of the constructed certificate.
@@ -267,7 +267,7 @@ class CertificateAuthority(BaseModel):
         return self.issued_certificates[certificate_arn]
 
     def set_revocation_configuration(
-        self, revocation_configuration: Optional[Dict[str, Any]]
+        self, revocation_configuration: Optional[dict[str, Any]]
     ) -> None:
         if revocation_configuration is not None:
             self.revocation_configuration = revocation_configuration
@@ -314,7 +314,7 @@ class CertificateAuthority(BaseModel):
         self.status = "ACTIVE"
         self.updated_at = unix_time()
 
-    def to_json(self) -> Dict[str, Any]:
+    def to_json(self) -> dict[str, Any]:
         dct = {
             "Arn": self.arn,
             "OwnerAccount": self.account_id,
@@ -352,16 +352,16 @@ class ACMPCABackend(BaseBackend):
 
     def __init__(self, region_name: str, account_id: str):
         super().__init__(region_name, account_id)
-        self.certificate_authorities: Dict[str, CertificateAuthority] = dict()
+        self.certificate_authorities: dict[str, CertificateAuthority] = dict()
         self.tagger = TaggingService()
 
     def create_certificate_authority(
         self,
-        certificate_authority_configuration: Dict[str, Any],
-        revocation_configuration: Dict[str, Any],
+        certificate_authority_configuration: dict[str, Any],
+        revocation_configuration: dict[str, Any],
         certificate_authority_type: str,
         security_standard: Optional[str],
-        tags: List[Dict[str, str]],
+        tags: list[dict[str, str]],
     ) -> str:
         """
         The following parameters are not yet implemented: IdempotencyToken, KeyStorageSecurityStandard, UsageMode
@@ -388,7 +388,7 @@ class ACMPCABackend(BaseBackend):
 
     def get_certificate_authority_certificate(
         self, certificate_authority_arn: str
-    ) -> Tuple[bytes, Optional[bytes]]:
+    ) -> tuple[bytes, Optional[bytes]]:
         ca = self.describe_certificate_authority(certificate_authority_arn)
         if ca.status != "ACTIVE":
             raise InvalidStateException(certificate_authority_arn)
@@ -400,7 +400,7 @@ class ACMPCABackend(BaseBackend):
 
     def list_tags(
         self, certificate_authority_arn: str
-    ) -> Dict[str, List[Dict[str, str]]]:
+    ) -> dict[str, list[dict[str, str]]]:
         """
         Pagination is not yet implemented
         """
@@ -409,7 +409,7 @@ class ACMPCABackend(BaseBackend):
     def update_certificate_authority(
         self,
         certificate_authority_arn: str,
-        revocation_configuration: Dict[str, Any],
+        revocation_configuration: dict[str, Any],
         status: str,
     ) -> None:
         ca = self.describe_certificate_authority(certificate_authority_arn)
@@ -435,7 +435,7 @@ class ACMPCABackend(BaseBackend):
 
     def get_certificate(
         self, certificate_authority_arn: str, certificate_arn: str
-    ) -> Tuple[bytes, Optional[str]]:
+    ) -> tuple[bytes, Optional[str]]:
         """
         The CertificateChain will always return None for now
         """
@@ -464,12 +464,12 @@ class ACMPCABackend(BaseBackend):
         """
 
     def tag_certificate_authority(
-        self, certificate_authority_arn: str, tags: List[Dict[str, str]]
+        self, certificate_authority_arn: str, tags: list[dict[str, str]]
     ) -> None:
         self.tagger.tag_resource(certificate_authority_arn, tags)
 
     def untag_certificate_authority(
-        self, certificate_authority_arn: str, tags: List[Dict[str, str]]
+        self, certificate_authority_arn: str, tags: list[dict[str, str]]
     ) -> None:
         self.tagger.untag_resource_using_tags(certificate_authority_arn, tags)
 
@@ -502,7 +502,7 @@ class ACMPCABackend(BaseBackend):
     def list_certificate_authorities(
         self,
         resource_owner: Optional[str] = None,
-    ) -> List[CertificateAuthority]:
+    ) -> list[CertificateAuthority]:
         """
         Lists the private certificate authorities that you created by using the CreateCertificateAuthority action.
         """

--- a/moto/apigateway/integration_parsers/__init__.py
+++ b/moto/apigateway/integration_parsers/__init__.py
@@ -1,5 +1,5 @@
 import abc
-from typing import Tuple, Union
+from typing import Union
 
 from requests.models import PreparedRequest
 
@@ -10,5 +10,5 @@ class IntegrationParser:
     @abc.abstractmethod
     def invoke(
         self, request: PreparedRequest, integration: Integration
-    ) -> Tuple[int, Union[str, bytes]]:
+    ) -> tuple[int, Union[str, bytes]]:
         pass

--- a/moto/apigateway/integration_parsers/aws_parser.py
+++ b/moto/apigateway/integration_parsers/aws_parser.py
@@ -1,4 +1,4 @@
-from typing import Tuple, Union
+from typing import Union
 
 import requests
 
@@ -9,7 +9,7 @@ from . import IntegrationParser
 class TypeAwsParser(IntegrationParser):
     def invoke(
         self, request: requests.PreparedRequest, integration: Integration
-    ) -> Tuple[int, Union[str, bytes]]:
+    ) -> tuple[int, Union[str, bytes]]:
         # integration.uri = arn:aws:apigateway:{region}:{subdomain.service|service}:path|action/{service_api}
         # example value = 'arn:aws:apigateway:us-west-2:dynamodb:action/PutItem'
         try:

--- a/moto/apigateway/integration_parsers/http_parser.py
+++ b/moto/apigateway/integration_parsers/http_parser.py
@@ -1,4 +1,4 @@
-from typing import Tuple, Union
+from typing import Union
 
 import requests
 
@@ -13,7 +13,7 @@ class TypeHttpParser(IntegrationParser):
 
     def invoke(
         self, request: requests.PreparedRequest, integration: Integration
-    ) -> Tuple[int, Union[str, bytes]]:
+    ) -> tuple[int, Union[str, bytes]]:
         uri = integration.uri
         requests_func = getattr(requests, integration.http_method.lower())  # type: ignore[union-attr]
         response = requests_func(uri)

--- a/moto/apigateway/integration_parsers/unknown_parser.py
+++ b/moto/apigateway/integration_parsers/unknown_parser.py
@@ -1,4 +1,4 @@
-from typing import Tuple, Union
+from typing import Union
 
 import requests
 
@@ -13,6 +13,6 @@ class TypeUnknownParser(IntegrationParser):
 
     def invoke(
         self, request: requests.PreparedRequest, integration: Integration
-    ) -> Tuple[int, Union[str, bytes]]:
+    ) -> tuple[int, Union[str, bytes]]:
         _type = integration.integration_type
         raise NotImplementedError(f"The {_type} type has not been implemented")

--- a/moto/apigateway/models.py
+++ b/moto/apigateway/models.py
@@ -3,7 +3,7 @@ import string
 import time
 from collections import defaultdict
 from datetime import datetime
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Optional, Union
 from urllib.parse import urlparse
 
 import requests
@@ -93,7 +93,7 @@ class Deployment(CloudFormationModel):
         self.description = description
         self.created_date = int(time.time())
 
-    def to_json(self) -> Dict[str, Any]:
+    def to_json(self) -> dict[str, Any]:
         return {
             "id": self.id,
             "stageName": self.stage_name,
@@ -113,7 +113,7 @@ class Deployment(CloudFormationModel):
     def create_from_cloudformation_json(  # type: ignore[misc]
         cls,
         resource_name: str,
-        cloudformation_json: Dict[str, Any],
+        cloudformation_json: dict[str, Any],
         account_id: str,
         region_name: str,
         **kwargs: Any,
@@ -122,7 +122,7 @@ class Deployment(CloudFormationModel):
         rest_api_id = properties["RestApiId"]
         name = properties.get("StageName")
         desc = properties.get("Description", "")
-        backend: "APIGatewayBackend" = apigateway_backends[account_id][region_name]
+        backend: APIGatewayBackend = apigateway_backends[account_id][region_name]
         return backend.create_deployment(
             function_id=rest_api_id, name=name, description=desc
         )
@@ -133,8 +133,8 @@ class IntegrationResponse(BaseModel):
         self,
         status_code: Union[str, int],
         selection_pattern: Optional[str] = None,
-        response_templates: Optional[Dict[str, Any]] = None,
-        response_parameters: Optional[Dict[str, str]] = None,
+        response_templates: Optional[dict[str, Any]] = None,
+        response_parameters: Optional[dict[str, str]] = None,
         content_handling: Optional[Any] = None,
     ):
         if response_templates is None:
@@ -150,7 +150,7 @@ class IntegrationResponse(BaseModel):
         self.response_parameters = response_parameters
         self.content_handling = content_handling
 
-    def to_json(self) -> Dict[str, Any]:
+    def to_json(self) -> dict[str, Any]:
         resp = {
             "responseTemplates": self.response_templates,
             "statusCode": self.status_code,
@@ -170,13 +170,13 @@ class Integration(BaseModel):
         integration_type: str,
         uri: str,
         http_method: str,
-        request_templates: Optional[Dict[str, Any]] = None,
+        request_templates: Optional[dict[str, Any]] = None,
         passthrough_behavior: Optional[str] = "WHEN_NO_MATCH",
-        cache_key_parameters: Optional[List[str]] = None,
-        tls_config: Optional[Dict[str, Any]] = None,
+        cache_key_parameters: Optional[list[str]] = None,
+        tls_config: Optional[dict[str, Any]] = None,
         cache_namespace: Optional[str] = None,
         timeout_in_millis: Optional[str] = None,
-        request_parameters: Optional[Dict[str, Any]] = None,
+        request_parameters: Optional[dict[str, Any]] = None,
         content_handling: Optional[str] = None,
         credentials: Optional[str] = None,
         connection_type: Optional[str] = None,
@@ -185,7 +185,7 @@ class Integration(BaseModel):
         self.uri = uri
         self.http_method = http_method if integration_type != "MOCK" else None
         self.passthrough_behaviour = passthrough_behavior
-        self.cache_key_parameters: List[str] = cache_key_parameters or []
+        self.cache_key_parameters: list[str] = cache_key_parameters or []
         self.request_templates = request_templates
         self.tls_config = tls_config
         self.cache_namespace = cache_namespace
@@ -194,10 +194,10 @@ class Integration(BaseModel):
         self.content_handling = content_handling
         self.credentials = credentials
         self.connection_type = connection_type
-        self.integration_responses: Optional[Dict[str, IntegrationResponse]] = None
+        self.integration_responses: Optional[dict[str, IntegrationResponse]] = None
 
-    def to_json(self) -> Dict[str, Any]:
-        int_responses: Optional[Dict[str, Any]] = None
+    def to_json(self) -> dict[str, Any]:
+        int_responses: Optional[dict[str, Any]] = None
         if self.integration_responses is not None:
             int_responses = {
                 k: v.to_json() for k, v in self.integration_responses.items()
@@ -223,8 +223,8 @@ class Integration(BaseModel):
         self,
         status_code: str,
         selection_pattern: str,
-        response_templates: Dict[str, str],
-        response_parameters: Dict[str, str],
+        response_templates: dict[str, str],
+        response_parameters: dict[str, str],
         content_handling: str,
     ) -> IntegrationResponse:
         integration_response = IntegrationResponse(
@@ -253,14 +253,14 @@ class MethodResponse(BaseModel):
     def __init__(
         self,
         status_code: str,
-        response_models: Dict[str, str],
-        response_parameters: Dict[str, Dict[str, str]],
+        response_models: dict[str, str],
+        response_parameters: dict[str, dict[str, str]],
     ):
         self.status_code = status_code
         self.response_models = response_models
         self.response_parameters = response_parameters
 
-    def to_json(self) -> Dict[str, Any]:
+    def to_json(self) -> dict[str, Any]:
         return {
             "statusCode": self.status_code,
             "responseModels": self.response_models,
@@ -282,9 +282,9 @@ class Method(CloudFormationModel):
         self.method_integration: Optional[Integration] = None
         self.operation_name = kwargs.get("operation_name")
         self.request_validator_id = kwargs.get("request_validator_id")
-        self.method_responses: Dict[str, MethodResponse] = {}
+        self.method_responses: dict[str, MethodResponse] = {}
 
-    def to_json(self) -> Dict[str, Any]:
+    def to_json(self) -> dict[str, Any]:
         return {
             "httpMethod": self.http_method,
             "authorizationType": self.authorization_type,
@@ -315,7 +315,7 @@ class Method(CloudFormationModel):
     def create_from_cloudformation_json(  # type: ignore[misc]
         cls,
         resource_name: str,
-        cloudformation_json: Dict[str, Any],
+        cloudformation_json: dict[str, Any],
         account_id: str,
         region_name: str,
         **kwargs: Any,
@@ -350,8 +350,8 @@ class Method(CloudFormationModel):
     def create_response(
         self,
         response_code: str,
-        response_models: Dict[str, str],
-        response_parameters: Dict[str, Dict[str, str]],
+        response_models: dict[str, str],
+        response_parameters: dict[str, dict[str, str]],
     ) -> MethodResponse:
         method_response = MethodResponse(
             response_code, response_models, response_parameters
@@ -382,20 +382,20 @@ class Resource(CloudFormationModel):
         self.api_id = api_id
         self.path_part = path_part
         self.parent_id = parent_id
-        self.resource_methods: Dict[str, Method] = {}
+        self.resource_methods: dict[str, Method] = {}
         from .integration_parsers import IntegrationParser
         from .integration_parsers.aws_parser import TypeAwsParser
         from .integration_parsers.http_parser import TypeHttpParser
         from .integration_parsers.unknown_parser import TypeUnknownParser
 
-        self.integration_parsers: Dict[str, IntegrationParser] = defaultdict(
+        self.integration_parsers: dict[str, IntegrationParser] = defaultdict(
             TypeUnknownParser
         )
         self.integration_parsers["HTTP"] = TypeHttpParser()
         self.integration_parsers["AWS"] = TypeAwsParser()
 
-    def to_dict(self) -> Dict[str, Any]:
-        response: Dict[str, Any] = {
+    def to_dict(self) -> dict[str, Any]:
+        response: dict[str, Any] = {
             "path": self.get_path(),
             "id": self.id,
         }
@@ -424,7 +424,7 @@ class Resource(CloudFormationModel):
     def create_from_cloudformation_json(  # type: ignore[misc]
         cls,
         resource_name: str,
-        cloudformation_json: Dict[str, Any],
+        cloudformation_json: dict[str, Any],
         account_id: str,
         region_name: str,
         **kwargs: Any,
@@ -462,7 +462,7 @@ class Resource(CloudFormationModel):
 
     def get_response(
         self, request: requests.PreparedRequest
-    ) -> Tuple[int, Union[str, bytes]]:
+    ) -> tuple[int, Union[str, bytes]]:
         integration = self.get_integration(str(request.method))
         integration_type = integration.integration_type  # type: ignore[union-attr]
 
@@ -515,13 +515,13 @@ class Resource(CloudFormationModel):
         method_type: str,
         integration_type: str,
         uri: str,
-        request_templates: Optional[Dict[str, Any]] = None,
+        request_templates: Optional[dict[str, Any]] = None,
         passthrough_behavior: Optional[str] = None,
         integration_method: Optional[str] = None,
-        tls_config: Optional[Dict[str, Any]] = None,
+        tls_config: Optional[dict[str, Any]] = None,
         cache_namespace: Optional[str] = None,
         timeout_in_millis: Optional[str] = None,
-        request_parameters: Optional[Dict[str, Any]] = None,
+        request_parameters: Optional[dict[str, Any]] = None,
         content_handling: Optional[str] = None,
         credentials: Optional[str] = None,
         connection_type: Optional[str] = None,
@@ -575,7 +575,7 @@ class Authorizer(BaseModel):
         )
         self.authorizer_result_ttl = kwargs.get("authorizer_result_ttl")
 
-    def to_json(self) -> Dict[str, Any]:
+    def to_json(self) -> dict[str, Any]:
         dct = {
             "id": self.id,
             "name": self.name,
@@ -596,7 +596,7 @@ class Authorizer(BaseModel):
             dct["identityValidationExpression"] = self.identity_validation_expression
         return dct
 
-    def apply_operations(self, patch_operations: List[Dict[str, Any]]) -> "Authorizer":
+    def apply_operations(self, patch_operations: list[dict[str, Any]]) -> "Authorizer":
         for op in patch_operations:
             if "/authorizerUri" in op["path"]:
                 self.authorizer_uri = op["value"]
@@ -629,16 +629,16 @@ class Stage(BaseModel):
         self,
         name: Optional[str] = None,
         deployment_id: Optional[str] = None,
-        variables: Optional[Dict[str, Any]] = None,
+        variables: Optional[dict[str, Any]] = None,
         description: str = "",
         cacheClusterEnabled: Optional[bool] = False,
         cacheClusterSize: Optional[str] = None,
-        tags: Optional[Dict[str, str]] = None,
+        tags: Optional[dict[str, str]] = None,
         tracing_enabled: Optional[bool] = None,
     ):
         self.name = name
         self.deployment_id = deployment_id
-        self.method_settings: Dict[str, Any] = {}
+        self.method_settings: dict[str, Any] = {}
         self.variables = variables or {}
         self.description = description
         self.cache_cluster_enabled = cacheClusterEnabled
@@ -648,11 +648,11 @@ class Stage(BaseModel):
         )
         self.tags = tags
         self.tracing_enabled = tracing_enabled
-        self.access_log_settings: Optional[Dict[str, Any]] = None
+        self.access_log_settings: Optional[dict[str, Any]] = None
         self.web_acl_arn: Optional[str] = None
 
-    def to_json(self) -> Dict[str, Any]:
-        dct: Dict[str, Any] = {
+    def to_json(self) -> dict[str, Any]:
+        dct: dict[str, Any] = {
             "stageName": self.name,
             "deploymentId": self.deployment_id,
             "methodSettings": self.method_settings,
@@ -676,7 +676,7 @@ class Stage(BaseModel):
             dct["webAclArn"] = self.web_acl_arn
         return dct
 
-    def apply_operations(self, patch_operations: List[Dict[str, Any]]) -> "Stage":
+    def apply_operations(self, patch_operations: list[dict[str, Any]]) -> "Stage":
         for op in patch_operations:
             if "variables/" in op["path"]:
                 self._apply_operation_to_variables(op)
@@ -728,7 +728,7 @@ class Stage(BaseModel):
                 self._convert_to_type(updated_key, value)
             )
 
-    def _get_default_method_settings(self) -> Dict[str, Any]:
+    def _get_default_method_settings(self) -> dict[str, Any]:
         return {
             "throttlingRateLimit": 1000.0,
             "dataTraceEnabled": False,
@@ -788,7 +788,7 @@ class Stage(BaseModel):
         else:
             return str(val)
 
-    def _apply_operation_to_variables(self, op: Dict[str, Any]) -> None:
+    def _apply_operation_to_variables(self, op: dict[str, Any]) -> None:
         key = op["path"][op["path"].rindex("variables/") + 10 :]
         if op["op"] == "remove":
             self.variables.pop(key, None)
@@ -808,7 +808,7 @@ class ApiKey(BaseModel):
         generateDistinctId: bool = False,
         value: Optional[str] = None,
         stageKeys: Optional[Any] = None,
-        tags: Optional[List[Dict[str, str]]] = None,
+        tags: Optional[list[dict[str, str]]] = None,
         customerId: Optional[str] = None,
     ):
         self.id = api_key_id
@@ -823,7 +823,7 @@ class ApiKey(BaseModel):
         self.stage_keys = stageKeys or []
         self.tags = tags
 
-    def to_json(self) -> Dict[str, Any]:
+    def to_json(self) -> dict[str, Any]:
         return {
             "id": self.id,
             "value": self.value,
@@ -837,7 +837,7 @@ class ApiKey(BaseModel):
             "tags": self.tags,
         }
 
-    def update_operations(self, patch_operations: List[Dict[str, Any]]) -> "ApiKey":
+    def update_operations(self, patch_operations: list[dict[str, Any]]) -> "ApiKey":
         for op in patch_operations:
             if op["op"] == "replace":
                 if "/name" in op["path"]:
@@ -863,10 +863,10 @@ class UsagePlan(BaseModel):
         name: Optional[str] = None,
         description: Optional[str] = None,
         apiStages: Any = None,
-        throttle: Optional[Dict[str, Any]] = None,
-        quota: Optional[Dict[str, Any]] = None,
+        throttle: Optional[dict[str, Any]] = None,
+        quota: Optional[dict[str, Any]] = None,
         productCode: Optional[str] = None,
-        tags: Optional[List[Dict[str, str]]] = None,
+        tags: Optional[list[dict[str, str]]] = None,
     ):
         self.id = usage_plan_id
         self.name = name
@@ -877,7 +877,7 @@ class UsagePlan(BaseModel):
         self.product_code = productCode
         self.tags = tags
 
-    def to_json(self) -> Dict[str, Any]:
+    def to_json(self) -> dict[str, Any]:
         resp = {
             "id": self.id,
             "name": self.name,
@@ -892,7 +892,7 @@ class UsagePlan(BaseModel):
             resp["quota"] = self.quota
         return resp
 
-    def apply_patch_operations(self, patch_operations: List[Dict[str, Any]]) -> None:
+    def apply_patch_operations(self, patch_operations: list[dict[str, Any]]) -> None:
         for op in patch_operations:
             path = op["path"]
             if op["op"] == "add":
@@ -959,7 +959,7 @@ class RequestValidator(BaseModel):
         self.validate_request_body = validateRequestBody
         self.validate_request_parameters = validateRequestParameters
 
-    def apply_patch_operations(self, operations: List[Dict[str, Any]]) -> None:
+    def apply_patch_operations(self, operations: list[dict[str, Any]]) -> None:
         for operation in operations:
             path = operation[RequestValidator.OP_PATH]
             value = operation[RequestValidator.OP_VALUE]
@@ -971,7 +971,7 @@ class RequestValidator(BaseModel):
                 if to_path(RequestValidator.PROP_VALIDATE_REQUEST_PARAMETERS) in path:
                     self.validate_request_parameters = value.lower() in ("true")
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         return {
             RequestValidator.PROP_ID: self.id,
             RequestValidator.PROP_NAME: self.name,
@@ -987,7 +987,7 @@ class UsagePlanKey(BaseModel):
         self.type = plan_type
         self.value = value
 
-    def to_json(self) -> Dict[str, Any]:
+    def to_json(self) -> dict[str, Any]:
         return {
             "id": self.id,
             "name": self.name,
@@ -1002,8 +1002,8 @@ class VpcLink(BaseModel):
         vpc_link_id: str,
         name: str,
         description: str,
-        target_arns: List[str],
-        tags: List[Dict[str, str]],
+        target_arns: list[str],
+        tags: list[dict[str, str]],
     ):
         self.id = vpc_link_id
         self.name = name
@@ -1012,7 +1012,7 @@ class VpcLink(BaseModel):
         self.tags = tags
         self.status = "AVAILABLE"
 
-    def to_json(self) -> Dict[str, Any]:
+    def to_json(self) -> dict[str, Any]:
         return {
             "id": self.id,
             "name": self.name,
@@ -1073,20 +1073,20 @@ class RestAPI(CloudFormationModel):
             kwargs.get("disable_execute_api_endpoint") or False
         )
         self.minimum_compression_size = kwargs.get("minimum_compression_size")
-        self.deployments: Dict[str, Deployment] = {}
-        self.authorizers: Dict[str, Authorizer] = {}
-        self.gateway_responses: Dict[str, GatewayResponse] = {}
-        self.stages: Dict[str, Stage] = {}
-        self.resources: Dict[str, Resource] = {}
-        self.models: Dict[str, Model] = {}
-        self.request_validators: Dict[str, RequestValidator] = {}
+        self.deployments: dict[str, Deployment] = {}
+        self.authorizers: dict[str, Authorizer] = {}
+        self.gateway_responses: dict[str, GatewayResponse] = {}
+        self.stages: dict[str, Stage] = {}
+        self.resources: dict[str, Resource] = {}
+        self.models: dict[str, Model] = {}
+        self.request_validators: dict[str, RequestValidator] = {}
         self.default = self.add_child("/")  # Add default child
         self.root_resource_id = self.default.id
 
     def __repr__(self) -> str:
         return str(self.id)
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         return {
             self.PROP_ID: self.id,
             self.PROP_NAME: self.name,
@@ -1103,7 +1103,7 @@ class RestAPI(CloudFormationModel):
             self.PROP_ROOT_RESOURCE_ID: self.root_resource_id,
         }
 
-    def apply_patch_operations(self, patch_operations: List[Dict[str, Any]]) -> None:
+    def apply_patch_operations(self, patch_operations: list[dict[str, Any]]) -> None:
         for op in patch_operations:
             path = op[self.OPERATION_PATH]
             value = ""
@@ -1162,7 +1162,7 @@ class RestAPI(CloudFormationModel):
     def create_from_cloudformation_json(  # type: ignore[misc]
         cls,
         resource_name: str,
-        cloudformation_json: Dict[str, Any],
+        cloudformation_json: dict[str, Any],
         account_id: str,
         region_name: str,
         **kwargs: Any,
@@ -1220,7 +1220,7 @@ class RestAPI(CloudFormationModel):
 
     def resource_callback(
         self, request: Any
-    ) -> Tuple[int, Dict[str, str], Union[str, bytes]]:
+    ) -> tuple[int, dict[str, str], Union[str, bytes]]:
         path = path_url(request.url)
         path_after_stage_name = "/" + "/".join(path.split("/")[2:])
 
@@ -1255,7 +1255,7 @@ class RestAPI(CloudFormationModel):
         authorizer_id: str,
         name: str,
         authorizer_type: str,
-        provider_arns: Optional[List[str]],
+        provider_arns: Optional[list[str]],
         auth_type: Optional[str],
         authorizer_uri: Optional[str],
         authorizer_credentials: Optional[str],
@@ -1286,7 +1286,7 @@ class RestAPI(CloudFormationModel):
         description: str,
         cacheClusterEnabled: Optional[bool],
         cacheClusterSize: Optional[str],
-        tags: Optional[Dict[str, str]],
+        tags: Optional[dict[str, str]],
         tracing_enabled: Optional[bool],
     ) -> Stage:
         if name in self.stages:
@@ -1330,13 +1330,13 @@ class RestAPI(CloudFormationModel):
     def get_deployment(self, deployment_id: str) -> Deployment:
         return self.deployments[deployment_id]
 
-    def get_authorizers(self) -> List[Authorizer]:
+    def get_authorizers(self) -> list[Authorizer]:
         return list(self.authorizers.values())
 
-    def get_stages(self) -> List[Stage]:
+    def get_stages(self) -> list[Stage]:
         return list(self.stages.values())
 
-    def get_deployments(self) -> List[Deployment]:
+    def get_deployments(self) -> list[Deployment]:
         return list(self.deployments.values())
 
     def delete_deployment(self, deployment_id: str) -> Deployment:
@@ -1367,7 +1367,7 @@ class RestAPI(CloudFormationModel):
         self.request_validators[validator_id] = request_validator
         return request_validator
 
-    def get_request_validators(self) -> List[RequestValidator]:
+    def get_request_validators(self) -> list[RequestValidator]:
         return list(self.request_validators.values())
 
     def get_request_validator(self, validator_id: str) -> RequestValidator:
@@ -1380,7 +1380,7 @@ class RestAPI(CloudFormationModel):
         return self.request_validators.pop(validator_id)
 
     def update_request_validator(
-        self, validator_id: str, patch_operations: List[Dict[str, Any]]
+        self, validator_id: str, patch_operations: list[dict[str, Any]]
     ) -> RequestValidator:
         self.request_validators[validator_id].apply_patch_operations(patch_operations)
         return self.request_validators[validator_id]
@@ -1389,8 +1389,8 @@ class RestAPI(CloudFormationModel):
         self,
         response_type: str,
         status_code: int,
-        response_parameters: Dict[str, Any],
-        response_templates: Dict[str, str],
+        response_parameters: dict[str, Any],
+        response_templates: dict[str, str],
     ) -> "GatewayResponse":
         response = GatewayResponse(
             response_type=response_type,
@@ -1406,7 +1406,7 @@ class RestAPI(CloudFormationModel):
             raise GatewayResponseNotFound()
         return self.gateway_responses[response_type]
 
-    def get_gateway_responses(self) -> List["GatewayResponse"]:
+    def get_gateway_responses(self) -> list["GatewayResponse"]:
         return list(self.gateway_responses.values())
 
     def delete_gateway_response(self, response_type: str) -> None:
@@ -1437,7 +1437,7 @@ class DomainName(BaseModel):
         self.regional_certificate_arn = kwargs.get("regional_certificate_arn")
         self.endpoint_configuration = kwargs.get("endpoint_configuration")
 
-    def to_json(self) -> Dict[str, Any]:
+    def to_json(self) -> dict[str, Any]:
         dct = {
             "domainName": self.domain_name,
             "regionalDomainName": self.regional_domain_name,
@@ -1479,7 +1479,7 @@ class Model(BaseModel):
         self.schema = kwargs.get("schema")
         self.content_type = kwargs.get("content_type")
 
-    def to_json(self) -> Dict[str, Any]:
+    def to_json(self) -> dict[str, Any]:
         dct = {
             "id": self.id,
             "name": self.name,
@@ -1506,7 +1506,7 @@ class BasePathMapping(BaseModel):
         self.base_path = kwargs.get("basePath") or "(none)"
         self.stage = kwargs.get("stage")
 
-    def to_json(self) -> Dict[str, Any]:
+    def to_json(self) -> dict[str, Any]:
         dct = {
             "domain_name": self.domain_name,
             "restApiId": self.rest_api_id,
@@ -1516,7 +1516,7 @@ class BasePathMapping(BaseModel):
             dct["stage"] = self.stage
         return dct
 
-    def apply_patch_operations(self, patch_operations: List[Dict[str, Any]]) -> None:
+    def apply_patch_operations(self, patch_operations: list[dict[str, Any]]) -> None:
         for op in patch_operations:
             path = op["path"]
             value = op["value"]
@@ -1535,8 +1535,8 @@ class GatewayResponse(BaseModel):
         self,
         response_type: str,
         status_code: int,
-        response_parameters: Dict[str, Any],
-        response_templates: Dict[str, str],
+        response_parameters: dict[str, Any],
+        response_templates: dict[str, str],
     ):
         self.response_type = response_type
         self.default_response = False
@@ -1544,7 +1544,7 @@ class GatewayResponse(BaseModel):
         self.response_parameters = response_parameters
         self.response_templates = response_templates
 
-    def to_json(self) -> Dict[str, Any]:
+    def to_json(self) -> dict[str, Any]:
         dct = {
             "responseType": self.response_type,
             "defaultResponse": self.default_response,
@@ -1561,15 +1561,15 @@ class GatewayResponse(BaseModel):
 class Account(BaseModel):
     def __init__(self) -> None:
         self.cloudwatch_role_arn: Optional[str] = None
-        self.throttle_settings: Dict[str, Any] = {
+        self.throttle_settings: dict[str, Any] = {
             "burstLimit": 5000,
             "rateLimit": 10000.0,
         }
-        self.features: Optional[List[str]] = None
+        self.features: Optional[list[str]] = None
         self.api_key_version: str = "1"
 
     def apply_patch_operations(
-        self, patch_operations: List[Dict[str, Any]]
+        self, patch_operations: list[dict[str, Any]]
     ) -> "Account":
         for op in patch_operations:
             if "/cloudwatchRoleArn" in op["path"]:
@@ -1597,7 +1597,7 @@ class Account(BaseModel):
                 )
         return self
 
-    def to_json(self) -> Dict[str, Any]:
+    def to_json(self) -> dict[str, Any]:
         return {
             "cloudwatchRoleArn": self.cloudwatch_role_arn,
             "throttleSettings": self.throttle_settings,
@@ -1636,14 +1636,14 @@ class APIGatewayBackend(BaseBackend):
     def __init__(self, region_name: str, account_id: str):
         super().__init__(region_name, account_id)
         self.account: Account = Account()
-        self.apis: Dict[str, RestAPI] = {}
-        self.keys: Dict[str, ApiKey] = {}
-        self.usage_plans: Dict[str, UsagePlan] = {}
-        self.usage_plan_keys: Dict[str, Dict[str, UsagePlanKey]] = {}
-        self.domain_names: Dict[str, DomainName] = {}
-        self.models: Dict[str, Model] = {}
-        self.base_path_mappings: Dict[str, Dict[str, BasePathMapping]] = {}
-        self.vpc_links: Dict[str, VpcLink] = {}
+        self.apis: dict[str, RestAPI] = {}
+        self.keys: dict[str, ApiKey] = {}
+        self.usage_plans: dict[str, UsagePlan] = {}
+        self.usage_plan_keys: dict[str, dict[str, UsagePlanKey]] = {}
+        self.domain_names: dict[str, DomainName] = {}
+        self.models: dict[str, Model] = {}
+        self.base_path_mappings: dict[str, dict[str, BasePathMapping]] = {}
+        self.vpc_links: dict[str, VpcLink] = {}
 
     def create_rest_api(
         self,
@@ -1651,7 +1651,7 @@ class APIGatewayBackend(BaseBackend):
         description: str,
         api_key_source: Optional[str] = None,
         endpoint_configuration: Optional[str] = None,
-        tags: Optional[List[Dict[str, str]]] = None,
+        tags: Optional[list[dict[str, str]]] = None,
         policy: Optional[str] = None,
         minimum_compression_size: Optional[int] = None,
         disable_execute_api_endpoint: Optional[bool] = None,
@@ -1676,7 +1676,7 @@ class APIGatewayBackend(BaseBackend):
         return rest_api
 
     def import_rest_api(
-        self, api_doc: Dict[str, Any], fail_on_warnings: bool
+        self, api_doc: dict[str, Any], fail_on_warnings: bool
     ) -> RestAPI:
         """
         Only a subset of the OpenAPI spec 3.x is currently implemented.
@@ -1692,7 +1692,7 @@ class APIGatewayBackend(BaseBackend):
         self.put_rest_api(api.id, api_doc, fail_on_warnings=fail_on_warnings)
         return api
 
-    def export_api(self, rest_api_id: str, export_type: str) -> Dict[str, Any]:
+    def export_api(self, rest_api_id: str, export_type: str) -> dict[str, Any]:
         """
         Not all fields are implemented yet.
         The export-type is currently ignored - we will only return the 'swagger'-format
@@ -1704,7 +1704,7 @@ class APIGatewayBackend(BaseBackend):
         if export_type not in ["swagger", "oas30"]:
             raise BadRequestException(f"No API exporter for type '{export_type}'")
         now = datetime.now().strftime("%Y-%m-%dT%H:%m:%S")
-        resp: Dict[str, Any] = {
+        resp: dict[str, Any] = {
             "swagger": "2.0",
             "info": {"version": now, "title": api.name},
             "host": f"{api.id}.execute-api.{self.region_name}.amazonaws.com",
@@ -1737,7 +1737,7 @@ class APIGatewayBackend(BaseBackend):
     def put_rest_api(
         self,
         function_id: str,
-        api_doc: Dict[str, Any],
+        api_doc: dict[str, Any],
         fail_on_warnings: bool,
         mode: str = "merge",
     ) -> RestAPI:
@@ -1813,7 +1813,7 @@ class APIGatewayBackend(BaseBackend):
         return self.get_rest_api(function_id)
 
     def update_rest_api(
-        self, function_id: str, patch_operations: List[Dict[str, Any]]
+        self, function_id: str, patch_operations: list[dict[str, Any]]
     ) -> RestAPI:
         rest_api = self.apis.get(function_id)
         if rest_api is None:
@@ -1821,14 +1821,14 @@ class APIGatewayBackend(BaseBackend):
         self.apis[function_id].apply_patch_operations(patch_operations)
         return self.apis[function_id]
 
-    def list_apis(self) -> List[RestAPI]:
+    def list_apis(self) -> list[RestAPI]:
         return list(self.apis.values())
 
     def delete_rest_api(self, function_id: str) -> RestAPI:
         rest_api = self.apis.pop(function_id)
         return rest_api
 
-    def get_resources(self, function_id: str) -> List[Resource]:
+    def get_resources(self, function_id: str) -> list[Resource]:
         api = self.get_rest_api(function_id)
         return list(api.resources.values())
 
@@ -1866,8 +1866,8 @@ class APIGatewayBackend(BaseBackend):
         method_type: str,
         authorization_type: Optional[str],
         api_key_required: Optional[bool] = None,
-        request_parameters: Optional[Dict[str, Any]] = None,
-        request_models: Optional[Dict[str, Any]] = None,
+        request_parameters: Optional[dict[str, Any]] = None,
+        request_models: Optional[dict[str, Any]] = None,
         operation_name: Optional[str] = None,
         authorizer_id: Optional[str] = None,
         authorization_scopes: Optional[str] = None,
@@ -1901,7 +1901,7 @@ class APIGatewayBackend(BaseBackend):
         else:
             return authorizer
 
-    def get_authorizers(self, restapi_id: str) -> List[Authorizer]:
+    def get_authorizers(self, restapi_id: str) -> list[Authorizer]:
         api = self.get_rest_api(restapi_id)
         return api.get_authorizers()
 
@@ -1942,7 +1942,7 @@ class APIGatewayBackend(BaseBackend):
             raise StageNotFoundException()
         return stage
 
-    def get_stages(self, function_id: str) -> List[Stage]:
+    def get_stages(self, function_id: str) -> list[Stage]:
         api = self.get_rest_api(function_id)
         return api.get_stages()
 
@@ -1955,7 +1955,7 @@ class APIGatewayBackend(BaseBackend):
         description: str = "",
         cacheClusterEnabled: Optional[bool] = None,
         cacheClusterSize: Optional[str] = None,
-        tags: Optional[Dict[str, str]] = None,
+        tags: Optional[dict[str, str]] = None,
         tracing_enabled: Optional[bool] = None,
     ) -> Stage:
         if variables is None:
@@ -2022,12 +2022,12 @@ class APIGatewayBackend(BaseBackend):
         uri: str,
         integration_method: str,
         credentials: Optional[str] = None,
-        request_templates: Optional[Dict[str, Any]] = None,
+        request_templates: Optional[dict[str, Any]] = None,
         passthrough_behavior: Optional[str] = None,
-        tls_config: Optional[Dict[str, Any]] = None,
+        tls_config: Optional[dict[str, Any]] = None,
         cache_namespace: Optional[str] = None,
         timeout_in_millis: Optional[str] = None,
-        request_parameters: Optional[Dict[str, Any]] = None,
+        request_parameters: Optional[dict[str, Any]] = None,
         content_handling: Optional[str] = None,
         connection_type: Optional[str] = None,
     ) -> Integration:
@@ -2102,8 +2102,8 @@ class APIGatewayBackend(BaseBackend):
         method_type: str,
         status_code: str,
         selection_pattern: str,
-        response_templates: Dict[str, str],
-        response_parameters: Dict[str, str],
+        response_templates: dict[str, str],
+        response_parameters: dict[str, str],
         content_handling: str,
     ) -> IntegrationResponse:
         integration = self.get_integration(function_id, resource_id, method_type)
@@ -2160,7 +2160,7 @@ class APIGatewayBackend(BaseBackend):
         api = self.get_rest_api(function_id)
         return api.get_deployment(deployment_id)
 
-    def get_deployments(self, function_id: str) -> List[Deployment]:
+    def get_deployments(self, function_id: str) -> list[Deployment]:
         api = self.get_rest_api(function_id)
         return api.get_deployments()
 
@@ -2168,7 +2168,7 @@ class APIGatewayBackend(BaseBackend):
         api = self.get_rest_api(function_id)
         return api.delete_deployment(deployment_id)
 
-    def create_api_key(self, payload: Dict[str, Any]) -> ApiKey:
+    def create_api_key(self, payload: dict[str, Any]) -> ApiKey:
         if payload.get("value"):
             if len(payload.get("value", [])) < 20:
                 raise ApiKeyValueMinLength()
@@ -2185,7 +2185,7 @@ class APIGatewayBackend(BaseBackend):
         self.keys[key.id] = key
         return key
 
-    def get_api_keys(self, name: Optional[str] = None) -> List[ApiKey]:
+    def get_api_keys(self, name: Optional[str] = None) -> list[ApiKey]:
         return [
             key
             for key in self.keys.values()
@@ -2216,7 +2216,7 @@ class APIGatewayBackend(BaseBackend):
         self.usage_plans[plan.id] = plan
         return plan
 
-    def get_usage_plans(self, api_key_id: Optional[str] = None) -> List[UsagePlan]:
+    def get_usage_plans(self, api_key_id: Optional[str] = None) -> list[UsagePlan]:
         plans = list(self.usage_plans.values())
         if api_key_id is not None:
             plans = [
@@ -2248,7 +2248,7 @@ class APIGatewayBackend(BaseBackend):
         self.usage_plans.pop(usage_plan_id)
 
     def create_usage_plan_key(
-        self, usage_plan_id: str, payload: Dict[str, Any]
+        self, usage_plan_id: str, payload: dict[str, Any]
     ) -> UsagePlanKey:
         if usage_plan_id not in self.usage_plan_keys:
             self.usage_plan_keys[usage_plan_id] = {}
@@ -2270,7 +2270,7 @@ class APIGatewayBackend(BaseBackend):
 
     def get_usage_plan_keys(
         self, usage_plan_id: str, name: Optional[str] = None
-    ) -> List[UsagePlanKey]:
+    ) -> list[UsagePlanKey]:
         if usage_plan_id not in self.usage_plan_keys:
             return []
 
@@ -2311,7 +2311,7 @@ class APIGatewayBackend(BaseBackend):
         self,
         domain_name: str,
         certificate_name: str,
-        tags: List[Dict[str, str]],
+        tags: list[dict[str, str]],
         certificate_arn: str,
         certificate_body: str,
         certificate_private_key: str,
@@ -2342,7 +2342,7 @@ class APIGatewayBackend(BaseBackend):
         self.domain_names[domain_name] = new_domain_name
         return new_domain_name
 
-    def get_domain_names(self) -> List[DomainName]:
+    def get_domain_names(self) -> list[DomainName]:
         return list(self.domain_names.values())
 
     def get_domain_name(self, domain_name: str) -> DomainName:
@@ -2380,7 +2380,7 @@ class APIGatewayBackend(BaseBackend):
 
         return new_model
 
-    def get_models(self, rest_api_id: str) -> List[Model]:
+    def get_models(self, rest_api_id: str) -> list[Model]:
         if not rest_api_id:
             raise InvalidRestApiId
         api = self.get_rest_api(rest_api_id)
@@ -2397,7 +2397,7 @@ class APIGatewayBackend(BaseBackend):
         else:
             return model
 
-    def get_request_validators(self, restapi_id: str) -> List[RequestValidator]:
+    def get_request_validators(self, restapi_id: str) -> list[RequestValidator]:
         restApi = self.get_rest_api(restapi_id)
         return restApi.get_request_validators()
 
@@ -2459,7 +2459,7 @@ class APIGatewayBackend(BaseBackend):
         self.base_path_mappings[domain_name][new_base_path] = new_base_path_mapping
         return new_base_path_mapping
 
-    def get_base_path_mappings(self, domain_name: str) -> List[BasePathMapping]:
+    def get_base_path_mappings(self, domain_name: str) -> list[BasePathMapping]:
         if domain_name not in self.domain_names:
             raise DomainNameNotFound()
 
@@ -2536,8 +2536,8 @@ class APIGatewayBackend(BaseBackend):
         self,
         name: str,
         description: str,
-        target_arns: List[str],
-        tags: List[Dict[str, str]],
+        target_arns: list[str],
+        tags: list[dict[str, str]],
     ) -> VpcLink:
         vpc_link_id = ApigwVpcLinkIdentifier(
             self.account_id, self.region_name, name
@@ -2560,7 +2560,7 @@ class APIGatewayBackend(BaseBackend):
             raise VpcLinkNotFound
         return self.vpc_links[vpc_link_id]
 
-    def get_vpc_links(self) -> List[VpcLink]:
+    def get_vpc_links(self) -> list[VpcLink]:
         """
         Pagination has not yet been implemented
         """
@@ -2589,7 +2589,7 @@ class APIGatewayBackend(BaseBackend):
         api = self.get_rest_api(rest_api_id)
         return api.get_gateway_response(response_type)
 
-    def get_gateway_responses(self, rest_api_id: str) -> List[GatewayResponse]:
+    def get_gateway_responses(self, rest_api_id: str) -> list[GatewayResponse]:
         """
         Pagination is not yet implemented
         """
@@ -2600,7 +2600,7 @@ class APIGatewayBackend(BaseBackend):
         api = self.get_rest_api(rest_api_id)
         api.delete_gateway_response(response_type)
 
-    def update_account(self, patch_operations: List[Dict[str, Any]]) -> Account:
+    def update_account(self, patch_operations: list[dict[str, Any]]) -> Account:
         account = self.account.apply_patch_operations(patch_operations)
         return account
 

--- a/moto/apigateway/responses.py
+++ b/moto/apigateway/responses.py
@@ -1,5 +1,5 @@
 import json
-from typing import Any, Dict, List, Optional
+from typing import Any, Optional
 from urllib.parse import unquote
 
 from moto.core.responses import TYPE_RESPONSE, BaseResponse
@@ -34,15 +34,15 @@ class APIGatewayResponse(BaseResponse):
                 "ValidationException",
                 (
                     "1 validation error detected: "
-                    "Value '{api_key_source}' at 'createRestApiInput.apiKeySource' failed "
+                    f"Value '{api_key_source}' at 'createRestApiInput.apiKeySource' failed "
                     "to satisfy constraint: Member must satisfy enum value set: "
                     "[AUTHORIZER, HEADER]"
-                ).format(api_key_source=api_key_source),
+                ),
             )
         return None
 
     def __validate_endpoint_configuration(
-        self, endpoint_configuration: Dict[str, str]
+        self, endpoint_configuration: dict[str, str]
     ) -> Optional[TYPE_RESPONSE]:
         if endpoint_configuration and "types" in endpoint_configuration:
             invalid_types = list(
@@ -52,11 +52,11 @@ class APIGatewayResponse(BaseResponse):
                 return self.error(
                     "ValidationException",
                     (
-                        "1 validation error detected: Value '{endpoint_type}' "
+                        f"1 validation error detected: Value '{invalid_types[0]}' "
                         "at 'createRestApiInput.endpointConfiguration.types' failed "
                         "to satisfy constraint: Member must satisfy enum value set: "
                         "[PRIVATE, EDGE, REGIONAL]"
-                    ).format(endpoint_type=invalid_types[0]),
+                    ),
                 )
         return None
 
@@ -105,7 +105,7 @@ class APIGatewayResponse(BaseResponse):
         return json.dumps({"item": [api.to_dict() for api in apis]})
 
     def __validte_rest_patch_operations(
-        self, patch_operations: List[Dict[str, str]]
+        self, patch_operations: list[dict[str, str]]
     ) -> Optional[TYPE_RESPONSE]:
         for op in patch_operations:
             path = op["path"]
@@ -284,10 +284,10 @@ class APIGatewayResponse(BaseResponse):
                 "ValidationException",
                 (
                     "1 validation error detected: "
-                    "Value '{authorizer_type}' at 'createAuthorizerInput.type' failed "
+                    f"Value '{authorizer_type}' at 'createAuthorizerInput.type' failed "
                     "to satisfy constraint: Member must satisfy enum value set: "
                     "[TOKEN, REQUEST, COGNITO_USER_POOLS]"
-                ).format(authorizer_type=authorizer_type),
+                ),
             )
 
         authorizer_response = self.backend.create_authorizer(

--- a/moto/apigateway/utils.py
+++ b/moto/apigateway/utils.py
@@ -1,6 +1,6 @@
 import json
 import string
-from typing import Any, Dict, List, Union
+from typing import Any, Union
 
 import yaml
 
@@ -15,7 +15,7 @@ class ApigwIdentifier(ResourceIdentifier):
         super().__init__(account_id, region, name)
 
     def generate(
-        self, existing_ids: Union[List[str], None] = None, tags: Tags = None
+        self, existing_ids: Union[list[str], None] = None, tags: Tags = None
     ) -> str:
         return generate_str_id(
             resource_identifier=self,
@@ -84,7 +84,7 @@ def create_id() -> str:
     return "".join(str(random.choice(chars)) for x in range(size))
 
 
-def deserialize_body(body: str) -> Dict[str, Any]:
+def deserialize_body(body: str) -> dict[str, Any]:
     try:
         api_doc = json.loads(body)
     except json.JSONDecodeError:

--- a/moto/apigatewaymanagementapi/models.py
+++ b/moto/apigatewaymanagementapi/models.py
@@ -1,7 +1,7 @@
 """ApiGatewayManagementApiBackend class with methods for supported APIs."""
 
 from collections import defaultdict
-from typing import Any, Dict
+from typing import Any
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.utils import unix_time
@@ -14,7 +14,7 @@ class Connection:
         self.user_agent = "Moto Mocks"
         self.data = b""
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         return {
             "connectedAt": self.connected_at,
             "lastActiveAt": unix_time(),
@@ -32,7 +32,7 @@ class ApiGatewayManagementApiBackend(BaseBackend):
 
     def __init__(self, region_name: str, account_id: str):
         super().__init__(region_name, account_id)
-        self.connections: Dict[str, Connection] = defaultdict(Connection)
+        self.connections: dict[str, Connection] = defaultdict(Connection)
 
     def delete_connection(self, connection_id: str) -> None:
         self.connections.pop(connection_id, None)

--- a/moto/apigatewayv2/models.py
+++ b/moto/apigatewayv2/models.py
@@ -3,7 +3,7 @@
 import hashlib
 import string
 from datetime import datetime
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Optional, Union
 
 import yaml
 
@@ -32,7 +32,7 @@ from .exceptions import (
 
 
 class Stage(BaseModel):
-    def __init__(self, api: "Api", config: Dict[str, Any]):
+    def __init__(self, api: "Api", config: dict[str, Any]):
         self.config = config
         self.name = config["stageName"]
         if api.protocol_type == "HTTP":
@@ -57,7 +57,7 @@ class Stage(BaseModel):
         self.tags = config.get("tags", {})
         self.created = self.updated = datetime.now()
 
-    def to_json(self) -> Dict[str, Any]:
+    def to_json(self) -> dict[str, Any]:
         dct = {
             "stageName": self.name,
             "defaultRouteSettings": self.default_route_settings,
@@ -138,7 +138,7 @@ class Authorizer(BaseModel):
         if name is not None:
             self.name = name
 
-    def to_json(self) -> Dict[str, Any]:
+    def to_json(self) -> dict[str, Any]:
         return {
             "authorizerId": self.id,
             "authorizerCredentialsArn": self.auth_creds_arn,
@@ -168,12 +168,12 @@ class Integration(BaseModel):
         passthrough_behavior: Optional[str],
         payload_format_version: Optional[str],
         integration_subtype: Optional[str],
-        request_parameters: Optional[Dict[str, str]],
-        request_templates: Optional[Dict[str, str]],
-        response_parameters: Optional[Dict[str, Dict[str, str]]],
+        request_parameters: Optional[dict[str, str]],
+        request_templates: Optional[dict[str, str]],
+        response_parameters: Optional[dict[str, dict[str, str]]],
         template_selection_expression: Optional[str],
         timeout_in_millis: Optional[str],
-        tls_config: Optional[Dict[str, str]],
+        tls_config: Optional[dict[str, str]],
     ):
         self.id = "".join(random.choice(string.ascii_lowercase) for _ in range(8))
         self.connection_id = connection_id
@@ -215,7 +215,7 @@ class Integration(BaseModel):
         else:
             self.timeout_in_millis = self.timeout_in_millis or 30000
 
-        self.responses: Dict[str, IntegrationResponse] = dict()
+        self.responses: dict[str, IntegrationResponse] = dict()
 
     def create_response(
         self,
@@ -243,7 +243,7 @@ class Integration(BaseModel):
             raise IntegrationResponseNotFound(integration_response_id)
         return self.responses[integration_response_id]
 
-    def get_responses(self) -> List["IntegrationResponse"]:
+    def get_responses(self) -> list["IntegrationResponse"]:
         return list(self.responses.values())
 
     def update_response(
@@ -278,12 +278,12 @@ class Integration(BaseModel):
         passthrough_behavior: str,
         payload_format_version: str,
         integration_subtype: str,
-        request_parameters: Dict[str, str],
-        request_templates: Dict[str, str],
-        response_parameters: Dict[str, Dict[str, str]],
+        request_parameters: dict[str, str],
+        request_templates: dict[str, str],
+        response_parameters: dict[str, dict[str, str]],
         template_selection_expression: str,
         timeout_in_millis: Optional[int],
-        tls_config: Dict[str, str],
+        tls_config: dict[str, str],
     ) -> None:
         if connection_id is not None:
             self.connection_id = connection_id
@@ -324,7 +324,7 @@ class Integration(BaseModel):
         if tls_config is not None:
             self.tls_config = tls_config
 
-    def to_json(self) -> Dict[str, Any]:
+    def to_json(self) -> dict[str, Any]:
         return {
             "connectionId": self.connection_id,
             "connectionType": self.connection_type,
@@ -383,7 +383,7 @@ class IntegrationResponse(BaseModel):
         if template_selection_expression is not None:
             self.template_selection_expression = template_selection_expression
 
-    def to_json(self) -> Dict[str, str]:
+    def to_json(self) -> dict[str, str]:
         return {
             "integrationResponseId": self.id,
             "integrationResponseKey": self.integration_response_key,
@@ -414,7 +414,7 @@ class Model(BaseModel):
         if schema is not None:
             self.schema = schema
 
-    def to_json(self) -> Dict[str, str]:
+    def to_json(self) -> dict[str, str]:
         return {
             "modelId": self.id,
             "contentType": self.content_type,
@@ -436,7 +436,7 @@ class RouteResponse(BaseModel):
         self.model_selection_expression = model_selection_expression
         self.response_models = response_models
 
-    def to_json(self) -> Dict[str, str]:
+    def to_json(self) -> dict[str, str]:
         return {
             "modelSelectionExpression": self.model_selection_expression,
             "responseModels": self.response_models,
@@ -449,13 +449,13 @@ class Route(BaseModel):
     def __init__(
         self,
         api_key_required: bool,
-        authorization_scopes: List[str],
+        authorization_scopes: list[str],
         authorization_type: Optional[str],
         authorizer_id: Optional[str],
         model_selection_expression: Optional[str],
         operation_name: Optional[str],
-        request_models: Optional[Dict[str, str]],
-        request_parameters: Optional[Dict[str, Dict[str, bool]]],
+        request_models: Optional[dict[str, str]],
+        request_parameters: Optional[dict[str, dict[str, bool]]],
         route_key: str,
         route_response_selection_expression: Optional[str],
         target: str,
@@ -473,7 +473,7 @@ class Route(BaseModel):
         self.route_response_selection_expression = route_response_selection_expression
         self.target = target
 
-        self.route_responses: Dict[str, RouteResponse] = dict()
+        self.route_responses: dict[str, RouteResponse] = dict()
 
     def create_route_response(
         self,
@@ -503,13 +503,13 @@ class Route(BaseModel):
     def update(
         self,
         api_key_required: Optional[bool],
-        authorization_scopes: Optional[List[str]],
+        authorization_scopes: Optional[list[str]],
         authorization_type: str,
         authorizer_id: str,
         model_selection_expression: str,
         operation_name: str,
-        request_models: Dict[str, str],
-        request_parameters: Dict[str, Dict[str, bool]],
+        request_models: dict[str, str],
+        request_parameters: dict[str, dict[str, bool]],
         route_key: str,
         route_response_selection_expression: str,
         target: str,
@@ -539,7 +539,7 @@ class Route(BaseModel):
         if target:
             self.target = target
 
-    def to_json(self) -> Dict[str, Any]:
+    def to_json(self) -> dict[str, Any]:
         return {
             "apiKeyRequired": self.api_key_required,
             "authorizationScopes": self.authorization_scopes,
@@ -568,7 +568,7 @@ class Api(BaseModel):
         disable_schema_validation: str,
         protocol_type: str,
         route_selection_expression: str,
-        tags: Dict[str, str],
+        tags: dict[str, str],
         version: str,
         backend: "ApiGatewayV2Backend",
     ):
@@ -590,11 +590,11 @@ class Api(BaseModel):
         )
         self.version = version
 
-        self.authorizers: Dict[str, Authorizer] = dict()
-        self.integrations: Dict[str, Integration] = dict()
-        self.models: Dict[str, Model] = dict()
-        self.routes: Dict[str, Route] = dict()
-        self.stages: Dict[str, Stage] = dict()
+        self.authorizers: dict[str, Authorizer] = dict()
+        self.integrations: dict[str, Integration] = dict()
+        self.models: dict[str, Model] = dict()
+        self.routes: dict[str, Route] = dict()
+        self.stages: dict[str, Stage] = dict()
 
         self.arn = (
             f"arn:{get_partition(region)}:apigateway:{region}::/apis/{self.api_id}"
@@ -780,12 +780,12 @@ class Api(BaseModel):
         passthrough_behavior: Optional[str] = None,
         payload_format_version: Optional[str] = None,
         integration_subtype: Optional[str] = None,
-        request_parameters: Optional[Dict[str, str]] = None,
-        request_templates: Optional[Dict[str, str]] = None,
-        response_parameters: Optional[Dict[str, Dict[str, str]]] = None,
+        request_parameters: Optional[dict[str, str]] = None,
+        request_templates: Optional[dict[str, str]] = None,
+        response_parameters: Optional[dict[str, dict[str, str]]] = None,
         template_selection_expression: Optional[str] = None,
         timeout_in_millis: Optional[str] = None,
-        tls_config: Optional[Dict[str, str]] = None,
+        tls_config: Optional[dict[str, str]] = None,
     ) -> Integration:
         integration = Integration(
             connection_id=connection_id,
@@ -817,7 +817,7 @@ class Api(BaseModel):
             raise IntegrationNotFound(integration_id)
         return self.integrations[integration_id]
 
-    def get_integrations(self) -> List[Integration]:
+    def get_integrations(self) -> list[Integration]:
         return list(self.integrations.values())
 
     def update_integration(
@@ -834,12 +834,12 @@ class Api(BaseModel):
         passthrough_behavior: str,
         payload_format_version: str,
         integration_subtype: str,
-        request_parameters: Dict[str, str],
-        request_templates: Dict[str, str],
-        response_parameters: Dict[str, Dict[str, str]],
+        request_parameters: dict[str, str],
+        request_templates: dict[str, str],
+        response_parameters: dict[str, dict[str, str]],
         template_selection_expression: str,
         timeout_in_millis: Optional[int],
-        tls_config: Dict[str, str],
+        tls_config: dict[str, str],
     ) -> Integration:
         integration = self.integrations[integration_id]
         integration.update(
@@ -895,7 +895,7 @@ class Api(BaseModel):
 
     def get_integration_responses(
         self, integration_id: str
-    ) -> List[IntegrationResponse]:
+    ) -> list[IntegrationResponse]:
         integration = self.get_integration(integration_id)
         return integration.get_responses()
 
@@ -922,15 +922,15 @@ class Api(BaseModel):
     def create_route(
         self,
         api_key_required: bool,
-        authorization_scopes: List[str],
+        authorization_scopes: list[str],
         route_key: str,
         target: str,
         authorization_type: Optional[str] = None,
         authorizer_id: Optional[str] = None,
         model_selection_expression: Optional[str] = None,
         operation_name: Optional[str] = None,
-        request_models: Optional[Dict[str, str]] = None,
-        request_parameters: Optional[Dict[str, Dict[str, bool]]] = None,
+        request_models: Optional[dict[str, str]] = None,
+        request_parameters: Optional[dict[str, dict[str, bool]]] = None,
         route_response_selection_expression: Optional[str] = None,
     ) -> Route:
         route = Route(
@@ -961,20 +961,20 @@ class Api(BaseModel):
             raise RouteNotFound(route_id)
         return self.routes[route_id]
 
-    def get_routes(self) -> List[Route]:
+    def get_routes(self) -> list[Route]:
         return list(self.routes.values())
 
     def update_route(
         self,
         route_id: str,
         api_key_required: Optional[bool],
-        authorization_scopes: List[str],
+        authorization_scopes: list[str],
         authorization_type: str,
         authorizer_id: str,
         model_selection_expression: str,
         operation_name: str,
-        request_models: Dict[str, str],
-        request_parameters: Dict[str, Dict[str, bool]],
+        request_models: dict[str, str],
+        request_parameters: dict[str, dict[str, bool]],
         route_key: str,
         route_response_selection_expression: str,
         target: str,
@@ -1019,7 +1019,7 @@ class Api(BaseModel):
         route = self.get_route(route_id)
         return route.get_route_response(route_response_id)
 
-    def create_stage(self, config: Dict[str, Any]) -> Stage:
+    def create_stage(self, config: dict[str, Any]) -> Stage:
         stage = Stage(api=self, config=config)
         self.stages[stage.name] = stage
         return stage
@@ -1032,7 +1032,7 @@ class Api(BaseModel):
     def delete_stage(self, stage_name: str) -> None:
         self.stages.pop(stage_name, None)
 
-    def to_json(self) -> Dict[str, Any]:
+    def to_json(self) -> dict[str, Any]:
         return {
             "apiId": self.api_id,
             "apiEndpoint": self.api_endpoint,
@@ -1054,9 +1054,9 @@ class VpcLink(BaseModel):
     def __init__(
         self,
         name: str,
-        sg_ids: List[str],
-        subnet_ids: List[str],
-        tags: Dict[str, str],
+        sg_ids: list[str],
+        subnet_ids: list[str],
+        tags: dict[str, str],
         backend: "ApiGatewayV2Backend",
     ):
         self.created = datetime.now()
@@ -1072,7 +1072,7 @@ class VpcLink(BaseModel):
     def update(self, name: str) -> None:
         self.name = name
 
-    def to_json(self) -> Dict[str, Any]:
+    def to_json(self) -> dict[str, Any]:
         return {
             "createdDate": iso_8601_datetime_without_milliseconds(self.created),
             "name": self.name,
@@ -1089,9 +1089,9 @@ class DomainName(BaseModel):
     def __init__(
         self,
         domain_name: str,
-        domain_name_configurations: List[Dict[str, str]],
-        mutual_tls_authentication: Dict[str, str],
-        tags: Dict[str, str],
+        domain_name_configurations: list[dict[str, str]],
+        mutual_tls_authentication: dict[str, str],
+        tags: dict[str, str],
         backend: "ApiGatewayV2Backend",
     ):
         self.api_mapping_selection_expression = "$request.basepath"
@@ -1101,7 +1101,7 @@ class DomainName(BaseModel):
         self.tags = tags
         self.domain_name_arn = f"arn:{get_partition(backend.region_name)}:apigateway:{backend.region_name}::/domainnames/{domain_name}"
 
-    def to_json(self) -> Dict[str, Any]:
+    def to_json(self) -> dict[str, Any]:
         return {
             "apiMappingSelectionExpression": self.api_mapping_selection_expression,
             "domainName": self.domain_name,
@@ -1127,7 +1127,7 @@ class ApiMapping(BaseModel):
         self.domain_name = domain_name
         self.stage = stage
 
-    def to_json(self) -> Dict[str, Any]:
+    def to_json(self) -> dict[str, Any]:
         return {
             "apiId": self.api_id,
             "apiMappingId": self.api_mapping_id,
@@ -1142,10 +1142,10 @@ class ApiGatewayV2Backend(BaseBackend):
 
     def __init__(self, region_name: str, account_id: str):
         super().__init__(region_name, account_id)
-        self.apis: Dict[str, Api] = dict()
-        self.vpc_links: Dict[str, VpcLink] = dict()
-        self.domain_names: Dict[str, DomainName] = dict()
-        self.api_mappings: Dict[str, ApiMapping] = dict()
+        self.apis: dict[str, Api] = dict()
+        self.vpc_links: dict[str, VpcLink] = dict()
+        self.domain_names: dict[str, DomainName] = dict()
+        self.api_mappings: dict[str, ApiMapping] = dict()
         self.tagger = TaggingService()
 
     def create_api(
@@ -1158,7 +1158,7 @@ class ApiGatewayV2Backend(BaseBackend):
         name: str,
         protocol_type: str,
         route_selection_expression: str,
-        tags: Dict[str, str],
+        tags: dict[str, str],
         version: str,
     ) -> Api:
         """
@@ -1190,7 +1190,7 @@ class ApiGatewayV2Backend(BaseBackend):
             raise ApiNotFound(api_id)
         return self.apis[api_id]
 
-    def get_apis(self) -> List[Api]:
+    def get_apis(self) -> list[Api]:
         """
         Pagination is not yet implemented
         """
@@ -1344,27 +1344,27 @@ class ApiGatewayV2Backend(BaseBackend):
         api = self.get_api(api_id)
         return api.update_model(model_id, content_type, description, name, schema)
 
-    def get_tags(self, resource_id: str) -> Dict[str, str]:
+    def get_tags(self, resource_id: str) -> dict[str, str]:
         return self.tagger.get_tag_dict_for_resource(resource_id)
 
-    def tag_resource(self, resource_arn: str, tags: Dict[str, str]) -> None:
+    def tag_resource(self, resource_arn: str, tags: dict[str, str]) -> None:
         tags_input = TaggingService.convert_dict_to_tags_input(tags or {})
         self.tagger.tag_resource(resource_arn, tags_input)
 
-    def untag_resource(self, resource_arn: str, tag_keys: List[str]) -> None:
+    def untag_resource(self, resource_arn: str, tag_keys: list[str]) -> None:
         self.tagger.untag_resource_using_names(resource_arn, tag_keys)
 
     def create_route(
         self,
         api_id: str,
         api_key_required: bool,
-        authorization_scopes: List[str],
+        authorization_scopes: list[str],
         authorization_type: str,
         authorizer_id: str,
         model_selection_expression: str,
         operation_name: str,
-        request_models: Optional[Dict[str, str]],
-        request_parameters: Optional[Dict[str, Dict[str, bool]]],
+        request_models: Optional[dict[str, str]],
+        request_parameters: Optional[dict[str, dict[str, bool]]],
         route_key: str,
         route_response_selection_expression: str,
         target: str,
@@ -1399,7 +1399,7 @@ class ApiGatewayV2Backend(BaseBackend):
         api = self.get_api(api_id)
         return api.get_route(route_id)
 
-    def get_routes(self, api_id: str) -> List[Route]:
+    def get_routes(self, api_id: str) -> list[Route]:
         """
         Pagination is not yet implemented
         """
@@ -1410,13 +1410,13 @@ class ApiGatewayV2Backend(BaseBackend):
         self,
         api_id: str,
         api_key_required: bool,
-        authorization_scopes: List[str],
+        authorization_scopes: list[str],
         authorization_type: str,
         authorizer_id: str,
         model_selection_expression: str,
         operation_name: str,
-        request_models: Dict[str, str],
-        request_parameters: Dict[str, Dict[str, bool]],
+        request_models: dict[str, str],
+        request_parameters: dict[str, dict[str, bool]],
         route_id: str,
         route_key: str,
         route_response_selection_expression: str,
@@ -1484,12 +1484,12 @@ class ApiGatewayV2Backend(BaseBackend):
         integration_uri: str,
         passthrough_behavior: str,
         payload_format_version: str,
-        request_parameters: Optional[Dict[str, str]],
-        request_templates: Optional[Dict[str, str]],
-        response_parameters: Optional[Dict[str, Dict[str, str]]],
+        request_parameters: Optional[dict[str, str]],
+        request_templates: Optional[dict[str, str]],
+        response_parameters: Optional[dict[str, dict[str, str]]],
         template_selection_expression: str,
         timeout_in_millis: str,
-        tls_config: Dict[str, str],
+        tls_config: dict[str, str],
     ) -> Integration:
         api = self.get_api(api_id)
         integration = api.create_integration(
@@ -1518,7 +1518,7 @@ class ApiGatewayV2Backend(BaseBackend):
         integration = api.get_integration(integration_id)
         return integration
 
-    def get_integrations(self, api_id: str) -> List[Integration]:
+    def get_integrations(self, api_id: str) -> list[Integration]:
         """
         Pagination is not yet implemented
         """
@@ -1544,12 +1544,12 @@ class ApiGatewayV2Backend(BaseBackend):
         integration_uri: str,
         passthrough_behavior: str,
         payload_format_version: str,
-        request_parameters: Dict[str, str],
-        request_templates: Dict[str, str],
-        response_parameters: Dict[str, Dict[str, str]],
+        request_parameters: dict[str, str],
+        request_templates: dict[str, str],
+        response_parameters: dict[str, dict[str, str]],
         template_selection_expression: str,
         timeout_in_millis: Optional[int],
-        tls_config: Dict[str, str],
+        tls_config: dict[str, str],
     ) -> Integration:
         api = self.get_api(api_id)
         integration = api.update_integration(
@@ -1613,7 +1613,7 @@ class ApiGatewayV2Backend(BaseBackend):
 
     def get_integration_responses(
         self, api_id: str, integration_id: str
-    ) -> List[IntegrationResponse]:
+    ) -> list[IntegrationResponse]:
         api = self.get_api(api_id)
         return api.get_integration_responses(integration_id)
 
@@ -1641,7 +1641,7 @@ class ApiGatewayV2Backend(BaseBackend):
         return integration_response
 
     def create_vpc_link(
-        self, name: str, sg_ids: List[str], subnet_ids: List[str], tags: Dict[str, str]
+        self, name: str, sg_ids: list[str], subnet_ids: list[str], tags: dict[str, str]
     ) -> VpcLink:
         vpc_link = VpcLink(
             name, sg_ids=sg_ids, subnet_ids=subnet_ids, tags=tags, backend=self
@@ -1657,7 +1657,7 @@ class ApiGatewayV2Backend(BaseBackend):
     def delete_vpc_link(self, vpc_link_id: str) -> None:
         self.vpc_links.pop(vpc_link_id, None)
 
-    def get_vpc_links(self) -> List[VpcLink]:
+    def get_vpc_links(self) -> list[VpcLink]:
         return list(self.vpc_links.values())
 
     def update_vpc_link(self, vpc_link_id: str, name: str) -> VpcLink:
@@ -1668,9 +1668,9 @@ class ApiGatewayV2Backend(BaseBackend):
     def create_domain_name(
         self,
         domain_name: str,
-        domain_name_configurations: List[Dict[str, str]],
-        mutual_tls_authentication: Dict[str, str],
-        tags: Dict[str, str],
+        domain_name_configurations: list[dict[str, str]],
+        mutual_tls_authentication: dict[str, str],
+        tags: dict[str, str],
     ) -> DomainName:
         if domain_name in self.domain_names.keys():
             raise DomainNameAlreadyExists
@@ -1690,7 +1690,7 @@ class ApiGatewayV2Backend(BaseBackend):
             raise DomainNameNotFound
         return self.domain_names[domain_name]
 
-    def get_domain_names(self) -> List[DomainName]:
+    def get_domain_names(self) -> list[DomainName]:
         """
         Pagination is not yet implemented
         """
@@ -1711,7 +1711,7 @@ class ApiGatewayV2Backend(BaseBackend):
     ) -> str:
         return str(
             hashlib.sha256(
-                f"{stage} {domain_name}/{api_mapping_key}".encode("utf-8")
+                f"{stage} {domain_name}/{api_mapping_key}".encode()
             ).hexdigest()
         )[:5]
 
@@ -1756,7 +1756,7 @@ class ApiGatewayV2Backend(BaseBackend):
 
         return self.api_mappings[api_mapping_id]
 
-    def get_api_mappings(self, domain_name: str) -> List[ApiMapping]:
+    def get_api_mappings(self, domain_name: str) -> list[ApiMapping]:
         domain_mappings = []
         for mapping in self.api_mappings.values():
             if mapping.domain_name == domain_name:
@@ -1774,7 +1774,7 @@ class ApiGatewayV2Backend(BaseBackend):
 
         del self.api_mappings[api_mapping_id]
 
-    def create_stage(self, api_id: str, config: Dict[str, Any]) -> Stage:
+    def create_stage(self, api_id: str, config: dict[str, Any]) -> Stage:
         api = self.get_api(api_id)
         return api.create_stage(config)
 
@@ -1786,7 +1786,7 @@ class ApiGatewayV2Backend(BaseBackend):
         api = self.get_api(api_id)
         api.delete_stage(stage_name)
 
-    def get_stages(self, api_id: str) -> List[Stage]:
+    def get_stages(self, api_id: str) -> list[Stage]:
         api = self.get_api(api_id)
         return list(api.stages.values())
 

--- a/moto/appconfig/models.py
+++ b/moto/appconfig/models.py
@@ -1,4 +1,5 @@
-from typing import Any, Dict, Iterable, List, Optional
+from collections.abc import Iterable
+from typing import Any, Optional
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
@@ -32,7 +33,7 @@ class HostedConfigurationVersion(BaseModel):
         self.content_type = content_type
         self.version_label = version_label
 
-    def get_headers(self) -> Dict[str, Any]:
+    def get_headers(self) -> dict[str, Any]:
         return {
             "application-id": self.app_id,
             "configuration-profile-id": self.config_id,
@@ -53,7 +54,7 @@ class ConfigurationProfile(BaseModel):
         description: str,
         location_uri: str,
         retrieval_role_arn: str,
-        validators: List[Dict[str, str]],
+        validators: list[dict[str, str]],
         _type: str,
     ):
         self.id = mock_random.get_random_hex(7)
@@ -65,7 +66,7 @@ class ConfigurationProfile(BaseModel):
         self.retrieval_role_arn = retrieval_role_arn
         self.validators = validators
         self._type = _type
-        self.config_versions: Dict[int, HostedConfigurationVersion] = dict()
+        self.config_versions: dict[int, HostedConfigurationVersion] = dict()
 
     def create_version(
         self,
@@ -99,7 +100,7 @@ class ConfigurationProfile(BaseModel):
     def delete_version(self, version: int) -> None:
         self.config_versions.pop(version)
 
-    def to_json(self) -> Dict[str, Any]:
+    def to_json(self) -> dict[str, Any]:
         return {
             "Id": self.id,
             "Name": self.name,
@@ -121,9 +122,9 @@ class Application(BaseModel):
         self.name = name
         self.description = description
 
-        self.config_profiles: Dict[str, ConfigurationProfile] = dict()
+        self.config_profiles: dict[str, ConfigurationProfile] = dict()
 
-    def to_json(self) -> Dict[str, Any]:
+    def to_json(self) -> dict[str, Any]:
         return {
             "Id": self.id,
             "Name": self.name,
@@ -136,11 +137,11 @@ class AppConfigBackend(BaseBackend):
 
     def __init__(self, region_name: str, account_id: str):
         super().__init__(region_name, account_id)
-        self.applications: Dict[str, Application] = dict()
+        self.applications: dict[str, Application] = dict()
         self.tagger = TaggingService()
 
     def create_application(
-        self, name: str, description: Optional[str], tags: Dict[str, str]
+        self, name: str, description: Optional[str], tags: dict[str, str]
     ) -> Application:
         app = Application(
             name, description, region=self.region_name, account_id=self.account_id
@@ -174,9 +175,9 @@ class AppConfigBackend(BaseBackend):
         description: str,
         location_uri: str,
         retrieval_role_arn: str,
-        validators: List[Dict[str, str]],
+        validators: list[dict[str, str]],
         _type: str,
-        tags: Dict[str, str],
+        tags: dict[str, str],
     ) -> ConfigurationProfile:
         config_profile = ConfigurationProfile(
             application_id=application_id,
@@ -213,7 +214,7 @@ class AppConfigBackend(BaseBackend):
         name: str,
         description: str,
         retrieval_role_arn: str,
-        validators: List[Dict[str, str]],
+        validators: list[dict[str, str]],
     ) -> ConfigurationProfile:
         config_profile = self.get_configuration_profile(
             application_id, config_profile_id
@@ -272,13 +273,13 @@ class AppConfigBackend(BaseBackend):
         )
         profile.delete_version(version=version)
 
-    def list_tags_for_resource(self, arn: str) -> Dict[str, str]:
+    def list_tags_for_resource(self, arn: str) -> dict[str, str]:
         return self.tagger.get_tag_dict_for_resource(arn)
 
-    def tag_resource(self, arn: str, tags: Dict[str, str]) -> None:
+    def tag_resource(self, arn: str, tags: dict[str, str]) -> None:
         self.tagger.tag_resource(arn, TaggingService.convert_dict_to_tags_input(tags))
 
-    def untag_resource(self, arn: str, tag_keys: List[str]) -> None:
+    def untag_resource(self, arn: str, tag_keys: list[str]) -> None:
         self.tagger.untag_resource_using_names(arn, tag_keys)
 
 

--- a/moto/appconfig/responses.py
+++ b/moto/appconfig/responses.py
@@ -1,5 +1,5 @@
 import json
-from typing import Any, Dict, Tuple
+from typing import Any
 from urllib.parse import unquote
 
 from moto.core.responses import BaseResponse
@@ -121,7 +121,7 @@ class AppConfigResponse(BaseResponse):
         self.appconfig_backend.untag_resource(arn, tag_keys)  # type: ignore[arg-type]
         return "{}"
 
-    def create_hosted_configuration_version(self) -> Tuple[str, Dict[str, Any]]:
+    def create_hosted_configuration_version(self) -> tuple[str, dict[str, Any]]:
         app_id = self._get_param("ApplicationId")
         config_profile_id = self._get_param("ConfigurationProfileId")
         description = self.headers.get("Description")
@@ -138,7 +138,7 @@ class AppConfigResponse(BaseResponse):
         )
         return version.content, version.get_headers()
 
-    def get_hosted_configuration_version(self) -> Tuple[str, Dict[str, Any]]:
+    def get_hosted_configuration_version(self) -> tuple[str, dict[str, Any]]:
         app_id = self._get_param("ApplicationId")
         config_profile_id = self._get_param("ConfigurationProfileId")
         version_number = self._get_int_param("VersionNumber")

--- a/moto/applicationautoscaling/models.py
+++ b/moto/applicationautoscaling/models.py
@@ -2,7 +2,7 @@ import re
 import time
 from collections import OrderedDict
 from enum import Enum, unique
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any, Optional, Union
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
@@ -74,13 +74,13 @@ class ApplicationAutoscalingBackend(BaseBackend):
     def __init__(self, region_name: str, account_id: str) -> None:
         super().__init__(region_name, account_id)
         self.ecs_backend = ecs_backends[account_id][region_name]
-        self.targets: Dict[str, Dict[str, FakeScalableTarget]] = OrderedDict()
-        self.policies: Dict[str, FakeApplicationAutoscalingPolicy] = {}
-        self.scheduled_actions: List[FakeScheduledAction] = list()
+        self.targets: dict[str, dict[str, FakeScalableTarget]] = OrderedDict()
+        self.policies: dict[str, FakeApplicationAutoscalingPolicy] = {}
+        self.scheduled_actions: list[FakeScheduledAction] = list()
 
     def describe_scalable_targets(
-        self, namespace: str, r_ids: Union[None, List[str]], dimension: Union[None, str]
-    ) -> List["FakeScalableTarget"]:
+        self, namespace: str, r_ids: Union[None, list[str]], dimension: Union[None, str]
+    ) -> list["FakeScalableTarget"]:
         if r_ids is None:
             r_ids = []
         targets = self._flatten_scalable_targets(namespace)
@@ -90,7 +90,7 @@ class ApplicationAutoscalingBackend(BaseBackend):
             targets = [t for t in targets if t.resource_id in r_ids]
         return targets
 
-    def _flatten_scalable_targets(self, namespace: str) -> List["FakeScalableTarget"]:
+    def _flatten_scalable_targets(self, namespace: str) -> list["FakeScalableTarget"]:
         """Flatten scalable targets for a given service namespace down to a list."""
         targets = []
         for dimension in self.targets.keys():
@@ -167,7 +167,7 @@ class ApplicationAutoscalingBackend(BaseBackend):
         service_namespace: str,
         resource_id: str,
         scalable_dimension: str,
-        policy_body: Dict[str, Any],
+        policy_body: dict[str, Any],
         policy_type: Optional[None],
     ) -> "FakeApplicationAutoscalingPolicy":
         policy_key = FakeApplicationAutoscalingPolicy.formulate_key(
@@ -206,7 +206,7 @@ class ApplicationAutoscalingBackend(BaseBackend):
         scalable_dimension: str,
         max_results: Optional[int],
         next_token: str,
-    ) -> Tuple[Optional[str], List["FakeApplicationAutoscalingPolicy"]]:
+    ) -> tuple[Optional[str], list["FakeApplicationAutoscalingPolicy"]]:
         max_results = max_results or 100
         policies = [
             policy
@@ -272,7 +272,7 @@ class ApplicationAutoscalingBackend(BaseBackend):
         service_namespace: str,
         resource_id: str,
         scalable_dimension: str,
-    ) -> List["FakeScheduledAction"]:
+    ) -> list["FakeScheduledAction"]:
         """
         Pagination is not yet implemented
         """
@@ -444,7 +444,7 @@ class FakeApplicationAutoscalingPolicy(BaseModel):
         resource_id: str,
         scalable_dimension: str,
         policy_type: Optional[str],
-        policy_body: Dict[str, Any],
+        policy_body: dict[str, Any],
     ) -> None:
         self.step_scaling_policy_configuration = None
         self.target_tracking_scaling_policy_configuration = None
@@ -469,7 +469,7 @@ class FakeApplicationAutoscalingPolicy(BaseModel):
         self._guid = mock_random.uuid4()
         self.policy_arn = f"arn:{get_partition(region_name)}:autoscaling:{region_name}:{account_id}:scalingPolicy:{self._guid}:resource/{self.service_namespace}/{self.resource_id}:policyName/{self.policy_name}"
         self.creation_time = time.time()
-        self.alarms: List["Alarm"] = []
+        self.alarms: list[Alarm] = []
 
         self.account_id = account_id
         self.region_name = region_name
@@ -483,7 +483,7 @@ class FakeApplicationAutoscalingPolicy(BaseModel):
             if self.service_namespace == "ecs":
                 self.alarms.extend(self._generate_ecs_alarms())
 
-    def _generate_dynamodb_alarms(self) -> List["Alarm"]:
+    def _generate_dynamodb_alarms(self) -> list["Alarm"]:
         from moto.cloudwatch.models import CloudWatchBackend, cloudwatch_backends
 
         cloudwatch: CloudWatchBackend = cloudwatch_backends[self.account_id][
@@ -554,13 +554,13 @@ class FakeApplicationAutoscalingPolicy(BaseModel):
         alarms.append(alarm4)
         return alarms
 
-    def _generate_ecs_alarms(self) -> List["Alarm"]:
+    def _generate_ecs_alarms(self) -> list["Alarm"]:
         from moto.cloudwatch.models import CloudWatchBackend, cloudwatch_backends
 
         cloudwatch: CloudWatchBackend = cloudwatch_backends[self.account_id][
             self.region_name
         ]
-        alarms: List["Alarm"] = []
+        alarms: list[Alarm] = []
         alarm_action = f"{self.policy_arn}:createdBy/{mock_random.uuid4()}"
         config = self.target_tracking_scaling_policy_configuration or {}
         metric_spec = config.get("PredefinedMetricSpecification", {})

--- a/moto/applicationautoscaling/responses.py
+++ b/moto/applicationautoscaling/responses.py
@@ -1,5 +1,5 @@
 import json
-from typing import Any, Dict, List
+from typing import Any
 
 from moto.core.responses import BaseResponse
 
@@ -194,7 +194,7 @@ class ApplicationAutoScalingResponse(BaseResponse):
         return json.dumps(response_obj)
 
 
-def _build_target(t: FakeScalableTarget) -> Dict[str, Any]:
+def _build_target(t: FakeScalableTarget) -> dict[str, Any]:
     return {
         "CreationTime": t.creation_time,
         "MaxCapacity": t.max_capacity,
@@ -208,11 +208,11 @@ def _build_target(t: FakeScalableTarget) -> Dict[str, Any]:
     }
 
 
-def _build_alarms(policy: FakeApplicationAutoscalingPolicy) -> List[Dict[str, str]]:
+def _build_alarms(policy: FakeApplicationAutoscalingPolicy) -> list[dict[str, str]]:
     return [{"AlarmARN": a.alarm_arn, "AlarmName": a.name} for a in policy.alarms]
 
 
-def _build_policy(p: FakeApplicationAutoscalingPolicy) -> Dict[str, Any]:
+def _build_policy(p: FakeApplicationAutoscalingPolicy) -> dict[str, Any]:
     response = {
         "PolicyARN": p.policy_arn,
         "PolicyName": p.policy_name,
@@ -232,7 +232,7 @@ def _build_policy(p: FakeApplicationAutoscalingPolicy) -> Dict[str, Any]:
     return response
 
 
-def _build_scheduled_action(a: FakeScheduledAction) -> Dict[str, Any]:
+def _build_scheduled_action(a: FakeScheduledAction) -> dict[str, Any]:
     response = {
         "ScheduledActionName": a.scheduled_action_name,
         "ScheduledActionARN": a.arn,

--- a/moto/appmesh/dataclasses/mesh.py
+++ b/moto/appmesh/dataclasses/mesh.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, field
-from typing import Any, Dict, List, Literal, Optional
+from typing import Any, Literal, Optional
 
 from moto.appmesh.dataclasses.shared import Metadata, Status
 from moto.appmesh.dataclasses.virtual_node import VirtualNode
@@ -8,8 +8,8 @@ from moto.appmesh.dataclasses.virtual_router import VirtualRouter
 
 @dataclass
 class MeshSpec:
-    egress_filter: Dict[Literal["type"], Optional[str]]
-    service_discovery: Dict[Literal["ip_preference"], Optional[str]]
+    egress_filter: dict[Literal["type"], Optional[str]]
+    service_discovery: dict[Literal["ip_preference"], Optional[str]]
 
 
 @dataclass
@@ -18,11 +18,11 @@ class Mesh:
     metadata: Metadata
     spec: MeshSpec
     status: Status
-    virtual_nodes: Dict[str, VirtualNode] = field(default_factory=dict)
-    virtual_routers: Dict[str, VirtualRouter] = field(default_factory=dict)
-    tags: List[Dict[str, str]] = field(default_factory=list)
+    virtual_nodes: dict[str, VirtualNode] = field(default_factory=dict)
+    virtual_routers: dict[str, VirtualRouter] = field(default_factory=dict)
+    tags: list[dict[str, str]] = field(default_factory=list)
 
-    def to_dict(self) -> Dict[str, Any]:  # type ignore[misc]
+    def to_dict(self) -> dict[str, Any]:  # type ignore[misc]
         return {
             "meshName": self.mesh_name,
             "metadata": {

--- a/moto/appmesh/dataclasses/route.py
+++ b/moto/appmesh/dataclasses/route.py
@@ -1,5 +1,5 @@
 from dataclasses import asdict, dataclass, field
-from typing import Any, Dict, List, Optional
+from typing import Any, Optional
 
 from moto.appmesh.dataclasses.shared import (
     Duration,
@@ -17,7 +17,7 @@ class RouteActionWeightedTarget:
     weight: int
     port: Optional[int] = field(default=None)
 
-    def to_dict(self) -> Dict[str, Any]:  # type: ignore[misc]
+    def to_dict(self) -> dict[str, Any]:  # type: ignore[misc]
         return clean_dict(
             {"port": self.port, "virtualNode": self.virtual_node, "weight": self.weight}
         )
@@ -25,9 +25,9 @@ class RouteActionWeightedTarget:
 
 @dataclass
 class RouteAction:
-    weighted_targets: List[RouteActionWeightedTarget]
+    weighted_targets: list[RouteActionWeightedTarget]
 
-    def to_dict(self) -> Dict[str, Any]:  # type: ignore[misc]
+    def to_dict(self) -> dict[str, Any]:  # type: ignore[misc]
         return clean_dict(
             {"weightedTargets": [target.to_dict() for target in self.weighted_targets]}
         )
@@ -48,7 +48,7 @@ class Match:
     regex: Optional[str]
     suffix: Optional[str]
 
-    def to_dict(self) -> Dict[str, Any]:  # type: ignore[misc]
+    def to_dict(self) -> dict[str, Any]:  # type: ignore[misc]
         return clean_dict(
             {
                 "exact": self.exact,
@@ -66,7 +66,7 @@ class GrpcMetadatum:
     match: Optional[Match]
     name: str
 
-    def to_dict(self) -> Dict[str, Any]:  # type: ignore[misc]
+    def to_dict(self) -> dict[str, Any]:  # type: ignore[misc]
         return clean_dict(
             {
                 "invert": self.invert,
@@ -98,7 +98,7 @@ class RouteMatchQueryParameter:
     name: str
     match: Optional[QueryParameterMatch] = field(default=None)
 
-    def to_dict(self) -> Dict[str, Any]:  # type: ignore[misc]
+    def to_dict(self) -> dict[str, Any]:  # type: ignore[misc]
         return clean_dict(
             {"match": (self.match or MissingField()).to_dict(), "name": self.name}
         )
@@ -106,15 +106,15 @@ class RouteMatchQueryParameter:
 
 @dataclass
 class HttpRouteMatch:
-    headers: Optional[List[HttpRouteMatchHeader]] = field(default=None)
+    headers: Optional[list[HttpRouteMatchHeader]] = field(default=None)
     method: Optional[str] = field(default=None)
     path: Optional[RouteMatchPath] = field(default=None)
     port: Optional[int] = field(default=None)
     prefix: Optional[str] = field(default=None)
-    query_parameters: Optional[List[RouteMatchQueryParameter]] = field(default=None)
+    query_parameters: Optional[list[RouteMatchQueryParameter]] = field(default=None)
     scheme: Optional[str] = field(default=None)
 
-    def to_dict(self) -> Dict[str, Any]:  # type: ignore[misc]
+    def to_dict(self) -> dict[str, Any]:  # type: ignore[misc]
         return clean_dict(
             {
                 "headers": [header.to_dict() for header in self.headers or []],
@@ -133,11 +133,11 @@ class HttpRouteMatch:
 @dataclass
 class HttpRouteRetryPolicy:
     max_retries: int
-    http_retry_events: Optional[List[str]]
+    http_retry_events: Optional[list[str]]
     per_retry_timeout: Duration
-    tcp_retry_events: Optional[List[str]]
+    tcp_retry_events: Optional[list[str]]
 
-    def to_dict(self) -> Dict[str, Any]:  # type: ignore[misc]
+    def to_dict(self) -> dict[str, Any]:  # type: ignore[misc]
         return clean_dict(
             {
                 "httpRetryEvents": self.http_retry_events or [],
@@ -150,12 +150,12 @@ class HttpRouteRetryPolicy:
 
 @dataclass
 class GrpcRouteMatch:
-    metadata: Optional[List[GrpcMetadatum]]
+    metadata: Optional[list[GrpcMetadatum]]
     method_name: Optional[str]
     port: Optional[int]
     service_name: Optional[str]
 
-    def to_dict(self) -> Dict[str, Any]:  # type: ignore[misc]
+    def to_dict(self) -> dict[str, Any]:  # type: ignore[misc]
         return clean_dict(
             {
                 "metadata": [meta.to_dict() for meta in self.metadata or []],
@@ -170,11 +170,11 @@ class GrpcRouteMatch:
 class GrcpRouteRetryPolicy:
     max_retries: int
     per_retry_timeout: Duration
-    grpc_retry_events: Optional[List[str]]
-    http_retry_events: Optional[List[str]]
-    tcp_retry_events: Optional[List[str]]
+    grpc_retry_events: Optional[list[str]]
+    http_retry_events: Optional[list[str]]
+    tcp_retry_events: Optional[list[str]]
 
-    def to_dict(self) -> Dict[str, Any]:  # type: ignore[misc]
+    def to_dict(self) -> dict[str, Any]:  # type: ignore[misc]
         return clean_dict(
             {
                 "grpcRetryEvents": self.grpc_retry_events or [],
@@ -193,7 +193,7 @@ class GrpcRoute:
     retry_policy: Optional[GrcpRouteRetryPolicy]
     timeout: Optional[Timeout]
 
-    def to_dict(self) -> Dict[str, Any]:  # type: ignore[misc]
+    def to_dict(self) -> dict[str, Any]:  # type: ignore[misc]
         return clean_dict(
             {
                 "action": self.action.to_dict(),
@@ -211,7 +211,7 @@ class HttpRoute:
     retry_policy: Optional[HttpRouteRetryPolicy] = field(default=None)
     timeout: Optional[Timeout] = field(default=None)
 
-    def to_dict(self) -> Dict[str, Any]:  # type: ignore[misc]
+    def to_dict(self) -> dict[str, Any]:  # type: ignore[misc]
         return clean_dict(
             {
                 "action": self.action.to_dict(),
@@ -234,7 +234,7 @@ class TCPRoute:
     match: Optional[TCPRouteMatch]
     timeout: Optional[Timeout]
 
-    def to_dict(self) -> Dict[str, Any]:  # type: ignore[misc]
+    def to_dict(self) -> dict[str, Any]:  # type: ignore[misc]
         return clean_dict(
             {
                 "action": self.action.to_dict(),
@@ -252,7 +252,7 @@ class RouteSpec:
     http2_route: Optional[HttpRoute] = field(default=None)
     tcp_route: Optional[TCPRoute] = field(default=None)
 
-    def to_dict(self) -> Dict[str, Any]:  # type: ignore[misc]
+    def to_dict(self) -> dict[str, Any]:  # type: ignore[misc]
         spec = {
             "grpcRoute": (self.grpc_route or MissingField()).to_dict(),
             "httpRoute": (self.http_route or MissingField()).to_dict(),
@@ -279,7 +279,7 @@ class RouteMetadata(Metadata):
                 "__init__ missing 1 required argument: 'virtual_router_name'"
             )
 
-    def formatted_for_list_api(self) -> Dict[str, Any]:  # type: ignore
+    def formatted_for_list_api(self) -> dict[str, Any]:  # type: ignore
         return {
             "arn": self.arn,
             "createdAt": self.created_at.strftime("%d/%m/%Y, %H:%M:%S"),
@@ -292,7 +292,7 @@ class RouteMetadata(Metadata):
             "virtualRouterName": self.virtual_router_name,
         }
 
-    def formatted_for_crud_apis(self) -> Dict[str, Any]:  # type: ignore
+    def formatted_for_crud_apis(self) -> dict[str, Any]:  # type: ignore
         return {
             "arn": self.arn,
             "createdAt": self.created_at.strftime("%d/%m/%Y, %H:%M:%S"),
@@ -313,9 +313,9 @@ class Route:
     spec: RouteSpec
     virtual_router_name: str
     status: Status = field(default_factory=lambda: {"status": "ACTIVE"})
-    tags: List[Dict[str, str]] = field(default_factory=list)
+    tags: list[dict[str, str]] = field(default_factory=list)
 
-    def to_dict(self) -> Dict[str, Any]:  # type: ignore[misc]
+    def to_dict(self) -> dict[str, Any]:  # type: ignore[misc]
         return clean_dict(
             {
                 "meshName": self.mesh_name,

--- a/moto/appmesh/dataclasses/shared.py
+++ b/moto/appmesh/dataclasses/shared.py
@@ -1,11 +1,11 @@
 from dataclasses import asdict, dataclass, field
 from datetime import datetime
-from typing import Any, Dict, Literal, Optional
+from typing import Any, Literal, Optional
 from uuid import uuid4
 
 from moto.appmesh.utils.common import clean_dict
 
-Status = Dict[Literal["status"], str]
+Status = dict[Literal["status"], str]
 
 
 @dataclass
@@ -39,7 +39,7 @@ class Timeout:
     idle: Optional[Duration] = field(default=None)
     per_request: Optional[Duration] = field(default=None)
 
-    def to_dict(self) -> Dict[str, Any]:  # type: ignore[misc]
+    def to_dict(self) -> dict[str, Any]:  # type: ignore[misc]
         return clean_dict(
             {
                 "idle": (self.idle or MissingField()).to_dict(),

--- a/moto/appmesh/dataclasses/virtual_node.py
+++ b/moto/appmesh/dataclasses/virtual_node.py
@@ -1,5 +1,5 @@
 from dataclasses import asdict, dataclass, field
-from typing import Any, Dict, List, Optional
+from typing import Any, Optional
 
 from moto.appmesh.dataclasses.shared import (
     Duration,
@@ -15,7 +15,7 @@ from moto.appmesh.utils.common import clean_dict
 class CertificateFile:
     certificate_chain: str
 
-    def to_dict(self) -> Dict[str, Any]:  # type: ignore[misc]
+    def to_dict(self) -> dict[str, Any]:  # type: ignore[misc]
         return {"certificateChain": self.certificate_chain}
 
 
@@ -23,7 +23,7 @@ class CertificateFile:
 class CertificateFileWithPrivateKey(CertificateFile):
     private_key: str
 
-    def to_dict(self) -> Dict[str, Any]:  # type: ignore[misc]
+    def to_dict(self) -> dict[str, Any]:  # type: ignore[misc]
         return {
             "certificateChain": self.certificate_chain,
             "privateKey": self.private_key,
@@ -34,7 +34,7 @@ class CertificateFileWithPrivateKey(CertificateFile):
 class SDS:
     secret_name: str
 
-    def to_dict(self) -> Dict[str, Any]:  # type: ignore[misc]
+    def to_dict(self) -> dict[str, Any]:  # type: ignore[misc]
         return {"secretName": self.secret_name}
 
 
@@ -43,7 +43,7 @@ class Certificate:
     file: Optional[CertificateFileWithPrivateKey]
     sds: Optional[SDS]
 
-    def to_dict(self) -> Dict[str, Any]:  # type: ignore[misc]
+    def to_dict(self) -> dict[str, Any]:  # type: ignore[misc]
         return clean_dict(
             {
                 "file": (self.file or MissingField()).to_dict(),
@@ -56,7 +56,7 @@ class Certificate:
 class ListenerCertificateACM:
     certificate_arn: str
 
-    def to_dict(self) -> Dict[str, Any]:  # type: ignore[misc]
+    def to_dict(self) -> dict[str, Any]:  # type: ignore[misc]
         return {"certificateArn": self.certificate_arn}
 
 
@@ -64,7 +64,7 @@ class ListenerCertificateACM:
 class TLSListenerCertificate(Certificate):
     acm: Optional[ListenerCertificateACM]
 
-    def to_dict(self) -> Dict[str, Any]:  # type: ignore[misc]
+    def to_dict(self) -> dict[str, Any]:  # type: ignore[misc]
         return clean_dict(
             {
                 "acm": (self.acm or MissingField()).to_dict(),
@@ -76,7 +76,7 @@ class TLSListenerCertificate(Certificate):
 
 @dataclass
 class Match:
-    exact: List[str]
+    exact: list[str]
 
     to_dict = asdict
 
@@ -85,15 +85,15 @@ class Match:
 class SubjectAlternativeNames:
     match: Match
 
-    def to_dict(self) -> Dict[str, Any]:  # type: ignore[misc]
+    def to_dict(self) -> dict[str, Any]:  # type: ignore[misc]
         return {"match": self.match.to_dict()}
 
 
 @dataclass
 class ACM:
-    certificate_authority_arns: List[str]
+    certificate_authority_arns: list[str]
 
-    def to_dict(self) -> Dict[str, Any]:  # type: ignore[misc]
+    def to_dict(self) -> dict[str, Any]:  # type: ignore[misc]
         return {"certificateAuthorityArns": self.certificate_authority_arns}
 
 
@@ -102,7 +102,7 @@ class Trust:
     file: Optional[CertificateFile]
     sds: Optional[SDS]
 
-    def to_dict(self) -> Dict[str, Any]:  # type: ignore[misc]
+    def to_dict(self) -> dict[str, Any]:  # type: ignore[misc]
         return clean_dict(
             {
                 "file": (self.file or MissingField()).to_dict(),
@@ -115,7 +115,7 @@ class Trust:
 class BackendTrust(Trust):
     acm: Optional[ACM]
 
-    def to_dict(self) -> Dict[str, Any]:  # type: ignore[misc]
+    def to_dict(self) -> dict[str, Any]:  # type: ignore[misc]
         return clean_dict(
             {
                 "acm": (self.acm or MissingField()).to_dict(),
@@ -129,7 +129,7 @@ class BackendTrust(Trust):
 class Validation:
     subject_alternative_names: Optional[SubjectAlternativeNames]
 
-    def to_dict(self) -> Dict[str, Any]:  # type: ignore[misc]
+    def to_dict(self) -> dict[str, Any]:  # type: ignore[misc]
         return clean_dict(
             {
                 "subjectAlternativeNames": (
@@ -143,7 +143,7 @@ class Validation:
 class TLSBackendValidation(Validation):
     trust: BackendTrust
 
-    def to_dict(self) -> Dict[str, Any]:  # type: ignore[misc]
+    def to_dict(self) -> dict[str, Any]:  # type: ignore[misc]
         return clean_dict(
             {
                 "subjectAlternativeNames": (
@@ -158,7 +158,7 @@ class TLSBackendValidation(Validation):
 class TLSListenerValidation(Validation):
     trust: Trust
 
-    def to_dict(self) -> Dict[str, Any]:  # type: ignore[misc]
+    def to_dict(self) -> dict[str, Any]:  # type: ignore[misc]
         return clean_dict(
             {
                 "subjectAlternativeNames": (
@@ -173,10 +173,10 @@ class TLSListenerValidation(Validation):
 class TLSClientPolicy:
     certificate: Optional[Certificate]
     enforce: Optional[bool]
-    ports: Optional[List[int]]
+    ports: Optional[list[int]]
     validation: TLSBackendValidation
 
-    def to_dict(self) -> Dict[str, Any]:  # type: ignore[misc]
+    def to_dict(self) -> dict[str, Any]:  # type: ignore[misc]
         return clean_dict(
             {
                 "certificate": (self.certificate or MissingField()).to_dict(),
@@ -191,7 +191,7 @@ class TLSClientPolicy:
 class ClientPolicy:
     tls: Optional[TLSClientPolicy]
 
-    def to_dict(self) -> Dict[str, Any]:  # type: ignore[misc]
+    def to_dict(self) -> dict[str, Any]:  # type: ignore[misc]
         return clean_dict({"tls": (self.tls or MissingField()).to_dict()})
 
 
@@ -199,7 +199,7 @@ class ClientPolicy:
 class BackendDefaults:
     client_policy: Optional[ClientPolicy]
 
-    def to_dict(self) -> Dict[str, Any]:  # type: ignore[misc]
+    def to_dict(self) -> dict[str, Any]:  # type: ignore[misc]
         return clean_dict(
             {"clientPolicy": (self.client_policy or MissingField()).to_dict()}
         )
@@ -210,7 +210,7 @@ class VirtualService:
     client_policy: Optional[ClientPolicy]
     virtual_service_name: str
 
-    def to_dict(self) -> Dict[str, Any]:  # type: ignore[misc]
+    def to_dict(self) -> dict[str, Any]:  # type: ignore[misc]
         return clean_dict(
             {
                 "clientPolicy": (self.client_policy or MissingField()).to_dict(),
@@ -223,7 +223,7 @@ class VirtualService:
 class Backend:
     virtual_service: Optional[VirtualService]
 
-    def to_dict(self) -> Dict[str, Any]:  # type: ignore[misc]
+    def to_dict(self) -> dict[str, Any]:  # type: ignore[misc]
         return clean_dict(
             {"virtualService": (self.virtual_service or MissingField()).to_dict()}
         )
@@ -234,7 +234,7 @@ class HTTPConnection:
     max_connections: int
     max_pending_requests: Optional[int]
 
-    def to_dict(self) -> Dict[str, Any]:  # type: ignore[misc]
+    def to_dict(self) -> dict[str, Any]:  # type: ignore[misc]
         return clean_dict(
             {
                 "maxConnections": self.max_connections,
@@ -247,7 +247,7 @@ class HTTPConnection:
 class GRPCOrHTTP2Connection:
     max_requests: int
 
-    def to_dict(self) -> Dict[str, Any]:  # type: ignore[misc]
+    def to_dict(self) -> dict[str, Any]:  # type: ignore[misc]
         return {"maxRequests": self.max_requests}
 
 
@@ -255,7 +255,7 @@ class GRPCOrHTTP2Connection:
 class TCPConnection:
     max_connections: int
 
-    def to_dict(self) -> Dict[str, Any]:  # type: ignore[misc]
+    def to_dict(self) -> dict[str, Any]:  # type: ignore[misc]
         return {"maxConnections": self.max_connections}
 
 
@@ -266,7 +266,7 @@ class ConnectionPool:
     http2: Optional[GRPCOrHTTP2Connection]
     tcp: Optional[TCPConnection]
 
-    def to_dict(self) -> Dict[str, Any]:  # type: ignore[misc]
+    def to_dict(self) -> dict[str, Any]:  # type: ignore[misc]
         return clean_dict(
             {
                 "grpc": (self.grpc or MissingField()).to_dict(),
@@ -287,7 +287,7 @@ class HealthCheck:
     timeout_millis: int
     unhealthy_threshold: int
 
-    def to_dict(self) -> Dict[str, Any]:  # type: ignore[misc]
+    def to_dict(self) -> dict[str, Any]:  # type: ignore[misc]
         return clean_dict(
             {
                 "healthyThreshold": self.healthy_threshold,
@@ -308,7 +308,7 @@ class OutlierDetection:
     max_ejection_percent: int
     max_server_errors: int
 
-    def to_dict(self) -> Dict[str, Any]:  # type: ignore[misc]
+    def to_dict(self) -> dict[str, Any]:  # type: ignore[misc]
         return {
             "baseEjectionDuration": self.base_ejection_duration.to_dict(),
             "interval": self.interval.to_dict(),
@@ -328,7 +328,7 @@ class PortMapping:
 class TCPTimeout:
     idle: Duration
 
-    def to_dict(self) -> Dict[str, Any]:  # type: ignore[misc]
+    def to_dict(self) -> dict[str, Any]:  # type: ignore[misc]
         return {"idle": self.idle.to_dict()}
 
 
@@ -339,7 +339,7 @@ class ProtocolTimeouts:
     http2: Optional[Timeout]
     tcp: Optional[TCPTimeout]
 
-    def to_dict(self) -> Dict[str, Any]:  # type: ignore[misc]
+    def to_dict(self) -> dict[str, Any]:  # type: ignore[misc]
         return clean_dict(
             {
                 "grpc": (self.grpc or MissingField()).to_dict(),
@@ -356,7 +356,7 @@ class ListenerTLS:
     mode: str
     validation: Optional[TLSListenerValidation]
 
-    def to_dict(self) -> Dict[str, Any]:  # type: ignore[misc]
+    def to_dict(self) -> dict[str, Any]:  # type: ignore[misc]
         return clean_dict(
             {
                 "certificate": self.certificate.to_dict(),
@@ -375,7 +375,7 @@ class Listener:
     timeout: Optional[ProtocolTimeouts]
     tls: Optional[ListenerTLS]
 
-    def to_dict(self) -> Dict[str, Any]:  # type: ignore[misc]
+    def to_dict(self) -> dict[str, Any]:  # type: ignore[misc]
         return clean_dict(
             {
                 "connectionPool": (self.connection_pool or MissingField()).to_dict(),
@@ -399,10 +399,10 @@ class KeyValue:
 
 @dataclass
 class LoggingFormat:
-    json: Optional[List[KeyValue]]
+    json: Optional[list[KeyValue]]
     text: Optional[str]
 
-    def to_dict(self) -> Dict[str, Any]:  # type: ignore[misc]
+    def to_dict(self) -> dict[str, Any]:  # type: ignore[misc]
         return clean_dict(
             {"json": [pair.to_dict() for pair in self.json or []], "text": self.text}
         )
@@ -413,7 +413,7 @@ class AccessLogFile:
     format: Optional[LoggingFormat]
     path: str
 
-    def to_dict(self) -> Dict[str, Any]:  # type: ignore[misc]
+    def to_dict(self) -> dict[str, Any]:  # type: ignore[misc]
         return clean_dict(
             {"format": (self.format or MissingField()).to_dict(), "path": self.path}
         )
@@ -423,7 +423,7 @@ class AccessLogFile:
 class AccessLog:
     file: Optional[AccessLogFile]
 
-    def to_dict(self) -> Dict[str, Any]:  # type: ignore[misc]
+    def to_dict(self) -> dict[str, Any]:  # type: ignore[misc]
         return clean_dict({"file": (self.file or MissingField()).to_dict()})
 
 
@@ -431,18 +431,18 @@ class AccessLog:
 class Logging:
     access_log: Optional[AccessLog]
 
-    def to_dict(self) -> Dict[str, Any]:  # type: ignore[misc]
+    def to_dict(self) -> dict[str, Any]:  # type: ignore[misc]
         return clean_dict({"accessLog": (self.access_log or MissingField()).to_dict()})
 
 
 @dataclass
 class AWSCloudMap:
-    attributes: Optional[List[KeyValue]]
+    attributes: Optional[list[KeyValue]]
     ip_preference: Optional[str]
     namespace_name: str
     service_name: str
 
-    def to_dict(self) -> Dict[str, Any]:  # type: ignore[misc]
+    def to_dict(self) -> dict[str, Any]:  # type: ignore[misc]
         return clean_dict(
             {
                 "attributes": [
@@ -461,7 +461,7 @@ class DNS:
     ip_preference: Optional[str]
     response_type: Optional[str]
 
-    def to_dict(self) -> Dict[str, Any]:  # type: ignore[misc]
+    def to_dict(self) -> dict[str, Any]:  # type: ignore[misc]
         return clean_dict(
             {
                 "hostname": self.hostname,
@@ -476,7 +476,7 @@ class ServiceDiscovery:
     aws_cloud_map: Optional[AWSCloudMap]
     dns: Optional[DNS]
 
-    def to_dict(self) -> Dict[str, Any]:  # type: ignore[misc]
+    def to_dict(self) -> dict[str, Any]:  # type: ignore[misc]
         return clean_dict(
             {
                 "awsCloudMap": (self.aws_cloud_map or MissingField()).to_dict(),
@@ -488,12 +488,12 @@ class ServiceDiscovery:
 @dataclass
 class VirtualNodeSpec:
     backend_defaults: Optional[BackendDefaults]
-    backends: Optional[List[Backend]]
-    listeners: Optional[List[Listener]]
+    backends: Optional[list[Backend]]
+    listeners: Optional[list[Listener]]
     logging: Optional[Logging]
     service_discovery: Optional[ServiceDiscovery]
 
-    def to_dict(self) -> Dict[str, Any]:  # type: ignore[misc]
+    def to_dict(self) -> dict[str, Any]:  # type: ignore[misc]
         return clean_dict(
             {
                 "backendDefaults": (self.backend_defaults or MissingField()).to_dict(),
@@ -520,7 +520,7 @@ class VirtualNodeMetadata(Metadata):
         if self.virtual_node_name == "":
             raise TypeError("__init__ missing 1 required argument: 'virtual_node_name'")
 
-    def formatted_for_list_api(self) -> Dict[str, Any]:  # type: ignore
+    def formatted_for_list_api(self) -> dict[str, Any]:  # type: ignore
         return {
             "arn": self.arn,
             "createdAt": self.created_at.strftime("%d/%m/%Y, %H:%M:%S"),
@@ -532,7 +532,7 @@ class VirtualNodeMetadata(Metadata):
             "virtualNodeName": self.virtual_node_name,
         }
 
-    def formatted_for_crud_apis(self) -> Dict[str, Any]:  # type: ignore
+    def formatted_for_crud_apis(self) -> dict[str, Any]:  # type: ignore
         return {
             "arn": self.arn,
             "createdAt": self.created_at.strftime("%d/%m/%Y, %H:%M:%S"),
@@ -552,9 +552,9 @@ class VirtualNode:
     spec: VirtualNodeSpec
     virtual_node_name: str
     status: Status = field(default_factory=lambda: {"status": "ACTIVE"})
-    tags: List[Dict[str, str]] = field(default_factory=list)
+    tags: list[dict[str, str]] = field(default_factory=list)
 
-    def to_dict(self) -> Dict[str, Any]:  # type: ignore[misc]
+    def to_dict(self) -> dict[str, Any]:  # type: ignore[misc]
         return clean_dict(
             {
                 "meshName": self.mesh_name,

--- a/moto/appmesh/dataclasses/virtual_router.py
+++ b/moto/appmesh/dataclasses/virtual_router.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, field
-from typing import Any, Dict, List, Literal, Optional
+from typing import Any, Literal, Optional
 
 from moto.appmesh.dataclasses.route import Route
 from moto.appmesh.dataclasses.shared import Metadata, Status
@@ -13,7 +13,7 @@ class PortMapping:
 
 @dataclass
 class VirtualRouterSpec:
-    listeners: List[Dict[Literal["port_mapping"], PortMapping]]
+    listeners: list[dict[Literal["port_mapping"], PortMapping]]
 
 
 @dataclass
@@ -23,10 +23,10 @@ class VirtualRouter:
     spec: VirtualRouterSpec
     status: Status
     virtual_router_name: str
-    routes: Dict[str, Route] = field(default_factory=dict)
-    tags: List[Dict[str, str]] = field(default_factory=list)
+    routes: dict[str, Route] = field(default_factory=dict)
+    tags: list[dict[str, str]] = field(default_factory=list)
 
-    def to_dict(self) -> Dict[str, Any]:  # type ignore[misc]
+    def to_dict(self) -> dict[str, Any]:  # type ignore[misc]
         return {
             "meshName": self.mesh_name,
             "metadata": {

--- a/moto/appmesh/models.py
+++ b/moto/appmesh/models.py
@@ -1,6 +1,6 @@
 """AppMeshBackend class with methods for supported APIs."""
 
-from typing import Dict, List, Literal, Optional, Union
+from typing import Literal, Optional, Union
 
 from moto.appmesh.dataclasses.mesh import (
     Mesh,
@@ -71,7 +71,7 @@ class AppMeshBackend(BaseBackend):
 
     def __init__(self, region_name: str, account_id: str) -> None:
         super().__init__(region_name, account_id)
-        self.meshes: Dict[str, Mesh] = dict()
+        self.meshes: dict[str, Mesh] = dict()
 
     def _validate_mesh(self, mesh_name: str, mesh_owner: Optional[str]) -> None:
         if mesh_name not in self.meshes:
@@ -184,7 +184,7 @@ class AppMeshBackend(BaseBackend):
         mesh_name: str,
         egress_filter_type: Optional[str],
         ip_preference: Optional[str],
-        tags: Optional[List[Dict[str, str]]],
+        tags: Optional[list[dict[str, str]]],
     ) -> Mesh:
         from moto.sts import sts_backends
 
@@ -250,7 +250,7 @@ class AppMeshBackend(BaseBackend):
         return mesh
 
     @paginate(pagination_model=PAGINATION_MODEL)
-    def list_meshes(self) -> List[Dict[str, Union[str, int]]]:
+    def list_meshes(self) -> list[dict[str, Union[str, int]]]:
         return [
             {
                 "arn": mesh.metadata.arn,
@@ -284,10 +284,10 @@ class AppMeshBackend(BaseBackend):
         raise ResourceNotFoundError(resource_arn)
 
     @paginate(pagination_model=PAGINATION_MODEL)  # type: ignore
-    def list_tags_for_resource(self, resource_arn: str) -> List[Dict[str, str]]:
+    def list_tags_for_resource(self, resource_arn: str) -> list[dict[str, str]]:
         return self._get_resource_with_arn(resource_arn=resource_arn).tags
 
-    def tag_resource(self, resource_arn: str, tags: List[Dict[str, str]]) -> None:
+    def tag_resource(self, resource_arn: str, tags: list[dict[str, str]]) -> None:
         if len(tags) > 0:
             resource = self._get_resource_with_arn(resource_arn=resource_arn)
             resource.tags.extend(tags)
@@ -308,8 +308,8 @@ class AppMeshBackend(BaseBackend):
         client_token: str,
         mesh_name: str,
         mesh_owner: Optional[str],
-        port_mappings: List[PortMapping],
-        tags: Optional[List[Dict[str, str]]],
+        port_mappings: list[PortMapping],
+        tags: Optional[list[dict[str, str]]],
         virtual_router_name: str,
     ) -> VirtualRouter:
         self._check_router_availability(
@@ -323,7 +323,7 @@ class AppMeshBackend(BaseBackend):
             resource_owner=owner,
             arn=f"arn:aws:appmesh:{self.region_name}:{self.account_id}:mesh/{mesh_name}/virtualRouter/{virtual_router_name}",
         )
-        listeners: List[Dict[Literal["port_mapping"], PortMapping]] = [
+        listeners: list[dict[Literal["port_mapping"], PortMapping]] = [
             {"port_mapping": port_mapping} for port_mapping in port_mappings
         ]
         spec = VirtualRouterSpec(listeners=listeners)
@@ -343,7 +343,7 @@ class AppMeshBackend(BaseBackend):
         client_token: str,
         mesh_name: str,
         mesh_owner: Optional[str],
-        port_mappings: List[PortMapping],
+        port_mappings: list[PortMapping],
         virtual_router_name: str,
     ) -> VirtualRouter:
         self._check_router_validity(
@@ -351,7 +351,7 @@ class AppMeshBackend(BaseBackend):
             mesh_owner=mesh_owner,
             virtual_router_name=virtual_router_name,
         )
-        listeners: List[Dict[Literal["port_mapping"], PortMapping]] = [
+        listeners: list[dict[Literal["port_mapping"], PortMapping]] = [
             {"port_mapping": port_mapping} for port_mapping in port_mappings
         ]
         spec = VirtualRouterSpec(listeners=listeners)
@@ -378,7 +378,7 @@ class AppMeshBackend(BaseBackend):
     @paginate(pagination_model=PAGINATION_MODEL)
     def list_virtual_routers(
         self, mesh_name: str, mesh_owner: Optional[str]
-    ) -> List[Dict[str, Union[str, int]]]:
+    ) -> list[dict[str, Union[str, int]]]:
         self._validate_mesh(mesh_name=mesh_name, mesh_owner=mesh_owner)
         return [
             {
@@ -405,7 +405,7 @@ class AppMeshBackend(BaseBackend):
         mesh_owner: Optional[str],
         route_name: str,
         spec: RouteSpec,
-        tags: Optional[List[Dict[str, str]]],
+        tags: Optional[list[dict[str, str]]],
         virtual_router_name: str,
     ) -> Route:
         self._check_route_availability(
@@ -513,7 +513,7 @@ class AppMeshBackend(BaseBackend):
         mesh_name: str,
         mesh_owner: Optional[str],
         virtual_router_name: str,
-    ) -> List[RouteMetadata]:
+    ) -> list[RouteMetadata]:
         self._check_router_validity(
             mesh_name=mesh_name,
             mesh_owner=mesh_owner,
@@ -538,7 +538,7 @@ class AppMeshBackend(BaseBackend):
         mesh_name: str,
         mesh_owner: Optional[str],
         spec: VirtualNodeSpec,
-        tags: Optional[List[Dict[str, str]]],
+        tags: Optional[list[dict[str, str]]],
         virtual_node_name: str,
     ) -> VirtualNode:
         self._check_virtual_node_availability(
@@ -602,7 +602,7 @@ class AppMeshBackend(BaseBackend):
         self,
         mesh_name: str,
         mesh_owner: Optional[str],
-    ) -> List[VirtualNodeMetadata]:
+    ) -> list[VirtualNodeMetadata]:
         self._validate_mesh(mesh_name=mesh_name, mesh_owner=mesh_owner)
         virtual_nodes = self.meshes[mesh_name].virtual_nodes
         return [virtual_node.metadata for virtual_node in virtual_nodes.values()]

--- a/moto/appmesh/utils/common.py
+++ b/moto/appmesh/utils/common.py
@@ -1,7 +1,7 @@
-from typing import Any, Dict
+from typing import Any
 
 
-def clean_dict(obj: Dict[str, Any]) -> Dict[str, Any]:  # type: ignore[misc]
+def clean_dict(obj: dict[str, Any]) -> dict[str, Any]:  # type: ignore[misc]
     return {
         key: value for key, value in obj.items() if value is not None and value != []
     }

--- a/moto/appmesh/utils/spec_parsing.py
+++ b/moto/appmesh/utils/spec_parsing.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional
+from typing import Any, Optional
 
 from moto.appmesh.dataclasses.route import (
     GrcpRouteRetryPolicy,
@@ -68,7 +68,7 @@ from moto.appmesh.exceptions import (
 )
 
 
-def port_mappings_from_router_spec(spec: Any) -> List[RouterPortMapping]:  # type: ignore[misc]
+def port_mappings_from_router_spec(spec: Any) -> list[RouterPortMapping]:  # type: ignore[misc]
     return [
         RouterPortMapping(
             port=(listener.get("portMapping") or {}).get("port"),
@@ -90,7 +90,7 @@ def get_action_from_route(route: Any) -> RouteAction:  # type: ignore[misc]
     return RouteAction(weighted_targets=weighted_targets)
 
 
-def get_route_match_metadata(metadata: List[Any]) -> List[GrpcMetadatum]:  # type: ignore[misc]
+def get_route_match_metadata(metadata: list[Any]) -> list[GrpcMetadatum]:  # type: ignore[misc]
     output = []
     for _metadatum in metadata:
         _match = _metadatum.get("match")
@@ -251,7 +251,7 @@ def get_tls_for_client_policy(tls: Any) -> TLSClientPolicy:  # type: ignore[misc
     )
 
 
-def build_route_spec(spec: Dict[str, Any]) -> RouteSpec:  # type: ignore[misc]
+def build_route_spec(spec: dict[str, Any]) -> RouteSpec:  # type: ignore[misc]
     _grpc_route = spec.get("grpcRoute")
     _http_route = spec.get("httpRoute")
     _http2_route = spec.get("http2Route")
@@ -332,7 +332,7 @@ def build_route_spec(spec: Dict[str, Any]) -> RouteSpec:  # type: ignore[misc]
     )
 
 
-def build_virtual_node_spec(spec: Dict[str, Any]) -> VirtualNodeSpec:  # type: ignore[misc]
+def build_virtual_node_spec(spec: dict[str, Any]) -> VirtualNodeSpec:  # type: ignore[misc]
     _backend_defaults = spec.get("backendDefaults")
     _backends = spec.get("backends")
     _listeners = spec.get("listeners")

--- a/moto/appsync/models.py
+++ b/moto/appsync/models.py
@@ -1,7 +1,8 @@
 import base64
 import json
+from collections.abc import Iterable
 from datetime import datetime, timedelta, timezone
-from typing import Any, Dict, Iterable, List, Optional, Tuple, Union
+from typing import Any, Optional, Union
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
@@ -78,7 +79,7 @@ class APICache(BaseModel):
         if health_metrics_config is not None:
             self.health_metrics_config = health_metrics_config
 
-    def to_json(self) -> Dict[str, Any]:
+    def to_json(self) -> dict[str, Any]:
         return {
             "ttl": self.ttl,
             "transitEncryptionEnabled": self.transit_encryption_enabled,
@@ -99,13 +100,13 @@ class GraphqlSchema(BaseModel):
         self.definition = definition
         self.region_name = region_name
         # [graphql.language.ast.ObjectTypeDefinitionNode, ..]
-        self.types: List[Any] = []
+        self.types: list[Any] = []
 
         self.status = "PROCESSING"
         self.parse_error: Optional[str] = None
         self._parse_graphql_definition()
 
-    def get_type(self, name: str) -> Optional[Dict[str, Any]]:  # type: ignore[return]
+    def get_type(self, name: str) -> Optional[dict[str, Any]]:  # type: ignore[return]
         for graphql_type in self.types:
             if graphql_type.name.value == name:
                 return {
@@ -117,7 +118,7 @@ class GraphqlSchema(BaseModel):
                     "definition": "NotYetImplemented",
                 }
 
-    def get_status(self) -> Tuple[str, Optional[str]]:
+    def get_status(self) -> tuple[str, Optional[str]]:
         return self.status, self.parse_error
 
     def _parse_graphql_definition(self) -> None:
@@ -177,7 +178,7 @@ class GraphqlAPIKey(BaseModel):
         if expires:
             self.expires = expires
 
-    def to_json(self) -> Dict[str, Any]:
+    def to_json(self) -> dict[str, Any]:
         return {
             "id": self.key_id,
             "description": self.description,
@@ -193,7 +194,7 @@ class GraphqlAPI(BaseModel):
         region: str,
         name: str,
         authentication_type: str,
-        additional_authentication_providers: Optional[List[str]],
+        additional_authentication_providers: Optional[list[str]],
         log_config: str,
         xray_enabled: str,
         user_pool_config: str,
@@ -217,7 +218,7 @@ class GraphqlAPI(BaseModel):
         self.arn = f"arn:{get_partition(self.region)}:appsync:{self.region}:{account_id}:apis/{self.api_id}"
         self.graphql_schema: Optional[GraphqlSchema] = None
 
-        self.api_keys: Dict[str, GraphqlAPIKey] = dict()
+        self.api_keys: dict[str, GraphqlAPIKey] = dict()
 
         self.api_cache: Optional[APICache] = None
         self.backend = backend
@@ -225,7 +226,7 @@ class GraphqlAPI(BaseModel):
     def update(
         self,
         name: str,
-        additional_authentication_providers: Optional[List[str]],
+        additional_authentication_providers: Optional[list[str]],
         authentication_type: str,
         lambda_authorizer_config: str,
         log_config: str,
@@ -315,7 +316,7 @@ class GraphqlAPI(BaseModel):
     def delete_api_cache(self) -> None:
         self.api_cache = None
 
-    def to_json(self) -> Dict[str, Any]:
+    def to_json(self) -> dict[str, Any]:
         return {
             "name": self.name,
             "apiId": self.api_id,
@@ -357,7 +358,7 @@ class EventsAPIKey(BaseModel):
         if expires:
             self.expires = expires
 
-    def to_json(self) -> Dict[str, Any]:
+    def to_json(self) -> dict[str, Any]:
         return {
             "id": self.key_id,
             "description": self.description,
@@ -371,10 +372,10 @@ class ChannelNamespace(BaseModel):
         self,
         api_id: str,
         name: str,
-        subscribe_auth_modes: List[Dict[str, str]],
-        publish_auth_modes: List[Dict[str, str]],
-        code_handlers: Optional[List[Dict[str, Any]]] = None,
-        handler_configs: Optional[Dict[str, Any]] = None,
+        subscribe_auth_modes: list[dict[str, str]],
+        publish_auth_modes: list[dict[str, str]],
+        code_handlers: Optional[list[dict[str, Any]]] = None,
+        handler_configs: Optional[dict[str, Any]] = None,
         account_id: str = "",
         region: str = "",
         backend: Optional["AppSyncBackend"] = None,
@@ -394,7 +395,7 @@ class ChannelNamespace(BaseModel):
 
         self.backend = backend
 
-    def to_json(self) -> Dict[str, Any]:
+    def to_json(self) -> dict[str, Any]:
         response = {
             "apiId": self.api_id,
             "name": self.name,
@@ -424,7 +425,7 @@ class EventsAPI(BaseModel):
         region: str,
         name: str,
         owner_contact: Optional[str],
-        event_config: Optional[Dict[str, Any]],
+        event_config: Optional[dict[str, Any]],
         backend: "AppSyncBackend",
     ) -> None:
         self.region = region
@@ -435,8 +436,8 @@ class EventsAPI(BaseModel):
 
         self.api_arn = f"arn:{get_partition(self.region)}:appsync:{self.region}:{account_id}:apis/{self.api_id}"
 
-        self.api_keys: Dict[str, EventsAPIKey] = dict()
-        self.channel_namespaces: List[ChannelNamespace] = list()
+        self.api_keys: dict[str, EventsAPIKey] = dict()
+        self.channel_namespaces: list[ChannelNamespace] = list()
 
         dns_prefix = str(mock_random.get_random_string(length=26))
         self.dns = {
@@ -448,7 +449,7 @@ class EventsAPI(BaseModel):
 
         self.backend = backend
 
-    def to_json(self) -> Dict[str, Any]:
+    def to_json(self) -> dict[str, Any]:
         response = {
             "apiId": self.api_id,
             "name": self.name,
@@ -492,8 +493,8 @@ class AppSyncBackend(BaseBackend):
 
     def __init__(self, region_name: str, account_id: str) -> None:
         super().__init__(region_name, account_id)
-        self.graphql_apis: Dict[str, GraphqlAPI] = dict()
-        self.events_apis: Dict[str, EventsAPI] = dict()
+        self.graphql_apis: dict[str, GraphqlAPI] = dict()
+        self.events_apis: dict[str, EventsAPI] = dict()
         self.tagger = TaggingService()
 
     def create_graphql_api(
@@ -503,10 +504,10 @@ class AppSyncBackend(BaseBackend):
         authentication_type: str,
         user_pool_config: str,
         open_id_connect_config: str,
-        additional_authentication_providers: Optional[List[str]],
+        additional_authentication_providers: Optional[list[str]],
         xray_enabled: str,
         lambda_authorizer_config: str,
-        tags: Dict[str, str],
+        tags: dict[str, str],
         visibility: str,
     ) -> GraphqlAPI:
         graphql_api = GraphqlAPI(
@@ -537,7 +538,7 @@ class AppSyncBackend(BaseBackend):
         authentication_type: str,
         user_pool_config: str,
         open_id_connect_config: str,
-        additional_authentication_providers: Optional[List[str]],
+        additional_authentication_providers: Optional[list[str]],
         xray_enabled: str,
         lambda_authorizer_config: str,
     ) -> GraphqlAPI:
@@ -627,15 +628,15 @@ class AppSyncBackend(BaseBackend):
     def get_schema_creation_status(self, api_id: str) -> Any:
         return self.graphql_apis[api_id].get_schema_status()
 
-    def tag_resource(self, resource_arn: str, tags: Dict[str, str]) -> None:
+    def tag_resource(self, resource_arn: str, tags: dict[str, str]) -> None:
         self.tagger.tag_resource(
             resource_arn, TaggingService.convert_dict_to_tags_input(tags)
         )
 
-    def untag_resource(self, resource_arn: str, tag_keys: List[str]) -> None:
+    def untag_resource(self, resource_arn: str, tag_keys: list[str]) -> None:
         self.tagger.untag_resource_using_names(resource_arn, tag_keys)
 
-    def list_tags_for_resource(self, resource_arn: str) -> Dict[str, str]:
+    def list_tags_for_resource(self, resource_arn: str) -> dict[str, str]:
         return self.tagger.get_tag_dict_for_resource(resource_arn)
 
     def get_type(self, api_id: str, type_name: str, type_format: str) -> Any:
@@ -711,8 +712,8 @@ class AppSyncBackend(BaseBackend):
         self,
         name: str,
         owner_contact: Optional[str],
-        tags: Optional[Dict[str, str]],
-        event_config: Optional[Dict[str, Any]],
+        tags: Optional[dict[str, str]],
+        event_config: Optional[dict[str, Any]],
     ) -> EventsAPI:
         events_api = EventsAPI(
             account_id=self.account_id,
@@ -744,11 +745,11 @@ class AppSyncBackend(BaseBackend):
         self,
         api_id: str,
         name: str,
-        subscribe_auth_modes: List[Dict[str, str]],
-        publish_auth_modes: List[Dict[str, str]],
-        code_handlers: Optional[List[Dict[str, Any]]] = None,
-        tags: Optional[Dict[str, str]] = None,
-        handler_configs: Optional[Dict[str, Any]] = None,
+        subscribe_auth_modes: list[dict[str, str]],
+        publish_auth_modes: list[dict[str, str]],
+        code_handlers: Optional[list[dict[str, Any]]] = None,
+        tags: Optional[dict[str, str]] = None,
+        handler_configs: Optional[dict[str, Any]] = None,
     ) -> ChannelNamespace:
         # Check if API exists
         if api_id not in self.events_apis:

--- a/moto/athena/responses.py
+++ b/moto/athena/responses.py
@@ -1,5 +1,5 @@
 import json
-from typing import Dict, Tuple, Union
+from typing import Union
 
 from moto.core.responses import BaseResponse
 
@@ -14,7 +14,7 @@ class AthenaResponse(BaseResponse):
     def athena_backend(self) -> AthenaBackend:
         return athena_backends[self.current_account][self.region]
 
-    def create_work_group(self) -> Union[Tuple[str, Dict[str, int]], str]:
+    def create_work_group(self) -> Union[tuple[str, dict[str, int]], str]:
         name = self._get_param("Name")
         description = self._get_param("Description")
         configuration = self._get_param("Configuration")
@@ -46,7 +46,7 @@ class AthenaResponse(BaseResponse):
         self.athena_backend.delete_work_group(name)
         return "{}"
 
-    def start_query_execution(self) -> Union[Tuple[str, Dict[str, int]], str]:
+    def start_query_execution(self) -> Union[tuple[str, dict[str, int]], str]:
         query = self._get_param("QueryString")
         context = self._get_param("QueryExecutionContext")
         config = self._get_param("ResultConfiguration")
@@ -104,14 +104,14 @@ class AthenaResponse(BaseResponse):
             )
         return json.dumps(result)
 
-    def create_capacity_reservation(self) -> Union[Tuple[str, Dict[str, int]], str]:
+    def create_capacity_reservation(self) -> Union[tuple[str, dict[str, int]], str]:
         name = self._get_param("Name")
         target_dpus = self._get_param("TargetDpus")
         tags = self._get_param("Tags")
         self.athena_backend.create_capacity_reservation(name, target_dpus, tags)
         return json.dumps(dict())
 
-    def get_capacity_reservation(self) -> Union[str, Tuple[str, Dict[str, int]]]:
+    def get_capacity_reservation(self) -> Union[str, tuple[str, dict[str, int]]]:
         name = self._get_param("Name")
         capacity_reservation = self.athena_backend.get_capacity_reservation(name)
         if not capacity_reservation:
@@ -151,13 +151,13 @@ class AthenaResponse(BaseResponse):
         self.athena_backend.stop_query_execution(exec_id)
         return json.dumps({})
 
-    def error(self, msg: str, status: int) -> Tuple[str, Dict[str, int]]:
+    def error(self, msg: str, status: int) -> tuple[str, dict[str, int]]:
         return (
             json.dumps({"__type": "InvalidRequestException", "Message": msg}),
             dict(status=status),
         )
 
-    def create_named_query(self) -> Union[Tuple[str, Dict[str, int]], str]:
+    def create_named_query(self) -> Union[tuple[str, dict[str, int]], str]:
         name = self._get_param("Name")
         description = self._get_param("Description")
         database = self._get_param("Database")
@@ -191,7 +191,7 @@ class AthenaResponse(BaseResponse):
             {"DataCatalogsSummary": self.athena_backend.list_data_catalogs()}
         )
 
-    def list_tags_for_resource(self) -> Union[Tuple[str, Dict[str, int]], str]:
+    def list_tags_for_resource(self) -> Union[tuple[str, dict[str, int]], str]:
         resource_arn = self._get_param("ResourceARN")
         tags = self.athena_backend.list_tags_for_resource(resource_arn)
         if not tags:
@@ -202,7 +202,7 @@ class AthenaResponse(BaseResponse):
         name = self._get_param("Name")
         return json.dumps({"DataCatalog": self.athena_backend.get_data_catalog(name)})
 
-    def create_data_catalog(self) -> Union[Tuple[str, Dict[str, int]], str]:
+    def create_data_catalog(self) -> Union[tuple[str, dict[str, int]], str]:
         name = self._get_param("Name")
         catalog_type = self._get_param("Type")
         description = self._get_param("Description")
@@ -232,7 +232,7 @@ class AthenaResponse(BaseResponse):
         )
         return json.dumps({"NamedQueryIds": named_query_ids, "NextToken": next_token})
 
-    def create_prepared_statement(self) -> Union[str, Tuple[str, Dict[str, int]]]:
+    def create_prepared_statement(self) -> Union[str, tuple[str, dict[str, int]]]:
         statement_name = self._get_param("StatementName")
         work_group = self._get_param("WorkGroup")
         query_statement = self._get_param("QueryStatement")
@@ -266,7 +266,7 @@ class AthenaResponse(BaseResponse):
             }
         )
 
-    def get_query_runtime_statistics(self) -> Union[str, Tuple[str, Dict[str, int]]]:
+    def get_query_runtime_statistics(self) -> Union[str, tuple[str, dict[str, int]]]:
         query_execution_id = self._get_param("QueryExecutionId")
 
         ps = self.athena_backend.get_query_runtime_statistics(

--- a/moto/autoscaling/models.py
+++ b/moto/autoscaling/models.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import itertools
 from collections import OrderedDict
 from datetime import datetime
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Optional, Union
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel, CloudFormationModel
@@ -121,11 +121,11 @@ class DetachInstanceActivity(Activity):
 class InstanceState:
     def __init__(
         self,
-        instance: "Instance",
+        instance: Instance,
         lifecycle_state: str = "InService",
         health_status: str = "Healthy",
         protected_from_scale_in: Optional[bool] = False,
-        autoscaling_group: Optional["FakeAutoScalingGroup"] = None,
+        autoscaling_group: Optional[FakeAutoScalingGroup] = None,
     ):
         self.instance = instance
         self.lifecycle_state = lifecycle_state
@@ -210,7 +210,7 @@ class FakeScalingPolicy(BaseModel):
         step_adjustments: str,
         estimated_instance_warmup: str,
         predictive_scaling_configuration: str,
-        autoscaling_backend: "AutoScalingBackend",
+        autoscaling_backend: AutoScalingBackend,
     ):
         self.name = name
         self.policy_name = name  # property alias
@@ -262,7 +262,7 @@ class FakeLaunchConfiguration(CloudFormationModel):
         key_name: Optional[str],
         ramdisk_id: str,
         kernel_id: str,
-        security_groups: List[str],
+        security_groups: list[str],
         user_data: str,
         instance_type: str,
         instance_monitoring: bool,
@@ -270,7 +270,7 @@ class FakeLaunchConfiguration(CloudFormationModel):
         spot_price: Optional[str],
         ebs_optimized: bool,
         associate_public_ip_address: bool,
-        block_device_mapping_dict: List[Dict[str, Any]],
+        block_device_mapping_dict: list[dict[str, Any]],
         account_id: str,
         region_name: str,
         metadata_options: Optional[str],
@@ -299,8 +299,8 @@ class FakeLaunchConfiguration(CloudFormationModel):
 
     @classmethod
     def create_from_instance(
-        cls, name: str, instance: Instance, backend: "AutoScalingBackend"
-    ) -> "FakeLaunchConfiguration":
+        cls, name: str, instance: Instance, backend: AutoScalingBackend
+    ) -> FakeLaunchConfiguration:
         security_group_names = [sg.name for sg in instance.security_groups]
         config = backend.create_launch_configuration(
             name=name,
@@ -338,7 +338,7 @@ class FakeLaunchConfiguration(CloudFormationModel):
         account_id: str,
         region_name: str,
         **kwargs: Any,
-    ) -> "FakeLaunchConfiguration":
+    ) -> FakeLaunchConfiguration:
         properties = cloudformation_json["Properties"]
 
         instance_profile_name = properties.get("IamInstanceProfile")
@@ -370,7 +370,7 @@ class FakeLaunchConfiguration(CloudFormationModel):
         cloudformation_json: Any,
         account_id: str,
         region_name: str,
-    ) -> "FakeLaunchConfiguration":
+    ) -> FakeLaunchConfiguration:
         cls.delete_from_cloudformation_json(
             original_resource.name, cloudformation_json, account_id, region_name
         )
@@ -401,7 +401,7 @@ class FakeLaunchConfiguration(CloudFormationModel):
         return self.name
 
     @property
-    def block_device_mappings(self) -> List[dict[str, Any]]:
+    def block_device_mappings(self) -> list[dict[str, Any]]:
         if not self.block_device_mapping_dict:
             return []
         parsed = self._parse_block_device_mappings()
@@ -486,11 +486,11 @@ class FakeScheduledAction(CloudFormationModel):
     def create_from_cloudformation_json(  # type: ignore[misc]
         cls,
         resource_name: str,
-        cloudformation_json: Dict[str, Any],
+        cloudformation_json: dict[str, Any],
         account_id: str,
         region_name: str,
         **kwargs: Any,
-    ) -> "FakeScheduledAction":
+    ) -> FakeScheduledAction:
         properties = cloudformation_json["Properties"]
 
         backend = autoscaling_backends[account_id][region_name]
@@ -534,7 +534,7 @@ class FakeWarmPool(CloudFormationModel):
         max_group_prepared_capacity: Optional[int],
         min_size: Optional[int],
         pool_state: Optional[str],
-        instance_reuse_policy: Optional[Dict[str, bool]],
+        instance_reuse_policy: Optional[dict[str, bool]],
     ):
         self.max_group_prepared_capacity = max_group_prepared_capacity
         self.min_size = min_size or 0
@@ -546,24 +546,24 @@ class FakeAutoScalingGroup(CloudFormationModel):
     def __init__(
         self,
         name: str,
-        availability_zones: List[str],
+        availability_zones: list[str],
         desired_capacity: Optional[int],
         max_size: Optional[int],
         min_size: Optional[int],
         launch_config_name: str,
-        launch_template: Dict[str, Any],
+        launch_template: dict[str, Any],
         vpc_zone_identifier: Optional[str],
         default_cooldown: Optional[int],
         health_check_period: Optional[int],
         health_check_type: Optional[str],
-        load_balancers: List[str],
-        target_group_arns: List[str],
+        load_balancers: list[str],
+        target_group_arns: list[str],
         placement_group: Optional[str],
-        termination_policies: List[str],
-        autoscaling_backend: "AutoScalingBackend",
+        termination_policies: list[str],
+        autoscaling_backend: AutoScalingBackend,
         ec2_backend: EC2Backend,
-        tags: List[Dict[str, str]],
-        mixed_instances_policy: Optional[Dict[str, Any]],
+        tags: list[dict[str, str]],
+        mixed_instances_policy: Optional[dict[str, Any]],
         capacity_rebalance: bool,
         new_instances_protected_from_scale_in: bool = False,
     ):
@@ -606,11 +606,11 @@ class FakeAutoScalingGroup(CloudFormationModel):
         )
 
         self.suspended_processes = []
-        self.instance_states: List[InstanceState] = []
-        self.tags: List[Dict[str, str]] = tags or []
+        self.instance_states: list[InstanceState] = []
+        self.tags: list[dict[str, str]] = tags or []
         self.set_desired_capacity(desired_capacity)
 
-        self.metrics: List[str] = []
+        self.metrics: list[str] = []
         self.warm_pool: Optional[FakeWarmPool] = None
         self.created_time = datetime.now().isoformat()
 
@@ -626,26 +626,26 @@ class FakeAutoScalingGroup(CloudFormationModel):
         return lt
 
     @property
-    def enabled_metrics(self) -> List[dict[str, str]]:
+    def enabled_metrics(self) -> list[dict[str, str]]:
         return [{"Metric": metric, "Granularity": "1Minute"} for metric in self.metrics]
 
     @property
-    def suspended_processes(self) -> List[dict[str, str]]:
+    def suspended_processes(self) -> list[dict[str, str]]:
         return [
             {"ProcessName": process, "SuspensionReason": ""}
             for process in self._suspended_processes
         ]
 
     @suspended_processes.setter
-    def suspended_processes(self, processes: List[str]) -> None:
+    def suspended_processes(self, processes: list[str]) -> None:
         self._suspended_processes = processes
 
     @property
-    def tags(self) -> List[Dict[str, str]]:
+    def tags(self) -> list[dict[str, str]]:
         return self._tags
 
     @tags.setter
-    def tags(self, tags: List[Dict[str, Any]]) -> None:
+    def tags(self, tags: list[dict[str, Any]]) -> None:
         for tag in tags:
             if "ResourceId" not in tag or not tag["ResourceId"]:
                 tag["ResourceId"] = self.name
@@ -659,12 +659,12 @@ class FakeAutoScalingGroup(CloudFormationModel):
     def arn(self) -> str:
         return f"arn:{get_partition(self.region)}:autoscaling:{self.region}:{self.account_id}:autoScalingGroup:{self._id}:autoScalingGroupName/{self.name}"
 
-    def active_instances(self) -> List[InstanceState]:
+    def active_instances(self) -> list[InstanceState]:
         return [x for x in self.instance_states if x.lifecycle_state == "InService"]
 
     def _set_azs_and_vpcs(
         self,
-        availability_zones: List[str],
+        availability_zones: list[str],
         vpc_zone_identifier: Optional[str],
         update: bool = False,
     ) -> None:
@@ -701,8 +701,8 @@ class FakeAutoScalingGroup(CloudFormationModel):
     def _set_launch_configuration(
         self,
         launch_config_name: str,
-        launch_template: Dict[str, Any],
-        mixed_instances_policy: Optional[Dict[str, Any]],
+        launch_template: dict[str, Any],
+        mixed_instances_policy: Optional[dict[str, Any]],
     ) -> None:
         if launch_config_name:
             self.launch_config = self.autoscaling_backend.launch_configurations[
@@ -774,11 +774,11 @@ class FakeAutoScalingGroup(CloudFormationModel):
     def create_from_cloudformation_json(  # type: ignore[misc]
         cls,
         resource_name: str,
-        cloudformation_json: Dict[str, Any],
+        cloudformation_json: dict[str, Any],
         account_id: str,
         region_name: str,
         **kwargs: Any,
-    ) -> "FakeAutoScalingGroup":
+    ) -> FakeAutoScalingGroup:
         properties = cloudformation_json["Properties"]
 
         launch_config_name = properties.get("LaunchConfigurationName")
@@ -819,10 +819,10 @@ class FakeAutoScalingGroup(CloudFormationModel):
         cls,
         original_resource: Any,
         new_resource_name: str,
-        cloudformation_json: Dict[str, Any],
+        cloudformation_json: dict[str, Any],
         account_id: str,
         region_name: str,
-    ) -> "FakeAutoScalingGroup":
+    ) -> FakeAutoScalingGroup:
         cls.delete_from_cloudformation_json(
             original_resource.name, cloudformation_json, account_id, region_name
         )
@@ -834,7 +834,7 @@ class FakeAutoScalingGroup(CloudFormationModel):
     def delete_from_cloudformation_json(  # type: ignore[misc]
         cls,
         resource_name: str,
-        cloudformation_json: Dict[str, Any],
+        cloudformation_json: dict[str, Any],
         account_id: str,
         region_name: str,
     ) -> None:
@@ -877,7 +877,7 @@ class FakeAutoScalingGroup(CloudFormationModel):
         return self.launch_config.user_data  # type: ignore[union-attr]
 
     @property
-    def security_groups(self) -> List[str]:
+    def security_groups(self) -> list[str]:
         if self.ec2_launch_template:
             version = self.ec2_launch_template.get_version(self.launch_template_version)
             return version.security_groups
@@ -885,14 +885,14 @@ class FakeAutoScalingGroup(CloudFormationModel):
         return self.launch_config.security_groups  # type: ignore[union-attr]
 
     @property
-    def instance_tags(self) -> Dict[str, str]:
+    def instance_tags(self) -> dict[str, str]:
         if self.ec2_launch_template:
             version = self.ec2_launch_template.get_version(self.launch_template_version)
             return version.instance_tags
         return {}
 
     @property
-    def instances(self) -> List[InstanceState]:
+    def instances(self) -> list[InstanceState]:
         return self.instance_states
 
     @property
@@ -901,12 +901,12 @@ class FakeAutoScalingGroup(CloudFormationModel):
 
     def update(
         self,
-        availability_zones: List[str],
+        availability_zones: list[str],
         desired_capacity: Optional[int],
         max_size: Optional[int],
         min_size: Optional[int],
         launch_config_name: str,
-        launch_template: Dict[str, Any],
+        launch_template: dict[str, Any],
         vpc_zone_identifier: str,
         health_check_period: int,
         health_check_type: str,
@@ -979,7 +979,7 @@ class FakeAutoScalingGroup(CloudFormationModel):
             self.autoscaling_backend.update_attached_elbs(self.name)
             self.autoscaling_backend.update_attached_target_groups(self.name)
 
-    def get_propagated_tags(self) -> Dict[str, str]:
+    def get_propagated_tags(self) -> dict[str, str]:
         propagated_tags = {}
         for tag in self.tags:
             if tag.get("PropagateAtLaunch"):
@@ -987,7 +987,7 @@ class FakeAutoScalingGroup(CloudFormationModel):
         return propagated_tags
 
     def replace_autoscaling_group_instances(
-        self, count_needed: int, propagated_tags: Dict[str, str]
+        self, count_needed: int, propagated_tags: dict[str, str]
     ) -> None:
         propagated_tags[ASG_NAME_TAG] = self.name
         propagated_tags.update(self.instance_tags)
@@ -1032,11 +1032,11 @@ class FakeAutoScalingGroup(CloudFormationModel):
                 )
             )
 
-    def append_target_groups(self, target_group_arns: List[str]) -> None:
+    def append_target_groups(self, target_group_arns: list[str]) -> None:
         append = [x for x in target_group_arns if x not in self.target_group_arns]
         self.target_group_arns.extend(append)
 
-    def enable_metrics_collection(self, metrics: List[str]) -> None:
+    def enable_metrics_collection(self, metrics: list[str]) -> None:
         self.metrics = metrics or []
 
     def put_warm_pool(
@@ -1044,7 +1044,7 @@ class FakeAutoScalingGroup(CloudFormationModel):
         max_group_prepared_capacity: Optional[int],
         min_size: Optional[int],
         pool_state: Optional[str],
-        instance_reuse_policy: Optional[Dict[str, bool]],
+        instance_reuse_policy: Optional[dict[str, bool]],
     ) -> None:
         self.warm_pool = FakeWarmPool(
             max_group_prepared_capacity=max_group_prepared_capacity,
@@ -1060,11 +1060,11 @@ class FakeAutoScalingGroup(CloudFormationModel):
 class AutoScalingBackend(BaseBackend):
     def __init__(self, region_name: str, account_id: str):
         super().__init__(region_name, account_id)
-        self.autoscaling_groups: Dict[str, FakeAutoScalingGroup] = OrderedDict()
-        self.launch_configurations: Dict[str, FakeLaunchConfiguration] = OrderedDict()
-        self.scheduled_actions: Dict[str, FakeScheduledAction] = OrderedDict()
-        self.policies: Dict[str, FakeScalingPolicy] = {}
-        self.lifecycle_hooks: Dict[str, LifecycleHook] = {}
+        self.autoscaling_groups: dict[str, FakeAutoScalingGroup] = OrderedDict()
+        self.launch_configurations: dict[str, FakeLaunchConfiguration] = OrderedDict()
+        self.scheduled_actions: dict[str, FakeScheduledAction] = OrderedDict()
+        self.policies: dict[str, FakeScalingPolicy] = {}
+        self.lifecycle_hooks: dict[str, LifecycleHook] = {}
         self.ec2_backend: EC2Backend = ec2_backends[self.account_id][region_name]
         self.elb_backend: ELBBackend = elb_backends[self.account_id][region_name]
         self.elbv2_backend: ELBv2Backend = elbv2_backends[self.account_id][region_name]
@@ -1076,7 +1076,7 @@ class AutoScalingBackend(BaseBackend):
         key_name: Optional[str],
         kernel_id: str,
         ramdisk_id: str,
-        security_groups: List[str],
+        security_groups: list[str],
         user_data: str,
         instance_type: str,
         instance_monitoring: bool,
@@ -1084,7 +1084,7 @@ class AutoScalingBackend(BaseBackend):
         spot_price: Optional[str],
         ebs_optimized: bool,
         associate_public_ip_address: bool,
-        block_device_mappings: List[Dict[str, Any]],
+        block_device_mappings: list[dict[str, Any]],
         instance_id: Optional[str] = None,
         metadata_options: Optional[str] = None,
         classic_link_vpc_id: Optional[str] = None,
@@ -1126,8 +1126,8 @@ class AutoScalingBackend(BaseBackend):
         return launch_configuration
 
     def describe_launch_configurations(
-        self, names: Optional[List[str]]
-    ) -> List[FakeLaunchConfiguration]:
+        self, names: Optional[list[str]]
+    ) -> list[FakeLaunchConfiguration]:
         configurations = self.launch_configurations.values()
         if names:
             return [
@@ -1173,8 +1173,8 @@ class AutoScalingBackend(BaseBackend):
         return scheduled_action
 
     def batch_put_scheduled_update_group_action(
-        self, name: str, actions: List[Dict[str, Any]]
-    ) -> List[FailedScheduledUpdateGroupActionRequest]:
+        self, name: str, actions: list[dict[str, Any]]
+    ) -> list[FailedScheduledUpdateGroupActionRequest]:
         result = []
         for action in actions:
             try:
@@ -1202,8 +1202,8 @@ class AutoScalingBackend(BaseBackend):
     def describe_scheduled_actions(
         self,
         autoscaling_group_name: Optional[str] = None,
-        scheduled_action_names: Optional[List[str]] = None,
-    ) -> List[FakeScheduledAction]:
+        scheduled_action_names: Optional[list[str]] = None,
+    ) -> list[FakeScheduledAction]:
         scheduled_actions = []
         for scheduled_action in self.scheduled_actions.values():
             if (
@@ -1230,8 +1230,8 @@ class AutoScalingBackend(BaseBackend):
             raise ValidationError("Scheduled action name not found")
 
     def batch_delete_scheduled_action(
-        self, auto_scaling_group_name: str, scheduled_action_names: List[str]
-    ) -> List[FailedScheduledUpdateGroupActionRequest]:
+        self, auto_scaling_group_name: str, scheduled_action_names: list[str]
+    ) -> list[FailedScheduledUpdateGroupActionRequest]:
         result = []
         for scheduled_action_name in scheduled_action_names:
             try:
@@ -1251,25 +1251,25 @@ class AutoScalingBackend(BaseBackend):
     def create_auto_scaling_group(
         self,
         name: str,
-        availability_zones: List[str],
+        availability_zones: list[str],
         desired_capacity: Union[None, str, int],
         max_size: Union[None, str, int],
         min_size: Union[None, str, int],
         launch_config_name: str,
-        launch_template: Dict[str, Any],
+        launch_template: dict[str, Any],
         vpc_zone_identifier: Optional[str],
         default_cooldown: Optional[int],
         health_check_period: Union[None, str, int],
         health_check_type: Optional[str],
-        load_balancers: List[str],
-        target_group_arns: List[str],
+        load_balancers: list[str],
+        target_group_arns: list[str],
         placement_group: Optional[str],
-        termination_policies: List[str],
-        tags: List[Dict[str, str]],
+        termination_policies: list[str],
+        tags: list[dict[str, str]],
         capacity_rebalance: bool = False,
         new_instances_protected_from_scale_in: bool = False,
         instance_id: Optional[str] = None,
-        mixed_instances_policy: Optional[Dict[str, Any]] = None,
+        mixed_instances_policy: Optional[dict[str, Any]] = None,
     ) -> FakeAutoScalingGroup:
         max_size = make_int(max_size)
         min_size = make_int(min_size)
@@ -1333,12 +1333,12 @@ class AutoScalingBackend(BaseBackend):
     def update_auto_scaling_group(
         self,
         name: str,
-        availability_zones: List[str],
+        availability_zones: list[str],
         desired_capacity: Optional[int],
         max_size: Optional[int],
         min_size: Optional[int],
         launch_config_name: str,
-        launch_template: Dict[str, Any],
+        launch_template: dict[str, Any],
         vpc_zone_identifier: str,
         health_check_period: int,
         health_check_type: str,
@@ -1373,8 +1373,8 @@ class AutoScalingBackend(BaseBackend):
         return group
 
     def describe_auto_scaling_groups(
-        self, names: List[str], filters: Optional[List[Dict[str, str]]] = None
-    ) -> List[FakeAutoScalingGroup]:
+        self, names: list[str], filters: Optional[list[dict[str, str]]] = None
+    ) -> list[FakeAutoScalingGroup]:
         groups = list(self.autoscaling_groups.values())
 
         if filters:
@@ -1412,8 +1412,8 @@ class AutoScalingBackend(BaseBackend):
         self.autoscaling_groups.pop(group_name, None)
 
     def describe_auto_scaling_instances(
-        self, instance_ids: List[str]
-    ) -> List[InstanceState]:
+        self, instance_ids: list[str]
+    ) -> list[InstanceState]:
         instance_states = []
         for group in self.autoscaling_groups.values():
             instance_states.extend(
@@ -1425,7 +1425,7 @@ class AutoScalingBackend(BaseBackend):
             )
         return instance_states
 
-    def attach_instances(self, group_name: str, instance_ids: List[str]) -> None:
+    def attach_instances(self, group_name: str, instance_ids: list[str]) -> None:
         group = self.autoscaling_groups[group_name]
         original_size = len(group.instance_states)
 
@@ -1463,8 +1463,8 @@ class AutoScalingBackend(BaseBackend):
         instance_state.health_status = health_status
 
     def detach_instances(
-        self, group_name: str, instance_ids: List[str], should_decrement: bool
-    ) -> List[DetachInstanceActivity]:
+        self, group_name: str, instance_ids: list[str], should_decrement: bool
+    ) -> list[DetachInstanceActivity]:
         group = self.autoscaling_groups[group_name]
         original_size = group.desired_capacity
         activities = []
@@ -1534,8 +1534,8 @@ class AutoScalingBackend(BaseBackend):
         return lifecycle_hook
 
     def describe_lifecycle_hooks(
-        self, as_name: str, lifecycle_hook_names: Optional[List[str]] = None
-    ) -> List[LifecycleHook]:
+        self, as_name: str, lifecycle_hook_names: Optional[list[str]] = None
+    ) -> list[LifecycleHook]:
         return [
             lifecycle_hook
             for lifecycle_hook in self.lifecycle_hooks.values()
@@ -1585,9 +1585,9 @@ class AutoScalingBackend(BaseBackend):
     def describe_policies(
         self,
         autoscaling_group_name: Optional[str] = None,
-        policy_names: Optional[List[str]] = None,
-        policy_types: Optional[List[str]] = None,
-    ) -> List[FakeScalingPolicy]:
+        policy_names: Optional[list[str]] = None,
+        policy_types: Optional[list[str]] = None,
+    ) -> list[FakeScalingPolicy]:
         return [
             policy
             for policy in self.policies.values()
@@ -1653,7 +1653,7 @@ class AutoScalingBackend(BaseBackend):
             ]
             self.elbv2_backend.register_targets(target_group.arn, (asg_targets))
 
-    def create_or_update_tags(self, tags: List[Dict[str, str]]) -> None:
+    def create_or_update_tags(self, tags: list[dict[str, str]]) -> None:
         for tag in tags:
             group_name = tag["ResourceId"]
             group = self.autoscaling_groups[group_name]
@@ -1673,7 +1673,7 @@ class AutoScalingBackend(BaseBackend):
 
             group.tags = new_tags
 
-    def delete_tags(self, tags: List[Dict[str, str]]) -> None:
+    def delete_tags(self, tags: list[dict[str, str]]) -> None:
         for tag_to_delete in tags:
             group_name = tag_to_delete["ResourceId"]
             key_to_delete = tag_to_delete["Key"]
@@ -1682,7 +1682,7 @@ class AutoScalingBackend(BaseBackend):
             group.tags = [x for x in old_tags if x["Key"] != key_to_delete]
 
     def attach_load_balancers(
-        self, group_name: str, load_balancer_names: List[str]
+        self, group_name: str, load_balancer_names: list[str]
     ) -> None:
         group = self.autoscaling_groups[group_name]
         group.load_balancer_names.extend(
@@ -1690,11 +1690,11 @@ class AutoScalingBackend(BaseBackend):
         )
         self.update_attached_elbs(group_name)
 
-    def describe_load_balancers(self, group_name: str) -> List[str]:
+    def describe_load_balancers(self, group_name: str) -> list[str]:
         return self.autoscaling_groups[group_name].load_balancer_names
 
     def detach_load_balancers(
-        self, group_name: str, load_balancer_names: List[str]
+        self, group_name: str, load_balancer_names: list[str]
     ) -> None:
         group = self.autoscaling_groups[group_name]
         group_instance_ids = set(state.instance.id for state in group.instance_states)
@@ -1708,17 +1708,17 @@ class AutoScalingBackend(BaseBackend):
         ]
 
     def attach_load_balancer_target_groups(
-        self, group_name: str, target_group_arns: List[str]
+        self, group_name: str, target_group_arns: list[str]
     ) -> None:
         group = self.autoscaling_groups[group_name]
         group.append_target_groups(target_group_arns)
         self.update_attached_target_groups(group_name)
 
-    def describe_load_balancer_target_groups(self, group_name: str) -> List[str]:
+    def describe_load_balancer_target_groups(self, group_name: str) -> list[str]:
         return self.autoscaling_groups[group_name].target_group_arns
 
     def detach_load_balancer_target_groups(
-        self, group_name: str, target_group_arns: List[str]
+        self, group_name: str, target_group_arns: list[str]
     ) -> None:
         group = self.autoscaling_groups[group_name]
         group.target_group_arns = [
@@ -1728,7 +1728,7 @@ class AutoScalingBackend(BaseBackend):
             asg_targets = [{"Id": x.instance.id} for x in group.instance_states]
             self.elbv2_backend.deregister_targets(target_group, (asg_targets))
 
-    def suspend_processes(self, group_name: str, scaling_processes: List[str]) -> None:
+    def suspend_processes(self, group_name: str, scaling_processes: list[str]) -> None:
         all_proc_names = [
             "Launch",
             "Terminate",
@@ -1745,7 +1745,7 @@ class AutoScalingBackend(BaseBackend):
         suspended_processes = [p["ProcessName"] for p in group.suspended_processes]
         group.suspended_processes = list(set(suspended_processes).union(set_to_add))
 
-    def resume_processes(self, group_name: str, scaling_processes: List[str]) -> None:
+    def resume_processes(self, group_name: str, scaling_processes: list[str]) -> None:
         group = self.autoscaling_groups[group_name]
         if scaling_processes:
             suspended_processes = [p["ProcessName"] for p in group.suspended_processes]
@@ -1758,7 +1758,7 @@ class AutoScalingBackend(BaseBackend):
     def set_instance_protection(
         self,
         group_name: str,
-        instance_ids: List[str],
+        instance_ids: list[str],
         protected_from_scale_in: Optional[bool],
     ) -> None:
         group = self.autoscaling_groups[group_name]
@@ -1768,7 +1768,7 @@ class AutoScalingBackend(BaseBackend):
         for instance in protected_instances:
             instance.protected_from_scale_in = protected_from_scale_in
 
-    def notify_terminate_instances(self, instance_ids: List[str]) -> None:
+    def notify_terminate_instances(self, instance_ids: list[str]) -> None:
         for (
             autoscaling_group_name,
             autoscaling_group,
@@ -1790,8 +1790,8 @@ class AutoScalingBackend(BaseBackend):
                 self.update_attached_elbs(autoscaling_group_name)
 
     def enter_standby_instances(
-        self, group_name: str, instance_ids: List[str], should_decrement: bool
-    ) -> List[EnterStandbyActivity]:
+        self, group_name: str, instance_ids: list[str], should_decrement: bool
+    ) -> list[EnterStandbyActivity]:
         group = self.autoscaling_groups[group_name]
         activities = []
         for instance_state in group.instance_states:
@@ -1807,8 +1807,8 @@ class AutoScalingBackend(BaseBackend):
         return activities
 
     def exit_standby_instances(
-        self, group_name: str, instance_ids: List[str]
-    ) -> List[ExitStandbyActivity]:
+        self, group_name: str, instance_ids: list[str]
+    ) -> list[ExitStandbyActivity]:
         group = self.autoscaling_groups[group_name]
         activities = []
         for instance_state in group.instance_states:
@@ -1838,7 +1838,7 @@ class AutoScalingBackend(BaseBackend):
         self.ec2_backend.terminate_instances([instance.id])
         return TerminateInstanceActivity(instance, original_size)
 
-    def describe_tags(self, filters: List[Dict[str, str]]) -> List[Dict[str, str]]:
+    def describe_tags(self, filters: list[dict[str, str]]) -> list[dict[str, str]]:
         """
         Pagination is not yet implemented.
         """
@@ -1858,7 +1858,7 @@ class AutoScalingBackend(BaseBackend):
                 tags = [t for t in tags if t["Value"] in f["Values"]]
         return tags
 
-    def enable_metrics_collection(self, group_name: str, metrics: List[str]) -> None:
+    def enable_metrics_collection(self, group_name: str, metrics: list[str]) -> None:
         group = self.describe_auto_scaling_groups([group_name])[0]
         group.enable_metrics_collection(metrics)
 
@@ -1868,7 +1868,7 @@ class AutoScalingBackend(BaseBackend):
         max_group_prepared_capacity: Optional[int],
         min_size: Optional[int],
         pool_state: Optional[str],
-        instance_reuse_policy: Optional[Dict[str, bool]],
+        instance_reuse_policy: Optional[dict[str, bool]],
     ) -> None:
         group = self.describe_auto_scaling_groups([group_name])[0]
         group.put_warm_pool(

--- a/moto/awslambda/models.py
+++ b/moto/awslambda/models.py
@@ -16,10 +16,11 @@ import warnings
 import weakref
 import zipfile
 from collections import defaultdict
+from collections.abc import Iterable
 from datetime import datetime
 from gzip import GzipFile
 from sys import platform
-from typing import Any, Dict, Iterable, List, Optional, Tuple, TypedDict, Union
+from typing import Any, Optional, TypedDict, Union
 
 import requests.exceptions
 
@@ -119,12 +120,12 @@ class _VolumeRefCount:
 
 class _DockerDataVolumeContext:
     # {sha256: _VolumeRefCount}
-    _data_vol_map: Dict[str, _VolumeRefCount] = defaultdict(
+    _data_vol_map: dict[str, _VolumeRefCount] = defaultdict(
         lambda: _VolumeRefCount(0, None)
     )
     _lock = threading.Lock()
 
-    def __init__(self, lambda_func: "LambdaFunction"):
+    def __init__(self, lambda_func: LambdaFunction):
         self._lambda_func = lambda_func
         self._vol_ref: Optional[_VolumeRefCount] = None
 
@@ -132,7 +133,7 @@ class _DockerDataVolumeContext:
     def name(self) -> str:
         return self._vol_ref.volume.name  # type: ignore[union-attr]
 
-    def __enter__(self) -> "_DockerDataVolumeContext":
+    def __enter__(self) -> _DockerDataVolumeContext:
         # See if volume is already known
         with self.__class__._lock:
             self._vol_ref = self.__class__._data_vol_map[self._lambda_func.code_digest]
@@ -184,14 +185,14 @@ class _DockerDataVolumeContext:
 
 
 class _DockerDataVolumeLayerContext:
-    _data_vol_map: Dict[str, _VolumeRefCount] = defaultdict(
+    _data_vol_map: dict[str, _VolumeRefCount] = defaultdict(
         lambda: _VolumeRefCount(0, None)
     )
     _lock = threading.Lock()
 
-    def __init__(self, lambda_func: "LambdaFunction"):
+    def __init__(self, lambda_func: LambdaFunction):
         self._lambda_func = lambda_func
-        self._layers: List[LayerDataType] = self._lambda_func.layers
+        self._layers: list[LayerDataType] = self._lambda_func.layers
         self._vol_ref: Optional[_VolumeRefCount] = None
 
     @property
@@ -207,7 +208,7 @@ class _DockerDataVolumeLayerContext:
             ]
         )
 
-    def __enter__(self) -> "_DockerDataVolumeLayerContext":
+    def __enter__(self) -> _DockerDataVolumeLayerContext:
         # See if volume is already known
         with self.__class__._lock:
             self._vol_ref = self.__class__._data_vol_map[self.hash]
@@ -235,7 +236,7 @@ class _DockerDataVolumeLayerContext:
             container = self._lambda_func.docker_client.containers.run(
                 "busybox", "sleep 100", volumes=volumes, detach=True
             )
-            backend: "LambdaBackend" = lambda_backends[self._lambda_func.account_id][
+            backend: LambdaBackend = lambda_backends[self._lambda_func.account_id][
                 self._lambda_func.region
             ]
             try:
@@ -270,7 +271,7 @@ class _DockerDataVolumeLayerContext:
                     raise  # multiple processes trying to use same volume?
 
 
-def _zipfile_content(zipfile_content: Union[str, bytes]) -> Tuple[bytes, int, str, str]:
+def _zipfile_content(zipfile_content: Union[str, bytes]) -> tuple[bytes, int, str, str]:
     try:
         to_unzip_code = base64.b64decode(bytes(zipfile_content, "utf-8"))  # type: ignore[arg-type]
     except Exception:
@@ -282,7 +283,7 @@ def _zipfile_content(zipfile_content: Union[str, bytes]) -> Tuple[bytes, int, st
     return to_unzip_code, len(to_unzip_code), base64ed_sha, sha_hex_digest
 
 
-def _s3_content(key: Any) -> Tuple[bytes, int, str, str]:
+def _s3_content(key: Any) -> tuple[bytes, int, str, str]:
     sha_code = hashlib.sha256(key.value)
     base64ed_sha = base64.b64encode(sha_code.digest()).decode("utf-8")
     sha_hex_digest = sha_code.hexdigest()
@@ -290,7 +291,7 @@ def _s3_content(key: Any) -> Tuple[bytes, int, str, str]:
 
 
 def _validate_s3_bucket_and_key(
-    account_id: str, partition: str, data: Dict[str, Any]
+    account_id: str, partition: str, data: dict[str, Any]
 ) -> Optional[FakeKey]:
     key = None
     try:
@@ -313,7 +314,7 @@ def _validate_s3_bucket_and_key(
 
 
 class EventInvokeConfig:
-    def __init__(self, arn: str, last_modified: str, config: Dict[str, Any]) -> None:
+    def __init__(self, arn: str, last_modified: str, config: dict[str, Any]) -> None:
         self.config = config
         self.validate_max()
         self.validate()
@@ -372,19 +373,19 @@ class EventInvokeConfig:
                         f"Member must satisfy regular expression pattern: {regex}",
                     )
 
-    def response(self) -> Dict[str, Any]:
+    def response(self) -> dict[str, Any]:
         response = {"FunctionArn": self.arn, "LastModified": self.last_modified}
         response.update(self.config)
         return response
 
 
 class ImageConfig:
-    def __init__(self, config: Dict[str, Any]) -> None:
+    def __init__(self, config: dict[str, Any]) -> None:
         self.cmd = config.get("Command", [])
         self.entry_point = config.get("EntryPoint", [])
         self.working_directory = config.get("WorkingDirectory", None)
 
-    def response(self) -> Dict[str, Any]:
+    def response(self) -> dict[str, Any]:
         content = {
             "Command": self.cmd,
             "EntryPoint": self.entry_point,
@@ -410,11 +411,11 @@ class Permission(CloudFormationModel):
     def create_from_cloudformation_json(  # type: ignore[misc]
         cls,
         resource_name: str,
-        cloudformation_json: Dict[str, Any],
+        cloudformation_json: dict[str, Any],
         account_id: str,
         region_name: str,
         **kwargs: Any,
-    ) -> "Permission":
+    ) -> Permission:
         properties = cloudformation_json["Properties"]
         backend = lambda_backends[account_id][region_name]
         fn = backend.get_function(properties["FunctionName"])
@@ -423,7 +424,7 @@ class Permission(CloudFormationModel):
 
 
 class LayerVersion(CloudFormationModel):
-    def __init__(self, spec: Dict[str, Any], account_id: str, region: str):
+    def __init__(self, spec: dict[str, Any], account_id: str, region: str):
         # required
         self.account_id = account_id
         self.region = region
@@ -444,7 +445,7 @@ class LayerVersion(CloudFormationModel):
         self.created_date = utcnow().strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3] + "+0000"
         self.version: int = 1
         self._attached = False
-        self._layer: Optional["Layer"] = None
+        self._layer: Optional[Layer] = None
 
         if "ZipFile" in self.content:
             (
@@ -479,12 +480,12 @@ class LayerVersion(CloudFormationModel):
             )
         raise ValueError("Layer version is not set")
 
-    def attach(self, layer: "Layer", version: int) -> None:
+    def attach(self, layer: Layer, version: int) -> None:
         self._attached = True
         self._layer = layer
         self.version = version
 
-    def get_layer_version(self) -> Dict[str, Any]:
+    def get_layer_version(self) -> dict[str, Any]:
         version = {
             "Content": {
                 "Location": "s3://",
@@ -517,11 +518,11 @@ class LayerVersion(CloudFormationModel):
     def create_from_cloudformation_json(  # type: ignore[misc]
         cls,
         resource_name: str,
-        cloudformation_json: Dict[str, Any],
+        cloudformation_json: dict[str, Any],
         account_id: str,
         region_name: str,
         **kwargs: Any,
-    ) -> "LayerVersion":
+    ) -> LayerVersion:
         properties = cloudformation_json["Properties"]
         optional_properties = ("Description", "CompatibleRuntimes", "LicenseInfo")
 
@@ -570,7 +571,7 @@ class LambdaAlias(BaseModel):
         if routing_config is not None:
             self.routing_config = routing_config
 
-    def to_json(self) -> Dict[str, Any]:
+    def to_json(self) -> dict[str, Any]:
         return {
             "AliasArn": self.arn,
             "Description": self.description,
@@ -581,7 +582,7 @@ class LambdaAlias(BaseModel):
         }
 
 
-class Layer(object):
+class Layer:
     def __init__(self, layer_version: LayerVersion):
         self.region = layer_version.region
         self.name = layer_version.name
@@ -590,7 +591,7 @@ class Layer(object):
             self.region, layer_version.account_id, self.name
         )
         self._latest_version = 0
-        self.layer_versions: Dict[str, LayerVersion] = {}
+        self.layer_versions: dict[str, LayerVersion] = {}
 
     def attach_version(self, layer_version: LayerVersion) -> None:
         self._latest_version += 1
@@ -600,7 +601,7 @@ class Layer(object):
     def delete_version(self, layer_version: str) -> None:
         self.layer_versions.pop(str(layer_version), None)
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         if not self.layer_versions:
             return {}
 
@@ -618,7 +619,7 @@ class LambdaFunction(CloudFormationModel, DockerModel):
     def __init__(
         self,
         account_id: str,
-        spec: Dict[str, Any],
+        spec: dict[str, Any],
         region: str,
         version: Union[str, int] = 1,
     ):
@@ -643,19 +644,19 @@ class LambdaFunction(CloudFormationModel, DockerModel):
         self.ephemeral_storage: str
         self.code_digest: str
         self.code_bytes: bytes
-        self.event_invoke_config: List[EventInvokeConfig] = []
+        self.event_invoke_config: list[EventInvokeConfig] = []
 
         self.description = spec.get("Description", "")
         self.memory_size = spec.get("MemorySize", 128)
         self.package_type = spec.get("PackageType", "Zip")
         self.publish = spec.get("Publish", False)  # this is ignored currently
         self.timeout = spec.get("Timeout", 3)
-        self.layers: List[LayerDataType] = self._get_layers_data(spec.get("Layers", []))
+        self.layers: list[LayerDataType] = self._get_layers_data(spec.get("Layers", []))
         self.signing_profile_version_arn = spec.get("SigningProfileVersionArn")
         self.signing_job_arn = spec.get("SigningJobArn")
         self.code_signing_config_arn = spec.get("CodeSigningConfigArn")
         self.tracing_config = spec.get("TracingConfig") or {"Mode": "PassThrough"}
-        self.architectures: List[str] = spec.get("Architectures", ["x86_64"])
+        self.architectures: list[str] = spec.get("Architectures", ["x86_64"])
         self.image_config: ImageConfig = ImageConfig(spec.get("ImageConfig", {}))
         _es = spec.get("EphemeralStorage")
         if _es:
@@ -681,7 +682,7 @@ class LambdaFunction(CloudFormationModel, DockerModel):
 
         self.tags = spec.get("Tags") or dict()
 
-    def __getstate__(self) -> Dict[str, Any]:
+    def __getstate__(self) -> dict[str, Any]:
         return {
             k: v
             for (k, v) in self.__dict__.items()
@@ -696,11 +697,11 @@ class LambdaFunction(CloudFormationModel, DockerModel):
         self.last_modified = iso_8601_datetime_with_nanoseconds()
 
     @property
-    def architectures(self) -> List[str]:
+    def architectures(self) -> list[str]:
         return self._architectures
 
     @architectures.setter
-    def architectures(self, architectures: List[str]) -> None:
+    def architectures(self, architectures: list[str]) -> None:
         if (
             len(architectures) > 1
             or not architectures
@@ -731,7 +732,7 @@ class LambdaFunction(CloudFormationModel, DockerModel):
         self._ephemeral_storage = ephemeral_storage
 
     @property
-    def vpc_config(self) -> Optional[Dict[str, Any]]:  # type: ignore[misc]
+    def vpc_config(self) -> Optional[dict[str, Any]]:  # type: ignore[misc]
         if not self._vpc_config:
             return None
         config = self._vpc_config.copy()
@@ -746,7 +747,7 @@ class LambdaFunction(CloudFormationModel, DockerModel):
     def __repr__(self) -> str:
         return json.dumps(self.get_configuration())
 
-    def _get_layers_data(self, layers_versions_arns: List[str]) -> List[LayerDataType]:
+    def _get_layers_data(self, layers_versions_arns: list[str]) -> list[LayerDataType]:
         backend = lambda_backends[self.account_id][self.region]
         layer_versions = [
             backend.layers_versions_by_arn(layer_version)
@@ -760,13 +761,13 @@ class LambdaFunction(CloudFormationModel, DockerModel):
             {"Arn": lv.arn, "CodeSize": lv.code_size} for lv in layer_versions if lv
         ]
 
-    def get_function_code_signing_config(self) -> Dict[str, Any]:
+    def get_function_code_signing_config(self) -> dict[str, Any]:
         return {
             "CodeSigningConfigArn": self.code_signing_config_arn,
             "FunctionName": self.function_name,
         }
 
-    def get_configuration(self, on_create: bool = False) -> Dict[str, Any]:
+    def get_configuration(self, on_create: bool = False) -> dict[str, Any]:
         config = {
             "CodeSha256": self.code_sha_256,
             "CodeSize": self.code_size,
@@ -805,7 +806,7 @@ class LambdaFunction(CloudFormationModel, DockerModel):
 
         return config
 
-    def get_code(self) -> Dict[str, Any]:
+    def get_code(self) -> dict[str, Any]:
         resp = {"Configuration": self.get_configuration()}
         if "S3Key" in self.code:
             resp["Code"] = {
@@ -832,7 +833,7 @@ class LambdaFunction(CloudFormationModel, DockerModel):
             )
         return resp
 
-    def update_configuration(self, config_updates: Dict[str, Any]) -> Dict[str, Any]:
+    def update_configuration(self, config_updates: dict[str, Any]) -> dict[str, Any]:
         for key, value in config_updates.items():
             if key == "Description":
                 self.description = value
@@ -857,7 +858,7 @@ class LambdaFunction(CloudFormationModel, DockerModel):
 
         return self.get_configuration()
 
-    def _set_function_code(self, updated_spec: Dict[str, Any]) -> None:
+    def _set_function_code(self, updated_spec: dict[str, Any]) -> None:
         from_update = updated_spec is not self.code
 
         # "DryRun" is only used for UpdateFunctionCode
@@ -951,7 +952,7 @@ class LambdaFunction(CloudFormationModel, DockerModel):
             if from_update:
                 self.code["ImageUri"] = updated_spec["ImageUri"]
 
-    def update_function_code(self, updated_spec: Dict[str, Any]) -> Dict[str, Any]:
+    def update_function_code(self, updated_spec: dict[str, Any]) -> dict[str, Any]:
         self._set_function_code(updated_spec)
         self.code_or_config_updated = True
         return self.get_configuration()
@@ -963,7 +964,7 @@ class LambdaFunction(CloudFormationModel, DockerModel):
         except Exception:
             return s
 
-    def _invoke_lambda(self, event: Optional[str] = None) -> Tuple[str, bool, str]:
+    def _invoke_lambda(self, event: Optional[str] = None) -> tuple[str, bool, str]:
         import docker
         import docker.errors
 
@@ -1009,7 +1010,7 @@ class LambdaFunction(CloudFormationModel, DockerModel):
                 _DockerDataVolumeLayerContext(self) as layer_context,
             ):
                 try:
-                    run_kwargs: Dict[str, Any] = dict()
+                    run_kwargs: dict[str, Any] = dict()
                     network_name = settings.moto_network_name()
                     network_mode = settings.moto_network_mode()
                     if network_name:
@@ -1152,11 +1153,11 @@ class LambdaFunction(CloudFormationModel, DockerModel):
     def create_from_cloudformation_json(  # type: ignore[misc]
         cls,
         resource_name: str,
-        cloudformation_json: Dict[str, Any],
+        cloudformation_json: dict[str, Any],
         account_id: str,
         region_name: str,
         **kwargs: Any,
-    ) -> "LambdaFunction":
+    ) -> LambdaFunction:
         properties = cloudformation_json["Properties"]
         optional_properties = (
             "Description",
@@ -1209,12 +1210,12 @@ class LambdaFunction(CloudFormationModel, DockerModel):
     @classmethod
     def update_from_cloudformation_json(  # type: ignore[misc]
         cls,
-        original_resource: "LambdaFunction",
+        original_resource: LambdaFunction,
         new_resource_name: str,
-        cloudformation_json: Dict[str, Any],
+        cloudformation_json: dict[str, Any],
         account_id: str,
         region_name: str,
-    ) -> "LambdaFunction":
+    ) -> LambdaFunction:
         updated_props = cloudformation_json["Properties"]
         original_resource.update_configuration(updated_props)
         original_resource.update_function_code(updated_props["Code"])
@@ -1237,32 +1238,32 @@ class LambdaFunction(CloudFormationModel, DockerModel):
     def delete(self, account_id: str, region: str) -> None:
         lambda_backends[account_id][region].delete_function(self.function_name)
 
-    def create_url_config(self, config: Dict[str, Any]) -> "FunctionUrlConfig":
+    def create_url_config(self, config: dict[str, Any]) -> FunctionUrlConfig:
         self.url_config = FunctionUrlConfig(function=self, config=config)
         return self.url_config
 
     def delete_url_config(self) -> None:
         self.url_config = None
 
-    def get_url_config(self) -> "FunctionUrlConfig":
+    def get_url_config(self) -> FunctionUrlConfig:
         if not self.url_config:
             raise GenericResourcNotFound()
         return self.url_config
 
-    def update_url_config(self, config: Dict[str, Any]) -> "FunctionUrlConfig":
+    def update_url_config(self, config: dict[str, Any]) -> FunctionUrlConfig:
         self.url_config.update(config)  # type: ignore[union-attr]
         return self.url_config  # type: ignore[return-value]
 
 
 class FunctionUrlConfig:
-    def __init__(self, function: LambdaFunction, config: Dict[str, Any]):
+    def __init__(self, function: LambdaFunction, config: dict[str, Any]):
         self.function = function
         self.config = config
         self.url = f"https://{random.uuid4().hex}.lambda-url.{function.region}.on.aws"
         self.created = utcnow().strftime("%Y-%m-%dT%H:%M:%S.000+0000")
         self.last_modified = self.created
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         return {
             "FunctionUrl": self.url,
             "FunctionArn": self.function.function_arn,
@@ -1273,7 +1274,7 @@ class FunctionUrlConfig:
             "InvokeMode": self.config.get("InvokeMode") or "Buffered",
         }
 
-    def update(self, new_config: Dict[str, Any]) -> None:
+    def update(self, new_config: dict[str, Any]) -> None:
         if new_config.get("Cors"):
             self.config["Cors"] = new_config["Cors"]
         if new_config.get("AuthType"):
@@ -1282,7 +1283,7 @@ class FunctionUrlConfig:
 
 
 class EventSourceMapping(CloudFormationModel):
-    def __init__(self, spec: Dict[str, Any]):
+    def __init__(self, spec: dict[str, Any]):
         # required
         self.region = spec["RegionName"]
         self.account_id = spec["AccountId"]
@@ -1376,7 +1377,7 @@ class EventSourceMapping(CloudFormationModel):
         else:
             self._batch_size = int(new_batch_size)
 
-    def get_configuration(self) -> Dict[str, Any]:
+    def get_configuration(self) -> dict[str, Any]:
         response_dict = {
             "UUID": self.uuid,
             "BatchSize": self.batch_size,
@@ -1426,11 +1427,11 @@ class EventSourceMapping(CloudFormationModel):
     def create_from_cloudformation_json(  # type: ignore[misc]
         cls,
         resource_name: str,
-        cloudformation_json: Dict[str, Any],
+        cloudformation_json: dict[str, Any],
         account_id: str,
         region_name: str,
         **kwargs: Any,
-    ) -> "EventSourceMapping":
+    ) -> EventSourceMapping:
         properties = cloudformation_json["Properties"]
         lambda_backend = lambda_backends[account_id][region_name]
         return lambda_backend.create_event_source_mapping(properties)
@@ -1440,10 +1441,10 @@ class EventSourceMapping(CloudFormationModel):
         cls,
         original_resource: Any,
         new_resource_name: str,
-        cloudformation_json: Dict[str, Any],
+        cloudformation_json: dict[str, Any],
         account_id: str,
         region_name: str,
-    ) -> "EventSourceMapping":
+    ) -> EventSourceMapping:
         properties = cloudformation_json["Properties"]
         event_source_uuid = original_resource.uuid
         lambda_backend = lambda_backends[account_id][region_name]
@@ -1453,7 +1454,7 @@ class EventSourceMapping(CloudFormationModel):
     def delete_from_cloudformation_json(  # type: ignore[misc]
         cls,
         resource_name: str,
-        cloudformation_json: Dict[str, Any],
+        cloudformation_json: dict[str, Any],
         account_id: str,
         region_name: str,
     ) -> None:
@@ -1474,7 +1475,7 @@ class EventSourceMapping(CloudFormationModel):
 
 
 class LambdaVersion(CloudFormationModel):
-    def __init__(self, spec: Dict[str, Any]):
+    def __init__(self, spec: dict[str, Any]):
         self.version = spec["Version"]
 
     def __repr__(self) -> str:
@@ -1489,11 +1490,11 @@ class LambdaVersion(CloudFormationModel):
     def create_from_cloudformation_json(  # type: ignore[misc]
         cls,
         resource_name: str,
-        cloudformation_json: Dict[str, Any],
+        cloudformation_json: dict[str, Any],
         account_id: str,
         region_name: str,
         **kwargs: Any,
-    ) -> "LambdaVersion":
+    ) -> LambdaVersion:
         properties = cloudformation_json["Properties"]
         function_name = properties["FunctionName"]
         func = lambda_backends[account_id][region_name].publish_version(function_name)
@@ -1501,10 +1502,10 @@ class LambdaVersion(CloudFormationModel):
         return LambdaVersion(spec)
 
 
-class LambdaStorage(object):
+class LambdaStorage:
     def __init__(self, region_name: str, account_id: str):
         # Format 'func_name' {'versions': []}
-        self._functions: Dict[str, Any] = {}
+        self._functions: dict[str, Any] = {}
         self._arns: weakref.WeakValueDictionary[str, LambdaFunction] = (
             weakref.WeakValueDictionary()
         )
@@ -1513,7 +1514,7 @@ class LambdaStorage(object):
         self.partition = get_partition(region_name)
 
         # function-arn -> alias -> LambdaAlias
-        self._aliases: Dict[str, Dict[str, LambdaAlias]] = defaultdict(lambda: {})
+        self._aliases: dict[str, dict[str, LambdaAlias]] = defaultdict(lambda: {})
 
     def _get_latest(self, name: str) -> LambdaFunction:
         return self._functions[name]["latest"]
@@ -1525,7 +1526,7 @@ class LambdaStorage(object):
 
         return None
 
-    def _get_function_aliases(self, function_name: str) -> Dict[str, LambdaAlias]:
+    def _get_function_aliases(self, function_name: str) -> dict[str, LambdaAlias]:
         fn = self.get_function_by_name_or_arn_with_qualifier(function_name)
         # Split ARN to retrieve an ARN without a qualifier present
         [arn, _, _] = self.split_function_arn(fn.function_arn)
@@ -1664,7 +1665,7 @@ class LambdaStorage(object):
         [arn_without_qualifier, _, _] = self.split_function_arn(arn)
         return self._arns.get(arn_without_qualifier, None)
 
-    def split_function_arn(self, arn: str) -> Tuple[str, str, Optional[str]]:
+    def split_function_arn(self, arn: str) -> tuple[str, str, Optional[str]]:
         """
         Handy utility to parse an ARN into:
         - ARN without qualifier
@@ -1845,9 +1846,9 @@ class LambdaStorage(object):
         return result
 
 
-class LayerStorage(object):
+class LayerStorage:
     def __init__(self) -> None:
-        self._layers: Dict[str, Layer] = {}
+        self._layers: dict[str, Layer] = {}
         self._arns: weakref.WeakValueDictionary[str, LambdaFunction] = (
             weakref.WeakValueDictionary()
         )
@@ -1868,7 +1869,7 @@ class LayerStorage(object):
             self._layers[layer_version.name] = Layer(layer_version)
         self._layers[layer_version.name].attach_version(layer_version)
 
-    def list_layers(self) -> Iterable[Dict[str, Any]]:
+    def list_layers(self) -> Iterable[dict[str, Any]]:
         return [
             layer.to_dict() for layer in self._layers.values() if layer.layer_versions
         ]
@@ -1884,7 +1885,7 @@ class LayerStorage(object):
                 return lv
         raise UnknownLayerException()
 
-    def get_layer_versions(self, layer_name: str) -> List[LayerVersion]:
+    def get_layer_versions(self, layer_name: str) -> list[LayerVersion]:
         if layer_name in self._layers:
             return list(iter(self._layers[layer_name].layer_versions.values()))
         return []
@@ -1981,7 +1982,7 @@ class LambdaBackend(BaseBackend):
     def __init__(self, region_name: str, account_id: str):
         super().__init__(region_name, account_id)
         self._lambdas = LambdaStorage(region_name=region_name, account_id=account_id)
-        self._event_source_mappings: Dict[str, EventSourceMapping] = {}
+        self._event_source_mappings: dict[str, EventSourceMapping] = {}
         self._layers = LayerStorage()
 
     def create_alias(
@@ -2017,7 +2018,7 @@ class LambdaBackend(BaseBackend):
             name, function_name, function_version, description, routing_config
         )
 
-    def create_function(self, spec: Dict[str, Any]) -> LambdaFunction:
+    def create_function(self, spec: dict[str, Any]) -> LambdaFunction:
         """
         The Code.ImageUri is not validated by default. Set environment variable MOTO_LAMBDA_STUB_ECR=false if you want to validate the image exists in our mocked ECR.
         """
@@ -2043,7 +2044,7 @@ class LambdaBackend(BaseBackend):
         return fn
 
     def create_function_url_config(
-        self, name_or_arn: str, config: Dict[str, Any]
+        self, name_or_arn: str, config: dict[str, Any]
     ) -> FunctionUrlConfig:
         """
         The Qualifier-parameter is not yet implemented.
@@ -2075,7 +2076,7 @@ class LambdaBackend(BaseBackend):
         return function.get_url_config()
 
     def update_function_url_config(
-        self, name_or_arn: str, config: Dict[str, Any]
+        self, name_or_arn: str, config: dict[str, Any]
     ) -> FunctionUrlConfig:
         """
         The Qualifier-parameter is not yet implemented
@@ -2085,7 +2086,7 @@ class LambdaBackend(BaseBackend):
         )
         return function.update_url_config(config)
 
-    def create_event_source_mapping(self, spec: Dict[str, Any]) -> EventSourceMapping:
+    def create_event_source_mapping(self, spec: dict[str, Any]) -> EventSourceMapping:
         required = ["EventSourceArn", "FunctionName"]
         for param in required:
             if not spec.get(param):
@@ -2141,7 +2142,7 @@ class LambdaBackend(BaseBackend):
 
         raise RESTError("ResourceNotFoundException", "Invalid EventSourceArn")
 
-    def publish_layer_version(self, spec: Dict[str, Any]) -> LayerVersion:
+    def publish_layer_version(self, spec: dict[str, Any]) -> LayerVersion:
         required = ["LayerName", "Content"]
         for param in required:
             if not spec.get(param):
@@ -2152,7 +2153,7 @@ class LambdaBackend(BaseBackend):
         self._layers.put_layer_version(layer_version)
         return layer_version
 
-    def list_layers(self) -> Iterable[Dict[str, Any]]:
+    def list_layers(self) -> Iterable[dict[str, Any]]:
         return self._layers.list_layers()
 
     def delete_layer_version(self, layer_name: str, layer_version: str) -> None:
@@ -2192,7 +2193,7 @@ class LambdaBackend(BaseBackend):
         return self._event_source_mappings.pop(uuid, None)
 
     def update_event_source_mapping(
-        self, uuid: str, spec: Dict[str, Any]
+        self, uuid: str, spec: dict[str, Any]
     ) -> Optional[EventSourceMapping]:
         esm = self.get_event_source_mapping(uuid)
         if not esm:
@@ -2307,8 +2308,8 @@ class LambdaBackend(BaseBackend):
                 }
             )
 
-        request_headers: Dict[str, Any] = {}
-        response_headers: Dict[str, Any] = {}
+        request_headers: dict[str, Any] = {}
+        response_headers: dict[str, Any] = {}
         self.invoke(
             function_name=function_arn,
             qualifier=None,
@@ -2390,7 +2391,7 @@ class LambdaBackend(BaseBackend):
         func.invoke(json.dumps(event), {}, {})
 
     def send_dynamodb_items(
-        self, function_arn: str, items: List[Any], source: str
+        self, function_arn: str, items: list[Any], source: str
     ) -> Union[str, bytes]:
         event = {
             "Records": [
@@ -2450,22 +2451,22 @@ class LambdaBackend(BaseBackend):
             return esm
         return self._lambdas.get_function_by_name_or_arn_with_qualifier(arn)
 
-    def list_tags(self, resource_arn: str) -> Dict[str, str]:
+    def list_tags(self, resource_arn: str) -> dict[str, str]:
         resource = self._get_resource_by_arn(resource_arn)
         return resource.tags
 
-    def tag_resource(self, resource_arn: str, tags: Dict[str, str]) -> None:
+    def tag_resource(self, resource_arn: str, tags: dict[str, str]) -> None:
         resource = self._get_resource_by_arn(resource_arn)
         resource.tags.update(tags)
 
-    def untag_resource(self, resource_arn: str, tagKeys: List[str]) -> None:
+    def untag_resource(self, resource_arn: str, tagKeys: list[str]) -> None:
         resource = self._get_resource_by_arn(resource_arn)
         for key in tagKeys:
             resource.tags.pop(key, None)
 
     def add_permission(
         self, function_name: str, qualifier: str, raw: str
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         fn = self.get_function(function_name, qualifier)
         statement, revision = fn.policy.add_statement(raw, qualifier)
         return statement
@@ -2476,7 +2477,7 @@ class LambdaBackend(BaseBackend):
         fn = self.get_function(function_name)
         fn.policy.del_statement(sid, revision)
 
-    def get_function_code_signing_config(self, function_name: str) -> Dict[str, Any]:
+    def get_function_code_signing_config(self, function_name: str) -> dict[str, Any]:
         fn = self.get_function(function_name)
         return fn.get_function_code_signing_config()
 
@@ -2487,8 +2488,8 @@ class LambdaBackend(BaseBackend):
         return fn.policy.wire_format()
 
     def update_function_code(
-        self, function_name: str, qualifier: str, body: Dict[str, Any]
-    ) -> Optional[Dict[str, Any]]:
+        self, function_name: str, qualifier: str, body: dict[str, Any]
+    ) -> Optional[dict[str, Any]]:
         fn: LambdaFunction = self.get_function(function_name, qualifier)
         fn.update_function_code(body)
 
@@ -2498,8 +2499,8 @@ class LambdaBackend(BaseBackend):
         return fn.update_function_code(body)
 
     def update_function_configuration(
-        self, function_name: str, qualifier: str, body: Dict[str, Any]
-    ) -> Optional[Dict[str, Any]]:
+        self, function_name: str, qualifier: str, body: dict[str, Any]
+    ) -> Optional[dict[str, Any]]:
         fn = self.get_function(function_name, qualifier)
 
         return fn.update_configuration(body)
@@ -2582,21 +2583,21 @@ class LambdaBackend(BaseBackend):
         return fn.reserved_concurrency
 
     def put_function_event_invoke_config(
-        self, function_name: str, config: Dict[str, Any]
-    ) -> Dict[str, Any]:
+        self, function_name: str, config: dict[str, Any]
+    ) -> dict[str, Any]:
         fn = self.get_function(function_name)
         event_config = EventInvokeConfig(fn.function_arn, fn.last_modified, config)
         fn.event_invoke_config.append(event_config)
         return event_config.response()
 
     def update_function_event_invoke_config(
-        self, function_name: str, config: Dict[str, Any]
-    ) -> Dict[str, Any]:
+        self, function_name: str, config: dict[str, Any]
+    ) -> dict[str, Any]:
         # partial functionality, the update function just does a put
         # instead of partial update
         return self.put_function_event_invoke_config(function_name, config)
 
-    def get_function_event_invoke_config(self, function_name: str) -> Dict[str, Any]:
+    def get_function_event_invoke_config(self, function_name: str) -> dict[str, Any]:
         fn = self.get_function(function_name)
         if fn.event_invoke_config:
             response = fn.event_invoke_config[0]
@@ -2609,8 +2610,8 @@ class LambdaBackend(BaseBackend):
             fn = self.get_function(function_name)
             fn.event_invoke_config = []
 
-    def list_function_event_invoke_configs(self, function_name: str) -> Dict[str, Any]:
-        response: Dict[str, List[Dict[str, Any]]] = {"FunctionEventInvokeConfigs": []}
+    def list_function_event_invoke_configs(self, function_name: str) -> dict[str, Any]:
+        response: dict[str, list[dict[str, Any]]] = {"FunctionEventInvokeConfigs": []}
         try:
             response["FunctionEventInvokeConfigs"] = [
                 self.get_function_event_invoke_config(function_name)
@@ -2621,7 +2622,7 @@ class LambdaBackend(BaseBackend):
 
     def add_layer_version_permission(
         self, layer_name: str, version_number: int, statement: str
-    ) -> Tuple[str, str]:
+    ) -> tuple[str, str]:
         layer_version = self.get_layer_version(layer_name, str(version_number))
         return layer_version.policy.add_statement(statement)
 

--- a/moto/awslambda/policy.py
+++ b/moto/awslambda/policy.py
@@ -3,10 +3,7 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Callable,
-    Dict,
-    List,
     Optional,
-    Tuple,
     TypeVar,
     Union,
 )
@@ -27,7 +24,7 @@ TYPE_IDENTITY = TypeVar("TYPE_IDENTITY")
 class Policy:
     def __init__(self, parent: Union["LambdaFunction", "LayerVersion"]):
         self.revision = str(mock_random.uuid4())
-        self.statements: List[Dict[str, Any]] = []
+        self.statements: list[dict[str, Any]] = []
         self.parent = parent
 
     def wire_format(self) -> str:
@@ -35,7 +32,7 @@ class Policy:
         p["Policy"] = json.dumps(p["Policy"])
         return json.dumps(p)
 
-    def get_policy(self) -> Dict[str, Any]:
+    def get_policy(self) -> dict[str, Any]:
         if not self.statements:
             raise GenericResourcNotFound()
         return {
@@ -50,7 +47,7 @@ class Policy:
     # adds the raw JSON statement to the policy
     def add_statement(
         self, raw: str, qualifier: Optional[str] = None
-    ) -> Tuple[Any, str]:
+    ) -> tuple[Any, str]:
         policy = json.loads(raw, object_hook=self.decode_policy)
         if len(policy.revision) > 0 and self.revision != policy.revision:
             raise PreconditionFailedException(
@@ -86,7 +83,7 @@ class Policy:
 
     # converts AddPermission request to PolicyStatement
     # https://docs.aws.amazon.com/lambda/latest/dg/API_AddPermission.html
-    def decode_policy(self, obj: Dict[str, Any]) -> "Policy":
+    def decode_policy(self, obj: dict[str, Any]) -> "Policy":
         # Circumvent circular cimport
         from moto.awslambda.models import LayerVersion
 
@@ -131,11 +128,11 @@ class Policy:
     def nop_formatter(self, obj: TYPE_IDENTITY) -> TYPE_IDENTITY:
         return obj
 
-    def ensure_set(self, obj: Dict[str, Any], key: str, value: Any) -> None:
+    def ensure_set(self, obj: dict[str, Any], key: str, value: Any) -> None:
         if key not in obj:
             obj[key] = value
 
-    def principal_formatter(self, obj: Dict[str, Any]) -> Dict[str, Any]:
+    def principal_formatter(self, obj: dict[str, Any]) -> dict[str, Any]:
         if isinstance(obj, str):
             if obj.endswith(".amazonaws.com"):
                 return {"Service": obj}
@@ -145,22 +142,22 @@ class Policy:
 
     def source_account_formatter(
         self, obj: TYPE_IDENTITY
-    ) -> Dict[str, Dict[str, TYPE_IDENTITY]]:
+    ) -> dict[str, dict[str, TYPE_IDENTITY]]:
         return {"StringEquals": {"AWS:SourceAccount": obj}}
 
     def source_arn_formatter(
         self, obj: TYPE_IDENTITY
-    ) -> Dict[str, Dict[str, TYPE_IDENTITY]]:
+    ) -> dict[str, dict[str, TYPE_IDENTITY]]:
         return {"ArnLike": {"AWS:SourceArn": obj}}
 
     def principal_org_id_formatter(
         self, obj: TYPE_IDENTITY
-    ) -> Dict[str, Dict[str, TYPE_IDENTITY]]:
+    ) -> dict[str, dict[str, TYPE_IDENTITY]]:
         return {"StringEquals": {"aws:PrincipalOrgID": obj}}
 
     def transform_property(
         self,
-        obj: Dict[str, Any],
+        obj: dict[str, Any],
         old_name: str,
         new_name: str,
         formatter: Callable[..., Any],
@@ -170,12 +167,12 @@ class Policy:
             if new_name != old_name:
                 del obj[old_name]
 
-    def remove_if_set(self, obj: Dict[str, Any], keys: List[str]) -> None:
+    def remove_if_set(self, obj: dict[str, Any], keys: list[str]) -> None:
         for key in keys:
             if key in obj:
                 del obj[key]
 
-    def condition_merge(self, obj: Dict[str, Any]) -> None:
+    def condition_merge(self, obj: dict[str, Any]) -> None:
         if "SourceArn" in obj:
             if "Condition" not in obj:
                 obj["Condition"] = {}

--- a/moto/awslambda/responses.py
+++ b/moto/awslambda/responses.py
@@ -1,7 +1,7 @@
 import json
 import re
 import sys
-from typing import Any, Dict, List, Tuple, Union
+from typing import Any, Union
 from urllib.parse import unquote
 
 from moto.core.responses import TYPE_RESPONSE, BaseResponse
@@ -18,7 +18,7 @@ class LambdaResponse(BaseResponse):
         super().__init__(service_name="awslambda")
 
     @property
-    def json_body(self) -> Dict[str, Any]:  # type: ignore[misc]
+    def json_body(self) -> dict[str, Any]:  # type: ignore[misc]
         return json.loads(self.body)
 
     @property
@@ -48,8 +48,8 @@ class LambdaResponse(BaseResponse):
             return 404, {"status": 404}, "{}"
 
     @amz_crc32
-    def invoke(self) -> Tuple[int, Dict[str, str], Union[str, bytes]]:
-        response_headers: Dict[str, str] = {}
+    def invoke(self) -> tuple[int, dict[str, str], Union[str, bytes]]:
+        response_headers: dict[str, str] = {}
 
         # URL Decode in case it's a ARN:
         function_name = unquote(self.path.rsplit("/", 2)[-2])
@@ -88,8 +88,8 @@ class LambdaResponse(BaseResponse):
             return 404, response_headers, "{}"
 
     @amz_crc32
-    def invoke_async(self) -> Tuple[int, Dict[str, str], Union[str, bytes]]:
-        response_headers: Dict[str, Any] = {}
+    def invoke_async(self) -> tuple[int, dict[str, str], Union[str, bytes]]:
+        response_headers: dict[str, Any] = {}
 
         function_index = -3 if self.path.endswith("/") else -2
         function_name = unquote(self.path.rsplit("/", 3)[function_index])
@@ -103,7 +103,7 @@ class LambdaResponse(BaseResponse):
     def list_functions(self) -> str:
         querystring = self.querystring
         func_version = querystring.get("FunctionVersion", [None])[0]
-        result: Dict[str, List[Dict[str, Any]]] = {"Functions": []}
+        result: dict[str, list[dict[str, Any]]] = {"Functions": []}
 
         for fn in self.backend.list_functions(func_version):
             json_data = fn.get_configuration()
@@ -113,7 +113,7 @@ class LambdaResponse(BaseResponse):
 
     def list_versions_by_function(self) -> str:
         function_name = self.path.split("/")[-2]
-        result: Dict[str, Any] = {"Versions": []}
+        result: dict[str, Any] = {"Versions": []}
 
         functions = self.backend.list_versions_by_function(function_name)
         for fn in functions:
@@ -125,7 +125,7 @@ class LambdaResponse(BaseResponse):
     def list_aliases(self) -> TYPE_RESPONSE:
         path = self.path
         function_name = path.split("/")[-2]
-        result: Dict[str, Any] = {"Aliases": []}
+        result: dict[str, Any] = {"Aliases": []}
 
         aliases = self.backend.list_aliases(function_name)
         for alias in aliases:
@@ -224,8 +224,8 @@ class LambdaResponse(BaseResponse):
 
     @staticmethod
     def _set_configuration_qualifier(  # type: ignore[misc]
-        configuration: Dict[str, Any], function_name: str, qualifier: str
-    ) -> Dict[str, Any]:
+        configuration: dict[str, Any], function_name: str, qualifier: str
+    ) -> dict[str, Any]:
         # Qualifier may be explicitly passed or part of function name or ARN, extract it here
         if re.match(ARN_PARTITION_REGEX, function_name):
             # Extract from ARN

--- a/moto/awslambda/utils.py
+++ b/moto/awslambda/utils.py
@@ -1,6 +1,6 @@
 from collections import namedtuple
 from functools import partial
-from typing import TYPE_CHECKING, Any, Type, Union
+from typing import TYPE_CHECKING, Any, Union
 
 from moto.utilities.utils import PARTITION_NAMES, get_partition
 
@@ -33,7 +33,7 @@ make_function_ver_arn = partial(make_ver_arn, "function")
 make_layer_ver_arn = partial(make_ver_arn, "layer")
 
 
-def split_arn(arn_type: Union[Type[ARN], Type[LAYER_ARN]], arn: str) -> Any:
+def split_arn(arn_type: Union[type[ARN], type[LAYER_ARN]], arn: str) -> Any:
     for partition in PARTITION_NAMES:
         arn = arn.replace(f"arn:{partition}:lambda:", "")
 

--- a/moto/awslambda_simple/models.py
+++ b/moto/awslambda_simple/models.py
@@ -1,4 +1,4 @@
-from typing import Any, List, Optional, Union
+from typing import Any, Optional, Union
 
 from moto.awslambda.models import LambdaBackend
 from moto.core.base_backend import BackendDict
@@ -12,7 +12,7 @@ class LambdaSimpleBackend(LambdaBackend):
 
     def __init__(self, region_name: str, account_id: str):
         super().__init__(region_name, account_id)
-        self.lambda_simple_results_queue: List[str] = []
+        self.lambda_simple_results_queue: list[str] = []
 
     def invoke(
         self,

--- a/moto/backends.py
+++ b/moto/backends.py
@@ -1,6 +1,7 @@
 import importlib
 import os
-from typing import TYPE_CHECKING, Iterable, Optional, Union, overload
+from collections.abc import Iterable
+from typing import TYPE_CHECKING, Optional, Union, overload
 
 import moto
 

--- a/moto/backup/models.py
+++ b/moto/backup/models.py
@@ -1,5 +1,5 @@
 from copy import deepcopy
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Optional
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
@@ -14,7 +14,7 @@ from .exceptions import AlreadyExistsException, ResourceNotFoundException
 class Plan(BaseModel):
     def __init__(
         self,
-        backup_plan: Dict[str, Any],
+        backup_plan: dict[str, Any],
         creator_request_id: str,
         backend: "BackupBackend",
     ):
@@ -46,7 +46,7 @@ class Plan(BaseModel):
             )  # set to Etc/UTc by default
             rule["RuleId"] = str(mock_random.uuid4())
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         dct = {
             "BackupPlanId": self.backup_plan_id,
             "BackupPlanArn": self.backup_plan_arn,
@@ -56,7 +56,7 @@ class Plan(BaseModel):
         }
         return {k: v for k, v in dct.items() if v}
 
-    def to_get_dict(self) -> Dict[str, Any]:
+    def to_get_dict(self) -> dict[str, Any]:
         dct = self.to_dict()
         dct_options = {
             "BackupPlan": self.backup_plan,
@@ -69,7 +69,7 @@ class Plan(BaseModel):
                 dct[key] = value
         return dct
 
-    def to_list_dict(self) -> Dict[str, Any]:
+    def to_list_dict(self) -> dict[str, Any]:
         dct = self.to_get_dict()
         dct.pop("BackupPlan")
         dct["BackupPlanName"] = self.backup_plan.get("BackupPlanName")
@@ -95,7 +95,7 @@ class Vault(BaseModel):
         self.max_retention_days = 0  # put_backup_vault_lock_configuration
         self.lock_date = None  # put_backup_vault_lock_configuration
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         dct = {
             "BackupVaultName": self.backup_vault_name,
             "BackupVaultArn": self.backup_vault_arn,
@@ -103,9 +103,9 @@ class Vault(BaseModel):
         }
         return dct
 
-    def to_list_dict(self) -> Dict[str, Any]:
+    def to_list_dict(self) -> dict[str, Any]:
         dct = self.to_dict()
-        dct_options: Dict[str, Any] = dict()
+        dct_options: dict[str, Any] = dict()
         dct_options = {
             "EncryptionKeyArn": self.encryption_key_arn,
             "CreatorRequestId": self.creator_request_id,
@@ -127,14 +127,14 @@ class BackupBackend(BaseBackend):
     def __init__(self, region_name: str, account_id: str):
         super().__init__(region_name, account_id)
 
-        self.vaults: Dict[str, Vault] = dict()
-        self.plans: Dict[str, Plan] = dict()
+        self.vaults: dict[str, Vault] = dict()
+        self.plans: dict[str, Plan] = dict()
         self.tagger = TaggingService()
 
     def create_backup_plan(
         self,
-        backup_plan: Dict[str, Any],
-        backup_plan_tags: Dict[str, str],
+        backup_plan: dict[str, Any],
+        backup_plan_tags: dict[str, str],
         creator_request_id: str,
     ) -> Plan:
         if backup_plan["BackupPlanName"] in list(
@@ -165,7 +165,7 @@ class BackupBackend(BaseBackend):
                 raise ResourceNotFoundException(msg=msg)
         return plan
 
-    def delete_backup_plan(self, backup_plan_id: str) -> Tuple[str, str, float, str]:
+    def delete_backup_plan(self, backup_plan_id: str) -> tuple[str, str, float, str]:
         if backup_plan_id not in self.plans:
             raise ResourceNotFoundException(
                 msg="Failed reading Backup plan with provided version"
@@ -175,7 +175,7 @@ class BackupBackend(BaseBackend):
         res.deletion_date = deletion_date
         return res.backup_plan_id, res.backup_plan_arn, deletion_date, res.version_id
 
-    def list_backup_plans(self, include_deleted: Any) -> List[Plan]:
+    def list_backup_plans(self, include_deleted: Any) -> list[Plan]:
         """
         Pagination is not yet implemented
         """
@@ -192,7 +192,7 @@ class BackupBackend(BaseBackend):
     def create_backup_vault(
         self,
         backup_vault_name: str,
-        backup_vault_tags: Dict[str, str],
+        backup_vault_tags: dict[str, str],
         encryption_key_arn: str,
         creator_request_id: str,
     ) -> Vault:
@@ -211,23 +211,23 @@ class BackupBackend(BaseBackend):
         self.vaults[backup_vault_name] = vault
         return vault
 
-    def list_backup_vaults(self) -> List[Vault]:
+    def list_backup_vaults(self) -> list[Vault]:
         """
         Pagination is not yet implemented
         """
         return list(self.vaults.values())
 
-    def list_tags(self, resource_arn: str) -> Dict[str, str]:
+    def list_tags(self, resource_arn: str) -> dict[str, str]:
         """
         Pagination is not yet implemented
         """
         return self.tagger.get_tag_dict_for_resource(resource_arn)
 
-    def tag_resource(self, resource_arn: str, tags: Dict[str, str]) -> None:
+    def tag_resource(self, resource_arn: str, tags: dict[str, str]) -> None:
         tags_input = TaggingService.convert_dict_to_tags_input(tags or {})
         self.tagger.tag_resource(resource_arn, tags_input)
 
-    def untag_resource(self, resource_arn: str, tag_key_list: List[str]) -> None:
+    def untag_resource(self, resource_arn: str, tag_key_list: list[str]) -> None:
         self.tagger.untag_resource_using_names(resource_arn, tag_key_list)
 
 

--- a/moto/batch/models.py
+++ b/moto/batch/models.py
@@ -6,7 +6,7 @@ import time
 from itertools import cycle
 from sys import platform
 from time import sleep
-from typing import Any, Dict, List, Optional, Set, Tuple, Union
+from typing import Any, Optional, Union
 
 import dateutil.parser
 
@@ -65,7 +65,7 @@ class ComputeEnvironment(CloudFormationModel):
         compute_environment_name: str,
         _type: str,
         state: str,
-        compute_resources: Dict[str, Any],
+        compute_resources: dict[str, Any],
         service_role: str,
         account_id: str,
         region_name: str,
@@ -79,7 +79,7 @@ class ComputeEnvironment(CloudFormationModel):
             account_id, compute_environment_name, region_name
         )
 
-        self.instances: List[Instance] = []
+        self.instances: list[Instance] = []
         self.ecs_arn = ""
         self.ecs_name = ""
 
@@ -107,7 +107,7 @@ class ComputeEnvironment(CloudFormationModel):
     def create_from_cloudformation_json(  # type: ignore[misc]
         cls,
         resource_name: str,
-        cloudformation_json: Dict[str, Any],
+        cloudformation_json: dict[str, Any],
         account_id: str,
         region_name: str,
         **kwargs: Any,
@@ -130,11 +130,11 @@ class JobQueue(CloudFormationModel):
         name: str,
         priority: str,
         state: str,
-        environments: List[ComputeEnvironment],
-        env_order_json: List[Dict[str, Any]],
+        environments: list[ComputeEnvironment],
+        env_order_json: list[dict[str, Any]],
         schedule_policy: Optional[str],
         backend: "BatchBackend",
-        tags: Optional[Dict[str, str]] = None,
+        tags: Optional[dict[str, str]] = None,
     ):
         """
         :param name: Job queue name
@@ -161,9 +161,9 @@ class JobQueue(CloudFormationModel):
         if tags:
             backend.tag_resource(self.arn, tags)
 
-        self.jobs: List[Job] = []
+        self.jobs: list[Job] = []
 
-    def describe(self) -> Dict[str, Any]:
+    def describe(self) -> dict[str, Any]:
         return {
             "computeEnvironmentOrder": self.env_order_json,
             "jobQueueArn": self.arn,
@@ -192,7 +192,7 @@ class JobQueue(CloudFormationModel):
     def create_from_cloudformation_json(  # type: ignore[misc]
         cls,
         resource_name: str,
-        cloudformation_json: Dict[str, Any],
+        cloudformation_json: dict[str, Any],
         account_id: str,
         region_name: str,
         **kwargs: Any,
@@ -220,15 +220,15 @@ class JobDefinition(CloudFormationModel):
     def __init__(
         self,
         name: str,
-        parameters: Optional[Dict[str, Any]],
+        parameters: Optional[dict[str, Any]],
         _type: str,
-        container_properties: Dict[str, Any],
-        node_properties: Dict[str, Any],
-        tags: Dict[str, str],
-        retry_strategy: Dict[str, str],
-        timeout: Dict[str, int],
+        container_properties: dict[str, Any],
+        node_properties: dict[str, Any],
+        tags: dict[str, str],
+        retry_strategy: dict[str, str],
+        timeout: dict[str, int],
         backend: "BatchBackend",
-        platform_capabilities: List[str],
+        platform_capabilities: list[str],
         propagate_tags: bool,
         revision: Optional[int] = 0,
     ):
@@ -248,7 +248,7 @@ class JobDefinition(CloudFormationModel):
 
         if self.container_properties is not None:
             # Set some default values
-            default_values: Dict[str, List[Any]] = {
+            default_values: dict[str, list[Any]] = {
                 "command": [],
                 "resourceRequirements": [],
                 "secrets": [],
@@ -289,7 +289,7 @@ class JobDefinition(CloudFormationModel):
 
         self.backend.tagger.tag_resource(self.arn, tag_list)
 
-    def _format_tags(self, tags: Dict[str, str]) -> List[Dict[str, str]]:
+    def _format_tags(self, tags: dict[str, str]) -> list[dict[str, str]]:
         return [{"Key": k, "Value": v} for k, v in tags.items()]
 
     def _get_resource_requirement(self, req_type: str, default: Any = None) -> Any:
@@ -362,13 +362,13 @@ class JobDefinition(CloudFormationModel):
 
     def update(
         self,
-        parameters: Optional[Dict[str, Any]],
+        parameters: Optional[dict[str, Any]],
         _type: str,
-        container_properties: Dict[str, Any],
-        node_properties: Dict[str, Any],
-        retry_strategy: Dict[str, Any],
-        tags: Dict[str, str],
-        timeout: Dict[str, int],
+        container_properties: dict[str, Any],
+        node_properties: dict[str, Any],
+        retry_strategy: dict[str, Any],
+        tags: dict[str, str],
+        timeout: dict[str, int],
     ) -> "JobDefinition":
         if self.status != "INACTIVE":
             if parameters is None:
@@ -398,7 +398,7 @@ class JobDefinition(CloudFormationModel):
             propagate_tags=self.propagate_tags,
         )
 
-    def describe(self) -> Dict[str, Any]:
+    def describe(self) -> dict[str, Any]:
         result = {
             "jobDefinitionArn": self.arn,
             "jobDefinitionName": self.name,
@@ -435,7 +435,7 @@ class JobDefinition(CloudFormationModel):
     def create_from_cloudformation_json(  # type: ignore[misc]
         cls,
         resource_name: str,
-        cloudformation_json: Dict[str, Any],
+        cloudformation_json: dict[str, Any],
         account_id: str,
         region_name: str,
         **kwargs: Any,
@@ -472,14 +472,14 @@ class Job(threading.Thread, BaseModel, DockerModel, ManagedState):
         job_queue: JobQueue,
         backend: "BatchBackend",
         log_backend: LogsBackend,
-        container_overrides: Optional[Dict[str, Any]],
-        depends_on: Optional[List[Dict[str, str]]],
-        parameters: Optional[Dict[str, str]],
-        all_jobs: Dict[str, "Job"],
-        timeout: Optional[Dict[str, int]],
-        array_properties: Dict[str, Any],
+        container_overrides: Optional[dict[str, Any]],
+        depends_on: Optional[list[dict[str, str]]],
+        parameters: Optional[dict[str, str]],
+        all_jobs: dict[str, "Job"],
+        timeout: Optional[dict[str, int]],
+        array_properties: dict[str, Any],
         provided_job_id: Optional[str] = None,
-        tags: Optional[Dict[str, str]] = None,
+        tags: Optional[dict[str, str]] = None,
     ):
         threading.Thread.__init__(self)
         DockerModel.__init__(self)
@@ -492,7 +492,7 @@ class Job(threading.Thread, BaseModel, DockerModel, ManagedState):
         self.job_name = name
         self.job_id = provided_job_id or str(mock_random.uuid4())
         self.job_definition = job_def
-        self.container_overrides: Dict[str, Any] = container_overrides or {}
+        self.container_overrides: dict[str, Any] = container_overrides or {}
         self.job_queue = job_queue
         self.backend = backend
         self.job_queue.jobs.append(self)
@@ -505,7 +505,7 @@ class Job(threading.Thread, BaseModel, DockerModel, ManagedState):
         self.parameters = {**self.job_definition.parameters, **(parameters or {})}
         self.timeout = timeout
         self.all_jobs = all_jobs
-        self.array_properties: Dict[str, Any] = array_properties
+        self.array_properties: dict[str, Any] = array_properties
 
         self.arn = make_arn_for_job(
             job_def.backend.account_id, self.job_id, job_def._region
@@ -523,9 +523,9 @@ class Job(threading.Thread, BaseModel, DockerModel, ManagedState):
         self._stream_name = f"{self.job_definition.name}/default/{self.job_id}"
         self.log_stream_name: Optional[str] = None
 
-        self.attempts: List[Dict[str, Any]] = []
-        self.latest_attempt: Optional[Dict[str, Any]] = None
-        self._child_jobs: Optional[List[Job]] = None
+        self.attempts: list[dict[str, Any]] = []
+        self.latest_attempt: Optional[dict[str, Any]] = None
+        self._child_jobs: Optional[list[Job]] = None
 
         tag_list = self.backend.tagger.convert_dict_to_tags_input(tags or {})
         # Validate the tag list. Maximum entires in the map is 50
@@ -535,7 +535,7 @@ class Job(threading.Thread, BaseModel, DockerModel, ManagedState):
 
         self.backend.tagger.tag_resource(self.arn, tag_list)
 
-    def describe_short(self) -> Dict[str, Any]:
+    def describe_short(self) -> dict[str, Any]:
         result = {
             "jobId": self.job_id,
             "jobArn": self.arn,
@@ -555,7 +555,7 @@ class Job(threading.Thread, BaseModel, DockerModel, ManagedState):
                 result["container"] = {"exitCode": self.exit_code}
         return result
 
-    def describe(self) -> Dict[str, Any]:
+    def describe(self) -> dict[str, Any]:
         result = self.describe_short()
         result["jobQueue"] = self.job_queue.arn
         result["dependsOn"] = self.depends_on or []
@@ -595,7 +595,7 @@ class Job(threading.Thread, BaseModel, DockerModel, ManagedState):
                 result["status"] = self.status
         return result
 
-    def _container_details(self) -> Dict[str, Any]:
+    def _container_details(self) -> dict[str, Any]:
         details = {}
         details["command"] = self._get_container_property("command", [])
         details["privileged"] = self._get_container_property("privileged", False)
@@ -643,7 +643,7 @@ class Job(threading.Thread, BaseModel, DockerModel, ManagedState):
             return self.job_definition.timeout["attemptDurationSeconds"]
         return None
 
-    def _add_parameters_to_command(self, command: Union[str, List[str]]) -> List[str]:
+    def _add_parameters_to_command(self, command: Union[str, list[str]]) -> list[str]:
         if isinstance(command, str):
             command = [command]
 
@@ -684,7 +684,7 @@ class Job(threading.Thread, BaseModel, DockerModel, ManagedState):
             return
 
         try:
-            containers: List[docker.models.containers.Container] = []
+            containers: list[docker.models.containers.Container] = []
 
             self.advance()
             while self.status == JobStatus.SUBMITTED:
@@ -982,7 +982,7 @@ class Job(threading.Thread, BaseModel, DockerModel, ManagedState):
 
     def _wait_for_dependencies(self) -> bool:
         dependent_ids = [dependency["jobId"] for dependency in self.depends_on]  # type: ignore[union-attr]
-        successful_dependencies: Set[str] = set()
+        successful_dependencies: set[str] = set()
         while len(successful_dependencies) != len(dependent_ids):
             for dependent_id in dependent_ids:
                 if dependent_id in self.all_jobs:
@@ -1011,9 +1011,9 @@ class SchedulingPolicy(BaseModel):
         account_id: str,
         region: str,
         name: str,
-        fairshare_policy: Dict[str, Any],
+        fairshare_policy: dict[str, Any],
         backend: "BatchBackend",
-        tags: Dict[str, str],
+        tags: dict[str, str],
     ):
         self.name = name
         self.arn = f"arn:{get_partition(region)}:batch:{region}:{account_id}:scheduling-policy/{name}"
@@ -1026,8 +1026,8 @@ class SchedulingPolicy(BaseModel):
         if tags:
             backend.tag_resource(self.arn, tags)
 
-    def to_dict(self, create: bool = False) -> Dict[str, Any]:
-        resp: Dict[str, Any] = {"name": self.name, "arn": self.arn}
+    def to_dict(self, create: bool = False) -> dict[str, Any]:
+        resp: dict[str, Any] = {"name": self.name, "arn": self.arn}
         if not create:
             resp["fairsharePolicy"] = self.fairshare_policy
             resp["tags"] = self.backend.list_tags_for_resource(self.arn)
@@ -1047,11 +1047,11 @@ class BatchBackend(BaseBackend):
         super().__init__(region_name, account_id)
         self.tagger = TaggingService()
 
-        self._compute_environments: Dict[str, ComputeEnvironment] = {}
-        self._job_queues: Dict[str, JobQueue] = {}
-        self._job_definitions: Dict[str, JobDefinition] = {}
-        self._jobs: Dict[str, Job] = {}
-        self._scheduling_policies: Dict[str, SchedulingPolicy] = {}
+        self._compute_environments: dict[str, ComputeEnvironment] = {}
+        self._job_queues: dict[str, JobQueue] = {}
+        self._job_definitions: dict[str, JobDefinition] = {}
+        self._jobs: dict[str, Job] = {}
+        self._scheduling_policies: dict[str, SchedulingPolicy] = {}
 
     @property
     def iam_backend(self) -> IAMBackend:
@@ -1180,7 +1180,7 @@ class BatchBackend(BaseBackend):
                 job_def = self.get_job_definition_by_name(identifier)
         return job_def
 
-    def get_job_definitions(self, identifier: str) -> List[JobDefinition]:
+    def get_job_definitions(self, identifier: str) -> list[JobDefinition]:
         """
         Get job definitions by name or ARN
         :param identifier: Name or ARN
@@ -1207,8 +1207,8 @@ class BatchBackend(BaseBackend):
             return None
 
     def describe_compute_environments(
-        self, environments: Optional[List[str]] = None
-    ) -> List[Dict[str, Any]]:
+        self, environments: Optional[list[str]] = None
+    ) -> list[dict[str, Any]]:
         """
         Pagination is not yet implemented
         """
@@ -1222,7 +1222,7 @@ class BatchBackend(BaseBackend):
             if len(envs) > 0 and arn not in envs and environment.name not in envs:
                 continue
 
-            json_part: Dict[str, Any] = {
+            json_part: dict[str, Any] = {
                 "computeEnvironmentArn": arn,
                 "computeEnvironmentName": environment.name,
                 "ecsClusterArn": environment.ecs_arn,
@@ -1245,9 +1245,9 @@ class BatchBackend(BaseBackend):
         compute_environment_name: str,
         _type: str,
         state: str,
-        compute_resources: Dict[str, Any],
+        compute_resources: dict[str, Any],
         service_role: str,
-        tags: Optional[Dict[str, str]] = None,
+        tags: Optional[dict[str, str]] = None,
     ) -> ComputeEnvironment:
         # Validate
         if COMPUTE_ENVIRONMENT_NAME_REGEX.match(compute_environment_name) is None:
@@ -1344,7 +1344,7 @@ class BatchBackend(BaseBackend):
 
         return new_comp_env
 
-    def _validate_compute_resources(self, cr: Dict[str, Any]) -> None:
+    def _validate_compute_resources(self, cr: dict[str, Any]) -> None:
         """
         Checks contents of sub dictionary for managed clusters
 
@@ -1424,8 +1424,8 @@ class BatchBackend(BaseBackend):
 
     @staticmethod
     def find_min_instances_to_meet_vcpus(
-        instance_types: List[str], target: float
-    ) -> List[str]:
+        instance_types: list[str], target: float
+    ) -> list[str]:
         """
         Finds the minimum needed instances to meed a vcpu target
 
@@ -1505,7 +1505,7 @@ class BatchBackend(BaseBackend):
         state: Optional[str],
         compute_resources: Optional[Any],
         service_role: Optional[str],
-    ) -> Tuple[str, str]:
+    ) -> tuple[str, str]:
         # Validate
         compute_env = self.get_compute_environment(compute_environment_name)
         if compute_env is None:
@@ -1543,8 +1543,8 @@ class BatchBackend(BaseBackend):
         priority: str,
         schedule_policy: Optional[str],
         state: str,
-        compute_env_order: List[Dict[str, str]],
-        tags: Optional[Dict[str, str]] = None,
+        compute_env_order: list[dict[str, str]],
+        tags: Optional[dict[str, str]] = None,
     ) -> JobQueue:
         for variable, var_name in (
             (queue_name, "jobQueueName"),
@@ -1596,8 +1596,8 @@ class BatchBackend(BaseBackend):
         return queue
 
     def describe_job_queues(
-        self, job_queues: Optional[List[str]] = None
-    ) -> List[Dict[str, Any]]:
+        self, job_queues: Optional[list[str]] = None
+    ) -> list[dict[str, Any]]:
         """
         Pagination is not yet implemented
         """
@@ -1620,9 +1620,9 @@ class BatchBackend(BaseBackend):
         queue_name: str,
         priority: Optional[str],
         state: Optional[str],
-        compute_env_order: Optional[List[Dict[str, Any]]],
+        compute_env_order: Optional[list[dict[str, Any]]],
         schedule_policy: Optional[str],
-    ) -> Tuple[str, str]:
+    ) -> tuple[str, str]:
         if queue_name is None:
             raise ClientException("jobQueueName must be provided")
 
@@ -1678,14 +1678,14 @@ class BatchBackend(BaseBackend):
     def register_job_definition(
         self,
         def_name: str,
-        parameters: Dict[str, Any],
+        parameters: dict[str, Any],
         _type: str,
-        tags: Dict[str, str],
-        retry_strategy: Dict[str, Any],
-        container_properties: Dict[str, Any],
-        node_properties: Dict[str, Any],
-        timeout: Dict[str, int],
-        platform_capabilities: List[str],
+        tags: dict[str, str],
+        retry_strategy: dict[str, Any],
+        container_properties: dict[str, Any],
+        node_properties: dict[str, Any],
+        timeout: dict[str, int],
+        platform_capabilities: list[str],
         propagate_tags: bool,
     ) -> JobDefinition:
         if def_name is None:
@@ -1740,9 +1740,9 @@ class BatchBackend(BaseBackend):
     def describe_job_definitions(
         self,
         job_def_name: Optional[str] = None,
-        job_def_list: Optional[List[str]] = None,
+        job_def_list: Optional[list[str]] = None,
         status: Optional[str] = None,
-    ) -> List[JobDefinition]:
+    ) -> list[JobDefinition]:
         """
         Pagination is not yet implemented
         """
@@ -1773,13 +1773,13 @@ class BatchBackend(BaseBackend):
         job_name: str,
         job_def_id: str,
         job_queue: str,
-        array_properties: Dict[str, int],
-        depends_on: Optional[List[Dict[str, str]]] = None,
-        container_overrides: Optional[Dict[str, Any]] = None,
-        timeout: Optional[Dict[str, int]] = None,
-        parameters: Optional[Dict[str, str]] = None,
-        tags: Optional[Dict[str, str]] = None,
-    ) -> Tuple[str, str, str]:
+        array_properties: dict[str, int],
+        depends_on: Optional[list[dict[str, str]]] = None,
+        container_overrides: Optional[dict[str, Any]] = None,
+        timeout: Optional[dict[str, int]] = None,
+        parameters: Optional[dict[str, str]] = None,
+        tags: Optional[dict[str, str]] = None,
+    ) -> tuple[str, str, str]:
         """
         Parameters RetryStrategy and Parameters are not yet implemented.
         """
@@ -1842,7 +1842,7 @@ class BatchBackend(BaseBackend):
             job.start()
         return job_name, job.job_id, job.arn
 
-    def describe_jobs(self, jobs: Optional[List[str]]) -> List[Dict[str, Any]]:
+    def describe_jobs(self, jobs: Optional[list[str]]) -> list[dict[str, Any]]:
         job_filter = set()
         if jobs is not None:
             job_filter = set(jobs)
@@ -1865,15 +1865,15 @@ class BatchBackend(BaseBackend):
         job_queue_name: Optional[str],
         array_job_id: Optional[str],
         job_status: Optional[str] = None,
-        filters: Optional[List[Dict[str, Any]]] = None,
-    ) -> List[Job]:
+        filters: Optional[list[dict[str, Any]]] = None,
+    ) -> list[Job]:
         """
         TODO: Pagination is not yet implemented
         TODO: Acording to Boto3 documentation, filters are not supported when filtering by batch array job id.
             Current implementation does not differentiate between array job listing and normal job listing.
         """
-        jobs_to_check: List[Job] = []
-        jobs: List[Job] = []
+        jobs_to_check: list[Job] = []
+        jobs: list[Job] = []
 
         if job_queue_name:
             if job_queue := self.get_job_queue(job_queue_name):
@@ -1896,7 +1896,7 @@ class BatchBackend(BaseBackend):
                 "Job status is not one of SUBMITTED | PENDING | RUNNABLE | STARTING | RUNNING | SUCCEEDED | FAILED"
             )
 
-        def matches_filter(job: Job, filter: Dict[str, Any]) -> bool:
+        def matches_filter(job: Job, filter: dict[str, Any]) -> bool:
             if filter["name"] == "JOB_NAME":
                 for value in filter["values"]:
                     if value.endswith("*"):
@@ -1960,18 +1960,18 @@ class BatchBackend(BaseBackend):
         if job is not None:
             job.terminate(reason)
 
-    def tag_resource(self, resource_arn: str, tags: Dict[str, str]) -> None:
+    def tag_resource(self, resource_arn: str, tags: dict[str, str]) -> None:
         tag_list = self.tagger.convert_dict_to_tags_input(tags or {})
         self.tagger.tag_resource(resource_arn, tag_list)
 
-    def list_tags_for_resource(self, resource_arn: str) -> Dict[str, str]:
+    def list_tags_for_resource(self, resource_arn: str) -> dict[str, str]:
         return self.tagger.get_tag_dict_for_resource(resource_arn)
 
-    def untag_resource(self, resource_arn: str, tag_keys: List[str]) -> None:
+    def untag_resource(self, resource_arn: str, tag_keys: list[str]) -> None:
         self.tagger.untag_resource_using_names(resource_arn, tag_keys)
 
     def create_scheduling_policy(
-        self, name: str, fairshare_policy: Dict[str, Any], tags: Dict[str, str]
+        self, name: str, fairshare_policy: dict[str, Any], tags: dict[str, str]
     ) -> SchedulingPolicy:
         policy = SchedulingPolicy(
             self.account_id, self.region_name, name, fairshare_policy, self, tags
@@ -1979,10 +1979,10 @@ class BatchBackend(BaseBackend):
         self._scheduling_policies[policy.arn] = policy
         return self._scheduling_policies[policy.arn]
 
-    def describe_scheduling_policies(self, arns: List[str]) -> List[SchedulingPolicy]:
+    def describe_scheduling_policies(self, arns: list[str]) -> list[SchedulingPolicy]:
         return [pol for arn, pol in self._scheduling_policies.items() if arn in arns]
 
-    def list_scheduling_policies(self) -> List[str]:
+    def list_scheduling_policies(self) -> list[str]:
         """
         Pagination is not yet implemented
         """
@@ -1992,7 +1992,7 @@ class BatchBackend(BaseBackend):
         self._scheduling_policies.pop(arn, None)
 
     def update_scheduling_policy(
-        self, arn: str, fairshare_policy: Dict[str, Any]
+        self, arn: str, fairshare_policy: dict[str, Any]
     ) -> None:
         self._scheduling_policies[arn].fairshare_policy = fairshare_policy
 

--- a/moto/batch/utils.py
+++ b/moto/batch/utils.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Optional
 
 from moto.utilities.utils import get_partition
 
@@ -24,8 +24,8 @@ def make_arn_for_task_def(
     return f"arn:{get_partition(region_name)}:batch:{region_name}:{account_id}:job-definition/{name}:{revision}"
 
 
-def lowercase_first_key(some_dict: Dict[str, Any]) -> Dict[str, Any]:
-    new_dict: Dict[str, Any] = {}
+def lowercase_first_key(some_dict: dict[str, Any]) -> dict[str, Any]:
+    new_dict: dict[str, Any] = {}
     for key, value in some_dict.items():
         new_key = key[0].lower() + key[1:]
         try:
@@ -41,13 +41,11 @@ def lowercase_first_key(some_dict: Dict[str, Any]) -> Dict[str, Any]:
     return new_dict
 
 
-def validate_job_status(target_job_status: str, valid_job_statuses: List[str]) -> None:
+def validate_job_status(target_job_status: str, valid_job_statuses: list[str]) -> None:
     if target_job_status not in valid_job_statuses:
         raise ValidationError(
-            (
-                "1 validation error detected: Value at 'current_status' failed "
-                "to satisfy constraint: Member must satisfy enum value set: {valid_statues}"
-            ).format(valid_statues=valid_job_statuses)
+            "1 validation error detected: Value at 'current_status' failed "
+            f"to satisfy constraint: Member must satisfy enum value set: {valid_job_statuses}"
         )
 
 
@@ -61,7 +59,7 @@ class JobStatus(str, Enum):
     FAILED = "FAILED"
 
     @classmethod
-    def job_statuses(self) -> List[str]:
+    def job_statuses(self) -> list[str]:
         return sorted([item.value for item in JobStatus])
 
     @classmethod
@@ -84,7 +82,7 @@ class JobStatus(str, Enum):
         ]
 
     @classmethod
-    def status_transitions(self) -> List[Tuple[Optional[str], str]]:
+    def status_transitions(self) -> list[tuple[Optional[str], str]]:
         return [
             (JobStatus.SUBMITTED.value, JobStatus.PENDING.value),
             (JobStatus.PENDING.value, JobStatus.RUNNABLE.value),

--- a/moto/batch_simple/models.py
+++ b/moto/batch_simple/models.py
@@ -1,7 +1,7 @@
 import datetime
 from os import getenv
 from time import sleep
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Optional
 
 from moto.batch.exceptions import ClientException
 from moto.batch.models import BatchBackend, Job, batch_backends
@@ -52,13 +52,13 @@ class BatchSimpleBackend(BatchBackend):
         job_name: str,
         job_def_id: str,
         job_queue: str,
-        array_properties: Dict[str, Any],
-        depends_on: Optional[List[Dict[str, str]]] = None,
-        container_overrides: Optional[Dict[str, Any]] = None,
-        timeout: Optional[Dict[str, int]] = None,
-        parameters: Optional[Dict[str, str]] = None,
-        tags: Optional[Dict[str, str]] = None,
-    ) -> Tuple[str, str, str]:
+        array_properties: dict[str, Any],
+        depends_on: Optional[list[dict[str, str]]] = None,
+        container_overrides: Optional[dict[str, Any]] = None,
+        timeout: Optional[dict[str, int]] = None,
+        parameters: Optional[dict[str, str]] = None,
+        tags: Optional[dict[str, str]] = None,
+    ) -> tuple[str, str, str]:
         # Look for job definition
         job_def = self.get_job_definition(job_def_id)
         if job_def is None:
@@ -84,7 +84,7 @@ class BatchSimpleBackend(BatchBackend):
         )
 
         if "size" in array_properties:
-            child_jobs: List[Job] = []
+            child_jobs: list[Job] = []
             for array_index in range(array_properties.get("size", 0)):
                 provided_job_id = f"{job.job_id}:{array_index}"
                 child_job = Job(

--- a/moto/bedrock/models.py
+++ b/moto/bedrock/models.py
@@ -2,7 +2,7 @@
 
 import re
 from datetime import datetime
-from typing import Any, Dict, List, Optional
+from typing import Any, Optional
 
 from moto.bedrock.exceptions import (
     ResourceInUseException,
@@ -24,18 +24,18 @@ class ModelCustomizationJob(BaseModel):
         custom_model_name: str,
         role_arn: str,
         base_model_identifier: str,
-        training_data_config: Dict[str, str],
-        output_data_config: Dict[str, str],
-        hyper_parameters: Dict[str, str],
+        training_data_config: dict[str, str],
+        output_data_config: dict[str, str],
+        hyper_parameters: dict[str, str],
         region_name: str,
         account_id: str,
         client_request_token: Optional[str],
         customization_type: Optional[str],
         custom_model_kms_key_id: Optional[str],
-        job_tags: Optional[List[Dict[str, str]]],
-        custom_model_tags: Optional[List[Dict[str, str]]],
-        validation_data_config: Optional[Dict[str, Any]],
-        vpc_config: Optional[Dict[str, Any]],
+        job_tags: Optional[list[dict[str, str]]],
+        custom_model_tags: Optional[list[dict[str, str]]],
+        validation_data_config: Optional[dict[str, Any]],
+        vpc_config: Optional[dict[str, Any]],
     ):
         self.job_name = job_name
         self.custom_model_name = custom_model_name
@@ -94,7 +94,7 @@ class ModelCustomizationJob(BaseModel):
         self.training_metrics = {"trainingLoss": 0.0}  # hard coded
         self.validation_metrics = [{"validationLoss": 0.0}]  # hard coded
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         dct = {
             "baseModelArn": self.base_model_arn,
             "clientRequestToken": self.client_request_token,
@@ -128,17 +128,17 @@ class CustomModel(BaseModel):
         job_name: str,
         job_arn: str,
         base_model_arn: str,
-        hyper_parameters: Dict[str, str],
-        output_data_config: Dict[str, str],
-        training_data_config: Dict[str, str],
-        training_metrics: Dict[str, float],
+        hyper_parameters: dict[str, str],
+        output_data_config: dict[str, str],
+        training_data_config: dict[str, str],
+        training_metrics: dict[str, float],
         base_model_name: str,
         region_name: str,
         account_id: str,
         customization_type: Optional[str],
         model_kms_key_arn: Optional[str],
-        validation_data_config: Optional[Dict[str, Any]],
-        validation_metrics: Optional[List[Dict[str, float]]],
+        validation_data_config: Optional[dict[str, Any]],
+        validation_metrics: Optional[list[dict[str, float]]],
     ):
         self.model_name = model_name
         self.job_name = job_name
@@ -158,7 +158,7 @@ class CustomModel(BaseModel):
         self.creation_time = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
         self.base_model_name = base_model_name
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         dct = {
             "baseModelArn": self.base_model_arn,
             "creationTime": self.creation_time,
@@ -179,7 +179,7 @@ class CustomModel(BaseModel):
 
 
 class model_invocation_logging_configuration(BaseModel):
-    def __init__(self, logging_config: Dict[str, Any]) -> None:
+    def __init__(self, logging_config: dict[str, Any]) -> None:
         self.logging_config = logging_config
 
 
@@ -203,14 +203,14 @@ class BedrockBackend(BaseBackend):
 
     def __init__(self, region_name: str, account_id: str) -> None:
         super().__init__(region_name, account_id)
-        self.model_customization_jobs: Dict[str, ModelCustomizationJob] = {}
-        self.custom_models: Dict[str, CustomModel] = {}
+        self.model_customization_jobs: dict[str, ModelCustomizationJob] = {}
+        self.custom_models: dict[str, CustomModel] = {}
         self.model_invocation_logging_configuration: Optional[
             model_invocation_logging_configuration
         ] = None
         self.tagger = TaggingService()
 
-    def _list_arns(self) -> List[str]:
+    def _list_arns(self) -> list[str]:
         return [job.job_arn for job in self.model_customization_jobs.values()] + [
             model.model_arn for model in self.custom_models.values()
         ]
@@ -221,16 +221,16 @@ class BedrockBackend(BaseBackend):
         custom_model_name: str,
         role_arn: str,
         base_model_identifier: str,
-        training_data_config: Dict[str, Any],
-        output_data_config: Dict[str, str],
-        hyper_parameters: Dict[str, str],
+        training_data_config: dict[str, Any],
+        output_data_config: dict[str, str],
+        hyper_parameters: dict[str, str],
         client_request_token: Optional[str],
         customization_type: Optional[str],
         custom_model_kms_key_id: Optional[str],
-        job_tags: Optional[List[Dict[str, str]]],
-        custom_model_tags: Optional[List[Dict[str, str]]],
-        validation_data_config: Optional[Dict[str, Any]],
-        vpc_config: Optional[Dict[str, Any]],
+        job_tags: Optional[list[dict[str, str]]],
+        custom_model_tags: Optional[list[dict[str, str]]],
+        validation_data_config: Optional[dict[str, Any]],
+        vpc_config: Optional[dict[str, Any]],
     ) -> str:
         if job_name in self.model_customization_jobs.keys():
             raise ResourceInUseException(
@@ -310,7 +310,7 @@ class BedrockBackend(BaseBackend):
         name_contains: Optional[str],
         sort_by: Optional[str],
         sort_order: Optional[str],
-    ) -> List[ModelCustomizationJob]:
+    ) -> list[ModelCustomizationJob]:
         customization_jobs_fetched = list(self.model_customization_jobs.values())
 
         if name_contains is not None:
@@ -363,14 +363,14 @@ class BedrockBackend(BaseBackend):
 
         return customization_jobs_fetched
 
-    def get_model_invocation_logging_configuration(self) -> Optional[Dict[str, Any]]:
+    def get_model_invocation_logging_configuration(self) -> Optional[dict[str, Any]]:
         if self.model_invocation_logging_configuration:
             return self.model_invocation_logging_configuration.logging_config
         else:
             return {}
 
     def put_model_invocation_logging_configuration(
-        self, logging_config: Dict[str, Any]
+        self, logging_config: dict[str, Any]
     ) -> None:
         invocation_logging = model_invocation_logging_configuration(logging_config)
         self.model_invocation_logging_configuration = invocation_logging
@@ -410,7 +410,7 @@ class BedrockBackend(BaseBackend):
         foundation_model_arn_equals: Optional[str],
         sort_by: Optional[str],
         sort_order: Optional[str],
-    ) -> List[CustomModel]:
+    ) -> list[CustomModel]:
         """
         The foundation_model_arn_equals-argument is not yet supported
         """
@@ -465,7 +465,7 @@ class BedrockBackend(BaseBackend):
                 raise ValidationException(f"Invalid sort by field: {sort_by}")
         return custom_models_fetched
 
-    def tag_resource(self, resource_arn: str, tags: List[Dict[str, str]]) -> None:
+    def tag_resource(self, resource_arn: str, tags: list[dict[str, str]]) -> None:
         if resource_arn not in self._list_arns():
             raise ResourceNotFoundException(f"Resource {resource_arn} not found")
         fixed_tags = []
@@ -478,13 +478,13 @@ class BedrockBackend(BaseBackend):
         self.tagger.tag_resource(resource_arn, fixed_tags)
         return
 
-    def untag_resource(self, resource_arn: str, tag_keys: List[str]) -> None:
+    def untag_resource(self, resource_arn: str, tag_keys: list[str]) -> None:
         if resource_arn not in self._list_arns():
             raise ResourceNotFoundException(f"Resource {resource_arn} not found")
         self.tagger.untag_resource_using_names(resource_arn, tag_keys)
         return
 
-    def list_tags_for_resource(self, resource_arn: str) -> List[Dict[str, str]]:
+    def list_tags_for_resource(self, resource_arn: str) -> list[dict[str, str]]:
         if resource_arn not in self._list_arns():
             raise ResourceNotFoundException(f"Resource {resource_arn} not found")
         tags = self.tagger.list_tags_for_resource(resource_arn)

--- a/moto/bedrockagent/models.py
+++ b/moto/bedrockagent/models.py
@@ -1,6 +1,6 @@
 """AgentsforBedrockBackend class with methods for supported APIs."""
 
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Optional
 
 from moto.bedrockagent.exceptions import (
     ConflictException,
@@ -29,7 +29,7 @@ class Agent(BaseModel):
         description: Optional[str],
         idle_session_ttl_in_seconds: Optional[int],
         customer_encryption_key_arn: Optional[str],
-        prompt_override_configuration: Optional[Dict[str, Any]],
+        prompt_override_configuration: Optional[dict[str, Any]],
     ):
         self.agent_name = agent_name
         self.client_token = client_token
@@ -49,10 +49,10 @@ class Agent(BaseModel):
         self.agent_id = self.agent_name + str(mock_random.uuid4())[:8]
         self.agent_arn = f"arn:{get_partition(self.region_name)}:bedrock:{self.region_name}:{self.account_id}:agent/{self.agent_id}"
         self.agent_version = "1.0"
-        self.failure_reasons: List[str] = []
+        self.failure_reasons: list[str] = []
         self.recommended_actions = ["action"]
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         dct = {
             "agentId": self.agent_id,
             "agentName": self.agent_name,
@@ -75,7 +75,7 @@ class Agent(BaseModel):
         }
         return {k: v for k, v in dct.items() if v}
 
-    def dict_summary(self) -> Dict[str, Any]:
+    def dict_summary(self) -> dict[str, Any]:
         dct = {
             "agentId": self.agent_id,
             "agentName": self.agent_name,
@@ -94,8 +94,8 @@ class KnowledgeBase(BaseModel):
         role_arn: str,
         region_name: str,
         account_id: str,
-        knowledge_base_configuration: Dict[str, Any],
-        storage_configuration: Dict[str, Any],
+        knowledge_base_configuration: dict[str, Any],
+        storage_configuration: dict[str, Any],
         client_token: Optional[str],
         description: Optional[str],
     ):
@@ -129,9 +129,9 @@ class KnowledgeBase(BaseModel):
         self.created_at = unix_time()
         self.updated_at = unix_time()
         self.status = "Active"
-        self.failure_reasons: List[str] = []
+        self.failure_reasons: list[str] = []
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         dct = {
             "knowledgeBaseId": self.knowledge_base_id,
             "name": self.name,
@@ -147,7 +147,7 @@ class KnowledgeBase(BaseModel):
         }
         return {k: v for k, v in dct.items() if v}
 
-    def dict_summary(self) -> Dict[str, Any]:
+    def dict_summary(self) -> dict[str, Any]:
         dct = {
             "knowledgeBaseId": self.knowledge_base_id,
             "name": self.name,
@@ -178,11 +178,11 @@ class AgentsforBedrockBackend(BaseBackend):
 
     def __init__(self, region_name: str, account_id: str):
         super().__init__(region_name, account_id)
-        self.agents: Dict[str, Agent] = {}
-        self.knowledge_bases: Dict[str, KnowledgeBase] = {}
+        self.agents: dict[str, Agent] = {}
+        self.knowledge_bases: dict[str, KnowledgeBase] = {}
         self.tagger = TaggingService()
 
-    def _list_arns(self) -> List[str]:
+    def _list_arns(self) -> list[str]:
         return [agent.agent_arn for agent in self.agents.values()] + [
             knowledge_base.knowledge_base_arn
             for knowledge_base in self.knowledge_bases.values()
@@ -198,8 +198,8 @@ class AgentsforBedrockBackend(BaseBackend):
         description: Optional[str],
         idle_session_ttl_in_seconds: Optional[int],
         customer_encryption_key_arn: Optional[str],
-        tags: Optional[Dict[str, str]],
-        prompt_override_configuration: Optional[Dict[str, Any]],
+        tags: Optional[dict[str, str]],
+        prompt_override_configuration: Optional[dict[str, Any]],
     ) -> Agent:
         agent = Agent(
             agent_name,
@@ -225,12 +225,12 @@ class AgentsforBedrockBackend(BaseBackend):
         return self.agents[agent_id]
 
     @paginate(pagination_model=PAGINATION_MODEL)
-    def list_agents(self) -> List[Agent]:
+    def list_agents(self) -> list[Agent]:
         return [agent for agent in self.agents.values()]
 
     def delete_agent(
         self, agent_id: str, skip_resource_in_use_check: Optional[bool]
-    ) -> Tuple[str, str]:
+    ) -> tuple[str, str]:
         if agent_id in self.agents:
             if (
                 skip_resource_in_use_check
@@ -249,11 +249,11 @@ class AgentsforBedrockBackend(BaseBackend):
         self,
         name: str,
         role_arn: str,
-        knowledge_base_configuration: Dict[str, Any],
-        storage_configuration: Dict[str, Any],
+        knowledge_base_configuration: dict[str, Any],
+        storage_configuration: dict[str, Any],
         client_token: Optional[str],
         description: Optional[str],
-        tags: Optional[Dict[str, str]],
+        tags: Optional[dict[str, str]],
     ) -> KnowledgeBase:
         knowledge_base = KnowledgeBase(
             name,
@@ -271,10 +271,10 @@ class AgentsforBedrockBackend(BaseBackend):
         return knowledge_base
 
     @paginate(pagination_model=PAGINATION_MODEL)
-    def list_knowledge_bases(self) -> List[KnowledgeBase]:
+    def list_knowledge_bases(self) -> list[KnowledgeBase]:
         return [knowledge_base for knowledge_base in self.knowledge_bases.values()]
 
-    def delete_knowledge_base(self, knowledge_base_id: str) -> Tuple[str, str]:
+    def delete_knowledge_base(self, knowledge_base_id: str) -> tuple[str, str]:
         if knowledge_base_id in self.knowledge_bases:
             self.knowledge_bases[knowledge_base_id].status = "DELETING"
             knowledge_base_status = self.knowledge_bases[knowledge_base_id].status
@@ -292,20 +292,20 @@ class AgentsforBedrockBackend(BaseBackend):
             )
         return self.knowledge_bases[knowledge_base_id]
 
-    def tag_resource(self, resource_arn: str, tags: Dict[str, str]) -> None:
+    def tag_resource(self, resource_arn: str, tags: dict[str, str]) -> None:
         if resource_arn not in self._list_arns():
             raise ResourceNotFoundException(f"Resource {resource_arn} not found")
         tags_input = TaggingService.convert_dict_to_tags_input(tags or {})
         self.tagger.tag_resource(resource_arn, tags_input)
         return
 
-    def untag_resource(self, resource_arn: str, tag_keys: List[str]) -> None:
+    def untag_resource(self, resource_arn: str, tag_keys: list[str]) -> None:
         if resource_arn not in self._list_arns():
             raise ResourceNotFoundException(f"Resource {resource_arn} not found")
         self.tagger.untag_resource_using_names(resource_arn, tag_keys)
         return
 
-    def list_tags_for_resource(self, resource_arn: str) -> Dict[str, str]:
+    def list_tags_for_resource(self, resource_arn: str) -> dict[str, str]:
         if resource_arn not in self._list_arns():
             raise ResourceNotFoundException(f"Resource {resource_arn} not found")
         return self.tagger.get_tag_dict_for_resource(resource_arn)

--- a/moto/budgets/models.py
+++ b/moto/budgets/models.py
@@ -1,7 +1,8 @@
 from collections import defaultdict
+from collections.abc import Iterable
 from copy import deepcopy
 from datetime import datetime
-from typing import Any, Dict, Iterable, List
+from typing import Any
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
@@ -12,13 +13,13 @@ from .exceptions import BudgetMissingLimit, DuplicateRecordException, NotFoundEx
 
 
 class Notification(BaseModel):
-    def __init__(self, details: Dict[str, Any], subscribers: Dict[str, Any]):
+    def __init__(self, details: dict[str, Any], subscribers: dict[str, Any]):
         self.details = details
         self.subscribers = subscribers
 
 
 class Budget(BaseModel):
-    def __init__(self, budget: Dict[str, Any], notifications: List[Dict[str, Any]]):
+    def __init__(self, budget: dict[str, Any], notifications: list[dict[str, Any]]):
         if "BudgetLimit" not in budget and "PlannedBudgetLimits" not in budget:
             raise BudgetMissingLimit()
         # Storing the budget as a Dict for now - if we need more control, we can always read/write it back
@@ -37,7 +38,7 @@ class Budget(BaseModel):
                 "End": 3706473600,  # "2087-06-15T00:00:00+00:00"
             }
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         cp = deepcopy(self.budget)
         if "CalculatedSpend" not in cp:
             cp["CalculatedSpend"] = {
@@ -61,14 +62,14 @@ class Budget(BaseModel):
         return cp
 
     def add_notification(
-        self, details: Dict[str, Any], subscribers: Dict[str, Any]
+        self, details: dict[str, Any], subscribers: dict[str, Any]
     ) -> None:
         self.notifications.append(Notification(details, subscribers))
 
-    def delete_notification(self, details: Dict[str, Any]) -> None:
+    def delete_notification(self, details: dict[str, Any]) -> None:
         self.notifications = [n for n in self.notifications if n.details != details]
 
-    def get_notifications(self) -> Iterable[Dict[str, Any]]:
+    def get_notifications(self) -> Iterable[dict[str, Any]]:
         return [n.details for n in self.notifications]
 
 
@@ -77,13 +78,13 @@ class BudgetsBackend(BaseBackend):
 
     def __init__(self, region_name: str, account_id: str):
         super().__init__(region_name, account_id)
-        self.budgets: Dict[str, Dict[str, Budget]] = defaultdict(dict)
+        self.budgets: dict[str, dict[str, Budget]] = defaultdict(dict)
 
     def create_budget(
         self,
         account_id: str,
-        budget: Dict[str, Any],
-        notifications: List[Dict[str, Any]],
+        budget: dict[str, Any],
+        notifications: list[dict[str, Any]],
     ) -> None:
         budget_name = budget["BudgetName"]
         if budget_name in self.budgets[account_id]:
@@ -92,14 +93,14 @@ class BudgetsBackend(BaseBackend):
             )
         self.budgets[account_id][budget_name] = Budget(budget, notifications)
 
-    def describe_budget(self, account_id: str, budget_name: str) -> Dict[str, Any]:
+    def describe_budget(self, account_id: str, budget_name: str) -> dict[str, Any]:
         if budget_name not in self.budgets[account_id]:
             raise NotFoundException(
                 f"Unable to get budget: {budget_name} - the budget doesn't exist."
             )
         return self.budgets[account_id][budget_name].to_dict()
 
-    def describe_budgets(self, account_id: str) -> Iterable[Dict[str, Any]]:
+    def describe_budgets(self, account_id: str) -> Iterable[dict[str, Any]]:
         """
         Pagination is not yet implemented
         """
@@ -115,8 +116,8 @@ class BudgetsBackend(BaseBackend):
         self,
         account_id: str,
         budget_name: str,
-        notification: Dict[str, Any],
-        subscribers: Dict[str, Any],
+        notification: dict[str, Any],
+        subscribers: dict[str, Any],
     ) -> None:
         if budget_name not in self.budgets[account_id]:
             raise NotFoundException(
@@ -127,7 +128,7 @@ class BudgetsBackend(BaseBackend):
         )
 
     def delete_notification(
-        self, account_id: str, budget_name: str, notification: Dict[str, Any]
+        self, account_id: str, budget_name: str, notification: dict[str, Any]
     ) -> None:
         if budget_name not in self.budgets[account_id]:
             raise NotFoundException(
@@ -137,7 +138,7 @@ class BudgetsBackend(BaseBackend):
 
     def describe_notifications_for_budget(
         self, account_id: str, budget_name: str
-    ) -> Iterable[Dict[str, Any]]:
+    ) -> Iterable[dict[str, Any]]:
         """
         Pagination has not yet been implemented
         """

--- a/moto/ce/models.py
+++ b/moto/ce/models.py
@@ -1,7 +1,7 @@
 """CostExplorerBackend class with methods for supported APIs."""
 
 from datetime import datetime
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Optional
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
@@ -32,9 +32,9 @@ class CostCategoryDefinition(BaseModel):
         name: str,
         effective_start: Optional[str],
         rule_version: str,
-        rules: List[Dict[str, Any]],
+        rules: list[dict[str, Any]],
         default_value: str,
-        split_charge_rules: List[Dict[str, Any]],
+        split_charge_rules: list[dict[str, Any]],
     ):
         self.name = name
         self.rule_version = rule_version
@@ -48,9 +48,9 @@ class CostCategoryDefinition(BaseModel):
         self,
         rule_version: str,
         effective_start: Optional[str],
-        rules: List[Dict[str, Any]],
+        rules: list[dict[str, Any]],
         default_value: str,
-        split_charge_rules: List[Dict[str, Any]],
+        split_charge_rules: list[dict[str, Any]],
     ) -> None:
         self.rule_version = rule_version
         self.rules = rules
@@ -58,7 +58,7 @@ class CostCategoryDefinition(BaseModel):
         self.split_charge_rules = split_charge_rules
         self.effective_start = effective_start or first_day()
 
-    def to_json(self) -> Dict[str, Any]:
+    def to_json(self) -> dict[str, Any]:
         return {
             "CostCategoryArn": self.arn,
             "Name": self.name,
@@ -75,9 +75,9 @@ class CostExplorerBackend(BaseBackend):
 
     def __init__(self, region_name: str, account_id: str):
         super().__init__(region_name, account_id)
-        self.cost_categories: Dict[str, CostCategoryDefinition] = dict()
-        self.cost_usage_results_queue: List[Dict[str, Any]] = []
-        self.cost_usage_results: Dict[str, Dict[str, Any]] = {}
+        self.cost_categories: dict[str, CostCategoryDefinition] = dict()
+        self.cost_usage_results_queue: list[dict[str, Any]] = []
+        self.cost_usage_results: dict[str, dict[str, Any]] = {}
         self.tagger = TaggingService()
 
     def create_cost_category_definition(
@@ -85,11 +85,11 @@ class CostExplorerBackend(BaseBackend):
         name: str,
         effective_start: Optional[str],
         rule_version: str,
-        rules: List[Dict[str, Any]],
+        rules: list[dict[str, Any]],
         default_value: str,
-        split_charge_rules: List[Dict[str, Any]],
-        tags: List[Dict[str, str]],
-    ) -> Tuple[str, str]:
+        split_charge_rules: list[dict[str, Any]],
+        tags: list[dict[str, str]],
+    ) -> tuple[str, str]:
         """
         The EffectiveOn and ResourceTags-parameters are not yet implemented
         """
@@ -120,7 +120,7 @@ class CostExplorerBackend(BaseBackend):
 
     def delete_cost_category_definition(
         self, cost_category_arn: str
-    ) -> Tuple[str, str]:
+    ) -> tuple[str, str]:
         """
         The EffectiveOn-parameter is not yet implemented
         """
@@ -132,10 +132,10 @@ class CostExplorerBackend(BaseBackend):
         cost_category_arn: str,
         effective_start: Optional[str],
         rule_version: str,
-        rules: List[Dict[str, Any]],
+        rules: list[dict[str, Any]],
         default_value: str,
-        split_charge_rules: List[Dict[str, Any]],
-    ) -> Tuple[str, str]:
+        split_charge_rules: list[dict[str, Any]],
+    ) -> tuple[str, str]:
         """
         The EffectiveOn-parameter is not yet implemented
         """
@@ -150,16 +150,16 @@ class CostExplorerBackend(BaseBackend):
 
         return cost_category_arn, cost_category.effective_start
 
-    def list_tags_for_resource(self, resource_arn: str) -> List[Dict[str, str]]:
+    def list_tags_for_resource(self, resource_arn: str) -> list[dict[str, str]]:
         return self.tagger.list_tags_for_resource(arn=resource_arn)["Tags"]
 
-    def tag_resource(self, resource_arn: str, tags: List[Dict[str, str]]) -> None:
+    def tag_resource(self, resource_arn: str, tags: list[dict[str, str]]) -> None:
         self.tagger.tag_resource(resource_arn, tags)
 
-    def untag_resource(self, resource_arn: str, tag_keys: List[str]) -> None:
+    def untag_resource(self, resource_arn: str, tag_keys: list[str]) -> None:
         self.tagger.untag_resource_using_names(resource_arn, tag_keys)
 
-    def get_cost_and_usage(self, body: str) -> Dict[str, Any]:
+    def get_cost_and_usage(self, body: str) -> dict[str, Any]:
         """
         There is no validation yet on any of the input parameters.
 
@@ -202,7 +202,7 @@ class CostExplorerBackend(BaseBackend):
             ce = boto3.client("ce", region_name="us-east-1")
             resp = ce.get_cost_and_usage(...)
         """
-        default_result: Dict[str, Any] = {
+        default_result: dict[str, Any] = {
             "ResultsByTime": [],
             "DimensionValueAttributes": [],
         }

--- a/moto/clouddirectory/models.py
+++ b/moto/clouddirectory/models.py
@@ -1,7 +1,6 @@
 """CloudDirectoryBackend class with methods for supported APIs."""
 
 import datetime
-from typing import Dict, List
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
@@ -49,7 +48,7 @@ class Directory(BaseModel):
         self.creation_date_time = datetime.datetime.now()
         self.object_identifier = f"directory-{name}"
 
-    def to_dict(self) -> Dict[str, str]:
+    def to_dict(self) -> dict[str, str]:
         return {
             "Name": self.name,
             "SchemaArn": self.schema_arn,
@@ -65,8 +64,8 @@ class CloudDirectoryBackend(BaseBackend):
 
     def __init__(self, region_name: str, account_id: str) -> None:
         super().__init__(region_name, account_id)
-        self.directories: Dict[str, Directory] = {}
-        self.schemas_states: Dict[str, List[str]] = {
+        self.directories: dict[str, Directory] = {}
+        self.schemas_states: dict[str, list[str]] = {
             "development": [],
             "published": [],
             "applied": [],
@@ -115,15 +114,15 @@ class CloudDirectoryBackend(BaseBackend):
         return
 
     @paginate(pagination_model=PAGINATION_MODEL)
-    def list_development_schema_arns(self) -> List[str]:
+    def list_development_schema_arns(self) -> list[str]:
         return self.schemas_states["development"]
 
     @paginate(pagination_model=PAGINATION_MODEL)
-    def list_published_schema_arns(self) -> List[str]:
+    def list_published_schema_arns(self) -> list[str]:
         return self.schemas_states["published"]
 
     @paginate(pagination_model=PAGINATION_MODEL)
-    def list_directories(self, state: str) -> List[Directory]:
+    def list_directories(self, state: str) -> list[Directory]:
         directories = list(self.directories.values())
         if state:
             directories = [
@@ -131,11 +130,11 @@ class CloudDirectoryBackend(BaseBackend):
             ]
         return directories
 
-    def tag_resource(self, resource_arn: str, tags: List[Dict[str, str]]) -> None:
+    def tag_resource(self, resource_arn: str, tags: list[dict[str, str]]) -> None:
         self.tagger.tag_resource(resource_arn, tags)
         return
 
-    def untag_resource(self, resource_arn: str, tag_keys: List[str]) -> None:
+    def untag_resource(self, resource_arn: str, tag_keys: list[str]) -> None:
         if not isinstance(tag_keys, list):
             tag_keys = [tag_keys]
         self.tagger.untag_resource_using_names(resource_arn, tag_keys)
@@ -153,7 +152,7 @@ class CloudDirectoryBackend(BaseBackend):
 
     def list_tags_for_resource(
         self, resource_arn: str, next_token: str, max_results: int
-    ) -> List[Dict[str, str]]:
+    ) -> list[dict[str, str]]:
         tags = self.tagger.list_tags_for_resource(resource_arn)["Tags"]
         return tags
 

--- a/moto/cloudformation/custom_model.py
+++ b/moto/cloudformation/custom_model.py
@@ -1,6 +1,6 @@
 import json
 import threading
-from typing import Any, Dict
+from typing import Any
 
 from moto import settings
 from moto.awslambda import lambda_backends
@@ -16,10 +16,10 @@ class CustomModel(CloudFormationModel):
         self.request_id = request_id
         self.logical_id = logical_id
         self.resource_name = resource_name
-        self.data: Dict[str, Any] = dict()
+        self.data: dict[str, Any] = dict()
         self._finished = False
 
-    def set_data(self, data: Dict[str, Any]) -> None:
+    def set_data(self, data: dict[str, Any]) -> None:
         self.data = data
         self._finished = True
 
@@ -38,7 +38,7 @@ class CustomModel(CloudFormationModel):
     def create_from_cloudformation_json(  # type: ignore[misc]
         cls,
         resource_name: str,
-        cloudformation_json: Dict[str, Any],
+        cloudformation_json: dict[str, Any],
         account_id: str,
         region_name: str,
         **kwargs: Any,

--- a/moto/cloudformation/models.py
+++ b/moto/cloudformation/models.py
@@ -2,8 +2,9 @@ from __future__ import annotations
 
 import json
 from collections import OrderedDict
+from collections.abc import Iterable
 from datetime import timedelta
-from typing import Any, Dict, Iterable, List, Optional, Tuple, Type, Union
+from typing import Any, Optional, Union
 
 import yaml
 from yaml.parser import ParserError
@@ -46,9 +47,9 @@ class StackSet(BaseModel):
         template: str,
         region: str,
         description: Optional[str],
-        parameters: Dict[str, str],
+        parameters: dict[str, str],
         permission_model: str,
-        tags: Optional[Dict[str, str]],
+        tags: Optional[dict[str, str]],
         admin_role: Optional[str],
         execution_role: Optional[str],
     ):
@@ -76,7 +77,7 @@ class StackSet(BaseModel):
             stackset_name=self.name,
         )
         self.stack_instances = self.instances.stack_instances
-        self.operations: List[Dict[str, Any]] = []
+        self.operations: list[dict[str, Any]] = []
         self.permission_model = permission_model or "SELF_MANAGED"
 
     @property
@@ -84,7 +85,7 @@ class StackSet(BaseModel):
         return self.template
 
     @property
-    def managed_execution(self) -> Dict[str, Any]:
+    def managed_execution(self) -> dict[str, Any]:
         return {"Active": False}
 
     def _create_operation(
@@ -92,9 +93,9 @@ class StackSet(BaseModel):
         operation_id: str,
         action: str,
         status: str,
-        accounts: Optional[List[str]] = None,
-        regions: Optional[List[str]] = None,
-    ) -> Dict[str, Any]:
+        accounts: Optional[list[str]] = None,
+        regions: Optional[list[str]] = None,
+    ) -> dict[str, Any]:
         accounts = accounts or []
         regions = regions or []
         operation = {
@@ -111,7 +112,7 @@ class StackSet(BaseModel):
         self.operations += [operation]
         return operation
 
-    def get_operation(self, operation_id: str) -> Dict[str, Any]:
+    def get_operation(self, operation_id: str) -> dict[str, Any]:
         for operation in self.operations:
             if operation_id == operation["OperationId"]:
                 return operation
@@ -129,14 +130,14 @@ class StackSet(BaseModel):
         self,
         template: str,
         description: str,
-        parameters: Dict[str, str],
-        tags: Dict[str, str],
+        parameters: dict[str, str],
+        tags: dict[str, str],
         admin_role: str,
         execution_role: str,
-        accounts: List[str],
-        regions: List[str],
+        accounts: list[str],
+        regions: list[str],
         operation_id: str,
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         self.template = template or self.template
         self.description = description if description is not None else self.description
         self.parameters = parameters or self.parameters
@@ -158,10 +159,10 @@ class StackSet(BaseModel):
 
     def create_stack_instances(
         self,
-        accounts: List[str],
-        regions: List[str],
-        deployment_targets: Optional[Dict[str, Any]],
-        parameters: List[Dict[str, Any]],
+        accounts: list[str],
+        regions: list[str],
+        deployment_targets: Optional[dict[str, Any]],
+        parameters: list[dict[str, Any]],
     ) -> str:
         if self.permission_model == "SERVICE_MANAGED":
             if not deployment_targets:
@@ -195,7 +196,7 @@ class StackSet(BaseModel):
         )
         return operation_id
 
-    def delete_stack_instances(self, accounts: List[str], regions: List[str]) -> None:
+    def delete_stack_instances(self, accounts: list[str], regions: list[str]) -> None:
         operation_id = str(mock_random.uuid4())
 
         self.instances.delete(accounts, regions)
@@ -209,8 +210,8 @@ class StackSet(BaseModel):
         )
 
     def update_instances(
-        self, accounts: List[str], regions: List[str], parameters: List[Dict[str, Any]]
-    ) -> Dict[str, Any]:
+        self, accounts: list[str], regions: list[str], parameters: list[dict[str, Any]]
+    ) -> dict[str, Any]:
         operation_id = str(mock_random.uuid4())
 
         self.instances.update(accounts, regions, parameters)
@@ -233,7 +234,7 @@ class StackInstance(BaseModel):
         stack_name: str,
         name: str,
         template: str,
-        parameters: Optional[List[Dict[str, Any]]],
+        parameters: Optional[list[dict[str, Any]]],
         permission_model: str,
     ):
         self.account_id = account_id
@@ -283,7 +284,7 @@ class StackInstance(BaseModel):
             # Our stack is hidden - we have to delete it manually
             self.stack.delete()
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         return {
             "StackId": generate_stack_id(
                 self.stack_name, self.region_name, self.account_id
@@ -303,7 +304,7 @@ class StackInstances(BaseModel):
         account_id: str,
         region: str,
         template: str,
-        parameters: Dict[str, str],
+        parameters: dict[str, str],
         stackset_id: str,
         stackset_name: str,
     ):
@@ -314,7 +315,7 @@ class StackInstances(BaseModel):
         self.stackset_id = stackset_id
         self.stack_name = f"StackSet-{stackset_id}"
         self.stackset_name = stackset_name
-        self.stack_instances: List[StackInstance] = []
+        self.stack_instances: list[StackInstance] = []
 
     @property
     def org_backend(self) -> OrganizationsBackend:
@@ -322,13 +323,13 @@ class StackInstances(BaseModel):
 
     def create_instances(
         self,
-        accounts: List[str],
-        regions: List[str],
-        parameters: Optional[List[Dict[str, Any]]],
-        deployment_targets: Dict[str, Any],
+        accounts: list[str],
+        regions: list[str],
+        parameters: Optional[list[dict[str, Any]]],
+        deployment_targets: dict[str, Any],
         permission_model: str,
-    ) -> List[Dict[str, Any]]:
-        targets: List[Tuple[str, str]] = []
+    ) -> list[dict[str, Any]]:
+        targets: list[tuple[str, str]] = []
         all_accounts = self.org_backend.accounts
         requested_ous = deployment_targets.get("OrganizationalUnitIds", [])
         child_ous = [
@@ -360,16 +361,16 @@ class StackInstances(BaseModel):
 
     def update(
         self,
-        accounts: List[str],
-        regions: List[str],
-        parameters: Optional[List[Dict[str, Any]]],
+        accounts: list[str],
+        regions: list[str],
+        parameters: Optional[list[dict[str, Any]]],
     ) -> Any:
         for account in accounts:
             for region in regions:
                 instance = self.get_instance(account, region)
                 instance.parameters = parameters or []
 
-    def delete(self, accounts: List[str], regions: List[str]) -> None:
+    def delete(self, accounts: list[str], regions: list[str]) -> None:
         to_delete = [
             i
             for i in self.stack_instances
@@ -395,14 +396,14 @@ class Stack(CloudFormationModel):
         self,
         stack_id: str,
         name: str,
-        template: Union[str, Dict[str, Any]],
-        parameters: Dict[str, str],
+        template: Union[str, dict[str, Any]],
+        parameters: dict[str, str],
         account_id: str,
         region_name: str,
-        notification_arns: Optional[List[str]] = None,
-        tags: Optional[Dict[str, str]] = None,
+        notification_arns: Optional[list[str]] = None,
+        tags: Optional[dict[str, str]] = None,
         role_arn: Optional[str] = None,
-        cross_stack_resources: Optional[Dict[str, Export]] = None,
+        cross_stack_resources: Optional[dict[str, Export]] = None,
         enable_termination_protection: Optional[bool] = False,
         timeout_in_mins: Optional[int] = None,
         stack_policy_body: Optional[str] = None,
@@ -411,7 +412,7 @@ class Stack(CloudFormationModel):
         self.name = name
         self.account_id = account_id
         self.template = template
-        self.template_dict: Dict[str, Any]
+        self.template_dict: dict[str, Any]
         if template != {}:
             self._parse_template()
             self.description = self.template_dict.get("Description")
@@ -423,17 +424,17 @@ class Stack(CloudFormationModel):
         self.notification_arns = notification_arns if notification_arns else []
         self.role_arn = role_arn
         self.tags = tags if tags else {}
-        self.events: List[Event] = []
+        self.events: list[Event] = []
         self.timeout_in_minutes = timeout_in_mins
         self.policy = stack_policy_body or ""
 
-        self.cross_stack_resources: Dict[str, Export] = cross_stack_resources or {}
+        self.cross_stack_resources: dict[str, Export] = cross_stack_resources or {}
         self.enable_termination_protection: bool = (
             enable_termination_protection or False
         )
         self.resource_map = self._create_resource_map()
 
-        self.custom_resources: Dict[str, CustomModel] = dict()
+        self.custom_resources: dict[str, CustomModel] = dict()
 
         self.output_map = self._create_output_map()
         self.creation_time = utcnow()
@@ -444,7 +445,7 @@ class Stack(CloudFormationModel):
         self._parse_template()
         return self.template_dict == self.parse_template(other_template)
 
-    def has_parameters(self, other_parameters: Dict[str, Any]) -> bool:
+    def has_parameters(self, other_parameters: dict[str, Any]) -> bool:
         return self.parameters == other_parameters
 
     def _create_resource_map(self) -> ResourceMap:
@@ -488,7 +489,7 @@ class Stack(CloudFormationModel):
         self.template_dict = self.parse_template(self.template)  # type: ignore[arg-type]
 
     @staticmethod
-    def parse_template(template: str) -> Dict[str, Any]:  # type: ignore[misc]
+    def parse_template(template: str) -> dict[str, Any]:  # type: ignore[misc]
         yaml.add_multi_constructor("", yaml_tag_constructor)
         try:
             return yaml.load(template, Loader=yaml.Loader)
@@ -496,7 +497,7 @@ class Stack(CloudFormationModel):
             return json.loads(template)
 
     @property
-    def parameter_list(self) -> List[Dict[str, Any]]:  # type: ignore[misc]
+    def parameter_list(self) -> list[dict[str, Any]]:  # type: ignore[misc]
         parameters = [
             {
                 "ParameterKey": k,
@@ -509,15 +510,15 @@ class Stack(CloudFormationModel):
         return parameters
 
     @property
-    def stack_parameters(self) -> Dict[str, Any]:  # type: ignore[misc]
+    def stack_parameters(self) -> dict[str, Any]:  # type: ignore[misc]
         return self.resource_map.resolved_parameters
 
     @property
-    def stack_resources(self) -> Iterable[Type[CloudFormationModel]]:
+    def stack_resources(self) -> Iterable[type[CloudFormationModel]]:
         return self.resource_map.values()
 
     @property
-    def outputs(self) -> Optional[List[Dict[str, Any]]]:
+    def outputs(self) -> Optional[list[dict[str, Any]]]:
         def get_export_name(output_value: Any) -> Optional[str]:
             for export in self.exports:
                 if output_value == export.value:
@@ -537,7 +538,7 @@ class Stack(CloudFormationModel):
         return outputs if outputs else None
 
     @property
-    def exports(self) -> List[Export]:
+    def exports(self) -> list[Export]:
         return self.output_map.exports
 
     @property
@@ -570,8 +571,8 @@ class Stack(CloudFormationModel):
         self,
         template: str,
         role_arn: Optional[str] = None,
-        parameters: Optional[Dict[str, Any]] = None,
-        tags: Optional[Dict[str, str]] = None,
+        parameters: Optional[dict[str, Any]] = None,
+        tags: Optional[dict[str, str]] = None,
     ) -> None:
         self._add_stack_event(
             "UPDATE_IN_PROGRESS", resource_status_reason="User Initiated"
@@ -614,7 +615,7 @@ class Stack(CloudFormationModel):
     def create_from_cloudformation_json(  # type: ignore[misc]
         cls,
         resource_name: str,
-        cloudformation_json: Dict[str, Any],
+        cloudformation_json: dict[str, Any],
         account_id: str,
         region_name: str,
         **kwargs: Any,
@@ -655,7 +656,7 @@ class Stack(CloudFormationModel):
     def delete_from_cloudformation_json(  # type: ignore[misc]
         cls,
         resource_name: str,
-        cloudformation_json: Dict[str, Any],
+        cloudformation_json: dict[str, Any],
         account_id: str,
         region_name: str,
     ) -> None:
@@ -680,10 +681,10 @@ class ChangeSet(BaseModel):
         change_set_name: str,
         stack: Stack,
         template: str,
-        parameters: Dict[str, str],
+        parameters: dict[str, str],
         description: str,
-        notification_arns: Optional[List[str]] = None,
-        tags: Optional[Dict[str, str]] = None,
+        notification_arns: Optional[list[str]] = None,
+        tags: Optional[dict[str, str]] = None,
         role_arn: Optional[str] = None,
     ):
         self.change_set_type = change_set_type
@@ -715,7 +716,7 @@ class ChangeSet(BaseModel):
         except (ParserError, ScannerError):
             self.template_dict = json.loads(self.template)
 
-    def diff(self) -> List[Change]:
+    def diff(self) -> list[Change]:
         changes = []
         resources_by_action = self.stack.resource_map.build_change_set_actions(
             self.template_dict
@@ -760,7 +761,7 @@ class Event(BaseModel):
         self.client_request_token = None
 
     def sendToSns(
-        self, account_id: str, region: str, sns_topic_arns: List[str]
+        self, account_id: str, region: str, sns_topic_arns: list[str]
     ) -> None:
         message = f"""StackId='{self.stack_id}'
 Timestamp='{iso_8601_datetime_with_milliseconds(self.timestamp)}'
@@ -781,8 +782,8 @@ ClientRequestToken='{self.client_request_token}'"""
 
 
 def filter_stacks(
-    all_stacks: List[Stack], status_filter: Optional[List[str]]
-) -> List[Stack]:
+    all_stacks: list[Stack], status_filter: Optional[list[str]]
+) -> list[Stack]:
     filtered_stacks = []
     if not status_filter:
         return all_stacks
@@ -801,16 +802,16 @@ class CloudFormationBackend(BaseBackend):
 
     def __init__(self, region_name: str, account_id: str):
         super().__init__(region_name, account_id)
-        self.stacks: Dict[str, Stack] = OrderedDict()
-        self.stacksets: Dict[str, StackSet] = OrderedDict()
-        self.deleted_stacks: Dict[str, Stack] = {}
-        self.exports: Dict[str, Export] = OrderedDict()
-        self.change_sets: Dict[str, ChangeSet] = OrderedDict()
+        self.stacks: dict[str, Stack] = OrderedDict()
+        self.stacksets: dict[str, StackSet] = OrderedDict()
+        self.deleted_stacks: dict[str, Stack] = {}
+        self.exports: dict[str, Export] = OrderedDict()
+        self.change_sets: dict[str, ChangeSet] = OrderedDict()
 
     @staticmethod
     def default_vpc_endpoint_service(
-        service_region: str, zones: List[str]
-    ) -> List[Dict[str, str]]:
+        service_region: str, zones: list[str]
+    ) -> list[dict[str, str]]:
         """Default VPC endpoint service."""
         return BaseBackend.default_vpc_endpoint_service_factory(
             service_region, zones, "cloudformation", policy_supported=False
@@ -819,8 +820,8 @@ class CloudFormationBackend(BaseBackend):
     def _resolve_update_parameters(
         self,
         instance: Union[Stack, StackSet],
-        incoming_params: List[Dict[str, str]],
-    ) -> Dict[str, str]:
+        incoming_params: list[dict[str, str]],
+    ) -> dict[str, str]:
         parameters = dict(
             [
                 (parameter["ParameterKey"], parameter["ParameterValue"])
@@ -846,8 +847,8 @@ class CloudFormationBackend(BaseBackend):
         self,
         name: str,
         template: str,
-        parameters: Dict[str, str],
-        tags: Dict[str, str],
+        parameters: dict[str, str],
+        tags: dict[str, str],
         permission_model: str,
         admin_role: Optional[str],
         exec_role: Optional[str],
@@ -902,7 +903,7 @@ class CloudFormationBackend(BaseBackend):
     def list_stack_sets(self) -> Iterable[StackSet]:
         return self.stacksets.values()
 
-    def list_stack_set_operations(self, stackset_name: str) -> List[Dict[str, Any]]:
+    def list_stack_set_operations(self, stackset_name: str) -> list[dict[str, Any]]:
         stackset = self.describe_stack_set(stackset_name)
         return stackset.operations
 
@@ -912,24 +913,24 @@ class CloudFormationBackend(BaseBackend):
 
     def describe_stack_set_operation(
         self, stackset_name: str, operation_id: str
-    ) -> Tuple[StackSet, Dict[str, Any]]:
+    ) -> tuple[StackSet, dict[str, Any]]:
         stackset = self.describe_stack_set(stackset_name)
         operation = stackset.get_operation(operation_id)
         return stackset, operation
 
     def list_stack_set_operation_results(
         self, stackset_name: str, operation_id: str
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         stackset = self.describe_stack_set(stackset_name)
         return stackset.get_operation(operation_id)
 
     def create_stack_instances(
         self,
         stackset_name: str,
-        accounts: List[str],
-        regions: List[str],
-        parameters: List[Dict[str, str]],
-        deployment_targets: Optional[Dict[str, Any]],
+        accounts: list[str],
+        regions: list[str],
+        parameters: list[dict[str, str]],
+        deployment_targets: Optional[dict[str, Any]],
     ) -> str:
         """
         The following parameters are not yet implemented: DeploymentTargets.AccountFilterType, DeploymentTargets.AccountsUrl, OperationPreferences, CallAs
@@ -947,10 +948,10 @@ class CloudFormationBackend(BaseBackend):
     def update_stack_instances(
         self,
         stackset_name: str,
-        accounts: List[str],
-        regions: List[str],
-        parameters: List[Dict[str, Any]],
-    ) -> Dict[str, Any]:
+        accounts: list[str],
+        regions: list[str],
+        parameters: list[dict[str, Any]],
+    ) -> dict[str, Any]:
         """
         Calling this will update the parameters, but the actual resources are not updated
         """
@@ -962,14 +963,14 @@ class CloudFormationBackend(BaseBackend):
         stackset_name: str,
         template: str,
         description: str,
-        parameters: List[Dict[str, str]],
-        tags: Dict[str, str],
+        parameters: list[dict[str, str]],
+        tags: dict[str, str],
         admin_role: str,
         execution_role: str,
-        accounts: List[str],
-        regions: List[str],
+        accounts: list[str],
+        regions: list[str],
         operation_id: str,
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         stackset = self.describe_stack_set(stackset_name)
         resolved_parameters = self._resolve_update_parameters(
             instance=stackset, incoming_params=parameters
@@ -988,7 +989,7 @@ class CloudFormationBackend(BaseBackend):
         return update
 
     def delete_stack_instances(
-        self, stackset_name: str, accounts: List[str], regions: List[str]
+        self, stackset_name: str, accounts: list[str], regions: list[str]
     ) -> StackSet:
         """
         The following parameters are not  yet implemented: DeploymentTargets, OperationPreferences, RetainStacks, OperationId, CallAs
@@ -1001,9 +1002,9 @@ class CloudFormationBackend(BaseBackend):
         self,
         name: str,
         template: str,
-        parameters: Dict[str, Any],
-        notification_arns: Optional[List[str]] = None,
-        tags: Optional[Dict[str, str]] = None,
+        parameters: dict[str, Any],
+        notification_arns: Optional[list[str]] = None,
+        tags: Optional[dict[str, str]] = None,
         role_arn: Optional[str] = None,
         enable_termination_protection: Optional[bool] = False,
         timeout_in_mins: Optional[int] = None,
@@ -1045,13 +1046,13 @@ class CloudFormationBackend(BaseBackend):
         stack_name: str,
         change_set_name: str,
         template: str,
-        parameters: Dict[str, str],
+        parameters: dict[str, str],
         description: str,
         change_set_type: str,
-        notification_arns: Optional[List[str]] = None,
-        tags: Optional[Dict[str, str]] = None,
+        notification_arns: Optional[list[str]] = None,
+        tags: Optional[dict[str, str]] = None,
         role_arn: Optional[str] = None,
-    ) -> Tuple[str, str]:
+    ) -> tuple[str, str]:
         validate_create_change_set(change_set_name)
         if change_set_type == "UPDATE":
             for stack in self.stacks.values():
@@ -1167,7 +1168,7 @@ class CloudFormationBackend(BaseBackend):
         stack.status = f"{change_set.change_set_type}_COMPLETE"
         stack.template = change_set.template
 
-    def describe_stacks(self, name_or_stack_id: str) -> List[Stack]:
+    def describe_stacks(self, name_or_stack_id: str) -> list[Stack]:
         stacks = self.stacks.values()
         if name_or_stack_id:
             for stack in stacks:
@@ -1184,11 +1185,11 @@ class CloudFormationBackend(BaseBackend):
 
     def describe_stack_instance(
         self, stack_set_name: str, account_id: str, region: str
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         stack_set = self.describe_stack_set(stack_set_name)
         return stack_set.instances.get_instance(account_id, region).to_dict()
 
-    def list_stack_instances(self, stackset_name: str) -> List[Dict[str, Any]]:
+    def list_stack_instances(self, stackset_name: str) -> list[dict[str, Any]]:
         """
         Pagination is not yet implemented.
         The parameters StackInstanceAccount/StackInstanceRegion are not yet implemented.
@@ -1199,7 +1200,7 @@ class CloudFormationBackend(BaseBackend):
     def list_change_sets(self) -> Iterable[ChangeSet]:
         return self.change_sets.values()
 
-    def list_stacks(self, status_filter: Optional[List[str]] = None) -> List[Stack]:
+    def list_stacks(self, status_filter: Optional[list[str]] = None) -> list[Stack]:
         total_stacks = [v for v in self.stacks.values()] + [
             v for v in self.deleted_stacks.values()
         ]
@@ -1222,8 +1223,8 @@ class CloudFormationBackend(BaseBackend):
         name: str,
         template: str,
         role_arn: Optional[str],
-        parameters: List[Dict[str, Any]],
-        tags: Optional[Dict[str, str]],
+        parameters: list[dict[str, Any]],
+        tags: Optional[dict[str, str]],
     ) -> Stack:
         stack = self.get_stack(name)
         resolved_parameters = self._resolve_update_parameters(
@@ -1251,7 +1252,7 @@ class CloudFormationBackend(BaseBackend):
 
     def describe_stack_resource(
         self, stack_name: str, logical_resource_id: str
-    ) -> Tuple[Stack, Type[CloudFormationModel]]:
+    ) -> tuple[Stack, type[CloudFormationModel]]:
         stack = self.get_stack(stack_name)
 
         for stack_resource in stack.stack_resources:
@@ -1265,7 +1266,7 @@ class CloudFormationBackend(BaseBackend):
 
     def describe_stack_resources(
         self, stack_name: str, logical_resource_id: str
-    ) -> Tuple[Stack, Iterable[Type[CloudFormationModel]]]:
+    ) -> tuple[Stack, Iterable[type[CloudFormationModel]]]:
         stack = self.get_stack(stack_name)
 
         if logical_resource_id is not None:
@@ -1278,7 +1279,7 @@ class CloudFormationBackend(BaseBackend):
 
     def list_stack_resources(
         self, stack_name_or_id: str
-    ) -> Iterable[Type[CloudFormationModel]]:
+    ) -> Iterable[type[CloudFormationModel]]:
         stack = self.get_stack(stack_name_or_id)
         return stack.stack_resources
 
@@ -1300,7 +1301,7 @@ class CloudFormationBackend(BaseBackend):
 
     def list_exports(
         self, tokenstr: Optional[str]
-    ) -> Tuple[List[Export], Optional[str]]:
+    ) -> tuple[list[Export], Optional[str]]:
         all_exports = list(self.exports.values())
         if tokenstr is None:
             exports = all_exports[0:100]
@@ -1311,13 +1312,13 @@ class CloudFormationBackend(BaseBackend):
             next_token = str(token + 100) if len(all_exports) > token + 100 else None
         return exports, next_token
 
-    def describe_stack_events(self, stack_name: str) -> List[Event]:
+    def describe_stack_events(self, stack_name: str) -> list[Event]:
         return self.get_stack(stack_name).events
 
-    def get_template(self, name_or_stack_id: str) -> Union[str, Dict[str, Any]]:
+    def get_template(self, name_or_stack_id: str) -> Union[str, dict[str, Any]]:
         return self.get_stack(name_or_stack_id).template
 
-    def validate_template(self, template: str) -> List[Any]:
+    def validate_template(self, template: str) -> list[Any]:
         return validate_template_cfn_lint(template)
 
     def _validate_export_uniqueness(self, stack: Stack) -> None:

--- a/moto/cloudformation/responses.py
+++ b/moto/cloudformation/responses.py
@@ -1,6 +1,6 @@
 import json
 import re
-from typing import Any, Dict, List, Optional, Tuple, Type
+from typing import Any, Optional
 
 import yaml
 from yaml.parser import ParserError
@@ -22,7 +22,7 @@ from .utils import get_stack_from_s3_url, yaml_tag_constructor
 
 
 class StackResourceDTO:
-    def __init__(self, stack: Stack, resource: Type[CloudFormationModel]) -> None:
+    def __init__(self, stack: Stack, resource: type[CloudFormationModel]) -> None:
         self.stack_id = stack.stack_id
         self.stack_name = stack.name
         # FIXME: None of these attributes are part of CloudFormationModel interface...
@@ -36,7 +36,7 @@ class StackResourceDTO:
 
 
 class StackSetOperationDTO:
-    def __init__(self, operation: Dict[str, Any], stack_set: StackSet) -> None:
+    def __init__(self, operation: dict[str, Any], stack_set: StackSet) -> None:
         self.execution_role_name = stack_set.execution_role_name
         self.administration_role_arn = stack_set.administration_role_arn
         self.stack_set_id = stack_set.id
@@ -53,8 +53,8 @@ class ChangeDTO:
         self.resource_change = change
 
 
-def get_template_summary_response_from_template(template_body: str) -> Dict[str, Any]:
-    def get_resource_types(template_dict: Dict[str, Any]) -> List[Any]:
+def get_template_summary_response_from_template(template_body: str) -> dict[str, Any]:
+    def get_resource_types(template_dict: dict[str, Any]) -> list[Any]:
         resources = {}
         for key, value in template_dict.items():
             if key == "Resources":
@@ -138,8 +138,8 @@ class CloudFormationResponse(BaseResponse):
         )
 
     def _get_params_from_list(
-        self, parameters_list: List[Dict[str, Any]]
-    ) -> Dict[str, Any]:
+        self, parameters_list: list[dict[str, Any]]
+    ) -> dict[str, Any]:
         # Hack dict-comprehension
         return dict(
             [
@@ -149,8 +149,8 @@ class CloudFormationResponse(BaseResponse):
         )
 
     def _get_param_values(
-        self, parameters_list: List[Dict[str, str]], existing_params: Dict[str, str]
-    ) -> Dict[str, Any]:
+        self, parameters_list: list[dict[str, str]], existing_params: dict[str, str]
+    ) -> dict[str, Any]:
         result = {}
         for parameter in parameters_list:
             if set(parameter.keys()) >= {"ParameterKey", "ParameterValue"}:
@@ -166,7 +166,7 @@ class CloudFormationResponse(BaseResponse):
                 raise MissingParameterError(parameter["ParameterKey"])
         return result
 
-    def process_cfn_response(self) -> Tuple[int, Dict[str, int], str]:
+    def process_cfn_response(self) -> tuple[int, dict[str, int], str]:
         status = self._get_param("Status")
         if status == "SUCCESS":
             stack_id = self._get_param("StackId")
@@ -397,7 +397,7 @@ class CloudFormationResponse(BaseResponse):
 
     def _validate_different_update(
         self,
-        incoming_params: Optional[List[Dict[str, Any]]],
+        incoming_params: Optional[list[dict[str, Any]]],
         stack_body: str,
         old_stack: Stack,
     ) -> None:
@@ -440,7 +440,7 @@ class CloudFormationResponse(BaseResponse):
         # boto3 is supposed to let you clear the tags by passing an empty value, but the request body doesn't
         # end up containing anything we can use to differentiate between passing an empty value versus not
         # passing anything. so until that changes, moto won't be able to clear tags, only update them.
-        tags: Optional[Dict[str, str]] = dict(
+        tags: Optional[dict[str, str]] = dict(
             (item["Key"], item["Value"]) for item in self._get_param("Tags", [])
         )
         # so that if we don't pass the parameter, we don't clear all the tags accidentally

--- a/moto/cloudformation/utils.py
+++ b/moto/cloudformation/utils.py
@@ -1,6 +1,6 @@
 import os
 import string
-from typing import Any, List
+from typing import Any
 from urllib.parse import urlparse
 
 import yaml
@@ -59,7 +59,7 @@ def yaml_tag_constructor(loader: Any, tag: Any, node: Any) -> Any:
     return {key: _f(loader, tag, node)}
 
 
-def validate_template_cfn_lint(template: str) -> List[Any]:
+def validate_template_cfn_lint(template: str) -> list[Any]:
     # Importing cfnlint adds a significant overhead, so we keep it local
 
     try:

--- a/moto/cloudfront/models.py
+++ b/moto/cloudfront/models.py
@@ -1,5 +1,6 @@
 import string
-from typing import Any, Dict, Iterable, List, Optional, Tuple
+from collections.abc import Iterable
+from typing import Any, Optional
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
@@ -33,14 +34,14 @@ class ActiveTrustedSigners:
     def __init__(self) -> None:
         self.enabled = False
         self.quantity = 0
-        self.signers: List[Any] = []
+        self.signers: list[Any] = []
 
 
 class ActiveTrustedKeyGroups:
     def __init__(self) -> None:
         self.enabled = False
         self.quantity = 0
-        self.kg_key_pair_ids: List[Any] = []
+        self.kg_key_pair_ids: list[Any] = []
 
 
 class LambdaFunctionAssociation:
@@ -51,7 +52,7 @@ class LambdaFunctionAssociation:
 
 
 class ForwardedValues:
-    def __init__(self, config: Dict[str, Any]):
+    def __init__(self, config: dict[str, Any]):
         self.query_string = config.get("QueryString", "false")
         self.cookie_forward = config.get("Cookies", {}).get("Forward") or "none"
         self.whitelisted_names = (
@@ -60,13 +61,13 @@ class ForwardedValues:
         self.whitelisted_names = self.whitelisted_names.get("Name") or []
         if isinstance(self.whitelisted_names, str):
             self.whitelisted_names = [self.whitelisted_names]
-        self.headers: List[Any] = []
-        self.query_string_cache_keys: List[Any] = []
-        self.cookies: List[Dict[str, Any]] = config.get("Cookies") or []
+        self.headers: list[Any] = []
+        self.query_string_cache_keys: list[Any] = []
+        self.cookies: list[dict[str, Any]] = config.get("Cookies") or []
 
 
 class TrustedSigners:
-    def __init__(self, config: Dict[str, Any]):
+    def __init__(self, config: dict[str, Any]):
         items = config.get("Items") or {}
         self.acct_nums = items.get("AwsAccountNumber") or []
         if isinstance(self.acct_nums, str):
@@ -74,7 +75,7 @@ class TrustedSigners:
 
 
 class TrustedKeyGroups:
-    def __init__(self, config: Dict[str, Any]):
+    def __init__(self, config: dict[str, Any]):
         items = config.get("Items") or {}
         self.group_ids = items.get("KeyGroup") or []
         if isinstance(self.group_ids, str):
@@ -82,7 +83,7 @@ class TrustedKeyGroups:
 
 
 class DefaultCacheBehaviour:
-    def __init__(self, config: Dict[str, Any]):
+    def __init__(self, config: dict[str, Any]):
         self.target_origin_id = config["TargetOriginId"]
         self.trusted_signers_enabled = False
         self.trusted_signers = TrustedSigners(config.get("TrustedSigners") or {})
@@ -97,8 +98,8 @@ class DefaultCacheBehaviour:
         )
         self.smooth_streaming = config.get("SmoothStreaming") or True
         self.compress = config.get("Compress", "true").lower() == "true"
-        self.lambda_function_associations: List[Any] = []
-        self.function_associations: List[Any] = []
+        self.lambda_function_associations: list[Any] = []
+        self.function_associations: list[Any] = []
         self.field_level_encryption_id = config.get("FieldLevelEncryptionId") or ""
         self.forwarded_values = ForwardedValues(config.get("ForwardedValues", {}))
         self.min_ttl = config.get("MinTTL") or 0
@@ -108,20 +109,20 @@ class DefaultCacheBehaviour:
 
 
 class CacheBehaviour(DefaultCacheBehaviour):
-    def __init__(self, config: Dict[str, Any]):
+    def __init__(self, config: dict[str, Any]):
         super().__init__(config)
         self.path_pattern: str = config.get("PathPattern", "")
         methods = config.get("AllowedMethods", {})
-        self.cached_methods: List[str] = (
+        self.cached_methods: list[str] = (
             methods.get("CachedMethods", {}).get("Items", {}).get("Method", [])
         )
-        self.allowed_methods: List[str] = methods.get("Items", {}).get("Method", [])
+        self.allowed_methods: list[str] = methods.get("Items", {}).get("Method", [])
         self.cache_policy_id = config.get("CachePolicyId", "")
         self.origin_request_policy_id = config.get("OriginRequestPolicyId", "")
 
 
 class Logging:
-    def __init__(self, config: Dict[str, Any]) -> None:
+    def __init__(self, config: dict[str, Any]) -> None:
         self.enabled = config.get("Enabled") or False
         self.include_cookies = config.get("IncludeCookies") or False
         self.bucket = config.get("Bucket") or ""
@@ -129,7 +130,7 @@ class Logging:
 
 
 class ViewerCertificate:
-    def __init__(self, config: Dict[str, Any]) -> None:
+    def __init__(self, config: dict[str, Any]) -> None:
         self.cloud_front_default_certificate = config.get(
             "CloudFrontDefaultCertificate", True
         )
@@ -145,7 +146,7 @@ class ViewerCertificate:
 
 
 class CustomOriginConfig:
-    def __init__(self, config: Dict[str, Any]):
+    def __init__(self, config: dict[str, Any]):
         self.http_port = config.get("HTTPPort")
         self.https_port = config.get("HTTPSPort")
         self.keep_alive = config.get("OriginKeepaliveTimeout") or 5
@@ -158,7 +159,7 @@ class CustomOriginConfig:
 
 
 class Origin:
-    def __init__(self, origin: Dict[str, Any]):
+    def __init__(self, origin: dict[str, Any]):
         self.id = origin["Id"]
         self.domain_name = origin["DomainName"]
         self.origin_path = origin.get("OriginPath") or ""
@@ -187,14 +188,14 @@ class Origin:
 
 
 class GeoRestrictions:
-    def __init__(self, config: Dict[str, Any]):
+    def __init__(self, config: dict[str, Any]):
         config = config.get("GeoRestriction") or {}
         self._type = config.get("RestrictionType", "none")
         self.restrictions = (config.get("Items") or {}).get("Location") or []
 
 
 class DistributionConfig:
-    def __init__(self, config: Dict[str, Any]):
+    def __init__(self, config: dict[str, Any]):
         self.config = config
         self.aliases = ((config.get("Aliases") or {}).get("Items") or {}).get(
             "CNAME"
@@ -205,11 +206,11 @@ class DistributionConfig:
         self.default_cache_behavior = DefaultCacheBehaviour(
             config["DefaultCacheBehavior"]
         )
-        self.cache_behaviors: List[Any] = []
+        self.cache_behaviors: list[Any] = []
         if config.get("CacheBehaviors", {}).get("Items"):
             for _, v in config.get("CacheBehaviors", {}).get("Items").items():
                 self.cache_behaviors.append(CacheBehaviour(v))
-        self.custom_error_responses: List[Any] = []
+        self.custom_error_responses: list[Any] = []
         self.logging = Logging(config.get("Logging") or {})
         self.enabled = config.get("Enabled") or False
         self.viewer_certificate = ViewerCertificate(
@@ -236,7 +237,7 @@ class DistributionConfig:
 
 
 class Distribution(BaseModel, ManagedState):
-    def __init__(self, account_id: str, region_name: str, config: Dict[str, Any]):
+    def __init__(self, account_id: str, region_name: str, config: dict[str, Any]):
         # Configured ManagedState
         super().__init__(
             "cloudfront::distribution", transitions=[("InProgress", "Deployed")]
@@ -247,8 +248,8 @@ class Distribution(BaseModel, ManagedState):
         self.distribution_config = DistributionConfig(config)
         self.active_trusted_signers = ActiveTrustedSigners()
         self.active_trusted_key_groups = ActiveTrustedKeyGroups()
-        self.origin_groups: List[Any] = []
-        self.alias_icp_recordals: List[Any] = []
+        self.origin_groups: list[Any] = []
+        self.alias_icp_recordals: list[Any] = []
         self.last_modified_time = "2021-11-27T10:34:26.802Z"
         self.in_progress_invalidation_batches = 0
         self.has_active_trusted_key_groups = False
@@ -261,7 +262,7 @@ class Distribution(BaseModel, ManagedState):
 
 
 class OriginAccessControl(BaseModel):
-    def __init__(self, config_dict: Dict[str, str]):
+    def __init__(self, config_dict: dict[str, str]):
         self.id = random_id()
         self.name = config_dict.get("Name")
         self.description = config_dict.get("Description")
@@ -270,7 +271,7 @@ class OriginAccessControl(BaseModel):
         self.origin_type = config_dict.get("OriginAccessControlOriginType")
         self.etag = random_id()
 
-    def update(self, config: Dict[str, str]) -> None:
+    def update(self, config: dict[str, str]) -> None:
         if "Name" in config:
             self.name = config["Name"]
         if "Description" in config:
@@ -285,7 +286,7 @@ class OriginAccessControl(BaseModel):
 
 class Invalidation(BaseModel):
     def __init__(
-        self, distribution: Distribution, paths: Dict[str, Any], caller_ref: str
+        self, distribution: Distribution, paths: dict[str, Any], caller_ref: str
     ):
         self.invalidation_id = random_id()
         self.create_time = iso_8601_datetime_with_milliseconds()
@@ -318,7 +319,7 @@ class PublicKey(BaseModel):
 
 
 class KeyGroup(BaseModel):
-    def __init__(self, name: str, items: List[str]):
+    def __init__(self, name: str, items: list[str]):
         self.id = random_id(length=14)
         self.name = name
         self.items = items
@@ -331,16 +332,16 @@ class KeyGroup(BaseModel):
 class CloudFrontBackend(BaseBackend):
     def __init__(self, region_name: str, account_id: str):
         super().__init__(region_name, account_id)
-        self.distributions: Dict[str, Distribution] = dict()
-        self.invalidations: Dict[str, List[Invalidation]] = dict()
-        self.origin_access_controls: Dict[str, OriginAccessControl] = dict()
-        self.public_keys: Dict[str, PublicKey] = dict()
-        self.key_groups: Dict[str, KeyGroup] = dict()
+        self.distributions: dict[str, Distribution] = dict()
+        self.invalidations: dict[str, list[Invalidation]] = dict()
+        self.origin_access_controls: dict[str, OriginAccessControl] = dict()
+        self.public_keys: dict[str, PublicKey] = dict()
+        self.key_groups: dict[str, KeyGroup] = dict()
         self.tagger = TaggingService()
 
     def create_distribution(
-        self, distribution_config: Dict[str, Any], tags: List[Dict[str, str]]
-    ) -> Tuple[Distribution, str, str]:
+        self, distribution_config: dict[str, Any], tags: list[dict[str, str]]
+    ) -> tuple[Distribution, str, str]:
         """
         Not all configuration options are supported yet.  Please raise an issue if
         we're not persisting/returning the correct attributes for your
@@ -350,8 +351,8 @@ class CloudFrontBackend(BaseBackend):
         return self.create_distribution_with_tags(distribution_config, tags)
 
     def create_distribution_with_tags(
-        self, distribution_config: Dict[str, Any], tags: List[Dict[str, str]]
-    ) -> Tuple[Distribution, str, str]:
+        self, distribution_config: dict[str, Any], tags: list[dict[str, str]]
+    ) -> tuple[Distribution, str, str]:
         dist = Distribution(self.account_id, self.region_name, distribution_config)
         caller_reference = dist.distribution_config.caller_reference
         existing_dist = self._distribution_with_caller_reference(caller_reference)
@@ -361,14 +362,14 @@ class CloudFrontBackend(BaseBackend):
         self.tagger.tag_resource(dist.arn, tags)
         return dist, dist.location, dist.etag
 
-    def get_distribution(self, distribution_id: str) -> Tuple[Distribution, str]:
+    def get_distribution(self, distribution_id: str) -> tuple[Distribution, str]:
         if distribution_id not in self.distributions:
             raise NoSuchDistribution
         dist = self.distributions[distribution_id]
         dist.advance()
         return dist, dist.etag
 
-    def get_distribution_config(self, distribution_id: str) -> Tuple[Distribution, str]:
+    def get_distribution_config(self, distribution_id: str) -> tuple[Distribution, str]:
         if distribution_id not in self.distributions:
             raise NoSuchDistribution
         dist = self.distributions[distribution_id]
@@ -404,8 +405,8 @@ class CloudFrontBackend(BaseBackend):
         return None
 
     def update_distribution(
-        self, dist_config: Dict[str, Any], _id: str, if_match: bool
-    ) -> Tuple[Distribution, str, str]:
+        self, dist_config: dict[str, Any], _id: str, if_match: bool
+    ) -> tuple[Distribution, str, str]:
         """
         The IfMatch-value is ignored - any value is considered valid.
         Calling this function without a value is invalid, per AWS' behaviour
@@ -424,7 +425,7 @@ class CloudFrontBackend(BaseBackend):
         return dist, dist.location, dist.etag
 
     def create_invalidation(
-        self, dist_id: str, paths: Dict[str, Any], caller_ref: str
+        self, dist_id: str, paths: dict[str, Any], caller_ref: str
     ) -> Invalidation:
         dist, _ = self.get_distribution(dist_id)
         invalidation = Invalidation(dist, paths, caller_ref)
@@ -454,11 +455,11 @@ class CloudFrontBackend(BaseBackend):
             pass
         raise NoSuchInvalidation
 
-    def list_tags_for_resource(self, resource: str) -> Dict[str, List[Dict[str, str]]]:
+    def list_tags_for_resource(self, resource: str) -> dict[str, list[dict[str, str]]]:
         return self.tagger.list_tags_for_resource(resource)
 
     def create_origin_access_control(
-        self, config_dict: Dict[str, str]
+        self, config_dict: dict[str, str]
     ) -> OriginAccessControl:
         control = OriginAccessControl(config_dict)
         self.origin_access_controls[control.id] = control
@@ -470,7 +471,7 @@ class CloudFrontBackend(BaseBackend):
         return self.origin_access_controls[control_id]
 
     def update_origin_access_control(
-        self, control_id: str, config: Dict[str, str]
+        self, control_id: str, config: dict[str, str]
     ) -> OriginAccessControl:
         """
         The IfMatch-parameter is not yet implemented
@@ -507,13 +508,13 @@ class CloudFrontBackend(BaseBackend):
         """
         self.public_keys.pop(key_id, None)
 
-    def list_public_keys(self) -> List[PublicKey]:
+    def list_public_keys(self) -> list[PublicKey]:
         """
         Pagination is not yet implemented
         """
         return list(self.public_keys.values())
 
-    def create_key_group(self, name: str, items: List[str]) -> KeyGroup:
+    def create_key_group(self, name: str, items: list[str]) -> KeyGroup:
         key_group = KeyGroup(name=name, items=items)
         self.key_groups[key_group.id] = key_group
         return key_group
@@ -521,7 +522,7 @@ class CloudFrontBackend(BaseBackend):
     def get_key_group(self, group_id: str) -> KeyGroup:
         return self.key_groups[group_id]
 
-    def list_key_groups(self) -> List[KeyGroup]:
+    def list_key_groups(self) -> list[KeyGroup]:
         """
         Pagination is not yet implemented
         """

--- a/moto/cloudfront/responses.py
+++ b/moto/cloudfront/responses.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict
+from typing import Any
 from urllib.parse import unquote
 
 import xmltodict
@@ -14,7 +14,7 @@ class CloudFrontResponse(BaseResponse):
     def __init__(self) -> None:
         super().__init__(service_name="cloudfront")
 
-    def _get_xml_body(self) -> Dict[str, Any]:
+    def _get_xml_body(self) -> dict[str, Any]:
         return xmltodict.parse(self.body, dict_constructor=dict, force_list="Path")
 
     @property

--- a/moto/cloudhsmv2/models.py
+++ b/moto/cloudhsmv2/models.py
@@ -1,7 +1,7 @@
 """CloudHSMV2Backend class with methods for supported APIs."""
 
 import uuid
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Optional
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.utils import utcnow
@@ -13,12 +13,12 @@ from .exceptions import ResourceNotFoundException
 class Cluster:
     def __init__(
         self,
-        backup_retention_policy: Optional[Dict[str, str]],
+        backup_retention_policy: Optional[dict[str, str]],
         hsm_type: str,
         source_backup_id: Optional[str],
-        subnet_ids: List[str],
+        subnet_ids: list[str],
         network_type: str = "IPV4",
-        tag_list: Optional[List[Dict[str, str]]] = None,
+        tag_list: Optional[list[dict[str, str]]] = None,
         mode: str = "DEFAULT",
         region_name: str = "us-east-1",
     ):
@@ -26,7 +26,7 @@ class Cluster:
         self.backup_policy = "DEFAULT"
         self.backup_retention_policy = backup_retention_policy
         self.create_timestamp = utcnow()
-        self.hsms: List[Dict[str, Any]] = []
+        self.hsms: list[dict[str, Any]] = []
         self.hsm_type = hsm_type
         self.source_backup_id = source_backup_id
         self.state = "ACTIVE"
@@ -47,7 +47,7 @@ class Cluster:
         self.tag_list = tag_list or []
         self.mode = mode
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         return {
             "BackupPolicy": self.backup_policy,
             "BackupRetentionPolicy": self.backup_retention_policy,
@@ -73,7 +73,7 @@ class Backup:
         cluster_id: str,
         hsm_type: str,
         mode: str,
-        tag_list: Optional[List[Dict[str, str]]],
+        tag_list: Optional[list[dict[str, str]]],
         source_backup: Optional[str] = None,
         source_cluster: Optional[str] = None,
         source_region: Optional[str] = None,
@@ -97,7 +97,7 @@ class Backup:
         self.hsm_type = hsm_type
         self.mode = mode
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         result = {
             "BackupId": self.backup_id,
             "BackupArn": self.backup_arn,
@@ -146,14 +146,14 @@ class CloudHSMV2Backend(BaseBackend):
 
     def __init__(self, region_name: str, account_id: str) -> None:
         super().__init__(region_name, account_id)
-        self.tags: Dict[str, List[Dict[str, str]]] = {}
-        self.clusters: Dict[str, Cluster] = {}
-        self.resource_policies: Dict[str, str] = {}
-        self.backups: Dict[str, Backup] = {}
+        self.tags: dict[str, list[dict[str, str]]] = {}
+        self.clusters: dict[str, Cluster] = {}
+        self.resource_policies: dict[str, str] = {}
+        self.backups: dict[str, Backup] = {}
 
     def list_tags(
         self, resource_id: str, next_token: str, max_results: int
-    ) -> Tuple[List[Dict[str, str]], Optional[str]]:
+    ) -> tuple[list[dict[str, str]], Optional[str]]:
         """
         Pagination is not yet implemented
         """
@@ -165,8 +165,8 @@ class CloudHSMV2Backend(BaseBackend):
         return tags, None
 
     def tag_resource(
-        self, resource_id: str, tag_list: List[Dict[str, str]]
-    ) -> Dict[str, Any]:
+        self, resource_id: str, tag_list: list[dict[str, str]]
+    ) -> dict[str, Any]:
         if resource_id not in self.tags:
             self.tags[resource_id] = []
 
@@ -183,8 +183,8 @@ class CloudHSMV2Backend(BaseBackend):
         return {}
 
     def untag_resource(
-        self, resource_id: str, tag_key_list: List[str]
-    ) -> Dict[str, Any]:
+        self, resource_id: str, tag_key_list: list[str]
+    ) -> dict[str, Any]:
         if resource_id in self.tags:
             self.tags[resource_id] = [
                 tag for tag in self.tags[resource_id] if tag["Key"] not in tag_key_list
@@ -194,14 +194,14 @@ class CloudHSMV2Backend(BaseBackend):
 
     def create_cluster(
         self,
-        backup_retention_policy: Optional[Dict[str, str]],
+        backup_retention_policy: Optional[dict[str, str]],
         hsm_type: str,
         source_backup_id: Optional[str],
-        subnet_ids: List[str],
+        subnet_ids: list[str],
         network_type: Optional[str],
-        tag_list: Optional[List[Dict[str, str]]],
+        tag_list: Optional[list[dict[str, str]]],
         mode: Optional[str],
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         cluster = Cluster(
             backup_retention_policy=backup_retention_policy,
             hsm_type=hsm_type,
@@ -225,7 +225,7 @@ class CloudHSMV2Backend(BaseBackend):
 
         return cluster.to_dict()
 
-    def delete_cluster(self, cluster_id: str) -> Dict[str, Any]:
+    def delete_cluster(self, cluster_id: str) -> dict[str, Any]:
         if cluster_id not in self.clusters:
             raise ResourceNotFoundException(f"Cluster {cluster_id} not found")
 
@@ -237,8 +237,8 @@ class CloudHSMV2Backend(BaseBackend):
 
     @paginate(pagination_model=PAGINATION_MODEL)
     def describe_clusters(
-        self, filters: Optional[Dict[str, List[str]]] = None
-    ) -> List[Dict[str, str]]:
+        self, filters: Optional[dict[str, list[str]]] = None
+    ) -> list[dict[str, str]]:
         clusters = list(self.clusters.values())
 
         if filters:
@@ -259,10 +259,10 @@ class CloudHSMV2Backend(BaseBackend):
     @paginate(PAGINATION_MODEL)
     def describe_backups(
         self,
-        filters: Optional[Dict[str, List[str]]],
+        filters: Optional[dict[str, list[str]]],
         shared: Optional[bool],
         sort_ascending: Optional[bool],
-    ) -> List[Backup]:
+    ) -> list[Backup]:
         backups = list(self.backups.values())
 
         if filters:
@@ -285,7 +285,7 @@ class CloudHSMV2Backend(BaseBackend):
         )
         return backups
 
-    def put_resource_policy(self, resource_arn: str, policy: str) -> Dict[str, str]:
+    def put_resource_policy(self, resource_arn: str, policy: str) -> dict[str, str]:
         self.resource_policies[resource_arn] = policy
         return {"ResourceArn": resource_arn, "Policy": policy}
 

--- a/moto/cloudtrail/models.py
+++ b/moto/cloudtrail/models.py
@@ -1,7 +1,8 @@
 import re
 import time
+from collections.abc import Iterable
 from datetime import datetime
-from typing import Any, Dict, Iterable, List, Optional, Tuple
+from typing import Any, Optional
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
@@ -43,13 +44,13 @@ class TrailStatus:
         self.is_logging = False
         self.stopped = utcnow()
 
-    def description(self) -> Dict[str, Any]:
+    def description(self) -> dict[str, Any]:
         if self.is_logging:
             self.latest_delivery_time = datetime2int(utcnow())
             self.latest_delivery_attempt = iso_8601_datetime_without_milliseconds(
                 utcnow()
             )
-        desc: Dict[str, Any] = {
+        desc: dict[str, Any] = {
             "IsLogging": self.is_logging,
             "LatestDeliveryAttemptTime": self.latest_delivery_attempt,
             "LatestNotificationAttemptTime": "",
@@ -107,9 +108,9 @@ class Trail(BaseModel):
         self.check_bucket_exists()
         self.check_topic_exists()
         self.status = TrailStatus()
-        self.event_selectors: List[Dict[str, Any]] = list()
-        self.advanced_event_selectors: List[Dict[str, Any]] = list()
-        self.insight_selectors: List[Dict[str, str]] = list()
+        self.event_selectors: list[dict[str, Any]] = list()
+        self.advanced_event_selectors: list[dict[str, Any]] = list()
+        self.insight_selectors: list[dict[str, str]] = list()
 
     @property
     def arn(self) -> str:
@@ -163,8 +164,8 @@ class Trail(BaseModel):
 
     def put_event_selectors(
         self,
-        event_selectors: List[Dict[str, Any]],
-        advanced_event_selectors: List[Dict[str, Any]],
+        event_selectors: list[dict[str, Any]],
+        advanced_event_selectors: list[dict[str, Any]],
     ) -> None:
         if event_selectors:
             self.event_selectors = event_selectors
@@ -172,13 +173,13 @@ class Trail(BaseModel):
             self.event_selectors = []
             self.advanced_event_selectors = advanced_event_selectors
 
-    def get_event_selectors(self) -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]]]:
+    def get_event_selectors(self) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
         return self.event_selectors, self.advanced_event_selectors
 
-    def put_insight_selectors(self, insight_selectors: List[Dict[str, str]]) -> None:
+    def put_insight_selectors(self, insight_selectors: list[dict[str, str]]) -> None:
         self.insight_selectors.extend(insight_selectors)
 
-    def get_insight_selectors(self) -> List[Dict[str, str]]:
+    def get_insight_selectors(self) -> list[dict[str, str]]:
         return self.insight_selectors
 
     def update(
@@ -215,14 +216,14 @@ class Trail(BaseModel):
         if kms_key_id is not None:
             self.kms_key_id = kms_key_id
 
-    def short(self) -> Dict[str, str]:
+    def short(self) -> dict[str, str]:
         return {
             "Name": self.trail_name,
             "TrailARN": self.arn,
             "HomeRegion": self.region_name,
         }
 
-    def description(self, include_region: bool = False) -> Dict[str, Any]:
+    def description(self, include_region: bool = False) -> dict[str, Any]:
         desc = {
             "Name": self.trail_name,
             "S3BucketName": self.bucket_name,
@@ -252,7 +253,7 @@ class CloudTrailBackend(BaseBackend):
 
     def __init__(self, region_name: str, account_id: str):
         super().__init__(region_name, account_id)
-        self.trails: Dict[str, Trail] = dict()
+        self.trails: dict[str, Trail] = dict()
         self.tagging_service = TaggingService(tag_name="TagsList")
 
     def create_trail(
@@ -268,7 +269,7 @@ class CloudTrailBackend(BaseBackend):
         cw_log_group_arn: str,
         cw_role_arn: str,
         kms_key_id: str,
-        tags_list: List[Dict[str, str]],
+        tags_list: list[dict[str, str]],
     ) -> Trail:
         trail = Trail(
             self.account_id,
@@ -377,9 +378,9 @@ class CloudTrailBackend(BaseBackend):
     def put_event_selectors(
         self,
         trail_name: str,
-        event_selectors: List[Dict[str, Any]],
-        advanced_event_selectors: List[Dict[str, Any]],
-    ) -> Tuple[str, List[Dict[str, Any]], List[Dict[str, Any]]]:
+        event_selectors: list[dict[str, Any]],
+        advanced_event_selectors: list[dict[str, Any]],
+    ) -> tuple[str, list[dict[str, Any]], list[dict[str, Any]]]:
         trail = self.get_trail(trail_name)
         trail.put_event_selectors(event_selectors, advanced_event_selectors)
         trail_arn = trail.arn
@@ -387,22 +388,22 @@ class CloudTrailBackend(BaseBackend):
 
     def get_event_selectors(
         self, trail_name: str
-    ) -> Tuple[str, List[Dict[str, Any]], List[Dict[str, Any]]]:
+    ) -> tuple[str, list[dict[str, Any]], list[dict[str, Any]]]:
         trail = self.get_trail(trail_name)
         event_selectors, advanced_event_selectors = trail.get_event_selectors()
         return trail.arn, event_selectors, advanced_event_selectors
 
-    def add_tags(self, resource_id: str, tags_list: List[Dict[str, str]]) -> None:
+    def add_tags(self, resource_id: str, tags_list: list[dict[str, str]]) -> None:
         self.tagging_service.tag_resource(resource_id, tags_list)
 
-    def remove_tags(self, resource_id: str, tags_list: List[Dict[str, str]]) -> None:
+    def remove_tags(self, resource_id: str, tags_list: list[dict[str, str]]) -> None:
         self.tagging_service.untag_resource_using_tags(resource_id, tags_list)
 
-    def list_tags(self, resource_id_list: List[str]) -> List[Dict[str, Any]]:
+    def list_tags(self, resource_id_list: list[str]) -> list[dict[str, Any]]:
         """
         Pagination is not yet implemented
         """
-        resp: List[Dict[str, Any]] = [{"ResourceId": r_id} for r_id in resource_id_list]
+        resp: list[dict[str, Any]] = [{"ResourceId": r_id} for r_id in resource_id_list]
         for item in resp:
             item["TagsList"] = self.tagging_service.list_tags_for_resource(
                 item["ResourceId"]
@@ -410,15 +411,15 @@ class CloudTrailBackend(BaseBackend):
         return resp
 
     def put_insight_selectors(
-        self, trail_name: str, insight_selectors: List[Dict[str, str]]
-    ) -> Tuple[str, List[Dict[str, str]]]:
+        self, trail_name: str, insight_selectors: list[dict[str, str]]
+    ) -> tuple[str, list[dict[str, str]]]:
         trail = self.get_trail(trail_name)
         trail.put_insight_selectors(insight_selectors)
         return trail.arn, insight_selectors
 
     def get_insight_selectors(
         self, trail_name: str
-    ) -> Tuple[str, List[Dict[str, str]]]:
+    ) -> tuple[str, list[dict[str, str]]]:
         trail = self.get_trail(trail_name)
         return trail.arn, trail.get_insight_selectors()
 

--- a/moto/cloudtrail/responses.py
+++ b/moto/cloudtrail/responses.py
@@ -1,7 +1,7 @@
 """Handles incoming cloudtrail requests, invokes methods, returns responses."""
 
 import json
-from typing import Any, Dict
+from typing import Any
 
 from moto.core.responses import BaseResponse
 
@@ -190,7 +190,7 @@ class CloudTrailResponse(BaseResponse):
         trail_arn, insight_selectors = self.cloudtrail_backend.get_insight_selectors(
             trail_name=trail_name
         )
-        resp: Dict[str, Any] = {"TrailARN": trail_arn}
+        resp: dict[str, Any] = {"TrailARN": trail_arn}
         if insight_selectors:
             resp["InsightSelectors"] = insight_selectors
         return json.dumps(resp)

--- a/moto/cloudwatch/metric_data_expression_parser.py
+++ b/moto/cloudwatch/metric_data_expression_parser.py
@@ -1,12 +1,12 @@
 from datetime import datetime
-from typing import Any, Dict, List, SupportsFloat, Tuple
+from typing import Any, SupportsFloat
 
 
 def parse_expression(
-    expression: str, results: List[Dict[str, Any]]
-) -> Tuple[List[SupportsFloat], List[datetime]]:
-    values: List[SupportsFloat] = []
-    timestamps: List[datetime] = []
+    expression: str, results: list[dict[str, Any]]
+) -> tuple[list[SupportsFloat], list[datetime]]:
+    values: list[SupportsFloat] = []
+    timestamps: list[datetime] = []
     for result in results:
         if result.get("id") == expression:
             values.extend(result["values"])

--- a/moto/cloudwatch/models.py
+++ b/moto/cloudwatch/models.py
@@ -1,7 +1,8 @@
 import json
 import math
+from collections.abc import Iterable
 from datetime import datetime, timedelta
-from typing import Any, Dict, Iterable, List, Optional, SupportsFloat, Tuple
+from typing import Any, Optional, SupportsFloat
 
 from moto.core.base_backend import BaseBackend
 from moto.core.common_models import BackendDict, BaseModel, CloudWatchMetricProvider
@@ -27,7 +28,7 @@ from .utils import (
 _EMPTY_LIST: Any = tuple()
 
 
-class Dimension(object):
+class Dimension:
     def __init__(self, name: Optional[str], value: Optional[str]):
         self.name = name
         self.value = value
@@ -43,14 +44,14 @@ class Dimension(object):
         return self.name < other.name and self.value < other.name  # type: ignore[operator]
 
 
-class Metric(object):
-    def __init__(self, metric_name: str, namespace: str, dimensions: List[Dimension]):
+class Metric:
+    def __init__(self, metric_name: str, namespace: str, dimensions: list[Dimension]):
         self.metric_name = metric_name
         self.namespace = namespace
         self.dimensions = dimensions
 
 
-class MetricStat(object):
+class MetricStat:
     def __init__(self, metric: Metric, period: str, stat: str, unit: str):
         self.metric = metric
         self.period = period
@@ -58,7 +59,7 @@ class MetricStat(object):
         self.unit = unit
 
 
-class MetricDataQuery(object):
+class MetricDataQuery:
     def __init__(
         self,
         query_id: str,
@@ -117,7 +118,7 @@ class Alarm(BaseModel):
         name: str,
         namespace: str,
         metric_name: str,
-        metric_data_queries: Optional[List[MetricDataQuery]],
+        metric_data_queries: Optional[list[MetricDataQuery]],
         comparison_operator: str,
         evaluation_periods: int,
         datapoints_to_alarm: Optional[int],
@@ -126,10 +127,10 @@ class Alarm(BaseModel):
         statistic: str,
         extended_statistic: Optional[str],
         description: str,
-        dimensions: List[Dict[str, str]],
-        alarm_actions: List[str],
-        ok_actions: Optional[List[str]],
-        insufficient_data_actions: Optional[List[str]],
+        dimensions: list[dict[str, str]],
+        alarm_actions: list[str],
+        ok_actions: Optional[list[str]],
+        insufficient_data_actions: Optional[list[str]],
         unit: Optional[str],
         actions_enabled: bool,
         treat_missing_data: Optional[str],
@@ -164,7 +165,7 @@ class Alarm(BaseModel):
         self.evaluate_low_sample_count_percentile = evaluate_low_sample_count_percentile
         self.threshold_metric_id = threshold_metric_id
 
-        self.history: List[Any] = []
+        self.history: list[Any] = []
 
         self.state_reason = "Unchecked: Initial alarm creation"
         self.state_reason_data = "{}"
@@ -193,7 +194,7 @@ class Alarm(BaseModel):
 
 
 def are_dimensions_same(
-    metric_dimensions: List[Dimension], dimensions: List[Dimension]
+    metric_dimensions: list[Dimension], dimensions: list[Dimension]
 ) -> bool:
     if len(metric_dimensions) != len(dimensions):
         return False
@@ -216,7 +217,7 @@ class MetricDatumBase(BaseModel):
         self,
         namespace: str,
         name: str,
-        dimensions: List[Dict[str, str]],
+        dimensions: list[dict[str, str]],
         timestamp: Optional[datetime],
         unit: Any = None,
     ):
@@ -232,8 +233,8 @@ class MetricDatumBase(BaseModel):
         self,
         namespace: Optional[str],
         name: Optional[str],
-        dimensions: List[Dict[str, str]],
-        already_present_metrics: Optional[List["MetricDatumBase"]] = None,
+        dimensions: list[dict[str, str]],
+        already_present_metrics: Optional[list["MetricDatumBase"]] = None,
     ) -> bool:
         if namespace and namespace != self.namespace:
             return False
@@ -269,7 +270,7 @@ class MetricDatum(MetricDatumBase):
         namespace: str,
         name: str,
         value: float,
-        dimensions: List[Dict[str, str]],
+        dimensions: list[dict[str, str]],
         timestamp: Optional[datetime],
         unit: Any = None,
     ):
@@ -290,7 +291,7 @@ class MetricAggregatedDatum(MetricDatumBase):
         max_stat: float,
         sample_count: float,
         sum_stat: float,
-        dimensions: List[Dict[str, str]],
+        dimensions: list[dict[str, str]],
         timestamp: Optional[datetime],
         unit: Any = None,
     ):
@@ -325,9 +326,9 @@ class Statistics:
     Helper class to calculate statics for a list of metrics (MetricDatum, or MetricAggregatedDatum)
     """
 
-    def __init__(self, stats: List[str], dt: datetime, unit: Optional[str] = None):
+    def __init__(self, stats: list[str], dt: datetime, unit: Optional[str] = None):
         self.timestamp: datetime = dt or utcnow()
-        self.metric_data: List[MetricDatumBase] = []
+        self.metric_data: list[MetricDatumBase] = []
         self.stats = stats
         self.unit = unit
 
@@ -350,14 +351,14 @@ class Statistics:
         return None
 
     @property
-    def metric_single_values_list(self) -> List[float]:
+    def metric_single_values_list(self) -> list[float]:
         """
         :return: list of all values for the MetricDatum instances of the metric_data list
         """
         return [m.value for m in self.metric_data or [] if isinstance(m, MetricDatum)]
 
     @property
-    def metric_aggregated_list(self) -> List[MetricAggregatedDatum]:
+    def metric_aggregated_list(self) -> list[MetricAggregatedDatum]:
         """
         :return: list of all MetricAggregatedDatum instances from the metric_data list
         """
@@ -449,17 +450,17 @@ class InsightRule(BaseModel):
 class CloudWatchBackend(BaseBackend):
     def __init__(self, region_name: str, account_id: str):
         super().__init__(region_name, account_id)
-        self.alarms: Dict[str, Alarm] = {}
-        self.dashboards: Dict[str, Dashboard] = {}
-        self.metric_data: List[MetricDatumBase] = []
-        self.paged_metric_data: Dict[str, List[MetricDatumBase]] = {}
-        self.insight_rules: Dict[str, InsightRule] = {}
+        self.alarms: dict[str, Alarm] = {}
+        self.dashboards: dict[str, Dashboard] = {}
+        self.metric_data: list[MetricDatumBase] = []
+        self.paged_metric_data: dict[str, list[MetricDatumBase]] = {}
+        self.insight_rules: dict[str, InsightRule] = {}
         self.tagger = TaggingService()
 
     @property
     # Retrieve a list of all OOTB metrics that are provided by metrics providers
     # Computed on the fly
-    def aws_metric_data(self) -> List[MetricDatumBase]:
+    def aws_metric_data(self) -> list[MetricDatumBase]:
         providers = CloudWatchMetricProvider.__subclasses__()
         md = []
         for provider in providers:
@@ -481,20 +482,20 @@ class CloudWatchBackend(BaseBackend):
         threshold: float,
         statistic: str,
         description: str,
-        dimensions: List[Dict[str, str]],
-        alarm_actions: List[str],
-        metric_data_queries: Optional[List[MetricDataQuery]] = None,
+        dimensions: list[dict[str, str]],
+        alarm_actions: list[str],
+        metric_data_queries: Optional[list[MetricDataQuery]] = None,
         datapoints_to_alarm: Optional[int] = None,
         extended_statistic: Optional[str] = None,
-        ok_actions: Optional[List[str]] = None,
-        insufficient_data_actions: Optional[List[str]] = None,
+        ok_actions: Optional[list[str]] = None,
+        insufficient_data_actions: Optional[list[str]] = None,
         unit: Optional[str] = None,
         actions_enabled: bool = True,
         treat_missing_data: Optional[str] = None,
         evaluate_low_sample_count_percentile: Optional[str] = None,
         threshold_metric_id: Optional[str] = None,
         rule: Optional[str] = None,
-        tags: Optional[List[Dict[str, str]]] = None,
+        tags: Optional[list[dict[str, str]]] = None,
     ) -> Alarm:
         if extended_statistic and not extended_statistic.startswith("p"):
             raise InvalidParameterValue(
@@ -546,7 +547,7 @@ class CloudWatchBackend(BaseBackend):
         return self.alarms.values()
 
     @staticmethod
-    def _list_element_starts_with(items: List[str], needle: str) -> bool:
+    def _list_element_starts_with(items: list[str], needle: str) -> bool:
         """True of any of the list elements starts with needle"""
         for item in items:
             if item.startswith(needle):
@@ -569,7 +570,7 @@ class CloudWatchBackend(BaseBackend):
             if alarm.name.startswith(name_prefix)
         ]
 
-    def get_alarms_by_alarm_names(self, alarm_names: List[str]) -> Iterable[Alarm]:
+    def get_alarms_by_alarm_names(self, alarm_names: list[str]) -> Iterable[Alarm]:
         return [alarm for alarm in self.alarms.values() if alarm.name in alarm_names]
 
     def get_alarms_by_state_value(self, target_state: str) -> Iterable[Alarm]:
@@ -577,12 +578,12 @@ class CloudWatchBackend(BaseBackend):
             lambda alarm: alarm.state_value == target_state, self.alarms.values()
         )
 
-    def delete_alarms(self, alarm_names: List[str]) -> None:
+    def delete_alarms(self, alarm_names: list[str]) -> None:
         for alarm_name in alarm_names:
             self.alarms.pop(alarm_name, None)
 
     def put_metric_data(
-        self, namespace: str, metric_data: List[Dict[str, Any]]
+        self, namespace: str, metric_data: list[dict[str, Any]]
     ) -> None:
         for i, metric in enumerate(metric_data):
             self._validate_parameters_put_metric_data(metric, i + 1)
@@ -644,11 +645,11 @@ class CloudWatchBackend(BaseBackend):
 
     def get_metric_data(
         self,
-        queries: List[Dict[str, Any]],
+        queries: list[dict[str, Any]],
         start_time: datetime,
         end_time: datetime,
         scan_by: str = "TimestampAscending",
-    ) -> List[Dict[str, Any]]:
+    ) -> list[dict[str, Any]]:
         start_time = start_time.replace(microsecond=0)
         end_time = end_time.replace(microsecond=0)
 
@@ -689,8 +690,8 @@ class CloudWatchBackend(BaseBackend):
                 for d in metric_stat["Metric"].get("Dimensions", [])
             ]
             unit = metric_stat.get("Unit")
-            result_vals: List[SupportsFloat] = []
-            timestamps: List[datetime] = []
+            result_vals: list[SupportsFloat] = []
+            timestamps: list[datetime] = []
             stat = metric_stat["Stat"]
             while period_start_time <= end_time:
                 period_end_time = period_start_time + delta
@@ -767,8 +768,8 @@ class CloudWatchBackend(BaseBackend):
         for query in metric_insights_expression_queries:
             period_start_time = start_time
             delta = timedelta(seconds=int(query["Period"]))
-            result_vals: List[SupportsFloat] = []  # type: ignore[no-redef]
-            timestamps: List[datetime] = []  # type: ignore[no-redef]
+            result_vals: list[SupportsFloat] = []  # type: ignore[no-redef]
+            timestamps: list[datetime] = []  # type: ignore[no-redef]
             while period_start_time <= end_time:
                 period_end_time = period_start_time + delta
                 period_md = [
@@ -811,10 +812,10 @@ class CloudWatchBackend(BaseBackend):
         start_time: datetime,
         end_time: datetime,
         period: int,
-        stats: List[str],
-        dimensions: List[Dict[str, str]],
+        stats: list[str],
+        dimensions: list[dict[str, str]],
         unit: Optional[str] = None,
-    ) -> List[Statistics]:
+    ) -> list[Statistics]:
         start_time = start_time.replace(microsecond=0)
         end_time = end_time.replace(microsecond=0)
 
@@ -845,7 +846,7 @@ class CloudWatchBackend(BaseBackend):
             return []
 
         idx = 0
-        data: List[Statistics] = list()
+        data: list[Statistics] = list()
         for dt in daterange(
             filtered_data[0].timestamp,
             filtered_data[-1].timestamp + period_delta,
@@ -866,7 +867,7 @@ class CloudWatchBackend(BaseBackend):
 
         return data
 
-    def get_all_metrics(self) -> List[MetricDatumBase]:
+    def get_all_metrics(self) -> list[MetricDatumBase]:
         return self.metric_data + self.aws_metric_data
 
     def put_dashboard(self, name: str, body: str) -> None:
@@ -877,7 +878,7 @@ class CloudWatchBackend(BaseBackend):
             if key.startswith(prefix):
                 yield value
 
-    def delete_dashboards(self, dashboards: List[str]) -> Optional[str]:
+    def delete_dashboards(self, dashboards: list[str]) -> Optional[str]:
         to_delete = set(dashboards)
         all_dashboards = set(self.dashboards.keys())
 
@@ -921,8 +922,8 @@ class CloudWatchBackend(BaseBackend):
         next_token: Optional[str],
         namespace: str,
         metric_name: str,
-        dimensions: List[Dict[str, str]],
-    ) -> Tuple[Optional[str], List[MetricDatumBase]]:
+        dimensions: list[dict[str, str]],
+    ) -> tuple[Optional[str], list[MetricDatumBase]]:
         if next_token:
             if next_token not in self.paged_metric_data:
                 raise InvalidParameterValue("Request parameter NextToken is invalid")
@@ -935,10 +936,10 @@ class CloudWatchBackend(BaseBackend):
             return self._get_paginated(metrics)
 
     def get_filtered_metrics(
-        self, metric_name: str, namespace: str, dimensions: List[Dict[str, str]]
-    ) -> List[MetricDatumBase]:
+        self, metric_name: str, namespace: str, dimensions: list[dict[str, str]]
+    ) -> list[MetricDatumBase]:
         metrics = self.get_all_metrics()
-        new_metrics: List[MetricDatumBase] = []
+        new_metrics: list[MetricDatumBase] = []
         for md in metrics:
             if md.filter(
                 namespace=namespace,
@@ -949,10 +950,10 @@ class CloudWatchBackend(BaseBackend):
                 new_metrics.append(md)
         return new_metrics
 
-    def list_tags_for_resource(self, arn: str) -> Dict[str, str]:
+    def list_tags_for_resource(self, arn: str) -> dict[str, str]:
         return self.tagger.get_tag_dict_for_resource(arn)
 
-    def tag_resource(self, arn: str, tags: List[Dict[str, str]]) -> None:
+    def tag_resource(self, arn: str, tags: list[dict[str, str]]) -> None:
         # From boto3:
         # Currently, the only CloudWatch resources that can be tagged are alarms and Contributor Insights rules.
         all_arns = [alarm.alarm_arn for alarm in self.describe_alarms()]
@@ -961,15 +962,15 @@ class CloudWatchBackend(BaseBackend):
 
         self.tagger.tag_resource(arn, tags)
 
-    def untag_resource(self, arn: str, tag_keys: List[str]) -> None:
+    def untag_resource(self, arn: str, tag_keys: list[str]) -> None:
         if arn not in self.tagger.tags.keys():
             raise ResourceNotFoundException
 
         self.tagger.untag_resource_using_names(arn, tag_keys)
 
     def _get_paginated(
-        self, metrics: List[MetricDatumBase]
-    ) -> Tuple[Optional[str], List[MetricDatumBase]]:
+        self, metrics: list[MetricDatumBase]
+    ) -> tuple[Optional[str], list[MetricDatumBase]]:
         if len(metrics) > 500:
             next_token = str(mock_random.uuid4())
             self.paged_metric_data[next_token] = metrics[500:]
@@ -978,7 +979,7 @@ class CloudWatchBackend(BaseBackend):
             return None, metrics
 
     def _validate_parameters_put_metric_data(
-        self, metric: Dict[str, Any], query_num: int
+        self, metric: dict[str, Any], query_num: int
     ) -> None:
         """Runs some basic validation of the Metric Query
 
@@ -989,7 +990,7 @@ class CloudWatchBackend(BaseBackend):
         :raises: InvalidParameterCombination
         """
         # basic validation of input
-        if math.isnan(metric.get("Value", float())):
+        if math.isnan(metric.get("Value", 0.0)):
             # single value
             raise InvalidParameterValue(
                 f"The value NaN for parameter MetricData.member.{query_num}.Value is invalid."
@@ -1030,7 +1031,7 @@ class CloudWatchBackend(BaseBackend):
         name: str,
         state: str,
         definition: str,
-        tags: Optional[List[Dict[str, str]]] = None,
+        tags: Optional[list[dict[str, str]]] = None,
     ) -> InsightRule:
         rule = InsightRule(
             account_id=self.account_id,
@@ -1052,7 +1053,7 @@ class CloudWatchBackend(BaseBackend):
         self,
         next_token: Optional[str] = "",
         max_results: Optional[int] = 500,
-    ) -> List[InsightRule]:
+    ) -> list[InsightRule]:
         rules = list(self.insight_rules.values())
 
         if max_results is None or len(rules) <= max_results:
@@ -1060,7 +1061,7 @@ class CloudWatchBackend(BaseBackend):
 
         return rules[:max_results]
 
-    def delete_insight_rules(self, rule_names: List[str]) -> List[Dict[str, Any]]:
+    def delete_insight_rules(self, rule_names: list[str]) -> list[dict[str, Any]]:
         failures = []
         for rule_name in list(self.insight_rules.keys()):
             if rule_name in rule_names:
@@ -1079,7 +1080,7 @@ class CloudWatchBackend(BaseBackend):
 
         return failures
 
-    def disable_insight_rules(self, rule_names: List[str]) -> List[Dict[str, Any]]:
+    def disable_insight_rules(self, rule_names: list[str]) -> list[dict[str, Any]]:
         failures = []
         for rule_name in list(self.insight_rules.keys()):
             if rule_name in rule_names:
@@ -1098,7 +1099,7 @@ class CloudWatchBackend(BaseBackend):
 
         return failures
 
-    def enable_insight_rules(self, rule_names: List[str]) -> List[Dict[str, Any]]:
+    def enable_insight_rules(self, rule_names: list[str]) -> list[dict[str, Any]]:
         failures = []
         for rule_name in list(self.insight_rules.keys()):
             if rule_name in rule_names:

--- a/moto/cloudwatch/responses.py
+++ b/moto/cloudwatch/responses.py
@@ -1,5 +1,5 @@
 import json
-from typing import Iterable, List
+from collections.abc import Iterable
 
 from moto.core.responses import ActionResult, BaseResponse, EmptyResult
 
@@ -236,7 +236,7 @@ class CloudWatchResponse(BaseResponse):
     @staticmethod
     def filter_alarms(
         alarms: Iterable[Alarm], metric_name: str, namespace: str
-    ) -> List[Alarm]:
+    ) -> list[Alarm]:
         metric_filtered_alarms = []
 
         for alarm in alarms:

--- a/moto/codebuild/models.py
+++ b/moto/codebuild/models.py
@@ -1,6 +1,6 @@
 import datetime
 from collections import defaultdict
-from typing import Any, Dict, List, Optional
+from typing import Any, Optional
 
 from dateutil import parser
 
@@ -18,12 +18,12 @@ class CodeBuildProjectMetadata(BaseModel):
         region_name: str,
         project_name: str,
         source_version: Optional[str],
-        artifacts: Optional[Dict[str, Any]],
+        artifacts: Optional[dict[str, Any]],
         build_id: str,
         service_role: str,
     ):
         current_date = iso_8601_datetime_with_milliseconds()
-        self.build_metadata: Dict[str, Any] = dict()
+        self.build_metadata: dict[str, Any] = dict()
 
         self.build_metadata["id"] = build_id
         self.build_metadata["arn"] = (
@@ -99,23 +99,23 @@ class CodeBuild(BaseModel):
         region: str,
         project_name: str,
         description: Optional[str],
-        project_source: Dict[str, Any],
-        artifacts: Dict[str, Any],
-        environment: Dict[str, Any],
+        project_source: dict[str, Any],
+        artifacts: dict[str, Any],
+        environment: dict[str, Any],
         serviceRole: str = "some_role",
-        tags: Optional[List[Dict[str, str]]] = None,
-        cache: Optional[Dict[str, Any]] = None,
+        tags: Optional[list[dict[str, str]]] = None,
+        cache: Optional[dict[str, Any]] = None,
         timeout: Optional[int] = 0,
         queued_timeout: Optional[int] = 0,
         source_version: Optional[str] = None,
-        logs_config: Optional[Dict[str, Any]] = None,
-        vpc_config: Optional[Dict[str, Any]] = None,
+        logs_config: Optional[dict[str, Any]] = None,
+        vpc_config: Optional[dict[str, Any]] = None,
     ):
         self.arn = f"arn:{get_partition(region)}:codebuild:{region}:{account_id}:project/{project_name}"
         self.service_role = serviceRole
         self.tags = tags
         current_date = unix_time()
-        self.project_metadata: Dict[str, Any] = dict()
+        self.project_metadata: dict[str, Any] = dict()
 
         self.project_metadata["name"] = project_name
         if description:
@@ -154,27 +154,27 @@ class CodeBuild(BaseModel):
 class CodeBuildBackend(BaseBackend):
     def __init__(self, region_name: str, account_id: str):
         super().__init__(region_name, account_id)
-        self.codebuild_projects: Dict[str, CodeBuild] = dict()
-        self.build_history: Dict[str, List[str]] = dict()
-        self.build_metadata: Dict[str, CodeBuildProjectMetadata] = dict()
-        self.build_metadata_history: Dict[str, List[Dict[str, Any]]] = defaultdict(list)
+        self.codebuild_projects: dict[str, CodeBuild] = dict()
+        self.build_history: dict[str, list[str]] = dict()
+        self.build_metadata: dict[str, CodeBuildProjectMetadata] = dict()
+        self.build_metadata_history: dict[str, list[dict[str, Any]]] = defaultdict(list)
 
     def create_project(
         self,
         project_name: str,
         description: Optional[str],
-        project_source: Dict[str, Any],
-        artifacts: Dict[str, Any],
-        environment: Dict[str, Any],
+        project_source: dict[str, Any],
+        artifacts: dict[str, Any],
+        environment: dict[str, Any],
         service_role: str,
-        tags: Optional[List[Dict[str, str]]],
-        cache: Optional[Dict[str, Any]],
+        tags: Optional[list[dict[str, str]]],
+        cache: Optional[dict[str, Any]],
         timeout: Optional[int],
         queued_timeout: Optional[int],
         source_version: Optional[str],
-        logs_config: Optional[Dict[str, Any]],
-        vpc_config: Optional[Dict[str, Any]],
-    ) -> Dict[str, Any]:
+        logs_config: Optional[dict[str, Any]],
+        vpc_config: Optional[dict[str, Any]],
+    ) -> dict[str, Any]:
         self.codebuild_projects[project_name] = CodeBuild(
             self.account_id,
             self.region_name,
@@ -198,7 +198,7 @@ class CodeBuildBackend(BaseBackend):
 
         return self.codebuild_projects[project_name].project_metadata
 
-    def list_projects(self) -> List[str]:
+    def list_projects(self) -> list[str]:
         projects = []
 
         for project in self.codebuild_projects.keys():
@@ -206,7 +206,7 @@ class CodeBuildBackend(BaseBackend):
 
         return projects
 
-    def batch_get_projects(self, names: List[str]) -> List[Dict[str, Any]]:
+    def batch_get_projects(self, names: list[str]) -> list[dict[str, Any]]:
         result = []
         for name in names:
             if name in self.codebuild_projects:
@@ -221,8 +221,8 @@ class CodeBuildBackend(BaseBackend):
         self,
         project_name: str,
         source_version: Optional[str] = None,
-        artifact_override: Optional[Dict[str, Any]] = None,
-    ) -> Dict[str, Any]:
+        artifact_override: Optional[dict[str, Any]] = None,
+    ) -> dict[str, Any]:
         project = self.codebuild_projects[project_name]
         build_id = f"{project_name}:{mock_random.uuid4()}"
 
@@ -246,7 +246,7 @@ class CodeBuildBackend(BaseBackend):
 
         return self.build_metadata[project_name].build_metadata
 
-    def _set_phases(self, phases: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    def _set_phases(self, phases: list[dict[str, Any]]) -> list[dict[str, Any]]:
         current_date = iso_8601_datetime_with_milliseconds()
         # No phaseStatus for QUEUED on first start
         for existing_phase in phases:
@@ -266,7 +266,7 @@ class CodeBuildBackend(BaseBackend):
         ]
 
         for status in statuses:
-            phase: Dict[str, Any] = dict()
+            phase: dict[str, Any] = dict()
             phase["phaseType"] = status
             phase["phaseStatus"] = "SUCCEEDED"
             phase["startTime"] = current_date
@@ -276,8 +276,8 @@ class CodeBuildBackend(BaseBackend):
 
         return phases
 
-    def batch_get_builds(self, ids: List[str]) -> List[Dict[str, Any]]:
-        batch_build_metadata: List[Dict[str, Any]] = []
+    def batch_get_builds(self, ids: list[str]) -> list[dict[str, Any]]:
+        batch_build_metadata: list[dict[str, Any]] = []
 
         for metadata in self.build_metadata_history.values():
             for build in metadata:
@@ -294,13 +294,13 @@ class CodeBuildBackend(BaseBackend):
 
         return batch_build_metadata
 
-    def list_builds_for_project(self, project_name: str) -> List[str]:
+    def list_builds_for_project(self, project_name: str) -> list[str]:
         try:
             return self.build_history[project_name]
         except KeyError:
             return list()
 
-    def list_builds(self) -> List[str]:
+    def list_builds(self) -> list[str]:
         ids = []
 
         for build_ids in self.build_history.values():
@@ -311,7 +311,7 @@ class CodeBuildBackend(BaseBackend):
         self.build_metadata.pop(project_name, None)
         self.codebuild_projects.pop(project_name, None)
 
-    def stop_build(self, build_id: str) -> Optional[Dict[str, Any]]:  # type: ignore[return]
+    def stop_build(self, build_id: str) -> Optional[dict[str, Any]]:  # type: ignore[return]
         for metadata in self.build_metadata_history.values():
             for build in metadata:
                 if build["id"] == build_id:

--- a/moto/codebuild/responses.py
+++ b/moto/codebuild/responses.py
@@ -1,6 +1,6 @@
 import json
 import re
-from typing import Any, Dict, List
+from typing import Any
 
 from moto.core.responses import BaseResponse
 from moto.utilities.utils import get_partition
@@ -13,7 +13,7 @@ from .exceptions import (
 from .models import CodeBuildBackend, codebuild_backends
 
 
-def _validate_required_params_source(source: Dict[str, Any]) -> None:
+def _validate_required_params_source(source: dict[str, Any]) -> None:
     if source["type"] not in [
         "BITBUCKET",
         "CODECOMMIT",
@@ -43,7 +43,7 @@ def _validate_required_params_service_role(
         )
 
 
-def _validate_required_params_artifacts(artifacts: Dict[str, Any]) -> None:
+def _validate_required_params_artifacts(artifacts: dict[str, Any]) -> None:
     if artifacts["type"] not in ["CODEPIPELINE", "S3", "NO_ARTIFACTS"]:
         raise InvalidInputException("Invalid type provided: Artifact type")
 
@@ -56,7 +56,7 @@ def _validate_required_params_artifacts(artifacts: Dict[str, Any]) -> None:
         raise InvalidInputException("Project source location is required")
 
 
-def _validate_required_params_environment(environment: Dict[str, Any]) -> None:
+def _validate_required_params_environment(environment: dict[str, Any]) -> None:
     if environment["type"] not in [
         "WINDOWS_CONTAINER",
         "LINUX_CONTAINER",
@@ -88,7 +88,7 @@ def _validate_required_params_project_name(name: str) -> None:
         )
 
 
-def _validate_required_params_id(build_id: str, build_ids: List[str]) -> None:
+def _validate_required_params_id(build_id: str, build_ids: list[str]) -> None:
     if ":" not in build_id:
         raise InvalidInputException("Invalid build ID provided")
 

--- a/moto/codecommit/models.py
+++ b/moto/codecommit/models.py
@@ -1,4 +1,4 @@
-from typing import Dict, Optional
+from typing import Optional
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
@@ -39,11 +39,11 @@ class CodeCommit(BaseModel):
 class CodeCommitBackend(BaseBackend):
     def __init__(self, region_name: str, account_id: str):
         super().__init__(region_name, account_id)
-        self.repositories: Dict[str, CodeCommit] = {}
+        self.repositories: dict[str, CodeCommit] = {}
 
     def create_repository(
         self, repository_name: str, repository_description: str
-    ) -> Dict[str, str]:
+    ) -> dict[str, str]:
         repository = self.repositories.get(repository_name)
         if repository:
             raise RepositoryNameExistsException(repository_name)
@@ -54,7 +54,7 @@ class CodeCommitBackend(BaseBackend):
 
         return self.repositories[repository_name].repository_metadata
 
-    def get_repository(self, repository_name: str) -> Dict[str, str]:
+    def get_repository(self, repository_name: str) -> dict[str, str]:
         repository = self.repositories.get(repository_name)
         if not repository:
             raise RepositoryDoesNotExistException(repository_name)

--- a/moto/codedeploy/models.py
+++ b/moto/codedeploy/models.py
@@ -2,7 +2,7 @@
 
 import uuid
 from enum import Enum
-from typing import Any, Dict, List, Optional
+from typing import Any, Optional
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
@@ -22,7 +22,7 @@ from .exceptions import (
 
 class Application(BaseModel):
     def __init__(
-        self, application_name: str, compute_platform: str, tags: List[Dict[str, str]]
+        self, application_name: str, compute_platform: str, tags: list[dict[str, str]]
     ):
         self.id = str(uuid.uuid4())
         self.application_name = application_name
@@ -37,7 +37,7 @@ class Application(BaseModel):
         # self.github_account_name = ""
         # self.linked_to_github = False
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         return {
             "applicationId": self.id,
             "applicationName": self.application_name,
@@ -59,7 +59,7 @@ class CodeDeployDefault(str, Enum):
 class AlarmConfiguration(BaseModel):
     def __init__(
         self,
-        alarms: Optional[List[Dict[str, Any]]] = None,
+        alarms: Optional[list[dict[str, Any]]] = None,
         enabled: Optional[bool] = False,
         ignore_poll_alarm_failure: bool = False,
     ):
@@ -74,21 +74,21 @@ class DeploymentGroup(BaseModel):
         application: Application,
         deployment_group_name: str,
         deployment_config_name: Optional[str],
-        ec2_tag_filters: Optional[List[Any]],
-        on_premises_instance_tag_filters: Optional[List[Any]],
-        auto_scaling_groups: Optional[List[str]],
+        ec2_tag_filters: Optional[list[Any]],
+        on_premises_instance_tag_filters: Optional[list[Any]],
+        auto_scaling_groups: Optional[list[str]],
         service_role_arn: str,
-        trigger_configurations: Optional[List[Any]],
+        trigger_configurations: Optional[list[Any]],
         alarm_configuration: Optional[AlarmConfiguration],
-        auto_rollback_configuration: Optional[Dict[str, Any]],
+        auto_rollback_configuration: Optional[dict[str, Any]],
         outdated_instances_strategy: Optional[str],
         deployment_style: Optional[Any],
         blue_green_deployment_configuration: Optional[Any],
         load_balancer_info: Optional[Any],
         ec2_tag_set: Optional[Any],
-        ecs_services: Optional[List[Any]],
+        ecs_services: Optional[list[Any]],
         on_premises_tag_set: Optional[Any],
-        tags: Optional[List[Dict[str, str]]],
+        tags: Optional[list[dict[str, str]]],
         termination_hook_enabled: Optional[bool],
     ):
         self.application = application
@@ -114,7 +114,7 @@ class DeploymentGroup(BaseModel):
         self.termination_hook_enabled = termination_hook_enabled
         self.deployment_group_id = str(uuid.uuid4())
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         return {
             "applicationName": self.application.application_name,
             "deploymentGroupId": self.deployment_group_id,
@@ -151,8 +151,8 @@ class DeploymentInfo(BaseModel):
         deployment_config_name: Optional[str],
         description: Optional[str],
         ignore_application_stop_failures: Optional[bool],
-        targetInstances: Optional[Dict[str, Any]],
-        auto_rollback_configuration: Optional[Dict[str, Any]],
+        targetInstances: Optional[dict[str, Any]],
+        auto_rollback_configuration: Optional[dict[str, Any]],
         update_outdated_instances_only: Optional[bool],
         file_exists_behavior: Optional[str],
         override_alarm_configuration: Optional[AlarmConfiguration],
@@ -198,10 +198,10 @@ class DeploymentInfo(BaseModel):
         self.file_exists_behavior = file_exists_behavior
         self.deployment_status_messages: list[str] = []
         self.external_id = ""
-        self.related_deployments: Dict[str, Any] = {}
+        self.related_deployments: dict[str, Any] = {}
         self.override_alarm_configuration = override_alarm_configuration
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         return {
             "applicationName": self.application_name,
             "deploymentGroupName": self.deployment_group_name,
@@ -241,9 +241,9 @@ class CodeDeployBackend(BaseBackend):
 
     def __init__(self, region_name: str, account_id: str):
         super().__init__(region_name, account_id)
-        self.applications: Dict[str, Application] = {}
-        self.deployments: Dict[str, DeploymentInfo] = {}
-        self.deployment_groups: Dict[str, Dict[str, DeploymentGroup]] = {}
+        self.applications: dict[str, Application] = {}
+        self.deployments: dict[str, DeploymentInfo] = {}
+        self.deployment_groups: dict[str, dict[str, DeploymentGroup]] = {}
         self.tagger = TaggingService()
 
     def get_application(self, application_name: str) -> Application:
@@ -253,7 +253,7 @@ class CodeDeployBackend(BaseBackend):
             )
         return self.applications[application_name]
 
-    def batch_get_applications(self, application_names: List[str]) -> List[Application]:
+    def batch_get_applications(self, application_names: list[str]) -> list[Application]:
         applications_info = []
         for app_name in application_names:
             app_info = self.get_application(app_name)
@@ -286,7 +286,7 @@ class CodeDeployBackend(BaseBackend):
             )
         return self.deployment_groups[application_name][deployment_group_name]
 
-    def batch_get_deployments(self, deployment_ids: List[str]) -> List[DeploymentInfo]:
+    def batch_get_deployments(self, deployment_ids: list[str]) -> list[DeploymentInfo]:
         deployments = []
         for id in deployment_ids:
             if id in self.deployments:
@@ -296,7 +296,7 @@ class CodeDeployBackend(BaseBackend):
         return deployments
 
     def create_application(
-        self, application_name: str, compute_platform: str, tags: List[Dict[str, str]]
+        self, application_name: str, compute_platform: str, tags: list[dict[str, str]]
     ) -> str:
         if application_name in self.applications:
             raise ApplicationAlreadyExistsException(
@@ -386,21 +386,21 @@ class CodeDeployBackend(BaseBackend):
         application_name: str,
         deployment_group_name: str,
         deployment_config_name: Optional[str],
-        ec2_tag_filters: Optional[List[Dict[str, str]]],
-        on_premises_instance_tag_filters: Optional[List[Dict[str, str]]],
-        auto_scaling_groups: Optional[List[str]],
+        ec2_tag_filters: Optional[list[dict[str, str]]],
+        on_premises_instance_tag_filters: Optional[list[dict[str, str]]],
+        auto_scaling_groups: Optional[list[str]],
         service_role_arn: str,
-        trigger_configurations: Optional[List[Dict[str, Any]]] = None,
+        trigger_configurations: Optional[list[dict[str, Any]]] = None,
         alarm_configuration: Optional[AlarmConfiguration] = None,
-        auto_rollback_configuration: Optional[Dict[str, Any]] = None,
+        auto_rollback_configuration: Optional[dict[str, Any]] = None,
         outdated_instances_strategy: Optional[str] = None,
-        deployment_style: Optional[Dict[str, str]] = None,
-        blue_green_deployment_configuration: Optional[Dict[str, Any]] = None,
-        load_balancer_info: Optional[Dict[str, Any]] = None,
-        ec2_tag_set: Optional[Dict[str, Any]] = None,
-        ecs_services: Optional[List[Dict[str, str]]] = None,
-        on_premises_tag_set: Optional[Dict[str, Any]] = None,
-        tags: Optional[List[Dict[str, str]]] = None,
+        deployment_style: Optional[dict[str, str]] = None,
+        blue_green_deployment_configuration: Optional[dict[str, Any]] = None,
+        load_balancer_info: Optional[dict[str, Any]] = None,
+        ec2_tag_set: Optional[dict[str, Any]] = None,
+        ecs_services: Optional[list[dict[str, str]]] = None,
+        on_premises_tag_set: Optional[dict[str, Any]] = None,
+        tags: Optional[list[dict[str, str]]] = None,
         termination_hook_enabled: Optional[bool] = None,
     ) -> str:
         if application_name not in self.applications:
@@ -450,7 +450,7 @@ class CodeDeployBackend(BaseBackend):
         return dg.deployment_group_id
 
     # TODO: implement pagination
-    def list_applications(self) -> List[str]:
+    def list_applications(self) -> list[str]:
         return list(self.applications.keys())
 
     # TODO: implement pagination and complete filtering
@@ -459,9 +459,9 @@ class CodeDeployBackend(BaseBackend):
         application_name: str,
         deployment_group_name: str,
         external_id: str,
-        include_only_statuses: List[str],
-        create_time_range: Dict[str, Any],
-    ) -> List[str]:
+        include_only_statuses: list[str],
+        create_time_range: dict[str, Any],
+    ) -> list[str]:
         # Ensure if applicationName is specified, then deploymentGroupName must be specified.
         # If deploymentGroupName is specified, application must be specified else error.
         if application_name and not deployment_group_name:
@@ -503,7 +503,7 @@ class CodeDeployBackend(BaseBackend):
     # TODO: implement pagination
     def list_deployment_groups(
         self, application_name: str, next_token: str
-    ) -> List[str]:
+    ) -> list[str]:
         if application_name not in self.deployment_groups:
             return []
 
@@ -514,16 +514,16 @@ class CodeDeployBackend(BaseBackend):
 
     def list_tags_for_resource(
         self, resource_arn: str
-    ) -> Dict[str, List[Dict[str, str]]]:
+    ) -> dict[str, list[dict[str, str]]]:
         return self.tagger.list_tags_for_resource(resource_arn)
 
     def tag_resource(
-        self, resource_arn: str, tags: List[Dict[str, str]]
-    ) -> Dict[str, Any]:
+        self, resource_arn: str, tags: list[dict[str, str]]
+    ) -> dict[str, Any]:
         self.tagger.tag_resource(resource_arn, tags)
         return {}
 
-    def untag_resource(self, resource_arn: str, tag_keys: List[str]) -> Dict[str, Any]:
+    def untag_resource(self, resource_arn: str, tag_keys: list[str]) -> dict[str, Any]:
         self.tagger.untag_resource_using_names(resource_arn, tag_keys)
         return {}
 

--- a/moto/cognitoidentity/models.py
+++ b/moto/cognitoidentity/models.py
@@ -2,7 +2,7 @@ import datetime
 import json
 import re
 from collections import OrderedDict
-from typing import Any, Dict, List, Optional
+from typing import Any, Optional
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
@@ -54,8 +54,8 @@ class CognitoIdentityPool(BaseModel):
 class CognitoIdentityBackend(BaseBackend):
     def __init__(self, region_name: str, account_id: str):
         super().__init__(region_name, account_id)
-        self.identity_pools: Dict[str, CognitoIdentityPool] = OrderedDict()
-        self.pools_identities: Dict[str, Dict[str, Any]] = {}
+        self.identity_pools: dict[str, CognitoIdentityPool] = OrderedDict()
+        self.pools_identities: dict[str, dict[str, Any]] = {}
 
     def describe_identity_pool(self, identity_pool_id: str) -> str:
         identity_pool = self.identity_pools.get(identity_pool_id, None)
@@ -69,12 +69,12 @@ class CognitoIdentityBackend(BaseBackend):
         self,
         identity_pool_name: str,
         allow_unauthenticated_identities: bool,
-        supported_login_providers: Dict[str, str],
+        supported_login_providers: dict[str, str],
         developer_provider_name: str,
-        open_id_connect_provider_arns: List[str],
-        cognito_identity_providers: List[Dict[str, Any]],
-        saml_provider_arns: List[str],
-        tags: Dict[str, str],
+        open_id_connect_provider_arns: list[str],
+        cognito_identity_providers: list[dict[str, Any]],
+        saml_provider_arns: list[str],
+        tags: dict[str, str],
     ) -> str:
         new_identity = CognitoIdentityPool(
             self.region_name,
@@ -103,12 +103,12 @@ class CognitoIdentityBackend(BaseBackend):
         identity_pool_id: str,
         identity_pool_name: str,
         allow_unauthenticated: Optional[bool],
-        login_providers: Optional[Dict[str, str]],
+        login_providers: Optional[dict[str, str]],
         provider_name: Optional[str],
-        provider_arns: Optional[List[str]],
-        identity_providers: Optional[List[Dict[str, Any]]],
-        saml_providers: Optional[List[str]],
-        tags: Optional[Dict[str, str]],
+        provider_arns: Optional[list[str]],
+        identity_providers: Optional[list[dict[str, Any]]],
+        saml_providers: Optional[list[str]],
+        tags: Optional[dict[str, str]],
     ) -> str:
         """
         The AllowClassic-parameter has not yet been implemented

--- a/moto/cognitoidp/models.py
+++ b/moto/cognitoidp/models.py
@@ -1,9 +1,8 @@
 import enum
 import re
 import time
-import typing
 from collections import OrderedDict
-from typing import Any, Dict, List, Optional, Set, Tuple
+from typing import Any, Optional
 
 from joserfc import jwk, jwt
 
@@ -58,7 +57,7 @@ class AuthFlow(str, enum.Enum):
     USER_PASSWORD_AUTH = "USER_PASSWORD_AUTH"
 
     @classmethod
-    def list(cls) -> List[str]:
+    def list(cls) -> list[str]:
         return [e.value for e in cls]
 
 
@@ -186,7 +185,7 @@ class CognitoIdpUserPoolAttribute(BaseModel):
 
     ATTRIBUTE_DATA_TYPES = {"Boolean", "DateTime", "String", "Number"}
 
-    def __init__(self, name: str, custom: bool, schema: Dict[str, Any]):
+    def __init__(self, name: str, custom: bool, schema: dict[str, Any]):
         self.name = name
         self.custom = custom
         attribute_data_type = schema.get("AttributeDataType", None)
@@ -204,7 +203,7 @@ class CognitoIdpUserPoolAttribute(BaseModel):
         else:
             self._init_standard(schema)
 
-    def _init_custom(self, schema: Dict[str, Any]) -> None:
+    def _init_custom(self, schema: dict[str, Any]) -> None:
         self.name = "custom:" + self.name
         attribute_data_type = schema.get("AttributeDataType", None)
         if not attribute_data_type:
@@ -223,7 +222,7 @@ class CognitoIdpUserPoolAttribute(BaseModel):
         self.required = False
         self._init_constraints(schema, None, show_empty_constraints=True)
 
-    def _init_standard(self, schema: Dict[str, Any]) -> None:
+    def _init_standard(self, schema: dict[str, Any]) -> None:
         attribute_data_type = schema.get("AttributeDataType", None)
         default_attribute_data_type = CognitoIdpUserPoolAttribute.STANDARD_SCHEMA[
             self.name
@@ -260,7 +259,7 @@ class CognitoIdpUserPoolAttribute(BaseModel):
 
     def _init_constraints(
         self,
-        schema: Dict[str, Any],
+        schema: dict[str, Any],
         default_constraints: Any,
         show_empty_constraints: bool = False,
     ) -> None:
@@ -278,7 +277,7 @@ class CognitoIdpUserPoolAttribute(BaseModel):
                 )
             return parsed
 
-        self.string_constraints: Optional[Dict[str, Any]] = (
+        self.string_constraints: Optional[dict[str, Any]] = (
             {} if show_empty_constraints else None
         )
         self.number_constraints = None
@@ -334,7 +333,7 @@ class CognitoIdpUserPoolAttribute(BaseModel):
                 self.number_constraints = None
                 self.string_constraints = None
 
-    def to_json(self) -> Dict[str, Any]:
+    def to_json(self) -> dict[str, Any]:
         return {
             "Name": self.name,
             "AttributeDataType": self.data_type,
@@ -346,7 +345,7 @@ class CognitoIdpUserPoolAttribute(BaseModel):
         }
 
 
-DEFAULT_USER_POOL_CONFIG: Dict[str, Any] = {
+DEFAULT_USER_POOL_CONFIG: dict[str, Any] = {
     "Policies": {
         "PasswordPolicy": {
             "MinimumLength": 8,
@@ -386,7 +385,7 @@ class CognitoIdpUserPool(BaseModel):
     MAX_ID_LENGTH = 55
 
     def __init__(
-        self, account_id: str, region: str, name: str, extended_config: Dict[str, Any]
+        self, account_id: str, region: str, name: str, extended_config: dict[str, Any]
     ):
         self.account_id = account_id
         self.region = region
@@ -406,8 +405,8 @@ class CognitoIdpUserPool(BaseModel):
         self.last_modified_date = utcnow()
 
         self.mfa_config = extended_config.get("MfaConfiguration") or "OFF"
-        self.sms_mfa_config: Optional[Dict[str, Any]] = None
-        self.token_mfa_config: Optional[Dict[str, bool]] = None
+        self.sms_mfa_config: Optional[dict[str, Any]] = None
+        self.token_mfa_config: Optional[dict[str, bool]] = None
 
         self.schema_attributes = {}
         for schema in self.extended_config.pop("Schema", {}):
@@ -429,14 +428,14 @@ class CognitoIdpUserPool(BaseModel):
                     )
                 )
 
-        self.clients: Dict[str, CognitoIdpUserPoolClient] = OrderedDict()
-        self.identity_providers: Dict[str, CognitoIdpIdentityProvider] = OrderedDict()
-        self.groups: Dict[str, CognitoIdpGroup] = OrderedDict()
-        self.users: Dict[str, CognitoIdpUser] = OrderedDict()
-        self.resource_servers: Dict[str, CognitoResourceServer] = OrderedDict()
-        self.refresh_tokens: Dict[str, Optional[Tuple[str, str, str]]] = {}
-        self.access_tokens: Dict[str, Tuple[str, str]] = {}
-        self.id_tokens: Dict[str, Tuple[str, str]] = {}
+        self.clients: dict[str, CognitoIdpUserPoolClient] = OrderedDict()
+        self.identity_providers: dict[str, CognitoIdpIdentityProvider] = OrderedDict()
+        self.groups: dict[str, CognitoIdpGroup] = OrderedDict()
+        self.users: dict[str, CognitoIdpUser] = OrderedDict()
+        self.resource_servers: dict[str, CognitoResourceServer] = OrderedDict()
+        self.refresh_tokens: dict[str, Optional[tuple[str, str, str]]] = {}
+        self.access_tokens: dict[str, tuple[str, str]] = {}
+        self.id_tokens: dict[str, tuple[str, str]] = {}
 
         jwks_file = load_resource(__name__, "resources/jwks-private.json")
         self.json_web_key = jwk.RSAKey.import_key(jwks_file)
@@ -456,7 +455,7 @@ class CognitoIdpUserPool(BaseModel):
             None,
         )
 
-    def update_extended_config(self, extended_config: Dict[str, Any]) -> None:
+    def update_extended_config(self, extended_config: dict[str, Any]) -> None:
         self.extended_config = DEFAULT_USER_POOL_CONFIG.copy()
         self.extended_config.update(extended_config or {})
 
@@ -474,7 +473,7 @@ class CognitoIdpUserPool(BaseModel):
                 "EmailMessage"
             )
 
-    def _base_json(self) -> Dict[str, Any]:
+    def _base_json(self) -> dict[str, Any]:
         return {
             "Id": self.id,
             "Arn": self.arn,
@@ -486,7 +485,7 @@ class CognitoIdpUserPool(BaseModel):
             "EstimatedNumberOfUsers": len(self.users),
         }
 
-    def to_json(self, extended: bool = False) -> Dict[str, Any]:
+    def to_json(self, extended: bool = False) -> dict[str, Any]:
         user_pool_json = self._base_json()
         if extended:
             user_pool_json.update(self.extended_config)
@@ -525,8 +524,8 @@ class CognitoIdpUserPool(BaseModel):
         username: str,
         token_use: str,
         expires_in: int = 60 * 60,
-        extra_data: Optional[Dict[str, Any]] = None,
-    ) -> Tuple[str, int]:
+        extra_data: Optional[dict[str, Any]] = None,
+    ) -> tuple[str, int]:
         now = int(time.time())
         payload = {
             "iss": f"https://cognito-idp.{self.region}.amazonaws.com/{self.id}",
@@ -560,7 +559,7 @@ class CognitoIdpUserPool(BaseModel):
             expires_in,
         )
 
-    def add_custom_attributes(self, custom_attributes: List[Dict[str, str]]) -> None:
+    def add_custom_attributes(self, custom_attributes: list[dict[str, str]]) -> None:
         attributes = []
         for attribute_schema in custom_attributes:
             base_name = attribute_schema["Name"]
@@ -578,7 +577,7 @@ class CognitoIdpUserPool(BaseModel):
 
     def create_id_token(
         self, client_id: str, username: str, origin_jti: str
-    ) -> Tuple[str, int]:
+    ) -> tuple[str, int]:
         """
         :returns: (id_token, expires_in)
         """
@@ -596,7 +595,7 @@ class CognitoIdpUserPool(BaseModel):
         self.id_tokens[id_token] = (client_id, username)
         return id_token, expires_in
 
-    def create_refresh_token(self, client_id: str, username: str) -> Tuple[str, str]:
+    def create_refresh_token(self, client_id: str, username: str) -> tuple[str, str]:
         """
         :returns: (refresh_token, origin_jti)
         """
@@ -607,11 +606,11 @@ class CognitoIdpUserPool(BaseModel):
 
     def create_access_token(
         self, client_id: str, username: str, origin_jti: str
-    ) -> Tuple[str, int]:
+    ) -> tuple[str, int]:
         """
         :returns: (access_token, expires_in)
         """
-        extra_data: Dict[str, Any] = {
+        extra_data: dict[str, Any] = {
             "origin_jti": origin_jti,
             "scope": "aws.cognito.signin.user.admin",
         }
@@ -627,7 +626,7 @@ class CognitoIdpUserPool(BaseModel):
 
     def create_tokens_from_refresh_token(
         self, refresh_token: str
-    ) -> Tuple[str, str, int]:
+    ) -> tuple[str, str, int]:
         res = self.refresh_tokens[refresh_token]
         if res is None:
             raise NotAuthorizedError(refresh_token)
@@ -643,7 +642,7 @@ class CognitoIdpUserPool(BaseModel):
 
     def get_user_extra_data_by_client_id(
         self, client_id: str, username: str
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         extra_data = {}
         current_client = self.clients.get(client_id, None)
         if current_client:
@@ -675,7 +674,7 @@ class CognitoIdpUserPoolDomain(BaseModel):
         self,
         user_pool_id: str,
         domain: str,
-        custom_domain_config: Optional[Dict[str, Any]] = None,
+        custom_domain_config: Optional[dict[str, Any]] = None,
     ):
         self.user_pool_id = user_pool_id
         self.domain = domain
@@ -690,7 +689,7 @@ class CognitoIdpUserPoolDomain(BaseModel):
         unique_hash = md5_hash(self.user_pool_id.encode("utf-8")).hexdigest()
         return f"{unique_hash[:16]}.amazoncognito.com"
 
-    def to_json(self, extended: bool = True) -> Dict[str, Any]:
+    def to_json(self, extended: bool = True) -> dict[str, Any]:
         distribution = self._distribution_name()
         if extended:
             return {
@@ -713,7 +712,7 @@ class CognitoIdpUserPoolClient(BaseModel):
         self,
         user_pool_id: str,
         generate_secret: bool,
-        extended_config: Optional[Dict[str, Any]],
+        extended_config: Optional[dict[str, Any]],
     ):
         self.user_pool_id = user_pool_id
         self.id = generate_id(
@@ -725,7 +724,7 @@ class CognitoIdpUserPoolClient(BaseModel):
         self.secret = str(random.uuid4())
         self.generate_secret = generate_secret or False
         # Some default values - may be overridden by the user
-        self.extended_config: Dict[str, Any] = {
+        self.extended_config: dict[str, Any] = {
             "AllowedOAuthFlowsUserPoolClient": False,
             "AuthSessionValidity": 3,
             "EnablePropagateAdditionalUserContextData": False,
@@ -734,14 +733,14 @@ class CognitoIdpUserPoolClient(BaseModel):
         }
         self.extended_config.update(extended_config or {})
 
-    def _base_json(self) -> Dict[str, Any]:
+    def _base_json(self) -> dict[str, Any]:
         return {
             "ClientId": self.id,
             "ClientName": self.extended_config.get("ClientName"),
             "UserPoolId": self.user_pool_id,
         }
 
-    def to_json(self, extended: bool = False) -> Dict[str, Any]:
+    def to_json(self, extended: bool = False) -> dict[str, Any]:
         user_pool_client_json = self._base_json()
         if self.generate_secret:
             user_pool_client_json.update({"ClientSecret": self.secret})
@@ -750,12 +749,12 @@ class CognitoIdpUserPoolClient(BaseModel):
 
         return user_pool_client_json
 
-    def get_readable_fields(self) -> List[str]:
+    def get_readable_fields(self) -> list[str]:
         return self.extended_config.get("ReadAttributes", [])
 
 
 class CognitoIdpIdentityProvider(BaseModel):
-    def __init__(self, name: str, extended_config: Optional[Dict[str, Any]]):
+    def __init__(self, name: str, extended_config: Optional[dict[str, Any]]):
         self.name = name
         self.extended_config = extended_config or {}
         self.creation_date = utcnow()
@@ -764,7 +763,7 @@ class CognitoIdpIdentityProvider(BaseModel):
         if "AttributeMapping" not in self.extended_config:
             self.extended_config["AttributeMapping"] = {"username": "sub"}
 
-    def _base_json(self) -> Dict[str, Any]:
+    def _base_json(self) -> dict[str, Any]:
         return {
             "ProviderName": self.name,
             "ProviderType": self.extended_config.get("ProviderType"),
@@ -772,7 +771,7 @@ class CognitoIdpIdentityProvider(BaseModel):
             "LastModifiedDate": self.last_modified_date,
         }
 
-    def to_json(self, extended: bool = False) -> Dict[str, Any]:
+    def to_json(self, extended: bool = False) -> dict[str, Any]:
         identity_provider_json = self._base_json()
         if extended:
             identity_provider_json.update(self.extended_config)
@@ -799,7 +798,7 @@ class CognitoIdpGroup(BaseModel):
 
         # Users who are members of this group.
         # Note that these links are bidirectional.
-        self.users: Set[CognitoIdpUser] = set()
+        self.users: set[CognitoIdpUser] = set()
 
     def update(
         self,
@@ -815,7 +814,7 @@ class CognitoIdpGroup(BaseModel):
             self.precedence = precedence
         self.last_modified_date = utcnow()
 
-    def to_json(self) -> Dict[str, Any]:
+    def to_json(self) -> dict[str, Any]:
         return {
             "GroupName": self.group_name,
             "UserPoolId": self.user_pool_id,
@@ -834,7 +833,7 @@ class CognitoIdpUser(BaseModel):
         username: Optional[str],
         password: Optional[str],
         status: str,
-        attributes: List[Dict[str, str]],
+        attributes: list[dict[str, str]],
     ):
         self.id = str(random.uuid4())
         self.user_pool_id = user_pool_id
@@ -856,11 +855,11 @@ class CognitoIdpUser(BaseModel):
 
         # Groups this user is a member of.
         # Note that these links are bidirectional.
-        self.groups: Set[CognitoIdpGroup] = set()
+        self.groups: set[CognitoIdpGroup] = set()
 
         self.update_attributes([{"Name": "sub", "Value": self.id}])
 
-    def _base_json(self) -> Dict[str, Any]:
+    def _base_json(self) -> dict[str, Any]:
         return {
             "UserPoolId": self.user_pool_id,
             "Username": self.username,
@@ -874,8 +873,8 @@ class CognitoIdpUser(BaseModel):
         self,
         extended: bool = False,
         attributes_key: str = "Attributes",
-        attributes_to_get: Optional[List[str]] = None,
-    ) -> Dict[str, Any]:
+        attributes_to_get: Optional[list[str]] = None,
+    ) -> dict[str, Any]:
         user_mfa_setting_list = []
         if self.software_token_mfa_enabled:
             user_mfa_setting_list.append("SOFTWARE_TOKEN_MFA")
@@ -900,14 +899,14 @@ class CognitoIdpUser(BaseModel):
 
         return user_json
 
-    def update_attributes(self, new_attributes: List[Dict[str, Any]]) -> None:
+    def update_attributes(self, new_attributes: list[dict[str, Any]]) -> None:
         flat_attributes = flatten_attrs(self.attributes)
         flat_attributes.update(flatten_attrs(new_attributes))
         self.attribute_lookup = flat_attributes
         self.attributes = expand_attrs(flat_attributes)
         self.last_modified_date = utcnow()
 
-    def delete_attributes(self, attrs_to_delete: List[str]) -> None:
+    def delete_attributes(self, attrs_to_delete: list[str]) -> None:
         flat_attributes = flatten_attrs(self.attributes)
         wrong_attrs = []
         for attr in attrs_to_delete:
@@ -937,15 +936,15 @@ class CognitoResourceServer(BaseModel):
         user_pool_id: str,
         identifier: str,
         name: str,
-        scopes: List[Dict[str, str]],
+        scopes: list[dict[str, str]],
     ):
         self.user_pool_id = user_pool_id
         self.identifier = identifier
         self.name = name
         self.scopes = scopes
 
-    def to_json(self) -> Dict[str, Any]:
-        res: Dict[str, Any] = {
+    def to_json(self) -> dict[str, Any]:
+        res: dict[str, Any] = {
             "UserPoolId": self.user_pool_id,
             "Identifier": self.identifier,
             "Name": self.name,
@@ -975,13 +974,13 @@ class CognitoIdpBackend(BaseBackend):
 
     def __init__(self, region_name: str, account_id: str):
         super().__init__(region_name, account_id)
-        self.user_pools: Dict[str, CognitoIdpUserPool] = OrderedDict()
-        self.user_pool_domains: Dict[str, CognitoIdpUserPoolDomain] = OrderedDict()
-        self.sessions: Dict[str, Tuple[str, CognitoIdpUserPool]] = {}
+        self.user_pools: dict[str, CognitoIdpUserPool] = OrderedDict()
+        self.user_pool_domains: dict[str, CognitoIdpUserPoolDomain] = OrderedDict()
+        self.sessions: dict[str, tuple[str, CognitoIdpUserPool]] = {}
 
     # User pool
     def create_user_pool(
-        self, name: str, extended_config: Dict[str, Any]
+        self, name: str, extended_config: dict[str, Any]
     ) -> CognitoIdpUserPool:
         user_pool = CognitoIdpUserPool(
             self.account_id, self.region_name, name, extended_config
@@ -992,10 +991,10 @@ class CognitoIdpBackend(BaseBackend):
     def set_user_pool_mfa_config(
         self,
         user_pool_id: str,
-        sms_config: Dict[str, Any],
-        token_config: Dict[str, bool],
+        sms_config: dict[str, Any],
+        token_config: dict[str, bool],
         mfa_config: str,
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         user_pool = self.describe_user_pool(user_pool_id)
         user_pool.mfa_config = mfa_config
         user_pool.sms_mfa_config = sms_config
@@ -1003,7 +1002,7 @@ class CognitoIdpBackend(BaseBackend):
 
         return self.get_user_pool_mfa_config(user_pool_id)
 
-    def get_user_pool_mfa_config(self, user_pool_id: str) -> Dict[str, Any]:
+    def get_user_pool_mfa_config(self, user_pool_id: str) -> dict[str, Any]:
         user_pool = self.describe_user_pool(user_pool_id)
 
         return {
@@ -1013,7 +1012,7 @@ class CognitoIdpBackend(BaseBackend):
         }
 
     @paginate(pagination_model=PAGINATION_MODEL)
-    def list_user_pools(self) -> List[CognitoIdpUserPool]:
+    def list_user_pools(self) -> list[CognitoIdpUserPool]:
         return list(self.user_pools.values())
 
     def describe_user_pool(self, user_pool_id: str) -> CognitoIdpUserPool:
@@ -1024,7 +1023,7 @@ class CognitoIdpBackend(BaseBackend):
         return user_pool
 
     def update_user_pool(
-        self, user_pool_id: str, extended_config: Dict[str, Any]
+        self, user_pool_id: str, extended_config: dict[str, Any]
     ) -> None:
         user_pool = self.describe_user_pool(user_pool_id)
         user_pool.update_extended_config(extended_config)
@@ -1039,7 +1038,7 @@ class CognitoIdpBackend(BaseBackend):
         self,
         user_pool_id: str,
         domain: str,
-        custom_domain_config: Optional[Dict[str, str]] = None,
+        custom_domain_config: Optional[dict[str, str]] = None,
     ) -> CognitoIdpUserPoolDomain:
         self.describe_user_pool(user_pool_id)
 
@@ -1064,7 +1063,7 @@ class CognitoIdpBackend(BaseBackend):
         del self.user_pool_domains[domain]
 
     def update_user_pool_domain(
-        self, domain: str, custom_domain_config: Dict[str, str]
+        self, domain: str, custom_domain_config: dict[str, str]
     ) -> CognitoIdpUserPoolDomain:
         if domain not in self.user_pool_domains:
             raise ResourceNotFoundError(domain)
@@ -1075,7 +1074,7 @@ class CognitoIdpBackend(BaseBackend):
 
     # User pool client
     def create_user_pool_client(
-        self, user_pool_id: str, generate_secret: bool, extended_config: Dict[str, str]
+        self, user_pool_id: str, generate_secret: bool, extended_config: dict[str, str]
     ) -> CognitoIdpUserPoolClient:
         user_pool = self.describe_user_pool(user_pool_id)
 
@@ -1088,7 +1087,7 @@ class CognitoIdpBackend(BaseBackend):
     @paginate(pagination_model=PAGINATION_MODEL)
     def list_user_pool_clients(
         self, user_pool_id: str
-    ) -> List[CognitoIdpUserPoolClient]:
+    ) -> list[CognitoIdpUserPoolClient]:
         user_pool = self.describe_user_pool(user_pool_id)
 
         return list(user_pool.clients.values())
@@ -1105,7 +1104,7 @@ class CognitoIdpBackend(BaseBackend):
         return client
 
     def update_user_pool_client(
-        self, user_pool_id: str, client_id: str, extended_config: Dict[str, str]
+        self, user_pool_id: str, client_id: str, extended_config: dict[str, str]
     ) -> CognitoIdpUserPoolClient:
         user_pool = self.describe_user_pool(user_pool_id)
 
@@ -1126,7 +1125,7 @@ class CognitoIdpBackend(BaseBackend):
 
     # Identity provider
     def create_identity_provider(
-        self, user_pool_id: str, name: str, extended_config: Dict[str, str]
+        self, user_pool_id: str, name: str, extended_config: dict[str, str]
     ) -> CognitoIdpIdentityProvider:
         user_pool = self.describe_user_pool(user_pool_id)
 
@@ -1137,7 +1136,7 @@ class CognitoIdpBackend(BaseBackend):
     @paginate(pagination_model=PAGINATION_MODEL)
     def list_identity_providers(
         self, user_pool_id: str
-    ) -> List[CognitoIdpIdentityProvider]:
+    ) -> list[CognitoIdpIdentityProvider]:
         user_pool = self.describe_user_pool(user_pool_id)
 
         return list(user_pool.identity_providers.values())
@@ -1154,7 +1153,7 @@ class CognitoIdpBackend(BaseBackend):
         return identity_provider
 
     def update_identity_provider(
-        self, user_pool_id: str, name: str, extended_config: Dict[str, str]
+        self, user_pool_id: str, name: str, extended_config: dict[str, str]
     ) -> CognitoIdpIdentityProvider:
         user_pool = self.describe_user_pool(user_pool_id)
 
@@ -1203,7 +1202,7 @@ class CognitoIdpBackend(BaseBackend):
         return user_pool.groups[group_name]
 
     @paginate(pagination_model=PAGINATION_MODEL)
-    def list_groups(self, user_pool_id: str) -> List[CognitoIdpGroup]:
+    def list_groups(self, user_pool_id: str) -> list[CognitoIdpGroup]:
         user_pool = self.describe_user_pool(user_pool_id)
 
         return list(user_pool.groups.values())
@@ -1246,7 +1245,7 @@ class CognitoIdpBackend(BaseBackend):
     @paginate(pagination_model=PAGINATION_MODEL)
     def list_users_in_group(
         self, user_pool_id: str, group_name: str
-    ) -> List[CognitoIdpUser]:
+    ) -> list[CognitoIdpUser]:
         user_pool = self.describe_user_pool(user_pool_id)
         group = self.get_group(user_pool_id, group_name)
         return list(filter(lambda user: user in group.users, user_pool.users.values()))
@@ -1254,7 +1253,7 @@ class CognitoIdpBackend(BaseBackend):
     @paginate(pagination_model=PAGINATION_MODEL)
     def admin_list_groups_for_user(
         self, user_pool_id: str, username: str
-    ) -> List[CognitoIdpGroup]:
+    ) -> list[CognitoIdpGroup]:
         user = self.admin_get_user(user_pool_id, username)
         return list(user.groups)
 
@@ -1293,7 +1292,7 @@ class CognitoIdpBackend(BaseBackend):
         username: str,
         message_action: str,
         temporary_password: str,
-        attributes: List[Dict[str, str]],
+        attributes: list[dict[str, str]],
     ) -> CognitoIdpUser:
         user_pool = self.describe_user_pool(user_pool_id)
 
@@ -1383,16 +1382,16 @@ class CognitoIdpBackend(BaseBackend):
         raise NotAuthorizedError("Invalid token")
 
     @paginate(pagination_model=PAGINATION_MODEL)
-    def list_users(self, user_pool_id: str, filt: str) -> List[CognitoIdpUser]:
+    def list_users(self, user_pool_id: str, filt: str) -> list[CognitoIdpUser]:
         user_pool = self.describe_user_pool(user_pool_id)
         users = list(user_pool.users.values())
         if filt:
-            inherent_attributes: Dict[str, Any] = {
+            inherent_attributes: dict[str, Any] = {
                 "cognito:user_status": lambda u: u.status,
                 "status": lambda u: "Enabled" if u.enabled else "Disabled",
                 "username": lambda u: u.username,
             }
-            comparisons: Dict[str, Any] = {
+            comparisons: dict[str, Any] = {
                 "=": lambda x, y: x == y,
                 "^=": lambda x, y: x.startswith(y),
             }
@@ -1455,7 +1454,7 @@ class CognitoIdpBackend(BaseBackend):
         user_pool: CognitoIdpUserPool,
         client: CognitoIdpUserPoolClient,
         username: str,
-    ) -> Dict[str, Dict[str, Any]]:
+    ) -> dict[str, dict[str, Any]]:
         refresh_token, _ = user_pool.create_refresh_token(client.id, username)
         access_token, id_token, expires_in = user_pool.create_tokens_from_refresh_token(
             refresh_token
@@ -1473,7 +1472,7 @@ class CognitoIdpBackend(BaseBackend):
         }
 
     def _validate_auth_flow(
-        self, auth_flow: str, valid_flows: typing.List[AuthFlow]
+        self, auth_flow: str, valid_flows: list[AuthFlow]
     ) -> AuthFlow:
         """validate auth_flow value and convert auth_flow to enum"""
 
@@ -1496,8 +1495,8 @@ class CognitoIdpBackend(BaseBackend):
         user_pool_id: str,
         client_id: str,
         auth_flow: str,
-        auth_parameters: Dict[str, str],
-    ) -> Dict[str, Any]:
+        auth_parameters: dict[str, str],
+    ) -> dict[str, Any]:
         admin_auth_flows = [
             AuthFlow.ADMIN_NO_SRP_AUTH,
             AuthFlow.ADMIN_USER_PASSWORD_AUTH,
@@ -1587,8 +1586,8 @@ class CognitoIdpBackend(BaseBackend):
         session: str,
         client_id: str,
         challenge_name: str,
-        challenge_responses: Dict[str, str],
-    ) -> Dict[str, Any]:
+        challenge_responses: dict[str, str],
+    ) -> dict[str, Any]:
         # Responds to an authentication challenge, as an administrator.
         # The only differences between this admin endpoint and public endpoint are not relevant and so we can safely call
         # the public endpoint to do the work:
@@ -1604,8 +1603,8 @@ class CognitoIdpBackend(BaseBackend):
         session: str,
         client_id: str,
         challenge_name: str,
-        challenge_responses: Dict[str, str],
-    ) -> Dict[str, Any]:
+        challenge_responses: dict[str, str],
+    ) -> dict[str, Any]:
         if challenge_name == "PASSWORD_VERIFIER":
             session = challenge_responses.get("PASSWORD_CLAIM_SECRET_BLOCK")  # type: ignore[assignment]
 
@@ -1750,7 +1749,7 @@ class CognitoIdpBackend(BaseBackend):
 
     def forgot_password(
         self, client_id: str, username: str
-    ) -> Tuple[Optional[str], Dict[str, Any]]:
+    ) -> tuple[Optional[str], dict[str, Any]]:
         """
         The ForgotPassword operation is partially broken in AWS. If the input is 100% correct it works fine.
 
@@ -1786,7 +1785,7 @@ class CognitoIdpBackend(BaseBackend):
 
     def _get_code_delivery_details(
         self, recovery_settings: Any, user: Optional[CognitoIdpUser], username: str
-    ) -> Dict[str, str]:
+    ) -> dict[str, str]:
         selected_recovery = min(
             recovery_settings["RecoveryMechanisms"],
             key=lambda recovery_mechanism: recovery_mechanism["Priority"],
@@ -1840,7 +1839,7 @@ class CognitoIdpBackend(BaseBackend):
             raise NotAuthorizedError(access_token)
 
     def admin_update_user_attributes(
-        self, user_pool_id: str, username: str, attributes: List[Dict[str, str]]
+        self, user_pool_id: str, username: str, attributes: list[dict[str, str]]
     ) -> None:
         user = self.admin_get_user(user_pool_id, username)
 
@@ -1850,7 +1849,7 @@ class CognitoIdpBackend(BaseBackend):
         user.update_attributes(attributes)
 
     def admin_delete_user_attributes(
-        self, user_pool_id: str, username: str, attributes: List[str]
+        self, user_pool_id: str, username: str, attributes: list[str]
     ) -> None:
         self.admin_get_user(user_pool_id, username).delete_attributes(attributes)
 
@@ -1874,7 +1873,7 @@ class CognitoIdpBackend(BaseBackend):
         user_pool_id: str,
         identifier: str,
         name: str,
-        scopes: List[Dict[str, str]],
+        scopes: list[dict[str, str]],
     ) -> CognitoResourceServer:
         user_pool = self.describe_user_pool(user_pool_id)
 
@@ -1901,7 +1900,7 @@ class CognitoIdpBackend(BaseBackend):
         return resource_server
 
     @paginate(pagination_model=PAGINATION_MODEL)
-    def list_resource_servers(self, user_pool_id: str) -> List[CognitoResourceServer]:
+    def list_resource_servers(self, user_pool_id: str) -> list[CognitoResourceServer]:
         user_pool = self.user_pools[user_pool_id]
         resource_servers = list(user_pool.resource_servers.values())
         return resource_servers
@@ -1911,8 +1910,8 @@ class CognitoIdpBackend(BaseBackend):
         client_id: str,
         username: str,
         password: str,
-        attributes: List[Dict[str, str]],
-    ) -> Tuple[CognitoIdpUser, Any]:
+        attributes: list[dict[str, str]],
+    ) -> tuple[CognitoIdpUser, Any]:
         user_pool = None
         for p in self.user_pools.values():
             if client_id in p.clients:
@@ -2010,8 +2009,8 @@ class CognitoIdpBackend(BaseBackend):
         return ""
 
     def initiate_auth(
-        self, client_id: str, auth_flow: str, auth_parameters: Dict[str, str]
-    ) -> Dict[str, Any]:
+        self, client_id: str, auth_flow: str, auth_parameters: dict[str, str]
+    ) -> dict[str, Any]:
         user_auth_flows = [
             AuthFlow.USER_SRP_AUTH,
             AuthFlow.REFRESH_TOKEN_AUTH,
@@ -2171,7 +2170,7 @@ class CognitoIdpBackend(BaseBackend):
 
     def associate_software_token(
         self, access_token: str, session: str
-    ) -> Dict[str, str]:
+    ) -> dict[str, str]:
         secret_code = "asdfasdfasdf"
         if session:
             if session in self.sessions:
@@ -2187,7 +2186,7 @@ class CognitoIdpBackend(BaseBackend):
 
         raise NotAuthorizedError(access_token)
 
-    def verify_software_token(self, access_token: str, session: str) -> Dict[str, str]:
+    def verify_software_token(self, access_token: str, session: str) -> dict[str, str]:
         """
         The parameter UserCode has not yet been implemented
         """
@@ -2219,8 +2218,8 @@ class CognitoIdpBackend(BaseBackend):
     def set_user_mfa_preference(
         self,
         access_token: str,
-        software_token_mfa_settings: Dict[str, bool],
-        sms_mfa_settings: Dict[str, bool],
+        software_token_mfa_settings: dict[str, bool],
+        sms_mfa_settings: dict[str, bool],
     ) -> None:
         for user_pool in self.user_pools.values():
             if access_token in user_pool.access_tokens:
@@ -2239,8 +2238,8 @@ class CognitoIdpBackend(BaseBackend):
         self,
         user_pool_id: str,
         username: str,
-        software_token_mfa_settings: Dict[str, bool],
-        sms_mfa_settings: Dict[str, bool],
+        software_token_mfa_settings: dict[str, bool],
+        sms_mfa_settings: dict[str, bool],
     ) -> None:
         user = self.admin_get_user(user_pool_id, username)
 
@@ -2313,13 +2312,13 @@ class CognitoIdpBackend(BaseBackend):
             user.status = UserStatus.FORCE_CHANGE_PASSWORD
 
     def add_custom_attributes(
-        self, user_pool_id: str, custom_attributes: List[Dict[str, Any]]
+        self, user_pool_id: str, custom_attributes: list[dict[str, Any]]
     ) -> None:
         user_pool = self.describe_user_pool(user_pool_id)
         user_pool.add_custom_attributes(custom_attributes)
 
     def update_user_attributes(
-        self, access_token: str, attributes: List[Dict[str, str]]
+        self, access_token: str, attributes: list[dict[str, str]]
     ) -> None:
         """
         The parameter ClientMetadata has not yet been implemented. No CodeDeliveryDetails are returned.
@@ -2337,7 +2336,7 @@ class CognitoIdpBackend(BaseBackend):
 
         raise NotAuthorizedError(access_token)
 
-    def _find_attr(self, name: str, attrs: List[Dict[str, str]]) -> Optional[str]:
+    def _find_attr(self, name: str, attrs: list[dict[str, str]]) -> Optional[str]:
         return next((a["Value"] for a in attrs if a["Name"] == name), None)
 
     def _verify_email_is_not_used(
@@ -2404,14 +2403,14 @@ class RegionAgnosticBackend:
         client_id: str,
         username: str,
         password: str,
-        attributes: List[Dict[str, str]],
-    ) -> Tuple[CognitoIdpUser, Any]:
+        attributes: list[dict[str, str]],
+    ) -> tuple[CognitoIdpUser, Any]:
         backend = self._find_backend_for_clientid(client_id)
         return backend.sign_up(client_id, username, password, attributes)
 
     def initiate_auth(
-        self, client_id: str, auth_flow: str, auth_parameters: Dict[str, str]
-    ) -> Dict[str, Any]:
+        self, client_id: str, auth_flow: str, auth_parameters: dict[str, str]
+    ) -> dict[str, Any]:
         backend = self._find_backend_for_clientid(client_id)
         return backend.initiate_auth(client_id, auth_flow, auth_parameters)
 
@@ -2428,8 +2427,8 @@ class RegionAgnosticBackend:
         session: str,
         client_id: str,
         challenge_name: str,
-        challenge_responses: Dict[str, str],
-    ) -> Dict[str, Any]:
+        challenge_responses: dict[str, str],
+    ) -> dict[str, Any]:
         backend = self._find_backend_for_clientid(client_id)
         return backend.admin_respond_to_auth_challenge(
             session, client_id, challenge_name, challenge_responses
@@ -2440,8 +2439,8 @@ class RegionAgnosticBackend:
         session: str,
         client_id: str,
         challenge_name: str,
-        challenge_responses: Dict[str, str],
-    ) -> Dict[str, Any]:
+        challenge_responses: dict[str, str],
+    ) -> dict[str, Any]:
         backend = self._find_backend_for_clientid(client_id)
         return backend.respond_to_auth_challenge(
             session, client_id, challenge_name, challenge_responses
@@ -2449,19 +2448,19 @@ class RegionAgnosticBackend:
 
     def associate_software_token(
         self, access_token: str, session: str
-    ) -> Dict[str, str]:
+    ) -> dict[str, str]:
         backend = self._find_backend_by_access_token_or_session(access_token, session)
         return backend.associate_software_token(access_token, session)
 
-    def verify_software_token(self, access_token: str, session: str) -> Dict[str, str]:
+    def verify_software_token(self, access_token: str, session: str) -> dict[str, str]:
         backend = self._find_backend_by_access_token_or_session(access_token, session)
         return backend.verify_software_token(access_token, session)
 
     def set_user_mfa_preference(
         self,
         access_token: str,
-        software_token_mfa_settings: Dict[str, bool],
-        sms_mfa_settings: Dict[str, bool],
+        software_token_mfa_settings: dict[str, bool],
+        sms_mfa_settings: dict[str, bool],
     ) -> None:
         backend = self._find_backend_by_access_token(access_token)
         return backend.set_user_mfa_preference(
@@ -2469,7 +2468,7 @@ class RegionAgnosticBackend:
         )
 
     def update_user_attributes(
-        self, access_token: str, attributes: List[Dict[str, str]]
+        self, access_token: str, attributes: list[dict[str, str]]
     ) -> None:
         backend = self._find_backend_by_access_token(access_token)
         return backend.update_user_attributes(access_token, attributes)
@@ -2482,8 +2481,8 @@ cognitoidp_backends = BackendDict(CognitoIdpBackend, "cognito-idp")
 # specified in the host header. Some endpoints (change password, confirm forgot
 # password) have no authorization header from which to extract the region.
 def find_account_region_by_value(
-    key: str, value: str, fallback: Tuple[str, str]
-) -> Tuple[str, str]:
+    key: str, value: str, fallback: tuple[str, str]
+) -> tuple[str, str]:
     for account_id, account_specific_backend in cognitoidp_backends.items():
         for region, backend in account_specific_backend.items():
             for user_pool in backend.user_pools.values():

--- a/moto/cognitoidp/responses.py
+++ b/moto/cognitoidp/responses.py
@@ -1,5 +1,5 @@
 import json
-from typing import Any, Dict
+from typing import Any
 
 from moto.core.responses import TYPE_RESPONSE, ActionResult, BaseResponse, EmptyResult
 from moto.utilities.utils import load_resource
@@ -22,7 +22,7 @@ class CognitoIdpResponse(BaseResponse):
         return RegionAgnosticBackend(self.current_account, self.region)
 
     @property
-    def parameters(self) -> Dict[str, Any]:  # type: ignore[misc]
+    def parameters(self) -> dict[str, Any]:  # type: ignore[misc]
         return json.loads(self.body)
 
     @property
@@ -73,7 +73,7 @@ class CognitoIdpResponse(BaseResponse):
         user_pools, next_token = self.backend.list_user_pools(
             max_results=max_results, next_token=next_token
         )
-        response: Dict[str, Any] = {
+        response: dict[str, Any] = {
             "UserPools": [user_pool.to_json() for user_pool in user_pools]
         }
         if next_token:
@@ -108,7 +108,7 @@ class CognitoIdpResponse(BaseResponse):
     def describe_user_pool_domain(self) -> ActionResult:
         domain = self._get_param("Domain")
         user_pool_domain = self.backend.describe_user_pool_domain(domain)
-        domain_description: Dict[str, Any] = {}
+        domain_description: dict[str, Any] = {}
         if user_pool_domain:
             domain_description = user_pool_domain.to_json()
 
@@ -144,7 +144,7 @@ class CognitoIdpResponse(BaseResponse):
         user_pool_clients, next_token = self.backend.list_user_pool_clients(
             user_pool_id, max_results=max_results, next_token=next_token
         )
-        response: Dict[str, Any] = {
+        response: dict[str, Any] = {
             "UserPoolClients": [
                 user_pool_client.to_json() for user_pool_client in user_pool_clients
             ]
@@ -193,7 +193,7 @@ class CognitoIdpResponse(BaseResponse):
         identity_providers, next_token = self.backend.list_identity_providers(
             user_pool_id, max_results=max_results, next_token=next_token
         )
-        response: Dict[str, Any] = {
+        response: dict[str, Any] = {
             "Providers": [
                 identity_provider.to_json() for identity_provider in identity_providers
             ]
@@ -370,7 +370,7 @@ class CognitoIdpResponse(BaseResponse):
         users, token = self.backend.list_users(
             user_pool_id, filt, limit=limit, pagination_token=token
         )
-        response: Dict[str, Any] = {
+        response: dict[str, Any] = {
             "Users": [
                 user.to_json(extended=True, attributes_to_get=attributes_to_get)
                 for user in users
@@ -528,7 +528,7 @@ class CognitoIdpResponse(BaseResponse):
         resource_servers, next_token = self.backend.list_resource_servers(
             user_pool_id, max_results=max_results, next_token=next_token
         )
-        response: Dict[str, Any] = {
+        response: dict[str, Any] = {
             "ResourceServers": [
                 resource_server.to_json() for resource_server in resource_servers
             ]

--- a/moto/cognitoidp/utils.py
+++ b/moto/cognitoidp/utils.py
@@ -3,7 +3,7 @@ import hashlib
 import hmac
 import re
 import string
-from typing import Any, Dict, List, Optional
+from typing import Any, Optional
 
 from moto.moto_api._internal import mock_random as random
 
@@ -91,11 +91,11 @@ def validate_username_format(username: str, _format: str = "email") -> bool:
     return re.fullmatch(FORMATS.get(_format, r"a^"), username) is not None
 
 
-def flatten_attrs(attrs: List[Dict[str, Any]]) -> Dict[str, Any]:
+def flatten_attrs(attrs: list[dict[str, Any]]) -> dict[str, Any]:
     return {attr["Name"]: attr["Value"] for attr in attrs}
 
 
-def expand_attrs(attrs: Dict[str, Any]) -> List[Dict[str, Any]]:
+def expand_attrs(attrs: dict[str, Any]) -> list[dict[str, Any]]:
     return [{"Name": k, "Value": v} for k, v in attrs.items()]
 
 

--- a/moto/comprehend/exceptions.py
+++ b/moto/comprehend/exceptions.py
@@ -1,7 +1,5 @@
 """Exceptions raised by the comprehend service."""
 
-from typing import List
-
 from moto.core.exceptions import JsonRESTError
 
 
@@ -14,7 +12,7 @@ class ResourceNotFound(JsonRESTError):
 
 
 class DetectPIIValidationException(JsonRESTError):
-    def __init__(self, language: str, all_languages: List[str]) -> None:
+    def __init__(self, language: str, all_languages: list[str]) -> None:
         all_languages_str = str(all_languages).replace("'", "")
         super().__init__(
             "ValidationException",

--- a/moto/comprehend/models.py
+++ b/moto/comprehend/models.py
@@ -2,8 +2,9 @@
 
 import random
 import uuid
+from collections.abc import Iterable
 from datetime import datetime, timezone
-from typing import Any, Dict, Iterable, List, Optional, Tuple
+from typing import Any, Optional
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
@@ -73,12 +74,12 @@ class EntityRecognizer(BaseModel):
         region_name: str,
         account_id: str,
         language_code: str,
-        input_data_config: Dict[str, Any],
+        input_data_config: dict[str, Any],
         data_access_role_arn: str,
         version_name: str,
         recognizer_name: str,
         volume_kms_key_id: str,
-        vpc_config: Dict[str, List[str]],
+        vpc_config: dict[str, list[str]],
         model_kms_key_id: str,
         model_policy: str,
     ):
@@ -96,7 +97,7 @@ class EntityRecognizer(BaseModel):
         self.model_policy = model_policy
         self.status = "TRAINED"
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         return {
             "EntityRecognizerArn": self.arn,
             "LanguageCode": self.language_code,
@@ -118,14 +119,14 @@ class DocumentClassifier(BaseModel):
         account_id: str,
         language_code: str,
         version_name: str,
-        input_data_config: Dict[str, Any],
-        output_data_config: Dict[str, Any],
+        input_data_config: dict[str, Any],
+        output_data_config: dict[str, Any],
         data_access_role_arn: str,
         document_classifier_name: str,
         volume_kms_key_id: str,
         client_request_token: str,
         mode: str,
-        vpc_config: Dict[str, List[str]],
+        vpc_config: dict[str, list[str]],
         model_kms_key_id: str,
         model_policy: str,
     ):
@@ -144,7 +145,7 @@ class DocumentClassifier(BaseModel):
         self.model_policy = model_policy
         self.status = "TRAINING"
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         return {
             "DocumentClassifierArn": self.arn,
             "LanguageCode": self.language_code,
@@ -180,7 +181,7 @@ class Endpoint(BaseModel):
         self.desired_inference_units = desired_inference_units
         self.status = "IN_SERVICE"
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         return {
             "EndpointArn": self.arn,
             "ModelArn": self.model_arn,
@@ -200,10 +201,10 @@ class Flywheel(BaseModel):
         flywheel_name: str,
         active_model_arn: str,
         data_access_role_arn: str,
-        task_config: Dict[str, Any],
+        task_config: dict[str, Any],
         model_type: str,
         data_lake_s3_uri: str,
-        data_security_config: Dict[str, Any],
+        data_security_config: dict[str, Any],
         client_request_token: str,
     ):
         self.name = flywheel_name
@@ -217,7 +218,7 @@ class Flywheel(BaseModel):
         self.client_request_token = client_request_token
         self.status = "ACTIVE"
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         return {
             "FlywheelArn": self.arn,
             "ActiveModelArn": self.active_model_arn,
@@ -239,8 +240,8 @@ class ComprehendJob(BaseModel):
         region_name: str,
         job_type: str,
         job_name: Optional[str],
-        input_s3_config: Dict[str, Any],
-        output_s3_config: Dict[str, Any],
+        input_s3_config: dict[str, Any],
+        output_s3_config: dict[str, Any],
         data_access_role_arn: str,
         language_code: Optional[str],
         **kwargs: Any,
@@ -262,7 +263,7 @@ class ComprehendJob(BaseModel):
         ).lstrip("-")
         self.job_arn = f"arn:{get_partition(region_name)}:comprehend:{region_name}:{account_id}:{job_type_path}-job/{self.job_id}"
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         base_dict = {
             "JobId": self.job_id,
             "JobArn": self.job_arn,
@@ -310,16 +311,16 @@ class ComprehendBackend(BaseBackend):
 
     def __init__(self, region_name: str, account_id: str):
         super().__init__(region_name, account_id)
-        self.recognizers: Dict[str, EntityRecognizer] = dict()
+        self.recognizers: dict[str, EntityRecognizer] = dict()
         self.tagger = TaggingService()
-        self.endpoints: Dict[str, Endpoint] = dict()
-        self.classifiers: Dict[str, DocumentClassifier] = dict()
-        self.flywheels: Dict[str, Flywheel] = dict()
-        self.resource_policies: Dict[str, Dict[str, Any]] = dict()
-        self.jobs: Dict[str, ComprehendJob] = {}
+        self.endpoints: dict[str, Endpoint] = dict()
+        self.classifiers: dict[str, DocumentClassifier] = dict()
+        self.flywheels: dict[str, Flywheel] = dict()
+        self.resource_policies: dict[str, dict[str, Any]] = dict()
+        self.jobs: dict[str, ComprehendJob] = {}
 
     def list_entity_recognizers(
-        self, _filter: Dict[str, Any]
+        self, _filter: dict[str, Any]
     ) -> Iterable[EntityRecognizer]:
         """
         Pagination is not yet implemented.
@@ -338,11 +339,11 @@ class ComprehendBackend(BaseBackend):
         recognizer_name: str,
         version_name: str,
         data_access_role_arn: str,
-        tags: List[Dict[str, str]],
-        input_data_config: Dict[str, Any],
+        tags: list[dict[str, str]],
+        input_data_config: dict[str, Any],
         language_code: str,
         volume_kms_key_id: str,
-        vpc_config: Dict[str, List[str]],
+        vpc_config: dict[str, list[str]],
         model_kms_key_id: str,
         model_policy: str,
     ) -> str:
@@ -378,19 +379,19 @@ class ComprehendBackend(BaseBackend):
         if recognizer.status == "TRAINING":
             recognizer.status = "STOP_REQUESTED"
 
-    def list_tags_for_resource(self, resource_arn: str) -> List[Dict[str, str]]:
+    def list_tags_for_resource(self, resource_arn: str) -> list[dict[str, str]]:
         return self.tagger.list_tags_for_resource(resource_arn)["Tags"]
 
     def delete_entity_recognizer(self, entity_recognizer_arn: str) -> None:
         self.recognizers.pop(entity_recognizer_arn, None)
 
-    def tag_resource(self, resource_arn: str, tags: List[Dict[str, str]]) -> None:
+    def tag_resource(self, resource_arn: str, tags: list[dict[str, str]]) -> None:
         self.tagger.tag_resource(resource_arn, tags)
 
-    def untag_resource(self, resource_arn: str, tag_keys: List[str]) -> None:
+    def untag_resource(self, resource_arn: str, tag_keys: list[str]) -> None:
         self.tagger.untag_resource_using_names(resource_arn, tag_keys)
 
-    def detect_pii_entities(self, text: str, language: str) -> List[Dict[str, Any]]:
+    def detect_pii_entities(self, text: str, language: str) -> list[dict[str, Any]]:
         if language not in self.detect_pii_entities_languages:
             raise DetectPIIValidationException(
                 language, self.detect_pii_entities_languages
@@ -400,7 +401,7 @@ class ComprehendBackend(BaseBackend):
             raise TextSizeLimitExceededException(text_size)
         return CANNED_DETECT_RESPONSE
 
-    def detect_key_phrases(self, text: str, language: str) -> List[Dict[str, Any]]:
+    def detect_key_phrases(self, text: str, language: str) -> list[dict[str, Any]]:
         if language not in self.detect_key_phrases_languages:
             raise DetectPIIValidationException(
                 language, self.detect_key_phrases_languages
@@ -410,7 +411,7 @@ class ComprehendBackend(BaseBackend):
             raise TextSizeLimitExceededException(text_size)
         return CANNED_PHRASES_RESPONSE
 
-    def detect_sentiment(self, text: str, language: str) -> Dict[str, Any]:
+    def detect_sentiment(self, text: str, language: str) -> dict[str, Any]:
         if language not in self.detect_key_phrases_languages:
             raise DetectPIIValidationException(
                 language, self.detect_key_phrases_languages
@@ -425,13 +426,13 @@ class ComprehendBackend(BaseBackend):
         document_classifier_name: str,
         version_name: str,
         data_access_role_arn: str,
-        tags: List[Dict[str, str]],
-        input_data_config: Dict[str, Any],
-        output_data_config: Dict[str, Any],
+        tags: list[dict[str, str]],
+        input_data_config: dict[str, Any],
+        output_data_config: dict[str, Any],
         client_request_token: str,
         language_code: str,
         volume_kms_key_id: str,
-        vpc_config: Dict[str, List[str]],
+        vpc_config: dict[str, list[str]],
         mode: str,
         model_kms_key_id: str,
         model_policy: str,
@@ -462,10 +463,10 @@ class ComprehendBackend(BaseBackend):
         model_arn: str,
         desired_inference_units: int,
         client_request_token: str,
-        tags: List[Dict[str, str]],
+        tags: list[dict[str, str]],
         data_access_role_arn: str,
         flywheel_arn: str,
-    ) -> Tuple[str, str]:
+    ) -> tuple[str, str]:
         endpoint = Endpoint(
             endpoint_name=endpoint_name,
             region_name=self.region_name,
@@ -485,13 +486,13 @@ class ComprehendBackend(BaseBackend):
         flywheel_name: str,
         active_model_arn: str,
         data_access_role_arn: str,
-        task_config: Dict[str, Any],
+        task_config: dict[str, Any],
         model_type: str,
         data_lake_s3_uri: str,
-        data_security_config: Dict[str, Any],
+        data_security_config: dict[str, Any],
         client_request_token: str,
-        tags: List[Dict[str, str]],
-    ) -> Tuple[str, str]:
+        tags: list[dict[str, str]],
+    ) -> tuple[str, str]:
         flywheel = Flywheel(
             region_name=self.region_name,
             account_id=self.account_id,
@@ -536,10 +537,10 @@ class ComprehendBackend(BaseBackend):
 
     def list_document_classifiers(
         self,
-        filter: Optional[Dict[str, Any]] = None,
+        filter: Optional[dict[str, Any]] = None,
         next_token: Optional[str] = None,
         max_results: Optional[int] = None,
-    ) -> Tuple[List[Dict[str, Any]], None]:
+    ) -> tuple[list[dict[str, Any]], None]:
         """
         List document classifiers with optional filtering.
         Pagination is not yet implemented.
@@ -567,10 +568,10 @@ class ComprehendBackend(BaseBackend):
 
     def list_endpoints(
         self,
-        filter: Optional[Dict[str, Any]] = None,
+        filter: Optional[dict[str, Any]] = None,
         next_token: Optional[str] = None,
         max_results: Optional[int] = None,
-    ) -> Tuple[List[Dict[str, Any]], None]:
+    ) -> tuple[list[dict[str, Any]], None]:
         """
         List endpoints with optional filtering.
         Pagination is not yet implemented.
@@ -596,10 +597,10 @@ class ComprehendBackend(BaseBackend):
 
     def list_flywheels(
         self,
-        filter: Optional[Dict[str, Any]] = None,
+        filter: Optional[dict[str, Any]] = None,
         next_token: Optional[str] = None,
         max_results: Optional[int] = None,
-    ) -> Tuple[List[Dict[str, Any]], None]:
+    ) -> tuple[list[dict[str, Any]], None]:
         """
         List flywheels with optional filtering.
         Pagination is not yet implemented.
@@ -629,7 +630,7 @@ class ComprehendBackend(BaseBackend):
 
     def start_flywheel_iteration(
         self, flywheel_arn: str, client_request_token: str
-    ) -> Tuple[str, int]:
+    ) -> tuple[str, int]:
         if flywheel_arn not in self.flywheels:
             raise ResourceNotFound
         flywheel_iteration_id = int(random.randint(0, 1000000))
@@ -670,7 +671,7 @@ class ComprehendBackend(BaseBackend):
         }
         return revision_id
 
-    def describe_resource_policy(self, resource_arn: str) -> Dict[str, Any]:
+    def describe_resource_policy(self, resource_arn: str) -> dict[str, Any]:
         policy_details = self.resource_policies.get(resource_arn)
         if not policy_details:
             raise ResourceNotFound
@@ -714,8 +715,8 @@ class ComprehendBackend(BaseBackend):
         return self.jobs[job_id]
 
     def _list_jobs(
-        self, job_type: str, job_filter: Optional[Dict[str, Any]]
-    ) -> List[ComprehendJob]:
+        self, job_type: str, job_filter: Optional[dict[str, Any]]
+    ) -> list[ComprehendJob]:
         """Generic method to list and filter jobs."""
         # Pagination is not yet implemented
         job_filter = job_filter or {}
@@ -747,8 +748,8 @@ class ComprehendBackend(BaseBackend):
         self._get_job(job_id).stop()
 
     def list_pii_entities_detection_jobs(
-        self, filter: Optional[Dict[str, Any]]
-    ) -> List[ComprehendJob]:
+        self, filter: Optional[dict[str, Any]]
+    ) -> list[ComprehendJob]:
         return self._list_jobs("PiiEntitiesDetection", filter)
 
     def start_key_phrases_detection_job(self, **kwargs: Any) -> ComprehendJob:
@@ -761,8 +762,8 @@ class ComprehendBackend(BaseBackend):
         self._get_job(job_id).stop()
 
     def list_key_phrases_detection_jobs(
-        self, filter: Optional[Dict[str, Any]]
-    ) -> List[ComprehendJob]:
+        self, filter: Optional[dict[str, Any]]
+    ) -> list[ComprehendJob]:
         return self._list_jobs("KeyPhrasesDetection", filter)
 
     def start_sentiment_detection_job(self, **kwargs: Any) -> ComprehendJob:
@@ -775,8 +776,8 @@ class ComprehendBackend(BaseBackend):
         self._get_job(job_id).stop()
 
     def list_sentiment_detection_jobs(
-        self, filter: Optional[Dict[str, Any]]
-    ) -> List[ComprehendJob]:
+        self, filter: Optional[dict[str, Any]]
+    ) -> list[ComprehendJob]:
         return self._list_jobs("SentimentDetection", filter)
 
     def start_dominant_language_detection_job(self, **kwargs: Any) -> ComprehendJob:
@@ -789,8 +790,8 @@ class ComprehendBackend(BaseBackend):
         self._get_job(job_id).stop()
 
     def list_dominant_language_detection_jobs(
-        self, filter: Optional[Dict[str, Any]]
-    ) -> List[ComprehendJob]:
+        self, filter: Optional[dict[str, Any]]
+    ) -> list[ComprehendJob]:
         return self._list_jobs("DominantLanguageDetection", filter)
 
     def start_entities_detection_job(self, **kwargs: Any) -> ComprehendJob:
@@ -807,8 +808,8 @@ class ComprehendBackend(BaseBackend):
         self._get_job(job_id).stop()
 
     def list_entities_detection_jobs(
-        self, filter: Optional[Dict[str, Any]]
-    ) -> List[ComprehendJob]:
+        self, filter: Optional[dict[str, Any]]
+    ) -> list[ComprehendJob]:
         return self._list_jobs("EntitiesDetection", filter)
 
     def start_topics_detection_job(self, **kwargs: Any) -> ComprehendJob:
@@ -818,8 +819,8 @@ class ComprehendBackend(BaseBackend):
         return self._get_job(job_id)
 
     def list_topics_detection_jobs(
-        self, filter: Optional[Dict[str, Any]]
-    ) -> List[ComprehendJob]:
+        self, filter: Optional[dict[str, Any]]
+    ) -> list[ComprehendJob]:
         return self._list_jobs("TopicsDetection", filter)
 
     def start_document_classification_job(self, **kwargs: Any) -> ComprehendJob:
@@ -833,8 +834,8 @@ class ComprehendBackend(BaseBackend):
         return self._get_job(job_id)
 
     def list_document_classification_jobs(
-        self, filter: Optional[Dict[str, Any]]
-    ) -> List[ComprehendJob]:
+        self, filter: Optional[dict[str, Any]]
+    ) -> list[ComprehendJob]:
         return self._list_jobs("DocumentClassification", filter)
 
     def start_events_detection_job(self, **kwargs: Any) -> ComprehendJob:
@@ -851,8 +852,8 @@ class ComprehendBackend(BaseBackend):
         self._get_job(job_id).stop()
 
     def list_events_detection_jobs(
-        self, filter: Optional[Dict[str, Any]]
-    ) -> List[ComprehendJob]:
+        self, filter: Optional[dict[str, Any]]
+    ) -> list[ComprehendJob]:
         return self._list_jobs("EventsDetection", filter)
 
     def start_targeted_sentiment_detection_job(self, **kwargs: Any) -> ComprehendJob:
@@ -865,8 +866,8 @@ class ComprehendBackend(BaseBackend):
         self._get_job(job_id).stop()
 
     def list_targeted_sentiment_detection_jobs(
-        self, filter: Optional[Dict[str, Any]]
-    ) -> List[ComprehendJob]:
+        self, filter: Optional[dict[str, Any]]
+    ) -> list[ComprehendJob]:
         return self._list_jobs("TargetedSentimentDetection", filter)
 
 

--- a/moto/comprehend/responses.py
+++ b/moto/comprehend/responses.py
@@ -1,7 +1,7 @@
 """Handles incoming comprehend requests, invokes methods, returns responses."""
 
 import json
-from typing import Any, Dict, List
+from typing import Any
 
 from moto.core.responses import BaseResponse
 
@@ -349,7 +349,7 @@ class ComprehendResponse(BaseResponse):
 
         return json.dumps(dict(DesiredModelArn=desired_model_arn))
 
-    def _job_to_dict_resp(self, job_properties: Dict[str, Any]) -> str:
+    def _job_to_dict_resp(self, job_properties: dict[str, Any]) -> str:
         job_type_key = job_properties.pop("job_type")
 
         if job_properties.get("SubmitTime"):
@@ -361,7 +361,7 @@ class ComprehendResponse(BaseResponse):
         return json.dumps({key_name: job_properties})
 
     def _list_jobs_to_dict_resp(
-        self, job_list: List[Dict[str, Any]], job_type: str
+        self, job_list: list[dict[str, Any]], job_type: str
     ) -> str:
         for job_properties in job_list:
             job_properties.pop("job_type")

--- a/moto/config/exceptions.py
+++ b/moto/config/exceptions.py
@@ -1,4 +1,4 @@
-from typing import Any, List, Optional
+from typing import Any, Optional
 
 from moto.core.exceptions import JsonRESTError
 
@@ -47,7 +47,7 @@ class InvalidRecordingGroupException(JsonRESTError):
 class InvalidResourceTypeException(JsonRESTError):
     code = 400
 
-    def __init__(self, bad_list: List[str], good_list: Any):
+    def __init__(self, bad_list: list[str], good_list: Any):
         message = (
             f"{len(bad_list)} validation error detected: Value '{bad_list}' at "
             "'configurationRecorder.recordingGroup.resourceTypes' failed to satisfy constraint: "
@@ -316,7 +316,7 @@ class ResourceNotFoundException(JsonRESTError):
 class TooManyResourceKeys(JsonRESTError):
     code = 400
 
-    def __init__(self, bad_list: List[str]):
+    def __init__(self, bad_list: list[str]):
         message = (
             f"1 validation error detected: Value '{bad_list}' at "
             "'resourceKeys' failed to satisfy constraint: "

--- a/moto/config/models.py
+++ b/moto/config/models.py
@@ -4,7 +4,7 @@ import json
 import re
 import time
 from datetime import datetime
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Optional, Union
 
 from moto.config.exceptions import (
     DuplicateTags,
@@ -72,7 +72,7 @@ DEFAULT_PAGE_SIZE = 100
 CONFIG_RULE_PAGE_SIZE = 25
 
 # Map the Config resource type to a backend:
-RESOURCE_MAP: Dict[str, ConfigQueryModel[Any]] = {
+RESOURCE_MAP: dict[str, ConfigQueryModel[Any]] = {
     "AWS::S3::Bucket": s3_config_query,
     "AWS::S3::AccountPublicAccessBlock": s3_account_public_access_block_query,
     "AWS::IAM::Role": role_config_query,
@@ -137,7 +137,7 @@ def validate_tag_key(tag_key: str, exception_param: str = "tags.X.member.key") -
         raise InvalidTagCharacters(tag_key, param=exception_param)
 
 
-def check_tag_duplicate(all_tags: Dict[str, str], tag_key: str) -> None:
+def check_tag_duplicate(all_tags: dict[str, str], tag_key: str) -> None:
     """Validates that a tag key is not a duplicate
 
     :param all_tags: Dict to check if there is a duplicate tag.
@@ -148,8 +148,8 @@ def check_tag_duplicate(all_tags: Dict[str, str], tag_key: str) -> None:
         raise DuplicateTags()
 
 
-def validate_tags(tags: List[Dict[str, str]]) -> Dict[str, str]:
-    proper_tags: Dict[str, str] = {}
+def validate_tags(tags: list[dict[str, str]]) -> dict[str, str]:
+    proper_tags: dict[str, str] = {}
 
     if len(tags) > MAX_TAGS_IN_ARG:
         raise TooManyTags(tags)
@@ -168,7 +168,7 @@ def validate_tags(tags: List[Dict[str, str]]) -> Dict[str, str]:
     return proper_tags
 
 
-def convert_to_class_args(dict_arg: Dict[str, Any]) -> Dict[str, Any]:
+def convert_to_class_args(dict_arg: dict[str, Any]) -> dict[str, Any]:
     """Return dict that can be used to instantiate it's representative class.
 
     Given a dictionary in the incoming API request, convert the keys to
@@ -200,8 +200,8 @@ class ConfigEmptyDictable(BaseModel):
         self.capitalize_start = capitalize_start
         self.capitalize_arn = capitalize_arn
 
-    def to_dict(self) -> Dict[str, Any]:
-        data: Dict[str, Any] = {}
+    def to_dict(self) -> dict[str, Any]:
+        data: dict[str, Any] = {}
         for item, value in self.__dict__.items():
             # ignore private attributes
             if not item.startswith("_") and value is not None:
@@ -276,7 +276,7 @@ class ConfigDeliveryChannel(ConfigEmptyDictable):
         self.sns_topic_arn = sns_arn
         self.config_snapshot_delivery_properties = snapshot_properties
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         """Need to override this function because the KMS Key ARN is written as `Arn` vs. SNS which is `ARN`."""
         data = super().to_dict()
 
@@ -293,9 +293,9 @@ class RecordingGroup(ConfigEmptyDictable):
         self,
         all_supported: bool = True,
         include_global_resource_types: bool = False,
-        resource_types: Optional[List[str]] = None,
-        exclusion_by_resource_types: Optional[Dict[str, List[str]]] = None,
-        recording_strategy: Optional[Dict[str, str]] = None,
+        resource_types: Optional[list[str]] = None,
+        exclusion_by_resource_types: Optional[dict[str, list[str]]] = None,
+        recording_strategy: Optional[dict[str, str]] = None,
     ):
         super().__init__()
 
@@ -329,8 +329,8 @@ class ConfigRecorder(ConfigEmptyDictable):
 class AccountAggregatorSource(ConfigEmptyDictable):
     def __init__(
         self,
-        account_ids: List[str],
-        aws_regions: Optional[List[str]] = None,
+        account_ids: list[str],
+        aws_regions: Optional[list[str]] = None,
         all_aws_regions: Optional[bool] = None,
     ):
         super().__init__(capitalize_start=True)
@@ -363,7 +363,7 @@ class OrganizationAggregationSource(ConfigEmptyDictable):
     def __init__(
         self,
         role_arn: str,
-        aws_regions: Optional[List[str]] = None,
+        aws_regions: Optional[list[str]] = None,
         all_aws_regions: Optional[bool] = None,
     ):
         super().__init__(capitalize_start=True, capitalize_arn=False)
@@ -397,9 +397,9 @@ class ConfigAggregator(ConfigEmptyDictable):
         name: str,
         account_id: str,
         region: str,
-        account_sources: Optional[List[AccountAggregatorSource]] = None,
+        account_sources: Optional[list[AccountAggregatorSource]] = None,
         org_source: Optional[OrganizationAggregationSource] = None,
-        tags: Optional[Dict[str, str]] = None,
+        tags: Optional[dict[str, str]] = None,
     ):
         super().__init__(capitalize_start=True, capitalize_arn=False)
 
@@ -414,7 +414,7 @@ class ConfigAggregator(ConfigEmptyDictable):
         self.tags = tags or {}
 
     # Override the to_dict so that we can format the tags properly...
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         result = super().to_dict()
 
         # Override the account aggregation sources if present:
@@ -438,7 +438,7 @@ class ConfigAggregationAuthorization(ConfigEmptyDictable):
         current_region: str,
         authorized_account_id: str,
         authorized_aws_region: str,
-        tags: Dict[str, str],
+        tags: dict[str, str],
     ):
         super().__init__(capitalize_start=True, capitalize_arn=False)
 
@@ -459,8 +459,8 @@ class OrganizationConformancePack(ConfigEmptyDictable):
         name: str,
         delivery_s3_bucket: str,
         delivery_s3_key_prefix: Optional[str] = None,
-        input_parameters: Optional[List[Dict[str, Any]]] = None,
-        excluded_accounts: Optional[List[str]] = None,
+        input_parameters: Optional[list[dict[str, Any]]] = None,
+        excluded_accounts: Optional[list[str]] = None,
     ):
         super().__init__(capitalize_start=True, capitalize_arn=False)
 
@@ -479,8 +479,8 @@ class OrganizationConformancePack(ConfigEmptyDictable):
         self,
         delivery_s3_bucket: str,
         delivery_s3_key_prefix: str,
-        input_parameters: List[Dict[str, Any]],
-        excluded_accounts: List[str],
+        input_parameters: list[dict[str, Any]],
+        excluded_accounts: list[str],
     ) -> None:
         self._status = "UPDATE_SUCCESSFUL"
 
@@ -505,7 +505,7 @@ class Scope(ConfigEmptyDictable):
 
     def __init__(
         self,
-        compliance_resource_types: Optional[List[str]] = None,
+        compliance_resource_types: Optional[list[str]] = None,
         tag_key: Optional[str] = None,
         tag_value: Optional[str] = None,
         compliance_resource_id: Optional[str] = None,
@@ -582,7 +582,7 @@ class SourceDetail(ConfigEmptyDictable):
                 f"Value '{event_source}' at "
                 f"'configRule.source.sourceDetails.eventSource' failed "
                 f"to satisfy constraint: Member must satisfy enum value set: {{"
-                + ", ".join((SourceDetail.EVENT_SOURCES))
+                + ", ".join(SourceDetail.EVENT_SOURCES)
                 + "}"
             )
 
@@ -705,7 +705,7 @@ class Source(ConfigEmptyDictable):
         self.owner = owner
         self.source_identifier = source_identifier
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         """Format the SourceDetails properly."""
         result = super().to_dict()
         if self.source_details:
@@ -727,8 +727,8 @@ class ConfigRule(ConfigEmptyDictable):
         self,
         account_id: str,
         region: str,
-        config_rule: Dict[str, Any],
-        tags: Dict[str, str],
+        config_rule: dict[str, Any],
+        tags: dict[str, str],
     ):
         super().__init__(capitalize_start=True, capitalize_arn=False)
         self.account_id = account_id
@@ -747,7 +747,7 @@ class ConfigRule(ConfigEmptyDictable):
         self.config_rule_arn = f"arn:{get_partition(region)}:config:{region}:{account_id}:config-rule/{self.config_rule_id}"
 
     def modify_fields(
-        self, region: str, config_rule: Dict[str, Any], tags: Dict[str, str]
+        self, region: str, config_rule: dict[str, Any], tags: dict[str, str]
     ) -> None:
         """Initialize or update ConfigRule fields."""
         self.config_rule_state = config_rule.get("ConfigRuleState", "ACTIVE")
@@ -909,20 +909,20 @@ class RetentionConfiguration(ConfigEmptyDictable):
 class ConfigBackend(BaseBackend):
     def __init__(self, region_name: str, account_id: str):
         super().__init__(region_name, account_id)
-        self.recorders: Dict[str, ConfigRecorder] = {}
-        self.delivery_channels: Dict[str, ConfigDeliveryChannel] = {}
-        self.config_aggregators: Dict[str, ConfigAggregator] = {}
-        self.aggregation_authorizations: Dict[str, ConfigAggregationAuthorization] = {}
-        self.organization_conformance_packs: Dict[str, OrganizationConformancePack] = {}
+        self.recorders: dict[str, ConfigRecorder] = {}
+        self.delivery_channels: dict[str, ConfigDeliveryChannel] = {}
+        self.config_aggregators: dict[str, ConfigAggregator] = {}
+        self.aggregation_authorizations: dict[str, ConfigAggregationAuthorization] = {}
+        self.organization_conformance_packs: dict[str, OrganizationConformancePack] = {}
         self.config_schema = get_service_model("config")
-        self.query_results: Dict[str, List[Dict[str, Any]]] = {}
-        self.query_results_queue: List[List[Dict[str, Any]]] = []
+        self.query_results: dict[str, list[dict[str, Any]]] = {}
+        self.query_results_queue: list[list[dict[str, Any]]] = []
         self.retention_configuration: Optional[RetentionConfiguration] = None
-        self._custom_resources: Dict[str, Dict[str, Any]] = {}
-        self._expression_results: Dict[str, List[Dict[str, Any]]] = {}
-        self.config_rules: Dict[str, ConfigRule] = {}
+        self._custom_resources: dict[str, dict[str, Any]] = {}
+        self._expression_results: dict[str, list[dict[str, Any]]] = {}
+        self.config_rules: dict[str, ConfigRule] = {}
 
-    def _validate_resource_types(self, resource_list: List[str]) -> None:
+    def _validate_resource_types(self, resource_list: list[str]) -> None:
         shape = self.config_schema.shape_for("ResourceType")
         valid_resource_types = getattr(shape, "enum", [])
         # Verify that each entry exists in the supported list:
@@ -934,7 +934,7 @@ class ConfigBackend(BaseBackend):
             raise InvalidResourceTypeException(bad_list, valid_resource_types)
 
     def _validate_delivery_snapshot_properties(
-        self, properties: Dict[str, Any]
+        self, properties: dict[str, Any]
     ) -> None:
         shape = self.config_schema.shape_for("MaximumExecutionFrequency")
         valid_delivery_frequencies = getattr(shape, "enum", [])
@@ -946,14 +946,14 @@ class ConfigBackend(BaseBackend):
             )
 
     def put_configuration_aggregator(
-        self, config_aggregator: Dict[str, Any]
-    ) -> Dict[str, Any]:
+        self, config_aggregator: dict[str, Any]
+    ) -> dict[str, Any]:
         # Validate the name:
         config_aggr_name = config_aggregator["ConfigurationAggregatorName"]
         if len(config_aggr_name) > 256:
             raise NameTooLongException(config_aggr_name, "configurationAggregatorName")
 
-        account_sources: Optional[List[AccountAggregatorSource]] = None
+        account_sources: Optional[list[AccountAggregatorSource]] = None
         org_source: Optional[OrganizationAggregationSource] = None
 
         # Tag validation:
@@ -1032,11 +1032,11 @@ class ConfigBackend(BaseBackend):
         return aggregator.to_dict()
 
     def describe_configuration_aggregators(
-        self, names: List[str], token: str, limit: Optional[int]
-    ) -> Dict[str, Any]:
+        self, names: list[str], token: str, limit: Optional[int]
+    ) -> dict[str, Any]:
         limit = DEFAULT_PAGE_SIZE if not limit or limit < 0 else limit
         agg_list = []
-        result: Dict[str, Any] = {"ConfigurationAggregators": []}
+        result: dict[str, Any] = {"ConfigurationAggregators": []}
 
         if names:
             for name in names:
@@ -1086,8 +1086,8 @@ class ConfigBackend(BaseBackend):
         self,
         authorized_account: str,
         authorized_region: str,
-        tags: List[Dict[str, str]],
-    ) -> Dict[str, Any]:
+        tags: list[dict[str, str]],
+    ) -> dict[str, Any]:
         # Tag validation:
         tag_dict = validate_tags(tags or [])
 
@@ -1111,9 +1111,9 @@ class ConfigBackend(BaseBackend):
 
     def describe_aggregation_authorizations(
         self, token: Optional[str], limit: Optional[int]
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         limit = DEFAULT_PAGE_SIZE if not limit or limit < 0 else limit
-        result: Dict[str, Any] = {"AggregationAuthorizations": []}
+        result: dict[str, Any] = {"AggregationAuthorizations": []}
 
         if not self.aggregation_authorizations:
             return result
@@ -1150,7 +1150,7 @@ class ConfigBackend(BaseBackend):
         key = f"{authorized_account}/{authorized_region}"
         self.aggregation_authorizations.pop(key, None)
 
-    def put_configuration_recorder(self, config_recorder: Dict[str, Any]) -> None:
+    def put_configuration_recorder(self, config_recorder: dict[str, Any]) -> None:
         # Validate the name:
         if not config_recorder.get("name"):
             raise InvalidConfigurationRecorderNameException(config_recorder.get("name"))
@@ -1285,9 +1285,9 @@ class ConfigBackend(BaseBackend):
         )
 
     def describe_configuration_recorders(
-        self, recorder_names: Optional[List[str]]
-    ) -> List[Dict[str, Any]]:
-        recorders: List[Dict[str, Any]] = []
+        self, recorder_names: Optional[list[str]]
+    ) -> list[dict[str, Any]]:
+        recorders: list[dict[str, Any]] = []
 
         if recorder_names:
             for rname in recorder_names:
@@ -1304,9 +1304,9 @@ class ConfigBackend(BaseBackend):
         return recorders
 
     def describe_configuration_recorder_status(
-        self, recorder_names: List[str]
-    ) -> List[Dict[str, Any]]:
-        recorders: List[Dict[str, Any]] = []
+        self, recorder_names: list[str]
+    ) -> list[dict[str, Any]]:
+        recorders: list[dict[str, Any]] = []
 
         if recorder_names:
             for rname in recorder_names:
@@ -1322,7 +1322,7 @@ class ConfigBackend(BaseBackend):
 
         return recorders
 
-    def put_delivery_channel(self, delivery_channel: Dict[str, Any]) -> None:
+    def put_delivery_channel(self, delivery_channel: dict[str, Any]) -> None:
         # Must have a configuration recorder:
         if not self.recorders:
             raise NoAvailableConfigurationRecorderException()
@@ -1386,9 +1386,9 @@ class ConfigBackend(BaseBackend):
         )
 
     def describe_delivery_channels(
-        self, channel_names: List[str]
-    ) -> List[Dict[str, Any]]:
-        channels: List[Dict[str, Any]] = []
+        self, channel_names: list[str]
+    ) -> list[dict[str, Any]]:
+        channels: list[dict[str, Any]] = []
 
         if channel_names:
             for cname in channel_names:
@@ -1442,11 +1442,11 @@ class ConfigBackend(BaseBackend):
     def list_discovered_resources(
         self,
         resource_type: str,
-        resource_ids: List[str],
+        resource_ids: list[str],
         resource_name: str,
         limit: int,
         next_token: str,
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         """Queries against AWS Config (non-aggregated) listing function.
 
         The listing function must exist for the resource backend.
@@ -1459,7 +1459,7 @@ class ConfigBackend(BaseBackend):
         :param next_token:
         :return:
         """
-        identifiers: List[Dict[str, Any]] = []
+        identifiers: list[dict[str, Any]] = []
         new_token = None
 
         limit = limit or DEFAULT_PAGE_SIZE
@@ -1520,7 +1520,7 @@ class ConfigBackend(BaseBackend):
 
             resource_identifiers.append(item)
 
-        result: Dict[str, Any] = {"resourceIdentifiers": resource_identifiers}
+        result: dict[str, Any] = {"resourceIdentifiers": resource_identifiers}
 
         if new_token:
             result["nextToken"] = new_token
@@ -1531,10 +1531,10 @@ class ConfigBackend(BaseBackend):
         self,
         aggregator_name: str,
         resource_type: str,
-        filters: Dict[str, str],
+        filters: dict[str, str],
         limit: Optional[int],
         next_token: Optional[str],
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         """Queries AWS Config listing function that must exist for resource backend.
 
         As far a moto goes -- the only real difference between this function
@@ -1552,7 +1552,7 @@ class ConfigBackend(BaseBackend):
         if not self.config_aggregators.get(aggregator_name):
             raise NoSuchConfigurationAggregatorException()
 
-        identifiers: List[Dict[str, Any]] = []
+        identifiers: list[dict[str, Any]] = []
         new_token = None
         filters = filters or {}
 
@@ -1595,7 +1595,7 @@ class ConfigBackend(BaseBackend):
 
             resource_identifiers.append(item)
 
-        result: Dict[str, Any] = {"ResourceIdentifiers": resource_identifiers}
+        result: dict[str, Any] = {"ResourceIdentifiers": resource_identifiers}
 
         if new_token:
             result["NextToken"] = new_token
@@ -1604,7 +1604,7 @@ class ConfigBackend(BaseBackend):
 
     def get_resource_config_history(
         self, resource_type: str, resource_id: str, backend_region: str
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         """Returns configuration of resource for the current regional backend.
 
         Item returned in AWS Config format.
@@ -1650,8 +1650,8 @@ class ConfigBackend(BaseBackend):
         return {"configurationItems": [item]}
 
     def batch_get_resource_config(
-        self, resource_keys: List[Dict[str, str]], backend_region: str
-    ) -> Dict[str, Any]:
+        self, resource_keys: list[dict[str, str]], backend_region: str
+    ) -> dict[str, Any]:
         """Returns configuration of resource for the current regional backend.
 
         Item is returned in AWS Config format.
@@ -1712,8 +1712,8 @@ class ConfigBackend(BaseBackend):
         }  # At this time, moto is not adding unprocessed items.
 
     def batch_get_aggregate_resource_config(
-        self, aggregator_name: str, resource_identifiers: List[Dict[str, str]]
-    ) -> Dict[str, Any]:
+        self, aggregator_name: str, resource_identifiers: list[dict[str, str]]
+    ) -> dict[str, Any]:
         """Returns configuration of resource for current regional backend.
 
         Item is returned in AWS Config format.
@@ -1774,10 +1774,10 @@ class ConfigBackend(BaseBackend):
 
     def put_evaluations(
         self,
-        evaluations: Optional[List[Dict[str, Any]]] = None,
+        evaluations: Optional[list[dict[str, Any]]] = None,
         result_token: Optional[str] = None,
         test_mode: Optional[bool] = False,
-    ) -> Dict[str, List[Any]]:
+    ) -> dict[str, list[Any]]:
         if not evaluations:
             raise InvalidParameterValueException(
                 "The Evaluations object in your request cannot be null."
@@ -1805,9 +1805,9 @@ class ConfigBackend(BaseBackend):
         template_body: str,
         delivery_s3_bucket: str,
         delivery_s3_key_prefix: str,
-        input_parameters: List[Dict[str, str]],
-        excluded_accounts: List[str],
-    ) -> Dict[str, Any]:
+        input_parameters: list[dict[str, str]],
+        excluded_accounts: list[str],
+    ) -> dict[str, Any]:
         # a real validation of the content of the template is missing at the moment
         if not template_s3_uri and not template_body:
             raise ValidationException("Template body is invalid")
@@ -1847,8 +1847,8 @@ class ConfigBackend(BaseBackend):
         }
 
     def describe_organization_conformance_packs(
-        self, names: List[str]
-    ) -> Dict[str, Any]:
+        self, names: list[str]
+    ) -> dict[str, Any]:
         packs = []
 
         for name in names:
@@ -1866,8 +1866,8 @@ class ConfigBackend(BaseBackend):
         return {"OrganizationConformancePacks": packs}
 
     def describe_organization_conformance_pack_statuses(
-        self, names: List[str]
-    ) -> Dict[str, Any]:
+        self, names: list[str]
+    ) -> dict[str, Any]:
         packs = []
         statuses = []
 
@@ -1899,7 +1899,7 @@ class ConfigBackend(BaseBackend):
 
     def get_organization_conformance_pack_detailed_status(
         self, name: str
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         pack = self.organization_conformance_packs.get(name)
 
         if not pack:
@@ -1956,7 +1956,7 @@ class ConfigBackend(BaseBackend):
             raise ResourceNotFoundException(resource_arn)
         return matched_config
 
-    def tag_resource(self, resource_arn: str, tags: List[Dict[str, str]]) -> None:
+    def tag_resource(self, resource_arn: str, tags: list[dict[str, str]]) -> None:
         """Add tags in config with a matching ARN."""
         # Tag validation:
         tag_dict = validate_tags(tags)
@@ -1967,7 +1967,7 @@ class ConfigBackend(BaseBackend):
         # Merge the new tags with the existing tags.
         matched_config.tags.update(tag_dict)
 
-    def untag_resource(self, resource_arn: str, tag_keys: List[str]) -> None:
+    def untag_resource(self, resource_arn: str, tag_keys: list[str]) -> None:
         """Remove tags in config with a matching ARN.
 
         If the tags in the tag_keys don't match any keys for that
@@ -1984,7 +1984,7 @@ class ConfigBackend(BaseBackend):
 
     def list_tags_for_resource(
         self, resource_arn: str, limit: int
-    ) -> Dict[str, List[Dict[str, str]]]:
+    ) -> dict[str, list[dict[str, str]]]:
         """Return list of tags for AWS Config resource."""
         # The limit argument is essentially ignored as a config instance
         # can only have 50 tags, but we'll check the argument anyway.
@@ -2002,7 +2002,7 @@ class ConfigBackend(BaseBackend):
         }
 
     def put_config_rule(
-        self, config_rule: Dict[str, Any], tags: Optional[List[Dict[str, str]]] = None
+        self, config_rule: dict[str, Any], tags: Optional[list[dict[str, str]]] = None
     ) -> str:
         """Add/Update config rule for evaluating resource compliance.
 
@@ -2066,10 +2066,10 @@ class ConfigBackend(BaseBackend):
         return ""
 
     def describe_config_rules(
-        self, config_rule_names: Optional[List[str]], next_token: Optional[str]
-    ) -> Dict[str, Any]:
+        self, config_rule_names: Optional[list[str]], next_token: Optional[str]
+    ) -> dict[str, Any]:
         """Return details for the given ConfigRule names or for all rules."""
-        result: Dict[str, Any] = {"ConfigRules": []}
+        result: dict[str, Any] = {"ConfigRules": []}
         if not self.config_rules:
             return result
 
@@ -2114,7 +2114,7 @@ class ConfigBackend(BaseBackend):
 
     def put_retention_configuration(
         self, retention_period_in_days: int
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         """Creates a Retention Configuration."""
         if retention_period_in_days < 30:
             raise ValidationException(
@@ -2130,8 +2130,8 @@ class ConfigBackend(BaseBackend):
         return {"RetentionConfiguration": self.retention_configuration.to_dict()}
 
     def describe_retention_configurations(
-        self, retention_configuration_names: Optional[List[str]]
-    ) -> List[Dict[str, Any]]:
+        self, retention_configuration_names: Optional[list[str]]
+    ) -> list[dict[str, Any]]:
         """
         This will return the retention configuration if one is present.
 
@@ -2178,7 +2178,7 @@ class ConfigBackend(BaseBackend):
         expression: str,
         limit: Optional[int] = None,
         next_token: Optional[str] = None,
-    ) -> Tuple[List[Dict[str, Any]], Dict[str, List[Dict[str, str]]], Optional[str]]:
+    ) -> tuple[list[dict[str, Any]], dict[str, list[dict[str, str]]], Optional[str]]:
         """
         This method doesn't actually execute SQL but uses predefined results
         that can be configured through the moto API. Modeled after AWS Athena's approach.
@@ -2211,7 +2211,7 @@ class ConfigBackend(BaseBackend):
         resource_id: str,
         resource_name: str,
         configuration: str,
-        tags: Optional[Dict[str, str]],
+        tags: Optional[dict[str, str]],
     ) -> None:
         if resource_type.split("::")[0].lower() in [
             "amzn",

--- a/moto/config/responses.py
+++ b/moto/config/responses.py
@@ -1,5 +1,5 @@
 import json
-from typing import Any, Dict
+from typing import Any
 
 from moto.core.responses import BaseResponse
 
@@ -270,7 +270,7 @@ class ConfigResponse(BaseResponse):
             next_token=next_token,
         )
 
-        response: Dict[str, Any] = {"Results": results}
+        response: dict[str, Any] = {"Results": results}
         if query_info:
             response["QueryInfo"] = query_info
 
@@ -287,7 +287,7 @@ class ConfigResponse(BaseResponse):
         resource_name: str = params.get("ResourceName", "")
         configuration = params.get("Configuration", {})
         configuration_str: str = json.dumps(configuration) if configuration else ""
-        tags: Dict[str, str] = params.get("Tags", {})
+        tags: dict[str, str] = params.get("Tags", {})
         self.config_backend.put_resource_config(
             resource_type=resource_type,
             schema_version_id=schema_version_id,

--- a/moto/connectcampaigns/responses.py
+++ b/moto/connectcampaigns/responses.py
@@ -1,7 +1,7 @@
 """Handles incoming connectcampaigns requests, invokes methods, returns responses."""
 
 import json
-from typing import Dict, List, Optional, Tuple
+from typing import Optional
 
 from moto.core.responses import BaseResponse
 
@@ -139,7 +139,7 @@ class ConnectCampaignServiceResponse(BaseResponse):
         next_token = self._get_param("nextToken")
         filters = self._get_param("filters", {})
 
-        campaigns_result: Tuple[List[Dict[str, str]], Optional[str]] = (
+        campaigns_result: tuple[list[dict[str, str]], Optional[str]] = (
             self.connectcampaigns_backend.list_campaigns(
                 filters=filters,
                 max_results=max_results,

--- a/moto/core/common_models.py
+++ b/moto/core/common_models.py
@@ -1,5 +1,5 @@
 from abc import abstractmethod
-from typing import Any, Dict, Generic, List, Optional, Tuple
+from typing import Any, Generic, Optional
 
 from .base_backend import SERVICE_BACKEND, BackendDict, InstanceTrackerMeta
 
@@ -10,7 +10,7 @@ class BaseModel(metaclass=InstanceTrackerMeta):
         *args: Any,
         **kwargs: Any,
     ) -> "BaseModel":
-        instance = super(BaseModel, cls).__new__(cls)
+        instance = super().__new__(cls)
         cls.instances_tracked.append(instance)  # type: ignore[attr-defined]
         return instance
 
@@ -45,7 +45,7 @@ class CloudFormationModel(BaseModel):
     def create_from_cloudformation_json(  # type: ignore[misc]
         cls,
         resource_name: str,
-        cloudformation_json: Dict[str, Any],
+        cloudformation_json: dict[str, Any],
         account_id: str,
         region_name: str,
         **kwargs: Any,
@@ -62,7 +62,7 @@ class CloudFormationModel(BaseModel):
         cls,
         original_resource: Any,
         new_resource_name: str,
-        cloudformation_json: Dict[str, Any],
+        cloudformation_json: dict[str, Any],
         account_id: str,
         region_name: str,
     ) -> Any:
@@ -78,7 +78,7 @@ class CloudFormationModel(BaseModel):
     def delete_from_cloudformation_json(  # type: ignore[misc]
         cls,
         resource_name: str,
-        cloudformation_json: Dict[str, Any],
+        cloudformation_json: dict[str, Any],
         account_id: str,
         region_name: str,
     ) -> None:
@@ -105,14 +105,14 @@ class ConfigQueryModel(Generic[SERVICE_BACKEND]):
         self,
         account_id: str,
         partition: str,
-        resource_ids: Optional[List[str]],
+        resource_ids: Optional[list[str]],
         resource_name: Optional[str],
         limit: int,
         next_token: Optional[str],
         backend_region: Optional[str] = None,
         resource_region: Optional[str] = None,
-        aggregator: Optional[Dict[str, Any]] = None,
-    ) -> Tuple[List[Dict[str, Any]], Optional[str]]:
+        aggregator: Optional[dict[str, Any]] = None,
+    ) -> tuple[list[dict[str, Any]], Optional[str]]:
         """For AWS Config. This will list all of the resources of the given type and optional resource name and region.
 
         This supports both aggregated and non-aggregated listing. The following notes the difference:
@@ -170,7 +170,7 @@ class ConfigQueryModel(Generic[SERVICE_BACKEND]):
         resource_name: Optional[str] = None,
         backend_region: Optional[str] = None,
         resource_region: Optional[str] = None,
-    ) -> Optional[Dict[str, Any]]:
+    ) -> Optional[dict[str, Any]]:
         """For AWS Config. This will query the backend for the specific resource type configuration.
 
         This supports both aggregated, and non-aggregated fetching -- for batched fetching -- the Config batching requests

--- a/moto/core/common_types.py
+++ b/moto/core/common_types.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Tuple, TypeVar, Union
+from typing import Any, TypeVar, Union
 
-TYPE_RESPONSE = Tuple[int, Dict[str, Any], Union[str, bytes]]
+TYPE_RESPONSE = tuple[int, dict[str, Any], Union[str, bytes]]
 TYPE_IF_NONE = TypeVar("TYPE_IF_NONE")

--- a/moto/core/config.py
+++ b/moto/core/config.py
@@ -1,5 +1,5 @@
 import re
-from typing import List, Optional, TypedDict
+from typing import Optional, TypedDict
 
 
 class _docker_config(TypedDict, total=False):
@@ -7,15 +7,15 @@ class _docker_config(TypedDict, total=False):
 
 
 class _passthrough_config(TypedDict, total=False):
-    services: List[str]
-    urls: List[str]
+    services: list[str]
+    urls: list[str]
 
 
 class _core_config(TypedDict, total=False):
     mock_credentials: bool
     passthrough: _passthrough_config
     reset_boto3_session: bool
-    service_whitelist: Optional[List[str]]
+    service_whitelist: Optional[list[str]]
 
 
 class _iam_config(TypedDict, total=False):

--- a/moto/core/custom_responses_mock.py
+++ b/moto/core/custom_responses_mock.py
@@ -1,7 +1,7 @@
 import types
 from http.client import responses as http_responses
 from io import BytesIO
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Optional
 from urllib.parse import urlparse
 
 import responses
@@ -72,7 +72,7 @@ class CallbackResponse(responses.CallbackResponse):
             decode_content=False,
         )
 
-    def matches(self, request: "responses.PreparedRequest") -> Tuple[bool, str]:
+    def matches(self, request: "responses.PreparedRequest") -> tuple[bool, str]:
         if request.method != self.method:
             return False, "Method does not match"
 
@@ -108,7 +108,7 @@ class CallbackResponse(responses.CallbackResponse):
 
 def not_implemented_callback(request: Any) -> TYPE_RESPONSE:
     status = 400
-    headers: Dict[str, str] = {}
+    headers: dict[str, str] = {}
     response = "The method is not implemented"
 
     return status, headers, response
@@ -124,7 +124,7 @@ def not_implemented_callback(request: Any) -> TYPE_RESPONSE:
 # This method should be used for Responses 0.12.1 < .. < 0.17.0
 def _find_first_match(
     self: Any, request: Any
-) -> Tuple[Optional[responses.BaseResponse], List[str]]:
+) -> tuple[Optional[responses.BaseResponse], list[str]]:
     matches = []
     match_failed_reasons = []
     all_possibles = self._matches + responses._default_mock._matches  # type: ignore[attr-defined]

--- a/moto/core/exceptions.py
+++ b/moto/core/exceptions.py
@@ -1,5 +1,5 @@
 import json
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Optional
 
 from jinja2 import DictLoader, Environment
 from werkzeug.exceptions import HTTPException
@@ -121,7 +121,7 @@ class RESTError(HTTPException):
             )
             self.content_type = APP_XML
 
-    def get_headers(self, *args: Any, **kwargs: Any) -> List[Tuple[str, str]]:
+    def get_headers(self, *args: Any, **kwargs: Any) -> list[tuple[str, str]]:
         return [
             ("X-Amzn-ErrorType", self.relative_error_type or "UnknownError"),
             ("Content-Type", self.content_type),
@@ -140,7 +140,7 @@ class RESTError(HTTPException):
         return err
 
     @classmethod
-    def extended_environment(cls, extended_templates: Dict[str, str]) -> Environment:
+    def extended_environment(cls, extended_templates: dict[str, str]) -> Environment:
         templates = cls.templates | extended_templates
         return Environment(loader=DictLoader(templates))
 

--- a/moto/core/model.py
+++ b/moto/core/model.py
@@ -20,7 +20,8 @@ which may change over time.
 
 from __future__ import annotations
 
-from typing import Any, Mapping, cast
+from collections.abc import Mapping
+from typing import Any, cast
 
 from botocore.model import ListShape as BotocoreListShape
 from botocore.model import MapShape as BotocoreMapShape
@@ -84,7 +85,7 @@ class ServiceModel(BotocoreServiceModel):
     def __init__(
         self, service_description: Mapping[str, Any], service_name: str | None = None
     ):
-        super(ServiceModel, self).__init__(service_description, service_name)
+        super().__init__(service_description, service_name)
         # Use our custom shape resolver.
         self._shape_resolver = ShapeResolver(service_description.get("shapes", {}))
 

--- a/moto/core/model_instances.py
+++ b/moto/core/model_instances.py
@@ -1,11 +1,10 @@
 from collections import defaultdict
-from typing import Dict
 
 """
 Storage of all instances that extend BaseModel
 This allows us to easily expose all internal state using the MotoServer dashboard
 """
-model_data: Dict[str, Dict[str, object]] = defaultdict(dict)
+model_data: dict[str, dict[str, object]] = defaultdict(dict)
 
 
 def reset_model_data() -> None:

--- a/moto/core/models.py
+++ b/moto/core/models.py
@@ -4,16 +4,14 @@ import itertools
 import os
 import re
 import unittest
+from contextlib import AbstractContextManager
 from threading import Lock
 from types import FunctionType
 from typing import (
     TYPE_CHECKING,
     Any,
     Callable,
-    ContextManager,
-    Dict,
     Optional,
-    Set,
     TypeVar,
 )
 from unittest.mock import patch
@@ -48,7 +46,7 @@ DEFAULT_ACCOUNT_ID = "123456789012"
 T = TypeVar("T")
 
 
-class MockAWS(ContextManager["MockAWS"]):
+class MockAWS(AbstractContextManager["MockAWS"]):
     _nested_count = 0
     _mocks_active = False
     _mock_init_lock = Lock()
@@ -58,7 +56,7 @@ class MockAWS(ContextManager["MockAWS"]):
             "AWS_ACCESS_KEY_ID": "FOOBARKEY",
             "AWS_SECRET_ACCESS_KEY": "FOOBARSECRET",
         }
-        self._orig_creds: Dict[str, Optional[str]] = {}
+        self._orig_creds: dict[str, Optional[str]] = {}
         self._default_session_mock = patch("boto3.DEFAULT_SESSION", None)
         current_user_config = default_user_config.copy()
         current_user_config.update(config or {})
@@ -245,7 +243,7 @@ class MockAWS(ContextManager["MockAWS"]):
         responses_mock.stop()
 
 
-def get_direct_methods_of(klass: object) -> Set[str]:
+def get_direct_methods_of(klass: object) -> set[str]:
     return set(
         x
         for x, y in klass.__dict__.items()

--- a/moto/core/parsers.py
+++ b/moto/core/parsers.py
@@ -65,7 +65,7 @@ class QueryParser(RequestParser):
         return parsed if parsed is not UNDEFINED else {}
 
     def _parse_shape(self, shape, node, prefix=""):
-        handler = getattr(self, "_handle_%s" % shape.type_name, self._default_handle)
+        handler = getattr(self, f"_handle_{shape.type_name}", self._default_handle)
         return handler(shape, node, prefix)
 
     def _gonna_recurse(self, query_params, prefix):
@@ -82,7 +82,7 @@ class QueryParser(RequestParser):
             member_shape = members[member_name]
             member_prefix = self._get_serialized_name(member_shape, member_name)
             if prefix:
-                member_prefix = "%s.%s" % (prefix, member_prefix)
+                member_prefix = f"{prefix}.{member_prefix}"
             value = self._parse_shape(member_shape, query_params, member_prefix)
             parsed_key = self._parsed_key_name(member_name)
             if value is not UNDEFINED:
@@ -207,7 +207,7 @@ class JSONParser(RequestParser):
         return original_parsed
 
     def _parse_shape(self, shape, node):
-        handler = getattr(self, "_handle_%s" % shape.type_name, self._default_handle)
+        handler = getattr(self, f"_handle_{shape.type_name}", self._default_handle)
         return handler(shape, node)
 
     def _default_handle(self, _, value):

--- a/moto/core/responses.py
+++ b/moto/core/responses.py
@@ -13,11 +13,7 @@ from typing import (
     Any,
     Callable,
     ClassVar,
-    Dict,
-    List,
     Optional,
-    Set,
-    Tuple,
     TypeVar,
     Union,
     cast,
@@ -54,7 +50,7 @@ from moto.utilities.utils import get_partition
 
 log = logging.getLogger(__name__)
 
-JINJA_ENVS: Dict[type, Environment] = {}
+JINJA_ENVS: dict[type, Environment] = {}
 
 if TYPE_CHECKING:
     from typing_extensions import ParamSpec
@@ -69,8 +65,8 @@ ResponseShape = TypeVar("ResponseShape", bound="BaseResponse")
 boto3_service_name = {"awslambda": "lambda"}
 
 
-def _decode_dict(d: Dict[Any, Any]) -> Dict[str, Any]:
-    decoded: Dict[str, Any] = OrderedDict()
+def _decode_dict(d: dict[Any, Any]) -> dict[str, Any]:
+    decoded: dict[str, Any] = OrderedDict()
     for key, value in d.items():
         if isinstance(key, bytes):
             newkey = key.decode("utf-8")
@@ -93,9 +89,9 @@ def _decode_dict(d: Dict[Any, Any]) -> Dict[str, Any]:
     return decoded
 
 
-@functools.lru_cache(maxsize=None)
-def _get_method_urls(service_name: str, region: str) -> Dict[str, Dict[str, str]]:
-    method_urls: Dict[str, Dict[str, str]] = defaultdict(dict)
+@functools.cache
+def _get_method_urls(service_name: str, region: str) -> dict[str, dict[str, str]]:
+    method_urls: dict[str, dict[str, str]] = defaultdict(dict)
     service_name = boto3_service_name.get(service_name) or service_name  # type: ignore
     conn = boto3.client(service_name, region_name=region)
     op_names = conn._service_model.operation_names
@@ -128,14 +124,14 @@ def _get_method_urls(service_name: str, region: str) -> Dict[str, Dict[str, str]
 
 
 class DynamicDictLoader(DictLoader):
-    def update(self, mapping: Dict[str, str]) -> None:
+    def update(self, mapping: dict[str, str]) -> None:
         self.mapping.update(mapping)  # type: ignore[attr-defined]
 
     def contains(self, template: str) -> bool:
         return bool(template in self.mapping)
 
 
-class _TemplateEnvironmentMixin(object):
+class _TemplateEnvironmentMixin:
     LEFT_PATTERN = re.compile(r"[\s\n]+<")
     RIGHT_PATTERN = re.compile(r">[\s\n]+")
 
@@ -188,7 +184,7 @@ class _TemplateEnvironmentMixin(object):
         return self.environment.get_template(template_id)
 
 
-class ActionAuthenticatorMixin(object):
+class ActionAuthenticatorMixin:
     request_count: ClassVar[int] = 0
 
     PUBLIC_OPERATIONS = [
@@ -249,11 +245,11 @@ class ActionAuthenticatorMixin(object):
     @staticmethod
     def set_initial_no_auth_action_count(
         initial_no_auth_action_count: int,
-    ) -> "Callable[[Callable[P, T]], Callable[P, T]]":
+    ) -> Callable[[Callable[P, T]], Callable[P, T]]:
         _test_server_mode_endpoint = settings.test_server_mode_endpoint()
 
-        def decorator(function: "Callable[P, T]") -> "Callable[P, T]":
-            def wrapper(*args: "P.args", **kwargs: "P.kwargs") -> T:
+        def decorator(function: Callable[P, T]) -> Callable[P, T]:
+            def wrapper(*args: P.args, **kwargs: P.kwargs) -> T:
                 if settings.TEST_SERVER_MODE:
                     response = requests.post(
                         f"{_test_server_mode_endpoint}/moto-api/reset-auth",
@@ -401,7 +397,7 @@ class BaseResponse(_TemplateEnvironmentMixin, ActionAuthenticatorMixin):
         """
         self.is_werkzeug_request = "werkzeug" in str(type(request))
         self.parsed_url = urlparse(full_url)
-        querystring: Dict[str, Any] = OrderedDict()
+        querystring: dict[str, Any] = OrderedDict()
         if hasattr(request, "body"):
             # Boto
             self.body = request.body
@@ -702,7 +698,7 @@ class BaseResponse(_TemplateEnvironmentMixin, ActionAuthenticatorMixin):
                 se_headers["status"] = se_status
                 response = se_body, se_headers  # type: ignore[assignment]
             except HTTPException as http_error:
-                response_headers: Dict[str, Union[str, int]] = dict(
+                response_headers: dict[str, Union[str, int]] = dict(
                     http_error.get_headers() or []
                 )
                 response_headers["status"] = http_error.code  # type: ignore[assignment]
@@ -726,7 +722,7 @@ class BaseResponse(_TemplateEnvironmentMixin, ActionAuthenticatorMixin):
         raise NotImplementedError(f"The {action} action has not been implemented")
 
     @staticmethod
-    def _transform_response(headers: Dict[str, str], response: Any) -> TYPE_RESPONSE:  # type: ignore[misc]
+    def _transform_response(headers: dict[str, str], response: Any) -> TYPE_RESPONSE:  # type: ignore[misc]
         if response is None:
             response = "", {}
         if len(response) == 2:
@@ -739,8 +735,8 @@ class BaseResponse(_TemplateEnvironmentMixin, ActionAuthenticatorMixin):
 
     @staticmethod
     def _enrich_response(  # type: ignore[misc]
-        headers: Dict[str, str], body: Any
-    ) -> Tuple[Dict[str, str], Any]:
+        headers: dict[str, str], body: Any
+    ) -> tuple[dict[str, str], Any]:
         # Cast status to string
         if "status" in headers:
             headers["status"] = str(headers["status"])
@@ -811,14 +807,14 @@ class BaseResponse(_TemplateEnvironmentMixin, ActionAuthenticatorMixin):
                 return False
         return if_none
 
-    def _get_multi_param_dict(self, param_prefix: str) -> Dict[str, Any]:
+    def _get_multi_param_dict(self, param_prefix: str) -> dict[str, Any]:
         return self._get_multi_param_helper(param_prefix, skip_result_conversion=True)
 
     def _get_multi_param_helper(
         self,
         param_prefix: str,
         skip_result_conversion: bool = False,
-        tracked_prefixes: Optional[Set[str]] = None,
+        tracked_prefixes: Optional[set[str]] = None,
     ) -> Any:
         value_dict: Any = dict()
         tracked_prefixes = (
@@ -885,7 +881,7 @@ class BaseResponse(_TemplateEnvironmentMixin, ActionAuthenticatorMixin):
 
     def _get_multi_param(
         self, param_prefix: str, skip_result_conversion: bool = False
-    ) -> List[Any]:
+    ) -> list[Any]:
         """
         Given a querystring of ?LaunchConfigurationNames.member.1=my-test-1&LaunchConfigurationNames.member.2=my-test-2
         this will return ['my-test-1', 'my-test-2']
@@ -908,7 +904,7 @@ class BaseResponse(_TemplateEnvironmentMixin, ActionAuthenticatorMixin):
 
         return values
 
-    def _get_dict_param(self, param_prefix: str) -> Dict[str, Any]:
+    def _get_dict_param(self, param_prefix: str) -> dict[str, Any]:
         """
         Given a parameter dict of
         {
@@ -922,7 +918,7 @@ class BaseResponse(_TemplateEnvironmentMixin, ActionAuthenticatorMixin):
             "instance_count": "1",
         }
         """
-        params: Dict[str, Any] = {}
+        params: dict[str, Any] = {}
         for key, value in self.querystring.items():
             if key.startswith(param_prefix):
                 params[camelcase_to_underscores(key.replace(param_prefix, ""))] = value[
@@ -930,7 +926,7 @@ class BaseResponse(_TemplateEnvironmentMixin, ActionAuthenticatorMixin):
                 ]
         return params
 
-    def _get_params(self) -> Dict[str, Any]:
+    def _get_params(self) -> dict[str, Any]:
         """
         Given a querystring of
         {
@@ -968,7 +964,7 @@ class BaseResponse(_TemplateEnvironmentMixin, ActionAuthenticatorMixin):
         """
         if self.automated_parameter_parsing:
             return self.params
-        params: Dict[str, Any] = {}
+        params: dict[str, Any] = {}
         for k, v in sorted(self.querystring.items(), key=params_sort_function):
             self._parse_param(k, v[0], params)
         return params
@@ -1007,7 +1003,7 @@ class BaseResponse(_TemplateEnvironmentMixin, ActionAuthenticatorMixin):
         else:
             obj[keylist[-1]] = value
 
-    def _get_list_prefix(self, param_prefix: str) -> List[Dict[str, Any]]:
+    def _get_list_prefix(self, param_prefix: str) -> list[dict[str, Any]]:
         """
         Given a query dict like
         {

--- a/moto/core/responses_custom_registry.py
+++ b/moto/core/responses_custom_registry.py
@@ -1,6 +1,6 @@
 # This will only exist in responses >= 0.17
 from collections import defaultdict
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Optional
 from urllib.parse import urlunparse
 
 import responses
@@ -19,10 +19,10 @@ class CustomRegistry(responses.registries.FirstMatchRegistry):
     """
 
     def __init__(self) -> None:
-        self._registered: Dict[str, List[responses.BaseResponse]] = defaultdict(list)
+        self._registered: dict[str, list[responses.BaseResponse]] = defaultdict(list)
 
     @property
-    def registered(self) -> List[responses.BaseResponse]:
+    def registered(self) -> list[responses.BaseResponse]:
         res = []
         for resps in self._registered.values():
             res += resps
@@ -41,7 +41,7 @@ class CustomRegistry(responses.registries.FirstMatchRegistry):
         registered[index] = response
         return response
 
-    def remove(self, response: responses.BaseResponse) -> List[responses.BaseResponse]:
+    def remove(self, response: responses.BaseResponse) -> list[responses.BaseResponse]:
         removed_responses = []
         registered = self._registered[response.method]
         while response in registered:
@@ -52,7 +52,7 @@ class CustomRegistry(responses.registries.FirstMatchRegistry):
     def reset(self) -> None:
         self._registered.clear()
 
-    def find(self, request: Any) -> Tuple[Optional[responses.BaseResponse], List[str]]:
+    def find(self, request: Any) -> tuple[Optional[responses.BaseResponse], list[str]]:
         # We don't have to search through all possible methods - only the ones registered for this particular method
         all_possibles = (
             responses._default_mock._registry.registered

--- a/moto/core/serialize.py
+++ b/moto/core/serialize.py
@@ -57,14 +57,12 @@ import base64
 import calendar
 import json
 from collections import namedtuple
+from collections.abc import Generator, Mapping, MutableMapping
 from dataclasses import dataclass
 from datetime import datetime
 from typing import (
     Any,
     Callable,
-    Generator,
-    Mapping,
-    MutableMapping,
     Optional,
     TypedDict,
     Union,
@@ -140,7 +138,7 @@ class TimestampSerializer:
         self, value: Union[int, str, datetime], timestamp_format: str
     ) -> str:
         timestamp_format = timestamp_format.lower()
-        converter = getattr(self, "_timestamp_%s" % timestamp_format)
+        converter = getattr(self, f"_timestamp_{timestamp_format}")
         datetime_obj = parse_to_aware_datetime(value)  # type: ignore
         final_value = converter(datetime_obj)
         return final_value
@@ -159,7 +157,7 @@ class HeaderSerializer:
         self, serialized: Serialized, value: Any, shape: Shape, key: str
     ) -> None:
         method = getattr(
-            self, "_serialize_type_%s" % shape.type_name, self._default_serialize
+            self, f"_serialize_type_{shape.type_name}", self._default_serialize
         )
         method(serialized, value, shape, key)
 
@@ -338,7 +336,7 @@ class ResponseSerializer:
         self, serialized: Serialized, value: Any, shape: Shape, key: str
     ) -> None:
         method = getattr(
-            self, "_serialize_type_%s" % shape.type_name, self._default_serialize
+            self, f"_serialize_type_{shape.type_name}", self._default_serialize
         )
         if not key:
             self.path.append(shape.name)

--- a/moto/core/utils.py
+++ b/moto/core/utils.py
@@ -5,7 +5,7 @@ import inspect
 import re
 from functools import cache
 from gzip import compress, decompress
-from typing import Any, Callable, Dict, List, Optional, Tuple
+from typing import Any, Callable, Optional
 from urllib.parse import ParseResult, urlparse
 
 from botocore.exceptions import ClientError
@@ -71,7 +71,7 @@ def camelcase_to_pascal(argument: str) -> str:
     return argument[0].upper() + argument[1:]
 
 
-def method_names_from_class(clazz: object) -> List[str]:
+def method_names_from_class(clazz: object) -> list[str]:
     predicate = inspect.isfunction
     return [x[0] for x in inspect.getmembers(clazz, predicate=predicate)]
 
@@ -95,7 +95,7 @@ def convert_regex_to_flask_path(url_path: str) -> str:
     return url_path
 
 
-class convert_to_flask_response(object):
+class convert_to_flask_response:
     def __init__(self, callback: Callable[..., Any]):
         self.callback = callback
 
@@ -131,7 +131,7 @@ class convert_to_flask_response(object):
         return response
 
 
-class convert_flask_to_responses_response(object):
+class convert_flask_to_responses_response:
     def __init__(self, callback: Callable[..., Any]):
         self.callback = callback
 
@@ -277,11 +277,11 @@ def path_url(url: str) -> str:
 
 
 def tags_from_query_string(
-    querystring_dict: Dict[str, Any],
+    querystring_dict: dict[str, Any],
     prefix: str = "Tag",
     key_suffix: str = "Key",
     value_suffix: str = "Value",
-) -> Dict[str, str]:
+) -> dict[str, str]:
     response_values = {}
     for key in querystring_dict.keys():
         if key.startswith(prefix) and key.endswith(key_suffix):
@@ -296,8 +296,8 @@ def tags_from_query_string(
 
 
 def tags_from_cloudformation_tags_list(
-    tags_list: List[Dict[str, str]],
-) -> Dict[str, str]:
+    tags_list: list[dict[str, str]],
+) -> dict[str, str]:
     """Return tags in dict form from cloudformation resource tags form (list of dicts)"""
     tags = {}
     for entry in tags_list:
@@ -336,7 +336,7 @@ def remap_nested_keys(root: Any, key_transform: Callable[[str], str]) -> Any:
 
 
 def merge_dicts(
-    dict1: Dict[str, Any], dict2: Dict[str, Any], remove_nulls: bool = False
+    dict1: dict[str, Any], dict2: dict[str, Any], remove_nulls: bool = False
 ) -> None:
     """Given two arbitrarily nested dictionaries, merge the second dict into the first.
 
@@ -360,7 +360,7 @@ def merge_dicts(
                 dict1.pop(key)
 
 
-def remove_null_from_dict(dct: Dict[str, Any]) -> None:
+def remove_null_from_dict(dct: dict[str, Any]) -> None:
     for key in list(dct.keys()):
         if dct[key] is None:
             dct.pop(key)
@@ -397,7 +397,7 @@ def extract_region_from_aws_authorization(string: str) -> Optional[str]:
     return region
 
 
-def params_sort_function(item: Tuple[str, Any]) -> Tuple[str, int, str]:
+def params_sort_function(item: tuple[str, Any]) -> tuple[str, int, str]:
     """
     sort by <string-prefix>.member.<integer>.<string-postfix>:
     in case there are more than 10 members, the default-string sort would lead to IndexError when parsing the content.
@@ -429,7 +429,7 @@ ISO_REGION_DOMAINS = {
 ALT_DOMAIN_SUFFIXES = list(ISO_REGION_DOMAINS.values()) + ["amazonaws.com.cn"]
 
 
-def get_equivalent_url_in_aws_domain(url: str) -> Tuple[ParseResult, bool]:
+def get_equivalent_url_in_aws_domain(url: str) -> tuple[ParseResult, bool]:
     """Parses a URL and converts non-standard AWS endpoint hostnames (from ISO
     regions or custom S3 endpoints) to the equivalent standard AWS domain.
 

--- a/moto/databrew/models.py
+++ b/moto/databrew/models.py
@@ -3,7 +3,7 @@ from abc import ABCMeta, abstractmethod
 from collections import OrderedDict
 from copy import deepcopy
 from datetime import datetime
-from typing import Any, Dict, List, Optional
+from typing import Any, Optional
 
 from moto.core.base_backend import BackendDict, BaseBackend, InstanceTrackerMeta
 from moto.core.common_models import BaseModel
@@ -57,10 +57,10 @@ class DataBrewBackend(BaseBackend):
 
     def __init__(self, region_name: str, account_id: str):
         super().__init__(region_name, account_id)
-        self.recipes: Dict[str, FakeRecipe] = OrderedDict()
-        self.rulesets: Dict[str, FakeRuleset] = OrderedDict()
-        self.datasets: Dict[str, FakeDataset] = OrderedDict()
-        self.jobs: Dict[str, FakeJob] = OrderedDict()
+        self.recipes: dict[str, FakeRecipe] = OrderedDict()
+        self.rulesets: dict[str, FakeRuleset] = OrderedDict()
+        self.datasets: dict[str, FakeDataset] = OrderedDict()
+        self.jobs: dict[str, FakeJob] = OrderedDict()
 
     @staticmethod
     def validate_length(param: str, param_name: str, max_length: int) -> None:
@@ -74,8 +74,8 @@ class DataBrewBackend(BaseBackend):
         self,
         recipe_name: str,
         recipe_description: str,
-        recipe_steps: List[Dict[str, Any]],
-        tags: Dict[str, str],
+        recipe_steps: list[dict[str, Any]],
+        tags: dict[str, str],
     ) -> "FakeRecipeVersion":
         # https://docs.aws.amazon.com/databrew/latest/dg/API_CreateRecipe.html
         if recipe_name in self.recipes:
@@ -124,7 +124,7 @@ class DataBrewBackend(BaseBackend):
         self,
         recipe_name: str,
         recipe_description: str,
-        recipe_steps: List[Dict[str, Any]],
+        recipe_steps: list[dict[str, Any]],
     ) -> None:
         if recipe_name not in self.recipes:
             raise ResourceNotFoundException(f"The recipe {recipe_name} wasn't found")
@@ -135,7 +135,7 @@ class DataBrewBackend(BaseBackend):
     @paginate(pagination_model=PAGINATION_MODEL)
     def list_recipes(
         self, recipe_version: Optional[str] = None
-    ) -> List["FakeRecipeVersion"]:
+    ) -> list["FakeRecipeVersion"]:
         # https://docs.aws.amazon.com/databrew/latest/dg/API_ListRecipes.html
         if recipe_version == FakeRecipe.LATEST_WORKING:
             version = "latest_working"
@@ -150,7 +150,7 @@ class DataBrewBackend(BaseBackend):
         return [r for r in recipes if r is not None]
 
     @paginate(pagination_model=PAGINATION_MODEL)
-    def list_recipe_versions(self, recipe_name: str) -> List["FakeRecipeVersion"]:
+    def list_recipe_versions(self, recipe_name: str) -> list["FakeRecipeVersion"]:
         # https://docs.aws.amazon.com/databrew/latest/dg/API_ListRecipeVersions.html
         self.validate_length(recipe_name, "name", 255)
 
@@ -210,9 +210,9 @@ class DataBrewBackend(BaseBackend):
         self,
         ruleset_name: str,
         ruleset_description: str,
-        ruleset_rules: List[Dict[str, Any]],
+        ruleset_rules: list[dict[str, Any]],
         ruleset_target_arn: str,
-        tags: Dict[str, str],
+        tags: dict[str, str],
     ) -> "FakeRuleset":
         if ruleset_name in self.rulesets:
             raise RulesetAlreadyExistsException()
@@ -232,8 +232,8 @@ class DataBrewBackend(BaseBackend):
         self,
         ruleset_name: str,
         ruleset_description: str,
-        ruleset_rules: List[Dict[str, Any]],
-        tags: Dict[str, str],
+        ruleset_rules: list[dict[str, Any]],
+        tags: dict[str, str],
     ) -> "FakeRuleset":
         if ruleset_name not in self.rulesets:
             raise RulesetNotFoundException(ruleset_name)
@@ -254,7 +254,7 @@ class DataBrewBackend(BaseBackend):
         return self.rulesets[ruleset_name]
 
     @paginate(pagination_model=PAGINATION_MODEL)
-    def list_rulesets(self) -> List["FakeRuleset"]:
+    def list_rulesets(self) -> list["FakeRuleset"]:
         return list(self.rulesets.values())
 
     def delete_ruleset(self, ruleset_name: str) -> None:
@@ -267,10 +267,10 @@ class DataBrewBackend(BaseBackend):
         self,
         dataset_name: str,
         dataset_format: str,
-        dataset_format_options: Dict[str, Any],
-        dataset_input: Dict[str, Any],
-        dataset_path_options: Dict[str, Any],
-        tags: Dict[str, str],
+        dataset_format_options: dict[str, Any],
+        dataset_input: dict[str, Any],
+        dataset_path_options: dict[str, Any],
+        tags: dict[str, str],
     ) -> "FakeDataset":
         if dataset_name in self.datasets:
             raise AlreadyExistsException(dataset_name)
@@ -289,17 +289,17 @@ class DataBrewBackend(BaseBackend):
         return dataset
 
     @paginate(pagination_model=PAGINATION_MODEL)
-    def list_datasets(self) -> List["FakeDataset"]:
+    def list_datasets(self) -> list["FakeDataset"]:
         return list(self.datasets.values())
 
     def update_dataset(
         self,
         dataset_name: str,
         dataset_format: str,
-        dataset_format_options: Dict[str, Any],
-        dataset_input: Dict[str, Any],
-        dataset_path_options: Dict[str, Any],
-        tags: Dict[str, str],
+        dataset_format_options: dict[str, Any],
+        dataset_input: dict[str, Any],
+        dataset_path_options: dict[str, Any],
+        tags: dict[str, str],
     ) -> "FakeDataset":
         if dataset_name not in self.datasets:
             raise ResourceNotFoundException("One or more resources can't be found.")
@@ -407,7 +407,7 @@ class DataBrewBackend(BaseBackend):
     @paginate(pagination_model=PAGINATION_MODEL)
     def list_jobs(
         self, dataset_name: Optional[str] = None, project_name: Optional[str] = None
-    ) -> List["FakeJob"]:
+    ) -> list["FakeJob"]:
         # https://docs.aws.amazon.com/databrew/latest/dg/API_ListJobs.html
         if dataset_name is not None:
             self.validate_length(dataset_name, "datasetName", 255)
@@ -456,10 +456,10 @@ class FakeRecipe(BaseModel):
         region_name: str,
         recipe_name: str,
         recipe_description: str,
-        recipe_steps: List[Dict[str, Any]],
-        tags: Dict[str, str],
+        recipe_steps: list[dict[str, Any]],
+        tags: dict[str, str],
     ):
-        self.versions: Dict[float, FakeRecipeVersion] = OrderedDict()
+        self.versions: dict[float, FakeRecipeVersion] = OrderedDict()
         self.versions[self.INITIAL_VERSION] = FakeRecipeVersion(
             region_name,
             recipe_name,
@@ -484,7 +484,7 @@ class FakeRecipe(BaseModel):
         self.versions[self.latest_working.version] = self.latest_working
 
     def update(
-        self, description: Optional[str], steps: Optional[List[Dict[str, Any]]]
+        self, description: Optional[str], steps: Optional[list[dict[str, Any]]]
     ) -> None:
         if description is not None:
             self.latest_working.description = description
@@ -514,8 +514,8 @@ class FakeRecipeVersion(BaseModel):
         region_name: str,
         recipe_name: str,
         recipe_description: str,
-        recipe_steps: List[Dict[str, Any]],
-        tags: Dict[str, str],
+        recipe_steps: list[dict[str, Any]],
+        tags: dict[str, str],
         version: float,
     ):
         self.region_name = region_name
@@ -527,7 +527,7 @@ class FakeRecipeVersion(BaseModel):
         self.published_date: Optional[datetime] = None
         self.version = version
 
-    def as_dict(self) -> Dict[str, Any]:
+    def as_dict(self) -> dict[str, Any]:
         dict_recipe = {
             "Name": self.name,
             "Steps": self.steps,
@@ -554,9 +554,9 @@ class FakeRuleset(BaseModel):
         region_name: str,
         ruleset_name: str,
         ruleset_description: str,
-        ruleset_rules: List[Dict[str, Any]],
+        ruleset_rules: list[dict[str, Any]],
         ruleset_target_arn: str,
-        tags: Dict[str, str],
+        tags: dict[str, str],
     ):
         self.region_name = region_name
         self.name = ruleset_name
@@ -567,7 +567,7 @@ class FakeRuleset(BaseModel):
 
         self.tags = tags
 
-    def as_dict(self) -> Dict[str, Any]:
+    def as_dict(self) -> dict[str, Any]:
         return {
             "Name": self.name,
             "Rules": self.rules,
@@ -585,10 +585,10 @@ class FakeDataset(BaseModel):
         account_id: str,
         dataset_name: str,
         dataset_format: str,
-        dataset_format_options: Dict[str, Any],
-        dataset_input: Dict[str, Any],
-        dataset_path_options: Dict[str, Any],
-        tags: Dict[str, str],
+        dataset_format_options: dict[str, Any],
+        dataset_input: dict[str, Any],
+        dataset_path_options: dict[str, Any],
+        tags: dict[str, str],
     ):
         self.region_name = region_name
         self.account_id = account_id
@@ -604,7 +604,7 @@ class FakeDataset(BaseModel):
     def resource_arn(self) -> str:
         return f"arn:{get_partition(self.region_name)}:databrew:{self.region_name}:{self.account_id}:dataset/{self.name}"
 
-    def as_dict(self) -> Dict[str, Any]:
+    def as_dict(self) -> dict[str, Any]:
         return {
             "Name": self.name,
             "Format": self.format,
@@ -627,7 +627,7 @@ class FakeJob(BaseModel, metaclass=JobMetaclass):
 
     @property
     @abstractmethod
-    def local_attrs(self) -> List[str]:
+    def local_attrs(self) -> list[str]:
         raise NotImplementedError
 
     def __init__(self, account_id: str, region_name: str, **kwargs: Any):
@@ -668,7 +668,7 @@ class FakeJob(BaseModel, metaclass=JobMetaclass):
     def resource_arn(self) -> str:
         return f"arn:{get_partition(self.region_name)}:databrew:{self.region_name}:{self.account_id}:job/{self.name}"
 
-    def as_dict(self) -> Dict[str, Any]:
+    def as_dict(self) -> dict[str, Any]:
         rtn_dict = {
             "Name": self.name,
             "AccountId": self.account_id,

--- a/moto/databrew/responses.py
+++ b/moto/databrew/responses.py
@@ -1,5 +1,5 @@
 import json
-from typing import Any, Dict
+from typing import Any
 from urllib.parse import unquote
 
 from moto.core.responses import BaseResponse
@@ -18,7 +18,7 @@ class DataBrewResponse(BaseResponse):
 
     # region Recipes
     @property
-    def parameters(self) -> Dict[str, Any]:  # type: ignore[misc]
+    def parameters(self) -> dict[str, Any]:  # type: ignore[misc]
         return json.loads(self.body)
 
     def create_recipe(self) -> str:

--- a/moto/datapipeline/models.py
+++ b/moto/datapipeline/models.py
@@ -1,6 +1,7 @@
 import datetime
 from collections import OrderedDict
-from typing import Any, Dict, Iterable, List
+from collections.abc import Iterable
+from typing import Any
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel, CloudFormationModel
@@ -15,7 +16,7 @@ class PipelineObject(BaseModel):
         self.name = name
         self.fields = fields
 
-    def to_json(self) -> Dict[str, Any]:
+    def to_json(self) -> dict[str, Any]:
         return {"fields": self.fields, "id": self.object_id, "name": self.name}
 
 
@@ -26,7 +27,7 @@ class Pipeline(CloudFormationModel):
         self.description = kwargs.get("description", "")
         self.pipeline_id = get_random_pipeline_id()
         self.creation_time = utcnow()
-        self.objects: List[Any] = []
+        self.objects: list[Any] = []
         self.status = "PENDING"
         self.tags = kwargs.get("tags", [])
 
@@ -34,10 +35,10 @@ class Pipeline(CloudFormationModel):
     def physical_resource_id(self) -> str:
         return self.pipeline_id
 
-    def to_meta_json(self) -> Dict[str, str]:
+    def to_meta_json(self) -> dict[str, str]:
         return {"id": self.pipeline_id, "name": self.name}
 
-    def to_json(self) -> Dict[str, Any]:
+    def to_json(self) -> dict[str, Any]:
         return {
             "description": self.description,
             "fields": [
@@ -88,7 +89,7 @@ class Pipeline(CloudFormationModel):
     def create_from_cloudformation_json(  # type: ignore[misc]
         cls,
         resource_name: str,
-        cloudformation_json: Dict[str, Any],
+        cloudformation_json: dict[str, Any],
         account_id: str,
         region_name: str,
         **kwargs: Any,
@@ -112,7 +113,7 @@ class Pipeline(CloudFormationModel):
 class DataPipelineBackend(BaseBackend):
     def __init__(self, region_name: str, account_id: str):
         super().__init__(region_name, account_id)
-        self.pipelines: Dict[str, Pipeline] = OrderedDict()
+        self.pipelines: dict[str, Pipeline] = OrderedDict()
 
     def create_pipeline(self, name: str, unique_id: str, **kwargs: Any) -> Pipeline:
         pipeline = Pipeline(name, unique_id, **kwargs)
@@ -122,7 +123,7 @@ class DataPipelineBackend(BaseBackend):
     def list_pipelines(self) -> Iterable[Pipeline]:
         return self.pipelines.values()
 
-    def describe_pipelines(self, pipeline_ids: List[str]) -> List[Pipeline]:
+    def describe_pipelines(self, pipeline_ids: list[str]) -> list[Pipeline]:
         pipelines = [
             pipeline
             for pipeline in self.pipelines.values()
@@ -144,7 +145,7 @@ class DataPipelineBackend(BaseBackend):
         pipeline = self.get_pipeline(pipeline_id)
         return pipeline.objects
 
-    def describe_objects(self, object_ids: List[str], pipeline_id: str) -> List[Any]:
+    def describe_objects(self, object_ids: list[str], pipeline_id: str) -> list[Any]:
         pipeline = self.get_pipeline(pipeline_id)
         pipeline_objects = [
             pipeline_object

--- a/moto/datasync/models.py
+++ b/moto/datasync/models.py
@@ -1,5 +1,5 @@
 from collections import OrderedDict
-from typing import Any, Dict, Optional
+from typing import Any, Optional
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
@@ -14,7 +14,7 @@ class Location(BaseModel):
         location_uri: str,
         region_name: str,
         typ: str,
-        metadata: Dict[str, Any],
+        metadata: dict[str, Any],
         arn_counter: int = 0,
     ):
         self.uri = location_uri
@@ -32,7 +32,7 @@ class Task(BaseModel):
         destination_location_arn: str,
         name: str,
         region_name: str,
-        metadata: Dict[str, Any],
+        metadata: dict[str, Any],
         arn_counter: int = 0,
     ):
         self.source_location_arn = source_location_arn
@@ -100,12 +100,12 @@ class DataSyncBackend(BaseBackend):
         # Always increase when new things are created
         # This ensures uniqueness
         self.arn_counter = 0
-        self.locations: Dict[str, Location] = OrderedDict()
-        self.tasks: Dict[str, Task] = OrderedDict()
-        self.task_executions: Dict[str, TaskExecution] = OrderedDict()
+        self.locations: dict[str, Location] = OrderedDict()
+        self.tasks: dict[str, Task] = OrderedDict()
+        self.task_executions: dict[str, TaskExecution] = OrderedDict()
 
     def create_location(
-        self, location_uri: str, typ: str, metadata: Dict[str, Any]
+        self, location_uri: str, typ: str, metadata: dict[str, Any]
     ) -> str:
         """
         # AWS DataSync allows for duplicate LocationUris
@@ -145,7 +145,7 @@ class DataSyncBackend(BaseBackend):
         source_location_arn: str,
         destination_location_arn: str,
         name: str,
-        metadata: Dict[str, Any],
+        metadata: dict[str, Any],
     ) -> str:
         if source_location_arn not in self.locations:
             raise InvalidRequestException(f"Location {source_location_arn} not found.")
@@ -171,7 +171,7 @@ class DataSyncBackend(BaseBackend):
         else:
             raise InvalidRequestException
 
-    def update_task(self, task_arn: str, name: str, metadata: Dict[str, Any]) -> None:
+    def update_task(self, task_arn: str, name: str, metadata: dict[str, Any]) -> None:
         if task_arn in self.tasks:
             task = self.tasks[task_arn]
             task.name = name

--- a/moto/dms/models.py
+++ b/moto/dms/models.py
@@ -1,5 +1,6 @@
+from collections.abc import Iterable
 from datetime import datetime
-from typing import Any, Dict, Iterable, List, Optional
+from typing import Any, Optional
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
@@ -19,9 +20,9 @@ from .utils import filter_tasks, random_id
 class DatabaseMigrationServiceBackend(BaseBackend):
     def __init__(self, region_name: str, account_id: str):
         super().__init__(region_name, account_id)
-        self.replication_tasks: Dict[str, "FakeReplicationTask"] = {}
-        self.replication_instances: Dict[str, "FakeReplicationInstance"] = {}
-        self.endpoints: Dict[str, "Endpoint"] = {}
+        self.replication_tasks: dict[str, FakeReplicationTask] = {}
+        self.replication_instances: dict[str, FakeReplicationInstance] = {}
+        self.endpoints: dict[str, Endpoint] = {}
         self.tagger = TaggingService()
 
     def create_replication_task(
@@ -90,7 +91,7 @@ class DatabaseMigrationServiceBackend(BaseBackend):
         return task
 
     def describe_replication_tasks(
-        self, filters: List[Dict[str, Any]], max_records: int
+        self, filters: list[dict[str, Any]], max_records: int
     ) -> Iterable["FakeReplicationTask"]:
         """
         The parameter WithoutSettings has not yet been implemented
@@ -107,20 +108,20 @@ class DatabaseMigrationServiceBackend(BaseBackend):
         replication_instance_identifier: str,
         replication_instance_class: str,
         allocated_storage: Optional[int] = None,
-        vpc_security_group_ids: Optional[List[str]] = None,
+        vpc_security_group_ids: Optional[list[str]] = None,
         availability_zone: Optional[str] = None,
         replication_subnet_group_identifier: Optional[str] = None,
         preferred_maintenance_window: Optional[str] = None,
         multi_az: Optional[bool] = False,
         engine_version: Optional[str] = None,
         auto_minor_version_upgrade: Optional[bool] = True,
-        tags: Optional[List[Dict[str, str]]] = None,
+        tags: Optional[list[dict[str, str]]] = None,
         kms_key_id: Optional[str] = None,
         publicly_accessible: Optional[bool] = True,
         dns_name_servers: Optional[str] = None,
         resource_identifier: Optional[str] = None,
         network_type: Optional[str] = None,
-        kerberos_authentication_settings: Optional[Dict[str, str]] = None,
+        kerberos_authentication_settings: Optional[dict[str, str]] = None,
     ) -> "FakeReplicationInstance":
         replication_instance = FakeReplicationInstance(
             replication_instance_identifier=replication_instance_identifier,
@@ -157,10 +158,10 @@ class DatabaseMigrationServiceBackend(BaseBackend):
 
     def describe_replication_instances(
         self,
-        filters: Optional[List[Dict[str, Any]]] = None,
+        filters: Optional[list[dict[str, Any]]] = None,
         max_records: Optional[int] = None,
         marker: Optional[str] = None,
-    ) -> List["FakeReplicationInstance"]:
+    ) -> list["FakeReplicationInstance"]:
         """Get information about replication instances with optional filtering"""
         ### TODO: Implement pagination
 
@@ -210,31 +211,31 @@ class DatabaseMigrationServiceBackend(BaseBackend):
         database_name: str,
         extra_connection_attributes: str,
         kms_key_id: str,
-        tags: Optional[List[Dict[str, str]]],
+        tags: Optional[list[dict[str, str]]],
         certificate_arn: str,
         ssl_mode: str,
         service_access_role_arn: str,
         external_table_definition: str,
-        dynamo_db_settings: Optional[Dict[str, Any]],
-        s3_settings: Optional[Dict[str, Any]],
-        dms_transfer_settings: Optional[Dict[str, Any]],
-        mongo_db_settings: Optional[Dict[str, Any]],
-        kinesis_settings: Optional[Dict[str, Any]],
-        kafka_settings: Optional[Dict[str, Any]],
-        elasticsearch_settings: Optional[Dict[str, Any]],
-        neptune_settings: Optional[Dict[str, Any]],
-        redshift_settings: Optional[Dict[str, Any]],
-        postgre_sql_settings: Optional[Dict[str, Any]],
-        my_sql_settings: Optional[Dict[str, Any]],
-        oracle_settings: Optional[Dict[str, Any]],
-        sybase_settings: Optional[Dict[str, Any]],
-        microsoft_sql_server_settings: Optional[Dict[str, Any]],
-        ibm_db2_settings: Optional[Dict[str, Any]],
+        dynamo_db_settings: Optional[dict[str, Any]],
+        s3_settings: Optional[dict[str, Any]],
+        dms_transfer_settings: Optional[dict[str, Any]],
+        mongo_db_settings: Optional[dict[str, Any]],
+        kinesis_settings: Optional[dict[str, Any]],
+        kafka_settings: Optional[dict[str, Any]],
+        elasticsearch_settings: Optional[dict[str, Any]],
+        neptune_settings: Optional[dict[str, Any]],
+        redshift_settings: Optional[dict[str, Any]],
+        postgre_sql_settings: Optional[dict[str, Any]],
+        my_sql_settings: Optional[dict[str, Any]],
+        oracle_settings: Optional[dict[str, Any]],
+        sybase_settings: Optional[dict[str, Any]],
+        microsoft_sql_server_settings: Optional[dict[str, Any]],
+        ibm_db2_settings: Optional[dict[str, Any]],
         resource_identifier: Optional[str],
-        doc_db_settings: Optional[Dict[str, Any]],
-        redis_settings: Optional[Dict[str, Any]],
-        gcp_my_sql_settings: Optional[Dict[str, Any]],
-        timestream_settings: Optional[Dict[str, Any]],
+        doc_db_settings: Optional[dict[str, Any]],
+        redis_settings: Optional[dict[str, Any]],
+        gcp_my_sql_settings: Optional[dict[str, Any]],
+        timestream_settings: Optional[dict[str, Any]],
     ) -> "Endpoint":
         if endpoint_type not in ["source", "target"]:
             raise ValidationError("Invalid endpoint type")
@@ -290,10 +291,10 @@ class DatabaseMigrationServiceBackend(BaseBackend):
     # TODO implement pagination
     def describe_endpoints(
         self,
-        filters: List[Dict[str, Any]],
+        filters: list[dict[str, Any]],
         max_records: Optional[int],
         marker: Optional[str],
-    ) -> List["Endpoint"]:
+    ) -> list["Endpoint"]:
         endpoints = list(self.endpoints.values())
         filter_map = {
             "endpoint-arn": "endpoint_arn",
@@ -318,8 +319,8 @@ class DatabaseMigrationServiceBackend(BaseBackend):
         return endpoints
 
     def list_tags_for_resource(
-        self, resource_arn_list: List[str]
-    ) -> List[Dict[str, Any]]:
+        self, resource_arn_list: list[str]
+    ) -> list[dict[str, Any]]:
         result = []
         for resource_arn in resource_arn_list:
             tags = self.tagger.get_tag_dict_for_resource(resource_arn)
@@ -348,26 +349,26 @@ class Endpoint(BaseModel):
         service_access_role_arn: Optional[str],
         external_table_definition: Optional[str],
         external_id: Optional[str],
-        dynamo_db_settings: Optional[Dict[str, Any]],
-        s3_settings: Optional[Dict[str, Any]],
-        dms_transfer_settings: Optional[Dict[str, Any]],
-        mongo_db_settings: Optional[Dict[str, Any]],
-        kinesis_settings: Optional[Dict[str, Any]],
-        kafka_settings: Optional[Dict[str, Any]],
-        elasticsearch_settings: Optional[Dict[str, Any]],
-        neptune_settings: Optional[Dict[str, Any]],
-        redshift_settings: Optional[Dict[str, Any]],
-        postgre_sql_settings: Optional[Dict[str, Any]],
-        my_sql_settings: Optional[Dict[str, Any]],
-        oracle_settings: Optional[Dict[str, Any]],
-        sybase_settings: Optional[Dict[str, Any]],
-        microsoft_sql_server_settings: Optional[Dict[str, Any]],
-        ibm_db2_settings: Optional[Dict[str, Any]],
+        dynamo_db_settings: Optional[dict[str, Any]],
+        s3_settings: Optional[dict[str, Any]],
+        dms_transfer_settings: Optional[dict[str, Any]],
+        mongo_db_settings: Optional[dict[str, Any]],
+        kinesis_settings: Optional[dict[str, Any]],
+        kafka_settings: Optional[dict[str, Any]],
+        elasticsearch_settings: Optional[dict[str, Any]],
+        neptune_settings: Optional[dict[str, Any]],
+        redshift_settings: Optional[dict[str, Any]],
+        postgre_sql_settings: Optional[dict[str, Any]],
+        my_sql_settings: Optional[dict[str, Any]],
+        oracle_settings: Optional[dict[str, Any]],
+        sybase_settings: Optional[dict[str, Any]],
+        microsoft_sql_server_settings: Optional[dict[str, Any]],
+        ibm_db2_settings: Optional[dict[str, Any]],
         resource_identifier: Optional[str],
-        doc_db_settings: Optional[Dict[str, Any]],
-        redis_settings: Optional[Dict[str, Any]],
-        gcp_my_sql_settings: Optional[Dict[str, Any]],
-        timestream_settings: Optional[Dict[str, Any]],
+        doc_db_settings: Optional[dict[str, Any]],
+        redis_settings: Optional[dict[str, Any]],
+        gcp_my_sql_settings: Optional[dict[str, Any]],
+        timestream_settings: Optional[dict[str, Any]],
         account_id: str,
         region_name: str,
     ):
@@ -415,7 +416,7 @@ class Endpoint(BaseModel):
         self.gcp_my_sql_settings = gcp_my_sql_settings
         self.timestream_settings = timestream_settings
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         return {
             "EndpointIdentifier": self.endpoint_identifier,
             "EndpointType": self.endpoint_type,
@@ -485,7 +486,7 @@ class FakeReplicationTask(BaseModel):
         self.start_date: Optional[datetime] = None
         self.stop_date: Optional[datetime] = None
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         start_date = self.start_date.isoformat() if self.start_date else None
         stop_date = self.stop_date.isoformat() if self.stop_date else None
 
@@ -551,20 +552,20 @@ class FakeReplicationInstance(BaseModel):
         account_id: str,
         region_name: str,
         allocated_storage: Optional[int] = None,
-        vpc_security_group_ids: Optional[List[str]] = None,
+        vpc_security_group_ids: Optional[list[str]] = None,
         availability_zone: Optional[str] = None,
         replication_subnet_group_identifier: Optional[str] = None,
         preferred_maintenance_window: Optional[str] = None,
         multi_az: Optional[bool] = False,
         engine_version: Optional[str] = None,
         auto_minor_version_upgrade: Optional[bool] = True,
-        tags: Optional[List[Dict[str, str]]] = None,
+        tags: Optional[list[dict[str, str]]] = None,
         kms_key_id: Optional[str] = None,
         publicly_accessible: Optional[bool] = True,
         dns_name_servers: Optional[str] = None,
         resource_identifier: Optional[str] = None,
         network_type: Optional[str] = None,
-        kerberos_authentication_settings: Optional[Dict[str, str]] = None,
+        kerberos_authentication_settings: Optional[dict[str, str]] = None,
     ):
         self.id = replication_instance_identifier
         self.replication_instance_class = replication_instance_class
@@ -592,9 +593,9 @@ class FakeReplicationInstance(BaseModel):
         self.creation_date = utcnow()
         self.private_ip_addresses = ["10.0.0.1"]
         self.public_ip_addresses = ["54.0.0.1"] if publicly_accessible else []
-        self.ipv6_addresses: List[str] = []
+        self.ipv6_addresses: list[str] = []
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         kerberos_settings = None
         if self.kerberos_authentication_settings:
             kerberos_settings = {

--- a/moto/dms/utils.py
+++ b/moto/dms/utils.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import random
 import string
-from typing import TYPE_CHECKING, Any, Dict, List
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from moto.dms.models import FakeReplicationTask
@@ -17,22 +17,22 @@ def random_id(uppercase: bool = True, length: int = 13) -> str:
     return resource_id
 
 
-def match_task_arn(task: FakeReplicationTask, arns: List[str]) -> bool:
+def match_task_arn(task: FakeReplicationTask, arns: list[str]) -> bool:
     return task.arn in arns
 
 
-def match_task_id(task: FakeReplicationTask, ids: List[str]) -> bool:
+def match_task_id(task: FakeReplicationTask, ids: list[str]) -> bool:
     return task.id in ids
 
 
 def match_task_migration_type(
-    task: FakeReplicationTask, migration_types: List[str]
+    task: FakeReplicationTask, migration_types: list[str]
 ) -> bool:
     return task.migration_type in migration_types
 
 
 def match_task_endpoint_arn(
-    task: FakeReplicationTask, endpoint_arns: List[str]
+    task: FakeReplicationTask, endpoint_arns: list[str]
 ) -> bool:
     return (
         task.source_endpoint_arn in endpoint_arns
@@ -41,7 +41,7 @@ def match_task_endpoint_arn(
 
 
 def match_task_replication_instance_arn(
-    task: FakeReplicationTask, replication_instance_arns: List[str]
+    task: FakeReplicationTask, replication_instance_arns: list[str]
 ) -> bool:
     return task.replication_instance_arn in replication_instance_arns
 
@@ -56,7 +56,7 @@ task_filter_functions = {
 
 
 def filter_tasks(
-    tasks: List[FakeReplicationTask], filters: List[Dict[str, Any]]
+    tasks: list[FakeReplicationTask], filters: list[dict[str, Any]]
 ) -> Any:
     matching_tasks = tasks
 

--- a/moto/ds/exceptions.py
+++ b/moto/ds/exceptions.py
@@ -1,7 +1,5 @@
 """Exceptions raised by the Directory Service service."""
 
-from typing import List, Tuple
-
 from moto.core.exceptions import JsonRESTError
 
 
@@ -10,7 +8,7 @@ class DsValidationException(JsonRESTError):
 
     code = 400
 
-    def __init__(self, error_tuples: List[Tuple[str, str, str]]):
+    def __init__(self, error_tuples: list[tuple[str, str, str]]):
         """Validation errors are concatenated into one exception message.
 
         error_tuples is a list of tuples.  Each tuple contains:

--- a/moto/ds/models.py
+++ b/moto/ds/models.py
@@ -1,7 +1,7 @@
 """DirectoryServiceBackend class with methods for supported APIs."""
 
 import copy
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Optional
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
@@ -31,7 +31,7 @@ class LdapsSettingInfo(BaseModel):
         self.ldaps_status = "Enabled"
         self.ldaps_status_reason = ""
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         return {
             "LastUpdatedDateTime": self.last_updated_date_time,
             "LDAPSStatus": self.ldaps_status,
@@ -45,7 +45,7 @@ class LogSubscription(BaseModel):
         self.log_group_name = log_group_name
         self.created_date_time = unix_time()
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         return {
             "SubscriptionCreatedDateTime": self.created_date_time,
             "DirectoryId": self.directory_id,
@@ -61,7 +61,7 @@ class Trust(BaseModel):
         trust_password: str,
         trust_direction: str,
         trust_type: Optional[str],
-        conditional_forwarder_ip_addrs: Optional[List[str]],
+        conditional_forwarder_ip_addrs: Optional[list[str]],
         selective_auth: Optional[str],
     ) -> None:
         self.trust_id = f"t-{mock_random.get_random_hex(10)}"
@@ -78,7 +78,7 @@ class Trust(BaseModel):
         self.conditional_forwarder_ip_addrs = conditional_forwarder_ip_addrs
         self.selective_auth = selective_auth
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         return {
             "CreatedDateTime": self.created_date_time,
             "DirectoryId": self.directory_id,
@@ -126,8 +126,8 @@ class Directory(BaseModel):
         password: str,
         directory_type: str,
         size: Optional[str] = None,
-        vpc_settings: Optional[Dict[str, Any]] = None,
-        connect_settings: Optional[Dict[str, Any]] = None,
+        vpc_settings: Optional[dict[str, Any]] = None,
+        connect_settings: Optional[dict[str, Any]] = None,
         short_name: Optional[str] = None,
         description: Optional[str] = None,
         edition: Optional[str] = None,
@@ -153,8 +153,8 @@ class Directory(BaseModel):
         self.stage = "Active"
         self.launch_time = unix_time()
         self.stage_last_updated_date_time = unix_time()
-        self.ldaps_settings_info: List[LdapsSettingInfo] = []
-        self.trusts: List[Trust] = []
+        self.ldaps_settings_info: list[LdapsSettingInfo] = []
+        self.trusts: list[Trust] = []
         self.settings = (
             copy.deepcopy(SETTINGS_ENTRIES_MODEL)
             if self.directory_type == "MicrosoftAD"
@@ -205,8 +205,8 @@ class Directory(BaseModel):
         )
 
     def create_eni(
-        self, security_group_id: str, subnet_ids: List[str]
-    ) -> Tuple[List[str], List[str]]:
+        self, security_group_id: str, subnet_ids: list[str]
+    ) -> tuple[list[str], list[str]]:
         """Return ENI ids and primary addresses created for each subnet."""
         eni_ids = []
         subnet_ips = []
@@ -253,7 +253,7 @@ class Directory(BaseModel):
             for setting in self.ldaps_settings_info:
                 setting.ldaps_status = "Disabled"
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         """Create a dictionary of attributes for Directory."""
         attributes = {
             "AccessUrl": self.access_url,
@@ -291,11 +291,11 @@ class DirectoryServiceBackend(BaseBackend):
 
     def __init__(self, region_name: str, account_id: str):
         super().__init__(region_name, account_id)
-        self.directories: Dict[str, Directory] = {}
-        self.log_subscriptions: Dict[str, LogSubscription] = {}
+        self.directories: dict[str, Directory] = {}
+        self.log_subscriptions: dict[str, LogSubscription] = {}
         self.tagger = TaggingService()
 
-    def _verify_subnets(self, region: str, vpc_settings: Dict[str, Any]) -> None:
+    def _verify_subnets(self, region: str, vpc_settings: dict[str, Any]) -> None:
         """Verify subnets are valid, else raise an exception.
 
         If settings are valid, add AvailabilityZones to vpc_settings.
@@ -338,8 +338,8 @@ class DirectoryServiceBackend(BaseBackend):
         password: str,
         description: str,
         size: str,
-        connect_settings: Dict[str, Any],
-        tags: List[Dict[str, str]],
+        connect_settings: dict[str, Any],
+        tags: list[dict[str, str]],
     ) -> str:
         """Create a fake AD Connector."""
         if len(self.directories) > Directory.CONNECTED_DIRECTORIES_LIMIT:
@@ -398,8 +398,8 @@ class DirectoryServiceBackend(BaseBackend):
         password: str,
         description: str,
         size: str,
-        vpc_settings: Dict[str, Any],
-        tags: List[Dict[str, str]],
+        vpc_settings: dict[str, Any],
+        tags: list[dict[str, str]],
     ) -> str:
         """Create a fake Simple Ad Directory."""
         if len(self.directories) > Directory.CLOUDONLY_DIRECTORIES_LIMIT:
@@ -453,7 +453,7 @@ class DirectoryServiceBackend(BaseBackend):
                 f"Directory {directory_id} does not exist"
             )
 
-    def create_alias(self, directory_id: str, alias: str) -> Dict[str, str]:
+    def create_alias(self, directory_id: str, alias: str) -> dict[str, str]:
         """Create and assign an alias to a directory."""
         self._validate_directory_id(directory_id)
 
@@ -481,9 +481,9 @@ class DirectoryServiceBackend(BaseBackend):
         short_name: str,
         password: str,
         description: str,
-        vpc_settings: Dict[str, Any],
+        vpc_settings: dict[str, Any],
         edition: str,
-        tags: List[Dict[str, str]],
+        tags: list[dict[str, str]],
     ) -> str:
         """Create a fake Microsoft Ad Directory."""
         if len(self.directories) > Directory.CLOUDONLY_MICROSOFT_AD_LIMIT:
@@ -568,8 +568,8 @@ class DirectoryServiceBackend(BaseBackend):
 
     @paginate(pagination_model=PAGINATION_MODEL)
     def describe_directories(
-        self, directory_ids: Optional[List[str]] = None
-    ) -> List[Directory]:
+        self, directory_ids: Optional[list[str]] = None
+    ) -> list[Directory]:
         """Return info on all directories or directories with matching IDs."""
         for directory_id in directory_ids or self.directories:
             self._validate_directory_id(directory_id)
@@ -579,7 +579,7 @@ class DirectoryServiceBackend(BaseBackend):
             directories = [x for x in directories if x.directory_id in directory_ids]
         return sorted(directories, key=lambda x: x.launch_time)
 
-    def get_directory_limits(self) -> Dict[str, Any]:
+    def get_directory_limits(self) -> dict[str, Any]:
         """Return hard-coded limits for the directories."""
         counts = {"SimpleAD": 0, "MicrosoftAD": 0, "ConnectedAD": 0}
         for directory in self.directories.values():
@@ -606,7 +606,7 @@ class DirectoryServiceBackend(BaseBackend):
         }
 
     def add_tags_to_resource(
-        self, resource_id: str, tags: List[Dict[str, str]]
+        self, resource_id: str, tags: list[dict[str, str]]
     ) -> None:
         """Add or overwrite one or more tags for specified directory."""
         self._validate_directory_id(resource_id)
@@ -617,13 +617,13 @@ class DirectoryServiceBackend(BaseBackend):
             raise TagLimitExceededException("Tag limit exceeded")
         self.tagger.tag_resource(resource_id, tags)
 
-    def remove_tags_from_resource(self, resource_id: str, tag_keys: List[str]) -> None:
+    def remove_tags_from_resource(self, resource_id: str, tag_keys: list[str]) -> None:
         """Removes tags from a directory."""
         self._validate_directory_id(resource_id)
         self.tagger.untag_resource_using_names(resource_id, tag_keys)
 
     @paginate(pagination_model=PAGINATION_MODEL)
-    def list_tags_for_resource(self, resource_id: str) -> List[Dict[str, str]]:
+    def list_tags_for_resource(self, resource_id: str) -> list[dict[str, str]]:
         """List all tags on a directory."""
         self._validate_directory_id(resource_id)
         return self.tagger.list_tags_for_resource(resource_id).get("Tags")  # type: ignore[return-value]
@@ -635,7 +635,7 @@ class DirectoryServiceBackend(BaseBackend):
         trust_password: str,
         trust_direction: str,
         trust_type: Optional[str],
-        conditional_forwarder_ip_addrs: Optional[List[str]],
+        conditional_forwarder_ip_addrs: Optional[list[str]],
         selective_auth: Optional[str],
     ) -> str:
         self._validate_directory_id(directory_id)
@@ -661,8 +661,8 @@ class DirectoryServiceBackend(BaseBackend):
 
     @paginate(pagination_model=PAGINATION_MODEL)
     def describe_trusts(
-        self, directory_id: Optional[str], trust_ids: Optional[List[str]]
-    ) -> List[Trust]:
+        self, directory_id: Optional[str], trust_ids: Optional[list[str]]
+    ) -> list[Trust]:
         if directory_id:
             self._validate_directory_id(directory_id)
             directory = self.directories[directory_id]
@@ -696,7 +696,7 @@ class DirectoryServiceBackend(BaseBackend):
     @paginate(pagination_model=PAGINATION_MODEL)
     def describe_ldaps_settings(
         self, directory_id: str, type: str
-    ) -> List[LdapsSettingInfo]:
+    ) -> list[LdapsSettingInfo]:
         """Describe LDAPS settings for a Directory"""
         self._validate_directory_id(directory_id)
         directory = self.directories[directory_id]
@@ -722,7 +722,7 @@ class DirectoryServiceBackend(BaseBackend):
     @paginate(pagination_model=PAGINATION_MODEL)
     def describe_settings(
         self, directory_id: str, status: Optional[str]
-    ) -> List[Dict[str, str]]:
+    ) -> list[dict[str, str]]:
         """Describe settings for a Directory"""
         self._validate_directory_id(directory_id)
         directory = self.directories[directory_id]
@@ -740,7 +740,7 @@ class DirectoryServiceBackend(BaseBackend):
             queried_settings = directory.settings
         return queried_settings
 
-    def update_settings(self, directory_id: str, settings: List[Dict[str, Any]]) -> str:
+    def update_settings(self, directory_id: str, settings: list[dict[str, Any]]) -> str:
         self._validate_directory_id(directory_id)
         directory = self.directories[directory_id]
         if directory.directory_type not in ("MicrosoftAD"):
@@ -768,7 +768,7 @@ class DirectoryServiceBackend(BaseBackend):
     def list_log_subscriptions(
         self,
         directory_id: str,
-    ) -> List[LogSubscription]:
+    ) -> list[LogSubscription]:
         if directory_id:
             self._validate_directory_id(directory_id)
             log_subscription = self.log_subscriptions.get(directory_id, None)

--- a/moto/dsql/models.py
+++ b/moto/dsql/models.py
@@ -1,7 +1,7 @@
 """AuroraDSQLBackend class with methods for supported APIs."""
 
 from collections import OrderedDict
-from typing import Any, Dict, Optional
+from typing import Any, Optional
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
@@ -16,7 +16,7 @@ from .exceptions import ValidationException
 class Cluster(BaseModel, ManagedState):
     """Model for an AuroraDSQL cluster."""
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         dct = {
             "identifier": self.identifier,
             "arn": self.arn,
@@ -31,7 +31,7 @@ class Cluster(BaseModel, ManagedState):
         region_name: str,
         account_id: str,
         deletion_protection_enabled: Optional[bool],
-        tags: Optional[Dict[str, str]],
+        tags: Optional[dict[str, str]],
         client_token: Optional[str],
     ):
         ManagedState.__init__(
@@ -55,12 +55,12 @@ class AuroraDSQLBackend(BaseBackend):
         self.region_name = region_name
         self.account_id = account_id
         self.partition = get_partition(region_name)
-        self.clusters: Dict[str, Cluster] = OrderedDict()
+        self.clusters: dict[str, Cluster] = OrderedDict()
 
     def create_cluster(
         self,
         deletion_protection_enabled: bool,
-        tags: Optional[Dict[str, str]],
+        tags: Optional[dict[str, str]],
         client_token: Optional[str],
     ) -> Cluster:
         cluster = Cluster(

--- a/moto/dynamodb/comparisons.py
+++ b/moto/dynamodb/comparisons.py
@@ -1,6 +1,7 @@
 import re
 from collections import deque, namedtuple
-from typing import Any, Deque, Dict, Iterable, List, Optional, Tuple, Union
+from collections.abc import Iterable
+from typing import Any, Optional, Union
 
 from moto.dynamodb.exceptions import ConditionAttributeIsReservedKeyword
 from moto.dynamodb.models.dynamo_type import Item
@@ -9,16 +10,16 @@ from moto.dynamodb.parsing.reserved_keywords import ReservedKeywords
 
 def create_condition_expression_parser(
     expr: Optional[str],
-    names: Optional[Dict[str, str]],
-    values: Optional[Dict[str, Dict[str, str]]],
+    names: Optional[dict[str, str]],
+    values: Optional[dict[str, dict[str, str]]],
 ) -> "ConditionExpressionParser":
     return ConditionExpressionParser(expr, names, values)
 
 
 def get_filter_expression(
     expr: Optional[str],
-    names: Optional[Dict[str, str]],
-    values: Optional[Dict[str, Dict[str, str]]],
+    names: Optional[dict[str, str]],
+    values: Optional[dict[str, dict[str, str]]],
 ) -> Union["Op", "Func"]:
     """
     Parse a filter expression into an Op.
@@ -31,7 +32,7 @@ def get_filter_expression(
     return parser.parse()
 
 
-def get_expected(expected: Dict[str, Any]) -> Union["Op", "Func"]:
+def get_expected(expected: dict[str, Any]) -> Union["Op", "Func"]:
     """
     Parse a filter expression into an Op.
 
@@ -39,7 +40,7 @@ def get_expected(expected: Dict[str, Any]) -> Union["Op", "Func"]:
         expr = 'Id > 5 AND attribute_exists(test) AND Id BETWEEN 5 AND 6 OR length < 6 AND contains(test, 1) AND 5 IN (4,5, 6) OR (Id < 5 AND 5 > Id)'
         expr = 'Id > 5 AND Subs < 7'
     """
-    ops: Dict[str, Any] = {
+    ops: dict[str, Any] = {
         "EQ": OpEqual,
         "NE": OpNotEqual,
         "LE": OpLessThanOrEqual,
@@ -56,7 +57,7 @@ def get_expected(expected: Dict[str, Any]) -> Union["Op", "Func"]:
     }
 
     # NOTE: Always uses ConditionalOperator=AND
-    conditions: List[Union["Op", "Func"]] = []
+    conditions: list[Union[Op, Func]] = []
     for key, cond in expected.items():
         path = AttributePath([key])
         if "Exists" in cond:
@@ -152,15 +153,15 @@ class ConditionExpressionParser:
     def __init__(
         self,
         condition_expression: Optional[str],
-        expression_attribute_names: Optional[Dict[str, str]],
-        expression_attribute_values: Optional[Dict[str, Dict[str, str]]],
+        expression_attribute_names: Optional[dict[str, str]],
+        expression_attribute_values: Optional[dict[str, dict[str, str]]],
     ):
         self.condition_expression = condition_expression
         self.expression_attribute_names = expression_attribute_names
         self.expression_attribute_values = expression_attribute_values
 
-        self.expr_attr_names_found: List[str] = []
-        self.expr_attr_values_found: List[str] = []
+        self.expr_attr_names_found: list[str] = []
+        self.expr_attr_values_found: list[str] = []
 
     def parse(self) -> Union[Op, "Func"]:
         """Returns a syntax tree for the expression.
@@ -264,8 +265,8 @@ class ConditionExpressionParser:
     Node = namedtuple("Node", ["nonterminal", "kind", "text", "value", "children"])
 
     @classmethod
-    def _find_literals(cls, parent: Node) -> List[str]:  # type: ignore
-        literals: List[str] = []
+    def _find_literals(cls, parent: Node) -> list[str]:  # type: ignore
+        literals: list[str] = []
         if (
             parent.kind == cls.Kind.LITERAL
             and parent.nonterminal == cls.Nonterminal.IDENTIFIER
@@ -277,8 +278,8 @@ class ConditionExpressionParser:
         return literals
 
     @classmethod
-    def _find_expr_attr_values(cls, parent: Node) -> List[str]:  # type: ignore
-        literals: List[str] = []
+    def _find_expr_attr_values(cls, parent: Node) -> list[str]:  # type: ignore
+        literals: list[str] = []
         if parent.kind == ConditionExpressionParser.Kind.EXPRESSION_ATTRIBUTE_VALUE:
             literals.append(parent.text)
         else:
@@ -291,8 +292,8 @@ class ConditionExpressionParser:
         if attribute.upper() in ReservedKeywords.get_reserved_keywords():
             raise ConditionAttributeIsReservedKeyword(attribute)
 
-    def _lex_condition_expression(self) -> Deque[Node]:
-        nodes: Deque[ConditionExpressionParser.Node] = deque()
+    def _lex_condition_expression(self) -> deque[Node]:
+        nodes: deque[ConditionExpressionParser.Node] = deque()
         remaining_expression = self.condition_expression
         while remaining_expression:
             node, remaining_expression = self._lex_one_node(remaining_expression)
@@ -301,7 +302,7 @@ class ConditionExpressionParser:
             nodes.append(node)
         return nodes
 
-    def _lex_one_node(self, remaining_expression: str) -> Tuple[Node, str]:
+    def _lex_one_node(self, remaining_expression: str) -> tuple[Node, str]:
         # TODO: Handle indexing like [1]
         attribute_regex = r"(:|#)?[A-z0-9\-_]+"
         patterns = [
@@ -345,8 +346,8 @@ class ConditionExpressionParser:
                 return node, remaining_expression
         raise ValueError(f"Cannot parse condition starting at:{remaining_expression}")
 
-    def _parse_paths(self, nodes: Deque[Node]) -> Deque[Node]:
-        output: Deque[ConditionExpressionParser.Node] = deque()
+    def _parse_paths(self, nodes: deque[Node]) -> deque[Node]:
+        output: deque[ConditionExpressionParser.Node] = deque()
 
         while nodes:
             node = nodes.popleft()
@@ -456,7 +457,7 @@ class ConditionExpressionParser:
                 children=[],
             )
 
-    def _lookup_expression_attribute_value(self, name: str) -> Dict[str, str]:
+    def _lookup_expression_attribute_value(self, name: str) -> dict[str, str]:
         return self.expression_attribute_values[name]  # type: ignore[index]
 
     def _lookup_expression_attribute_name(self, name: str) -> str:
@@ -504,7 +505,7 @@ class ConditionExpressionParser:
     #     contains (path, operand)
     #     size (path)
 
-    def _matches(self, nodes: Deque[Node], production: List[str]) -> bool:
+    def _matches(self, nodes: deque[Node], production: list[str]) -> bool:
         """Check if the nodes start with the given production.
 
         Parameters
@@ -524,9 +525,9 @@ class ConditionExpressionParser:
                 return False
         return True
 
-    def _apply_comparator(self, nodes: Deque[Node]) -> Deque[Node]:
+    def _apply_comparator(self, nodes: deque[Node]) -> deque[Node]:
         """Apply condition := operand comparator operand."""
-        output: Deque[ConditionExpressionParser.Node] = deque()
+        output: deque[ConditionExpressionParser.Node] = deque()
 
         while nodes:
             if self._matches(nodes, ["*", "COMPARATOR"]):
@@ -551,9 +552,9 @@ class ConditionExpressionParser:
                 output.append(nodes.popleft())
         return output
 
-    def _apply_in(self, nodes: Deque[Node]) -> Deque[Node]:
+    def _apply_in(self, nodes: deque[Node]) -> deque[Node]:
         """Apply condition := operand IN ( operand , ... )."""
-        output: Deque[ConditionExpressionParser.Node] = deque()
+        output: deque[ConditionExpressionParser.Node] = deque()
         while nodes:
             if self._matches(nodes, ["*", "IN"]):
                 self._assert(
@@ -593,9 +594,9 @@ class ConditionExpressionParser:
                 output.append(nodes.popleft())
         return output
 
-    def _apply_between(self, nodes: Deque[Node]) -> Deque[Node]:
+    def _apply_between(self, nodes: deque[Node]) -> deque[Node]:
         """Apply condition := operand BETWEEN operand AND operand."""
-        output: Deque[ConditionExpressionParser.Node] = deque()
+        output: deque[ConditionExpressionParser.Node] = deque()
         while nodes:
             if self._matches(nodes, ["*", "BETWEEN"]):
                 self._assert(
@@ -624,9 +625,9 @@ class ConditionExpressionParser:
                 output.append(nodes.popleft())
         return output
 
-    def _apply_functions(self, nodes: Deque[Node]) -> Deque[Node]:
+    def _apply_functions(self, nodes: deque[Node]) -> deque[Node]:
         """Apply condition := function_name (operand , ...)."""
-        output: Deque[ConditionExpressionParser.Node] = deque()
+        output: deque[ConditionExpressionParser.Node] = deque()
         either_kind = {self.Kind.PATH, self.Kind.EXPRESSION_ATTRIBUTE_VALUE}
         expected_argument_kind_map = {
             "attribute_exists": [{self.Kind.PATH}],
@@ -697,10 +698,10 @@ class ConditionExpressionParser:
         return output
 
     def _apply_parens_and_booleans(
-        self, nodes: Deque[Node], left_paren: Any = None
-    ) -> Deque[Node]:
+        self, nodes: deque[Node], left_paren: Any = None
+    ) -> deque[Node]:
         """Apply condition := ( condition ) and booleans."""
-        output: Deque[ConditionExpressionParser.Node] = deque()
+        output: deque[ConditionExpressionParser.Node] = deque()
         while nodes:
             if self._matches(nodes, ["LEFT_PAREN"]):
                 parsed = self._apply_parens_and_booleans(
@@ -738,7 +739,7 @@ class ConditionExpressionParser:
         self._assert(left_paren is None, "Unmatched ( at", list(output))
         return self._apply_booleans(output)
 
-    def _apply_booleans(self, nodes: Deque[Node]) -> Deque[Node]:
+    def _apply_booleans(self, nodes: deque[Node]) -> deque[Node]:
         """Apply and, or, and not constructions."""
         nodes = self._apply_not(nodes)
         nodes = self._apply_and(nodes)
@@ -752,9 +753,9 @@ class ConditionExpressionParser:
         )
         return nodes
 
-    def _apply_not(self, nodes: Deque[Node]) -> Deque[Node]:
+    def _apply_not(self, nodes: deque[Node]) -> deque[Node]:
         """Apply condition := NOT condition."""
-        output: Deque[ConditionExpressionParser.Node] = deque()
+        output: deque[ConditionExpressionParser.Node] = deque()
         while nodes:
             if self._matches(nodes, ["NOT"]):
                 self._assert(
@@ -778,9 +779,9 @@ class ConditionExpressionParser:
 
         return output
 
-    def _apply_and(self, nodes: Deque[Node]) -> Deque[Node]:
+    def _apply_and(self, nodes: deque[Node]) -> deque[Node]:
         """Apply condition := condition AND condition."""
-        output: Deque[ConditionExpressionParser.Node] = deque()
+        output: deque[ConditionExpressionParser.Node] = deque()
         while nodes:
             if self._matches(nodes, ["*", "AND"]):
                 self._assert(
@@ -806,9 +807,9 @@ class ConditionExpressionParser:
 
         return output
 
-    def _apply_or(self, nodes: Deque[Node]) -> Deque[Node]:
+    def _apply_or(self, nodes: deque[Node]) -> deque[Node]:
         """Apply condition := condition OR condition."""
-        output: Deque[ConditionExpressionParser.Node] = deque()
+        output: deque[ConditionExpressionParser.Node] = deque()
         while nodes:
             if self._matches(nodes, ["*", "OR"]):
                 self._assert(
@@ -903,7 +904,7 @@ class Operand:
 
 
 class AttributePath(Operand):
-    def __init__(self, path: List[Any]):
+    def __init__(self, path: list[Any]):
         """Initialize the AttributePath.
 
         Parameters
@@ -949,7 +950,7 @@ class AttributePath(Operand):
 
 
 class AttributeValue(Operand):
-    def __init__(self, value: Dict[str, Any]):
+    def __init__(self, value: dict[str, Any]):
         """Initialize the AttributePath.
 
         Parameters
@@ -1247,7 +1248,7 @@ COMPARATOR_CLASS = {
     "<>": OpNotEqual,
 }
 
-FUNC_CLASS: Dict[str, Any] = {
+FUNC_CLASS: dict[str, Any] = {
     "attribute_exists": FuncAttrExists,
     "attribute_not_exists": FuncAttrNotExists,
     "attribute_type": FuncAttrType,

--- a/moto/dynamodb/exceptions.py
+++ b/moto/dynamodb/exceptions.py
@@ -1,5 +1,5 @@
 import json
-from typing import Any, Dict, List, Optional
+from typing import Any, Optional
 
 from moto.core.exceptions import JsonRESTError
 from moto.dynamodb.limits import HASH_KEY_MAX_LENGTH, RANGE_KEY_MAX_LENGTH
@@ -208,7 +208,7 @@ class ConditionalCheckFailed(DynamodbException):
     error_type = ERROR_TYPE_PREFIX + "ConditionalCheckFailedException"
 
     def __init__(
-        self, msg: Optional[str] = None, item: Optional[Dict[str, Any]] = None
+        self, msg: Optional[str] = None, item: Optional[dict[str, Any]] = None
     ):
         _msg = msg or "The conditional request failed"
         super().__init__(ConditionalCheckFailed.error_type, _msg)
@@ -238,7 +238,7 @@ class TransactionCanceledException(DynamodbException):
     cancel_reason_msg = "Transaction cancelled, please refer cancellation reasons for specific reasons [{}]"
     error_type = "com.amazonaws.dynamodb.v20120810#TransactionCanceledException"
 
-    def __init__(self, errors: List[Any]):
+    def __init__(self, errors: list[Any]):
         msg = self.cancel_reason_msg.format(
             ", ".join([str(code) for code, _, _ in errors])
         )

--- a/moto/dynamodb/models/__init__.py
+++ b/moto/dynamodb/models/__init__.py
@@ -1,7 +1,7 @@
 import copy
 import re
 from collections import OrderedDict
-from typing import Any, Dict, List, Optional, Set, Tuple, Union
+from typing import Any, Optional, Union
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.exceptions import JsonRESTError
@@ -51,16 +51,16 @@ from moto.dynamodb.parsing.validators import UpdateExpressionValidator
 class DynamoDBBackend(BaseBackend):
     def __init__(self, region_name: str, account_id: str):
         super().__init__(region_name, account_id)
-        self.tables: Dict[str, Table] = OrderedDict()
-        self.backups: Dict[str, Backup] = OrderedDict()
-        self.table_imports: Dict[str, TableImport] = {}
-        self.table_exports: Dict[str, TableExport] = {}
-        self.resource_policies: Dict[str, ResourcePolicy] = {}
+        self.tables: dict[str, Table] = OrderedDict()
+        self.backups: dict[str, Backup] = OrderedDict()
+        self.table_imports: dict[str, TableImport] = {}
+        self.table_exports: dict[str, TableExport] = {}
+        self.resource_policies: dict[str, ResourcePolicy] = {}
 
     @staticmethod
     def default_vpc_endpoint_service(
-        service_region: str, zones: List[str]
-    ) -> List[Dict[str, str]]:
+        service_region: str, zones: list[str]
+    ) -> list[dict[str, str]]:
         """Default VPC endpoint service."""
         # No 'vpce' in the base endpoint DNS name
         return BaseBackend.default_vpc_endpoint_service_factory(
@@ -75,17 +75,17 @@ class DynamoDBBackend(BaseBackend):
     def create_table(
         self,
         name: str,
-        schema: List[Dict[str, str]],
-        throughput: Optional[Dict[str, int]],
-        attr: List[Dict[str, str]],
-        global_indexes: Optional[List[Dict[str, Any]]],
-        indexes: Optional[List[Dict[str, Any]]],
-        streams: Optional[Dict[str, Any]],
+        schema: list[dict[str, str]],
+        throughput: Optional[dict[str, int]],
+        attr: list[dict[str, str]],
+        global_indexes: Optional[list[dict[str, Any]]],
+        indexes: Optional[list[dict[str, Any]]],
+        streams: Optional[dict[str, Any]],
         billing_mode: str,
-        sse_specification: Optional[Dict[str, Any]],
-        tags: List[Dict[str, str]],
+        sse_specification: Optional[dict[str, Any]],
+        tags: list[dict[str, str]],
         deletion_protection_enabled: Optional[bool],
-        warm_throughput: Optional[Dict[str, Any]],
+        warm_throughput: Optional[dict[str, Any]],
     ) -> Table:
         if name in self.tables:
             raise ResourceInUseException(f"Table already exists: {name}")
@@ -115,7 +115,7 @@ class DynamoDBBackend(BaseBackend):
                 raise DeletionProtectedException(name)
         return self.tables.pop(table_for_deletion.name)
 
-    def describe_endpoints(self) -> List[Dict[str, Union[int, str]]]:
+    def describe_endpoints(self) -> list[dict[str, Union[int, str]]]:
         return [
             {
                 "Address": f"dynamodb.{self.region_name}.amazonaws.com",
@@ -123,19 +123,19 @@ class DynamoDBBackend(BaseBackend):
             }
         ]
 
-    def tag_resource(self, table_arn: str, tags: List[Dict[str, str]]) -> None:
+    def tag_resource(self, table_arn: str, tags: list[dict[str, str]]) -> None:
         for table in self.tables:
             if self.tables[table].table_arn == table_arn:
                 self.tables[table].tags.extend(tags)
 
-    def untag_resource(self, table_arn: str, tag_keys: List[str]) -> None:
+    def untag_resource(self, table_arn: str, tag_keys: list[str]) -> None:
         for table in self.tables:
             if self.tables[table].table_arn == table_arn:
                 self.tables[table].tags = [
                     tag for tag in self.tables[table].tags if tag["Key"] not in tag_keys
                 ]
 
-    def list_tags_of_resource(self, table_arn: str) -> List[Dict[str, str]]:
+    def list_tags_of_resource(self, table_arn: str) -> list[dict[str, str]]:
         for table in self.tables:
             if self.tables[table].table_arn == table_arn:
                 return self.tables[table].tags
@@ -143,8 +143,8 @@ class DynamoDBBackend(BaseBackend):
 
     def list_tables(
         self, limit: int, exclusive_start_table_name: str
-    ) -> Tuple[List[str], Optional[str]]:
-        all_tables: List[str] = list(self.tables.keys())
+    ) -> tuple[list[str], Optional[str]]:
+        all_tables: list[str] = list(self.tables.keys())
 
         if exclusive_start_table_name:
             try:
@@ -165,7 +165,7 @@ class DynamoDBBackend(BaseBackend):
             return tables, tables[-1]
         return tables, None
 
-    def describe_table(self, name: str) -> Dict[str, Any]:
+    def describe_table(self, name: str) -> dict[str, Any]:
         # Error message is slightly different for this operation
         try:
             table = self.get_table(name)
@@ -176,13 +176,13 @@ class DynamoDBBackend(BaseBackend):
     def update_table(
         self,
         name: str,
-        attr_definitions: List[Dict[str, str]],
-        global_index: List[Dict[str, Any]],
-        throughput: Dict[str, Any],
+        attr_definitions: list[dict[str, str]],
+        global_index: list[dict[str, Any]],
+        throughput: dict[str, Any],
         billing_mode: str,
-        stream_spec: Dict[str, Any],
+        stream_spec: dict[str, Any],
         deletion_protection_enabled: Optional[bool],
-        warm_throughput: Optional[Dict[str, Any]],
+        warm_throughput: Optional[dict[str, Any]],
     ) -> Table:
         table = self.get_table(name)
         if attr_definitions:
@@ -203,7 +203,7 @@ class DynamoDBBackend(BaseBackend):
         return table
 
     def update_table_streams(
-        self, table: Table, stream_specification: Dict[str, Any]
+        self, table: Table, stream_specification: dict[str, Any]
     ) -> None:
         if (
             stream_specification.get("StreamEnabled")
@@ -213,7 +213,7 @@ class DynamoDBBackend(BaseBackend):
         table.set_stream_specification(stream_specification)
 
     def update_table_global_indexes(
-        self, table: Table, global_index_updates: List[Dict[str, Any]]
+        self, table: Table, global_index_updates: list[dict[str, Any]]
     ) -> None:
         gsis_by_name = dict((i.name, i) for i in table.global_indexes)
         for gsi_update in global_index_updates:
@@ -225,8 +225,9 @@ class DynamoDBBackend(BaseBackend):
                 index_name = gsi_to_delete["IndexName"]
                 if index_name not in gsis_by_name:
                     raise ValueError(
-                        "Global Secondary Index does not exist, but tried to delete: %s"
-                        % gsi_to_delete["IndexName"]
+                        "Global Secondary Index does not exist, but tried to delete: {}".format(
+                            gsi_to_delete["IndexName"]
+                        )
                     )
 
                 del gsis_by_name[index_name]
@@ -235,16 +236,16 @@ class DynamoDBBackend(BaseBackend):
                 index_name = gsi_to_update["IndexName"]
                 if index_name not in gsis_by_name:
                     raise ValueError(
-                        "Global Secondary Index does not exist, but tried to update: %s"
-                        % index_name
+                        f"Global Secondary Index does not exist, but tried to update: {index_name}"
                     )
                 gsis_by_name[index_name].update(gsi_to_update)
 
             if gsi_to_create:
                 if gsi_to_create["IndexName"] in gsis_by_name:
                     raise ValueError(
-                        "Global Secondary Index already exists: %s"
-                        % gsi_to_create["IndexName"]
+                        "Global Secondary Index already exists: {}".format(
+                            gsi_to_create["IndexName"]
+                        )
                     )
 
                 gsis_by_name[gsi_to_create["IndexName"]] = GlobalSecondaryIndex.create(
@@ -256,11 +257,11 @@ class DynamoDBBackend(BaseBackend):
     def put_item(
         self,
         table_name: str,
-        item_attrs: Dict[str, Any],
-        expected: Optional[Dict[str, Any]] = None,
+        item_attrs: dict[str, Any],
+        expected: Optional[dict[str, Any]] = None,
         condition_expression: Optional[str] = None,
-        expression_attribute_names: Optional[Dict[str, Any]] = None,
-        expression_attribute_values: Optional[Dict[str, Any]] = None,
+        expression_attribute_names: Optional[dict[str, Any]] = None,
+        expression_attribute_values: Optional[dict[str, Any]] = None,
         overwrite: bool = False,
         return_values_on_condition_check_failure: Optional[str] = None,
     ) -> Item:
@@ -276,8 +277,8 @@ class DynamoDBBackend(BaseBackend):
         )
 
     def get_table_keys_name(
-        self, table_name: str, keys: Dict[str, Any]
-    ) -> Tuple[Optional[str], Optional[str]]:
+        self, table_name: str, keys: dict[str, Any]
+    ) -> tuple[Optional[str], Optional[str]]:
         """
         Given a set of keys, extracts the key and range key
         """
@@ -299,8 +300,8 @@ class DynamoDBBackend(BaseBackend):
             return potential_hash, potential_range
 
     def get_keys_value(
-        self, table: Table, keys: Dict[str, Any]
-    ) -> Tuple[DynamoType, Optional[DynamoType]]:
+        self, table: Table, keys: dict[str, Any]
+    ) -> tuple[DynamoType, Optional[DynamoType]]:
         if table.hash_key_attr not in keys or (
             table.has_range_key and table.range_key_attr not in keys
         ):
@@ -314,7 +315,7 @@ class DynamoDBBackend(BaseBackend):
 
     def get_schema(
         self, table_name: str, index_name: Optional[str]
-    ) -> List[Dict[str, Any]]:
+    ) -> list[dict[str, Any]]:
         table = self.get_table(table_name)
         if index_name:
             all_indexes = (table.global_indexes or []) + (table.indexes or [])
@@ -345,8 +346,8 @@ class DynamoDBBackend(BaseBackend):
     def get_item(
         self,
         table_name: str,
-        keys: Dict[str, Any],
-        projection_expressions: Optional[List[List[str]]] = None,
+        keys: dict[str, Any],
+        projection_expressions: Optional[list[list[str]]] = None,
     ) -> Optional[Item]:
         table = self.get_table(table_name)
         hash_key, range_key = self.get_keys_value(table, keys)
@@ -355,20 +356,20 @@ class DynamoDBBackend(BaseBackend):
     def query(
         self,
         table_name: str,
-        hash_key_dict: Dict[str, Any],
+        hash_key_dict: dict[str, Any],
         range_comparison: Optional[str],
-        range_value_dicts: List[Dict[str, Any]],
+        range_value_dicts: list[dict[str, Any]],
         limit: int,
-        exclusive_start_key: Dict[str, Any],
+        exclusive_start_key: dict[str, Any],
         scan_index_forward: bool,
-        projection_expressions: Optional[List[List[str]]],
+        projection_expressions: Optional[list[list[str]]],
         index_name: Optional[str] = None,
         consistent_read: bool = False,
-        expr_names: Optional[Dict[str, str]] = None,
-        expr_values: Optional[Dict[str, Dict[str, str]]] = None,
+        expr_names: Optional[dict[str, str]] = None,
+        expr_values: Optional[dict[str, dict[str, str]]] = None,
         filter_expression: Optional[str] = None,
         **filter_kwargs: Any,
-    ) -> Tuple[List[Item], int, Optional[Dict[str, Any]]]:
+    ) -> tuple[list[Item], int, Optional[dict[str, Any]]]:
         table = self.get_table(table_name)
 
         hash_key = DynamoType(hash_key_dict)
@@ -395,20 +396,20 @@ class DynamoDBBackend(BaseBackend):
     def scan(
         self,
         table_name: str,
-        filters: Dict[str, Any],
+        filters: dict[str, Any],
         limit: int,
-        exclusive_start_key: Dict[str, Any],
+        exclusive_start_key: dict[str, Any],
         filter_expression: Optional[str],
-        expr_names: Dict[str, Any],
-        expr_values: Dict[str, Any],
+        expr_names: dict[str, Any],
+        expr_values: dict[str, Any],
         index_name: str,
         consistent_read: bool,
-        projection_expression: Optional[List[List[str]]],
-        segments: Union[Tuple[None, None], Tuple[int, int]],
-    ) -> Tuple[List[Item], int, Optional[Dict[str, Any]]]:
+        projection_expression: Optional[list[list[str]]],
+        segments: Union[tuple[None, None], tuple[int, int]],
+    ) -> tuple[list[Item], int, Optional[dict[str, Any]]]:
         table = self.get_table(table_name)
 
-        scan_filters: Dict[str, Any] = {}
+        scan_filters: dict[str, Any] = {}
         for key, (comparison_operator, comparison_values) in filters.items():
             dynamo_types = [DynamoType(value) for value in comparison_values]
             scan_filters[key] = (comparison_operator, dynamo_types)
@@ -431,12 +432,12 @@ class DynamoDBBackend(BaseBackend):
     def update_item(
         self,
         table_name: str,
-        key: Dict[str, Dict[str, Any]],
+        key: dict[str, dict[str, Any]],
         update_expression: str,
-        expression_attribute_names: Dict[str, Any],
-        expression_attribute_values: Dict[str, Any],
-        attribute_updates: Optional[Dict[str, Any]] = None,
-        expected: Optional[Dict[str, Any]] = None,
+        expression_attribute_names: dict[str, Any],
+        expression_attribute_values: dict[str, Any],
+        attribute_updates: Optional[dict[str, Any]] = None,
+        expected: Optional[dict[str, Any]] = None,
         condition_expression: Optional[str] = None,
         return_values_on_condition_check_failure: Optional[str] = None,
     ) -> Item:
@@ -498,7 +499,7 @@ class DynamoDBBackend(BaseBackend):
                     item=item,
                     table=table,
                 ).validate()
-            data: Dict[str, Any] = {
+            data: dict[str, Any] = {
                 table.hash_key_attr: {hash_value.type: hash_value.value}
             }
             if range_value:
@@ -541,9 +542,9 @@ class DynamoDBBackend(BaseBackend):
     def delete_item(
         self,
         table_name: str,
-        key: Dict[str, Any],
-        expression_attribute_names: Optional[Dict[str, Any]] = None,
-        expression_attribute_values: Optional[Dict[str, Any]] = None,
+        key: dict[str, Any],
+        expression_attribute_names: Optional[dict[str, Any]] = None,
+        expression_attribute_values: Optional[dict[str, Any]] = None,
         condition_expression: Optional[str] = None,
         return_values_on_condition_check_failure: Optional[str] = None,
     ) -> Optional[Item]:
@@ -568,7 +569,7 @@ class DynamoDBBackend(BaseBackend):
 
         return table.delete_item(hash_value, range_value)
 
-    def update_time_to_live(self, table_name: str, ttl_spec: Dict[str, Any]) -> None:
+    def update_time_to_live(self, table_name: str, ttl_spec: dict[str, Any]) -> None:
         try:
             table = self.get_table(table_name)
         except ResourceNotFoundException:
@@ -586,7 +587,7 @@ class DynamoDBBackend(BaseBackend):
             table.ttl["TimeToLiveStatus"] = "DISABLED"
         table.ttl["AttributeName"] = ttl_spec["AttributeName"]
 
-    def describe_time_to_live(self, table_name: str) -> Dict[str, Any]:
+    def describe_time_to_live(self, table_name: str) -> dict[str, Any]:
         try:
             table = self.get_table(table_name)
         except ResourceNotFoundException:
@@ -594,24 +595,24 @@ class DynamoDBBackend(BaseBackend):
 
         return table.ttl
 
-    def transact_write_items(self, transact_items: List[Dict[str, Any]]) -> None:
+    def transact_write_items(self, transact_items: list[dict[str, Any]]) -> None:
         if len(transact_items) > 100:
             raise TooManyTransactionsException()
         # Create a backup in case any of the transactions fail
         original_table_state = copy.deepcopy(self.tables)
-        target_items: Set[Tuple[str, str]] = set()
+        target_items: set[tuple[str, str]] = set()
 
-        def check_unicity(table_name: str, key: Dict[str, Any]) -> None:
+        def check_unicity(table_name: str, key: dict[str, Any]) -> None:
             item = (str(table_name), str(key))
             if item in target_items:
                 raise MultipleTransactionsException()
             target_items.add(item)
 
-        errors: List[
-            Union[Tuple[str, str, Dict[str, Any]], Tuple[None, None, None]]
+        errors: list[
+            Union[tuple[str, str, dict[str, Any]], tuple[None, None, None]]
         ] = []  # [(Code, Message, Item), ..]
         for item in transact_items:
-            original_item: Optional[Dict[str, Any]] = None
+            original_item: Optional[dict[str, Any]] = None
             # Check transact writes are not performing multiple operations on the same item
             if len(list(item.keys())) > 1:
                 raise TransactWriteSingleOpException
@@ -698,7 +699,7 @@ class DynamoDBBackend(BaseBackend):
             self.tables = original_table_state
             raise TransactionCanceledException(errors)
 
-    def describe_continuous_backups(self, table_name: str) -> Dict[str, Any]:
+    def describe_continuous_backups(self, table_name: str) -> dict[str, Any]:
         try:
             table = self.get_table(table_name)
         except ResourceNotFoundException:
@@ -707,8 +708,8 @@ class DynamoDBBackend(BaseBackend):
         return table.continuous_backups
 
     def update_continuous_backups(
-        self, table_name: str, point_in_time_spec: Dict[str, Any]
-    ) -> Dict[str, Any]:
+        self, table_name: str, point_in_time_spec: dict[str, Any]
+    ) -> dict[str, Any]:
         try:
             table = self.get_table(table_name)
         except ResourceNotFoundException:
@@ -738,7 +739,7 @@ class DynamoDBBackend(BaseBackend):
             raise BackupNotFoundException(backup_arn)
         return self.backups[backup_arn]
 
-    def list_backups(self, table_name: str) -> List[Backup]:
+    def list_backups(self, table_name: str) -> list[Backup]:
         backups = list(self.backups.values())
         if table_name is not None:
             backups = [
@@ -826,8 +827,8 @@ class DynamoDBBackend(BaseBackend):
         pass
 
     def execute_statement(
-        self, statement: str, parameters: List[Dict[str, Any]]
-    ) -> List[Dict[str, Any]]:
+        self, statement: str, parameters: list[dict[str, Any]]
+    ) -> list[dict[str, Any]]:
         """
         Pagination is not yet implemented.
 
@@ -876,8 +877,8 @@ class DynamoDBBackend(BaseBackend):
         return return_data
 
     def execute_transaction(
-        self, statements: List[Dict[str, Any]]
-    ) -> List[Dict[str, Any]]:
+        self, statements: list[dict[str, Any]]
+    ) -> list[dict[str, Any]]:
         """
         Please see the documentation for `execute_statement` to see the limitations of what is supported.
         """
@@ -890,8 +891,8 @@ class DynamoDBBackend(BaseBackend):
         return responses
 
     def batch_execute_statement(
-        self, statements: List[Dict[str, Any]]
-    ) -> List[Dict[str, Any]]:
+        self, statements: list[dict[str, Any]]
+    ) -> list[dict[str, Any]]:
         """
         Please see the documentation for `execute_statement` to see the limitations of what is supported.
         """
@@ -938,15 +939,15 @@ class DynamoDBBackend(BaseBackend):
 
     def import_table(
         self,
-        s3_source: Dict[str, str],
+        s3_source: dict[str, str],
         input_format: Optional[str],
         compression_type: Optional[str],
         table_name: str,
         billing_mode: str,
-        throughput: Optional[Dict[str, int]],
-        key_schema: List[Dict[str, str]],
-        global_indexes: Optional[List[Dict[str, Any]]],
-        attrs: List[Dict[str, str]],
+        throughput: Optional[dict[str, int]],
+        key_schema: list[dict[str, str]],
+        global_indexes: Optional[list[dict[str, Any]]],
+        attrs: list[dict[str, str]],
     ) -> TableImport:
         """
         Only InputFormat=DYNAMODB_JSON is supported so far.
@@ -1013,7 +1014,7 @@ class DynamoDBBackend(BaseBackend):
     def describe_export(self, export_arn: str) -> TableExport:
         return self.table_exports[export_arn]
 
-    def list_exports(self, table_arn: str) -> List[TableExport]:
+    def list_exports(self, table_arn: str) -> list[TableExport]:
         exports = []
         for export_arn in self.table_exports:
             if self.table_exports[export_arn].table.table_arn == table_arn:

--- a/moto/dynamodb/models/table.py
+++ b/moto/dynamodb/models/table.py
@@ -1,6 +1,7 @@
 import copy
 from collections import defaultdict
-from typing import Any, Dict, List, Optional, Sequence, Tuple, Union
+from collections.abc import Sequence
+from typing import Any, Optional, Union
 
 from moto.core.common_models import BaseModel, CloudFormationModel
 from moto.core.utils import unix_time, unix_time_millis, utcnow
@@ -30,9 +31,9 @@ class SecondaryIndex(BaseModel):
     def __init__(
         self,
         index_name: str,
-        schema: List[Dict[str, str]],
-        projection: Dict[str, Any],
-        table_key_attrs: List[str],
+        schema: list[dict[str, str]],
+        projection: dict[str, Any],
+        table_key_attrs: list[str],
     ):
         self.name = index_name
         self.schema = schema
@@ -71,7 +72,7 @@ class SecondaryIndex(BaseModel):
 
 
 class LocalSecondaryIndex(SecondaryIndex):
-    def describe(self) -> Dict[str, Any]:
+    def describe(self) -> dict[str, Any]:
         return {
             "IndexName": self.name,
             "KeySchema": self.schema,
@@ -80,7 +81,7 @@ class LocalSecondaryIndex(SecondaryIndex):
 
     @staticmethod
     def create(  # type: ignore[misc]
-        dct: Dict[str, Any], table_key_attrs: List[str]
+        dct: dict[str, Any], table_key_attrs: list[str]
     ) -> "LocalSecondaryIndex":
         return LocalSecondaryIndex(
             index_name=dct["IndexName"],
@@ -94,12 +95,12 @@ class GlobalSecondaryIndex(SecondaryIndex):
     def __init__(
         self,
         index_name: str,
-        schema: List[Dict[str, str]],
-        projection: Dict[str, Any],
-        table_key_attrs: List[str],
+        schema: list[dict[str, str]],
+        projection: dict[str, Any],
+        table_key_attrs: list[str],
         status: str = "ACTIVE",
-        throughput: Optional[Dict[str, Any]] = None,
-        warm_throughput: Optional[Dict[str, Any]] = None,
+        throughput: Optional[dict[str, Any]] = None,
+        warm_throughput: Optional[dict[str, Any]] = None,
     ):
         super().__init__(index_name, schema, projection, table_key_attrs)
         self.status = status
@@ -120,7 +121,7 @@ class GlobalSecondaryIndex(SecondaryIndex):
             }
         self.warm_throughput["Status"] = "ACTIVE"
 
-    def describe(self) -> Dict[str, Any]:
+    def describe(self) -> dict[str, Any]:
         return {
             "IndexName": self.name,
             "KeySchema": self.schema,
@@ -132,7 +133,7 @@ class GlobalSecondaryIndex(SecondaryIndex):
 
     @staticmethod
     def create(  # type: ignore[misc]
-        dct: Dict[str, Any], table_key_attrs: List[str]
+        dct: dict[str, Any], table_key_attrs: list[str]
     ) -> "GlobalSecondaryIndex":
         return GlobalSecondaryIndex(
             index_name=dct["IndexName"],
@@ -143,7 +144,7 @@ class GlobalSecondaryIndex(SecondaryIndex):
             warm_throughput=dct.get("WarmThroughput", None),
         )
 
-    def update(self, u: Dict[str, Any]) -> None:
+    def update(self, u: dict[str, Any]) -> None:
         self.name = u.get("IndexName", self.name)
         self.schema = u.get("KeySchema", self.schema)
         self.projection = u.get("Projection", self.projection)
@@ -170,7 +171,7 @@ class StreamRecord(BaseModel):
         if table.range_key_attr is not None and rec is not None:
             keys[table.range_key_attr] = rec.range_key.to_json()  # type: ignore
 
-        self.record: Dict[str, Any] = {
+        self.record: dict[str, Any] = {
             "eventID": mock_random.uuid4().hex,
             "eventName": event_name,
             "eventSource": "aws:dynamodb",
@@ -195,7 +196,7 @@ class StreamRecord(BaseModel):
             dynamo_json_dump(self.record["dynamodb"])
         )
 
-    def to_json(self) -> Dict[str, Any]:
+    def to_json(self) -> dict[str, Any]:
         return self.record
 
 
@@ -205,10 +206,10 @@ class StreamShard(BaseModel):
         self.table = table
         self.id = "shardId-00000001541626099285-f35f62ef"
         self.starting_sequence_number = 1100000000017454423009
-        self.items: List[StreamRecord] = []
+        self.items: list[StreamRecord] = []
         self.created_on = utcnow()
 
-    def to_json(self) -> Dict[str, Any]:
+    def to_json(self) -> dict[str, Any]:
         return {
             "ShardId": self.id,
             "SequenceNumberRange": {
@@ -239,7 +240,7 @@ class StreamShard(BaseModel):
         if result:
             self.items = []
 
-    def get(self, start: int, quantity: int) -> List[Dict[str, Any]]:
+    def get(self, start: int, quantity: int) -> list[dict[str, Any]]:
         start -= self.starting_sequence_number
         assert start >= 0
         end = start + quantity
@@ -252,17 +253,17 @@ class Table(CloudFormationModel):
         table_name: str,
         account_id: str,
         region: str,
-        schema: List[Dict[str, Any]],
-        attr: List[Dict[str, str]],
-        throughput: Optional[Dict[str, int]] = None,
+        schema: list[dict[str, Any]],
+        attr: list[dict[str, str]],
+        throughput: Optional[dict[str, int]] = None,
         billing_mode: Optional[str] = None,
-        indexes: Optional[List[Dict[str, Any]]] = None,
-        global_indexes: Optional[List[Dict[str, Any]]] = None,
-        streams: Optional[Dict[str, Any]] = None,
-        sse_specification: Optional[Dict[str, Any]] = None,
-        tags: Optional[List[Dict[str, str]]] = None,
+        indexes: Optional[list[dict[str, Any]]] = None,
+        global_indexes: Optional[list[dict[str, Any]]] = None,
+        streams: Optional[dict[str, Any]] = None,
+        sse_specification: Optional[dict[str, Any]] = None,
+        tags: Optional[list[dict[str, str]]] = None,
         deletion_protection_enabled: Optional[bool] = False,
-        warm_throughput: Optional[Dict[str, Any]] = None,
+        warm_throughput: Optional[dict[str, Any]] = None,
     ):
         self.name = table_name
         self.account_id = account_id
@@ -322,12 +323,12 @@ class Table(CloudFormationModel):
             "TimeToLiveStatus": "DISABLED"  # One of 'ENABLING'|'DISABLING'|'ENABLED'|'DISABLED',
             # 'AttributeName': 'string'  # Can contain this
         }
-        self.stream_specification: Optional[Dict[str, Any]] = {"StreamEnabled": False}
+        self.stream_specification: Optional[dict[str, Any]] = {"StreamEnabled": False}
         self.latest_stream_label: Optional[str] = None
         self.stream_shard: Optional[StreamShard] = None
         self.set_stream_specification(streams)
-        self.lambda_event_source_mappings: Dict[str, Any] = {}
-        self.continuous_backups: Dict[str, Any] = {
+        self.lambda_event_source_mappings: dict[str, Any] = {}
+        self.continuous_backups: dict[str, Any] = {
             "ContinuousBackupsStatus": "ENABLED",  # One of 'ENABLED'|'DISABLED', it's enabled by default
             "PointInTimeRecoveryDescription": {
                 "PointInTimeRecoveryStatus": "DISABLED"  # One of 'ENABLED'|'DISABLED'
@@ -379,9 +380,9 @@ class Table(CloudFormationModel):
         return self.name
 
     @property
-    def attribute_keys(self) -> List[str]:
+    def attribute_keys(self) -> list[str]:
         # A set of all the hash or range attributes for all indexes
-        def keys_from_index(idx: SecondaryIndex) -> List[str]:
+        def keys_from_index(idx: SecondaryIndex) -> list[str]:
             schema = idx.schema
             return [attr["AttributeName"] for attr in schema]
 
@@ -403,7 +404,7 @@ class Table(CloudFormationModel):
     def create_from_cloudformation_json(  # type: ignore[misc]
         cls,
         resource_name: str,
-        cloudformation_json: Dict[str, Any],
+        cloudformation_json: dict[str, Any],
         account_id: str,
         region_name: str,
         **kwargs: Any,
@@ -444,7 +445,7 @@ class Table(CloudFormationModel):
     def delete_from_cloudformation_json(  # type: ignore[misc]
         cls,
         resource_name: str,
-        cloudformation_json: Dict[str, Any],
+        cloudformation_json: dict[str, Any],
         account_id: str,
         region_name: str,
     ) -> None:
@@ -455,7 +456,7 @@ class Table(CloudFormationModel):
     def _generate_arn(self, name: str) -> str:
         return f"arn:{get_partition(self.region_name)}:dynamodb:{self.region_name}:{self.account_id}:table/{name}"
 
-    def set_stream_specification(self, streams: Optional[Dict[str, Any]]) -> None:
+    def set_stream_specification(self, streams: Optional[dict[str, Any]]) -> None:
         self.stream_specification = streams
         if (
             self.stream_specification
@@ -468,8 +469,8 @@ class Table(CloudFormationModel):
         else:
             self.stream_specification = {"StreamEnabled": False}
 
-    def describe(self, base_key: str = "TableDescription") -> Dict[str, Any]:
-        results: Dict[str, Any] = {
+    def describe(self, base_key: str = "TableDescription") -> dict[str, Any]:
+        results: dict[str, Any] = {
             base_key: {
                 "AttributeDefinitions": self.attr,
                 "ProvisionedThroughput": self.throughput,
@@ -510,7 +511,7 @@ class Table(CloudFormationModel):
         )
 
     @property
-    def hash_key_names(self) -> List[str]:
+    def hash_key_names(self) -> list[str]:
         keys = [self.hash_key_attr]
         for index in self.global_indexes:
             for key in index.schema:
@@ -519,7 +520,7 @@ class Table(CloudFormationModel):
         return keys
 
     @property
-    def range_key_names(self) -> List[str]:
+    def range_key_names(self) -> list[str]:
         keys = [self.range_key_attr] if self.has_range_key else []
         for index in self.global_indexes:
             for key in index.schema:
@@ -527,7 +528,7 @@ class Table(CloudFormationModel):
                     keys.append(key["AttributeName"])
         return keys  # type: ignore[return-value]
 
-    def _validate_key_sizes(self, item_attrs: Dict[str, Any]) -> None:
+    def _validate_key_sizes(self, item_attrs: dict[str, Any]) -> None:
         for hash_name in self.hash_key_names:
             hash_value = item_attrs.get(hash_name)
             if hash_value:
@@ -540,7 +541,7 @@ class Table(CloudFormationModel):
                     raise RangeKeyTooLong
 
     def _validate_item_types(
-        self, item_attrs: Dict[str, Any], attr: Optional[str] = None
+        self, item_attrs: dict[str, Any], attr: Optional[str] = None
     ) -> None:
         for key, value in item_attrs.items():
             if isinstance(value, dict):
@@ -561,11 +562,11 @@ class Table(CloudFormationModel):
 
     def put_item(
         self,
-        item_attrs: Dict[str, Any],
-        expected: Optional[Dict[str, Any]] = None,
+        item_attrs: dict[str, Any],
+        expected: Optional[dict[str, Any]] = None,
         condition_expression: Optional[str] = None,
-        expression_attribute_names: Optional[Dict[str, str]] = None,
-        expression_attribute_values: Optional[Dict[str, Any]] = None,
+        expression_attribute_names: Optional[dict[str, str]] = None,
+        expression_attribute_values: Optional[dict[str, Any]] = None,
         overwrite: bool = False,
         return_values_on_condition_check_failure: Optional[str] = None,
     ) -> Item:
@@ -654,7 +655,7 @@ class Table(CloudFormationModel):
         self,
         hash_key: DynamoType,
         range_key: Optional[DynamoType] = None,
-        projection_expression: Optional[List[List[str]]] = None,
+        projection_expression: Optional[list[list[str]]] = None,
     ) -> Optional[Item]:
         if self.has_range_key and not range_key:
             raise MockValidationException(
@@ -695,16 +696,16 @@ class Table(CloudFormationModel):
         self,
         hash_key: DynamoType,
         range_comparison: Optional[str],
-        range_objs: List[DynamoType],
+        range_objs: list[DynamoType],
         limit: int,
-        exclusive_start_key: Dict[str, Any],
+        exclusive_start_key: dict[str, Any],
         scan_index_forward: bool,
-        projection_expressions: Optional[List[List[str]]],
+        projection_expressions: Optional[list[list[str]]],
         index_name: Optional[str] = None,
         consistent_read: bool = False,
         filter_expression: Any = None,
         **filter_kwargs: Any,
-    ) -> Tuple[List[Item], int, Optional[Dict[str, Any]]]:
+    ) -> tuple[list[Item], int, Optional[dict[str, Any]]]:
         # FIND POSSIBLE RESULTS
         if index_name:
             all_indexes = self.all_indexes()
@@ -790,7 +791,7 @@ class Table(CloudFormationModel):
             possible_results.reverse()
 
         # FILTER
-        results: List[Item] = []
+        results: list[Item] = []
         result_size = 0
         scanned_count = 0
         last_evaluated_key = None
@@ -869,8 +870,8 @@ class Table(CloudFormationModel):
 
         return results, scanned_count, last_evaluated_key
 
-    def all_items(self) -> List[Item]:
-        items: List[Item] = []
+    def all_items(self) -> list[Item]:
+        items: list[Item] = []
         for hash_set in self.items.values():
             if self.range_key_attr:
                 for item in hash_set.values():
@@ -894,11 +895,11 @@ class Table(CloudFormationModel):
             )
         return indexes_by_name[index_name]
 
-    def has_idx_items(self, index_name: str) -> List[Item]:
+    def has_idx_items(self, index_name: str) -> list[Item]:
         idx = self.get_index(index_name)
         idx_col_set = set([i["AttributeName"] for i in idx.schema])
 
-        items: List[Item] = []
+        items: list[Item] = []
 
         for hash_set in self.items.values():
             if self.range_key_attr:
@@ -912,16 +913,16 @@ class Table(CloudFormationModel):
 
     def scan(
         self,
-        filters: Dict[str, Any],
+        filters: dict[str, Any],
         limit: int,
-        exclusive_start_key: Dict[str, Any],
+        exclusive_start_key: dict[str, Any],
         filter_expression: Any = None,
         index_name: Optional[str] = None,
         consistent_read: bool = False,
-        projection_expression: Optional[List[List[str]]] = None,
-        segments: Union[Tuple[None, None], Tuple[int, int]] = (None, None),
-    ) -> Tuple[List[Item], int, Optional[Dict[str, Any]]]:
-        results: List[Item] = []
+        projection_expression: Optional[list[list[str]]] = None,
+        segments: Union[tuple[None, None], tuple[int, int]] = (None, None),
+    ) -> tuple[list[Item], int, Optional[dict[str, Any]]]:
+        results: list[Item] = []
         result_size = 0
         scanned_count = 0
 
@@ -1035,9 +1036,9 @@ class Table(CloudFormationModel):
     def _item_comes_before_dct(
         self,
         item: Item,
-        dct: Dict[str, Any],
-        hash_key_attrs: List[str],
-        range_key_attrs: List[Optional[str]],
+        dct: dict[str, Any],
+        hash_key_attrs: list[str],
+        range_key_attrs: list[Optional[str]],
         scan_index_forward: bool,
     ) -> bool:
         """
@@ -1067,10 +1068,10 @@ class Table(CloudFormationModel):
 
     def sorted_items(
         self,
-        hash_key_attrs: List[str],
-        range_key_attrs: List[Optional[str]],
-        items: List[Item],
-    ) -> List[Item]:
+        hash_key_attrs: list[str],
+        range_key_attrs: list[Optional[str]],
+        items: list[Item],
+    ) -> list[Item]:
         attrs_to_sort_by = self._generate_attr_to_sort_by(
             hash_key_attrs, range_key_attrs
         )
@@ -1080,8 +1081,8 @@ class Table(CloudFormationModel):
         return items
 
     def _generate_attr_to_sort_by(
-        self, hash_key_attrs: List[str], range_key_attrs: List[Optional[str]]
-    ) -> List[str]:
+        self, hash_key_attrs: list[str], range_key_attrs: list[Optional[str]]
+    ) -> list[str]:
         gsi_hash_key = hash_key_attrs[0] if len(hash_key_attrs) == 2 else None
         table_hash_key = str(
             hash_key_attrs[0] if gsi_hash_key is None else hash_key_attrs[1]
@@ -1103,7 +1104,7 @@ class Table(CloudFormationModel):
 
     def _get_last_evaluated_key(
         self, last_result: Item, index_name: Optional[str]
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         last_evaluated_key = {self.hash_key_attr: last_result.hash_key}
         if self.range_key_attr is not None and last_result.range_key is not None:
             last_evaluated_key[self.range_key_attr] = last_result.range_key
@@ -1151,7 +1152,7 @@ class Backup:
         return f"arn:{get_partition(self.region_name)}:dynamodb:{self.region_name}:{self.account_id}:table/{self.table.name}/backup/{self.identifier}"
 
     @property
-    def details(self) -> Dict[str, Any]:  # type: ignore[misc]
+    def details(self) -> dict[str, Any]:  # type: ignore[misc]
         return {
             "BackupArn": self.arn,
             "BackupName": self.name,
@@ -1162,7 +1163,7 @@ class Backup:
         }
 
     @property
-    def summary(self) -> Dict[str, Any]:  # type: ignore[misc]
+    def summary(self) -> dict[str, Any]:  # type: ignore[misc]
         return {
             "TableName": self.table.name,
             # 'TableId': 'string',
@@ -1177,7 +1178,7 @@ class Backup:
         }
 
     @property
-    def description(self) -> Dict[str, Any]:  # type: ignore[misc]
+    def description(self) -> dict[str, Any]:  # type: ignore[misc]
         source_table_details = self.table.describe()["TableDescription"]
         source_table_details["TableCreationDateTime"] = source_table_details[
             "CreationDateTime"
@@ -1201,14 +1202,14 @@ class RestoredTable(Table):
         self.source_table_arn = backup.table.table_arn
         self.restore_date_time = self.created_at
 
-    def _parse_params_from_backup(self, backup: "Backup") -> Dict[str, Any]:
+    def _parse_params_from_backup(self, backup: "Backup") -> dict[str, Any]:
         return {
             "schema": copy.deepcopy(backup.table.schema),
             "attr": copy.deepcopy(backup.table.attr),
             "throughput": copy.deepcopy(backup.table.throughput),
         }
 
-    def describe(self, base_key: str = "TableDescription") -> Dict[str, Any]:
+    def describe(self, base_key: str = "TableDescription") -> dict[str, Any]:
         result = super().describe(base_key=base_key)
         result[base_key]["RestoreSummary"] = {
             "SourceBackupArn": self.source_backup_arn,
@@ -1230,14 +1231,14 @@ class RestoredPITTable(Table):
         self.source_table_arn = source.table_arn
         self.restore_date_time = self.created_at
 
-    def _parse_params_from_table(self, table: Table) -> Dict[str, Any]:
+    def _parse_params_from_table(self, table: Table) -> dict[str, Any]:
         return {
             "schema": copy.deepcopy(table.schema),
             "attr": copy.deepcopy(table.attr),
             "throughput": copy.deepcopy(table.throughput),
         }
 
-    def describe(self, base_key: str = "TableDescription") -> Dict[str, Any]:
+    def describe(self, base_key: str = "TableDescription") -> dict[str, Any]:
         result = super().describe(base_key=base_key)
         result[base_key]["RestoreSummary"] = {
             "SourceTableArn": self.source_table_arn,

--- a/moto/dynamodb/models/table_export.py
+++ b/moto/dynamodb/models/table_export.py
@@ -1,6 +1,6 @@
 import json
 from threading import Thread
-from typing import TYPE_CHECKING, Any, Dict, Optional
+from typing import TYPE_CHECKING, Any, Optional
 from uuid import uuid4
 
 from moto.core.utils import gzip_compress
@@ -76,7 +76,7 @@ class TableExport(Thread):
 
         self.status = "COMPLETED" if self.error_count == 0 else "FAILED"
 
-    def response(self) -> Dict[str, Any]:
+    def response(self) -> dict[str, Any]:
         return {
             "ExportArn": self.arn,
             "ExportStatus": self.status,

--- a/moto/dynamodb/models/table_import.py
+++ b/moto/dynamodb/models/table_import.py
@@ -1,5 +1,5 @@
 from threading import Thread
-from typing import TYPE_CHECKING, Any, Dict, List, Optional
+from typing import TYPE_CHECKING, Any, Optional
 from uuid import uuid4
 
 from moto.core.utils import gzip_decompress
@@ -15,14 +15,14 @@ class TableImport(Thread):
     def __init__(
         self,
         account_id: str,
-        s3_source: Dict[str, str],
+        s3_source: dict[str, str],
         region_name: str,
         table_name: str,
         billing_mode: str,
-        throughput: Optional[Dict[str, int]],
-        key_schema: List[Dict[str, str]],
-        global_indexes: Optional[List[Dict[str, Any]]],
-        attrs: List[Dict[str, str]],
+        throughput: Optional[dict[str, int]],
+        key_schema: list[dict[str, str]],
+        global_indexes: Optional[list[dict[str, Any]]],
+        attrs: list[dict[str, str]],
         compression_type: Optional[str],
     ):
         super().__init__()
@@ -43,7 +43,7 @@ class TableImport(Thread):
 
         self.failure_code: Optional[str] = None
         self.failure_message: Optional[str] = None
-        self.table: Optional["Table"] = None
+        self.table: Optional[Table] = None
         self.table_arn = f"arn:{get_partition(self.region_name)}:dynamodb:{self.region_name}:{self.account_id}:table/{table_name}"
 
         self.processed_count = 0
@@ -122,7 +122,7 @@ class TableImport(Thread):
 
         self.status = "COMPLETED" if self.error_count == 0 else "FAILED"
 
-    def response(self) -> Dict[str, Any]:
+    def response(self) -> dict[str, Any]:
         return {
             "ImportArn": self.arn,
             "ImportStatus": self.status,

--- a/moto/dynamodb/models/utilities.py
+++ b/moto/dynamodb/models/utilities.py
@@ -1,7 +1,7 @@
 import base64
 import json
 import re
-from typing import Any, Dict, List, Optional
+from typing import Any, Optional
 
 
 class DynamoJsonEncoder(json.JSONEncoder):
@@ -21,11 +21,11 @@ def bytesize(val: str) -> int:
 
 
 def find_nested_key(
-    keys: List[str],
-    dct: Dict[str, Any],
-    processed_keys: Optional[List[str]] = None,
-    result: Optional[Dict[str, Any]] = None,
-) -> Dict[str, Any]:
+    keys: list[str],
+    dct: dict[str, Any],
+    processed_keys: Optional[list[str]] = None,
+    result: Optional[dict[str, Any]] = None,
+) -> dict[str, Any]:
     """
     keys   : A list of keys that may be present in the provided dictionary
              ["level1", "level2"]

--- a/moto/dynamodb/parsing/ast_nodes.py
+++ b/moto/dynamodb/parsing/ast_nodes.py
@@ -339,7 +339,7 @@ class NoneExistingPath(LeafNode):
         return self.children[0]
 
 
-class DepthFirstTraverser(object):
+class DepthFirstTraverser:
     """
     Helper class that allows depth first traversal and to implement custom processing for certain AST nodes. The
     processor of a node must return the new resulting node. This node will be placed in the tree. Processing of a
@@ -404,7 +404,7 @@ class DepthFirstTraverser(object):
         return self.traverse_node_recursively(node)
 
 
-class NodeDepthLeftTypeFetcher(object):
+class NodeDepthLeftTypeFetcher:
     """Helper class to fetch a node of a specific type. Depth left-first traversal"""
 
     def __init__(self, node_type, root_node):

--- a/moto/dynamodb/parsing/executors.py
+++ b/moto/dynamodb/parsing/executors.py
@@ -1,5 +1,5 @@
 from abc import abstractmethod
-from typing import Any, Dict, List, Optional, Type, Union
+from typing import Any, Optional, Union
 
 from moto.dynamodb.exceptions import (
     IncorrectDataType,
@@ -29,7 +29,7 @@ from moto.dynamodb.parsing.validators import ExpressionPathResolver
 
 
 class NodeExecutor:
-    def __init__(self, ast_node: Node, expression_attribute_names: Dict[str, str]):
+    def __init__(self, ast_node: Node, expression_attribute_names: dict[str, str]):
         self.node = ast_node
         self.expression_attribute_names = expression_attribute_names
 
@@ -38,8 +38,8 @@ class NodeExecutor:
         pass
 
     def get_item_part_for_path_nodes(
-        self, item: Item, path_nodes: List[Node]
-    ) -> Union[DynamoType, Dict[str, Any]]:
+        self, item: Item, path_nodes: list[Node]
+    ) -> Union[DynamoType, dict[str, Any]]:
         """
         For a list of path nodes travers the item by following the path_nodes
         Args:
@@ -58,7 +58,7 @@ class NodeExecutor:
 
     def get_item_before_end_of_path(
         self, item: Item
-    ) -> Union[DynamoType, Dict[str, Any]]:
+    ) -> Union[DynamoType, dict[str, Any]]:
         """
         Get the part ot the item where the item will perform the action. For most actions this should be the parent. As
         that element will need to be modified by the action.
@@ -72,7 +72,7 @@ class NodeExecutor:
             item, self.get_path_expression_nodes()[:-1]
         )
 
-    def get_item_at_end_of_path(self, item: Item) -> Union[DynamoType, Dict[str, Any]]:
+    def get_item_at_end_of_path(self, item: Item) -> Union[DynamoType, dict[str, Any]]:
         """
         For a DELETE the path points at the stringset so we need to evaluate the full path.
         Args:
@@ -87,7 +87,7 @@ class NodeExecutor:
     # that element will need to be modified by the action.
     get_item_part_in_which_to_perform_action = get_item_before_end_of_path
 
-    def get_path_expression_nodes(self) -> List[Node]:
+    def get_path_expression_nodes(self) -> list[Node]:
         update_expression_path = self.node.children[0]
         assert isinstance(update_expression_path, UpdateExpressionPath)
         return update_expression_path.children
@@ -122,10 +122,10 @@ class SetExecutor(NodeExecutor):
     @classmethod
     def set(  # type: ignore[misc]
         cls,
-        item_part_to_modify_with_set: Union[DynamoType, Dict[str, Any]],
+        item_part_to_modify_with_set: Union[DynamoType, dict[str, Any]],
         element_to_set: Any,
         value_to_set: Any,
-        expression_attribute_names: Dict[str, str],
+        expression_attribute_names: dict[str, str],
     ) -> None:
         if isinstance(element_to_set, ExpressionAttribute):
             attribute_name = element_to_set.get_attribute_name()
@@ -281,7 +281,7 @@ class UpdateExpressionExecutor:
     }
 
     def __init__(
-        self, update_ast: Node, item: Item, expression_attribute_names: Dict[str, str]
+        self, update_ast: Node, item: Item, expression_attribute_names: dict[str, str]
     ):
         self.update_ast = update_ast
         self.item = item
@@ -312,7 +312,7 @@ class UpdateExpressionExecutor:
         else:
             node_executor(node, self.expression_attribute_names).execute(self.item)
 
-    def get_specific_execution(self, node: Node) -> Optional[Type[NodeExecutor]]:
+    def get_specific_execution(self, node: Node) -> Optional[type[NodeExecutor]]:
         for node_class in self.execution_map:
             if isinstance(node, node_class):
                 return self.execution_map[node_class]

--- a/moto/dynamodb/parsing/key_condition_expression.py
+++ b/moto/dynamodb/parsing/key_condition_expression.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Optional, Union
 
 from moto.dynamodb.exceptions import KeyIsEmptyStringException, MockValidationException
 from moto.utilities.tokenizer import GenericTokenizer
@@ -13,17 +13,17 @@ class EXPRESSION_STAGES(Enum):
     EOF = "EOF"
 
 
-def get_key(schema: List[Dict[str, str]], key_type: str) -> Optional[str]:
+def get_key(schema: list[dict[str, str]], key_type: str) -> Optional[str]:
     keys = [key for key in schema if key["KeyType"] == key_type]
     return keys[0]["AttributeName"] if keys else None
 
 
 def parse_expression(
     key_condition_expression: str,
-    expression_attribute_values: Dict[str, Dict[str, str]],
-    expression_attribute_names: Dict[str, str],
-    schema: List[Dict[str, str]],
-) -> Tuple[Dict[str, Any], Optional[str], List[Dict[str, Any]], List[str]]:
+    expression_attribute_values: dict[str, dict[str, str]],
+    expression_attribute_names: dict[str, str],
+    schema: list[dict[str, str]],
+) -> tuple[dict[str, Any], Optional[str], list[dict[str, Any]], list[str]]:
     """
     Parse a KeyConditionExpression using the provided expression attribute names/values
 
@@ -36,9 +36,9 @@ def parse_expression(
     current_stage: Optional[EXPRESSION_STAGES] = None
     current_phrase = ""
     key_name = comparison = ""
-    key_values: List[Union[Dict[str, str], str]] = []
-    expression_attribute_names_used: List[str] = []
-    results: List[Tuple[str, str, Any]] = []
+    key_values: list[Union[dict[str, str], str]] = []
+    expression_attribute_names_used: list[str] = []
+    results: list[tuple[str, str, Any]] = []
     tokenizer = GenericTokenizer(key_condition_expression)
     for crnt_char in tokenizer:
         if crnt_char == " ":
@@ -205,8 +205,8 @@ def parse_expression(
 
 # Validate that the schema-keys are encountered in our query
 def validate_schema(
-    results: Any, schema: List[Dict[str, str]]
-) -> Tuple[Dict[str, Any], Optional[str], List[Dict[str, Any]]]:
+    results: Any, schema: list[dict[str, str]]
+) -> tuple[dict[str, Any], Optional[str], list[dict[str, Any]]]:
     index_hash_key = get_key(schema, "HASH")
     comparison, hash_value = next(
         (

--- a/moto/dynamodb/parsing/partiql.py
+++ b/moto/dynamodb/parsing/partiql.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
+from typing import TYPE_CHECKING, Any, Optional
 
 from moto.dynamodb.exceptions import MockValidationException, ResourceNotFoundException
 
@@ -7,10 +7,10 @@ if TYPE_CHECKING:
 
 
 def query(
-    statement: str, source_data: Dict[str, list[Any]], parameters: List[Dict[str, Any]]
-) -> Tuple[
-    List[Dict[str, Any]],
-    Dict[str, List[Tuple[Optional[Dict[str, Any]], Optional[Dict[str, Any]]]]],
+    statement: str, source_data: dict[str, list[Any]], parameters: list[dict[str, Any]]
+) -> tuple[
+    list[dict[str, Any]],
+    dict[str, list[tuple[Optional[dict[str, Any]], Optional[dict[str, Any]]]]],
 ]:
     from py_partiql_parser import DynamoDBStatementParser
     from py_partiql_parser.exceptions import DocumentNotFoundException

--- a/moto/dynamodb/parsing/reserved_keywords.py
+++ b/moto/dynamodb/parsing/reserved_keywords.py
@@ -1,4 +1,4 @@
-from typing import List, Optional
+from typing import Optional
 
 from moto.utilities.utils import load_resource_as_str
 
@@ -10,16 +10,16 @@ class ReservedKeywords:
         'Invalid UpdateExpression: Syntax error; token: "1", near: "VALUE 1"'
     """
 
-    KEYWORDS: Optional[List[str]] = None
+    KEYWORDS: Optional[list[str]] = None
 
     @classmethod
-    def get_reserved_keywords(cls) -> List[str]:
+    def get_reserved_keywords(cls) -> list[str]:
         if cls.KEYWORDS is None:
             cls.KEYWORDS = cls._get_reserved_keywords()
         return cls.KEYWORDS
 
     @classmethod
-    def _get_reserved_keywords(cls) -> List[str]:
+    def _get_reserved_keywords(cls) -> list[str]:
         """
         Get a list of reserved keywords of DynamoDB
         """

--- a/moto/dynamodb/parsing/tokens.py
+++ b/moto/dynamodb/parsing/tokens.py
@@ -1,5 +1,5 @@
 import re
-from typing import List, Union
+from typing import Union
 
 from moto.dynamodb.exceptions import (
     InvalidExpressionAttributeNameKey,
@@ -72,7 +72,7 @@ class Token:
         return self.type == other.type and self.value == other.value
 
 
-class ExpressionTokenizer(object):
+class ExpressionTokenizer:
     """
     Takes a string and returns a list of tokens. While attribute names in DynamoDB must be between 1 and 255 characters
     long there are no other restrictions for attribute names. For expressions however there are additional rules. If an
@@ -144,11 +144,11 @@ class ExpressionTokenizer(object):
 
     def __init__(self, input_expression_str: str):
         self.input_expression_str = input_expression_str
-        self.token_list: List[Token] = []
+        self.token_list: list[Token] = []
         self.staged_characters = ""
 
     @classmethod
-    def make_list(cls, input_expression_str: str) -> List[Token]:
+    def make_list(cls, input_expression_str: str) -> list[Token]:
         assert isinstance(input_expression_str, str)
 
         return ExpressionTokenizer(input_expression_str)._make_list()
@@ -181,7 +181,7 @@ class ExpressionTokenizer(object):
         else:
             self.raise_unexpected_token()
 
-    def _make_list(self) -> List[Token]:
+    def _make_list(self) -> list[Token]:
         """
         Just go through characters
           if a character is not a token boundary,  stage it for adding it as a grouped token later

--- a/moto/dynamodb/responses.py
+++ b/moto/dynamodb/responses.py
@@ -2,7 +2,7 @@ import copy
 import itertools
 import json
 from functools import wraps
-from typing import Any, Callable, Dict, List, Optional, Union
+from typing import Any, Callable, Optional, Union
 
 from moto.core.common_types import TYPE_RESPONSE
 from moto.core.responses import BaseResponse
@@ -92,7 +92,7 @@ def include_consumed_capacity(
 
 
 def validate_put_has_empty_keys(
-    field_updates: Dict[str, Any], table: Table, custom_error_msg: Optional[str] = None
+    field_updates: dict[str, Any], table: Table, custom_error_msg: Optional[str] = None
 ) -> None:
     """
     Error if any keys have an empty value. Checks Global index attributes as well
@@ -132,9 +132,9 @@ def validate_put_has_empty_keys(
             raise MockValidationException(msg.format(empty_key))
 
 
-def validate_put_has_empty_attrs(field_updates: Dict[str, Any], table: Table) -> None:
+def validate_put_has_empty_attrs(field_updates: dict[str, Any], table: Table) -> None:
     # Example invalid attribute: [{'M': {'SS': {'NS': []}}}]
-    def _validate_attr(attr: Dict[str, Any]) -> None:
+    def _validate_attr(attr: dict[str, Any]) -> None:
         for set_type, error in [("NS", "number"), ("SS", "string")]:
             if set_type in attr and attr[set_type] == []:
                 raise MockValidationException(
@@ -152,7 +152,7 @@ def validate_put_has_empty_attrs(field_updates: Dict[str, Any], table: Table) ->
                 _validate_attr(val)
 
 
-def validate_put_has_gsi_keys_set_to_none(item: Dict[str, Any], table: Table) -> None:
+def validate_put_has_gsi_keys_set_to_none(item: dict[str, Any], table: Table) -> None:
     for gsi in table.global_indexes:
         for attr in gsi.schema:
             attr_name = attr["AttributeName"]
@@ -163,8 +163,8 @@ def validate_put_has_gsi_keys_set_to_none(item: Dict[str, Any], table: Table) ->
 
 
 def validate_attributes_used(
-    attribute_names: Optional[Dict[str, Any]],
-    names_used: List[str],
+    attribute_names: Optional[dict[str, Any]],
+    names_used: list[str],
     provided_attr: str = "Names",
 ) -> None:
     for name in attribute_names or []:
@@ -193,16 +193,16 @@ class ProjectionExpressionParser:
     def __init__(
         self,
         projection_expression: Optional[str],
-        expression_attribute_names: Optional[Dict[str, str]],
+        expression_attribute_names: Optional[dict[str, str]],
     ):
         self.projection_expression = projection_expression
         self.expression_attribute_names = (
             expression_attribute_names if expression_attribute_names else {}
         )
 
-        self.expr_attr_names_found: List[str] = []
+        self.expr_attr_names_found: list[str] = []
 
-    def parse(self) -> List[List[str]]:
+    def parse(self) -> list[list[str]]:
         """
         lvl1.lvl2.attr1,lvl1.attr2 --> [["lvl1", "lvl2", "attr1"], ["lvl1", "attr2]]
         """
@@ -265,7 +265,7 @@ class DynamoHandler(BaseResponse):
             limit, exclusive_start_table_name
         )
 
-        response: Dict[str, Any] = {"TableNames": tables}
+        response: dict[str, Any] = {"TableNames": tables}
         if last_eval:
             response["LastEvaluatedTableName"] = last_eval
 
@@ -319,12 +319,12 @@ class DynamoHandler(BaseResponse):
     def _validate_table_creation(
         self,
         billing_mode: str,
-        throughput: Optional[Dict[str, Any]],
-        key_schema: List[Dict[str, str]],
-        global_indexes: Optional[List[Dict[str, Any]]],
-        local_secondary_indexes: Optional[List[Dict[str, Any]]],
-        attr: List[Dict[str, str]],
-        warm_throughput: Optional[Dict[str, Any]],
+        throughput: Optional[dict[str, Any]],
+        key_schema: list[dict[str, str]],
+        global_indexes: Optional[list[dict[str, Any]]],
+        local_secondary_indexes: Optional[list[dict[str, Any]]],
+        attr: list[dict[str, str]],
+        warm_throughput: Optional[dict[str, Any]],
     ) -> None:
         # Validate Throughput
         if billing_mode == "PAY_PER_REQUEST" and throughput:
@@ -464,9 +464,9 @@ class DynamoHandler(BaseResponse):
             raise MockValidationException(error_wcu)
 
     def _throw_attr_error(
-        self, actual_attrs: List[str], expected_attrs: List[str], indexes: bool
+        self, actual_attrs: list[str], expected_attrs: list[str], indexes: bool
     ) -> None:
-        def dump_list(list_: List[str]) -> str:
+        def dump_list(list_: list[str]) -> str:
             return str(list_).replace("'", "")
 
         err_head = "One or more parameter values were invalid: "
@@ -760,7 +760,7 @@ class DynamoHandler(BaseResponse):
     def batch_get_item(self) -> str:
         table_batches = self.body["RequestItems"]
 
-        results: Dict[str, Any] = {
+        results: dict[str, Any] = {
             "ConsumedCapacity": [],
             "Responses": {},
             "UnprocessedKeys": {},
@@ -827,7 +827,7 @@ class DynamoHandler(BaseResponse):
             )
         return dynamo_json_dump(results)
 
-    def _contains_duplicates(self, keys: List[str]) -> bool:
+    def _contains_duplicates(self, keys: list[str]) -> bool:
         unique_keys = []
         for k in keys:
             if k in unique_keys:
@@ -944,7 +944,7 @@ class DynamoHandler(BaseResponse):
             **filter_kwargs,
         )
 
-        result: Dict[str, Any] = {
+        result: dict[str, Any] = {
             "Count": len(items),
             "ScannedCount": scanned_count,
         }
@@ -1215,7 +1215,7 @@ class DynamoHandler(BaseResponse):
             )
         return dynamo_json_dump(item_dict)
 
-    def _get_expr_attr_values(self) -> Dict[str, Dict[str, str]]:
+    def _get_expr_attr_values(self) -> dict[str, dict[str, str]]:
         values = self.body.get("ExpressionAttributeValues")
         if values is None:
             return {}
@@ -1283,7 +1283,7 @@ class DynamoHandler(BaseResponse):
 
     def transact_get_items(self) -> str:
         transact_items = self.body["TransactItems"]
-        responses: List[Dict[str, Any]] = list()
+        responses: list[dict[str, Any]] = list()
 
         if len(transact_items) > TRANSACTION_MAX_ITEMS:
             msg = "1 validation error detected: Value '["
@@ -1293,20 +1293,18 @@ class DynamoHandler(BaseResponse):
                 request_id += 1
                 hex_request_id = format(request_id, "x")
                 err_list.append(
-                    "com.amazonaws.dynamodb.v20120810.TransactGetItem@%s"
-                    % hex_request_id
+                    f"com.amazonaws.dynamodb.v20120810.TransactGetItem@{hex_request_id}"
                 )
             msg += ", ".join(err_list)
             msg += (
                 "'] at 'transactItems' failed to satisfy constraint: "
-                "Member must have length less than or equal to %s"
-                % TRANSACTION_MAX_ITEMS
+                f"Member must have length less than or equal to {TRANSACTION_MAX_ITEMS}"
             )
 
             raise MockValidationException(msg)
 
         ret_consumed_capacity = self.body.get("ReturnConsumedCapacity", "NONE")
-        consumed_capacity: Dict[str, Any] = dict()
+        consumed_capacity: dict[str, Any] = dict()
 
         for transact_item in transact_items:
             table_name = transact_item["Get"]["TableName"]
@@ -1397,7 +1395,7 @@ class DynamoHandler(BaseResponse):
             )
 
         self.dynamodb_backend.transact_write_items(transact_items)
-        response: Dict[str, Any] = {"ConsumedCapacity": [], "ItemCollectionMetrics": {}}
+        response: dict[str, Any] = {"ConsumedCapacity": [], "ItemCollectionMetrics": {}}
         return dynamo_json_dump(response)
 
     def describe_continuous_backups(self) -> str:

--- a/moto/dynamodb/utils.py
+++ b/moto/dynamodb/utils.py
@@ -1,7 +1,4 @@
-from typing import List
-
-
-def find_duplicates(input_list: List[str]) -> List[str]:
+def find_duplicates(input_list: list[str]) -> list[str]:
     input_list_copy = input_list.copy()
     while len(input_list_copy) > 0:
         # start at front of list
@@ -11,7 +8,7 @@ def find_duplicates(input_list: List[str]) -> List[str]:
     return []
 
 
-def find_path_overlaps(input_list: List[str]) -> List[str]:
+def find_path_overlaps(input_list: list[str]) -> list[str]:
     input_list_copy = input_list.copy()
     while len(input_list_copy) > 0:
         # start at front of list

--- a/moto/dynamodb_v20111205/responses.py
+++ b/moto/dynamodb_v20111205/responses.py
@@ -1,5 +1,5 @@
 import json
-from typing import Any, Dict, Optional, Union
+from typing import Any, Optional, Union
 
 from moto.core.common_types import TYPE_RESPONSE
 from moto.core.responses import BaseResponse
@@ -12,7 +12,7 @@ class DynamoHandler(BaseResponse):
     def __init__(self) -> None:
         super().__init__(service_name="dynamodb")
 
-    def get_endpoint_name(self, headers: Dict[str, str]) -> Optional[str]:  # type: ignore[return]
+    def get_endpoint_name(self, headers: dict[str, str]) -> Optional[str]:  # type: ignore[return]
         """Parses request headers and extracts part od the X-Amz-Target
         that corresponds to a method of DynamoHandler
 
@@ -59,7 +59,7 @@ class DynamoHandler(BaseResponse):
             tables = all_tables[start : start + limit]
         else:
             tables = all_tables[start:]
-        response: Dict[str, Any] = {"TableNames": tables}
+        response: dict[str, Any] = {"TableNames": tables}
         if limit and len(all_tables) > start + limit:
             response["LastEvaluatedTableName"] = tables[-1]
         return dynamo_json_dump(response)
@@ -182,7 +182,7 @@ class DynamoHandler(BaseResponse):
     def batch_get_item(self) -> str:
         table_batches = self.body["RequestItems"]
 
-        results: Dict[str, Any] = {"Responses": {"UnprocessedKeys": {}}}
+        results: dict[str, Any] = {"Responses": {"UnprocessedKeys": {}}}
 
         for table_name, table_request in table_batches.items():
             items = []

--- a/moto/dynamodbstreams/models.py
+++ b/moto/dynamodbstreams/models.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import base64
 import os
-from typing import Any, Dict, Optional
+from typing import Any, Optional
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
@@ -37,7 +37,7 @@ class ShardIterator(BaseModel):
     def arn(self) -> str:
         return f"{self.stream_shard.table.table_arn}/stream/{self.stream_shard.table.latest_stream_label}|1|{self.id}"
 
-    def get(self, limit: int = 1000) -> Dict[str, Any]:
+    def get(self, limit: int = 1000) -> dict[str, Any]:
         items = self.stream_shard.get(self.sequence_number, limit)
         try:
             last_sequence_number = max(
@@ -65,7 +65,7 @@ class ShardIterator(BaseModel):
 class DynamoDBStreamsBackend(BaseBackend):
     def __init__(self, region_name: str, account_id: str):
         super().__init__(region_name, account_id)
-        self.shard_iterators: Dict[str, ShardIterator] = {}
+        self.shard_iterators: dict[str, ShardIterator] = {}
 
     @property
     def dynamodb(self) -> DynamoDBBackend:

--- a/moto/ebs/models.py
+++ b/moto/ebs/models.py
@@ -1,6 +1,6 @@
 """EBSBackend class with methods for supported APIs."""
 
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Optional
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
@@ -34,7 +34,7 @@ class EBSSnapshot(BaseModel):
         ]
         self.description = snapshot.description
 
-        self.blocks: Dict[str, Block] = dict()
+        self.blocks: dict[str, Block] = dict()
 
     def put_block(
         self,
@@ -47,7 +47,7 @@ class EBSSnapshot(BaseModel):
         block = Block(block_data, checksum, checksum_algorithm, data_length)
         self.blocks[block_idx] = block
 
-    def to_json(self) -> Dict[str, Any]:
+    def to_json(self) -> dict[str, Any]:
         return {
             "SnapshotId": self.snapshot_id,
             "OwnerId": self.account_id,
@@ -65,14 +65,14 @@ class EBSBackend(BaseBackend):
 
     def __init__(self, region_name: str, account_id: str):
         super().__init__(region_name, account_id)
-        self.snapshots: Dict[str, EBSSnapshot] = dict()
+        self.snapshots: dict[str, EBSSnapshot] = dict()
 
     @property
     def ec2_backend(self) -> EC2Backend:
         return ec2_backends[self.account_id][self.region_name]
 
     def start_snapshot(
-        self, volume_size: int, tags: Optional[List[Dict[str, str]]], description: str
+        self, volume_size: int, tags: Optional[list[dict[str, str]]], description: str
     ) -> EBSSnapshot:
         """
         The following parameters are not yet implemented: ParentSnapshotId, ClientToken, Encrypted, KmsKeyArn, Timeout
@@ -88,7 +88,7 @@ class EBSBackend(BaseBackend):
         self.snapshots[ebs_snapshot.snapshot_id] = ebs_snapshot
         return ebs_snapshot
 
-    def complete_snapshot(self, snapshot_id: str) -> Dict[str, str]:
+    def complete_snapshot(self, snapshot_id: str) -> dict[str, str]:
         """
         The following parameters are not yet supported: ChangedBlocksCount, Checksum, ChecksumAlgorithm, ChecksumAggregationMethod
         """
@@ -103,7 +103,7 @@ class EBSBackend(BaseBackend):
         checksum: str,
         checksum_algorithm: str,
         data_length: str,
-    ) -> Tuple[str, str]:
+    ) -> tuple[str, str]:
         """
         The following parameters are currently not taken into account: DataLength, Progress.
         The Checksum and ChecksumAlgorithm are taken at face-value, but no validation takes place.
@@ -123,14 +123,14 @@ class EBSBackend(BaseBackend):
 
     def list_changed_blocks(
         self, first_snapshot_id: str, second_snapshot_id: str
-    ) -> Tuple[Dict[str, Tuple[str, Optional[str]]], EBSSnapshot]:
+    ) -> tuple[dict[str, tuple[str, Optional[str]]], EBSSnapshot]:
         """
         The following parameters are not yet implemented: NextToken, MaxResults, StartingBlockIndex
         """
         snapshot1 = self.snapshots[first_snapshot_id]
         snapshot2 = self.snapshots[second_snapshot_id]
-        changed_blocks: Dict[
-            str, Tuple[str, Optional[str]]
+        changed_blocks: dict[
+            str, tuple[str, Optional[str]]
         ] = {}  # {idx: (token1, token2), ..}
         for idx in snapshot1.blocks:
             block1 = snapshot1.blocks[idx]

--- a/moto/ec2/exceptions.py
+++ b/moto/ec2/exceptions.py
@@ -1,4 +1,5 @@
-from typing import Any, Iterable, List, Optional, Union
+from collections.abc import Iterable
+from typing import Any, Optional, Union
 
 from moto.core.exceptions import RESTError
 
@@ -320,7 +321,7 @@ class InvalidInstanceTypeError(EC2ClientError):
 
 
 class InvalidAMIIdError(EC2ClientError):
-    def __init__(self, ami_id: Union[List[str], str]):
+    def __init__(self, ami_id: Union[list[str], str]):
         super().__init__(
             "InvalidAMIID.NotFound",
             f"The image id '[{ami_id}]' does not exist",
@@ -344,7 +345,7 @@ class InvalidAMIAttributeItemValueError(EC2ClientError):
 
 
 class MalformedAMIIdError(EC2ClientError):
-    def __init__(self, ami_id: List[str]):
+    def __init__(self, ami_id: list[str]):
         super().__init__(
             "InvalidAMIID.Malformed", f'Invalid id: "{ami_id}" (expecting "ami-...")'
         )

--- a/moto/ec2/models/__init__.py
+++ b/moto/ec2/models/__init__.py
@@ -1,5 +1,3 @@
-from typing import List
-
 from moto.core.base_backend import BackendDict, BaseBackend
 
 from ..exceptions import (
@@ -52,7 +50,7 @@ from .vpn_gateway import VpnGatewayBackend
 from .windows import WindowsBackend
 
 
-def validate_resource_ids(resource_ids: List[str]) -> bool:
+def validate_resource_ids(resource_ids: list[str]) -> bool:
     if not resource_ids:
         raise MissingParameterError(parameter="resourceIdSet")
     for resource_id in resource_ids:
@@ -160,7 +158,7 @@ class EC2Backend(
     def raise_not_implemented_error(self, blurb: str) -> None:
         raise MotoNotImplementedError(blurb)
 
-    def do_resources_exist(self, resource_ids: List[str]) -> bool:
+    def do_resources_exist(self, resource_ids: list[str]) -> bool:
         for resource_id in resource_ids:
             resource_prefix = get_prefix(resource_id)
             if resource_prefix == EC2_RESOURCE_TO_PREFIX["customer-gateway"]:

--- a/moto/ec2/models/amis.py
+++ b/moto/ec2/models/amis.py
@@ -2,7 +2,7 @@ import json
 import os
 import re
 from os import environ
-from typing import Any, Dict, List, Optional, Set, cast
+from typing import Any, Optional, cast
 
 from moto import settings
 from moto.utilities.utils import load_resource
@@ -23,8 +23,8 @@ from .core import TaggedEC2Resource
 from .instances import Instance
 
 if "MOTO_AMIS_PATH" in environ:
-    with open(environ["MOTO_AMIS_PATH"], "r", encoding="utf-8") as f:
-        AMIS: List[Dict[str, Any]] = json.load(f)
+    with open(environ["MOTO_AMIS_PATH"], encoding="utf-8") as f:
+        AMIS: list[dict[str, Any]] = json.load(f)
 else:
     AMIS = load_resource(__name__, "../resources/amis.json")
 
@@ -54,9 +54,9 @@ class Ami(TaggedEC2Resource):
         sriov: str = "simple",
         region_name: str = "us-east-1a",
         snapshot_description: Optional[str] = None,
-        product_codes: Optional[Set[str]] = None,
+        product_codes: Optional[set[str]] = None,
         boot_mode: str = "uefi",
-        tags: Optional[Dict[str, Any]] = None,
+        tags: Optional[dict[str, Any]] = None,
     ):
         self.ec2_backend = ec2_backend
         self.id = ami_id
@@ -106,7 +106,7 @@ class Ami(TaggedEC2Resource):
             if not description:
                 self.description = source_ami.description
 
-        self.launch_permissions: List[Dict[str, str]] = []
+        self.launch_permissions: list[dict[str, str]] = []
 
         if public:
             self.launch_permissions.append({"Group": "all"})
@@ -126,7 +126,7 @@ class Ami(TaggedEC2Resource):
         return {"Group": "all"} in self.launch_permissions
 
     @property
-    def block_device_mappings(self) -> List[Dict[str, Any]]:
+    def block_device_mappings(self) -> list[dict[str, Any]]:
         return [
             {
                 "DeviceName": self.root_device_name,
@@ -178,8 +178,8 @@ class AmiBackend:
     AMI_REGEX = re.compile("ami-[a-z0-9]+")
 
     def __init__(self) -> None:
-        self.amis: Dict[str, Ami] = {}
-        self.deleted_amis: List[str] = list()
+        self.amis: dict[str, Ami] = {}
+        self.deleted_amis: list[str] = list()
         self._load_amis()
 
     def _load_amis(self) -> None:
@@ -195,7 +195,7 @@ class AmiBackend:
             for path in ["latest_amis", "ecs/optimized_amis"]:
                 try:
                     latest_amis = cast(
-                        List[Dict[str, Any]],
+                        list[dict[str, Any]],
                         load_resource(
                             __name__,
                             f"../resources/{path}/{self.region_name}.json",  # type: ignore[attr-defined]
@@ -214,7 +214,7 @@ class AmiBackend:
         instance_id: str,
         name: str,
         description: str,
-        tag_specifications: List[Dict[str, Any]],
+        tag_specifications: list[dict[str, Any]],
     ) -> Ami:
         # TODO: check that instance exists and pull info from it.
         ami_id = random_ami_id()
@@ -269,11 +269,11 @@ class AmiBackend:
 
     def describe_images(
         self,
-        ami_ids: Optional[List[str]] = None,
-        filters: Optional[Dict[str, Any]] = None,
-        exec_users: Optional[List[str]] = None,
-        owners: Optional[List[str]] = None,
-    ) -> List[Ami]:
+        ami_ids: Optional[list[str]] = None,
+        filters: Optional[dict[str, Any]] = None,
+        exec_users: Optional[list[str]] = None,
+        owners: Optional[list[str]] = None,
+    ) -> list[Ami]:
         images = list(self.amis.copy().values())
 
         if ami_ids and len(ami_ids):
@@ -340,7 +340,7 @@ class AmiBackend:
         else:
             raise InvalidAMIIdError(ami_id)
 
-    def validate_permission_targets(self, permissions: List[Dict[str, str]]) -> None:
+    def validate_permission_targets(self, permissions: list[dict[str, str]]) -> None:
         for perm in permissions:
             # If anything is invalid, nothing is added. (No partial success.)
             # AWS docs:
@@ -358,8 +358,8 @@ class AmiBackend:
     def modify_image_attribute(
         self,
         ami_id: str,
-        launch_permissions_to_add: List[Dict[str, str]],
-        launch_permissions_to_remove: List[Dict[str, str]],
+        launch_permissions_to_add: list[dict[str, str]],
+        launch_permissions_to_remove: list[dict[str, str]],
     ) -> None:
         ami = self.describe_images(ami_ids=[ami_id])[0]
         self.validate_permission_targets(launch_permissions_to_add)

--- a/moto/ec2/models/availability_zones_and_regions.py
+++ b/moto/ec2/models/availability_zones_and_regions.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional
+from typing import Any, Optional
 
 from boto3 import Session
 
@@ -25,7 +25,7 @@ class Zone:
         self.zone_id = zone_id
         self.zone_type = zone_type
         self.state = "available"
-        self.messages: List[dict[str, Optional[str]]] = []
+        self.messages: list[dict[str, Optional[str]]] = []
 
 
 class RegionsAndZonesBackend:
@@ -203,8 +203,8 @@ class RegionsAndZonesBackend:
             ]
 
     def describe_regions(
-        self, region_names: Optional[List[str]] = None
-    ) -> List[Region]:
+        self, region_names: Optional[list[str]] = None
+    ) -> list[Region]:
         if not region_names:
             return self.regions
         ret = []
@@ -216,10 +216,10 @@ class RegionsAndZonesBackend:
 
     def describe_availability_zones(
         self,
-        filters: Optional[List[Dict[str, Any]]] = None,
-        zone_names: Optional[List[str]] = None,
-        zone_ids: Optional[List[str]] = None,
-    ) -> List[Zone]:
+        filters: Optional[list[dict[str, Any]]] = None,
+        zone_names: Optional[list[str]] = None,
+        zone_ids: Optional[list[str]] = None,
+    ) -> list[Zone]:
         """
         The following parameters are supported: ZoneIds, ZoneNames, Filters
         The following filters are supported: zone-id, zone-type, zone-name, region-name, state

--- a/moto/ec2/models/carrier_gateways.py
+++ b/moto/ec2/models/carrier_gateways.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional
+from typing import Any, Optional
 
 from moto.utilities.utils import filter_resources
 
@@ -9,7 +9,7 @@ from .core import TaggedEC2Resource
 
 class CarrierGateway(TaggedEC2Resource):
     def __init__(
-        self, ec2_backend: Any, vpc_id: str, tags: Optional[Dict[str, str]] = None
+        self, ec2_backend: Any, vpc_id: str, tags: Optional[dict[str, str]] = None
     ):
         self.id = random_carrier_gateway_id()
         self.ec2_backend = ec2_backend
@@ -28,10 +28,10 @@ class CarrierGateway(TaggedEC2Resource):
 
 class CarrierGatewayBackend:
     def __init__(self) -> None:
-        self.carrier_gateways: Dict[str, CarrierGateway] = {}
+        self.carrier_gateways: dict[str, CarrierGateway] = {}
 
     def create_carrier_gateway(
-        self, vpc_id: str, tags: Optional[Dict[str, str]] = None
+        self, vpc_id: str, tags: Optional[dict[str, str]] = None
     ) -> CarrierGateway:
         vpc = self.get_vpc(vpc_id)  # type: ignore[attr-defined]
         if not vpc:
@@ -48,8 +48,8 @@ class CarrierGatewayBackend:
         return carrier_gateway
 
     def describe_carrier_gateways(
-        self, ids: Optional[List[str]] = None, filters: Any = None
-    ) -> List[CarrierGateway]:
+        self, ids: Optional[list[str]] = None, filters: Any = None
+    ) -> list[CarrierGateway]:
         carrier_gateways = list(self.carrier_gateways.values())
 
         if ids:

--- a/moto/ec2/models/core.py
+++ b/moto/ec2/models/core.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional
+from typing import Any, Optional
 
 from moto.core.common_models import BaseModel
 
@@ -6,7 +6,7 @@ from ..exceptions import FilterNotImplementedError
 
 
 class TaggedEC2Resource(BaseModel):
-    def get_tags(self) -> List[Dict[str, str]]:
+    def get_tags(self) -> list[dict[str, str]]:
         tags = []
         if self.id:  # type: ignore[attr-defined]
             tags = self.ec2_backend.describe_tags(filters={"resource-id": [self.id]})  # type: ignore[attr-defined]
@@ -23,7 +23,7 @@ class TaggedEC2Resource(BaseModel):
     def add_tag(self, key: str, value: str) -> None:
         self.ec2_backend.create_tags([self.id], {key: value})  # type: ignore[attr-defined]
 
-    def add_tags(self, tag_map: Dict[str, str]) -> None:
+    def add_tags(self, tag_map: dict[str, str]) -> None:
         for key, value in tag_map.items():
             self.ec2_backend.create_tags([self.id], {key: value})  # type: ignore[attr-defined]
 
@@ -50,7 +50,7 @@ class TaggedEC2Resource(BaseModel):
 
         raise FilterNotImplementedError(filter_name, method_name)
 
-    def match_tags(self, filters: Dict[str, str]) -> bool:
+    def match_tags(self, filters: dict[str, str]) -> bool:
         for tag_name in filters.keys():
             tag_value = self.get_filter_value(tag_name)
             if tag_value == filters[tag_name][0]:

--- a/moto/ec2/models/customer_gateways.py
+++ b/moto/ec2/models/customer_gateways.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional
+from typing import Any, Optional
 
 from ..exceptions import InvalidCustomerGatewayIdError
 from ..utils import random_customer_gateway_id
@@ -14,7 +14,7 @@ class CustomerGateway(TaggedEC2Resource):
         ip_address: str,
         bgp_asn: str,
         state: str = "available",
-        tags: Optional[Dict[str, str]] = None,
+        tags: Optional[dict[str, str]] = None,
     ):
         self.ec2_backend = ec2_backend
         self.id = gateway_id
@@ -33,14 +33,14 @@ class CustomerGateway(TaggedEC2Resource):
 
 class CustomerGatewayBackend:
     def __init__(self) -> None:
-        self.customer_gateways: Dict[str, CustomerGateway] = {}
+        self.customer_gateways: dict[str, CustomerGateway] = {}
 
     def create_customer_gateway(
         self,
         gateway_type: str,
         ip_address: str,
         bgp_asn: str,
-        tags: Optional[Dict[str, str]] = None,
+        tags: Optional[dict[str, str]] = None,
     ) -> CustomerGateway:
         customer_gateway_id = random_customer_gateway_id()
         customer_gateway = CustomerGateway(
@@ -50,8 +50,8 @@ class CustomerGatewayBackend:
         return customer_gateway
 
     def describe_customer_gateways(
-        self, filters: Any = None, customer_gateway_ids: Optional[List[str]] = None
-    ) -> List[CustomerGateway]:
+        self, filters: Any = None, customer_gateway_ids: Optional[list[str]] = None
+    ) -> list[CustomerGateway]:
         customer_gateways = list(self.customer_gateways.copy().values())
         if customer_gateway_ids:
             customer_gateways = [

--- a/moto/ec2/models/dhcp_options.py
+++ b/moto/ec2/models/dhcp_options.py
@@ -1,5 +1,5 @@
 import itertools
-from typing import Any, Dict, List, Optional
+from typing import Any, Optional
 
 from ..exceptions import (
     DependencyViolationError,
@@ -15,10 +15,10 @@ class DHCPOptionsSet(TaggedEC2Resource):
     def __init__(
         self,
         ec2_backend: Any,
-        domain_name_servers: Optional[List[str]] = None,
+        domain_name_servers: Optional[list[str]] = None,
         domain_name: Optional[str] = None,
-        ntp_servers: Optional[List[str]] = None,
-        netbios_name_servers: Optional[List[str]] = None,
+        ntp_servers: Optional[list[str]] = None,
+        netbios_name_servers: Optional[list[str]] = None,
         netbios_node_type: Optional[str] = None,
     ):
         self.ec2_backend = ec2_backend
@@ -58,13 +58,13 @@ class DHCPOptionsSet(TaggedEC2Resource):
             return super().get_filter_value(filter_name, "DescribeDhcpOptions")
 
     @property
-    def options(self) -> Dict[str, Any]:  # type: ignore[misc]
+    def options(self) -> dict[str, Any]:  # type: ignore[misc]
         return self._options
 
 
 class DHCPOptionsSetBackend:
     def __init__(self) -> None:
-        self.dhcp_options_sets: Dict[str, DHCPOptionsSet] = {}
+        self.dhcp_options_sets: dict[str, DHCPOptionsSet] = {}
 
     def associate_dhcp_options(self, dhcp_options: DHCPOptionsSet, vpc: Any) -> None:
         dhcp_options.vpc = vpc
@@ -77,10 +77,10 @@ class DHCPOptionsSetBackend:
 
     def create_dhcp_options(
         self,
-        domain_name_servers: Optional[List[str]] = None,
+        domain_name_servers: Optional[list[str]] = None,
         domain_name: Optional[str] = None,
-        ntp_servers: Optional[List[str]] = None,
-        netbios_name_servers: Optional[List[str]] = None,
+        ntp_servers: Optional[list[str]] = None,
+        netbios_name_servers: Optional[list[str]] = None,
         netbios_node_type: Optional[str] = None,
     ) -> DHCPOptionsSet:
         NETBIOS_NODE_TYPES = [1, 2, 4, 8]
@@ -115,8 +115,8 @@ class DHCPOptionsSetBackend:
             raise InvalidDHCPOptionsIdError(options_id)
 
     def describe_dhcp_options(
-        self, dhcp_options_ids: Optional[List[str]] = None, filters: Any = None
-    ) -> List[DHCPOptionsSet]:
+        self, dhcp_options_ids: Optional[list[str]] = None, filters: Any = None
+    ) -> list[DHCPOptionsSet]:
         dhcp_options_sets = list(self.dhcp_options_sets.copy().values())
 
         if dhcp_options_ids:

--- a/moto/ec2/models/elastic_block_store.py
+++ b/moto/ec2/models/elastic_block_store.py
@@ -1,4 +1,5 @@
-from typing import Any, Dict, Iterable, List, Optional, Set
+from collections.abc import Iterable
+from typing import Any, Optional
 
 from moto.core.common_models import CloudFormationModel
 from moto.packages.boto.ec2.blockdevicemapping import BlockDeviceType
@@ -128,7 +129,7 @@ class Volume(TaggedEC2Resource, CloudFormationModel):
         self.ec2_backend = ec2_backend
         self.encrypted = encrypted
         self.kms_key_id = kms_key_id
-        self.modifications: List[VolumeModification] = []
+        self.modifications: list[VolumeModification] = []
         self.iops = iops
         self.throughput = throughput
 
@@ -231,8 +232,8 @@ class Snapshot(TaggedEC2Resource):
         self.volume = volume
         self.description = description
         self.start_time = utc_date_and_time()
-        self.create_volume_permission_groups: Set[str] = set()
-        self.create_volume_permission_userids: Set[str] = set()
+        self.create_volume_permission_groups: set[str] = set()
+        self.create_volume_permission_userids: set[str] = set()
         self.ec2_backend = ec2_backend
         self.status = "completed"
         self.encrypted = encrypted or (kms_key_id is not None)
@@ -267,9 +268,9 @@ class Snapshot(TaggedEC2Resource):
 
 class EBSBackend:
     def __init__(self) -> None:
-        self.volumes: Dict[str, Volume] = {}
-        self.attachments: Dict[str, VolumeAttachment] = {}
-        self.snapshots: Dict[str, Snapshot] = {}
+        self.volumes: dict[str, Volume] = {}
+        self.attachments: dict[str, VolumeAttachment] = {}
+        self.snapshots: dict[str, Snapshot] = {}
         self.default_kms_key_id: str = ""
 
     def create_volume(
@@ -326,8 +327,8 @@ class EBSBackend:
         return volume
 
     def describe_volumes(
-        self, volume_ids: Optional[List[str]] = None, filters: Any = None
-    ) -> List[Volume]:
+        self, volume_ids: Optional[list[str]] = None, filters: Any = None
+    ) -> list[Volume]:
         matches = list(self.volumes.values())
         if volume_ids:
             matches = [vol for vol in matches if vol.id in volume_ids]
@@ -349,8 +350,8 @@ class EBSBackend:
         return volume
 
     def describe_volumes_modifications(
-        self, volume_ids: Optional[List[str]] = None, filters: Any = None
-    ) -> List[VolumeModification]:
+        self, volume_ids: Optional[list[str]] = None, filters: Any = None
+    ) -> list[VolumeModification]:
         volumes = self.describe_volumes(volume_ids)
         modifications = []
         for volume in volumes:
@@ -444,8 +445,8 @@ class EBSBackend:
         return snapshot
 
     def create_snapshots(
-        self, instance_spec: Dict[str, Any], description: str, tags: Dict[str, str]
-    ) -> List[Snapshot]:
+        self, instance_spec: dict[str, Any], description: str, tags: dict[str, str]
+    ) -> list[Snapshot]:
         """
         The CopyTagsFromSource-parameter is not yet implemented.
         """
@@ -469,8 +470,8 @@ class EBSBackend:
         return snapshots
 
     def describe_snapshots(
-        self, snapshot_ids: Optional[List[str]] = None, filters: Any = None
-    ) -> List[Snapshot]:
+        self, snapshot_ids: Optional[list[str]] = None, filters: Any = None
+    ) -> list[Snapshot]:
         matches = list(self.snapshots.values())
         if snapshot_ids:
             matches = [snap for snap in matches if snap.id in snapshot_ids]
@@ -519,16 +520,16 @@ class EBSBackend:
             return self.snapshots.pop(snapshot_id)
         raise InvalidSnapshotIdError()
 
-    def get_create_volume_permission_groups(self, snapshot_id: str) -> Set[str]:
+    def get_create_volume_permission_groups(self, snapshot_id: str) -> set[str]:
         snapshot = self.get_snapshot(snapshot_id)
         return snapshot.create_volume_permission_groups
 
-    def get_create_volume_permission_userids(self, snapshot_id: str) -> Set[str]:
+    def get_create_volume_permission_userids(self, snapshot_id: str) -> set[str]:
         snapshot = self.get_snapshot(snapshot_id)
         return snapshot.create_volume_permission_userids
 
     def add_create_volume_permission(
-        self, snapshot_id: str, user_ids: List[str], groups: List[str]
+        self, snapshot_id: str, user_ids: list[str], groups: list[str]
     ) -> None:
         snapshot = self.get_snapshot(snapshot_id)
         if user_ids:
@@ -542,7 +543,7 @@ class EBSBackend:
     def remove_create_volume_permission(
         self,
         snapshot_id: str,
-        user_ids: Optional[List[str]] = None,
+        user_ids: Optional[list[str]] = None,
         groups: Optional[Iterable[str]] = None,
     ) -> None:
         snapshot = self.get_snapshot(snapshot_id)

--- a/moto/ec2/models/elastic_ip_addresses.py
+++ b/moto/ec2/models/elastic_ip_addresses.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional
+from typing import Any, Optional
 
 from moto.core.common_models import CloudFormationModel
 
@@ -24,7 +24,7 @@ class ElasticAddress(TaggedEC2Resource, CloudFormationModel):
         ec2_backend: Any,
         domain: str,
         address: Optional[str] = None,
-        tags: Optional[Dict[str, str]] = None,
+        tags: Optional[dict[str, str]] = None,
     ):
         self.ec2_backend = ec2_backend
         if address:
@@ -124,13 +124,13 @@ class ElasticAddress(TaggedEC2Resource, CloudFormationModel):
 
 class ElasticAddressBackend:
     def __init__(self) -> None:
-        self.addresses: List[ElasticAddress] = []
+        self.addresses: list[ElasticAddress] = []
 
     def allocate_address(
         self,
         domain: str,
         address: Optional[str] = None,
-        tags: Optional[Dict[str, str]] = None,
+        tags: Optional[dict[str, str]] = None,
     ) -> ElasticAddress:
         if domain not in ["standard", "vpc"]:
             domain = "vpc"
@@ -142,8 +142,8 @@ class ElasticAddressBackend:
         return ea
 
     def address_by_ip(
-        self, ips: List[str], fail_if_not_found: bool = True
-    ) -> List[ElasticAddress]:
+        self, ips: list[str], fail_if_not_found: bool = True
+    ) -> list[ElasticAddress]:
         eips = [
             address for address in self.addresses.copy() if address.public_ip in ips
         ]
@@ -154,7 +154,7 @@ class ElasticAddressBackend:
 
         return eips
 
-    def address_by_allocation(self, allocation_ids: List[str]) -> List[ElasticAddress]:
+    def address_by_allocation(self, allocation_ids: list[str]) -> list[ElasticAddress]:
         eips = [
             address
             for address in self.addresses
@@ -168,8 +168,8 @@ class ElasticAddressBackend:
         return eips
 
     def address_by_association(
-        self, association_ids: List[str]
-    ) -> List[ElasticAddress]:
+        self, association_ids: list[str]
+    ) -> list[ElasticAddress]:
         eips = [
             address
             for address in self.addresses
@@ -219,10 +219,10 @@ class ElasticAddressBackend:
 
     def describe_addresses(
         self,
-        allocation_ids: Optional[List[str]] = None,
-        public_ips: Optional[List[str]] = None,
+        allocation_ids: Optional[list[str]] = None,
+        public_ips: Optional[list[str]] = None,
         filters: Any = None,
-    ) -> List[ElasticAddress]:
+    ) -> list[ElasticAddress]:
         matches = self.addresses.copy()
         if allocation_ids:
             matches = [addr for addr in matches if addr.allocation_id in allocation_ids]
@@ -240,8 +240,8 @@ class ElasticAddressBackend:
         return matches
 
     def describe_addresses_attribute(
-        self, allocation_ids: Optional[List[str]] = None
-    ) -> List[ElasticAddress]:
+        self, allocation_ids: Optional[list[str]] = None
+    ) -> list[ElasticAddress]:
         return self.describe_addresses(allocation_ids)
 
     def disassociate_address(

--- a/moto/ec2/models/elastic_network_interfaces.py
+++ b/moto/ec2/models/elastic_network_interfaces.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
+from typing import TYPE_CHECKING, Any, Optional, Union
 
 from moto.core.common_models import CloudFormationModel
 
@@ -42,13 +42,13 @@ class NetworkInterface(TaggedEC2Resource, CloudFormationModel):
         self,
         ec2_backend: Any,
         subnet: Any,
-        private_ip_address: Union[List[str], str],
-        private_ip_addresses: Optional[List[Dict[str, Any]]] = None,
+        private_ip_address: Union[list[str], str],
+        private_ip_addresses: Optional[list[dict[str, Any]]] = None,
         device_index: int = 0,
         public_ip_auto_assign: bool = False,
-        group_ids: Optional[List[str]] = None,
+        group_ids: Optional[list[str]] = None,
         description: Optional[str] = None,
-        tags: Optional[Dict[str, str]] = None,
+        tags: Optional[dict[str, str]] = None,
         delete_on_termination: Optional[bool] = False,
         **kwargs: Any,
     ):
@@ -58,7 +58,7 @@ class NetworkInterface(TaggedEC2Resource, CloudFormationModel):
         if isinstance(private_ip_address, list) and private_ip_address:
             private_ip_address = private_ip_address[0]
         self.private_ip_address: Optional[str] = private_ip_address or None  # type: ignore
-        self.private_ip_addresses: List[Dict[str, Any]] = private_ip_addresses or []
+        self.private_ip_addresses: list[dict[str, Any]] = private_ip_addresses or []
         self.ipv6_addresses = kwargs.get("ipv6_addresses") or []
 
         self.subnet = subnet
@@ -176,8 +176,8 @@ class NetworkInterface(TaggedEC2Resource, CloudFormationModel):
         return addresses
 
     @property
-    def association(self) -> Dict[str, Any]:  # type: ignore[misc]
-        association: Dict[str, Any] = {}
+    def association(self) -> dict[str, Any]:  # type: ignore[misc]
+        association: dict[str, Any] = {}
         if self.public_ip:
             eips = self.ec2_backend.address_by_ip(
                 [self.public_ip], fail_if_not_found=False
@@ -221,7 +221,7 @@ class NetworkInterface(TaggedEC2Resource, CloudFormationModel):
         account_id: str,
         region_name: str,
         **kwargs: Any,
-    ) -> "NetworkInterface":
+    ) -> NetworkInterface:
         from ..models import ec2_backends
 
         properties = cloudformation_json["Properties"]
@@ -318,16 +318,16 @@ class NetworkInterface(TaggedEC2Resource, CloudFormationModel):
 
 class NetworkInterfaceBackend:
     def __init__(self) -> None:
-        self.enis: Dict[str, NetworkInterface] = {}
+        self.enis: dict[str, NetworkInterface] = {}
 
     def create_network_interface(
         self,
         subnet: Any,
-        private_ip_address: Union[str, List[str]],
-        private_ip_addresses: Optional[List[Dict[str, Any]]] = None,
-        group_ids: Optional[List[str]] = None,
+        private_ip_address: Union[str, list[str]],
+        private_ip_addresses: Optional[list[dict[str, Any]]] = None,
+        group_ids: Optional[list[str]] = None,
         description: Optional[str] = None,
-        tags: Optional[Dict[str, str]] = None,
+        tags: Optional[dict[str, str]] = None,
         delete_on_termination: Optional[bool] = False,
         **kwargs: Any,
     ) -> NetworkInterface:
@@ -358,7 +358,7 @@ class NetworkInterfaceBackend:
 
     def describe_network_interfaces(
         self, filters: Any = None
-    ) -> List[NetworkInterface]:
+    ) -> list[NetworkInterface]:
         # Note: This is only used in EC2Backend#do_resources_exist
         # Client-calls use #get_all_network_interfaces()
         # We should probably merge these at some point..
@@ -398,7 +398,7 @@ class NetworkInterfaceBackend:
     def modify_network_interface_attribute(
         self,
         eni_id: str,
-        group_ids: List[str],
+        group_ids: list[str],
         source_dest_check: Optional[bool] = None,
         description: Optional[str] = None,
     ) -> None:
@@ -413,8 +413,8 @@ class NetworkInterfaceBackend:
             eni.description = description
 
     def get_all_network_interfaces(
-        self, eni_ids: Optional[List[str]] = None, filters: Any = None
-    ) -> List[NetworkInterface]:
+        self, eni_ids: Optional[list[str]] = None, filters: Any = None
+    ) -> list[NetworkInterface]:
         enis = list(self.enis.values())
 
         if eni_ids:
@@ -428,7 +428,7 @@ class NetworkInterfaceBackend:
         return generic_filter(filters, enis)
 
     def unassign_private_ip_addresses(
-        self, eni_id: str, private_ip_address: Optional[List[str]] = None
+        self, eni_id: str, private_ip_address: Optional[list[str]] = None
     ) -> NetworkInterface:
         eni = self.get_network_interface(eni_id)
         if private_ip_address:
@@ -440,7 +440,7 @@ class NetworkInterfaceBackend:
     def assign_private_ip_addresses(
         self,
         eni_id: str,
-        private_ip_addresses: Optional[List[str]] = None,
+        private_ip_addresses: Optional[list[str]] = None,
         secondary_ips_count: Optional[int] = None,
     ) -> NetworkInterface:
         eni = self.get_network_interface(eni_id)
@@ -466,13 +466,13 @@ class NetworkInterfaceBackend:
     def assign_ipv6_addresses(
         self,
         eni_id: str,
-        ipv6_addresses: Optional[List[str]] = None,
+        ipv6_addresses: Optional[list[str]] = None,
         ipv6_count: Optional[int] = None,
     ) -> NetworkInterface:
         eni = self.get_network_interface(eni_id)
         if ipv6_addresses:
             eni.ipv6_addresses.extend(
-                (ip for ip in ipv6_addresses if ip not in eni.ipv6_addresses)
+                ip for ip in ipv6_addresses if ip not in eni.ipv6_addresses
             )
 
         while ipv6_count:
@@ -485,7 +485,7 @@ class NetworkInterfaceBackend:
         return eni
 
     def unassign_ipv6_addresses(
-        self, eni_id: str, ips: Optional[List[str]] = None
+        self, eni_id: str, ips: Optional[list[str]] = None
     ) -> list[str]:
         unassigned_addresses = []
         eni = self.get_network_interface(eni_id)

--- a/moto/ec2/models/fleets.py
+++ b/moto/ec2/models/fleets.py
@@ -1,6 +1,6 @@
 import datetime
 from collections import defaultdict
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Optional
 
 from moto.ec2.models.spot_requests import SpotFleetLaunchSpec, SpotInstanceRequest
 
@@ -16,17 +16,17 @@ class Fleet(TaggedEC2Resource):
         self,
         ec2_backend: Any,
         fleet_id: str,
-        on_demand_options: Dict[str, Any],
-        spot_options: Dict[str, Any],
-        target_capacity_specification: Dict[str, Any],
-        launch_template_configs: List[Dict[str, Any]],
+        on_demand_options: dict[str, Any],
+        spot_options: dict[str, Any],
+        target_capacity_specification: dict[str, Any],
+        launch_template_configs: list[dict[str, Any]],
         excess_capacity_termination_policy: str,
         replace_unhealthy_instances: bool,
         terminate_instances_with_expiration: bool,
         fleet_type: str,
         valid_from: str,
         valid_until: str,
-        tag_specifications: List[Dict[str, Any]],
+        tag_specifications: list[dict[str, Any]],
     ):
         self.ec2_backend = ec2_backend
         self.id = fleet_id
@@ -57,9 +57,9 @@ class Fleet(TaggedEC2Resource):
         self.fulfilled_on_demand_capacity = 0.0
         self.fulfilled_spot_capacity = 0.0
 
-        self.launch_specs: List[SpotFleetLaunchSpec] = []
+        self.launch_specs: list[SpotFleetLaunchSpec] = []
 
-        launch_specs_from_config: List[Dict[str, Any]] = []
+        launch_specs_from_config: list[dict[str, Any]] = []
         for config in launch_template_configs or []:
             launch_spec = config["LaunchTemplateSpecification"]
             if "LaunchTemplateId" in launch_spec:
@@ -100,8 +100,8 @@ class Fleet(TaggedEC2Resource):
                 )
             )
 
-        self.spot_requests: List[SpotInstanceRequest] = []
-        self.on_demand_instances: List[Dict[str, Any]] = []
+        self.spot_requests: list[SpotInstanceRequest] = []
+        self.on_demand_instances: list[dict[str, Any]] = []
         default_capacity = (
             target_capacity_specification.get("DefaultTargetCapacityType")
             or "on-demand"
@@ -133,7 +133,7 @@ class Fleet(TaggedEC2Resource):
     def physical_resource_id(self) -> str:
         return self.id
 
-    def create_spot_requests(self, weight_to_add: float) -> List[SpotInstanceRequest]:
+    def create_spot_requests(self, weight_to_add: float) -> list[SpotInstanceRequest]:
         weight_map, added_weight = self.get_launch_spec_counts(weight_to_add)
         for launch_spec, count in weight_map.items():
             requests = self.ec2_backend.request_spot_instances(
@@ -193,8 +193,8 @@ class Fleet(TaggedEC2Resource):
 
     def get_launch_spec_counts(
         self, weight_to_add: float
-    ) -> Tuple[Dict[SpotFleetLaunchSpec, int], float]:
-        weight_map: Dict[SpotFleetLaunchSpec, int] = defaultdict(int)
+    ) -> tuple[dict[SpotFleetLaunchSpec, int], float]:
+        weight_map: dict[SpotFleetLaunchSpec, int] = defaultdict(int)
 
         weight_so_far = 0.0
         if (
@@ -259,21 +259,21 @@ class Fleet(TaggedEC2Resource):
 
 class FleetsBackend:
     def __init__(self) -> None:
-        self.fleets: Dict[str, Fleet] = {}
+        self.fleets: dict[str, Fleet] = {}
 
     def create_fleet(
         self,
-        on_demand_options: Dict[str, Any],
-        spot_options: Dict[str, Any],
-        target_capacity_specification: Dict[str, Any],
-        launch_template_configs: List[Dict[str, Any]],
+        on_demand_options: dict[str, Any],
+        spot_options: dict[str, Any],
+        target_capacity_specification: dict[str, Any],
+        launch_template_configs: list[dict[str, Any]],
         excess_capacity_termination_policy: str,
         replace_unhealthy_instances: bool,
         terminate_instances_with_expiration: bool,
         fleet_type: str,
         valid_from: str,
         valid_until: str,
-        tag_specifications: List[Dict[str, Any]],
+        tag_specifications: list[dict[str, Any]],
     ) -> Fleet:
         fleet_id = random_fleet_id()
         fleet = Fleet(
@@ -297,13 +297,13 @@ class FleetsBackend:
     def get_fleet(self, fleet_id: str) -> Optional[Fleet]:
         return self.fleets.get(fleet_id)
 
-    def describe_fleet_instances(self, fleet_id: str) -> List[Any]:
+    def describe_fleet_instances(self, fleet_id: str) -> list[Any]:
         fleet = self.get_fleet(fleet_id)
         if not fleet:
             return []
         return fleet.spot_requests + fleet.on_demand_instances
 
-    def describe_fleets(self, fleet_ids: Optional[List[str]]) -> List[Fleet]:
+    def describe_fleets(self, fleet_ids: Optional[list[str]]) -> list[Fleet]:
         fleets = list(self.fleets.values())
 
         if fleet_ids:
@@ -312,8 +312,8 @@ class FleetsBackend:
         return fleets
 
     def delete_fleets(
-        self, fleet_ids: List[str], terminate_instances: bool
-    ) -> List[Fleet]:
+        self, fleet_ids: list[str], terminate_instances: bool
+    ) -> list[Fleet]:
         fleets = []
         for fleet_id in fleet_ids:
             fleet = self.fleets[fleet_id]

--- a/moto/ec2/models/flow_logs.py
+++ b/moto/ec2/models/flow_logs.py
@@ -1,5 +1,5 @@
 import itertools
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Optional
 
 from moto.core.common_models import CloudFormationModel
 
@@ -139,7 +139,7 @@ class FlowLogs(TaggedEC2Resource, CloudFormationModel):
 
 class FlowLogsBackend:
     def __init__(self) -> None:
-        self.flow_logs: Dict[str, FlowLogs] = {}
+        self.flow_logs: dict[str, FlowLogs] = {}
 
     def _validate_request(
         self,
@@ -173,7 +173,7 @@ class FlowLogsBackend:
     def create_flow_logs(
         self,
         resource_type: str,
-        resource_ids: List[str],
+        resource_ids: list[str],
         traffic_type: str,
         deliver_logs_permission_arn: str,
         log_destination_type: str,
@@ -181,7 +181,7 @@ class FlowLogsBackend:
         log_group_name: str,
         log_format: str,
         max_aggregation_interval: str,
-    ) -> Tuple[List[FlowLogs], List[Any]]:
+    ) -> tuple[list[FlowLogs], list[Any]]:
         # Guess it's best to put it here due to possible
         # lack of them in the CloudFormation template
         max_aggregation_interval = (
@@ -280,8 +280,8 @@ class FlowLogsBackend:
         return flow_logs_set, unsuccessful
 
     def describe_flow_logs(
-        self, flow_log_ids: Optional[List[str]] = None, filters: Any = None
-    ) -> List[FlowLogs]:
+        self, flow_log_ids: Optional[list[str]] = None, filters: Any = None
+    ) -> list[FlowLogs]:
         matches = list(itertools.chain([i for i in self.flow_logs.values()]))
         if flow_log_ids:
             matches = [flow_log for flow_log in matches if flow_log.id in flow_log_ids]
@@ -289,7 +289,7 @@ class FlowLogsBackend:
             matches = generic_filter(filters, matches)
         return matches
 
-    def delete_flow_logs(self, flow_log_ids: List[str]) -> None:
+    def delete_flow_logs(self, flow_log_ids: list[str]) -> None:
         non_existing = []
         for flow_log in flow_log_ids:
             if flow_log in self.flow_logs:

--- a/moto/ec2/models/hosts.py
+++ b/moto/ec2/models/hosts.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional
+from typing import Any, Optional
 
 from moto.core.utils import unix_time
 
@@ -45,7 +45,7 @@ class Host(TaggedEC2Resource):
 
 class HostsBackend:
     def __init__(self) -> None:
-        self.hosts: Dict[str, Host] = {}
+        self.hosts: dict[str, Host] = {}
 
     def allocate_hosts(
         self,
@@ -55,8 +55,8 @@ class HostsBackend:
         instance_type: str,
         instance_family: str,
         auto_placement: str,
-        tags: Dict[str, str],
-    ) -> List[str]:
+        tags: dict[str, str],
+    ) -> list[str]:
         hosts = [
             Host(
                 host_recovery,
@@ -75,8 +75,8 @@ class HostsBackend:
         return [host.id for host in hosts]
 
     def describe_hosts(
-        self, host_ids: List[str], filters: Dict[str, Any]
-    ) -> List[Host]:
+        self, host_ids: list[str], filters: dict[str, Any]
+    ) -> list[Host]:
         """
         Pagination is not yet implemented
         """
@@ -89,7 +89,7 @@ class HostsBackend:
 
     def modify_hosts(
         self,
-        host_ids: List[str],
+        host_ids: list[str],
         auto_placement: str,
         host_recovery: str,
         instance_type: str,
@@ -108,6 +108,6 @@ class HostsBackend:
                 host.instance_family = instance_family
                 host.instance_type = None
 
-    def release_hosts(self, host_ids: List[str]) -> None:
+    def release_hosts(self, host_ids: list[str]) -> None:
         for host_id in host_ids:
             self.hosts[host_id].release()

--- a/moto/ec2/models/iam_instance_profile.py
+++ b/moto/ec2/models/iam_instance_profile.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Optional
 
 from moto.core.common_models import CloudFormationModel
 from moto.ec2.models.instances import Instance
@@ -38,7 +38,7 @@ class IamInstanceProfileAssociation(CloudFormationModel):
 
 class IamInstanceProfileAssociationBackend:
     def __init__(self) -> None:
-        self.iam_instance_profile_associations: Dict[
+        self.iam_instance_profile_associations: dict[
             str, IamInstanceProfileAssociation
         ] = {}
 
@@ -74,12 +74,12 @@ class IamInstanceProfileAssociationBackend:
 
     def describe_iam_instance_profile_associations(
         self,
-        association_ids: List[str],
+        association_ids: list[str],
         filters: Any = None,
         max_results: int = 100,
         next_token: Optional[str] = None,
-    ) -> Tuple[List[IamInstanceProfileAssociation], Optional[str]]:
-        associations_list: List[IamInstanceProfileAssociation] = []
+    ) -> tuple[list[IamInstanceProfileAssociation], Optional[str]]:
+        associations_list: list[IamInstanceProfileAssociation] = []
         if association_ids:
             for association in self.iam_instance_profile_associations.values():
                 if association.association_id in association_ids:

--- a/moto/ec2/models/instance_types.py
+++ b/moto/ec2/models/instance_types.py
@@ -1,20 +1,20 @@
 import pathlib
 from os import listdir
-from typing import Any, Dict, List, Optional
+from typing import Any, Optional
 
 from moto.utilities.utils import load_resource
 
 from ..exceptions import InvalidFilter, InvalidInstanceTypeError
 from ..utils import generic_filter
 
-INSTANCE_TYPES: Dict[str, Any] = load_resource(
+INSTANCE_TYPES: dict[str, Any] = load_resource(
     __name__, "../resources/instance_types.json"
 )
 INSTANCE_FAMILIES = list(set([i.split(".")[0] for i in INSTANCE_TYPES.keys()]))
 
 root = pathlib.Path(__file__).parent
 offerings_path = "../resources/instance_type_offerings"
-INSTANCE_TYPE_OFFERINGS: Dict[str, Any] = {}
+INSTANCE_TYPE_OFFERINGS: dict[str, Any] = {}
 for _location_type in listdir(root / offerings_path):
     INSTANCE_TYPE_OFFERINGS[_location_type] = {}
     for data_file in listdir(root / offerings_path / _location_type):
@@ -28,7 +28,7 @@ for _location_type in listdir(root / offerings_path):
         INSTANCE_TYPE_OFFERINGS[_location_type][_region] = res
 
 
-class InstanceType(Dict[str, Any]):
+class InstanceType(dict[str, Any]):
     _filter_attributes = {
         "auto-recovery-supported": ["AutoRecoverySupported"],
         "bare-metal": ["BareMetal"],
@@ -144,8 +144,8 @@ class InstanceTypeBackend:
     instance_types = list(map(InstanceType, INSTANCE_TYPES.keys()))
 
     def describe_instance_types(
-        self, instance_types: Optional[List[str]] = None, filters: Any = None
-    ) -> List[InstanceType]:
+        self, instance_types: Optional[list[str]] = None, filters: Any = None
+    ) -> list[InstanceType]:
         matches = self.instance_types
         if instance_types:
             matches = [t for t in matches if t.get("InstanceType") in instance_types]
@@ -165,8 +165,8 @@ class InstanceTypeOfferingBackend:
     def describe_instance_type_offerings(
         self,
         location_type: Optional[str] = None,
-        filters: Optional[Dict[str, Any]] = None,
-    ) -> List[Any]:
+        filters: Optional[dict[str, Any]] = None,
+    ) -> list[Any]:
         location_type = location_type or "region"
         matches = INSTANCE_TYPE_OFFERINGS[location_type]
         matches = matches.get(self.region_name, [])  # type: ignore[attr-defined]
@@ -176,9 +176,9 @@ class InstanceTypeOfferingBackend:
         return matches
 
     def matches_filters(
-        self, offering: Dict[str, Any], filters: Any, location_type: str
+        self, offering: dict[str, Any], filters: Any, location_type: str
     ) -> bool:
-        def matches_filter(key: str, values: List[str]) -> bool:
+        def matches_filter(key: str, values: list[str]) -> bool:
             if key == "location":
                 if location_type in ("availability-zone", "availability-zone-id"):
                     return offering.get("Location") in values

--- a/moto/ec2/models/instances.py
+++ b/moto/ec2/models/instances.py
@@ -1,7 +1,8 @@
 import contextlib
 import copy
 from collections import OrderedDict
-from typing import Any, Dict, ItemsView, List, Optional, Set, Tuple
+from collections.abc import ItemsView
+from typing import Any, Optional
 
 from moto import settings
 from moto.core.common_models import CloudFormationModel
@@ -58,7 +59,7 @@ class StateReason:
 
 
 class MetadataOptions:
-    def __init__(self, options: Optional[Dict[str, Any]] = None):
+    def __init__(self, options: Optional[dict[str, Any]] = None):
         options = options or {}
         self.state = options.get("State", "applied")
         self.http_tokens = options.get("HttpTokens", "optional")
@@ -67,7 +68,7 @@ class MetadataOptions:
         self.http_protocol = options.get("HttpProtocolIpv6", "disabled")
         self.instance_metadata_tags = options.get("InstanceMetadataTags", "disabled")
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         return {
             "State": str(self.state),
             "HttpTokens": str(self.http_tokens),
@@ -101,7 +102,7 @@ class Instance(TaggedEC2Resource, BotoInstance, CloudFormationModel):
         ec2_backend: Any,
         image_id: str,
         user_data: Any,
-        security_groups: List[SecurityGroup],
+        security_groups: list[SecurityGroup],
         **kwargs: Any,
     ):
         super().__init__()
@@ -196,7 +197,7 @@ class Instance(TaggedEC2Resource, BotoInstance, CloudFormationModel):
 
         self.block_device_mapping: BlockDeviceMapping = BlockDeviceMapping()
 
-        self._private_ips: Set[str] = set()
+        self._private_ips: set[str] = set()
         self.prep_nics(
             nics,
             private_ip=kwargs.get("private_ip"),
@@ -480,10 +481,10 @@ class Instance(TaggedEC2Resource, BotoInstance, CloudFormationModel):
         self._state_reason = StateReason()
 
     @property
-    def dynamic_group_list(self) -> List[SecurityGroup]:
+    def dynamic_group_list(self) -> list[SecurityGroup]:
         return self.security_groups
 
-    def _get_private_ip_from_nic(self, nic: Dict[str, Any]) -> Optional[str]:
+    def _get_private_ip_from_nic(self, nic: dict[str, Any]) -> Optional[str]:
         private_ip = nic.get("PrivateIpAddress")
         if private_ip:
             return private_ip
@@ -494,13 +495,13 @@ class Instance(TaggedEC2Resource, BotoInstance, CloudFormationModel):
 
     def prep_nics(
         self,
-        nic_spec: List[Dict[str, Any]],
+        nic_spec: list[dict[str, Any]],
         private_ip: Optional[str] = None,
         associate_public_ip: Optional[bool] = None,
-        security_groups: Optional[List[SecurityGroup]] = None,
+        security_groups: Optional[list[SecurityGroup]] = None,
         ipv6_address_count: Optional[int] = None,
     ) -> None:
-        self.nics: Dict[int, NetworkInterface] = {}
+        self.nics: dict[int, NetworkInterface] = {}
         for nic in nic_spec:
             if int(nic.get("DeviceIndex")) == 0:  # type: ignore[arg-type]
                 nic_associate_public_ip = nic.get("AssociatePublicIpAddress")
@@ -640,7 +641,7 @@ class Instance(TaggedEC2Resource, BotoInstance, CloudFormationModel):
             return self.public_ip
         raise UnformattedGetAttTemplateException()
 
-    def applies(self, filters: List[Dict[str, Any]]) -> bool:
+    def applies(self, filters: list[dict[str, Any]]) -> bool:
         if filters:
             # https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/ec2/client/describe_instances.html
             # Filters Section in the boto3 documentation
@@ -660,7 +661,7 @@ class Instance(TaggedEC2Resource, BotoInstance, CloudFormationModel):
 
 class InstanceBackend:
     def __init__(self) -> None:
-        self.reservations: Dict[str, Reservation] = OrderedDict()
+        self.reservations: dict[str, Reservation] = OrderedDict()
 
     def get_instance(self, instance_id: str) -> Instance:
         for instance in self.all_instances():
@@ -673,7 +674,7 @@ class InstanceBackend:
         image_id: str,
         count: int,
         user_data: Optional[str],
-        security_group_names: List[str],
+        security_group_names: list[str],
         **kwargs: Any,
     ) -> Reservation:
         """
@@ -797,8 +798,8 @@ class InstanceBackend:
         return new_reservation
 
     def start_instances(
-        self, instance_ids: List[str]
-    ) -> List[Tuple[Instance, InstanceState]]:
+        self, instance_ids: list[str]
+    ) -> list[tuple[Instance, InstanceState]]:
         started_instances = []
         for instance in self.get_multi_instances_by_id(instance_ids):
             previous_state = instance.start()
@@ -807,8 +808,8 @@ class InstanceBackend:
         return started_instances
 
     def stop_instances(
-        self, instance_ids: List[str]
-    ) -> List[Tuple[Instance, InstanceState]]:
+        self, instance_ids: list[str]
+    ) -> list[tuple[Instance, InstanceState]]:
         stopped_instances = []
         for instance in self.get_multi_instances_by_id(instance_ids):
             if instance.disable_api_stop == "true":
@@ -819,8 +820,8 @@ class InstanceBackend:
         return stopped_instances
 
     def terminate_instances(
-        self, instance_ids: List[str]
-    ) -> List[Tuple[Instance, InstanceState]]:
+        self, instance_ids: list[str]
+    ) -> list[tuple[Instance, InstanceState]]:
         terminated_instances = []
         if not instance_ids:
             raise InvalidParameterCombination("No instances specified")
@@ -832,7 +833,7 @@ class InstanceBackend:
 
         return terminated_instances
 
-    def reboot_instances(self, instance_ids: List[str]) -> List[Instance]:
+    def reboot_instances(self, instance_ids: list[str]) -> list[Instance]:
         rebooted_instances = []
         for instance in self.get_multi_instances_by_id(instance_ids):
             instance.reboot()
@@ -875,7 +876,7 @@ class InstanceBackend:
         return metadata_options
 
     def modify_instance_security_groups(
-        self, instance_id: str, new_group_id_list: List[str]
+        self, instance_id: str, new_group_id_list: list[str]
     ) -> Instance:
         instance = self.get_instance(instance_id)
         new_group_list = []
@@ -886,7 +887,7 @@ class InstanceBackend:
 
     def describe_instance_attribute(
         self, instance_id: str, attribute: str
-    ) -> Tuple[Instance, Any]:
+    ) -> tuple[Instance, Any]:
         if attribute not in Instance.VALID_ATTRIBUTES:
             raise InvalidParameterValueErrorUnknownAttribute(attribute)
 
@@ -899,14 +900,14 @@ class InstanceBackend:
         return instance, value
 
     def describe_instance_credit_specifications(
-        self, instance_ids: List[str]
-    ) -> List[Instance]:
+        self, instance_ids: list[str]
+    ) -> list[Instance]:
         queried_instances = []
         for instance in self.get_multi_instances_by_id(instance_ids):
             queried_instances.append(instance)
         return queried_instances
 
-    def all_instances(self, filters: Any = None) -> List[Instance]:
+    def all_instances(self, filters: Any = None) -> list[Instance]:
         instances = []
         for reservation in self.all_reservations():
             for instance in reservation.instances:
@@ -914,7 +915,7 @@ class InstanceBackend:
                     instances.append(instance)
         return instances
 
-    def all_running_instances(self, filters: Any = None) -> List[Instance]:
+    def all_running_instances(self, filters: Any = None) -> list[Instance]:
         instances = []
         for reservation in self.all_reservations():
             for instance in reservation.instances:
@@ -923,8 +924,8 @@ class InstanceBackend:
         return instances
 
     def get_multi_instances_by_id(
-        self, instance_ids: List[str], filters: Any = None
-    ) -> List[Instance]:
+        self, instance_ids: list[str], filters: Any = None
+    ) -> list[Instance]:
         """
         :param instance_ids: A string list with instance ids
         :return: A list with instance objects
@@ -954,8 +955,8 @@ class InstanceBackend:
         return None
 
     def get_reservations_by_instance_ids(
-        self, instance_ids: List[str], filters: Any = None
-    ) -> List[Reservation]:
+        self, instance_ids: list[str], filters: Any = None
+    ) -> list[Reservation]:
         """Go through all of the reservations and filter to only return those
         associated with the given instance_ids.
         """
@@ -986,12 +987,12 @@ class InstanceBackend:
             reservations = filter_reservations(reservations, filters)
         return reservations
 
-    def describe_instances(self, filters: Any = None) -> List[Reservation]:
+    def describe_instances(self, filters: Any = None) -> list[Reservation]:
         return self.all_reservations(filters)
 
     def describe_instance_status(
-        self, instance_ids: List[str], include_all_instances: bool, filters: Any
-    ) -> List[Instance]:
+        self, instance_ids: list[str], include_all_instances: bool, filters: Any
+    ) -> list[Instance]:
         if instance_ids:
             instances = self.get_multi_instances_by_id(instance_ids, filters)
             if include_all_instances:
@@ -1002,7 +1003,7 @@ class InstanceBackend:
         else:
             return self.all_running_instances(filters)
 
-    def all_reservations(self, filters: Any = None) -> List[Reservation]:
+    def all_reservations(self, filters: Any = None) -> list[Reservation]:
         reservations = [
             copy.copy(reservation) for reservation in self.reservations.copy().values()
         ]
@@ -1011,7 +1012,7 @@ class InstanceBackend:
         return reservations
 
     def _get_template_from_args(
-        self, launch_template_arg: Dict[str, Any]
+        self, launch_template_arg: dict[str, Any]
     ) -> LaunchTemplateVersion:
         template = (
             self.describe_launch_templates(  # type: ignore[attr-defined]

--- a/moto/ec2/models/internet_gateways.py
+++ b/moto/ec2/models/internet_gateways.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional
+from typing import Any, Optional
 
 from moto.core.common_models import CloudFormationModel
 
@@ -21,7 +21,7 @@ from .vpn_gateway import VPCGatewayAttachment
 
 class EgressOnlyInternetGateway(TaggedEC2Resource):
     def __init__(
-        self, ec2_backend: Any, vpc_id: str, tags: Optional[Dict[str, str]] = None
+        self, ec2_backend: Any, vpc_id: str, tags: Optional[dict[str, str]] = None
     ):
         self.id = random_egress_only_internet_gateway_id()
         self.ec2_backend = ec2_backend
@@ -34,16 +34,16 @@ class EgressOnlyInternetGateway(TaggedEC2Resource):
         return self.id
 
     @property
-    def attachments(self) -> List[Dict[str, str]]:
+    def attachments(self) -> list[dict[str, str]]:
         return [{"State": self.state, "VpcId": self.vpc_id}]
 
 
 class EgressOnlyInternetGatewayBackend:
     def __init__(self) -> None:
-        self.egress_only_internet_gateways: Dict[str, EgressOnlyInternetGateway] = {}
+        self.egress_only_internet_gateways: dict[str, EgressOnlyInternetGateway] = {}
 
     def create_egress_only_internet_gateway(
-        self, vpc_id: str, tags: Optional[Dict[str, str]] = None
+        self, vpc_id: str, tags: Optional[dict[str, str]] = None
     ) -> EgressOnlyInternetGateway:
         vpc = self.get_vpc(vpc_id)  # type: ignore[attr-defined]
         if not vpc:
@@ -53,8 +53,8 @@ class EgressOnlyInternetGatewayBackend:
         return egress_only_igw
 
     def describe_egress_only_internet_gateways(
-        self, ids: Optional[List[str]] = None
-    ) -> List[EgressOnlyInternetGateway]:
+        self, ids: Optional[list[str]] = None
+    ) -> list[EgressOnlyInternetGateway]:
         """
         The Filters-argument is not yet supported
         """
@@ -129,10 +129,10 @@ class InternetGateway(TaggedEC2Resource, CloudFormationModel):
 
 class InternetGatewayBackend:
     def __init__(self) -> None:
-        self.internet_gateways: Dict[str, InternetGateway] = {}
+        self.internet_gateways: dict[str, InternetGateway] = {}
 
     def create_internet_gateway(
-        self, tags: Optional[List[Dict[str, str]]] = None
+        self, tags: Optional[list[dict[str, str]]] = None
     ) -> InternetGateway:
         igw = InternetGateway(self)
         for tag in tags or []:
@@ -141,8 +141,8 @@ class InternetGatewayBackend:
         return igw
 
     def describe_internet_gateways(
-        self, internet_gateway_ids: Optional[List[str]] = None, filters: Any = None
-    ) -> List[InternetGateway]:
+        self, internet_gateway_ids: Optional[list[str]] = None, filters: Any = None
+    ) -> list[InternetGateway]:
         igws = []
         if internet_gateway_ids is None:
             igws = list(self.internet_gateways.values())

--- a/moto/ec2/models/key_pairs.py
+++ b/moto/ec2/models/key_pairs.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional
+from typing import Any, Optional
 
 from moto.core.utils import iso_8601_datetime_with_milliseconds, utcnow
 
@@ -26,7 +26,7 @@ class KeyPair(TaggedEC2Resource):
         fingerprint: str,
         material: Optional[str],
         material_public: str,
-        tags: Dict[str, str],
+        tags: dict[str, str],
         ec2_backend: Any,
     ):
         self.id = random_key_pair_id()
@@ -55,10 +55,10 @@ class KeyPair(TaggedEC2Resource):
 
 class KeyPairBackend:
     def __init__(self) -> None:
-        self.keypairs: Dict[str, KeyPair] = {}
+        self.keypairs: dict[str, KeyPair] = {}
 
     def create_key_pair(
-        self, name: str, key_type: str, tags: Dict[str, str]
+        self, name: str, key_type: str, tags: dict[str, str]
     ) -> KeyPair:
         if name in self.keypairs:
             raise InvalidKeyPairDuplicateError(name)
@@ -78,8 +78,8 @@ class KeyPairBackend:
         self.keypairs.pop(name, None)
 
     def describe_key_pairs(
-        self, key_names: List[str], filters: Any = None
-    ) -> List[KeyPair]:
+        self, key_names: list[str], filters: Any = None
+    ) -> list[KeyPair]:
         if any(key_names):
             results = [
                 keypair
@@ -98,7 +98,7 @@ class KeyPairBackend:
             return results
 
     def import_key_pair(
-        self, key_name: str, public_key_material: str, tags: Dict[str, str]
+        self, key_name: str, public_key_material: str, tags: dict[str, str]
     ) -> KeyPair:
         if key_name in self.keypairs:
             raise InvalidKeyPairDuplicateError(key_name)

--- a/moto/ec2/models/launch_templates.py
+++ b/moto/ec2/models/launch_templates.py
@@ -1,5 +1,5 @@
 from collections import OrderedDict
-from typing import Any, Dict, List, Optional
+from typing import Any, Optional
 
 from moto.core.common_models import CloudFormationModel
 
@@ -24,7 +24,7 @@ class LaunchTemplateVersion:
         self,
         template: "LaunchTemplate",
         number: int,
-        data: Dict[str, Any],
+        data: dict[str, Any],
         description: str,
     ):
         self.template = template
@@ -45,7 +45,7 @@ class LaunchTemplateVersion:
         return self.data.get("InstanceType", "")
 
     @property
-    def security_groups(self) -> List[str]:
+    def security_groups(self) -> list[str]:
         return self.data.get("SecurityGroups", [])
 
     @property
@@ -58,24 +58,24 @@ class LaunchTemplate(TaggedEC2Resource, CloudFormationModel):
         self,
         backend: Any,
         name: str,
-        template_data: Dict[str, Any],
+        template_data: dict[str, Any],
         version_description: str,
-        tag_spec: Dict[str, Dict[str, str]],
+        tag_spec: dict[str, dict[str, str]],
     ):
         self.ec2_backend = backend
         self.name = name
         self.id = random_launch_template_id()
         self.create_time = utc_date_and_time()
-        tag_map: Dict[str, str] = tag_spec.get("launch-template", {})
+        tag_map: dict[str, str] = tag_spec.get("launch-template", {})
         self.add_tags(tag_map)
         self.tags = self.get_tags()
 
-        self.versions: List[LaunchTemplateVersion] = []
+        self.versions: list[LaunchTemplateVersion] = []
         self.create_version(template_data, version_description)
         self.default_version_number = 1
 
     def create_version(
-        self, data: Dict[str, Any], description: str
+        self, data: dict[str, Any], description: str
     ) -> LaunchTemplateVersion:
         num = len(self.versions) + 1
         version = LaunchTemplateVersion(self, num, data, description)
@@ -209,16 +209,16 @@ class LaunchTemplate(TaggedEC2Resource, CloudFormationModel):
 
 class LaunchTemplateBackend:
     def __init__(self) -> None:
-        self.launch_template_name_to_ids: Dict[str, str] = {}
-        self.launch_templates: Dict[str, LaunchTemplate] = OrderedDict()
-        self.launch_template_insert_order: List[str] = []
+        self.launch_template_name_to_ids: dict[str, str] = {}
+        self.launch_templates: dict[str, LaunchTemplate] = OrderedDict()
+        self.launch_template_insert_order: list[str] = []
 
     def create_launch_template(
         self,
         name: str,
         description: str,
-        template_data: Dict[str, Any],
-        tag_spec: Dict[str, Any],
+        template_data: dict[str, Any],
+        tag_spec: dict[str, Any],
     ) -> LaunchTemplate:
         if name in self.launch_template_name_to_ids:
             raise InvalidLaunchTemplateNameAlreadyExistsError()
@@ -265,10 +265,10 @@ class LaunchTemplateBackend:
 
     def describe_launch_templates(
         self,
-        template_names: Optional[List[str]] = None,
-        template_ids: Optional[List[str]] = None,
+        template_names: Optional[list[str]] = None,
+        template_ids: Optional[list[str]] = None,
         filters: Any = None,
-    ) -> List[LaunchTemplate]:
+    ) -> list[LaunchTemplate]:
         if template_names and not template_ids:
             template_ids = []
             for name in template_names:

--- a/moto/ec2/models/managed_prefixes.py
+++ b/moto/ec2/models/managed_prefixes.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional
+from typing import Any, Optional
 
 from moto.utilities.utils import filter_resources, get_partition
 
@@ -12,10 +12,10 @@ class ManagedPrefixList(TaggedEC2Resource):
         backend: Any,
         region: str,
         address_family: Optional[str] = None,
-        entry: Optional[List[Dict[str, str]]] = None,
+        entry: Optional[list[dict[str, str]]] = None,
         max_entries: Optional[str] = None,
         prefix_list_name: Optional[str] = None,
-        tags: Optional[Dict[str, str]] = None,
+        tags: Optional[dict[str, str]] = None,
         owner_id: Optional[str] = None,
     ):
         self.ec2_backend = backend
@@ -48,16 +48,16 @@ class ManagedPrefixList(TaggedEC2Resource):
 
 class ManagedPrefixListBackend:
     def __init__(self) -> None:
-        self.managed_prefix_lists: Dict[str, ManagedPrefixList] = {}
+        self.managed_prefix_lists: dict[str, ManagedPrefixList] = {}
         self.create_default_pls()
 
     def create_managed_prefix_list(
         self,
         address_family: Optional[str] = None,
-        entry: Optional[List[Dict[str, str]]] = None,
+        entry: Optional[list[dict[str, str]]] = None,
         max_entries: Optional[str] = None,
         prefix_list_name: Optional[str] = None,
-        tags: Optional[Dict[str, str]] = None,
+        tags: Optional[dict[str, str]] = None,
         owner_id: Optional[str] = None,
     ) -> ManagedPrefixList:
         managed_prefix_list = ManagedPrefixList(
@@ -74,8 +74,8 @@ class ManagedPrefixListBackend:
         return managed_prefix_list
 
     def describe_managed_prefix_lists(
-        self, prefix_list_ids: Optional[List[str]] = None, filters: Any = None
-    ) -> List[ManagedPrefixList]:
+        self, prefix_list_ids: Optional[list[str]] = None, filters: Any = None
+    ) -> list[ManagedPrefixList]:
         managed_prefix_lists = list(self.managed_prefix_lists.values())
         attr_pairs = (
             ("owner-id", "owner_id"),
@@ -117,8 +117,8 @@ class ManagedPrefixListBackend:
 
     def modify_managed_prefix_list(
         self,
-        add_entry: List[Dict[str, str]],
-        remove_entry: List[Dict[str, str]],
+        add_entry: list[dict[str, str]],
+        remove_entry: list[dict[str, str]],
         prefix_list_id: Optional[str] = None,
         current_version: Optional[str] = None,
         prefix_list_name: Optional[str] = None,
@@ -145,7 +145,7 @@ class ManagedPrefixListBackend:
         return managed_pl
 
     def _create_aws_managed_prefix_list(
-        self, name: str, address_family: str, entries: List[Dict[str, str]]
+        self, name: str, address_family: str, entries: list[dict[str, str]]
     ) -> None:
         managed_prefix_list = self.create_managed_prefix_list(
             address_family=address_family,

--- a/moto/ec2/models/nat_gateways.py
+++ b/moto/ec2/models/nat_gateways.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional
+from typing import Any, Optional
 
 from moto.core.common_models import CloudFormationModel
 from moto.core.utils import iso_8601_datetime_with_milliseconds, utcnow
@@ -13,13 +13,13 @@ class NatGateway(CloudFormationModel, TaggedEC2Resource):
         backend: Any,
         subnet_id: str,
         allocation_id: str,
-        tags: Optional[Dict[str, str]] = None,
+        tags: Optional[dict[str, str]] = None,
         connectivity_type: str = "public",
     ):
         # public properties
         self.id = random_nat_gateway_id()
         self.subnet_id = subnet_id
-        self.address_set: List[Dict[str, Any]] = []
+        self.address_set: list[dict[str, Any]] = []
         self.state = "available"
         self.private_ip = random_private_ip()
         self.connectivity_type = connectivity_type
@@ -78,11 +78,11 @@ class NatGateway(CloudFormationModel, TaggedEC2Resource):
 
 class NatGatewayBackend:
     def __init__(self) -> None:
-        self.nat_gateways: Dict[str, NatGateway] = {}
+        self.nat_gateways: dict[str, NatGateway] = {}
 
     def describe_nat_gateways(
-        self, filters: Any, nat_gateway_ids: Optional[List[str]]
-    ) -> List[NatGateway]:
+        self, filters: Any, nat_gateway_ids: Optional[list[str]]
+    ) -> list[NatGateway]:
         nat_gateways = list(self.nat_gateways.values())
 
         if nat_gateway_ids:
@@ -120,13 +120,13 @@ class NatGatewayBackend:
         self,
         subnet_id: str,
         allocation_id: str,
-        tags: Optional[Dict[str, str]] = None,
+        tags: Optional[dict[str, str]] = None,
         connectivity_type: str = "public",
     ) -> NatGateway:
         nat_gateway = NatGateway(
             self, subnet_id, allocation_id, tags, connectivity_type
         )
-        address_set: Dict[str, Any] = {}
+        address_set: dict[str, Any] = {}
         if allocation_id:
             eips = self.address_by_allocation([allocation_id])  # type: ignore[attr-defined]
             eip = eips[0] if len(eips) > 0 else None

--- a/moto/ec2/models/network_acls.py
+++ b/moto/ec2/models/network_acls.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional
+from typing import Any, Optional
 
 from ..exceptions import (
     DependencyViolationError,
@@ -16,7 +16,7 @@ from .core import TaggedEC2Resource
 
 class NetworkAclBackend:
     def __init__(self) -> None:
-        self.network_acls: Dict[str, "NetworkAcl"] = {}
+        self.network_acls: dict[str, NetworkAcl] = {}
 
     def get_network_acl(self, network_acl_id: str) -> "NetworkAcl":
         network_acl = self.network_acls.get(network_acl_id, None)
@@ -27,7 +27,7 @@ class NetworkAclBackend:
     def create_network_acl(
         self,
         vpc_id: str,
-        tags: Optional[List[Dict[str, str]]] = None,
+        tags: Optional[list[dict[str, str]]] = None,
         default: bool = False,
     ) -> "NetworkAcl":
         network_acl_id = random_network_acl_id()
@@ -196,8 +196,8 @@ class NetworkAclBackend:
         )
 
     def describe_network_acls(
-        self, network_acl_ids: Optional[List[str]] = None, filters: Any = None
-    ) -> List["NetworkAcl"]:
+        self, network_acl_ids: Optional[list[str]] = None, filters: Any = None
+    ) -> list["NetworkAcl"]:
         network_acls = list(self.network_acls.values())
 
         if network_acl_ids:
@@ -245,8 +245,8 @@ class NetworkAcl(TaggedEC2Resource):
         self.id = network_acl_id
         self.vpc_id = vpc_id
         self.owner_id = owner_id or ec2_backend.account_id
-        self.network_acl_entries: List[NetworkAclEntry] = []
-        self.associations: Dict[str, NetworkAclAssociation] = {}
+        self.network_acl_entries: list[NetworkAclEntry] = []
+        self.associations: dict[str, NetworkAclAssociation] = {}
         self.default = "true" if default is True else "false"
 
     def get_filter_value(

--- a/moto/ec2/models/route_tables.py
+++ b/moto/ec2/models/route_tables.py
@@ -1,5 +1,5 @@
 import ipaddress
-from typing import Any, Dict, List, Optional, Set
+from typing import Any, Optional
 
 from moto.core.common_models import CloudFormationModel
 from moto.ec2.models.carrier_gateways import CarrierGateway
@@ -40,8 +40,8 @@ class RouteTable(TaggedEC2Resource, CloudFormationModel):
         self.id = route_table_id
         self.vpc_id = vpc_id
         self.main_association_id = random_subnet_association_id() if main else None
-        self.associations: Dict[str, str] = {}
-        self.routes: Dict[str, Route] = {}
+        self.associations: dict[str, str] = {}
+        self.routes: dict[str, Route] = {}
 
     @property
     def owner_id(self) -> str:
@@ -132,7 +132,7 @@ class RouteTable(TaggedEC2Resource, CloudFormationModel):
             return super().get_filter_value(filter_name, "DescribeRouteTables")
 
     @property
-    def all_associations_ids(self) -> Set[str]:
+    def all_associations_ids(self) -> set[str]:
         # NOTE(yoctozepto): Doing an explicit copy to not touch the original.
         all_associations = set(self.associations)
         if self.main_association_id is not None:
@@ -231,12 +231,12 @@ class Route(CloudFormationModel):
 
 class RouteBackend:
     def __init__(self) -> None:
-        self.route_tables: Dict[str, RouteTable] = {}
+        self.route_tables: dict[str, RouteTable] = {}
 
     def create_route_table(
         self,
         vpc_id: str,
-        tags: Optional[List[Dict[str, str]]] = None,
+        tags: Optional[list[dict[str, str]]] = None,
         main: bool = False,
     ) -> RouteTable:
         route_table_id = random_route_table_id()
@@ -270,8 +270,8 @@ class RouteBackend:
         return route_table
 
     def describe_route_tables(
-        self, route_table_ids: Optional[List[str]] = None, filters: Any = None
-    ) -> List[RouteTable]:
+        self, route_table_ids: Optional[list[str]] = None, filters: Any = None
+    ) -> list[RouteTable]:
         route_tables = list(self.route_tables.values())
 
         if route_table_ids:

--- a/moto/ec2/models/security_groups.py
+++ b/moto/ec2/models/security_groups.py
@@ -2,7 +2,8 @@ import copy
 import itertools
 import json
 from collections import defaultdict
-from typing import Any, Dict, Iterator, List, Optional, Tuple
+from collections.abc import Iterator
+from typing import Any, Optional
 
 from moto.core.common_models import BaseModel, CloudFormationModel
 from moto.core.utils import aws_api_matches
@@ -42,11 +43,11 @@ class SecurityGroupRule(TaggedEC2Resource):
         group_id: str,
         from_port: Optional[str],
         to_port: Optional[str],
-        ip_range: Optional[Dict[str, str]],
-        source_group: Optional[Dict[str, str]] = None,
-        prefix_list_id: Optional[Dict[str, str]] = None,
+        ip_range: Optional[dict[str, str]],
+        source_group: Optional[dict[str, str]] = None,
+        prefix_list_id: Optional[dict[str, str]] = None,
         is_egress: bool = True,
-        tags: Optional[Dict[str, str]] = None,
+        tags: Optional[dict[str, str]] = None,
     ):
         self.ec2_backend = ec2_backend
         self.id = random_security_group_rule_id()
@@ -103,7 +104,7 @@ class SecurityGroupRule(TaggedEC2Resource):
         return self.ip_range.get("CidrIpv6", None)
 
     @property
-    def referenced_group_info(self) -> Optional[Dict[str, str]]:
+    def referenced_group_info(self) -> Optional[dict[str, str]]:
         return self.source_group if self.source_group else None
 
     @property
@@ -133,7 +134,7 @@ class SecurityGroupRule(TaggedEC2Resource):
 
         return True
 
-    def __deepcopy__(self, memodict: Dict[Any, Any]) -> BaseModel:
+    def __deepcopy__(self, memodict: dict[Any, Any]) -> BaseModel:
         memodict = memodict or {}
         cls = self.__class__
         new = cls.__new__(cls)
@@ -145,13 +146,13 @@ class SecurityGroupRule(TaggedEC2Resource):
                 setattr(new, k, copy.deepcopy(v, memodict))
         return new
 
-    def filter_id(self, values: List[Any]) -> bool:
+    def filter_id(self, values: list[Any]) -> bool:
         for value in values:
             if aws_api_matches(value, self.id):
                 return True
         return False
 
-    def filter_group_id(self, values: List[Any]) -> bool:
+    def filter_group_id(self, values: list[Any]) -> bool:
         for value in values:
             if aws_api_matches(value, self.group_id):
                 return True
@@ -180,20 +181,20 @@ class GroupedSecurityRuleView:
         self.from_port = from_port
         self.to_port = to_port
         self.ip_protocol = ip_protocol
-        self.all_ip_ranges: List[Dict[str, str]] = []
-        self.source_groups: List[Dict[str, str]] = []
-        self.prefix_list_ids: List[Dict[str, str]] = []
+        self.all_ip_ranges: list[dict[str, str]] = []
+        self.source_groups: list[dict[str, str]] = []
+        self.prefix_list_ids: list[dict[str, str]] = []
 
     @property
-    def user_id_group_pairs(self) -> List[Dict[str, str]]:
+    def user_id_group_pairs(self) -> list[dict[str, str]]:
         return self.source_groups
 
     @property
-    def ip_ranges(self) -> List[Dict[str, str]]:
+    def ip_ranges(self) -> list[dict[str, str]]:
         return [ip_range for ip_range in self.all_ip_ranges if ip_range.get("CidrIp")]
 
     @property
-    def ipv6_ranges(self) -> List[Dict[str, str]]:
+    def ipv6_ranges(self) -> list[dict[str, str]]:
         return [ip_range for ip_range in self.all_ip_ranges if ip_range.get("CidrIpv6")]
 
 
@@ -205,7 +206,7 @@ class SecurityGroup(TaggedEC2Resource, CloudFormationModel):
         name: str,
         description: str,
         vpc_id: Optional[str] = None,
-        tags: Optional[Dict[str, str]] = None,
+        tags: Optional[dict[str, str]] = None,
         is_default: Optional[bool] = None,
     ):
         self.ec2_backend = ec2_backend
@@ -214,8 +215,8 @@ class SecurityGroup(TaggedEC2Resource, CloudFormationModel):
         self.name = name
         self.group_name = self.name
         self.description = description
-        self.ingress_rules: List[SecurityGroupRule] = []
-        self.egress_rules: List[SecurityGroupRule] = []
+        self.ingress_rules: list[SecurityGroupRule] = []
+        self.egress_rules: list[SecurityGroupRule] = []
         self.vpc_id: Optional[str] = vpc_id
         self.owner_id = ec2_backend.account_id
         self.add_tags(tags or {})
@@ -387,20 +388,20 @@ class SecurityGroup(TaggedEC2Resource, CloudFormationModel):
     def physical_resource_id(self) -> str:
         return self.id
 
-    def filter_description(self, values: List[Any]) -> bool:
+    def filter_description(self, values: list[Any]) -> bool:
         for value in values:
             if aws_api_matches(value, self.description):
                 return True
         return False
 
-    def filter_egress__ip_permission__cidr(self, values: List[Any]) -> bool:
+    def filter_egress__ip_permission__cidr(self, values: list[Any]) -> bool:
         for value in values:
             for rule in self.egress_rules:
                 if aws_api_matches(value, rule.ip_range.get("CidrIp", "NONE")):
                     return True
         return False
 
-    def filter_egress__ip_permission__from_port(self, values: List[Any]) -> bool:
+    def filter_egress__ip_permission__from_port(self, values: list[Any]) -> bool:
         for value in values:
             for rule in self.egress_rules:
                 if rule.ip_protocol != "-1" and aws_api_matches(
@@ -409,121 +410,121 @@ class SecurityGroup(TaggedEC2Resource, CloudFormationModel):
                     return True
         return False
 
-    def filter_egress__ip_permission__group_id(self, values: List[Any]) -> bool:
+    def filter_egress__ip_permission__group_id(self, values: list[Any]) -> bool:
         for value in values:
             for rule in self.egress_rules:
                 if aws_api_matches(value, rule.source_group.get("GroupId", None)):
                     return True
         return False
 
-    def filter_egress__ip_permission__group_name(self, values: List[Any]) -> bool:
+    def filter_egress__ip_permission__group_name(self, values: list[Any]) -> bool:
         for value in values:
             for rule in self.egress_rules:
                 if aws_api_matches(value, rule.source_group.get("GroupName", None)):
                     return True
         return False
 
-    def filter_egress__ip_permission__ipv6_cidr(self, values: List[Any]) -> bool:
+    def filter_egress__ip_permission__ipv6_cidr(self, values: list[Any]) -> bool:
         raise MotoNotImplementedError("egress.ip-permission.ipv6-cidr filter")
 
-    def filter_egress__ip_permission__prefix_list_id(self, values: List[Any]) -> bool:
+    def filter_egress__ip_permission__prefix_list_id(self, values: list[Any]) -> bool:
         raise MotoNotImplementedError("egress.ip-permission.prefix-list-id filter")
 
-    def filter_egress__ip_permission__protocol(self, values: List[Any]) -> bool:
+    def filter_egress__ip_permission__protocol(self, values: list[Any]) -> bool:
         for value in values:
             for rule in self.egress_rules:
                 if aws_api_matches(value, rule.ip_protocol):
                     return True
         return False
 
-    def filter_egress__ip_permission__to_port(self, values: List[Any]) -> bool:
+    def filter_egress__ip_permission__to_port(self, values: list[Any]) -> bool:
         for value in values:
             for rule in self.egress_rules:
                 if aws_api_matches(value, rule.to_port):
                     return True
         return False
 
-    def filter_egress__ip_permission__user_id(self, values: List[Any]) -> bool:
+    def filter_egress__ip_permission__user_id(self, values: list[Any]) -> bool:
         for value in values:
             for rule in self.egress_rules:
                 if aws_api_matches(value, rule.owner_id):
                     return True
         return False
 
-    def filter_group_id(self, values: List[Any]) -> bool:
+    def filter_group_id(self, values: list[Any]) -> bool:
         for value in values:
             if aws_api_matches(value, self.id):
                 return True
         return False
 
-    def filter_group_name(self, values: List[Any]) -> bool:
+    def filter_group_name(self, values: list[Any]) -> bool:
         for value in values:
             if aws_api_matches(value, self.group_name):
                 return True
         return False
 
-    def filter_ip_permission__cidr(self, values: List[Any]) -> bool:
+    def filter_ip_permission__cidr(self, values: list[Any]) -> bool:
         for value in values:
             for rule in self.ingress_rules:
                 if aws_api_matches(value, rule.ip_range.get("CidrIp", "NONE")):
                     return True
         return False
 
-    def filter_ip_permission__from_port(self, values: List[Any]) -> bool:
+    def filter_ip_permission__from_port(self, values: list[Any]) -> bool:
         for value in values:
             for rule in self.ingress_rules:
                 if aws_api_matches(value, rule.from_port):
                     return True
         return False
 
-    def filter_ip_permission__group_id(self, values: List[Any]) -> bool:
+    def filter_ip_permission__group_id(self, values: list[Any]) -> bool:
         for value in values:
             for rule in self.ingress_rules:
                 if aws_api_matches(value, rule.source_group.get("GroupId", None)):
                     return True
         return False
 
-    def filter_ip_permission__group_name(self, values: List[Any]) -> bool:
+    def filter_ip_permission__group_name(self, values: list[Any]) -> bool:
         for value in values:
             for rule in self.ingress_rules:
                 if aws_api_matches(value, rule.source_group.get("GroupName", None)):
                     return True
         return False
 
-    def filter_ip_permission__ipv6_cidr(self, values: List[Any]) -> None:
+    def filter_ip_permission__ipv6_cidr(self, values: list[Any]) -> None:
         raise MotoNotImplementedError("ip-permission.ipv6 filter")
 
-    def filter_ip_permission__prefix_list_id(self, values: List[Any]) -> None:
+    def filter_ip_permission__prefix_list_id(self, values: list[Any]) -> None:
         raise MotoNotImplementedError("ip-permission.prefix-list-id filter")
 
-    def filter_ip_permission__protocol(self, values: List[Any]) -> bool:
+    def filter_ip_permission__protocol(self, values: list[Any]) -> bool:
         for value in values:
             for rule in self.ingress_rules:
                 if aws_api_matches(value, rule.ip_protocol):
                     return True
         return False
 
-    def filter_ip_permission__to_port(self, values: List[Any]) -> bool:
+    def filter_ip_permission__to_port(self, values: list[Any]) -> bool:
         for value in values:
             for rule in self.ingress_rules:
                 if aws_api_matches(value, rule.to_port):
                     return True
         return False
 
-    def filter_ip_permission__user_id(self, values: List[Any]) -> bool:
+    def filter_ip_permission__user_id(self, values: list[Any]) -> bool:
         for value in values:
             for rule in self.ingress_rules:
                 if aws_api_matches(value, rule.owner_id):
                     return True
         return False
 
-    def filter_owner_id(self, values: List[Any]) -> bool:
+    def filter_owner_id(self, values: list[Any]) -> bool:
         for value in values:
             if aws_api_matches(value, self.owner_id):
                 return True
         return False
 
-    def filter_vpc_id(self, values: List[Any]) -> bool:
+    def filter_vpc_id(self, values: list[Any]) -> bool:
         for value in values:
             if aws_api_matches(value, self.vpc_id):
                 return True
@@ -579,17 +580,17 @@ class SecurityGroup(TaggedEC2Resource, CloudFormationModel):
         return len(self.egress_rules)
 
     @property
-    def ip_permissions(self) -> List[GroupedSecurityRuleView]:
+    def ip_permissions(self) -> list[GroupedSecurityRuleView]:
         return self._flattened_rules(copy.copy(self.ingress_rules))
 
     @property
-    def ip_permissions_egress(self) -> List[GroupedSecurityRuleView]:
+    def ip_permissions_egress(self) -> list[GroupedSecurityRuleView]:
         return self._flattened_rules(copy.copy(self.egress_rules))
 
     def _flattened_rules(
-        self, rules: List[SecurityGroupRule]
-    ) -> List[GroupedSecurityRuleView]:
-        rules_to_return: List[GroupedSecurityRuleView] = []
+        self, rules: list[SecurityGroupRule]
+    ) -> list[GroupedSecurityRuleView]:
+        rules_to_return: list[GroupedSecurityRuleView] = []
         for rule in rules:
             for already_added in rules_to_return:
                 if (
@@ -623,14 +624,14 @@ class SecurityGroup(TaggedEC2Resource, CloudFormationModel):
 class SecurityGroupBackend:
     def __init__(self) -> None:
         # the key in the dict group is the vpc_id or None (non-vpc)
-        self.groups: Dict[str, Dict[str, SecurityGroup]] = defaultdict(dict)
+        self.groups: dict[str, dict[str, SecurityGroup]] = defaultdict(dict)
 
     def create_security_group(
         self,
         name: str,
         description: str,
         vpc_id: Optional[str] = None,
-        tags: Optional[Dict[str, str]] = None,
+        tags: Optional[dict[str, str]] = None,
         force: bool = False,
         is_default: Optional[bool] = None,
     ) -> SecurityGroup:
@@ -658,10 +659,10 @@ class SecurityGroupBackend:
 
     def describe_security_groups(
         self,
-        group_ids: Optional[List[str]] = None,
-        groupnames: Optional[List[str]] = None,
+        group_ids: Optional[list[str]] = None,
+        groupnames: Optional[list[str]] = None,
         filters: Any = None,
-    ) -> List[SecurityGroup]:
+    ) -> list[SecurityGroup]:
         all_groups = self.groups.copy()
         matches = list(
             itertools.chain(*[x.copy().values() for x in all_groups.values()])
@@ -685,7 +686,7 @@ class SecurityGroupBackend:
         self,
         sg_rule_ids: list[str],
         filters: dict[str, list[str]],
-    ) -> List[SecurityGroupRule]:
+    ) -> list[SecurityGroupRule]:
         if "group-id" in filters:
             for group_id in filters["group-id"]:
                 if not is_valid_security_group_id(group_id):
@@ -784,11 +785,11 @@ class SecurityGroupBackend:
         group_id: str,
         from_port: str,
         to_port: str,
-        ip_ranges: List[Any],
-        source_groups: List[Dict[str, Any]],
-        prefix_list_ids: List[Dict[str, str]],
+        ip_ranges: list[Any],
+        source_groups: list[dict[str, Any]],
+        prefix_list_ids: list[dict[str, str]],
         is_egress: bool = False,
-        tags: Optional[Dict[str, str]] = None,
+        tags: Optional[dict[str, str]] = None,
     ) -> Iterator[SecurityGroupRule]:
         for ip_range in ip_ranges:
             yield SecurityGroupRule(
@@ -901,13 +902,13 @@ class SecurityGroupBackend:
         ip_protocol: str,
         from_port: str,
         to_port: str,
-        ip_ranges: List[Any],
-        sgrule_tags: Optional[Dict[str, str]] = None,
-        source_groups: Optional[List[Dict[str, str]]] = None,
-        prefix_list_ids: Optional[List[Dict[str, str]]] = None,
-        security_rule_ids: Optional[List[str]] = None,
+        ip_ranges: list[Any],
+        sgrule_tags: Optional[dict[str, str]] = None,
+        source_groups: Optional[list[dict[str, str]]] = None,
+        prefix_list_ids: Optional[list[dict[str, str]]] = None,
+        security_rule_ids: Optional[list[str]] = None,
         vpc_id: Optional[str] = None,
-    ) -> Tuple[List[SecurityGroupRule], SecurityGroup]:
+    ) -> tuple[list[SecurityGroupRule], SecurityGroup]:
         group = self.get_security_group_by_name_or_id(group_name_or_id, vpc_id)
         if group is None:
             raise InvalidSecurityGroupNotFoundError(group_name_or_id)
@@ -938,7 +939,7 @@ class SecurityGroupBackend:
 
         _source_groups = self._add_source_group(source_groups, vpc_id)
 
-        rules_added: List[SecurityGroupRule] = []
+        rules_added: list[SecurityGroupRule] = []
 
         for security_rule in self._iterate_security_rules(
             ip_protocol,
@@ -964,10 +965,10 @@ class SecurityGroupBackend:
         ip_protocol: str,
         from_port: str,
         to_port: str,
-        ip_ranges: List[Any],
-        source_groups: Optional[List[Dict[str, Any]]] = None,
-        prefix_list_ids: Optional[List[Dict[str, str]]] = None,
-        security_rule_ids: Optional[List[str]] = None,
+        ip_ranges: list[Any],
+        source_groups: Optional[list[dict[str, Any]]] = None,
+        prefix_list_ids: Optional[list[dict[str, str]]] = None,
+        security_rule_ids: Optional[list[str]] = None,
         vpc_id: Optional[str] = None,
     ) -> None:
         group: SecurityGroup = self.get_security_group_by_name_or_id(
@@ -977,7 +978,7 @@ class SecurityGroupBackend:
         if group is None:
             raise InvalidSecurityGroupNotFoundError(group_name_or_id)
 
-        rules_to_remove: List[str] = []
+        rules_to_remove: list[str] = []
         has_unknown_rules = False
 
         if security_rule_ids:
@@ -1021,13 +1022,13 @@ class SecurityGroupBackend:
         ip_protocol: str,
         from_port: str,
         to_port: str,
-        ip_ranges: List[Any],
-        sgrule_tags: Optional[Dict[str, str]] = None,
-        source_groups: Optional[List[Dict[str, Any]]] = None,
-        prefix_list_ids: Optional[List[Dict[str, str]]] = None,
-        security_rule_ids: Optional[List[str]] = None,
+        ip_ranges: list[Any],
+        sgrule_tags: Optional[dict[str, str]] = None,
+        source_groups: Optional[list[dict[str, Any]]] = None,
+        prefix_list_ids: Optional[list[dict[str, str]]] = None,
+        security_rule_ids: Optional[list[str]] = None,
         vpc_id: Optional[str] = None,
-    ) -> Tuple[List[SecurityGroupRule], SecurityGroup]:
+    ) -> tuple[list[SecurityGroupRule], SecurityGroup]:
         group = self.get_security_group_by_name_or_id(group_name_or_id, vpc_id)
         if group is None:
             raise InvalidSecurityGroupNotFoundError(group_name_or_id)
@@ -1061,7 +1062,7 @@ class SecurityGroupBackend:
 
         _source_groups = self._add_source_group(source_groups, vpc_id)
 
-        rules_added: List[SecurityGroupRule] = []
+        rules_added: list[SecurityGroupRule] = []
 
         for security_rule in self._iterate_security_rules(
             ip_protocol,
@@ -1087,10 +1088,10 @@ class SecurityGroupBackend:
         ip_protocol: str,
         from_port: str,
         to_port: str,
-        ip_ranges: List[Any],
-        source_groups: Optional[List[Dict[str, Any]]] = None,
-        prefix_list_ids: Optional[List[Dict[str, str]]] = None,
-        security_rule_ids: Optional[List[str]] = None,
+        ip_ranges: list[Any],
+        source_groups: Optional[list[dict[str, Any]]] = None,
+        prefix_list_ids: Optional[list[dict[str, str]]] = None,
+        security_rule_ids: Optional[list[str]] = None,
         vpc_id: Optional[str] = None,
     ) -> None:
         group: SecurityGroup = self.get_security_group_by_name_or_id(
@@ -1100,7 +1101,7 @@ class SecurityGroupBackend:
         if group is None:
             raise InvalidSecurityGroupNotFoundError(group_name_or_id)
 
-        rules_to_remove: List[str] = []
+        rules_to_remove: list[str] = []
         has_unknown_rules = False
 
         if security_rule_ids:
@@ -1158,10 +1159,10 @@ class SecurityGroupBackend:
         ip_protocol: str,
         from_port: str,
         to_port: str,
-        ip_ranges: List[str],
-        source_groups: Optional[List[Dict[str, Any]]] = None,
-        prefix_list_ids: Optional[List[Dict[str, str]]] = None,
-        security_rule_ids: Optional[List[str]] = None,
+        ip_ranges: list[str],
+        source_groups: Optional[list[dict[str, Any]]] = None,
+        prefix_list_ids: Optional[list[dict[str, str]]] = None,
+        security_rule_ids: Optional[list[str]] = None,
         vpc_id: Optional[str] = None,
     ) -> SecurityGroup:
         group = self.get_security_group_by_name_or_id(group_name_or_id, vpc_id)
@@ -1213,10 +1214,10 @@ class SecurityGroupBackend:
         ip_protocol: str,
         from_port: str,
         to_port: str,
-        ip_ranges: List[str],
-        source_groups: Optional[List[Dict[str, Any]]] = None,
-        prefix_list_ids: Optional[List[Dict[str, str]]] = None,
-        security_rule_ids: Optional[List[str]] = None,
+        ip_ranges: list[str],
+        source_groups: Optional[list[dict[str, Any]]] = None,
+        prefix_list_ids: Optional[list[dict[str, str]]] = None,
+        security_rule_ids: Optional[list[str]] = None,
         vpc_id: Optional[str] = None,
     ) -> SecurityGroup:
         group = self.get_security_group_by_name_or_id(group_name_or_id, vpc_id)
@@ -1286,8 +1287,8 @@ class SecurityGroupBackend:
                 rule.source_group["Description"] = description
 
     def _add_source_group(
-        self, source_groups: Optional[List[Dict[str, Any]]], vpc_id: Optional[str]
-    ) -> List[Dict[str, Any]]:
+        self, source_groups: Optional[list[dict[str, Any]]], vpc_id: Optional[str]
+    ) -> list[dict[str, Any]]:
         _source_groups = []
         for item in source_groups or []:
             if "OwnerId" not in item:
@@ -1315,8 +1316,8 @@ class SecurityGroupBackend:
         self,
         group: SecurityGroup,
         current_rule_nb: int,
-        ip_ranges: List[str],
-        source_groups: Optional[List[Dict[str, str]]] = None,
+        ip_ranges: list[str],
+        source_groups: Optional[list[dict[str, str]]] = None,
         egress: bool = False,
     ) -> None:
         max_nb_rules = 60 if group.vpc_id else 100

--- a/moto/ec2/models/spot_requests.py
+++ b/moto/ec2/models/spot_requests.py
@@ -1,5 +1,5 @@
 from collections import defaultdict
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
+from typing import TYPE_CHECKING, Any, Optional
 
 from moto.core.common_models import BaseModel, CloudFormationModel
 from moto.ec2.exceptions import InvalidParameterValueErrorTagSpotFleetRequest
@@ -32,7 +32,7 @@ class LaunchSpecification(BaseModel):
         self.key_name = key_name
         self.instance_type = instance_type
         self.image_id = image_id
-        self.groups: List[SecurityGroup] = []
+        self.groups: list[SecurityGroup] = []
         self.placement = placement
         self.kernel = kernel_id
         self.ramdisk = ramdisk_id
@@ -54,15 +54,15 @@ class SpotInstanceRequest(TaggedEC2Resource):
         launch_group: Optional[str],
         availability_zone_group: Optional[str],
         key_name: str,
-        security_groups: List[str],
-        user_data: Dict[str, Any],
+        security_groups: list[str],
+        user_data: dict[str, Any],
         instance_type: str,
         placement: Optional[str],
         kernel_id: Optional[str],
         ramdisk_id: Optional[str],
         monitoring_enabled: bool,
         subnet_id: str,
-        tags: Dict[str, Dict[str, str]],
+        tags: dict[str, dict[str, str]],
         spot_fleet_id: Optional[str],
         instance_interruption_behaviour: Optional[str],
     ):
@@ -147,7 +147,7 @@ class SpotFleetLaunchSpec:
     def __init__(
         self,
         ebs_optimized: Any,
-        group_set: List[str],
+        group_set: list[str],
         iam_instance_profile: Any,
         image_id: str,
         instance_type: str,
@@ -155,7 +155,7 @@ class SpotFleetLaunchSpec:
         monitoring: Any,
         spot_price: Any,
         subnet_id: Any,
-        tag_specifications: Dict[str, Dict[str, str]],
+        tag_specifications: dict[str, dict[str, str]],
         user_data: Any,
         weighted_capacity: float,
     ):
@@ -183,10 +183,10 @@ class SpotFleetRequest(TaggedEC2Resource, CloudFormationModel):
         target_capacity: str,
         iam_fleet_role: str,
         allocation_strategy: str,
-        launch_specs: List[Dict[str, Any]],
-        launch_template_config: Optional[List[Dict[str, Any]]],
+        launch_specs: list[dict[str, Any]],
+        launch_template_config: Optional[list[dict[str, Any]]],
         instance_interruption_behaviour: Optional[str],
-        tag_specifications: Optional[List[Dict[str, Any]]],
+        tag_specifications: Optional[list[dict[str, Any]]],
     ):
         self.ec2_backend = ec2_backend
         self.spot_backend = spot_backend
@@ -251,7 +251,7 @@ class SpotFleetRequest(TaggedEC2Resource, CloudFormationModel):
                 )
             )
 
-        self.spot_requests: List[SpotInstanceRequest] = []
+        self.spot_requests: list[SpotInstanceRequest] = []
         self.create_spot_requests(self.target_capacity)
 
     @property
@@ -299,8 +299,8 @@ class SpotFleetRequest(TaggedEC2Resource, CloudFormationModel):
 
     def get_launch_spec_counts(
         self, weight_to_add: float
-    ) -> Tuple[Dict[Any, int], float]:
-        weight_map: Dict[Any, int] = defaultdict(int)
+    ) -> tuple[dict[Any, int], float]:
+        weight_map: dict[Any, int] = defaultdict(int)
 
         weight_so_far = 0.0
         if self.allocation_strategy == "diversified":
@@ -381,8 +381,8 @@ class SpotFleetRequest(TaggedEC2Resource, CloudFormationModel):
 
 class SpotRequestBackend:
     def __init__(self) -> None:
-        self.spot_instance_requests: Dict[str, SpotInstanceRequest] = {}
-        self.spot_fleet_requests: Dict[str, SpotFleetRequest] = {}
+        self.spot_instance_requests: dict[str, SpotInstanceRequest] = {}
+        self.spot_fleet_requests: dict[str, SpotFleetRequest] = {}
 
     def request_spot_instances(
         self,
@@ -395,18 +395,18 @@ class SpotRequestBackend:
         launch_group: Optional[str],
         availability_zone_group: Optional[str],
         key_name: str,
-        security_groups: List[str],
-        user_data: Dict[str, Any],
+        security_groups: list[str],
+        user_data: dict[str, Any],
         instance_type: str,
         placement: Optional[str],
         kernel_id: Optional[str],
         ramdisk_id: Optional[str],
         monitoring_enabled: bool,
         subnet_id: str,
-        tags: Optional[Dict[str, Dict[str, str]]] = None,
+        tags: Optional[dict[str, dict[str, str]]] = None,
         spot_fleet_id: Optional[str] = None,
         instance_interruption_behaviour: Optional[str] = None,
-    ) -> List[SpotInstanceRequest]:
+    ) -> list[SpotInstanceRequest]:
         requests = []
         tags = tags or {}
         for _ in range(count):
@@ -439,8 +439,8 @@ class SpotRequestBackend:
         return requests
 
     def describe_spot_instance_requests(
-        self, filters: Any = None, spot_instance_ids: Optional[List[str]] = None
-    ) -> List[SpotInstanceRequest]:
+        self, filters: Any = None, spot_instance_ids: Optional[list[str]] = None
+    ) -> list[SpotInstanceRequest]:
         requests = list(self.spot_instance_requests.values())
 
         if spot_instance_ids:
@@ -449,8 +449,8 @@ class SpotRequestBackend:
         return generic_filter(filters, requests)
 
     def cancel_spot_instance_requests(
-        self, request_ids: List[str]
-    ) -> List[SpotInstanceRequest]:
+        self, request_ids: list[str]
+    ) -> list[SpotInstanceRequest]:
         requests = []
         for request_id in request_ids:
             requests.append(self.spot_instance_requests.pop(request_id))
@@ -462,10 +462,10 @@ class SpotRequestBackend:
         target_capacity: str,
         iam_fleet_role: str,
         allocation_strategy: str,
-        launch_specs: List[Dict[str, Any]],
-        launch_template_config: Optional[List[Dict[str, Any]]] = None,
+        launch_specs: list[dict[str, Any]],
+        launch_template_config: Optional[list[dict[str, Any]]] = None,
         instance_interruption_behaviour: Optional[str] = None,
-        tag_specifications: Optional[List[Dict[str, Any]]] = None,
+        tag_specifications: Optional[list[dict[str, Any]]] = None,
     ) -> SpotFleetRequest:
         spot_fleet_request_id = random_spot_fleet_request_id()
         request = SpotFleetRequest(
@@ -491,15 +491,15 @@ class SpotRequestBackend:
 
     def describe_spot_fleet_instances(
         self, spot_fleet_request_id: str
-    ) -> List[SpotInstanceRequest]:
+    ) -> list[SpotInstanceRequest]:
         spot_fleet = self.get_spot_fleet_request(spot_fleet_request_id)
         if not spot_fleet:
             return []
         return spot_fleet.spot_requests
 
     def describe_spot_fleet_requests(
-        self, spot_fleet_request_ids: List[str]
-    ) -> List[SpotFleetRequest]:
+        self, spot_fleet_request_ids: list[str]
+    ) -> list[SpotFleetRequest]:
         requests = list(self.spot_fleet_requests.values())
 
         if spot_fleet_request_ids:
@@ -510,8 +510,8 @@ class SpotRequestBackend:
         return requests
 
     def cancel_spot_fleet_requests(
-        self, spot_fleet_request_ids: List[str], terminate_instances: bool
-    ) -> List[SpotFleetRequest]:
+        self, spot_fleet_request_ids: list[str], terminate_instances: bool
+    ) -> list[SpotFleetRequest]:
         spot_requests = []
         for spot_fleet_request_id in spot_fleet_request_ids:
             spot_fleet = self.spot_fleet_requests[spot_fleet_request_id]
@@ -538,13 +538,13 @@ class SpotRequestBackend:
             spot_fleet_request.terminate_instances()
 
     def describe_spot_price_history(
-        self, instance_types: Optional[List[str]] = None, filters: Any = None
-    ) -> List[Dict[str, str]]:
+        self, instance_types: Optional[list[str]] = None, filters: Any = None
+    ) -> list[dict[str, str]]:
         matches = INSTANCE_TYPE_OFFERINGS["availability-zone"]
         matches = matches.get(self.region_name, [])  # type: ignore[attr-defined]
 
-        def matches_filters(offering: Dict[str, Any], filters: Any) -> bool:
-            def matches_filter(key: str, values: List[str]) -> bool:
+        def matches_filters(offering: dict[str, Any], filters: Any) -> bool:
+            def matches_filter(key: str, values: list[str]) -> bool:
                 if key == "availability-zone":
                     return offering.get("Location") in values
                 elif key == "instance-type":

--- a/moto/ec2/models/subnets.py
+++ b/moto/ec2/models/subnets.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import ipaddress
 import itertools
 from collections import defaultdict
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set, Tuple
+from typing import TYPE_CHECKING, Any, Optional
 
 from moto.core.common_models import CloudFormationModel
 
@@ -59,7 +59,7 @@ class Subnet(TaggedEC2Resource, CloudFormationModel):
         self.default_for_az = default_for_az
         self.map_public_ip_on_launch = map_public_ip_on_launch
         self.assign_ipv6_address_on_creation = ipv6_native
-        self.ipv6_cidr_block_associations: Dict[str, Dict[str, Any]] = {}
+        self.ipv6_cidr_block_associations: dict[str, dict[str, Any]] = {}
         if ipv6_cidr_block:
             self.attach_ipv6_cidr_block_associations(ipv6_cidr_block)
 
@@ -68,10 +68,10 @@ class Subnet(TaggedEC2Resource, CloudFormationModel):
         self.reserved_ips = [
             next(iter(self._subnet_ip_generator)) for _ in range(0, 3)
         ]  # Reserved by AWS
-        self._unused_ips: Set[str] = (
+        self._unused_ips: set[str] = (
             set()
         )  # if instance is destroyed hold IP here for reuse
-        self._subnet_ips: Dict[str, "Instance"] = {}
+        self._subnet_ips: dict[str, Instance] = {}
         self.state = "available"
 
         # Placeholder for response templates until Ipv6 support implemented.
@@ -82,7 +82,7 @@ class Subnet(TaggedEC2Resource, CloudFormationModel):
         return f"arn:aws:ec2:{self.ec2_backend.region_name}:{self.owner_id}:subnet/{self.id}"
 
     @property
-    def ipv6_cidr_block_association_set(self) -> List[Dict[str, str]]:
+    def ipv6_cidr_block_association_set(self) -> list[dict[str, str]]:
         association_set = [
             {
                 "ipv6CidrBlock": association["ipv6CidrBlock"],
@@ -117,7 +117,7 @@ class Subnet(TaggedEC2Resource, CloudFormationModel):
         account_id: str,
         region_name: str,
         **kwargs: Any,
-    ) -> "Subnet":
+    ) -> Subnet:
         from ..models import ec2_backends
 
         properties = cloudformation_json["Properties"]
@@ -140,7 +140,7 @@ class Subnet(TaggedEC2Resource, CloudFormationModel):
     def delete_from_cloudformation_json(  # type: ignore[misc]
         cls,
         resource_name: str,
-        cloudformation_json: Dict[str, Any],
+        cloudformation_json: dict[str, Any],
         account_id: str,
         region_name: str,
     ) -> None:
@@ -218,7 +218,7 @@ class Subnet(TaggedEC2Resource, CloudFormationModel):
             raise NotImplementedError('"Fn::GetAtt" : [ "{0}" , "AvailabilityZone" ]"')
         raise UnformattedGetAttTemplateException()
 
-    def get_available_subnet_ip(self, instance: "Instance") -> str:
+    def get_available_subnet_ip(self, instance: Instance) -> str:
         try:
             new_ip = str(self._unused_ips.pop())
         except KeyError:
@@ -239,7 +239,7 @@ class Subnet(TaggedEC2Resource, CloudFormationModel):
 
     # EFS calls this method as request_ip(str, MountTarget)
     # So technically it's not just Instances that are stored
-    def request_ip(self, ip: str, instance: "Instance") -> None:
+    def request_ip(self, ip: str, instance: Instance) -> None:
         if ipaddress.ip_address(ip) not in self.cidr:
             raise Exception(f"IP does not fall in the subnet CIDR of {self.cidr}")
 
@@ -261,7 +261,7 @@ class Subnet(TaggedEC2Resource, CloudFormationModel):
 
     def attach_ipv6_cidr_block_associations(
         self, ipv6_cidr_block: str
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         association = {
             "associationId": random_subnet_ipv6_cidr_block_association_id(),
             "ipv6CidrBlock": ipv6_cidr_block,
@@ -272,7 +272,7 @@ class Subnet(TaggedEC2Resource, CloudFormationModel):
         )
         return association
 
-    def detach_subnet_cidr_block(self, association_id: str) -> Dict[str, Any]:
+    def detach_subnet_cidr_block(self, association_id: str) -> dict[str, Any]:
         association = self.ipv6_cidr_block_associations.get(association_id)
         assert association is not None
         association["ipv6CidrBlockState"] = {"State": "disassociated"}
@@ -305,7 +305,7 @@ class SubnetRouteTableAssociation(CloudFormationModel):
         account_id: str,
         region_name: str,
         **kwargs: Any,
-    ) -> "SubnetRouteTableAssociation":
+    ) -> SubnetRouteTableAssociation:
         from ..models import ec2_backends
 
         properties = cloudformation_json["Properties"]
@@ -323,8 +323,8 @@ class SubnetRouteTableAssociation(CloudFormationModel):
 class SubnetBackend:
     def __init__(self) -> None:
         # maps availability zone to dict of (subnet_id, subnet)
-        self.subnets: Dict[str, Dict[str, Subnet]] = defaultdict(dict)
-        self.subnet_associations: Dict[str, SubnetRouteTableAssociation] = {}
+        self.subnets: dict[str, dict[str, Subnet]] = defaultdict(dict)
+        self.subnet_associations: dict[str, SubnetRouteTableAssociation] = {}
 
     def get_subnet(self, subnet_id: str) -> Subnet:
         for subnets_per_zone in self.subnets.values():
@@ -332,7 +332,7 @@ class SubnetBackend:
                 return subnets_per_zone[subnet_id]
         raise InvalidSubnetIdError(subnet_id)
 
-    def get_default_subnets(self) -> Dict[str, Subnet]:
+    def get_default_subnets(self) -> dict[str, Subnet]:
         return {
             subnet.availability_zone: subnet
             for subnet in self.describe_subnets()
@@ -367,7 +367,7 @@ class SubnetBackend:
         availability_zone: Optional[str] = None,
         availability_zone_id: Optional[str] = None,
         ipv6_native: bool = False,
-        tags: Optional[Dict[str, Dict[str, str]]] = None,
+        tags: Optional[dict[str, dict[str, str]]] = None,
     ) -> Subnet:
         subnet_id = random_subnet_id()
         # Validate VPC exists and the supplied CIDR block is a subnet of the VPC's
@@ -456,8 +456,8 @@ class SubnetBackend:
         return subnet
 
     def describe_subnets(
-        self, subnet_ids: Optional[List[str]] = None, filters: Optional[Any] = None
-    ) -> List[Subnet]:
+        self, subnet_ids: Optional[list[str]] = None, filters: Optional[Any] = None
+    ) -> list[Subnet]:
         # Extract a list of all subnets
         matches = list(
             itertools.chain(*[x.copy().values() for x in self.subnets.copy().values()])
@@ -496,7 +496,7 @@ class SubnetBackend:
 
     def associate_subnet_cidr_block(
         self, subnet_id: str, ipv6_cidr_block: str
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         subnet = self.get_subnet(subnet_id)
         if not subnet:
             raise InvalidSubnetIdError(subnet_id)
@@ -505,7 +505,7 @@ class SubnetBackend:
 
     def disassociate_subnet_cidr_block(
         self, association_id: str
-    ) -> Tuple[str, Dict[str, str]]:
+    ) -> tuple[str, dict[str, str]]:
         subnet = self.get_subnet_from_ipv6_association(association_id)
         if not subnet:
             raise InvalidSubnetCidrBlockAssociationID(association_id)

--- a/moto/ec2/models/tags.py
+++ b/moto/ec2/models/tags.py
@@ -1,6 +1,6 @@
 import re
 from collections import defaultdict
-from typing import Dict, List, Optional
+from typing import Optional
 
 from ..exceptions import (
     InvalidParameterValueErrorTagNull,
@@ -17,9 +17,9 @@ class TagBackend:
     VALID_TAG_FILTERS = ["key", "resource-id", "resource-type", "value"]
 
     def __init__(self) -> None:
-        self.tags: Dict[str, Dict[str, str]] = defaultdict(dict)
+        self.tags: dict[str, dict[str, str]] = defaultdict(dict)
 
-    def create_tags(self, resource_ids: List[str], tags: Dict[str, str]) -> bool:
+    def create_tags(self, resource_ids: list[str], tags: dict[str, str]) -> bool:
         if None in set([tags[tag] for tag in tags]):
             raise InvalidParameterValueErrorTagNull()
         for resource_id in resource_ids:
@@ -44,7 +44,7 @@ class TagBackend:
                 self.tags[resource_id][tag] = tags[tag]
         return True
 
-    def delete_tags(self, resource_ids: List[str], tags: Dict[str, str]) -> bool:
+    def delete_tags(self, resource_ids: list[str], tags: dict[str, str]) -> bool:
         for resource_id in resource_ids:
             for tag in tags:
                 if tag in self.tags[resource_id]:
@@ -55,8 +55,8 @@ class TagBackend:
         return True
 
     def describe_tags(
-        self, filters: Optional[Dict[str, List[str]]] = None
-    ) -> List[Dict[str, str]]:
+        self, filters: Optional[dict[str, list[str]]] = None
+    ) -> list[dict[str, str]]:
         results = []
         key_filters = []
         resource_id_filters = []

--- a/moto/ec2/models/transit_gateway.py
+++ b/moto/ec2/models/transit_gateway.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional
+from typing import Any, Optional
 
 from moto.core.common_models import CloudFormationModel
 from moto.core.utils import iso_8601_datetime_with_milliseconds, utcnow
@@ -29,7 +29,7 @@ class TransitGateway(TaggedEC2Resource, CloudFormationModel):
         self,
         backend: Any,
         description: Optional[str],
-        options: Optional[Dict[str, str]] = None,
+        options: Optional[dict[str, str]] = None,
     ):
         self.ec2_backend = backend
         self.id = random_transit_gateway_id()
@@ -49,7 +49,7 @@ class TransitGateway(TaggedEC2Resource, CloudFormationModel):
         self.options["PropagationDefaultRouteTableId"] = self.default_route_table.id
 
     @property
-    def tags(self) -> List[Dict[str, str]]:
+    def tags(self) -> list[dict[str, str]]:
         return self.get_tags()
 
     @property
@@ -107,13 +107,13 @@ class TransitGateway(TaggedEC2Resource, CloudFormationModel):
 
 class TransitGatewayBackend:
     def __init__(self) -> None:
-        self.transit_gateways: Dict[str, TransitGateway] = {}
+        self.transit_gateways: dict[str, TransitGateway] = {}
 
     def create_transit_gateway(
         self,
         description: Optional[str],
-        options: Optional[Dict[str, str]] = None,
-        tags: Optional[List[Dict[str, str]]] = None,
+        options: Optional[dict[str, str]] = None,
+        tags: Optional[list[dict[str, str]]] = None,
     ) -> TransitGateway:
         transit_gateway = TransitGateway(self, description, options)
         for tag in tags or []:
@@ -123,8 +123,8 @@ class TransitGatewayBackend:
         return transit_gateway
 
     def describe_transit_gateways(
-        self, filters: Any, transit_gateway_ids: Optional[List[str]]
-    ) -> List[TransitGateway]:
+        self, filters: Any, transit_gateway_ids: Optional[list[str]]
+    ) -> list[TransitGateway]:
         transit_gateways = list(self.transit_gateways.values())
 
         if transit_gateway_ids:
@@ -152,7 +152,7 @@ class TransitGatewayBackend:
         self,
         transit_gateway_id: str,
         description: Optional[str] = None,
-        options: Optional[Dict[str, str]] = None,
+        options: Optional[dict[str, str]] = None,
     ) -> TransitGateway:
         transit_gateway = self.transit_gateways[transit_gateway_id]
         if description:

--- a/moto/ec2/models/transit_gateway_attachments.py
+++ b/moto/ec2/models/transit_gateway_attachments.py
@@ -1,6 +1,7 @@
 import weakref
 from collections import defaultdict
-from typing import TYPE_CHECKING, Any, Dict, Iterator, List, Optional
+from collections.abc import Iterator
+from typing import TYPE_CHECKING, Any, Optional
 
 from moto.core.utils import iso_8601_datetime_with_milliseconds, utcnow
 from moto.utilities.utils import filter_resources, merge_multiple_dicts
@@ -26,11 +27,11 @@ class TransitGatewayAttachment(TaggedEC2Resource):
         resource_id: str,
         resource_type: str,
         transit_gateway: "TransitGateway",
-        tags: Optional[Dict[str, str]] = None,
+        tags: Optional[dict[str, str]] = None,
     ):
         self.ec2_backend = backend
-        self.association: Dict[str, str] = {}
-        self.propagation: Dict[str, str] = {}
+        self.association: dict[str, str] = {}
+        self.propagation: dict[str, str] = {}
         self.resource_id = resource_id
         self.resource_type = resource_type
 
@@ -64,9 +65,9 @@ class TransitGatewayVpcAttachment(TransitGatewayAttachment):
         backend: Any,
         transit_gateway: "TransitGateway",
         vpc_id: str,
-        subnet_ids: List[str],
-        tags: Optional[Dict[str, str]] = None,
-        options: Optional[Dict[str, str]] = None,
+        subnet_ids: list[str],
+        tags: Optional[dict[str, str]] = None,
+        options: Optional[dict[str, str]] = None,
     ):
         super().__init__(
             backend=backend,
@@ -89,7 +90,7 @@ class TransitGatewayPeeringAttachment(TransitGatewayAttachment):
         peer_transit_gateway_id: str,
         peer_region: str,
         peer_account_id: str,
-        tags: Dict[str, str],
+        tags: dict[str, str],
         region_name: str,
     ):
         super().__init__(
@@ -117,7 +118,7 @@ class TransitGatewayAttachmentBackend:
     backend_refs = defaultdict(set)  # type: ignore
 
     def __init__(self) -> None:
-        self.transit_gateway_attachments: Dict[str, TransitGatewayAttachment] = {}
+        self.transit_gateway_attachments: dict[str, TransitGatewayAttachment] = {}
         self.backend_refs[self.__class__].add(weakref.ref(self))
 
     @classmethod
@@ -133,7 +134,7 @@ class TransitGatewayAttachmentBackend:
         self,
         vpn_id: str,
         transit_gateway_id: str,
-        tags: Optional[Dict[str, str]] = None,
+        tags: Optional[dict[str, str]] = None,
     ) -> TransitGatewayAttachment:
         transit_gateway = self.transit_gateways[transit_gateway_id]  # type: ignore[attr-defined]
         transit_gateway_vpn_attachment = TransitGatewayAttachment(
@@ -152,9 +153,9 @@ class TransitGatewayAttachmentBackend:
         self,
         transit_gateway_id: str,
         vpc_id: str,
-        subnet_ids: List[str],
-        tags: Optional[Dict[str, str]] = None,
-        options: Optional[Dict[str, str]] = None,
+        subnet_ids: list[str],
+        tags: Optional[dict[str, str]] = None,
+        options: Optional[dict[str, str]] = None,
     ) -> TransitGatewayVpcAttachment:
         # Validate that the TransitGateway exists
         if not (transit_gateway := self.transit_gateways.get(transit_gateway_id)):  # type: ignore[attr-defined]
@@ -184,9 +185,9 @@ class TransitGatewayAttachmentBackend:
 
     def describe_transit_gateway_attachments(
         self,
-        transit_gateways_attachment_ids: Optional[List[str]] = None,
+        transit_gateways_attachment_ids: Optional[list[str]] = None,
         filters: Any = None,
-    ) -> List[TransitGatewayAttachment]:
+    ) -> list[TransitGatewayAttachment]:
         transit_gateway_attachments = list(self.transit_gateway_attachments.values())
 
         attr_pairs = (
@@ -212,9 +213,9 @@ class TransitGatewayAttachmentBackend:
 
     def describe_transit_gateway_vpc_attachments(
         self,
-        transit_gateways_attachment_ids: Optional[List[str]] = None,
+        transit_gateways_attachment_ids: Optional[list[str]] = None,
         filters: Any = None,
-    ) -> List[TransitGatewayAttachment]:
+    ) -> list[TransitGatewayAttachment]:
         transit_gateway_attachments = list(self.transit_gateway_attachments.values())
 
         attr_pairs = (
@@ -250,7 +251,7 @@ class TransitGatewayAttachmentBackend:
             route_table_id = transit_gateway_attachment.propagation.get(
                 "transitGatewayRouteTableId"
             )
-            route_table: "TransitGatewayRouteTable" = (
+            route_table: TransitGatewayRouteTable = (
                 self.transit_gateways_route_tables[route_table_id]  # type: ignore[attr-defined]
             )
             route_table.route_table_propagation = [
@@ -265,9 +266,9 @@ class TransitGatewayAttachmentBackend:
     def modify_transit_gateway_vpc_attachment(
         self,
         transit_gateway_attachment_id: str,
-        add_subnet_ids: Optional[List[str]] = None,
-        options: Optional[Dict[str, str]] = None,
-        remove_subnet_ids: Optional[List[str]] = None,
+        add_subnet_ids: Optional[list[str]] = None,
+        options: Optional[dict[str, str]] = None,
+        remove_subnet_ids: Optional[list[str]] = None,
     ) -> TransitGatewayAttachment:
         tgw_attachment = self.transit_gateway_attachments[transit_gateway_attachment_id]
         if remove_subnet_ids:
@@ -321,7 +322,7 @@ class TransitGatewayAttachmentBackend:
         peer_transit_gateway_id: str,
         peer_region: str,
         peer_account_id: str,
-        tags: Dict[str, str],
+        tags: dict[str, str],
     ) -> TransitGatewayPeeringAttachment:
         transit_gateway = self.transit_gateways[transit_gateway_id]  # type: ignore[attr-defined]
         transit_gateway_peering_attachment = TransitGatewayPeeringAttachment(
@@ -355,9 +356,9 @@ class TransitGatewayAttachmentBackend:
 
     def describe_transit_gateway_peering_attachments(
         self,
-        transit_gateways_attachment_ids: Optional[List[str]] = None,
+        transit_gateways_attachment_ids: Optional[list[str]] = None,
         filters: Any = None,
-    ) -> List[TransitGatewayAttachment]:
+    ) -> list[TransitGatewayAttachment]:
         transit_gateway_attachments = list(self.transit_gateway_attachments.values())
 
         attr_pairs = (

--- a/moto/ec2/models/transit_gateway_route_tables.py
+++ b/moto/ec2/models/transit_gateway_route_tables.py
@@ -1,6 +1,6 @@
 import itertools
 from datetime import datetime
-from typing import Any, Dict, List, Optional
+from typing import Any, Optional
 
 from moto.core.utils import utcnow
 from moto.utilities.utils import filter_resources
@@ -32,7 +32,7 @@ class TransitGatewayRouteTable(TaggedEC2Resource):
         self,
         backend: Any,
         transit_gateway_id: str,
-        tags: Optional[Dict[str, str]] = None,
+        tags: Optional[dict[str, str]] = None,
         default_association_route_table: bool = False,
         default_propagation_route_table: bool = False,
     ):
@@ -45,10 +45,10 @@ class TransitGatewayRouteTable(TaggedEC2Resource):
         self.default_association_route_table = default_association_route_table
         self.default_propagation_route_table = default_propagation_route_table
         self.state = "available"
-        self.routes: Dict[str, Dict[str, Optional[str]]] = {}
+        self.routes: dict[str, dict[str, Optional[str]]] = {}
         self.add_tags(tags or {})
         self.route_table_associations: dict[str, RouteTableAssociation] = {}
-        self.route_table_propagation: List[RouteTablePropagation] = []
+        self.route_table_propagation: list[RouteTablePropagation] = []
 
     @property
     def physical_resource_id(self) -> str:
@@ -86,14 +86,14 @@ class TransitGatewayRelations:
 
 class TransitGatewayRouteTableBackend:
     def __init__(self) -> None:
-        self.transit_gateways_route_tables: Dict[str, TransitGatewayRouteTable] = {}
-        self.transit_gateway_associations: Dict[str, TransitGatewayRelations] = {}
-        self.transit_gateway_propagations: Dict[str, TransitGatewayRelations] = {}
+        self.transit_gateways_route_tables: dict[str, TransitGatewayRouteTable] = {}
+        self.transit_gateway_associations: dict[str, TransitGatewayRelations] = {}
+        self.transit_gateway_propagations: dict[str, TransitGatewayRelations] = {}
 
     def create_transit_gateway_route_table(
         self,
         transit_gateway_id: str,
-        tags: Optional[Dict[str, str]] = None,
+        tags: Optional[dict[str, str]] = None,
         default_association_route_table: bool = False,
         default_propagation_route_table: bool = False,
     ) -> TransitGatewayRouteTable:
@@ -111,7 +111,7 @@ class TransitGatewayRouteTableBackend:
 
     def get_all_transit_gateway_route_tables(
         self, transit_gateway_route_table_ids: Optional[str] = None, filters: Any = None
-    ) -> List[TransitGatewayRouteTable]:
+    ) -> list[TransitGatewayRouteTable]:
         transit_gateway_route_tables = list(self.transit_gateways_route_tables.values())
 
         attr_pairs = (
@@ -149,7 +149,7 @@ class TransitGatewayRouteTableBackend:
         destination_cidr_block: str,
         transit_gateway_attachment_id: Optional[str] = None,
         blackhole: bool = False,
-    ) -> Dict[str, Optional[str]]:
+    ) -> dict[str, Optional[str]]:
         transit_gateways_route_table = self.transit_gateways_route_tables[
             transit_gateway_route_table_id
         ]
@@ -190,7 +190,7 @@ class TransitGatewayRouteTableBackend:
         transit_gateway_route_table_id: str,
         filters: Any,
         max_results: Optional[int] = None,
-    ) -> list[Dict[str, Optional[str]]]:
+    ) -> list[dict[str, Optional[str]]]:
         """
         The following filters are currently supported: type, state, route-search.exact-match
         """
@@ -260,7 +260,7 @@ class TransitGatewayRouteTableBackend:
         ]
 
     def get_transit_gateway_route_table_associations(
-        self, transit_gateway_route_table_id: List[str], filters: Any = None
+        self, transit_gateway_route_table_id: list[str], filters: Any = None
     ) -> list[RouteTableAssociation]:
         transit_gateway_route_tables = list(self.transit_gateways_route_tables.values())
 
@@ -289,7 +289,7 @@ class TransitGatewayRouteTableBackend:
 
     def get_transit_gateway_route_table_propagations(
         self, transit_gateway_route_table_id: str, filters: Any = None
-    ) -> List[RouteTablePropagation]:
+    ) -> list[RouteTablePropagation]:
         transit_gateway_route_tables = list(self.transit_gateways_route_tables.values())
 
         if transit_gateway_route_tables:

--- a/moto/ec2/models/vpc_peering_connections.py
+++ b/moto/ec2/models/vpc_peering_connections.py
@@ -1,6 +1,7 @@
 import weakref
 from collections import defaultdict
-from typing import Any, Dict, Iterator, List, Optional
+from collections.abc import Iterator
+from typing import Any, Optional
 
 from moto.core.common_models import CloudFormationModel
 
@@ -58,7 +59,7 @@ class VPCPeeringConnection(TaggedEC2Resource, CloudFormationModel):
         vpc_pcx_id: str,
         vpc: VPC,
         peer_vpc: VPC,
-        tags: Optional[Dict[str, str]] = None,
+        tags: Optional[dict[str, str]] = None,
     ):
         self.id = vpc_pcx_id
         self.ec2_backend = backend
@@ -109,7 +110,7 @@ class VPCPeeringConnectionBackend:
     vpc_pcx_refs = defaultdict(set)  # type: ignore
 
     def __init__(self) -> None:
-        self.vpc_pcxs: Dict[str, VPCPeeringConnection] = {}
+        self.vpc_pcxs: dict[str, VPCPeeringConnection] = {}
         self.vpc_pcx_refs[self.__class__].add(weakref.ref(self))
 
     @classmethod
@@ -120,7 +121,7 @@ class VPCPeeringConnectionBackend:
                 yield inst
 
     def create_vpc_peering_connection(
-        self, vpc: VPC, peer_vpc: VPC, tags: Optional[Dict[str, str]] = None
+        self, vpc: VPC, peer_vpc: VPC, tags: Optional[dict[str, str]] = None
     ) -> VPCPeeringConnection:
         vpc_pcx_id = random_vpc_peering_connection_id()
         vpc_pcx = VPCPeeringConnection(self, vpc_pcx_id, vpc, peer_vpc, tags)
@@ -138,8 +139,8 @@ class VPCPeeringConnectionBackend:
         return vpc_pcx
 
     def describe_vpc_peering_connections(
-        self, vpc_peering_ids: Optional[List[str]] = None
-    ) -> List[VPCPeeringConnection]:
+        self, vpc_peering_ids: Optional[list[str]] = None
+    ) -> list[VPCPeeringConnection]:
         all_pcxs = list(self.vpc_pcxs.values())
         if vpc_peering_ids:
             return [pcx for pcx in all_pcxs if pcx.id in vpc_peering_ids]
@@ -198,8 +199,8 @@ class VPCPeeringConnectionBackend:
     def modify_vpc_peering_connection_options(
         self,
         vpc_pcx_id: str,
-        accepter_options: Optional[Dict[str, Any]] = None,
-        requester_options: Optional[Dict[str, Any]] = None,
+        accepter_options: Optional[dict[str, Any]] = None,
+        requester_options: Optional[dict[str, Any]] = None,
     ) -> None:
         vpc_pcx = self.get_vpc_peering_connection(vpc_pcx_id)
         if not vpc_pcx:

--- a/moto/ec2/models/vpc_service_configuration.py
+++ b/moto/ec2/models/vpc_service_configuration.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional
+from typing import Any, Optional
 
 from moto.core.common_models import CloudFormationModel
 from moto.moto_api._internal import mock_random
@@ -10,7 +10,7 @@ from .core import TaggedEC2Resource
 class VPCServiceConfiguration(TaggedEC2Resource, CloudFormationModel):
     def __init__(
         self,
-        load_balancers: List[Any],
+        load_balancers: list[Any],
         region: str,
         acceptance_required: bool,
         private_dns_name: str,
@@ -42,10 +42,10 @@ class VPCServiceConfiguration(TaggedEC2Resource, CloudFormationModel):
         self.endpoint_dns_name = f"{self.id}.{region}.vpce.amazonaws.com"
         self.supported_regions = supported_regions
 
-        self.principals: List[str] = []
+        self.principals: list[str] = []
         self.ec2_backend = ec2_backend
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         return {
             "AcceptanceRequired": self.acceptance_required,
             "AvailabilityZones": self.availability_zones,
@@ -63,7 +63,7 @@ class VPCServiceConfiguration(TaggedEC2Resource, CloudFormationModel):
 
 class VPCServiceConfigurationBackend:
     def __init__(self) -> None:
-        self.configurations: Dict[str, VPCServiceConfiguration] = {}
+        self.configurations: dict[str, VPCServiceConfiguration] = {}
 
     @property
     def elbv2_backend(self) -> Any:  # type: ignore[misc]
@@ -78,10 +78,10 @@ class VPCServiceConfigurationBackend:
 
     def create_vpc_endpoint_service_configuration(
         self,
-        lb_arns: List[Any],
+        lb_arns: list[Any],
         acceptance_required: bool,
         private_dns_name: str,
-        tags: List[Dict[str, str]],
+        tags: list[dict[str, str]],
         supported_regions: list[str],
     ) -> VPCServiceConfiguration:
         lbs = self.elbv2_backend.describe_load_balancers(arns=lb_arns, names=None)
@@ -100,8 +100,8 @@ class VPCServiceConfigurationBackend:
         return config
 
     def describe_vpc_endpoint_service_configurations(
-        self, service_ids: Optional[List[str]]
-    ) -> List[VPCServiceConfiguration]:
+        self, service_ids: Optional[list[str]]
+    ) -> list[VPCServiceConfiguration]:
         """
         The Filters, MaxResults, NextToken parameters are not yet implemented
         """
@@ -116,14 +116,14 @@ class VPCServiceConfigurationBackend:
         return list(self.configurations.values())
 
     def delete_vpc_endpoint_service_configurations(
-        self, service_ids: List[str]
-    ) -> List[str]:
+        self, service_ids: list[str]
+    ) -> list[str]:
         missing = [s for s in service_ids if s not in self.configurations]
         for s in service_ids:
             self.configurations.pop(s, None)
         return missing
 
-    def describe_vpc_endpoint_service_permissions(self, service_id: str) -> List[str]:
+    def describe_vpc_endpoint_service_permissions(self, service_id: str) -> list[str]:
         """
         The Filters, MaxResults, NextToken parameters are not yet implemented
         """
@@ -131,7 +131,7 @@ class VPCServiceConfigurationBackend:
         return config.principals
 
     def modify_vpc_endpoint_service_permissions(
-        self, service_id: str, add_principals: List[str], remove_principals: List[str]
+        self, service_id: str, add_principals: list[str], remove_principals: list[str]
     ) -> None:
         config = self.describe_vpc_endpoint_service_configurations([service_id])[0]
         config.principals += add_principals
@@ -143,10 +143,10 @@ class VPCServiceConfigurationBackend:
         service_id: str,
         acceptance_required: Optional[str],
         private_dns_name: Optional[str],
-        add_network_lbs: List[str],
-        remove_network_lbs: List[str],
-        add_gateway_lbs: List[str],
-        remove_gateway_lbs: List[str],
+        add_network_lbs: list[str],
+        remove_network_lbs: list[str],
+        add_gateway_lbs: list[str],
+        remove_gateway_lbs: list[str],
         add_supported_regions: list[str],
         remove_supported_regions: list[str],
     ) -> None:

--- a/moto/ec2/models/vpcs.py
+++ b/moto/ec2/models/vpcs.py
@@ -5,7 +5,7 @@ import threading
 import weakref
 from collections import defaultdict
 from operator import itemgetter
-from typing import Any, Dict, List, Optional
+from typing import Any, Optional
 
 from moto.core.base_backend import BaseBackend
 from moto.core.common_models import CloudFormationModel
@@ -321,7 +321,7 @@ AWS_ENDPOINT_SERVICES = [
     "xray",
 ]
 MAX_NUMBER_OF_ENDPOINT_SERVICES_RESULTS = 1000
-DEFAULT_VPC_ENDPOINT_SERVICES: Dict[str, List[Dict[str, str]]] = {}
+DEFAULT_VPC_ENDPOINT_SERVICES: dict[str, list[dict[str, str]]] = {}
 ENDPOINT_SERVICE_COLLECTION_LOCK = threading.Lock()
 
 
@@ -341,13 +341,13 @@ class VPCEndPoint(TaggedEC2Resource, CloudFormationModel):
         service_name: str,
         endpoint_type: Optional[str],
         policy_document: Optional[str],
-        route_table_ids: List[str],
-        subnet_ids: Optional[List[str]] = None,
-        network_interface_ids: Optional[List[str]] = None,
-        dns_entries: Optional[List[Dict[str, str]]] = None,
+        route_table_ids: list[str],
+        subnet_ids: Optional[list[str]] = None,
+        network_interface_ids: Optional[list[str]] = None,
+        dns_entries: Optional[list[dict[str, str]]] = None,
         client_token: Optional[str] = None,
-        security_group_ids: Optional[List[str]] = None,
-        tags: Optional[Dict[str, str]] = None,
+        security_group_ids: Optional[list[str]] = None,
+        tags: Optional[dict[str, str]] = None,
         private_dns_enabled: Optional[bool] = None,
         destination_prefix_list_id: Optional[str] = None,
     ):
@@ -371,7 +371,7 @@ class VPCEndPoint(TaggedEC2Resource, CloudFormationModel):
         self.creation_timestamp = utcnow()
 
     @property
-    def groups(self) -> List[Dict[str, str]]:
+    def groups(self) -> list[dict[str, str]]:
         return [
             {"GroupId": sg.id, "GroupName": sg.name}
             for id in self.security_group_ids
@@ -381,12 +381,12 @@ class VPCEndPoint(TaggedEC2Resource, CloudFormationModel):
     def modify(
         self,
         policy_doc: Optional[str],
-        add_subnets: Optional[List[str]],
-        remove_subnets: Optional[List[str]],
-        add_route_tables: Optional[List[str]],
-        remove_route_tables: Optional[List[str]],
-        add_security_groups: Optional[List[str]],
-        remove_security_groups: Optional[List[str]],
+        add_subnets: Optional[list[str]],
+        remove_subnets: Optional[list[str]],
+        add_route_tables: Optional[list[str]],
+        remove_route_tables: Optional[list[str]],
+        add_security_groups: Optional[list[str]],
+        remove_security_groups: Optional[list[str]],
     ) -> None:
         if policy_doc:
             self.policy_document = policy_doc
@@ -496,7 +496,7 @@ class VPC(TaggedEC2Resource, CloudFormationModel):
         self.ec2_backend = ec2_backend
         self.id = vpc_id
         self.cidr_block = cidr_block
-        self._cidr_block_association_set: Dict[str, Any] = {}
+        self._cidr_block_association_set: dict[str, Any] = {}
         self.dhcp_options = None
         self.state = "available"
         self.instance_tenancy = instance_tenancy
@@ -525,11 +525,11 @@ class VPC(TaggedEC2Resource, CloudFormationModel):
         return id_
 
     @property
-    def cidr_block_association_set(self) -> list[Dict[str, Any]]:  # type: ignore[misc]
+    def cidr_block_association_set(self) -> list[dict[str, Any]]:  # type: ignore[misc]
         return self.get_cidr_block_association_set(ipv6=False)
 
     @property
-    def ipv6_cidr_block_association_set(self) -> list[Dict[str, Any]]:  # type: ignore[misc]
+    def ipv6_cidr_block_association_set(self) -> list[dict[str, Any]]:  # type: ignore[misc]
         association_set = self.get_cidr_block_association_set(ipv6=True)
         ipv6_association_sets = []
         for association in association_set:
@@ -603,7 +603,7 @@ class VPC(TaggedEC2Resource, CloudFormationModel):
     def delete_from_cloudformation_json(  # type: ignore[misc]
         cls,
         resource_name: str,
-        cloudformation_json: Dict[str, Any],
+        cloudformation_json: dict[str, Any],
         account_id: str,
         region_name: str,
     ) -> None:
@@ -666,7 +666,7 @@ class VPC(TaggedEC2Resource, CloudFormationModel):
         cidr_block: str,
         amazon_provided_ipv6_cidr_block: bool = False,
         ipv6_cidr_block_network_border_group: Optional[str] = None,
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         max_associations = 5 if not amazon_provided_ipv6_cidr_block else 1
 
         for cidr in self._cidr_block_association_set.copy():
@@ -685,7 +685,7 @@ class VPC(TaggedEC2Resource, CloudFormationModel):
 
         association_id = random_vpc_cidr_association_id()
 
-        association_set: Dict[str, Any] = {
+        association_set: dict[str, Any] = {
             "association_id": association_id,
             "cidr_block_state": {"state": "associated", "StatusMessage": None},
         }
@@ -727,7 +727,7 @@ class VPC(TaggedEC2Resource, CloudFormationModel):
         self.classic_link_dns_supported = False
         return self.classic_link_dns_supported
 
-    def disassociate_vpc_cidr_block(self, association_id: str) -> Dict[str, Any]:
+    def disassociate_vpc_cidr_block(self, association_id: str) -> dict[str, Any]:
         if self.cidr_block == self._cidr_block_association_set.get(
             association_id, {}
         ).get("cidr_block"):
@@ -743,7 +743,7 @@ class VPC(TaggedEC2Resource, CloudFormationModel):
 
     def get_cidr_block_association_set(
         self, ipv6: bool = False
-    ) -> List[Dict[str, Any]]:
+    ) -> list[dict[str, Any]]:
         return [
             c
             for c in self._cidr_block_association_set.values()
@@ -755,8 +755,8 @@ class VPCBackend:
     vpc_refs = defaultdict(set)  # type: ignore
 
     def __init__(self) -> None:
-        self.vpcs: Dict[str, VPC] = {}
-        self.vpc_end_points: Dict[str, VPCEndPoint] = {}
+        self.vpcs: dict[str, VPC] = {}
+        self.vpc_end_points: dict[str, VPCEndPoint] = {}
         self.vpc_refs[self.__class__].add(weakref.ref(self))
 
     def create_default_vpc(self) -> VPC:
@@ -782,7 +782,7 @@ class VPCBackend:
         instance_tenancy: str = "default",
         amazon_provided_ipv6_cidr_block: bool = False,
         ipv6_cidr_block_network_border_group: Optional[str] = None,
-        tags: Optional[List[Dict[str, str]]] = None,
+        tags: Optional[list[dict[str, str]]] = None,
         is_default: bool = False,
     ) -> VPC:
         vpc_id = random_vpc_id()
@@ -827,8 +827,8 @@ class VPCBackend:
         return self.vpcs[vpc_id]
 
     def describe_vpcs(
-        self, vpc_ids: Optional[List[str]] = None, filters: Any = None
-    ) -> List[VPC]:
+        self, vpc_ids: Optional[list[str]] = None, filters: Any = None
+    ) -> list[VPC]:
         matches = list(self.vpcs.values())
         if vpc_ids:
             matches = [vpc for vpc in matches if vpc.id in vpc_ids]
@@ -930,7 +930,7 @@ class VPCBackend:
         else:
             raise InvalidParameterValueError(attr_name)
 
-    def disassociate_vpc_cidr_block(self, association_id: str) -> Dict[str, Any]:
+    def disassociate_vpc_cidr_block(self, association_id: str) -> dict[str, Any]:
         for vpc in self.vpcs.copy().values():
             response = vpc.disassociate_vpc_cidr_block(association_id)
             for route_table in self.route_tables.copy().values():  # type: ignore[attr-defined]
@@ -947,7 +947,7 @@ class VPCBackend:
 
     def associate_vpc_cidr_block(
         self, vpc_id: str, cidr_block: str, amazon_provided_ipv6_cidr_block: bool
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         vpc = self.get_vpc(vpc_id)
         association_set = vpc.associate_vpc_cidr_block(
             cidr_block, amazon_provided_ipv6_cidr_block
@@ -973,13 +973,13 @@ class VPCBackend:
         service_name: str,
         endpoint_type: Optional[str],
         policy_document: Optional[str],
-        route_table_ids: List[str],
-        subnet_ids: Optional[List[str]] = None,
-        network_interface_ids: Optional[List[str]] = None,
-        dns_entries: Optional[Dict[str, str]] = None,
+        route_table_ids: list[str],
+        subnet_ids: Optional[list[str]] = None,
+        network_interface_ids: Optional[list[str]] = None,
+        dns_entries: Optional[dict[str, str]] = None,
         client_token: Optional[str] = None,
-        security_group_ids: Optional[List[str]] = None,
-        tags: Optional[Dict[str, str]] = None,
+        security_group_ids: Optional[list[str]] = None,
+        tags: Optional[dict[str, str]] = None,
         private_dns_enabled: Optional[bool] = None,
     ) -> VPCEndPoint:
         vpc_endpoint_id = random_vpc_ep_id()
@@ -1038,12 +1038,12 @@ class VPCBackend:
         self,
         vpc_id: str,
         policy_doc: str,
-        add_subnets: Optional[List[str]],
-        remove_subnets: Optional[List[str]],
-        remove_route_tables: Optional[List[str]],
-        add_route_tables: Optional[List[str]],
-        add_security_groups: Optional[List[str]],
-        remove_security_groups: Optional[List[str]],
+        add_subnets: Optional[list[str]],
+        remove_subnets: Optional[list[str]],
+        remove_route_tables: Optional[list[str]],
+        add_route_tables: Optional[list[str]],
+        add_security_groups: Optional[list[str]],
+        remove_security_groups: Optional[list[str]],
     ) -> None:
         endpoint = self.describe_vpc_endpoints(vpc_end_point_ids=[vpc_id])[0]
         endpoint.modify(
@@ -1056,7 +1056,7 @@ class VPCBackend:
             remove_security_groups,
         )
 
-    def delete_vpc_endpoints(self, vpce_ids: Optional[List[str]] = None) -> None:
+    def delete_vpc_endpoints(self, vpce_ids: Optional[list[str]] = None) -> None:
         for vpce_id in vpce_ids or []:
             vpc_endpoint = self.vpc_end_points.get(vpce_id, None)
             if vpc_endpoint:
@@ -1071,8 +1071,8 @@ class VPCBackend:
                 vpc_endpoint.state = "deleted"
 
     def describe_vpc_endpoints(
-        self, vpc_end_point_ids: Optional[List[str]], filters: Any = None
-    ) -> List[VPCEndPoint]:
+        self, vpc_end_point_ids: Optional[list[str]], filters: Any = None
+    ) -> list[VPCEndPoint]:
         vpc_end_points = list(self.vpc_end_points.values())
 
         if vpc_end_point_ids:
@@ -1094,7 +1094,7 @@ class VPCBackend:
     @staticmethod
     def _collect_default_endpoint_services(
         account_id: str, region: str
-    ) -> List[Dict[str, str]]:
+    ) -> list[dict[str, str]]:
         """Return list of default services using list of backends."""
         with ENDPOINT_SERVICE_COLLECTION_LOCK:
             if region in DEFAULT_VPC_ENDPOINT_SERVICES:
@@ -1140,7 +1140,7 @@ class VPCBackend:
 
     @staticmethod
     def _matches_service_by_tags(  # type: ignore[misc]
-        service: Dict[str, Any], filter_item: Dict[str, Any]
+        service: dict[str, Any], filter_item: dict[str, Any]
     ) -> bool:
         """Return True if service tags are not filtered by their tags.
 
@@ -1174,10 +1174,10 @@ class VPCBackend:
 
     @staticmethod
     def _filter_endpoint_services(  # type: ignore[misc]
-        service_names_filters: List[str],
-        filters: List[Dict[str, Any]],
-        services: List[Dict[str, Any]],
-    ) -> List[Dict[str, Any]]:
+        service_names_filters: list[str],
+        filters: list[dict[str, Any]],
+        services: list[dict[str, Any]],
+    ) -> list[dict[str, Any]]:
         """Return filtered list of VPC endpoint services."""
         if not service_names_filters and not filters:
             return services
@@ -1233,12 +1233,12 @@ class VPCBackend:
 
     def describe_vpc_endpoint_services(
         self,
-        service_names: List[str],
+        service_names: list[str],
         filters: Any,
         max_results: int,
         next_token: Optional[str],
         region: str,
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         """Return info on services to which you can create a VPC endpoint.
 
         Currently only the default endpoint services are returned.  When

--- a/moto/ec2/models/vpn_connections.py
+++ b/moto/ec2/models/vpn_connections.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional
+from typing import Any, Optional
 
 from ..exceptions import (
     InvalidParameterValue,
@@ -18,12 +18,12 @@ class VPNConnection(TaggedEC2Resource):
         customer_gateway_id: str,
         vpn_gateway_id: Optional[str] = None,
         transit_gateway_id: Optional[str] = None,
-        tags: Optional[Dict[str, str]] = None,
+        tags: Optional[dict[str, str]] = None,
     ):
         self.ec2_backend = ec2_backend
         self.id = vpn_connection_id
         self.state = "available"
-        self.customer_gateway_configuration: Dict[str, str] = {}
+        self.customer_gateway_configuration: dict[str, str] = {}
         self.type = vpn_conn_type
         self.customer_gateway_id = customer_gateway_id
         self.vpn_gateway_id = vpn_gateway_id
@@ -41,7 +41,7 @@ class VPNConnection(TaggedEC2Resource):
 
 class VPNConnectionBackend:
     def __init__(self) -> None:
-        self.vpn_connections: Dict[str, VPNConnection] = {}
+        self.vpn_connections: dict[str, VPNConnection] = {}
 
     def create_vpn_connection(
         self,
@@ -49,7 +49,7 @@ class VPNConnectionBackend:
         customer_gateway_id: str,
         vpn_gateway_id: Optional[str] = None,
         transit_gateway_id: Optional[str] = None,
-        tags: Optional[Dict[str, str]] = None,
+        tags: Optional[dict[str, str]] = None,
     ) -> VPNConnection:
         if vpn_gateway_id and transit_gateway_id:
             # From the docs (parentheses mine):
@@ -83,8 +83,8 @@ class VPNConnectionBackend:
         return self.vpn_connections[vpn_connection_id]
 
     def describe_vpn_connections(
-        self, vpn_connection_ids: Optional[List[str]] = None, filters: Any = None
-    ) -> List[VPNConnection]:
+        self, vpn_connection_ids: Optional[list[str]] = None, filters: Any = None
+    ) -> list[VPNConnection]:
         vpn_connections = list(self.vpn_connections.values())
 
         if vpn_connection_ids:

--- a/moto/ec2/models/vpn_gateway.py
+++ b/moto/ec2/models/vpn_gateway.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional
+from typing import Any, Optional
 
 from moto.core.common_models import CloudFormationModel
 
@@ -64,7 +64,7 @@ class VpnGateway(CloudFormationModel, TaggedEC2Resource):
         gateway_type: str,
         amazon_side_asn: Optional[str],
         availability_zone: Optional[str],
-        tags: Optional[Dict[str, str]] = None,
+        tags: Optional[dict[str, str]] = None,
         state: str = "available",
     ):
         self.ec2_backend = ec2_backend
@@ -74,7 +74,7 @@ class VpnGateway(CloudFormationModel, TaggedEC2Resource):
         self.availability_zone = availability_zone
         self.state = state
         self.add_tags(tags or {})
-        self.attachments: Dict[str, VPCGatewayAttachment] = {}
+        self.attachments: dict[str, VPCGatewayAttachment] = {}
         super().__init__()
 
     @staticmethod
@@ -124,14 +124,14 @@ class VpnGateway(CloudFormationModel, TaggedEC2Resource):
 
 class VpnGatewayBackend:
     def __init__(self) -> None:
-        self.vpn_gateways: Dict[str, VpnGateway] = {}
+        self.vpn_gateways: dict[str, VpnGateway] = {}
 
     def create_vpn_gateway(
         self,
         gateway_type: str = "ipsec.1",
         amazon_side_asn: Optional[str] = None,
         availability_zone: Optional[str] = None,
-        tags: Optional[Dict[str, str]] = None,
+        tags: Optional[dict[str, str]] = None,
     ) -> VpnGateway:
         vpn_gateway_id = random_vpn_gateway_id()
         vpn_gateway = VpnGateway(
@@ -141,8 +141,8 @@ class VpnGatewayBackend:
         return vpn_gateway
 
     def describe_vpn_gateways(
-        self, filters: Any = None, vpn_gw_ids: Optional[List[str]] = None
-    ) -> List[VpnGateway]:
+        self, filters: Any = None, vpn_gw_ids: Optional[list[str]] = None
+    ) -> list[VpnGateway]:
         vpn_gateways = list(self.vpn_gateways.values() or [])
         if vpn_gw_ids:
             vpn_gateways = [item for item in vpn_gateways if item.id in vpn_gw_ids]

--- a/moto/ec2/responses/_base_response.py
+++ b/moto/ec2/responses/_base_response.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Optional
+from typing import Any, Optional
 
 from moto.core.responses import BaseResponse
 from moto.core.serialize import return_if_not_empty
@@ -23,7 +23,7 @@ class EC2BaseResponse(BaseResponse):
 
         return ec2_backends[self.current_account][self.region]
 
-    def _filters_from_querystring(self) -> Dict[str, str]:
+    def _filters_from_querystring(self) -> dict[str, str]:
         # [{"Name": x1, "Value": y1}, ..]
         _filters = self._get_multi_param("Filter.", skip_result_conversion=True)
         # return {x1: y1, ...}
@@ -36,7 +36,7 @@ class EC2BaseResponse(BaseResponse):
 
     def _parse_tag_specification(
         self, expected_type: Optional[str] = None
-    ) -> Dict[str, Dict[str, str]]:
+    ) -> dict[str, dict[str, str]]:
         # [{"ResourceType": _type, "Tag": [{"Key": k, "Value": v}, ..]}]
         tag_spec_set = self._get_multi_param(
             "TagSpecification", skip_result_conversion=True

--- a/moto/ec2/responses/instances.py
+++ b/moto/ec2/responses/instances.py
@@ -1,5 +1,5 @@
 from copy import deepcopy
-from typing import Any, Dict, List, Optional
+from typing import Any, Optional
 
 from moto.core.utils import camelcase_to_underscores
 from moto.ec2.exceptions import (
@@ -183,8 +183,8 @@ class InstanceResponse(EC2BaseResponse):
         return template.render(instances=instances)
 
     def _get_list_of_dict_params(
-        self, param_prefix: str, _dct: Dict[str, Any]
-    ) -> List[Any]:
+        self, param_prefix: str, _dct: dict[str, Any]
+    ) -> list[Any]:
         """
         Simplified version of _get_dict_param
         Allows you to pass in a custom dict instead of using self.querystring by default
@@ -392,12 +392,12 @@ class InstanceResponse(EC2BaseResponse):
         )
         return EC2_MODIFY_INSTANCE_ATTRIBUTE
 
-    def _parse_block_device_mapping(self) -> List[Dict[str, Any]]:
+    def _parse_block_device_mapping(self) -> list[dict[str, Any]]:
         device_mappings = self._get_list_prefix("BlockDeviceMapping")
         mappings = []
         for device_mapping in device_mappings:
             self._validate_block_device_mapping(device_mapping)
-            device_template: Dict[str, Any] = deepcopy(BLOCK_DEVICE_MAPPING_TEMPLATE)
+            device_template: dict[str, Any] = deepcopy(BLOCK_DEVICE_MAPPING_TEMPLATE)
             device_template["VirtualName"] = device_mapping.get("virtual_name")
             device_template["DeviceName"] = device_mapping.get("device_name")
             device_template["Ebs"]["SnapshotId"] = device_mapping.get(
@@ -423,7 +423,7 @@ class InstanceResponse(EC2BaseResponse):
         return mappings
 
     @staticmethod
-    def _validate_block_device_mapping(device_mapping: Dict[str, Any]) -> None:  # type: ignore[misc]
+    def _validate_block_device_mapping(device_mapping: dict[str, Any]) -> None:  # type: ignore[misc]
         from botocore import __version__ as botocore_version
 
         if "no_device" in device_mapping:

--- a/moto/ec2/responses/security_groups.py
+++ b/moto/ec2/responses/security_groups.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Tuple
+from typing import Any
 
 from moto.core.responses import ActionResult, EmptyResult
 
@@ -12,12 +12,12 @@ def try_parse_int(value: Any, default: Any = None) -> Any:
         return default
 
 
-def parse_sg_attributes_from_dict(sg_attributes: Dict[str, Any]) -> Tuple[Any, ...]:
+def parse_sg_attributes_from_dict(sg_attributes: dict[str, Any]) -> tuple[Any, ...]:
     ip_protocol = sg_attributes.get("IpProtocol", [None])[0]
     from_port = sg_attributes.get("FromPort", [None])[0]
     to_port = sg_attributes.get("ToPort", [None])[0]
 
-    ip_ranges: List[Dict[str, Any]] = []
+    ip_ranges: list[dict[str, Any]] = []
     ip_ranges_tree = sg_attributes.get("IpRanges") or {}
     for ip_range_idx in sorted(ip_ranges_tree.keys()):
         ip_range = {"CidrIp": ip_ranges_tree[ip_range_idx]["CidrIp"][0]}
@@ -26,7 +26,7 @@ def parse_sg_attributes_from_dict(sg_attributes: Dict[str, Any]) -> Tuple[Any, .
 
         ip_ranges.append(ip_range)
 
-    ip_ranges_tree: Dict[str, Any] = sg_attributes.get("Ipv6Ranges") or {}  # type: ignore[no-redef]
+    ip_ranges_tree: dict[str, Any] = sg_attributes.get("Ipv6Ranges") or {}  # type: ignore[no-redef]
     for ip_range_idx in sorted(ip_ranges_tree.keys()):
         ip_range = {"CidrIpv6": ip_ranges_tree[ip_range_idx]["CidrIpv6"][0]}
         if ip_ranges_tree[ip_range_idx].get("Description"):
@@ -42,8 +42,8 @@ def parse_sg_attributes_from_dict(sg_attributes: Dict[str, Any]) -> Tuple[Any, .
         cidr_ipv6 = sg_attributes.get("CidrIpv6")[0]  # type: ignore
         ip_ranges.append({"CidrIpv6": cidr_ipv6})
 
-    source_groups: List[Dict[str, Any]] = []
-    groups_tree: Dict[str, Any] = sg_attributes.get("Groups") or {}
+    source_groups: list[dict[str, Any]] = []
+    groups_tree: dict[str, Any] = sg_attributes.get("Groups") or {}
     for group_idx in sorted(groups_tree.keys()):
         group_dict = groups_tree[group_idx]
         source_group = {}
@@ -57,8 +57,8 @@ def parse_sg_attributes_from_dict(sg_attributes: Dict[str, Any]) -> Tuple[Any, .
             source_group["OwnerId"] = group_dict["OwnerId"][0]
         source_groups.append(source_group)
 
-    prefix_list_ids: List[Dict[str, Any]] = []
-    pl_tree: Dict[str, Any] = sg_attributes.get("PrefixListIds") or {}
+    prefix_list_ids: list[dict[str, Any]] = []
+    pl_tree: dict[str, Any] = sg_attributes.get("PrefixListIds") or {}
     for pl_index in sorted(pl_tree):
         pl_dict = pl_tree.get(pl_index, {})
         pl_item = {}
@@ -76,7 +76,7 @@ class SecurityGroups(EC2BaseResponse):
         group_name_or_id = self._get_param("GroupName") or self._get_param("GroupId")
         security_rule_ids = self._get_multi_param("SecurityGroupRuleId")
 
-        querytree: Dict[str, Any] = {}
+        querytree: dict[str, Any] = {}
         for key, value in self.querystring.items():
             key_splitted = key.split(".")
             key_splitted = [try_parse_int(e, e) for e in key_splitted]

--- a/moto/ec2/responses/vpcs.py
+++ b/moto/ec2/responses/vpcs.py
@@ -1,5 +1,3 @@
-from typing import List
-
 from moto.core.responses import ActionResult, EmptyResult
 from moto.core.utils import camelcase_to_underscores
 from moto.ec2.utils import add_tag_specification
@@ -295,7 +293,7 @@ class VPCs(EC2BaseResponse):
         managed_prefix_list = self.ec2_backend.get_managed_prefix_list_entries(
             prefix_list_id=prefix_list_id
         )
-        entries: List[ManagedPrefixList] = []
+        entries: list[ManagedPrefixList] = []
         if managed_prefix_list:
             entries = (
                 list(managed_prefix_list.entries.values())[-1]

--- a/moto/ec2/utils.py
+++ b/moto/ec2/utils.py
@@ -7,11 +7,7 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Callable,
-    Dict,
-    List,
     Optional,
-    Set,
-    Tuple,
     TypeVar,
     Union,
 )
@@ -317,7 +313,7 @@ def generate_route_id(
     return f"{route_table_id}~{cidr_block}"
 
 
-def create_dns_entries(service_name: str, vpc_endpoint_id: str) -> Dict[str, str]:
+def create_dns_entries(service_name: str, vpc_endpoint_id: str) -> dict[str, str]:
     return {
         "dns_name": f"{vpc_endpoint_id}-{random_resource_id(8)}.{service_name}",
         "hosted_zone_id": random_resource_id(13).upper(),
@@ -330,13 +326,13 @@ def utc_date_and_time() -> str:
     return f"{x.year}-{x.month:02d}-{x.day:02d}T{x.hour:02d}:{x.minute:02d}:{x.second:02d}.000Z"
 
 
-def split_route_id(route_id: str) -> Tuple[str, str]:
+def split_route_id(route_id: str) -> tuple[str, str]:
     values = route_id.split("~")
     return values[0], values[1]
 
 
 def get_attribute_value(
-    parameter: str, querystring_dict: Dict[str, List[str]]
+    parameter: str, querystring_dict: dict[str, list[str]]
 ) -> Union[None, bool, str]:
     for key, value in querystring_dict.items():
         match = re.search(rf"{parameter}.Value", key)
@@ -381,26 +377,26 @@ def get_obj_tag(obj: Any, filter_name: str) -> Optional[str]:
     return tags.get(tag_name)
 
 
-def get_obj_tag_names(obj: Any) -> Set[str]:
-    tags = set((tag["key"] for tag in obj.get_tags()))
+def get_obj_tag_names(obj: Any) -> set[str]:
+    tags = set(tag["key"] for tag in obj.get_tags())
     return tags
 
 
-def get_obj_tag_values(obj: Any, key: Optional[str] = None) -> Set[str]:
+def get_obj_tag_values(obj: Any, key: Optional[str] = None) -> set[str]:
     tags = set(
-        (tag["value"] for tag in obj.get_tags() if tag["key"] == key or key is None)
+        tag["value"] for tag in obj.get_tags() if tag["key"] == key or key is None
     )
     return tags
 
 
-def add_tag_specification(tags: Any) -> Dict[str, str]:
+def add_tag_specification(tags: Any) -> dict[str, str]:
     tags = tags[0] if isinstance(tags, list) and len(tags) == 1 else tags
     tags = (tags or {}).get("Tag", [])
     tags = {t["Key"]: t["Value"] for t in tags}
     return tags
 
 
-def tag_filter_matches(obj: Any, filter_name: str, filter_values: List[str]) -> bool:
+def tag_filter_matches(obj: Any, filter_name: str, filter_values: list[str]) -> bool:
     regex_filters = [re.compile(simple_aws_filter_to_re(f)) for f in filter_values]
     if filter_name == "tag-key":
         tag_values = get_obj_tag_names(obj)
@@ -446,7 +442,7 @@ filter_dict_attribute_mapping = {
 }
 
 
-def passes_filter_dict(instance: Any, filter_dict: Dict[str, Any]) -> bool:
+def passes_filter_dict(instance: Any, filter_dict: dict[str, Any]) -> bool:
     for filter_name, filter_values in filter_dict.items():
         if filter_name in filter_dict_attribute_mapping:
             instance_attr = filter_dict_attribute_mapping[filter_name]
@@ -459,8 +455,7 @@ def passes_filter_dict(instance: Any, filter_dict: Dict[str, Any]) -> bool:
                 return False
         else:
             raise NotImplementedError(
-                "Filter dicts have not been implemented in Moto for '%s' yet. Feel free to open an issue at https://github.com/getmoto/moto/issues"
-                % filter_name
+                f"Filter dicts have not been implemented in Moto for '{filter_name}' yet. Feel free to open an issue at https://github.com/getmoto/moto/issues"
             )
     return True
 
@@ -478,8 +473,8 @@ FILTER_TYPE = TypeVar("FILTER_TYPE")
 
 
 def filter_reservations(
-    reservations: List[FILTER_TYPE], filter_dict: Any
-) -> List[FILTER_TYPE]:
+    reservations: list[FILTER_TYPE], filter_dict: Any
+) -> list[FILTER_TYPE]:
     result = []
     for reservation in reservations:
         new_instances = []
@@ -499,7 +494,7 @@ filter_dict_igw_mapping = {
 }
 
 
-def passes_igw_filter_dict(igw: Any, filter_dict: Dict[str, Any]) -> bool:
+def passes_igw_filter_dict(igw: Any, filter_dict: dict[str, Any]) -> bool:
     for filter_name, filter_values in filter_dict.items():
         if filter_name in filter_dict_igw_mapping:
             igw_attr = filter_dict_igw_mapping[filter_name]
@@ -517,8 +512,8 @@ def passes_igw_filter_dict(igw: Any, filter_dict: Dict[str, Any]) -> bool:
 
 
 def filter_internet_gateways(
-    igws: List[FILTER_TYPE], filter_dict: Any
-) -> List[FILTER_TYPE]:
+    igws: list[FILTER_TYPE], filter_dict: Any
+) -> list[FILTER_TYPE]:
     result = []
     for igw in igws:
         if passes_igw_filter_dict(igw, filter_dict):
@@ -561,8 +556,8 @@ def is_filter_matching(obj: Any, _filter: str, filter_value: Any) -> bool:
 
 
 def generic_filter(
-    filters: Dict[str, Any], objects: List[FILTER_TYPE]
-) -> List[FILTER_TYPE]:
+    filters: dict[str, Any], objects: list[FILTER_TYPE]
+) -> list[FILTER_TYPE]:
     if filters:
         for _filter, _filter_value in filters.items():
             objects = [
@@ -581,7 +576,7 @@ def simple_aws_filter_to_re(filter_string: str) -> str:
     return tmp_filter
 
 
-def random_ed25519_key_pair() -> Dict[str, str]:
+def random_ed25519_key_pair() -> dict[str, str]:
     private_key = Ed25519PrivateKey.generate()
     private_key_material = private_key.private_bytes(
         encoding=serialization.Encoding.PEM,
@@ -603,7 +598,7 @@ def random_ed25519_key_pair() -> Dict[str, str]:
     }
 
 
-def random_rsa_key_pair() -> Dict[str, str]:
+def random_rsa_key_pair() -> dict[str, str]:
     private_key = rsa.generate_private_key(
         public_exponent=65537, key_size=2048, backend=default_backend()
     )
@@ -677,7 +672,7 @@ def is_valid_security_group_id(sg_id: str) -> bool:
     return compiled_re.match(sg_id) is not None
 
 
-def generate_instance_identity_document(instance: Any) -> Dict[str, Any]:
+def generate_instance_identity_document(instance: Any) -> dict[str, Any]:
     """
     http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-identity-documents.html
 
@@ -796,8 +791,8 @@ def select_hash_algorithm(
 
 
 def filter_iam_instance_profile_associations(
-    iam_instance_associations: List[FILTER_TYPE], filter_dict: Any
-) -> List[FILTER_TYPE]:
+    iam_instance_associations: list[FILTER_TYPE], filter_dict: Any
+) -> list[FILTER_TYPE]:
     if not filter_dict:
         return iam_instance_associations
     result = []
@@ -848,8 +843,8 @@ def filter_iam_instance_profiles(
 
 
 def describe_tag_filter(
-    filters: Any, instances: List[FILTER_TYPE]
-) -> List[FILTER_TYPE]:
+    filters: Any, instances: list[FILTER_TYPE]
+) -> list[FILTER_TYPE]:
     result = instances.copy()
     for instance in instances:
         for key in filters:
@@ -873,8 +868,8 @@ def describe_tag_filter(
 
 
 def gen_moto_amis(
-    described_images: List[Dict[str, Any]], drop_images_missing_keys: bool = True
-) -> List[Dict[str, Any]]:
+    described_images: list[dict[str, Any]], drop_images_missing_keys: bool = True
+) -> list[dict[str, Any]]:
     """Convert `boto3.EC2.Client.describe_images` output to form acceptable to `MOTO_AMIS_PATH`
 
     Parameters
@@ -928,12 +923,12 @@ def gen_moto_amis(
 
 
 def convert_tag_spec(
-    tag_spec_set: List[Dict[str, Any]], tag_key: str = "Tag"
-) -> Dict[str, Dict[str, str]]:
+    tag_spec_set: list[dict[str, Any]], tag_key: str = "Tag"
+) -> dict[str, dict[str, str]]:
     # IN:   [{"ResourceType": _type, "Tag": [{"Key": k, "Value": v}, ..]}]
     #  (or) [{"ResourceType": _type, "Tags": [{"Key": k, "Value": v}, ..]}] <-- special cfn case
     # OUT:  {_type: {k: v, ..}}
-    tags: Dict[str, Dict[str, str]] = {}
+    tags: dict[str, dict[str, str]] = {}
     for tag_spec in tag_spec_set:
         if tag_spec["ResourceType"] not in tags:
             tags[tag_spec["ResourceType"]] = {}

--- a/moto/ecr/policy_validation.py
+++ b/moto/ecr/policy_validation.py
@@ -1,5 +1,5 @@
 import json
-from typing import Any, Dict, List
+from typing import Any
 
 from moto.ecr.exceptions import InvalidParameterException
 
@@ -32,8 +32,8 @@ class EcrLifecyclePolicyValidator:
 
     def __init__(self, policy_text: str):
         self._policy_text = policy_text
-        self._policy_json: Dict[str, Any] = {}
-        self._rules: List[Any] = []
+        self._policy_json: dict[str, Any] = {}
+        self._rules: list[Any] = []
 
     def validate(self) -> None:
         try:

--- a/moto/ecs/models.py
+++ b/moto/ecs/models.py
@@ -1,8 +1,9 @@
 import re
+from collections.abc import Iterator
 from copy import copy
 from datetime import datetime, timezone
 from os import getenv
-from typing import Any, Dict, Iterator, List, Optional, Tuple
+from typing import Any, Optional
 
 from moto import settings
 from moto.core.base_backend import BackendDict, BaseBackend
@@ -40,7 +41,7 @@ class BaseObject(BaseModel):
                 words.append(word)
         return "".join(words)
 
-    def gen_response_object(self) -> Dict[str, Any]:
+    def gen_response_object(self) -> dict[str, Any]:
         response_object = copy(self.__dict__)
         for key, value in self.__dict__.items():
             if key.startswith("_"):
@@ -51,7 +52,7 @@ class BaseObject(BaseModel):
         return response_object
 
     @property
-    def response_object(self) -> Dict[str, Any]:  # type: ignore[misc]
+    def response_object(self) -> dict[str, Any]:  # type: ignore[misc]
         return self.gen_response_object()
 
 
@@ -67,12 +68,12 @@ class Cluster(BaseObject, CloudFormationModel):
         cluster_name: str,
         account_id: str,
         region_name: str,
-        cluster_settings: Optional[List[Dict[str, str]]] = None,
-        configuration: Optional[Dict[str, Any]] = None,
-        capacity_providers: Optional[List[str]] = None,
-        default_capacity_provider_strategy: Optional[List[Dict[str, Any]]] = None,
-        tags: Optional[List[Dict[str, str]]] = None,
-        service_connect_defaults: Optional[Dict[str, str]] = None,
+        cluster_settings: Optional[list[dict[str, str]]] = None,
+        configuration: Optional[dict[str, Any]] = None,
+        capacity_providers: Optional[list[str]] = None,
+        default_capacity_provider_strategy: Optional[list[dict[str, Any]]] = None,
+        tags: Optional[list[dict[str, str]]] = None,
+        service_connect_defaults: Optional[dict[str, str]] = None,
     ):
         self.active_services_count = 0
         self.arn = f"arn:{get_partition(region_name)}:ecs:{region_name}:{account_id}:cluster/{cluster_name}"
@@ -96,7 +97,7 @@ class Cluster(BaseObject, CloudFormationModel):
         return self.name
 
     @property
-    def response_object(self) -> Dict[str, Any]:  # type: ignore[misc]
+    def response_object(self) -> dict[str, Any]:  # type: ignore[misc]
         response_object = self.gen_response_object()
         response_object["clusterArn"] = self.arn
         response_object["clusterName"] = self.name
@@ -170,24 +171,24 @@ class TaskDefinition(BaseObject, CloudFormationModel):
         self,
         family: str,
         revision: int,
-        container_definitions: List[Dict[str, Any]],
+        container_definitions: list[dict[str, Any]],
         account_id: str,
         region_name: str,
         network_mode: Optional[str] = None,
-        volumes: Optional[List[Dict[str, Any]]] = None,
-        tags: Optional[List[Dict[str, str]]] = None,
-        placement_constraints: Optional[List[Dict[str, str]]] = None,
-        requires_compatibilities: Optional[List[str]] = None,
+        volumes: Optional[list[dict[str, Any]]] = None,
+        tags: Optional[list[dict[str, str]]] = None,
+        placement_constraints: Optional[list[dict[str, str]]] = None,
+        requires_compatibilities: Optional[list[str]] = None,
         cpu: Optional[str] = None,
         memory: Optional[str] = None,
         task_role_arn: Optional[str] = None,
         execution_role_arn: Optional[str] = None,
-        proxy_configuration: Optional[Dict[str, Any]] = None,
-        inference_accelerators: Optional[List[Dict[str, str]]] = None,
-        runtime_platform: Optional[Dict[str, str]] = None,
+        proxy_configuration: Optional[dict[str, Any]] = None,
+        inference_accelerators: Optional[list[dict[str, str]]] = None,
+        runtime_platform: Optional[dict[str, str]] = None,
         ipc_mode: Optional[str] = None,
         pid_mode: Optional[str] = None,
-        ephemeral_storage: Optional[Dict[str, int]] = None,
+        ephemeral_storage: Optional[dict[str, int]] = None,
     ):
         self.family = family
         self.revision = revision
@@ -254,7 +255,7 @@ class TaskDefinition(BaseObject, CloudFormationModel):
         self.status = "ACTIVE"
 
     @property
-    def response_object(self) -> Dict[str, Any]:  # type: ignore[misc]
+    def response_object(self) -> dict[str, Any]:  # type: ignore[misc]
         response_object = self.gen_response_object()
         response_object["taskDefinitionArn"] = response_object.pop("arn")
 
@@ -353,7 +354,7 @@ class DeleteTaskDefinitionFailure(BaseObject):
         self.arn = name
 
     @property
-    def response_object(self) -> Dict[str, Any]:  # type: ignore[misc]
+    def response_object(self) -> dict[str, Any]:  # type: ignore[misc]
         response_object = self.gen_response_object()
         response_object["reason"] = self.reason
         response_object["arn"] = self.arn
@@ -366,14 +367,14 @@ class Task(BaseObject, ManagedState):
         cluster: Cluster,
         task_definition: TaskDefinition,
         container_instance_arn: Optional[str],
-        resource_requirements: Optional[Dict[str, str]],
+        resource_requirements: Optional[dict[str, str]],
         backend: "EC2ContainerServiceBackend",
         group: str,
         launch_type: str = "",
-        overrides: Optional[Dict[str, Any]] = None,
+        overrides: Optional[dict[str, Any]] = None,
         started_by: str = "",
-        tags: Optional[List[Dict[str, str]]] = None,
-        networking_configuration: Optional[Dict[str, Any]] = None,
+        tags: Optional[list[dict[str, str]]] = None,
+        networking_configuration: Optional[dict[str, Any]] = None,
         platform_version: Optional[str] = None,
     ):
         # Configure ManagedState
@@ -462,7 +463,7 @@ class Task(BaseObject, ManagedState):
             return f"arn:{get_partition(self.region_name)}:ecs:{self.region_name}:{self._account_id}:task/{self.cluster_name}/{self.id}"
         return f"arn:{get_partition(self.region_name)}:ecs:{self.region_name}:{self._account_id}:task/{self.id}"
 
-    def response_object(self, include_tags: bool = True) -> Dict[str, Any]:  # type: ignore
+    def response_object(self, include_tags: bool = True) -> dict[str, Any]:  # type: ignore
         response_object = self.gen_response_object()
         if not include_tags:
             response_object.pop("tags", None)
@@ -479,8 +480,8 @@ class CapacityProvider(BaseObject):
         account_id: str,
         region_name: str,
         name: str,
-        asg_details: Dict[str, Any],
-        tags: Optional[List[Dict[str, str]]],
+        asg_details: dict[str, Any],
+        tags: Optional[list[dict[str, str]]],
     ):
         self._id = str(mock_random.uuid4())
         self.capacity_provider_arn = f"arn:{get_partition(region_name)}:ecs:{region_name}:{account_id}:capacity-provider/{name}"
@@ -491,7 +492,7 @@ class CapacityProvider(BaseObject):
 
         self.update_status: Optional[str] = None
 
-    def _prepare_asg_provider(self, asg_details: Dict[str, Any]) -> Dict[str, Any]:
+    def _prepare_asg_provider(self, asg_details: dict[str, Any]) -> dict[str, Any]:
         if "managedScaling" not in asg_details:
             asg_details["managedScaling"] = {}
         if asg_details["managedScaling"].get("instanceWarmupPeriod") is None:
@@ -508,7 +509,7 @@ class CapacityProvider(BaseObject):
             asg_details["managedTerminationProtection"] = "DISABLED"
         return asg_details
 
-    def update(self, asg_details: Dict[str, Any]) -> None:
+    def update(self, asg_details: dict[str, Any]) -> None:
         if "managedTerminationProtection" in asg_details:
             self.auto_scaling_group_provider["managedTerminationProtection"] = (
                 asg_details["managedTerminationProtection"]
@@ -538,7 +539,7 @@ class CapacityProviderFailure(BaseObject):
         self.arn = f"arn:{get_partition(region_name)}:ecs:{region_name}:{account_id}:capacity_provider/{name}"
 
     @property
-    def response_object(self) -> Dict[str, Any]:  # type: ignore[misc]
+    def response_object(self) -> dict[str, Any]:  # type: ignore[misc]
         response_object = self.gen_response_object()
         response_object["reason"] = self.reason
         response_object["arn"] = self.arn
@@ -553,14 +554,14 @@ class Service(BaseObject, CloudFormationModel):
         desired_count: int,
         backend: "EC2ContainerServiceBackend",
         task_definition: Optional[TaskDefinition] = None,
-        load_balancers: Optional[List[Dict[str, Any]]] = None,
-        scheduling_strategy: Optional[List[Dict[str, Any]]] = None,
-        tags: Optional[List[Dict[str, str]]] = None,
-        deployment_controller: Optional[Dict[str, str]] = None,
+        load_balancers: Optional[list[dict[str, Any]]] = None,
+        scheduling_strategy: Optional[list[dict[str, Any]]] = None,
+        tags: Optional[list[dict[str, str]]] = None,
+        deployment_controller: Optional[dict[str, str]] = None,
         launch_type: Optional[str] = None,
-        service_registries: Optional[List[Dict[str, Any]]] = None,
+        service_registries: Optional[list[dict[str, Any]]] = None,
         platform_version: Optional[str] = None,
-        network_configuration: Optional[Dict[str, Dict[str, List[str]]]] = None,
+        network_configuration: Optional[dict[str, dict[str, list[str]]]] = None,
         propagate_tags: str = "NONE",
         role_arn: Optional[str] = None,
     ):
@@ -570,9 +571,9 @@ class Service(BaseObject, CloudFormationModel):
         self.status = "ACTIVE"
         self.task_definition = task_definition.arn if task_definition else None
         self.desired_count = desired_count
-        self.task_sets: List[TaskSet] = []
+        self.task_sets: list[TaskSet] = []
         self.deployment_controller = deployment_controller or {"type": "ECS"}
-        self.events: List[Dict[str, Any]] = []
+        self.events: list[dict[str, Any]] = []
         self.launch_type = launch_type
         self.service_registries = service_registries or []
         self.load_balancers = load_balancers if load_balancers is not None else []
@@ -623,8 +624,8 @@ class Service(BaseObject, CloudFormationModel):
             self.network_configuration = {}
 
     def _validate_network(
-        self, nc: Dict[str, Dict[str, List[str]]]
-    ) -> Dict[str, Dict[str, List[str]]]:
+        self, nc: dict[str, dict[str, list[str]]]
+    ) -> dict[str, dict[str, list[str]]]:
         c = nc["awsvpcConfiguration"]
         if len(c["subnets"]) == 0:
             raise InvalidParameterException("subnets can not be empty.")
@@ -659,7 +660,7 @@ class Service(BaseObject, CloudFormationModel):
         return self.arn
 
     @property
-    def response_object(self) -> Dict[str, Any]:  # type: ignore[misc]
+    def response_object(self) -> dict[str, Any]:  # type: ignore[misc]
         response_object = self.gen_response_object()
         del response_object["name"], response_object["tags"]
         response_object["serviceName"] = self.name
@@ -797,7 +798,7 @@ class Container(BaseObject, CloudFormationModel):
         self.last_status = "PENDING"
         self.exitCode = 0
 
-        self.network_interfaces: List[Dict[str, Any]] = []
+        self.network_interfaces: list[dict[str, Any]] = []
         self.health_status = "HEALTHY"
 
         self.cpu = container_def.get("cpu")
@@ -819,7 +820,7 @@ class ContainerInstance(BaseObject):
         self.ec2_instance_id = ec2_instance_id
         self.agent_connected = True
         self.status = "ACTIVE"
-        self.registered_resources: List[Dict[str, Any]] = [
+        self.registered_resources: list[dict[str, Any]] = [
             {
                 "doubleValue": 0.0,
                 "integerValue": 4096,
@@ -852,7 +853,7 @@ class ContainerInstance(BaseObject):
             },
         ]
         self.pending_tasks_count = 0
-        self.remaining_resources: List[Dict[str, Any]] = [
+        self.remaining_resources: list[dict[str, Any]] = [
             {
                 "doubleValue": 0.0,
                 "integerValue": 4096,
@@ -916,7 +917,7 @@ class ContainerInstance(BaseObject):
         return f"arn:{get_partition(self.region_name)}:ecs:{self.region_name}:{self._account_id}:container-instance/{self.id}"
 
     @property
-    def response_object(self) -> Dict[str, Any]:  # type: ignore[misc]
+    def response_object(self) -> dict[str, Any]:  # type: ignore[misc]
         response_object = self.gen_response_object()
         response_object["containerInstanceArn"] = self.container_instance_arn
         response_object["attributes"] = [
@@ -929,7 +930,7 @@ class ContainerInstance(BaseObject):
             )
         return response_object
 
-    def _format_attribute(self, name: str, value: Optional[str]) -> Dict[str, str]:
+    def _format_attribute(self, name: str, value: Optional[str]) -> dict[str, str]:
         formatted_attr = {"name": name}
         if value is not None:
             formatted_attr["value"] = value
@@ -944,7 +945,7 @@ class ClusterFailure(BaseObject):
         self.arn = f"arn:{get_partition(region_name)}:ecs:{region_name}:{account_id}:cluster/{cluster_name}"
 
     @property
-    def response_object(self) -> Dict[str, Any]:  # type: ignore[misc]
+    def response_object(self) -> dict[str, Any]:  # type: ignore[misc]
         response_object = self.gen_response_object()
         response_object["reason"] = self.reason
         response_object["arn"] = self.arn
@@ -959,7 +960,7 @@ class ContainerInstanceFailure(BaseObject):
         self.arn = f"arn:{get_partition(region_name)}:ecs:{region_name}:{account_id}:container-instance/{container_instance_id}"
 
     @property
-    def response_object(self) -> Dict[str, Any]:  # type: ignore[misc]
+    def response_object(self) -> dict[str, Any]:  # type: ignore[misc]
         response_object = self.gen_response_object()
         response_object["reason"] = self.reason
         response_object["arn"] = self.arn
@@ -975,15 +976,15 @@ class TaskSet(BaseObject):
         account_id: str,
         region_name: str,
         external_id: Optional[str] = None,
-        network_configuration: Optional[Dict[str, Any]] = None,
-        load_balancers: Optional[List[Dict[str, Any]]] = None,
-        service_registries: Optional[List[Dict[str, Any]]] = None,
+        network_configuration: Optional[dict[str, Any]] = None,
+        load_balancers: Optional[list[dict[str, Any]]] = None,
+        service_registries: Optional[list[dict[str, Any]]] = None,
         launch_type: Optional[str] = None,
-        capacity_provider_strategy: Optional[List[Dict[str, Any]]] = None,
+        capacity_provider_strategy: Optional[list[dict[str, Any]]] = None,
         platform_version: Optional[str] = None,
-        scale: Optional[Dict[str, Any]] = None,
+        scale: Optional[dict[str, Any]] = None,
         client_token: Optional[str] = None,
-        tags: Optional[List[Dict[str, str]]] = None,
+        tags: Optional[list[dict[str, str]]] = None,
     ):
         self.service = service
         self.cluster = cluster
@@ -1013,7 +1014,7 @@ class TaskSet(BaseObject):
         self.task_set_arn = f"arn:{get_partition(region_name)}:ecs:{region_name}:{account_id}:task-set/{cluster_name}/{service_name}/{self.id}"
 
     @property
-    def response_object(self) -> Dict[str, Any]:  # type: ignore[misc]
+    def response_object(self) -> dict[str, Any]:  # type: ignore[misc]
         response_object = self.gen_response_object()
         if isinstance(response_object["createdAt"], datetime):
             response_object["createdAt"] = unix_time(
@@ -1049,13 +1050,13 @@ class EC2ContainerServiceBackend(BaseBackend):
 
     def __init__(self, region_name: str, account_id: str):
         super().__init__(region_name, account_id)
-        self.account_settings: Dict[str, AccountSetting] = dict()
-        self.capacity_providers: Dict[str, CapacityProvider] = dict()
-        self.clusters: Dict[str, Cluster] = {}
-        self.task_definitions: Dict[str, Dict[int, TaskDefinition]] = {}
-        self.tasks: Dict[str, Dict[str, Task]] = {}
-        self.services: Dict[str, Service] = {}
-        self.container_instances: Dict[str, Dict[str, ContainerInstance]] = {}
+        self.account_settings: dict[str, AccountSetting] = dict()
+        self.capacity_providers: dict[str, CapacityProvider] = dict()
+        self.clusters: dict[str, Cluster] = {}
+        self.task_definitions: dict[str, dict[int, TaskDefinition]] = {}
+        self.tasks: dict[str, dict[str, Task]] = {}
+        self.services: dict[str, Service] = {}
+        self.container_instances: dict[str, dict[str, ContainerInstance]] = {}
 
     def _get_cluster(self, name: str) -> Cluster:
         # short name or full ARN of the cluster
@@ -1070,8 +1071,8 @@ class EC2ContainerServiceBackend(BaseBackend):
     def create_capacity_provider(
         self,
         name: str,
-        asg_details: Dict[str, Any],
-        tags: Optional[List[Dict[str, str]]],
+        asg_details: dict[str, Any],
+        tags: Optional[list[dict[str, str]]],
     ) -> CapacityProvider:
         capacity_provider = CapacityProvider(
             self.account_id, self.region_name, name, asg_details, tags
@@ -1101,10 +1102,10 @@ class EC2ContainerServiceBackend(BaseBackend):
         cluster_name: str,
         tags: Any = None,
         cluster_settings: Any = None,
-        configuration: Optional[Dict[str, Any]] = None,
-        capacity_providers: Optional[List[str]] = None,
-        default_capacity_provider_strategy: Optional[List[Dict[str, Any]]] = None,
-        service_connect_defaults: Optional[Dict[str, str]] = None,
+        configuration: Optional[dict[str, Any]] = None,
+        capacity_providers: Optional[list[str]] = None,
+        default_capacity_provider_strategy: Optional[list[dict[str, Any]]] = None,
+        service_connect_defaults: Optional[dict[str, str]] = None,
     ) -> Cluster:
         cluster = Cluster(
             cluster_name,
@@ -1123,9 +1124,9 @@ class EC2ContainerServiceBackend(BaseBackend):
     def update_cluster(
         self,
         cluster_name: str,
-        cluster_settings: Optional[List[Dict[str, str]]],
-        configuration: Optional[Dict[str, Any]],
-        service_connect_defaults: Optional[Dict[str, str]],
+        cluster_settings: Optional[list[dict[str, str]]],
+        configuration: Optional[dict[str, Any]],
+        service_connect_defaults: Optional[dict[str, str]],
     ) -> Cluster:
         """
         The serviceConnectDefaults-parameter is not yet implemented
@@ -1156,8 +1157,8 @@ class EC2ContainerServiceBackend(BaseBackend):
     def put_cluster_capacity_providers(
         self,
         cluster_name: str,
-        capacity_providers: Optional[List[str]],
-        default_capacity_provider_strategy: Optional[List[Dict[str, Any]]],
+        capacity_providers: Optional[list[str]],
+        default_capacity_provider_strategy: Optional[list[dict[str, Any]]],
     ) -> Cluster:
         cluster = self._get_cluster(cluster_name)
         if capacity_providers is not None:
@@ -1178,8 +1179,8 @@ class EC2ContainerServiceBackend(BaseBackend):
         return None
 
     def describe_capacity_providers(
-        self, names: List[str]
-    ) -> Tuple[List[CapacityProvider], List[CapacityProviderFailure]]:
+        self, names: list[str]
+    ) -> tuple[list[CapacityProvider], list[CapacityProviderFailure]]:
         providers = []
         failures = []
         for name in names:
@@ -1200,13 +1201,13 @@ class EC2ContainerServiceBackend(BaseBackend):
         return provider
 
     def update_capacity_provider(
-        self, name_or_arn: str, asg_provider: Dict[str, Any]
+        self, name_or_arn: str, asg_provider: dict[str, Any]
     ) -> CapacityProvider:
         provider: CapacityProvider = self._get_provider(name_or_arn)  # type: ignore[assignment]
         provider.update(asg_provider)
         return provider
 
-    def list_clusters(self) -> List[str]:
+    def list_clusters(self) -> list[str]:
         """
         maxSize and pagination not implemented
         """
@@ -1214,9 +1215,9 @@ class EC2ContainerServiceBackend(BaseBackend):
 
     def describe_clusters(
         self,
-        list_clusters_name: Optional[List[str]] = None,
-        include: Optional[List[str]] = None,
-    ) -> Tuple[List[Dict[str, Any]], List[ClusterFailure]]:
+        list_clusters_name: Optional[list[str]] = None,
+        include: Optional[list[str]] = None,
+    ) -> tuple[list[dict[str, Any]], list[ClusterFailure]]:
         """
         Only include=TAGS is currently supported.
         """
@@ -1256,22 +1257,22 @@ class EC2ContainerServiceBackend(BaseBackend):
     def register_task_definition(
         self,
         family: str,
-        container_definitions: List[Dict[str, Any]],
-        volumes: Optional[List[Dict[str, Any]]] = None,
+        container_definitions: list[dict[str, Any]],
+        volumes: Optional[list[dict[str, Any]]] = None,
         network_mode: Optional[str] = None,
-        tags: Optional[List[Dict[str, str]]] = None,
-        placement_constraints: Optional[List[Dict[str, str]]] = None,
-        requires_compatibilities: Optional[List[str]] = None,
+        tags: Optional[list[dict[str, str]]] = None,
+        placement_constraints: Optional[list[dict[str, str]]] = None,
+        requires_compatibilities: Optional[list[str]] = None,
         cpu: Optional[str] = None,
         memory: Optional[str] = None,
         task_role_arn: Optional[str] = None,
         execution_role_arn: Optional[str] = None,
-        proxy_configuration: Optional[Dict[str, Any]] = None,
-        inference_accelerators: Optional[List[Dict[str, str]]] = None,
-        runtime_platform: Optional[Dict[str, str]] = None,
+        proxy_configuration: Optional[dict[str, Any]] = None,
+        inference_accelerators: Optional[list[dict[str, str]]] = None,
+        runtime_platform: Optional[dict[str, str]] = None,
         ipc_mode: Optional[str] = None,
         pid_mode: Optional[str] = None,
-        ephemeral_storage: Optional[Dict[str, int]] = None,
+        ephemeral_storage: Optional[dict[str, int]] = None,
     ) -> TaskDefinition:
         if requires_compatibilities and "FARGATE" in requires_compatibilities:
             # TODO need more validation for Fargate
@@ -1318,8 +1319,8 @@ class EC2ContainerServiceBackend(BaseBackend):
     @staticmethod
     def _validate_container_defs(  # type: ignore[misc]
         memory: Optional[str],
-        container_definitions: List[Dict[str, Any]],
-        requires_compatibilities: Optional[List[str]],
+        container_definitions: list[dict[str, Any]],
+        requires_compatibilities: Optional[list[str]],
     ) -> None:
         # The capitalised keys are passed by Cloudformation
         for cd in container_definitions:
@@ -1344,7 +1345,7 @@ class EC2ContainerServiceBackend(BaseBackend):
 
     def list_task_definitions(
         self, family_prefix: str, status: str = "ACTIVE"
-    ) -> List[str]:
+    ) -> list[str]:
         task_arns = []
         for task_definition_list in self.task_definitions.values():
             task_arns.extend(
@@ -1386,14 +1387,14 @@ class EC2ContainerServiceBackend(BaseBackend):
         cluster_str: str,
         task_definition_str: str,
         count: int,
-        overrides: Optional[Dict[str, Any]],
+        overrides: Optional[dict[str, Any]],
         started_by: str,
-        tags: Optional[List[Dict[str, str]]],
+        tags: Optional[list[dict[str, str]]],
         launch_type: Optional[str],
-        networking_configuration: Optional[Dict[str, Any]] = None,
+        networking_configuration: Optional[dict[str, Any]] = None,
         group: Optional[str] = None,
         platform_version: Optional[str] = None,
-    ) -> List[Task]:
+    ) -> list[Task]:
         if launch_type and launch_type not in ["EC2", "FARGATE", "EXTERNAL"]:
             raise InvalidParameterException(
                 "launch type should be one of [EC2,FARGATE,EXTERNAL]"
@@ -1482,8 +1483,8 @@ class EC2ContainerServiceBackend(BaseBackend):
     @staticmethod
     def _calculate_task_resource_requirements(  # type: ignore[misc]
         task_definition: TaskDefinition,
-    ) -> Dict[str, Any]:
-        resource_requirements: Dict[str, Any] = {
+    ) -> dict[str, Any]:
+        resource_requirements: dict[str, Any] = {
             "CPU": 0,
             "MEMORY": 0,
             "PORTS": [],
@@ -1526,7 +1527,7 @@ class EC2ContainerServiceBackend(BaseBackend):
     @staticmethod
     def _can_be_placed(  # type: ignore[misc]
         container_instance: ContainerInstance,
-        task_resource_requirements: Dict[str, Any],
+        task_resource_requirements: dict[str, Any],
     ) -> bool:
         """
 
@@ -1539,7 +1540,7 @@ class EC2ContainerServiceBackend(BaseBackend):
         # docs.aws.amazon.com/AmazonECS/latest/developerguide/task-placement.html
         remaining_cpu = 0
         remaining_memory = 0
-        reserved_ports: List[str] = []
+        reserved_ports: list[str] = []
         for resource in container_instance.remaining_resources:
             if resource.get("name") == "CPU":
                 remaining_cpu = resource.get("integerValue")  # type: ignore[assignment]
@@ -1561,12 +1562,12 @@ class EC2ContainerServiceBackend(BaseBackend):
         self,
         cluster_str: str,
         task_definition_str: str,
-        container_instances: List[str],
-        overrides: Dict[str, Any],
+        container_instances: list[str],
+        overrides: dict[str, Any],
         started_by: str,
-        tags: Optional[List[Dict[str, str]]] = None,
+        tags: Optional[list[dict[str, str]]] = None,
         group: Optional[str] = None,
-    ) -> List[Task]:
+    ) -> list[Task]:
         cluster = self._get_cluster(cluster_str)
 
         task_definition = self.describe_task_definition(task_definition_str)
@@ -1605,7 +1606,7 @@ class EC2ContainerServiceBackend(BaseBackend):
             self.tasks[cluster.name][task.task_arn] = task
         return tasks
 
-    def describe_tasks(self, cluster_str: str, tasks: Optional[str]) -> List[Task]:
+    def describe_tasks(self, cluster_str: str, tasks: Optional[str]) -> list[Task]:
         """
         Only include=TAGS is currently supported.
         """
@@ -1635,7 +1636,7 @@ class EC2ContainerServiceBackend(BaseBackend):
         started_by: Optional[str] = None,
         service_name: Optional[str] = None,
         desiredStatus: Optional[str] = None,
-    ) -> List[Task]:
+    ) -> list[Task]:
         filtered_tasks = []
         for tasks in self.tasks.values():
             for task in tasks.values():
@@ -1722,15 +1723,15 @@ class EC2ContainerServiceBackend(BaseBackend):
         service_name: str,
         desired_count: int,
         task_definition_str: Optional[str] = None,
-        load_balancers: Optional[List[Dict[str, Any]]] = None,
-        scheduling_strategy: Optional[List[Dict[str, Any]]] = None,
-        tags: Optional[List[Dict[str, str]]] = None,
-        deployment_controller: Optional[Dict[str, str]] = None,
+        load_balancers: Optional[list[dict[str, Any]]] = None,
+        scheduling_strategy: Optional[list[dict[str, Any]]] = None,
+        tags: Optional[list[dict[str, str]]] = None,
+        deployment_controller: Optional[dict[str, str]] = None,
         launch_type: Optional[str] = None,
-        service_registries: Optional[List[Dict[str, Any]]] = None,
+        service_registries: Optional[list[dict[str, Any]]] = None,
         platform_version: Optional[str] = None,
         propagate_tags: str = "NONE",
-        network_configuration: Optional[Dict[str, Dict[str, List[str]]]] = None,
+        network_configuration: Optional[dict[str, dict[str, list[str]]]] = None,
         role_arn: Optional[str] = None,
     ) -> Service:
         cluster = self._get_cluster(cluster_str)
@@ -1779,7 +1780,7 @@ class EC2ContainerServiceBackend(BaseBackend):
         cluster_str: str,
         scheduling_strategy: Optional[str] = None,
         launch_type: Optional[str] = None,
-    ) -> List[str]:
+    ) -> list[str]:
         cluster = self._get_cluster(cluster_str)
         service_arns = []
         for key, service in self.services.items():
@@ -1800,8 +1801,8 @@ class EC2ContainerServiceBackend(BaseBackend):
         return sorted(service_arns)
 
     def describe_services(
-        self, cluster_str: str, service_names_or_arns: List[str]
-    ) -> Tuple[List[Service], List[Dict[str, str]]]:
+        self, cluster_str: str, service_names_or_arns: list[str]
+    ) -> tuple[list[Service], list[dict[str, str]]]:
         cluster = self._get_cluster(cluster_str)
 
         result = []
@@ -1820,7 +1821,7 @@ class EC2ContainerServiceBackend(BaseBackend):
 
         return result, failures
 
-    def update_service(self, service_properties: Dict[str, Any]) -> Service:
+    def update_service(self, service_properties: dict[str, Any]) -> Service:
         cluster_str = service_properties.pop("cluster", "default")
         task_definition_str = service_properties.pop("task_definition", None)
         cluster = self._get_cluster(cluster_str)
@@ -1910,7 +1911,7 @@ class EC2ContainerServiceBackend(BaseBackend):
         self.clusters[cluster_name].registered_container_instances_count += 1
         return container_instance
 
-    def list_container_instances(self, cluster_str: str) -> List[str]:
+    def list_container_instances(self, cluster_str: str) -> list[str]:
         cluster_name = cluster_str.split("/")[-1]
         container_instances_values = self.container_instances.get(
             cluster_name, {}
@@ -1921,8 +1922,8 @@ class EC2ContainerServiceBackend(BaseBackend):
         return sorted(container_instances)
 
     def describe_container_instances(
-        self, cluster_str: str, list_container_instance_ids: List[str]
-    ) -> Tuple[List[ContainerInstance], List[ContainerInstanceFailure]]:
+        self, cluster_str: str, list_container_instance_ids: list[str]
+    ) -> tuple[list[ContainerInstance], list[ContainerInstanceFailure]]:
         cluster = self._get_cluster(cluster_str)
 
         if not list_container_instance_ids:
@@ -1949,8 +1950,8 @@ class EC2ContainerServiceBackend(BaseBackend):
         return container_instance_objects, failures
 
     def update_container_instances_state(
-        self, cluster_str: str, list_container_instance_ids: List[str], status: str
-    ) -> Tuple[List[ContainerInstance], List[ContainerInstanceFailure]]:
+        self, cluster_str: str, list_container_instance_ids: list[str], status: str
+    ) -> tuple[list[ContainerInstance], list[ContainerInstanceFailure]]:
         cluster = self._get_cluster(cluster_str)
 
         status = status.upper()
@@ -1985,7 +1986,7 @@ class EC2ContainerServiceBackend(BaseBackend):
     def update_container_instance_resources(
         self,
         container_instance: ContainerInstance,
-        task_resources: Dict[str, Any],
+        task_resources: dict[str, Any],
         removing: bool = False,
     ) -> None:
         resource_multiplier = 1
@@ -2042,7 +2043,7 @@ class EC2ContainerServiceBackend(BaseBackend):
         pass
 
     def put_attributes(
-        self, cluster_name: str, attributes: Optional[List[Dict[str, Any]]] = None
+        self, cluster_name: str, attributes: Optional[list[dict[str, Any]]] = None
     ) -> None:
         cluster = self._get_cluster(cluster_name)
 
@@ -2135,7 +2136,7 @@ class EC2ContainerServiceBackend(BaseBackend):
         return filter(lambda x: all(f(x) for f in filters), all_attrs)  # type: ignore
 
     def delete_attributes(
-        self, cluster_name: str, attributes: Optional[List[Dict[str, Any]]] = None
+        self, cluster_name: str, attributes: Optional[list[dict[str, Any]]] = None
     ) -> None:
         cluster = self._get_cluster(cluster_name)
 
@@ -2205,7 +2206,7 @@ class EC2ContainerServiceBackend(BaseBackend):
             yield task_fam
 
     @staticmethod
-    def _parse_resource_arn(resource_arn: str) -> Dict[str, str]:
+    def _parse_resource_arn(resource_arn: str) -> dict[str, str]:
         regexes = [
             ARN_PARTITION_REGEX
             + ":ecs:(?P<region>[^:]+):(?P<account_id>[^:]+):(?P<service>[^:]+)/(?P<cluster_id>[^:]+)/(?P<service_id>[^:]+)/ecs-svc/(?P<id>.*)$",
@@ -2220,7 +2221,7 @@ class EC2ContainerServiceBackend(BaseBackend):
                 return match.groupdict()
         raise JsonRESTError("InvalidParameterException", "The ARN provided is invalid.")
 
-    def _get_resource(self, resource_arn: str, parsed_arn: Dict[str, str]) -> Any:
+    def _get_resource(self, resource_arn: str, parsed_arn: dict[str, str]) -> Any:
         if parsed_arn["service"] == "cluster":
             return self._get_cluster(parsed_arn["id"])
         if parsed_arn["service"] == "service":
@@ -2252,7 +2253,7 @@ class EC2ContainerServiceBackend(BaseBackend):
                     return task
         raise NotImplementedError()
 
-    def list_tags_for_resource(self, resource_arn: str) -> List[Dict[str, str]]:
+    def list_tags_for_resource(self, resource_arn: str) -> list[dict[str, str]]:
         """Currently implemented only for task definitions and services"""
         parsed_arn = self._parse_resource_arn(resource_arn)
         resource = self._get_resource(resource_arn, parsed_arn)
@@ -2263,14 +2264,14 @@ class EC2ContainerServiceBackend(BaseBackend):
         if definitions:
             return max(definitions.keys())
 
-    def tag_resource(self, resource_arn: str, tags: List[Dict[str, str]]) -> None:
+    def tag_resource(self, resource_arn: str, tags: list[dict[str, str]]) -> None:
         parsed_arn = self._parse_resource_arn(resource_arn)
         resource = self._get_resource(resource_arn, parsed_arn)
         resource.tags = self._merge_tags(resource.tags or [], tags)
 
     def _merge_tags(
-        self, existing_tags: List[Dict[str, str]], new_tags: List[Dict[str, str]]
-    ) -> List[Dict[str, str]]:
+        self, existing_tags: list[dict[str, str]], new_tags: list[dict[str, str]]
+    ) -> list[dict[str, str]]:
         merged_tags = new_tags
         new_keys = self._get_keys(new_tags)
         for existing_tag in existing_tags:
@@ -2279,10 +2280,10 @@ class EC2ContainerServiceBackend(BaseBackend):
         return merged_tags
 
     @staticmethod
-    def _get_keys(tags: List[Dict[str, str]]) -> List[str]:
+    def _get_keys(tags: list[dict[str, str]]) -> list[str]:
         return [tag["key"] for tag in tags]
 
-    def untag_resource(self, resource_arn: str, tag_keys: List[str]) -> None:
+    def untag_resource(self, resource_arn: str, tag_keys: list[str]) -> None:
         parsed_arn = self._parse_resource_arn(resource_arn)
         resource = self._get_resource(resource_arn, parsed_arn)
         resource.tags = [tag for tag in resource.tags if tag["key"] not in tag_keys]
@@ -2293,15 +2294,15 @@ class EC2ContainerServiceBackend(BaseBackend):
         cluster_str: str,
         task_definition: str,
         external_id: Optional[str] = None,
-        network_configuration: Optional[Dict[str, Any]] = None,
-        load_balancers: Optional[List[Dict[str, Any]]] = None,
-        service_registries: Optional[List[Dict[str, Any]]] = None,
+        network_configuration: Optional[dict[str, Any]] = None,
+        load_balancers: Optional[list[dict[str, Any]]] = None,
+        service_registries: Optional[list[dict[str, Any]]] = None,
         launch_type: Optional[str] = None,
-        capacity_provider_strategy: Optional[List[Dict[str, Any]]] = None,
+        capacity_provider_strategy: Optional[list[dict[str, Any]]] = None,
         platform_version: Optional[str] = None,
-        scale: Optional[Dict[str, Any]] = None,
+        scale: Optional[dict[str, Any]] = None,
         client_token: Optional[str] = None,
-        tags: Optional[List[Dict[str, str]]] = None,
+        tags: Optional[list[dict[str, str]]] = None,
     ) -> TaskSet:
         launch_type = launch_type if launch_type is not None else "EC2"
         if launch_type not in ["EC2", "FARGATE"]:
@@ -2364,8 +2365,8 @@ class EC2ContainerServiceBackend(BaseBackend):
         return task_set
 
     def describe_task_sets(
-        self, cluster_str: str, service: str, task_sets: Optional[List[str]] = None
-    ) -> List[TaskSet]:
+        self, cluster_str: str, service: str, task_sets: Optional[list[str]] = None
+    ) -> list[TaskSet]:
         task_sets = task_sets or []
 
         cluster_obj = self._get_cluster(cluster_str)
@@ -2418,7 +2419,7 @@ class EC2ContainerServiceBackend(BaseBackend):
         return deleted_task_set
 
     def update_task_set(
-        self, cluster: str, service: str, task_set: str, scale: Dict[str, Any]
+        self, cluster: str, service: str, task_set: str, scale: dict[str, Any]
     ) -> TaskSet:
         cluster_name = cluster.split("/")[-1]
         service_name = service.split("/")[-1]
@@ -2452,7 +2453,7 @@ class EC2ContainerServiceBackend(BaseBackend):
 
     def list_account_settings(
         self, name: Optional[str] = None, value: Optional[str] = None
-    ) -> List[AccountSetting]:
+    ) -> list[AccountSetting]:
         expected_names = [
             "serviceLongArnFormat",
             "taskLongArnFormat",
@@ -2486,8 +2487,8 @@ class EC2ContainerServiceBackend(BaseBackend):
         return settings.ecs_new_arn_format()
 
     def delete_task_definitions(
-        self, task_definitions: List[str]
-    ) -> Tuple[List[TaskDefinition], List[DeleteTaskDefinitionFailure]]:
+        self, task_definitions: list[str]
+    ) -> tuple[list[TaskDefinition], list[DeleteTaskDefinitionFailure]]:
         if not task_definitions:
             raise InvalidParameterException(
                 "size of TaskDefinition references list must be greater than 0"

--- a/moto/ecs/responses.py
+++ b/moto/ecs/responses.py
@@ -1,5 +1,5 @@
 import json
-from typing import Any, Dict
+from typing import Any
 
 from moto.core.responses import BaseResponse
 from moto.core.utils import camelcase_to_underscores
@@ -161,7 +161,7 @@ class EC2ContainerServiceResponse(BaseResponse):
     def describe_task_definition(self) -> str:
         task_definition_str = self._get_param("taskDefinition")
         data = self.ecs_backend.describe_task_definition(task_definition_str)
-        resp: Dict[str, Any] = data.response_object
+        resp: dict[str, Any] = data.response_object
         resp["failures"] = []
         if "TAGS" in self._get_param("include", []):
             resp["tags"] = self.ecs_backend.list_tags_for_resource(data.arn)

--- a/moto/efs/models.py
+++ b/moto/efs/models.py
@@ -6,8 +6,9 @@ https://docs.aws.amazon.com/efs/latest/ug/whatisefs.html
 
 import json
 import time
+from collections.abc import Iterator
 from copy import deepcopy
-from typing import Any, Dict, Iterator, List, Optional, Set, Tuple, Union
+from typing import Any, Optional, Union
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import CloudFormationModel
@@ -51,8 +52,8 @@ class AccessPoint(CloudFormationModel):
         client_token: str,
         file_system_id: str,
         name: Optional[str],
-        posix_user: Dict[str, Any],
-        root_directory: Dict[str, str],
+        posix_user: dict[str, Any],
+        root_directory: dict[str, str],
         context: "EFSBackend",
     ):
         self.access_point_id = f"fsap-{mock_random.get_random_hex(8)}"
@@ -69,7 +70,7 @@ class AccessPoint(CloudFormationModel):
         self.root_directory = root_directory
         self.context = context
 
-    def info_json(self) -> Dict[str, Any]:
+    def info_json(self) -> dict[str, Any]:
         tags = self.context.list_tags_for_resource(self.access_point_id)
         return {
             "ClientToken": self.client_token,
@@ -154,7 +155,7 @@ class FileSystem(CloudFormationModel):
                 account_id, self.availability_zone_name
             )
         self._backup = backup
-        self.lifecycle_policies: List[Dict[str, str]] = []
+        self.lifecycle_policies: list[dict[str, str]] = []
         self.file_system_policy: Optional[str] = None
 
         self._context = context
@@ -167,11 +168,11 @@ class FileSystem(CloudFormationModel):
 
         # Initialize some state parameters
         self.life_cycle_state = "available"
-        self._mount_targets: Dict[str, MountTarget] = {}
+        self._mount_targets: dict[str, MountTarget] = {}
         self._size_value = 0
 
     @property
-    def size_in_bytes(self) -> Dict[str, Any]:  # type: ignore[misc]
+    def size_in_bytes(self) -> dict[str, Any]:  # type: ignore[misc]
         return {
             "Value": self._size_value,
             "ValueInIA": 0,
@@ -188,13 +189,13 @@ class FileSystem(CloudFormationModel):
         return len(self._mount_targets)
 
     @property
-    def backup_policy(self) -> Optional[Dict[str, str]]:
+    def backup_policy(self) -> Optional[dict[str, str]]:
         if self._backup:
             return {"Status": "ENABLED"}
         else:
             return None
 
-    def info_json(self) -> Dict[str, Any]:
+    def info_json(self) -> dict[str, Any]:
         ret = {
             underscores_to_camelcase(k.capitalize()): v
             for k, v in self.__dict__.items()
@@ -232,8 +233,7 @@ class FileSystem(CloudFormationModel):
         return subnet.availability_zone in self._mount_targets
 
     def iter_mount_targets(self) -> Iterator["MountTarget"]:
-        for mt in self._mount_targets.values():
-            yield mt
+        yield from self._mount_targets.values()
 
     def remove_mount_target(self, subnet: Subnet) -> None:
         del self._mount_targets[subnet.availability_zone]
@@ -306,7 +306,7 @@ class MountTarget(CloudFormationModel):
         file_system: FileSystem,
         subnet: Subnet,
         ip_address: Optional[str],
-        security_groups: Optional[List[str]],
+        security_groups: Optional[list[str]],
     ):
         # Set the simple given parameters.
         self.file_system_id = file_system.file_system_id
@@ -353,7 +353,7 @@ class MountTarget(CloudFormationModel):
     def set_network_interface(self, network_interface: NetworkInterface) -> None:
         self.network_interface_id = network_interface.id
 
-    def info_json(self) -> Dict[str, Any]:
+    def info_json(self) -> dict[str, Any]:
         return {
             underscores_to_camelcase(k.capitalize()): v
             for k, v in self.__dict__.items()
@@ -423,15 +423,15 @@ class EFSBackend(BaseBackend):
 
     def __init__(self, region_name: str, account_id: str):
         super().__init__(region_name, account_id)
-        self.creation_tokens: Set[str] = set()
-        self.access_points: Dict[str, AccessPoint] = dict()
-        self.file_systems_by_id: Dict[str, FileSystem] = {}
-        self.mount_targets_by_id: Dict[str, MountTarget] = {}
-        self.next_markers: Dict[str, Union[List[MountTarget], List[FileSystem]]] = {}
+        self.creation_tokens: set[str] = set()
+        self.access_points: dict[str, AccessPoint] = dict()
+        self.file_systems_by_id: dict[str, FileSystem] = {}
+        self.mount_targets_by_id: dict[str, MountTarget] = {}
+        self.next_markers: dict[str, Union[list[MountTarget], list[FileSystem]]] = {}
         self.tagging_service = TaggingService()
 
     def _mark_description(
-        self, corpus: Union[List[MountTarget], List[FileSystem]], max_items: int
+        self, corpus: Union[list[MountTarget], list[FileSystem]], max_items: int
     ) -> Optional[str]:
         if max_items < len(corpus):
             new_corpus = corpus[max_items:]
@@ -457,7 +457,7 @@ class EFSBackend(BaseBackend):
         provisioned_throughput_in_mibps: int,
         availability_zone_name: str,
         backup: bool,
-        tags: List[Dict[str, str]],
+        tags: list[dict[str, str]],
     ) -> FileSystem:
         """Create a new EFS File System Volume.
 
@@ -499,7 +499,7 @@ class EFSBackend(BaseBackend):
         max_items: int = 10,
         creation_token: Optional[str] = None,
         file_system_id: Optional[str] = None,
-    ) -> Tuple[Optional[str], List[FileSystem]]:
+    ) -> tuple[Optional[str], list[FileSystem]]:
         """Describe all the EFS File Systems, or specific File Systems.
 
         https://docs.aws.amazon.com/efs/latest/ug/API_DescribeFileSystems.html
@@ -539,7 +539,7 @@ class EFSBackend(BaseBackend):
         file_system_id: str,
         subnet_id: str,
         ip_address: Optional[str] = None,
-        security_groups: Optional[List[str]] = None,
+        security_groups: Optional[list[str]] = None,
     ) -> MountTarget:
         """Create a new EFS Mount Target for a given File System to a given subnet.
 
@@ -586,7 +586,7 @@ class EFSBackend(BaseBackend):
         mount_target_id: Optional[str],
         access_point_id: Optional[str],
         marker: Optional[str],
-    ) -> Tuple[Optional[str], List[MountTarget]]:
+    ) -> tuple[Optional[str], list[MountTarget]]:
         """Describe the mount targets given an access point ID, mount target ID or a file system ID.
 
         https://docs.aws.amazon.com/efs/latest/ug/API_DescribeMountTargets.html
@@ -661,14 +661,14 @@ class EFSBackend(BaseBackend):
         del self.mount_targets_by_id[mount_target_id]
         mount_target.clean_up()
 
-    def describe_backup_policy(self, file_system_id: str) -> Dict[str, str]:
+    def describe_backup_policy(self, file_system_id: str) -> dict[str, str]:
         backup_policy = self.file_systems_by_id[file_system_id].backup_policy
         if not backup_policy:
             raise PolicyNotFound("None")
         return backup_policy
 
     def put_lifecycle_configuration(
-        self, file_system_id: str, policies: List[Dict[str, str]]
+        self, file_system_id: str, policies: list[dict[str, str]]
     ) -> None:
         _, fss = self.describe_file_systems(file_system_id=file_system_id)
         file_system = fss[0]
@@ -676,14 +676,14 @@ class EFSBackend(BaseBackend):
 
     def describe_lifecycle_configuration(
         self, file_system_id: str
-    ) -> List[Dict[str, str]]:
+    ) -> list[dict[str, str]]:
         _, fss = self.describe_file_systems(file_system_id=file_system_id)
         file_system = fss[0]
         return file_system.lifecycle_policies
 
     def describe_mount_target_security_groups(
         self, mount_target_id: str
-    ) -> Optional[List[str]]:
+    ) -> Optional[list[str]]:
         if mount_target_id not in self.mount_targets_by_id:
             raise MountTargetNotFound(mount_target_id)
 
@@ -691,7 +691,7 @@ class EFSBackend(BaseBackend):
         return mount_target.security_groups
 
     def modify_mount_target_security_groups(
-        self, mount_target_id: str, security_groups: List[str]
+        self, mount_target_id: str, security_groups: list[str]
     ) -> None:
         if mount_target_id not in self.mount_targets_by_id:
             raise MountTargetNotFound(mount_target_id)
@@ -706,10 +706,10 @@ class EFSBackend(BaseBackend):
     def create_access_point(
         self,
         client_token: str,
-        tags: List[Dict[str, str]],
+        tags: list[dict[str, str]],
         file_system_id: str,
-        posix_user: Dict[str, Any],
-        root_directory: Dict[str, Any],
+        posix_user: dict[str, Any],
+        root_directory: dict[str, Any],
     ) -> AccessPoint:
         name = next((tag["Value"] for tag in tags if tag["Key"] == "Name"), None)
         access_point = AccessPoint(
@@ -730,7 +730,7 @@ class EFSBackend(BaseBackend):
         self,
         access_point_id: Optional[str],
         file_system_id: Optional[str],
-    ) -> List[AccessPoint]:
+    ) -> list[AccessPoint]:
         """
         Pagination is not yet implemented
         """
@@ -749,13 +749,13 @@ class EFSBackend(BaseBackend):
     def delete_access_point(self, access_point_id: str) -> None:
         self.access_points.pop(access_point_id, None)
 
-    def list_tags_for_resource(self, resource_id: str) -> List[Dict[str, str]]:
+    def list_tags_for_resource(self, resource_id: str) -> list[dict[str, str]]:
         return self.tagging_service.list_tags_for_resource(resource_id)["Tags"]
 
-    def tag_resource(self, resource_id: str, tags: List[Dict[str, str]]) -> None:
+    def tag_resource(self, resource_id: str, tags: list[dict[str, str]]) -> None:
         self.tagging_service.tag_resource(resource_id, tags)
 
-    def untag_resource(self, resource_id: str, tag_keys: List[str]) -> None:
+    def untag_resource(self, resource_id: str, tag_keys: list[str]) -> None:
         self.tagging_service.untag_resource_using_names(resource_id, tag_keys)
 
     def describe_file_system_policy(self, file_system_id: str) -> str:

--- a/moto/efs/responses.py
+++ b/moto/efs/responses.py
@@ -1,11 +1,11 @@
 import json
-from typing import Any, Dict, Tuple, Union
+from typing import Any, Union
 
 from moto.core.responses import BaseResponse
 
 from .models import EFSBackend, efs_backends
 
-TYPE_RESPONSE = Tuple[str, Dict[str, Union[str, int]]]
+TYPE_RESPONSE = tuple[str, dict[str, Union[str, int]]]
 
 
 class EFSResponse(BaseResponse):
@@ -55,7 +55,7 @@ class EFSResponse(BaseResponse):
             creation_token=creation_token,
             file_system_id=file_system_id,
         )
-        resp_json: Dict[str, Any] = {
+        resp_json: dict[str, Any] = {
             "FileSystems": [fs.info_json() for fs in file_systems]
         }
         if marker:
@@ -93,7 +93,7 @@ class EFSResponse(BaseResponse):
             access_point_id=access_point_id,
             marker=marker,
         )
-        resp_json: Dict[str, Any] = {
+        resp_json: dict[str, Any] = {
             "MountTargets": [mt.info_json() for mt in mount_targets]
         }
         if marker:

--- a/moto/eks/exceptions.py
+++ b/moto/eks/exceptions.py
@@ -1,5 +1,5 @@
 import json
-from typing import Any, Dict, Tuple
+from typing import Any
 
 from moto.core.exceptions import AWSError
 
@@ -11,7 +11,7 @@ class EKSError(AWSError):
         self.headers = {"status": self.STATUS, "x-amzn-ErrorType": self.TYPE}
         self.code = self.STATUS
 
-    def response(self) -> Tuple[int, Dict[str, Any], str]:  # type: ignore[override]
+    def response(self) -> tuple[int, dict[str, Any], str]:  # type: ignore[override]
         return self.STATUS, self.headers, self.description
 
 

--- a/moto/eks/models.py
+++ b/moto/eks/models.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Optional
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.utils import utcnow
@@ -53,7 +53,7 @@ DEFAULT_AMI_TYPE = "AL2_x86_64"
 DEFAULT_CAPACITY_TYPE = "ON_DEMAND"
 DEFAULT_DISK_SIZE = "20"
 DEFAULT_INSTANCE_TYPES = ["t3.medium"]
-DEFAULT_NODEGROUP_HEALTH: Dict[str, Any] = {"issues": []}
+DEFAULT_NODEGROUP_HEALTH: dict[str, Any] = {"issues": []}
 DEFAULT_RELEASE_VERSION = "1.19.8-20210414"
 DEFAULT_REMOTE_ACCESS = {"ec2SshKey": "eksKeypair"}
 DEFAULT_SCALING_CONFIG = {"minSize": 2, "maxSize": 2, "desiredSize": 2}
@@ -94,27 +94,27 @@ class Cluster:
         self,
         name: str,
         role_arn: str,
-        resources_vpc_config: Dict[str, Any],
+        resources_vpc_config: dict[str, Any],
         account_id: str,
         region_name: str,
         aws_partition: str,
         version: Optional[str] = None,
-        kubernetes_network_config: Optional[Dict[str, str]] = None,
-        logging: Optional[Dict[str, Any]] = None,
+        kubernetes_network_config: Optional[dict[str, str]] = None,
+        logging: Optional[dict[str, Any]] = None,
         client_request_token: Optional[str] = None,
-        tags: Optional[Dict[str, str]] = None,
-        encryption_config: Optional[List[Dict[str, Any]]] = None,
-        remote_network_config: Optional[Dict[str, List[Dict[str, List[str]]]]] = None,
+        tags: Optional[dict[str, str]] = None,
+        encryption_config: Optional[list[dict[str, Any]]] = None,
+        remote_network_config: Optional[dict[str, list[dict[str, list[str]]]]] = None,
     ):
         if encryption_config is None:
             encryption_config = []
         if tags is None:
             tags = dict()
 
-        self.nodegroups: Dict[str, Nodegroup] = dict()
+        self.nodegroups: dict[str, Nodegroup] = dict()
         self.nodegroup_count = 0
 
-        self.fargate_profiles: Dict[str, FargateProfile] = dict()
+        self.fargate_profiles: dict[str, FargateProfile] = dict()
         self.fargate_profile_count = 0
 
         self.arn = CLUSTER_ARN_TEMPLATE.format(
@@ -155,13 +155,13 @@ class FargateProfile:
         cluster_name: str,
         fargate_profile_name: str,
         pod_execution_role_arn: str,
-        selectors: List[Dict[str, Any]],
+        selectors: list[dict[str, Any]],
         account_id: str,
         region_name: str,
         aws_partition: str,
         client_request_token: Optional[str] = None,
-        subnets: Optional[List[str]] = None,
-        tags: Optional[Dict[str, str]] = None,
+        subnets: Optional[list[str]] = None,
+        tags: Optional[dict[str, str]] = None,
     ):
         if subnets is None:
             subnets = list()
@@ -195,20 +195,20 @@ class Nodegroup:
         cluster_name: str,
         node_role: str,
         nodegroup_name: str,
-        subnets: List[str],
+        subnets: list[str],
         account_id: str,
         region_name: str,
         aws_partition: str,
-        scaling_config: Optional[Dict[str, int]] = None,
+        scaling_config: Optional[dict[str, int]] = None,
         disk_size: Optional[int] = None,
-        instance_types: Optional[List[str]] = None,
+        instance_types: Optional[list[str]] = None,
         ami_type: Optional[str] = None,
-        remote_access: Optional[Dict[str, Any]] = None,
-        labels: Optional[Dict[str, str]] = None,
-        taints: Optional[List[Dict[str, str]]] = None,
-        tags: Optional[Dict[str, str]] = None,
+        remote_access: Optional[dict[str, Any]] = None,
+        labels: Optional[dict[str, str]] = None,
+        taints: Optional[list[dict[str, str]]] = None,
+        tags: Optional[dict[str, str]] = None,
         client_request_token: Optional[str] = None,
-        launch_template: Optional[Dict[str, str]] = None,
+        launch_template: Optional[dict[str, str]] = None,
         capacity_type: Optional[str] = None,
         version: Optional[str] = None,
         release_version: Optional[str] = None,
@@ -282,7 +282,7 @@ class Nodegroup:
 class EKSBackend(BaseBackend):
     def __init__(self, region_name: str, account_id: str):
         super().__init__(region_name, account_id)
-        self.clusters: Dict[str, Cluster] = dict()
+        self.clusters: dict[str, Cluster] = dict()
         self.cluster_count = 0
         self.partition = get_partition(region_name)
 
@@ -290,14 +290,14 @@ class EKSBackend(BaseBackend):
         self,
         name: str,
         role_arn: str,
-        resources_vpc_config: Dict[str, Any],
+        resources_vpc_config: dict[str, Any],
         version: Optional[str] = None,
-        kubernetes_network_config: Optional[Dict[str, str]] = None,
-        logging: Optional[Dict[str, Any]] = None,
+        kubernetes_network_config: Optional[dict[str, str]] = None,
+        logging: Optional[dict[str, Any]] = None,
         client_request_token: Optional[str] = None,
-        tags: Optional[Dict[str, str]] = None,
-        encryption_config: Optional[List[Dict[str, Any]]] = None,
-        remote_network_config: Optional[Dict[str, List[Dict[str, List[str]]]]] = None,
+        tags: Optional[dict[str, str]] = None,
+        encryption_config: Optional[list[dict[str, Any]]] = None,
+        remote_network_config: Optional[dict[str, list[dict[str, list[str]]]]] = None,
     ) -> Cluster:
         if name in self.clusters:
             # Cluster exists.
@@ -332,11 +332,11 @@ class EKSBackend(BaseBackend):
         self,
         fargate_profile_name: str,
         cluster_name: str,
-        selectors: List[Dict[str, Any]],
+        selectors: list[dict[str, Any]],
         pod_execution_role_arn: str,
-        subnets: Optional[List[str]] = None,
+        subnets: Optional[list[str]] = None,
         client_request_token: Optional[str] = None,
-        tags: Optional[Dict[str, str]] = None,
+        tags: Optional[dict[str, str]] = None,
     ) -> FargateProfile:
         try:
             # Cluster exists.
@@ -387,17 +387,17 @@ class EKSBackend(BaseBackend):
         cluster_name: str,
         node_role: str,
         nodegroup_name: str,
-        subnets: List[str],
-        scaling_config: Optional[Dict[str, int]] = None,
+        subnets: list[str],
+        scaling_config: Optional[dict[str, int]] = None,
         disk_size: Optional[int] = None,
-        instance_types: Optional[List[str]] = None,
+        instance_types: Optional[list[str]] = None,
         ami_type: Optional[str] = None,
-        remote_access: Optional[Dict[str, Any]] = None,
-        labels: Optional[Dict[str, str]] = None,
-        taints: Optional[List[Dict[str, str]]] = None,
-        tags: Optional[Dict[str, str]] = None,
+        remote_access: Optional[dict[str, Any]] = None,
+        labels: Optional[dict[str, str]] = None,
+        taints: Optional[list[dict[str, str]]] = None,
+        tags: Optional[dict[str, str]] = None,
         client_request_token: Optional[str] = None,
-        launch_template: Optional[Dict[str, str]] = None,
+        launch_template: Optional[dict[str, str]] = None,
         capacity_type: Optional[str] = None,
         version: Optional[str] = None,
         release_version: Optional[str] = None,
@@ -609,7 +609,7 @@ class EKSBackend(BaseBackend):
         cluster.nodegroup_count -= 1
         return result
 
-    def tag_resource(self, resource_arn: str, tags: Dict[str, str]) -> None:
+    def tag_resource(self, resource_arn: str, tags: dict[str, str]) -> None:
         """
         This function currently will tag an EKS cluster only.  It does not tag a managed node group
         """
@@ -631,7 +631,7 @@ class EKSBackend(BaseBackend):
             )
         cluster.tags.update(tags)
 
-    def untag_resource(self, resource_arn: str, tag_keys: List[str]) -> None:
+    def untag_resource(self, resource_arn: str, tag_keys: list[str]) -> None:
         """
         This function currently will remove tags on an EKS cluster only.  It does not remove tags from a managed node group
         """
@@ -657,7 +657,7 @@ class EKSBackend(BaseBackend):
             if name in cluster.tags:
                 del cluster.tags[name]
 
-    def list_tags_for_resource(self, resource_arn: str) -> Dict[str, str]:
+    def list_tags_for_resource(self, resource_arn: str) -> dict[str, str]:
         """
         This function currently will list tags on an EKS cluster only.  It does not list tags from a managed node group
         """
@@ -681,12 +681,12 @@ class EKSBackend(BaseBackend):
 
     def list_clusters(
         self, max_results: int, next_token: Optional[str]
-    ) -> Tuple[List[Cluster], Optional[Cluster]]:
+    ) -> tuple[list[Cluster], Optional[Cluster]]:
         return paginated_list(list(self.clusters.keys()), max_results, next_token)
 
     def list_fargate_profiles(
         self, cluster_name: str, max_results: int, next_token: Optional[str]
-    ) -> Tuple[List[FargateProfile], Optional[FargateProfile]]:
+    ) -> tuple[list[FargateProfile], Optional[FargateProfile]]:
         cluster = self.clusters[cluster_name]
         return paginated_list(
             list(cluster.fargate_profiles.keys()), max_results, next_token
@@ -694,18 +694,18 @@ class EKSBackend(BaseBackend):
 
     def list_nodegroups(
         self, cluster_name: str, max_results: int, next_token: Optional[str]
-    ) -> Tuple[List[Nodegroup], Optional[Nodegroup]]:
+    ) -> tuple[list[Nodegroup], Optional[Nodegroup]]:
         cluster = self.clusters[cluster_name]
         return paginated_list(list(cluster.nodegroups.keys()), max_results, next_token)
 
     def update_cluster_config(
         self,
         name: str,
-        resources_vpc_config: Dict[str, Any],
-        logging: Optional[Dict[str, Any]] = None,
+        resources_vpc_config: dict[str, Any],
+        logging: Optional[dict[str, Any]] = None,
         client_request_token: Optional[str] = None,
-        kubernetes_network_config: Optional[Dict[str, str]] = None,
-        remote_network_config: Optional[Dict[str, List[Dict[str, List[str]]]]] = None,
+        kubernetes_network_config: Optional[dict[str, str]] = None,
+        remote_network_config: Optional[dict[str, list[dict[str, list[str]]]]] = None,
     ) -> Cluster:
         cluster = self.clusters.get(name)
         if cluster:
@@ -732,8 +732,8 @@ class EKSBackend(BaseBackend):
 
 
 def paginated_list(
-    full_list: List[Any], max_results: int, next_token: Optional[str]
-) -> Tuple[List[Any], Optional[Any]]:
+    full_list: list[Any], max_results: int, next_token: Optional[str]
+) -> tuple[list[Any], Optional[Any]]:
     """
     Returns a tuple containing a slice of the full list
     starting at next_token and ending with at most the
@@ -764,7 +764,7 @@ def validate_safe_to_delete(cluster: Cluster) -> None:
 
 
 def validate_launch_template_combination(
-    disk_size: Optional[int], remote_access: Optional[Dict[str, Any]]
+    disk_size: Optional[int], remote_access: Optional[dict[str, Any]]
 ) -> None:
     if not (disk_size or remote_access):
         return
@@ -776,7 +776,7 @@ def validate_launch_template_combination(
     )
 
 
-def _validate_fargate_profile_selectors(selectors: List[Dict[str, Any]]) -> None:
+def _validate_fargate_profile_selectors(selectors: list[dict[str, Any]]) -> None:
     def raise_exception(message: str) -> None:
         raise InvalidParameterException(
             clusterName=None,

--- a/moto/elasticache/models.py
+++ b/moto/elasticache/models.py
@@ -2,7 +2,7 @@ import copy
 import random
 import string
 from re import compile as re_compile
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Optional, Union
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
@@ -41,9 +41,9 @@ class User(BaseModel):
         access_string: str,
         engine: str,
         no_password_required: bool,
-        passwords: Optional[List[str]] = None,
+        passwords: Optional[list[str]] = None,
         authentication_type: Optional[str] = None,
-        tags: Optional[List[Dict[str, str]]] = None,
+        tags: Optional[list[dict[str, str]]] = None,
     ):
         self.id = user_id
         self.name = user_name
@@ -54,14 +54,14 @@ class User(BaseModel):
         self.no_password_required = no_password_required
         self.status = "active"
         self.minimum_engine_version = "6.0"
-        self.user_group_ids: List[str] = []
+        self.user_group_ids: list[str] = []
         self.region = region
         self.arn = f"arn:{get_partition(self.region)}:elasticache:{self.region}:{account_id}:user:{self.id}"
         self.authentication_type = authentication_type
         self.tags = tags or []
 
     @property
-    def authentication(self) -> Dict[str, Union[str, int, None]]:
+    def authentication(self) -> dict[str, Union[str, int, None]]:
         return {
             "Type": "no-password"
             if self.no_password_required
@@ -98,15 +98,15 @@ class CacheCluster(BaseModel):
         auth_token: Optional[str],
         outpost_mode: Optional[str],
         preferred_outpost_arn: Optional[str],
-        preferred_availability_zones: Optional[List[str]],
-        cache_security_group_names: Optional[List[str]],
-        security_group_ids: Optional[List[str]],
-        tags: Optional[List[Dict[str, str]]],
-        snapshot_arns: Optional[List[str]],
-        preferred_outpost_arns: Optional[List[str]],
-        log_delivery_configurations: List[Dict[str, Any]],
-        cache_node_ids_to_remove: Optional[List[str]],
-        cache_node_ids_to_reboot: Optional[List[str]],
+        preferred_availability_zones: Optional[list[str]],
+        cache_security_group_names: Optional[list[str]],
+        security_group_ids: Optional[list[str]],
+        tags: Optional[list[dict[str, str]]],
+        snapshot_arns: Optional[list[str]],
+        preferred_outpost_arns: Optional[list[str]],
+        log_delivery_configurations: list[dict[str, Any]],
+        cache_node_ids_to_remove: Optional[list[str]],
+        cache_node_ids_to_reboot: Optional[list[str]],
     ):
         self.cache_cluster_id = cache_cluster_id
         self.az_mode = az_mode
@@ -163,8 +163,8 @@ class CacheSubnetGroup(BaseModel):
         region_name: str,
         cache_subnet_group_name: str,
         cache_subnet_group_description: str,
-        subnet_ids: List[str],
-        tags: Optional[List[Dict[str, str]]],
+        subnet_ids: list[str],
+        tags: Optional[list[dict[str, str]]],
     ):
         self.cache_subnet_group_name = cache_subnet_group_name
         self.cache_subnet_group_description = cache_subnet_group_description
@@ -186,7 +186,7 @@ class CacheSubnetGroup(BaseModel):
             # Should raise InvalidSubnet if subnet_ids are invalid
             if "InvalidSubnet" in str(e):
                 for subnet_id in subnet_ids:
-                    subnet_response: Dict[str, Any] = {}
+                    subnet_response: dict[str, Any] = {}
                     subnet_response["subnet_identifier"] = subnet_id
                     subnet_response["Subnet_availability_zone"] = {"Name": "us-east-1a"}
                     subnet_response["supported_network_types"] = ["ipv4"]
@@ -235,11 +235,11 @@ class ReplicationGroup(BaseModel):
         account_id: str,
         region_name: str,
         replication_group_id: str,
-        preferred_cache_cluster_azs: Optional[List[str]],
+        preferred_cache_cluster_azs: Optional[list[str]],
         num_cache_clusters: Optional[int],
         num_node_groups: Optional[int],
         replicas_per_node_group: Optional[int],
-        node_group_configuration: List[Dict[str, Any]],
+        node_group_configuration: list[dict[str, Any]],
         preferred_maintenance_window: Optional[str],
         replication_group_description: str,
         primary_cluster_id: Optional[str],
@@ -255,23 +255,23 @@ class ReplicationGroup(BaseModel):
         transit_encryption_enabled: Optional[bool],
         at_rest_encryption_enabled: Optional[bool],
         kms_key_id: Optional[str],
-        user_group_ids: List[str],
-        log_delivery_configurations: List[Dict[str, Any]],
+        user_group_ids: list[str],
+        log_delivery_configurations: list[dict[str, Any]],
         data_tiering_enabled: Optional[bool],
         auto_minor_version_upgrade: Optional[bool],
         engine: Optional[str],
         network_type: Optional[str],
         ip_discovery: Optional[str],
         transit_encryption_mode: Optional[str],
-        cache_security_group_names: Optional[List[str]],
+        cache_security_group_names: Optional[list[str]],
         cache_subnet_group_name: Optional[str],
-        security_group_ids: Optional[List[str]],
-        tags: Optional[List[Dict[str, str]]],
+        security_group_ids: Optional[list[str]],
+        tags: Optional[list[dict[str, str]]],
         notification_topic_arn: Optional[str],
         serverless_cache_snapshot_name: Optional[str],
         cache_parameter_group_name: Optional[str],
         engine_version: Optional[str],
-        snapshot_arns: Optional[List[str]],
+        snapshot_arns: Optional[list[str]],
         snapshot_name: Optional[str],
     ):
         tags = tags or []
@@ -305,13 +305,13 @@ class ReplicationGroup(BaseModel):
         replication_group_domain = (
             f"{replication_group_id}.{random_str}.{region_short}.cache.amazonaws.com"
         )
-        self.member_clusters: List[str] = []
-        self.member_clusters_outpost_arns: List[str] = []
+        self.member_clusters: list[str] = []
+        self.member_clusters_outpost_arns: list[str] = []
         if not num_node_groups:
             num_node_groups = 1
 
         for i in range(num_node_groups):
-            node_group: Dict[str, Any] = {}
+            node_group: dict[str, Any] = {}
             node_group["node_group_id"] = f"{i + 1:0>4}"
             node_group["status"] = "available"
             node_group["node_group_members"] = []
@@ -335,7 +335,7 @@ class ReplicationGroup(BaseModel):
                     member_clusters_outpost_arns=self.member_clusters_outpost_arns,
                 )
 
-                self.configuration_endpoint: Dict[str, Any] = {}
+                self.configuration_endpoint: dict[str, Any] = {}
                 self.configuration_endpoint["address"] = (
                     f"clustercfg.{replication_group_domain}"
                 )
@@ -423,8 +423,8 @@ class ReplicationGroup(BaseModel):
         }
 
     def _get_log_delivery_configurations(
-        self, log_delivery_configurations: List[Dict[str, Any]]
-    ) -> List[Dict[str, Any]]:
+        self, log_delivery_configurations: list[dict[str, Any]]
+    ) -> list[dict[str, Any]]:
         log_delivery_configurations_resp = []
         if log_delivery_configurations:
             for log_delivery_configuration in log_delivery_configurations:
@@ -439,12 +439,12 @@ class ReplicationGroup(BaseModel):
     # and member_clusters with the cache_cluster_ids of the primary and replicas.
     def _set_node_members_clusters_enabled(
         self,
-        member_clusters: List[str],
+        member_clusters: list[str],
         replication_group_id: str,
         replicas_per_node_group: int,
-        node_group_configuration: List[Dict[str, Any]],
-        node_group: Dict[str, Any],
-        member_clusters_outpost_arns: List[str],
+        node_group_configuration: list[dict[str, Any]],
+        node_group: dict[str, Any],
+        member_clusters_outpost_arns: list[str],
     ) -> None:
         replica_count = replicas_per_node_group
         primary_node = {}
@@ -522,15 +522,15 @@ class ReplicationGroup(BaseModel):
 
     def _set_node_members_clusters_disabled(
         self,
-        member_clusters: List[str],
+        member_clusters: list[str],
         replication_group_id: str,
         replication_group_domain: str,
-        node_group: Dict[str, Any],
-        preferred_cache_cluster_azs: List[str],
+        node_group: dict[str, Any],
+        preferred_cache_cluster_azs: list[str],
         num_cache_clusters: int,
         replicas_per_node_group: int,
     ) -> None:
-        primary_node: Dict[str, Any] = {}
+        primary_node: dict[str, Any] = {}
         primary_node["cache_cluster_id"] = f"{replication_group_id}-001"
         primary_node["cache_node_id"] = node_group["node_group_id"]
         primary_node["read_endpoint"] = {}
@@ -555,7 +555,7 @@ class ReplicationGroup(BaseModel):
 
         # Use num_cache_clusters when cluster_mode is disabled
         for r in range(1, num_cache_clusters):
-            replica_node: Dict[str, Any] = {}
+            replica_node: dict[str, Any] = {}
             # r + 1 because primary is 001
             replica_node["cache_cluster_id"] = f"{replication_group_id}-{r + 1:0>3}"
             replica_node["cache_node_id"] = node_group["node_group_id"]
@@ -611,7 +611,7 @@ class Snapshot(BaseModel):
         snapshot_status: Optional[str],
         snapshot_window: Optional[str],
         topic_arn: Optional[str],
-        tags: Optional[List[Dict[str, str]]],
+        tags: Optional[list[dict[str, str]]],
         vpc_id: Optional[str] = None,
     ):
         self.arn = f"arn:{get_partition(region_name)}:elasticache:{region_name}:{account_id}:snapshot:{snapshot_name}"
@@ -662,17 +662,17 @@ class ElastiCacheBackend(BaseBackend):
             no_password_required=True,
         )
 
-        self.cache_clusters: Dict[str, Any] = dict()
-        self.cache_subnet_groups: Dict[str, CacheSubnetGroup] = dict()
-        self.replication_groups: Dict[str, ReplicationGroup] = dict()
-        self.snapshots: Dict[str, Snapshot] = dict()
+        self.cache_clusters: dict[str, Any] = dict()
+        self.cache_subnet_groups: dict[str, CacheSubnetGroup] = dict()
+        self.replication_groups: dict[str, ReplicationGroup] = dict()
+        self.snapshots: dict[str, Snapshot] = dict()
         self.tagging_service = TaggingService()
 
     def _get_snapshots_by_param(
         self,
         ref_id: Optional[str] = None,
         source: Optional[str] = None,
-    ) -> List[Snapshot]:
+    ) -> list[Snapshot]:
         source_map = {
             "system": "automated",
             "user": "manual",
@@ -706,11 +706,11 @@ class ElastiCacheBackend(BaseBackend):
         user_id: str,
         user_name: str,
         engine: str,
-        passwords: List[str],
+        passwords: list[str],
         access_string: str,
         no_password_required: bool,
         authentication_type: str,  # contain it to the str in the enums TODO
-        tags: Optional[List[Dict[str, str]]] = None,
+        tags: Optional[list[dict[str, str]]] = None,
     ) -> User:
         if user_id in self.users:
             raise UserAlreadyExists
@@ -765,7 +765,7 @@ class ElastiCacheBackend(BaseBackend):
             return user
         raise UserNotFound(user_id)
 
-    def describe_users(self, user_id: Optional[str]) -> List[User]:
+    def describe_users(self, user_id: Optional[str]) -> list[User]:
         """
         Only the `user_id` parameter is currently supported.
         Pagination is not yet implemented.
@@ -805,15 +805,15 @@ class ElastiCacheBackend(BaseBackend):
         auth_token: str,
         outpost_mode: str,
         preferred_outpost_arn: str,
-        preferred_availability_zones: List[str],
-        cache_security_group_names: List[str],
-        security_group_ids: List[str],
-        tags: List[Dict[str, str]],
-        snapshot_arns: List[str],
-        preferred_outpost_arns: List[str],
-        log_delivery_configurations: List[Dict[str, Any]],
-        cache_node_ids_to_remove: List[str],
-        cache_node_ids_to_reboot: List[str],
+        preferred_availability_zones: list[str],
+        cache_security_group_names: list[str],
+        security_group_ids: list[str],
+        tags: list[dict[str, str]],
+        snapshot_arns: list[str],
+        preferred_outpost_arns: list[str],
+        log_delivery_configurations: list[dict[str, Any]],
+        cache_node_ids_to_remove: list[str],
+        cache_node_ids_to_reboot: list[str],
     ) -> CacheCluster:
         if cache_cluster_id in self.cache_clusters:
             raise CacheClusterAlreadyExists(cache_cluster_id)
@@ -870,7 +870,7 @@ class ElastiCacheBackend(BaseBackend):
         cache_cluster_id: Optional[str] = None,
         max_records: Optional[int] = None,
         marker: Optional[str] = None,
-    ) -> List[CacheCluster]:
+    ) -> list[CacheCluster]:
         if cache_cluster_id:
             if cache_cluster_id in self.cache_clusters:
                 cache_cluster = self.cache_clusters[cache_cluster_id]
@@ -891,8 +891,8 @@ class ElastiCacheBackend(BaseBackend):
         self,
         cache_subnet_group_name: str,
         cache_subnet_group_description: str,
-        subnet_ids: List[str],
-        tags: Optional[List[Dict[str, str]]],
+        subnet_ids: list[str],
+        tags: Optional[list[dict[str, str]]],
     ) -> CacheSubnetGroup:
         if cache_subnet_group_name in self.cache_subnet_groups:
             raise CacheSubnetGroupAlreadyExists(cache_subnet_group_name)
@@ -916,7 +916,7 @@ class ElastiCacheBackend(BaseBackend):
     def describe_cache_subnet_groups(
         self,
         cache_subnet_group_name: Optional[str] = None,
-    ) -> List[CacheSubnetGroup]:
+    ) -> list[CacheSubnetGroup]:
         if cache_subnet_group_name:
             if cache_subnet_group_name in self.cache_subnet_groups:
                 cache_subnet_group = self.cache_subnet_groups[cache_subnet_group_name]
@@ -925,17 +925,17 @@ class ElastiCacheBackend(BaseBackend):
                 raise CacheSubnetGroupNotFound(cache_subnet_group_name)
         return list(self.cache_subnet_groups.values())
 
-    def list_tags_for_resource(self, arn: str) -> Dict[str, List[Dict[str, str]]]:
+    def list_tags_for_resource(self, arn: str) -> dict[str, list[dict[str, str]]]:
         if self.arn_regex.match(arn):
             return self.tagging_service.list_tags_for_resource(arn)
         else:
             raise InvalidARNFault(arn)
 
-    def add_tags_to_resource(self, arn: str, tags: List[Dict[str, str]]) -> None:
+    def add_tags_to_resource(self, arn: str, tags: list[dict[str, str]]) -> None:
         # Docs user "ResourceName" as input but the param is technically the ARN, will just use arn
         self.tagging_service.tag_resource(arn, tags)
 
-    def remove_tags_from_resource(self, arn: str, tags: List[str]) -> None:
+    def remove_tags_from_resource(self, arn: str, tags: list[str]) -> None:
         # Docs user "ResourceName" as input but the param is technically the ARN, will just use arn
         self.tagging_service.untag_resource_using_names(arn, tags)
 
@@ -948,19 +948,19 @@ class ElastiCacheBackend(BaseBackend):
         automatic_failover_enabled: bool,
         multi_az_enabled: bool,
         num_cache_clusters: int,
-        preferred_cache_cluster_azs: List[str],
+        preferred_cache_cluster_azs: list[str],
         num_node_groups: int,
         replicas_per_node_group: int,
-        node_group_configuration: List[Dict[str, Any]],
+        node_group_configuration: list[dict[str, Any]],
         cache_node_type: str,
         engine: str,
         engine_version: str,
         cache_parameter_group_name: str,
         cache_subnet_group_name: str,
-        cache_security_group_names: List[str],
-        security_group_ids: List[str],
-        tags: List[Dict[str, str]],
-        snapshot_arns: List[str],
+        cache_security_group_names: list[str],
+        security_group_ids: list[str],
+        tags: list[dict[str, str]],
+        snapshot_arns: list[str],
         snapshot_name: str,
         preferred_maintenance_window: str,
         port: int,
@@ -972,8 +972,8 @@ class ElastiCacheBackend(BaseBackend):
         transit_encryption_enabled: bool,
         at_rest_encryption_enabled: bool,
         kms_key_id: str,
-        user_group_ids: List[str],
-        log_delivery_configurations: List[Dict[str, Any]],
+        user_group_ids: list[str],
+        log_delivery_configurations: list[dict[str, Any]],
         data_tiering_enabled: bool,
         network_type: str,
         ip_discovery: str,
@@ -1037,7 +1037,7 @@ class ElastiCacheBackend(BaseBackend):
     def describe_replication_groups(
         self,
         replication_group_id: Optional[str] = None,
-    ) -> List[ReplicationGroup]:
+    ) -> list[ReplicationGroup]:
         if replication_group_id:
             if replication_group_id in self.replication_groups:
                 replication_group = self.replication_groups[replication_group_id]
@@ -1068,7 +1068,7 @@ class ElastiCacheBackend(BaseBackend):
         replication_group_id: Optional[str],
         cache_cluster_id: Optional[str],
         kms_key_id: Optional[str],
-        tags: Optional[List[Dict[str, str]]],
+        tags: Optional[list[dict[str, str]]],
     ) -> Snapshot:
         resource = None
         num_node_groups = None
@@ -1153,7 +1153,7 @@ class ElastiCacheBackend(BaseBackend):
         marker: Optional[str] = None,
         max_records: Optional[int] = None,
         show_node_group_config: Optional[bool] = None,
-    ) -> List[Snapshot]:
+    ) -> list[Snapshot]:
         if snapshot_name:
             try:
                 return [self.snapshots[snapshot_name]]

--- a/moto/elasticbeanstalk/models.py
+++ b/moto/elasticbeanstalk/models.py
@@ -1,5 +1,4 @@
 import weakref
-from typing import Dict, List
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
@@ -18,7 +17,7 @@ class Environment(BaseModel):
         application: "Application",
         environment_name: str,
         solution_stack_name: str,
-        tags: Dict[str, str],
+        tags: dict[str, str],
     ):
         self.application = weakref.proxy(
             application
@@ -73,7 +72,7 @@ class Application(BaseModel):
     ):
         self.backend = weakref.proxy(backend)  # weakref to break cycles
         self.application_name = application_name
-        self.environments: Dict[str, Environment] = dict()
+        self.environments: dict[str, Environment] = dict()
         self.account_id = self.backend.account_id
         self.region = self.backend.region_name
         self.arn = make_arn(
@@ -81,7 +80,7 @@ class Application(BaseModel):
         )
 
     def create_environment(
-        self, environment_name: str, solution_stack_name: str, tags: Dict[str, str]
+        self, environment_name: str, solution_stack_name: str, tags: dict[str, str]
     ) -> Environment:
         if environment_name in self.environments:
             raise InvalidParameterValueError(message="")
@@ -100,7 +99,7 @@ class Application(BaseModel):
 class EBBackend(BaseBackend):
     def __init__(self, region_name: str, account_id: str):
         super().__init__(region_name, account_id)
-        self.applications: Dict[str, Application] = dict()
+        self.applications: dict[str, Application] = dict()
 
     def create_application(self, application_name: str) -> Application:
         if application_name in self.applications:
@@ -116,13 +115,13 @@ class EBBackend(BaseBackend):
         app: Application,
         environment_name: str,
         stack_name: str,
-        tags: Dict[str, str],
+        tags: dict[str, str],
     ) -> Environment:
         return app.create_environment(
             environment_name=environment_name, solution_stack_name=stack_name, tags=tags
         )
 
-    def describe_environments(self) -> List[Environment]:
+    def describe_environments(self) -> list[Environment]:
         envs = []
         for app in self.applications.values():
             for env in app.environments.values():
@@ -134,7 +133,7 @@ class EBBackend(BaseBackend):
         pass
 
     def update_tags_for_resource(
-        self, resource_arn: str, tags_to_add: Dict[str, str], tags_to_remove: List[str]
+        self, resource_arn: str, tags_to_add: dict[str, str], tags_to_remove: list[str]
     ) -> None:
         try:
             res = self._find_environment_by_arn(resource_arn)
@@ -149,7 +148,7 @@ class EBBackend(BaseBackend):
         for key in tags_to_remove:
             del res.tags[key]
 
-    def list_tags_for_resource(self, resource_arn: str) -> Dict[str, str]:
+    def list_tags_for_resource(self, resource_arn: str) -> dict[str, str]:
         try:
             res = self._find_environment_by_arn(resource_arn)
         except KeyError:

--- a/moto/elastictranscoder/models.py
+++ b/moto/elastictranscoder/models.py
@@ -1,5 +1,5 @@
 import string
-from typing import Any, Dict, List, Tuple
+from typing import Any
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
@@ -16,8 +16,8 @@ class Pipeline(BaseModel):
         input_bucket: str,
         output_bucket: str,
         role: str,
-        content_config: Dict[str, Any],
-        thumbnail_config: Dict[str, Any],
+        content_config: dict[str, Any],
+        thumbnail_config: dict[str, Any],
     ):
         a = "".join(random.choice(string.digits) for _ in range(13))
         b = "".join(random.choice(string.ascii_lowercase) for _ in range(6))
@@ -43,7 +43,7 @@ class Pipeline(BaseModel):
         if role:
             self.role = role
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         return {
             "Id": self.id,
             "Name": self.name,
@@ -66,7 +66,7 @@ class Pipeline(BaseModel):
 class ElasticTranscoderBackend(BaseBackend):
     def __init__(self, region_name: str, account_id: str):
         super().__init__(region_name, account_id)
-        self.pipelines: Dict[str, Pipeline] = {}
+        self.pipelines: dict[str, Pipeline] = {}
 
     def create_pipeline(
         self,
@@ -74,9 +74,9 @@ class ElasticTranscoderBackend(BaseBackend):
         input_bucket: str,
         output_bucket: str,
         role: str,
-        content_config: Dict[str, Any],
-        thumbnail_config: Dict[str, Any],
-    ) -> Tuple[Pipeline, List[str]]:
+        content_config: dict[str, Any],
+        thumbnail_config: dict[str, Any],
+    ) -> tuple[Pipeline, list[str]]:
         """
         The following parameters are not yet implemented:
         AWSKMSKeyArn, Notifications
@@ -92,10 +92,10 @@ class ElasticTranscoderBackend(BaseBackend):
             thumbnail_config,
         )
         self.pipelines[pipeline.id] = pipeline
-        warnings: List[str] = []
+        warnings: list[str] = []
         return pipeline, warnings
 
-    def list_pipelines(self) -> List[Dict[str, Any]]:
+    def list_pipelines(self) -> list[dict[str, Any]]:
         return [p.to_dict() for _, p in self.pipelines.items()]
 
     def read_pipeline(self, pipeline_id: str) -> Pipeline:
@@ -103,14 +103,14 @@ class ElasticTranscoderBackend(BaseBackend):
 
     def update_pipeline(
         self, pipeline_id: str, name: str, input_bucket: str, role: str
-    ) -> Tuple[Pipeline, List[str]]:
+    ) -> tuple[Pipeline, list[str]]:
         """
         The following parameters are not yet implemented:
         AWSKMSKeyArn, Notifications, ContentConfig, ThumbnailConfig
         """
         pipeline = self.read_pipeline(pipeline_id)
         pipeline.update(name, input_bucket, role)
-        warnings: List[str] = []
+        warnings: list[str] = []
         return pipeline, warnings
 
     def delete_pipeline(self, pipeline_id: str) -> None:

--- a/moto/elb/models.py
+++ b/moto/elb/models.py
@@ -1,7 +1,8 @@
 import datetime
 import re
 from collections import OrderedDict
-from typing import Any, Dict, Iterable, List, Optional
+from collections.abc import Iterable
+from typing import Any, Optional
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel, CloudFormationModel
@@ -60,7 +61,7 @@ class FakeListener(BaseModel):
         self.instance_port = instance_port
         self.protocol = protocol.upper()
         self.ssl_certificate_id = ssl_certificate_id
-        self.policy_names: List[str] = []
+        self.policy_names: list[str] = []
 
     @property
     def instance_protocol(self) -> str:
@@ -73,7 +74,7 @@ class FakeListener(BaseModel):
 class FakeBackend(BaseModel):
     def __init__(self, instance_port: str):
         self.instance_port = instance_port
-        self.policy_names: List[str] = []
+        self.policy_names: list[str] = []
 
     def __repr__(self) -> str:
         return f"FakeBackend(inp: {self.instance_port}, policies: {self.policy_names})"
@@ -84,29 +85,29 @@ class LoadBalancer(CloudFormationModel):
         self,
         account_id: str,
         name: str,
-        zones: List[str],
-        ports: List[Dict[str, Any]],
+        zones: list[str],
+        ports: list[dict[str, Any]],
         scheme: Optional[str],
         vpc_id: Optional[str],
-        subnets: Optional[List[str]],
-        security_groups: Optional[List[str]],
+        subnets: Optional[list[str]],
+        security_groups: Optional[list[str]],
     ):
         self.account_id = account_id
         self.name = name
         self.health_check: Optional[FakeHealthCheck] = None
-        self.instance_sparse_ids: List[str] = []
-        self.instance_autoscaling_ids: List[str] = []
+        self.instance_sparse_ids: list[str] = []
+        self.instance_autoscaling_ids: list[str] = []
         self.availability_zones = zones
         self.listeners = []
         self.backends = []
         self.created_time = datetime.datetime.now(datetime.timezone.utc)
         self.scheme = scheme or "internet-facing"
         self.attributes = LoadBalancer.get_default_attributes()
-        self.policies: List[Policy] = []
+        self.policies: list[Policy] = []
         self.security_groups = security_groups or []
         self.subnets = subnets or []
         self.vpc_id = vpc_id
-        self.tags: Dict[str, str] = {}
+        self.tags: dict[str, str] = {}
         self.dns_name = f"{name}.us-east-1.elb.amazonaws.com"
 
         for port in ports:
@@ -157,7 +158,7 @@ class LoadBalancer(CloudFormationModel):
         return descriptions
 
     @property
-    def instance_ids(self) -> List[str]:
+    def instance_ids(self) -> list[str]:
         """Return all the instances attached to the ELB"""
         return self.instance_sparse_ids + self.instance_autoscaling_ids
 
@@ -194,7 +195,7 @@ class LoadBalancer(CloudFormationModel):
             elb_backend.register_instances(new_elb.name, [instance_id])
 
         policies = properties.get("Policies", [])
-        port_policies: Dict[str, Any] = {}
+        port_policies: dict[str, Any] = {}
         for policy in policies:
             policy_name = policy["PolicyName"]
             policy_type_name = policy["PolicyType"]
@@ -296,8 +297,8 @@ class LoadBalancer(CloudFormationModel):
         raise UnformattedGetAttTemplateException()
 
     @classmethod
-    def get_default_attributes(cls) -> Dict[str, Any]:  # type: ignore[misc]
-        attributes: Dict[str, Any] = dict()
+    def get_default_attributes(cls) -> dict[str, Any]:  # type: ignore[misc]
+        attributes: dict[str, Any] = dict()
         attributes["cross_zone_load_balancing"] = {"enabled": False}
         attributes["connection_draining"] = {"enabled": False}
         attributes["access_log"] = {"enabled": False}
@@ -311,7 +312,7 @@ class LoadBalancer(CloudFormationModel):
             raise TooManyTagsError()
         self.tags[key] = value
 
-    def list_tags(self) -> Dict[str, str]:
+    def list_tags(self) -> dict[str, str]:
         return self.tags
 
     def remove_tag(self, key: str) -> None:
@@ -326,16 +327,16 @@ class LoadBalancer(CloudFormationModel):
 class ELBBackend(BaseBackend):
     def __init__(self, region_name: str, account_id: str):
         super().__init__(region_name, account_id)
-        self.load_balancers: Dict[str, LoadBalancer] = OrderedDict()
+        self.load_balancers: dict[str, LoadBalancer] = OrderedDict()
 
     def create_load_balancer(
         self,
         name: str,
-        zones: List[str],
-        ports: List[Dict[str, Any]],
+        zones: list[str],
+        ports: list[dict[str, Any]],
         scheme: str = "internet-facing",
-        subnets: Optional[List[str]] = None,
-        security_groups: Optional[List[str]] = None,
+        subnets: Optional[list[str]] = None,
+        security_groups: Optional[list[str]] = None,
     ) -> LoadBalancer:
         vpc_id = None
         ec2_backend = ec2_backends[self.account_id][self.region_name]
@@ -385,7 +386,7 @@ class ELBBackend(BaseBackend):
         return new_load_balancer
 
     def create_load_balancer_listeners(
-        self, name: str, ports: List[Dict[str, Any]]
+        self, name: str, ports: list[dict[str, Any]]
     ) -> Optional[LoadBalancer]:
         balancer = self.load_balancers.get(name, None)
         if balancer:
@@ -421,7 +422,7 @@ class ELBBackend(BaseBackend):
 
         return balancer
 
-    def describe_load_balancers(self, names: List[str]) -> List[LoadBalancer]:
+    def describe_load_balancers(self, names: list[str]) -> list[LoadBalancer]:
         balancers = list(self.load_balancers.values())
         if names:
             matched_balancers = [
@@ -435,8 +436,8 @@ class ELBBackend(BaseBackend):
             return balancers
 
     def describe_load_balancer_policies(
-        self, lb_name: str, policy_names: List[str]
-    ) -> List[Policy]:
+        self, lb_name: str, policy_names: list[str]
+    ) -> list[Policy]:
         lb = self.describe_load_balancers([lb_name])[0]
         policies = lb.policies
         if policy_names:
@@ -446,8 +447,8 @@ class ELBBackend(BaseBackend):
         return policies
 
     def describe_instance_health(
-        self, lb_name: str, instances: List[Dict[str, str]]
-    ) -> List[Dict[str, Any]]:
+        self, lb_name: str, instances: list[dict[str, str]]
+    ) -> list[dict[str, Any]]:
         elb = self.get_load_balancer(lb_name)
         if elb is None:
             raise NoActiveLoadBalancerFoundError(name=lb_name)
@@ -471,7 +472,7 @@ class ELBBackend(BaseBackend):
         return instances
 
     def delete_load_balancer_listeners(
-        self, name: str, ports: List[str]
+        self, name: str, ports: list[str]
     ) -> Optional[LoadBalancer]:
         balancer = self.get_load_balancer(name)
         listeners = []
@@ -496,7 +497,7 @@ class ELBBackend(BaseBackend):
         return self.load_balancers.get(load_balancer_name)  # type: ignore[return-value]
 
     def apply_security_groups_to_load_balancer(
-        self, load_balancer_name: str, security_group_ids: List[str]
+        self, load_balancer_name: str, security_group_ids: list[str]
     ) -> None:
         load_balancer = self.get_load_balancer(load_balancer_name)
         ec2_backend = ec2_backends[self.account_id][self.region_name]
@@ -582,11 +583,11 @@ class ELBBackend(BaseBackend):
     def modify_load_balancer_attributes(
         self,
         load_balancer_name: str,
-        cross_zone: Optional[Dict[str, Any]] = None,
-        connection_settings: Optional[Dict[str, Any]] = None,
-        connection_draining: Optional[Dict[str, Any]] = None,
-        access_log: Optional[Dict[str, Any]] = None,
-        additional_attributes: Optional[List[Dict[str, str]]] = None,
+        cross_zone: Optional[dict[str, Any]] = None,
+        connection_settings: Optional[dict[str, Any]] = None,
+        connection_draining: Optional[dict[str, Any]] = None,
+        access_log: Optional[dict[str, Any]] = None,
+        additional_attributes: Optional[list[dict[str, str]]] = None,
     ) -> None:
         load_balancer = self.get_load_balancer(load_balancer_name)
         if cross_zone:
@@ -617,7 +618,7 @@ class ELBBackend(BaseBackend):
         load_balancer_name: str,
         policy_name: str,
         policy_type_name: str,
-        policy_attrs: List[Dict[str, str]],
+        policy_attrs: list[dict[str, str]],
     ) -> LoadBalancer:
         load_balancer = self.get_load_balancer(load_balancer_name)
         if policy_name not in [p.policy_name for p in load_balancer.policies]:
@@ -647,7 +648,7 @@ class ELBBackend(BaseBackend):
         return load_balancer
 
     def set_load_balancer_policies_for_backend_server(
-        self, load_balancer_name: str, instance_port: int, policies: List[str]
+        self, load_balancer_name: str, instance_port: int, policies: list[str]
     ) -> LoadBalancer:
         load_balancer = self.get_load_balancer(load_balancer_name)
         backend = [
@@ -659,7 +660,7 @@ class ELBBackend(BaseBackend):
         return load_balancer
 
     def set_load_balancer_policies_of_listener(
-        self, load_balancer_name: str, load_balancer_port: int, policies: List[str]
+        self, load_balancer_name: str, load_balancer_port: int, policies: list[str]
     ) -> LoadBalancer:
         load_balancer = self.get_load_balancer(load_balancer_name)
         listener = [
@@ -673,8 +674,8 @@ class ELBBackend(BaseBackend):
         return load_balancer
 
     def enable_availability_zones_for_load_balancer(
-        self, load_balancer_name: str, availability_zones: List[str]
-    ) -> List[str]:
+        self, load_balancer_name: str, availability_zones: list[str]
+    ) -> list[str]:
         load_balancer = self.get_load_balancer(load_balancer_name)
         load_balancer.availability_zones = sorted(
             list(set(load_balancer.availability_zones + availability_zones))
@@ -682,8 +683,8 @@ class ELBBackend(BaseBackend):
         return load_balancer.availability_zones
 
     def disable_availability_zones_for_load_balancer(
-        self, load_balancer_name: str, availability_zones: List[str]
-    ) -> List[str]:
+        self, load_balancer_name: str, availability_zones: list[str]
+    ) -> list[str]:
         load_balancer = self.get_load_balancer(load_balancer_name)
         load_balancer.availability_zones = sorted(
             list(
@@ -699,15 +700,15 @@ class ELBBackend(BaseBackend):
         return load_balancer.availability_zones
 
     def attach_load_balancer_to_subnets(
-        self, load_balancer_name: str, subnets: List[str]
-    ) -> List[str]:
+        self, load_balancer_name: str, subnets: list[str]
+    ) -> list[str]:
         load_balancer = self.get_load_balancer(load_balancer_name)
         load_balancer.subnets = list(set(load_balancer.subnets + subnets))
         return load_balancer.subnets
 
     def detach_load_balancer_from_subnets(
-        self, load_balancer_name: str, subnets: List[str]
-    ) -> List[str]:
+        self, load_balancer_name: str, subnets: list[str]
+    ) -> list[str]:
         load_balancer = self.get_load_balancer(load_balancer_name)
         load_balancer.subnets = [s for s in load_balancer.subnets if s not in subnets]
         return load_balancer.subnets

--- a/moto/elb/policies.py
+++ b/moto/elb/policies.py
@@ -1,7 +1,7 @@
-from typing import Any, Dict, List, Optional
+from typing import Any, Optional
 
 
-class Policy(object):
+class Policy:
     def __init__(self, policy_name: str, policy_type_name: str):
         self.policy_name = policy_name
         self.policy_type_name = policy_type_name
@@ -24,7 +24,7 @@ class OtherPolicy(Policy):
         self,
         policy_name: str,
         policy_type_name: str,
-        policy_attrs: List[Dict[str, Any]],
+        policy_attrs: list[dict[str, Any]],
     ):
         super().__init__(policy_name, policy_type_name=policy_type_name)
         self.policy_attribute_descriptions = policy_attrs or []

--- a/moto/elbv2/exceptions.py
+++ b/moto/elbv2/exceptions.py
@@ -1,4 +1,4 @@
-from typing import Any, List, Optional
+from typing import Any, Optional
 
 from moto.core.exceptions import ServiceException
 
@@ -180,13 +180,13 @@ class InvalidConfigurationRequest(ELBClientError):
 
 
 class InvalidProtocol(ELBClientError):
-    def __init__(self, protocol: str, valid_protocols: List[str]):
+    def __init__(self, protocol: str, valid_protocols: list[str]):
         msg = f"Listener protocol '{protocol}' must be one of '{', '.join(valid_protocols)}'"
         super().__init__("ValidationError", msg)
 
 
 class InvalidProtocolValue(ELBClientError):
-    def __init__(self, protocol: str, valid_protocols: List[str]):
+    def __init__(self, protocol: str, valid_protocols: list[str]):
         msg = (
             f"1 validation error detected: Value '{protocol}' at 'protocol' failed to satisfy constraint: "
             f"Member must satisfy enum value set: [{', '.join(valid_protocols)}]"

--- a/moto/emr/models.py
+++ b/moto/emr/models.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from datetime import datetime, timedelta
 from functools import cache, cached_property
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Optional
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel, CloudFormationModel
@@ -28,7 +28,7 @@ EXAMPLE_AMI_ID = "ami-12c6146b"
 
 class Application(BaseModel):
     def __init__(
-        self, name: str, version: str, args: List[str], additional_info: Dict[str, str]
+        self, name: str, version: str, args: list[str], additional_info: dict[str, str]
     ):
         self.additional_info = additional_info or {}
         self.args = args or []
@@ -46,7 +46,7 @@ class BootstrapAction(BaseModel):
         return self.script_bootstrap_action.get("path")
 
     @property
-    def args(self) -> List[str]:
+    def args(self) -> list[str]:
         return self.script_bootstrap_action.get("args", [])
 
 
@@ -133,8 +133,8 @@ class InstanceGroup(CloudFormationModel):
         name: Optional[str] = None,
         instance_group_id: Optional[str] = None,
         bid_price: Optional[str] = None,
-        ebs_configuration: Optional[Dict[str, Any]] = None,
-        auto_scaling_policy: Optional[Dict[str, Any]] = None,
+        ebs_configuration: Optional[dict[str, Any]] = None,
+        auto_scaling_policy: Optional[dict[str, Any]] = None,
     ) -> None:
         self.id = instance_group_id or random_instance_group_id()
         self.cluster_id = cluster_id
@@ -292,7 +292,7 @@ class Step(BaseModel):
         self,
         state: str,
         name: str = "",
-        hadoop_jar_step: Optional[Dict[str, Any]] = None,
+        hadoop_jar_step: Optional[dict[str, Any]] = None,
         action_on_failure: str = "TERMINATE_CLUSTER",
     ):
         self.id = random_step_id()
@@ -375,10 +375,10 @@ class Cluster(CloudFormationModel):
         log_uri: str,
         job_flow_role: str,
         service_role: str,
-        steps: List[Dict[str, Any]],
-        instance_attrs: Dict[str, Any],
-        bootstrap_actions: Optional[List[Dict[str, Any]]] = None,
-        configurations: Optional[List[Dict[str, Any]]] = None,
+        steps: list[dict[str, Any]],
+        instance_attrs: dict[str, Any],
+        bootstrap_actions: Optional[list[dict[str, Any]]] = None,
+        configurations: Optional[list[dict[str, Any]]] = None,
         cluster_id: Optional[str] = None,
         visible_to_all_users: bool = False,
         release_label: Optional[str] = None,
@@ -387,7 +387,7 @@ class Cluster(CloudFormationModel):
         custom_ami_id: Optional[str] = None,
         step_concurrency_level: int = 1,
         security_configuration: Optional[str] = None,
-        kerberos_attributes: Optional[Dict[str, str]] = None,
+        kerberos_attributes: Optional[dict[str, str]] = None,
         auto_scaling_role: Optional[str] = None,
         ebs_root_volume_size: Optional[int] = None,
         ebs_root_volume_iops: Optional[int] = None,
@@ -397,27 +397,27 @@ class Cluster(CloudFormationModel):
         emr_backend.clusters[self.id] = self
         self.emr_backend = emr_backend
 
-        self.applications: List[Application] = []
+        self.applications: list[Application] = []
 
-        self.bootstrap_actions: List[BootstrapAction] = []
+        self.bootstrap_actions: list[BootstrapAction] = []
         for bootstrap_action in bootstrap_actions or []:
             self.add_bootstrap_action(bootstrap_action)
 
         self.configurations = configurations or []
 
-        self._tags: Dict[str, str] = {}
+        self._tags: dict[str, str] = {}
 
         self.log_uri = log_uri
         self.name = name
         self.normalized_instance_hours = 0
 
-        self.steps: List[Step] = []
+        self.steps: list[Step] = []
         self.add_steps(steps)
 
         self.set_visibility(visible_to_all_users)
 
-        self.instance_group_ids: List[str] = []
-        self.ec2_instances: List[Instance] = []
+        self.instance_group_ids: list[str] = []
+        self.ec2_instances: list[Instance] = []
         self.master_instance_group_id: Optional[str] = None
         self.core_instance_group_id: Optional[str] = None
         if (
@@ -607,7 +607,7 @@ class Cluster(CloudFormationModel):
         return tags
 
     @property
-    def instance_groups(self) -> List[InstanceGroup]:
+    def instance_groups(self) -> list[InstanceGroup]:
         return self.emr_backend.get_instance_groups(self.instance_group_ids)
 
     @property
@@ -643,7 +643,7 @@ class Cluster(CloudFormationModel):
         self.end_datetime = utcnow()
         self.state = "TERMINATED"
 
-    def add_applications(self, applications: List[Dict[str, Any]]) -> None:
+    def add_applications(self, applications: list[dict[str, Any]]) -> None:
         self.applications.extend(
             [
                 Application(
@@ -656,7 +656,7 @@ class Cluster(CloudFormationModel):
             ]
         )
 
-    def add_bootstrap_action(self, bootstrap_action: Dict[str, Any]) -> None:
+    def add_bootstrap_action(self, bootstrap_action: dict[str, Any]) -> None:
         self.bootstrap_actions.append(BootstrapAction(**bootstrap_action))
 
     def add_instance_group(self, instance_group: InstanceGroup) -> None:
@@ -682,7 +682,7 @@ class Cluster(CloudFormationModel):
     def add_instance(self, instance: Instance) -> None:
         self.ec2_instances.append(instance)
 
-    def add_steps(self, steps: List[Dict[str, Any]]) -> List[Step]:
+    def add_steps(self, steps: list[dict[str, Any]]) -> list[Step]:
         added_steps = []
         for step in steps:
             if self.steps:
@@ -695,10 +695,10 @@ class Cluster(CloudFormationModel):
         self.state = "RUNNING"
         return added_steps
 
-    def add_tags(self, tags: Dict[str, str]) -> None:
+    def add_tags(self, tags: dict[str, str]) -> None:
         self._tags.update(tags)
 
-    def remove_tags(self, tag_keys: List[str]) -> None:
+    def remove_tags(self, tag_keys: list[str]) -> None:
         for key in tag_keys:
             self._tags.pop(key, None)
 
@@ -776,7 +776,7 @@ class Cluster(CloudFormationModel):
     def delete_from_cloudformation_json(
         cls,
         resource_name: str,
-        cloudformation_json: Dict[str, Any],
+        cloudformation_json: dict[str, Any],
         account_id: str,
         region_name: str,
     ) -> None:
@@ -820,7 +820,7 @@ class SecurityConfiguration(CloudFormationModel):
     def delete_from_cloudformation_json(
         cls,
         resource_name: str,
-        cloudformation_json: Dict[str, Any],
+        cloudformation_json: dict[str, Any],
         account_id: str,
         region_name: str,
     ) -> None:
@@ -834,10 +834,10 @@ class SecurityConfiguration(CloudFormationModel):
 class ElasticMapReduceBackend(BaseBackend):
     def __init__(self, region_name: str, account_id: str):
         super().__init__(region_name, account_id)
-        self.clusters: Dict[str, Cluster] = {}
-        self.instance_groups: Dict[str, InstanceGroup] = {}
-        self.security_configurations: Dict[str, SecurityConfiguration] = {}
-        self.block_public_access_configuration: Dict[str, Any] = {}
+        self.clusters: dict[str, Cluster] = {}
+        self.instance_groups: dict[str, InstanceGroup] = {}
+        self.security_configurations: dict[str, SecurityConfiguration] = {}
+        self.block_public_access_configuration: dict[str, Any] = {}
 
     @cached_property
     def _release_labels(self) -> list[str]:
@@ -867,14 +867,14 @@ class ElasticMapReduceBackend(BaseBackend):
         return ec2_backends[self.account_id][self.region_name]
 
     def add_applications(
-        self, cluster_id: str, applications: List[Dict[str, Any]]
+        self, cluster_id: str, applications: list[dict[str, Any]]
     ) -> None:
         cluster = self.describe_cluster(cluster_id)
         cluster.add_applications(applications)
 
     def add_instance_groups(
-        self, cluster_id: str, instance_groups: List[Dict[str, Any]]
-    ) -> List[InstanceGroup]:
+        self, cluster_id: str, instance_groups: list[dict[str, Any]]
+    ) -> list[InstanceGroup]:
         cluster = self.clusters[cluster_id]
         result_groups = []
         for instance_group in instance_groups:
@@ -887,7 +887,7 @@ class ElasticMapReduceBackend(BaseBackend):
     def run_instances(
         self,
         cluster_id: str,
-        instances: Dict[str, Any],
+        instances: dict[str, Any],
         instance_group: InstanceGroup,
     ) -> None:
         cluster = self.clusters[cluster_id]
@@ -900,22 +900,22 @@ class ElasticMapReduceBackend(BaseBackend):
             cluster.add_instance(instance)
 
     def add_job_flow_steps(
-        self, job_flow_id: str, steps: List[Dict[str, Any]]
-    ) -> List[Step]:
+        self, job_flow_id: str, steps: list[dict[str, Any]]
+    ) -> list[Step]:
         cluster = self.clusters[job_flow_id]
         return cluster.add_steps(steps)
 
-    def add_tags(self, cluster_id: str, tags: Dict[str, str]) -> None:
+    def add_tags(self, cluster_id: str, tags: dict[str, str]) -> None:
         cluster = self.describe_cluster(cluster_id)
         cluster.add_tags(tags)
 
     def describe_job_flows(
         self,
-        job_flow_ids: Optional[List[str]] = None,
-        job_flow_states: Optional[List[str]] = None,
+        job_flow_ids: Optional[list[str]] = None,
+        job_flow_states: Optional[list[str]] = None,
         created_after: Optional[datetime] = None,
         created_before: Optional[datetime] = None,
-    ) -> List[Cluster]:
+    ) -> list[Cluster]:
         clusters = list(self.clusters.values())
 
         within_two_month = utcnow() - timedelta(days=60)
@@ -945,7 +945,7 @@ class ElasticMapReduceBackend(BaseBackend):
             return self.clusters[cluster_id]
         raise InvalidCluster(cluster_id)
 
-    def get_instance_groups(self, instance_group_ids: List[str]) -> List[InstanceGroup]:
+    def get_instance_groups(self, instance_group_ids: list[str]) -> list[InstanceGroup]:
         return [
             group
             for group_id, group in self.instance_groups.items()
@@ -954,7 +954,7 @@ class ElasticMapReduceBackend(BaseBackend):
 
     def list_bootstrap_actions(
         self, cluster_id: str, marker: Optional[str] = None
-    ) -> Tuple[List[BootstrapAction], Optional[str]]:
+    ) -> tuple[list[BootstrapAction], Optional[str]]:
         max_items = 50
         actions = self.clusters[cluster_id].bootstrap_actions
         start_idx = 0 if marker is None else int(marker)
@@ -967,11 +967,11 @@ class ElasticMapReduceBackend(BaseBackend):
 
     def list_clusters(
         self,
-        cluster_states: Optional[List[str]] = None,
+        cluster_states: Optional[list[str]] = None,
         created_after: Optional[datetime] = None,
         created_before: Optional[datetime] = None,
         marker: Optional[str] = None,
-    ) -> Tuple[List[Cluster], Optional[str]]:
+    ) -> tuple[list[Cluster], Optional[str]]:
         max_items = 50
         clusters = list(self.clusters.values())
         if cluster_states:
@@ -991,7 +991,7 @@ class ElasticMapReduceBackend(BaseBackend):
 
     def list_instance_groups(
         self, cluster_id: str, marker: Optional[str] = None
-    ) -> Tuple[List[InstanceGroup], Optional[str]]:
+    ) -> tuple[list[InstanceGroup], Optional[str]]:
         max_items = 50
         groups = sorted(self.clusters[cluster_id].instance_groups, key=lambda x: x.id)
         start_idx = 0 if marker is None else int(marker)
@@ -1005,8 +1005,8 @@ class ElasticMapReduceBackend(BaseBackend):
         cluster_id: str,
         marker: Optional[str] = None,
         instance_group_id: Optional[str] = None,
-        instance_group_types: Optional[List[str]] = None,
-    ) -> Tuple[List[Instance], Optional[str]]:
+        instance_group_types: Optional[list[str]] = None,
+    ) -> tuple[list[Instance], Optional[str]]:
         max_items = 50
         groups = sorted(self.clusters[cluster_id].ec2_instances, key=lambda x: x.id)
         start_idx = 0 if marker is None else int(marker)
@@ -1025,9 +1025,9 @@ class ElasticMapReduceBackend(BaseBackend):
         self,
         cluster_id: str,
         marker: Optional[str] = None,
-        step_ids: Optional[List[str]] = None,
-        step_states: Optional[List[str]] = None,
-    ) -> Tuple[List[Step], Optional[str]]:
+        step_ids: Optional[list[str]] = None,
+        step_states: Optional[list[str]] = None,
+    ) -> tuple[list[Step], Optional[str]]:
         max_items = 50
         steps = sorted(
             self.clusters[cluster_id].steps,
@@ -1049,12 +1049,12 @@ class ElasticMapReduceBackend(BaseBackend):
         cluster.step_concurrency_level = step_concurrency_level
         return cluster
 
-    def modify_instance_groups(self, instance_groups: List[Dict[str, Any]]) -> None:
+    def modify_instance_groups(self, instance_groups: list[dict[str, Any]]) -> None:
         for instance_group in instance_groups:
             group = self.instance_groups[instance_group["instance_group_id"]]
             group.set_instance_count(int(instance_group["instance_count"]))
 
-    def remove_tags(self, cluster_id: str, tag_keys: List[str]) -> None:
+    def remove_tags(self, cluster_id: str, tag_keys: list[str]) -> None:
         cluster = self.describe_cluster(cluster_id)
         cluster.remove_tags(tag_keys)
 
@@ -1065,7 +1065,7 @@ class ElasticMapReduceBackend(BaseBackend):
         emr_managed_slave_security_group: str,
         service_access_security_group: str,
         **_: Any,
-    ) -> Tuple[str, str, str]:
+    ) -> tuple[str, str, str]:
         default_return_value = (
             emr_managed_master_security_group,
             emr_managed_slave_security_group,
@@ -1099,18 +1099,18 @@ class ElasticMapReduceBackend(BaseBackend):
         return Cluster(self, **kwargs)
 
     def set_visible_to_all_users(
-        self, job_flow_ids: List[str], visible_to_all_users: bool
+        self, job_flow_ids: list[str], visible_to_all_users: bool
     ) -> None:
         for job_flow_id in job_flow_ids:
             cluster = self.clusters[job_flow_id]
             cluster.set_visibility(visible_to_all_users)
 
-    def set_termination_protection(self, job_flow_ids: List[str], value: bool) -> None:
+    def set_termination_protection(self, job_flow_ids: list[str], value: bool) -> None:
         for job_flow_id in job_flow_ids:
             cluster = self.clusters[job_flow_id]
             cluster.set_termination_protection(value)
 
-    def terminate_job_flows(self, job_flow_ids: List[str]) -> List[Cluster]:
+    def terminate_job_flows(self, job_flow_ids: list[str]) -> list[Cluster]:
         clusters_terminated = []
         clusters_protected = []
         for job_flow_id in job_flow_ids:
@@ -1127,7 +1127,7 @@ class ElasticMapReduceBackend(BaseBackend):
         return clusters_terminated
 
     def put_auto_scaling_policy(
-        self, instance_group_id: str, auto_scaling_policy: Optional[Dict[str, Any]]
+        self, instance_group_id: str, auto_scaling_policy: Optional[dict[str, Any]]
     ) -> Optional[InstanceGroup]:
         instance_groups = self.get_instance_groups(
             instance_group_ids=[instance_group_id]
@@ -1170,13 +1170,13 @@ class ElasticMapReduceBackend(BaseBackend):
 
     def get_block_public_access_configuration(
         self,
-    ) -> Dict[str, Any]:  # type ignore[misc]
+    ) -> dict[str, Any]:  # type ignore[misc]
         return self.block_public_access_configuration
 
     def put_block_public_access_configuration(
         self,
         block_public_security_group_rules: bool,
-        rule_ranges: Optional[List[Dict[str, int]]],
+        rule_ranges: Optional[list[dict[str, int]]],
     ) -> None:
         from moto.sts import sts_backends
 

--- a/moto/emr/responses.py
+++ b/moto/emr/responses.py
@@ -1,5 +1,6 @@
 import re
-from typing import Any, List, Pattern
+from re import Pattern
+from typing import Any
 
 from moto.core.parsers import XFormedDict
 from moto.core.responses import ActionResult, BaseResponse, EmptyResult
@@ -12,7 +13,7 @@ from .utils import ReleaseLabel
 class ElasticMapReduceResponse(BaseResponse):
     # EMR end points are inconsistent in the placement of region name
     # in the URL, so parsing it out needs to be handled differently
-    emr_region_regex: List[Pattern[str]] = [
+    emr_region_regex: list[Pattern[str]] = [
         re.compile(r"elasticmapreduce\.(.+?)\.amazonaws\.com"),
         re.compile(r"(.+?)\.elasticmapreduce\.amazonaws\.com"),
     ]
@@ -237,8 +238,8 @@ class ElasticMapReduceResponse(BaseResponse):
             if ami_version:
                 message = (
                     "Only one AMI version and release label may be specified. "
-                    "Provided AMI: {0}, release label: {1}."
-                ).format(ami_version, release_label)
+                    f"Provided AMI: {ami_version}, release label: {release_label}."
+                )
                 raise ValidationException(message)
         else:
             if ami_version:

--- a/moto/emr/utils.py
+++ b/moto/emr/utils.py
@@ -1,7 +1,8 @@
 import copy
 import re
 import string
-from typing import Any, Dict, Iterator, List, Tuple
+from collections.abc import Iterator
+from typing import Any
 
 from moto.core.utils import iso_8601_datetime_with_milliseconds
 from moto.moto_api._internal import mock_random as random
@@ -35,7 +36,7 @@ class ReleaseLabel:
         self.patch = patch
 
     @classmethod
-    def parse(cls, release_label: str) -> Tuple[int, int, int]:
+    def parse(cls, release_label: str) -> tuple[int, int, int]:
         if not release_label:
             raise ValueError(f"Invalid empty ReleaseLabel: {release_label}")
 
@@ -54,7 +55,7 @@ class ReleaseLabel:
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}({str(self)})"
 
-    def __iter__(self) -> Iterator[Tuple[int, int, int]]:
+    def __iter__(self) -> Iterator[tuple[int, int, int]]:
         return iter((self.major, self.minor, self.patch))  # type: ignore
 
     def __eq__(self, other: Any) -> bool:
@@ -261,7 +262,7 @@ class EmrSecurityGroupManager:
         master_security_group: str,
         slave_security_group: str,
         service_access_security_group: str,
-    ) -> Tuple[Any, Any, Any]:
+    ) -> tuple[Any, Any, Any]:
         group_metadata = [
             (
                 master_security_group,
@@ -279,7 +280,7 @@ class EmrSecurityGroupManager:
                 EmrManagedServiceAccessSecurityGroup,
             ),
         ]
-        managed_groups: Dict[str, Any] = {}
+        managed_groups: dict[str, Any] = {}
         for name, kind, defaults in group_metadata:
             managed_groups[kind] = self._get_or_create_sg(name, defaults)
         self._add_rules_to(managed_groups)
@@ -302,7 +303,7 @@ class EmrSecurityGroupManager:
             group = create_sg(defaults.group_name, defaults.description(), self.vpc_id)
         return group
 
-    def _add_rules_to(self, managed_groups: Dict[str, Any]) -> None:
+    def _add_rules_to(self, managed_groups: dict[str, Any]) -> None:
         rules_metadata = [
             (self.MANAGED_RULES_EGRESS, self.ec2.authorize_security_group_egress),
             (self.MANAGED_RULES_INGRESS, self.ec2.authorize_security_group_ingress),
@@ -320,8 +321,8 @@ class EmrSecurityGroupManager:
 
     @staticmethod
     def _render_rules(  # type: ignore[misc]
-        rules: Any, managed_groups: Dict[str, Any]
-    ) -> List[Dict[str, Any]]:
+        rules: Any, managed_groups: dict[str, Any]
+    ) -> list[dict[str, Any]]:
         rendered_rules = copy.deepcopy(rules)
         for rule in rendered_rules:
             rule["group_name_or_id"] = managed_groups[rule["group_name_or_id"]].id

--- a/moto/emrcontainers/models.py
+++ b/moto/emrcontainers/models.py
@@ -1,8 +1,9 @@
 """EMRContainersBackend class with methods for supported APIs."""
 
 import re
+from collections.abc import Iterator
 from datetime import datetime
-from typing import Any, Dict, Iterator, List, Optional, Tuple
+from typing import Any, Optional
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
@@ -26,12 +27,12 @@ class FakeCluster(BaseModel):
     def __init__(
         self,
         name: str,
-        container_provider: Dict[str, Any],
+        container_provider: dict[str, Any],
         client_token: str,
         account_id: str,
         region_name: str,
         aws_partition: str,
-        tags: Optional[Dict[str, str]] = None,
+        tags: Optional[dict[str, str]] = None,
         virtual_cluster_id: Optional[str] = None,
     ):
         self.id = virtual_cluster_id or random_cluster_id()
@@ -53,7 +54,7 @@ class FakeCluster(BaseModel):
         )
         self.tags = tags
 
-    def __iter__(self) -> Iterator[Tuple[str, Any]]:
+    def __iter__(self) -> Iterator[tuple[str, Any]]:
         yield "id", self.id
         yield "name", self.name
         yield "arn", self.arn
@@ -62,7 +63,7 @@ class FakeCluster(BaseModel):
         yield "createdAt", self.creation_date
         yield "tags", self.tags
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         # Format for summary https://docs.aws.amazon.com/emr-on-eks/latest/APIReference/API_DescribeVirtualCluster.html
         # (response syntax section)
         return {
@@ -85,11 +86,11 @@ class FakeJob(BaseModel):
         execution_role_arn: str,
         release_label: str,
         job_driver: str,
-        configuration_overrides: Dict[str, Any],
+        configuration_overrides: dict[str, Any],
         account_id: str,
         region_name: str,
         aws_partition: str,
-        tags: Optional[Dict[str, str]],
+        tags: Optional[dict[str, str]],
     ):
         self.id = random_job_id()
         self.name = name
@@ -116,7 +117,7 @@ class FakeJob(BaseModel):
         self.failure_reason = None
         self.tags = tags
 
-    def __iter__(self) -> Iterator[Tuple[str, Any]]:
+    def __iter__(self) -> Iterator[tuple[str, Any]]:
         yield "id", self.id
         yield "name", self.name
         yield "virtualClusterId", self.virtual_cluster_id
@@ -134,7 +135,7 @@ class FakeJob(BaseModel):
         yield "failureReason", self.failure_reason
         yield "tags", self.tags
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         # Format for summary https://docs.aws.amazon.com/emr-on-eks/latest/APIReference/API_DescribeJobRun.html
         # (response syntax section)
         return {
@@ -162,18 +163,18 @@ class EMRContainersBackend(BaseBackend):
 
     def __init__(self, region_name: str, account_id: str):
         super().__init__(region_name, account_id)
-        self.virtual_clusters: Dict[str, FakeCluster] = dict()
+        self.virtual_clusters: dict[str, FakeCluster] = dict()
         self.virtual_cluster_count = 0
-        self.jobs: Dict[str, FakeJob] = dict()
+        self.jobs: dict[str, FakeJob] = dict()
         self.job_count = 0
         self.partition = get_partition(region_name)
 
     def create_virtual_cluster(
         self,
         name: str,
-        container_provider: Dict[str, Any],
+        container_provider: dict[str, Any],
         client_token: str,
-        tags: Optional[Dict[str, str]] = None,
+        tags: Optional[dict[str, str]] = None,
     ) -> FakeCluster:
         occupied_namespaces = [
             virtual_cluster.namespace
@@ -206,7 +207,7 @@ class EMRContainersBackend(BaseBackend):
         self.virtual_clusters[cluster_id].state = "TERMINATED"
         return self.virtual_clusters[cluster_id]
 
-    def describe_virtual_cluster(self, cluster_id: str) -> Dict[str, Any]:
+    def describe_virtual_cluster(self, cluster_id: str) -> dict[str, Any]:
         if cluster_id not in self.virtual_clusters:
             raise ValidationException(f"Virtual cluster {cluster_id} doesn't exist.")
 
@@ -218,10 +219,10 @@ class EMRContainersBackend(BaseBackend):
         container_provider_type: str,
         created_after: str,
         created_before: str,
-        states: Optional[List[str]],
+        states: Optional[list[str]],
         max_results: int,
         next_token: Optional[str],
-    ) -> Tuple[List[Dict[str, Any]], Optional[str]]:
+    ) -> tuple[list[dict[str, Any]], Optional[str]]:
         virtual_clusters = [
             virtual_cluster.to_dict()
             for virtual_cluster in self.virtual_clusters.values()
@@ -273,8 +274,8 @@ class EMRContainersBackend(BaseBackend):
         execution_role_arn: str,
         release_label: str,
         job_driver: str,
-        configuration_overrides: Dict[str, Any],
-        tags: Dict[str, str],
+        configuration_overrides: dict[str, Any],
+        tags: dict[str, str],
     ) -> FakeJob:
         if virtual_cluster_id not in self.virtual_clusters.keys():
             raise ResourceNotFoundException(
@@ -337,10 +338,10 @@ class EMRContainersBackend(BaseBackend):
         created_before: str,
         created_after: str,
         name: str,
-        states: Optional[List[str]],
+        states: Optional[list[str]],
         max_results: int,
         next_token: Optional[str],
-    ) -> Tuple[List[Dict[str, Any]], Optional[str]]:
+    ) -> tuple[list[dict[str, Any]], Optional[str]]:
         jobs = [job.to_dict() for job in self.jobs.values()]
 
         jobs = [job for job in jobs if job["virtualClusterId"] == virtual_cluster_id]
@@ -360,7 +361,7 @@ class EMRContainersBackend(BaseBackend):
         sort_key = "id"
         return paginated_list(jobs, sort_key, max_results, next_token)
 
-    def describe_job_run(self, job_id: str, virtual_cluster_id: str) -> Dict[str, Any]:
+    def describe_job_run(self, job_id: str, virtual_cluster_id: str) -> dict[str, Any]:
         if not re.match(r"[a-z,A-Z,0-9]{19}", job_id):
             raise ValidationException("Invalid job run short id")
 

--- a/moto/emrcontainers/utils.py
+++ b/moto/emrcontainers/utils.py
@@ -1,6 +1,6 @@
 # import json
 import string
-from typing import Any, List, Optional, Tuple
+from typing import Any, Optional
 
 from moto.moto_api._internal import mock_random as random
 
@@ -19,8 +19,8 @@ def random_job_id() -> str:
 
 
 def paginated_list(
-    full_list: List[Any], sort_key: str, max_results: int, next_token: Optional[str]
-) -> Tuple[List[Any], Optional[str]]:
+    full_list: list[Any], sort_key: str, max_results: int, next_token: Optional[str]
+) -> tuple[list[Any], Optional[str]]:
     """
     Returns a tuple containing a slice of the full list starting at next_token and ending with at most the max_results
     number of elements, and the new next_token which can be passed back in for the next segment of the full list.

--- a/moto/emrserverless/models.py
+++ b/moto/emrserverless/models.py
@@ -2,8 +2,9 @@
 
 import inspect
 import re
+from collections.abc import Iterator
 from datetime import datetime
-from typing import Any, Dict, Iterator, List, Optional, Tuple, Union
+from typing import Any, Optional, Union
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
@@ -42,7 +43,7 @@ class FakeApplication(BaseModel):
         region_name: str,
         initial_capacity: str,
         maximum_capacity: str,
-        tags: Dict[str, str],
+        tags: dict[str, str],
         auto_start_configuration: str,
         auto_stop_configuration: str,
         network_configuration: str,
@@ -61,7 +62,7 @@ class FakeApplication(BaseModel):
             auto_stop_configuration or default_auto_stop_configuration()
         )
         self.network_configuration = network_configuration
-        self.tags: Dict[str, str] = tags or {}
+        self.tags: dict[str, str] = tags or {}
 
         # Service-generated-parameters
         self.id = random_appplication_id()
@@ -78,7 +79,7 @@ class FakeApplication(BaseModel):
         )
         self.updated_at = self.created_at
 
-    def __iter__(self) -> Iterator[Tuple[str, Any]]:
+    def __iter__(self) -> Iterator[tuple[str, Any]]:
         yield "applicationId", self.id
         yield "name", self.name
         yield "arn", self.arn
@@ -91,7 +92,7 @@ class FakeApplication(BaseModel):
             self.auto_stop_configuration,
         )
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         """
         Dictionary representation of an EMR Serverless Application.
         When used in `list-applications`, capacity, auto-start/stop configs, and tags are not returned. https://docs.aws.amazon.com/emr-serverless/latest/APIReference/API_ListApplications.html
@@ -148,10 +149,10 @@ class FakeJobRun(BaseModel):
         region_name: str,
         release_label: str,
         application_type: str,
-        job_driver: Optional[Dict[str, Dict[str, Union[str, List[str]]]]],
-        configuration_overrides: Optional[Dict[str, Union[List[Any], Dict[str, Any]]]],
-        tags: Optional[Dict[str, str]],
-        network_configuration: Optional[Dict[str, List[str]]],
+        job_driver: Optional[dict[str, dict[str, Union[str, list[str]]]]],
+        configuration_overrides: Optional[dict[str, Union[list[Any], dict[str, Any]]]],
+        tags: Optional[dict[str, str]],
+        network_configuration: Optional[dict[str, list[str]]],
         execution_timeout_minutes: Optional[int],
         name: Optional[str],
     ):
@@ -189,7 +190,7 @@ class FakeJobRun(BaseModel):
         self.updated_at: str = self.created_at
 
         self.total_execution_duration_seconds: int = 0
-        self.billed_resource_utilization: Dict[str, float] = {
+        self.billed_resource_utilization: dict[str, float] = {
             "vCPUHour": 0.0,
             "memoryGBHour": 0.0,
             "storageGBHour": 0.0,
@@ -197,7 +198,7 @@ class FakeJobRun(BaseModel):
 
         self.tags = tags
 
-    def to_dict(self, caller_methods_type: str) -> Dict[str, Any]:
+    def to_dict(self, caller_methods_type: str) -> dict[str, Any]:
         # The response structure is different for get/update and list
         if caller_methods_type in ["get", "update"]:
             response = {
@@ -246,8 +247,8 @@ class EMRServerlessBackend(BaseBackend):
         super().__init__(region_name, account_id)
         self.region_name = region_name
         self.partition = get_partition(region_name)
-        self.applications: Dict[str, FakeApplication] = dict()
-        self.job_runs: Dict[str, List[FakeJobRun]] = (
+        self.applications: dict[str, FakeApplication] = dict()
+        self.job_runs: dict[str, list[FakeJobRun]] = (
             dict()
         )  # {application_id: [job_run1, job_run2]}
 
@@ -259,7 +260,7 @@ class EMRServerlessBackend(BaseBackend):
         client_token: str,
         initial_capacity: str,
         maximum_capacity: str,
-        tags: Dict[str, str],
+        tags: dict[str, str],
         auto_start_configuration: str,
         auto_stop_configuration: str,
         network_configuration: str,
@@ -300,15 +301,15 @@ class EMRServerlessBackend(BaseBackend):
             )
         self.applications[application_id].state = "TERMINATED"
 
-    def get_application(self, application_id: str) -> Dict[str, Any]:
+    def get_application(self, application_id: str) -> dict[str, Any]:
         if application_id not in self.applications.keys():
             raise ResourceNotFoundException(application_id)
 
         return self.applications[application_id].to_dict()
 
     def list_applications(
-        self, next_token: Optional[str], max_results: int, states: Optional[List[str]]
-    ) -> Tuple[List[Dict[str, Any]], Optional[str]]:
+        self, next_token: Optional[str], max_results: int, states: Optional[list[str]]
+    ) -> tuple[list[dict[str, Any]], Optional[str]]:
         applications = [
             application.to_dict() for application in self.applications.values()
         ]
@@ -339,7 +340,7 @@ class EMRServerlessBackend(BaseBackend):
         auto_start_configuration: Optional[str],
         auto_stop_configuration: Optional[str],
         network_configuration: Optional[str],
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         if application_id not in self.applications.keys():
             raise ResourceNotFoundException(application_id)
 
@@ -383,9 +384,9 @@ class EMRServerlessBackend(BaseBackend):
         application_id: str,
         client_token: str,
         execution_role_arn: str,
-        job_driver: Optional[Dict[str, Dict[str, Union[str, List[str]]]]],
-        configuration_overrides: Optional[Dict[str, Union[List[Any], Dict[str, Any]]]],
-        tags: Optional[Dict[str, str]],
+        job_driver: Optional[dict[str, dict[str, Union[str, list[str]]]]],
+        configuration_overrides: Optional[dict[str, Union[list[Any], dict[str, Any]]]],
+        tags: Optional[dict[str, str]],
         execution_timeout_minutes: Optional[int],
         name: Optional[str],
     ) -> FakeJobRun:
@@ -441,7 +442,7 @@ class EMRServerlessBackend(BaseBackend):
 
         return job_run
 
-    def cancel_job_run(self, application_id: str, job_run_id: str) -> Tuple[str, str]:
+    def cancel_job_run(self, application_id: str, job_run_id: str) -> tuple[str, str]:
         # implement here
         if application_id not in self.job_runs.keys():
             raise ResourceNotFoundException(application_id, "Application")
@@ -460,8 +461,8 @@ class EMRServerlessBackend(BaseBackend):
         next_token: Optional[str],
         created_at_after: Optional[str],
         created_at_before: Optional[str],
-        states: Optional[List[str]],
-    ) -> Tuple[List[Dict[str, Any]], Optional[str]]:
+        states: Optional[list[str]],
+    ) -> tuple[list[dict[str, Any]], Optional[str]]:
         if application_id not in self.job_runs.keys():
             raise ResourceNotFoundException(application_id, "Application")
         job_runs = self.job_runs[application_id]

--- a/moto/emrserverless/utils.py
+++ b/moto/emrserverless/utils.py
@@ -1,5 +1,5 @@
 import string
-from typing import Any, Dict
+from typing import Any
 
 from moto.moto_api._internal import mock_random as random
 
@@ -17,9 +17,9 @@ def random_job_id() -> str:
     return random_id(size=16)
 
 
-def default_auto_start_configuration() -> Dict[str, bool]:
+def default_auto_start_configuration() -> dict[str, bool]:
     return {"enabled": True}
 
 
-def default_auto_stop_configuration() -> Dict[str, Any]:
+def default_auto_stop_configuration() -> dict[str, Any]:
     return {"enabled": True, "idleTimeoutMinutes": 15}

--- a/moto/events/models.py
+++ b/moto/events/models.py
@@ -7,7 +7,7 @@ from collections import OrderedDict
 from enum import Enum, unique
 from json import JSONDecodeError
 from operator import eq, ge, gt, le, lt
-from typing import TYPE_CHECKING, Any, Dict, List, Optional
+from typing import TYPE_CHECKING, Any, Optional
 
 import requests
 
@@ -73,7 +73,7 @@ class Rule(CloudFormationModel):
         event_bus_name: str,
         state: Optional[str],
         managed_by: Optional[str] = None,
-        targets: Optional[List[Dict[str, Any]]] = None,
+        targets: Optional[list[dict[str, Any]]] = None,
     ):
         self.name = name
         self.account_id = account_id
@@ -119,7 +119,7 @@ class Rule(CloudFormationModel):
         self.remove_targets([t["Id"] for t in self.targets])
         event_backend.delete_rule(name=self.name, event_bus_arn=self.event_bus_name)
 
-    def put_targets(self, targets: List[Dict[str, Any]]) -> None:
+    def put_targets(self, targets: list[dict[str, Any]]) -> None:
         # Not testing for valid ARNs.
         for target in targets:
             index = self._check_target_exists(target["Id"])
@@ -128,7 +128,7 @@ class Rule(CloudFormationModel):
             else:
                 self.targets.append(target)
 
-    def remove_targets(self, ids: List[str]) -> None:
+    def remove_targets(self, ids: list[str]) -> None:
         for target_id in ids:
             index = self._check_target_exists(target_id)
             if index is not None:
@@ -198,7 +198,7 @@ class Rule(CloudFormationModel):
             else:
                 raise NotImplementedError(f"Expr not defined for {type(self)}")
 
-    def _send_to_cw_log_group(self, name: str, event: Dict[str, Any]) -> None:
+    def _send_to_cw_log_group(self, name: str, event: dict[str, Any]) -> None:
         from moto.logs import logs_backends
 
         if "time" in event:
@@ -224,12 +224,12 @@ class Rule(CloudFormationModel):
             archive.events.append(event)  # type: ignore[union-attr]
 
     def _find_api_destination(self, resource_id: str) -> "Destination":
-        backend: "EventsBackend" = events_backends[self.account_id][self.region_name]
+        backend: EventsBackend = events_backends[self.account_id][self.region_name]
         destination_name = resource_id.split("/")[0]
         return backend.destinations[destination_name]
 
     def _send_to_sqs_queue(
-        self, resource_id: str, event: Dict[str, Any], group_id: Optional[str] = None
+        self, resource_id: str, event: dict[str, Any], group_id: Optional[str] = None
     ) -> None:
         from moto.sqs import sqs_backends
 
@@ -302,7 +302,7 @@ class Rule(CloudFormationModel):
         event_bus_arn = properties.get("EventBusName")
         tags = properties.get("Tags")
 
-        backend: "EventsBackend" = events_backends[account_id][region_name]
+        backend: EventsBackend = events_backends[account_id][region_name]
         rule = backend.put_rule(
             event_name,
             scheduled_expression=scheduled_expression,
@@ -352,7 +352,7 @@ class Rule(CloudFormationModel):
 
         event_backend.delete_rule(resource_name, event_bus_arn)
 
-    def describe(self) -> Dict[str, Any]:
+    def describe(self) -> dict[str, Any]:
         attributes = {
             "Arn": self.arn,
             "CreatedBy": self.created_by,
@@ -379,8 +379,8 @@ class EventBus(CloudFormationModel):
         name: str,
         description: Optional[str] = None,
         kms_key_identifier: Optional[str] = None,
-        dead_letter_config: Optional[Dict[str, str]] = None,
-        tags: Optional[List[Dict[str, str]]] = None,
+        dead_letter_config: Optional[dict[str, str]] = None,
+        tags: Optional[list[dict[str, str]]] = None,
     ):
         self.account_id = account_id
         self.region = region_name
@@ -395,8 +395,8 @@ class EventBus(CloudFormationModel):
         self.creation_time = unix_time()
         self.last_modified_time = self.creation_time
 
-        self._statements: Dict[str, EventBusPolicyStatement] = {}
-        self.rules: Dict[str, Rule] = OrderedDict()
+        self._statements: dict[str, EventBusPolicyStatement] = {}
+        self.rules: dict[str, Rule] = OrderedDict()
 
     @property
     def policy(self) -> Optional[str]:
@@ -502,8 +502,8 @@ class EventBus(CloudFormationModel):
         self,
         statement_id: str,
         action: str,
-        principal: Dict[str, str],
-        condition: Optional[Dict[str, Any]],
+        principal: dict[str, str],
+        condition: Optional[dict[str, Any]],
     ) -> None:
         self._remove_principals_statements(principal)
         statement = EventBusPolicyStatement(
@@ -515,7 +515,7 @@ class EventBus(CloudFormationModel):
         )
         self._statements[statement_id] = statement
 
-    def add_policy(self, policy: Dict[str, Any]) -> None:
+    def add_policy(self, policy: dict[str, Any]) -> None:
         policy_statements = policy["Statement"]
 
         principals = [stmt["Principal"] for stmt in policy_statements]
@@ -536,11 +536,11 @@ class EventBusPolicyStatement:
     def __init__(
         self,
         sid: str,
-        principal: Dict[str, str],
+        principal: dict[str, str],
         action: str,
         resource: str,
         effect: str = "Allow",
-        condition: Optional[Dict[str, Any]] = None,
+        condition: Optional[dict[str, Any]] = None,
     ):
         self.sid = sid
         self.principal = principal
@@ -549,8 +549,8 @@ class EventBusPolicyStatement:
         self.effect = effect
         self.condition = condition
 
-    def describe(self) -> Dict[str, Any]:
-        statement: Dict[str, Any] = dict(
+    def describe(self) -> dict[str, Any]:
+        statement: dict[str, Any] = dict(
             Sid=self.sid,
             Effect=self.effect,
             Principal=self.principal,
@@ -563,7 +563,7 @@ class EventBusPolicyStatement:
         return statement
 
     @classmethod
-    def from_dict(cls, statement_dict: Dict[str, Any]) -> "EventBusPolicyStatement":  # type: ignore[misc]
+    def from_dict(cls, statement_dict: dict[str, Any]) -> "EventBusPolicyStatement":  # type: ignore[misc]
         params = dict(
             sid=statement_dict["Sid"],
             effect=statement_dict["Effect"],
@@ -611,11 +611,11 @@ class Archive(CloudFormationModel):
         self.state = "ENABLED"
         self.uuid = str(random.uuid4())
 
-        self.events: List[EventMessageType] = []
+        self.events: list[EventMessageType] = []
         self.event_bus_name = source_arn.split("/")[-1]
         self.rule: Optional[Rule] = None
 
-    def describe_short(self) -> Dict[str, Any]:
+    def describe_short(self) -> dict[str, Any]:
         return {
             "ArchiveName": self.name,
             "EventSourceArn": self.source_arn,
@@ -626,7 +626,7 @@ class Archive(CloudFormationModel):
             "CreationTime": self.creation_time,
         }
 
-    def describe(self) -> Dict[str, Any]:
+    def describe(self) -> dict[str, Any]:
         result = {
             "ArchiveArn": self.arn,
             "Description": self.description,
@@ -748,7 +748,7 @@ class Replay(BaseModel):
         source_arn: str,
         start_time: str,
         end_time: str,
-        destination: Dict[str, Any],
+        destination: dict[str, Any],
     ):
         self.account_id = account_id
         self.region = region_name
@@ -764,7 +764,7 @@ class Replay(BaseModel):
         self.start_time = unix_time()
         self.end_time: Optional[float] = None
 
-    def describe_short(self) -> Dict[str, Any]:
+    def describe_short(self) -> dict[str, Any]:
         return {
             "ReplayName": self.name,
             "EventSourceArn": self.source_arn,
@@ -775,7 +775,7 @@ class Replay(BaseModel):
             "ReplayEndTime": self.end_time,
         }
 
-    def describe(self) -> Dict[str, Any]:
+    def describe(self) -> dict[str, Any]:
         result = {
             "ReplayArn": self.arn,
             "Description": self.description,
@@ -813,7 +813,7 @@ class Connection(BaseModel):
         region_name: str,
         description: str,
         authorization_type: str,
-        auth_parameters: Dict[str, Any],
+        auth_parameters: dict[str, Any],
     ):
         self.uuid = random.uuid4()
         self.name = name
@@ -843,7 +843,7 @@ class Connection(BaseModel):
         self.secret_arn = secret.arn
         self.arn = f"arn:{get_partition(region_name)}:events:{region_name}:{account_id}:connection/{connection_id}"
 
-    def describe_short(self) -> Dict[str, Any]:
+    def describe_short(self) -> dict[str, Any]:
         """
         Create the short description for the Connection object.
 
@@ -866,7 +866,7 @@ class Connection(BaseModel):
             "CreationTime": self.creation_time,
         }
 
-    def describe(self) -> Dict[str, Any]:
+    def describe(self) -> dict[str, Any]:
         """
         Create a complete description for the Connection object.
 
@@ -920,7 +920,7 @@ class Destination(BaseModel):
         self.state = "ACTIVE"
         self.arn = f"arn:{get_partition(region_name)}:events:{region_name}:{account_id}:api-destination/{name}/{self.uuid}"
 
-    def describe(self) -> Dict[str, Any]:
+    def describe(self) -> dict[str, Any]:
         return {
             "ApiDestinationArn": self.arn,
             "ApiDestinationState": self.state,
@@ -934,7 +934,7 @@ class Destination(BaseModel):
             "Name": self.name,
         }
 
-    def describe_short(self) -> Dict[str, Any]:
+    def describe_short(self) -> dict[str, Any]:
         return {
             "ApiDestinationArn": self.arn,
             "ApiDestinationState": self.state,
@@ -944,11 +944,11 @@ class Destination(BaseModel):
 
 
 class EventPattern:
-    def __init__(self, raw_pattern: Optional[str], pattern: Dict[str, Any]):
+    def __init__(self, raw_pattern: Optional[str], pattern: dict[str, Any]):
         self._raw_pattern = raw_pattern
         self._pattern = pattern
 
-    def get_pattern(self) -> Dict[str, Any]:
+    def get_pattern(self) -> dict[str, Any]:
         return self._pattern
 
     def matches_event(self, event: EventMessageType) -> bool:
@@ -958,7 +958,7 @@ class EventPattern:
         return self._does_event_match(event, self._pattern)
 
     def _does_event_match(
-        self, event: EventMessageType, pattern: Dict[str, Any]
+        self, event: EventMessageType, pattern: dict[str, Any]
     ) -> bool:
         items_and_filters = [(event.get(k, UNDEFINED), v) for k, v in pattern.items()]
         nested_filter_matches = [
@@ -1024,7 +1024,7 @@ class EventPatternParser:
     def __init__(self, pattern: Optional[str]):
         self.pattern = pattern
 
-    def _validate_event_pattern(self, pattern: Dict[str, Any]) -> None:
+    def _validate_event_pattern(self, pattern: dict[str, Any]) -> None:
         # values in the event pattern have to be either a dict or an array
         for attr, value in pattern.items():
             if isinstance(value, dict):
@@ -1039,7 +1039,7 @@ class EventPatternParser:
                     reason=f"'{attr}' must be an object or an array"
                 )
 
-    def parse(self) -> Dict[str, Any]:
+    def parse(self) -> dict[str, Any]:
         try:
             parsed_pattern = json.loads(self.pattern) if self.pattern else dict()
             self._validate_event_pattern(parsed_pattern)
@@ -1053,10 +1053,10 @@ class PartnerEventSource(BaseModel):
         self.name = name
         self.arn = f"arn:{get_partition(region)}:events:{region}::event-source/aws.partner/{name}"
         self.created_on = unix_time()
-        self.accounts: List[str] = []
+        self.accounts: list[str] = []
         self.state = "ACTIVE"
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         return {
             "Arn": self.arn,
             "CreatedBy": self.name.split("/")[0],
@@ -1089,18 +1089,18 @@ class EventsBackend(BaseBackend):
 
     def __init__(self, region_name: str, account_id: str):
         super().__init__(region_name, account_id)
-        self.next_tokens: Dict[str, int] = {}
-        self.event_buses: Dict[str, EventBus] = {}
-        self.event_sources: Dict[str, PartnerEventSource] = {}
-        self.archives: Dict[str, Archive] = {}
-        self.replays: Dict[str, Replay] = {}
+        self.next_tokens: dict[str, int] = {}
+        self.event_buses: dict[str, EventBus] = {}
+        self.event_sources: dict[str, PartnerEventSource] = {}
+        self.archives: dict[str, Archive] = {}
+        self.replays: dict[str, Replay] = {}
         self.tagger = TaggingService()
 
         self._add_default_event_bus()
-        self.connections: Dict[str, Connection] = {}
-        self.destinations: Dict[str, Destination] = {}
-        self.partner_event_sources: Dict[str, PartnerEventSource] = {}
-        self.approved_parent_event_bus_names: List[str] = []
+        self.connections: dict[str, Connection] = {}
+        self.destinations: dict[str, Destination] = {}
+        self.partner_event_sources: dict[str, PartnerEventSource] = {}
+        self.approved_parent_event_bus_names: list[str] = []
 
     def _add_default_event_bus(self) -> None:
         self.event_buses["default"] = EventBus(
@@ -1135,7 +1135,7 @@ class EventsBackend(BaseBackend):
         scheduled_expression: Optional[str] = None,
         state: Optional[str] = None,
         managed_by: Optional[str] = None,
-        tags: Optional[List[Dict[str, str]]] = None,
+        tags: Optional[list[dict[str, str]]] = None,
     ) -> Rule:
         event_bus_name = self._normalize_event_bus_arn(event_bus_arn)
 
@@ -1232,7 +1232,7 @@ class EventsBackend(BaseBackend):
     @paginate(pagination_model=PAGINATION_MODEL)
     def list_rule_names_by_target(
         self, target_arn: str, event_bus_arn: Optional[str]
-    ) -> List[Rule]:
+    ) -> list[Rule]:
         event_bus_name = self._normalize_event_bus_arn(event_bus_arn)
         event_bus = self._get_event_bus(event_bus_name)
         matching_rules = []
@@ -1247,7 +1247,7 @@ class EventsBackend(BaseBackend):
     @paginate(pagination_model=PAGINATION_MODEL)
     def list_rules(
         self, prefix: Optional[str] = None, event_bus_arn: Optional[str] = None
-    ) -> List[Rule]:
+    ) -> list[Rule]:
         event_bus_name = self._normalize_event_bus_arn(event_bus_arn)
         event_bus = self._get_event_bus(event_bus_name)
         match_string = ".*"
@@ -1267,7 +1267,7 @@ class EventsBackend(BaseBackend):
     @paginate(pagination_model=PAGINATION_MODEL)
     def list_targets_by_rule(  # type: ignore[misc]
         self, rule_id: str, event_bus_arn: Optional[str]
-    ) -> List[Dict[str, Any]]:
+    ) -> list[dict[str, Any]]:
         # We'll let a KeyError exception be thrown for response to handle if
         # rule doesn't exist.
         event_bus_name = self._normalize_event_bus_arn(event_bus_arn)
@@ -1276,7 +1276,7 @@ class EventsBackend(BaseBackend):
         return rule.targets
 
     def put_targets(
-        self, name: str, event_bus_arn: Optional[str], targets: List[Dict[str, Any]]
+        self, name: str, event_bus_arn: Optional[str], targets: list[dict[str, Any]]
     ) -> None:
         event_bus_name = self._normalize_event_bus_arn(event_bus_arn)
         event_bus = self._get_event_bus(event_bus_name)
@@ -1315,7 +1315,7 @@ class EventsBackend(BaseBackend):
 
         rule.put_targets(targets)
 
-    def put_events(self, events: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    def put_events(self, events: list[dict[str, Any]]) -> list[dict[str, Any]]:
         """
         The following targets are supported at the moment:
 
@@ -1400,7 +1400,7 @@ class EventsBackend(BaseBackend):
         return entries
 
     def remove_targets(
-        self, name: str, event_bus_arn: Optional[str], ids: List[str]
+        self, name: str, event_bus_arn: Optional[str], ids: list[str]
     ) -> None:
         event_bus_name = self._normalize_event_bus_arn(event_bus_arn)
         event_bus = self._get_event_bus(event_bus_name)
@@ -1428,8 +1428,8 @@ class EventsBackend(BaseBackend):
 
     @staticmethod
     def _condition_param_to_stmt_condition(  # type: ignore[misc]
-        condition: Optional[Dict[str, Any]],
-    ) -> Optional[Dict[str, Any]]:
+        condition: Optional[dict[str, Any]],
+    ) -> Optional[dict[str, Any]]:
         if condition:
             key = condition["Key"]
             value = condition["Value"]
@@ -1443,7 +1443,7 @@ class EventsBackend(BaseBackend):
         action: Optional[str],
         principal: str,
         statement_id: str,
-        condition: Dict[str, str],
+        condition: dict[str, str],
     ) -> None:
         if principal is None:
             raise JsonRESTError(
@@ -1486,7 +1486,7 @@ class EventsBackend(BaseBackend):
         action: str,
         principal: str,
         statement_id: str,
-        condition: Dict[str, str],
+        condition: dict[str, str],
         policy: str,
     ) -> None:
         if not event_bus_name:
@@ -1541,8 +1541,8 @@ class EventsBackend(BaseBackend):
         event_source_name: Optional[str] = None,
         description: Optional[str] = None,
         kms_key_identifier: Optional[str] = None,
-        dead_letter_config: Optional[Dict[str, str]] = None,
-        tags: Optional[List[Dict[str, str]]] = None,
+        dead_letter_config: Optional[dict[str, str]] = None,
+        tags: Optional[list[dict[str, str]]] = None,
     ) -> EventBus:
         if name in self.event_buses:
             raise JsonRESTError(
@@ -1575,7 +1575,7 @@ class EventsBackend(BaseBackend):
 
         return self.event_buses[name]
 
-    def list_event_buses(self, name_prefix: Optional[str]) -> List[EventBus]:
+    def list_event_buses(self, name_prefix: Optional[str]) -> list[EventBus]:
         if name_prefix:
             return [
                 event_bus
@@ -1594,7 +1594,7 @@ class EventsBackend(BaseBackend):
         if event_bus:
             self.tagger.delete_all_tags_for_resource(event_bus.arn)
 
-    def list_tags_for_resource(self, arn: str) -> Dict[str, List[Dict[str, str]]]:
+    def list_tags_for_resource(self, arn: str) -> dict[str, list[dict[str, str]]]:
         name = arn.split("/")[-1]
         rules = [bus.rules for bus in self.event_buses.values()]
         for registry in rules + [self.event_buses]:
@@ -1604,7 +1604,7 @@ class EventsBackend(BaseBackend):
             f"Rule {name} does not exist on EventBus default."
         )
 
-    def tag_resource(self, arn: str, tags: List[Dict[str, str]]) -> None:
+    def tag_resource(self, arn: str, tags: list[dict[str, str]]) -> None:
         name = arn.split("/")[-1]
         rules = [bus.rules for bus in self.event_buses.values()]
         for registry in rules + [self.event_buses]:
@@ -1615,7 +1615,7 @@ class EventsBackend(BaseBackend):
             f"Rule {name} does not exist on EventBus default."
         )
 
-    def untag_resource(self, arn: str, tag_names: List[str]) -> None:
+    def untag_resource(self, arn: str, tag_names: list[str]) -> None:
         name = arn.split("/")[-1]
         rules = [bus.rules for bus in self.event_buses.values()]
         for registry in rules + [self.event_buses]:
@@ -1687,7 +1687,7 @@ class EventsBackend(BaseBackend):
 
         return archive
 
-    def describe_archive(self, name: str) -> Dict[str, Any]:
+    def describe_archive(self, name: str) -> dict[str, Any]:
         archive = self.archives.get(name)
 
         if not archive:
@@ -1700,7 +1700,7 @@ class EventsBackend(BaseBackend):
         name_prefix: Optional[str],
         source_arn: Optional[str],
         state: Optional[str],
-    ) -> List[Dict[str, Any]]:
+    ) -> list[dict[str, Any]]:
         if [name_prefix, source_arn, state].count(None) < 2:
             raise ValidationException(
                 "At most one filter is allowed for ListArchives. "
@@ -1732,7 +1732,7 @@ class EventsBackend(BaseBackend):
 
     def update_archive(
         self, name: str, description: str, event_pattern: str, retention: str
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         archive = self.archives.get(name)
 
         if not archive:
@@ -1761,8 +1761,8 @@ class EventsBackend(BaseBackend):
         source_arn: str,
         start_time: str,
         end_time: str,
-        destination: Dict[str, Any],
-    ) -> Dict[str, Any]:
+        destination: dict[str, Any],
+    ) -> dict[str, Any]:
         event_bus_arn = destination["Arn"]
         event_bus_arn_pattern = (
             rf"{ARN_PARTITION_REGEX}:events:[a-zA-Z0-9-]+:\d{{12}}:event-bus/"
@@ -1817,14 +1817,14 @@ class EventsBackend(BaseBackend):
             "State": ReplayState.STARTING.value,  # the replay will be done before returning the response
         }
 
-    def describe_replay(self, name: str) -> Dict[str, Any]:
+    def describe_replay(self, name: str) -> dict[str, Any]:
         replay = self._get_replay(name)
 
         return replay.describe()
 
     def list_replays(
         self, name_prefix: str, source_arn: str, state: str
-    ) -> List[Dict[str, Any]]:
+    ) -> list[dict[str, Any]]:
         if [name_prefix, source_arn, state].count(None) < 2:  # type: ignore
             raise ValidationException(
                 "At most one filter is allowed for ListReplays. "
@@ -1853,7 +1853,7 @@ class EventsBackend(BaseBackend):
 
         return result
 
-    def cancel_replay(self, name: str) -> Dict[str, str]:
+    def cancel_replay(self, name: str) -> dict[str, str]:
         replay = self._get_replay(name)
 
         # replays in the state 'COMPLETED' can't be canceled,
@@ -1877,7 +1877,7 @@ class EventsBackend(BaseBackend):
         name: str,
         description: str,
         authorization_type: str,
-        auth_parameters: Dict[str, Any],
+        auth_parameters: dict[str, Any],
     ) -> Connection:
         connection = Connection(
             name,
@@ -1890,7 +1890,7 @@ class EventsBackend(BaseBackend):
         self.connections[name] = connection
         return connection
 
-    def update_connection(self, name: str, **kwargs: Any) -> Dict[str, Any]:
+    def update_connection(self, name: str, **kwargs: Any) -> dict[str, Any]:
         connection = self.connections.get(name)
         if not connection:
             raise ResourceNotFoundException(f"Connection '{name}' does not exist.")
@@ -1900,17 +1900,17 @@ class EventsBackend(BaseBackend):
                 setattr(connection, attr, value)
         return connection.describe_short()
 
-    def list_connections(self) -> List[Connection]:
+    def list_connections(self) -> list[Connection]:
         return list(self.connections.values())
 
-    def describe_connection(self, name: str) -> Dict[str, Any]:
+    def describe_connection(self, name: str) -> dict[str, Any]:
         connection = self.connections.get(name)
         if not connection:
             raise ResourceNotFoundException(f"Connection '{name}' does not exist.")
 
         return connection.describe()
 
-    def delete_connection(self, name: str) -> Dict[str, Any]:
+    def delete_connection(self, name: str) -> dict[str, Any]:
         connection = self.connections.pop(name, None)
         if not connection:
             raise ResourceNotFoundException(f"Connection '{name}' does not exist.")
@@ -1935,7 +1935,7 @@ class EventsBackend(BaseBackend):
         invocation_endpoint: str,
         invocation_rate_limit_per_second: str,
         http_method: str,
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         destination = Destination(
             name=name,
             account_id=self.account_id,
@@ -1950,10 +1950,10 @@ class EventsBackend(BaseBackend):
         self.destinations[name] = destination
         return destination.describe_short()
 
-    def list_api_destinations(self) -> List[Destination]:
+    def list_api_destinations(self) -> list[Destination]:
         return list(self.destinations.values())
 
-    def describe_api_destination(self, name: str) -> Dict[str, Any]:
+    def describe_api_destination(self, name: str) -> dict[str, Any]:
         destination = self.destinations.get(name)
         if not destination:
             raise ResourceNotFoundException(
@@ -1961,7 +1961,7 @@ class EventsBackend(BaseBackend):
             )
         return destination.describe()
 
-    def update_api_destination(self, name: str, **kwargs: Any) -> Dict[str, Any]:
+    def update_api_destination(self, name: str, **kwargs: Any) -> dict[str, Any]:
         destination = self.destinations.get(name)
         if not destination:
             raise ResourceNotFoundException(
@@ -2000,7 +2000,7 @@ class EventsBackend(BaseBackend):
         client_backend = events_backends[account_id][self.region_name]
         client_backend.event_sources[name].state = "DELETED"
 
-    def put_partner_events(self, entries: List[Dict[str, Any]]) -> None:
+    def put_partner_events(self, entries: list[dict[str, Any]]) -> None:
         """
         Validation of the entries is not yet implemented.
         """

--- a/moto/events/responses.py
+++ b/moto/events/responses.py
@@ -1,5 +1,5 @@
 import json
-from typing import Any, Dict, Tuple
+from typing import Any
 
 from moto.core.responses import BaseResponse
 from moto.events.models import EventsBackend, events_backends
@@ -13,7 +13,7 @@ class EventsHandler(BaseResponse):
     def events_backend(self) -> EventsBackend:
         return events_backends[self.current_account][self.region]
 
-    def _create_response(self, result: Any) -> Tuple[str, Dict[str, Any]]:
+    def _create_response(self, result: Any) -> tuple[str, dict[str, Any]]:
         """
         Creates a proper response for the API.
 
@@ -29,12 +29,12 @@ class EventsHandler(BaseResponse):
 
     def error(
         self, type_: str, message: str = "", status: int = 400
-    ) -> Tuple[str, Dict[str, Any]]:
-        headers: Dict[str, Any] = self.response_headers
+    ) -> tuple[str, dict[str, Any]]:
+        headers: dict[str, Any] = self.response_headers
         headers["status"] = status
         return json.dumps({"__type": type_, "message": message}), headers
 
-    def put_rule(self) -> Tuple[str, Dict[str, Any]]:
+    def put_rule(self) -> tuple[str, dict[str, Any]]:
         name = self._get_param("Name")
         event_pattern = self._get_param("EventPattern")
         scheduled_expression = self._get_param("ScheduleExpression")
@@ -57,7 +57,7 @@ class EventsHandler(BaseResponse):
         result = {"RuleArn": rule.arn}
         return self._create_response(result)
 
-    def delete_rule(self) -> Tuple[str, Dict[str, Any]]:
+    def delete_rule(self) -> tuple[str, dict[str, Any]]:
         name = self._get_param("Name")
         event_bus_arn = self._get_param("EventBusName")
 
@@ -67,7 +67,7 @@ class EventsHandler(BaseResponse):
 
         return "", self.response_headers
 
-    def describe_rule(self) -> Tuple[str, Dict[str, Any]]:
+    def describe_rule(self) -> tuple[str, dict[str, Any]]:
         name = self._get_param("Name")
         event_bus_arn = self._get_param("EventBusName")
 
@@ -79,7 +79,7 @@ class EventsHandler(BaseResponse):
         result = rule.describe()
         return self._create_response(result)
 
-    def disable_rule(self) -> Tuple[str, Dict[str, Any]]:
+    def disable_rule(self) -> tuple[str, dict[str, Any]]:
         name = self._get_param("Name")
         event_bus_arn = self._get_param("EventBusName")
 
@@ -93,7 +93,7 @@ class EventsHandler(BaseResponse):
 
         return "", self.response_headers
 
-    def enable_rule(self) -> Tuple[str, Dict[str, Any]]:
+    def enable_rule(self) -> tuple[str, dict[str, Any]]:
         name = self._get_param("Name")
         event_bus_arn = self._get_param("EventBusName")
 
@@ -110,7 +110,7 @@ class EventsHandler(BaseResponse):
     def generate_presigned_url(self) -> None:
         pass
 
-    def list_rule_names_by_target(self) -> Tuple[str, Dict[str, Any]]:
+    def list_rule_names_by_target(self) -> tuple[str, dict[str, Any]]:
         target_arn = self._get_param("TargetArn")
         event_bus_arn = self._get_param("EventBusName")
         next_token = self._get_param("NextToken")
@@ -130,7 +130,7 @@ class EventsHandler(BaseResponse):
 
         return json.dumps(res), self.response_headers
 
-    def list_rules(self) -> Tuple[str, Dict[str, Any]]:
+    def list_rules(self) -> tuple[str, dict[str, Any]]:
         prefix = self._get_param("NamePrefix")
         event_bus_arn = self._get_param("EventBusName")
         next_token = self._get_param("NextToken")
@@ -149,7 +149,7 @@ class EventsHandler(BaseResponse):
 
         return json.dumps(rules_obj), self.response_headers
 
-    def list_targets_by_rule(self) -> Tuple[str, Dict[str, Any]]:
+    def list_targets_by_rule(self) -> tuple[str, dict[str, Any]]:
         rule_name = self._get_param("Rule")
         event_bus_arn = self._get_param("EventBusName")
         next_token = self._get_param("NextToken")
@@ -183,7 +183,7 @@ class EventsHandler(BaseResponse):
 
         return json.dumps(response)
 
-    def put_targets(self) -> Tuple[str, Dict[str, Any]]:
+    def put_targets(self) -> tuple[str, dict[str, Any]]:
         rule_name = self._get_param("Rule")
         event_bus_name = self._get_param("EventBusName")
         targets = self._get_param("Targets")
@@ -195,7 +195,7 @@ class EventsHandler(BaseResponse):
             self.response_headers,
         )
 
-    def remove_targets(self) -> Tuple[str, Dict[str, Any]]:
+    def remove_targets(self) -> tuple[str, dict[str, Any]]:
         rule_name = self._get_param("Rule")
         event_bus_name = self._get_param("EventBusName")
         ids = self._get_param("Ids")
@@ -235,7 +235,7 @@ class EventsHandler(BaseResponse):
 
         return ""
 
-    def describe_event_bus(self) -> Tuple[str, Dict[str, Any]]:
+    def describe_event_bus(self) -> tuple[str, dict[str, Any]]:
         name = self._get_param("Name")
 
         event_bus = self.events_backend.describe_event_bus(name)
@@ -260,7 +260,7 @@ class EventsHandler(BaseResponse):
 
         return json.dumps(response), self.response_headers
 
-    def create_event_bus(self) -> Tuple[str, Dict[str, Any]]:
+    def create_event_bus(self) -> tuple[str, dict[str, Any]]:
         name = self._get_param("Name")
         event_source_name = self._get_param("EventSourceName")
         description = self._get_param("Description")
@@ -278,7 +278,7 @@ class EventsHandler(BaseResponse):
         )
         return json.dumps({"EventBusArn": event_bus.arn}), self.response_headers
 
-    def list_event_buses(self) -> Tuple[str, Dict[str, Any]]:
+    def list_event_buses(self) -> tuple[str, dict[str, Any]]:
         name_prefix = self._get_param("NamePrefix")
         # ToDo: add 'NextToken' & 'Limit' parameters
 
@@ -293,21 +293,21 @@ class EventsHandler(BaseResponse):
 
         return json.dumps({"EventBuses": response}), self.response_headers
 
-    def delete_event_bus(self) -> Tuple[str, Dict[str, Any]]:
+    def delete_event_bus(self) -> tuple[str, dict[str, Any]]:
         name = self._get_param("Name")
 
         self.events_backend.delete_event_bus(name)
 
         return "", self.response_headers
 
-    def list_tags_for_resource(self) -> Tuple[str, Dict[str, Any]]:
+    def list_tags_for_resource(self) -> tuple[str, dict[str, Any]]:
         arn = self._get_param("ResourceARN")
 
         result = self.events_backend.list_tags_for_resource(arn)
 
         return json.dumps(result), self.response_headers
 
-    def tag_resource(self) -> Tuple[str, Dict[str, Any]]:
+    def tag_resource(self) -> tuple[str, dict[str, Any]]:
         arn = self._get_param("ResourceARN")
         tags = self._get_param("Tags")
 
@@ -315,7 +315,7 @@ class EventsHandler(BaseResponse):
 
         return "{}", self.response_headers
 
-    def untag_resource(self) -> Tuple[str, Dict[str, Any]]:
+    def untag_resource(self) -> tuple[str, dict[str, Any]]:
         arn = self._get_param("ResourceARN")
         tags = self._get_param("TagKeys")
 
@@ -323,7 +323,7 @@ class EventsHandler(BaseResponse):
 
         return "{}", self.response_headers
 
-    def create_archive(self) -> Tuple[str, Dict[str, Any]]:
+    def create_archive(self) -> tuple[str, dict[str, Any]]:
         name = self._get_param("ArchiveName")
         source_arn = self._get_param("EventSourceArn")
         description = self._get_param("Description")
@@ -345,14 +345,14 @@ class EventsHandler(BaseResponse):
             self.response_headers,
         )
 
-    def describe_archive(self) -> Tuple[str, Dict[str, Any]]:
+    def describe_archive(self) -> tuple[str, dict[str, Any]]:
         name = self._get_param("ArchiveName")
 
         result = self.events_backend.describe_archive(name)
 
         return json.dumps(result), self.response_headers
 
-    def list_archives(self) -> Tuple[str, Dict[str, Any]]:
+    def list_archives(self) -> tuple[str, dict[str, Any]]:
         name_prefix = self._get_param("NamePrefix")
         source_arn = self._get_param("EventSourceArn")
         state = self._get_param("State")
@@ -361,7 +361,7 @@ class EventsHandler(BaseResponse):
 
         return json.dumps({"Archives": result}), self.response_headers
 
-    def update_archive(self) -> Tuple[str, Dict[str, Any]]:
+    def update_archive(self) -> tuple[str, dict[str, Any]]:
         name = self._get_param("ArchiveName")
         description = self._get_param("Description")
         event_pattern = self._get_param("EventPattern")
@@ -373,14 +373,14 @@ class EventsHandler(BaseResponse):
 
         return json.dumps(result), self.response_headers
 
-    def delete_archive(self) -> Tuple[str, Dict[str, Any]]:
+    def delete_archive(self) -> tuple[str, dict[str, Any]]:
         name = self._get_param("ArchiveName")
 
         self.events_backend.delete_archive(name)
 
         return "", self.response_headers
 
-    def start_replay(self) -> Tuple[str, Dict[str, Any]]:
+    def start_replay(self) -> tuple[str, dict[str, Any]]:
         name = self._get_param("ReplayName")
         description = self._get_param("Description")
         source_arn = self._get_param("EventSourceArn")
@@ -394,14 +394,14 @@ class EventsHandler(BaseResponse):
 
         return json.dumps(result), self.response_headers
 
-    def describe_replay(self) -> Tuple[str, Dict[str, Any]]:
+    def describe_replay(self) -> tuple[str, dict[str, Any]]:
         name = self._get_param("ReplayName")
 
         result = self.events_backend.describe_replay(name)
 
         return json.dumps(result), self.response_headers
 
-    def list_replays(self) -> Tuple[str, Dict[str, Any]]:
+    def list_replays(self) -> tuple[str, dict[str, Any]]:
         name_prefix = self._get_param("NamePrefix")
         source_arn = self._get_param("EventSourceArn")
         state = self._get_param("State")
@@ -410,14 +410,14 @@ class EventsHandler(BaseResponse):
 
         return json.dumps({"Replays": result}), self.response_headers
 
-    def cancel_replay(self) -> Tuple[str, Dict[str, Any]]:
+    def cancel_replay(self) -> tuple[str, dict[str, Any]]:
         name = self._get_param("ReplayName")
 
         result = self.events_backend.cancel_replay(name)
 
         return json.dumps(result), self.response_headers
 
-    def create_connection(self) -> Tuple[str, Dict[str, Any]]:
+    def create_connection(self) -> tuple[str, dict[str, Any]]:
         name = self._get_param("Name")
         description = self._get_param("Description")
         authorization_type = self._get_param("AuthorizationType")
@@ -439,7 +439,7 @@ class EventsHandler(BaseResponse):
             self.response_headers,
         )
 
-    def list_connections(self) -> Tuple[str, Dict[str, Any]]:
+    def list_connections(self) -> tuple[str, dict[str, Any]]:
         connections = self.events_backend.list_connections()
         result = []
         for connection in connections:
@@ -456,12 +456,12 @@ class EventsHandler(BaseResponse):
 
         return json.dumps({"Connections": result}), self.response_headers
 
-    def describe_connection(self) -> Tuple[str, Dict[str, Any]]:
+    def describe_connection(self) -> tuple[str, dict[str, Any]]:
         name = self._get_param("Name")
         result = self.events_backend.describe_connection(name)
         return json.dumps(result), self.response_headers
 
-    def update_connection(self) -> Tuple[str, Dict[str, Any]]:
+    def update_connection(self) -> tuple[str, dict[str, Any]]:
         updates = dict(
             name=self._get_param("Name"),
             description=self._get_param("Description"),
@@ -471,12 +471,12 @@ class EventsHandler(BaseResponse):
         result = self.events_backend.update_connection(**updates)
         return self._create_response(result)
 
-    def delete_connection(self) -> Tuple[str, Dict[str, Any]]:
+    def delete_connection(self) -> tuple[str, dict[str, Any]]:
         name = self._get_param("Name")
         result = self.events_backend.delete_connection(name)
         return json.dumps(result), self.response_headers
 
-    def create_api_destination(self) -> Tuple[str, Dict[str, Any]]:
+    def create_api_destination(self) -> tuple[str, dict[str, Any]]:
         name = self._get_param("Name")
         description = self._get_param("Description")
         connection_arn = self._get_param("ConnectionArn")
@@ -496,7 +496,7 @@ class EventsHandler(BaseResponse):
         )
         return self._create_response(result)
 
-    def list_api_destinations(self) -> Tuple[str, Dict[str, Any]]:
+    def list_api_destinations(self) -> tuple[str, dict[str, Any]]:
         destinations = self.events_backend.list_api_destinations()
         result = []
         for destination in destinations:
@@ -515,12 +515,12 @@ class EventsHandler(BaseResponse):
 
         return json.dumps({"ApiDestinations": result}), self.response_headers
 
-    def describe_api_destination(self) -> Tuple[str, Dict[str, Any]]:
+    def describe_api_destination(self) -> tuple[str, dict[str, Any]]:
         name = self._get_param("Name")
         result = self.events_backend.describe_api_destination(name)
         return self._create_response(result)
 
-    def update_api_destination(self) -> Tuple[str, Dict[str, Any]]:
+    def update_api_destination(self) -> tuple[str, dict[str, Any]]:
         updates = dict(
             connection_arn=self._get_param("ConnectionArn"),
             description=self._get_param("Description"),
@@ -535,7 +535,7 @@ class EventsHandler(BaseResponse):
         result = self.events_backend.update_api_destination(**updates)
         return self._create_response(result)
 
-    def delete_api_destination(self) -> Tuple[str, Dict[str, Any]]:
+    def delete_api_destination(self) -> tuple[str, dict[str, Any]]:
         name = self._get_param("Name")
         self.events_backend.delete_api_destination(name)
         return self._create_response({})

--- a/moto/events/utils.py
+++ b/moto/events/utils.py
@@ -1,8 +1,10 @@
 import json
-from typing import TYPE_CHECKING, Any, Dict, List, TypedDict
+from typing import TYPE_CHECKING, Any, TypedDict
 
 if TYPE_CHECKING:
-    from typing_extensions import Any, Dict, Required, Union
+    from typing import Union
+
+    from typing_extensions import Any, Required
 
 
 # NOTE: Typing is based on the following document https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-event-patterns.html
@@ -11,15 +13,15 @@ EventMessageType = TypedDict(
     {
         "version": str,
         "id": str,
-        "detail-type": "Required[Union[str, List[str]]]",
-        "source": "Required[Union[str, List[str]]]",
+        "detail-type": "Required[Union[str, list[str]]]",
+        "source": "Required[Union[str, list[str]]]",
         "account": str,
         # support float type for internal use of moto.
         "time": "Union[str, float]",
         "replay-name": str,
         "region": str,
-        "resources": List[str],
-        "detail": "Required[Dict[str, Any]]",
+        "resources": list[str],
+        "detail": "Required[dict[str, Any]]",
         "ingestion-time": float,
     },
     total=False,
@@ -87,8 +89,8 @@ class EventTemplateParser:
 
     @staticmethod
     def parse(  # type: ignore[misc]
-        input_template: str, input_paths_map: Dict[str, Any], event: EventMessageType
-    ) -> Dict[str, Any]:
+        input_template: str, input_paths_map: dict[str, Any], event: EventMessageType
+    ) -> dict[str, Any]:
         from jsonpath_ng.ext import parse
 
         template_to_use = (

--- a/moto/firehose/models.py
+++ b/moto/firehose/models.py
@@ -19,7 +19,7 @@ from base64 import b64decode, b64encode
 from datetime import datetime, timezone
 from gzip import GzipFile
 from time import time
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Optional
 
 import requests
 
@@ -52,7 +52,7 @@ DESTINATION_TYPES_TO_NAMES = {
 }
 
 
-def find_destination_config_in_args(api_args: Dict[str, Any]) -> Tuple[str, Any]:
+def find_destination_config_in_args(api_args: dict[str, Any]) -> tuple[str, Any]:
     """Return (config_name, config) tuple for destination config.
 
     Determines which destination config(s) have been specified.  The
@@ -86,8 +86,8 @@ def find_destination_config_in_args(api_args: Dict[str, Any]) -> Tuple[str, Any]
 
 
 def create_s3_destination_config(
-    extended_s3_destination_config: Dict[str, Any],
-) -> Dict[str, Any]:
+    extended_s3_destination_config: dict[str, Any],
+) -> dict[str, Any]:
     """Return dict with selected fields copied from ExtendedS3 config.
 
     When an ExtendedS3 config is chosen, AWS tacks on a S3 config as
@@ -128,10 +128,10 @@ class DeliveryStream(BaseModel):
         region: str,
         delivery_stream_name: str,
         delivery_stream_type: str,
-        encryption: Dict[str, Any],
-        kinesis_stream_source_configuration: Dict[str, Any],
+        encryption: dict[str, Any],
+        kinesis_stream_source_configuration: dict[str, Any],
         destination_name: str,
-        destination_config: Dict[str, Any],
+        destination_config: dict[str, Any],
     ):
         self.delivery_stream_status = "CREATING"
         self.delivery_stream_name = delivery_stream_name
@@ -141,7 +141,7 @@ class DeliveryStream(BaseModel):
         self.delivery_stream_encryption_configuration = encryption
 
         self.source = kinesis_stream_source_configuration
-        self.destinations: List[Dict[str, Any]] = [
+        self.destinations: list[dict[str, Any]] = [
             {
                 "destination_id": "destinationId-000000000001",
                 destination_name: destination_config,
@@ -176,13 +176,13 @@ class FirehoseBackend(BaseBackend):
 
     def __init__(self, region_name: str, account_id: str):
         super().__init__(region_name, account_id)
-        self.delivery_streams: Dict[str, DeliveryStream] = {}
+        self.delivery_streams: dict[str, DeliveryStream] = {}
         self.tagger = TaggingService()
 
     @staticmethod
     def default_vpc_endpoint_service(
-        service_region: str, zones: List[str]
-    ) -> List[Dict[str, str]]:
+        service_region: str, zones: list[str]
+    ) -> list[dict[str, str]]:
         """Default VPC endpoint service."""
         return BaseBackend.default_vpc_endpoint_service_factory(
             service_region, zones, "firehose", special_service_name="kinesis-firehose"
@@ -193,16 +193,16 @@ class FirehoseBackend(BaseBackend):
         region: str,
         delivery_stream_name: str,
         delivery_stream_type: str,
-        kinesis_stream_source_configuration: Dict[str, Any],
-        delivery_stream_encryption_configuration_input: Dict[str, Any],
-        s3_destination_configuration: Dict[str, Any],
-        extended_s3_destination_configuration: Dict[str, Any],
-        redshift_destination_configuration: Dict[str, Any],
-        elasticsearch_destination_configuration: Dict[str, Any],
-        splunk_destination_configuration: Dict[str, Any],
-        http_endpoint_destination_configuration: Dict[str, Any],
-        snowflake_destination_configuration: Dict[str, Any],
-        tags: List[Dict[str, str]],
+        kinesis_stream_source_configuration: dict[str, Any],
+        delivery_stream_encryption_configuration_input: dict[str, Any],
+        s3_destination_configuration: dict[str, Any],
+        extended_s3_destination_configuration: dict[str, Any],
+        redshift_destination_configuration: dict[str, Any],
+        elasticsearch_destination_configuration: dict[str, Any],
+        splunk_destination_configuration: dict[str, Any],
+        http_endpoint_destination_configuration: dict[str, Any],
+        snowflake_destination_configuration: dict[str, Any],
+        tags: list[dict[str, str]],
     ) -> str:
         """Create a Kinesis Data Firehose delivery stream."""
         (destination_name, destination_config) = find_destination_config_in_args(
@@ -286,7 +286,7 @@ class FirehoseBackend(BaseBackend):
         delivery_stream.delivery_stream_status = "DELETING"
         self.delivery_streams.pop(delivery_stream_name)
 
-    def describe_delivery_stream(self, delivery_stream_name: str) -> Dict[str, Any]:
+    def describe_delivery_stream(self, delivery_stream_name: str) -> dict[str, Any]:
         """Return description of specified delivery stream and its status.
 
         Note:  the 'limit' and 'exclusive_start_destination_id' parameters
@@ -299,7 +299,7 @@ class FirehoseBackend(BaseBackend):
                 f"not found."
             )
 
-        result: Dict[str, Any] = {
+        result: dict[str, Any] = {
             "DeliveryStreamDescription": {"HasMoreDestinations": False}
         }
         for attribute, attribute_value in vars(delivery_stream).items():
@@ -341,7 +341,7 @@ class FirehoseBackend(BaseBackend):
         limit: Optional[int],
         delivery_stream_type: str,
         exclusive_start_delivery_stream_name: str,
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         """Return list of delivery streams in alphabetic order of names."""
         result = {"DeliveryStreamNames": [], "HasMoreDeliveryStreams": False}
         if not self.delivery_streams:
@@ -381,7 +381,7 @@ class FirehoseBackend(BaseBackend):
         delivery_stream_name: str,
         exclusive_start_tag_key: str,
         limit: Optional[int],
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         """Return list of tags."""
         result = {"Tags": [], "HasMoreTags": False}
         delivery_stream = self.delivery_streams.get(delivery_stream_name)
@@ -409,8 +409,8 @@ class FirehoseBackend(BaseBackend):
         return result
 
     def put_record(
-        self, delivery_stream_name: str, record: Dict[str, bytes]
-    ) -> Dict[str, Any]:
+        self, delivery_stream_name: str, record: dict[str, bytes]
+    ) -> dict[str, Any]:
         """Write a single data record into a Kinesis Data firehose stream."""
         result = self.put_record_batch(delivery_stream_name, [record])
         return {
@@ -420,8 +420,8 @@ class FirehoseBackend(BaseBackend):
 
     @staticmethod
     def put_http_records(  # type: ignore[misc]
-        http_destination: Dict[str, Any], records: List[Dict[str, bytes]]
-    ) -> List[Dict[str, str]]:
+        http_destination: dict[str, Any], records: list[dict[str, bytes]]
+    ) -> list[dict[str, str]]:
         """Put records to a HTTP destination."""
         # Mostly copied from localstack
         url = http_destination["EndpointConfiguration"]["Url"]
@@ -462,9 +462,9 @@ class FirehoseBackend(BaseBackend):
         self,
         delivery_stream_name: str,
         version_id: str,
-        s3_destination: Dict[str, Any],
-        records: List[Dict[str, bytes]],
-    ) -> List[Dict[str, str]]:
+        s3_destination: dict[str, Any],
+        records: list[dict[str, bytes]],
+    ) -> list[dict[str, str]]:
         """Put records to a ExtendedS3 or S3 destination."""
         # Taken from LocalStack's firehose logic, with minor changes.
         bucket_name = s3_destination["BucketARN"].split(":")[-1]
@@ -486,8 +486,8 @@ class FirehoseBackend(BaseBackend):
         return [{"RecordId": str(mock_random.uuid4())} for _ in range(len(records))]
 
     def put_record_batch(
-        self, delivery_stream_name: str, records: List[Dict[str, bytes]]
-    ) -> Dict[str, Any]:
+        self, delivery_stream_name: str, records: list[dict[str, bytes]]
+    ) -> dict[str, Any]:
         """Write multiple data records into a Kinesis Data firehose stream."""
         delivery_stream = self.delivery_streams.get(delivery_stream_name)
         if not delivery_stream:
@@ -534,7 +534,7 @@ class FirehoseBackend(BaseBackend):
         }
 
     def tag_delivery_stream(
-        self, delivery_stream_name: str, tags: List[Dict[str, str]]
+        self, delivery_stream_name: str, tags: list[dict[str, str]]
     ) -> None:
         """Add/update tags for specified delivery stream."""
         delivery_stream = self.delivery_streams.get(delivery_stream_name)
@@ -558,7 +558,7 @@ class FirehoseBackend(BaseBackend):
         self.tagger.tag_resource(delivery_stream.delivery_stream_arn, tags)
 
     def untag_delivery_stream(
-        self, delivery_stream_name: str, tag_keys: List[str]
+        self, delivery_stream_name: str, tag_keys: list[str]
     ) -> None:
         """Removes tags from specified delivery stream."""
         delivery_stream = self.delivery_streams.get(delivery_stream_name)
@@ -573,7 +573,7 @@ class FirehoseBackend(BaseBackend):
         )
 
     def start_delivery_stream_encryption(
-        self, stream_name: str, encryption_config: Dict[str, Any]
+        self, stream_name: str, encryption_config: dict[str, Any]
     ) -> None:
         delivery_stream = self.delivery_streams.get(stream_name)
         if not delivery_stream:
@@ -598,14 +598,14 @@ class FirehoseBackend(BaseBackend):
         delivery_stream_name: str,
         current_delivery_stream_version_id: str,
         destination_id: str,
-        s3_destination_update: Dict[str, Any],
-        extended_s3_destination_update: Dict[str, Any],
+        s3_destination_update: dict[str, Any],
+        extended_s3_destination_update: dict[str, Any],
         s3_backup_mode: str,
-        redshift_destination_update: Dict[str, Any],
-        elasticsearch_destination_update: Dict[str, Any],
-        splunk_destination_update: Dict[str, Any],
-        http_endpoint_destination_update: Dict[str, Any],
-        snowflake_destination_configuration: Dict[str, Any],
+        redshift_destination_update: dict[str, Any],
+        elasticsearch_destination_update: dict[str, Any],
+        splunk_destination_update: dict[str, Any],
+        http_endpoint_destination_update: dict[str, Any],
+        snowflake_destination_configuration: dict[str, Any],
     ) -> None:
         (dest_name, dest_config) = find_destination_config_in_args(locals())
 
@@ -702,7 +702,7 @@ class FirehoseBackend(BaseBackend):
         filter_name: str,
         log_group_name: str,
         log_stream_name: str,
-        log_events: List[Dict[str, Any]],
+        log_events: list[dict[str, Any]],
     ) -> None:
         """Send log events to a S3 bucket after encoding and gzipping it."""
         data = {

--- a/moto/forecast/models.py
+++ b/moto/forecast/models.py
@@ -1,6 +1,6 @@
 import re
 from datetime import datetime
-from typing import Dict, List, Optional
+from typing import Optional
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.utils import iso_8601_datetime_without_milliseconds
@@ -31,10 +31,10 @@ class DatasetGroup:
         self,
         account_id: str,
         region_name: str,
-        dataset_arns: List[str],
+        dataset_arns: list[str],
         dataset_group_name: str,
         domain: str,
-        tags: Optional[List[Dict[str, str]]] = None,
+        tags: Optional[list[dict[str, str]]] = None,
     ):
         self.creation_date = iso_8601_datetime_without_milliseconds(datetime.now())
         self.modified_date = self.creation_date
@@ -46,7 +46,7 @@ class DatasetGroup:
         self.tags = tags
         self._validate()
 
-    def update(self, dataset_arns: List[str]) -> None:
+    def update(self, dataset_arns: list[str]) -> None:
         self.dataset_arns = dataset_arns
         self.last_modified_date = iso_8601_datetime_without_milliseconds(datetime.now())
 
@@ -65,7 +65,7 @@ class DatasetGroup:
             message += "; ".join(errors)
             raise ValidationException(message)
 
-    def _validate_dataset_group_name(self) -> List[str]:
+    def _validate_dataset_group_name(self) -> list[str]:
         errors = []
         if not re.match(
             self.accepted_dataset_group_name_format, self.dataset_group_name
@@ -78,7 +78,7 @@ class DatasetGroup:
             )
         return errors
 
-    def _validate_dataset_group_name_len(self) -> List[str]:
+    def _validate_dataset_group_name_len(self) -> list[str]:
         errors = []
         if len(self.dataset_group_name) >= 64:
             errors.append(
@@ -88,7 +88,7 @@ class DatasetGroup:
             )
         return errors
 
-    def _validate_dataset_group_domain(self) -> List[str]:
+    def _validate_dataset_group_domain(self) -> list[str]:
         errors = []
         if self.domain not in self.accepted_dataset_types:
             errors.append(
@@ -103,15 +103,15 @@ class DatasetGroup:
 class ForecastBackend(BaseBackend):
     def __init__(self, region_name: str, account_id: str):
         super().__init__(region_name, account_id)
-        self.dataset_groups: Dict[str, DatasetGroup] = {}
-        self.datasets: Dict[str, str] = {}
+        self.dataset_groups: dict[str, DatasetGroup] = {}
+        self.datasets: dict[str, str] = {}
 
     def create_dataset_group(
         self,
         dataset_group_name: str,
         domain: str,
-        dataset_arns: List[str],
-        tags: List[Dict[str, str]],
+        dataset_arns: list[str],
+        tags: list[dict[str, str]],
     ) -> DatasetGroup:
         dataset_group = DatasetGroup(
             account_id=self.account_id,
@@ -150,7 +150,7 @@ class ForecastBackend(BaseBackend):
             raise ResourceNotFoundException("No resource found " + dataset_group_arn)
 
     def update_dataset_group(
-        self, dataset_group_arn: str, dataset_arns: List[str]
+        self, dataset_group_arn: str, dataset_arns: list[str]
     ) -> None:
         try:
             dsg = self.dataset_groups[dataset_group_arn]
@@ -165,7 +165,7 @@ class ForecastBackend(BaseBackend):
 
         dsg.update(dataset_arns)
 
-    def list_dataset_groups(self) -> List[DatasetGroup]:
+    def list_dataset_groups(self) -> list[DatasetGroup]:
         return [v for (_, v) in self.dataset_groups.items()]
 
 

--- a/moto/fsx/models.py
+++ b/moto/fsx/models.py
@@ -1,7 +1,7 @@
 """FSxBackend class with methods for supported APIs."""
 
 import time
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Optional
 from uuid import uuid4
 
 from moto.core.base_backend import BackendDict, BaseBackend
@@ -30,14 +30,14 @@ class FileSystem(BaseModel):
         file_system_type: str,
         storage_capacity: int,
         storage_type: str,
-        subnet_ids: List[str],
-        security_group_ids: List[str],
-        tags: Optional[List[Dict[str, str]]],
+        subnet_ids: list[str],
+        security_group_ids: list[str],
+        tags: Optional[list[dict[str, str]]],
         kms_key_id: Optional[str],
-        windows_configuration: Optional[Dict[str, Any]],
-        lustre_configuration: Optional[Dict[str, Any]],
-        ontap_configuration: Optional[Dict[str, Any]],
-        open_zfs_configuration: Optional[Dict[str, Any]],
+        windows_configuration: Optional[dict[str, Any]],
+        lustre_configuration: Optional[dict[str, Any]],
+        ontap_configuration: Optional[dict[str, Any]],
+        open_zfs_configuration: Optional[dict[str, Any]],
         backend: "FSxBackend",
     ) -> None:
         self.file_system_id = f"fs-{uuid4().hex[:8]}"
@@ -61,7 +61,7 @@ class FileSystem(BaseModel):
         if tags:
             self.backend.tag_resource(self.resource_arn, tags)
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         dct = {
             "FileSystemId": self.file_system_id,
             "FileSystemType": self.file_system_type,
@@ -89,7 +89,7 @@ class Backup(BaseModel):
         file_system_id: str,
         client_request_token: Optional[str],
         volume_id: Optional[str],
-        tags: Optional[List[Dict[str, str]]],
+        tags: Optional[list[dict[str, str]]],
         backend: "FSxBackend",
     ) -> None:
         self.backup_id = f"backup-{uuid4().hex[:8]}"
@@ -105,7 +105,7 @@ class Backup(BaseModel):
         if tags:
             self.backend.tag_resource(self.resource_arn, tags)
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         dct = {
             "BackupId": self.backup_id,
             "FileSystemId": self.file_system_id,
@@ -124,8 +124,8 @@ class FSxBackend(BaseBackend):
 
     def __init__(self, region_name: str, account_id: str) -> None:
         super().__init__(region_name, account_id)
-        self.file_systems: Dict[str, FileSystem] = {}
-        self.backups: Dict[str, Backup] = {}
+        self.file_systems: dict[str, FileSystem] = {}
+        self.backups: dict[str, Backup] = {}
         self.tagger = TaggingService()
 
     def create_file_system(
@@ -134,15 +134,15 @@ class FSxBackend(BaseBackend):
         file_system_type: str,
         storage_capacity: int,
         storage_type: str,
-        subnet_ids: List[str],
-        security_group_ids: List[str],
-        tags: Optional[List[Dict[str, str]]],
+        subnet_ids: list[str],
+        security_group_ids: list[str],
+        tags: Optional[list[dict[str, str]]],
         kms_key_id: Optional[str],
-        windows_configuration: Optional[Dict[str, Any]],
-        lustre_configuration: Optional[Dict[str, Any]],
-        ontap_configuration: Optional[Dict[str, Any]],
+        windows_configuration: Optional[dict[str, Any]],
+        lustre_configuration: Optional[dict[str, Any]],
+        ontap_configuration: Optional[dict[str, Any]],
         file_system_type_version: Optional[str],
-        open_zfs_configuration: Optional[Dict[str, Any]],
+        open_zfs_configuration: Optional[dict[str, Any]],
     ) -> FileSystem:
         file_system = FileSystem(
             account_id=self.account_id,
@@ -169,7 +169,7 @@ class FSxBackend(BaseBackend):
         return file_system
 
     @paginate(pagination_model=PAGINATION_MODEL)
-    def describe_file_systems(self, file_system_ids: List[str]) -> List[FileSystem]:
+    def describe_file_systems(self, file_system_ids: list[str]) -> list[FileSystem]:
         file_systems = []
         if not file_system_ids:
             file_systems = list(self.file_systems.values())
@@ -183,15 +183,15 @@ class FSxBackend(BaseBackend):
         self,
         file_system_id: str,
         client_request_token: str,
-        windows_configuration: Optional[Dict[str, Any]],
-        lustre_configuration: Optional[Dict[str, Any]],
-        open_zfs_configuration: Optional[Dict[str, Any]],
-    ) -> Tuple[
+        windows_configuration: Optional[dict[str, Any]],
+        lustre_configuration: Optional[dict[str, Any]],
+        open_zfs_configuration: Optional[dict[str, Any]],
+    ) -> tuple[
         str,
         str,
-        Optional[Dict[str, Any]],
-        Optional[Dict[str, Any]],
-        Optional[Dict[str, Any]],
+        Optional[dict[str, Any]],
+        Optional[dict[str, Any]],
+        Optional[dict[str, Any]],
     ]:
         response_template = {"FinalBackUpId": "", "FinalBackUpTags": []}
 
@@ -224,7 +224,7 @@ class FSxBackend(BaseBackend):
         file_system_id: str,
         client_request_token: Optional[str],
         volume_id: Optional[str],
-        tags: Optional[List[Dict[str, str]]],
+        tags: Optional[list[dict[str, str]]],
     ) -> Backup:
         backup = Backup(
             account_id=self.account_id,
@@ -246,7 +246,7 @@ class FSxBackend(BaseBackend):
 
     def delete_backup(
         self, backup_id: str, client_request_token: Optional[str]
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         if backup_id not in self.backups:
             raise ResourceNotFoundException(
                 msg=f"FSx resource, {backup_id} does not exist"
@@ -255,13 +255,13 @@ class FSxBackend(BaseBackend):
 
         return {"BackupId": backup_id, "Lifecycle": "DELETED"}
 
-    def tag_resource(self, resource_arn: str, tags: List[Dict[str, str]]) -> None:
+    def tag_resource(self, resource_arn: str, tags: list[dict[str, str]]) -> None:
         self.tagger.tag_resource(resource_arn, tags)
 
-    def untag_resource(self, resource_arn: str, tag_keys: List[str]) -> None:
+    def untag_resource(self, resource_arn: str, tag_keys: list[str]) -> None:
         self.tagger.untag_resource_using_names(resource_arn, tag_keys)
 
-    def list_tags_for_resource(self, resource_arn: str) -> List[Dict[str, str]]:
+    def list_tags_for_resource(self, resource_arn: str) -> list[dict[str, str]]:
         """
         Pagination is not yet implemented
         """

--- a/moto/fsx/utils.py
+++ b/moto/fsx/utils.py
@@ -1,5 +1,4 @@
 from enum import Enum
-from typing import List
 
 
 class FileSystemType(str, Enum):
@@ -9,5 +8,5 @@ class FileSystemType(str, Enum):
     OPEN_ZFS = "OPENZFS"
 
     @classmethod
-    def list_values(self) -> List[str]:
+    def list_values(self) -> list[str]:
         return sorted([item.value for item in FileSystemType])

--- a/moto/glue/glue_schema_registry_utils.py
+++ b/moto/glue/glue_schema_registry_utils.py
@@ -1,6 +1,7 @@
 import json
 import re
-from typing import Any, Dict, Optional, Pattern, Tuple
+from re import Pattern
+from typing import Any, Optional
 
 from .exceptions import (
     DisabledCompatibilityVersioningException,
@@ -137,13 +138,13 @@ def validate_schema_version_id_pattern(schema_version_id: str) -> None:
         raise ParamValueContainsInvalidCharactersException(SCHEMA_VERSION_ID)
 
 
-def validate_number_of_tags(tags: Dict[str, str]) -> None:
+def validate_number_of_tags(tags: dict[str, str]) -> None:
     if len(tags) > MAX_TAGS_ALLOWED:
         raise InvalidNumberOfTagsException()
 
 
 def validate_registry_id(
-    registry_id: Dict[str, Any], registries: Dict[str, Any]
+    registry_id: dict[str, Any], registries: dict[str, Any]
 ) -> str:
     if not registry_id:
         return DEFAULT_REGISTRY_NAME
@@ -181,7 +182,7 @@ def validate_registry_params(
     registries: Any,
     registry_name: str,
     description: Optional[str] = None,
-    tags: Optional[Dict[str, str]] = None,
+    tags: Optional[dict[str, str]] = None,
 ) -> None:
     validate_registry_name_pattern_and_length(registry_name)
 
@@ -203,8 +204,8 @@ def validate_registry_params(
 
 
 def validate_schema_id(
-    schema_id: Dict[str, str], registries: Dict[str, Any]
-) -> Tuple[str, str, Optional[str]]:
+    schema_id: dict[str, str], registries: dict[str, Any]
+) -> tuple[str, str, Optional[str]]:
     schema_arn = schema_id.get(SCHEMA_ARN)
     registry_name = schema_id.get(REGISTRY_NAME)
     schema_name = schema_id.get(SCHEMA_NAME)
@@ -239,7 +240,7 @@ def validate_schema_params(
     schema_definition: str,
     num_schemas: int,
     description: Optional[str] = None,
-    tags: Optional[Dict[str, str]] = None,
+    tags: Optional[dict[str, str]] = None,
 ) -> None:
     validate_schema_name_pattern_and_length(schema_name)
 
@@ -298,11 +299,11 @@ def validate_register_schema_version_params(
 
 
 def validate_schema_version_params(  # type: ignore[return]
-    registries: Dict[str, Any],
-    schema_id: Optional[Dict[str, Any]],
+    registries: dict[str, Any],
+    schema_id: Optional[dict[str, Any]],
     schema_version_id: Optional[str],
-    schema_version_number: Optional[Dict[str, Any]],
-) -> Tuple[
+    schema_version_number: Optional[dict[str, Any]],
+) -> tuple[
     Optional[str],
     Optional[str],
     Optional[str],
@@ -346,11 +347,11 @@ def validate_schema_version_params(  # type: ignore[return]
 
 
 def validate_schema_version_number(
-    registries: Dict[str, Any],
+    registries: dict[str, Any],
     registry_name: str,
     schema_name: str,
-    schema_version_number: Dict[str, str],
-) -> Tuple[str, str]:
+    schema_version_number: dict[str, str],
+) -> tuple[str, str]:
     latest_version = schema_version_number.get(LATEST_VERSION)
     version_number = schema_version_number.get(VERSION_NUMBER)
     schema = registries[registry_name].schemas[schema_name]
@@ -363,8 +364,8 @@ def validate_schema_version_number(
 
 
 def validate_schema_version_metadata_pattern_and_length(
-    metadata_key_value: Dict[str, str],
-) -> Tuple[str, str]:
+    metadata_key_value: dict[str, str],
+) -> tuple[str, str]:
     metadata_key = metadata_key_value.get(METADATA_KEY)
     metadata_value = metadata_key_value.get(METADATA_VALUE)
 
@@ -375,7 +376,7 @@ def validate_schema_version_metadata_pattern_and_length(
 
 
 def validate_number_of_schema_version_metadata_allowed(
-    metadata: Dict[str, Any],
+    metadata: dict[str, Any],
 ) -> None:
     num_metadata_key_value_pairs = 0
     for m in metadata.values():
@@ -387,7 +388,7 @@ def validate_number_of_schema_version_metadata_allowed(
 
 def get_schema_version_if_definition_exists(
     schema_versions: Any, data_format: str, schema_definition: str
-) -> Optional[Dict[str, Any]]:
+) -> Optional[dict[str, Any]]:
     if data_format in ["AVRO", "JSON"]:
         for schema_version in schema_versions:
             if json.loads(schema_definition) == json.loads(
@@ -402,12 +403,12 @@ def get_schema_version_if_definition_exists(
 
 
 def get_put_schema_version_metadata_response(
-    schema_id: Dict[str, Any],
-    schema_version_number: Optional[Dict[str, str]],
+    schema_id: dict[str, Any],
+    schema_version_number: Optional[dict[str, str]],
     schema_version_id: str,
-    metadata_key_value: Dict[str, str],
-) -> Dict[str, Any]:
-    put_schema_version_metadata_response_dict: Dict[str, Any] = {}
+    metadata_key_value: dict[str, str],
+) -> dict[str, Any]:
+    put_schema_version_metadata_response_dict: dict[str, Any] = {}
     if schema_version_id:
         put_schema_version_metadata_response_dict[SCHEMA_VERSION_ID] = schema_version_id
     if schema_id:
@@ -445,7 +446,7 @@ def get_put_schema_version_metadata_response(
 
 def delete_schema_response(
     schema_name: str, schema_arn: str, status: str
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     return {
         "SchemaName": schema_name,
         "SchemaArn": schema_arn,

--- a/moto/glue/models.py
+++ b/moto/glue/models.py
@@ -4,7 +4,7 @@ import re
 import time
 from collections import OrderedDict
 from datetime import datetime
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Optional, Union
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
@@ -70,7 +70,7 @@ class FakeDevEndpoint(BaseModel):
         self,
         endpoint_name: str,
         role_arn: str,
-        security_group_ids: List[str],
+        security_group_ids: list[str],
         subnet_id: str,
         worker_type: str = "Standard",
         glue_version: str = "1.0",
@@ -79,8 +79,8 @@ class FakeDevEndpoint(BaseModel):
         extra_python_libs_s3_path: Optional[str] = None,
         extra_jars_s3_path: Optional[str] = None,
         security_configuration: Optional[str] = None,
-        arguments: Optional[Dict[str, str]] = None,
-        tags: Optional[Dict[str, str]] = None,
+        arguments: Optional[dict[str, str]] = None,
+        tags: Optional[dict[str, str]] = None,
     ):
         pubkey = """ssh-rsa
         AAAAB3NzaC1yc2EAAAADAQABAAABAQDV5+voluw2zmzqpqCAqtsyoP01TQ8Ydx1eS1yD6wUsHcPqMIqpo57YxiC8XPwrdeKQ6GG6MC3bHsgXoPypGP0LyixbiuLTU31DnnqorcHt4bWs6rQa7dK2pCCflz2fhYRt5ZjqSNsAKivIbqkH66JozN0SySIka3kEV79GdB0BicioKeEJlCwM9vvxafyzjWf/z8E0lh4ni3vkLpIVJ0t5l+Qd9QMJrT6Is0SCQPVagTYZoi8+fWDoGsBa8vyRwDjEzBl28ZplKh9tSyDkRIYszWTpmK8qHiqjLYZBfAxXjGJbEYL1iig4ZxvbYzKEiKSBi1ZMW9iWjHfZDZuxXAmB
@@ -123,7 +123,7 @@ class FakeDevEndpoint(BaseModel):
         self.public_key = pubkey
         self.public_keys = [self.public_key]
 
-    def as_dict(self) -> Dict[str, Any]:
+    def as_dict(self) -> dict[str, Any]:
         response = {
             "EndpointName": self.endpoint_name,
             "RoleArn": self.role_arn,
@@ -233,31 +233,31 @@ class GlueBackend(BaseBackend):
         super().__init__(region_name, account_id)
         self.region_name = region_name
         self.account_id = account_id
-        self.databases: Dict[str, FakeDatabase] = OrderedDict()
-        self.crawlers: Dict[str, FakeCrawler] = OrderedDict()
-        self.connections: Dict[str, FakeConnection] = OrderedDict()
-        self.jobs: Dict[str, FakeJob] = OrderedDict()
-        self.job_runs: Dict[str, FakeJobRun] = OrderedDict()
-        self.sessions: Dict[str, FakeSession] = OrderedDict()
+        self.databases: dict[str, FakeDatabase] = OrderedDict()
+        self.crawlers: dict[str, FakeCrawler] = OrderedDict()
+        self.connections: dict[str, FakeConnection] = OrderedDict()
+        self.jobs: dict[str, FakeJob] = OrderedDict()
+        self.job_runs: dict[str, FakeJobRun] = OrderedDict()
+        self.sessions: dict[str, FakeSession] = OrderedDict()
         self.tagger = TaggingService()
-        self.triggers: Dict[str, FakeTrigger] = OrderedDict()
-        self.registries: Dict[str, FakeRegistry] = OrderedDict()
-        self.workflows: Dict[str, FakeWorkflow] = OrderedDict()
-        self.security_configurations: Dict[str, FakeSecurityConfiguration] = (
+        self.triggers: dict[str, FakeTrigger] = OrderedDict()
+        self.registries: dict[str, FakeRegistry] = OrderedDict()
+        self.workflows: dict[str, FakeWorkflow] = OrderedDict()
+        self.security_configurations: dict[str, FakeSecurityConfiguration] = (
             OrderedDict()
         )
         self.num_schemas = 0
         self.num_schema_versions = 0
-        self.dev_endpoints: Dict[str, FakeDevEndpoint] = OrderedDict()
-        self.data_catalog_encryption_settings: Dict[str, Dict[str, Any]] = {}
-        self.resource_policies: Dict[str, Dict[str, Any]] = {}
+        self.dev_endpoints: dict[str, FakeDevEndpoint] = OrderedDict()
+        self.data_catalog_encryption_settings: dict[str, dict[str, Any]] = {}
+        self.resource_policies: dict[str, dict[str, Any]] = {}
         self.default_catalog_arn = f"arn:{get_partition(self.region_name)}:glue:{self.region_name}:{self.account_id}:catalog"
 
     def create_database(
         self,
         database_name: str,
-        database_input: Dict[str, Any],
-        tags: Optional[Dict[str, str]] = None,
+        database_input: dict[str, Any],
+        tags: Optional[dict[str, str]] = None,
     ) -> "FakeDatabase":
         if database_name in self.databases:
             raise DatabaseAlreadyExistsException()
@@ -277,14 +277,14 @@ class GlueBackend(BaseBackend):
             raise DatabaseNotFoundException(database_name)
 
     def update_database(
-        self, database_name: str, database_input: Dict[str, Any]
+        self, database_name: str, database_input: dict[str, Any]
     ) -> None:
         if database_name not in self.databases:
             raise DatabaseNotFoundException(database_name)
 
         self.databases[database_name].input = database_input
 
-    def get_databases(self) -> List["FakeDatabase"]:
+    def get_databases(self) -> list["FakeDatabase"]:
         return [self.databases[key] for key in self.databases] if self.databases else []
 
     def delete_database(self, database_name: str) -> None:
@@ -293,7 +293,7 @@ class GlueBackend(BaseBackend):
         del self.databases[database_name]
 
     def create_table(
-        self, database_name: str, table_name: str, table_input: Dict[str, Any]
+        self, database_name: str, table_name: str, table_input: dict[str, Any]
     ) -> "FakeTable":
         database = self.get_database(database_name)
 
@@ -315,7 +315,7 @@ class GlueBackend(BaseBackend):
 
     def get_tables(
         self, database_name: str, expression: Optional[str]
-    ) -> List["FakeTable"]:
+    ) -> list["FakeTable"]:
         database = self.get_database(database_name)
         if expression:
             # sanitise expression, * is treated as a glob-like wildcard
@@ -343,7 +343,7 @@ class GlueBackend(BaseBackend):
             raise TableNotFoundException(table_name)
 
     def update_table(
-        self, database_name: str, table_name: str, table_input: Dict[str, Any]
+        self, database_name: str, table_name: str, table_input: dict[str, Any]
     ) -> None:
         table = self.get_table(database_name, table_name)
         table.update(table_input)
@@ -364,7 +364,7 @@ class GlueBackend(BaseBackend):
 
     def get_table_versions(
         self, database_name: str, table_name: str
-    ) -> Dict[str, Dict[str, Any]]:
+    ) -> dict[str, dict[str, Any]]:
         table = self.get_table(database_name, table_name)
         return {version: table.as_dict(version) for version in table.versions.keys()}
 
@@ -375,7 +375,7 @@ class GlueBackend(BaseBackend):
         table.delete_version(version_id)
 
     def create_partition(
-        self, database_name: str, table_name: str, part_input: Dict[str, Any]
+        self, database_name: str, table_name: str, part_input: dict[str, Any]
     ) -> None:
         table = self.get_table(database_name, table_name)
         table.create_partition(part_input)
@@ -388,7 +388,7 @@ class GlueBackend(BaseBackend):
 
     def get_partitions(
         self, database_name: str, table_name: str, expression: str
-    ) -> List["FakePartition"]:
+    ) -> list["FakePartition"]:
         """
         See https://docs.aws.amazon.com/glue/latest/webapi/API_GetPartitions.html
         for supported expressions.
@@ -407,7 +407,7 @@ class GlueBackend(BaseBackend):
         self,
         database_name: str,
         table_name: str,
-        part_input: Dict[str, Any],
+        part_input: dict[str, Any],
         part_to_update: str,
     ) -> None:
         table = self.get_table(database_name, table_name)
@@ -425,16 +425,16 @@ class GlueBackend(BaseBackend):
         role: str,
         database_name: str,
         description: str,
-        targets: Dict[str, Any],
+        targets: dict[str, Any],
         schedule: str,
-        classifiers: List[str],
+        classifiers: list[str],
         table_prefix: str,
-        schema_change_policy: Dict[str, str],
-        recrawl_policy: Dict[str, str],
-        lineage_configuration: Dict[str, str],
+        schema_change_policy: dict[str, str],
+        recrawl_policy: dict[str, str],
+        lineage_configuration: dict[str, str],
         configuration: str,
         crawler_security_configuration: str,
-        tags: Dict[str, str],
+        tags: dict[str, str],
     ) -> None:
         if name in self.crawlers:
             raise CrawlerAlreadyExistsException()
@@ -464,11 +464,11 @@ class GlueBackend(BaseBackend):
         except KeyError:
             raise CrawlerNotFoundException(name)
 
-    def get_crawlers(self) -> List["FakeCrawler"]:
+    def get_crawlers(self) -> list["FakeCrawler"]:
         return [self.crawlers[key] for key in self.crawlers] if self.crawlers else []
 
     @paginate(pagination_model=PAGINATION_MODEL)
-    def list_crawlers(self) -> List["FakeCrawler"]:
+    def list_crawlers(self) -> list["FakeCrawler"]:
         return [crawler for _, crawler in self.crawlers.items()]
 
     def start_crawler(self, name: str) -> None:
@@ -487,8 +487,8 @@ class GlueBackend(BaseBackend):
 
     @paginate(pagination_model=PAGINATION_MODEL)
     def list_crawls(
-        self, crawler_name: str, filters: List[CrawlFilter]
-    ) -> List["FakeCrawl"]:
+        self, crawler_name: str, filters: list[CrawlFilter]
+    ) -> list["FakeCrawl"]:
         filter_functions = []
         for filter in filters:
             if filter.field_name == FilterField.CRAWL_ID:
@@ -563,23 +563,23 @@ class GlueBackend(BaseBackend):
         command: str,
         description: str,
         log_uri: str,
-        execution_property: Dict[str, int],
-        default_arguments: Dict[str, str],
-        non_overridable_arguments: Dict[str, str],
-        connections: Dict[str, List[str]],
+        execution_property: dict[str, int],
+        default_arguments: dict[str, str],
+        non_overridable_arguments: dict[str, str],
+        connections: dict[str, list[str]],
         max_retries: int,
         allocated_capacity: int,
         timeout: int,
         max_capacity: float,
         security_configuration: str,
-        tags: Dict[str, str],
-        notification_property: Dict[str, int],
+        tags: dict[str, str],
+        notification_property: dict[str, int],
         glue_version: str,
         number_of_workers: int,
         worker_type: str,
-        code_gen_configuration_nodes: Dict[str, Any],
+        code_gen_configuration_nodes: dict[str, Any],
         execution_class: str,
-        source_control_details: Dict[str, str],
+        source_control_details: dict[str, str],
     ) -> None:
         self.jobs[name] = FakeJob(
             name,
@@ -614,20 +614,20 @@ class GlueBackend(BaseBackend):
             raise JobNotFoundException(name)
 
     @paginate(pagination_model=PAGINATION_MODEL)
-    def get_jobs(self) -> List["FakeJob"]:
+    def get_jobs(self) -> list["FakeJob"]:
         return [job for _, job in self.jobs.items()]
 
     def start_job_run(
         self,
         name: str,
-        arguments: Optional[Dict[str, str]],
+        arguments: Optional[dict[str, str]],
         allocated_capacity: Optional[int],
         max_capacity: Optional[float],
         timeout: Optional[int],
         worker_type: Optional[str],
         security_configuration: Optional[str],
         number_of_workers: Optional[int],
-        notification_property: Optional[Dict[str, int]],
+        notification_property: Optional[dict[str, int]],
         previous_run_id: Optional[str],
     ) -> str:
         job = self.get_job(name)
@@ -648,34 +648,34 @@ class GlueBackend(BaseBackend):
         return job.get_job_run(run_id)
 
     @paginate(pagination_model=PAGINATION_MODEL)
-    def get_job_runs(self, job_name: str) -> List["FakeJobRun"]:
+    def get_job_runs(self, job_name: str) -> list["FakeJobRun"]:
         job = self.get_job(job_name)
         return job.get_job_runs()
 
     @paginate(pagination_model=PAGINATION_MODEL)
-    def list_jobs(self) -> List["FakeJob"]:
+    def list_jobs(self) -> list["FakeJob"]:
         return [job for _, job in self.jobs.items()]
 
     def delete_job(self, name: str) -> None:
         if name in self.jobs:
             del self.jobs[name]
 
-    def get_tags(self, resource_id: str) -> Dict[str, str]:
+    def get_tags(self, resource_id: str) -> dict[str, str]:
         return self.tagger.get_tag_dict_for_resource(resource_id)
 
-    def tag_resource(self, resource_arn: str, tags: Optional[Dict[str, str]]) -> None:
+    def tag_resource(self, resource_arn: str, tags: Optional[dict[str, str]]) -> None:
         tag_list = TaggingService.convert_dict_to_tags_input(tags or {})
         self.tagger.tag_resource(resource_arn, tag_list)
 
-    def untag_resource(self, resource_arn: str, tag_keys: List[str]) -> None:
+    def untag_resource(self, resource_arn: str, tag_keys: list[str]) -> None:
         self.tagger.untag_resource_using_names(resource_arn, tag_keys)
 
     def create_registry(
         self,
         registry_name: str,
         description: Optional[str] = None,
-        tags: Optional[Dict[str, str]] = None,
-    ) -> Dict[str, Any]:
+        tags: Optional[dict[str, str]] = None,
+    ) -> dict[str, Any]:
         # If registry name id default-registry, create default-registry
         if registry_name == DEFAULT_REGISTRY_NAME:
             registry = FakeRegistry(self, registry_name, description, tags)
@@ -689,27 +689,27 @@ class GlueBackend(BaseBackend):
         self.registries[registry_name] = registry
         return registry.as_dict()
 
-    def delete_registry(self, registry_id: Dict[str, Any]) -> Dict[str, Any]:
+    def delete_registry(self, registry_id: dict[str, Any]) -> dict[str, Any]:
         registry_name = validate_registry_id(registry_id, self.registries)
         return self.registries.pop(registry_name).as_dict()
 
-    def get_registry(self, registry_id: Dict[str, Any]) -> Dict[str, Any]:
+    def get_registry(self, registry_id: dict[str, Any]) -> dict[str, Any]:
         registry_name = validate_registry_id(registry_id, self.registries)
         return self.registries[registry_name].as_dict()
 
-    def list_registries(self) -> List[Dict[str, Any]]:
+    def list_registries(self) -> list[dict[str, Any]]:
         return [reg.as_dict() for reg in self.registries.values()]
 
     def create_schema(
         self,
-        registry_id: Dict[str, Any],
+        registry_id: dict[str, Any],
         schema_name: str,
         data_format: str,
         compatibility: str,
         schema_definition: str,
         description: Optional[str] = None,
-        tags: Optional[Dict[str, str]] = None,
-    ) -> Dict[str, Any]:
+        tags: Optional[dict[str, str]] = None,
+    ) -> dict[str, Any]:
         """
         The following parameters/features are not yet implemented: Glue Schema Registry: compatibility checks NONE | BACKWARD | BACKWARD_ALL | FORWARD | FORWARD_ALL | FULL | FULL_ALL and  Data format parsing and syntax validation.
         """
@@ -768,8 +768,8 @@ class GlueBackend(BaseBackend):
         return resp
 
     def register_schema_version(
-        self, schema_id: Dict[str, Any], schema_definition: str
-    ) -> Dict[str, Any]:
+        self, schema_id: dict[str, Any], schema_definition: str
+    ) -> dict[str, Any]:
         # Validate Schema Id
         registry_name, schema_name, schema_arn = validate_schema_id(
             schema_id, self.registries
@@ -829,10 +829,10 @@ class GlueBackend(BaseBackend):
 
     def get_schema_version(
         self,
-        schema_id: Optional[Dict[str, str]] = None,
+        schema_id: Optional[dict[str, str]] = None,
         schema_version_id: Optional[str] = None,
-        schema_version_number: Optional[Dict[str, Any]] = None,
-    ) -> Dict[str, Any]:
+        schema_version_number: Optional[dict[str, Any]] = None,
+    ) -> dict[str, Any]:
         # Validate Schema Parameters
         (
             schema_version_id,
@@ -878,8 +878,8 @@ class GlueBackend(BaseBackend):
         )
 
     def get_schema_by_definition(
-        self, schema_id: Dict[str, str], schema_definition: str
-    ) -> Dict[str, Any]:
+        self, schema_id: dict[str, str], schema_definition: str
+    ) -> dict[str, Any]:
         # Validate SchemaId
         validate_schema_definition_length(schema_definition)
         registry_name, schema_name, schema_arn = validate_schema_id(
@@ -902,11 +902,11 @@ class GlueBackend(BaseBackend):
 
     def put_schema_version_metadata(
         self,
-        schema_id: Dict[str, Any],
-        schema_version_number: Dict[str, str],
+        schema_id: dict[str, Any],
+        schema_version_number: dict[str, str],
         schema_version_id: str,
-        metadata_key_value: Dict[str, str],
-    ) -> Dict[str, Any]:
+        metadata_key_value: dict[str, str],
+    ) -> dict[str, Any]:
         # Validate metadata_key_value and schema version params
         (
             metadata_key,
@@ -976,12 +976,12 @@ class GlueBackend(BaseBackend):
             registry_name, schema_name, schema_arn, version_number, latest_version
         )
 
-    def get_schema(self, schema_id: Dict[str, str]) -> Dict[str, Any]:
+    def get_schema(self, schema_id: dict[str, str]) -> dict[str, Any]:
         registry_name, schema_name, _ = validate_schema_id(schema_id, self.registries)
         schema = self.registries[registry_name].schemas[schema_name]
         return schema.as_dict()
 
-    def delete_schema(self, schema_id: Dict[str, str]) -> Dict[str, Any]:
+    def delete_schema(self, schema_id: dict[str, str]) -> dict[str, Any]:
         # Validate schema_id
         registry_name, schema_name, _ = validate_schema_id(schema_id, self.registries)
 
@@ -1001,8 +1001,8 @@ class GlueBackend(BaseBackend):
         return response
 
     def update_schema(
-        self, schema_id: Dict[str, str], compatibility: str, description: str
-    ) -> Dict[str, Any]:
+        self, schema_id: dict[str, str], compatibility: str, description: str
+    ) -> dict[str, Any]:
         """
         The SchemaVersionNumber-argument is not yet implemented
         """
@@ -1021,17 +1021,17 @@ class GlueBackend(BaseBackend):
         session_id: str,
         description: str,
         role: str,
-        command: Dict[str, str],
+        command: dict[str, str],
         timeout: int,
         idle_timeout: int,
-        default_arguments: Dict[str, str],
-        connections: Dict[str, List[str]],
+        default_arguments: dict[str, str],
+        connections: dict[str, list[str]],
         max_capacity: float,
         number_of_workers: int,
         worker_type: str,
         security_configuration: str,
         glue_version: str,
-        tags: Dict[str, str],
+        tags: dict[str, str],
         request_origin: str,
     ) -> None:
         if session_id in self.sessions:
@@ -1064,7 +1064,7 @@ class GlueBackend(BaseBackend):
             raise SessionNotFoundException(session_id)
 
     @paginate(pagination_model=PAGINATION_MODEL)
-    def list_sessions(self) -> List["FakeSession"]:
+    def list_sessions(self) -> list["FakeSession"]:
         return [session for _, session in self.sessions.items()]
 
     def stop_session(self, session_id: str) -> None:
@@ -1084,11 +1084,11 @@ class GlueBackend(BaseBackend):
         trigger_type: str,
         schedule: str,
         predicate: Optional[Predicate],
-        actions: List[Action],
+        actions: list[Action],
         description: str,
         start_on_creation: bool,
-        tags: Dict[str, str],
-        event_batching_condition: Dict[str, Any],
+        tags: dict[str, str],
+        event_batching_condition: dict[str, Any],
     ) -> None:
         self.triggers[name] = FakeTrigger(
             name=name,
@@ -1119,7 +1119,7 @@ class GlueBackend(BaseBackend):
         trigger.stop_trigger()
 
     @paginate(pagination_model=PAGINATION_MODEL)
-    def get_triggers(self, dependent_job_name: str) -> List["FakeTrigger"]:
+    def get_triggers(self, dependent_job_name: str) -> list["FakeTrigger"]:
         if dependent_job_name:
             triggers = []
             for trigger in self.triggers.values():
@@ -1131,7 +1131,7 @@ class GlueBackend(BaseBackend):
         return list(self.triggers.values())
 
     @paginate(pagination_model=PAGINATION_MODEL)
-    def list_triggers(self, dependent_job_name: str) -> List["FakeTrigger"]:
+    def list_triggers(self, dependent_job_name: str) -> list["FakeTrigger"]:
         if dependent_job_name:
             triggers = []
             for trigger in self.triggers.values():
@@ -1147,8 +1147,8 @@ class GlueBackend(BaseBackend):
             del self.triggers[name]
 
     def batch_delete_table(
-        self, database_name: str, tables: List[str]
-    ) -> List[Dict[str, Any]]:
+        self, database_name: str, tables: list[str]
+    ) -> list[dict[str, Any]]:
         errors = []
         for table_name in tables:
             try:
@@ -1169,8 +1169,8 @@ class GlueBackend(BaseBackend):
         self,
         database_name: str,
         table_name: str,
-        partitions_to_get: List[Dict[str, str]],
-    ) -> List[Dict[str, Any]]:
+        partitions_to_get: list[dict[str, str]],
+    ) -> list[dict[str, Any]]:
         table = self.get_table(database_name, table_name)
 
         partitions = []
@@ -1183,8 +1183,8 @@ class GlueBackend(BaseBackend):
         return partitions
 
     def batch_create_partition(
-        self, database_name: str, table_name: str, partition_input: List[Dict[str, Any]]
-    ) -> List[Dict[str, Any]]:
+        self, database_name: str, table_name: str, partition_input: list[dict[str, Any]]
+    ) -> list[dict[str, Any]]:
         table = self.get_table(database_name, table_name)
 
         errors_output = []
@@ -1204,8 +1204,8 @@ class GlueBackend(BaseBackend):
         return errors_output
 
     def batch_update_partition(
-        self, database_name: str, table_name: str, entries: List[Dict[str, Any]]
-    ) -> List[Dict[str, Any]]:
+        self, database_name: str, table_name: str, entries: list[dict[str, Any]]
+    ) -> list[dict[str, Any]]:
         table = self.get_table(database_name, table_name)
 
         errors_output = []
@@ -1228,8 +1228,8 @@ class GlueBackend(BaseBackend):
         return errors_output
 
     def batch_delete_partition(
-        self, database_name: str, table_name: str, parts: List[Dict[str, Any]]
-    ) -> List[Dict[str, Any]]:
+        self, database_name: str, table_name: str, parts: list[dict[str, Any]]
+    ) -> list[dict[str, Any]]:
         table = self.get_table(database_name, table_name)
 
         errors_output = []
@@ -1249,21 +1249,21 @@ class GlueBackend(BaseBackend):
                 )
         return errors_output
 
-    def batch_get_crawlers(self, crawler_names: List[str]) -> List[Dict[str, Any]]:
+    def batch_get_crawlers(self, crawler_names: list[str]) -> list[dict[str, Any]]:
         crawlers = []
         for crawler in self.get_crawlers():
             if crawler.as_dict()["Name"] in crawler_names:
                 crawlers.append(crawler.as_dict())
         return crawlers
 
-    def batch_get_jobs(self, job_names: List[str]) -> List[Dict[str, Any]]:
+    def batch_get_jobs(self, job_names: list[str]) -> list[dict[str, Any]]:
         jobs = []
         for job_name in job_names:
             if job_name in self.jobs:
                 jobs.append(self.jobs[job_name].as_dict())
         return jobs
 
-    def batch_get_triggers(self, trigger_names: List[str]) -> List[Dict[str, Any]]:
+    def batch_get_triggers(self, trigger_names: list[str]) -> list[dict[str, Any]]:
         triggers = []
         for trigger_name in trigger_names:
             if trigger_name in self.triggers:
@@ -1271,17 +1271,17 @@ class GlueBackend(BaseBackend):
         return triggers
 
     @paginate(pagination_model=PAGINATION_MODEL)
-    def get_dev_endpoints(self) -> List["FakeDevEndpoint"]:
+    def get_dev_endpoints(self) -> list["FakeDevEndpoint"]:
         return [endpoint for endpoint in self.dev_endpoints.values()]
 
     def create_dev_endpoint(
         self,
         endpoint_name: str,
         role_arn: str,
-        security_group_ids: Optional[List[str]] = None,
+        security_group_ids: Optional[list[str]] = None,
         subnet_id: Optional[str] = None,
         public_key: Optional[str] = None,
-        public_keys: Optional[List[str]] = None,
+        public_keys: Optional[list[str]] = None,
         number_of_nodes: Optional[int] = None,
         worker_type: str = "Standard",
         glue_version: str = "5.0",
@@ -1289,8 +1289,8 @@ class GlueBackend(BaseBackend):
         extra_python_libs_s3_path: Optional[str] = None,
         extra_jars_s3_path: Optional[str] = None,
         security_configuration: Optional[str] = None,
-        tags: Optional[Dict[str, str]] = None,
-        arguments: Optional[Dict[str, str]] = None,
+        tags: Optional[dict[str, str]] = None,
+        arguments: Optional[dict[str, str]] = None,
     ) -> FakeDevEndpoint:
         if endpoint_name in self.dev_endpoints:
             raise AlreadyExistsException(f"DevEndpoint {endpoint_name} already exists")
@@ -1335,8 +1335,8 @@ class GlueBackend(BaseBackend):
     def create_connection(
         self,
         catalog_id: str,
-        connection_input: Dict[str, Any],
-        tags: Dict[str, str],
+        connection_input: dict[str, Any],
+        tags: dict[str, str],
     ) -> str:
         name = connection_input.get("Name", "")
         if name in self.connections:
@@ -1360,16 +1360,16 @@ class GlueBackend(BaseBackend):
 
     @paginate(pagination_model=PAGINATION_MODEL)
     def get_connections(
-        self, catalog_id: str, filter: Dict[str, Any], hide_password: bool
-    ) -> List["FakeConnection"]:
+        self, catalog_id: str, filter: dict[str, Any], hide_password: bool
+    ) -> list["FakeConnection"]:
         # TODO: Implement filtering
         return [connection for connection in self.connections.values()]
 
     def put_data_catalog_encryption_settings(
         self,
         catalog_id: Optional[str],
-        data_catalog_encryption_settings: Dict[str, Any],
-    ) -> Dict[str, Any]:
+        data_catalog_encryption_settings: dict[str, Any],
+    ) -> dict[str, Any]:
         if catalog_id is None:
             catalog_id = self.account_id
 
@@ -1380,7 +1380,7 @@ class GlueBackend(BaseBackend):
 
     def get_data_catalog_encryption_settings(
         self, catalog_id: Optional[str]
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         if catalog_id is None or catalog_id == "":
             catalog_id = self.account_id
 
@@ -1389,7 +1389,7 @@ class GlueBackend(BaseBackend):
         if not isinstance(settings, dict):
             settings = {}
 
-        response: Dict[str, Any] = {
+        response: dict[str, Any] = {
             "DataCatalogEncryptionSettings": {
                 "EncryptionAtRest": settings.get(
                     "EncryptionAtRest", {"CatalogEncryptionMode": "DISABLED"}
@@ -1410,7 +1410,7 @@ class GlueBackend(BaseBackend):
         policy_hash_condition: Optional[str] = None,
         policy_exists_condition: Optional[str] = None,
         enable_hybrid: Optional[str] = None,
-    ) -> Dict[str, str]:
+    ) -> dict[str, str]:
         if resource_arn is None:
             resource_arn = self.default_catalog_arn
 
@@ -1460,7 +1460,7 @@ class GlueBackend(BaseBackend):
 
         return {"PolicyHash": policy_hash}
 
-    def get_resource_policy(self, resource_arn: Optional[str] = None) -> Dict[str, Any]:
+    def get_resource_policy(self, resource_arn: Optional[str] = None) -> dict[str, Any]:
         if resource_arn is None:
             resource_arn = self.default_catalog_arn
 
@@ -1490,7 +1490,7 @@ class GlueBackend(BaseBackend):
         self,
         resource_arn: Optional[str] = None,
         policy_hash_condition: Optional[str] = None,
-    ) -> Dict[str, str]:
+    ) -> dict[str, str]:
         if resource_arn is None:
             resource_arn = self.default_catalog_arn
 
@@ -1515,10 +1515,10 @@ class GlueBackend(BaseBackend):
     def create_workflow(
         self,
         name: str,
-        default_run_properties: Optional[Dict[str, str]],
+        default_run_properties: Optional[dict[str, str]],
         description: Optional[str],
         max_concurrent_runs: Optional[int],
-        tags: Optional[Dict[str, str]],
+        tags: Optional[dict[str, str]],
     ) -> str:
         self.workflows[name] = FakeWorkflow(
             name, default_run_properties, description, max_concurrent_runs, tags
@@ -1528,7 +1528,7 @@ class GlueBackend(BaseBackend):
     def get_workflow(
         self,
         name: str,
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         workflow = self.workflows.get(name)
         if workflow:
             return workflow.as_dict()
@@ -1536,13 +1536,13 @@ class GlueBackend(BaseBackend):
             raise EntityNotFoundException("Entity not found")
 
     @paginate(pagination_model=PAGINATION_MODEL)
-    def list_workflows(self) -> List[str]:
+    def list_workflows(self) -> list[str]:
         return [workflow.name for workflow in self.workflows.values()]
 
     def update_workflow(
         self,
         name: str,
-        default_run_properties: Optional[Dict[str, str]],
+        default_run_properties: Optional[dict[str, str]],
         description: Optional[str],
         max_concurrent_runs: Optional[int],
     ) -> str:
@@ -1571,7 +1571,7 @@ class GlueBackend(BaseBackend):
         self,
         workflow_name: str,
         run_id: str,
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         workflow = self.workflows.get(workflow_name)
         if not workflow:
             raise EntityNotFoundException("Entity not found")
@@ -1581,14 +1581,14 @@ class GlueBackend(BaseBackend):
     def get_workflow_runs(
         self,
         workflow_name: str,
-    ) -> List[Dict[str, Union[str, Dict[str, str]]]]:
+    ) -> list[dict[str, Union[str, dict[str, str]]]]:
         workflow = self.workflows.get(workflow_name)
         if not workflow:
             raise EntityNotFoundException("Entity not found")
         return [run.as_dict() for run in workflow.runs.values()]
 
     def start_workflow_run(
-        self, workflow_name: str, properties: Optional[Dict[str, str]]
+        self, workflow_name: str, properties: Optional[dict[str, str]]
     ) -> str:
         workflow = self.workflows.get(workflow_name)
         if not workflow:
@@ -1609,7 +1609,7 @@ class GlueBackend(BaseBackend):
         self,
         workflow_name: str,
         run_id: str,
-    ) -> Dict[str, str]:
+    ) -> dict[str, str]:
         workflow = self.workflows.get(workflow_name)
         if not workflow:
             raise EntityNotFoundException("Entity not found")
@@ -1619,7 +1619,7 @@ class GlueBackend(BaseBackend):
         self,
         workflow_name: str,
         run_id: str,
-        properties: Dict[str, str],
+        properties: dict[str, str],
     ) -> None:
         workflow = self.workflows.get(workflow_name)
         if not workflow:
@@ -1627,7 +1627,7 @@ class GlueBackend(BaseBackend):
         workflow.get_run(run_id).properties.update(properties)
 
     def create_security_configuration(
-        self, name: str, configuration: Dict[str, Any]
+        self, name: str, configuration: dict[str, Any]
     ) -> "FakeSecurityConfiguration":
         if name in self.security_configurations:
             raise AlreadyExistsException(f"SecurityConfiguration {name} already exists")
@@ -1647,17 +1647,17 @@ class GlueBackend(BaseBackend):
         except KeyError:
             raise EntityNotFoundException(f"SecurityConfiguration {name} not found")
 
-    def get_security_configurations(self) -> List["FakeSecurityConfiguration"]:
+    def get_security_configurations(self) -> list["FakeSecurityConfiguration"]:
         return [sc for sc in self.security_configurations.values()]
 
 
 class FakeSecurityConfiguration(BaseModel):
-    def __init__(self, name: str, configuration: Dict[str, Any]):
+    def __init__(self, name: str, configuration: dict[str, Any]):
         self.name = name
         self.configuration = configuration
         self.created_time = utcnow()
 
-    def as_dict(self) -> Dict[str, Any]:
+    def as_dict(self) -> dict[str, Any]:
         return {
             "Name": self.name,
             "CreatedTime": unix_time(self.created_time),
@@ -1667,15 +1667,15 @@ class FakeSecurityConfiguration(BaseModel):
 
 class FakeDatabase(BaseModel):
     def __init__(
-        self, database_name: str, database_input: Dict[str, Any], catalog_id: str
+        self, database_name: str, database_input: dict[str, Any], catalog_id: str
     ):
         self.name = database_name
         self.input = database_input
         self.catalog_id = catalog_id
         self.created_time = utcnow()
-        self.tables: Dict[str, FakeTable] = OrderedDict()
+        self.tables: dict[str, FakeTable] = OrderedDict()
 
-    def as_dict(self) -> Dict[str, Any]:
+    def as_dict(self) -> dict[str, Any]:
         return {
             "Name": self.name,
             "Description": self.input.get("Description"),
@@ -1695,26 +1695,26 @@ class FakeTable(BaseModel):
         self,
         database_name: str,
         table_name: str,
-        table_input: Dict[str, Any],
+        table_input: dict[str, Any],
         catalog_id: str,
     ):
         self.database_name = database_name
         self.name = table_name
         self.catalog_id = catalog_id
-        self.partitions: Dict[str, FakePartition] = OrderedDict()
+        self.partitions: dict[str, FakePartition] = OrderedDict()
         self.created_time = utcnow()
         self.updated_time: Optional[datetime] = None
         self._current_version = 1
-        self.versions: Dict[str, Dict[str, Any]] = {
+        self.versions: dict[str, dict[str, Any]] = {
             str(self._current_version): table_input
         }
 
-    def update(self, table_input: Dict[str, Any]) -> None:
+    def update(self, table_input: dict[str, Any]) -> None:
         self.versions[str(self._current_version + 1)] = table_input
         self._current_version += 1
         self.updated_time = utcnow()
 
-    def get_version(self, ver: str) -> Dict[str, Any]:
+    def get_version(self, ver: str) -> dict[str, Any]:
         try:
             int(ver)
         except ValueError as e:
@@ -1728,7 +1728,7 @@ class FakeTable(BaseModel):
     def delete_version(self, version_id: str) -> None:
         self.versions.pop(version_id)
 
-    def as_dict(self, version: Optional[str] = None) -> Dict[str, Any]:
+    def as_dict(self, version: Optional[str] = None) -> dict[str, Any]:
         version = version or self._current_version  # type: ignore
         obj = {
             "DatabaseName": self.database_name,
@@ -1743,14 +1743,14 @@ class FakeTable(BaseModel):
             obj["UpdateTime"] = unix_time(self.updated_time)
         return obj
 
-    def create_partition(self, partiton_input: Dict[str, Any]) -> None:
+    def create_partition(self, partiton_input: dict[str, Any]) -> None:
         partition = FakePartition(self.database_name, self.name, partiton_input)
         key = str(partition.values)
         if key in self.partitions:
             raise PartitionAlreadyExistsException()
         self.partitions[str(partition.values)] = partition
 
-    def get_partitions(self, expression: str) -> List["FakePartition"]:
+    def get_partitions(self, expression: str) -> list["FakePartition"]:
         # Only load pyparsing when necessary
         from .utils import PartitionFilter
 
@@ -1762,7 +1762,7 @@ class FakeTable(BaseModel):
         except KeyError:
             raise PartitionNotFoundException()
 
-    def update_partition(self, old_values: str, partiton_input: Dict[str, Any]) -> None:
+    def update_partition(self, old_values: str, partiton_input: dict[str, Any]) -> None:
         partition = FakePartition(self.database_name, self.name, partiton_input)
         key = str(partition.values)
         if old_values == partiton_input["Values"]:
@@ -1788,7 +1788,7 @@ class FakeTable(BaseModel):
 
 class FakePartition(BaseModel):
     def __init__(
-        self, database_name: str, table_name: str, partiton_input: Dict[str, Any]
+        self, database_name: str, table_name: str, partiton_input: dict[str, Any]
     ):
         self.creation_time = time.time()
         self.database_name = database_name
@@ -1796,7 +1796,7 @@ class FakePartition(BaseModel):
         self.partition_input = partiton_input
         self.values = self.partition_input.get("Values", [])
 
-    def as_dict(self) -> Dict[str, Any]:
+    def as_dict(self) -> dict[str, Any]:
         obj = {
             "DatabaseName": self.database_name,
             "TableName": self.table_name,
@@ -1813,16 +1813,16 @@ class FakeCrawler(BaseModel):
         role: str,
         database_name: str,
         description: str,
-        targets: Dict[str, Any],
+        targets: dict[str, Any],
         schedule: str,
-        classifiers: List[str],
+        classifiers: list[str],
         table_prefix: str,
-        schema_change_policy: Dict[str, str],
-        recrawl_policy: Dict[str, str],
-        lineage_configuration: Dict[str, str],
+        schema_change_policy: dict[str, str],
+        recrawl_policy: dict[str, str],
+        lineage_configuration: dict[str, str],
         configuration: str,
         crawler_security_configuration: str,
-        tags: Dict[str, str],
+        tags: dict[str, str],
         backend: GlueBackend,
     ):
         self.name: str = name
@@ -1846,12 +1846,12 @@ class FakeCrawler(BaseModel):
         self.arn = f"arn:{get_partition(backend.region_name)}:glue:{backend.region_name}:{backend.account_id}:crawler/{self.name}"
         self.backend = backend
         self.backend.tag_resource(self.arn, tags)
-        self.crawls: List[FakeCrawl] = []
+        self.crawls: list[FakeCrawl] = []
 
     def get_name(self) -> str:
         return self.name
 
-    def as_dict(self) -> Dict[str, Any]:
+    def as_dict(self) -> dict[str, Any]:
         data = {
             "Name": self.name,
             "Role": self.role,
@@ -1942,8 +1942,8 @@ class FakeCrawl(ManagedState):
         self.message_prefix = self.crawl_id
         self.start_time = utcnow()
 
-    def as_dict(self) -> Dict[str, Union[str, int]]:
-        response_dict: Dict[str, Union[str, int]] = {
+    def as_dict(self) -> dict[str, Union[str, int]]:
+        response_dict: dict[str, Union[str, int]] = {
             "CrawlId": self.crawl_id,
             "DPUHour": self.dpu_hour,
             "LogGroup": self.log_group,
@@ -1979,23 +1979,23 @@ class FakeJob:
         command: str,
         description: str,
         log_uri: str,
-        execution_property: Dict[str, int],
-        default_arguments: Dict[str, str],
-        non_overridable_arguments: Dict[str, str],
-        connections: Dict[str, List[str]],
+        execution_property: dict[str, int],
+        default_arguments: dict[str, str],
+        non_overridable_arguments: dict[str, str],
+        connections: dict[str, list[str]],
         max_retries: int,
         allocated_capacity: int,
         timeout: int,
         max_capacity: float,
         security_configuration: str,
-        tags: Dict[str, str],
-        notification_property: Dict[str, int],
+        tags: dict[str, str],
+        notification_property: dict[str, int],
         glue_version: str,
         number_of_workers: int,
         worker_type: str,
-        code_gen_configuration_nodes: Dict[str, Any],
+        code_gen_configuration_nodes: dict[str, Any],
         execution_class: str,
-        source_control_details: Dict[str, str],
+        source_control_details: dict[str, str],
         backend: GlueBackend,
     ):
         self.name = name
@@ -2025,12 +2025,12 @@ class FakeJob:
         self.backend = backend
         self.backend.tag_resource(self.arn, tags)
 
-        self.job_runs: List[FakeJobRun] = []
+        self.job_runs: list[FakeJobRun] = []
 
     def get_name(self) -> str:
         return self.name
 
-    def as_dict(self) -> Dict[str, Any]:
+    def as_dict(self) -> dict[str, Any]:
         return {
             "Name": self.name,
             "Description": self.description,
@@ -2065,9 +2065,9 @@ class FakeJob:
         worker_type: Optional[str],
         security_configuration: Optional[str],
         number_of_workers: Optional[int],
-        notification_property: Optional[Dict[str, int]],
+        notification_property: Optional[dict[str, int]],
         previous_run_id: Optional[str],
-        arguments: Optional[Dict[str, str]],
+        arguments: Optional[dict[str, str]],
     ) -> str:
         running_jobs = len(
             [jr for jr in self.job_runs if jr.status in ["STARTING", "RUNNING"]]
@@ -2104,7 +2104,7 @@ class FakeJob:
                 return job_run
         raise JobRunNotFoundException(run_id)
 
-    def get_job_runs(self) -> List["FakeJobRun"]:
+    def get_job_runs(self) -> list["FakeJobRun"]:
         for job_run in self.job_runs:
             job_run.advance()
         return self.job_runs
@@ -2115,12 +2115,12 @@ class FakeJobRun(ManagedState):
         self,
         job_name: str,
         job_run_id: Optional[str] = None,
-        arguments: Optional[Dict[str, Any]] = None,
+        arguments: Optional[dict[str, Any]] = None,
         allocated_capacity: Optional[int] = 10,
         max_capacity: Optional[float] = 10.0,
         timeout: Optional[int] = None,
         worker_type: Optional[str] = "Standard",
-        notification_property: Optional[Dict[str, int]] = None,
+        notification_property: Optional[dict[str, int]] = None,
         security_configuration: Optional[str] = None,
         number_of_workers: Optional[int] = 10,
     ):
@@ -2147,7 +2147,7 @@ class FakeJobRun(ManagedState):
     def get_name(self) -> str:
         return self.job_name
 
-    def as_dict(self) -> Dict[str, Any]:
+    def as_dict(self) -> dict[str, Any]:
         return_dict = {
             "Id": self.job_run_id,
             "Attempt": 0,
@@ -2184,7 +2184,7 @@ class FakeRegistry(BaseModel):
         backend: GlueBackend,
         registry_name: str,
         description: Optional[str] = None,
-        tags: Optional[Dict[str, str]] = None,
+        tags: Optional[dict[str, str]] = None,
     ):
         self.name = registry_name
         self.description = description
@@ -2193,9 +2193,9 @@ class FakeRegistry(BaseModel):
         self.updated_time = utcnow()
         self.status = "AVAILABLE"
         self.registry_arn = f"arn:{get_partition(backend.region_name)}:glue:{backend.region_name}:{backend.account_id}:registry/{self.name}"
-        self.schemas: Dict[str, FakeSchema] = OrderedDict()
+        self.schemas: dict[str, FakeSchema] = OrderedDict()
 
-    def as_dict(self) -> Dict[str, Any]:
+    def as_dict(self) -> dict[str, Any]:
         return {
             "RegistryArn": self.registry_arn,
             "RegistryName": self.name,
@@ -2230,7 +2230,7 @@ class FakeSchema(BaseModel):
         self.schema_version_status = AVAILABLE_STATUS
         self.created_time = utcnow()
         self.updated_time = utcnow()
-        self.schema_versions: Dict[str, FakeSchemaVersion] = OrderedDict()
+        self.schema_versions: dict[str, FakeSchemaVersion] = OrderedDict()
 
     def update_next_schema_version(self) -> None:
         self.next_schema_version += 1
@@ -2241,7 +2241,7 @@ class FakeSchema(BaseModel):
     def get_next_schema_version(self) -> int:
         return self.next_schema_version
 
-    def as_dict(self) -> Dict[str, Any]:
+    def as_dict(self) -> dict[str, Any]:
         return {
             "RegistryArn": self.registry_arn,
             "RegistryName": self.registry_name,
@@ -2277,19 +2277,19 @@ class FakeSchemaVersion(BaseModel):
         self.schema_version_id = str(mock_random.uuid4())
         self.created_time = utcnow()
         self.updated_time = utcnow()
-        self.metadata: Dict[str, Any] = {}
+        self.metadata: dict[str, Any] = {}
 
     def get_schema_version_id(self) -> str:
         return self.schema_version_id
 
-    def as_dict(self) -> Dict[str, Any]:
+    def as_dict(self) -> dict[str, Any]:
         return {
             "SchemaVersionId": self.schema_version_id,
             "VersionNumber": self.version_number,
             "Status": self.schema_version_status,
         }
 
-    def get_schema_version_as_dict(self) -> Dict[str, Any]:
+    def get_schema_version_as_dict(self) -> dict[str, Any]:
         # add data_format for full return dictionary of get_schema_version
         return {
             "SchemaVersionId": self.schema_version_id,
@@ -2300,7 +2300,7 @@ class FakeSchemaVersion(BaseModel):
             "CreatedTime": str(self.created_time),
         }
 
-    def get_schema_by_definition_as_dict(self) -> Dict[str, Any]:
+    def get_schema_by_definition_as_dict(self) -> dict[str, Any]:
         # add data_format for full return dictionary of get_schema_by_definition
         return {
             "SchemaVersionId": self.schema_version_id,
@@ -2316,17 +2316,17 @@ class FakeSession(BaseModel):
         session_id: str,
         description: str,
         role: str,
-        command: Dict[str, str],
+        command: dict[str, str],
         timeout: int,
         idle_timeout: int,
-        default_arguments: Dict[str, str],
-        connections: Dict[str, List[str]],
+        default_arguments: dict[str, str],
+        connections: dict[str, list[str]],
         max_capacity: float,
         number_of_workers: int,
         worker_type: str,
         security_configuration: str,
         glue_version: str,
-        tags: Dict[str, str],
+        tags: dict[str, str],
         request_origin: str,
         backend: GlueBackend,
     ):
@@ -2355,7 +2355,7 @@ class FakeSession(BaseModel):
     def get_id(self) -> str:
         return self.session_id
 
-    def as_dict(self) -> Dict[str, Any]:
+    def as_dict(self) -> dict[str, Any]:
         return {
             "Id": self.session_id,
             "CreatedOn": self.creation_time.isoformat(),
@@ -2387,11 +2387,11 @@ class FakeTrigger(BaseModel):
         trigger_type: str,  # to avoid any issues with built-in function type()
         schedule: str,
         predicate: Optional[Predicate],
-        actions: List[Action],
+        actions: list[Action],
         description: str,
         start_on_creation: bool,
-        tags: Dict[str, str],
-        event_batching_condition: Dict[str, Any],
+        tags: dict[str, str],
+        event_batching_condition: dict[str, Any],
     ):
         self.name = name
         self.workflow_name = workflow_name
@@ -2418,8 +2418,8 @@ class FakeTrigger(BaseModel):
     def stop_trigger(self) -> None:
         self.state = "DEACTIVATED"
 
-    def as_dict(self) -> Dict[str, Any]:
-        data: Dict[str, Any] = {
+    def as_dict(self) -> dict[str, Any]:
+        data: dict[str, Any] = {
             "Name": self.name,
             "Type": self.trigger_type,
             "Actions": [action.as_dict() for action in self.actions],
@@ -2449,8 +2449,8 @@ class FakeConnection(BaseModel):
         self,
         backend: GlueBackend,
         catalog_id: str,
-        connection_input: Dict[str, Any],
-        tags: Dict[str, str],
+        connection_input: dict[str, Any],
+        tags: dict[str, str],
     ) -> None:
         self.catalog_id = catalog_id
         self.connection_input = connection_input
@@ -2469,7 +2469,7 @@ class FakeConnection(BaseModel):
         self.athena_properties = self.connection_input.get("AthenaProperties", {})
         self.python_properties = self.connection_input.get("PythonProperties", {})
 
-    def as_dict(self) -> Dict[str, Any]:
+    def as_dict(self) -> dict[str, Any]:
         return {
             "Name": self.name,
             "Description": self.description,
@@ -2493,7 +2493,7 @@ class FakeWorkflowRun:
         self,
         workflow_name: str,
         previous_run_id: Optional[str] = None,
-        properties: Optional[Dict[str, str]] = None,
+        properties: Optional[dict[str, str]] = None,
     ) -> None:
         self.workflow_name = workflow_name
         self.run_id = f"wr_{mock_random.get_random_hex(64)}"
@@ -2503,8 +2503,8 @@ class FakeWorkflowRun:
         self.started_on = utcnow()
         self.completed_on: Optional[datetime] = None
 
-    def as_dict(self) -> Dict[str, Union[str, Dict[str, str]]]:
-        return_dict: Dict[str, Union[str, Dict[str, str]]] = {
+    def as_dict(self) -> dict[str, Union[str, dict[str, str]]]:
+        return_dict: dict[str, Union[str, dict[str, str]]] = {
             "Name": self.workflow_name,
             "WorkflowRunId": self.run_id,
             "StartedOn": self.started_on.isoformat(),
@@ -2523,10 +2523,10 @@ class FakeWorkflow:
     def __init__(
         self,
         name: str,
-        default_run_properties: Optional[Dict[str, str]],
+        default_run_properties: Optional[dict[str, str]],
         description: Optional[str],
         max_concurrent_runs: Optional[int],
-        tags: Optional[Dict[str, str]],
+        tags: Optional[dict[str, str]],
     ) -> None:
         self.name = name
         self.default_run_properties = default_run_properties
@@ -2537,8 +2537,8 @@ class FakeWorkflow:
         self.last_modified_on = utcnow()
         self.runs: OrderedDict[str, FakeWorkflowRun] = OrderedDict()
 
-    def as_dict(self) -> Dict[str, Any]:
-        return_dict: Dict[str, Any] = {
+    def as_dict(self) -> dict[str, Any]:
+        return_dict: dict[str, Any] = {
             "CreatedOn": self.created_on.isoformat(),
             "LastModifiedOn": self.last_modified_on.isoformat(),
             "Name": self.name,
@@ -2553,7 +2553,7 @@ class FakeWorkflow:
             return_dict["LastRun"] = self.runs[next(reversed(self.runs))].as_dict()
         return return_dict
 
-    def start_run(self, properties: Optional[Dict[str, str]]) -> str:
+    def start_run(self, properties: Optional[dict[str, str]]) -> str:
         run_properties = (
             self.default_run_properties.copy() if self.default_run_properties else {}
         )

--- a/moto/glue/responses.py
+++ b/moto/glue/responses.py
@@ -1,6 +1,6 @@
 import json
 from datetime import datetime
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Optional, Union
 
 from moto.core.common_types import TYPE_RESPONSE
 from moto.core.responses import BaseResponse
@@ -33,7 +33,7 @@ class GlueResponse(BaseResponse):
         return glue_backends[self.current_account][self.region]
 
     @property
-    def parameters(self) -> Dict[str, Any]:  # type: ignore[misc]
+    def parameters(self) -> dict[str, Any]:  # type: ignore[misc]
         return json.loads(self.body)
 
     def create_database(self) -> str:
@@ -303,8 +303,8 @@ class GlueResponse(BaseResponse):
         )
 
     def filter_crawlers_by_tags(
-        self, crawlers: List[FakeCrawler], tags: Dict[str, str]
-    ) -> List[str]:
+        self, crawlers: list[FakeCrawler], tags: dict[str, str]
+    ) -> list[str]:
         if not tags:
             return [crawler.get_name() for crawler in crawlers]
         return [
@@ -492,15 +492,15 @@ class GlueResponse(BaseResponse):
         return 200, {}, "{}"
 
     def filter_jobs_by_tags(
-        self, jobs: List[FakeJob], tags: Dict[str, str]
-    ) -> List[str]:
+        self, jobs: list[FakeJob], tags: dict[str, str]
+    ) -> list[str]:
         if not tags:
             return [job.get_name() for job in jobs]
         return [job.get_name() for job in jobs if self.is_tags_match(job.arn, tags)]
 
     def filter_triggers_by_tags(
-        self, triggers: List[FakeTrigger], tags: Dict[str, str]
-    ) -> List[str]:
+        self, triggers: list[FakeTrigger], tags: dict[str, str]
+    ) -> list[str]:
         if not tags:
             return [trigger.get_name() for trigger in triggers]
         return [
@@ -509,7 +509,7 @@ class GlueResponse(BaseResponse):
             if self.is_tags_match(trigger.arn, tags)
         ]
 
-    def is_tags_match(self, resource_arn: str, tags: Dict[str, str]) -> bool:
+    def is_tags_match(self, resource_arn: str, tags: dict[str, str]) -> bool:
         glue_resource_tags = self.glue_backend.get_tags(resource_arn)
         mutual_keys = set(glue_resource_tags).intersection(tags)
         for key in mutual_keys:
@@ -656,8 +656,8 @@ class GlueResponse(BaseResponse):
         )
 
     def _filter_sessions_by_tags(
-        self, sessions: List[FakeSession], tags: Dict[str, str]
-    ) -> List[str]:
+        self, sessions: list[FakeSession], tags: dict[str, str]
+    ) -> list[str]:
         if not tags:
             return [session.get_id() for session in sessions]
         return [
@@ -709,7 +709,7 @@ class GlueResponse(BaseResponse):
         trigger_type = self._get_param("Type")
         schedule = self._get_param("Schedule")
 
-        predicate_input: Optional[Dict[str, Union[str, List[Dict[str, str]]]]] = (
+        predicate_input: Optional[dict[str, Union[str, list[dict[str, str]]]]] = (
             self._get_param("Predicate")
         )
         if predicate_input:

--- a/moto/greengrass/models.py
+++ b/moto/greengrass/models.py
@@ -1,8 +1,9 @@
 import json
 import re
 from collections import OrderedDict
+from collections.abc import Iterable
 from datetime import datetime
-from typing import Any, Dict, Iterable, List, Optional
+from typing import Any, Optional
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
@@ -31,7 +32,7 @@ class FakeCoreDefinition(BaseModel):
         self.latest_version = ""
         self.latest_version_arn = ""
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         return {
             "Arn": self.arn,
             "CreationTimestamp": iso_8601_datetime_with_milliseconds(
@@ -53,7 +54,7 @@ class FakeCoreDefinitionVersion(BaseModel):
         account_id: str,
         region_name: str,
         core_definition_id: str,
-        definition: Dict[str, Any],
+        definition: dict[str, Any],
     ):
         self.region_name = region_name
         self.core_definition_id = core_definition_id
@@ -62,8 +63,8 @@ class FakeCoreDefinitionVersion(BaseModel):
         self.arn = f"arn:{get_partition(region_name)}:greengrass:{region_name}:{account_id}:greengrass/definition/cores/{self.core_definition_id}/versions/{self.version}"
         self.created_at_datetime = utcnow()
 
-    def to_dict(self, include_detail: bool = False) -> Dict[str, Any]:
-        obj: Dict[str, Any] = {
+    def to_dict(self, include_detail: bool = False) -> dict[str, Any]:
+        obj: dict[str, Any] = {
             "Arn": self.arn,
             "CreationTimestamp": iso_8601_datetime_with_milliseconds(
                 self.created_at_datetime
@@ -84,7 +85,7 @@ class FakeDeviceDefinition(BaseModel):
         account_id: str,
         region_name: str,
         name: str,
-        initial_version: Dict[str, Any],
+        initial_version: dict[str, Any],
     ):
         self.region_name = region_name
         self.id = str(mock_random.uuid4())
@@ -96,7 +97,7 @@ class FakeDeviceDefinition(BaseModel):
         self.name = name
         self.initial_version = initial_version
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         res = {
             "Arn": self.arn,
             "CreationTimestamp": iso_8601_datetime_with_milliseconds(
@@ -120,7 +121,7 @@ class FakeDeviceDefinitionVersion(BaseModel):
         account_id: str,
         region_name: str,
         device_definition_id: str,
-        devices: List[Dict[str, Any]],
+        devices: list[dict[str, Any]],
     ):
         self.region_name = region_name
         self.device_definition_id = device_definition_id
@@ -129,8 +130,8 @@ class FakeDeviceDefinitionVersion(BaseModel):
         self.arn = f"arn:{get_partition(region_name)}:greengrass:{region_name}:{account_id}:greengrass/definition/devices/{self.device_definition_id}/versions/{self.version}"
         self.created_at_datetime = utcnow()
 
-    def to_dict(self, include_detail: bool = False) -> Dict[str, Any]:
-        obj: Dict[str, Any] = {
+    def to_dict(self, include_detail: bool = False) -> dict[str, Any]:
+        obj: dict[str, Any] = {
             "Arn": self.arn,
             "CreationTimestamp": iso_8601_datetime_with_milliseconds(
                 self.created_at_datetime
@@ -151,7 +152,7 @@ class FakeResourceDefinition(BaseModel):
         account_id: str,
         region_name: str,
         name: str,
-        initial_version: Dict[str, Any],
+        initial_version: dict[str, Any],
     ):
         self.region_name = region_name
         self.id = str(mock_random.uuid4())
@@ -163,7 +164,7 @@ class FakeResourceDefinition(BaseModel):
         self.name = name
         self.initial_version = initial_version
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         return {
             "Arn": self.arn,
             "CreationTimestamp": iso_8601_datetime_with_milliseconds(
@@ -185,7 +186,7 @@ class FakeResourceDefinitionVersion(BaseModel):
         account_id: str,
         region_name: str,
         resource_definition_id: str,
-        resources: List[Dict[str, Any]],
+        resources: list[dict[str, Any]],
     ):
         self.region_name = region_name
         self.resource_definition_id = resource_definition_id
@@ -194,7 +195,7 @@ class FakeResourceDefinitionVersion(BaseModel):
         self.arn = f"arn:{get_partition(region_name)}:greengrass:{region_name}:{account_id}:greengrass/definition/resources/{self.resource_definition_id}/versions/{self.version}"
         self.created_at_datetime = utcnow()
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         return {
             "Arn": self.arn,
             "CreationTimestamp": iso_8601_datetime_with_milliseconds(
@@ -212,7 +213,7 @@ class FakeFunctionDefinition(BaseModel):
         account_id: str,
         region_name: str,
         name: str,
-        initial_version: Dict[str, Any],
+        initial_version: dict[str, Any],
     ):
         self.region_name = region_name
         self.id = str(mock_random.uuid4())
@@ -224,7 +225,7 @@ class FakeFunctionDefinition(BaseModel):
         self.name = name
         self.initial_version = initial_version
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         res = {
             "Arn": self.arn,
             "CreationTimestamp": iso_8601_datetime_with_milliseconds(
@@ -248,8 +249,8 @@ class FakeFunctionDefinitionVersion(BaseModel):
         account_id: str,
         region_name: str,
         function_definition_id: str,
-        functions: List[Dict[str, Any]],
-        default_config: Dict[str, Any],
+        functions: list[dict[str, Any]],
+        default_config: dict[str, Any],
     ):
         self.region_name = region_name
         self.function_definition_id = function_definition_id
@@ -259,7 +260,7 @@ class FakeFunctionDefinitionVersion(BaseModel):
         self.arn = f"arn:{get_partition(self.region_name)}:greengrass:{self.region_name}:{account_id}:greengrass/definition/functions/{self.function_definition_id}/versions/{self.version}"
         self.created_at_datetime = utcnow()
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         return {
             "Arn": self.arn,
             "CreationTimestamp": iso_8601_datetime_with_milliseconds(
@@ -277,7 +278,7 @@ class FakeSubscriptionDefinition(BaseModel):
         account_id: str,
         region_name: str,
         name: str,
-        initial_version: Dict[str, Any],
+        initial_version: dict[str, Any],
     ):
         self.region_name = region_name
         self.id = str(mock_random.uuid4())
@@ -289,7 +290,7 @@ class FakeSubscriptionDefinition(BaseModel):
         self.name = name
         self.initial_version = initial_version
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         return {
             "Arn": self.arn,
             "CreationTimestamp": iso_8601_datetime_with_milliseconds(
@@ -311,7 +312,7 @@ class FakeSubscriptionDefinitionVersion(BaseModel):
         account_id: str,
         region_name: str,
         subscription_definition_id: str,
-        subscriptions: List[Dict[str, Any]],
+        subscriptions: list[dict[str, Any]],
     ):
         self.region_name = region_name
         self.subscription_definition_id = subscription_definition_id
@@ -320,7 +321,7 @@ class FakeSubscriptionDefinitionVersion(BaseModel):
         self.arn = f"arn:{get_partition(self.region_name)}:greengrass:{self.region_name}:{account_id}:greengrass/definition/subscriptions/{self.subscription_definition_id}/versions/{self.version}"
         self.created_at_datetime = utcnow()
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         return {
             "Arn": self.arn,
             "CreationTimestamp": iso_8601_datetime_with_milliseconds(
@@ -343,7 +344,7 @@ class FakeGroup(BaseModel):
         self.latest_version = ""
         self.latest_version_arn = ""
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         obj = {
             "Arn": self.arn,
             "CreationTimestamp": iso_8601_datetime_with_milliseconds(
@@ -383,7 +384,7 @@ class FakeGroupVersion(BaseModel):
         self.resource_definition_version_arn = resource_definition_version_arn
         self.subscription_definition_version_arn = subscription_definition_version_arn
 
-    def to_dict(self, include_detail: bool = False) -> Dict[str, Any]:
+    def to_dict(self, include_detail: bool = False) -> dict[str, Any]:
         definition = {}
         if self.core_definition_version_arn:
             definition["CoreDefinitionVersionArn"] = self.core_definition_version_arn
@@ -408,7 +409,7 @@ class FakeGroupVersion(BaseModel):
                 self.subscription_definition_version_arn
             )
 
-        obj: Dict[str, Any] = {
+        obj: dict[str, Any] = {
             "Arn": self.arn,
             "CreationTimestamp": iso_8601_datetime_with_milliseconds(
                 self.created_at_datetime
@@ -442,7 +443,7 @@ class FakeDeployment(BaseModel):
         self.deployment_type = deployment_type
         self.arn = f"arn:{get_partition(self.region_name)}:greengrass:{self.region_name}:{account_id}:/greengrass/groups/{self.group_id}/deployments/{self.id}"
 
-    def to_dict(self, include_detail: bool = False) -> Dict[str, Any]:
+    def to_dict(self, include_detail: bool = False) -> dict[str, Any]:
         obj = {"DeploymentId": self.id, "DeploymentArn": self.arn}
 
         if include_detail:
@@ -460,7 +461,7 @@ class FakeAssociatedRole(BaseModel):
         self.role_arn = role_arn
         self.associated_at = utcnow()
 
-    def to_dict(self, include_detail: bool = False) -> Dict[str, Any]:
+    def to_dict(self, include_detail: bool = False) -> dict[str, Any]:
         obj = {"AssociatedAt": iso_8601_datetime_with_milliseconds(self.associated_at)}
         if include_detail:
             obj["RoleArn"] = self.role_arn
@@ -479,7 +480,7 @@ class FakeDeploymentStatus(BaseModel):
         self.update_at_datetime = updated_at
         self.deployment_status = deployment_status
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         return {
             "DeploymentStatus": self.deployment_status,
             "DeploymentType": self.deployment_type,
@@ -490,35 +491,35 @@ class FakeDeploymentStatus(BaseModel):
 class GreengrassBackend(BaseBackend):
     def __init__(self, region_name: str, account_id: str):
         super().__init__(region_name, account_id)
-        self.groups: Dict[str, FakeGroup] = OrderedDict()
-        self.group_role_associations: Dict[str, FakeAssociatedRole] = OrderedDict()
-        self.group_versions: Dict[str, Dict[str, FakeGroupVersion]] = OrderedDict()
-        self.core_definitions: Dict[str, FakeCoreDefinition] = OrderedDict()
-        self.core_definition_versions: Dict[
-            str, Dict[str, FakeCoreDefinitionVersion]
+        self.groups: dict[str, FakeGroup] = OrderedDict()
+        self.group_role_associations: dict[str, FakeAssociatedRole] = OrderedDict()
+        self.group_versions: dict[str, dict[str, FakeGroupVersion]] = OrderedDict()
+        self.core_definitions: dict[str, FakeCoreDefinition] = OrderedDict()
+        self.core_definition_versions: dict[
+            str, dict[str, FakeCoreDefinitionVersion]
         ] = OrderedDict()
-        self.device_definitions: Dict[str, FakeDeviceDefinition] = OrderedDict()
-        self.device_definition_versions: Dict[
-            str, Dict[str, FakeDeviceDefinitionVersion]
+        self.device_definitions: dict[str, FakeDeviceDefinition] = OrderedDict()
+        self.device_definition_versions: dict[
+            str, dict[str, FakeDeviceDefinitionVersion]
         ] = OrderedDict()
-        self.function_definitions: Dict[str, FakeFunctionDefinition] = OrderedDict()
-        self.function_definition_versions: Dict[
-            str, Dict[str, FakeFunctionDefinitionVersion]
+        self.function_definitions: dict[str, FakeFunctionDefinition] = OrderedDict()
+        self.function_definition_versions: dict[
+            str, dict[str, FakeFunctionDefinitionVersion]
         ] = OrderedDict()
-        self.resource_definitions: Dict[str, FakeResourceDefinition] = OrderedDict()
-        self.resource_definition_versions: Dict[
-            str, Dict[str, FakeResourceDefinitionVersion]
+        self.resource_definitions: dict[str, FakeResourceDefinition] = OrderedDict()
+        self.resource_definition_versions: dict[
+            str, dict[str, FakeResourceDefinitionVersion]
         ] = OrderedDict()
-        self.subscription_definitions: Dict[str, FakeSubscriptionDefinition] = (
+        self.subscription_definitions: dict[str, FakeSubscriptionDefinition] = (
             OrderedDict()
         )
-        self.subscription_definition_versions: Dict[
-            str, Dict[str, FakeSubscriptionDefinitionVersion]
+        self.subscription_definition_versions: dict[
+            str, dict[str, FakeSubscriptionDefinitionVersion]
         ] = OrderedDict()
-        self.deployments: Dict[str, FakeDeployment] = OrderedDict()
+        self.deployments: dict[str, FakeDeployment] = OrderedDict()
 
     def create_core_definition(
-        self, name: str, initial_version: Dict[str, Any]
+        self, name: str, initial_version: dict[str, Any]
     ) -> FakeCoreDefinition:
         core_definition = FakeCoreDefinition(self.account_id, self.region_name, name)
         self.core_definitions[core_definition.id] = core_definition
@@ -551,7 +552,7 @@ class GreengrassBackend(BaseBackend):
         self.core_definitions[core_definition_id].name = name
 
     def create_core_definition_version(
-        self, core_definition_id: str, cores: List[Dict[str, Any]]
+        self, core_definition_id: str, cores: list[dict[str, Any]]
     ) -> FakeCoreDefinitionVersion:
         definition = {"Cores": cores}
         core_def_ver = FakeCoreDefinitionVersion(
@@ -594,7 +595,7 @@ class GreengrassBackend(BaseBackend):
         ]
 
     def create_device_definition(
-        self, name: str, initial_version: Dict[str, Any]
+        self, name: str, initial_version: dict[str, Any]
     ) -> FakeDeviceDefinition:
         device_def = FakeDeviceDefinition(
             self.account_id, self.region_name, name, initial_version
@@ -610,7 +611,7 @@ class GreengrassBackend(BaseBackend):
         return self.device_definitions.values()
 
     def create_device_definition_version(
-        self, device_definition_id: str, devices: List[Dict[str, Any]]
+        self, device_definition_id: str, devices: list[dict[str, Any]]
     ) -> FakeDeviceDefinitionVersion:
         if device_definition_id not in self.device_definitions:
             raise IdNotFoundException("That devices definition does not exist.")
@@ -678,7 +679,7 @@ class GreengrassBackend(BaseBackend):
         ]
 
     def create_resource_definition(
-        self, name: str, initial_version: Dict[str, Any]
+        self, name: str, initial_version: dict[str, Any]
     ) -> FakeResourceDefinition:
         resources = initial_version.get("Resources", [])
         GreengrassBackend._validate_resources(resources)
@@ -719,7 +720,7 @@ class GreengrassBackend(BaseBackend):
         self.resource_definitions[resource_definition_id].name = name
 
     def create_resource_definition_version(
-        self, resource_definition_id: str, resources: List[Dict[str, Any]]
+        self, resource_definition_id: str, resources: list[dict[str, Any]]
     ) -> FakeResourceDefinitionVersion:
         if resource_definition_id not in self.resource_definitions:
             raise IdNotFoundException("That resource definition does not exist.")
@@ -775,7 +776,7 @@ class GreengrassBackend(BaseBackend):
         ]
 
     @staticmethod
-    def _validate_resources(resources: List[Dict[str, Any]]) -> None:  # type: ignore[misc]
+    def _validate_resources(resources: list[dict[str, Any]]) -> None:  # type: ignore[misc]
         for resource in resources:
             volume_source_path = (
                 resource.get("ResourceDataContainer", {})
@@ -802,7 +803,7 @@ class GreengrassBackend(BaseBackend):
                     )
 
     def create_function_definition(
-        self, name: str, initial_version: Dict[str, Any]
+        self, name: str, initial_version: dict[str, Any]
     ) -> FakeFunctionDefinition:
         func_def = FakeFunctionDefinition(
             self.account_id, self.region_name, name, initial_version
@@ -815,7 +816,7 @@ class GreengrassBackend(BaseBackend):
 
         return func_def
 
-    def list_function_definitions(self) -> List[FakeFunctionDefinition]:
+    def list_function_definitions(self) -> list[FakeFunctionDefinition]:
         return list(self.function_definitions.values())
 
     def get_function_definition(
@@ -845,8 +846,8 @@ class GreengrassBackend(BaseBackend):
     def create_function_definition_version(
         self,
         function_definition_id: str,
-        functions: List[Dict[str, Any]],
-        default_config: Dict[str, Any],
+        functions: list[dict[str, Any]],
+        default_config: dict[str, Any],
     ) -> FakeFunctionDefinitionVersion:
         if function_definition_id not in self.function_definitions:
             raise IdNotFoundException("That lambdas does not exist.")
@@ -874,7 +875,7 @@ class GreengrassBackend(BaseBackend):
 
     def list_function_definition_versions(
         self, function_definition_id: str
-    ) -> Dict[str, FakeFunctionDefinitionVersion]:
+    ) -> dict[str, FakeFunctionDefinitionVersion]:
         if function_definition_id not in self.function_definition_versions:
             raise IdNotFoundException("That lambdas definition does not exist.")
         return self.function_definition_versions[function_definition_id]
@@ -918,10 +919,10 @@ class GreengrassBackend(BaseBackend):
 
     @staticmethod
     def _validate_subscription_target_or_source(  # type: ignore[misc]
-        subscriptions: List[Dict[str, Any]],
+        subscriptions: list[dict[str, Any]],
     ) -> None:
-        target_errors: List[str] = []
-        source_errors: List[str] = []
+        target_errors: list[str] = []
+        source_errors: list[str] = []
 
         for subscription in subscriptions:
             subscription_id = subscription["Id"]
@@ -953,7 +954,7 @@ class GreengrassBackend(BaseBackend):
             )
 
     def create_subscription_definition(
-        self, name: str, initial_version: Dict[str, Any]
+        self, name: str, initial_version: dict[str, Any]
     ) -> FakeSubscriptionDefinition:
         GreengrassBackend._validate_subscription_target_or_source(
             initial_version["Subscriptions"]
@@ -973,7 +974,7 @@ class GreengrassBackend(BaseBackend):
         sub_def.latest_version_arn = sub_def_ver.arn
         return sub_def
 
-    def list_subscription_definitions(self) -> List[FakeSubscriptionDefinition]:
+    def list_subscription_definitions(self) -> list[FakeSubscriptionDefinition]:
         return list(self.subscription_definitions.values())
 
     def get_subscription_definition(
@@ -1003,7 +1004,7 @@ class GreengrassBackend(BaseBackend):
         self.subscription_definitions[subscription_definition_id].name = name
 
     def create_subscription_definition_version(
-        self, subscription_definition_id: str, subscriptions: List[Dict[str, Any]]
+        self, subscription_definition_id: str, subscriptions: list[dict[str, Any]]
     ) -> FakeSubscriptionDefinitionVersion:
         GreengrassBackend._validate_subscription_target_or_source(subscriptions)
 
@@ -1024,7 +1025,7 @@ class GreengrassBackend(BaseBackend):
 
     def list_subscription_definition_versions(
         self, subscription_definition_id: str
-    ) -> Dict[str, FakeSubscriptionDefinitionVersion]:
+    ) -> dict[str, FakeSubscriptionDefinitionVersion]:
         if subscription_definition_id not in self.subscription_definition_versions:
             raise IdNotFoundException("That subscriptions definition does not exist.")
         return self.subscription_definition_versions[subscription_definition_id]
@@ -1047,7 +1048,7 @@ class GreengrassBackend(BaseBackend):
             subscription_definition_version_id
         ]
 
-    def create_group(self, name: str, initial_version: Dict[str, Any]) -> FakeGroup:
+    def create_group(self, name: str, initial_version: dict[str, Any]) -> FakeGroup:
         group = FakeGroup(self.account_id, self.region_name, name)
         self.groups[group.group_id] = group
 
@@ -1075,7 +1076,7 @@ class GreengrassBackend(BaseBackend):
 
         return group
 
-    def list_groups(self) -> List[FakeGroup]:
+    def list_groups(self) -> list[FakeGroup]:
         return list(self.groups.values())
 
     def get_group(self, group_id: str) -> Optional[FakeGroup]:
@@ -1215,7 +1216,7 @@ class GreengrassBackend(BaseBackend):
                 f"The group is invalid or corrupted. (ErrorDetails: [{error_details}])",
             )
 
-    def list_group_versions(self, group_id: str) -> List[FakeGroupVersion]:
+    def list_group_versions(self, group_id: str) -> list[FakeGroupVersion]:
         if group_id not in self.group_versions:
             raise IdNotFoundException("That group definition does not exist.")
         return list(self.group_versions[group_id].values())
@@ -1293,7 +1294,7 @@ class GreengrassBackend(BaseBackend):
         self.deployments[deployment.id] = deployment
         return deployment
 
-    def list_deployments(self, group_id: str) -> List[FakeDeployment]:
+    def list_deployments(self, group_id: str) -> list[FakeDeployment]:
         # ListDeployments API does not check specified group is exists
         return [
             deployment

--- a/moto/guardduty/exceptions.py
+++ b/moto/guardduty/exceptions.py
@@ -1,4 +1,4 @@
-from typing import Any, List, Tuple
+from typing import Any
 
 from moto.core.exceptions import JsonRESTError
 
@@ -16,7 +16,7 @@ class DetectorNotFoundException(GuardDutyException):
             "The request is rejected because the input detectorId is not owned by the current account.",
         )
 
-    def get_headers(self, *args: Any, **kwargs: Any) -> List[Tuple[str, str]]:
+    def get_headers(self, *args: Any, **kwargs: Any) -> list[tuple[str, str]]:
         return [("X-Amzn-ErrorType", "BadRequestException")]
 
 
@@ -29,5 +29,5 @@ class FilterNotFoundException(GuardDutyException):
             "The request is rejected since no such resource found.",
         )
 
-    def get_headers(self, *args: Any, **kwargs: Any) -> List[Tuple[str, str]]:
+    def get_headers(self, *args: Any, **kwargs: Any) -> list[tuple[str, str]]:
         return [("X-Amzn-ErrorType", "BadRequestException")]

--- a/moto/guardduty/models.py
+++ b/moto/guardduty/models.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import Any, Dict, List, Optional
+from typing import Any, Optional
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
@@ -12,9 +12,9 @@ from .exceptions import DetectorNotFoundException, FilterNotFoundException
 class GuardDutyBackend(BaseBackend):
     def __init__(self, region_name: str, account_id: str):
         super().__init__(region_name, account_id)
-        self.admin_account_ids: List[str] = []
-        self.detectors: Dict[str, Detector] = {}
-        self.admin_accounts: Dict[
+        self.admin_account_ids: list[str] = []
+        self.detectors: dict[str, Detector] = {}
+        self.admin_accounts: dict[
             str, Detector
         ] = {}  # Store admin accounts by detector_id
 
@@ -22,9 +22,9 @@ class GuardDutyBackend(BaseBackend):
         self,
         enable: bool,
         finding_publishing_frequency: str,
-        data_sources: Dict[str, Any],
-        tags: Dict[str, str],
-        features: List[Dict[str, Any]],
+        data_sources: dict[str, Any],
+        tags: dict[str, str],
+        features: list[dict[str, Any]],
     ) -> str:
         if finding_publishing_frequency not in [
             "FIFTEEN_MINUTES",
@@ -52,7 +52,7 @@ class GuardDutyBackend(BaseBackend):
         name: str,
         action: str,
         description: str,
-        finding_criteria: Dict[str, Any],
+        finding_criteria: dict[str, Any],
         rank: int,
     ) -> None:
         detector = self.get_detector(detector_id)
@@ -69,13 +69,13 @@ class GuardDutyBackend(BaseBackend):
     def enable_organization_admin_account(self, admin_account_id: str) -> None:
         self.admin_account_ids.append(admin_account_id)
 
-    def list_organization_admin_accounts(self) -> List[str]:
+    def list_organization_admin_accounts(self) -> list[str]:
         """
         Pagination is not yet implemented
         """
         return self.admin_account_ids
 
-    def list_detectors(self) -> List[str]:
+    def list_detectors(self) -> list[str]:
         """
         The MaxResults and NextToken-parameter have not yet been implemented.
         """
@@ -89,7 +89,7 @@ class GuardDutyBackend(BaseBackend):
             raise DetectorNotFoundException
         return self.detectors[detector_id]
 
-    def get_administrator_account(self, detector_id: str) -> Dict[str, Any]:
+    def get_administrator_account(self, detector_id: str) -> dict[str, Any]:
         """Get administrator account details."""
         self.get_detector(detector_id)
 
@@ -112,8 +112,8 @@ class GuardDutyBackend(BaseBackend):
         detector_id: str,
         enable: bool,
         finding_publishing_frequency: str,
-        data_sources: Dict[str, Any],
-        features: List[Dict[str, Any]],
+        data_sources: dict[str, Any],
+        features: list[dict[str, Any]],
     ) -> None:
         detector = self.get_detector(detector_id)
         detector.update(enable, finding_publishing_frequency, data_sources, features)
@@ -124,7 +124,7 @@ class GuardDutyBackend(BaseBackend):
         filter_name: str,
         action: str,
         description: str,
-        finding_criteria: Dict[str, Any],
+        finding_criteria: dict[str, Any],
         rank: int,
     ) -> None:
         detector = self.get_detector(detector_id)
@@ -143,7 +143,7 @@ class Filter(BaseModel):
         name: str,
         action: str,
         description: str,
-        finding_criteria: Dict[str, Any],
+        finding_criteria: dict[str, Any],
         rank: int,
     ):
         self.name = name
@@ -156,7 +156,7 @@ class Filter(BaseModel):
         self,
         action: Optional[str],
         description: Optional[str],
-        finding_criteria: Optional[Dict[str, Any]],
+        finding_criteria: Optional[dict[str, Any]],
         rank: Optional[int],
     ) -> None:
         if action is not None:
@@ -168,7 +168,7 @@ class Filter(BaseModel):
         if rank is not None:
             self.rank = rank
 
-    def to_json(self) -> Dict[str, Any]:
+    def to_json(self) -> dict[str, Any]:
         return {
             "name": self.name,
             "action": self.action,
@@ -186,9 +186,9 @@ class Detector(BaseModel):
         created_at: datetime,
         finding_publish_freq: str,
         enabled: bool,
-        datasources: Dict[str, Any],
-        tags: Dict[str, str],
-        features: List[Dict[str, Any]],
+        datasources: dict[str, Any],
+        tags: dict[str, str],
+        features: list[dict[str, Any]],
     ):
         self.id = mock_random.get_random_hex(length=32)
         self.created_at = created_at
@@ -202,7 +202,7 @@ class Detector(BaseModel):
         # https://docs.aws.amazon.com/guardduty/latest/APIReference/API_DetectorFeatureConfiguration.html
         self.features = features or []
 
-        self.filters: Dict[str, Filter] = dict()
+        self.filters: dict[str, Filter] = dict()
 
     def add_filter(self, _filter: Filter) -> None:
         self.filters[_filter.name] = _filter
@@ -220,7 +220,7 @@ class Detector(BaseModel):
         filter_name: str,
         action: str,
         description: str,
-        finding_criteria: Dict[str, Any],
+        finding_criteria: dict[str, Any],
         rank: int,
     ) -> None:
         _filter = self.get_filter(filter_name)
@@ -235,8 +235,8 @@ class Detector(BaseModel):
         self,
         enable: bool,
         finding_publishing_frequency: str,
-        data_sources: Dict[str, Any],
-        features: List[Dict[str, Any]],
+        data_sources: dict[str, Any],
+        features: list[dict[str, Any]],
     ) -> None:
         if enable is not None:
             self.enabled = enable
@@ -247,7 +247,7 @@ class Detector(BaseModel):
         if features is not None:
             self.features = features
 
-    def to_json(self) -> Dict[str, Any]:
+    def to_json(self) -> dict[str, Any]:
         data_sources = {
             "cloudTrail": {"status": "DISABLED"},
             "dnsLogs": {"status": "DISABLED"},

--- a/moto/iam/access_control.py
+++ b/moto/iam/access_control.py
@@ -17,7 +17,8 @@ import logging
 import re
 from abc import ABCMeta, abstractmethod
 from enum import Enum
-from typing import Any, Dict, List, Match, Optional, Union
+from re import Match
+from typing import Any, Optional, Union
 
 from botocore.auth import S3SigV4Auth, SigV4Auth
 from botocore.awsrequest import AWSRequest
@@ -54,7 +55,7 @@ log = logging.getLogger(__name__)
 
 
 def create_access_key(
-    account_id: str, partition: str, access_key_id: str, headers: Dict[str, str]
+    account_id: str, partition: str, access_key_id: str, headers: dict[str, str]
 ) -> Union["IAMUserAccessKey", "AssumedRoleAccessKey"]:
     if access_key_id.startswith("AKIA") or "X-Amz-Security-Token" not in headers:
         return IAMUserAccessKey(
@@ -82,7 +83,7 @@ class IAMUserAccessKey:
         account_id: str,
         partition: str,
         access_key_id: str,
-        headers: Dict[str, str],
+        headers: dict[str, str],
     ):
         self.account_id = account_id
         self.partition = partition
@@ -108,7 +109,7 @@ class IAMUserAccessKey:
     def create_credentials(self) -> Credentials:
         return Credentials(self._access_key_id, self._secret_access_key)
 
-    def collect_policies(self) -> List[Dict[str, str]]:
+    def collect_policies(self) -> list[dict[str, str]]:
         user_policies = []
 
         inline_policy_names = self.backend.list_user_policies(self._owner_user_name)
@@ -152,7 +153,7 @@ class AssumedRoleAccessKey:
         account_id: str,
         partition: str,
         access_key_id: str,
-        headers: Dict[str, str],
+        headers: dict[str, str],
     ):
         self.account_id = account_id
         self.partition = partition
@@ -177,7 +178,7 @@ class AssumedRoleAccessKey:
             self._access_key_id, self._secret_access_key, self._session_token
         )
 
-    def collect_policies(self) -> List[str]:
+    def collect_policies(self) -> list[str]:
         role_policies = []
 
         inline_policy_names = self.backend.list_role_policies(self._owner_role_name)
@@ -201,15 +202,15 @@ class CreateAccessKeyFailure(Exception):
         self.reason = reason
 
 
-class IAMRequestBase(object, metaclass=ABCMeta):
+class IAMRequestBase(metaclass=ABCMeta):
     def __init__(
         self,
         account_id: str,
         method: str,
         path: str,
-        data: Dict[str, str],
+        data: dict[str, str],
         body: bytes,
-        headers: Dict[str, str],
+        headers: dict[str, str],
         action: str,
     ):
         log.debug(
@@ -320,8 +321,8 @@ class IAMRequestBase(object, metaclass=ABCMeta):
 
     @staticmethod
     def _create_headers_for_aws_request(
-        signed_headers: List[str], original_headers: Dict[str, str]
-    ) -> Dict[str, str]:
+        signed_headers: list[str], original_headers: dict[str, str]
+    ) -> dict[str, str]:
         headers = {}
         for key, value in original_headers.items():
             if key.lower() in signed_headers:
@@ -428,7 +429,7 @@ class IAMPolicy:
         action: str,
         resource: str = "*",
         principal: Optional[str] = None,
-        incoming_condition_values: Optional[Dict[str, str]] = None,
+        incoming_condition_values: Optional[dict[str, str]] = None,
     ) -> "PermissionResult":
         permitted = False
         if isinstance(self._policy_json["Statement"], list):
@@ -465,7 +466,7 @@ class IAMPolicyStatement:
         action: str,
         resource: str = "*",
         principal: Optional[str] = None,
-        incoming_condition_values: Optional[Dict[str, str]] = None,
+        incoming_condition_values: Optional[dict[str, str]] = None,
     ) -> "PermissionResult":
         is_action_concerned = False
 
@@ -537,7 +538,7 @@ class IAMPolicyStatement:
         )
 
     def _check_conditions(
-        self, incoming_condition_values: Optional[Dict[str, str]]
+        self, incoming_condition_values: Optional[dict[str, str]]
     ) -> bool:
         expected_conditions = self._statement.get("Condition")
         if not expected_conditions:
@@ -545,7 +546,7 @@ class IAMPolicyStatement:
 
         trust_conditions = TrustRelationShipConditions(expected_conditions)
         for condition in trust_conditions:
-            actual_values: List[str] = []
+            actual_values: list[str] = []
 
             for context_key in condition.context_keys:
                 # TODO: expand functionality for covering internal data sources with backend component

--- a/moto/iam/config.py
+++ b/moto/iam/config.py
@@ -1,6 +1,6 @@
 import json
 import re
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Optional
 
 import boto3
 
@@ -15,14 +15,14 @@ class RoleConfigQuery(ConfigQueryModel[IAMBackend]):
         self,
         account_id: str,
         partition: str,
-        resource_ids: Optional[List[str]],
+        resource_ids: Optional[list[str]],
         resource_name: Optional[str],
         limit: int,
         next_token: Optional[str],
         backend_region: Optional[str] = None,
         resource_region: Optional[str] = None,
-        aggregator: Optional[Dict[str, Any]] = None,
-    ) -> Tuple[List[Dict[str, Any]], Optional[str]]:
+        aggregator: Optional[dict[str, Any]] = None,
+    ) -> tuple[list[dict[str, Any]], Optional[str]]:
         # IAM roles are "global" and aren't assigned into any availability zone
         # The resource ID is a AWS-assigned random string like "AROA0BSVNSZKXVHS00SBJ"
         # The resource name is a user-assigned string like "MyDevelopmentAdminRole"
@@ -141,7 +141,7 @@ class RoleConfigQuery(ConfigQueryModel[IAMBackend]):
         resource_name: Optional[str] = None,
         backend_region: Optional[str] = None,
         resource_region: Optional[str] = None,
-    ) -> Optional[Dict[str, Any]]:
+    ) -> Optional[dict[str, Any]]:
         role = self.backends[account_id][partition].roles.get(resource_id)
 
         if not role:
@@ -169,14 +169,14 @@ class PolicyConfigQuery(ConfigQueryModel[IAMBackend]):
         self,
         account_id: str,
         partition: str,
-        resource_ids: Optional[List[str]],
+        resource_ids: Optional[list[str]],
         resource_name: Optional[str],
         limit: int,
         next_token: Optional[str],
         backend_region: Optional[str] = None,
         resource_region: Optional[str] = None,
-        aggregator: Optional[Dict[str, Any]] = None,
-    ) -> Tuple[List[Dict[str, Any]], Optional[str]]:
+        aggregator: Optional[dict[str, Any]] = None,
+    ) -> tuple[list[dict[str, Any]], Optional[str]]:
         # IAM policies are "global" and aren't assigned into any availability zone
         # The resource ID is a AWS-assigned random string like "ANPA0BSVNSZK00SJSPVUJ"
         # The resource name is a user-assigned string like "my-development-policy"
@@ -317,7 +317,7 @@ class PolicyConfigQuery(ConfigQueryModel[IAMBackend]):
         resource_name: Optional[str] = None,
         backend_region: Optional[str] = None,
         resource_region: Optional[str] = None,
-    ) -> Optional[Dict[str, Any]]:
+    ) -> Optional[dict[str, Any]]:
         # policies are listed in the backend as arns, but we have to accept the PolicyID as the resource_id
         # we'll make a really crude search for it
         policy = None

--- a/moto/iam/policy_conditions.py
+++ b/moto/iam/policy_conditions.py
@@ -1,8 +1,9 @@
-from typing import Dict, Iterator, List, Union
+from collections.abc import Iterator
+from typing import Union
 
 
 def string_equals_operation(
-    expected_value: Union[List[str], str], actual_value: str
+    expected_value: Union[list[str], str], actual_value: str
 ) -> bool:
     if isinstance(expected_value, str):
         return actual_value == expected_value
@@ -22,8 +23,8 @@ class TrustCondition:
     def __init__(
         self,
         condition: str,
-        expected_value: List[Union[List[str], str]],
-        expected_value_source: List[str],
+        expected_value: list[Union[list[str], str]],
+        expected_value_source: list[str],
     ) -> None:
         self._condition = condition
 
@@ -31,10 +32,10 @@ class TrustCondition:
         self._expected_value = expected_value
 
     @property
-    def context_keys(self) -> List[str]:
+    def context_keys(self) -> list[str]:
         return self._expected_value_source
 
-    def verify_condition(self, actual_values: List[str]) -> bool:
+    def verify_condition(self, actual_values: list[str]) -> bool:
         verify_action = CONDITION_OPERATIONS.get(self._condition)
 
         # If the evaluation operation is not supported, ignore condition evaluation
@@ -48,17 +49,17 @@ class TrustCondition:
         return True
 
 
-ConditionData = Dict[str, Dict[str, Union[str, List[str]]]]
+ConditionData = dict[str, dict[str, Union[str, list[str]]]]
 
 
 class TrustRelationShipConditions:
     """Trust relationship conditions segment model"""
 
     def __init__(self, conditions: ConditionData) -> None:
-        self._conditions: List[TrustCondition] = []
+        self._conditions: list[TrustCondition] = []
         for conditions_operation, condition_values in conditions.items():
-            expected_value_source: List[str] = list(condition_values.keys())
-            expected_value_data: List[Union[str, List[str]]] = list(
+            expected_value_source: list[str] = list(condition_values.keys())
+            expected_value_data: list[Union[str, list[str]]] = list(
                 condition_values.values()
             )
 

--- a/moto/iam/policy_validation.py
+++ b/moto/iam/policy_validation.py
@@ -1,6 +1,6 @@
 import json
 import re
-from typing import Any, Dict, List
+from typing import Any
 
 from moto.iam.exceptions import MalformedPolicyDocument
 from moto.utilities.utils import PARTITION_NAMES
@@ -57,7 +57,7 @@ VALID_CONDITION_PREFIXES = ["ForAnyValue:", "ForAllValues:"]
 
 VALID_CONDITION_POSTFIXES = ["IfExists"]
 
-SERVICE_TYPE_REGION_INFORMATION_ERROR_ASSOCIATIONS: Dict[str, Any] = {
+SERVICE_TYPE_REGION_INFORMATION_ERROR_ASSOCIATIONS: dict[str, Any] = {
     "iam": {
         "error_message": "IAM resource {resource} cannot contain region information."
     },
@@ -68,7 +68,7 @@ SERVICE_TYPE_REGION_INFORMATION_ERROR_ASSOCIATIONS: Dict[str, Any] = {
 }
 
 
-VALID_RESOURCE_PATH_STARTING_VALUES: Dict[str, Any] = {
+VALID_RESOURCE_PATH_STARTING_VALUES: dict[str, Any] = {
     "iam": {
         "values": [
             "user/",
@@ -93,8 +93,8 @@ VALID_RESOURCE_PATH_STARTING_VALUES: Dict[str, Any] = {
 class BaseIAMPolicyValidator:
     def __init__(self, policy_document: str):
         self._policy_document = policy_document
-        self._policy_json: Dict[str, Any] = {}
-        self._statements: List[Dict[str, Any]] = []
+        self._policy_json: dict[str, Any] = {}
+        self._statements: list[dict[str, Any]] = []
         self._resource_error = ""  # the first resource error found that does not generate a legacy parsing error
 
     def validate(self) -> None:
@@ -174,7 +174,7 @@ class BaseIAMPolicyValidator:
             self._validate_statement_syntax(statement)
 
     @staticmethod
-    def _validate_statement_syntax(statement: Dict[str, Any]) -> None:  # type: ignore[misc]
+    def _validate_statement_syntax(statement: dict[str, Any]) -> None:  # type: ignore[misc]
         assert isinstance(statement, dict)
         for statement_element in statement.keys():
             assert statement_element in VALID_STATEMENT_ELEMENTS
@@ -191,7 +191,7 @@ class BaseIAMPolicyValidator:
         IAMPolicyDocumentValidator._validate_sid_syntax(statement)
 
     @staticmethod
-    def _validate_effect_syntax(statement: Dict[str, Any]) -> None:  # type: ignore[misc]
+    def _validate_effect_syntax(statement: dict[str, Any]) -> None:  # type: ignore[misc]
         assert "Effect" in statement
         assert isinstance(statement["Effect"], str)
         assert statement["Effect"].lower() in [
@@ -199,32 +199,32 @@ class BaseIAMPolicyValidator:
         ]
 
     @staticmethod
-    def _validate_action_syntax(statement: Dict[str, Any]) -> None:  # type: ignore[misc]
+    def _validate_action_syntax(statement: dict[str, Any]) -> None:  # type: ignore[misc]
         IAMPolicyDocumentValidator._validate_string_or_list_of_strings_syntax(
             statement, "Action"
         )
 
     @staticmethod
-    def _validate_not_action_syntax(statement: Dict[str, Any]) -> None:  # type: ignore[misc]
+    def _validate_not_action_syntax(statement: dict[str, Any]) -> None:  # type: ignore[misc]
         IAMPolicyDocumentValidator._validate_string_or_list_of_strings_syntax(
             statement, "NotAction"
         )
 
     @staticmethod
-    def _validate_resource_syntax(statement: Dict[str, Any]) -> None:  # type: ignore[misc]
+    def _validate_resource_syntax(statement: dict[str, Any]) -> None:  # type: ignore[misc]
         IAMPolicyDocumentValidator._validate_string_or_list_of_strings_syntax(
             statement, "Resource"
         )
 
     @staticmethod
-    def _validate_not_resource_syntax(statement: Dict[str, Any]) -> None:  # type: ignore[misc]
+    def _validate_not_resource_syntax(statement: dict[str, Any]) -> None:  # type: ignore[misc]
         IAMPolicyDocumentValidator._validate_string_or_list_of_strings_syntax(
             statement, "NotResource"
         )
 
     @staticmethod
     def _validate_string_or_list_of_strings_syntax(  # type: ignore[misc]
-        statement: Dict[str, Any],
+        statement: dict[str, Any],
         key: str,
     ) -> None:
         if key in statement:
@@ -234,7 +234,7 @@ class BaseIAMPolicyValidator:
                     assert isinstance(resource, str)
 
     @staticmethod
-    def _validate_condition_syntax(statement: Dict[str, Any]) -> None:  # type: ignore[misc]
+    def _validate_condition_syntax(statement: dict[str, Any]) -> None:  # type: ignore[misc]
         if "Condition" in statement:
             assert isinstance(statement["Condition"], dict)
             for condition_key, condition_value in statement["Condition"].items():
@@ -263,7 +263,7 @@ class BaseIAMPolicyValidator:
         return condition_key
 
     @staticmethod
-    def _validate_sid_syntax(statement: Dict[str, Any]) -> None:  # type: ignore[misc]
+    def _validate_sid_syntax(statement: dict[str, Any]) -> None:  # type: ignore[misc]
         if "Sid" in statement:
             assert isinstance(statement["Sid"], str)
 
@@ -440,7 +440,7 @@ class BaseIAMPolicyValidator:
             self._legacy_parse_statement(statement)
 
     @staticmethod
-    def _legacy_parse_statement(statement: Dict[str, Any]) -> None:  # type: ignore[misc]
+    def _legacy_parse_statement(statement: dict[str, Any]) -> None:  # type: ignore[misc]
         assert statement["Effect"] in VALID_EFFECTS  # case-sensitive matching
         if "Condition" in statement:
             for condition_key, condition_value in statement["Condition"].items():
@@ -449,7 +449,7 @@ class BaseIAMPolicyValidator:
                 )
 
     @staticmethod
-    def _legacy_parse_resource_like(statement: Dict[str, Any], key: str) -> None:  # type: ignore[misc]
+    def _legacy_parse_resource_like(statement: dict[str, Any], key: str) -> None:  # type: ignore[misc]
         if isinstance(statement[key], str):
             if statement[key] != "*":
                 assert statement[key].count(":") >= 5 or "::" not in statement[key]
@@ -463,7 +463,7 @@ class BaseIAMPolicyValidator:
     @staticmethod
     def _legacy_parse_condition(  # type: ignore[misc]
         condition_key: str,
-        condition_value: Dict[str, Any],
+        condition_value: dict[str, Any],
     ) -> None:
         stripped_condition_key = IAMPolicyDocumentValidator._strip_condition_key(
             condition_key

--- a/moto/iam/utils.py
+++ b/moto/iam/utils.py
@@ -1,6 +1,6 @@
 import base64
 import string
-from typing import Any, Dict
+from typing import Any
 
 from moto.moto_api._internal import mock_random as random
 
@@ -65,9 +65,9 @@ def random_policy_id() -> str:
 
 
 def format_incoming_conditional_values(
-    data: Dict[str, str],
-) -> Dict[str, str]:
-    incoming_conditional_values: Dict[str, str] = {}
+    data: dict[str, str],
+) -> dict[str, str]:
+    incoming_conditional_values: dict[str, str] = {}
 
     if "ExternalId" in data:
         incoming_conditional_values["sts:ExternalId"] = data["ExternalId"][0]
@@ -75,5 +75,5 @@ def format_incoming_conditional_values(
     return incoming_conditional_values
 
 
-def is_role_resource(data: Dict[str, Any]) -> bool:
+def is_role_resource(data: dict[str, Any]) -> bool:
     return "RoleName" in data

--- a/moto/identitystore/models.py
+++ b/moto/identitystore/models.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, Dict, List, NamedTuple, Optional, Tuple
+from typing import TYPE_CHECKING, Any, NamedTuple, Optional
 
 from botocore.exceptions import ParamValidationError
 
@@ -20,7 +20,7 @@ if TYPE_CHECKING:
 class Group(NamedTuple):
     GroupId: str
     DisplayName: str
-    ExternalIds: List[Optional[Dict[str, str]]]
+    ExternalIds: list[Optional[dict[str, str]]]
     Description: str
     IdentityStoreId: str
 
@@ -34,7 +34,7 @@ class Name(NamedTuple):
     HonorificSuffix: Optional[str]
 
     @classmethod
-    def from_dict(cls, name_dict: Dict[str, str]) -> "Optional[Self]":
+    def from_dict(cls, name_dict: dict[str, str]) -> "Optional[Self]":
         if not name_dict:
             return None
         return cls(
@@ -55,9 +55,9 @@ class User(NamedTuple):
     DisplayName: str
     NickName: str
     ProfileUrl: str
-    Emails: List[Dict[str, str]]
-    Addresses: List[Dict[str, str]]
-    PhoneNumbers: List[Dict[str, str]]
+    Emails: list[dict[str, str]]
+    Addresses: list[dict[str, str]]
+    PhoneNumbers: list[dict[str, str]]
     UserType: str
     Title: str
     PreferredLanguage: str
@@ -67,9 +67,9 @@ class User(NamedTuple):
 
 class IdentityStoreData:
     def __init__(self) -> None:
-        self.groups: Dict[str, Group] = {}
-        self.users: Dict[str, User] = {}
-        self.group_memberships: Dict[str, Any] = {}
+        self.groups: dict[str, Group] = {}
+        self.users: dict[str, User] = {}
+        self.group_memberships: dict[str, Any] = {}
 
 
 class IdentityStoreBackend(BaseBackend):
@@ -104,11 +104,11 @@ class IdentityStoreBackend(BaseBackend):
 
     def __init__(self, region_name: str, account_id: str) -> None:
         super().__init__(region_name, account_id)
-        self.identity_stores: Dict[str, IdentityStoreData] = {}
+        self.identity_stores: dict[str, IdentityStoreData] = {}
 
     def create_group(
         self, identity_store_id: str, display_name: str, description: str
-    ) -> Tuple[str, str]:
+    ) -> tuple[str, str]:
         identity_store = self.__get_identity_store(identity_store_id)
 
         matching = [
@@ -132,8 +132,8 @@ class IdentityStoreBackend(BaseBackend):
         return group_id, identity_store_id
 
     def get_group_id(
-        self, identity_store_id: str, alternate_identifier: Dict[str, Any]
-    ) -> Tuple[str, str]:
+        self, identity_store_id: str, alternate_identifier: dict[str, Any]
+    ) -> tuple[str, str]:
         """
         The ExternalId alternate identifier is not yet implemented
         """
@@ -160,7 +160,7 @@ class IdentityStoreBackend(BaseBackend):
         if group_id in identity_store.groups:
             g = identity_store.groups[group_id]
             # External Ids are not implemented
-            external_ids: List[Any] = []
+            external_ids: list[Any] = []
             return Group(
                 g.GroupId,
                 g.DisplayName,
@@ -181,19 +181,19 @@ class IdentityStoreBackend(BaseBackend):
         self,
         identity_store_id: str,
         user_name: str,
-        name: Dict[str, str],
+        name: dict[str, str],
         display_name: str,
         nick_name: str,
         profile_url: str,
-        emails: List[Dict[str, Any]],
-        addresses: List[Dict[str, Any]],
-        phone_numbers: List[Dict[str, Any]],
+        emails: list[dict[str, Any]],
+        addresses: list[dict[str, Any]],
+        phone_numbers: list[dict[str, Any]],
         user_type: str,
         title: str,
         preferred_language: str,
         locale: str,
         timezone: str,
-    ) -> Tuple[str, str]:
+    ) -> tuple[str, str]:
         identity_store = self.__get_identity_store(identity_store_id)
         user_id = str(mock_random.uuid4())
 
@@ -221,8 +221,8 @@ class IdentityStoreBackend(BaseBackend):
         return user_id, identity_store_id
 
     def get_user_id(
-        self, identity_store_id: str, alternate_identifier: Dict[str, Any]
-    ) -> Tuple[str, str]:
+        self, identity_store_id: str, alternate_identifier: dict[str, Any]
+    ) -> tuple[str, str]:
         """
         The ExternalId alternate identifier is not yet implemented
         """
@@ -267,8 +267,8 @@ class IdentityStoreBackend(BaseBackend):
             del identity_store.users[user_id]
 
     def create_group_membership(
-        self, identity_store_id: str, group_id: str, member_id: Dict[str, str]
-    ) -> Tuple[str, str]:
+        self, identity_store_id: str, group_id: str, member_id: dict[str, str]
+    ) -> tuple[str, str]:
         identity_store = self.__get_identity_store(identity_store_id)
         user_id = member_id["UserId"]
         if user_id not in identity_store.users:
@@ -294,7 +294,7 @@ class IdentityStoreBackend(BaseBackend):
     @paginate(pagination_model=PAGINATION_MODEL)  # type: ignore
     def list_group_memberships(  # type: ignore[misc]
         self, identity_store_id: str, group_id: str
-    ) -> List[Any]:
+    ) -> list[Any]:
         identity_store = self.__get_identity_store(identity_store_id)
 
         return [
@@ -305,8 +305,8 @@ class IdentityStoreBackend(BaseBackend):
 
     @paginate(pagination_model=PAGINATION_MODEL)  # type: ignore[misc]
     def list_group_memberships_for_member(  # type: ignore[misc]
-        self, identity_store_id: str, member_id: Dict[str, str]
-    ) -> List[Any]:
+        self, identity_store_id: str, member_id: dict[str, str]
+    ) -> list[Any]:
         identity_store = self.__get_identity_store(identity_store_id)
         user_id = member_id["UserId"]
 
@@ -318,8 +318,8 @@ class IdentityStoreBackend(BaseBackend):
 
     @paginate(pagination_model=PAGINATION_MODEL)
     def list_groups(
-        self, identity_store_id: str, filters: List[Dict[str, str]]
-    ) -> List[Group]:
+        self, identity_store_id: str, filters: list[dict[str, str]]
+    ) -> list[Group]:
         identity_store = self.__get_identity_store(identity_store_id)
 
         if filters:
@@ -335,8 +335,8 @@ class IdentityStoreBackend(BaseBackend):
 
     @paginate(pagination_model=PAGINATION_MODEL)
     def list_users(
-        self, identity_store_id: str, filters: List[Dict[str, str]]
-    ) -> List[Dict[str, str]]:
+        self, identity_store_id: str, filters: list[dict[str, str]]
+    ) -> list[dict[str, str]]:
         identity_store = self.__get_identity_store(identity_store_id)
 
         users = []

--- a/moto/identitystore/responses.py
+++ b/moto/identitystore/responses.py
@@ -1,7 +1,7 @@
 """Handles incoming identitystore requests, invokes methods, returns responses."""
 
 import json
-from typing import Any, Dict, NamedTuple, Optional
+from typing import Any, NamedTuple, Optional
 
 from moto.core.responses import BaseResponse
 
@@ -254,7 +254,7 @@ class IdentityStoreResponse(BaseResponse):
 
     def named_tuple_to_dict(
         self, value: Optional[NamedTuple]
-    ) -> Optional[Dict[str, Any]]:
+    ) -> Optional[dict[str, Any]]:
         if value:
             return value._asdict()
         return None

--- a/moto/inspector2/responses.py
+++ b/moto/inspector2/responses.py
@@ -1,5 +1,5 @@
 import json
-from typing import Any, Dict, List
+from typing import Any
 from urllib.parse import unquote
 
 from moto.core.responses import BaseResponse
@@ -89,20 +89,20 @@ class Inspector2Response(BaseResponse):
         account_ids = self._get_param("accountIds")
         resource_types = self._get_param("resourceTypes")
         accounts = self.inspector2_backend.enable(account_ids, resource_types)
-        failed: List[Dict[str, Any]] = []
+        failed: list[dict[str, Any]] = []
         return json.dumps({"accounts": accounts, "failedAccounts": failed})
 
     def disable(self) -> str:
         account_ids = self._get_param("accountIds")
         resource_types = self._get_param("resourceTypes")
         accounts = self.inspector2_backend.disable(account_ids, resource_types)
-        failed: List[Dict[str, Any]] = []
+        failed: list[dict[str, Any]] = []
         return json.dumps({"accounts": accounts, "failedAccounts": failed})
 
     def batch_get_account_status(self) -> str:
         account_ids = self._get_param("accountIds")
         accounts = self.inspector2_backend.batch_get_account_status(account_ids)
-        failed: List[Dict[str, Any]] = []
+        failed: list[dict[str, Any]] = []
         return json.dumps({"accounts": accounts, "failedAccounts": failed})
 
     def list_members(self) -> str:

--- a/moto/iotdata/models.py
+++ b/moto/iotdata/models.py
@@ -1,6 +1,6 @@
 import json
 import time
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Optional
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
@@ -23,7 +23,7 @@ class FakeShadow(BaseModel):
         self,
         desired: Optional[str],
         reported: Optional[str],
-        requested_payload: Optional[Dict[str, Any]],
+        requested_payload: Optional[dict[str, Any]],
         version: int,
         deleted: bool = False,
     ):
@@ -43,7 +43,7 @@ class FakeShadow(BaseModel):
 
     @classmethod
     def create_from_previous_version(  # type: ignore[misc]
-        cls, previous_shadow: Optional["FakeShadow"], payload: Optional[Dict[str, Any]]
+        cls, previous_shadow: Optional["FakeShadow"], payload: Optional[dict[str, Any]]
     ) -> "FakeShadow":
         """
         set None to payload when you want to delete shadow
@@ -93,7 +93,7 @@ class FakeShadow(BaseModel):
         return delta
 
     @classmethod
-    def _compute_delta_dict(cls, desired: Any, reported: Any) -> Dict[str, Any]:  # type: ignore[misc]
+    def _compute_delta_dict(cls, desired: Any, reported: Any) -> dict[str, Any]:  # type: ignore[misc]
         delta = {}
         for key, value in desired.items():
             delta_value = cls._compute_delta(reported.get(key), value)
@@ -134,7 +134,7 @@ class FakeShadow(BaseModel):
 
         return _f(state, ts)
 
-    def to_response_dict(self) -> Dict[str, Any]:
+    def to_response_dict(self) -> dict[str, Any]:
         metadata = {}
 
         if self.requested_payload["state"] is None:  # type: ignore
@@ -162,7 +162,7 @@ class FakeShadow(BaseModel):
             "version": self.version,
         }
 
-    def to_dict(self, include_delta: bool = True) -> Dict[str, Any]:
+    def to_dict(self, include_delta: bool = True) -> dict[str, Any]:
         """returning nothing except for just top-level keys for now."""
         if self.deleted:
             return {"timestamp": self.timestamp, "version": self.version}
@@ -192,7 +192,7 @@ class FakeShadow(BaseModel):
 class IoTDataPlaneBackend(BaseBackend):
     def __init__(self, region_name: str, account_id: str):
         super().__init__(region_name, account_id)
-        self.published_payloads: List[Tuple[str, bytes]] = list()
+        self.published_payloads: list[tuple[str, bytes]] = list()
 
     @property
     def iot_backend(self) -> IoTBackend:
@@ -255,7 +255,7 @@ class IoTDataPlaneBackend(BaseBackend):
     def publish(self, topic: str, payload: bytes) -> None:
         self.published_payloads.append((topic, payload))
 
-    def list_named_shadows_for_thing(self, thing_name: str) -> List[str]:
+    def list_named_shadows_for_thing(self, thing_name: str) -> list[str]:
         thing = self.iot_backend.describe_thing(thing_name)
         return [name for name in thing.thing_shadows.keys() if name is not None]
 

--- a/moto/ivs/models.py
+++ b/moto/ivs/models.py
@@ -1,6 +1,6 @@
 """IVSBackend class with methods for supported APIs."""
 
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Optional
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.ivs.exceptions import ResourceNotFoundException
@@ -23,7 +23,7 @@ class IVSBackend(BaseBackend):
 
     def __init__(self, region_name: str, account_id: str):
         super().__init__(region_name, account_id)
-        self.channels: List[Dict[str, Any]] = []
+        self.channels: list[dict[str, Any]] = []
 
     def create_channel(
         self,
@@ -33,9 +33,9 @@ class IVSBackend(BaseBackend):
         name: str,
         preset: str,
         recording_configuration_arn: str,
-        tags: Dict[str, str],
+        tags: dict[str, str],
         channel_type: str,
-    ) -> Tuple[Dict[str, Any], Dict[str, Any]]:
+    ) -> tuple[dict[str, Any], dict[str, Any]]:
         channel_id = mock_random.get_random_string(12)
         channel_arn = f"arn:{get_partition(self.region_name)}:ivs:{self.region_name}:{self.account_id}:channel/{channel_id}"
         channel = {
@@ -67,7 +67,7 @@ class IVSBackend(BaseBackend):
         self,
         filter_by_name: Optional[str],
         filter_by_recording_configuration_arn: Optional[str],
-    ) -> List[Dict[str, Any]]:
+    ) -> list[dict[str, Any]]:
         if filter_by_name is not None:
             channels = [
                 channel
@@ -85,18 +85,18 @@ class IVSBackend(BaseBackend):
             channels = self.channels
         return channels
 
-    def _find_channel(self, arn: str) -> Dict[str, Any]:
+    def _find_channel(self, arn: str) -> dict[str, Any]:
         try:
             return next(channel for channel in self.channels if channel["arn"] == arn)
         except StopIteration:
             raise ResourceNotFoundException(f"Resource: {arn} not found")
 
-    def get_channel(self, arn: str) -> Dict[str, Any]:
+    def get_channel(self, arn: str) -> dict[str, Any]:
         return self._find_channel(arn)
 
     def batch_get_channel(
-        self, arns: List[str]
-    ) -> Tuple[List[Dict[str, Any]], List[Dict[str, str]]]:
+        self, arns: list[str]
+    ) -> tuple[list[dict[str, Any]], list[dict[str, str]]]:
         return [channel for channel in self.channels if channel["arn"] in arns], []
 
     def update_channel(
@@ -109,7 +109,7 @@ class IVSBackend(BaseBackend):
         preset: Optional[str],
         recording_configuration_arn: Optional[str],
         channel_type: Optional[str],
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         channel = self._find_channel(arn)
         if authorized is not None:
             channel["authorized"] = authorized

--- a/moto/kafka/models.py
+++ b/moto/kafka/models.py
@@ -2,7 +2,7 @@
 
 import uuid
 from datetime import datetime
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Optional
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
@@ -18,19 +18,19 @@ class FakeKafkaCluster(BaseModel):
         account_id: str,
         region_name: str,
         cluster_type: str,
-        tags: Optional[Dict[str, str]] = None,
-        broker_node_group_info: Optional[Dict[str, Any]] = None,
+        tags: Optional[dict[str, str]] = None,
+        broker_node_group_info: Optional[dict[str, Any]] = None,
         kafka_version: Optional[str] = None,
         number_of_broker_nodes: Optional[int] = None,
-        configuration_info: Optional[Dict[str, Any]] = None,
-        serverless_config: Optional[Dict[str, Any]] = None,
-        encryption_info: Optional[Dict[str, Any]] = None,
+        configuration_info: Optional[dict[str, Any]] = None,
+        serverless_config: Optional[dict[str, Any]] = None,
+        encryption_info: Optional[dict[str, Any]] = None,
         enhanced_monitoring: str = "DEFAULT",
-        open_monitoring: Optional[Dict[str, Any]] = None,
-        logging_info: Optional[Dict[str, Any]] = None,
+        open_monitoring: Optional[dict[str, Any]] = None,
+        logging_info: Optional[dict[str, Any]] = None,
         storage_mode: str = "LOCAL",
         current_version: str = "1.0",
-        client_authentication: Optional[Dict[str, Any]] = None,
+        client_authentication: Optional[dict[str, Any]] = None,
         state: str = "CREATING",
         active_operation_arn: Optional[str] = None,
         zookeeper_connect_string: Optional[str] = None,
@@ -79,16 +79,16 @@ class KafkaBackend(BaseBackend):
 
     def __init__(self, region_name: str, account_id: str):
         super().__init__(region_name, account_id)
-        self.clusters: Dict[str, FakeKafkaCluster] = {}
+        self.clusters: dict[str, FakeKafkaCluster] = {}
         self.tagger = TaggingService()
 
     def create_cluster_v2(
         self,
         cluster_name: str,
-        tags: Optional[Dict[str, str]],
-        provisioned: Optional[Dict[str, Any]],
-        serverless: Optional[Dict[str, Any]],
-    ) -> Tuple[str, str, str, str]:
+        tags: Optional[dict[str, str]],
+        provisioned: Optional[dict[str, Any]],
+        serverless: Optional[dict[str, Any]],
+    ) -> tuple[str, str, str, str]:
         if provisioned:
             cluster_type = "PROVISIONED"
             broker_node_group_info = provisioned.get("brokerNodeGroupInfo")
@@ -131,10 +131,10 @@ class KafkaBackend(BaseBackend):
             new_cluster.cluster_type,
         )
 
-    def describe_cluster_v2(self, cluster_arn: str) -> Dict[str, Any]:
+    def describe_cluster_v2(self, cluster_arn: str) -> dict[str, Any]:
         cluster = self.clusters[cluster_arn]
 
-        cluster_info: Dict[str, Any] = {
+        cluster_info: dict[str, Any] = {
             "activeOperationArn": "arn:aws:kafka:region:account-id:operation/active-operation",
             "clusterArn": cluster.arn,
             "clusterName": cluster.cluster_name,
@@ -203,7 +203,7 @@ class KafkaBackend(BaseBackend):
         cluster_type_filter: Optional[str],
         max_results: Optional[int],
         next_token: Optional[str],
-    ) -> Tuple[List[Dict[str, Any]], Optional[str]]:
+    ) -> tuple[list[dict[str, Any]], Optional[str]]:
         cluster_info_list = []
         for cluster_arn in self.clusters.keys():
             cluster_info = self.describe_cluster_v2(cluster_arn)
@@ -213,19 +213,19 @@ class KafkaBackend(BaseBackend):
 
     def create_cluster(
         self,
-        broker_node_group_info: Dict[str, Any],
-        client_authentication: Optional[Dict[str, Any]],
+        broker_node_group_info: dict[str, Any],
+        client_authentication: Optional[dict[str, Any]],
         cluster_name: str,
-        configuration_info: Optional[Dict[str, Any]] = None,
-        encryption_info: Optional[Dict[str, Any]] = None,
+        configuration_info: Optional[dict[str, Any]] = None,
+        encryption_info: Optional[dict[str, Any]] = None,
         enhanced_monitoring: str = "DEFAULT",
-        open_monitoring: Optional[Dict[str, Any]] = None,
+        open_monitoring: Optional[dict[str, Any]] = None,
         kafka_version: str = "2.8.1",
-        logging_info: Optional[Dict[str, Any]] = None,
+        logging_info: Optional[dict[str, Any]] = None,
         number_of_broker_nodes: int = 1,
-        tags: Optional[Dict[str, str]] = None,
+        tags: Optional[dict[str, str]] = None,
         storage_mode: str = "LOCAL",
-    ) -> Tuple[str, str, str]:
+    ) -> tuple[str, str, str]:
         new_cluster = FakeKafkaCluster(
             cluster_name=cluster_name,
             account_id=self.account_id,
@@ -250,7 +250,7 @@ class KafkaBackend(BaseBackend):
 
         return new_cluster.arn, new_cluster.cluster_name, new_cluster.state
 
-    def describe_cluster(self, cluster_arn: str) -> Dict[str, Any]:
+    def describe_cluster(self, cluster_arn: str) -> dict[str, Any]:
         cluster = self.clusters[cluster_arn]
 
         return {
@@ -294,7 +294,7 @@ class KafkaBackend(BaseBackend):
         cluster_name_filter: Optional[str],
         max_results: Optional[int],
         next_token: Optional[str],
-    ) -> List[Dict[str, Any]]:
+    ) -> list[dict[str, Any]]:
         cluster_info_list = [
             {
                 "clusterArn": cluster.arn,
@@ -308,18 +308,18 @@ class KafkaBackend(BaseBackend):
 
         return cluster_info_list
 
-    def delete_cluster(self, cluster_arn: str, current_version: str) -> Tuple[str, str]:
+    def delete_cluster(self, cluster_arn: str, current_version: str) -> tuple[str, str]:
         cluster = self.clusters.pop(cluster_arn)
         return cluster_arn, cluster.state
 
-    def list_tags_for_resource(self, resource_arn: str) -> Dict[str, str]:
+    def list_tags_for_resource(self, resource_arn: str) -> dict[str, str]:
         return self.tagger.get_tag_dict_for_resource(resource_arn)
 
-    def tag_resource(self, resource_arn: str, tags: Dict[str, str]) -> None:
+    def tag_resource(self, resource_arn: str, tags: dict[str, str]) -> None:
         tags_list = [{"Key": k, "Value": v} for k, v in tags.items()]
         self.tagger.tag_resource(resource_arn, tags_list)
 
-    def untag_resource(self, resource_arn: str, tag_keys: List[str]) -> None:
+    def untag_resource(self, resource_arn: str, tag_keys: list[str]) -> None:
         self.tagger.untag_resource_using_names(resource_arn, tag_keys)
 
 

--- a/moto/kinesis/models.py
+++ b/moto/kinesis/models.py
@@ -5,9 +5,10 @@ import json
 import re
 from base64 import b64decode, b64encode
 from collections import OrderedDict
+from collections.abc import Iterable
 from gzip import GzipFile
 from operator import attrgetter
-from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Optional, Tuple
+from typing import TYPE_CHECKING, Any, Optional
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel, CloudFormationModel
@@ -53,7 +54,7 @@ class Consumer(BaseModel):
         stream_name = stream_arn.split("/")[-1]
         self.consumer_arn = f"arn:{get_partition(region_name)}:kinesis:{region_name}:{account_id}:stream/{stream_name}/consumer/{consumer_name}"
 
-    def to_json(self, include_stream_arn: bool = False) -> Dict[str, Any]:
+    def to_json(self, include_stream_arn: bool = False) -> dict[str, Any]:
         resp = {
             "ConsumerName": self.consumer_name,
             "ConsumerARN": self.consumer_arn,
@@ -80,7 +81,7 @@ class Record(BaseModel):
         self.created_at_datetime = utcnow()
         self.created_at = unix_time(self.created_at_datetime)
 
-    def to_json(self) -> Dict[str, Any]:
+    def to_json(self) -> dict[str, Any]:
         return {
             "Data": self.data,
             "PartitionKey": self.partition_key,
@@ -101,7 +102,7 @@ class Shard(BaseModel):
         self._shard_id = shard_id
         self.starting_hash = starting_hash
         self.ending_hash = ending_hash
-        self.records: Dict[int, Record] = OrderedDict()
+        self.records: dict[int, Record] = OrderedDict()
         self.is_open = True
         self.parent = parent
         self.adjacent_parent = adjacent_parent
@@ -112,7 +113,7 @@ class Shard(BaseModel):
 
     def get_records(
         self, last_sequence_id: str, limit: Optional[int]
-    ) -> Tuple[List[Record], int, int]:
+    ) -> tuple[list[Record], int, int]:
         last_sequence_int = int(last_sequence_id)
         results = []
         secs_behind_latest = 0.0
@@ -169,8 +170,8 @@ class Shard(BaseModel):
             )
             return r.sequence_number  # type: ignore
 
-    def to_json(self) -> Dict[str, Any]:
-        response: Dict[str, Any] = {
+    def to_json(self) -> dict[str, Any]:
+        response: dict[str, Any] = {
             "HashKeyRange": {
                 "EndingHashKey": str(self.ending_hash),
                 "StartingHashKey": str(self.starting_hash),
@@ -196,7 +197,7 @@ class Stream(CloudFormationModel):
         self,
         stream_name: str,
         shard_count: int,
-        stream_mode: Optional[Dict[str, str]],
+        stream_mode: Optional[dict[str, str]],
         retention_period_hours: Optional[int],
         account_id: str,
         region_name: str,
@@ -208,8 +209,8 @@ class Stream(CloudFormationModel):
         self.region = region_name
         self.account_id = account_id
         self.arn = f"arn:{get_partition(region_name)}:kinesis:{region_name}:{account_id}:stream/{stream_name}"
-        self.shards: Dict[str, Shard] = {}
-        self.tags: Dict[str, str] = {}
+        self.shards: dict[str, Shard] = {}
+        self.tags: dict[str, str] = {}
         self.status = "ACTIVE"
         self.shard_count: Optional[int] = None
         self.stream_mode = stream_mode or {"StreamMode": "PROVISIONED"}
@@ -217,11 +218,11 @@ class Stream(CloudFormationModel):
             shard_count = 4
         self.init_shards(shard_count)
         self.retention_period_hours = retention_period_hours or 24
-        self.shard_level_metrics: List[str] = []
+        self.shard_level_metrics: list[str] = []
         self.encryption_type = "NONE"
         self.key_id: Optional[str] = None
-        self.consumers: List[Consumer] = []
-        self.lambda_event_source_mappings: Dict[str, "EventSourceMapping"] = {}
+        self.consumers: list[Consumer] = []
+        self.lambda_event_source_mappings: dict[str, EventSourceMapping] = {}
 
     def delete_consumer(self, consumer_arn: str) -> None:
         self.consumers = [c for c in self.consumers if c.consumer_arn != consumer_arn]
@@ -409,7 +410,7 @@ class Stream(CloudFormationModel):
 
     def put_record(
         self, partition_key: str, explicit_hash_key: str, data: str
-    ) -> Tuple[str, str]:
+    ) -> tuple[str, str]:
         shard: Shard = self.get_shard_for_key(partition_key, explicit_hash_key)  # type: ignore
 
         sequence_number = shard.put_record(partition_key, data, explicit_hash_key)
@@ -430,7 +431,7 @@ class Stream(CloudFormationModel):
 
         return sequence_number, shard.shard_id
 
-    def to_json(self, shard_limit: Optional[int] = None) -> Dict[str, Any]:
+    def to_json(self, shard_limit: Optional[int] = None) -> dict[str, Any]:
         all_shards = list(self.shards.values())
         requested_shards = all_shards[0 : shard_limit or len(all_shards)]
         return {
@@ -448,7 +449,7 @@ class Stream(CloudFormationModel):
             }
         }
 
-    def to_json_summary(self) -> Dict[str, Any]:
+    def to_json_summary(self) -> dict[str, Any]:
         return {
             "StreamDescriptionSummary": {
                 "StreamARN": self.arn,
@@ -556,7 +557,7 @@ class Stream(CloudFormationModel):
         backend.delete_stream(stream_arn=None, stream_name=resource_name)
 
     @staticmethod
-    def is_replacement_update(properties: List[str]) -> bool:
+    def is_replacement_update(properties: list[str]) -> bool:
         properties_requiring_replacement_update = ["BucketName", "ObjectLockEnabled"]
         return any(
             [
@@ -584,13 +585,13 @@ class Stream(CloudFormationModel):
 class KinesisBackend(BaseBackend):
     def __init__(self, region_name: str, account_id: str):
         super().__init__(region_name, account_id)
-        self.streams: Dict[str, Stream] = OrderedDict()
-        self.resource_policies: Dict[str, str] = {}
+        self.streams: dict[str, Stream] = OrderedDict()
+        self.resource_policies: dict[str, str] = {}
 
     @staticmethod
     def default_vpc_endpoint_service(
-        service_region: str, zones: List[str]
-    ) -> List[Dict[str, str]]:
+        service_region: str, zones: list[str]
+    ) -> list[dict[str, str]]:
         """Default VPC endpoint service."""
         return BaseBackend.default_vpc_endpoint_service_factory(
             service_region, zones, "kinesis", special_service_name="kinesis-streams"
@@ -600,7 +601,7 @@ class KinesisBackend(BaseBackend):
         self,
         stream_name: str,
         shard_count: int,
-        stream_mode: Optional[Dict[str, str]] = None,
+        stream_mode: Optional[dict[str, str]] = None,
         retention_period_hours: Optional[int] = None,
     ) -> Stream:
         if stream_name in self.streams:
@@ -672,7 +673,7 @@ class KinesisBackend(BaseBackend):
 
     def get_records(
         self, stream_arn: Optional[str], shard_iterator: str, limit: Optional[int]
-    ) -> Tuple[str, List[Record], int]:
+    ) -> tuple[str, list[Record], int]:
         decomposed = decompose_shard_iterator(shard_iterator)
         stream_name, shard_id, last_sequence_id = decomposed
 
@@ -698,7 +699,7 @@ class KinesisBackend(BaseBackend):
         partition_key: str,
         explicit_hash_key: str,
         data: str,
-    ) -> Tuple[str, str]:
+    ) -> tuple[str, str]:
         stream = self.describe_stream(stream_arn=stream_arn, stream_name=stream_name)
 
         sequence_number, shard_id = stream.put_record(
@@ -708,11 +709,11 @@ class KinesisBackend(BaseBackend):
         return sequence_number, shard_id
 
     def put_records(
-        self, stream_arn: str, stream_name: str, records: List[Dict[str, Any]]
-    ) -> Dict[str, Any]:
+        self, stream_arn: str, stream_name: str, records: list[dict[str, Any]]
+    ) -> dict[str, Any]:
         stream = self.describe_stream(stream_arn=stream_arn, stream_name=stream_name)
 
-        response: Dict[str, Any] = {"FailedRecordCount": 0, "Records": []}
+        response: dict[str, Any] = {"FailedRecordCount": 0, "Records": []}
 
         if len(records) > 500:
             raise TooManyRecords
@@ -811,7 +812,7 @@ class KinesisBackend(BaseBackend):
     @paginate(pagination_model=PAGINATION_MODEL)
     def list_shards(
         self, stream_arn: Optional[str], stream_name: Optional[str]
-    ) -> List[Shard]:
+    ) -> list[Shard]:
         stream = self.describe_stream(stream_arn=stream_arn, stream_name=stream_name)
         return sorted(stream.shards.values(), key=lambda x: x.shard_id)
 
@@ -859,11 +860,11 @@ class KinesisBackend(BaseBackend):
         stream_name: str,
         exclusive_start_tag_key: Optional[str] = None,
         limit: Optional[int] = None,
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         stream = self.describe_stream(stream_arn=stream_arn, stream_name=stream_name)
 
-        tags: List[Dict[str, str]] = []
-        result: Dict[str, Any] = {"HasMoreTags": False, "Tags": tags}
+        tags: list[dict[str, str]] = []
+        result: dict[str, Any] = {"HasMoreTags": False, "Tags": tags}
         for key, val in sorted(stream.tags.items(), key=lambda x: x[0]):
             if limit and len(tags) >= limit:
                 result["HasMoreTags"] = True
@@ -879,13 +880,13 @@ class KinesisBackend(BaseBackend):
         self,
         stream_arn: Optional[str],
         stream_name: Optional[str],
-        tags: Dict[str, str],
+        tags: dict[str, str],
     ) -> None:
         stream = self.describe_stream(stream_arn=stream_arn, stream_name=stream_name)
         stream.tags.update(tags)
 
     def remove_tags_from_stream(
-        self, stream_arn: Optional[str], stream_name: Optional[str], tag_keys: List[str]
+        self, stream_arn: Optional[str], stream_name: Optional[str], tag_keys: list[str]
     ) -> None:
         stream = self.describe_stream(stream_arn=stream_arn, stream_name=stream_name)
         for key in tag_keys:
@@ -896,8 +897,8 @@ class KinesisBackend(BaseBackend):
         self,
         stream_arn: Optional[str],
         stream_name: Optional[str],
-        shard_level_metrics: List[str],
-    ) -> Tuple[str, str, List[str], List[str]]:
+        shard_level_metrics: list[str],
+    ) -> tuple[str, str, list[str], list[str]]:
         stream = self.describe_stream(stream_arn=stream_arn, stream_name=stream_name)
         current_shard_level_metrics = stream.shard_level_metrics
         desired_metrics = list(set(current_shard_level_metrics + shard_level_metrics))
@@ -913,8 +914,8 @@ class KinesisBackend(BaseBackend):
         self,
         stream_arn: Optional[str],
         stream_name: Optional[str],
-        to_be_disabled: List[str],
-    ) -> Tuple[str, str, List[str], List[str]]:
+        to_be_disabled: list[str],
+    ) -> tuple[str, str, list[str], list[str]]:
         stream = self.describe_stream(stream_arn=stream_arn, stream_name=stream_name)
         current_metrics = stream.shard_level_metrics
         if "ALL" in to_be_disabled:
@@ -931,7 +932,7 @@ class KinesisBackend(BaseBackend):
             if stream.arn == stream_arn:
                 return stream
 
-    def list_stream_consumers(self, stream_arn: str) -> List[Consumer]:
+    def list_stream_consumers(self, stream_arn: str) -> list[Consumer]:
         """
         Pagination is not yet implemented
         """
@@ -989,7 +990,7 @@ class KinesisBackend(BaseBackend):
         stream.encryption_type = "NONE"
         stream.key_id = None
 
-    def update_stream_mode(self, stream_arn: str, stream_mode: Dict[str, str]) -> None:
+    def update_stream_mode(self, stream_arn: str, stream_mode: dict[str, str]) -> None:
         stream = self._find_stream_by_arn(stream_arn)
         stream.stream_mode = stream_mode
 
@@ -1001,7 +1002,7 @@ class KinesisBackend(BaseBackend):
         filter_name: str,
         log_group_name: str,
         log_stream_name: str,
-        log_events: List[Dict[str, Any]],
+        log_events: list[dict[str, Any]],
     ) -> None:
         data = {
             "logEvents": log_events,

--- a/moto/kinesis/utils.py
+++ b/moto/kinesis/utils.py
@@ -1,6 +1,6 @@
 import base64
 from datetime import datetime
-from typing import Any, List, Optional
+from typing import Any, Optional
 
 from .exceptions import InvalidArgumentError
 
@@ -45,9 +45,9 @@ def compose_shard_iterator(
     stream_name: Optional[str], shard: Any, last_sequence_id: int
 ) -> str:
     return encode_method(
-        f"{stream_name}:{shard.shard_id}:{last_sequence_id}".encode("utf-8")
+        f"{stream_name}:{shard.shard_id}:{last_sequence_id}".encode()
     ).decode("utf-8")
 
 
-def decompose_shard_iterator(shard_iterator: str) -> List[str]:
+def decompose_shard_iterator(shard_iterator: str) -> list[str]:
     return decode_method(shard_iterator.encode("utf-8")).decode("utf-8").split(":")

--- a/moto/kinesisanalyticsv2/models.py
+++ b/moto/kinesisanalyticsv2/models.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import random
 from datetime import datetime
-from typing import Any, Dict, List, Optional
+from typing import Any, Optional
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
@@ -21,8 +21,8 @@ class Application(BaseModel):
         application_description: Optional[str],
         runtime_environment: str,
         service_execution_role: str,
-        application_configuration: Optional[Dict[str, Any]],
-        cloud_watch_logging_options: Optional[List[Dict[str, str]]],
+        application_configuration: Optional[dict[str, Any]],
+        cloud_watch_logging_options: Optional[list[dict[str, str]]],
         application_mode: Optional[str],
     ):
         self.account_id = account_id
@@ -53,8 +53,8 @@ class Application(BaseModel):
         return f"arn:aws:kinesisanalytics:{self.region_name}:{self.account_id}:application/{self.application_name}"
 
     def _generate_logging_options(
-        self, cloud_watch_logging_options: Optional[List[Dict[str, str]]]
-    ) -> List[Dict[str, str]] | None:
+        self, cloud_watch_logging_options: Optional[list[dict[str, str]]]
+    ) -> list[dict[str, str]] | None:
         cloud_watch_logging_option_descriptions = []
         option_id = f"{str(random.randint(1, 100))}.1"
 
@@ -77,8 +77,8 @@ class Application(BaseModel):
     # - "SqlApplicationConfigurationDescription" (discontinued)
     # - "RunConfigurationDescription" (which requires start_application)
     def _generate_app_config_description(
-        self, app_config: Dict[str, Any]
-    ) -> Dict[str, Any]:
+        self, app_config: dict[str, Any]
+    ) -> dict[str, Any]:
         # Keys that do not have extra values in the description besides renamed keys
         UPDATABLE_APP_CONFIG_TOP_LEVEL_KEYS = {
             "EnvironmentProperties": "EnvironmentPropertyDescriptions",
@@ -148,8 +148,8 @@ class Application(BaseModel):
         return app_config_description
 
     def __generate_flink_app_description(
-        self, app_config: Dict[str, Any]
-    ) -> Dict[str, Any]:
+        self, app_config: dict[str, Any]
+    ) -> dict[str, Any]:
         flink_config_description = {}
         flink_config = app_config.get("FlinkApplicationConfiguration")
         if flink_config and isinstance(flink_config, dict):
@@ -216,7 +216,7 @@ class Application(BaseModel):
                     }
         return flink_config_description
 
-    def __update_keys(self, old_dict: Any, key_map: Dict[str, str]) -> Any:
+    def __update_keys(self, old_dict: Any, key_map: dict[str, str]) -> Any:
         if not isinstance(old_dict, dict):
             return old_dict
 
@@ -241,7 +241,7 @@ class KinesisAnalyticsV2Backend(BaseBackend):
 
     def __init__(self, region_name: str, account_id: str) -> None:
         super().__init__(region_name, account_id)
-        self.applications: Dict[str, Application] = {}
+        self.applications: dict[str, Application] = {}
         self.tagger = TaggingService(
             tag_name="Tags", key_name="Key", value_name="Value"
         )
@@ -252,11 +252,11 @@ class KinesisAnalyticsV2Backend(BaseBackend):
         application_description: Optional[str],
         runtime_environment: str,
         service_execution_role: str,
-        application_configuration: Optional[Dict[str, Any]],
-        cloud_watch_logging_options: Optional[List[Dict[str, str]]],
-        tags: Optional[List[Dict[str, str]]],
+        application_configuration: Optional[dict[str, Any]],
+        cloud_watch_logging_options: Optional[list[dict[str, str]]],
+        tags: Optional[list[dict[str, str]]],
         application_mode: Optional[str],
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         app = Application(
             account_id=self.account_id,
             region_name=self.region_name,
@@ -293,16 +293,16 @@ class KinesisAnalyticsV2Backend(BaseBackend):
             "ApplicationMode": app.application_mode,
         }
 
-    def tag_resource(self, resource_arn: str, tags: List[Dict[str, str]]) -> None:
+    def tag_resource(self, resource_arn: str, tags: list[dict[str, str]]) -> None:
         self.tagger.tag_resource(resource_arn, tags)
 
-    def list_tags_for_resource(self, resource_arn: str) -> List[Dict[str, str]]:
+    def list_tags_for_resource(self, resource_arn: str) -> list[dict[str, str]]:
         return self.tagger.list_tags_for_resource(resource_arn)["Tags"]
 
     def describe_application(
         self,
         application_name: str,
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         app = self.applications[application_name]
         return {
             "ApplicationARN": app.application_arn,
@@ -324,7 +324,7 @@ class KinesisAnalyticsV2Backend(BaseBackend):
             "ApplicationMode": app.application_mode,
         }
 
-    def list_applications(self) -> List[Dict[str, Any]]:
+    def list_applications(self) -> list[dict[str, Any]]:
         application_summaries = [
             {
                 "ApplicationName": app.application_name,

--- a/moto/kinesisvideo/models.py
+++ b/moto/kinesisvideo/models.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List
+from typing import Any
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
@@ -19,7 +19,7 @@ class Stream(BaseModel):
         media_type: str,
         kms_key_id: str,
         data_retention_in_hours: int,
-        tags: Dict[str, str],
+        tags: dict[str, str],
     ):
         self.region_name = region_name
         self.stream_name = stream_name
@@ -39,7 +39,7 @@ class Stream(BaseModel):
         data_endpoint_prefix = "s-" if api_name in ("PUT_MEDIA", "GET_MEDIA") else "b-"
         return f"https://{data_endpoint_prefix}{self.data_endpoint_number}.kinesisvideo.{self.region_name}.amazonaws.com"
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         return {
             "DeviceName": self.device_name,
             "StreamName": self.stream_name,
@@ -56,7 +56,7 @@ class Stream(BaseModel):
 class KinesisVideoBackend(BaseBackend):
     def __init__(self, region_name: str, account_id: str):
         super().__init__(region_name, account_id)
-        self.streams: Dict[str, Stream] = {}
+        self.streams: dict[str, Stream] = {}
 
     def create_stream(
         self,
@@ -65,7 +65,7 @@ class KinesisVideoBackend(BaseBackend):
         media_type: str,
         kms_key_id: str,
         data_retention_in_hours: int,
-        tags: Dict[str, str],
+        tags: dict[str, str],
     ) -> str:
         streams = [_ for _ in self.streams.values() if _.stream_name == stream_name]
         if len(streams) > 0:
@@ -94,11 +94,11 @@ class KinesisVideoBackend(BaseBackend):
             raise ResourceNotFoundException()
         return stream
 
-    def describe_stream(self, stream_name: str, stream_arn: str) -> Dict[str, Any]:
+    def describe_stream(self, stream_name: str, stream_arn: str) -> dict[str, Any]:
         stream = self._get_stream(stream_name, stream_arn)
         return stream.to_dict()
 
-    def list_streams(self) -> List[Dict[str, Any]]:
+    def list_streams(self) -> list[dict[str, Any]]:
         """
         Pagination and the StreamNameCondition-parameter are not yet implemented
         """

--- a/moto/kinesisvideoarchivedmedia/models.py
+++ b/moto/kinesisvideoarchivedmedia/models.py
@@ -1,5 +1,3 @@
-from typing import Tuple
-
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.kinesisvideo.models import KinesisVideoBackend, kinesisvideo_backends
 from moto.sts.utils import random_session_token
@@ -33,7 +31,7 @@ class KinesisVideoArchivedMediaBackend(BaseBackend):
         api_name = "GET_DASH_STREAMING_SESSION_URL"
         return self._get_streaming_url(stream_name, stream_arn, api_name)
 
-    def get_clip(self, stream_name: str, stream_arn: str) -> Tuple[str, bytes]:
+    def get_clip(self, stream_name: str, stream_arn: str) -> tuple[str, bytes]:
         self.backend._get_stream(stream_name, stream_arn)
         content_type = "video/mp4"  # Fixed content_type as it depends on input stream
         payload = b"sample-mp4-video"

--- a/moto/kinesisvideoarchivedmedia/responses.py
+++ b/moto/kinesisvideoarchivedmedia/responses.py
@@ -1,5 +1,4 @@
 import json
-from typing import Dict, Tuple
 
 from moto.core.responses import BaseResponse
 
@@ -34,7 +33,7 @@ class KinesisVideoArchivedMediaResponse(BaseResponse):
         )
         return json.dumps(dict(DASHStreamingSessionURL=dash_streaming_session_url))
 
-    def get_clip(self) -> Tuple[bytes, Dict[str, str]]:
+    def get_clip(self) -> tuple[bytes, dict[str, str]]:
         stream_name = self._get_param("StreamName")
         stream_arn = self._get_param("StreamARN")
         content_type, payload = self.kinesisvideoarchivedmedia_backend.get_clip(

--- a/moto/kms/models.py
+++ b/moto/kms/models.py
@@ -1,10 +1,10 @@
 import json
 import os
-import typing
 from collections import defaultdict
+from collections.abc import Iterable
 from copy import copy
 from datetime import datetime, timedelta
-from typing import Any, Dict, Iterable, List, Optional, Set, Tuple, Union
+from typing import Any, Optional, Union
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel, CloudFormationModel
@@ -39,8 +39,8 @@ class Grant(BaseModel):
         key_id: str,
         name: str,
         grantee_principal: str,
-        operations: List[str],
-        constraints: Dict[str, Any],
+        operations: list[str],
+        constraints: dict[str, Any],
         retiring_principal: str,
     ):
         self.key_id = key_id
@@ -52,7 +52,7 @@ class Grant(BaseModel):
         self.id = mock_random.get_random_hex()
         self.token = mock_random.get_random_hex()
 
-    def to_json(self) -> Dict[str, Any]:
+    def to_json(self) -> dict[str, Any]:
         return {
             "KeyId": self.key_id,
             "GrantId": self.id,
@@ -87,7 +87,7 @@ class Key(CloudFormationModel):
         self.enabled = True
         self.multi_region = multi_region
         if self.multi_region:
-            self.multi_region_configuration: typing.Dict[str, Any] = {
+            self.multi_region_configuration: dict[str, Any] = {
                 "MultiRegionKeyType": "PRIMARY",
                 "PrimaryKey": {
                     "Arn": f"arn:{get_partition(region)}:kms:{region}:{account_id}:key/{self.id}",
@@ -105,16 +105,16 @@ class Key(CloudFormationModel):
         self.arn = (
             f"arn:{get_partition(region)}:kms:{region}:{account_id}:key/{self.id}"
         )
-        self.grants: Dict[str, Grant] = dict()
+        self.grants: dict[str, Grant] = dict()
 
-        self.rotations: List[Dict[str, Any]] = []
+        self.rotations: list[dict[str, Any]] = []
 
     def add_grant(
         self,
         name: str,
         grantee_principal: str,
-        operations: List[str],
-        constraints: Dict[str, Any],
+        operations: list[str],
+        constraints: dict[str, Any],
         retiring_principal: str,
     ) -> Grant:
         grant = Grant(
@@ -128,11 +128,11 @@ class Key(CloudFormationModel):
         self.grants[grant.id] = grant
         return grant
 
-    def list_grants(self, grant_id: str) -> List[Grant]:
+    def list_grants(self, grant_id: str) -> list[Grant]:
         grant_ids = [grant_id] if grant_id else self.grants.keys()
         return [grant for _id, grant in self.grants.items() if _id in grant_ids]
 
-    def list_retirable_grants(self, retiring_principal: str) -> List[Grant]:
+    def list_retirable_grants(self, retiring_principal: str) -> list[Grant]:
         return [
             grant
             for grant in self.grants.values()
@@ -177,7 +177,7 @@ class Key(CloudFormationModel):
         return self.id
 
     @property
-    def encryption_algorithms(self) -> Optional[List[str]]:
+    def encryption_algorithms(self) -> Optional[list[str]]:
         if self.key_usage == "SIGN_VERIFY":
             return None
         elif self.key_spec == "SYMMETRIC_DEFAULT":
@@ -186,7 +186,7 @@ class Key(CloudFormationModel):
             return ["RSAES_OAEP_SHA_1", "RSAES_OAEP_SHA_256"]
 
     @property
-    def signing_algorithms(self) -> List[str]:
+    def signing_algorithms(self) -> list[str]:
         if self.key_usage == "ENCRYPT_DECRYPT":
             return None  # type: ignore[return-value]
         elif self.key_spec in KeySpec.ecc_key_specs():
@@ -204,7 +204,7 @@ class Key(CloudFormationModel):
         else:
             return []
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         key_dict = {
             "KeyMetadata": {
                 "AWSAccountId": self.account_id,
@@ -292,8 +292,8 @@ class KmsBackend(BaseBackend):
 
     def __init__(self, region_name: str, account_id: Optional[str] = None):
         super().__init__(region_name=region_name, account_id=account_id)  # type: ignore
-        self.keys: Dict[str, Key] = {}
-        self.key_to_aliases: Dict[str, Set[str]] = defaultdict(set)
+        self.keys: dict[str, Key] = {}
+        self.key_to_aliases: dict[str, set[str]] = defaultdict(set)
         self.tagger = TaggingService(key_name="TagKey", value_name="TagValue")
 
     def _generate_default_keys(self, alias_name: str) -> Optional[str]:
@@ -316,7 +316,7 @@ class KmsBackend(BaseBackend):
         key_usage: str,
         key_spec: str,
         description: str,
-        tags: Optional[List[Dict[str, str]]],
+        tags: Optional[list[dict[str, str]]],
         multi_region: bool = False,
         origin: str = "AWS_KMS",
     ) -> Key:
@@ -454,7 +454,7 @@ class KmsBackend(BaseBackend):
             if alias_name in aliases:
                 aliases.remove(alias_name)
 
-    def list_aliases(self) -> Dict[str, Set[str]]:
+    def list_aliases(self) -> dict[str, set[str]]:
         return self.key_to_aliases
 
     def get_key_id_from_alias(self, alias_name: str) -> Optional[str]:
@@ -507,8 +507,8 @@ class KmsBackend(BaseBackend):
             return unix_time(self.keys[key_id].deletion_date)
 
     def encrypt(
-        self, key_id: str, plaintext: bytes, encryption_context: Dict[str, str]
-    ) -> Tuple[bytes, str]:
+        self, key_id: str, plaintext: bytes, encryption_context: dict[str, str]
+    ) -> tuple[bytes, str]:
         key_id = self.any_id_to_key_id(key_id)
 
         ciphertext_blob = encrypt(
@@ -521,8 +521,8 @@ class KmsBackend(BaseBackend):
         return ciphertext_blob, arn
 
     def decrypt(
-        self, ciphertext_blob: bytes, encryption_context: Dict[str, str]
-    ) -> Tuple[bytes, str]:
+        self, ciphertext_blob: bytes, encryption_context: dict[str, str]
+    ) -> tuple[bytes, str]:
         plaintext, key_id = decrypt(
             master_keys=self.keys,
             ciphertext_blob=ciphertext_blob,
@@ -534,10 +534,10 @@ class KmsBackend(BaseBackend):
     def re_encrypt(
         self,
         ciphertext_blob: bytes,
-        source_encryption_context: Dict[str, str],
+        source_encryption_context: dict[str, str],
         destination_key_id: str,
-        destination_encryption_context: Dict[str, str],
-    ) -> Tuple[bytes, str, str]:
+        destination_encryption_context: dict[str, str],
+    ) -> tuple[bytes, str, str]:
         destination_key_id = self.any_id_to_key_id(destination_key_id)
 
         plaintext, decrypting_arn = self.decrypt(
@@ -559,10 +559,10 @@ class KmsBackend(BaseBackend):
     def generate_data_key(
         self,
         key_id: str,
-        encryption_context: Dict[str, str],
+        encryption_context: dict[str, str],
         number_of_bytes: int,
         key_spec: str,
-    ) -> Tuple[bytes, bytes, str]:
+    ) -> tuple[bytes, bytes, str]:
         key_id = self.any_id_to_key_id(key_id)
 
         if key_spec:
@@ -587,7 +587,7 @@ class KmsBackend(BaseBackend):
         # Responses uses 'generate_data_key'
         pass
 
-    def list_resource_tags(self, key_id_or_arn: str) -> Dict[str, List[Dict[str, str]]]:
+    def list_resource_tags(self, key_id_or_arn: str) -> dict[str, list[dict[str, str]]]:
         key_id = self.get_key_id(key_id_or_arn)
         if key_id in self.keys:
             return self.tagger.list_tags_for_resource(key_id)
@@ -596,7 +596,7 @@ class KmsBackend(BaseBackend):
             "The request was rejected because the specified entity or resource could not be found.",
         )
 
-    def tag_resource(self, key_id_or_arn: str, tags: List[Dict[str, str]]) -> None:
+    def tag_resource(self, key_id_or_arn: str, tags: list[dict[str, str]]) -> None:
         key_id = self.get_key_id(key_id_or_arn)
         if key_id in self.keys:
             self.tagger.tag_resource(key_id, tags)
@@ -606,7 +606,7 @@ class KmsBackend(BaseBackend):
             "The request was rejected because the specified entity or resource could not be found.",
         )
 
-    def untag_resource(self, key_id_or_arn: str, tag_names: List[str]) -> None:
+    def untag_resource(self, key_id_or_arn: str, tag_names: list[str]) -> None:
         key_id = self.get_key_id(key_id_or_arn)
         if key_id in self.keys:
             self.tagger.untag_resource_using_names(key_id, tag_names)
@@ -620,11 +620,11 @@ class KmsBackend(BaseBackend):
         self,
         key_id: str,
         grantee_principal: str,
-        operations: List[str],
+        operations: list[str],
         name: str,
-        constraints: Dict[str, Any],
+        constraints: dict[str, Any],
         retiring_principal: str,
-    ) -> Tuple[str, str]:
+    ) -> tuple[str, str]:
         key = self.describe_key(key_id)
         grant = key.add_grant(
             name,
@@ -635,11 +635,11 @@ class KmsBackend(BaseBackend):
         )
         return grant.id, grant.token
 
-    def list_grants(self, key_id: str, grant_id: str) -> List[Grant]:
+    def list_grants(self, key_id: str, grant_id: str) -> list[Grant]:
         key = self.describe_key(key_id)
         return key.list_grants(grant_id)
 
-    def list_retirable_grants(self, retiring_principal: str) -> List[Grant]:
+    def list_retirable_grants(self, retiring_principal: str) -> list[Grant]:
         grants = []
         for key in self.keys.values():
             grants.extend(key.list_retirable_grants(retiring_principal))
@@ -660,10 +660,8 @@ class KmsBackend(BaseBackend):
     def __ensure_valid_sign_and_verify_key(self, key: Key) -> None:
         if key.key_usage != "SIGN_VERIFY":
             raise ValidationException(
-                (
-                    "1 validation error detected: Value '{key_id}' at 'KeyId' failed "
-                    "to satisfy constraint: Member must point to a key with usage: 'SIGN_VERIFY'"
-                ).format(key_id=key.id)
+                f"1 validation error detected: Value '{key.id}' at 'KeyId' failed "
+                "to satisfy constraint: Member must point to a key with usage: 'SIGN_VERIFY'"
             )
 
     def __ensure_valid_signing_algorithm(
@@ -671,29 +669,22 @@ class KmsBackend(BaseBackend):
     ) -> None:
         if signing_algorithm not in key.signing_algorithms:
             raise ValidationException(
-                (
-                    "1 validation error detected: Value '{signing_algorithm}' at 'SigningAlgorithm' failed "
-                    "to satisfy constraint: Member must satisfy enum value set: "
-                    "{valid_sign_algorithms}"
-                ).format(
-                    signing_algorithm=signing_algorithm,
-                    valid_sign_algorithms=key.signing_algorithms,
-                )
+                f"1 validation error detected: Value '{signing_algorithm}' at 'SigningAlgorithm' failed "
+                "to satisfy constraint: Member must satisfy enum value set: "
+                f"{key.signing_algorithms}"
             )
 
     def __ensure_valid_key_spec(self, key_spec: str) -> None:
         if key_spec not in KeySpec.key_specs():
             raise ValidationException(
-                (
-                    "1 validation error detected: Value '{key_spec}' at 'KeySpec' failed "
-                    "to satisfy constraint: Member must satisfy enum value set: "
-                    "{valid_key_specs}"
-                ).format(key_spec=key_spec, valid_key_specs=KeySpec.key_specs())
+                f"1 validation error detected: Value '{key_spec}' at 'KeySpec' failed "
+                "to satisfy constraint: Member must satisfy enum value set: "
+                f"{KeySpec.key_specs()}"
             )
 
     def sign(
         self, key_id: str, message: bytes, signing_algorithm: str
-    ) -> Tuple[str, bytes, str]:
+    ) -> tuple[str, bytes, str]:
         """
         Sign message using generated private key.
 
@@ -710,7 +701,7 @@ class KmsBackend(BaseBackend):
 
     def verify(
         self, key_id: str, message: bytes, signature: bytes, signing_algorithm: str
-    ) -> Tuple[str, bool, str]:
+    ) -> tuple[str, bool, str]:
         """
         Verify message using public key from generated private key.
 
@@ -724,14 +715,9 @@ class KmsBackend(BaseBackend):
 
         if signing_algorithm not in key.signing_algorithms:
             raise ValidationException(
-                (
-                    "1 validation error detected: Value '{signing_algorithm}' at 'SigningAlgorithm' failed "
-                    "to satisfy constraint: Member must satisfy enum value set: "
-                    "{valid_sign_algorithms}"
-                ).format(
-                    signing_algorithm=signing_algorithm,
-                    valid_sign_algorithms=key.signing_algorithms,
-                )
+                f"1 validation error detected: Value '{signing_algorithm}' at 'SigningAlgorithm' failed "
+                "to satisfy constraint: Member must satisfy enum value set: "
+                f"{key.signing_algorithms}"
             )
 
         return (
@@ -740,7 +726,7 @@ class KmsBackend(BaseBackend):
             signing_algorithm,
         )
 
-    def get_public_key(self, key_id: str) -> Tuple[Key, bytes]:
+    def get_public_key(self, key_id: str) -> tuple[Key, bytes]:
         key = self.describe_key(key_id)
         return key, key.private_key.public_key()
 
@@ -761,7 +747,7 @@ class KmsBackend(BaseBackend):
     @paginate(PAGINATION_MODEL)
     def list_key_rotations(
         self, key_id: str, limit: int, next_marker: str
-    ) -> List[Dict[str, Union[str, float]]]:
+    ) -> list[dict[str, Union[str, float]]]:
         key: Key = self.keys[self.get_key_id(key_id)]
 
         return key.rotations
@@ -771,9 +757,9 @@ class KmsBackend(BaseBackend):
         message: bytes,
         key_id: str,
         mac_algorithm: str,
-        grant_tokens: List[str],
+        grant_tokens: list[str],
         dry_run: bool,
-    ) -> Tuple[str, str, str]:
+    ) -> tuple[str, str, str]:
         key = self.keys[key_id]
 
         if (
@@ -793,7 +779,7 @@ class KmsBackend(BaseBackend):
         key_id: str,
         mac_algorithm: str,
         mac: str,
-        grant_tokens: List[str],
+        grant_tokens: list[str],
         dry_run: bool,
     ) -> None:
         regenerated_mac, _, _ = self.generate_mac(

--- a/moto/kms/policy_validator.py
+++ b/moto/kms/policy_validator.py
@@ -1,6 +1,6 @@
 import json
 from collections import defaultdict
-from typing import Any, Dict, List
+from typing import Any
 
 from .exceptions import AccessDeniedException
 from .models import Key
@@ -30,13 +30,13 @@ def validate_policy(key: Key, action: str) -> None:
             )
 
 
-def check_statement(statement: Dict[str, Any], resource: str, action: str) -> bool:
+def check_statement(statement: dict[str, Any], resource: str, action: str) -> bool:
     return action_matches(statement.get("Action", []), action) and resource_matches(
         statement.get("Resource", ""), resource
     )
 
 
-def action_matches(applicable_actions: List[str], action: str) -> bool:
+def action_matches(applicable_actions: list[str], action: str) -> bool:
     alternatives = ALTERNATIVE_ACTIONS[action]
     if any(alt in applicable_actions for alt in alternatives):
         return True

--- a/moto/kms/responses.py
+++ b/moto/kms/responses.py
@@ -2,7 +2,7 @@ import base64
 import json
 import os
 import re
-from typing import Any, Dict
+from typing import Any
 
 from moto.core.responses import BaseResponse
 from moto.kms.utils import RESERVED_ALIASE_TARGET_KEY_IDS, RESERVED_ALIASES
@@ -177,7 +177,7 @@ class KmsResponse(BaseResponse):
         key_id = self._get_param("KeyId")
         self._validate_cmk_id(key_id)
 
-        tags: Dict[str, Any] = self.kms_backend.list_resource_tags(key_id)
+        tags: dict[str, Any] = self.kms_backend.list_resource_tags(key_id)
         tags.update({"NextMarker": None, "Truncated": False})
         return json.dumps(tags)
 
@@ -555,20 +555,16 @@ class KmsResponse(BaseResponse):
 
         if number_of_bytes and (number_of_bytes > 1024 or number_of_bytes < 1):
             raise ValidationException(
-                (
-                    "1 validation error detected: Value '{number_of_bytes:d}' at 'numberOfBytes' failed "
-                    "to satisfy constraint: Member must have value less than or "
-                    "equal to 1024"
-                ).format(number_of_bytes=number_of_bytes)
+                f"1 validation error detected: Value '{number_of_bytes:d}' at 'numberOfBytes' failed "
+                "to satisfy constraint: Member must have value less than or "
+                "equal to 1024"
             )
 
         if key_spec and key_spec not in ("AES_256", "AES_128"):
             raise ValidationException(
-                (
-                    "1 validation error detected: Value '{key_spec}' at 'keySpec' failed "
-                    "to satisfy constraint: Member must satisfy enum value set: "
-                    "[AES_256, AES_128]"
-                ).format(key_spec=key_spec)
+                f"1 validation error detected: Value '{key_spec}' at 'keySpec' failed "
+                "to satisfy constraint: Member must satisfy enum value set: "
+                "[AES_256, AES_128]"
             )
         if not key_spec and not number_of_bytes:
             raise ValidationException(
@@ -641,11 +637,9 @@ class KmsResponse(BaseResponse):
 
         if number_of_bytes and (number_of_bytes > 1024 or number_of_bytes < 1):
             raise ValidationException(
-                (
-                    "1 validation error detected: Value '{number_of_bytes:d}' at 'numberOfBytes' failed "
-                    "to satisfy constraint: Member must have value less than or "
-                    "equal to 1024"
-                ).format(number_of_bytes=number_of_bytes)
+                f"1 validation error detected: Value '{number_of_bytes:d}' at 'numberOfBytes' failed "
+                "to satisfy constraint: Member must have value less than or "
+                "equal to 1024"
             )
 
         entropy = os.urandom(number_of_bytes)

--- a/moto/lakeformation/models.py
+++ b/moto/lakeformation/models.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 from collections import defaultdict
 from enum import Enum
-from typing import Any, Dict, List, Optional, Set, Tuple
+from typing import Any, Optional
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
@@ -24,7 +24,7 @@ class Resource(BaseModel):
         self.arn = arn
         self.role_arn = role_arn
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         return {
             "ResourceArn": self.arn,
             "RoleArn": self.role_arn,
@@ -34,10 +34,10 @@ class Resource(BaseModel):
 class Permission:
     def __init__(
         self,
-        principal: Dict[str, str],
-        resource: Dict[str, Any],
-        permissions: List[str],
-        permissions_with_grant_options: List[str],
+        principal: dict[str, str],
+        resource: dict[str, Any],
+        permissions: list[str],
+        permissions_with_grant_options: list[str],
     ):
         self.principal = principal
         self.resource = resource
@@ -93,7 +93,7 @@ class Permission:
             len(self.permissions) == 0 and len(self.permissions_with_grant_options) == 0
         )
 
-    def to_external_form(self) -> Dict[str, Any]:
+    def to_external_form(self) -> dict[str, Any]:
         return {
             "Permissions": self.permissions,
             "PermissionsWithGrantOption": self.permissions_with_grant_options,
@@ -104,7 +104,7 @@ class Permission:
 
 class PermissionCatalog:
     def __init__(self) -> None:
-        self.permissions: Set[Permission] = set()
+        self.permissions: set[Permission] = set()
 
     def add_permission(self, permission: Permission) -> None:
         for existing_permission in self.permissions:
@@ -141,7 +141,7 @@ class ListPermissionsResourceTable:
         database_name: str,
         name: Optional[str],
         table_wildcard: Optional[
-            Dict[str, str]
+            dict[str, str]
         ],  # Placeholder type, table_wildcard is an empty dict in docs
     ):
         if name is None and table_wildcard is None:
@@ -155,7 +155,7 @@ class ListPermissionsResourceTable:
 
 
 class ExcludedColumnNames:
-    def __init__(self, excluded_column_names: List[str]):
+    def __init__(self, excluded_column_names: list[str]):
         self.excluded_column_names = excluded_column_names
 
 
@@ -165,7 +165,7 @@ class ListPermissionsResourceTableWithColumns:
         catalog_id: Optional[str],
         database_name: str,
         name: str,
-        column_names: List[str],
+        column_names: list[str],
         column_wildcard: ExcludedColumnNames,
     ):
         self.database_name = database_name
@@ -192,20 +192,20 @@ class ListPermissionsResourceDataCellsFilter:
 
 
 class ListPermissionsResourceLFTag:
-    def __init__(self, catalog_id: str, tag_key: str, tag_values: List[str]):
+    def __init__(self, catalog_id: str, tag_key: str, tag_values: list[str]):
         self.catalog_id = catalog_id
         self.tag_key = tag_key
         self.tag_values = tag_values
 
 
 class LFTag:
-    def __init__(self, tag_key: str, tag_values: List[str]):
+    def __init__(self, tag_key: str, tag_values: list[str]):
         self.tag_key = tag_key
         self.tag_values = tag_values
 
 
 class ListPermissionsResourceLFTagPolicy:
-    def __init__(self, catalog_id: str, resource_type: str, expression: List[LFTag]):
+    def __init__(self, catalog_id: str, resource_type: str, expression: list[LFTag]):
         self.catalog_id = catalog_id
         self.resource_type = resource_type
         self.expression = expression
@@ -215,7 +215,7 @@ class ListPermissionsResource:
     def __init__(
         self,
         catalog: Optional[
-            Dict[str, str]
+            dict[str, str]
         ],  # Placeholder type, catalog is an empty dict in docs
         database: Optional[ListPermissionsResourceDatabase],
         table: Optional[ListPermissionsResourceTable],
@@ -246,7 +246,7 @@ class ListPermissionsResource:
         self.lf_tag_policy = lf_tag_policy
 
 
-def default_settings() -> Dict[str, Any]:
+def default_settings() -> dict[str, Any]:
     return {
         "DataLakeAdmins": [],
         "CreateDatabaseDefaultPermissions": [
@@ -270,13 +270,13 @@ def default_settings() -> Dict[str, Any]:
 class LakeFormationBackend(BaseBackend):
     def __init__(self, region_name: str, account_id: str):
         super().__init__(region_name, account_id)
-        self.resources: Dict[str, Resource] = dict()
-        self.settings: Dict[str, Dict[str, Any]] = defaultdict(default_settings)
-        self.grants: Dict[str, PermissionCatalog] = {}
+        self.resources: dict[str, Resource] = dict()
+        self.settings: dict[str, dict[str, Any]] = defaultdict(default_settings)
+        self.grants: dict[str, PermissionCatalog] = {}
         self.tagger = TaggingService()
-        self.lf_database_tags: Dict[Tuple[str, str], List[Dict[str, str]]] = {}
-        self.lf_table_tags: Dict[Tuple[str, str, str], List[Dict[str, str]]] = {}
-        self.lf_columns_tags: Dict[Tuple[str, ...], List[Dict[str, str]]] = {}
+        self.lf_database_tags: dict[tuple[str, str], list[dict[str, str]]] = {}
+        self.lf_table_tags: dict[tuple[str, str, str], list[dict[str, str]]] = {}
+        self.lf_columns_tags: dict[tuple[str, ...], list[dict[str, str]]] = {}
 
     def describe_resource(self, resource_arn: str) -> Resource:
         if resource_arn not in self.resources:
@@ -295,22 +295,22 @@ class LakeFormationBackend(BaseBackend):
             )
         self.resources[resource_arn] = Resource(resource_arn, role_arn)
 
-    def list_resources(self) -> List[Resource]:
+    def list_resources(self) -> list[Resource]:
         return list(self.resources.values())
 
-    def get_data_lake_settings(self, catalog_id: str) -> Dict[str, Any]:
+    def get_data_lake_settings(self, catalog_id: str) -> dict[str, Any]:
         return self.settings[catalog_id]
 
-    def put_data_lake_settings(self, catalog_id: str, settings: Dict[str, Any]) -> None:
+    def put_data_lake_settings(self, catalog_id: str, settings: dict[str, Any]) -> None:
         self.settings[catalog_id] = settings
 
     def grant_permissions(
         self,
         catalog_id: str,
-        principal: Dict[str, str],
-        resource: Dict[str, Any],
-        permissions: List[str],
-        permissions_with_grant_options: List[str],
+        principal: dict[str, str],
+        resource: dict[str, Any],
+        permissions: list[str],
+        permissions_with_grant_options: list[str],
     ) -> None:
         if catalog_id not in self.grants:
             self.grants[catalog_id] = PermissionCatalog()
@@ -327,10 +327,10 @@ class LakeFormationBackend(BaseBackend):
     def revoke_permissions(
         self,
         catalog_id: str,
-        principal: Dict[str, str],
-        resource: Dict[str, Any],
-        permissions_to_revoke: List[str],
-        permissions_with_grant_options_to_revoke: List[str],
+        principal: dict[str, str],
+        resource: dict[str, Any],
+        permissions_to_revoke: list[str],
+        permissions_with_grant_options_to_revoke: list[str],
     ) -> None:
         if catalog_id not in self.grants:
             return
@@ -349,10 +349,10 @@ class LakeFormationBackend(BaseBackend):
     def list_permissions(
         self,
         catalog_id: str,
-        principal: Optional[Dict[str, str]] = None,
+        principal: Optional[dict[str, str]] = None,
         resource: Optional[ListPermissionsResource] = None,
         resource_type: Optional[RessourceType] = None,
-    ) -> List[Dict[str, Any]]:
+    ) -> list[dict[str, Any]]:
         """
         No pagination has been implemented yet.
         """
@@ -453,13 +453,13 @@ class LakeFormationBackend(BaseBackend):
 
         return [permission.to_external_form() for permission in permissions]
 
-    def create_lf_tag(self, catalog_id: str, key: str, values: List[str]) -> None:
+    def create_lf_tag(self, catalog_id: str, key: str, values: list[str]) -> None:
         # There is no ARN that we can use, so just create another  unique identifier that's easy to recognize and reproduce
         arn = f"arn:lakeformation:{catalog_id}"
         tag_list = TaggingService.convert_dict_to_tags_input({key: values})  # type: ignore
         self.tagger.tag_resource(arn=arn, tags=tag_list)
 
-    def get_lf_tag(self, catalog_id: str, key: str) -> List[str]:
+    def get_lf_tag(self, catalog_id: str, key: str) -> list[str]:
         # There is no ARN that we can use, so just create another  unique identifier that's easy to recognize and reproduce
         arn = f"arn:lakeformation:{catalog_id}"
         all_tags = self.tagger.get_tag_dict_for_resource(arn=arn)
@@ -484,13 +484,13 @@ class LakeFormationBackend(BaseBackend):
                 tag for tag in self.lf_columns_tags[column] if tag["TagKey"] != key
             ]
 
-    def list_lf_tags(self, catalog_id: str) -> Dict[str, str]:
+    def list_lf_tags(self, catalog_id: str) -> dict[str, str]:
         # There is no ARN that we can use, so just create another  unique identifier that's easy to recognize and reproduce
         arn = f"arn:lakeformation:{catalog_id}"
         return self.tagger.get_tag_dict_for_resource(arn=arn)
 
     def update_lf_tag(
-        self, catalog_id: str, tag_key: str, to_delete: List[str], to_add: List[str]
+        self, catalog_id: str, tag_key: str, to_delete: list[str], to_add: list[str]
     ) -> None:
         arn = f"arn:lakeformation:{catalog_id}"
         existing_tags = self.list_lf_tags(catalog_id)
@@ -501,14 +501,14 @@ class LakeFormationBackend(BaseBackend):
             arn, TaggingService.convert_dict_to_tags_input(existing_tags)
         )
 
-    def list_data_cells_filter(self) -> List[Dict[str, Any]]:
+    def list_data_cells_filter(self) -> list[dict[str, Any]]:
         """
         This currently just returns an empty list, as the corresponding Create is not yet implemented
         """
         return []
 
     def batch_grant_permissions(
-        self, catalog_id: str, entries: List[Dict[str, Any]]
+        self, catalog_id: str, entries: list[dict[str, Any]]
     ) -> None:
         for entry in entries:
             self.grant_permissions(
@@ -520,7 +520,7 @@ class LakeFormationBackend(BaseBackend):
             )
 
     def batch_revoke_permissions(
-        self, catalog_id: str, entries: List[Dict[str, Any]]
+        self, catalog_id: str, entries: list[dict[str, Any]]
     ) -> None:
         for entry in entries:
             self.revoke_permissions(
@@ -534,8 +534,8 @@ class LakeFormationBackend(BaseBackend):
             )
 
     def add_lf_tags_to_resource(
-        self, catalog_id: str, resource: Dict[str, Any], tags: List[Dict[str, str]]
-    ) -> List[Dict[str, Any]]:
+        self, catalog_id: str, resource: dict[str, Any], tags: list[dict[str, str]]
+    ) -> list[dict[str, Any]]:
         existing_lf_tags = self.list_lf_tags(catalog_id)
         failures = []
 
@@ -578,8 +578,8 @@ class LakeFormationBackend(BaseBackend):
     def get_resource_lf_tags(
         self,
         catalog_id: str,
-        resource: Dict[str, Any],
-    ) -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]], List[Dict[str, Any]]]:
+        resource: dict[str, Any],
+    ) -> tuple[list[dict[str, Any]], list[dict[str, Any]], list[dict[str, Any]]]:
         database_tags = []
         table_tags = []
         column_tags = []
@@ -607,7 +607,7 @@ class LakeFormationBackend(BaseBackend):
         return database_tags, table_tags, column_tags
 
     def remove_lf_tags_from_resource(
-        self, catalog_id: str, resource: Dict[str, Any], tags: List[Dict[str, str]]
+        self, catalog_id: str, resource: dict[str, Any], tags: list[dict[str, str]]
     ) -> None:
         for tag in tags:
             if "CatalogId" not in tag:

--- a/moto/lakeformation/responses.py
+++ b/moto/lakeformation/responses.py
@@ -1,7 +1,7 @@
 """Handles incoming lakeformation requests, invokes methods, returns responses."""
 
 import json
-from typing import Any, Dict
+from typing import Any
 
 from moto.core.responses import BaseResponse
 
@@ -236,7 +236,7 @@ class LakeFormationResponse(BaseResponse):
         db, table, columns = self.lakeformation_backend.get_resource_lf_tags(
             catalog_id, resource
         )
-        resp: Dict[str, Any] = {}
+        resp: dict[str, Any] = {}
         if db:
             resp["LFTagOnDatabase"] = db
         if table:

--- a/moto/lexv2models/models.py
+++ b/moto/lexv2models/models.py
@@ -2,7 +2,7 @@
 
 import uuid
 from datetime import datetime
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Optional
 
 from moto.core.base_backend import BackendDict, BaseBackend
 
@@ -10,7 +10,7 @@ from ..utilities.tagging_service import TaggingService
 
 
 class FakeBot:
-    failure_reasons: List[str]
+    failure_reasons: list[str]
 
     def __init__(
         self,
@@ -19,10 +19,10 @@ class FakeBot:
         bot_name: str,
         description: str,
         role_arn: str,
-        data_privacy: Optional[Dict[str, Any]],
+        data_privacy: Optional[dict[str, Any]],
         idle_session_ttl_in_seconds: int,
         bot_type: str,
-        bot_members: Optional[Dict[str, Any]],
+        bot_members: Optional[dict[str, Any]],
     ):
         self.account_id = account_id
         self.region_name = region_name
@@ -47,8 +47,8 @@ class FakeBot:
 
 
 class FakeBotAlias:
-    parent_bot_networks: List[str]
-    history_events: List[str]
+    parent_bot_networks: list[str]
+    history_events: list[str]
 
     def __init__(
         self,
@@ -57,9 +57,9 @@ class FakeBotAlias:
         bot_alias_name: str,
         description: str,
         bot_version: str,
-        bot_alias_locale_settings: Optional[Dict[str, Any]],
-        conversation_log_settings: Optional[Dict[str, Any]],
-        sentiment_analysis_settings: Optional[Dict[str, Any]],
+        bot_alias_locale_settings: Optional[dict[str, Any]],
+        conversation_log_settings: Optional[dict[str, Any]],
+        sentiment_analysis_settings: Optional[dict[str, Any]],
         bot_id: str,
     ):
         self.account_id = account_id
@@ -97,9 +97,9 @@ class LexModelsV2Backend(BaseBackend):
 
     def __init__(self, region_name: str, account_id: str):
         super().__init__(region_name, account_id)
-        self.bots: Dict[str, FakeBot] = {}
-        self.bot_aliases: Dict[str, FakeBotAlias] = {}
-        self.resource_policies: Dict[str, FakeResourcePolicy] = {}
+        self.bots: dict[str, FakeBot] = {}
+        self.bot_aliases: dict[str, FakeBotAlias] = {}
+        self.resource_policies: dict[str, FakeResourcePolicy] = {}
         self.tagger = TaggingService()
 
     def create_bot(
@@ -107,13 +107,13 @@ class LexModelsV2Backend(BaseBackend):
         bot_name: str,
         description: str,
         role_arn: str,
-        data_privacy: Optional[Dict[str, Any]],
+        data_privacy: Optional[dict[str, Any]],
         idle_session_ttl_in_seconds: int,
-        bot_tags: Optional[Dict[str, str]],
-        test_bot_alias_tags: Optional[Dict[str, str]],
+        bot_tags: Optional[dict[str, str]],
+        test_bot_alias_tags: Optional[dict[str, str]],
         bot_type: str,
-        bot_members: Optional[Dict[str, Any]],
-    ) -> Dict[str, Any]:
+        bot_members: Optional[dict[str, Any]],
+    ) -> dict[str, Any]:
         bot = FakeBot(
             account_id=self.account_id,
             region_name=self.region_name,
@@ -159,7 +159,7 @@ class LexModelsV2Backend(BaseBackend):
             "botMembers": bot.bot_members,
         }
 
-    def describe_bot(self, bot_id: str) -> Dict[str, Any]:
+    def describe_bot(self, bot_id: str) -> dict[str, Any]:
         bot = self.bots[bot_id]
 
         return {
@@ -183,11 +183,11 @@ class LexModelsV2Backend(BaseBackend):
         bot_name: str,
         description: str,
         role_arn: str,
-        data_privacy: Optional[Dict[str, Any]],
+        data_privacy: Optional[dict[str, Any]],
         idle_session_ttl_in_seconds: int,
         bot_type: str,
-        bot_members: Optional[Dict[str, Any]],
-    ) -> Dict[str, Any]:
+        bot_members: Optional[dict[str, Any]],
+    ) -> dict[str, Any]:
         bot = self.bots[bot_id]
 
         bot.bot_name = bot_name
@@ -213,7 +213,7 @@ class LexModelsV2Backend(BaseBackend):
             "botMembers": bot.bot_members,
         }
 
-    def list_bots(self) -> List[Dict[str, Any]]:
+    def list_bots(self) -> list[dict[str, Any]]:
         bot_summaries = [
             {
                 "botId": bot.id,
@@ -230,7 +230,7 @@ class LexModelsV2Backend(BaseBackend):
 
     def delete_bot(
         self, bot_id: str, skip_resource_in_use_check: bool
-    ) -> Tuple[str, str]:
+    ) -> tuple[str, str]:
         bot = self.bots.pop(bot_id)
         return bot.id, bot.status
 
@@ -239,12 +239,12 @@ class LexModelsV2Backend(BaseBackend):
         bot_alias_name: str,
         description: str,
         bot_version: str,
-        bot_alias_locale_settings: Optional[Dict[str, Any]],
-        conversation_log_settings: Optional[Dict[str, Any]],
-        sentiment_analysis_settings: Optional[Dict[str, Any]],
+        bot_alias_locale_settings: Optional[dict[str, Any]],
+        conversation_log_settings: Optional[dict[str, Any]],
+        sentiment_analysis_settings: Optional[dict[str, Any]],
         bot_id: str,
-        tags: Optional[Dict[str, str]],
-    ) -> Dict[str, Any]:
+        tags: Optional[dict[str, str]],
+    ) -> dict[str, Any]:
         bot_alias = FakeBotAlias(
             self.account_id,
             self.region_name,
@@ -276,7 +276,7 @@ class LexModelsV2Backend(BaseBackend):
             "tags": self.list_tags_for_resource(bot_alias.arn),
         }
 
-    def describe_bot_alias(self, bot_alias_id: str, bot_id: str) -> Dict[str, Any]:
+    def describe_bot_alias(self, bot_alias_id: str, bot_id: str) -> dict[str, Any]:
         ba = self.bot_aliases[bot_alias_id]
 
         return {
@@ -301,11 +301,11 @@ class LexModelsV2Backend(BaseBackend):
         bot_alias_name: str,
         description: str,
         bot_version: str,
-        bot_alias_locale_settings: Optional[Dict[str, Any]],
-        conversation_log_settings: Optional[Dict[str, Any]],
-        sentiment_analysis_settings: Optional[Dict[str, Any]],
+        bot_alias_locale_settings: Optional[dict[str, Any]],
+        conversation_log_settings: Optional[dict[str, Any]],
+        sentiment_analysis_settings: Optional[dict[str, Any]],
         bot_id: str,
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         ba = self.bot_aliases[bot_alias_id]
 
         ba.bot_alias_name = bot_alias_name
@@ -333,7 +333,7 @@ class LexModelsV2Backend(BaseBackend):
 
     def list_bot_aliases(
         self, bot_id: str, max_results: int
-    ) -> Tuple[List[Dict[str, Any]], Optional[str]]:
+    ) -> tuple[list[dict[str, Any]], Optional[str]]:
         bot_alias_summaries = [
             {
                 "botAliasId": ba.id,
@@ -351,22 +351,22 @@ class LexModelsV2Backend(BaseBackend):
 
     def delete_bot_alias(
         self, bot_alias_id: str, bot_id: str, skip_resource_in_use_check: bool
-    ) -> Tuple[str, str, str]:
+    ) -> tuple[str, str, str]:
         ba = self.bot_aliases.pop(bot_alias_id)
         return ba.id, ba.bot_id, ba.status
 
-    def create_resource_policy(self, resource_arn: str, policy: str) -> Tuple[str, str]:
+    def create_resource_policy(self, resource_arn: str, policy: str) -> tuple[str, str]:
         rp = FakeResourcePolicy(resource_arn, policy)
         self.resource_policies[rp.resource_arn] = rp
         return rp.resource_arn, rp.revision_id
 
-    def describe_resource_policy(self, resource_arn: str) -> Tuple[str, str, str]:
+    def describe_resource_policy(self, resource_arn: str) -> tuple[str, str, str]:
         rp = self.resource_policies[resource_arn]
         return rp.resource_arn, rp.policy, rp.revision_id
 
     def update_resource_policy(
         self, resource_arn: str, policy: str, expected_revision_id: str
-    ) -> Tuple[str, str]:
+    ) -> tuple[str, str]:
         rp = self.resource_policies[resource_arn]
         if expected_revision_id != rp.revision_id:
             raise Exception("Revision ID mismatch")
@@ -376,21 +376,21 @@ class LexModelsV2Backend(BaseBackend):
 
     def delete_resource_policy(
         self, resource_arn: str, expected_revision_id: str
-    ) -> Tuple[str, str]:
+    ) -> tuple[str, str]:
         rp = self.resource_policies[resource_arn]
         if expected_revision_id != rp.revision_id:
             raise Exception("Revision ID mismatch")
         rp = self.resource_policies.pop(resource_arn)
         return rp.resource_arn, rp.revision_id
 
-    def tag_resource(self, resource_arn: str, tags: Dict[str, str]) -> None:
+    def tag_resource(self, resource_arn: str, tags: dict[str, str]) -> None:
         tags_list = [{"Key": k, "Value": v} for k, v in tags.items()]
         self.tagger.tag_resource(resource_arn, tags_list)
 
-    def untag_resource(self, resource_arn: str, tag_keys: List[str]) -> None:
+    def untag_resource(self, resource_arn: str, tag_keys: list[str]) -> None:
         self.tagger.untag_resource_using_names(resource_arn, tag_keys)
 
-    def list_tags_for_resource(self, resource_arn: str) -> Dict[str, str]:
+    def list_tags_for_resource(self, resource_arn: str) -> dict[str, str]:
         return self.tagger.get_tag_dict_for_resource(resource_arn)
 
 

--- a/moto/logs/logs_query/__init__.py
+++ b/moto/logs/logs_query/__init__.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, Dict, List
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from ..models import LogEvent, LogGroup, LogStream
@@ -20,8 +20,8 @@ class ParsedEvent:
         self.log_group = log_group
         self.fields = self._create_fields()
 
-    def _create_fields(self) -> Dict[str, Any]:
-        fields: Dict[str, Any] = {"@ptr": self.event.event_id}
+    def _create_fields(self) -> dict[str, Any]:
+        fields: dict[str, Any] = {"@ptr": self.event.event_id}
         if "@timestamp" in self.query.fields:
             fields["@timestamp"] = self.event.timestamp
         if "@message" in self.query.fields:
@@ -49,8 +49,8 @@ class ParsedEvent:
 
 
 def execute_query(
-    log_groups: List["LogGroup"], query: str, start_time: int, end_time: int
-) -> List[Dict[str, str]]:
+    log_groups: list["LogGroup"], query: str, start_time: int, end_time: int
+) -> list[dict[str, str]]:
     parsed = parse_query(query)
     all_events = _create_parsed_events(log_groups, parsed, start_time, end_time)
     sorted_events = sorted(all_events, reverse=parsed.sort_reversed())
@@ -61,8 +61,8 @@ def execute_query(
 
 
 def _create_parsed_events(
-    log_groups: List["LogGroup"], query: ParsedQuery, start_time: int, end_time: int
-) -> List["ParsedEvent"]:
+    log_groups: list["LogGroup"], query: ParsedQuery, start_time: int, end_time: int
+) -> list["ParsedEvent"]:
     def filter_func(event: "LogEvent") -> bool:
         # Start/End time is in epoch seconds
         # Event timestamp is in epoch milliseconds
@@ -74,7 +74,7 @@ def _create_parsed_events(
 
         return True
 
-    events: List["ParsedEvent"] = []
+    events: list[ParsedEvent] = []
     for group in log_groups:
         for stream in group.streams.values():
             events.extend(

--- a/moto/logs/logs_query/query_parser.py
+++ b/moto/logs/logs_query/query_parser.py
@@ -1,4 +1,4 @@
-from typing import List, Optional, Tuple
+from typing import Optional
 
 from moto.utilities.tokenizer import GenericTokenizer
 
@@ -6,8 +6,8 @@ from moto.utilities.tokenizer import GenericTokenizer
 class ParsedQuery:
     def __init__(self) -> None:
         self.limit: Optional[int] = None
-        self.fields: List[str] = []
-        self.sort: List[Tuple[str, str]] = []
+        self.fields: list[str] = []
+        self.sort: list[tuple[str, str]] = []
 
     def sort_reversed(self) -> bool:
         # Descending is the default

--- a/moto/logs/metric_filters.py
+++ b/moto/logs/metric_filters.py
@@ -1,9 +1,9 @@
-from typing import Any, Dict, List, Optional
+from typing import Any, Optional
 
 
 def find_metric_transformation_by_name(
-    metric_transformations: List[Dict[str, Any]], metric_name: str
-) -> Optional[Dict[str, Any]]:
+    metric_transformations: list[dict[str, Any]], metric_name: str
+) -> Optional[dict[str, Any]]:
     for metric in metric_transformations:
         if metric["metricName"] == metric_name:
             return metric
@@ -11,8 +11,8 @@ def find_metric_transformation_by_name(
 
 
 def find_metric_transformation_by_namespace(
-    metric_transformations: List[Dict[str, Any]], metric_namespace: str
-) -> Optional[Dict[str, Any]]:
+    metric_transformations: list[dict[str, Any]], metric_namespace: str
+) -> Optional[dict[str, Any]]:
     for metric in metric_transformations:
         if metric["metricNamespace"] == metric_namespace:
             return metric
@@ -21,7 +21,7 @@ def find_metric_transformation_by_namespace(
 
 class MetricFilters:
     def __init__(self) -> None:
-        self.metric_filters: List[Dict[str, Any]] = []
+        self.metric_filters: list[dict[str, Any]] = []
 
     def add_filter(
         self,
@@ -45,8 +45,8 @@ class MetricFilters:
         log_group_name: Optional[str] = None,
         metric_name: Optional[str] = None,
         metric_namespace: Optional[str] = None,
-    ) -> List[Dict[str, Any]]:
-        result: List[Dict[str, Any]] = []
+    ) -> list[dict[str, Any]]:
+        result: list[dict[str, Any]] = []
         for f in self.metric_filters:
             prefix_matches = prefix is None or f["filterName"].startswith(prefix)
             log_group_matches = (
@@ -77,7 +77,7 @@ class MetricFilters:
 
     def delete_filter(
         self, filter_name: Optional[str] = None, log_group_name: Optional[str] = None
-    ) -> List[Dict[str, Any]]:
+    ) -> list[dict[str, Any]]:
         for f in self.metric_filters:
             if f["filterName"] == filter_name and f["logGroupName"] == log_group_name:
                 self.metric_filters.remove(f)

--- a/moto/logs/models.py
+++ b/moto/logs/models.py
@@ -1,7 +1,8 @@
 import re
+from collections.abc import Iterable
 from datetime import datetime, timedelta
 from gzip import compress as gzip_compress
-from typing import Any, Dict, Iterable, List, Optional, Tuple
+from typing import Any, Optional
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel, CloudFormationModel
@@ -44,7 +45,7 @@ class Destination(BaseModel):
         self.role_arn = role_arn
         self.target_arn = target_arn
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         return {
             "accessPolicy": self.access_policy,
             "arn": self.arn,
@@ -62,7 +63,7 @@ class LogQuery(BaseModel):
         start_time: int,
         end_time: int,
         query: str,
-        log_groups: List["LogGroup"],
+        log_groups: list["LogGroup"],
     ):
         self.query_id = query_id
         self.start_time = start_time
@@ -76,7 +77,7 @@ class LogQuery(BaseModel):
         )
         self.status = "Complete"
 
-    def to_json(self, log_group_name: str) -> Dict[str, Any]:
+    def to_json(self, log_group_name: str) -> dict[str, Any]:
         return {
             "queryId": self.query_id,
             "queryString": self.query,
@@ -85,7 +86,7 @@ class LogQuery(BaseModel):
             "logGroupName": log_group_name,
         }
 
-    def to_result_json(self) -> Dict[str, Any]:
+    def to_result_json(self) -> dict[str, Any]:
         return {
             "results": [
                 [{"field": key, "value": str(val)} for key, val in result.items()]
@@ -98,7 +99,7 @@ class LogQuery(BaseModel):
 class LogEvent(BaseModel):
     _event_id = 0
 
-    def __init__(self, ingestion_time: int, log_event: Dict[str, Any]):
+    def __init__(self, ingestion_time: int, log_event: dict[str, Any]):
         self.ingestion_time = ingestion_time
         self.timestamp = log_event["timestamp"]
         self.message = log_event["message"]
@@ -106,7 +107,7 @@ class LogEvent(BaseModel):
         self.__class__._event_id += 1
         ""
 
-    def to_filter_dict(self) -> Dict[str, Any]:
+    def to_filter_dict(self) -> dict[str, Any]:
         return {
             "eventId": str(self.event_id),
             "ingestionTime": self.ingestion_time,
@@ -115,7 +116,7 @@ class LogEvent(BaseModel):
             "timestamp": self.timestamp,
         }
 
-    def to_response_dict(self) -> Dict[str, Any]:
+    def to_response_dict(self) -> dict[str, Any]:
         return {
             "ingestionTime": self.ingestion_time,
             "message": self.message,
@@ -139,7 +140,7 @@ class LogStream(BaseModel):
         self.stored_bytes = 0
         # I'm  guessing this is token needed for sequenceToken by put_events
         self.upload_sequence_token = 0
-        self.events: List[LogEvent] = []
+        self.events: list[LogEvent] = []
 
         self.__class__._log_ids += 1
 
@@ -152,7 +153,7 @@ class LogStream(BaseModel):
             max([x.timestamp for x in self.events]) if self.events else None
         )
 
-    def to_describe_dict(self) -> Dict[str, Any]:
+    def to_describe_dict(self) -> dict[str, Any]:
         # Compute start and end times
         self._update()
 
@@ -172,7 +173,7 @@ class LogStream(BaseModel):
             res.update(rest)
         return res
 
-    def put_log_events(self, log_events: List[Dict[str, Any]]) -> str:
+    def put_log_events(self, log_events: list[dict[str, Any]]) -> str:
         # TODO: ensure sequence_token
         # TODO: to be thread safe this would need a lock
         self.last_ingestion_time = int(unix_time_millis())
@@ -209,7 +210,7 @@ class LogStream(BaseModel):
         service: str,
         destination_arn: str,
         filter_name: str,
-        log_events: List[Dict[str, Any]],
+        log_events: list[dict[str, Any]],
     ) -> None:
         if service == "lambda":
             from moto.awslambda.utils import get_backend
@@ -250,7 +251,7 @@ class LogStream(BaseModel):
         limit: int,
         next_token: Optional[str],
         start_from_head: str,
-    ) -> Tuple[List[Dict[str, Any]], Optional[str], Optional[str]]:
+    ) -> tuple[list[dict[str, Any]], Optional[str], Optional[str]]:
         if limit is None:
             limit = 10000
 
@@ -265,7 +266,7 @@ class LogStream(BaseModel):
 
         def get_index_and_direction_from_token(
             token: Optional[str],
-        ) -> Tuple[Optional[str], int]:
+        ) -> tuple[Optional[str], int]:
             if token is not None:
                 try:
                     return token[0], int(token[2:])
@@ -317,7 +318,7 @@ class LogStream(BaseModel):
 
     def filter_log_events(
         self, start_time: int, end_time: int, filter_pattern: str
-    ) -> List[Dict[str, Any]]:
+    ) -> list[dict[str, Any]]:
         def filter_func(event: LogEvent) -> bool:
             if start_time and event.timestamp < start_time:
                 return False
@@ -330,7 +331,7 @@ class LogStream(BaseModel):
 
             return True
 
-        events: List[Dict[str, Any]] = []
+        events: list[dict[str, Any]] = []
         for event in sorted(
             filter(filter_func, self.events), key=lambda x: x.timestamp
         ):
@@ -361,7 +362,7 @@ class SubscriptionFilter(BaseModel):
         self.destination_arn = destination_arn
         self.role_arn = role_arn
 
-    def to_json(self) -> Dict[str, Any]:
+    def to_json(self) -> dict[str, Any]:
         return {
             "filterName": self.name,
             "logGroupName": self.log_group_name,
@@ -388,10 +389,10 @@ class LogGroup(CloudFormationModel):
             f"arn:{get_partition(region)}:logs:{region}:{account_id}:log-group:{name}"
         )
         self.creation_time = int(unix_time_millis())
-        self.streams: Dict[str, LogStream] = dict()  # {name: LogStream}
+        self.streams: dict[str, LogStream] = dict()  # {name: LogStream}
         # AWS defaults to Never Expire for log group retention
         self.retention_in_days = kwargs.get("RetentionInDays")
-        self.subscription_filters: Dict[str, SubscriptionFilter] = {}
+        self.subscription_filters: dict[str, SubscriptionFilter] = {}
 
         # The Amazon Resource Name (ARN) of the CMK to use when encrypting log data. It is optional.
         # Docs:
@@ -463,7 +464,7 @@ class LogGroup(CloudFormationModel):
         order_by: str,
         limit: int,
         next_token: Optional[str] = None,
-    ) -> Tuple[List[Dict[str, Any]], Optional[str]]:
+    ) -> tuple[list[dict[str, Any]], Optional[str]]:
         # responses only log_stream_name, creation_time, arn, stored_bytes when no events are stored.
 
         log_streams = [
@@ -511,7 +512,7 @@ class LogGroup(CloudFormationModel):
     def put_log_events(
         self,
         log_stream_name: str,
-        log_events: List[Dict[str, Any]],
+        log_events: list[dict[str, Any]],
     ) -> str:
         if log_stream_name not in self.streams:
             raise ResourceNotFoundException("The specified log stream does not exist.")
@@ -526,7 +527,7 @@ class LogGroup(CloudFormationModel):
         limit: int,
         next_token: Optional[str],
         start_from_head: str,
-    ) -> Tuple[List[Dict[str, Any]], Optional[str], Optional[str]]:
+    ) -> tuple[list[dict[str, Any]], Optional[str], Optional[str]]:
         if log_stream_name not in self.streams:
             raise ResourceNotFoundException()
         stream = self.streams[log_stream_name]
@@ -541,14 +542,14 @@ class LogGroup(CloudFormationModel):
     def filter_log_events(
         self,
         log_group_name: str,
-        log_stream_names: List[str],
+        log_stream_names: list[str],
         start_time: int,
         end_time: int,
         limit: Optional[int],
         next_token: Optional[str],
         filter_pattern: str,
         interleaved: bool,
-    ) -> Tuple[List[Dict[str, Any]], Optional[str], List[Dict[str, Any]]]:
+    ) -> tuple[list[dict[str, Any]], Optional[str], list[dict[str, Any]]]:
         if not limit:
             limit = 10000
         streams = [
@@ -599,7 +600,7 @@ class LogGroup(CloudFormationModel):
         ]
         return events_page, next_token, searched_streams
 
-    def to_describe_dict(self) -> Dict[str, Any]:
+    def to_describe_dict(self) -> dict[str, Any]:
         log_group = {
             "arn": f"{self.arn}:*",
             "logGroupArn": self.arn,
@@ -662,7 +663,7 @@ class LogResourcePolicy(CloudFormationModel):
         self.policy_document = policy_document
         self.last_updated_time = int(unix_time_millis())
 
-    def describe(self) -> Dict[str, Any]:
+    def describe(self) -> dict[str, Any]:
         return {
             "policyName": self.policy_name,
             "policyDocument": self.policy_document,
@@ -749,7 +750,7 @@ class ExportTask(BaseModel):
         self.to = to
         self.status = {"code": "active", "message": "Task is active"}
 
-    def to_json(self) -> Dict[str, Any]:
+    def to_json(self) -> dict[str, Any]:
         return {
             "taskId": self.task_id,
             "taskName": self.task_name,
@@ -769,8 +770,8 @@ class DeliveryDestination(BaseModel):
         region: str,
         name: str,
         output_format: Optional[str],
-        delivery_destination_configuration: Dict[str, str],
-        tags: Optional[Dict[str, str]],
+        delivery_destination_configuration: dict[str, str],
+        tags: Optional[dict[str, str]],
         policy: Optional[str] = None,
     ):
         self.name = name
@@ -789,7 +790,7 @@ class DeliveryDestination(BaseModel):
         self.tags = tags
         self.policy = policy
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         dct = {
             "name": self.name,
             "arn": self.arn,
@@ -810,7 +811,7 @@ class DeliverySource(BaseModel):
         name: str,
         resource_arn: str,
         log_type: str,
-        tags: Optional[Dict[str, str]],
+        tags: Optional[dict[str, str]],
     ):
         res_arns = []
         res_arns.append(resource_arn)
@@ -821,7 +822,7 @@ class DeliverySource(BaseModel):
         self.log_type = log_type
         self.tags = tags
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         dct = {
             "name": self.name,
             "arn": self.arn,
@@ -842,10 +843,10 @@ class Delivery(BaseModel):
         delivery_source_name: str,
         delivery_destination_arn: str,
         destination_type: str,
-        record_fields: Optional[List[str]],
+        record_fields: Optional[list[str]],
         field_delimiter: Optional[str],
-        s3_delivery_configuration: Optional[Dict[str, Any]],
-        tags: Optional[Dict[str, str]],
+        s3_delivery_configuration: Optional[dict[str, Any]],
+        tags: Optional[dict[str, str]],
     ):
         self.id = mock_random.get_random_string(length=16)
         self.arn = f"arn:aws:logs:{region}:{account_id}:delivery:{self.id}"
@@ -902,7 +903,7 @@ class Delivery(BaseModel):
         )
         self.tags = tags
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         dct = {
             "id": self.id,
             "arn": self.arn,
@@ -921,19 +922,19 @@ class Delivery(BaseModel):
 class LogsBackend(BaseBackend):
     def __init__(self, region_name: str, account_id: str):
         super().__init__(region_name, account_id)
-        self.groups: Dict[str, LogGroup] = dict()
+        self.groups: dict[str, LogGroup] = dict()
         self.filters = MetricFilters()
-        self.queries: Dict[str, LogQuery] = dict()
-        self.resource_policies: Dict[str, LogResourcePolicy] = dict()
-        self.destinations: Dict[str, Destination] = dict()
+        self.queries: dict[str, LogQuery] = dict()
+        self.resource_policies: dict[str, LogResourcePolicy] = dict()
+        self.destinations: dict[str, Destination] = dict()
         self.tagger = TaggingService()
-        self.export_tasks: Dict[str, ExportTask] = dict()
-        self.delivery_destinations: Dict[str, DeliveryDestination] = dict()
-        self.delivery_sources: Dict[str, DeliverySource] = dict()
-        self.deliveries: Dict[str, Delivery] = dict()
+        self.export_tasks: dict[str, ExportTask] = dict()
+        self.delivery_destinations: dict[str, DeliveryDestination] = dict()
+        self.delivery_sources: dict[str, DeliverySource] = dict()
+        self.deliveries: dict[str, Delivery] = dict()
 
     def create_log_group(
-        self, log_group_name: str, tags: Dict[str, str], **kwargs: Any
+        self, log_group_name: str, tags: dict[str, str], **kwargs: Any
     ) -> LogGroup:
         if log_group_name in self.groups:
             raise ResourceAlreadyExistsException()
@@ -966,7 +967,7 @@ class LogsBackend(BaseBackend):
     @paginate(pagination_model=PAGINATION_MODEL)
     def describe_log_groups(
         self, log_group_name_prefix: Optional[str] = None
-    ) -> List[LogGroup]:
+    ) -> list[LogGroup]:
         groups = [
             group
             for name, group in self.groups.items()
@@ -985,7 +986,7 @@ class LogsBackend(BaseBackend):
         destination_name: str,
         role_arn: str,
         target_arn: str,
-        tags: Dict[str, str],
+        tags: dict[str, str],
     ) -> Destination:
         for _, destination in self.destinations.items():
             if destination.destination_name == destination_name:
@@ -1008,7 +1009,7 @@ class LogsBackend(BaseBackend):
 
     def describe_destinations(
         self, destination_name_prefix: str, limit: int, next_token: Optional[int] = None
-    ) -> Tuple[List[Dict[str, Any]], Optional[int]]:
+    ) -> tuple[list[dict[str, Any]], Optional[int]]:
         if limit > 50:
             raise InvalidParameterException(
                 constraint="Member must have value less than or equal to 50",
@@ -1066,7 +1067,7 @@ class LogsBackend(BaseBackend):
         log_stream_name_prefix: str,
         next_token: Optional[str],
         order_by: str,
-    ) -> Tuple[List[Dict[str, Any]], Optional[str]]:
+    ) -> tuple[list[dict[str, Any]], Optional[str]]:
         log_group = self._find_log_group(log_group_id, log_group_name)
         if limit > 50:
             raise InvalidParameterException(
@@ -1097,8 +1098,8 @@ class LogsBackend(BaseBackend):
         self,
         log_group_name: str,
         log_stream_name: str,
-        log_events: List[Dict[str, Any]],
-    ) -> Tuple[str, Dict[str, Any]]:
+        log_events: list[dict[str, Any]],
+    ) -> tuple[str, dict[str, Any]]:
         """
         The SequenceToken-parameter is not yet implemented
         """
@@ -1138,7 +1139,7 @@ class LogsBackend(BaseBackend):
         limit: int,
         next_token: Optional[str],
         start_from_head: str,
-    ) -> Tuple[List[Dict[str, Any]], Optional[str], Optional[str]]:
+    ) -> tuple[list[dict[str, Any]], Optional[str], Optional[str]]:
         log_group = self._find_log_group(
             log_group_id=log_group_id, log_group_name=log_group_name
         )
@@ -1155,14 +1156,14 @@ class LogsBackend(BaseBackend):
     def filter_log_events(
         self,
         log_group_name: str,
-        log_stream_names: List[str],
+        log_stream_names: list[str],
         start_time: int,
         end_time: int,
         limit: Optional[int],
         next_token: Optional[str],
         filter_pattern: str,
         interleaved: bool,
-    ) -> Tuple[List[Dict[str, Any]], Optional[str], List[Dict[str, Any]]]:
+    ) -> tuple[list[dict[str, Any]], Optional[str], list[dict[str, Any]]]:
         """
         The following filter patterns are currently supported: Single Terms, Multiple Terms, Exact Phrases.
         If the pattern is not supported, all events are returned.
@@ -1197,7 +1198,7 @@ class LogsBackend(BaseBackend):
             raise ResourceNotFoundException()
         self.groups[log_group_name].set_retention_policy(None)
 
-    def describe_resource_policies(self) -> List[LogResourcePolicy]:
+    def describe_resource_policies(self) -> list[LogResourcePolicy]:
         """
         Return list of resource policies.
 
@@ -1234,19 +1235,19 @@ class LogsBackend(BaseBackend):
             )
         del self.resource_policies[policy_name]
 
-    def list_tags_log_group(self, log_group_name: str) -> Dict[str, str]:
+    def list_tags_log_group(self, log_group_name: str) -> dict[str, str]:
         if log_group_name not in self.groups:
             raise ResourceNotFoundException()
         log_group = self.groups[log_group_name]
         return self.list_tags_for_resource(log_group.arn)
 
-    def tag_log_group(self, log_group_name: str, tags: Dict[str, str]) -> None:
+    def tag_log_group(self, log_group_name: str, tags: dict[str, str]) -> None:
         if log_group_name not in self.groups:
             raise ResourceNotFoundException()
         log_group = self.groups[log_group_name]
         self.tag_resource(log_group.arn, tags)
 
-    def untag_log_group(self, log_group_name: str, tags: List[str]) -> None:
+    def untag_log_group(self, log_group_name: str, tags: list[str]) -> None:
         if log_group_name not in self.groups:
             raise ResourceNotFoundException()
         log_group = self.groups[log_group_name]
@@ -1269,7 +1270,7 @@ class LogsBackend(BaseBackend):
         log_group_name: Optional[str] = None,
         metric_name: Optional[str] = None,
         metric_namespace: Optional[str] = None,
-    ) -> List[Dict[str, Any]]:
+    ) -> list[dict[str, Any]]:
         filters = self.filters.get_matching_filters(
             prefix, log_group_name, metric_name, metric_namespace
         )
@@ -1360,7 +1361,7 @@ class LogsBackend(BaseBackend):
 
     def start_query(
         self,
-        log_group_names: List[str],
+        log_group_names: list[str],
         start_time: int,
         end_time: int,
         query_string: str,
@@ -1378,11 +1379,11 @@ class LogsBackend(BaseBackend):
 
     def describe_queries(
         self, log_stream_name: str, status: Optional[str]
-    ) -> List[LogQuery]:
+    ) -> list[LogQuery]:
         """
         Pagination is not yet implemented
         """
-        queries: List[LogQuery] = []
+        queries: list[LogQuery] = []
         for query in self.queries.values():
             if log_stream_name in query.log_group_names and (
                 not status or status == query.status
@@ -1470,7 +1471,7 @@ class LogsBackend(BaseBackend):
 
         return task_id
 
-    def describe_export_tasks(self, task_id: str) -> List[ExportTask]:
+    def describe_export_tasks(self, task_id: str) -> list[ExportTask]:
         """
         Pagination is not yet implemented
         """
@@ -1481,13 +1482,13 @@ class LogsBackend(BaseBackend):
         else:
             return list(self.export_tasks.values())
 
-    def list_tags_for_resource(self, resource_arn: str) -> Dict[str, str]:
+    def list_tags_for_resource(self, resource_arn: str) -> dict[str, str]:
         return self.tagger.get_tag_dict_for_resource(resource_arn)
 
-    def tag_resource(self, arn: str, tags: Dict[str, str]) -> None:
+    def tag_resource(self, arn: str, tags: dict[str, str]) -> None:
         self.tagger.tag_resource(arn, TaggingService.convert_dict_to_tags_input(tags))
 
-    def untag_resource(self, arn: str, tag_keys: List[str]) -> None:
+    def untag_resource(self, arn: str, tag_keys: list[str]) -> None:
         self.tagger.untag_resource_using_names(arn, tag_keys)
 
     def _find_log_group(self, log_group_id: str, log_group_name: str) -> LogGroup:
@@ -1514,8 +1515,8 @@ class LogsBackend(BaseBackend):
         self,
         name: str,
         output_format: Optional[str],
-        delivery_destination_configuration: Dict[str, str],
-        tags: Optional[Dict[str, str]],
+        delivery_destination_configuration: dict[str, str],
+        tags: Optional[dict[str, str]],
     ) -> DeliveryDestination:
         if output_format and output_format not in [
             "w3c",
@@ -1559,14 +1560,14 @@ class LogsBackend(BaseBackend):
         delivery_destination = self.delivery_destinations[name]
         return delivery_destination
 
-    def describe_delivery_destinations(self) -> List[DeliveryDestination]:
+    def describe_delivery_destinations(self) -> list[DeliveryDestination]:
         # Pagination not yet implemented
         delivery_destinations = list(self.delivery_destinations.values())
         return delivery_destinations
 
     def put_delivery_destination_policy(
         self, delivery_destination_name: str, delivery_destination_policy: str
-    ) -> Dict[str, str]:
+    ) -> dict[str, str]:
         if delivery_destination_name not in self.delivery_destinations:
             raise ResourceNotFoundException(
                 msg="Requested Delivery Destination does not exist in this account."
@@ -1577,7 +1578,7 @@ class LogsBackend(BaseBackend):
 
     def get_delivery_destination_policy(
         self, delivery_destination_name: str
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         if delivery_destination_name not in self.delivery_destinations:
             raise ResourceNotFoundException(
                 msg="Requested Delivery Destination does not exist in this account."
@@ -1586,7 +1587,7 @@ class LogsBackend(BaseBackend):
         return {"deliveryDestinationPolicy": policy}
 
     def put_delivery_source(
-        self, name: str, resource_arn: str, log_type: str, tags: Dict[str, str]
+        self, name: str, resource_arn: str, log_type: str, tags: dict[str, str]
     ) -> DeliverySource:
         log_types = {
             "cloudfront": "ACCESS_LOGS",
@@ -1641,7 +1642,7 @@ class LogsBackend(BaseBackend):
             self.tag_resource(delivery_source.arn, tags)
         return delivery_source
 
-    def describe_delivery_sources(self) -> List[DeliverySource]:
+    def describe_delivery_sources(self) -> list[DeliverySource]:
         # Pagination not yet implemented
         delivery_sources = list(self.delivery_sources.values())
         return delivery_sources
@@ -1658,10 +1659,10 @@ class LogsBackend(BaseBackend):
         self,
         delivery_source_name: str,
         delivery_destination_arn: str,
-        record_fields: Optional[List[str]],
+        record_fields: Optional[list[str]],
         field_delimiter: Optional[str],
-        s3_delivery_configuration: Optional[Dict[str, Any]],
-        tags: Optional[Dict[str, str]],
+        s3_delivery_configuration: Optional[dict[str, Any]],
+        tags: Optional[dict[str, str]],
     ) -> Delivery:
         if delivery_source_name not in self.delivery_sources:
             raise ResourceNotFoundException(
@@ -1710,7 +1711,7 @@ class LogsBackend(BaseBackend):
             self.tag_resource(delivery.arn, tags)
         return delivery
 
-    def describe_deliveries(self) -> List[Delivery]:
+    def describe_deliveries(self) -> list[Delivery]:
         # Pagination not yet implemented
         deliveries = list(self.deliveries.values())
         return deliveries

--- a/moto/logs/utils.py
+++ b/moto/logs/utils.py
@@ -1,5 +1,3 @@
-from typing import Type
-
 PAGINATION_MODEL = {
     "describe_log_groups": {
         "input_token": "next_token",
@@ -42,7 +40,7 @@ class UnsupportedFilterPattern(FilterPattern):
 class EventMessageFilter:
     def __init__(self, pattern: str):
         current_phrase = ""
-        current_type: Type[FilterPattern] = None  # type: ignore
+        current_type: type[FilterPattern] = None  # type: ignore
         if pattern:
             for char in pattern:
                 if not current_type:

--- a/moto/macie2/exceptions.py
+++ b/moto/macie2/exceptions.py
@@ -1,4 +1,4 @@
-from typing import Any, List, Tuple
+from typing import Any
 
 from moto.core.exceptions import JsonRESTError
 
@@ -13,7 +13,7 @@ class ValidationException(MacieException):
     def __init__(self, message: str):
         super().__init__("ValidationException", message)
 
-    def get_headers(self, *args: Any, **kwargs: Any) -> List[Tuple[str, str]]:
+    def get_headers(self, *args: Any, **kwargs: Any) -> list[tuple[str, str]]:
         return [("x-amzn-ErrorType", "ValidationException")]
 
 
@@ -23,7 +23,7 @@ class AccessDeniedException(MacieException):
     def __init__(self, message: str):
         super().__init__("AccessDeniedException", message)
 
-    def get_headers(self, *args: Any, **kwargs: Any) -> List[Tuple[str, str]]:
+    def get_headers(self, *args: Any, **kwargs: Any) -> list[tuple[str, str]]:
         return [("x-amzn-ErrorType", "AccessDeniedException")]
 
 
@@ -33,5 +33,5 @@ class ResourceNotFoundException(MacieException):
     def __init__(self, message: str):
         super().__init__("ResourceNotFoundException", message)
 
-    def get_headers(self, *args: Any, **kwargs: Any) -> List[Tuple[str, str]]:
+    def get_headers(self, *args: Any, **kwargs: Any) -> list[tuple[str, str]]:
         return [("x-amzn-ErrorType", "ResourceNotFoundException")]

--- a/moto/macie2/models.py
+++ b/moto/macie2/models.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import Any, Dict, List, Optional
+from typing import Any, Optional
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
@@ -16,7 +16,7 @@ class Invitation(BaseModel):
         self.relationship_status = "Invited"
         self.arn = f"arn:aws:macie2:{region_name}:{admin_account_id}:invitation/{self.invitation_id}"
 
-    def to_json(self) -> Dict[str, Any]:
+    def to_json(self) -> dict[str, Any]:
         return {
             "accountId": self.account_id,
             "invitationId": self.invitation_id,
@@ -42,7 +42,7 @@ class Member(BaseModel):
         self.administrator_account_id = admin_account_id
         self.invited_at = invitation.invited_at
 
-    def to_json(self) -> Dict[str, Any]:
+    def to_json(self) -> dict[str, Any]:
         return {
             "accountId": self.account_id,
             "administratorAccountId": self.administrator_account_id,
@@ -58,11 +58,11 @@ class Member(BaseModel):
 class MacieBackend(BaseBackend):
     def __init__(self, region_name: str, account_id: str):
         super().__init__(region_name, account_id)
-        self.invitations: Dict[str, Invitation] = {}
-        self.members: Dict[str, Member] = {}
+        self.invitations: dict[str, Invitation] = {}
+        self.members: dict[str, Member] = {}
         self.administrator_account: Optional[Member] = None
         self.organization_admin_account_id: Optional[str] = None
-        self.macie_session: Optional[Dict[str, Any]] = {
+        self.macie_session: Optional[dict[str, Any]] = {
             "createdAt": datetime.utcnow(),
             "findingPublishingFrequency": "FIFTEEN_MINUTES",
             "serviceRole": f"arn:aws:iam::{account_id}:role/aws-service-role/macie.amazonaws.com/AWSServiceRoleForAmazonMacie",
@@ -70,7 +70,7 @@ class MacieBackend(BaseBackend):
             "updatedAt": datetime.utcnow(),
         }
 
-    def create_invitations(self, account_ids: List[str]) -> None:
+    def create_invitations(self, account_ids: list[str]) -> None:
         for account_id in account_ids:
             invitation = Invitation(
                 account_id=account_id,
@@ -79,10 +79,10 @@ class MacieBackend(BaseBackend):
             )
             self.invitations[account_id] = invitation
 
-    def list_invitations(self) -> List[Invitation]:
+    def list_invitations(self) -> list[Invitation]:
         return list(self.invitations.values())
 
-    def decline_invitations(self, account_ids: List[str]) -> None:
+    def decline_invitations(self, account_ids: list[str]) -> None:
         for account_id in account_ids:
             for backend_dict in macie2_backends.values():
                 backend = backend_dict.get(self.region_name)
@@ -114,7 +114,7 @@ class MacieBackend(BaseBackend):
                 backend.invitations.pop(self.account_id)
                 return
 
-    def list_members(self) -> List[Member]:
+    def list_members(self) -> list[Member]:
         return list(self.members.values())
 
     def get_administrator_account(self) -> Optional[Member]:
@@ -148,7 +148,7 @@ class MacieBackend(BaseBackend):
                 backend.administrator_account = None
                 break
 
-    def get_macie_session(self) -> Dict[str, Any]:
+    def get_macie_session(self) -> dict[str, Any]:
         if not self.macie_session:
             raise ResourceNotFoundException(
                 "The request failed because the specified resource doesn't exist."

--- a/moto/managedblockchain/exceptions.py
+++ b/moto/managedblockchain/exceptions.py
@@ -1,5 +1,5 @@
 import json
-from typing import Any, List, Tuple
+from typing import Any
 
 from moto.core.exceptions import JsonRESTError
 
@@ -11,7 +11,7 @@ class ManagedBlockchainClientError(JsonRESTError):
         self.message = message
         self.description = json.dumps({"message": self.message})
 
-    def get_headers(self, *args: Any, **kwargs: Any) -> List[Tuple[str, str]]:
+    def get_headers(self, *args: Any, **kwargs: Any) -> list[tuple[str, str]]:
         return [
             ("Content-Type", "application/json"),
             ("x-amzn-ErrorType", self.error_type),

--- a/moto/managedblockchain/models.py
+++ b/moto/managedblockchain/models.py
@@ -1,6 +1,6 @@
 import datetime
 import re
-from typing import Any, Dict, List, Optional
+from typing import Any, Optional
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
@@ -34,7 +34,7 @@ FRAMEWORKVERSIONS = [
     "1.2",
 ]
 
-EDITIONS: Dict[str, Any] = {
+EDITIONS: dict[str, Any] = {
     "STARTER": {
         "MaxMembers": 5,
         "MaxNodesPerMember": 2,
@@ -57,9 +57,9 @@ class ManagedBlockchainNetwork(BaseModel):
         name: str,
         framework: str,
         frameworkversion: str,
-        frameworkconfiguration: Dict[str, Any],
-        voting_policy: Dict[str, Any],
-        member_configuration: Dict[str, Any],
+        frameworkconfiguration: dict[str, Any],
+        voting_policy: dict[str, Any],
+        member_configuration: dict[str, Any],
         region: str,
         description: Optional[str] = None,
     ):
@@ -110,7 +110,7 @@ class ManagedBlockchainNetwork(BaseModel):
     def vote_pol_threshold_comparator(self) -> str:
         return self.voting_policy["ApprovalThresholdPolicy"]["ThresholdComparator"]
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         # Format for list_networks
         d = {
             "Id": self.id,
@@ -124,7 +124,7 @@ class ManagedBlockchainNetwork(BaseModel):
             d["Description"] = self.description
         return d
 
-    def get_format(self) -> Dict[str, Any]:
+    def get_format(self) -> dict[str, Any]:
         # Format for get_network
         frameworkattributes = {
             "Fabric": {
@@ -161,7 +161,7 @@ class ManagedBlockchainProposal(BaseModel):
         memberid: str,
         membername: str,
         numofmembers: int,
-        actions: Dict[str, Any],
+        actions: dict[str, Any],
         network_expiration: float,
         network_threshold: float,
         network_threshold_comp: str,
@@ -188,7 +188,7 @@ class ManagedBlockchainProposal(BaseModel):
         self.no_vote_count = 0
         self.outstanding_vote_count = self.numofmembers
         self.status = "IN_PROGRESS"
-        self.votes: Dict[str, Dict[str, str]] = {}
+        self.votes: dict[str, dict[str, str]] = {}
 
     @property
     def network_id(self) -> str:
@@ -199,10 +199,10 @@ class ManagedBlockchainProposal(BaseModel):
         return self.status
 
     @property
-    def proposal_votes(self) -> Dict[str, Any]:  # type: ignore[misc]
+    def proposal_votes(self) -> dict[str, Any]:  # type: ignore[misc]
         return self.votes
 
-    def proposal_actions(self, action_type: str) -> List[Dict[str, Any]]:
+    def proposal_actions(self, action_type: str) -> list[dict[str, Any]]:
         if action_type.lower() == "invitations":
             if "Invitations" in self.actions:
                 return self.actions["Invitations"]
@@ -215,7 +215,7 @@ class ManagedBlockchainProposal(BaseModel):
         if utcnow() > self.expirationdate:
             self.status = "EXPIRED"
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         # Format for list_proposals
         return {
             "ProposalId": self.id,
@@ -226,7 +226,7 @@ class ManagedBlockchainProposal(BaseModel):
             "ExpirationDate": self.expirationdate.strftime("%Y-%m-%dT%H:%M:%S.%f%z"),
         }
 
-    def get_format(self) -> Dict[str, Any]:
+    def get_format(self) -> dict[str, Any]:
         # Format for get_proposal
         d = {
             "ProposalId": self.id,
@@ -315,8 +315,8 @@ class ManagedBlockchainInvitation(BaseModel):
     def invitation_networkid(self) -> str:
         return self.networkid
 
-    def to_dict(self) -> Dict[str, Any]:
-        d: Dict[str, Any] = {
+    def to_dict(self) -> dict[str, Any]:
+        d: dict[str, Any] = {
             "InvitationId": self.id,
             "CreationDate": self.creationdate.strftime("%Y-%m-%dT%H:%M:%S.%f%z"),
             "ExpirationDate": self.expirationdate.strftime("%Y-%m-%dT%H:%M:%S.%f%z"),
@@ -349,7 +349,7 @@ class ManagedBlockchainMember(BaseModel):
         self,
         member_id: str,
         networkid: str,
-        member_configuration: Dict[str, Any],
+        member_configuration: dict[str, Any],
         region: str,
     ):
         self.creationdate = utcnow()
@@ -372,7 +372,7 @@ class ManagedBlockchainMember(BaseModel):
     def member_status(self) -> str:
         return self.status
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         # Format for list_members
         d = {
             "Id": self.id,
@@ -385,7 +385,7 @@ class ManagedBlockchainMember(BaseModel):
             self.description = self.member_configuration["Description"]
         return d
 
-    def get_format(self) -> Dict[str, Any]:
+    def get_format(self) -> dict[str, Any]:
         # Format for get_member
         frameworkattributes = {
             "Fabric": {
@@ -414,7 +414,7 @@ class ManagedBlockchainMember(BaseModel):
     def delete(self) -> None:
         self.status = "DELETED"
 
-    def update(self, logpublishingconfiguration: Dict[str, Any]) -> None:
+    def update(self, logpublishingconfiguration: dict[str, Any]) -> None:
         self.member_configuration["LogPublishingConfiguration"] = (
             logpublishingconfiguration
         )
@@ -428,7 +428,7 @@ class ManagedBlockchainNode(BaseModel):
         memberid: str,
         availabilityzone: str,
         instancetype: str,
-        logpublishingconfiguration: Dict[str, Any],
+        logpublishingconfiguration: dict[str, Any],
         region: str,
     ):
         self.creationdate = utcnow()
@@ -449,7 +449,7 @@ class ManagedBlockchainNode(BaseModel):
     def node_status(self) -> str:
         return self.status
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         # Format for list_nodes
         return {
             "Id": self.id,
@@ -459,7 +459,7 @@ class ManagedBlockchainNode(BaseModel):
             "InstanceType": self.instancetype,
         }
 
-    def get_format(self) -> Dict[str, Any]:
+    def get_format(self) -> dict[str, Any]:
         # Format for get_node
         frameworkattributes = {
             "Fabric": {
@@ -483,29 +483,29 @@ class ManagedBlockchainNode(BaseModel):
     def delete(self) -> None:
         self.status = "DELETED"
 
-    def update(self, logpublishingconfiguration: Dict[str, Any]) -> None:
+    def update(self, logpublishingconfiguration: dict[str, Any]) -> None:
         self.logpublishingconfiguration = logpublishingconfiguration
 
 
 class ManagedBlockchainBackend(BaseBackend):
     def __init__(self, region_name: str, account_id: str):
         super().__init__(region_name, account_id)
-        self.networks: Dict[str, ManagedBlockchainNetwork] = {}
-        self.members: Dict[str, ManagedBlockchainMember] = {}
-        self.proposals: Dict[str, ManagedBlockchainProposal] = {}
-        self.invitations: Dict[str, ManagedBlockchainInvitation] = {}
-        self.nodes: Dict[str, ManagedBlockchainNode] = {}
+        self.networks: dict[str, ManagedBlockchainNetwork] = {}
+        self.members: dict[str, ManagedBlockchainMember] = {}
+        self.proposals: dict[str, ManagedBlockchainProposal] = {}
+        self.invitations: dict[str, ManagedBlockchainInvitation] = {}
+        self.nodes: dict[str, ManagedBlockchainNode] = {}
 
     def create_network(
         self,
         name: str,
         framework: str,
         frameworkversion: str,
-        frameworkconfiguration: Dict[str, Any],
-        voting_policy: Dict[str, Any],
-        member_configuration: Dict[str, Any],
+        frameworkconfiguration: dict[str, Any],
+        voting_policy: dict[str, Any],
+        member_configuration: dict[str, Any],
         description: Optional[str] = None,
-    ) -> Dict[str, str]:
+    ) -> dict[str, str]:
         # Check framework
         if framework not in FRAMEWORKS:
             raise BadRequestException("CreateNetwork", "Invalid request body")
@@ -548,7 +548,7 @@ class ManagedBlockchainBackend(BaseBackend):
         # Return the network and member ID
         return {"NetworkId": network_id, "MemberId": member_id}
 
-    def list_networks(self) -> List[ManagedBlockchainNetwork]:
+    def list_networks(self) -> list[ManagedBlockchainNetwork]:
         return list(self.networks.values())
 
     def get_network(self, network_id: str) -> ManagedBlockchainNetwork:
@@ -562,9 +562,9 @@ class ManagedBlockchainBackend(BaseBackend):
         self,
         networkid: str,
         memberid: str,
-        actions: Dict[str, Any],
+        actions: dict[str, Any],
         description: Optional[str] = None,
-    ) -> Dict[str, str]:
+    ) -> dict[str, str]:
         # Check if network exists
         if networkid not in self.networks:
             raise ResourceNotFoundException(
@@ -616,7 +616,7 @@ class ManagedBlockchainBackend(BaseBackend):
         # Return the proposal ID
         return {"ProposalId": proposal_id}
 
-    def list_proposals(self, networkid: str) -> List[ManagedBlockchainProposal]:
+    def list_proposals(self, networkid: str) -> list[ManagedBlockchainProposal]:
         # Check if network exists
         if networkid not in self.networks:
             raise ResourceNotFoundException(
@@ -721,7 +721,7 @@ class ManagedBlockchainBackend(BaseBackend):
             for propmember in self.proposals[proposalid].proposal_actions("Removals"):
                 self.delete_member(networkid, propmember["MemberId"])
 
-    def list_proposal_votes(self, networkid: str, proposalid: str) -> List[str]:
+    def list_proposal_votes(self, networkid: str, proposalid: str) -> list[str]:
         # Check if network exists
         if networkid not in self.networks:
             raise ResourceNotFoundException(
@@ -741,7 +741,7 @@ class ManagedBlockchainBackend(BaseBackend):
                     proposalvotesfornetwork.append(proposal_vote)
         return proposalvotesfornetwork
 
-    def list_invitations(self) -> List[ManagedBlockchainInvitation]:
+    def list_invitations(self) -> list[ManagedBlockchainInvitation]:
         return list(self.invitations.values())
 
     def reject_invitation(self, invitationid: str) -> None:
@@ -752,8 +752,8 @@ class ManagedBlockchainBackend(BaseBackend):
         self.invitations[invitationid].reject_invitation()
 
     def create_member(
-        self, invitationid: str, networkid: str, member_configuration: Dict[str, Any]
-    ) -> Dict[str, str]:
+        self, invitationid: str, networkid: str, member_configuration: dict[str, Any]
+    ) -> dict[str, str]:
         # Check if network exists
         if networkid not in self.networks:
             raise ResourceNotFoundException(
@@ -808,7 +808,7 @@ class ManagedBlockchainBackend(BaseBackend):
         # Return the member ID
         return {"MemberId": member_id}
 
-    def list_members(self, networkid: str) -> List[ManagedBlockchainMember]:
+    def list_members(self, networkid: str) -> list[ManagedBlockchainMember]:
         # Check if network exists
         if networkid not in self.networks:
             raise ResourceNotFoundException(
@@ -872,7 +872,7 @@ class ManagedBlockchainBackend(BaseBackend):
             del self.nodes[nodeid]
 
     def update_member(
-        self, networkid: str, memberid: str, logpublishingconfiguration: Dict[str, Any]
+        self, networkid: str, memberid: str, logpublishingconfiguration: dict[str, Any]
     ) -> None:
         # Check if network exists
         if networkid not in self.networks:
@@ -893,8 +893,8 @@ class ManagedBlockchainBackend(BaseBackend):
         memberid: str,
         availabilityzone: str,
         instancetype: str,
-        logpublishingconfiguration: Dict[str, Any],
-    ) -> Dict[str, str]:
+        logpublishingconfiguration: dict[str, Any],
+    ) -> dict[str, str]:
         # Check if network exists
         if networkid not in self.networks:
             raise ResourceNotFoundException(
@@ -961,7 +961,7 @@ class ManagedBlockchainBackend(BaseBackend):
 
     def list_nodes(
         self, networkid: str, memberid: str, status: Optional[str] = None
-    ) -> List[ManagedBlockchainNode]:
+    ) -> list[ManagedBlockchainNode]:
         if networkid not in self.networks:
             raise ResourceNotFoundException(
                 "ListNodes", f"Network {networkid} not found."
@@ -1029,7 +1029,7 @@ class ManagedBlockchainBackend(BaseBackend):
         networkid: str,
         memberid: str,
         nodeid: str,
-        logpublishingconfiguration: Dict[str, Any],
+        logpublishingconfiguration: dict[str, Any],
     ) -> None:
         # Check if network exists
         if networkid not in self.networks:

--- a/moto/managedblockchain/utils.py
+++ b/moto/managedblockchain/utils.py
@@ -1,7 +1,7 @@
 import json
 import re
 import string
-from typing import Any, Dict, List, Optional
+from typing import Any, Optional
 from urllib.parse import parse_qs, urlparse
 
 from moto.moto_api._internal import mock_random as random
@@ -21,7 +21,7 @@ def get_network_id() -> str:
     )
 
 
-def memberid_from_managedblockchain_request(full_url: str, body: Dict[str, Any]) -> str:
+def memberid_from_managedblockchain_request(full_url: str, body: dict[str, Any]) -> str:
     id_search = re.search(r"\/m-[A-Z0-9]{26}", full_url, re.IGNORECASE)
     return_id = None
     if id_search:
@@ -73,7 +73,7 @@ def get_invitation_id() -> str:
 
 
 def member_name_exist_in_network(
-    members: Dict[str, Any], networkid: str, membername: str
+    members: dict[str, Any], networkid: str, membername: str
 ) -> bool:
     for member in members.values():
         if member.network_id == networkid:
@@ -83,7 +83,7 @@ def member_name_exist_in_network(
 
 
 def number_of_members_in_network(
-    members: Dict[str, Any], networkid: str, member_status: Optional[str] = None
+    members: dict[str, Any], networkid: str, member_status: Optional[str] = None
 ) -> int:
     return len(
         [
@@ -123,7 +123,7 @@ def get_node_id() -> str:
 
 
 def number_of_nodes_in_member(
-    nodes: Dict[str, Any], memberid: str, node_status: Optional[str] = None
+    nodes: dict[str, Any], memberid: str, node_status: Optional[str] = None
 ) -> int:
     return len(
         [
@@ -135,5 +135,5 @@ def number_of_nodes_in_member(
     )
 
 
-def nodes_in_member(nodes: Dict[str, Any], memberid: str) -> List[str]:
+def nodes_in_member(nodes: dict[str, Any], memberid: str) -> list[str]:
     return [nodid for nodid in nodes if nodes[nodid].member_id == memberid]

--- a/moto/mediaconnect/models.py
+++ b/moto/mediaconnect/models.py
@@ -1,5 +1,5 @@
 from collections import OrderedDict
-from typing import Any, Dict, List, Optional
+from typing import Any, Optional
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
@@ -33,7 +33,7 @@ class Flow(BaseModel):
                 self.source,
             ]
 
-    def to_dict(self, include: Optional[List[str]] = None) -> Dict[str, Any]:
+    def to_dict(self, include: Optional[list[str]] = None) -> dict[str, Any]:
         data = {
             "availabilityZone": self.availability_zone,
             "description": self.description,
@@ -72,12 +72,12 @@ class Flow(BaseModel):
 class MediaConnectBackend(BaseBackend):
     def __init__(self, region_name: str, account_id: str):
         super().__init__(region_name, account_id)
-        self._flows: Dict[str, Flow] = OrderedDict()
+        self._flows: dict[str, Flow] = OrderedDict()
         self.tagger = TaggingService()
 
     def _add_source_details(
         self,
-        source: Optional[Dict[str, Any]],
+        source: Optional[dict[str, Any]],
         flow_id: str,
         ingest_ip: str = "127.0.0.1",
     ) -> None:
@@ -90,7 +90,7 @@ class MediaConnectBackend(BaseBackend):
                 source["ingestIp"] = ingest_ip
 
     def _add_entitlement_details(
-        self, entitlement: Optional[Dict[str, Any]], entitlement_id: str
+        self, entitlement: Optional[dict[str, Any]], entitlement_id: str
     ) -> None:
         if entitlement:
             entitlement["entitlementArn"] = (
@@ -120,14 +120,14 @@ class MediaConnectBackend(BaseBackend):
     def create_flow(
         self,
         availability_zone: str,
-        entitlements: List[Dict[str, Any]],
+        entitlements: list[dict[str, Any]],
         name: str,
-        outputs: List[Dict[str, Any]],
-        source: Dict[str, Any],
-        source_failover_config: Dict[str, Any],
-        sources: List[Dict[str, Any]],
-        vpc_interfaces: List[Dict[str, Any]],
-        maintenance: Optional[List[Dict[str, Any]]] = None,
+        outputs: list[dict[str, Any]],
+        source: dict[str, Any],
+        source_failover_config: dict[str, Any],
+        sources: list[dict[str, Any]],
+        vpc_interfaces: list[dict[str, Any]],
+        maintenance: Optional[list[dict[str, Any]]] = None,
     ) -> Flow:
         flow = Flow(
             account_id=self.account_id,
@@ -146,7 +146,7 @@ class MediaConnectBackend(BaseBackend):
         self._flows[flow.flow_arn] = flow
         return flow
 
-    def list_flows(self, max_results: Optional[int]) -> List[Dict[str, Any]]:
+    def list_flows(self, max_results: Optional[int]) -> list[dict[str, Any]]:
         """
         Pagination is not yet implemented
         """
@@ -193,17 +193,17 @@ class MediaConnectBackend(BaseBackend):
             return flow
         raise NotFoundException(message="Flow not found.")
 
-    def tag_resource(self, resource_arn: str, tags: Dict[str, Any]) -> None:
+    def tag_resource(self, resource_arn: str, tags: dict[str, Any]) -> None:
         tag_list = TaggingService.convert_dict_to_tags_input(tags)
         self.tagger.tag_resource(resource_arn, tag_list)
 
-    def list_tags_for_resource(self, resource_arn: str) -> Dict[str, str]:
+    def list_tags_for_resource(self, resource_arn: str) -> dict[str, str]:
         if self.tagger.has_tags(resource_arn):
             return self.tagger.get_tag_dict_for_resource(resource_arn)
         raise NotFoundException(message="Resource not found.")
 
     def add_flow_vpc_interfaces(
-        self, flow_arn: str, vpc_interfaces: List[Dict[str, Any]]
+        self, flow_arn: str, vpc_interfaces: list[dict[str, Any]]
     ) -> Flow:
         if flow_arn in self._flows:
             flow = self._flows[flow_arn]
@@ -211,7 +211,7 @@ class MediaConnectBackend(BaseBackend):
             return flow
         raise NotFoundException(message=f"flow with arn={flow_arn} not found")
 
-    def add_flow_outputs(self, flow_arn: str, outputs: List[Dict[str, Any]]) -> Flow:
+    def add_flow_outputs(self, flow_arn: str, outputs: list[dict[str, Any]]) -> Flow:
         if flow_arn in self._flows:
             flow = self._flows[flow_arn]
             flow.outputs = outputs
@@ -244,12 +244,12 @@ class MediaConnectBackend(BaseBackend):
         self,
         flow_arn: str,
         output_arn: str,
-        cidr_allow_list: List[str],
+        cidr_allow_list: list[str],
         description: str,
         destination: str,
-        encryption: Dict[str, str],
+        encryption: dict[str, str],
         max_latency: int,
-        media_stream_output_configuration: List[Dict[str, Any]],
+        media_stream_output_configuration: list[dict[str, Any]],
         min_latency: int,
         port: int,
         protocol: str,
@@ -258,8 +258,8 @@ class MediaConnectBackend(BaseBackend):
         sender_ip_address: str,
         smoothing_latency: int,
         stream_id: str,
-        vpc_interface_attachment: Dict[str, str],
-    ) -> Dict[str, Any]:
+        vpc_interface_attachment: dict[str, str],
+    ) -> dict[str, Any]:
         if flow_arn not in self._flows:
             raise NotFoundException(message=f"flow with arn={flow_arn} not found")
         flow = self._flows[flow_arn]
@@ -286,8 +286,8 @@ class MediaConnectBackend(BaseBackend):
         raise NotFoundException(message=f"output with arn={output_arn} not found")
 
     def add_flow_sources(
-        self, flow_arn: str, sources: List[Dict[str, Any]]
-    ) -> List[Dict[str, Any]]:
+        self, flow_arn: str, sources: list[dict[str, Any]]
+    ) -> list[dict[str, Any]]:
         if flow_arn not in self._flows:
             raise NotFoundException(message=f"flow with arn={flow_arn} not found")
         flow = self._flows[flow_arn]
@@ -310,7 +310,7 @@ class MediaConnectBackend(BaseBackend):
         max_bitrate: int,
         max_latency: int,
         max_sync_buffer: int,
-        media_stream_source_configurations: List[Dict[str, Any]],
+        media_stream_source_configurations: list[dict[str, Any]],
         min_latency: int,
         protocol: str,
         sender_control_port: int,
@@ -318,11 +318,11 @@ class MediaConnectBackend(BaseBackend):
         stream_id: str,
         vpc_interface_name: str,
         whitelist_cidr: str,
-    ) -> Optional[Dict[str, Any]]:
+    ) -> Optional[dict[str, Any]]:
         if flow_arn not in self._flows:
             raise NotFoundException(message=f"flow with arn={flow_arn} not found")
         flow = self._flows[flow_arn]
-        source: Optional[Dict[str, Any]] = next(
+        source: Optional[dict[str, Any]] = next(
             iter(
                 [source for source in flow.sources if source["sourceArn"] == source_arn]
             ),
@@ -351,8 +351,8 @@ class MediaConnectBackend(BaseBackend):
     def grant_flow_entitlements(
         self,
         flow_arn: str,
-        entitlements: List[Dict[str, Any]],
-    ) -> List[Dict[str, Any]]:
+        entitlements: list[dict[str, Any]],
+    ) -> list[dict[str, Any]]:
         if flow_arn not in self._flows:
             raise NotFoundException(message=f"flow with arn={flow_arn} not found")
         flow = self._flows[flow_arn]
@@ -382,11 +382,11 @@ class MediaConnectBackend(BaseBackend):
         flow_arn: str,
         entitlement_arn: str,
         description: str,
-        encryption: Dict[str, str],
+        encryption: dict[str, str],
         entitlement_status: str,
         name: str,
-        subscribers: List[str],
-    ) -> Dict[str, Any]:
+        subscribers: list[str],
+    ) -> dict[str, Any]:
         if flow_arn not in self._flows:
             raise NotFoundException(message=f"flow with arn={flow_arn} not found")
         flow = self._flows[flow_arn]

--- a/moto/medialive/models.py
+++ b/moto/medialive/models.py
@@ -1,5 +1,5 @@
 from collections import OrderedDict
-from typing import Any, Dict, List, Optional
+from typing import Any, Optional
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
@@ -42,7 +42,7 @@ class Input(BaseModel):
         self.tags = kwargs.get("tags")
         self.input_type = kwargs.get("input_type")
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         return {
             "arn": self.arn,
             "attachedChannels": self.attached_channels,
@@ -89,7 +89,7 @@ class Channel(BaseModel):
         self.tags = kwargs.get("tags")
         self._previous_state = None
 
-    def to_dict(self, exclude: Optional[List[str]] = None) -> Dict[str, Any]:
+    def to_dict(self, exclude: Optional[list[str]] = None) -> dict[str, Any]:
         data = {
             "arn": self.arn,
             "cdiInputSpecification": self.cdi_input_specification,
@@ -132,21 +132,21 @@ class Channel(BaseModel):
 class MediaLiveBackend(BaseBackend):
     def __init__(self, region_name: str, account_id: str):
         super().__init__(region_name, account_id)
-        self._channels: Dict[str, Channel] = OrderedDict()
-        self._inputs: Dict[str, Input] = OrderedDict()
+        self._channels: dict[str, Channel] = OrderedDict()
+        self._inputs: dict[str, Input] = OrderedDict()
 
     def create_channel(
         self,
-        cdi_input_specification: Dict[str, Any],
+        cdi_input_specification: dict[str, Any],
         channel_class: str,
-        destinations: List[Dict[str, Any]],
-        encoder_settings: Dict[str, Any],
-        input_attachments: List[Dict[str, Any]],
-        input_specification: Dict[str, str],
+        destinations: list[dict[str, Any]],
+        encoder_settings: dict[str, Any],
+        input_attachments: list[dict[str, Any]],
+        input_specification: dict[str, str],
         log_level: str,
         name: str,
         role_arn: str,
-        tags: Dict[str, str],
+        tags: dict[str, str],
     ) -> Channel:
         """
         The RequestID and Reserved parameters are not yet implemented
@@ -174,7 +174,7 @@ class MediaLiveBackend(BaseBackend):
         return channel
 
     @paginate(pagination_model=PAGINATION_MODEL)
-    def list_channels(self) -> List[Channel]:
+    def list_channels(self) -> list[Channel]:
         return [c for c in self._channels.values()]
 
     def describe_channel(self, channel_id: str) -> Channel:
@@ -200,11 +200,11 @@ class MediaLiveBackend(BaseBackend):
     def update_channel(
         self,
         channel_id: str,
-        cdi_input_specification: Dict[str, str],
-        destinations: List[Dict[str, Any]],
-        encoder_settings: Dict[str, Any],
-        input_attachments: List[Dict[str, Any]],
-        input_specification: Dict[str, str],
+        cdi_input_specification: dict[str, str],
+        destinations: list[dict[str, Any]],
+        encoder_settings: dict[str, Any],
+        input_attachments: list[dict[str, Any]],
+        input_specification: dict[str, str],
         log_level: str,
         name: str,
         role_arn: str,
@@ -227,14 +227,14 @@ class MediaLiveBackend(BaseBackend):
 
     def create_input(
         self,
-        destinations: List[Dict[str, str]],
-        input_devices: List[Dict[str, str]],
-        input_security_groups: List[str],
-        media_connect_flows: List[Dict[str, str]],
+        destinations: list[dict[str, str]],
+        input_devices: list[dict[str, str]],
+        input_security_groups: list[str],
+        media_connect_flows: list[dict[str, str]],
         name: str,
         role_arn: str,
-        sources: List[Dict[str, str]],
-        tags: Dict[str, str],
+        sources: list[dict[str, str]],
+        tags: dict[str, str],
         input_type: str,
     ) -> Input:
         """
@@ -265,7 +265,7 @@ class MediaLiveBackend(BaseBackend):
         return a_input
 
     @paginate(PAGINATION_MODEL)
-    def list_inputs(self) -> List[Input]:
+    def list_inputs(self) -> list[Input]:
         return [i for i in self._inputs.values()]
 
     def delete_input(self, input_id: str) -> None:
@@ -274,14 +274,14 @@ class MediaLiveBackend(BaseBackend):
 
     def update_input(
         self,
-        destinations: List[Dict[str, str]],
-        input_devices: List[Dict[str, str]],
+        destinations: list[dict[str, str]],
+        input_devices: list[dict[str, str]],
         input_id: str,
-        input_security_groups: List[str],
-        media_connect_flows: List[Dict[str, str]],
+        input_security_groups: list[str],
+        media_connect_flows: list[dict[str, str]],
         name: str,
         role_arn: str,
-        sources: List[Dict[str, str]],
+        sources: list[dict[str, str]],
     ) -> Input:
         a_input = self._inputs[input_id]
         a_input.destinations = destinations

--- a/moto/mediapackage/models.py
+++ b/moto/mediapackage/models.py
@@ -1,5 +1,5 @@
 from collections import OrderedDict
-from typing import Any, Dict, List
+from typing import Any
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
@@ -15,7 +15,7 @@ class Channel(BaseModel):
         self.description = kwargs.get("description")
         self.tags = kwargs.get("tags")
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         return {
             "arn": self.arn,
             "id": self.channel_id,
@@ -43,7 +43,7 @@ class OriginEndpoint(BaseModel):
         self.url = kwargs.get("url")
         self.whitelist = kwargs.get("whitelist")
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         return {
             "arn": self.arn,
             "authorization": self.authorization,
@@ -67,11 +67,11 @@ class OriginEndpoint(BaseModel):
 class MediaPackageBackend(BaseBackend):
     def __init__(self, region_name: str, account_id: str):
         super().__init__(region_name, account_id)
-        self._channels: Dict[str, Channel] = OrderedDict()
-        self._origin_endpoints: Dict[str, OriginEndpoint] = OrderedDict()
+        self._channels: dict[str, Channel] = OrderedDict()
+        self._origin_endpoints: dict[str, OriginEndpoint] = OrderedDict()
 
     def create_channel(
-        self, description: str, channel_id: str, tags: Dict[str, str]
+        self, description: str, channel_id: str, tags: dict[str, str]
     ) -> Channel:
         arn = f"arn:{get_partition(self.region_name)}:mediapackage:channel:{channel_id}"
         channel = Channel(
@@ -83,7 +83,7 @@ class MediaPackageBackend(BaseBackend):
         self._channels[channel_id] = channel
         return channel
 
-    def list_channels(self) -> List[Dict[str, Any]]:
+    def list_channels(self) -> list[dict[str, Any]]:
         return [c.to_dict() for c in self._channels.values()]
 
     def describe_channel(self, channel_id: str) -> Channel:
@@ -103,20 +103,20 @@ class MediaPackageBackend(BaseBackend):
 
     def create_origin_endpoint(
         self,
-        authorization: Dict[str, str],
+        authorization: dict[str, str],
         channel_id: str,
-        cmaf_package: Dict[str, Any],
-        dash_package: Dict[str, Any],
+        cmaf_package: dict[str, Any],
+        dash_package: dict[str, Any],
         description: str,
-        hls_package: Dict[str, Any],
+        hls_package: dict[str, Any],
         endpoint_id: str,
         manifest_name: str,
-        mss_package: Dict[str, Any],
+        mss_package: dict[str, Any],
         origination: str,
         startover_window_seconds: int,
-        tags: Dict[str, str],
+        tags: dict[str, str],
         time_delay_seconds: int,
-        whitelist: List[str],
+        whitelist: list[str],
     ) -> OriginEndpoint:
         arn = f"arn:{get_partition(self.region_name)}:mediapackage:origin_endpoint:{endpoint_id}"
         url = f"https://origin-endpoint.mediapackage.{self.region_name}.amazonaws.com/{endpoint_id}"
@@ -149,7 +149,7 @@ class MediaPackageBackend(BaseBackend):
                 "NotFoundException", f"origin endpoint with id={endpoint_id} not found"
             )
 
-    def list_origin_endpoints(self) -> List[Dict[str, Any]]:
+    def list_origin_endpoints(self) -> list[dict[str, Any]]:
         return [o.to_dict() for o in self._origin_endpoints.values()]
 
     def delete_origin_endpoint(self, endpoint_id: str) -> OriginEndpoint:
@@ -161,18 +161,18 @@ class MediaPackageBackend(BaseBackend):
 
     def update_origin_endpoint(
         self,
-        authorization: Dict[str, str],
-        cmaf_package: Dict[str, Any],
-        dash_package: Dict[str, Any],
+        authorization: dict[str, str],
+        cmaf_package: dict[str, Any],
+        dash_package: dict[str, Any],
         description: str,
-        hls_package: Dict[str, Any],
+        hls_package: dict[str, Any],
         endpoint_id: str,
         manifest_name: str,
-        mss_package: Dict[str, Any],
+        mss_package: dict[str, Any],
         origination: str,
         startover_window_seconds: int,
         time_delay_seconds: int,
-        whitelist: List[str],
+        whitelist: list[str],
     ) -> OriginEndpoint:
         try:
             origin_endpoint = self._origin_endpoints[endpoint_id]

--- a/moto/mediastore/models.py
+++ b/moto/mediastore/models.py
@@ -1,6 +1,6 @@
 from collections import OrderedDict
 from datetime import date
-from typing import Any, Dict, List, Optional
+from typing import Any, Optional
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
@@ -25,7 +25,7 @@ class Container(BaseModel):
         self.metric_policy: Optional[str] = None
         self.tags = kwargs.get("tags")
 
-    def to_dict(self, exclude: Optional[List[str]] = None) -> Dict[str, Any]:
+    def to_dict(self, exclude: Optional[list[str]] = None) -> dict[str, Any]:
         data = {
             "ARN": self.arn,
             "Name": self.name,
@@ -43,9 +43,9 @@ class Container(BaseModel):
 class MediaStoreBackend(BaseBackend):
     def __init__(self, region_name: str, account_id: str):
         super().__init__(region_name, account_id)
-        self._containers: Dict[str, Container] = OrderedDict()
+        self._containers: dict[str, Container] = OrderedDict()
 
-    def create_container(self, name: str, tags: Dict[str, str]) -> Container:
+    def create_container(self, name: str, tags: dict[str, str]) -> Container:
         arn = f"arn:{get_partition(self.region_name)}:mediastore:container:{name}"
         container = Container(
             arn=arn,
@@ -70,13 +70,13 @@ class MediaStoreBackend(BaseBackend):
         container.status = "ACTIVE"
         return container
 
-    def list_containers(self) -> List[Dict[str, Any]]:
+    def list_containers(self) -> list[dict[str, Any]]:
         """
         Pagination is not yet implemented
         """
         return [c.to_dict() for c in self._containers.values()]
 
-    def list_tags_for_resource(self, name: str) -> Optional[Dict[str, str]]:
+    def list_tags_for_resource(self, name: str) -> Optional[dict[str, str]]:
         if name not in self._containers:
             raise ContainerNotFoundException()
         tags = self._containers[name].tags

--- a/moto/mediastoredata/models.py
+++ b/moto/mediastoredata/models.py
@@ -1,6 +1,6 @@
 import hashlib
 from collections import OrderedDict
-from typing import Any, Dict, List
+from typing import Any
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
@@ -18,7 +18,7 @@ class Object(BaseModel):
         self.etag = etag
         self.storage_class = storage_class
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         return {
             "ETag": self.etag,
             "Name": self.path,
@@ -33,7 +33,7 @@ class Object(BaseModel):
 class MediaStoreDataBackend(BaseBackend):
     def __init__(self, region_name: str, account_id: str):
         super().__init__(region_name, account_id)
-        self._objects: Dict[str, Object] = OrderedDict()
+        self._objects: dict[str, Object] = OrderedDict()
 
     def put_object(
         self, body: str, path: str, storage_class: str = "TEMPORAL"
@@ -65,7 +65,7 @@ class MediaStoreDataBackend(BaseBackend):
             )
         return objects_found[0]
 
-    def list_items(self) -> List[Dict[str, Any]]:
+    def list_items(self) -> list[dict[str, Any]]:
         """
         The Path- and MaxResults-parameters are not yet supported.
         """

--- a/moto/mediastoredata/responses.py
+++ b/moto/mediastoredata/responses.py
@@ -1,5 +1,4 @@
 import json
-from typing import Dict, Tuple
 
 from moto.core.responses import BaseResponse
 
@@ -14,7 +13,7 @@ class MediaStoreDataResponse(BaseResponse):
     def mediastoredata_backend(self) -> MediaStoreDataBackend:
         return mediastoredata_backends[self.current_account][self.region]
 
-    def get_object(self) -> Tuple[str, Dict[str, str]]:
+    def get_object(self) -> tuple[str, dict[str, str]]:
         path = self._get_param("Path")
         result = self.mediastoredata_backend.get_object(path=path)
         headers = {"Path": result.path}

--- a/moto/memorydb/exceptions.py
+++ b/moto/memorydb/exceptions.py
@@ -1,7 +1,5 @@
 """Exceptions raised by the memorydb service."""
 
-from typing import List
-
 from moto.core.exceptions import JsonRESTError
 
 
@@ -15,7 +13,7 @@ class ClusterAlreadyExistsFault(MemoryDBClientError):
 
 
 class InvalidSubnetError(MemoryDBClientError):
-    def __init__(self, subnet_identifier: List[str]):
+    def __init__(self, subnet_identifier: list[str]):
         super().__init__("InvalidSubnetError", f"Subnet {subnet_identifier} not found.")
 
 

--- a/moto/meteringmarketplace/models.py
+++ b/moto/meteringmarketplace/models.py
@@ -1,12 +1,12 @@
 import collections
-from typing import Any, Deque, Dict, List
+from typing import Any
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
 from moto.moto_api._internal import mock_random
 
 
-class UsageRecord(BaseModel, Dict[str, Any]):  # type: ignore[misc]
+class UsageRecord(BaseModel, dict[str, Any]):  # type: ignore[misc]
     def __init__(
         self,
         timestamp: str,
@@ -54,7 +54,7 @@ class UsageRecord(BaseModel, Dict[str, Any]):  # type: ignore[misc]
         self["Quantity"] = value
 
 
-class Result(BaseModel, Dict[str, Any]):  # type: ignore[misc]
+class Result(BaseModel, dict[str, Any]):  # type: ignore[misc]
     SUCCESS = "Success"
     CUSTOMER_NOT_SUBSCRIBED = "CustomerNotSubscribed"
     DUPLICATE_RECORD = "DuplicateRecord"
@@ -105,12 +105,12 @@ class Result(BaseModel, Dict[str, Any]):  # type: ignore[misc]
         )
 
 
-class CustomerDeque(Deque[str]):
+class CustomerDeque(collections.deque[str]):
     def is_subscribed(self, customer: str) -> bool:
         return customer in self
 
 
-class ResultDeque(Deque[Result]):
+class ResultDeque(collections.deque[Result]):
     def is_duplicate(self, result: Result) -> bool:
         return any(record.is_duplicate(result) for record in self)
 
@@ -118,16 +118,16 @@ class ResultDeque(Deque[Result]):
 class MeteringMarketplaceBackend(BaseBackend):
     def __init__(self, region_name: str, account_id: str):
         super().__init__(region_name, account_id)
-        self.customers_by_product: Dict[str, CustomerDeque] = collections.defaultdict(
+        self.customers_by_product: dict[str, CustomerDeque] = collections.defaultdict(
             CustomerDeque
         )
-        self.records_by_product: Dict[str, ResultDeque] = collections.defaultdict(
+        self.records_by_product: dict[str, ResultDeque] = collections.defaultdict(
             ResultDeque
         )
 
     def batch_meter_usage(
-        self, product_code: str, usage_records: List[Dict[str, Any]]
-    ) -> List[Result]:
+        self, product_code: str, usage_records: list[dict[str, Any]]
+    ) -> list[Result]:
         results = []
         for usage in usage_records:
             result = Result(**usage)

--- a/moto/moto_api/_internal/managed_state_model.py
+++ b/moto/moto_api/_internal/managed_state_model.py
@@ -1,5 +1,5 @@
 from datetime import datetime, timedelta
-from typing import List, Optional, Tuple
+from typing import Optional
 
 from moto.moto_api import state_manager
 
@@ -9,7 +9,7 @@ class ManagedState:
     Subclass this class to configure state-transitions
     """
 
-    def __init__(self, model_name: str, transitions: List[Tuple[Optional[str], str]]):
+    def __init__(self, model_name: str, transitions: list[tuple[Optional[str], str]]):
         # Indicate the possible transitions for this model
         # Example: [(initializing,queued), (queued, starting), (starting, ready)]
         self._transitions = transitions

--- a/moto/moto_api/_internal/models.py
+++ b/moto/moto_api/_internal/models.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional, Set, Tuple
+from typing import Any, Optional
 
 from moto.core import DEFAULT_ACCOUNT_ID
 from moto.core.base_backend import BackendDict, BaseBackend
@@ -9,8 +9,8 @@ from moto.core.model_instances import reset_model_data
 class MotoAPIBackend(BaseBackend):
     def __init__(self, region_name: str, account_id: str):
         super().__init__(region_name, account_id)
-        self.proxy_urls_to_passthrough: Set[str] = set()
-        self.proxy_hosts_to_passthrough: Set[str] = set()
+        self.proxy_urls_to_passthrough: set[str] = set()
+        self.proxy_hosts_to_passthrough: set[str] = set()
 
     def reset(self) -> None:
         region_name = self.region_name
@@ -20,12 +20,12 @@ class MotoAPIBackend(BaseBackend):
         reset_model_data()
         self.__init__(region_name, account_id)  # type: ignore[misc]
 
-    def get_transition(self, model_name: str) -> Dict[str, Any]:
+    def get_transition(self, model_name: str) -> dict[str, Any]:
         from moto.moto_api import state_manager
 
         return state_manager.get_transition(model_name)
 
-    def set_transition(self, model_name: str, transition: Dict[str, Any]) -> None:
+    def set_transition(self, model_name: str, transition: dict[str, Any]) -> None:
         from moto.moto_api import state_manager
 
         state_manager.set_transition(model_name, transition)
@@ -37,8 +37,8 @@ class MotoAPIBackend(BaseBackend):
 
     def set_athena_result(
         self,
-        rows: List[Dict[str, Any]],
-        column_info: List[Dict[str, str]],
+        rows: list[dict[str, Any]],
+        column_info: list[dict[str, str]],
         account_id: str,
         region: str,
     ) -> None:
@@ -48,7 +48,7 @@ class MotoAPIBackend(BaseBackend):
         results = QueryResults(rows=rows, column_info=column_info)
         backend.query_results_queue.append(results)
 
-    def set_ce_cost_usage(self, result: Dict[str, Any], account_id: str) -> None:
+    def set_ce_cost_usage(self, result: dict[str, Any], account_id: str) -> None:
         from moto.ce.models import ce_backends
 
         backend = ce_backends[account_id]["global"]
@@ -63,7 +63,7 @@ class MotoAPIBackend(BaseBackend):
         backend.lambda_simple_results_queue.append(result)
 
     def set_resilience_result(
-        self, result: List[Dict[str, Any]], account_id: str, region: str
+        self, result: list[dict[str, Any]], account_id: str, region: str
     ) -> None:
         from moto.resiliencehub.models import resiliencehub_backends
 
@@ -98,10 +98,10 @@ class MotoAPIBackend(BaseBackend):
 
     def set_rds_data_result(
         self,
-        records: Optional[List[List[Dict[str, Any]]]],
-        column_metadata: Optional[List[Dict[str, Any]]],
+        records: Optional[list[list[dict[str, Any]]]],
+        column_metadata: Optional[list[dict[str, Any]]],
         nr_of_records_updated: Optional[int],
-        generated_fields: Optional[List[Dict[str, Any]]],
+        generated_fields: Optional[list[dict[str, Any]]],
         formatted_records: Optional[str],
         account_id: str,
         region: str,
@@ -121,7 +121,7 @@ class MotoAPIBackend(BaseBackend):
 
     def set_ecr_scan_finding_result(
         self,
-        results: Dict[str, Any],
+        results: dict[str, Any],
         account_id: str,
         region: str,
     ) -> None:
@@ -132,7 +132,7 @@ class MotoAPIBackend(BaseBackend):
 
     def set_inspector2_findings_result(
         self,
-        results: Optional[List[List[Dict[str, Any]]]],
+        results: Optional[list[list[dict[str, Any]]]],
         account_id: str,
         region: str,
     ) -> None:
@@ -144,7 +144,7 @@ class MotoAPIBackend(BaseBackend):
     def set_timestream_result(
         self,
         query: Optional[str],
-        query_results: List[Dict[str, Any]],
+        query_results: list[dict[str, Any]],
         account_id: str,
         region: str,
     ) -> None:
@@ -158,11 +158,11 @@ class MotoAPIBackend(BaseBackend):
             backend.query_result_queue[query] = []
         backend.query_result_queue[query].extend(query_results)
 
-    def get_proxy_passthrough(self) -> Tuple[Set[str], Set[str]]:
+    def get_proxy_passthrough(self) -> tuple[set[str], set[str]]:
         return self.proxy_urls_to_passthrough, self.proxy_hosts_to_passthrough
 
     def set_proxy_passthrough(
-        self, http_urls: List[str], https_hosts: List[str]
+        self, http_urls: list[str], https_hosts: list[str]
     ) -> None:
         for url in http_urls:
             self.proxy_urls_to_passthrough.add(url)
@@ -173,13 +173,13 @@ class MotoAPIBackend(BaseBackend):
         self.proxy_urls_to_passthrough.clear()
         self.proxy_hosts_to_passthrough.clear()
 
-    def get_config(self) -> Dict[str, Any]:
+    def get_config(self) -> dict[str, Any]:
         return {
             "batch": default_user_config["batch"],
             "lambda": default_user_config["lambda"],
         }
 
-    def set_config(self, config: Dict[str, Any]) -> None:
+    def set_config(self, config: dict[str, Any]) -> None:
         if "batch" in config:
             default_user_config["batch"] = config["batch"]
         if "lambda" in config:

--- a/moto/moto_api/_internal/recorder/models.py
+++ b/moto/moto_api/_internal/recorder/models.py
@@ -2,7 +2,7 @@ import base64
 import io
 import json
 import os
-from typing import Any, Optional, Tuple, Union
+from typing import Any, Optional, Union
 from urllib.parse import urlparse
 
 import requests
@@ -61,7 +61,7 @@ class Recorder:
             file.write(json.dumps(entry))
             file.write("\n")
 
-    def _encode_body(self, body: Any) -> Tuple[str, bool]:
+    def _encode_body(self, body: Any) -> tuple[str, bool]:
         body_encoded = False
         try:
             if isinstance(body, io.BytesIO):
@@ -105,7 +105,7 @@ class Recorder:
         Download the current recording. The result can be uploaded afterwards.
         """
         filepath = self._location
-        with open(filepath, "r") as file:
+        with open(filepath) as file:
             return file.read()
 
     def replay_recording(self, target_host: Optional[str] = None) -> None:
@@ -119,7 +119,7 @@ class Recorder:
         old_setting = self._user_enabled
         self._user_enabled = False
 
-        with open(filepath, "r") as file:
+        with open(filepath) as file:
             entries = file.readlines()
 
         for row in entries:

--- a/moto/moto_api/_internal/responses.py
+++ b/moto/moto_api/_internal/responses.py
@@ -1,5 +1,5 @@
 import json
-from typing import Any, Dict, List
+from typing import Any
 
 from botocore.awsrequest import AWSPreparedRequest
 
@@ -57,7 +57,7 @@ class MotoAPIResponse(BaseResponse):
     ) -> TYPE_RESPONSE:
         from moto.core.model_instances import model_data
 
-        results: Dict[str, Dict[str, List[Any]]] = {}
+        results: dict[str, dict[str, list[Any]]] = {}
         for service in sorted(model_data):
             models = model_data[service]
             results[service] = {}

--- a/moto/moto_api/_internal/state_manager.py
+++ b/moto/moto_api/_internal/state_manager.py
@@ -1,15 +1,15 @@
-from typing import Any, Dict, List
+from typing import Any
 
 DEFAULT_TRANSITION = {"progression": "immediate"}
 
 
 class StateManager:
     def __init__(self) -> None:
-        self._default_transitions: Dict[str, Dict[str, Any]] = dict()
-        self._transitions: Dict[str, Dict[str, Any]] = dict()
+        self._default_transitions: dict[str, dict[str, Any]] = dict()
+        self._transitions: dict[str, dict[str, Any]] = dict()
 
     def register_default_transition(
-        self, model_name: str, transition: Dict[str, Any]
+        self, model_name: str, transition: dict[str, Any]
     ) -> None:
         """
         Register the default transition for a specific model.
@@ -17,7 +17,7 @@ class StateManager:
         """
         self._default_transitions[model_name] = transition
 
-    def set_transition(self, model_name: str, transition: Dict[str, Any]) -> None:
+    def set_transition(self, model_name: str, transition: dict[str, Any]) -> None:
         """
         Set a transition for a specific model. Any transition added here will take precedence over the default transition that was registered.
 
@@ -32,7 +32,7 @@ class StateManager:
         """
         self._transitions.pop(model_name, None)
 
-    def get_transition(self, model_name: str) -> Dict[str, Any]:
+    def get_transition(self, model_name: str) -> dict[str, Any]:
         """
         Return the configuration for a specific model. This will return a user-specified configuration, a default configuration of none exists, or the default transition if none exists.
         """
@@ -42,5 +42,5 @@ class StateManager:
             return self._default_transitions[model_name]
         return DEFAULT_TRANSITION
 
-    def get_registered_models(self) -> List[str]:
+    def get_registered_models(self) -> list[str]:
         return list(self._default_transitions.keys())

--- a/moto/moto_proxy/certificate_creator.py
+++ b/moto/moto_proxy/certificate_creator.py
@@ -73,7 +73,7 @@ class CertificateCreator:
             certpath = f"{self.certdir.rstrip('/')}/{wildcard_filename}.crt"
             if not os.path.isfile(certpath):
                 # Create a Config-file that contains the wildcard-name
-                with open(f"{self.certdir.rstrip('/')}/req.conf.tmpl", "r") as f:
+                with open(f"{self.certdir.rstrip('/')}/req.conf.tmpl") as f:
                     config_template = f.read()
                 config_template = config_template.replace("{{full_name}}", full_name)
                 config_template = config_template.replace(

--- a/moto/moto_proxy/proxy3.py
+++ b/moto/moto_proxy/proxy3.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import re
 import select
 import socket
@@ -6,7 +5,7 @@ import ssl
 from http.server import BaseHTTPRequestHandler
 from subprocess import CalledProcessError, check_output
 from threading import Lock
-from typing import Any, Dict, Tuple
+from typing import Any
 from urllib.parse import urlparse
 
 from botocore.awsrequest import AWSPreparedRequest
@@ -75,7 +74,7 @@ class MotoRequestHandler:
         path: str,
         headers: Any,
         body: bytes,
-        form_data: Dict[str, Any],
+        form_data: dict[str, Any],
     ) -> Any:
         handler = self.get_handler_for_host(host=host, path=path)
         if handler is None:
@@ -121,7 +120,7 @@ class ProxyRequestHandler(BaseHTTPRequestHandler):
 
         certpath = self.cert_creator.create(self.path)
         self.wfile.write(
-            f"{self.protocol_version} 200 Connection Established\r\n".encode("utf-8")
+            f"{self.protocol_version} 200 Connection Established\r\n".encode()
         )
         self.send_header("k", "v")
         self.end_headers()
@@ -217,7 +216,7 @@ class ProxyRequestHandler(BaseHTTPRequestHandler):
             res_headers["Content-Length"] = str(len(res_body))
 
         self.wfile.write(
-            f"{self.protocol_version} {res_status} {res_reason}\r\n".encode("utf-8")
+            f"{self.protocol_version} {res_status} {res_reason}\r\n".encode()
         )
         if res_headers:
             for k, v in res_headers.items():
@@ -230,7 +229,7 @@ class ProxyRequestHandler(BaseHTTPRequestHandler):
             self.wfile.write(res_body)
         self.close_connection = True
 
-    def _get_host_and_path(self, req: Any) -> Tuple[str, str]:
+    def _get_host_and_path(self, req: Any) -> tuple[str, str]:
         if isinstance(self.connection, ssl.SSLSocket):
             host = "https://" + req.headers["Host"]
         else:
@@ -240,11 +239,11 @@ class ProxyRequestHandler(BaseHTTPRequestHandler):
             path = path[len(host) :]
         return host, path
 
-    def passthrough_http(self, address: Tuple[str, int]) -> None:
+    def passthrough_http(self, address: tuple[str, int]) -> None:
         s = socket.create_connection(address, timeout=self.timeout)
         s.send(self.raw_requestline)  # type: ignore[attr-defined]
         for key, val in self.headers.items():
-            s.send(f"{key}: {val}\r\n".encode("utf-8"))
+            s.send(f"{key}: {val}\r\n".encode())
         s.send(b"\r\n")
         while True:
             data = s.recv(1024)
@@ -252,7 +251,7 @@ class ProxyRequestHandler(BaseHTTPRequestHandler):
                 break
             self.wfile.write(data)
 
-    def connect_relay(self, address: Tuple[str, int]) -> None:
+    def connect_relay(self, address: tuple[str, int]) -> None:
         try:
             s = socket.create_connection(address, timeout=self.timeout)
         except Exception:
@@ -292,7 +291,7 @@ class ProxyRequestHandler(BaseHTTPRequestHandler):
                 break
         return chunked_body
 
-    def decode_request_body(self, headers: Dict[str, str], body: Any) -> Any:
+    def decode_request_body(self, headers: dict[str, str], body: Any) -> Any:
         if body is None:
             return body
         if headers.get("Content-Type", "") in [

--- a/moto/moto_proxy/utils.py
+++ b/moto/moto_proxy/utils.py
@@ -1,17 +1,17 @@
 import io
-from typing import Dict, Optional, Tuple
+from typing import Optional
 
 import multipart
 
 
 def get_body_from_form_data(
     body: bytes, boundary: str
-) -> Tuple[Optional[bytes], Dict[str, str]]:
+) -> tuple[Optional[bytes], dict[str, str]]:
     body_stream = io.BytesIO(body)
     parser = multipart.MultipartParser(body_stream, boundary=boundary)
 
     data = None
-    headers: Dict[str, str] = {}
+    headers: dict[str, str] = {}
     for prt in parser.parts():
         if prt.name == "upload_file":
             headers["key"] = prt.name

--- a/moto/moto_server/threaded_moto_server.py
+++ b/moto/moto_server/threaded_moto_server.py
@@ -1,5 +1,5 @@
 from threading import Event, Thread
-from typing import Optional, Tuple
+from typing import Optional
 
 from werkzeug.serving import BaseWSGIServer, make_server
 
@@ -34,7 +34,7 @@ class ThreadedMotoServer:
         self._thread.start()
         self._server_ready_event.wait()
 
-    def get_host_and_port(self) -> Tuple[str, int]:
+    def get_host_and_port(self) -> tuple[str, int]:
         assert self._server is not None, "Make sure to call start() first"
         host, port = self._server.server_address[:2]
         return (str(host), port)

--- a/moto/moto_server/utilities.py
+++ b/moto/moto_server/utilities.py
@@ -1,6 +1,6 @@
 import gzip
 import json
-from typing import Any, Dict
+from typing import Any
 from urllib.parse import urlencode
 
 from flask import current_app, request
@@ -31,7 +31,7 @@ class AWSTestHelper(FlaskClient):
         )
         return res.data.decode("utf-8")
 
-    def action_json(self, action_name: str, **kwargs: Any) -> Dict[str, Any]:
+    def action_json(self, action_name: str, **kwargs: Any) -> dict[str, Any]:
         """
         Method calls resource with action_name and returns object obtained via
         deserialization of output.

--- a/moto/moto_server/werkzeug_app.py
+++ b/moto/moto_server/werkzeug_app.py
@@ -2,7 +2,7 @@ import io
 import os
 import os.path
 from threading import Lock
-from typing import Any, Callable, Dict, Optional, Tuple
+from typing import Any, Callable, Optional
 
 try:
     from flask import Flask
@@ -62,7 +62,7 @@ class DomainDispatcherApplication:
     def __init__(self, create_app: Callable[[backends.SERVICE_NAMES], Flask]):
         self.create_app = create_app
         self.lock = Lock()
-        self.app_instances: Dict[str, Flask] = {}
+        self.app_instances: dict[str, Flask] = {}
         self.backend_url_patterns = backend_index.backend_url_patterns
 
     def get_backend_for_host(self, host: Optional[str]) -> Any:
@@ -86,7 +86,7 @@ class DomainDispatcherApplication:
             )
 
     def infer_service_region_host(
-        self, environ: Dict[str, Any], path: str
+        self, environ: dict[str, Any], path: str
     ) -> Optional[str]:
         auth = environ.get("HTTP_AUTHORIZATION")
         target = environ.get("HTTP_X_AMZ_TARGET")
@@ -176,7 +176,7 @@ class DomainDispatcherApplication:
 
         return host
 
-    def get_application(self, environ: Dict[str, Any]) -> Flask:
+    def get_application(self, environ: dict[str, Any]) -> Flask:
         path_info = environ.get("PATH_INFO", "")
 
         # The URL path might contain non-ASCII text, for instance unicode S3 bucket names
@@ -206,7 +206,7 @@ class DomainDispatcherApplication:
                 self.app_instances[backend] = app
             return app
 
-    def _get_body(self, environ: Dict[str, Any]) -> Optional[str]:
+    def _get_body(self, environ: dict[str, Any]) -> Optional[str]:
         body = None
         try:
             # AWS requests use querystrings as the body (Action=x&Data=y&...)
@@ -225,8 +225,8 @@ class DomainDispatcherApplication:
         return body
 
     def get_service_from_body(
-        self, body: Optional[str], environ: Dict[str, Any]
-    ) -> Tuple[Optional[str], Optional[str]]:
+        self, body: Optional[str], environ: dict[str, Any]
+    ) -> tuple[Optional[str], Optional[str]]:
         # Some services have the SDK Version in the body
         # If the version is unique, we can derive the service from it
         version = self.get_version_from_body(body)
@@ -253,7 +253,7 @@ class DomainDispatcherApplication:
 
     def get_service_from_path(
         self, path_info: str
-    ) -> Tuple[Optional[str], Optional[str]]:
+    ) -> tuple[Optional[str], Optional[str]]:
         # Moto sometimes needs to send a HTTP request to itself
         # In which case it will send a request to 'http://localhost/service_region/whatever'
         try:
@@ -262,7 +262,7 @@ class DomainDispatcherApplication:
         except (AttributeError, KeyError, ValueError):
             return None, None
 
-    def __call__(self, environ: Dict[str, Any], start_response: Any) -> Any:
+    def __call__(self, environ: dict[str, Any], start_response: Any) -> Any:
         backend_app = self.get_application(environ)
         return backend_app(environ, start_response)
 

--- a/moto/mq/models.py
+++ b/moto/mq/models.py
@@ -1,5 +1,6 @@
 import base64
-from typing import Any, Dict, Iterable, List, Optional, Tuple
+from collections.abc import Iterable
+from typing import Any, Optional
 
 import xmltodict
 
@@ -74,7 +75,7 @@ class Configuration(BaseModel):
         self.engine_type = engine_type
         self.engine_version = engine_version
 
-        self.revisions: Dict[str, ConfigurationRevision] = dict()
+        self.revisions: dict[str, ConfigurationRevision] = dict()
         default_desc = (
             f"Auto-generated default for {self.name} on {engine_type} {engine_version}"
         )
@@ -117,7 +118,7 @@ class User(BaseModel):
         broker_id: str,
         username: str,
         console_access: Optional[bool] = None,
-        groups: Optional[List[str]] = None,
+        groups: Optional[list[str]] = None,
     ):
         self.broker_id = broker_id
         self.username = username
@@ -125,7 +126,7 @@ class User(BaseModel):
         self.groups = groups or []
 
     def update(
-        self, console_access: Optional[bool], groups: Optional[List[str]]
+        self, console_access: Optional[bool], groups: Optional[list[str]]
     ) -> None:
         if console_access is not None:
             self.console_access = console_access
@@ -141,20 +142,20 @@ class Broker(BaseModel):
         region: str,
         authentication_strategy: str,
         auto_minor_version_upgrade: bool,
-        configuration: Dict[str, Any],
+        configuration: dict[str, Any],
         deployment_mode: str,
-        encryption_options: Optional[Dict[str, Any]],
+        encryption_options: Optional[dict[str, Any]],
         engine_type: str,
         engine_version: str,
         host_instance_type: str,
-        ldap_server_metadata: Optional[Dict[str, Any]],
-        logs: Dict[str, bool],
-        maintenance_window_start_time: Optional[Dict[str, Any]],
+        ldap_server_metadata: Optional[dict[str, Any]],
+        logs: dict[str, bool],
+        maintenance_window_start_time: Optional[dict[str, Any]],
         publicly_accessible: bool,
-        security_groups: List[str],
+        security_groups: list[str],
         storage_type: str,
-        subnet_ids: List[str],
-        users: List[Dict[str, Any]],
+        subnet_ids: list[str],
+        users: list[dict[str, Any]],
     ):
         self.name = name
         self.id = mock_random.get_random_hex(6)
@@ -204,7 +205,7 @@ class Broker(BaseModel):
             else:
                 self.subnet_ids = ["default-subnet"]
 
-        self._users: Dict[str, User] = dict()
+        self._users: dict[str, User] = dict()
         for user in users:
             self.create_user(
                 username=user["username"],
@@ -212,7 +213,7 @@ class Broker(BaseModel):
                 console_access=user.get("consoleAccess", False),
             )
 
-        self.configurations: Dict[str, Any] = {"current": configuration, "history": []}
+        self.configurations: dict[str, Any] = {"current": configuration, "history": []}
         if self.engine_type.upper() == "RABBITMQ":
             console_url = f"https://0000.mq.{region}.amazonaws.com"
             endpoints = ["amqps://mockmq:5671"]
@@ -246,13 +247,13 @@ class Broker(BaseModel):
         self,
         authentication_strategy: Optional[str],
         auto_minor_version_upgrade: Optional[bool],
-        configuration: Optional[Dict[str, Any]],
+        configuration: Optional[dict[str, Any]],
         engine_version: Optional[str],
         host_instance_type: Optional[str],
-        ldap_server_metadata: Optional[Dict[str, Any]],
-        logs: Optional[Dict[str, bool]],
-        maintenance_window_start_time: Optional[Dict[str, str]],
-        security_groups: Optional[List[str]],
+        ldap_server_metadata: Optional[dict[str, Any]],
+        logs: Optional[dict[str, bool]],
+        maintenance_window_start_time: Optional[dict[str, str]],
+        security_groups: Optional[list[str]],
     ) -> None:
         if authentication_strategy:
             self.authentication_strategy = authentication_strategy
@@ -278,13 +279,13 @@ class Broker(BaseModel):
         pass
 
     def create_user(
-        self, username: str, console_access: bool, groups: List[str]
+        self, username: str, console_access: bool, groups: list[str]
     ) -> None:
         user = User(self.id, username, console_access, groups)
         self._users[username] = user
 
     def update_user(
-        self, username: str, console_access: bool, groups: List[str]
+        self, username: str, console_access: bool, groups: list[str]
     ) -> None:
         user = self.get_user(username)
         user.update(console_access, groups)
@@ -312,8 +313,8 @@ class MQBackend(BaseBackend):
 
     def __init__(self, region_name: str, account_id: str):
         super().__init__(region_name, account_id)
-        self.brokers: Dict[str, Broker] = dict()
-        self.configs: Dict[str, Configuration] = dict()
+        self.brokers: dict[str, Broker] = dict()
+        self.configs: dict[str, Configuration] = dict()
         self.tagger = TaggingService()
 
     def create_broker(
@@ -321,22 +322,22 @@ class MQBackend(BaseBackend):
         authentication_strategy: str,
         auto_minor_version_upgrade: bool,
         broker_name: str,
-        configuration: Optional[Dict[str, Any]],
+        configuration: Optional[dict[str, Any]],
         deployment_mode: str,
-        encryption_options: Optional[Dict[str, Any]],
+        encryption_options: Optional[dict[str, Any]],
         engine_type: str,
         engine_version: str,
         host_instance_type: str,
-        ldap_server_metadata: Optional[Dict[str, Any]],
-        logs: Dict[str, bool],
-        maintenance_window_start_time: Optional[Dict[str, Any]],
+        ldap_server_metadata: Optional[dict[str, Any]],
+        logs: dict[str, bool],
+        maintenance_window_start_time: Optional[dict[str, Any]],
         publicly_accessible: bool,
-        security_groups: List[str],
+        security_groups: list[str],
         storage_type: str,
-        subnet_ids: List[str],
-        tags: Dict[str, str],
-        users: List[Dict[str, Any]],
-    ) -> Tuple[str, str]:
+        subnet_ids: list[str],
+        tags: dict[str, str],
+        users: list[dict[str, Any]],
+    ) -> tuple[str, str]:
         if configuration is None:
             # create default configuration
             default_config = self.create_configuration(
@@ -389,13 +390,13 @@ class MQBackend(BaseBackend):
         return self.brokers.values()
 
     def create_user(
-        self, broker_id: str, username: str, console_access: bool, groups: List[str]
+        self, broker_id: str, username: str, console_access: bool, groups: list[str]
     ) -> None:
         broker = self.describe_broker(broker_id)
         broker.create_user(username, console_access, groups)
 
     def update_user(
-        self, broker_id: str, console_access: bool, groups: List[str], username: str
+        self, broker_id: str, console_access: bool, groups: list[str], username: str
     ) -> None:
         broker = self.describe_broker(broker_id)
         broker.update_user(username, console_access, groups)
@@ -413,7 +414,7 @@ class MQBackend(BaseBackend):
         return broker.list_users()
 
     def create_configuration(
-        self, name: str, engine_type: str, engine_version: str, tags: Dict[str, str]
+        self, name: str, engine_type: str, engine_version: str, tags: dict[str, str]
     ) -> Configuration:
         if engine_type.upper() not in ["ACTIVEMQ", "RABBITMQ"]:
             raise UnknownEngineType(engine_type)
@@ -457,15 +458,15 @@ class MQBackend(BaseBackend):
         """
         return self.configs.values()
 
-    def create_tags(self, resource_arn: str, tags: Dict[str, str]) -> None:
+    def create_tags(self, resource_arn: str, tags: dict[str, str]) -> None:
         self.tagger.tag_resource(
             resource_arn, self.tagger.convert_dict_to_tags_input(tags)
         )
 
-    def list_tags(self, arn: str) -> Dict[str, str]:
+    def list_tags(self, arn: str) -> dict[str, str]:
         return self.tagger.get_tag_dict_for_resource(arn)
 
-    def delete_tags(self, resource_arn: str, tag_keys: List[str]) -> None:
+    def delete_tags(self, resource_arn: str, tag_keys: list[str]) -> None:
         if not isinstance(tag_keys, list):
             tag_keys = [tag_keys]
         self.tagger.untag_resource_using_names(resource_arn, tag_keys)
@@ -475,13 +476,13 @@ class MQBackend(BaseBackend):
         authentication_strategy: str,
         auto_minor_version_upgrade: bool,
         broker_id: str,
-        configuration: Dict[str, Any],
+        configuration: dict[str, Any],
         engine_version: str,
         host_instance_type: str,
-        ldap_server_metadata: Dict[str, Any],
-        logs: Dict[str, bool],
-        maintenance_window_start_time: Dict[str, str],
-        security_groups: List[str],
+        ldap_server_metadata: dict[str, Any],
+        logs: dict[str, bool],
+        maintenance_window_start_time: dict[str, str],
+        security_groups: list[str],
     ) -> None:
         broker = self.describe_broker(broker_id)
         broker.update(

--- a/moto/networkfirewall/models.py
+++ b/moto/networkfirewall/models.py
@@ -1,6 +1,6 @@
 """NetworkFirewallBackend class with methods for supported APIs."""
 
-from typing import Any, Dict, List, Optional
+from typing import Any, Optional
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
@@ -26,14 +26,14 @@ class NetworkFirewallModel(BaseModel):
         firewall_name: str,
         firewall_policy_arn: str,
         vpc_id: str,
-        subnet_mappings: List[str],
+        subnet_mappings: list[str],
         delete_protection: bool,
         subnet_change_protection: bool,
         firewall_policy_change_protection: bool,
         description: str,
-        tags: List[Dict[str, str]],
-        encryption_configuration: Dict[str, str],
-        enabled_analysis_types: List[str],
+        tags: list[dict[str, str]],
+        encryption_configuration: dict[str, str],
+        enabled_analysis_types: list[str],
     ):
         self.firewall_name = firewall_name
         self.firewall_policy_arn = firewall_policy_arn
@@ -62,9 +62,9 @@ class NetworkFirewallModel(BaseModel):
             "Status": "READY",
             "ConfigurationSyncStateSummary": "IN_SYNC",
         }
-        self.logging_configs: Dict[str, List[Dict[str, Any]]] = {}
+        self.logging_configs: dict[str, list[dict[str, Any]]] = {}
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         return {
             "FirewallName": self.firewall_name,
             "FirewallArn": self.arn,
@@ -86,7 +86,7 @@ class NetworkFirewallBackend(BaseBackend):
 
     def __init__(self, region_name: str, account_id: str) -> None:
         super().__init__(region_name, account_id)
-        self.firewalls: Dict[str, NetworkFirewallModel] = {}
+        self.firewalls: dict[str, NetworkFirewallModel] = {}
         self.tagger = TaggingService()
 
     def create_firewall(
@@ -94,14 +94,14 @@ class NetworkFirewallBackend(BaseBackend):
         firewall_name: str,
         firewall_policy_arn: str,
         vpc_id: str,
-        subnet_mappings: List[str],
+        subnet_mappings: list[str],
         delete_protection: bool,
         subnet_change_protection: bool,
         firewall_policy_change_protection: bool,
         description: str,
-        tags: List[Dict[str, str]],
-        encryption_configuration: Dict[str, str],
-        enabled_analysis_types: List[str],
+        tags: list[dict[str, str]],
+        encryption_configuration: dict[str, str],
+        enabled_analysis_types: list[str],
     ) -> NetworkFirewallModel:
         firewall = NetworkFirewallModel(
             self.account_id,
@@ -146,14 +146,14 @@ class NetworkFirewallBackend(BaseBackend):
         self,
         firewall_arn: str,
         firewall_name: str,
-        logging_configuration: Dict[str, List[Dict[str, Any]]],
+        logging_configuration: dict[str, list[dict[str, Any]]],
     ) -> NetworkFirewallModel:
         firewall: NetworkFirewallModel = self._get_firewall(firewall_arn, firewall_name)
         firewall.logging_configs = logging_configuration
         return firewall
 
     @paginate(pagination_model=PAGINATION_MODEL)
-    def list_firewalls(self, vpc_ids: List[str]) -> List[NetworkFirewallModel]:
+    def list_firewalls(self, vpc_ids: list[str]) -> list[NetworkFirewallModel]:
         firewalls = list(self.firewalls.values())
         if vpc_ids:
             firewalls = [fw for fw in firewalls if fw.vpc_id in vpc_ids]

--- a/moto/networkmanager/models.py
+++ b/moto/networkmanager/models.py
@@ -1,7 +1,7 @@
 """NetworkManagerBackend class with methods for supported APIs."""
 
 from datetime import datetime, timezone
-from typing import Any, Dict, List, Optional
+from typing import Any, Optional
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
@@ -51,7 +51,7 @@ class GlobalNetwork(BaseModel):
         account_id: str,
         partition: str,
         description: Optional[str],
-        tags: Optional[List[Dict[str, str]]],
+        tags: Optional[list[dict[str, str]]],
     ):
         self.description = description
         self.tags = tags or []
@@ -62,7 +62,7 @@ class GlobalNetwork(BaseModel):
         self.created_at = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%fZ")
         self.state = "PENDING"
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         return {
             "GlobalNetworkId": self.global_network_id,
             "GlobalNetworkArn": self.global_network_arn,
@@ -80,7 +80,7 @@ class CoreNetwork(BaseModel):
         partition: str,
         global_network_id: str,
         description: Optional[str],
-        tags: Optional[List[Dict[str, str]]],
+        tags: Optional[list[dict[str, str]]],
         policy_document: str,
         client_token: str,
     ):
@@ -96,7 +96,7 @@ class CoreNetwork(BaseModel):
         self.created_at = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%fZ")
         self.state = "PENDING"
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         return {
             "CoreNetworkId": self.core_network_id,
             "CoreNetworkArn": self.core_network_arn,
@@ -117,8 +117,8 @@ class Site(BaseModel):
         partition: str,
         global_network_id: str,
         description: Optional[str],
-        location: Optional[Dict[str, Any]],
-        tags: Optional[List[Dict[str, str]]],
+        location: Optional[dict[str, Any]],
+        tags: Optional[list[dict[str, str]]],
     ):
         self.global_network_id = global_network_id
         self.description = description
@@ -131,7 +131,7 @@ class Site(BaseModel):
         self.created_at = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%fZ")
         self.state = "PENDING"
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         return {
             "SiteId": self.site_id,
             "SiteArn": self.site_arn,
@@ -152,10 +152,10 @@ class Link(BaseModel):
         global_network_id: str,
         description: Optional[str],
         type: Optional[str],
-        bandwidth: Dict[str, int],
+        bandwidth: dict[str, int],
         provider: Optional[str],
         site_id: str,
-        tags: Optional[List[Dict[str, str]]],
+        tags: Optional[list[dict[str, str]]],
     ):
         self.global_network_id = global_network_id
         self.description = description
@@ -171,7 +171,7 @@ class Link(BaseModel):
         self.created_at = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%fZ")
         self.state = "PENDING"
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         return {
             "LinkId": self.link_id,
             "LinkArn": self.link_arn,
@@ -193,15 +193,15 @@ class Device(BaseModel):
         account_id: str,
         partition: str,
         global_network_id: str,
-        aws_location: Optional[Dict[str, str]],
+        aws_location: Optional[dict[str, str]],
         description: Optional[str],
         type: Optional[str],
         vendor: Optional[str],
         model: Optional[str],
         serial_number: Optional[str],
-        location: Optional[Dict[str, str]],
+        location: Optional[dict[str, str]],
         site_id: Optional[str],
-        tags: Optional[List[Dict[str, str]]],
+        tags: Optional[list[dict[str, str]]],
     ):
         self.global_network_id = global_network_id
         self.aws_location = aws_location
@@ -220,7 +220,7 @@ class Device(BaseModel):
         self.created_at = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%fZ")
         self.state = "PENDING"
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         return {
             "DeviceId": self.device_id,
             "DeviceArn": self.device_arn,
@@ -244,14 +244,14 @@ class NetworkManagerBackend(BaseBackend):
 
     def __init__(self, region_name: str, account_id: str) -> None:
         super().__init__(region_name, account_id)
-        self.global_networks: Dict[str, GlobalNetwork] = {}
-        self.core_networks: Dict[str, CoreNetwork] = {}
-        self.sites: Dict[str, Dict[str, Site]] = {}
-        self.links: Dict[str, Dict[str, Link]] = {}
-        self.devices: Dict[str, Dict[str, Device]] = {}
+        self.global_networks: dict[str, GlobalNetwork] = {}
+        self.core_networks: dict[str, CoreNetwork] = {}
+        self.sites: dict[str, dict[str, Site]] = {}
+        self.links: dict[str, dict[str, Link]] = {}
+        self.devices: dict[str, dict[str, Device]] = {}
 
     def _get_resource_from_arn(self, arn: str) -> Any:
-        resources_types: Dict[str, Dict[str, Any]] = {
+        resources_types: dict[str, dict[str, Any]] = {
             "core-network": self.core_networks,
             "global-network": self.global_networks,
             "site": self.sites,
@@ -280,7 +280,7 @@ class NetworkManagerBackend(BaseBackend):
     def create_global_network(
         self,
         description: Optional[str],
-        tags: Optional[List[Dict[str, str]]],
+        tags: Optional[list[dict[str, str]]],
     ) -> GlobalNetwork:
         global_network = GlobalNetwork(
             description=description,
@@ -300,7 +300,7 @@ class NetworkManagerBackend(BaseBackend):
         self,
         global_network_id: str,
         description: Optional[str],
-        tags: Optional[List[Dict[str, str]]],
+        tags: Optional[list[dict[str, str]]],
         policy_document: str,
         client_token: str,
     ) -> CoreNetwork:
@@ -329,17 +329,17 @@ class NetworkManagerBackend(BaseBackend):
         core_network.state = "DELETING"
         return core_network
 
-    def tag_resource(self, resource_arn: str, tags: List[Dict[str, Any]]) -> None:
+    def tag_resource(self, resource_arn: str, tags: list[dict[str, Any]]) -> None:
         resource = self._get_resource_from_arn(resource_arn)
         resource.tags.extend(tags)
 
-    def untag_resource(self, resource_arn: str, tag_keys: Optional[List[str]]) -> None:
+    def untag_resource(self, resource_arn: str, tag_keys: Optional[list[str]]) -> None:
         resource = self._get_resource_from_arn(resource_arn)
         if tag_keys:
             resource.tags = [tag for tag in resource.tags if tag["Key"] not in tag_keys]
 
     @paginate(pagination_model=PAGINATION_MODEL)
-    def list_core_networks(self) -> List[CoreNetwork]:
+    def list_core_networks(self) -> list[CoreNetwork]:
         return list(self.core_networks.values())
 
     def get_core_network(self, core_network_id: str) -> CoreNetwork:
@@ -350,8 +350,8 @@ class NetworkManagerBackend(BaseBackend):
 
     @paginate(pagination_model=PAGINATION_MODEL)
     def describe_global_networks(
-        self, global_network_ids: List[str]
-    ) -> List[GlobalNetwork]:
+        self, global_network_ids: list[str]
+    ) -> list[GlobalNetwork]:
         queried_global_networks = []
         if not global_network_ids:
             queried_global_networks = list(self.global_networks.values())
@@ -370,8 +370,8 @@ class NetworkManagerBackend(BaseBackend):
         self,
         global_network_id: str,
         description: Optional[str],
-        location: Optional[Dict[str, str]],
-        tags: Optional[List[Dict[str, str]]],
+        location: Optional[dict[str, str]],
+        tags: Optional[list[dict[str, str]]],
     ) -> Site:
         # check if global network exists
         if global_network_id not in self.global_networks:
@@ -399,7 +399,7 @@ class NetworkManagerBackend(BaseBackend):
         return site
 
     @paginate(pagination_model=PAGINATION_MODEL)
-    def get_sites(self, global_network_id: str, site_ids: List[str]) -> List[Site]:
+    def get_sites(self, global_network_id: str, site_ids: list[str]) -> list[Site]:
         if global_network_id not in self.global_networks:
             raise ValidationError("Incorrect input.")
         gn_sites = self.sites.get(global_network_id) or {}
@@ -419,10 +419,10 @@ class NetworkManagerBackend(BaseBackend):
         global_network_id: str,
         description: Optional[str],
         type: Optional[str],
-        bandwidth: Dict[str, Any],
+        bandwidth: dict[str, Any],
         provider: Optional[str],
         site_id: str,
-        tags: Optional[List[Dict[str, str]]],
+        tags: Optional[list[dict[str, str]]],
     ) -> Link:
         # check if global network exists
         if global_network_id not in self.global_networks:
@@ -445,11 +445,11 @@ class NetworkManagerBackend(BaseBackend):
     def get_links(
         self,
         global_network_id: str,
-        link_ids: List[str],
+        link_ids: list[str],
         site_id: str,
         type: str,
         provider: str,
-    ) -> List[Link]:
+    ) -> list[Link]:
         if global_network_id not in self.global_networks:
             raise ValidationError("Incorrect input.")
         # TODO: Implement filtering by site_id, type, provider
@@ -475,15 +475,15 @@ class NetworkManagerBackend(BaseBackend):
     def create_device(
         self,
         global_network_id: str,
-        aws_location: Optional[Dict[str, str]],
+        aws_location: Optional[dict[str, str]],
         description: Optional[str],
         type: Optional[str],
         vendor: Optional[str],
         model: Optional[str],
         serial_number: Optional[str],
-        location: Optional[Dict[str, str]],
+        location: Optional[dict[str, str]],
         site_id: Optional[str],
-        tags: Optional[List[Dict[str, str]]],
+        tags: Optional[list[dict[str, str]]],
     ) -> Device:
         # check if global network exists
         if global_network_id not in self.global_networks:
@@ -507,8 +507,8 @@ class NetworkManagerBackend(BaseBackend):
 
     @paginate(pagination_model=PAGINATION_MODEL)
     def get_devices(
-        self, global_network_id: str, device_ids: List[str], site_id: Optional[str]
-    ) -> List[Device]:
+        self, global_network_id: str, device_ids: list[str], site_id: Optional[str]
+    ) -> list[Device]:
         if global_network_id not in self.global_networks:
             raise ValidationError("Incorrect input.")
         # TODO: Implement filtering by site_id
@@ -532,7 +532,7 @@ class NetworkManagerBackend(BaseBackend):
         device.state = "DELETING"
         return device
 
-    def list_tags_for_resource(self, resource_arn: str) -> List[Dict[str, str]]:
+    def list_tags_for_resource(self, resource_arn: str) -> list[dict[str, str]]:
         resource = self._get_resource_from_arn(resource_arn)
         tag_list = resource.tags
         return tag_list

--- a/moto/opensearch/models.py
+++ b/moto/opensearch/models.py
@@ -1,5 +1,5 @@
 import datetime
-from typing import Any, Dict, List, Optional
+from typing import Any, Optional
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
@@ -50,7 +50,7 @@ class EngineVersion(BaseModel):
         self.create_time = unix_time(create_time)
         self.update_time = self.create_time
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         return {
             "Options": self.options,
             "Status": {
@@ -70,21 +70,21 @@ class OpenSearchDomain(BaseModel):
         region: str,
         domain_name: str,
         engine_version: str,
-        cluster_config: Dict[str, Any],
-        ebs_options: Dict[str, Any],
+        cluster_config: dict[str, Any],
+        ebs_options: dict[str, Any],
         access_policies: str,
-        snapshot_options: Dict[str, int],
-        vpc_options: Dict[str, List[str]],
-        cognito_options: Dict[str, Any],
-        encryption_at_rest_options: Dict[str, Any],
-        node_to_node_encryption_options: Dict[str, bool],
-        advanced_options: Dict[str, str],
-        log_publishing_options: Dict[str, Any],
-        domain_endpoint_options: Dict[str, Any],
-        advanced_security_options: Dict[str, Any],
-        auto_tune_options: Dict[str, Any],
-        off_peak_window_options: Dict[str, Any],
-        software_update_options: Dict[str, bool],
+        snapshot_options: dict[str, int],
+        vpc_options: dict[str, list[str]],
+        cognito_options: dict[str, Any],
+        encryption_at_rest_options: dict[str, Any],
+        node_to_node_encryption_options: dict[str, bool],
+        advanced_options: dict[str, str],
+        log_publishing_options: dict[str, Any],
+        domain_endpoint_options: dict[str, Any],
+        advanced_security_options: dict[str, Any],
+        auto_tune_options: dict[str, Any],
+        off_peak_window_options: dict[str, Any],
+        software_update_options: dict[str, bool],
         is_es: bool,
         elasticsearch_version: Optional[str],
         elasticsearch_cluster_config: Optional[str],
@@ -141,7 +141,7 @@ class OpenSearchDomain(BaseModel):
 
         if self.vpc_options is None:
             self.endpoint: Optional[str] = f"{domain_name}.{region}.es.amazonaws.com"
-            self.endpoints: Optional[Dict[str, str]] = None
+            self.endpoints: Optional[dict[str, str]] = None
         else:
             self.endpoint = None
             self.endpoints = {"vpc": f"{domain_name}.{region}.es.amazonaws.com"}
@@ -150,7 +150,7 @@ class OpenSearchDomain(BaseModel):
         self.deleted = True
         self.processing = True
 
-    def dct_options(self) -> Dict[str, Any]:
+    def dct_options(self) -> dict[str, Any]:
         return {
             "Endpoint": self.endpoint,
             "Endpoints": self.endpoints,
@@ -174,7 +174,7 @@ class OpenSearchDomain(BaseModel):
             "ElasticsearchClusterConfig": self.elasticsearch_cluster_config,
         }
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         dct = {
             "DomainId": self.domain_id,
             "DomainName": self.domain_name,
@@ -190,7 +190,7 @@ class OpenSearchDomain(BaseModel):
                 dct[key] = value
         return dct
 
-    def _status_block(self) -> Dict[str, Any]:
+    def _status_block(self) -> dict[str, Any]:
         return {
             "State": "Active",
             "CreationDate": self.creation_date,
@@ -199,12 +199,12 @@ class OpenSearchDomain(BaseModel):
             "PendingDeletion": False,
         }
 
-    def _wrap(self, options: Any) -> Dict[str, Any]:
+    def _wrap(self, options: Any) -> dict[str, Any]:
         # Most DomainConfig sections only need {"Options": ...}
         return {"Options": options}
 
-    def to_config_dict(self) -> Dict[str, Any]:
-        cfg: Dict[str, Any] = {}
+    def to_config_dict(self) -> dict[str, Any]:
+        cfg: dict[str, Any] = {}
 
         # Cluster config section (key differs for ES vs OS)
         cluster_key = "ElasticsearchClusterConfig" if self.is_es else "ClusterConfig"
@@ -282,21 +282,21 @@ class OpenSearchDomain(BaseModel):
 
     def update(
         self,
-        cluster_config: Dict[str, Any],
-        ebs_options: Dict[str, Any],
+        cluster_config: dict[str, Any],
+        ebs_options: dict[str, Any],
         access_policies: str,
-        snapshot_options: Dict[str, int],
-        vpc_options: Dict[str, List[str]],
-        cognito_options: Dict[str, Any],
-        encryption_at_rest_options: Dict[str, Any],
-        node_to_node_encryption_options: Dict[str, bool],
-        advanced_options: Dict[str, str],
-        log_publishing_options: Dict[str, Any],
-        domain_endpoint_options: Dict[str, Any],
-        advanced_security_options: Dict[str, Any],
-        auto_tune_options: Dict[str, Any],
-        off_peak_window_options: Dict[str, Any],
-        software_update_options: Dict[str, bool],
+        snapshot_options: dict[str, int],
+        vpc_options: dict[str, list[str]],
+        cognito_options: dict[str, Any],
+        encryption_at_rest_options: dict[str, Any],
+        node_to_node_encryption_options: dict[str, bool],
+        advanced_options: dict[str, str],
+        log_publishing_options: dict[str, Any],
+        domain_endpoint_options: dict[str, Any],
+        advanced_security_options: dict[str, Any],
+        auto_tune_options: dict[str, Any],
+        off_peak_window_options: dict[str, Any],
+        software_update_options: dict[str, bool],
     ) -> None:
         self.cluster_config = cluster_config or self.cluster_config
         self.ebs_options = ebs_options or self.ebs_options
@@ -336,29 +336,29 @@ class OpenSearchServiceBackend(BaseBackend):
 
     def __init__(self, region_name: str, account_id: str):
         super().__init__(region_name, account_id)
-        self.domains: Dict[str, OpenSearchDomain] = dict()
+        self.domains: dict[str, OpenSearchDomain] = dict()
         self.tagger = TaggingService()
 
     def create_domain(
         self,
         domain_name: str,
         engine_version: str,
-        cluster_config: Dict[str, Any],
-        ebs_options: Dict[str, Any],
+        cluster_config: dict[str, Any],
+        ebs_options: dict[str, Any],
         access_policies: str,
-        snapshot_options: Dict[str, Any],
-        vpc_options: Dict[str, Any],
-        cognito_options: Dict[str, Any],
-        encryption_at_rest_options: Dict[str, Any],
-        node_to_node_encryption_options: Dict[str, Any],
-        advanced_options: Dict[str, Any],
-        log_publishing_options: Dict[str, Any],
-        domain_endpoint_options: Dict[str, Any],
-        advanced_security_options: Dict[str, Any],
-        tag_list: List[Dict[str, str]],
-        auto_tune_options: Dict[str, Any],
-        off_peak_window_options: Dict[str, Any],
-        software_update_options: Dict[str, Any],
+        snapshot_options: dict[str, Any],
+        vpc_options: dict[str, Any],
+        cognito_options: dict[str, Any],
+        encryption_at_rest_options: dict[str, Any],
+        node_to_node_encryption_options: dict[str, Any],
+        advanced_options: dict[str, Any],
+        log_publishing_options: dict[str, Any],
+        domain_endpoint_options: dict[str, Any],
+        advanced_security_options: dict[str, Any],
+        tag_list: list[dict[str, str]],
+        auto_tune_options: dict[str, Any],
+        off_peak_window_options: dict[str, Any],
+        software_update_options: dict[str, Any],
         is_es: bool,
         elasticsearch_version: Optional[str],
         elasticsearch_cluster_config: Optional[str],
@@ -394,7 +394,7 @@ class OpenSearchServiceBackend(BaseBackend):
 
     def get_compatible_versions(
         self, domain_name: Optional[str]
-    ) -> List[Dict[str, Any]]:
+    ) -> list[dict[str, Any]]:
         if domain_name and domain_name not in self.domains:
             raise ResourceNotFoundException(domain_name)
         return compatible_versions
@@ -410,28 +410,28 @@ class OpenSearchServiceBackend(BaseBackend):
             raise ResourceNotFoundException(domain_name)
         return self.domains[domain_name]
 
-    def describe_domain_config(self, domain_name: str) -> Dict[str, Any]:
+    def describe_domain_config(self, domain_name: str) -> dict[str, Any]:
         domain = self.describe_domain(domain_name)
         return domain.to_config_dict()
 
     def update_domain_config(
         self,
         domain_name: str,
-        cluster_config: Dict[str, Any],
-        ebs_options: Dict[str, Any],
+        cluster_config: dict[str, Any],
+        ebs_options: dict[str, Any],
         access_policies: str,
-        snapshot_options: Dict[str, Any],
-        vpc_options: Dict[str, Any],
-        cognito_options: Dict[str, Any],
-        encryption_at_rest_options: Dict[str, Any],
-        node_to_node_encryption_options: Dict[str, Any],
-        advanced_options: Dict[str, Any],
-        log_publishing_options: Dict[str, Any],
-        domain_endpoint_options: Dict[str, Any],
-        advanced_security_options: Dict[str, Any],
-        auto_tune_options: Dict[str, Any],
-        off_peak_window_options: Dict[str, Any],
-        software_update_options: Dict[str, Any],
+        snapshot_options: dict[str, Any],
+        vpc_options: dict[str, Any],
+        cognito_options: dict[str, Any],
+        encryption_at_rest_options: dict[str, Any],
+        node_to_node_encryption_options: dict[str, Any],
+        advanced_options: dict[str, Any],
+        log_publishing_options: dict[str, Any],
+        domain_endpoint_options: dict[str, Any],
+        advanced_security_options: dict[str, Any],
+        auto_tune_options: dict[str, Any],
+        off_peak_window_options: dict[str, Any],
+        software_update_options: dict[str, Any],
     ) -> "OpenSearchDomain":
         domain = self.domains[domain_name]
         domain.cluster_config = cluster_config or domain.cluster_config
@@ -466,16 +466,16 @@ class OpenSearchServiceBackend(BaseBackend):
         )
         return domain
 
-    def add_tags(self, arn: str, tags: List[Dict[str, str]]) -> None:
+    def add_tags(self, arn: str, tags: list[dict[str, str]]) -> None:
         self.tagger.tag_resource(arn, tags)
 
-    def list_tags(self, arn: str) -> List[Dict[str, str]]:
+    def list_tags(self, arn: str) -> list[dict[str, str]]:
         return self.tagger.list_tags_for_resource(arn)["Tags"]
 
-    def remove_tags(self, arn: str, tag_keys: List[str]) -> None:
+    def remove_tags(self, arn: str, tag_keys: list[str]) -> None:
         self.tagger.untag_resource_using_names(arn, tag_keys)
 
-    def list_domain_names(self, engine_type: str) -> List[Dict[str, str]]:
+    def list_domain_names(self, engine_type: str) -> list[dict[str, str]]:
         domains = []
         if engine_type and engine_type not in ["Elasticsearch", "OpenSearch"]:
             raise EngineTypeNotFoundException(engine_type)
@@ -491,7 +491,7 @@ class OpenSearchServiceBackend(BaseBackend):
                 )
         return domains
 
-    def describe_domains(self, domain_names: List[str]) -> List[OpenSearchDomain]:
+    def describe_domains(self, domain_names: list[str]) -> list[OpenSearchDomain]:
         queried_domains = []
         for domain_name in domain_names:
             if domain_name in self.domains:

--- a/moto/opensearchserverless/models.py
+++ b/moto/opensearchserverless/models.py
@@ -1,7 +1,7 @@
 """OpenSearchServiceServerlessBackend class with methods for supported APIs."""
 
 import json
-from typing import Any, Dict, List, Tuple
+from typing import Any
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
@@ -46,7 +46,7 @@ class SecurityPolicy(BaseModel):
                 for res in rule["Resource"]
             ]
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         dct = {
             "createdDate": self.created_date,
             "description": self.description,
@@ -58,7 +58,7 @@ class SecurityPolicy(BaseModel):
         }
         return {k: v for k, v in dct.items() if v}
 
-    def to_dict_list(self) -> Dict[str, Any]:
+    def to_dict_list(self) -> dict[str, Any]:
         dct = self.to_dict()
         dct.pop("policy")
         return {k: v for k, v in dct.items() if v}
@@ -71,7 +71,7 @@ class Collection(BaseModel):
         description: str,
         name: str,
         standby_replicas: str,
-        tags: List[Dict[str, str]],
+        tags: list[dict[str, str]],
         type: str,
         policy: Any,
         region: str,
@@ -94,7 +94,7 @@ class Collection(BaseModel):
             f"https://{self.id}.{region}.aoss.amazonaws.com/_dashboards"
         )
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         dct = {
             "arn": self.arn,
             "createdDate": self.created_date,
@@ -109,11 +109,11 @@ class Collection(BaseModel):
         }
         return {k: v for k, v in dct.items() if v}
 
-    def to_dict_list(self) -> Dict[str, Any]:
+    def to_dict_list(self) -> dict[str, Any]:
         dct = {"arn": self.arn, "id": self.id, "name": self.name, "status": self.status}
         return {k: v for k, v in dct.items() if v}
 
-    def to_dict_batch(self) -> Dict[str, Any]:
+    def to_dict_batch(self) -> dict[str, Any]:
         dct = self.to_dict()
         dct_options = {
             "collectionEndpoint": self.collection_endpoint,
@@ -130,8 +130,8 @@ class OSEndpoint(BaseModel):
         self,
         client_token: str,
         name: str,
-        security_group_ids: List[str],
-        subnet_ids: List[str],
+        security_group_ids: list[str],
+        subnet_ids: list[str],
         vpc_id: str,
     ):
         self.client_token = client_token
@@ -142,7 +142,7 @@ class OSEndpoint(BaseModel):
         self.id = f"vpce-0{mock_random.get_random_string(length=16, lower_case=True)}"
         self.status = "ACTIVE"
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         dct = {"id": self.id, "name": self.name, "status": self.status}
         return {k: v for k, v in dct.items() if v}
 
@@ -153,9 +153,9 @@ class OpenSearchServiceServerlessBackend(BaseBackend):
     def __init__(self, region_name: str, account_id: str):
         super().__init__(region_name, account_id)
 
-        self.collections: Dict[str, Collection] = dict()
-        self.security_policies: Dict[str, SecurityPolicy] = dict()
-        self.os_endpoints: Dict[str, OSEndpoint] = dict()
+        self.collections: dict[str, Collection] = dict()
+        self.security_policies: dict[str, SecurityPolicy] = dict()
+        self.os_endpoints: dict[str, OSEndpoint] = dict()
         self.tagger = TaggingService(
             tag_name="tags", key_name="key", value_name="value"
         )
@@ -196,8 +196,8 @@ class OpenSearchServiceServerlessBackend(BaseBackend):
         )
 
     def list_security_policies(
-        self, resource: List[str], type: str
-    ) -> List[SecurityPolicy]:
+        self, resource: list[str], type: str
+    ) -> list[SecurityPolicy]:
         """
         Pagination is not yet implemented
         """
@@ -260,7 +260,7 @@ class OpenSearchServiceServerlessBackend(BaseBackend):
         description: str,
         name: str,
         standby_replicas: str,
-        tags: List[Dict[str, str]],
+        tags: list[dict[str, str]],
         type: str,
     ) -> Collection:
         policy = ""
@@ -290,7 +290,7 @@ class OpenSearchServiceServerlessBackend(BaseBackend):
         self.tag_resource(collection.arn, tags)
         return collection
 
-    def list_collections(self, collection_filters: Dict[str, str]) -> List[Collection]:
+    def list_collections(self, collection_filters: dict[str, str]) -> list[Collection]:
         """
         Pagination is not yet implemented
         """
@@ -311,8 +311,8 @@ class OpenSearchServiceServerlessBackend(BaseBackend):
         self,
         client_token: str,
         name: str,
-        security_group_ids: List[str],
-        subnet_ids: List[str],
+        security_group_ids: list[str],
+        subnet_ids: list[str],
         vpc_id: str,
     ) -> OSEndpoint:
         if not client_token:
@@ -344,18 +344,18 @@ class OpenSearchServiceServerlessBackend(BaseBackend):
             return self.collections.pop(id)
         raise ResourceNotFoundException(f"Collection with ID {id} cannot be found.")
 
-    def tag_resource(self, resource_arn: str, tags: List[Dict[str, str]]) -> None:
+    def tag_resource(self, resource_arn: str, tags: list[dict[str, str]]) -> None:
         self.tagger.tag_resource(resource_arn, tags)
 
-    def untag_resource(self, resource_arn: str, tag_keys: List[str]) -> None:
+    def untag_resource(self, resource_arn: str, tag_keys: list[str]) -> None:
         self.tagger.untag_resource_using_names(resource_arn, tag_keys)
 
-    def list_tags_for_resource(self, resource_arn: str) -> List[Dict[str, str]]:
+    def list_tags_for_resource(self, resource_arn: str) -> list[dict[str, str]]:
         return self.tagger.list_tags_for_resource(resource_arn)["tags"]
 
     def batch_get_collection(
-        self, ids: List[str], names: List[str]
-    ) -> Tuple[List[Any], List[Dict[str, str]]]:
+        self, ids: list[str], names: list[str]
+    ) -> tuple[list[Any], list[dict[str, str]]]:
         collection_details = []
         collection_error_details = []
         collection_error_detail = {

--- a/moto/organizations/models.py
+++ b/moto/organizations/models.py
@@ -1,6 +1,6 @@
 import json
 import re
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Optional
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
@@ -60,7 +60,7 @@ class FakeOrganization(BaseModel):
             partition, self.master_account_id, self.id
         )
 
-    def describe(self) -> Dict[str, Any]:
+    def describe(self) -> dict[str, Any]:
         return {
             "Organization": {
                 "Id": self.id,
@@ -88,7 +88,7 @@ class FakeAccount(BaseModel):
         self.status = "ACTIVE"
         self.joined_method = "CREATED"
         self.parent_id = organization.root_id
-        self.attached_policies: List[FakePolicy] = []
+        self.attached_policies: list[FakePolicy] = []
         self.tags = {tag["Key"]: tag["Value"] for tag in kwargs.get("Tags", [])}
 
         role_name = kwargs.get("RoleName", "OrganizationAccountAccessRole")
@@ -128,7 +128,7 @@ class FakeAccount(BaseModel):
         )
 
     @property
-    def create_account_status(self) -> Dict[str, Any]:  # type: ignore[misc]
+    def create_account_status(self) -> dict[str, Any]:  # type: ignore[misc]
         return {
             "CreateAccountStatus": {
                 "Id": self.create_account_status_id,
@@ -140,7 +140,7 @@ class FakeAccount(BaseModel):
             }
         }
 
-    def describe(self) -> Dict[str, Any]:
+    def describe(self) -> dict[str, Any]:
         return {
             "Id": self.id,
             "Arn": self.arn,
@@ -169,7 +169,7 @@ class FakeOrganizationalUnit(BaseModel):
         self.name = kwargs.get("Name")
         self.parent_id = kwargs.get("ParentId")
         self._arn_format = utils.OU_ARN_FORMAT
-        self.attached_policies: List[FakePolicy] = []
+        self.attached_policies: list[FakePolicy] = []
         self.tags = {tag["Key"]: tag["Value"] for tag in kwargs.get("Tags", [])}
 
     @property
@@ -179,7 +179,7 @@ class FakeOrganizationalUnit(BaseModel):
             partition, self.master_account_id, self.organization_id, self.id
         )
 
-    def describe(self) -> Dict[str, Dict[str, Any]]:
+    def describe(self) -> dict[str, dict[str, Any]]:
         return {
             "OrganizationalUnit": {"Id": self.id, "Arn": self.arn, "Name": self.name}
         }
@@ -198,12 +198,12 @@ class FakeRoot(FakeOrganizationalUnit):
         self.type = "ROOT"
         self.id = organization.root_id
         self.name = "Root"
-        self.policy_types: List[Dict[str, str]] = []
+        self.policy_types: list[dict[str, str]] = []
         self._arn_format = utils.ROOT_ARN_FORMAT
         self.attached_policies = []
         self.tags = {tag["Key"]: tag["Value"] for tag in kwargs.get("Tags", [])}
 
-    def describe(self) -> Dict[str, Any]:
+    def describe(self) -> dict[str, Any]:
         return {
             "Id": self.id,
             "Arn": self.arn,
@@ -248,7 +248,7 @@ class FakePolicy(BaseModel):
         self.region = organization.region
         self.organization_id = organization.id
         self.master_account_id = organization.master_account_id
-        self.attachments: List[Any] = []
+        self.attachments: list[Any] = []
         self.tags = {tag["Key"]: tag["Value"] for tag in kwargs.get("Tags", [])}
 
         if not FakePolicy.supported_policy_type(self.type):
@@ -271,7 +271,7 @@ class FakePolicy(BaseModel):
             partition, self.master_account_id, self.organization_id, self.id
         )
 
-    def describe(self) -> Dict[str, Any]:
+    def describe(self) -> dict[str, Any]:
         return {
             "Policy": {
                 "PolicySummary": {
@@ -344,7 +344,7 @@ class FakeServiceAccess(BaseModel):
         self.service_principal = kwargs["ServicePrincipal"]
         self.date_enabled = utcnow()
 
-    def describe(self) -> Dict[str, Any]:
+    def describe(self) -> dict[str, Any]:
         return {
             "ServicePrincipal": self.service_principal,
             "DateEnabled": unix_time(self.date_enabled),
@@ -370,7 +370,7 @@ class FakeDelegatedAdministrator(BaseModel):
     def __init__(self, account: FakeAccount):
         self.account = account
         self.enabled_date = utcnow()
-        self.services: Dict[str, Any] = {}
+        self.services: dict[str, Any] = {}
 
     def add_service_principal(self, service_principal: str) -> None:
         if service_principal in self.services:
@@ -394,7 +394,7 @@ class FakeDelegatedAdministrator(BaseModel):
 
         self.services.pop(service_principal)
 
-    def describe(self) -> Dict[str, Any]:
+    def describe(self) -> dict[str, Any]:
         admin = self.account.describe()
         admin["DelegationEnabledDate"] = unix_time(self.enabled_date)
 
@@ -412,11 +412,11 @@ class OrganizationsBackend(BaseBackend):
 
     def _reset(self) -> None:
         self.org: Optional[FakeOrganization] = None
-        self.accounts: List[FakeAccount] = []
-        self.ou: List[FakeOrganizationalUnit] = []
-        self.policies: List[FakePolicy] = []
-        self.services: List[Dict[str, Any]] = []
-        self.admins: List[FakeDelegatedAdministrator] = []
+        self.accounts: list[FakeAccount] = []
+        self.ou: list[FakeOrganizationalUnit] = []
+        self.policies: list[FakePolicy] = []
+        self.services: list[dict[str, Any]] = []
+        self.admins: list[FakeDelegatedAdministrator] = []
 
     def _get_root_by_id(self, root_id: str) -> FakeRoot:
         root = next((ou for ou in self.ou if ou.id == root_id), None)
@@ -425,7 +425,7 @@ class OrganizationsBackend(BaseBackend):
 
         return root  # type: ignore[return-value]
 
-    def create_organization(self, region: str, **kwargs: Any) -> Dict[str, Any]:
+    def create_organization(self, region: str, **kwargs: Any) -> dict[str, Any]:
         if self.org or self.account_id in organizations_backends.master_accounts:
             raise AlreadyInOrganizationException
 
@@ -460,7 +460,7 @@ class OrganizationsBackend(BaseBackend):
         self.attach_policy(PolicyId=default_policy.id, TargetId=master_account.id)
         return self.org.describe()
 
-    def describe_organization(self) -> Dict[str, Any]:
+    def describe_organization(self) -> dict[str, Any]:
         if self.org:
             # This is a master account
             return self.org.describe()
@@ -483,7 +483,7 @@ class OrganizationsBackend(BaseBackend):
 
         self._reset()
 
-    def list_roots(self) -> Dict[str, Any]:
+    def list_roots(self) -> dict[str, Any]:
         if self.org:
             return dict(
                 Roots=[ou.describe() for ou in self.ou if isinstance(ou, FakeRoot)]
@@ -497,7 +497,7 @@ class OrganizationsBackend(BaseBackend):
 
         raise AWSOrganizationsNotInUseException
 
-    def create_organizational_unit(self, **kwargs: Any) -> Dict[str, Any]:
+    def create_organizational_unit(self, **kwargs: Any) -> dict[str, Any]:
         new_ou = FakeOrganizationalUnit(self.org, **kwargs)  # type: ignore
         self.ou.append(new_ou)
         self.attach_policy(PolicyId=utils.DEFAULT_POLICY_ID, TargetId=new_ou.id)
@@ -509,7 +509,7 @@ class OrganizationsBackend(BaseBackend):
         )
         self.ou.remove(ou_to_delete)
 
-    def update_organizational_unit(self, **kwargs: Any) -> Dict[str, Any]:
+    def update_organizational_unit(self, **kwargs: Any) -> dict[str, Any]:
         for ou in self.ou:
             if ou.name == kwargs["Name"]:
                 raise DuplicateOrganizationalUnitException
@@ -535,18 +535,18 @@ class OrganizationsBackend(BaseBackend):
             )
         return parent_id
 
-    def describe_organizational_unit(self, **kwargs: Any) -> Dict[str, Any]:
+    def describe_organizational_unit(self, **kwargs: Any) -> dict[str, Any]:
         ou = self.get_organizational_unit_by_id(kwargs["OrganizationalUnitId"])
         return ou.describe()
 
     @paginate(pagination_model=PAGINATION_MODEL)
     def list_organizational_units_for_parent(
         self, parent_id: str
-    ) -> List[FakeOrganizationalUnit]:
+    ) -> list[FakeOrganizationalUnit]:
         parent_id = self.validate_parent_id(parent_id)
         return [ou for ou in self.ou if ou.parent_id == parent_id]
 
-    def create_account(self, **kwargs: Any) -> Dict[str, Any]:
+    def create_account(self, **kwargs: Any) -> dict[str, Any]:
         if self.org is None:
             raise AWSOrganizationsNotInUseException
 
@@ -591,17 +591,17 @@ class OrganizationsBackend(BaseBackend):
             raise AccountNotFoundException
         return account
 
-    def describe_account(self, **kwargs: Any) -> Dict[str, Any]:
+    def describe_account(self, **kwargs: Any) -> dict[str, Any]:
         account = self.get_account_by_id(kwargs["AccountId"])
         return dict(Account=account.describe())
 
-    def describe_create_account_status(self, **kwargs: Any) -> Dict[str, Any]:
+    def describe_create_account_status(self, **kwargs: Any) -> dict[str, Any]:
         account = self.get_account_by_attr(
             "create_account_status_id", kwargs["CreateAccountRequestId"]
         )
         return account.create_account_status
 
-    def list_create_account_status(self, **kwargs: Any) -> Dict[str, Any]:
+    def list_create_account_status(self, **kwargs: Any) -> dict[str, Any]:
         requested_states = kwargs.get("States")
         if not requested_states:
             requested_states = ["IN_PROGRESS", "SUCCEEDED", "FAILED"]
@@ -623,12 +623,12 @@ class OrganizationsBackend(BaseBackend):
         return dict(CreateAccountStatuses=accounts_resp, NextToken=next_token)
 
     @paginate(pagination_model=PAGINATION_MODEL)
-    def list_accounts(self) -> List[FakeAccount]:
+    def list_accounts(self) -> list[FakeAccount]:
         accounts = [account.describe() for account in self.accounts]
         return sorted(accounts, key=lambda x: x["JoinedTimestamp"])  # type: ignore
 
     @paginate(pagination_model=PAGINATION_MODEL)
-    def list_accounts_for_parent(self, parent_id: str) -> List[FakeAccount]:
+    def list_accounts_for_parent(self, parent_id: str) -> list[FakeAccount]:
         parent_id = self.validate_parent_id(parent_id)
         accounts = [
             account for account in self.accounts if account.parent_id == parent_id
@@ -642,7 +642,7 @@ class OrganizationsBackend(BaseBackend):
         index = self.accounts.index(account)
         self.accounts[index].parent_id = new_parent_id
 
-    def list_parents(self, **kwargs: Any) -> Dict[str, Any]:
+    def list_parents(self, **kwargs: Any) -> dict[str, Any]:
         if re.compile(r"[0-9]{12}").match(kwargs["ChildId"]):
             child_object: Any = self.get_account_by_id(kwargs["ChildId"])
         else:
@@ -655,10 +655,10 @@ class OrganizationsBackend(BaseBackend):
             ]
         )
 
-    def list_children(self, **kwargs: Any) -> Dict[str, Any]:
+    def list_children(self, **kwargs: Any) -> dict[str, Any]:
         parent_id = self.validate_parent_id(kwargs["ParentId"])
         if kwargs["ChildType"] == "ACCOUNT":
-            obj_list: List[Any] = self.accounts
+            obj_list: list[Any] = self.accounts
         elif kwargs["ChildType"] == "ORGANIZATIONAL_UNIT":
             obj_list = self.ou
         else:
@@ -671,7 +671,7 @@ class OrganizationsBackend(BaseBackend):
             ]
         )
 
-    def create_policy(self, **kwargs: Any) -> Dict[str, Any]:
+    def create_policy(self, **kwargs: Any) -> dict[str, Any]:
         new_policy = FakePolicy(self.org, **kwargs)  # type: ignore
         for policy in self.policies:
             if kwargs["Name"] == policy.name:
@@ -679,7 +679,7 @@ class OrganizationsBackend(BaseBackend):
         self.policies.append(new_policy)
         return new_policy.describe()
 
-    def describe_policy(self, **kwargs: Any) -> Dict[str, Any]:
+    def describe_policy(self, **kwargs: Any) -> dict[str, Any]:
         if re.compile(utils.POLICY_ID_REGEX).match(kwargs["PolicyId"]):
             policy = next(
                 (p for p in self.policies if p.id == kwargs["PolicyId"]), None
@@ -702,7 +702,7 @@ class OrganizationsBackend(BaseBackend):
             )
         return policy
 
-    def update_policy(self, **kwargs: Any) -> Dict[str, Any]:
+    def update_policy(self, **kwargs: Any) -> dict[str, Any]:
         policy = self.get_policy_by_id(kwargs["PolicyId"])
         policy.name = kwargs.get("Name", policy.name)
         policy.description = kwargs.get("Description", policy.description)
@@ -737,7 +737,7 @@ class OrganizationsBackend(BaseBackend):
         else:
             raise InvalidInputException("You specified an invalid value.")
 
-    def list_policies(self) -> Dict[str, Any]:
+    def list_policies(self) -> dict[str, Any]:
         return dict(
             Policies=[p.describe()["Policy"]["PolicySummary"] for p in self.policies]
         )
@@ -756,7 +756,7 @@ class OrganizationsBackend(BaseBackend):
             "We can't find a policy with the PolicyId that you specified.",
         )
 
-    def list_policies_for_target(self, **kwargs: Any) -> Dict[str, Any]:
+    def list_policies_for_target(self, **kwargs: Any) -> dict[str, Any]:
         _filter = kwargs["Filter"]
 
         if re.match(utils.ROOT_ID_REGEX, kwargs["TargetId"]):
@@ -816,7 +816,7 @@ class OrganizationsBackend(BaseBackend):
 
         return resource
 
-    def list_targets_for_policy(self, **kwargs: Any) -> Dict[str, Any]:
+    def list_targets_for_policy(self, **kwargs: Any) -> dict[str, Any]:
         if re.compile(utils.POLICY_ID_REGEX).match(kwargs["PolicyId"]):
             policy = next(
                 (p for p in self.policies if p.id == kwargs["PolicyId"]), None
@@ -838,7 +838,7 @@ class OrganizationsBackend(BaseBackend):
         new_tags = {tag["Key"]: tag["Value"] for tag in kwargs["Tags"]}
         resource.tags.update(new_tags)
 
-    def list_tags_for_resource(self, **kwargs: str) -> Dict[str, Any]:
+    def list_tags_for_resource(self, **kwargs: str) -> dict[str, Any]:
         resource = self._get_resource_for_tagging(kwargs["ResourceId"])
         tags = [{"Key": key, "Value": value} for key, value in resource.tags.items()]
         return dict(Tags=tags)
@@ -860,7 +860,7 @@ class OrganizationsBackend(BaseBackend):
 
         self.services.append(service.describe())
 
-    def list_aws_service_access_for_organization(self) -> Dict[str, Any]:
+    def list_aws_service_access_for_organization(self) -> dict[str, Any]:
         return dict(EnabledServicePrincipals=self.services)
 
     def disable_aws_service_access(self, **kwargs: str) -> None:
@@ -900,7 +900,7 @@ class OrganizationsBackend(BaseBackend):
 
         admin.add_service_principal(kwargs["ServicePrincipal"])
 
-    def list_delegated_administrators(self, **kwargs: str) -> Dict[str, Any]:
+    def list_delegated_administrators(self, **kwargs: str) -> dict[str, Any]:
         admins = self.admins
         service = kwargs.get("ServicePrincipal")
 
@@ -916,7 +916,7 @@ class OrganizationsBackend(BaseBackend):
 
         return dict(DelegatedAdministrators=delegated_admins)
 
-    def list_delegated_services_for_account(self, **kwargs: str) -> Dict[str, Any]:
+    def list_delegated_services_for_account(self, **kwargs: str) -> dict[str, Any]:
         admin = next(
             (admin for admin in self.admins if admin.account.id == kwargs["AccountId"]),
             None,
@@ -971,14 +971,14 @@ class OrganizationsBackend(BaseBackend):
         if not admin.services:
             self.admins.remove(admin)
 
-    def enable_policy_type(self, **kwargs: str) -> Dict[str, Any]:
+    def enable_policy_type(self, **kwargs: str) -> dict[str, Any]:
         root = self._get_root_by_id(kwargs["RootId"])
 
         root.add_policy_type(kwargs["PolicyType"])
 
         return dict(Root=root.describe())
 
-    def disable_policy_type(self, **kwargs: str) -> Dict[str, Any]:
+    def disable_policy_type(self, **kwargs: str) -> dict[str, Any]:
         root = self._get_root_by_id(kwargs["RootId"])
 
         root.remove_policy_type(kwargs["PolicyType"])
@@ -1037,12 +1037,12 @@ class OrganizationsBackendDict(BackendDict[OrganizationsBackend]):
         backend: Any,
         service_name: str,
         use_boto3_regions: bool = True,
-        additional_regions: Optional[List[str]] = None,
+        additional_regions: Optional[list[str]] = None,
     ):
         super().__init__(backend, service_name, use_boto3_regions, additional_regions)
 
         # Maps member account IDs to the (master account ID, partition) which owns the organisation
-        self.master_accounts: Dict[str, Tuple[str, str]] = {}
+        self.master_accounts: dict[str, tuple[str, str]] = {}
 
 
 organizations_backends = OrganizationsBackendDict(

--- a/moto/organizations/responses.py
+++ b/moto/organizations/responses.py
@@ -1,5 +1,5 @@
 import json
-from typing import Any, Dict
+from typing import Any
 
 from moto.core.responses import BaseResponse
 
@@ -15,7 +15,7 @@ class OrganizationsResponse(BaseResponse):
         return organizations_backends[self.current_account][self.partition]
 
     @property
-    def request_params(self) -> Dict[str, Any]:  # type: ignore[misc]
+    def request_params(self) -> dict[str, Any]:  # type: ignore[misc]
         try:
             return json.loads(self.body)
         except ValueError:

--- a/moto/organizations/utils.py
+++ b/moto/organizations/utils.py
@@ -1,6 +1,7 @@
 import re
 import string
-from typing import Pattern, Union
+from re import Pattern
+from typing import Union
 
 from moto.moto_api._internal import mock_random as random
 

--- a/moto/osis/exceptions.py
+++ b/moto/osis/exceptions.py
@@ -1,5 +1,5 @@
 import json
-from typing import List, Optional
+from typing import Optional
 
 from moto.core.exceptions import JsonRESTError
 
@@ -19,7 +19,7 @@ class PipelineAlreadyExistsException(OpensearchIngestionExceptions):
 
 class PipelineInvalidStateException(OpensearchIngestionExceptions):
     def __init__(
-        self, action: str, valid_states: List[str], current_state: Optional[str]
+        self, action: str, valid_states: list[str], current_state: Optional[str]
     ):
         super().__init__(
             "ConflictException",

--- a/moto/osis/models.py
+++ b/moto/osis/models.py
@@ -1,7 +1,7 @@
 """OpenSearchIngestionBackend class with methods for supported APIs."""
 
 from datetime import datetime
-from typing import TYPE_CHECKING, Any, ClassVar, Dict, List, Optional
+from typing import TYPE_CHECKING, Any, ClassVar, Optional
 
 import yaml
 
@@ -35,7 +35,7 @@ class Pipeline(ManagedState, BaseModel):
     STARTING_REASON = "The pipeline is starting. It is not able to ingest data"
     UPDATING_REASON = "An update was triggered for the pipeline. It is still available to ingest data."
 
-    STATUS_REASON_MAP: ClassVar[Dict[str, str]] = {
+    STATUS_REASON_MAP: ClassVar[dict[str, str]] = {
         "CREATING": CREATING_REASON,
         "ACTIVE": ACTIVE_REASON,
         "STOPPING": STOPPING_REASON,
@@ -53,11 +53,11 @@ class Pipeline(ManagedState, BaseModel):
         min_units: int,
         max_units: int,
         pipeline_configuration_body: str,
-        log_publishing_options: Optional[Dict[str, Any]],
-        vpc_options: Optional[Dict[str, Any]],
-        buffer_options: Optional[Dict[str, Any]],
-        encryption_at_rest_options: Optional[Dict[str, Any]],
-        ingest_endpoint_urls: List[str],
+        log_publishing_options: Optional[dict[str, Any]],
+        vpc_options: Optional[dict[str, Any]],
+        buffer_options: Optional[dict[str, Any]],
+        encryption_at_rest_options: Optional[dict[str, Any]],
+        ingest_endpoint_urls: list[str],
         serverless: bool,
         vpc_endpoint_service: Optional[str],
         vpc_endpoint: Optional[str],
@@ -112,14 +112,14 @@ class Pipeline(ManagedState, BaseModel):
     def _get_arn(self, name: str) -> str:
         return f"arn:{get_partition(self.region)}:osis:{self.region}:{self.account_id}:pipeline/{name}"
 
-    def _get_service_vpc_endpoints(self) -> Optional[List[Dict[str, str]]]:
+    def _get_service_vpc_endpoints(self) -> Optional[list[dict[str, str]]]:
         # ServiceVpcEndpoint.VpcEndpointId not implemented
         if self.serverless:
             return [{"ServiceName": "OPENSEARCH_SERVERLESS"}]
         else:
             return None
 
-    def _update_destinations(self) -> List[Dict[str, str]]:
+    def _update_destinations(self) -> list[dict[str, str]]:
         destinations = []
         for sub_pipeline in self.pipeline_configuration_body:
             if sub_pipeline != "version":
@@ -142,7 +142,7 @@ class Pipeline(ManagedState, BaseModel):
         return destinations
 
     @staticmethod
-    def is_serverless(pipeline_body: Dict[str, Any]) -> bool:  # type: ignore[misc]
+    def is_serverless(pipeline_body: dict[str, Any]) -> bool:  # type: ignore[misc]
         serverless = False
         for sub_pipeline in pipeline_body:
             if sub_pipeline != "version":
@@ -185,9 +185,9 @@ class Pipeline(ManagedState, BaseModel):
         min_units: Optional[int],
         max_units: Optional[int],
         pipeline_configuration_body: Optional[str],
-        log_publishing_options: Optional[Dict[str, Any]],
-        buffer_options: Optional[Dict[str, Any]],
-        encryption_at_rest_options: Optional[Dict[str, Any]],
+        log_publishing_options: Optional[dict[str, Any]],
+        buffer_options: Optional[dict[str, Any]],
+        encryption_at_rest_options: Optional[dict[str, Any]],
     ) -> None:
         if min_units is not None:
             self.min_units = min_units
@@ -210,7 +210,7 @@ class Pipeline(ManagedState, BaseModel):
         self.status = "UPDATING"
         self.set_last_updated()
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         return {
             "PipelineName": self.pipeline_name,
             "PipelineArn": self.arn,
@@ -242,7 +242,7 @@ class Pipeline(ManagedState, BaseModel):
             "Tags": self.backend.list_tags_for_resource(self.arn)["Tags"],
         }
 
-    def to_short_dict(self) -> Dict[str, Any]:
+    def to_short_dict(self) -> dict[str, Any]:
         return {
             "Status": self.status,
             "StatusReason": {
@@ -289,7 +289,7 @@ class OpenSearchIngestionBackend(BaseBackend):
 
     def __init__(self, region_name: str, account_id: str):
         super().__init__(region_name, account_id)
-        self._pipelines: Dict[str, Pipeline] = dict()
+        self._pipelines: dict[str, Pipeline] = dict()
         self.tagger = TaggingService()
 
     @property
@@ -299,7 +299,7 @@ class OpenSearchIngestionBackend(BaseBackend):
         return ec2_backends[self.account_id][self.region_name]
 
     @property
-    def pipelines(self) -> Dict[str, Pipeline]:
+    def pipelines(self) -> dict[str, Pipeline]:
         self._pipelines = {
             name: pipeline
             for name, pipeline in self._pipelines.items()
@@ -309,7 +309,7 @@ class OpenSearchIngestionBackend(BaseBackend):
 
     def _get_ingest_endpoint_urls(
         self, pipeline_name: str, endpoint_random_string: str
-    ) -> List[str]:
+    ) -> list[str]:
         return [
             f"{pipeline_name}-{endpoint_random_string}.{self.region_name}.osis.amazonaws.com"
         ]
@@ -318,7 +318,7 @@ class OpenSearchIngestionBackend(BaseBackend):
         return random.get_random_string(length=26, lower_case=True)
 
     def _get_vpc_endpoint(
-        self, vpc_id: str, vpc_options: Dict[str, Any], service_name: str
+        self, vpc_id: str, vpc_options: dict[str, Any], service_name: str
     ) -> Optional[str]:
         if vpc_options.get("VpcEndpointManagement", "SERVICE") == "SERVICE":
             service_managed_endpoint = self.ec2_backend.create_vpc_endpoint(
@@ -341,7 +341,7 @@ class OpenSearchIngestionBackend(BaseBackend):
     ) -> str:
         return f"com.amazonaws.osis.{self.region_name}.{pipeline_name}-{endpoint_random_string}"
 
-    def _validate_and_get_vpc(self, vpc_options: Dict[str, Any]) -> str:
+    def _validate_and_get_vpc(self, vpc_options: dict[str, Any]) -> str:
         from moto.ec2.exceptions import InvalidSubnetIdError
 
         vpc_id = ""
@@ -372,11 +372,11 @@ class OpenSearchIngestionBackend(BaseBackend):
         min_units: int,
         max_units: int,
         pipeline_configuration_body: str,
-        log_publishing_options: Optional[Dict[str, Any]],
-        vpc_options: Optional[Dict[str, Any]],
-        buffer_options: Optional[Dict[str, bool]],
-        encryption_at_rest_options: Optional[Dict[str, Any]],
-        tags: List[Dict[str, str]],
+        log_publishing_options: Optional[dict[str, Any]],
+        vpc_options: Optional[dict[str, Any]],
+        buffer_options: Optional[dict[str, bool]],
+        encryption_at_rest_options: Optional[dict[str, Any]],
+        tags: list[dict[str, str]],
     ) -> Pipeline:
         if pipeline_name in self.pipelines:
             raise PipelineAlreadyExistsException(pipeline_name)
@@ -460,12 +460,12 @@ class OpenSearchIngestionBackend(BaseBackend):
         return pipeline
 
     @paginate(pagination_model=PAGINATION_MODEL)  # type: ignore
-    def list_pipelines(self) -> List[Pipeline]:
+    def list_pipelines(self) -> list[Pipeline]:
         for pipeline in self.pipelines.values():
             pipeline.advance()
         return [p for p in self.pipelines.values()]
 
-    def list_tags_for_resource(self, arn: str) -> Dict[str, List[Dict[str, str]]]:
+    def list_tags_for_resource(self, arn: str) -> dict[str, list[dict[str, str]]]:
         return self.tagger.list_tags_for_resource(arn)
 
     def update_pipeline(
@@ -474,9 +474,9 @@ class OpenSearchIngestionBackend(BaseBackend):
         min_units: Optional[int],
         max_units: Optional[int],
         pipeline_configuration_body: Optional[str],
-        log_publishing_options: Optional[Dict[str, Any]],
-        buffer_options: Optional[Dict[str, Any]],
-        encryption_at_rest_options: Optional[Dict[str, Any]],
+        log_publishing_options: Optional[dict[str, Any]],
+        buffer_options: Optional[dict[str, Any]],
+        encryption_at_rest_options: Optional[dict[str, Any]],
     ) -> Pipeline:
         if pipeline_name not in self.pipelines:
             raise PipelineNotFoundException(pipeline_name)
@@ -495,10 +495,10 @@ class OpenSearchIngestionBackend(BaseBackend):
         )
         return pipeline
 
-    def tag_resource(self, arn: str, tags: List[Dict[str, str]]) -> None:
+    def tag_resource(self, arn: str, tags: list[dict[str, str]]) -> None:
         self.tagger.tag_resource(arn, tags)
 
-    def untag_resource(self, arn: str, tag_keys: List[str]) -> None:
+    def untag_resource(self, arn: str, tag_keys: list[str]) -> None:
         self.tagger.untag_resource_using_names(arn, tag_keys)
 
 

--- a/moto/packages/boto/ec2/blockdevicemapping.py
+++ b/moto/packages/boto/ec2/blockdevicemapping.py
@@ -20,10 +20,10 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 # IN THE SOFTWARE.
 #
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Optional, Union
 
 
-class BlockDeviceType(object):
+class BlockDeviceType:
     """
     Represents parameters for a block device.
     """
@@ -63,7 +63,7 @@ class BlockDeviceType(object):
 EBSBlockDeviceType = BlockDeviceType
 
 
-class BlockDeviceMapping(Dict[Any, Any]):
+class BlockDeviceMapping(dict[Any, Any]):
     """
     Represents a collection of BlockDeviceTypes when creating ec2 instances.
 
@@ -75,7 +75,7 @@ class BlockDeviceMapping(Dict[Any, Any]):
     reservation = image.run(..., block_device_map=bdm, ...)
     """
 
-    def to_source_dict(self) -> List[Dict[str, Any]]:
+    def to_source_dict(self) -> list[dict[str, Any]]:
         return [
             {
                 "DeviceName": device_name,

--- a/moto/packages/boto/ec2/ec2object.py
+++ b/moto/packages/boto/ec2/ec2object.py
@@ -47,5 +47,5 @@ class TaggedEC2Object(EC2Object):
     """
 
     def __init__(self, connection: Any = None):
-        super(TaggedEC2Object, self).__init__(connection)
+        super().__init__(connection)
         self.tags = TagSet()  # type: ignore

--- a/moto/packages/boto/ec2/instance.py
+++ b/moto/packages/boto/ec2/instance.py
@@ -72,7 +72,7 @@ class Reservation(EC2Object):
         self.instances: Any = []
 
     def __repr__(self) -> str:
-        return "Reservation:%s" % self.id
+        return f"Reservation:{self.id}"
 
 
 class Instance(TaggedEC2Object):
@@ -166,7 +166,7 @@ class Instance(TaggedEC2Object):
         self._placement = InstancePlacement()
 
     def __repr__(self) -> str:
-        return "Instance:%s" % self.id  # type: ignore
+        return f"Instance:{self.id}"  # type: ignore
 
     @property
     def state(self) -> str:

--- a/moto/packages/boto/ec2/instancetype.py
+++ b/moto/packages/boto/ec2/instancetype.py
@@ -35,7 +35,7 @@ class InstanceType(EC2Object):
     """
 
     def __init__(self, connection=None, name=None, cores=None, memory=None, disk=None):
-        super(InstanceType, self).__init__(connection)
+        super().__init__(connection)
         self.connection = connection
         self.name = name
         self.cores = cores
@@ -43,9 +43,4 @@ class InstanceType(EC2Object):
         self.disk = disk
 
     def __repr__(self):
-        return "InstanceType:%s-%s,%s,%s" % (
-            self.name,
-            self.cores,
-            self.memory,
-            self.disk,
-        )
+        return f"InstanceType:{self.name}-{self.cores},{self.memory},{self.disk}"

--- a/moto/packages/cfnresponse/cfnresponse.py
+++ b/moto/packages/cfnresponse/cfnresponse.py
@@ -4,7 +4,6 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: MIT-0
 
-from __future__ import print_function
 
 import json
 from typing import Any
@@ -33,9 +32,7 @@ def send(
     responseBody = {
         "Status": responseStatus,
         "Reason": reason
-        or "See the details in CloudWatch Log Stream: {}".format(
-            context.log_stream_name
-        ),
+        or f"See the details in CloudWatch Log Stream: {context.log_stream_name}",
         "PhysicalResourceId": physicalResourceId or context.log_stream_name,
         "StackId": event["StackId"],
         "RequestId": event["RequestId"],

--- a/moto/panorama/models.py
+++ b/moto/panorama/models.py
@@ -2,7 +2,7 @@ import base64
 import json
 import uuid
 from datetime import datetime, timedelta
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Optional, Union
 
 from dateutil.tz import tzutc
 
@@ -55,8 +55,8 @@ class BaseObject(BaseModel):
         for k in details.keys():
             setattr(self, k, details[k])
 
-    def gen_response_object(self) -> Dict[str, Any]:
-        response_object: Dict[str, Any] = dict()
+    def gen_response_object(self) -> dict[str, Any]:
+        response_object: dict[str, Any] = dict()
         for key, value in self.__dict__.items():
             if "_" in key:
                 response_object[self.camelCase(key)] = value
@@ -64,7 +64,7 @@ class BaseObject(BaseModel):
                 response_object[key[0].upper() + key[1:]] = value
         return response_object
 
-    def response_object(self) -> Dict[str, Any]:
+    def response_object(self) -> dict[str, Any]:
         return self.gen_response_object()
 
 
@@ -75,8 +75,8 @@ class Device(BaseObject):
         region_name: str,
         description: Optional[str],
         name: str,
-        network_configuration: Optional[Dict[str, Any]],
-        tags: Optional[Dict[str, str]],
+        network_configuration: Optional[dict[str, Any]],
+        tags: Optional[dict[str, str]],
     ) -> None:
         # ManagedState is a class that helps us manage the state of a resource.
         # A Panorama Device has a lot of different states that has their own lifecycle.
@@ -106,9 +106,7 @@ class Device(BaseObject):
         self.network_configuration = network_configuration
         self.tags = tags
 
-        self.certificates = base64.b64encode("certificate".encode("utf-8")).decode(
-            "utf-8"
-        )
+        self.certificates = base64.b64encode(b"certificate").decode("utf-8")
         self.arn = arn_formatter("device", self.name, self.account_id, self.region_name)
         self.device_id = f"device-{hash_name(name)}"
         self.iot_thing_name = ""
@@ -155,7 +153,7 @@ class Device(BaseObject):
         self.__device_provisioning_status_manager.advance()
         return self.__device_provisioning_status_manager.status  # type: ignore[return-value]
 
-    def response_object(self) -> Dict[str, Any]:
+    def response_object(self) -> dict[str, Any]:
         response_object = super().gen_response_object()
         response_object = deep_convert_datetime_to_isoformat(response_object)
         static_response_fields = [
@@ -190,7 +188,7 @@ class Device(BaseObject):
             },
         }
 
-    def response_listed(self) -> Dict[str, Any]:
+    def response_listed(self) -> dict[str, Any]:
         response_object = super().gen_response_object()
         response_object = deep_convert_datetime_to_isoformat(response_object)
         static_response_fields = [
@@ -219,7 +217,7 @@ class Device(BaseObject):
         }
 
     @property
-    def response_provision(self) -> Dict[str, Union[str, bytes]]:
+    def response_provision(self) -> dict[str, Union[str, bytes]]:
         return {
             "Arn": self.arn,
             "Certificates": self.certificates,
@@ -229,11 +227,11 @@ class Device(BaseObject):
         }
 
     @property
-    def response_updated(self) -> Dict[str, str]:
+    def response_updated(self) -> dict[str, str]:
         return {"DeviceId": self.device_id}
 
     @property
-    def response_deleted(self) -> Dict[str, str]:
+    def response_deleted(self) -> dict[str, str]:
         return {"DeviceId": self.device_id}
 
 
@@ -264,12 +262,12 @@ class Package(BaseObject):
             "package", self.package_id, account_id, region_name
         )
 
-    def response_object(self) -> Dict[str, Any]:
+    def response_object(self) -> dict[str, Any]:
         response_object = super().gen_response_object()
         response_object = deep_convert_datetime_to_isoformat(response_object)
         return response_object
 
-    def response_listed(self) -> Dict[str, Any]:
+    def response_listed(self) -> dict[str, Any]:
         package_response = self.response_object()
         return package_response
 
@@ -282,11 +280,11 @@ class ApplicationInstance(BaseObject):
         default_runtime_context_device: str,
         default_runtime_context_device_name: str,
         description: str,
-        manifest_overrides_payload: Dict[str, str],
-        manifest_payload: Dict[str, str],
+        manifest_overrides_payload: dict[str, str],
+        manifest_payload: dict[str, str],
         name: str,
         runtime_role_arn: str,
-        tags: Dict[str, str],
+        tags: dict[str, str],
     ) -> None:
         self.default_runtime_context_device = default_runtime_context_device
         self.default_runtime_context_device_name = default_runtime_context_device_name
@@ -332,19 +330,19 @@ class ApplicationInstance(BaseObject):
             }
         )
 
-    def response_object(self) -> Dict[str, Any]:
+    def response_object(self) -> dict[str, Any]:
         response_object = super().gen_response_object()
         response_object = deep_convert_datetime_to_isoformat(response_object)
         return response_object
 
-    def response_listed(self) -> Dict[str, Any]:
+    def response_listed(self) -> dict[str, Any]:
         package_response = self.response_object()
         return package_response
 
-    def response_created(self) -> Dict[str, str]:
+    def response_created(self) -> dict[str, str]:
         return {"ApplicationInstanceId": self.application_instance_id}
 
-    def response_describe(self) -> Dict[str, str]:
+    def response_describe(self) -> dict[str, str]:
         response_object = self.response_object()
         return response_object
 
@@ -353,12 +351,12 @@ class Node(BaseObject):
     def __init__(
         self,
         job_id: str,
-        job_tags: List[Dict[str, Union[str, Dict[str, str]]]],
+        job_tags: list[dict[str, Union[str, dict[str, str]]]],
         node_description: str,
         node_name: str,
         output_package_name: str,
         output_package_version: str,
-        template_parameters: Dict[str, str],
+        template_parameters: dict[str, str],
         template_type: str,
     ) -> None:
         self.job_id = job_id
@@ -374,19 +372,19 @@ class Node(BaseObject):
         self.template_parameters = self.protect_secrets(template_parameters)
         self.template_type = template_type
 
-    def response_object(self) -> Dict[str, Any]:
+    def response_object(self) -> dict[str, Any]:
         response_object = super().gen_response_object()
         response_object = deep_convert_datetime_to_isoformat(response_object)
         return response_object
 
-    def response_created(self) -> Dict[str, str]:
+    def response_created(self) -> dict[str, str]:
         return {"JobId": self.job_id}
 
-    def response_described(self) -> Dict[str, Any]:
+    def response_described(self) -> dict[str, Any]:
         return self.response_object()
 
     @staticmethod
-    def protect_secrets(template_parameters: Dict[str, str]) -> Dict[str, str]:
+    def protect_secrets(template_parameters: dict[str, str]) -> dict[str, str]:
         for key in template_parameters.keys():
             if key.lower() == "password":
                 template_parameters[key] = "SAVED_AS_SECRET"
@@ -398,17 +396,17 @@ class Node(BaseObject):
 class PanoramaBackend(BaseBackend):
     def __init__(self, region_name: str, account_id: str):
         super().__init__(region_name, account_id)
-        self.devices_memory: Dict[str, Device] = {}
-        self.node_from_template_memory: Dict[str, Node] = {}
-        self.nodes_memory: Dict[str, Package] = {}
-        self.application_instances_memory: Dict[str, ApplicationInstance] = {}
+        self.devices_memory: dict[str, Device] = {}
+        self.node_from_template_memory: dict[str, Node] = {}
+        self.nodes_memory: dict[str, Package] = {}
+        self.application_instances_memory: dict[str, ApplicationInstance] = {}
 
     def provision_device(
         self,
         description: Optional[str],
         name: str,
-        networking_configuration: Optional[Dict[str, Any]],
-        tags: Optional[Dict[str, str]],
+        networking_configuration: Optional[dict[str, Any]],
+        tags: Optional[dict[str, str]],
     ) -> Device:
         device_obj = Device(
             account_id=self.account_id,
@@ -435,7 +433,7 @@ class PanoramaBackend(BaseBackend):
         name_filter: str,
         sort_by: str,  # "DEVICE_ID", "CREATED_TIME", "NAME", "DEVICE_AGGREGATED_STATUS"
         sort_order: str,  # "ASCENDING", "DESCENDING"
-    ) -> List[Device]:
+    ) -> list[Device]:
         devices_list = list(
             filter(
                 lambda x: (name_filter is None or x.name.startswith(name_filter))
@@ -468,12 +466,12 @@ class PanoramaBackend(BaseBackend):
 
     def create_node_from_template_job(
         self,
-        job_tags: List[Dict[str, Union[str, Dict[str, str]]]],
+        job_tags: list[dict[str, Union[str, dict[str, str]]]],
         node_description: str,
         node_name: str,
         output_package_name: str,
         output_package_version: str,
-        template_parameters: Dict[str, str],
+        template_parameters: dict[str, str],
         template_type: str,
     ) -> Node:
         job_id = str(uuid.uuid4()).lower()
@@ -505,7 +503,7 @@ class PanoramaBackend(BaseBackend):
         return self.node_from_template_memory[job_id]
 
     @paginate(pagination_model=PAGINATION_MODEL)
-    def list_nodes(self, category: str) -> List[Package]:
+    def list_nodes(self, category: str) -> list[Package]:
         category_nodes = list(
             filter(
                 lambda x: x.category == category,
@@ -519,11 +517,11 @@ class PanoramaBackend(BaseBackend):
         application_instance_id_to_replace: Optional[str],
         default_runtime_context_device: str,
         description: str,
-        manifest_overrides_payload: Dict[str, str],
-        manifest_payload: Dict[str, str],
+        manifest_overrides_payload: dict[str, str],
+        manifest_payload: dict[str, str],
         name: str,
         runtime_role_arn: str,
-        tags: Dict[str, str],
+        tags: dict[str, str],
     ) -> ApplicationInstance:
         device = self.devices_memory.get(default_runtime_context_device)
         if device is None:
@@ -570,7 +568,7 @@ class PanoramaBackend(BaseBackend):
         self,
         device_id: Optional[str],
         status_filter: Optional[str],
-    ) -> List[ApplicationInstance]:
+    ) -> list[ApplicationInstance]:
         filtered_application_instances = filter(
             lambda x: x.status == status_filter if status_filter else True,
             filter(

--- a/moto/personalize/models.py
+++ b/moto/personalize/models.py
@@ -1,4 +1,5 @@
-from typing import Any, Dict, Iterable
+from collections.abc import Iterable
+from typing import Any
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
@@ -14,7 +15,7 @@ class Schema(BaseModel):
         account_id: str,
         region: str,
         name: str,
-        schema: Dict[str, Any],
+        schema: dict[str, Any],
         domain: str,
     ):
         self.name = name
@@ -23,8 +24,8 @@ class Schema(BaseModel):
         self.arn = f"arn:{get_partition(region)}:personalize:{region}:{account_id}:schema/{name}"
         self.created = unix_time()
 
-    def to_dict(self, full: bool = True) -> Dict[str, Any]:
-        d: Dict[str, Any] = {
+    def to_dict(self, full: bool = True) -> dict[str, Any]:
+        d: dict[str, Any] = {
             "name": self.name,
             "schemaArn": self.arn,
             "domain": self.domain,
@@ -41,9 +42,9 @@ class PersonalizeBackend(BaseBackend):
 
     def __init__(self, region_name: str, account_id: str):
         super().__init__(region_name, account_id)
-        self.schemas: Dict[str, Schema] = dict()
+        self.schemas: dict[str, Schema] = dict()
 
-    def create_schema(self, name: str, schema_dict: Dict[str, Any], domain: str) -> str:
+    def create_schema(self, name: str, schema_dict: dict[str, Any], domain: str) -> str:
         schema = Schema(
             region=self.region_name,
             account_id=self.account_id,

--- a/moto/pinpoint/models.py
+++ b/moto/pinpoint/models.py
@@ -1,5 +1,6 @@
+from collections.abc import Iterable
 from datetime import datetime
-from typing import Any, Dict, Iterable, List, Optional
+from typing import Any, Optional
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
@@ -23,7 +24,7 @@ class App(BaseModel):
     def get_settings(self) -> "AppSettings":
         return self.settings
 
-    def update_settings(self, settings: Dict[str, Any]) -> "AppSettings":
+    def update_settings(self, settings: dict[str, Any]) -> "AppSettings":
         self.settings.update(settings)
         return self.settings
 
@@ -41,7 +42,7 @@ class App(BaseModel):
         self.event_stream = EventStream(stream_arn, role_arn)
         return self.event_stream
 
-    def to_json(self) -> Dict[str, Any]:
+    def to_json(self) -> dict[str, Any]:
         return {
             "Arn": self.arn,
             "Id": self.application_id,
@@ -52,14 +53,14 @@ class App(BaseModel):
 
 class AppSettings(BaseModel):
     def __init__(self) -> None:
-        self.settings: Dict[str, Any] = dict()
+        self.settings: dict[str, Any] = dict()
         self.last_modified = datetime.now().strftime("%Y-%m-%dT%H:%M:%S.%fZ")
 
-    def update(self, settings: Dict[str, Any]) -> None:
+    def update(self, settings: dict[str, Any]) -> None:
         self.settings = settings
         self.last_modified = datetime.now().strftime("%Y-%m-%dT%H:%M:%S.%fZ")
 
-    def to_json(self) -> Dict[str, Any]:
+    def to_json(self) -> dict[str, Any]:
         return {
             "CampaignHook": self.settings.get("CampaignHook", {}),
             "CloudWatchMetricsEnabled": self.settings.get(
@@ -77,7 +78,7 @@ class EventStream(BaseModel):
         self.role_arn = role_arn
         self.last_modified = datetime.now().strftime("%Y-%m-%dT%H:%M:%S.%fZ")
 
-    def to_json(self) -> Dict[str, Any]:
+    def to_json(self) -> dict[str, Any]:
         return {
             "DestinationStreamArn": self.stream_arn,
             "RoleArn": self.role_arn,
@@ -90,10 +91,10 @@ class PinpointBackend(BaseBackend):
 
     def __init__(self, region_name: str, account_id: str):
         super().__init__(region_name, account_id)
-        self.apps: Dict[str, App] = {}
+        self.apps: dict[str, App] = {}
         self.tagger = TaggingService()
 
-    def create_app(self, name: str, tags: Dict[str, str]) -> App:
+    def create_app(self, name: str, tags: dict[str, str]) -> App:
         app = App(self.account_id, self.region_name, name)
         self.apps[app.application_id] = app
         tag_list = self.tagger.convert_dict_to_tags_input(tags)
@@ -116,7 +117,7 @@ class PinpointBackend(BaseBackend):
         return self.apps.values()
 
     def update_application_settings(
-        self, application_id: str, settings: Dict[str, Any]
+        self, application_id: str, settings: dict[str, Any]
     ) -> AppSettings:
         app = self.get_app(application_id)
         return app.update_settings(settings)
@@ -125,15 +126,15 @@ class PinpointBackend(BaseBackend):
         app = self.get_app(application_id)
         return app.get_settings()
 
-    def list_tags_for_resource(self, resource_arn: str) -> Dict[str, Dict[str, str]]:
+    def list_tags_for_resource(self, resource_arn: str) -> dict[str, dict[str, str]]:
         tags = self.tagger.get_tag_dict_for_resource(resource_arn)
         return {"tags": tags}
 
-    def tag_resource(self, resource_arn: str, tags: Dict[str, str]) -> None:
+    def tag_resource(self, resource_arn: str, tags: dict[str, str]) -> None:
         tag_list = TaggingService.convert_dict_to_tags_input(tags)
         self.tagger.tag_resource(resource_arn, tag_list)
 
-    def untag_resource(self, resource_arn: str, tag_keys: List[str]) -> None:
+    def untag_resource(self, resource_arn: str, tag_keys: list[str]) -> None:
         self.tagger.untag_resource_using_names(resource_arn, tag_keys)
 
     def put_event_stream(

--- a/moto/polly/models.py
+++ b/moto/polly/models.py
@@ -1,5 +1,5 @@
 import datetime
-from typing import Any, Dict, List, Optional
+from typing import Any, Optional
 from xml.etree import ElementTree as ET
 
 from moto.core.base_backend import BackendDict, BaseBackend
@@ -46,7 +46,7 @@ class Lexicon(BaseModel):
         except Exception as err:
             raise ValueError(f"Failure parsing XML: {err}")
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         return {
             "Attributes": {
                 "Alphabet": self.alphabet,
@@ -65,9 +65,9 @@ class Lexicon(BaseModel):
 class PollyBackend(BaseBackend):
     def __init__(self, region_name: str, account_id: str):
         super().__init__(region_name, account_id)
-        self._lexicons: Dict[str, Lexicon] = {}
+        self._lexicons: dict[str, Lexicon] = {}
 
-    def describe_voices(self, language_code: str) -> List[Dict[str, Any]]:
+    def describe_voices(self, language_code: str) -> list[dict[str, Any]]:
         """
         Pagination is not yet implemented
         """
@@ -84,7 +84,7 @@ class PollyBackend(BaseBackend):
         # Raises KeyError
         return self._lexicons[name]
 
-    def list_lexicons(self) -> List[Dict[str, Any]]:
+    def list_lexicons(self) -> list[dict[str, Any]]:
         """
         Pagination is not yet implemented
         """

--- a/moto/polly/resources.py
+++ b/moto/polly/resources.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This data is a verbatim copy of that produced using the AWS CLI (requires AWS
 # account) and jq utility to pull out the right part and reformat:
 #

--- a/moto/polly/responses.py
+++ b/moto/polly/responses.py
@@ -1,6 +1,6 @@
 import json
 import re
-from typing import Any, Dict, Tuple, Union
+from typing import Any, Union
 from urllib.parse import urlsplit
 
 from moto.core.responses import BaseResponse
@@ -20,12 +20,12 @@ class PollyResponse(BaseResponse):
         return polly_backends[self.current_account][self.region]
 
     @property
-    def json(self) -> Dict[str, Any]:  # type: ignore[misc]
+    def json(self) -> dict[str, Any]:  # type: ignore[misc]
         if not hasattr(self, "_json"):
             self._json = json.loads(self.body)
         return self._json
 
-    def _error(self, code: str, message: str) -> Tuple[str, Dict[str, int]]:
+    def _error(self, code: str, message: str) -> tuple[str, dict[str, int]]:
         return json.dumps({"__type": code, "message": message}), dict(status=400)
 
     def _get_action(self) -> str:
@@ -36,7 +36,7 @@ class PollyResponse(BaseResponse):
         return url_parts[1]
 
     # DescribeVoices
-    def voices(self) -> Union[str, Tuple[str, Dict[str, int]]]:
+    def voices(self) -> Union[str, tuple[str, dict[str, int]]]:
         language_code = self._get_param("LanguageCode")
 
         if language_code is not None and language_code not in LANGUAGE_CODES:
@@ -51,7 +51,7 @@ class PollyResponse(BaseResponse):
 
         return json.dumps({"Voices": voices})
 
-    def lexicons(self) -> Union[str, Tuple[str, Dict[str, int]]]:
+    def lexicons(self) -> Union[str, tuple[str, dict[str, int]]]:
         # Dish out requests based on methods
 
         # anything after the /v1/lexicons/
@@ -72,7 +72,7 @@ class PollyResponse(BaseResponse):
     # PutLexicon
     def _put_lexicons(
         self, lexicon_name: str
-    ) -> Union[str, Tuple[str, Dict[str, int]]]:
+    ) -> Union[str, tuple[str, dict[str, int]]]:
         if LEXICON_NAME_REGEX.match(lexicon_name) is None:
             return self._error(
                 "InvalidParameterValue", "Lexicon name must match [0-9A-Za-z]{1,20}"
@@ -92,7 +92,7 @@ class PollyResponse(BaseResponse):
         return json.dumps(result)
 
     # GetLexicon
-    def _get_lexicon(self, lexicon_name: str) -> Union[str, Tuple[str, Dict[str, int]]]:
+    def _get_lexicon(self, lexicon_name: str) -> Union[str, tuple[str, dict[str, int]]]:
         try:
             lexicon = self.polly_backend.get_lexicon(lexicon_name)
         except KeyError:
@@ -108,7 +108,7 @@ class PollyResponse(BaseResponse):
     # DeleteLexicon
     def _delete_lexicon(
         self, lexicon_name: str
-    ) -> Union[str, Tuple[str, Dict[str, int]]]:
+    ) -> Union[str, tuple[str, dict[str, int]]]:
         try:
             self.polly_backend.delete_lexicon(lexicon_name)
         except KeyError:
@@ -117,7 +117,7 @@ class PollyResponse(BaseResponse):
         return ""
 
     # SynthesizeSpeech
-    def speech(self) -> Tuple[str, Dict[str, Any]]:
+    def speech(self) -> tuple[str, dict[str, Any]]:
         # Sanity check params
         args = {
             "lexicon_names": None,

--- a/moto/quicksight/data_models.py
+++ b/moto/quicksight/data_models.py
@@ -1,5 +1,5 @@
 import datetime
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Optional, Union
 
 from moto.core.common_models import BaseModel
 from moto.moto_api._internal import mock_random as random
@@ -14,7 +14,7 @@ class QuicksightDataSet(BaseModel):
         self.region = region
         self.account_id = account_id
 
-    def to_json(self) -> Dict[str, Any]:
+    def to_json(self) -> dict[str, Any]:
         return {
             "Arn": self.arn,
             "DataSetId": self._id,
@@ -29,7 +29,7 @@ class QuicksightIngestion(BaseModel):
         self.arn = f"arn:{get_partition(region)}:quicksight:{region}:{account_id}:data-set/{data_set_id}/ingestions/{ingestion_id}"
         self.ingestion_id = ingestion_id
 
-    def to_json(self) -> Dict[str, Any]:
+    def to_json(self) -> dict[str, Any]:
         return {
             "Arn": self.arn,
             "IngestionId": self.ingestion_id,
@@ -43,7 +43,7 @@ class QuicksightMembership(BaseModel):
         self.user = user
         self.arn = f"arn:{get_partition(region)}:quicksight:{region}:{account_id}:group/default/{group}/{user}"
 
-    def to_json(self) -> Dict[str, str]:
+    def to_json(self) -> dict[str, str]:
         return {"Arn": self.arn, "MemberName": self.user}
 
 
@@ -63,7 +63,7 @@ class QuicksightGroup(BaseModel):
         self.namespace = namespace
         self.region = region
 
-        self.members: Dict[str, QuicksightMembership] = dict()
+        self.members: dict[str, QuicksightMembership] = dict()
 
     def add_member(self, member_name: str) -> QuicksightMembership:
         membership = QuicksightMembership(
@@ -78,10 +78,10 @@ class QuicksightGroup(BaseModel):
     def get_member(self, user_name: str) -> Union[QuicksightMembership, None]:
         return self.members.get(user_name, None)
 
-    def list_members(self) -> List[QuicksightMembership]:
+    def list_members(self) -> list[QuicksightMembership]:
         return list(self.members.values())
 
-    def to_json(self) -> Dict[str, Any]:
+    def to_json(self) -> dict[str, Any]:
         return {
             "Arn": self.arn,
             "GroupName": self.group_name,
@@ -109,7 +109,7 @@ class QuicksightUser(BaseModel):
         self.active = False
         self.principal_id = random.get_random_hex(10)
 
-    def to_json(self) -> Dict[str, Any]:
+    def to_json(self) -> dict[str, Any]:
         return {
             "Arn": self.arn,
             "Email": self.email,
@@ -129,19 +129,19 @@ class QuicksightDashboard(BaseModel):
         account_id: str,
         region: str,
         dashboard_id: str,
-        dashboard_publish_options: Dict[str, Any],
+        dashboard_publish_options: dict[str, Any],
         name: str,
-        definition: Dict[str, Any],
-        folder_arns: List[str],
-        link_entities: List[str],
-        link_sharing_configuration: Dict[str, Any],
-        parameters: Dict[str, Any],
-        permissions: List[Dict[str, Any]],
-        source_entity: Dict[str, Any],
-        tags: List[Dict[str, Any]],
+        definition: dict[str, Any],
+        folder_arns: list[str],
+        link_entities: list[str],
+        link_sharing_configuration: dict[str, Any],
+        parameters: dict[str, Any],
+        permissions: list[dict[str, Any]],
+        source_entity: dict[str, Any],
+        tags: list[dict[str, Any]],
         theme_arn: str,
         version_description: str,
-        validation_strategy: Dict[str, str],
+        validation_strategy: dict[str, str],
     ) -> None:
         self.arn = f"arn:{get_partition(region)}:quicksight:{region}:{account_id}:dashboard/{dashboard_id}"
         self.dashboard_id = dashboard_id
@@ -167,7 +167,7 @@ class QuicksightDashboard(BaseModel):
         self.last_updated_time = datetime.datetime.now()
         self.last_published_time = datetime.datetime.now()
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         return {
             "Arn": self.arn,
             "DashboardId": self.dashboard_id,
@@ -209,13 +209,13 @@ class QuickSightDataSource(BaseModel):
         region: str,
         data_source_id: str,
         name: str,
-        data_source_parameters: Optional[Dict[str, Dict[str, Any]]] = None,
-        alternate_data_source_parameters: Optional[List[Dict[str, Any]]] = None,
-        ssl_properties: Optional[Dict[str, Any]] = None,
+        data_source_parameters: Optional[dict[str, dict[str, Any]]] = None,
+        alternate_data_source_parameters: Optional[list[dict[str, Any]]] = None,
+        ssl_properties: Optional[dict[str, Any]] = None,
         status: Optional[str] = None,
-        tags: Optional[List[Dict[str, str]]] = None,
+        tags: Optional[list[dict[str, str]]] = None,
         data_source_type: Optional[str] = None,
-        vpc_connection_properties: Optional[Dict[str, Any]] = None,
+        vpc_connection_properties: Optional[dict[str, Any]] = None,
     ) -> None:
         self.account_id = account_id
         self.region = region
@@ -232,7 +232,7 @@ class QuickSightDataSource(BaseModel):
         self.ssl_properties = ssl_properties
         self.vpc_connection_properties = vpc_connection_properties
 
-    def to_json(self) -> Dict[str, Any]:
+    def to_json(self) -> dict[str, Any]:
         return {
             "AlternateDataSourceParameters": self.alternate_data_source_parameters,
             "Arn": self.arn,

--- a/moto/quicksight/models.py
+++ b/moto/quicksight/models.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import Any, Dict, List, Optional
+from typing import Any, Optional
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.utilities.paginator import paginate
@@ -28,21 +28,21 @@ class QuickSightBackend(BaseBackend):
 
     def __init__(self, region_name: str, account_id: str):
         super().__init__(region_name, account_id)
-        self.dashboards: Dict[str, QuicksightDashboard] = dict()
-        self.groups: Dict[str, QuicksightGroup] = dict()
-        self.users: Dict[str, QuicksightUser] = dict()
+        self.dashboards: dict[str, QuicksightDashboard] = dict()
+        self.groups: dict[str, QuicksightGroup] = dict()
+        self.users: dict[str, QuicksightUser] = dict()
         self.account_settings: QuicksightAccountSettings = QuicksightAccountSettings(
             account_id=account_id
         )
-        self.data_sources: Dict[str, QuickSightDataSource] = dict()
-        self.data_sets: Dict[str, QuicksightDataSet] = dict()
+        self.data_sources: dict[str, QuickSightDataSource] = dict()
+        self.data_sets: dict[str, QuicksightDataSet] = dict()
         self.tagger = TaggingService()
 
     def create_data_set(
         self,
         data_set_id: str,
         name: str,
-        tags: Optional[List[Dict[str, str]]] = None,
+        tags: Optional[list[dict[str, str]]] = None,
     ) -> QuicksightDataSet:
         dataset = QuicksightDataSet(
             self.account_id, self.region_name, data_set_id, name=name
@@ -124,7 +124,7 @@ class QuickSightBackend(BaseBackend):
         return self.users[_id]
 
     @paginate(pagination_model=PAGINATION_MODEL)
-    def list_groups(self, aws_account_id: str, namespace: str) -> List[QuicksightGroup]:
+    def list_groups(self, aws_account_id: str, namespace: str) -> list[QuicksightGroup]:
         id_for_ns = _create_id(aws_account_id, namespace, _id="")
         return [
             group for _id, group in self.groups.items() if _id.startswith(id_for_ns)
@@ -132,8 +132,8 @@ class QuickSightBackend(BaseBackend):
 
     @paginate(pagination_model=PAGINATION_MODEL)
     def search_groups(
-        self, aws_account_id: str, namespace: str, filters: List[Dict[str, str]]
-    ) -> List[QuicksightGroup]:
+        self, aws_account_id: str, namespace: str, filters: list[dict[str, str]]
+    ) -> list[QuicksightGroup]:
         id_for_ns = _create_id(aws_account_id, namespace, _id="")
         filter_list = QuicksightSearchFilterFactory.validate_and_create_filter(
             model_type=QuicksightGroup, input=filters
@@ -147,21 +147,21 @@ class QuickSightBackend(BaseBackend):
     @paginate(pagination_model=PAGINATION_MODEL)
     def list_group_memberships(
         self, aws_account_id: str, namespace: str, group_name: str
-    ) -> List[QuicksightMembership]:
+    ) -> list[QuicksightMembership]:
         group = self.describe_group(aws_account_id, namespace, group_name)
         return group.list_members()
 
     @paginate(pagination_model=PAGINATION_MODEL)
-    def list_users(self, aws_account_id: str, namespace: str) -> List[QuicksightUser]:
+    def list_users(self, aws_account_id: str, namespace: str) -> list[QuicksightUser]:
         id_for_ns = _create_id(aws_account_id, namespace, _id="")
         return [user for _id, user in self.users.items() if _id.startswith(id_for_ns)]
 
     @paginate(pagination_model=PAGINATION_MODEL)
     def list_user_groups(
         self, aws_account_id: str, namespace: str, user_name: str
-    ) -> List[QuicksightGroup]:
+    ) -> list[QuicksightGroup]:
         id_for_ns = _create_id(aws_account_id, namespace, _id="")
-        group_list: Dict[str, QuicksightGroup] = {}
+        group_list: dict[str, QuicksightGroup] = {}
         # Loop through all groups and check if the user is member.
         for id, group in self.groups.items():
             if group.get_member(user_name):
@@ -176,7 +176,7 @@ class QuickSightBackend(BaseBackend):
         aws_account_id: str,
         namespace: str,
         user_name: str,
-        tags: Optional[List[Dict[str, str]]] = None,
+        tags: Optional[list[dict[str, str]]] = None,
     ) -> QuicksightUser:
         """
         The following parameters are not yet implemented:
@@ -226,18 +226,18 @@ class QuickSightBackend(BaseBackend):
         aws_account_id: str,
         dashboard_id: str,
         name: str,
-        parameters: Dict[str, Any],
-        permissions: List[Dict[str, Any]],
-        source_entity: Dict[str, Any],
-        tags: List[Dict[str, str]],
+        parameters: dict[str, Any],
+        permissions: list[dict[str, Any]],
+        source_entity: dict[str, Any],
+        tags: list[dict[str, str]],
         version_description: str,
-        dashboard_publish_options: Dict[str, Any],
+        dashboard_publish_options: dict[str, Any],
         theme_arn: str,
-        definition: Dict[str, Any],
-        validation_strategy: Dict[str, str],
-        folder_arns: List[str],
-        link_sharing_configuration: Dict[str, Any],
-        link_entities: List[str],
+        definition: dict[str, Any],
+        validation_strategy: dict[str, str],
+        folder_arns: list[str],
+        link_sharing_configuration: dict[str, Any],
+        link_entities: list[str],
     ) -> QuicksightDashboard:
         dashboard = QuicksightDashboard(
             account_id=aws_account_id,
@@ -279,9 +279,9 @@ class QuickSightBackend(BaseBackend):
             raise ResourceNotFoundException(f"Dashboard {dashboard_id} not found")
         return dashboard
 
-    def list_dashboards(self, aws_account_id: str) -> List[Dict[str, Any]]:
+    def list_dashboards(self, aws_account_id: str) -> list[dict[str, Any]]:
         dashboards = self.dashboards.values()
-        dashboard_list: List[Dict[str, Any]] = []
+        dashboard_list: list[dict[str, Any]] = []
         for dashboard in dashboards:
             d_dict = {
                 "Arn": dashboard.arn,
@@ -326,10 +326,10 @@ class QuickSightBackend(BaseBackend):
         data_source_id: str,
         name: str,
         data_source_type: str,
-        data_source_parameters: Optional[Dict[str, Dict[str, Any]]] = None,
-        vpc_connection_properties: Optional[Dict[str, Any]] = None,
-        ssl_properties: Optional[Dict[str, Any]] = None,
-        tags: Optional[List[Dict[str, str]]] = None,
+        data_source_parameters: Optional[dict[str, dict[str, Any]]] = None,
+        vpc_connection_properties: Optional[dict[str, Any]] = None,
+        ssl_properties: Optional[dict[str, Any]] = None,
+        tags: Optional[list[dict[str, str]]] = None,
     ) -> QuickSightDataSource:
         data_source = QuickSightDataSource(
             account_id=aws_account_id,
@@ -358,9 +358,9 @@ class QuickSightBackend(BaseBackend):
         aws_account_id: str,
         data_source_id: str,
         name: str,
-        data_source_parameters: Optional[Dict[str, Any]] = None,
-        vpc_connection_properties: Optional[Dict[str, Any]] = None,
-        ssl_properties: Optional[Dict[str, Any]] = None,
+        data_source_parameters: Optional[dict[str, Any]] = None,
+        vpc_connection_properties: Optional[dict[str, Any]] = None,
+        ssl_properties: Optional[dict[str, Any]] = None,
     ) -> QuickSightDataSource:
         data_source = self.data_sources.get(data_source_id)
 
@@ -393,28 +393,28 @@ class QuickSightBackend(BaseBackend):
 
         return data_source
 
-    def list_data_sources(self, aws_account_id: str) -> List[Dict[str, Any]]:
+    def list_data_sources(self, aws_account_id: str) -> list[dict[str, Any]]:
         data_sources = self.data_sources.values()
-        data_source_list: List[Dict[str, Any]] = []
+        data_source_list: list[dict[str, Any]] = []
 
         for data_source in data_sources:
             data_source_list.append(data_source.to_json())
 
         return data_source_list
 
-    def tag_resource(self, resource_arn: str, tags: List[Dict[str, str]]) -> None:
+    def tag_resource(self, resource_arn: str, tags: list[dict[str, str]]) -> None:
         self.tagger.tag_resource(
             arn=resource_arn,
             tags=tags,
         )
 
-    def untag_resource(self, resource_arn: str, tag_keys: List[str]) -> None:
+    def untag_resource(self, resource_arn: str, tag_keys: list[str]) -> None:
         self.tagger.untag_resource_using_names(
             resource_arn,
             tag_keys,
         )
 
-    def list_tags_for_resource(self, arn: str) -> List[Dict[str, str]]:
+    def list_tags_for_resource(self, arn: str) -> list[dict[str, str]]:
         tags = self.tagger.list_tags_for_resource(arn)
         return tags.get("Tags", [])
 

--- a/moto/quicksight/utils.py
+++ b/moto/quicksight/utils.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Type, Union
+from typing import Any, Union
 
 from moto.core.common_models import BaseModel
 
@@ -54,7 +54,7 @@ PAGINATION_MODEL = {
 class QuicksightBaseSearchFilter(BaseModel):
     """Base Search Filter."""
 
-    schema: Dict[str, Any] = {
+    schema: dict[str, Any] = {
         "$schema": "https://json-schema.org/draft/2020-12/schema",
     }
 
@@ -98,7 +98,7 @@ class QuicksightGroupSearchFilter(QuicksightBaseSearchFilter):
         return False
 
     @classmethod
-    def parse_filter(cls, filter: Dict[str, str]) -> QuicksightBaseSearchFilter:
+    def parse_filter(cls, filter: dict[str, str]) -> QuicksightBaseSearchFilter:
         return QuicksightGroupSearchFilter(
             operator=filter.get("Operator", ""),
             name=filter.get("Name", ""),
@@ -109,8 +109,8 @@ class QuicksightGroupSearchFilter(QuicksightBaseSearchFilter):
 class QuicksightSearchFilterList:
     """Generic QuickSight Search Filter List."""
 
-    def __init__(self, filters: List[QuicksightBaseSearchFilter]):
-        self.filters: List[QuicksightBaseSearchFilter] = filters
+    def __init__(self, filters: list[QuicksightBaseSearchFilter]):
+        self.filters: list[QuicksightBaseSearchFilter] = filters
 
     def match(self, input: BaseModel) -> bool:
         return any([filter.match(input) for filter in self.filters])
@@ -121,7 +121,7 @@ class QuicksightSearchFilterFactory:
 
     @classmethod
     def validate_and_create_filter(
-        cls, model_type: Type[BaseModel], input: Union[List[Dict[str, str]], None]
+        cls, model_type: type[BaseModel], input: Union[list[dict[str, str]], None]
     ) -> QuicksightSearchFilterList:
         if issubclass(model_type, QuicksightGroup):
             if input is None:

--- a/moto/ram/models.py
+++ b/moto/ram/models.py
@@ -1,7 +1,7 @@
 import re
 import string
 from datetime import datetime, timezone
-from typing import Any, Dict, List, Optional
+from typing import Any, Optional
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
@@ -60,15 +60,15 @@ class ResourceShare(BaseModel):
         self.last_updated_time = utcnow()
         self.name = kwargs["name"]
         self.owning_account_id = account_id
-        self.principals: List[str] = []
-        self.resource_arns: List[str] = []
+        self.principals: list[str] = []
+        self.resource_arns: list[str] = []
         self.status = "ACTIVE"
 
     @property
     def organizations_backend(self) -> OrganizationsBackend:
         return organizations_backends[self.account_id][self.partition]
 
-    def add_principals(self, principals: List[str]) -> None:
+    def add_principals(self, principals: list[str]) -> None:
         for principal in principals:
             match = re.search(
                 r"^arn:aws:organizations::\d{12}:organization/(o-\w+)$", principal
@@ -118,7 +118,7 @@ class ResourceShare(BaseModel):
         for principal in principals:
             self.principals.append(principal)
 
-    def add_resources(self, resource_arns: List[str]) -> None:
+    def add_resources(self, resource_arns: list[str]) -> None:
         for resource in resource_arns:
             match = re.search(
                 r"^arn:aws:[a-z0-9-]+:[a-z0-9-]*:[0-9]{12}:([a-z-]+)[/:].*$", resource
@@ -140,7 +140,7 @@ class ResourceShare(BaseModel):
         self.last_updated_time = utcnow()
         self.status = "DELETED"
 
-    def describe(self) -> Dict[str, Any]:
+    def describe(self) -> dict[str, Any]:
         return {
             "allowExternalPrincipals": self.allow_external_principals,
             "creationTime": unix_time(self.creation_time),
@@ -166,7 +166,7 @@ class ResourceType(BaseModel):
         self.service_name = service_name
         self.resource_region_scope = resource_region_scope
 
-    def describe(self) -> Dict[str, Any]:
+    def describe(self) -> dict[str, Any]:
         return {
             "resourceType": self.resource_type,
             "serviceName": self.service_name,
@@ -211,7 +211,7 @@ class ManagedPermission(BaseModel):
         self.is_resource_type_default = is_resource_type_default
         self.permission_type = permission_type
 
-    def describe(self) -> Dict[str, Any]:
+    def describe(self) -> dict[str, Any]:
         return {
             "arn": self.arn,
             "name": self.name,
@@ -231,8 +231,8 @@ class ResourceAccessManagerBackend(BaseBackend):
 
     def __init__(self, region_name: str, account_id: str):
         super().__init__(region_name, account_id)
-        self.resource_shares: List[ResourceShare] = []
-        self.managed_permissions: List[ManagedPermission] = [
+        self.resource_shares: list[ResourceShare] = []
+        self.managed_permissions: list[ManagedPermission] = [
             ManagedPermission(
                 account_id=account_id,
                 region=region_name,
@@ -248,7 +248,7 @@ class ResourceAccessManagerBackend(BaseBackend):
             )
             for permission in AWS_MANAGED_PERMISSIONS
         ]
-        self.resource_types: List[ResourceType] = [
+        self.resource_types: list[ResourceType] = [
             ResourceType(
                 resource_type=resource_type["resourceType"],
                 service_name=resource_type["serviceName"],
@@ -261,7 +261,7 @@ class ResourceAccessManagerBackend(BaseBackend):
     def organizations_backend(self) -> OrganizationsBackend:
         return organizations_backends[self.account_id][self.partition]
 
-    def create_resource_share(self, **kwargs: Any) -> Dict[str, Any]:
+    def create_resource_share(self, **kwargs: Any) -> dict[str, Any]:
         resource = ResourceShare(self.account_id, self.region_name, **kwargs)
         resource.add_principals(kwargs.get("principals", []))
         resource.add_resources(kwargs.get("resourceArns", []))
@@ -273,7 +273,7 @@ class ResourceAccessManagerBackend(BaseBackend):
 
         return dict(resourceShare=response)
 
-    def get_resource_shares(self, resource_owner: Optional[str]) -> Dict[str, Any]:
+    def get_resource_shares(self, resource_owner: Optional[str]) -> dict[str, Any]:
         if resource_owner not in ["SELF", "OTHER-ACCOUNTS"]:
             raise InvalidParameterException(
                 f"{resource_owner} is not a valid resource owner. "
@@ -294,7 +294,7 @@ class ResourceAccessManagerBackend(BaseBackend):
         resource_share_arn: Optional[str],
         allow_external_principals: bool,
         name: Optional[str],
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         resource = next(
             (
                 resource
@@ -317,7 +317,7 @@ class ResourceAccessManagerBackend(BaseBackend):
 
     def delete_resource_share(
         self, resource_share_arn: Optional[str]
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         resource = next(
             (
                 resource
@@ -336,7 +336,7 @@ class ResourceAccessManagerBackend(BaseBackend):
 
         return dict(returnValue=True)
 
-    def enable_sharing_with_aws_organization(self) -> Dict[str, Any]:
+    def enable_sharing_with_aws_organization(self) -> dict[str, Any]:
         if not self.organizations_backend.org:
             raise OperationNotPermittedException
 
@@ -346,10 +346,10 @@ class ResourceAccessManagerBackend(BaseBackend):
         self,
         association_type: Optional[str],
         association_status: Optional[str],
-        resource_share_arns: List[str],
+        resource_share_arns: list[str],
         resource_arn: Optional[str],
         principal: Optional[str],
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         if association_type not in ["PRINCIPAL", "RESOURCE"]:
             raise InvalidParameterException(
                 f"{association_type} is not a valid association type. "
@@ -420,7 +420,7 @@ class ResourceAccessManagerBackend(BaseBackend):
 
         return dict(resourceShareAssociations=associations)
 
-    def list_resource_types(self, resource_region_scope: str) -> Dict[str, Any]:
+    def list_resource_types(self, resource_region_scope: str) -> dict[str, Any]:
         if resource_region_scope not in ["ALL", "REGIONAL", "GLOBAL"]:
             raise InvalidParameterException(
                 f"{resource_region_scope} is not a valid resource region "
@@ -443,7 +443,7 @@ class ResourceAccessManagerBackend(BaseBackend):
 
     def list_permissions(
         self, resource_type: str, permission_type: str
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         permission_types_relation = {
             "AWS": "AWS_MANAGED",
             "LOCAL": "CUSTOMER_MANAGED",

--- a/moto/ram/responses.py
+++ b/moto/ram/responses.py
@@ -1,5 +1,5 @@
 import json
-from typing import Any, Dict
+from typing import Any
 
 from moto.core.responses import BaseResponse
 
@@ -15,7 +15,7 @@ class ResourceAccessManagerResponse(BaseResponse):
         return ram_backends[self.current_account][self.region]
 
     @property
-    def request_params(self) -> Dict[str, Any]:  # type: ignore[misc]
+    def request_params(self) -> dict[str, Any]:  # type: ignore[misc]
         try:
             return json.loads(self.body)
         except ValueError:

--- a/moto/rds/responses.py
+++ b/moto/rds/responses.py
@@ -1,4 +1,4 @@
-from typing import Any, List, Optional, Tuple
+from typing import Any, Optional
 
 from moto.core.parsers import XFormedDict
 from moto.core.responses import ActionResult, BaseResponse
@@ -798,7 +798,7 @@ class RDSResponse(BaseResponse):
         result = {"BlueGreenDeployment": bg_deployment}
         return ActionResult(result)
 
-    def _paginate(self, resources: List[Any]) -> Tuple[List[Any], Optional[str]]:
+    def _paginate(self, resources: list[Any]) -> tuple[list[Any], Optional[str]]:
         from moto.rds.exceptions import InvalidParameterValue
 
         marker = self.params.get("Marker")

--- a/moto/rds/utils.py
+++ b/moto/rds/utils.py
@@ -6,7 +6,7 @@ import re
 from collections import OrderedDict
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Optional
 
 from botocore.utils import merge_dicts
 
@@ -49,7 +49,7 @@ class DbInstanceEngine(str, Enum):
     SQLSERVER_WEB = "sqlserver-web"
 
     @classmethod
-    def valid_db_instance_engine(self) -> List[str]:
+    def valid_db_instance_engine(self) -> list[str]:
         return sorted([item.value for item in DbInstanceEngine])
 
 
@@ -61,11 +61,11 @@ class ClusterEngine(str, Enum):
     RDS_MYSQL = "mysql"
 
     @classmethod
-    def list_cluster_engines(self) -> List[str]:
+    def list_cluster_engines(self) -> list[str]:
         return sorted([item.value for item in ClusterEngine])
 
     @classmethod
-    def serverless_engines(self) -> List[str]:
+    def serverless_engines(self) -> list[str]:
         return [ClusterEngine.AURORA_MYSQL, ClusterEngine.AURORA_POSTGRESQL]
 
 
@@ -95,8 +95,8 @@ def get_object_value(obj: Any, attr: str) -> Any:
 
 
 def merge_filters(
-    filters_to_update: Optional[Dict[str, Any]], filters_to_merge: Dict[str, Any]
-) -> Dict[str, Any]:
+    filters_to_update: Optional[dict[str, Any]], filters_to_merge: dict[str, Any]
+) -> dict[str, Any]:
     """Given two groups of filters, merge the second into the first.
 
     List values are appended instead of overwritten:
@@ -126,7 +126,7 @@ def merge_filters(
 
 
 def validate_filters(
-    filters: Dict[str, Any], filter_defs: Dict[str, FilterDef]
+    filters: dict[str, Any], filter_defs: dict[str, FilterDef]
 ) -> None:
     """Validates filters against a set of filter definitions.
 
@@ -199,7 +199,7 @@ def apply_filter(
 
 def get_start_date_end_date(
     base_date: str, window: str
-) -> Tuple[datetime.datetime, datetime.datetime]:
+) -> tuple[datetime.datetime, datetime.datetime]:
     """Gets the start date and end date given DDD:HH24:MM-DDD:HH24:MM.
 
     :param base_date:
@@ -223,7 +223,7 @@ def get_start_date_end_date(
 
 def get_start_date_end_date_from_time(
     base_date: str, window: str
-) -> Tuple[datetime.datetime, datetime.datetime, bool]:
+) -> tuple[datetime.datetime, datetime.datetime, bool]:
     """Gets the start date and end date given HH24:MM-HH24:MM.
 
     :param window:
@@ -373,7 +373,7 @@ ORDERABLE_DB_INSTANCE_DECODING = {
 }
 
 
-def encode_orderable_db_instance(db: Dict[str, Any]) -> Dict[str, Any]:
+def encode_orderable_db_instance(db: dict[str, Any]) -> dict[str, Any]:
     encoded = copy.deepcopy(db)
     if "AvailabilityZones" in encoded:
         encoded["AvailabilityZones"] = [
@@ -385,7 +385,7 @@ def encode_orderable_db_instance(db: Dict[str, Any]) -> Dict[str, Any]:
     }
 
 
-def decode_orderable_db_instance(db: Dict[str, Any]) -> Dict[str, Any]:
+def decode_orderable_db_instance(db: dict[str, Any]) -> dict[str, Any]:
     decoded = copy.deepcopy(db)
     decoded_az = ORDERABLE_DB_INSTANCE_ENCODING.get(
         "AvailabilityZones", "AvailabilityZones"

--- a/moto/rdsdata/models.py
+++ b/moto/rdsdata/models.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Optional
 
 from moto.core.base_backend import BackendDict, BaseBackend
 
@@ -6,10 +6,10 @@ from moto.core.base_backend import BackendDict, BaseBackend
 class QueryResults:
     def __init__(
         self,
-        records: Optional[List[List[Dict[str, Any]]]] = None,
-        column_metadata: Optional[List[Dict[str, Any]]] = None,
+        records: Optional[list[list[dict[str, Any]]]] = None,
+        column_metadata: Optional[list[dict[str, Any]]] = None,
         number_of_records_updated: Optional[int] = None,
-        generated_fields: Optional[List[Dict[str, Any]]] = None,
+        generated_fields: Optional[list[dict[str, Any]]] = None,
         formatted_records: Optional[str] = None,
     ):
         self.records = records
@@ -18,7 +18,7 @@ class QueryResults:
         self.generated_fields = generated_fields
         self.formatted_records = formatted_records
 
-    def to_json(self) -> Dict[str, Any]:
+    def to_json(self) -> dict[str, Any]:
         return {
             "records": self.records,
             "columnMetadata": self.column_metadata,
@@ -31,8 +31,8 @@ class QueryResults:
 class RDSDataServiceBackend(BaseBackend):
     def __init__(self, region_name: str, account_id: str):
         super().__init__(region_name, account_id)
-        self.results_queue: List[QueryResults] = []
-        self.sql_results: Dict[Tuple[str, str], QueryResults] = dict()
+        self.results_queue: list[QueryResults] = []
+        self.sql_results: dict[tuple[str, str], QueryResults] = dict()
 
     def execute_statement(self, resource_arn: str, sql: str) -> QueryResults:
         """

--- a/moto/redshift/exceptions.py
+++ b/moto/redshift/exceptions.py
@@ -1,4 +1,4 @@
-from typing import List, Optional
+from typing import Optional
 
 from moto.core.exceptions import ServiceException
 
@@ -38,7 +38,7 @@ class ClusterParameterGroupNotFoundError(RedshiftClientError):
 
 
 class InvalidSubnetError(RedshiftClientError):
-    def __init__(self, subnet_identifier: List[str]):
+    def __init__(self, subnet_identifier: list[str]):
         super().__init__("InvalidSubnet", f"Subnet {subnet_identifier} not found.")
 
 

--- a/moto/redshift/models.py
+++ b/moto/redshift/models.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 import datetime
 from collections import OrderedDict
-from typing import Any, Dict, Iterable, List, Optional
+from collections.abc import Iterable
+from typing import Any, Optional
 
 from dateutil.tz import tzutc
 
@@ -40,7 +41,7 @@ class TaggableResourceMixin:
     resource_type = ""
 
     def __init__(
-        self, account_id: str, region_name: str, tags: Optional[List[Dict[str, Any]]]
+        self, account_id: str, region_name: str, tags: Optional[list[dict[str, Any]]]
     ):
         self.account_id = account_id
         self.region = region_name
@@ -54,13 +55,13 @@ class TaggableResourceMixin:
     def arn(self) -> str:
         return f"arn:{get_partition(self.region)}:redshift:{self.region}:{self.account_id}:{self.resource_type}:{self.resource_id}"
 
-    def create_tags(self, tags: List[Dict[str, str]]) -> List[Dict[str, str]]:
+    def create_tags(self, tags: list[dict[str, str]]) -> list[dict[str, str]]:
         new_keys = [tag_set["Key"] for tag_set in tags]
         self.tags = [tag_set for tag_set in self.tags if tag_set["Key"] not in new_keys]
         self.tags.extend(tags)
         return self.tags
 
-    def delete_tags(self, tag_keys: List[str]) -> List[Dict[str, str]]:
+    def delete_tags(self, tag_keys: list[str]) -> list[dict[str, str]]:
         self.tags = [tag_set for tag_set in self.tags if tag_set["Key"] not in tag_keys]
         return self.tags
 
@@ -77,8 +78,8 @@ class Cluster(TaggableResourceMixin, CloudFormationModel):
         master_user_password: str,
         db_name: str,
         cluster_type: str,
-        cluster_security_groups: List[str],
-        vpc_security_group_ids: List[str],
+        cluster_security_groups: list[str],
+        vpc_security_group_ids: list[str],
         cluster_subnet_group_name: str,
         availability_zone: str,
         preferred_maintenance_window: str,
@@ -91,8 +92,8 @@ class Cluster(TaggableResourceMixin, CloudFormationModel):
         publicly_accessible: bool,
         encrypted: bool,
         region_name: str,
-        tags: Optional[List[Dict[str, str]]] = None,
-        iam_roles_arn: Optional[List[str]] = None,
+        tags: Optional[list[dict[str, str]]] = None,
+        iam_roles_arn: Optional[list[str]] = None,
         enhanced_vpc_routing: Optional[bool] = False,
         restored_from_snapshot: bool = False,
         kms_key_id: Optional[str] = None,
@@ -154,7 +155,7 @@ class Cluster(TaggableResourceMixin, CloudFormationModel):
         self.iam_roles_arn = iam_roles_arn or []
         self.restored_from_snapshot = restored_from_snapshot
         self.kms_key_id = kms_key_id
-        self.cluster_snapshot_copy_status: Optional[Dict[str, Any]] = None
+        self.cluster_snapshot_copy_status: Optional[dict[str, Any]] = None
         self.total_storage_capacity = 0
         self.logging_details = {
             "LoggingEnabled": "false",  # Lower case is required in response so we use string to simplify
@@ -241,7 +242,7 @@ class Cluster(TaggableResourceMixin, CloudFormationModel):
         return f"{self.cluster_identifier}.{self.unique_cluster_id}.{self.region}.redshift.amazonaws.com"
 
     @property
-    def security_groups(self) -> List[SecurityGroup]:
+    def security_groups(self) -> list[SecurityGroup]:
         return [
             security_group
             for security_group in self.redshift_backend.describe_cluster_security_groups()
@@ -250,7 +251,7 @@ class Cluster(TaggableResourceMixin, CloudFormationModel):
         ]
 
     @property
-    def vpc_security_groups(self) -> List[EC2SecurityGroup]:
+    def vpc_security_groups(self) -> list[EC2SecurityGroup]:
         return [
             security_group
             for security_group in self.redshift_backend.ec2_backend.describe_security_groups()
@@ -258,7 +259,7 @@ class Cluster(TaggableResourceMixin, CloudFormationModel):
         ]
 
     @property
-    def parameter_groups(self) -> List[ParameterGroup]:
+    def parameter_groups(self) -> list[ParameterGroup]:
         return [
             parameter_group
             for parameter_group in self.redshift_backend.describe_cluster_parameter_groups()
@@ -276,14 +277,14 @@ class Cluster(TaggableResourceMixin, CloudFormationModel):
         self.status = "available"
 
     @property
-    def vpc_security_group_membership_list(self) -> List[Dict[str, str]]:
+    def vpc_security_group_membership_list(self) -> list[dict[str, str]]:
         return [
             {"VpcSecurityGroupId": group.id, "Status": "active"}
             for group in self.vpc_security_groups
         ]
 
     @property
-    def cluster_parameter_group_status_list(self) -> List[Dict[str, str]]:
+    def cluster_parameter_group_status_list(self) -> list[dict[str, str]]:
         return [
             {
                 "ParameterGroupName": group.name,
@@ -293,7 +294,7 @@ class Cluster(TaggableResourceMixin, CloudFormationModel):
         ]
 
     @property
-    def cluster_security_group_membership_list(self) -> List[Dict[str, str]]:
+    def cluster_security_group_membership_list(self) -> list[dict[str, str]]:
         return [
             {
                 "ClusterSecurityGroupName": group.cluster_security_group_name,
@@ -303,7 +304,7 @@ class Cluster(TaggableResourceMixin, CloudFormationModel):
         ]
 
     @property
-    def endpoint(self) -> Dict[str, str | int]:
+    def endpoint(self) -> dict[str, str | int]:
         return {
             "Address": self.address,
             "Port": self.port,
@@ -314,7 +315,7 @@ class Cluster(TaggableResourceMixin, CloudFormationModel):
         return []
 
     @property
-    def iam_roles(self) -> List[Dict[str, str]]:
+    def iam_roles(self) -> list[dict[str, str]]:
         return [
             {"ApplyStatus": "in-sync", "IamRoleArn": iam_role_arn}
             for iam_role_arn in self.iam_roles_arn
@@ -325,7 +326,7 @@ class Cluster(TaggableResourceMixin, CloudFormationModel):
         return self.total_storage_capacity
 
     @property
-    def restore_status(self) -> Optional[Dict[str, Any]]:
+    def restore_status(self) -> Optional[dict[str, Any]]:
         if not self.restored_from_snapshot:
             return None
         status = {
@@ -355,9 +356,9 @@ class SubnetGroup(TaggableResourceMixin, CloudFormationModel):
         ec2_backend: Any,
         cluster_subnet_group_name: str,
         description: str,
-        subnet_ids: List[str],
+        subnet_ids: list[str],
         region_name: str,
-        tags: Optional[List[Dict[str, str]]] = None,
+        tags: Optional[list[dict[str, str]]] = None,
     ):
         super().__init__(ec2_backend.account_id, region_name, tags)
         self.ec2_backend = ec2_backend
@@ -410,7 +411,7 @@ class SubnetGroup(TaggableResourceMixin, CloudFormationModel):
         return self.cluster_subnet_group_name
 
     @property
-    def subnet_list(self) -> List[Dict[str, Any]]:
+    def subnet_list(self) -> list[dict[str, Any]]:
         return [
             {
                 "SubnetStatus": "Active",
@@ -430,12 +431,12 @@ class SecurityGroup(TaggableResourceMixin, BaseModel):
         description: str,
         account_id: str,
         region_name: str,
-        tags: Optional[List[Dict[str, str]]] = None,
+        tags: Optional[list[dict[str, str]]] = None,
     ):
         super().__init__(account_id, region_name, tags)
         self.cluster_security_group_name = cluster_security_group_name
         self.description = description
-        self.ingress_rules: List[str] = []
+        self.ingress_rules: list[str] = []
         self.ec2_security_groups: list[str] = []
         self.ip_ranges: list[str] = []
 
@@ -454,7 +455,7 @@ class ParameterGroup(TaggableResourceMixin, CloudFormationModel):
         description: str,
         account_id: str,
         region_name: str,
-        tags: Optional[List[Dict[str, str]]] = None,
+        tags: Optional[list[dict[str, str]]] = None,
     ):
         super().__init__(account_id, region_name, tags)
         self.name = cluster_parameter_group_name
@@ -504,8 +505,8 @@ class Snapshot(TaggableResourceMixin, BaseModel):
         snapshot_identifier: str,
         account_id: str,
         region_name: str,
-        tags: Optional[List[Dict[str, str]]] = None,
-        iam_roles_arn: Optional[List[str]] = None,
+        tags: Optional[list[dict[str, str]]] = None,
+        iam_roles_arn: Optional[list[str]] = None,
         snapshot_type: str = "manual",
     ):
         super().__init__(account_id, region_name, tags)
@@ -531,7 +532,7 @@ class Snapshot(TaggableResourceMixin, BaseModel):
         return f"{self.cluster_identifier}/{self.snapshot_identifier}"
 
     @property
-    def iam_roles(self) -> List[Dict[str, str]]:
+    def iam_roles(self) -> list[dict[str, str]]:
         return [
             {"ApplyStatus": "in-sync", "IamRoleArn": iam_role_arn}
             for iam_role_arn in self.iam_roles_arn
@@ -541,14 +542,14 @@ class Snapshot(TaggableResourceMixin, BaseModel):
 class RedshiftBackend(BaseBackend):
     def __init__(self, region_name: str, account_id: str):
         super().__init__(region_name, account_id)
-        self.clusters: Dict[str, Cluster] = {}
-        self.subnet_groups: Dict[str, SubnetGroup] = {}
-        self.security_groups: Dict[str, SecurityGroup] = {
+        self.clusters: dict[str, Cluster] = {}
+        self.subnet_groups: dict[str, SubnetGroup] = {}
+        self.security_groups: dict[str, SecurityGroup] = {
             "Default": SecurityGroup(
                 "Default", "Default Redshift Security Group", account_id, region_name
             )
         }
-        self.parameter_groups: Dict[str, ParameterGroup] = {
+        self.parameter_groups: dict[str, ParameterGroup] = {
             "default.redshift-1.0": ParameterGroup(
                 "default.redshift-1.0",
                 "redshift-1.0",
@@ -558,15 +559,15 @@ class RedshiftBackend(BaseBackend):
             )
         }
         self.ec2_backend = ec2_backends[self.account_id][self.region_name]
-        self.snapshots: Dict[str, Snapshot] = OrderedDict()
-        self.RESOURCE_TYPE_MAP: Dict[str, Dict[str, TaggableResourceMixin]] = {
+        self.snapshots: dict[str, Snapshot] = OrderedDict()
+        self.RESOURCE_TYPE_MAP: dict[str, dict[str, TaggableResourceMixin]] = {
             "cluster": self.clusters,  # type: ignore
             "parametergroup": self.parameter_groups,  # type: ignore
             "securitygroup": self.security_groups,  # type: ignore
             "snapshot": self.snapshots,  # type: ignore
             "subnetgroup": self.subnet_groups,  # type: ignore
         }
-        self.snapshot_copy_grants: Dict[str, SnapshotCopyGrant] = {}
+        self.snapshot_copy_grants: dict[str, SnapshotCopyGrant] = {}
         self.default_params = {
             "auto_analyze": "true",
             "datestyle": "ISO, MDY",
@@ -654,7 +655,7 @@ class RedshiftBackend(BaseBackend):
 
     def describe_clusters(
         self, cluster_identifier: Optional[str] = None
-    ) -> List[Cluster]:
+    ) -> list[Cluster]:
         if cluster_identifier:
             if cluster_identifier in self.clusters:
                 return [self.clusters[cluster_identifier]]
@@ -739,9 +740,9 @@ class RedshiftBackend(BaseBackend):
         self,
         cluster_subnet_group_name: str,
         description: str,
-        subnet_ids: List[str],
+        subnet_ids: list[str],
         region_name: str,
-        tags: Optional[List[Dict[str, str]]] = None,
+        tags: Optional[list[dict[str, str]]] = None,
     ) -> SubnetGroup:
         subnet_group = SubnetGroup(
             self.ec2_backend,
@@ -756,7 +757,7 @@ class RedshiftBackend(BaseBackend):
 
     def describe_cluster_subnet_groups(
         self, subnet_identifier: Optional[str] = None
-    ) -> List[SubnetGroup]:
+    ) -> list[SubnetGroup]:
         if subnet_identifier:
             if subnet_identifier in self.subnet_groups:
                 return [self.subnet_groups[subnet_identifier]]
@@ -772,7 +773,7 @@ class RedshiftBackend(BaseBackend):
         self,
         cluster_security_group_name: str,
         description: str,
-        tags: Optional[List[Dict[str, str]]] = None,
+        tags: Optional[list[dict[str, str]]] = None,
     ) -> SecurityGroup:
         security_group = SecurityGroup(
             cluster_security_group_name,
@@ -786,7 +787,7 @@ class RedshiftBackend(BaseBackend):
 
     def describe_cluster_security_groups(
         self, security_group_name: Optional[str] = None
-    ) -> List[SecurityGroup]:
+    ) -> list[SecurityGroup]:
         if security_group_name:
             if security_group_name in self.security_groups:
                 return [self.security_groups[security_group_name]]
@@ -818,7 +819,7 @@ class RedshiftBackend(BaseBackend):
         group_family: str,
         description: str,
         region_name: str,
-        tags: Optional[List[Dict[str, str]]] = None,
+        tags: Optional[list[dict[str, str]]] = None,
     ) -> ParameterGroup:
         parameter_group = ParameterGroup(
             cluster_parameter_group_name,
@@ -834,7 +835,7 @@ class RedshiftBackend(BaseBackend):
 
     def describe_cluster_parameter_groups(
         self, parameter_group_name: Optional[str] = None
-    ) -> List[ParameterGroup]:
+    ) -> list[ParameterGroup]:
         if parameter_group_name:
             if parameter_group_name in self.parameter_groups:
                 return [self.parameter_groups[parameter_group_name]]
@@ -848,7 +849,7 @@ class RedshiftBackend(BaseBackend):
             return self.parameter_groups.pop(parameter_group_name)
         raise ClusterParameterGroupNotFoundError(parameter_group_name)
 
-    def describe_default_cluster_parameters(self) -> List[Dict[str, Any]]:
+    def describe_default_cluster_parameters(self) -> list[dict[str, Any]]:
         return [
             {
                 "ParameterName": key,
@@ -864,7 +865,7 @@ class RedshiftBackend(BaseBackend):
 
     def describe_cluster_parameters(
         self, parameter_group_name: str
-    ) -> List[Dict[str, Any]]:
+    ) -> list[dict[str, Any]]:
         if parameter_group_name not in self.parameter_groups:
             raise ClusterParameterGroupNotFoundError(parameter_group_name)
         return self.describe_default_cluster_parameters()
@@ -874,7 +875,7 @@ class RedshiftBackend(BaseBackend):
         cluster_identifier: str,
         snapshot_identifier: str,
         region_name: str,
-        tags: Optional[List[Dict[str, str]]],
+        tags: Optional[list[dict[str, str]]],
         snapshot_type: str = "manual",
     ) -> Snapshot:
         cluster = self.clusters.get(cluster_identifier)
@@ -898,7 +899,7 @@ class RedshiftBackend(BaseBackend):
         cluster_identifier: Optional[str] = None,
         snapshot_identifier: Optional[str] = None,
         snapshot_type: Optional[str] = None,
-    ) -> List[Snapshot]:
+    ) -> list[Snapshot]:
         snapshot_types = (
             ["automated", "manual"] if snapshot_type is None else [snapshot_type]
         )
@@ -974,7 +975,7 @@ class RedshiftBackend(BaseBackend):
             return self.snapshot_copy_grants.pop(snapshot_copy_grant_name)
         raise SnapshotCopyGrantNotFoundFaultError(snapshot_copy_grant_name)
 
-    def describe_snapshot_copy_grants(self, **kwargs: Any) -> List[SnapshotCopyGrant]:
+    def describe_snapshot_copy_grants(self, **kwargs: Any) -> list[SnapshotCopyGrant]:
         copy_grants = list(self.snapshot_copy_grants.values())
         snapshot_copy_grant_name = kwargs["snapshot_copy_grant_name"]
         if snapshot_copy_grant_name:
@@ -1008,7 +1009,7 @@ class RedshiftBackend(BaseBackend):
         return resource
 
     @staticmethod
-    def _describe_tags_for_resources(resources: Iterable[Any]) -> List[Dict[str, Any]]:
+    def _describe_tags_for_resources(resources: Iterable[Any]) -> list[dict[str, Any]]:
         tagged_resources = []
         for resource in resources:
             for tag in resource.tags:
@@ -1022,7 +1023,7 @@ class RedshiftBackend(BaseBackend):
 
     def _describe_tags_for_resource_type(
         self, resource_type: str
-    ) -> List[Dict[str, Any]]:
+    ) -> list[dict[str, Any]]:
         resources = self.RESOURCE_TYPE_MAP.get(resource_type)
         if not resources:
             raise ResourceNotFoundFaultError(resource_type=resource_type)
@@ -1030,17 +1031,17 @@ class RedshiftBackend(BaseBackend):
 
     def _describe_tags_for_resource_name(
         self, resource_name: str
-    ) -> List[Dict[str, Any]]:
+    ) -> list[dict[str, Any]]:
         resource = self._get_resource_from_arn(resource_name)
         return self._describe_tags_for_resources([resource])
 
-    def create_tags(self, resource_name: str, tags: List[Dict[str, str]]) -> None:
+    def create_tags(self, resource_name: str, tags: list[dict[str, str]]) -> None:
         resource = self._get_resource_from_arn(resource_name)
         resource.create_tags(tags)
 
     def describe_tags(
         self, resource_name: str, resource_type: str
-    ) -> List[Dict[str, Any]]:
+    ) -> list[dict[str, Any]]:
         if resource_name and resource_type:
             raise InvalidParameterValueError(
                 "You cannot filter a list of resources using an Amazon "
@@ -1062,7 +1063,7 @@ class RedshiftBackend(BaseBackend):
                 pass
         return tagged_resources
 
-    def delete_tags(self, resource_name: str, tag_keys: List[str]) -> None:
+    def delete_tags(self, resource_name: str, tag_keys: list[str]) -> None:
         resource = self._get_resource_from_arn(resource_name)
         resource.delete_tags(tag_keys)
 
@@ -1072,7 +1073,7 @@ class RedshiftBackend(BaseBackend):
         db_user: str,
         auto_create: bool,
         duration_seconds: int,
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         if duration_seconds < 900 or duration_seconds > 3600:
             raise InvalidParameterValueError(
                 "Token duration must be between 900 and 3600 seconds"
@@ -1096,8 +1097,8 @@ class RedshiftBackend(BaseBackend):
         bucket_name: str,
         s3_key_prefix: str,
         log_destination_type: str,
-        log_exports: List[str],
-    ) -> Dict[str, Any]:
+        log_exports: list[str],
+    ) -> dict[str, Any]:
         if cluster_identifier not in self.clusters:
             raise ClusterNotFoundError(cluster_identifier)
         cluster = self.clusters[cluster_identifier]
@@ -1108,14 +1109,14 @@ class RedshiftBackend(BaseBackend):
         cluster.logging_details["LogExports"] = log_exports
         return cluster.logging_details
 
-    def disable_logging(self, cluster_identifier: str) -> Dict[str, Any]:
+    def disable_logging(self, cluster_identifier: str) -> dict[str, Any]:
         if cluster_identifier not in self.clusters:
             raise ClusterNotFoundError(cluster_identifier)
         cluster = self.clusters[cluster_identifier]
         cluster.logging_details["LoggingEnabled"] = "false"
         return cluster.logging_details
 
-    def describe_logging_status(self, cluster_identifier: str) -> Dict[str, Any]:
+    def describe_logging_status(self, cluster_identifier: str) -> dict[str, Any]:
         if cluster_identifier not in self.clusters:
             raise ClusterNotFoundError(cluster_identifier)
         cluster = self.clusters[cluster_identifier]

--- a/moto/rekognition/models.py
+++ b/moto/rekognition/models.py
@@ -1,7 +1,7 @@
 """RekognitionBackend class with methods for supported APIs."""
 
 import string
-from typing import Any, Dict, List, Tuple
+from typing import Any
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.moto_api._internal import mock_random as random
@@ -18,7 +18,7 @@ class RekognitionBackend(BaseBackend):
 
     def get_face_search(
         self,
-    ) -> Tuple[str, str, Dict[str, Any], List[Dict[str, Any]], str, str]:
+    ) -> tuple[str, str, dict[str, Any], list[dict[str, Any]], str, str]:
         """
         This returns hardcoded values and none of the parameters are taken into account.
         """
@@ -33,7 +33,7 @@ class RekognitionBackend(BaseBackend):
 
     def get_text_detection(
         self,
-    ) -> Tuple[str, str, Dict[str, Any], List[Dict[str, Any]], str, str]:
+    ) -> tuple[str, str, dict[str, Any], list[dict[str, Any]], str, str]:
         """
         This returns hardcoded values and none of the parameters are taken into account.
         """
@@ -48,12 +48,12 @@ class RekognitionBackend(BaseBackend):
 
     def compare_faces(
         self,
-    ) -> Tuple[
-        List[Dict[str, Any]],
+    ) -> tuple[
+        list[dict[str, Any]],
         str,
         str,
-        List[Dict[str, Any]],
-        Dict[str, Any],
+        list[dict[str, Any]],
+        dict[str, Any],
     ]:
         return (
             self._face_matches(),
@@ -63,20 +63,20 @@ class RekognitionBackend(BaseBackend):
             self.source_image_face(),
         )
 
-    def detect_labels(self) -> Tuple[List[Dict[str, Any]], Dict[str, Any], str]:
+    def detect_labels(self) -> tuple[list[dict[str, Any]], dict[str, Any], str]:
         return (
             self._mobile_phone_label(),
             self._image_properties(),
             "3.0",
         )
 
-    def detect_text(self) -> Tuple[List[Dict[str, Any]], str]:
+    def detect_text(self) -> tuple[list[dict[str, Any]], str]:
         return (
             self._detect_text_text_detections(),
             "3.0",
         )
 
-    def detect_custom_labels(self) -> Tuple[List[Dict[str, Any]]]:
+    def detect_custom_labels(self) -> tuple[list[dict[str, Any]]]:
         return (self._detect_custom_labels_detections(),)
 
     # private
@@ -98,7 +98,7 @@ class RekognitionBackend(BaseBackend):
     def _text_model_version(self) -> str:
         return "3.1"
 
-    def _video_metadata(self) -> Dict[str, Any]:
+    def _video_metadata(self) -> dict[str, Any]:
         return {
             "Codec": "h264",
             "DurationMillis": 15020,
@@ -109,7 +109,7 @@ class RekognitionBackend(BaseBackend):
             "ColorRange": "LIMITED",
         }
 
-    def _persons(self) -> List[Dict[str, Any]]:
+    def _persons(self) -> list[dict[str, Any]]:
         return [
             {
                 "Timestamp": 0,
@@ -226,7 +226,7 @@ class RekognitionBackend(BaseBackend):
             }
         ]
 
-    def _text_detections(self) -> List[Dict[str, Any]]:
+    def _text_detections(self) -> list[dict[str, Any]]:
         return [
             {
                 "Timestamp": 0,
@@ -372,7 +372,7 @@ class RekognitionBackend(BaseBackend):
             },
         ]
 
-    def _face_matches(self) -> List[Dict[str, Any]]:
+    def _face_matches(self) -> list[dict[str, Any]]:
         return [
             {
                 "Face": {
@@ -424,7 +424,7 @@ class RekognitionBackend(BaseBackend):
             }
         ]
 
-    def _unmatched_faces(self) -> List[Dict[str, Any]]:
+    def _unmatched_faces(self) -> list[dict[str, Any]]:
         return [
             {
                 "BoundingBox": {
@@ -469,7 +469,7 @@ class RekognitionBackend(BaseBackend):
             }
         ]
 
-    def source_image_face(self) -> Dict[str, Any]:
+    def source_image_face(self) -> dict[str, Any]:
         return {
             "BoundingBox": {
                 "Width": 0.5521978139877319,
@@ -480,7 +480,7 @@ class RekognitionBackend(BaseBackend):
             "Confidence": 99.98751068115234,
         }
 
-    def _mobile_phone_label(self) -> List[Dict[str, Any]]:
+    def _mobile_phone_label(self) -> list[dict[str, Any]]:
         return [
             {
                 "Name": "Mobile Phone",
@@ -513,7 +513,7 @@ class RekognitionBackend(BaseBackend):
             }
         ]
 
-    def _image_properties(self) -> Dict[str, Any]:
+    def _image_properties(self) -> dict[str, Any]:
         return {
             "ImageProperties": {
                 "Quality": {
@@ -569,7 +569,7 @@ class RekognitionBackend(BaseBackend):
             }
         }
 
-    def _detect_text_text_detections(self) -> List[Dict[str, Any]]:
+    def _detect_text_text_detections(self) -> list[dict[str, Any]]:
         return [
             {
                 "Confidence": 99.35693359375,
@@ -758,7 +758,7 @@ class RekognitionBackend(BaseBackend):
             },
         ]
 
-    def _detect_custom_labels_detections(self) -> List[Dict[str, Any]]:
+    def _detect_custom_labels_detections(self) -> list[dict[str, Any]]:
         return [
             {
                 "Name": "MyLogo",

--- a/moto/resiliencehub/models.py
+++ b/moto/resiliencehub/models.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional
+from typing import Any, Optional
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
@@ -32,7 +32,7 @@ class AppComponent(BaseModel):
         self.name = name
         self.type = _type
 
-    def to_json(self) -> Dict[str, Any]:
+    def to_json(self) -> dict[str, Any]:
         return {
             "id": self.id,
             "name": self.name,
@@ -46,9 +46,9 @@ class App(BaseModel):
         backend: "ResilienceHubBackend",
         assessment_schedule: str,
         description: str,
-        event_subscriptions: List[Dict[str, Any]],
+        event_subscriptions: list[dict[str, Any]],
         name: str,
-        permission_model: Dict[str, Any],
+        permission_model: dict[str, Any],
         policy_arn: str,
     ):
         self.backend = backend
@@ -63,7 +63,7 @@ class App(BaseModel):
         self.policy_arn = policy_arn
         self.resilience_score = 0.0
         self.status = "Active"
-        self.app_versions: List[AppVersion] = []
+        self.app_versions: list[AppVersion] = []
 
         app_version = AppVersion(app_arn=self.arn, version_name=None, identifier=0)
         self.app_versions.append(app_version)
@@ -74,7 +74,7 @@ class App(BaseModel):
                 return v
         raise AppVersionNotFound
 
-    def to_json(self) -> Dict[str, Any]:
+    def to_json(self) -> dict[str, Any]:
         resp = {
             "appArn": self.arn,
             "assessmentSchedule": self.assessment_schedule,
@@ -100,17 +100,17 @@ class App(BaseModel):
 class Resource:
     def __init__(
         self,
-        logical_resource_id: Dict[str, Any],
+        logical_resource_id: dict[str, Any],
         physical_resource_id: str,
         resource_type: str,
-        components: List[AppComponent],
+        components: list[AppComponent],
     ):
         self.logical_resource_id = logical_resource_id
         self.physical_resource_id = physical_resource_id
         self.resource_type = resource_type
         self.components = components
 
-    def to_json(self) -> Dict[str, Any]:
+    def to_json(self) -> dict[str, Any]:
         return {
             "appComponents": [c.to_json() for c in self.components],
             "resourceType": self.resource_type,
@@ -123,18 +123,18 @@ class Resource:
 class AppVersion(BaseModel):
     def __init__(self, app_arn: str, version_name: Optional[str], identifier: int):
         self.app_arn = app_arn
-        self.eks_sources: List[Dict[str, Any]] = []
-        self.source_arns: List[str] = []
-        self.terraform_sources: List[Dict[str, str]] = []
+        self.eks_sources: list[dict[str, Any]] = []
+        self.source_arns: list[str] = []
+        self.terraform_sources: list[dict[str, str]] = []
         self.app_version = "release" if version_name else "draft"
         self.identifier = identifier
         self.creation_time = unix_time()
         self.version_name = version_name
-        self.app_components: List[AppComponent] = []
+        self.app_components: list[AppComponent] = []
         self.status = "Pending"
-        self.resources: List[Resource] = []
+        self.resources: list[Resource] = []
 
-    def to_json(self) -> Dict[str, Any]:
+    def to_json(self) -> dict[str, Any]:
         resp = {
             "appVersion": self.app_version,
             "creationTime": self.creation_time,
@@ -149,7 +149,7 @@ class Policy(BaseModel):
     def __init__(
         self,
         backend: "ResilienceHubBackend",
-        policy: Dict[str, Dict[str, int]],
+        policy: dict[str, dict[str, int]],
         policy_name: str,
         data_location_constraint: str,
         policy_description: str,
@@ -164,7 +164,7 @@ class Policy(BaseModel):
         self.policy_name = policy_name
         self.tier = tier
 
-    def to_json(self) -> Dict[str, Any]:
+    def to_json(self) -> dict[str, Any]:
         resp = {
             "creationTime": self.creation_time,
             "policy": self.policy,
@@ -183,22 +183,22 @@ class Policy(BaseModel):
 class ResilienceHubBackend(BaseBackend):
     def __init__(self, region_name: str, account_id: str):
         super().__init__(region_name, account_id)
-        self.apps: Dict[str, App] = dict()
-        self.policies: Dict[str, Policy] = dict()
+        self.apps: dict[str, App] = dict()
+        self.policies: dict[str, Policy] = dict()
         self.tagger = TaggingService()
 
-        self.app_assessments_queue: List[List[Dict[str, Any]]] = []
-        self.app_assessments_results: Dict[str, List[Dict[str, Any]]] = {}
+        self.app_assessments_queue: list[list[dict[str, Any]]] = []
+        self.app_assessments_results: dict[str, list[dict[str, Any]]] = {}
 
     def create_app(
         self,
         assessment_schedule: str,
         description: str,
-        event_subscriptions: List[Dict[str, Any]],
+        event_subscriptions: list[dict[str, Any]],
         name: str,
-        permission_model: Dict[str, Any],
+        permission_model: dict[str, Any],
         policy_arn: str,
-        tags: Dict[str, str],
+        tags: dict[str, str],
     ) -> App:
         """
         The ClientToken-parameter is not yet implemented
@@ -219,10 +219,10 @@ class ResilienceHubBackend(BaseBackend):
     def create_resiliency_policy(
         self,
         data_location_constraint: str,
-        policy: Dict[str, Any],
+        policy: dict[str, Any],
         policy_description: str,
         policy_name: str,
-        tags: Dict[str, str],
+        tags: dict[str, str],
         tier: str,
     ) -> Policy:
         """
@@ -241,7 +241,7 @@ class ResilienceHubBackend(BaseBackend):
         return pol
 
     @paginate(PAGINATION_MODEL)
-    def list_apps(self, app_arn: str, name: str, reverse_order: bool) -> List[App]:
+    def list_apps(self, app_arn: str, name: str, reverse_order: bool) -> list[App]:
         """
         The FromAssessmentTime/ToAssessmentTime-parameters are not yet implemented
         """
@@ -255,7 +255,7 @@ class ResilienceHubBackend(BaseBackend):
             app_summaries.reverse()
         return app_summaries
 
-    def list_app_assessments(self, request_identifier: str) -> List[Dict[str, Any]]:
+    def list_app_assessments(self, request_identifier: str) -> list[dict[str, Any]]:
         """
         Moto will not actually execute any assessments, so this operation will return an empty list by default.
         You can use a dedicated API to override this, by configuring a queue of expected results.
@@ -306,7 +306,7 @@ class ResilienceHubBackend(BaseBackend):
         return self.apps[app_arn]
 
     @paginate(pagination_model=PAGINATION_MODEL)
-    def list_resiliency_policies(self, policy_name: str) -> List[Policy]:
+    def list_resiliency_policies(self, policy_name: str) -> list[Policy]:
         if policy_name:
             return [p for p in self.policies.values() if p.policy_name == policy_name]
         return list(self.policies.values())
@@ -316,23 +316,23 @@ class ResilienceHubBackend(BaseBackend):
             raise ResiliencyPolicyNotFound(policy_arn)
         return self.policies[policy_arn]
 
-    def tag_resource(self, resource_arn: str, tags: Dict[str, str]) -> None:
+    def tag_resource(self, resource_arn: str, tags: dict[str, str]) -> None:
         self.tagger.tag_resource(
             resource_arn, TaggingService.convert_dict_to_tags_input(tags)
         )
 
-    def untag_resource(self, resource_arn: str, tag_keys: List[str]) -> None:
+    def untag_resource(self, resource_arn: str, tag_keys: list[str]) -> None:
         self.tagger.untag_resource_using_names(resource_arn, tag_keys)
 
-    def list_tags_for_resource(self, resource_arn: str) -> Dict[str, str]:
+    def list_tags_for_resource(self, resource_arn: str) -> dict[str, str]:
         return self.tagger.get_tag_dict_for_resource(resource_arn)
 
     def import_resources_to_draft_app_version(
         self,
         app_arn: str,
-        eks_sources: List[Dict[str, Any]],
-        source_arns: List[str],
-        terraform_sources: List[Dict[str, str]],
+        eks_sources: list[dict[str, Any]],
+        source_arns: list[str],
+        terraform_sources: list[dict[str, str]],
     ) -> AppVersion:
         app = self.describe_app(app_arn)
         app_version = app.get_version("draft")
@@ -363,15 +363,15 @@ class ResilienceHubBackend(BaseBackend):
 
     def list_app_version_app_components(
         self, app_arn: str, app_version: str
-    ) -> List[AppComponent]:
+    ) -> list[AppComponent]:
         app = self.describe_app(app_arn)
         return app.get_version(app_version).app_components
 
     def create_app_version_resource(
         self,
         app_arn: str,
-        app_components: List[str],
-        logical_resource_id: Dict[str, str],
+        app_components: list[str],
+        logical_resource_id: dict[str, str],
         physical_resource_id: str,
         resource_type: str,
     ) -> Resource:
@@ -391,11 +391,11 @@ class ResilienceHubBackend(BaseBackend):
 
     def list_app_version_resources(
         self, app_arn: str, app_version: str
-    ) -> List[Resource]:
+    ) -> list[Resource]:
         app = self.describe_app(app_arn)
         return app.get_version(app_version).resources
 
-    def list_app_versions(self, app_arn: str) -> List[AppVersion]:
+    def list_app_versions(self, app_arn: str) -> list[AppVersion]:
         app = self.describe_app(app_arn)
         return app.app_versions
 

--- a/moto/resiliencehub/responses.py
+++ b/moto/resiliencehub/responses.py
@@ -46,7 +46,7 @@ class ResilienceHubResponse(BaseResponse):
 
         required_policy_types = ["Software", "Hardware", "AZ"]
         all_policy_types = required_policy_types + ["Region"]
-        if any((p_type not in all_policy_types for p_type in policy.keys())):
+        if any(p_type not in all_policy_types for p_type in policy.keys()):
             raise ValidationException(
                 "1 validation error detected: Value at 'policy' failed to satisfy constraint: Map keys must satisfy constraint: [Member must satisfy enum value set: [Software, Hardware, Region, AZ]]"
             )

--- a/moto/resourcegroups/models.py
+++ b/moto/resourcegroups/models.py
@@ -1,6 +1,6 @@
 import json
 import re
-from typing import Any, Dict, List, Optional
+from typing import Any, Optional
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
@@ -15,12 +15,12 @@ class FakeResourceGroup(BaseModel):
         account_id: str,
         region_name: str,
         name: str,
-        resource_query: Dict[str, str],
+        resource_query: dict[str, str],
         description: Optional[str] = None,
-        tags: Optional[Dict[str, str]] = None,
-        configuration: Optional[List[Dict[str, Any]]] = None,
+        tags: Optional[dict[str, str]] = None,
+        configuration: Optional[list[dict[str, Any]]] = None,
     ):
-        self.errors: List[str] = []
+        self.errors: list[str] = []
         description = description or ""
         tags = tags or {}
         if self._validate_description(value=description):
@@ -95,7 +95,7 @@ class FakeResourceGroup(BaseModel):
             return False
         return True
 
-    def _validate_resource_query(self, value: Dict[str, str]) -> bool:
+    def _validate_resource_query(self, value: dict[str, str]) -> bool:
         if not value:
             return True
         errors = []
@@ -120,7 +120,7 @@ class FakeResourceGroup(BaseModel):
             return False
         return True
 
-    def _validate_tags(self, value: Dict[str, str]) -> bool:
+    def _validate_tags(self, value: dict[str, str]) -> bool:
         errors = []
         # AWS only outputs one error for all keys and one for all values.
         error_keys = None
@@ -183,21 +183,21 @@ class FakeResourceGroup(BaseModel):
         self._name = value
 
     @property
-    def resource_query(self) -> Dict[str, str]:
+    def resource_query(self) -> dict[str, str]:
         return self._resource_query
 
     @resource_query.setter
-    def resource_query(self, value: Dict[str, str]) -> None:
+    def resource_query(self, value: dict[str, str]) -> None:
         if not self._validate_resource_query(value=value):
             self._raise_errors()
         self._resource_query = value
 
     @property
-    def tags(self) -> Dict[str, str]:
+    def tags(self) -> dict[str, str]:
         return self._tags
 
     @tags.setter
-    def tags(self, value: Dict[str, str]) -> None:
+    def tags(self, value: dict[str, str]) -> None:
         if not self._validate_tags(value=value):
             self._raise_errors()
         self._tags = value
@@ -205,8 +205,8 @@ class FakeResourceGroup(BaseModel):
 
 class ResourceGroups:
     def __init__(self) -> None:
-        self.by_name: Dict[str, FakeResourceGroup] = {}
-        self.by_arn: Dict[str, FakeResourceGroup] = {}
+        self.by_name: dict[str, FakeResourceGroup] = {}
+        self.by_arn: dict[str, FakeResourceGroup] = {}
 
     def __contains__(self, item: str) -> bool:
         return item in self.by_name or item in self.by_arn
@@ -235,7 +235,7 @@ class ResourceGroupsBackend(BaseBackend):
         self.groups = ResourceGroups()
 
     @staticmethod
-    def _validate_resource_query(resource_query: Dict[str, str]) -> None:
+    def _validate_resource_query(resource_query: dict[str, str]) -> None:
         if not resource_query:
             return
         query_type = resource_query["Type"]
@@ -304,7 +304,7 @@ class ResourceGroupsBackend(BaseBackend):
                         )
 
     @staticmethod
-    def _validate_tags(tags: Dict[str, str]) -> None:
+    def _validate_tags(tags: dict[str, str]) -> None:
         for tag in tags:
             if tag.lower().startswith("aws:"):
                 raise BadRequestException("Tag keys must not start with 'aws:'")
@@ -312,10 +312,10 @@ class ResourceGroupsBackend(BaseBackend):
     def create_group(
         self,
         name: str,
-        resource_query: Dict[str, str],
+        resource_query: dict[str, str],
         description: Optional[str] = None,
-        tags: Optional[Dict[str, str]] = None,
-        configuration: Optional[List[Dict[str, Any]]] = None,
+        tags: Optional[dict[str, str]] = None,
+        configuration: Optional[list[dict[str, Any]]] = None,
     ) -> FakeResourceGroup:
         tags = tags or {}
         group = FakeResourceGroup(
@@ -347,22 +347,22 @@ class ResourceGroupsBackend(BaseBackend):
             raise NotFoundException()
         return group
 
-    def get_tags(self, arn: str) -> Dict[str, str]:
+    def get_tags(self, arn: str) -> dict[str, str]:
         return self.groups.by_arn[arn].tags
 
-    def list_groups(self) -> Dict[str, FakeResourceGroup]:
+    def list_groups(self) -> dict[str, FakeResourceGroup]:
         """
         Pagination or the Filters-parameter is not yet implemented
         """
         return self.groups.by_name
 
-    def tag(self, arn: str, tags: Dict[str, str]) -> None:
+    def tag(self, arn: str, tags: dict[str, str]) -> None:
         all_tags = self.groups.by_arn[arn].tags
         all_tags.update(tags)
         self._validate_tags(all_tags)
         self.groups.by_arn[arn].tags = all_tags
 
-    def untag(self, arn: str, keys: List[str]) -> None:
+    def untag(self, arn: str, keys: list[str]) -> None:
         group = self.groups.by_arn[arn]
         for key in keys:
             del group.tags[key]
@@ -375,7 +375,7 @@ class ResourceGroupsBackend(BaseBackend):
         return self.groups.by_name[group_name]
 
     def update_group_query(
-        self, group_name: str, resource_query: Dict[str, str]
+        self, group_name: str, resource_query: dict[str, str]
     ) -> FakeResourceGroup:
         self._validate_resource_query(resource_query)
         self.groups.by_name[group_name].resource_query = resource_query
@@ -383,12 +383,12 @@ class ResourceGroupsBackend(BaseBackend):
 
     def get_group_configuration(
         self, group_name: str
-    ) -> Optional[List[Dict[str, Any]]]:
+    ) -> Optional[list[dict[str, Any]]]:
         group = self.groups.by_name[group_name]
         return group.configuration
 
     def put_group_configuration(
-        self, group_name: str, configuration: List[Dict[str, Any]]
+        self, group_name: str, configuration: list[dict[str, Any]]
     ) -> FakeResourceGroup:
         self.groups.by_name[group_name].configuration = configuration
         return self.groups.by_name[group_name]

--- a/moto/resourcegroupstaggingapi/models.py
+++ b/moto/resourcegroupstaggingapi/models.py
@@ -1,4 +1,5 @@
-from typing import Any, Dict, Iterator, List, Optional, Tuple
+from collections.abc import Iterator
+from typing import Any, Optional
 
 from moto.acm.models import AWSCertificateManagerBackend, acm_backends
 from moto.appsync.models import AppSyncBackend, appsync_backends
@@ -67,7 +68,7 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
     def __init__(self, region_name: str, account_id: str):
         super().__init__(region_name, account_id)
 
-        self._pages: Dict[str, Any] = {}
+        self._pages: dict[str, Any] = {}
         # Like 'someuuid': {'gen': <generator>, 'misc': None}
         # Misc is there for peeking from a generator and it cant
         # fit in the current request. As we only store generators
@@ -265,9 +266,9 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
 
     def _get_resources_generator(
         self,
-        tag_filters: Optional[List[Dict[str, Any]]] = None,
-        resource_type_filters: Optional[List[str]] = None,
-    ) -> Iterator[Dict[str, Any]]:
+        tag_filters: Optional[list[dict[str, Any]]] = None,
+        resource_type_filters: Optional[list[str]] = None,
+    ) -> Iterator[dict[str, Any]]:
         # Look at
         # https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html
 
@@ -291,7 +292,7 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
                     and v in vl
                 )
 
-        def tag_filter(tag_list: List[Dict[str, Any]]) -> bool:
+        def tag_filter(tag_list: list[dict[str, Any]]) -> bool:
             result = []
             if tag_filters:
                 for f in filters:
@@ -304,15 +305,15 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
             else:
                 return True
 
-        def format_tags(tags: Dict[str, Any]) -> List[Dict[str, Any]]:
+        def format_tags(tags: dict[str, Any]) -> list[dict[str, Any]]:
             result = []
             for key, value in tags.items():
                 result.append({"Key": key, "Value": value})
             return result
 
         def format_tag_keys(
-            tags: List[Dict[str, Any]], keys: List[str]
-        ) -> List[Dict[str, Any]]:
+            tags: list[dict[str, Any]], keys: list[str]
+        ) -> list[dict[str, Any]]:
             result = []
             for tag in tags:
                 result.append({"Key": tag[keys[0]], "Value": tag[keys[1]]})
@@ -484,7 +485,7 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
                 yield {"ResourceARN": f"{dist.arn}", "Tags": tags}
 
         if self.cloudwatch_backend:
-            cloudwatch_resource_map: Dict[str, Dict[str, Any]] = {
+            cloudwatch_resource_map: dict[str, dict[str, Any]] = {
                 "cloudwatch:alarm": self.cloudwatch_backend.alarms,
                 "cloudwatch:insight-rule": self.cloudwatch_backend.insight_rules,
             }
@@ -860,7 +861,7 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
 
         # LexV2
         if self.lexv2_backend:
-            lex_v2_resource_map: Dict[str, Dict[str, Any]] = {
+            lex_v2_resource_map: dict[str, dict[str, Any]] = {
                 "lexv2:bot": self.lexv2_backend.bots,
                 "lexv2:bot-alias": self.lexv2_backend.bot_aliases,
             }
@@ -1187,7 +1188,7 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
                 }
 
         # sagemaker cluster, automljob, compilation-job, domain, model-explainability-job-definition, model-quality-job-definition, and hyper-parameter-tuning-job currently supported
-        sagemaker_resource_map: Dict[str, Dict[str, Any]] = {
+        sagemaker_resource_map: dict[str, dict[str, Any]] = {
             "sagemaker:cluster": self.sagemaker_backend.clusters,
             "sagemaker:automl-job": self.sagemaker_backend.auto_ml_jobs,
             "sagemaker:compilation-job": self.sagemaker_backend.compilation_jobs,
@@ -1241,7 +1242,7 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
                 yield key
 
         # EC2 tags
-        def get_ec2_keys(res_id: str) -> List[Dict[str, str]]:
+        def get_ec2_keys(res_id: str) -> list[dict[str, str]]:
             result = []
             for key in self.ec2_backend.tags.get(res_id, {}):
                 result.append(key)
@@ -1285,8 +1286,7 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
 
         # Glue
         for tag_dict in self.glue_backend.tagger.tags.values():
-            for tag_key in tag_dict.keys():
-                yield tag_key
+            yield from tag_dict.keys()
 
     def _get_tag_values_generator(self, tag_key: str) -> Iterator[str]:
         # Look at
@@ -1300,7 +1300,7 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
                     yield value
 
         # EC2 tags
-        def get_ec2_values(res_id: str) -> List[Dict[str, str]]:
+        def get_ec2_values(res_id: str) -> list[dict[str, str]]:
             result = []
             for key, value in self.ec2_backend.tags.get(res_id, {}).items():
                 if key == tag_key:
@@ -1354,9 +1354,9 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
         pagination_token: Optional[str] = None,
         resources_per_page: int = 50,
         tags_per_page: int = 100,
-        tag_filters: Optional[List[Dict[str, Any]]] = None,
-        resource_type_filters: Optional[List[str]] = None,
-    ) -> Tuple[Optional[str], List[Dict[str, Any]]]:
+        tag_filters: Optional[list[dict[str, Any]]] = None,
+        resource_type_filters: Optional[list[str]] = None,
+    ) -> tuple[Optional[str], list[dict[str, Any]]]:
         # Simple range checking
         if 100 >= tags_per_page >= 500:
             raise RESTError(
@@ -1421,7 +1421,7 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
 
     def get_tag_keys(
         self, pagination_token: Optional[str] = None
-    ) -> Tuple[Optional[str], List[str]]:
+    ) -> tuple[Optional[str], list[str]]:
         if pagination_token:
             if pagination_token not in self._pages:
                 raise RESTError(
@@ -1468,7 +1468,7 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
 
     def get_tag_values(
         self, pagination_token: Optional[str], key: str
-    ) -> Tuple[Optional[str], List[str]]:
+    ) -> tuple[Optional[str], list[str]]:
         if pagination_token:
             if pagination_token not in self._pages:
                 raise RESTError(
@@ -1514,13 +1514,13 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
         return new_token, result
 
     def tag_resources(
-        self, resource_arns: List[str], tags: Dict[str, str]
-    ) -> Dict[str, Dict[str, Any]]:
+        self, resource_arns: list[str], tags: dict[str, str]
+    ) -> dict[str, dict[str, Any]]:
         """
         Only DynamoDB, EFS, Elasticache, Lambda Logs, Quicksight RDS, and SageMaker resources are currently supported
         """
         missing_resources = []
-        missing_error: Dict[str, Any] = {
+        missing_error: dict[str, Any] = {
             "StatusCode": 404,
             "ErrorCode": "InternalServiceException",
             "ErrorMessage": "Service not yet supported",
@@ -1577,13 +1577,13 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
         return dict.fromkeys(missing_resources, missing_error)
 
     def untag_resources(
-        self, resource_arn_list: List[str], tag_keys: List[str]
-    ) -> Dict[str, Dict[str, Any]]:
+        self, resource_arn_list: list[str], tag_keys: list[str]
+    ) -> dict[str, dict[str, Any]]:
         """
         Only EFS, Elasticache, Lambda, and Quicksight resources are currently supported
         """
         missing_resources = []
-        missing_error: Dict[str, Any] = {
+        missing_error: dict[str, Any] = {
             "StatusCode": 404,
             "ErrorCode": "InternalServiceException",
             "ErrorMessage": "Service not yet supported",

--- a/moto/route53/models.py
+++ b/moto/route53/models.py
@@ -6,7 +6,7 @@ import re
 import string
 from collections import defaultdict
 from datetime import datetime
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Optional
 
 from jinja2 import Template
 
@@ -81,7 +81,7 @@ class DelegationSet(BaseModel):
     def __init__(
         self,
         caller_reference: str,
-        name_servers: Optional[List[str]],
+        name_servers: Optional[list[str]],
         delegation_set_id: Optional[str],
     ):
         self.caller_reference = caller_reference
@@ -102,7 +102,7 @@ class HealthCheck(CloudFormationModel):
         self,
         health_check_id: str,
         caller_reference: str,
-        health_check_args: Dict[str, Any],
+        health_check_args: dict[str, Any],
     ):
         self.id = health_check_id
         self.ip_address = health_check_args.get("ip_address")
@@ -226,7 +226,7 @@ class HealthCheck(CloudFormationModel):
 
 
 class RecordSet(CloudFormationModel):
-    def __init__(self, kwargs: Dict[str, Any]):
+    def __init__(self, kwargs: dict[str, Any]):
         self.name = kwargs.get("Name", "")
         self.type_ = kwargs.get("Type")
         self.ttl = kwargs.get("TTL", 0)
@@ -332,7 +332,7 @@ def reverse_domain_name(domain_name: str) -> str:
     return ".".join(reversed(domain_name.split(".")))
 
 
-class ChangeList(List[Dict[str, Any]]):
+class ChangeList(list[dict[str, Any]]):
     """
     Contains a 'clean' list of ResourceRecordChangeSets
     """
@@ -345,7 +345,7 @@ class ChangeList(List[Dict[str, Any]]):
         item["ResourceRecordSet"]["Name"] = item["ResourceRecordSet"]["Name"].strip(".")
         return super().__contains__(item)
 
-    def has_insert_or_update(self, new_rr_set: Dict[str, Any]) -> bool:
+    def has_insert_or_update(self, new_rr_set: dict[str, Any]) -> bool:
         """
         Check if a CREATE or UPSERT record exists where the name and type is the same as the provided record
         If the existing record has TTL/ResourceRecords, the new TTL should have the same
@@ -379,21 +379,21 @@ class FakeZone(CloudFormationModel):
     ):
         self.name = name
         self.id = id_
-        self.vpcs: List[Dict[str, Any]] = []
+        self.vpcs: list[dict[str, Any]] = []
         if comment is not None:
             self.comment = comment
         self.caller_reference = caller_reference
         self.private_zone = private_zone
-        self.rrsets: List[RecordSet] = []
+        self.rrsets: list[RecordSet] = []
         self.delegation_set = delegation_set
         self.rr_changes = ChangeList()
 
-    def add_rrset(self, record_set: Dict[str, Any]) -> RecordSet:
+    def add_rrset(self, record_set: dict[str, Any]) -> RecordSet:
         record_set_obj = RecordSet(record_set)
         self.rrsets.append(record_set_obj)
         return record_set_obj
 
-    def upsert_rrset(self, record_set: Dict[str, Any]) -> RecordSet:
+    def upsert_rrset(self, record_set: dict[str, Any]) -> RecordSet:
         new_rrset = RecordSet(record_set)
         for i, rrset in enumerate(self.rrsets):
             if (
@@ -407,7 +407,7 @@ class FakeZone(CloudFormationModel):
             self.rrsets.append(new_rrset)
         return new_rrset
 
-    def delete_rrset(self, rrset: Dict[str, Any]) -> None:
+    def delete_rrset(self, rrset: dict[str, Any]) -> None:
         self.rrsets = [
             record_set
             for record_set in self.rrsets
@@ -424,7 +424,7 @@ class FakeZone(CloudFormationModel):
 
     def add_vpc(
         self, vpc_id: Optional[str], vpc_region: Optional[str]
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         vpc = {}
         if vpc_id is not None:
             vpc["vpc_id"] = vpc_id
@@ -437,7 +437,7 @@ class FakeZone(CloudFormationModel):
     def delete_vpc(self, vpc_id: str) -> None:
         self.vpcs = [vpc for vpc in self.vpcs if vpc["vpc_id"] != vpc_id]
 
-    def get_record_sets(self, start_type: str, start_name: str) -> List[RecordSet]:
+    def get_record_sets(self, start_type: str, start_name: str) -> list[RecordSet]:
         def predicate(rrset: RecordSet) -> bool:
             rrset_name_reversed = reverse_domain_name(rrset.name)
             start_name_reversed = reverse_domain_name(start_name)
@@ -485,7 +485,7 @@ class FakeZone(CloudFormationModel):
 
 
 class RecordSetGroup(CloudFormationModel):
-    def __init__(self, region_name: str, hosted_zone_id: str, record_sets: List[str]):
+    def __init__(self, region_name: str, hosted_zone_id: str, record_sets: list[str]):
         self.region_name = region_name
         self.hosted_zone_id = hosted_zone_id
         self.record_sets = record_sets
@@ -556,11 +556,11 @@ class QueryLoggingConfig(BaseModel):
 class Route53Backend(BaseBackend):
     def __init__(self, region_name: str, account_id: str):
         super().__init__(region_name, account_id)
-        self.zones: Dict[str, FakeZone] = {}
-        self.health_checks: Dict[str, HealthCheck] = {}
-        self.resource_tags: Dict[str, Any] = defaultdict(dict)
-        self.query_logging_configs: Dict[str, QueryLoggingConfig] = {}
-        self.delegation_sets: Dict[str, DelegationSet] = dict()
+        self.zones: dict[str, FakeZone] = {}
+        self.health_checks: dict[str, HealthCheck] = {}
+        self.resource_tags: dict[str, Any] = defaultdict(dict)
+        self.query_logging_configs: dict[str, QueryLoggingConfig] = {}
+        self.delegation_sets: dict[str, DelegationSet] = dict()
 
     def _has_prev_conflicting_domain(
         self, name: str, delegation_set_id: Optional[str]
@@ -677,12 +677,12 @@ class Route53Backend(BaseBackend):
                 else:
                     del self.resource_tags[resource_id][tags["Key"]]
 
-    def list_tags_for_resource(self, resource_id: str) -> Dict[str, str]:
+    def list_tags_for_resource(self, resource_id: str) -> dict[str, str]:
         if resource_id in self.resource_tags:
             return self.resource_tags[resource_id]
         return {}
 
-    def list_tags_for_resources(self, resource_ids: List[str]) -> List[Dict[str, Any]]:
+    def list_tags_for_resources(self, resource_ids: list[str]) -> list[dict[str, Any]]:
         resources = []
         for id in resource_ids:
             resource_set = {"ResourceId": id, "Tags": {}}
@@ -692,7 +692,7 @@ class Route53Backend(BaseBackend):
 
     def list_resource_record_sets(
         self, zone_id: str, start_type: str, start_name: str, max_items: int
-    ) -> Tuple[List[RecordSet], Optional[str], Optional[str], bool]:
+    ) -> tuple[list[RecordSet], Optional[str], Optional[str], bool]:
         """
         The StartRecordIdentifier-parameter is not yet implemented
         """
@@ -708,7 +708,7 @@ class Route53Backend(BaseBackend):
         return records, next_start_name, next_start_type, is_truncated
 
     def change_resource_record_sets(
-        self, zoneid: str, change_list: List[Dict[str, Any]]
+        self, zoneid: str, change_list: list[dict[str, Any]]
     ) -> None:
         the_zone = self.get_hosted_zone(zoneid)
 
@@ -777,15 +777,15 @@ class Route53Backend(BaseBackend):
             the_zone.rr_changes.append(original_change)
 
     @paginate(pagination_model=PAGINATION_MODEL)
-    def list_hosted_zones(self) -> List[FakeZone]:
+    def list_hosted_zones(self) -> list[FakeZone]:
         """
         The parameters DelegationSetId and HostedZoneType are not yet implemented
         """
         return list(self.zones.values())
 
     def list_hosted_zones_by_name(
-        self, dnsnames: Optional[List[str]]
-    ) -> Tuple[Optional[str], List[FakeZone]]:
+        self, dnsnames: Optional[list[str]]
+    ) -> tuple[Optional[str], list[FakeZone]]:
         if dnsnames:
             dnsname = dnsnames[0]
             if dnsname[-1] != ".":
@@ -805,7 +805,7 @@ class Route53Backend(BaseBackend):
             zones = sorted(self.zones.values(), key=sort_key)
         return dnsname, zones
 
-    def list_hosted_zones_by_vpc(self, vpc_id: str) -> List[Dict[str, Any]]:
+    def list_hosted_zones_by_vpc(self, vpc_id: str) -> list[dict[str, Any]]:
         """
         Pagination is not yet implemented
         """
@@ -855,7 +855,7 @@ class Route53Backend(BaseBackend):
         return zone
 
     def create_health_check(
-        self, caller_reference: str, health_check_args: Dict[str, Any]
+        self, caller_reference: str, health_check_args: dict[str, Any]
     ) -> HealthCheck:
         health_check_id = str(random.uuid4())
         health_check = HealthCheck(health_check_id, caller_reference, health_check_args)
@@ -865,7 +865,7 @@ class Route53Backend(BaseBackend):
         return health_check
 
     def update_health_check(
-        self, health_check_id: str, health_check_args: Dict[str, Any]
+        self, health_check_id: str, health_check_args: dict[str, Any]
     ) -> HealthCheck:
         health_check = self.health_checks.get(health_check_id)
         if not health_check:
@@ -900,7 +900,7 @@ class Route53Backend(BaseBackend):
 
         return health_check
 
-    def list_health_checks(self) -> List[HealthCheck]:
+    def list_health_checks(self) -> list[HealthCheck]:
         return list(self.health_checks.values())
 
     def delete_health_check(self, health_check_id: str) -> None:
@@ -982,7 +982,7 @@ class Route53Backend(BaseBackend):
     @paginate(pagination_model=PAGINATION_MODEL)
     def list_query_logging_configs(
         self, hosted_zone_id: Optional[str] = None
-    ) -> List[QueryLoggingConfig]:
+    ) -> list[QueryLoggingConfig]:
         """Return a list of query logging configs."""
         if hosted_zone_id:
             # Does the hosted_zone_id exist?
@@ -1001,7 +1001,7 @@ class Route53Backend(BaseBackend):
         delegation_set_id: Optional[str] = None,
         hosted_zone_id: Optional[str] = None,
     ) -> DelegationSet:
-        name_servers: Optional[List[str]] = None
+        name_servers: Optional[list[str]] = None
         if hosted_zone_id:
             hosted_zone = self.get_hosted_zone(hosted_zone_id)
             name_servers = hosted_zone.delegation_set.name_servers  # type: ignore
@@ -1011,7 +1011,7 @@ class Route53Backend(BaseBackend):
         self.delegation_sets[delegation_set.id] = delegation_set
         return delegation_set
 
-    def list_reusable_delegation_sets(self) -> List[DelegationSet]:
+    def list_reusable_delegation_sets(self) -> list[DelegationSet]:
         """
         Pagination is not yet implemented
         """

--- a/moto/route53domains/exceptions.py
+++ b/moto/route53domains/exceptions.py
@@ -1,5 +1,3 @@
-from typing import List
-
 from moto.core.exceptions import JsonRESTError
 
 
@@ -26,7 +24,7 @@ class DuplicateRequestException(JsonRESTError):
 class InvalidInputException(JsonRESTError):
     code = 400
 
-    def __init__(self, error_msgs: List[str]):
+    def __init__(self, error_msgs: list[str]):
         error_msgs_str = "\n\t".join(error_msgs)
         super().__init__(
             "InvalidInput", f"The requested item is not acceptable.\n\t{error_msgs_str}"

--- a/moto/route53domains/models.py
+++ b/moto/route53domains/models.py
@@ -1,5 +1,5 @@
 from datetime import datetime, timedelta, timezone
-from typing import Any, Dict, List, Optional
+from typing import Any, Optional
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.route53 import route53_backends
@@ -51,21 +51,21 @@ class Route53DomainsBackend(BaseBackend):
         self.__route53_backend: Route53Backend = route53_backends[account_id][
             self.partition
         ]
-        self.__domains: Dict[str, Route53Domain] = {}
-        self.__operations: Dict[str, Route53DomainsOperation] = {}
+        self.__domains: dict[str, Route53Domain] = {}
+        self.__operations: dict[str, Route53DomainsOperation] = {}
 
     def register_domain(
         self,
         domain_name: str,
         duration_in_years: int,
         auto_renew: bool,
-        admin_contact: Dict[str, Any],
-        registrant_contact: Dict[str, Any],
-        tech_contact: Dict[str, Any],
+        admin_contact: dict[str, Any],
+        registrant_contact: dict[str, Any],
+        tech_contact: dict[str, Any],
         private_protect_admin_contact: bool,
         private_protect_registrant_contact: bool,
         private_protect_tech_contact: bool,
-        extra_params: List[Dict[str, Any]],
+        extra_params: list[dict[str, Any]],
     ) -> Route53DomainsOperation:
         """Register a domain"""
 
@@ -115,7 +115,7 @@ class Route53DomainsBackend(BaseBackend):
         )
         self.__validate_duplicate_operations(requested_operation)
 
-        input_errors: List[str] = []
+        input_errors: list[str] = []
         Route53Domain.validate_domain_name(domain_name, input_errors)
 
         if input_errors:
@@ -141,7 +141,7 @@ class Route53DomainsBackend(BaseBackend):
                 raise DuplicateRequestException()
 
     def get_domain(self, domain_name: str) -> Route53Domain:
-        input_errors: List[str] = []
+        input_errors: list[str] = []
         Route53Domain.validate_domain_name(domain_name, input_errors)
         if input_errors:
             raise InvalidInputException(input_errors)
@@ -154,11 +154,11 @@ class Route53DomainsBackend(BaseBackend):
     @paginate(pagination_model=PAGINATION_MODEL)
     def list_domains(
         self,
-        filter_conditions: Optional[List[Dict[str, Any]]] = None,
-        sort_condition: Optional[Dict[str, Any]] = None,
-    ) -> List[Route53Domain]:
+        filter_conditions: Optional[list[dict[str, Any]]] = None,
+        sort_condition: Optional[dict[str, Any]] = None,
+    ) -> list[Route53Domain]:
         try:
-            filters: List[DomainsFilter] = (
+            filters: list[DomainsFilter] = (
                 [DomainsFilter.validate_dict(f) for f in filter_conditions]
                 if filter_conditions
                 else []
@@ -177,7 +177,7 @@ class Route53DomainsBackend(BaseBackend):
                 ["Sort condition must be the same as the filter condition"]
             )
 
-        domains_to_return: List[Route53Domain] = []
+        domains_to_return: list[Route53Domain] = []
 
         for domain in self.__domains.values():
             if all([f.filter(domain) for f in filters]):
@@ -201,12 +201,12 @@ class Route53DomainsBackend(BaseBackend):
     def list_operations(
         self,
         submitted_since_timestamp: Optional[int] = None,
-        statuses: Optional[List[str]] = None,
-        types: Optional[List[str]] = None,
+        statuses: Optional[list[str]] = None,
+        types: Optional[list[str]] = None,
         sort_by: Optional[str] = None,
         sort_order: Optional[str] = None,
-    ) -> List[Route53DomainsOperation]:
-        input_errors: List[str] = []
+    ) -> list[Route53DomainsOperation]:
+        input_errors: list[str] = []
         statuses = statuses or []
         types = types or []
 
@@ -224,7 +224,7 @@ class Route53DomainsBackend(BaseBackend):
             else None
         )
 
-        operations_to_return: List[Route53DomainsOperation] = []
+        operations_to_return: list[Route53DomainsOperation] = []
 
         for operation in self.__operations.values():
             if statuses and operation.status not in statuses:
@@ -255,14 +255,14 @@ class Route53DomainsBackend(BaseBackend):
         return self.__operations[operation_id]
 
     def update_domain_nameservers(
-        self, domain_name: str, nameservers: List[Dict[str, Any]]
+        self, domain_name: str, nameservers: list[dict[str, Any]]
     ) -> Route53DomainsOperation:
-        input_errors: List[str] = []
+        input_errors: list[str] = []
         Route53Domain.validate_domain_name(domain_name, input_errors)
         if len(nameservers) < 1:
             input_errors.append("Must supply nameservers")
 
-        servers: List[NameServer] = []
+        servers: list[NameServer] = []
         try:
             servers = [NameServer.validate_dict(obj) for obj in nameservers]
         except ValidationException as e:

--- a/moto/route53domains/responses.py
+++ b/moto/route53domains/responses.py
@@ -1,5 +1,5 @@
 import json
-from typing import Any, Dict
+from typing import Any
 
 from moto.core.responses import BaseResponse
 from moto.route53domains.models import Route53DomainsBackend, route53domains_backends
@@ -78,7 +78,7 @@ class Route53DomainsResponse(BaseResponse):
         return json.dumps(res)
 
     @staticmethod
-    def __map_domains_to_info(domain: Route53Domain) -> Dict[str, Any]:  # type: ignore[misc]
+    def __map_domains_to_info(domain: Route53Domain) -> dict[str, Any]:  # type: ignore[misc]
         return {
             "DomainName": domain.domain_name,
             "AutoRenew": domain.auto_renew,

--- a/moto/route53domains/validators.py
+++ b/moto/route53domains/validators.py
@@ -2,7 +2,7 @@ import re
 from datetime import datetime, timedelta, timezone
 from enum import Enum
 from ipaddress import IPv4Address, IPv6Address, ip_address
-from typing import Any, Dict, List, Optional, Type
+from typing import Any, Optional
 
 from moto.core.common_models import BaseModel
 from moto.moto_api._internal import mock_random
@@ -621,7 +621,7 @@ class DomainFilterOperator(str, Enum):
     BEGINS_WITH = "BEGINS_WITH"
 
 
-def is_valid_enum(value: Any, enum_cls: Type[Enum]) -> bool:
+def is_valid_enum(value: Any, enum_cls: type[Enum]) -> bool:
     try:
         enum_cls(value)
         return True
@@ -630,7 +630,7 @@ def is_valid_enum(value: Any, enum_cls: Type[Enum]) -> bool:
 
 
 class ValidationException(Exception):
-    def __init__(self, errors: List[str]):
+    def __init__(self, errors: list[str]):
         super().__init__("\n\t".join(errors))
         self.errors = errors
 
@@ -680,7 +680,7 @@ class Route53DomainsOperation(BaseModel):
             status_flag,
         )
 
-    def to_json(self) -> Dict[str, Any]:
+    def to_json(self) -> dict[str, Any]:
         d = {
             "OperationId": self.id,
             "Status": self.status,
@@ -706,7 +706,7 @@ class Route53DomainsContactDetail(BaseModel):
         contact_type: Optional[str] = None,
         country_code: Optional[str] = None,
         email: Optional[str] = None,
-        extra_params: Optional[List[Dict[str, Any]]] = None,
+        extra_params: Optional[list[dict[str, Any]]] = None,
         fax: Optional[str] = None,
         first_name: Optional[str] = None,
         last_name: Optional[str] = None,
@@ -740,7 +740,7 @@ class Route53DomainsContactDetail(BaseModel):
         contact_type: Optional[str] = None,
         country_code: Optional[str] = None,
         email: Optional[str] = None,
-        extra_params: Optional[List[Dict[str, Any]]] = None,
+        extra_params: Optional[list[dict[str, Any]]] = None,
         fax: Optional[str] = None,
         first_name: Optional[str] = None,
         last_name: Optional[str] = None,
@@ -749,7 +749,7 @@ class Route53DomainsContactDetail(BaseModel):
         state: Optional[str] = None,
         zip_code: Optional[str] = None,
     ):
-        input_errors: List[str] = []
+        input_errors: list[str] = []
 
         cls.__validate_str_len(address_line_1, "AddressLine1", 255, input_errors)
         cls.__validate_str_len(address_line_2, "AddressLine2", 255, input_errors)
@@ -797,7 +797,7 @@ class Route53DomainsContactDetail(BaseModel):
         )
 
     @classmethod
-    def validate_dict(cls, d: Dict[str, Any]):  # type: ignore[misc, no-untyped-def]
+    def validate_dict(cls, d: dict[str, Any]):  # type: ignore[misc, no-untyped-def]
         address_line_1 = d.get("AddressLine1")
         address_line_2 = d.get("AddressLine2")
         city = d.get("City")
@@ -831,12 +831,12 @@ class Route53DomainsContactDetail(BaseModel):
 
     @staticmethod
     def __validate_str_len(
-        value: Optional[str], field_name: str, max_len: int, input_errors: List[str]
+        value: Optional[str], field_name: str, max_len: int, input_errors: list[str]
     ) -> None:
         if value and len(value) > max_len:
             input_errors.append(f"Length of {field_name} is more than {max_len}")
 
-    def to_json(self) -> Dict[str, Any]:
+    def to_json(self) -> dict[str, Any]:
         d = {
             "FirstName": self.first_name,
             "LastName": self.last_name,
@@ -858,14 +858,14 @@ class Route53DomainsContactDetail(BaseModel):
 
 
 class NameServer:
-    def __init__(self, name: str, glue_ips: List[str]):
+    def __init__(self, name: str, glue_ips: list[str]):
         self.name = name
         self.glue_ips = glue_ips
 
     @classmethod
-    def validate(cls, name: str, glue_ips: Optional[List[str]] = None):  # type: ignore[misc,no-untyped-def]
+    def validate(cls, name: str, glue_ips: Optional[list[str]] = None):  # type: ignore[misc,no-untyped-def]
         glue_ips = glue_ips or []
-        input_errors: List[str] = []
+        input_errors: list[str] = []
 
         if not VALID_DOMAIN_REGEX.match(name):
             input_errors.append(f"{name} is not a valid host name")
@@ -893,13 +893,13 @@ class NameServer:
         return cls(name, glue_ips)
 
     @classmethod
-    def validate_dict(cls, data: Dict[str, Any]):  # type: ignore[misc,no-untyped-def]
+    def validate_dict(cls, data: dict[str, Any]):  # type: ignore[misc,no-untyped-def]
         name = data.get("Name")
         glue_ips = data.get("GlueIps")
         return cls.validate(name, glue_ips)  # type: ignore[arg-type]
 
-    def to_json(self) -> Dict[str, Any]:
-        d: Dict[str, Any] = {"Name": self.name}
+    def to_json(self) -> dict[str, Any]:
+        d: dict[str, Any] = {"Name": self.name}
         if self.glue_ips:
             d["GlueIps"] = self.glue_ips
         return d
@@ -909,7 +909,7 @@ class Route53Domain(BaseModel):
     def __init__(
         self,
         domain_name: str,
-        nameservers: List[NameServer],
+        nameservers: list[NameServer],
         auto_renew: bool,
         admin_contact: Route53DomainsContactDetail,
         registrant_contact: Route53DomainsContactDetail,
@@ -927,9 +927,9 @@ class Route53Domain(BaseModel):
         updated_date: datetime,
         expiration_date: datetime,
         reseller: str,
-        status_list: List[str],
-        dns_sec_keys: List[Dict[str, Any]],
-        extra_params: List[Dict[str, Any]],
+        status_list: list[str],
+        dns_sec_keys: list[dict[str, Any]],
+        extra_params: list[dict[str, Any]],
     ):
         self.domain_name = domain_name
         self.nameservers = nameservers
@@ -961,7 +961,7 @@ class Route53Domain(BaseModel):
         admin_contact: Route53DomainsContactDetail,
         registrant_contact: Route53DomainsContactDetail,
         tech_contact: Route53DomainsContactDetail,
-        nameservers: Optional[List[Dict[str, Any]]] = None,
+        nameservers: Optional[list[dict[str, Any]]] = None,
         auto_renew: bool = True,
         admin_privacy: bool = True,
         registrant_privacy: bool = True,
@@ -974,10 +974,10 @@ class Route53Domain(BaseModel):
         registry_domain_id: Optional[str] = None,
         expiration_date: Optional[datetime] = None,
         reseller: Optional[str] = None,
-        dns_sec_keys: Optional[List[Dict[str, Any]]] = None,
-        extra_params: Optional[List[Dict[str, Any]]] = None,
+        dns_sec_keys: Optional[list[dict[str, Any]]] = None,
+        extra_params: Optional[list[dict[str, Any]]] = None,
     ):
-        input_errors: List[str] = []
+        input_errors: list[str] = []
 
         cls.validate_domain_name(domain_name, input_errors)
 
@@ -1042,7 +1042,7 @@ class Route53Domain(BaseModel):
         )
 
     @staticmethod
-    def validate_domain_name(domain_name: str, input_errors: List[str]) -> None:
+    def validate_domain_name(domain_name: str, input_errors: list[str]) -> None:
         if not VALID_DOMAIN_REGEX.match(domain_name):
             input_errors.append("Invalid domain name")
             return
@@ -1051,7 +1051,7 @@ class Route53Domain(BaseModel):
         if tld not in AWS_SUPPORTED_TLDS:
             raise UnsupportedTLDException(tld)
 
-    def to_json(self) -> Dict[str, Any]:
+    def to_json(self) -> dict[str, Any]:
         return {
             "DomainName": self.domain_name,
             "Nameservers": [nameserver.to_json() for nameserver in self.nameservers],
@@ -1081,7 +1081,7 @@ class Route53Domain(BaseModel):
 
 class DomainsFilter:
     def __init__(
-        self, name: DomainFilterField, operator: DomainFilterOperator, values: List[str]
+        self, name: DomainFilterField, operator: DomainFilterOperator, values: list[str]
     ):
         self.name: DomainFilterField = name
         self.operator: DomainFilterOperator = operator
@@ -1117,8 +1117,8 @@ class DomainsFilter:
         )
 
     @classmethod
-    def validate(cls, name: str, operator: str, values: List[str]):  # type: ignore[misc, no-untyped-def]
-        input_errors: List[str] = []
+    def validate(cls, name: str, operator: str, values: list[str]):  # type: ignore[misc, no-untyped-def]
+        input_errors: list[str] = []
 
         if not is_valid_enum(name, DomainFilterField):
             input_errors.append(f"Cannot filter by field {name}")
@@ -1155,7 +1155,7 @@ class DomainsFilter:
         )
 
     @classmethod
-    def validate_dict(cls, data: Dict[str, Any]):  # type: ignore[misc,no-untyped-def]
+    def validate_dict(cls, data: dict[str, Any]):  # type: ignore[misc,no-untyped-def]
         name = data.get("Name")
         operator = data.get("Operator")
         values = data.get("Values")
@@ -1169,7 +1169,7 @@ class DomainsSortCondition:
 
     @classmethod
     def validate(cls, name: str, sort_order: str):  # type: ignore[misc,no-untyped-def]
-        input_errors: List[str] = []
+        input_errors: list[str] = []
         if not is_valid_enum(name, DomainFilterField):
             input_errors.append(f"Cannot sort by field {name}")
 
@@ -1182,7 +1182,7 @@ class DomainsSortCondition:
         return cls(name=DomainFilterField(name), sort_order=DomainSortOrder(sort_order))
 
     @classmethod
-    def validate_dict(cls, data: Dict[str, Any]):  # type: ignore[misc,no-untyped-def]
+    def validate_dict(cls, data: dict[str, Any]):  # type: ignore[misc,no-untyped-def]
         name = data.get("Name")
         sort_order = data.get("SortOrder")
         return cls.validate(name=name, sort_order=sort_order)  # type: ignore[arg-type]

--- a/moto/route53resolver/exceptions.py
+++ b/moto/route53resolver/exceptions.py
@@ -1,12 +1,10 @@
-from typing import List, Tuple
-
 from moto.core.exceptions import JsonRESTError
 
 
 class RRValidationException(JsonRESTError):
     code = 400
 
-    def __init__(self, error_tuples: List[Tuple[str, str, str]]):
+    def __init__(self, error_tuples: list[tuple[str, str, str]]):
         """Validation errors are concatenated into one exception message.
 
         error_tuples is a list of tuples.  Each tuple contains:

--- a/moto/route53resolver/models.py
+++ b/moto/route53resolver/models.py
@@ -4,7 +4,7 @@ import re
 from collections import defaultdict
 from datetime import datetime, timezone
 from ipaddress import IPv4Address, ip_address, ip_network
-from typing import Any, Dict, List, Optional, Set
+from typing import Any, Optional
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
@@ -62,7 +62,7 @@ class ResolverRuleAssociation(BaseModel):
         self.status = "COMPLETE"
         self.status_message = ""
 
-    def description(self) -> Dict[str, Any]:
+    def description(self) -> dict[str, Any]:
         """Return dictionary of relevant info for resolver rule association."""
         return {
             "Id": self.id,
@@ -99,7 +99,7 @@ class ResolverRule(BaseModel):
         creator_request_id: str,
         rule_type: str,
         domain_name: str,
-        target_ips: Optional[List[Dict[str, Any]]],
+        target_ips: Optional[list[dict[str, Any]]],
         resolver_endpoint_id: Optional[str],
         name: str,
     ):
@@ -132,7 +132,7 @@ class ResolverRule(BaseModel):
     def arn(self) -> str:
         return f"arn:{get_partition(self.region)}:route53resolver:{self.region}:{self.account_id}:resolver-rule/{self.id}"
 
-    def description(self) -> Dict[str, Any]:
+    def description(self) -> dict[str, Any]:
         """Return a dictionary of relevant info for this resolver rule."""
         return {
             "Id": self.id,
@@ -176,9 +176,9 @@ class ResolverEndpoint(BaseModel):
         region: str,
         endpoint_id: str,
         creator_request_id: str,
-        security_group_ids: List[str],
+        security_group_ids: list[str],
         direction: str,
-        ip_addresses: List[Dict[str, Any]],
+        ip_addresses: list[dict[str, Any]],
         name: str,
     ):
         self.account_id = account_id
@@ -226,19 +226,19 @@ class ResolverEndpoint(BaseModel):
         subnet_info = self.ec2_backend.describe_subnets(subnet_ids=[first_subnet_id])[0]
         return subnet_info.vpc_id
 
-    def _build_subnet_info(self) -> Dict[str, Any]:
+    def _build_subnet_info(self) -> dict[str, Any]:
         """Create a dict of subnet info, including ip addrs and ENI ids.
 
         self.subnets[subnet_id][ip_addr1] = eni-id1 ...
         """
-        subnets: Dict[str, Any] = defaultdict(dict)
+        subnets: dict[str, Any] = defaultdict(dict)
         for entry in self.ip_addresses:
             subnets[entry["SubnetId"]][entry["Ip"]] = (
                 f"rni-{mock_random.get_random_hex(17)}"
             )
         return subnets
 
-    def create_eni(self) -> List[str]:
+    def create_eni(self) -> list[str]:
         """Create a VPC ENI for each combo of AZ, subnet and IP."""
         eni_ids = []
         for subnet, ip_info in self.subnets.items():
@@ -261,7 +261,7 @@ class ResolverEndpoint(BaseModel):
         for eni_id in self.eni_ids:
             self.ec2_backend.delete_network_interface(eni_id)
 
-    def description(self) -> Dict[str, Any]:
+    def description(self) -> dict[str, Any]:
         """Return a dictionary of relevant info for this resolver endpoint."""
         return {
             "Id": self.id,
@@ -278,7 +278,7 @@ class ResolverEndpoint(BaseModel):
             "ModificationTime": self.modification_time,
         }
 
-    def ip_descriptions(self) -> List[Dict[str, str]]:
+    def ip_descriptions(self) -> list[dict[str, str]]:
         """Return a list of dicts describing resolver endpoint IP addresses."""
         description = []
         for subnet_id, ip_info in self.subnets.items():
@@ -301,7 +301,7 @@ class ResolverEndpoint(BaseModel):
         self.name = name
         self.modification_time = datetime.now(timezone.utc).isoformat()
 
-    def associate_ip_address(self, value: Dict[str, Any]) -> None:
+    def associate_ip_address(self, value: dict[str, Any]) -> None:
         self.ip_addresses.append(value)
         self.ip_address_count = len(self.ip_addresses)
 
@@ -320,7 +320,7 @@ class ResolverEndpoint(BaseModel):
         )
         self.eni_ids.append(eni_info.id)
 
-    def disassociate_ip_address(self, value: Dict[str, Any]) -> None:
+    def disassociate_ip_address(self, value: dict[str, Any]) -> None:
         if not value.get("Ip") and value.get("IpId"):
             for ip_addr, eni_id in self.subnets[value.get("SubnetId")].items():  # type: ignore
                 if value.get("IpId") == eni_id:
@@ -373,7 +373,7 @@ class ResolverQueryLogConfig(BaseModel):
     def arn(self) -> str:
         return f"arn:{get_partition(self.region)}:route53resolver:{self.region}:{self.account_id}:resolver-query-log-config/{self.id}"
 
-    def description(self) -> Dict[str, Any]:
+    def description(self) -> dict[str, Any]:
         """Return a dictionary of relevant info for this query log config."""
         return {
             "Id": self.id,
@@ -409,7 +409,7 @@ class ResolverQueryLogConfigAssociation(BaseModel):
         self.error_message = ""
         self.creation_time = datetime.now(timezone.utc).isoformat()
 
-    def description(self) -> Dict[str, Any]:
+    def description(self) -> dict[str, Any]:
         """Return a dictionary of relevant info for this query log config association."""
         return {
             "Id": self.id,
@@ -427,19 +427,19 @@ class Route53ResolverBackend(BaseBackend):
 
     def __init__(self, region_name: str, account_id: str):
         super().__init__(region_name, account_id)
-        self.resolver_endpoints: Dict[
+        self.resolver_endpoints: dict[
             str, ResolverEndpoint
         ] = {}  # Key is self-generated ID (endpoint_id)
-        self.resolver_rules: Dict[
+        self.resolver_rules: dict[
             str, ResolverRule
         ] = {}  # Key is self-generated ID (rule_id)
-        self.resolver_rule_associations: Dict[
+        self.resolver_rule_associations: dict[
             str, ResolverRuleAssociation
         ] = {}  # Key is resolver_rule_association_id)
-        self.resolver_query_log_configs: Dict[
+        self.resolver_query_log_configs: dict[
             str, ResolverQueryLogConfig
         ] = {}  # Key is resolver_query_log_config_id
-        self.resolver_query_log_config_associations: Dict[
+        self.resolver_query_log_config_associations: dict[
             str, ResolverQueryLogConfigAssociation
         ] = {}  # Key is resolver_query_log_config_association_id
         self.tagger = TaggingService()
@@ -448,8 +448,8 @@ class Route53ResolverBackend(BaseBackend):
 
     @staticmethod
     def default_vpc_endpoint_service(
-        service_region: str, zones: List[str]
-    ) -> List[Dict[str, str]]:
+        service_region: str, zones: list[str]
+    ) -> list[dict[str, str]]:
         """List of dicts representing default VPC endpoints for this service."""
         return BaseBackend.default_vpc_endpoint_service_factory(
             service_region, zones, "route53resolver"
@@ -501,7 +501,7 @@ class Route53ResolverBackend(BaseBackend):
         return rule_association
 
     def _verify_subnet_ips(
-        self, ip_addresses: List[Dict[str, Any]], initial: bool = True
+        self, ip_addresses: list[dict[str, Any]], initial: bool = True
     ) -> None:
         """
         Perform additional checks on the IPAddresses.
@@ -515,7 +515,7 @@ class Route53ResolverBackend(BaseBackend):
                     "Resolver endpoint needs to have at least 2 IP addresses"
                 )
 
-        subnets: Dict[str, Set[str]] = defaultdict(set)
+        subnets: dict[str, set[str]] = defaultdict(set)
         for subnet_id, ip_addr in [(x["SubnetId"], x["Ip"]) for x in ip_addresses]:
             try:
                 subnet_info = self.ec2_backend.describe_subnets(subnet_ids=[subnet_id])[
@@ -541,7 +541,7 @@ class Route53ResolverBackend(BaseBackend):
                 )
             subnets[subnet_id].add(ip_addr)
 
-    def _verify_security_group_ids(self, security_group_ids: List[str]) -> None:
+    def _verify_security_group_ids(self, security_group_ids: list[str]) -> None:
         """Perform additional checks on the security groups."""
         if len(security_group_ids) > 10:
             raise InvalidParameterException("Maximum of 10 security groups are allowed")
@@ -564,10 +564,10 @@ class Route53ResolverBackend(BaseBackend):
         region: str,
         creator_request_id: str,
         name: str,
-        security_group_ids: List[str],
+        security_group_ids: list[str],
         direction: str,
-        ip_addresses: List[Dict[str, Any]],
-        tags: List[Dict[str, str]],
+        ip_addresses: list[dict[str, Any]],
+        tags: list[dict[str, str]],
     ) -> ResolverEndpoint:
         """
         Return description for a newly created resolver endpoint.
@@ -637,9 +637,9 @@ class Route53ResolverBackend(BaseBackend):
         name: str,
         rule_type: str,
         domain_name: str,
-        target_ips: List[Dict[str, Any]],
+        target_ips: list[dict[str, Any]],
         resolver_endpoint_id: str,
-        tags: List[Dict[str, str]],
+        tags: list[dict[str, str]],
     ) -> ResolverRule:
         """Return description for a newly created resolver rule."""
         validate_args(
@@ -841,13 +841,13 @@ class Route53ResolverBackend(BaseBackend):
     @paginate(pagination_model=PAGINATION_MODEL)  # type: ignore[misc]
     def list_resolver_endpoint_ip_addresses(
         self, resolver_endpoint_id: str
-    ) -> List[Dict[str, str]]:
+    ) -> list[dict[str, str]]:
         self._validate_resolver_endpoint_id(resolver_endpoint_id)
         endpoint = self.resolver_endpoints[resolver_endpoint_id]
         return endpoint.ip_descriptions()
 
     @staticmethod
-    def _add_field_name_to_filter(filters: List[Dict[str, Any]]) -> None:  # type: ignore[misc]
+    def _add_field_name_to_filter(filters: list[dict[str, Any]]) -> None:  # type: ignore[misc]
         """Convert both styles of filter names to lowercase snake format.
 
         "IP_ADDRESS_COUNT" or "IpAddressCount" will become "ip_address_count".
@@ -870,7 +870,7 @@ class Route53ResolverBackend(BaseBackend):
             rr_filter["Field"] = filter_name.lower()
 
     @staticmethod
-    def _validate_filters(filters: Any, allowed_filter_names: List[str]) -> None:  # type: ignore[misc]
+    def _validate_filters(filters: Any, allowed_filter_names: list[str]) -> None:  # type: ignore[misc]
         """Raise exception if filter names are not as expected."""
         for rr_filter in filters:
             if rr_filter["Field"] not in allowed_filter_names:
@@ -900,7 +900,7 @@ class Route53ResolverBackend(BaseBackend):
         return True
 
     @paginate(pagination_model=PAGINATION_MODEL)
-    def list_resolver_endpoints(self, filters: Any) -> List[ResolverEndpoint]:
+    def list_resolver_endpoints(self, filters: Any) -> list[ResolverEndpoint]:
         if not filters:
             filters = []
 
@@ -914,7 +914,7 @@ class Route53ResolverBackend(BaseBackend):
         return endpoints
 
     @paginate(pagination_model=PAGINATION_MODEL)
-    def list_resolver_rules(self, filters: Any) -> List[ResolverRule]:
+    def list_resolver_rules(self, filters: Any) -> list[ResolverRule]:
         if not filters:
             filters = []
 
@@ -930,7 +930,7 @@ class Route53ResolverBackend(BaseBackend):
     @paginate(pagination_model=PAGINATION_MODEL)
     def list_resolver_rule_associations(
         self, filters: Any
-    ) -> List[ResolverRuleAssociation]:
+    ) -> list[ResolverRuleAssociation]:
         if not filters:
             filters = []
 
@@ -958,11 +958,11 @@ class Route53ResolverBackend(BaseBackend):
         )
 
     @paginate(pagination_model=PAGINATION_MODEL)
-    def list_tags_for_resource(self, resource_arn: str) -> List[Dict[str, str]]:
+    def list_tags_for_resource(self, resource_arn: str) -> list[dict[str, str]]:
         self._matched_arn(resource_arn)
         return self.tagger.list_tags_for_resource(resource_arn)["Tags"]
 
-    def tag_resource(self, resource_arn: str, tags: List[Dict[str, str]]) -> None:
+    def tag_resource(self, resource_arn: str, tags: list[dict[str, str]]) -> None:
         self._matched_arn(resource_arn)
         errmsg = self.tagger.validate_tags(
             tags, limit=ResolverEndpoint.MAX_TAGS_PER_RESOLVER_ENDPOINT
@@ -971,7 +971,7 @@ class Route53ResolverBackend(BaseBackend):
             raise TagValidationException(errmsg)
         self.tagger.tag_resource(resource_arn, tags)
 
-    def untag_resource(self, resource_arn: str, tag_keys: List[str]) -> None:
+    def untag_resource(self, resource_arn: str, tag_keys: list[str]) -> None:
         self._matched_arn(resource_arn)
         self.tagger.untag_resource_using_names(resource_arn, tag_keys)
 
@@ -985,7 +985,7 @@ class Route53ResolverBackend(BaseBackend):
         return resolver_endpoint
 
     def associate_resolver_endpoint_ip_address(
-        self, resolver_endpoint_id: str, value: Dict[str, Any]
+        self, resolver_endpoint_id: str, value: dict[str, Any]
     ) -> ResolverEndpoint:
         self._validate_resolver_endpoint_id(resolver_endpoint_id)
         resolver_endpoint = self.resolver_endpoints[resolver_endpoint_id]
@@ -1001,7 +1001,7 @@ class Route53ResolverBackend(BaseBackend):
         return resolver_endpoint
 
     def disassociate_resolver_endpoint_ip_address(
-        self, resolver_endpoint_id: str, value: Dict[str, Any]
+        self, resolver_endpoint_id: str, value: dict[str, Any]
     ) -> ResolverEndpoint:
         self._validate_resolver_endpoint_id(resolver_endpoint_id)
         resolver_endpoint = self.resolver_endpoints[resolver_endpoint_id]
@@ -1019,7 +1019,7 @@ class Route53ResolverBackend(BaseBackend):
         name: str,
         destination_arn: str,
         creator_request_id: str,
-        tags: Optional[List[Dict[str, str]]] = None,
+        tags: Optional[list[dict[str, str]]] = None,
     ) -> ResolverQueryLogConfig:
         if tags:
             errmsg = self.tagger.validate_tags(

--- a/moto/route53resolver/validations.py
+++ b/moto/route53resolver/validations.py
@@ -4,12 +4,12 @@ Note that ValidationExceptions are accumulative.
 """
 
 import re
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Optional
 
 from moto.route53resolver.exceptions import RRValidationException
 
 
-def validate_args(validators: List[Tuple[str, Any]]) -> None:
+def validate_args(validators: list[tuple[str, Any]]) -> None:
     """Raise exception if any of the validations fails.
 
     validators is a list of tuples each containing the following:
@@ -119,7 +119,7 @@ def validate_rule_type(value: Optional[str]) -> str:
     return ""
 
 
-def validate_security_group_ids(value: List[str]) -> str:
+def validate_security_group_ids(value: list[str]) -> str:
     """Raise exception if IPs fail to match length constraint."""
     # Too many security group IDs is an InvalidParameterException.
     for group_id in value:
@@ -131,7 +131,7 @@ def validate_security_group_ids(value: List[str]) -> str:
     return ""
 
 
-def validate_subnets(value: List[Dict[str, Any]]) -> str:
+def validate_subnets(value: list[dict[str, Any]]) -> str:
     """Raise exception if subnets fail to match length constraint."""
     for subnet_id in [x["SubnetId"] for x in value]:
         if len(subnet_id) > 32:
@@ -139,7 +139,7 @@ def validate_subnets(value: List[Dict[str, Any]]) -> str:
     return ""
 
 
-def validate_target_port(value: Optional[Dict[str, int]]) -> str:
+def validate_target_port(value: Optional[dict[str, int]]) -> str:
     """Raise exception if target port fails to match length constraint."""
     if value and value["Port"] > 65535:
         return "have value less than or equal to 65535"

--- a/moto/s3/cloud_formation.py
+++ b/moto/s3/cloud_formation.py
@@ -1,10 +1,10 @@
 from collections import OrderedDict
-from typing import Any, Dict
+from typing import Any
 
 
 def cfn_to_api_encryption(
-    bucket_encryption_properties: Dict[str, Any],
-) -> Dict[str, Any]:
+    bucket_encryption_properties: dict[str, Any],
+) -> dict[str, Any]:
     sse_algorithm = bucket_encryption_properties["ServerSideEncryptionConfiguration"][
         0
     ]["ServerSideEncryptionByDefault"]["SSEAlgorithm"]

--- a/moto/s3/config.py
+++ b/moto/s3/config.py
@@ -1,5 +1,5 @@
 import json
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Optional
 
 from moto.core.common_models import ConfigQueryModel
 from moto.core.exceptions import InvalidNextTokenException
@@ -12,14 +12,14 @@ class S3ConfigQuery(ConfigQueryModel[S3Backend]):
         self,
         account_id: str,
         partition: str,
-        resource_ids: Optional[List[str]],
+        resource_ids: Optional[list[str]],
         resource_name: Optional[str],
         limit: int,
         next_token: Optional[str],
         backend_region: Optional[str] = None,
         resource_region: Optional[str] = None,
-        aggregator: Optional[Dict[str, Any]] = None,
-    ) -> Tuple[List[Dict[str, Any]], Optional[str]]:
+        aggregator: Optional[dict[str, Any]] = None,
+    ) -> tuple[list[dict[str, Any]], Optional[str]]:
         # The resource_region only matters for aggregated queries as you can filter on bucket regions for them.
         # For other resource types, you would need to iterate appropriately for the backend_region.
 
@@ -104,7 +104,7 @@ class S3ConfigQuery(ConfigQueryModel[S3Backend]):
         resource_name: Optional[str] = None,
         backend_region: Optional[str] = None,
         resource_region: Optional[str] = None,
-    ) -> Optional[Dict[str, Any]]:
+    ) -> Optional[dict[str, Any]]:
         # Get the bucket:
         bucket = self.backends[account_id][partition].buckets.get(resource_id)
 

--- a/moto/s3/models.py
+++ b/moto/s3/models.py
@@ -13,9 +13,10 @@ import tempfile
 import threading
 import urllib.parse
 from bisect import insort
+from collections.abc import Iterator
 from importlib import reload
 from io import BytesIO
-from typing import Any, Dict, Iterator, List, Optional, Set, Tuple, Union
+from typing import Any, Optional, Union
 
 from moto.cloudwatch.models import MetricDatum
 from moto.core.base_backend import BackendDict, BaseBackend
@@ -290,8 +291,8 @@ class FakeKey(BaseModel, ManagedState):
         return self._metadata
 
     @property
-    def response_dict(self) -> Dict[str, Any]:  # type: ignore[misc]
-        res: Dict[str, Any] = {
+    def response_dict(self) -> dict[str, Any]:  # type: ignore[misc]
+        res: dict[str, Any] = {
             "ETag": self.etag,
             "last-modified": self.last_modified_RFC1123,
             "content-length": str(self.size),
@@ -359,7 +360,7 @@ class FakeKey(BaseModel, ManagedState):
     # Since file objects aren't pickleable, we need to override the default
     # behavior. The following is adapted from the Python docs:
     # https://docs.python.org/3/library/pickle.html#handling-stateful-objects
-    def __getstate__(self) -> Dict[str, Any]:
+    def __getstate__(self) -> dict[str, Any]:
         state = self.__dict__.copy()
         try:
             state["value"] = self.value
@@ -371,7 +372,7 @@ class FakeKey(BaseModel, ManagedState):
         del state["lock"]
         return state
 
-    def __setstate__(self, state: Dict[str, Any]) -> None:
+    def __setstate__(self, state: dict[str, Any]) -> None:
         self.__dict__.update({k: v for k, v in state.items() if k != "value"})
 
         self._value_buffer = tempfile.SpooledTemporaryFile(
@@ -432,7 +433,7 @@ class FakeMultipart(BaseModel):
         account_id: str,
         region_name: str,
         storage: Optional[str] = None,
-        tags: Optional[Dict[str, str]] = None,
+        tags: Optional[dict[str, str]] = None,
         acl: Optional["FakeAcl"] = None,
         sse_encryption: Optional[str] = None,
         kms_key_id: Optional[str] = None,
@@ -444,8 +445,8 @@ class FakeMultipart(BaseModel):
         self.storage = storage
         self.tags = tags
         self.acl = acl
-        self.parts: Dict[int, FakeKey] = {}
-        self.partlist: List[int] = []  # ordered list of part ID's
+        self.parts: dict[int, FakeKey] = {}
+        self.partlist: list[int] = []  # ordered list of part ID's
         rand_b64 = base64.b64encode(os.urandom(UPLOAD_ID_BYTES))
         self.id = (
             rand_b64.decode("utf-8").replace("=", "").replace("+", "").replace("/", "")
@@ -454,8 +455,8 @@ class FakeMultipart(BaseModel):
         self.kms_key_id = kms_key_id
 
     def complete(
-        self, body: Iterator[Tuple[int, str]]
-    ) -> Tuple[bytes, str, Optional[str]]:
+        self, body: Iterator[tuple[int, str]]
+    ) -> tuple[bytes, str, Optional[str]]:
         checksum_algo = self.metadata.get("x-amz-checksum-algorithm")
         decode_hex = codecs.getdecoder("hex_codec")
         total = bytearray()
@@ -569,7 +570,7 @@ CAMEL_CASED_PERMISSIONS = {
 
 
 class FakeGrant(BaseModel):
-    def __init__(self, grantees: List[FakeGrantee], permissions: List[str]):
+    def __init__(self, grantees: list[FakeGrantee], permissions: list[str]):
         self.grantees = grantees
         self.permissions = permissions
 
@@ -578,7 +579,7 @@ class FakeGrant(BaseModel):
 
 
 class FakeAcl(BaseModel):
-    def __init__(self, grants: Optional[List[FakeGrant]] = None):
+    def __init__(self, grants: Optional[list[FakeGrant]] = None):
         self.grants = grants or []
 
     @property
@@ -594,9 +595,9 @@ class FakeAcl(BaseModel):
     def __repr__(self) -> str:
         return f"FakeAcl(grants: {self.grants})"
 
-    def to_config_dict(self) -> Dict[str, Any]:
+    def to_config_dict(self) -> dict[str, Any]:
         """Returns the object into the format expected by AWS Config"""
-        data: Dict[str, Any] = {
+        data: dict[str, Any] = {
             "grantSet": None,  # Always setting this to None. Feel free to change.
             "owner": {"displayName": None, "id": OWNER},
         }
@@ -674,14 +675,14 @@ class LifecycleFilter(BaseModel):
     def __init__(
         self,
         prefix: Optional[str] = None,
-        tag: Optional[Tuple[str, str]] = None,
+        tag: Optional[tuple[str, str]] = None,
         and_filter: Optional["LifecycleAndFilter"] = None,
     ):
         self.prefix = prefix
         (self.tag_key, self.tag_value) = tag if tag else (None, None)
         self.and_filter = and_filter
 
-    def to_config_dict(self) -> Dict[str, Any]:
+    def to_config_dict(self) -> dict[str, Any]:
         if self.prefix is not None:
             return {
                 "predicate": {"type": "LifecyclePrefixPredicate", "prefix": self.prefix}
@@ -706,13 +707,13 @@ class LifecycleFilter(BaseModel):
 
 class LifecycleAndFilter(BaseModel):
     def __init__(
-        self, prefix: Optional[str] = None, tags: Optional[Dict[str, str]] = None
+        self, prefix: Optional[str] = None, tags: Optional[dict[str, str]] = None
     ):
         self.prefix = prefix
         self.tags = tags or {}
 
-    def to_config_dict(self) -> List[Dict[str, Any]]:
-        data: List[Dict[str, Any]] = []
+    def to_config_dict(self) -> list[dict[str, Any]]:
+        data: list[dict[str, Any]] = []
 
         if self.prefix is not None:
             data.append({"type": "LifecyclePrefixPredicate", "prefix": self.prefix})
@@ -736,8 +737,8 @@ class LifecycleTransition(BaseModel):
         self.days = days
         self.storage_class = storage_class
 
-    def to_config_dict(self) -> Dict[str, Any]:
-        config: Dict[str, Any] = {}
+    def to_config_dict(self) -> dict[str, Any]:
+        config: dict[str, Any] = {}
         if self.date is not None:
             config["date"] = self.date
         if self.days is not None:
@@ -755,8 +756,8 @@ class LifeCycleNoncurrentVersionTransition(BaseModel):
         self.days = days
         self.storage_class = storage_class
 
-    def to_config_dict(self) -> Dict[str, Any]:
-        config: Dict[str, Any] = {}
+    def to_config_dict(self) -> dict[str, Any]:
+        config: dict[str, Any] = {}
         if self.newer_versions is not None:
             config["newerNoncurrentVersions"] = self.newer_versions
         if self.days is not None:
@@ -775,11 +776,11 @@ class LifecycleRule(BaseModel):
         status: Optional[str] = None,
         expiration_days: Optional[str] = None,
         expiration_date: Optional[str] = None,
-        transitions: Optional[List[LifecycleTransition]] = None,
+        transitions: Optional[list[LifecycleTransition]] = None,
         expired_object_delete_marker: Optional[str] = None,
         nve_noncurrent_days: Optional[str] = None,
         noncurrent_version_transitions: Optional[
-            List[LifeCycleNoncurrentVersionTransition]
+            list[LifeCycleNoncurrentVersionTransition]
         ] = None,
         aimu_days: Optional[str] = None,
     ):
@@ -795,14 +796,14 @@ class LifecycleRule(BaseModel):
         self.noncurrent_version_transitions = noncurrent_version_transitions
         self.aimu_days = aimu_days
 
-    def to_config_dict(self) -> Dict[str, Any]:
+    def to_config_dict(self) -> dict[str, Any]:
         """Converts the object to the AWS Config data dict.
 
         :param kwargs:
         :return:
         """
 
-        lifecycle_dict: Dict[str, Any] = {
+        lifecycle_dict: dict[str, Any] = {
             "id": self.id,
             "prefix": self.prefix,
             "status": self.status,
@@ -877,8 +878,8 @@ class Notification(BaseModel):
     def __init__(
         self,
         arn: str,
-        events: List[str],
-        filters: Optional[Dict[str, Any]] = None,
+        events: list[str],
+        filters: Optional[dict[str, Any]] = None,
         notification_id: Optional[str] = None,
     ):
         self.id = notification_id or "".join(
@@ -918,9 +919,9 @@ class Notification(BaseModel):
                 return True
         return False
 
-    def to_config_dict(self) -> Dict[str, Any]:
+    def to_config_dict(self) -> dict[str, Any]:
         # Type and ARN will be filled in by NotificationConfiguration's to_config_dict:
-        data: Dict[str, Any] = {"events": [event for event in self.events]}
+        data: dict[str, Any] = {"events": [event for event in self.events]}
 
         if self.filters:
             data["filter"] = {
@@ -943,10 +944,10 @@ class Notification(BaseModel):
 class NotificationConfiguration(BaseModel):
     def __init__(
         self,
-        topic: Optional[List[Dict[str, Any]]] = None,
-        queue: Optional[List[Dict[str, Any]]] = None,
-        cloud_function: Optional[List[Dict[str, Any]]] = None,
-        event_bridge: Optional[Dict[str, Any]] = None,
+        topic: Optional[list[dict[str, Any]]] = None,
+        queue: Optional[list[dict[str, Any]]] = None,
+        cloud_function: Optional[list[dict[str, Any]]] = None,
+        event_bridge: Optional[dict[str, Any]] = None,
     ):
         self.topic = (
             [
@@ -989,8 +990,8 @@ class NotificationConfiguration(BaseModel):
         )
         self.event_bridge = event_bridge
 
-    def to_config_dict(self) -> Dict[str, Any]:
-        data: Dict[str, Any] = {"configurations": {}}
+    def to_config_dict(self) -> dict[str, Any]:
+        data: dict[str, Any] = {"configurations": {}}
 
         for topic in self.topic:
             topic_config = topic.to_config_dict()
@@ -1037,7 +1038,7 @@ class PublicAccessBlock(BaseModel):
         self.block_public_policy = block_public_policy or "false"
         self.restrict_public_buckets = restrict_public_buckets or "false"
 
-    def to_config_dict(self) -> Dict[str, bool]:
+    def to_config_dict(self) -> dict[str, bool]:
         # Need to make the string values booleans for Config:
         return {
             "blockPublicAcls": convert_str_to_bool(self.block_public_acls),
@@ -1047,7 +1048,7 @@ class PublicAccessBlock(BaseModel):
         }
 
 
-class MultipartDict(Dict[str, FakeMultipart]):
+class MultipartDict(dict[str, FakeMultipart]):
     def __delitem__(self, key: str) -> None:
         if key in self:
             self[key].dispose()
@@ -1063,24 +1064,24 @@ class FakeBucket(CloudFormationModel):
         self.keys = _VersionedKeyStore()
         self.multiparts = MultipartDict()
         self.versioning_status: Optional[str] = None
-        self.rules: List[LifecycleRule] = []
+        self.rules: list[LifecycleRule] = []
         self.policy: Optional[bytes] = None
         self.website_configuration: Optional[bytes] = None
         self.acl: Optional[FakeAcl] = get_canned_acl("private")
-        self.cors: List[CorsRule] = []
-        self.logging: Dict[str, Any] = {}
+        self.cors: list[CorsRule] = []
+        self.logging: dict[str, Any] = {}
         self.notification_configuration: Optional[NotificationConfiguration] = None
         self.accelerate_configuration: Optional[str] = None
         self.payer = "BucketOwner"
         self.creation_date = datetime.datetime.now(tz=datetime.timezone.utc)
         self.public_access_block: Optional[PublicAccessBlock] = None
-        self.encryption: Optional[Dict[str, Any]] = None
+        self.encryption: Optional[dict[str, Any]] = None
         self.object_lock_enabled = False
         self.default_lock_mode: Optional[str] = ""
         self.default_lock_days: Optional[int] = 0
         self.default_lock_years: Optional[int] = 0
-        self.ownership_rule: Optional[Dict[str, Any]] = None
-        self.inventory_configs: Dict[str, FakeBucketInventoryConfiguration] = {}
+        self.ownership_rule: Optional[dict[str, Any]] = None
+        self.inventory_configs: dict[str, FakeBucketInventoryConfiguration] = {}
         s3_backends.bucket_accounts[name] = (self.partition, account_id)
 
     @property
@@ -1104,7 +1105,7 @@ class FakeBucket(CloudFormationModel):
         iam_policy = IAMPolicy(self.policy.decode())
         return iam_policy.is_action_permitted(action, resource)
 
-    def set_lifecycle(self, rules: List[Dict[str, Any]]) -> None:
+    def set_lifecycle(self, rules: list[dict[str, Any]]) -> None:
         self.rules = []
         for rule in rules:
             # Extract and validate actions from Lifecycle rule
@@ -1256,7 +1257,7 @@ class FakeBucket(CloudFormationModel):
     def delete_lifecycle(self) -> None:
         self.rules = []
 
-    def set_cors(self, rules: List[Dict[str, Any]]) -> None:
+    def set_cors(self, rules: list[dict[str, Any]]) -> None:
         self.cors = []
 
         if len(rules) > 100:
@@ -1354,7 +1355,7 @@ class FakeBucket(CloudFormationModel):
         return write and read_acp
 
     def set_logging(
-        self, logging_config: Optional[Dict[str, Any]], bucket_backend: "S3Backend"
+        self, logging_config: Optional[dict[str, Any]], bucket_backend: "S3Backend"
     ) -> None:
         if not logging_config:
             self.logging = {}
@@ -1388,7 +1389,7 @@ class FakeBucket(CloudFormationModel):
         self.logging = logging_config
 
     def set_notification_configuration(
-        self, notification_config: Optional[Dict[str, Any]]
+        self, notification_config: Optional[dict[str, Any]]
     ) -> None:
         if not notification_config:
             self.notification_configuration = None
@@ -1565,14 +1566,14 @@ class FakeBucket(CloudFormationModel):
     ) -> None:
         s3_backends[account_id][get_partition(region_name)].delete_bucket(resource_name)
 
-    def to_config_dict(self) -> Dict[str, Any]:
+    def to_config_dict(self) -> dict[str, Any]:
         """Return the AWS Config JSON format of this S3 bucket.
 
         Note: The following features are not implemented and will need to be if you care about them:
         - Bucket Accelerate Configuration
         """
         backend = s3_backends[self.account_id][get_partition(self.region_name)]
-        config_dict: Dict[str, Any] = {
+        config_dict: dict[str, Any] = {
             "version": "1.3",
             "configurationItemCaptureTime": str(self.creation_date),
             "configurationItemStatus": "ResourceDiscovered",
@@ -1597,7 +1598,7 @@ class FakeBucket(CloudFormationModel):
 
         # Make the supplementary configuration:
         # This is a dobule-wrapped JSON for some reason...
-        s_config: Dict[str, Any] = {
+        s_config: dict[str, Any] = {
             "AccessControlList": json.dumps(json.dumps(self.acl.to_config_dict()))  # type: ignore
         }
 
@@ -1668,11 +1669,11 @@ class FakeBucketInventoryConfiguration(BaseModel):
     def __init__(
         self,
         id: str,
-        destination: Dict[str, Any],
+        destination: dict[str, Any],
         is_enabled: bool,
-        schedule: Dict[str, Any],
-        filters: Optional[Dict[str, Any]] = None,
-        optional_fields: Optional[List[str]] = None,
+        schedule: dict[str, Any],
+        filters: Optional[dict[str, Any]] = None,
+        optional_fields: Optional[list[str]] = None,
     ):
         self.id = id
         self.destination = destination
@@ -1746,11 +1747,11 @@ class S3Backend(BaseBackend, CloudWatchMetricProvider):
 
     def __init__(self, region_name: str, account_id: str):
         super().__init__(region_name, account_id)
-        self.buckets: Dict[str, FakeBucket] = {}
-        self.table_buckets: Dict[str, FakeTableStorageBucket] = {}
+        self.buckets: dict[str, FakeBucket] = {}
+        self.table_buckets: dict[str, FakeTableStorageBucket] = {}
         self.tagger = TaggingService()
-        self._pagination_tokens: Dict[str, str] = {}
-        self.inventory_configs: Dict[str, FakeBucketInventoryConfiguration] = {}
+        self._pagination_tokens: dict[str, str] = {}
+        self.inventory_configs: dict[str, FakeBucketInventoryConfiguration] = {}
 
     def reset(self) -> None:
         # For every key and multipart, Moto opens a TemporaryFile to write the value of those keys
@@ -1817,8 +1818,8 @@ class S3Backend(BaseBackend, CloudWatchMetricProvider):
 
     @staticmethod
     def default_vpc_endpoint_service(
-        service_region: str, zones: List[str]
-    ) -> List[Dict[str, str]]:
+        service_region: str, zones: list[str]
+    ) -> list[dict[str, str]]:
         """List of dicts representing default VPC endpoints for this service."""
         accesspoint = {
             "AcceptanceRequired": False,
@@ -1850,7 +1851,7 @@ class S3Backend(BaseBackend, CloudWatchMetricProvider):
         )
 
     @classmethod
-    def get_cloudwatch_metrics(cls, account_id: str, region: str) -> List[MetricDatum]:
+    def get_cloudwatch_metrics(cls, account_id: str, region: str) -> list[MetricDatum]:
         metrics = []
         for name, bucket in s3_backends[account_id][
             get_partition(region)
@@ -1925,7 +1926,7 @@ class S3Backend(BaseBackend, CloudWatchMetricProvider):
         self.table_buckets[bucket_name] = new_bucket
         return new_bucket
 
-    def list_buckets(self) -> List[FakeBucket]:
+    def list_buckets(self) -> list[FakeBucket]:
         return list(self.buckets.values())
 
     def get_bucket(self, bucket_name: str) -> FakeBucket:
@@ -1978,7 +1979,7 @@ class S3Backend(BaseBackend, CloudWatchMetricProvider):
     def get_bucket_versioning(self, bucket_name: str) -> Optional[str]:
         return self.get_bucket(bucket_name).versioning_status
 
-    def get_bucket_encryption(self, bucket_name: str) -> Optional[Dict[str, Any]]:
+    def get_bucket_encryption(self, bucket_name: str) -> Optional[dict[str, Any]]:
         return self.get_bucket(bucket_name).encryption
 
     def list_object_versions(
@@ -1989,8 +1990,8 @@ class S3Backend(BaseBackend, CloudWatchMetricProvider):
         max_keys: Optional[int] = 1000,
         prefix: str = "",
         version_id_marker: Optional[str] = None,
-    ) -> Tuple[
-        List[FakeKey], List[str], List[FakeDeleteMarker], Optional[str], Optional[str]
+    ) -> tuple[
+        list[FakeKey], list[str], list[FakeDeleteMarker], Optional[str], Optional[str]
     ]:
         """
         The default value for the MaxKeys-argument is 100. This can be configured with an environment variable:
@@ -1999,9 +2000,9 @@ class S3Backend(BaseBackend, CloudWatchMetricProvider):
         """
         bucket = self.get_bucket(bucket_name)
 
-        common_prefixes: Set[str] = set()
-        requested_versions: List[FakeKey] = []
-        delete_markers: List[FakeDeleteMarker] = []
+        common_prefixes: set[str] = set()
+        requested_versions: list[FakeKey] = []
+        delete_markers: list[FakeDeleteMarker] = []
         next_key_marker: Optional[str] = None
         next_version_id_marker: Optional[str] = None
         all_versions = list(
@@ -2121,7 +2122,7 @@ class S3Backend(BaseBackend, CloudWatchMetricProvider):
         bucket.policy = None
 
     def put_bucket_encryption(
-        self, bucket_name: str, encryption: Dict[str, Any]
+        self, bucket_name: str, encryption: dict[str, Any]
     ) -> None:
         self.get_bucket(bucket_name).encryption = encryption
 
@@ -2130,23 +2131,23 @@ class S3Backend(BaseBackend, CloudWatchMetricProvider):
 
     def get_bucket_ownership_controls(
         self, bucket_name: str
-    ) -> Optional[Dict[str, Any]]:
+    ) -> Optional[dict[str, Any]]:
         return self.get_bucket(bucket_name).ownership_rule
 
     def put_bucket_ownership_controls(
-        self, bucket_name: str, ownership: Dict[str, Any]
+        self, bucket_name: str, ownership: dict[str, Any]
     ) -> None:
         self.get_bucket(bucket_name).ownership_rule = ownership
 
     def delete_bucket_ownership_controls(self, bucket_name: str) -> None:
         self.get_bucket(bucket_name).ownership_rule = None
 
-    def get_bucket_replication(self, bucket_name: str) -> Optional[Dict[str, Any]]:
+    def get_bucket_replication(self, bucket_name: str) -> Optional[dict[str, Any]]:
         bucket = self.get_bucket(bucket_name)
         return getattr(bucket, "replication", None)
 
     def put_bucket_replication(
-        self, bucket_name: str, replication: Dict[str, Any]
+        self, bucket_name: str, replication: dict[str, Any]
     ) -> None:
         if isinstance(replication["Rule"], dict):
             replication["Rule"] = [replication["Rule"]]
@@ -2166,13 +2167,13 @@ class S3Backend(BaseBackend, CloudWatchMetricProvider):
         bucket.replication = None  # type: ignore
 
     def put_bucket_lifecycle(
-        self, bucket_name: str, rules: List[Dict[str, Any]]
+        self, bucket_name: str, rules: list[dict[str, Any]]
     ) -> None:
         # Equivalent operation, just a different name. Holdover from the boto2->boto3 switch
         return self.put_bucket_lifecycle_configuration(bucket_name, rules)
 
     def put_bucket_lifecycle_configuration(
-        self, bucket_name: str, rules: List[Dict[str, Any]]
+        self, bucket_name: str, rules: list[dict[str, Any]]
     ) -> None:
         bucket = self.get_bucket(bucket_name)
         bucket.set_lifecycle(rules)
@@ -2318,7 +2319,7 @@ class S3Backend(BaseBackend, CloudWatchMetricProvider):
         bucket_name: str,
         key_name: str,
         version_id: Optional[str],
-        legal_hold_status: Dict[str, Any],
+        legal_hold_status: dict[str, Any],
     ) -> None:
         key = self.get_object(bucket_name, key_name, version_id=version_id)
         key.lock_legal_status = legal_hold_status  # type: ignore
@@ -2328,7 +2329,7 @@ class S3Backend(BaseBackend, CloudWatchMetricProvider):
         bucket_name: str,
         key_name: str,
         version_id: Optional[str],
-        retention: Tuple[Optional[str], Optional[str]],
+        retention: tuple[Optional[str], Optional[str]],
     ) -> None:
         key = self.get_object(bucket_name, key_name, version_id=version_id)
         key.lock_mode = retention[0]  # type: ignore
@@ -2337,12 +2338,12 @@ class S3Backend(BaseBackend, CloudWatchMetricProvider):
     def get_object_attributes(
         self,
         key: FakeKey,
-        attributes_to_get: List[str],
-    ) -> Dict[str, Any]:
+        attributes_to_get: list[str],
+    ) -> dict[str, Any]:
         """
         The following attributes are not yet returned: DeleteMarker, RequestCharged, ObjectParts
         """
-        response_keys: Dict[str, Any] = {
+        response_keys: dict[str, Any] = {
             "etag": None,
             "checksum": None,
             "size": None,
@@ -2413,7 +2414,7 @@ class S3Backend(BaseBackend, CloudWatchMetricProvider):
 
     def get_object_lock_configuration(
         self, bucket_name: str
-    ) -> Tuple[bool, Optional[str], Optional[int], Optional[int]]:
+    ) -> tuple[bool, Optional[str], Optional[int], Optional[int]]:
         bucket = self.get_bucket(bucket_name)
         if not bucket.object_lock_enabled:
             raise ObjectLockConfigurationNotFoundError
@@ -2424,13 +2425,13 @@ class S3Backend(BaseBackend, CloudWatchMetricProvider):
             bucket.default_lock_years,
         )
 
-    def get_object_tagging(self, key: FakeKey) -> Dict[str, List[Dict[str, str]]]:
+    def get_object_tagging(self, key: FakeKey) -> dict[str, list[dict[str, str]]]:
         return self.tagger.list_tags_for_resource(key.arn)
 
     def put_object_tagging(
         self,
         key: Optional[FakeKey],
-        tags: Optional[Dict[str, str]],
+        tags: Optional[dict[str, str]],
         key_name: Optional[str] = None,
     ) -> FakeKey:
         if key is None:
@@ -2461,11 +2462,11 @@ class S3Backend(BaseBackend, CloudWatchMetricProvider):
         )
         return key
 
-    def get_bucket_tagging(self, bucket_name: str) -> Dict[str, List[Dict[str, str]]]:
+    def get_bucket_tagging(self, bucket_name: str) -> dict[str, list[dict[str, str]]]:
         bucket = self.get_bucket(bucket_name)
         return self.tagger.list_tags_for_resource(bucket.arn)
 
-    def put_bucket_tagging(self, bucket_name: str, tags: Dict[str, str]) -> None:
+    def put_bucket_tagging(self, bucket_name: str, tags: dict[str, str]) -> None:
         bucket = self.get_bucket(bucket_name)
         self.tagger.delete_all_tags_for_resource(bucket.arn)
         self.tagger.tag_resource(
@@ -2502,7 +2503,7 @@ class S3Backend(BaseBackend, CloudWatchMetricProvider):
         self.tagger.delete_all_tags_for_resource(bucket.arn)
 
     def put_bucket_cors(
-        self, bucket_name: str, cors_rules: List[Dict[str, Any]]
+        self, bucket_name: str, cors_rules: list[dict[str, Any]]
     ) -> None:
         """
         Note that the moto server configures global wildcard CORS settings by default. To avoid this from overriding empty bucket CORS, disable global CORS with an environment variable:
@@ -2513,7 +2514,7 @@ class S3Backend(BaseBackend, CloudWatchMetricProvider):
         bucket.set_cors(cors_rules)
 
     def put_bucket_logging(
-        self, bucket_name: str, logging_config: Dict[str, Any]
+        self, bucket_name: str, logging_config: dict[str, Any]
     ) -> None:
         bucket = self.get_bucket(bucket_name)
         bucket.set_logging(logging_config, self)
@@ -2527,7 +2528,7 @@ class S3Backend(BaseBackend, CloudWatchMetricProvider):
         bucket.public_access_block = None
 
     def put_bucket_notification_configuration(
-        self, bucket_name: str, notification_config: Dict[str, Any]
+        self, bucket_name: str, notification_config: dict[str, Any]
     ) -> None:
         """
         The configuration can be persisted, but at the moment we only send notifications to the following targets:
@@ -2560,7 +2561,7 @@ class S3Backend(BaseBackend, CloudWatchMetricProvider):
         bucket.set_accelerate_configuration(accelerate_configuration)
 
     def put_public_access_block(
-        self, bucket_name: str, pub_block_config: Optional[Dict[str, Any]]
+        self, bucket_name: str, pub_block_config: Optional[dict[str, Any]]
     ) -> None:
         bucket = self.get_bucket(bucket_name)
 
@@ -2587,7 +2588,7 @@ class S3Backend(BaseBackend, CloudWatchMetricProvider):
         multipart_id: str,
         part_number_marker: int = 0,
         max_parts: int = 1000,
-    ) -> List[FakeKey]:
+    ) -> list[FakeKey]:
         bucket = self.get_bucket(bucket_name)
         if multipart_id not in bucket.multiparts:
             raise NoSuchUpload(upload_id=multipart_id)
@@ -2607,7 +2608,7 @@ class S3Backend(BaseBackend, CloudWatchMetricProvider):
         key_name: str,
         metadata: CaseInsensitiveDict,  # type: ignore
         storage_type: str,
-        tags: Dict[str, str],
+        tags: dict[str, str],
         acl: Optional[FakeAcl],
         sse_encryption: str,
         kms_key_id: str,
@@ -2629,7 +2630,7 @@ class S3Backend(BaseBackend, CloudWatchMetricProvider):
         return multipart.id
 
     def complete_multipart_upload(
-        self, bucket_name: str, multipart_id: str, body: Iterator[Tuple[int, str]]
+        self, bucket_name: str, multipart_id: str, body: Iterator[tuple[int, str]]
     ) -> Optional[FakeKey]:
         bucket = self.get_bucket(bucket_name)
         multipart = bucket.multiparts[multipart_id]
@@ -2672,7 +2673,7 @@ class S3Backend(BaseBackend, CloudWatchMetricProvider):
         )
         return key
 
-    def list_multipart_uploads(self, bucket_name: str) -> Dict[str, FakeMultipart]:
+    def list_multipart_uploads(self, bucket_name: str) -> dict[str, FakeMultipart]:
         """
         The delimiter and max-uploads parameters have not yet been implemented.
         """
@@ -2714,7 +2715,7 @@ class S3Backend(BaseBackend, CloudWatchMetricProvider):
         delimiter: Optional[str],
         marker: Optional[str],
         max_keys: Optional[int],
-    ) -> Tuple[Set[FakeKey], Set[str], bool, Optional[str]]:
+    ) -> tuple[set[FakeKey], set[str], bool, Optional[str]]:
         """
         The default value for the MaxKeys-argument is 100. This can be configured with an environment variable:
 
@@ -2774,7 +2775,7 @@ class S3Backend(BaseBackend, CloudWatchMetricProvider):
         continuation_token: Optional[str],
         start_after: Optional[str],
         max_keys: int,
-    ) -> Tuple[Set[Union[FakeKey, str]], bool, Optional[str]]:
+    ) -> tuple[set[Union[FakeKey, str]], bool, Optional[str]]:
         """
         The default value for the MaxKeys-argument is 100. This can be configured with an environment variable:
 
@@ -2862,7 +2863,7 @@ class S3Backend(BaseBackend, CloudWatchMetricProvider):
         key_name: str,
         version_id: Optional[str] = None,
         bypass: bool = False,
-    ) -> Tuple[bool, Dict[str, Any]]:
+    ) -> tuple[bool, dict[str, Any]]:
         bucket = self.get_bucket(bucket_name)
         if isinstance(bucket, FakeTableStorageBucket):
             raise MethodNotAllowed()
@@ -2933,9 +2934,9 @@ class S3Backend(BaseBackend, CloudWatchMetricProvider):
     def delete_objects(
         self,
         bucket_name: str,
-        objects: List[Dict[str, Any]],
+        objects: list[dict[str, Any]],
         bypass_retention: bool = False,
-    ) -> Tuple[List[Tuple[str, Optional[str], Optional[str]]], List[str]]:
+    ) -> tuple[list[tuple[str, Optional[str], Optional[str]]], list[str]]:
         deleted = []
         errors = []
         for object_ in objects:
@@ -3046,11 +3047,11 @@ class S3Backend(BaseBackend, CloudWatchMetricProvider):
         bucket = self.get_bucket(bucket_name)
         return bucket.acl
 
-    def get_bucket_cors(self, bucket_name: str) -> List[CorsRule]:
+    def get_bucket_cors(self, bucket_name: str) -> list[CorsRule]:
         bucket = self.get_bucket(bucket_name)
         return bucket.cors
 
-    def get_bucket_lifecycle(self, bucket_name: str) -> List[LifecycleRule]:
+    def get_bucket_lifecycle(self, bucket_name: str) -> list[LifecycleRule]:
         # Equivalent operation, just a different name. Holdover from the boto2->boto3 switch
         return self.get_bucket_lifecycle_configuration(bucket_name)
 
@@ -3065,7 +3066,7 @@ class S3Backend(BaseBackend, CloudWatchMetricProvider):
 
         return bucket.location
 
-    def get_bucket_logging(self, bucket_name: str) -> Dict[str, Any]:
+    def get_bucket_logging(self, bucket_name: str) -> dict[str, Any]:
         bucket = self.get_bucket(bucket_name)
         return bucket.logging
 
@@ -3080,9 +3081,9 @@ class S3Backend(BaseBackend, CloudWatchMetricProvider):
         bucket_name: str,
         key_name: str,
         select_query: str,
-        input_details: Dict[str, Any],
-        output_details: Dict[str, Any],
-    ) -> Tuple[List[bytes], int]:
+        input_details: dict[str, Any],
+        output_details: dict[str, Any],
+    ) -> tuple[list[bytes], int]:
         """
         Highly experimental. Please raise an issue if you find any inconsistencies/bugs.
 
@@ -3167,7 +3168,7 @@ class S3Backend(BaseBackend, CloudWatchMetricProvider):
         pass
 
     def put_bucket_inventory_configuration(
-        self, bucket_name: str, inventory_configuration: Dict[str, Any]
+        self, bucket_name: str, inventory_configuration: dict[str, Any]
     ) -> None:
         bucket = self.get_bucket(bucket_name)
         inv_config = FakeBucketInventoryConfiguration(
@@ -3194,7 +3195,7 @@ class S3Backend(BaseBackend, CloudWatchMetricProvider):
 
     def list_bucket_inventory_configurations(
         self, bucket_name: str
-    ) -> List[FakeBucketInventoryConfiguration]:
+    ) -> list[FakeBucketInventoryConfiguration]:
         bucket = self.get_bucket(bucket_name)
         return list(bucket.inventory_configs.values())
 
@@ -3212,13 +3213,13 @@ class S3BackendDict(BackendDict[S3Backend]):
         backend: Any,
         service_name: str,
         use_boto3_regions: bool = True,
-        additional_regions: Optional[List[str]] = None,
+        additional_regions: Optional[list[str]] = None,
     ):
         super().__init__(backend, service_name, use_boto3_regions, additional_regions)
 
         # Maps bucket names to (partition, account IDs). This is used to locate the exact S3Backend
         # holding the bucket and to maintain the common bucket namespace.
-        self.bucket_accounts: Dict[str, Tuple[str, str]] = {}
+        self.bucket_accounts: dict[str, tuple[str, str]] = {}
 
 
 s3_backends = S3BackendDict(

--- a/moto/s3/notifications.py
+++ b/moto/s3/notifications.py
@@ -2,7 +2,7 @@ import copy
 import json
 from datetime import datetime
 from enum import Enum
-from typing import TYPE_CHECKING, Any, Dict, List
+from typing import TYPE_CHECKING, Any
 from urllib.parse import quote_plus
 
 from moto.core.utils import unix_time
@@ -53,7 +53,7 @@ class S3NotificationEvent(str, Enum):
     OBJECT_TAGGING_DELETE_EVENT = "s3:ObjectTagging:Delete"
 
     @classmethod
-    def events(self) -> List[str]:
+    def events(self) -> list[str]:
         return sorted([item.value for item in S3NotificationEvent])
 
     @classmethod
@@ -69,7 +69,7 @@ class S3NotificationEvent(str, Enum):
 
 def _get_s3_event(
     event_name: str, bucket: "FakeBucket", key: Any, notification_id: str
-) -> Dict[str, List[Dict[str, Any]]]:
+) -> dict[str, list[dict[str, Any]]]:
     etag = key.etag.replace('"', "")
     # s3:ObjectCreated:Put --> ObjectCreated:Put
     event_name = event_name[3:]
@@ -278,7 +278,7 @@ def _invoke_awslambda(
         pass
 
 
-def _get_test_event(bucket_name: str) -> Dict[str, Any]:
+def _get_test_event(bucket_name: str) -> dict[str, Any]:
     event_time = datetime.now().strftime(_EVENT_TIME_FORMAT)
     return {
         "Service": "Amazon S3",

--- a/moto/s3/responses.py
+++ b/moto/s3/responses.py
@@ -1,7 +1,8 @@
 import io
 import re
 import urllib.parse
-from typing import Any, Dict, Iterator, List, Optional, Tuple, Type, Union
+from collections.abc import Iterator
+from typing import Any, Optional, Union
 from urllib.parse import parse_qs, unquote, urlencode, urlparse, urlunparse
 from xml.dom import minidom
 from xml.parsers.expat import ExpatError
@@ -384,7 +385,7 @@ class S3Response(BaseResponse):
                 f"Method {method} has not been implemented in the S3 backend yet"
             )
 
-    def _get_querystring(self, request: Any, full_url: str) -> Dict[str, Any]:
+    def _get_querystring(self, request: Any, full_url: str) -> dict[str, Any]:
         # Flask's Request has the querystring already parsed
         # In ServerMode, we can use this, instead of manually parsing this
         if hasattr(request, "args"):
@@ -420,7 +421,7 @@ class S3Response(BaseResponse):
         return 200, headers, ""
 
     def _set_cors_headers_options(
-        self, headers: Dict[str, str], bucket: FakeBucket
+        self, headers: dict[str, str], bucket: FakeBucket
     ) -> None:
         """
         TODO: smarter way of matching the right CORS rule:
@@ -433,7 +434,7 @@ class S3Response(BaseResponse):
         if they are re-defining the same headers.
         """
 
-        def _to_string(header: Union[List[str], str]) -> str:
+        def _to_string(header: Union[list[str], str]) -> str:
             # We allow list and strs in header values. Transform lists in comma-separated strings
             if isinstance(header, list):
                 return ", ".join(header)
@@ -466,7 +467,7 @@ class S3Response(BaseResponse):
                 )
 
     def _response_options(
-        self, headers: Dict[str, str], bucket_name: str
+        self, headers: dict[str, str], bucket_name: str
     ) -> TYPE_RESPONSE:
         # Return 200 with the headers from the bucket CORS configuration
         self._authenticate_and_authorize_s3_action(bucket_name=bucket_name)
@@ -480,20 +481,20 @@ class S3Response(BaseResponse):
 
         return 200, self.response_headers, ""
 
-    def _get_cors_headers_other(self) -> Dict[str, Any]:
+    def _get_cors_headers_other(self) -> dict[str, Any]:
         """
         Returns a dictionary with the appropriate CORS headers
         Should be used for non-OPTIONS requests only
         Applicable if the 'Origin' header matches one of a CORS-rules - returns an empty dictionary otherwise
         """
-        response_headers: Dict[str, Any] = dict()
+        response_headers: dict[str, Any] = dict()
         try:
             origin = self.headers.get("Origin")
             if not origin:
                 return response_headers
             bucket = self.backend.get_bucket(self.bucket_name)
 
-            def _to_string(header: Union[List[str], str]) -> str:
+            def _to_string(header: Union[list[str], str]) -> str:
                 # We allow list and strs in header values. Transform lists in comma-separated strings
                 if isinstance(header, list):
                     return ", ".join(header)
@@ -526,7 +527,7 @@ class S3Response(BaseResponse):
         return response_headers
 
     def _bucket_response_get(
-        self, bucket_name: str, querystring: Dict[str, Any]
+        self, bucket_name: str, querystring: dict[str, Any]
     ) -> Union[str, TYPE_RESPONSE]:
         self._set_action("BUCKET", "GET", querystring)
         self._authenticate_and_authorize_s3_action(bucket_name=bucket_name)
@@ -580,7 +581,7 @@ class S3Response(BaseResponse):
         return self.list_objects()
 
     def _set_action(
-        self, action_resource_type: str, method: str, querystring: Dict[str, Any]
+        self, action_resource_type: str, method: str, querystring: dict[str, Any]
     ) -> None:
         action_set = False
         for action_in_querystring, action in ACTION_MAP[action_resource_type][
@@ -775,7 +776,7 @@ class S3Response(BaseResponse):
             pass
         return None
 
-    def _parse_pab_config(self) -> Dict[str, Any]:
+    def _parse_pab_config(self) -> dict[str, Any]:
         parsed_xml = xmltodict.parse(self.body)
         parsed_xml["PublicAccessBlockConfiguration"].pop("@xmlns", None)
 
@@ -785,7 +786,7 @@ class S3Response(BaseResponse):
         self,
         request: Any,
         bucket_name: str,
-        querystring: Dict[str, Any],
+        querystring: dict[str, Any],
     ) -> Union[str, TYPE_RESPONSE]:
         if querystring and not request.headers.get("Content-Length"):
             return 411, {}, "Content-Length required"
@@ -1127,7 +1128,7 @@ class S3Response(BaseResponse):
         )
 
     def _bucket_response_delete(
-        self, bucket_name: str, querystring: Dict[str, Any]
+        self, bucket_name: str, querystring: dict[str, Any]
     ) -> TYPE_RESPONSE:
         self._set_action("BUCKET", "DELETE", querystring)
         self._authenticate_and_authorize_s3_action(bucket_name=bucket_name)
@@ -1226,7 +1227,7 @@ class S3Response(BaseResponse):
         if "success_action_redirect" in self.querystring:
             redirect = self.querystring["success_action_redirect"][0]
             parts = urlparse(redirect)
-            queryargs: Dict[str, Any] = parse_qs(parts.query)
+            queryargs: dict[str, Any] = parse_qs(parts.query)
             queryargs["key"] = key
             queryargs["bucket"] = bucket_name
             redirect_queryargs = urlencode(queryargs, doseq=True)
@@ -1327,7 +1328,7 @@ class S3Response(BaseResponse):
         )
 
     def _handle_range_header(
-        self, request: Any, response_headers: Dict[str, Any], response_content: Any
+        self, request: Any, response_headers: dict[str, Any], response_content: Any
     ) -> TYPE_RESPONSE:
         if request.method == "HEAD":
             length = int(response_headers["content-length"])
@@ -1418,7 +1419,7 @@ class S3Response(BaseResponse):
         # amz-checksum-sha256:<..>\r\n
 
     def key_response(
-        self, request: Any, full_url: str, headers: Dict[str, Any]
+        self, request: Any, full_url: str, headers: dict[str, Any]
     ) -> TYPE_RESPONSE:
         # Key and Control are lumped in because splitting out the regex is too much of a pain :/
         self.setup_class(request, full_url, headers)
@@ -1520,7 +1521,7 @@ class S3Response(BaseResponse):
                 f"Method {method} has not been implemented in the S3 backend yet"
             )
 
-    def _key_response_get(self, query: Dict[str, Any], key_name: str) -> TYPE_RESPONSE:
+    def _key_response_get(self, query: dict[str, Any], key_name: str) -> TYPE_RESPONSE:
         self._set_action("KEY", "GET", query)
         self._authenticate_and_authorize_s3_action(
             bucket_name=self.bucket_name, key_name=key_name
@@ -1674,7 +1675,7 @@ class S3Response(BaseResponse):
             ),
         )
 
-    def _get_key(self, validate_storage_class: bool = True) -> Tuple[FakeKey, bool]:
+    def _get_key(self, validate_storage_class: bool = True) -> tuple[FakeKey, bool]:
         key_name = self.parse_key_name()
         version_id = self.querystring.get("versionId", [None])[0]
         if_modified_since = self.headers.get("If-Modified-Since")
@@ -1707,7 +1708,7 @@ class S3Response(BaseResponse):
             not_modified = True
         return key, not_modified
 
-    def _key_response_put(self, query: Dict[str, Any], key_name: str) -> TYPE_RESPONSE:
+    def _key_response_put(self, query: dict[str, Any], key_name: str) -> TYPE_RESPONSE:
         self._set_action("KEY", "PUT", query)
         self._authenticate_and_authorize_s3_action(
             bucket_name=self.bucket_name, key_name=key_name
@@ -1825,8 +1826,8 @@ class S3Response(BaseResponse):
         return 200, response_headers, ""
 
     def _get_checksum(
-        self, response_headers: Dict[str, Any]
-    ) -> Tuple[str, Optional[str]]:
+        self, response_headers: dict[str, Any]
+    ) -> tuple[str, Optional[str]]:
         checksum_algorithm = self.headers.get("x-amz-sdk-checksum-algorithm", "")
         checksum_header = f"x-amz-checksum-{checksum_algorithm.lower()}"
         checksum_value = self.headers.get(checksum_header)
@@ -1959,7 +1960,7 @@ class S3Response(BaseResponse):
 
     def _get_lock_details(
         self, bucket: "FakeBucket", lock_enabled: bool
-    ) -> Tuple[Optional[str], Optional[str], Optional[str]]:
+    ) -> tuple[Optional[str], Optional[str], Optional[str]]:
         lock_mode = self.headers.get("x-amz-object-lock-mode")
         lock_until = self.headers.get("x-amz-object-lock-retain-until-date")
         legal_hold = self.headers.get("x-amz-object-lock-legal-hold")
@@ -2087,16 +2088,16 @@ class S3Response(BaseResponse):
     def head_object(
         self,
         bucket_name: str,
-        query: Dict[str, Any],
+        query: dict[str, Any],
         key_name: str,
-        headers: Dict[str, Any],
+        headers: dict[str, Any],
     ) -> TYPE_RESPONSE:
         self._set_action("KEY", "HEAD", query)
         self._authenticate_and_authorize_s3_action(
             bucket_name=bucket_name, key_name=key_name
         )
 
-        response_headers: Dict[str, Any] = {}
+        response_headers: dict[str, Any] = {}
         version_id = query.get("versionId", [None])[0]
         if version_id and not self.backend.get_bucket(bucket_name).is_versioned:
             return 400, response_headers, ""
@@ -2168,7 +2169,7 @@ class S3Response(BaseResponse):
         else:
             return 404, response_headers, ""
 
-    def _process_lock_config_from_body(self) -> Dict[str, Any]:
+    def _process_lock_config_from_body(self) -> dict[str, Any]:
         try:
             return self._lock_config_from_body()
         except (TypeError, ExpatError):
@@ -2176,8 +2177,8 @@ class S3Response(BaseResponse):
         except KeyError:
             raise MalformedXML
 
-    def _lock_config_from_body(self) -> Dict[str, Any]:
-        response_dict: Dict[str, Any] = {
+    def _lock_config_from_body(self) -> dict[str, Any]:
+        response_dict: dict[str, Any] = {
             "enabled": False,
             "mode": None,
             "days": None,
@@ -2239,10 +2240,10 @@ class S3Response(BaseResponse):
 
     def _get_grants_from_xml(
         self,
-        grant_list: List[Dict[str, Any]],
-        exception_type: Type[S3ClientError],
-        permissions: List[str],
-    ) -> List[FakeGrant]:
+        grant_list: list[dict[str, Any]],
+        exception_type: type[S3ClientError],
+        permissions: list[str],
+    ) -> list[FakeGrant]:
         grants = []
         for grant in grant_list:
             if grant.get("Permission", "") not in permissions:
@@ -2272,7 +2273,7 @@ class S3Response(BaseResponse):
 
         return grants
 
-    def _acl_from_headers(self, headers: Dict[str, str]) -> Optional[FakeAcl]:
+    def _acl_from_headers(self, headers: dict[str, str]) -> Optional[FakeAcl]:
         canned_acl = headers.get("x-amz-acl", "")
 
         grants = []
@@ -2309,7 +2310,7 @@ class S3Response(BaseResponse):
         else:
             return None
 
-    def _tagging_from_headers(self, headers: Dict[str, Any]) -> Dict[str, str]:
+    def _tagging_from_headers(self, headers: dict[str, Any]) -> dict[str, str]:
         tags = {}
         if headers.get("x-amz-tagging"):
             parsed_header = parse_qs(headers["x-amz-tagging"], keep_blank_values=True)
@@ -2317,7 +2318,7 @@ class S3Response(BaseResponse):
                 tags[tag[0]] = tag[1][0]
         return tags
 
-    def _tagging_from_xml(self) -> Dict[str, str]:
+    def _tagging_from_xml(self) -> dict[str, str]:
         parsed_xml = xmltodict.parse(self.body, force_list={"Tag": True})
 
         tags = {}
@@ -2326,7 +2327,7 @@ class S3Response(BaseResponse):
 
         return tags
 
-    def _bucket_tagging_from_body(self) -> Dict[str, str]:
+    def _bucket_tagging_from_body(self) -> dict[str, str]:
         parsed_xml = xmltodict.parse(self.body)
 
         tags = {}
@@ -2350,7 +2351,7 @@ class S3Response(BaseResponse):
 
         return tags
 
-    def _cors_from_body(self) -> List[Dict[str, Any]]:
+    def _cors_from_body(self) -> list[dict[str, Any]]:
         parsed_xml = xmltodict.parse(self.body)
 
         if isinstance(parsed_xml["CORSConfiguration"]["CORSRule"], list):
@@ -2358,18 +2359,18 @@ class S3Response(BaseResponse):
 
         return [parsed_xml["CORSConfiguration"]["CORSRule"]]
 
-    def _mode_until_from_body(self) -> Tuple[Optional[str], Optional[str]]:
+    def _mode_until_from_body(self) -> tuple[Optional[str], Optional[str]]:
         parsed_xml = xmltodict.parse(self.body)
         return (
             parsed_xml.get("Retention", None).get("Mode", None),
             parsed_xml.get("Retention", None).get("RetainUntilDate", None),
         )
 
-    def _legal_hold_status_from_xml(self, xml: bytes) -> Dict[str, Any]:
+    def _legal_hold_status_from_xml(self, xml: bytes) -> dict[str, Any]:
         parsed_xml = xmltodict.parse(xml)
         return parsed_xml["LegalHold"]["Status"]
 
-    def _encryption_config_from_body(self) -> Dict[str, Any]:
+    def _encryption_config_from_body(self) -> dict[str, Any]:
         parsed_xml = xmltodict.parse(self.body)
 
         if (
@@ -2385,7 +2386,7 @@ class S3Response(BaseResponse):
 
         return parsed_xml["ServerSideEncryptionConfiguration"]
 
-    def _ownership_rule_from_body(self) -> Dict[str, Any]:
+    def _ownership_rule_from_body(self) -> dict[str, Any]:
         parsed_xml = xmltodict.parse(self.body)
 
         if not parsed_xml["OwnershipControls"]["Rule"].get("ObjectOwnership"):
@@ -2393,7 +2394,7 @@ class S3Response(BaseResponse):
 
         return parsed_xml["OwnershipControls"]["Rule"]["ObjectOwnership"]
 
-    def _logging_from_body(self) -> Dict[str, Any]:
+    def _logging_from_body(self) -> dict[str, Any]:
         parsed_xml = xmltodict.parse(self.body)
 
         if not parsed_xml["BucketLoggingStatus"].get("LoggingEnabled"):
@@ -2438,7 +2439,7 @@ class S3Response(BaseResponse):
 
         return parsed_xml["BucketLoggingStatus"]["LoggingEnabled"]
 
-    def _notification_config_from_body(self) -> Dict[str, Any]:
+    def _notification_config_from_body(self) -> dict[str, Any]:
         parsed_xml = xmltodict.parse(self.body)
 
         if not len(parsed_xml["NotificationConfiguration"]):
@@ -2512,18 +2513,18 @@ class S3Response(BaseResponse):
         config = parsed_xml["AccelerateConfiguration"]
         return config["Status"]
 
-    def _replication_config_from_xml(self, xml: str) -> Dict[str, Any]:
+    def _replication_config_from_xml(self, xml: str) -> dict[str, Any]:
         parsed_xml = xmltodict.parse(xml, dict_constructor=dict)
         config = parsed_xml["ReplicationConfiguration"]
         return config
 
-    def _inventory_config_from_body(self) -> Dict[str, Any]:
+    def _inventory_config_from_body(self) -> dict[str, Any]:
         parsed_xml = xmltodict.parse(self.body)
         config = parsed_xml["InventoryConfiguration"]
         return config
 
     def _key_response_delete(
-        self, bucket_name: str, query: Dict[str, Any], key_name: str
+        self, bucket_name: str, query: dict[str, Any], key_name: str
     ) -> TYPE_RESPONSE:
         self._set_action("KEY", "DELETE", query)
         self._authenticate_and_authorize_s3_action(
@@ -2557,7 +2558,7 @@ class S3Response(BaseResponse):
         template = self.response_template(S3_DELETE_KEY_TAGGING_RESPONSE)
         return 204, {}, template.render(version_id=version_id)
 
-    def _complete_multipart_body(self, body: bytes) -> Iterator[Tuple[int, str]]:
+    def _complete_multipart_body(self, body: bytes) -> Iterator[tuple[int, str]]:
         ps = minidom.parseString(body).getElementsByTagName("Part")
         prev = 0
         for p in ps:
@@ -2571,7 +2572,7 @@ class S3Response(BaseResponse):
         request: Any,
         body: bytes,
         bucket_name: str,
-        query: Dict[str, Any],
+        query: dict[str, Any],
         key_name: str,
     ) -> TYPE_RESPONSE:
         self._set_action("KEY", "POST", query)
@@ -2634,7 +2635,7 @@ class S3Response(BaseResponse):
             if key is None:
                 return 400, {}, ""
 
-            headers: Dict[str, Any] = {}
+            headers: dict[str, Any] = {}
 
             template = self.response_template(S3_MULTIPART_COMPLETE_RESPONSE)
             if key.version_id:
@@ -2679,7 +2680,7 @@ class S3Response(BaseResponse):
                 "Method POST had only been implemented for multipart uploads and restore operations, so far"
             )
 
-    def _invalid_headers(self, url: str, headers: Dict[str, str]) -> bool:
+    def _invalid_headers(self, url: str, headers: dict[str, str]) -> bool:
         """
         Verify whether the provided metadata in the URL is also present in the headers
         :param url: .../file.txt&content-type=app%2Fjson&Signature=..

--- a/moto/s3/select_object_content.py
+++ b/moto/s3/select_object_content.py
@@ -1,9 +1,9 @@
 import binascii
 import struct
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Optional
 
 
-def parse_query(text_input: str, query: str) -> Tuple[List[Dict[str, Any]], int]:
+def parse_query(text_input: str, query: str) -> tuple[list[dict[str, Any]], int]:
     from py_partiql_parser import S3SelectParser
 
     parser = S3SelectParser(source_data=text_input)
@@ -53,7 +53,7 @@ def _create_end_message() -> bytes:
     return _create_message(content_type=None, event_type=b"End", payload=b"")
 
 
-def serialize_select(data_list: List[bytes], bytes_scanned: int) -> bytes:
+def serialize_select(data_list: list[bytes], bytes_scanned: int) -> bytes:
     bytes_returned = 0
     all_data = b""
     for data in data_list:

--- a/moto/s3/utils.py
+++ b/moto/s3/utils.py
@@ -4,7 +4,8 @@ import hashlib
 import logging
 import re
 import sys
-from typing import Any, Dict, Iterator, List, Optional, Tuple, Union
+from collections.abc import Iterator
+from typing import Any, Optional, Union
 from urllib.parse import urlparse
 
 from requests.structures import CaseInsensitiveDict
@@ -68,7 +69,7 @@ def bucket_name_from_url(url: str) -> Optional[str]:  # type: ignore
 
 
 # 'owi-common-cf', 'snippets/test.json' = bucket_and_name_from_url('s3://owi-common-cf/snippets/test.json')
-def bucket_and_name_from_url(url: str) -> Union[Tuple[str, str], Tuple[None, None]]:
+def bucket_and_name_from_url(url: str) -> Union[tuple[str, str], tuple[None, None]]:
     prefix = "s3://"
     if url.startswith(prefix):
         bucket_name = url[len(prefix) : url.index("/", len(prefix))]
@@ -93,7 +94,7 @@ def parse_region_from_url(url: str, use_default_region: bool = True) -> str:
     return region
 
 
-def metadata_from_headers(headers: Dict[str, Any]) -> CaseInsensitiveDict:  # type: ignore
+def metadata_from_headers(headers: dict[str, Any]) -> CaseInsensitiveDict:  # type: ignore
     metadata = CaseInsensitiveDict()  # type: ignore
     meta_regex = re.compile(r"^x-amz-meta-([a-zA-Z0-9\-_.]+)$", flags=re.IGNORECASE)
     for header in headers.keys():
@@ -120,7 +121,7 @@ class _VersionedKeyStore(dict):  # type: ignore
     https://github.com/django/django/blob/70576740b0bb5289873f5a9a9a4e1a26b2c330e5/django/utils/datastructures.py#L282
     """
 
-    def __sgetitem__(self, key: str) -> List[Any]:
+    def __sgetitem__(self, key: str) -> list[Any]:
         return super().__getitem__(key)
 
     def pop(self, key: str) -> None:  # type: ignore
@@ -168,7 +169,7 @@ class _VersionedKeyStore(dict):  # type: ignore
 
         super().__setitem__(key, list_)
 
-    def _iteritems(self) -> Iterator[Tuple[str, Any]]:
+    def _iteritems(self) -> Iterator[tuple[str, Any]]:
         for key in self._self_iterable():
             yield key, self[key]
 
@@ -176,7 +177,7 @@ class _VersionedKeyStore(dict):  # type: ignore
         for key in self._self_iterable():
             yield self[key]
 
-    def _iterlists(self) -> Iterator[Tuple[str, List[Any]]]:
+    def _iterlists(self) -> Iterator[tuple[str, list[Any]]]:
         for key in self._self_iterable():
             yield key, self.getlist(key)
 
@@ -186,7 +187,7 @@ class _VersionedKeyStore(dict):  # type: ignore
             size += sys.getsizeof(val)
         return size
 
-    def _self_iterable(self) -> Dict[str, Any]:
+    def _self_iterable(self) -> dict[str, Any]:
         # to enable concurrency, return a copy, to avoid "dictionary changed size during iteration"
         # TODO: look into replacing with a locking mechanism, potentially
         return dict(self)
@@ -221,7 +222,7 @@ def _hash(fn: Any, args: Any) -> bytes:
     return fn(*args, usedforsecurity=False).digest()
 
 
-def cors_matches_origin(origin_header: str, allowed_origins: List[str]) -> bool:
+def cors_matches_origin(origin_header: str, allowed_origins: list[str]) -> bool:
     if "*" in allowed_origins:
         return True
     if origin_header in allowed_origins:

--- a/moto/s3control/config.py
+++ b/moto/s3control/config.py
@@ -1,5 +1,5 @@
 import json
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Optional
 
 from boto3 import Session
 
@@ -15,14 +15,14 @@ class S3AccountPublicAccessBlockConfigQuery(ConfigQueryModel[S3ControlBackend]):
         self,
         account_id: str,
         partition: str,
-        resource_ids: Optional[List[str]],
+        resource_ids: Optional[list[str]],
         resource_name: Optional[str],
         limit: int,
         next_token: Optional[str],
         backend_region: Optional[str] = None,
         resource_region: Optional[str] = None,
         aggregator: Any = None,
-    ) -> Tuple[List[Dict[str, Any]], Optional[str]]:
+    ) -> tuple[list[dict[str, Any]], Optional[str]]:
         # For the Account Public Access Block, they are the same for all regions. The resource ID is the AWS account ID
         # There is no resource name -- it should be a blank string "" if provided.
 
@@ -103,7 +103,7 @@ class S3AccountPublicAccessBlockConfigQuery(ConfigQueryModel[S3ControlBackend]):
         resource_name: Optional[str] = None,
         backend_region: Optional[str] = None,
         resource_region: Optional[str] = None,
-    ) -> Optional[Dict[str, Any]]:
+    ) -> Optional[dict[str, Any]]:
         # Do we even have this defined?
         backend = self.backends[account_id][partition]
         if not backend.public_access_block:
@@ -132,7 +132,7 @@ class S3AccountPublicAccessBlockConfigQuery(ConfigQueryModel[S3ControlBackend]):
 
         # Format the PAB to the AWS Config format:
         creation_time = utcnow()
-        config_data: Dict[str, Any] = {
+        config_data: dict[str, Any] = {
             "version": "1.3",
             "accountId": account_id,
             "configurationItemCaptureTime": str(creation_time),

--- a/moto/s3control/models.py
+++ b/moto/s3control/models.py
@@ -1,6 +1,6 @@
 from collections import defaultdict
 from datetime import datetime
-from typing import Any, Dict, List, Optional
+from typing import Any, Optional
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
@@ -39,8 +39,8 @@ class AccessPoint(BaseModel):
         region_name: str,
         name: str,
         bucket: str,
-        vpc_configuration: Dict[str, Any],
-        public_access_block_configuration: Dict[str, Any],
+        vpc_configuration: dict[str, Any],
+        public_access_block_configuration: dict[str, Any],
     ):
         self.name = name
         self.alias = f"{name}-{mock_random.get_random_hex(34)}-s3alias"
@@ -73,8 +73,8 @@ class StorageLensConfiguration(BaseModel):
         self,
         account_id: str,
         config_id: str,
-        storage_lens_configuration: Dict[str, Any],
-        tags: Optional[Dict[str, str]] = None,
+        storage_lens_configuration: dict[str, Any],
+        tags: Optional[dict[str, str]] = None,
     ):
         self.account_id = account_id
         self.config_id = config_id
@@ -87,8 +87,8 @@ class S3ControlBackend(BaseBackend):
     def __init__(self, region_name: str, account_id: str):
         super().__init__(region_name, account_id)
         self.public_access_block: Optional[PublicAccessBlock] = None
-        self.access_points: Dict[str, Dict[str, AccessPoint]] = defaultdict(dict)
-        self.storage_lens_configs: Dict[str, StorageLensConfiguration] = {}
+        self.access_points: dict[str, dict[str, AccessPoint]] = defaultdict(dict)
+        self.storage_lens_configs: dict[str, StorageLensConfiguration] = {}
         self.tagger = TaggingService()
 
     def get_public_access_block(self, account_id: str) -> PublicAccessBlock:
@@ -109,7 +109,7 @@ class S3ControlBackend(BaseBackend):
         self.public_access_block = None
 
     def put_public_access_block(
-        self, account_id: str, pub_block_config: Dict[str, Any]
+        self, account_id: str, pub_block_config: dict[str, Any]
     ) -> None:
         # The account ID should equal the account id that is set for Moto:
         if account_id != self.account_id:
@@ -130,8 +130,8 @@ class S3ControlBackend(BaseBackend):
         account_id: str,
         name: str,
         bucket: str,
-        vpc_configuration: Dict[str, Any],
-        public_access_block_configuration: Dict[str, Any],
+        vpc_configuration: dict[str, Any],
+        public_access_block_configuration: dict[str, Any],
     ) -> AccessPoint:
         access_point = AccessPoint(
             account_id,
@@ -177,8 +177,8 @@ class S3ControlBackend(BaseBackend):
         self,
         config_id: str,
         account_id: str,
-        storage_lens_configuration: Dict[str, Any],
-        tags: Optional[Dict[str, str]] = None,
+        storage_lens_configuration: dict[str, Any],
+        tags: Optional[dict[str, str]] = None,
     ) -> None:
         # The account ID should equal the account id that is set for Moto:
         if account_id != self.account_id:
@@ -204,7 +204,7 @@ class S3ControlBackend(BaseBackend):
     @paginate(pagination_model=PAGINATION_MODEL)
     def list_storage_lens_configurations(
         self, account_id: str
-    ) -> List[StorageLensConfiguration]:
+    ) -> list[StorageLensConfiguration]:
         storage_lens_configuration_list = list(self.storage_lens_configs.values())
         return storage_lens_configuration_list
 
@@ -215,7 +215,7 @@ class S3ControlBackend(BaseBackend):
         bucket: Optional[str] = None,
         max_results: Optional[int] = None,
         next_token: Optional[str] = None,
-    ) -> List[AccessPoint]:
+    ) -> list[AccessPoint]:
         account_access_points = self.access_points.get(account_id, {})
         all_access_points = list(account_access_points.values())
 
@@ -224,7 +224,7 @@ class S3ControlBackend(BaseBackend):
         return all_access_points
 
     def put_storage_lens_configuration_tagging(
-        self, config_id: str, account_id: str, tags: Dict[str, str]
+        self, config_id: str, account_id: str, tags: dict[str, str]
     ) -> None:
         # The account ID should equal the account id that is set for Moto:
         if account_id != self.account_id:
@@ -237,7 +237,7 @@ class S3ControlBackend(BaseBackend):
 
     def get_storage_lens_configuration_tagging(
         self, config_id: str, account_id: str
-    ) -> Dict[str, str]:
+    ) -> dict[str, str]:
         if account_id != self.account_id:
             raise WrongPublicAccessBlockAccountIdError()
         if config_id not in self.storage_lens_configs:

--- a/moto/s3control/responses.py
+++ b/moto/s3control/responses.py
@@ -1,5 +1,5 @@
 import json
-from typing import Any, Dict, Tuple
+from typing import Any
 
 import xmltodict
 
@@ -39,7 +39,7 @@ class S3ControlResponse(BaseResponse):
         self.backend.delete_public_access_block(account_id=account_id)
         return 204, {"status": 204}, json.dumps({})
 
-    def _parse_pab_config(self, body: str) -> Dict[str, Any]:
+    def _parse_pab_config(self, body: str) -> dict[str, Any]:
         parsed_xml = xmltodict.parse(body)
         parsed_xml["PublicAccessBlockConfiguration"].pop("@xmlns", None)
 
@@ -99,7 +99,7 @@ class S3ControlResponse(BaseResponse):
 
     def _get_accountid_and_name_from_accesspoint(
         self, full_url: str
-    ) -> Tuple[str, str]:
+    ) -> tuple[str, str]:
         url = full_url
         if full_url.startswith("http"):
             url = full_url.split("://")[1]
@@ -107,7 +107,7 @@ class S3ControlResponse(BaseResponse):
         name = url.split("v20180820/accesspoint/")[-1]
         return account_id, name
 
-    def _get_accountid_and_name_from_policy(self, full_url: str) -> Tuple[str, str]:
+    def _get_accountid_and_name_from_policy(self, full_url: str) -> tuple[str, str]:
         url = full_url
         if full_url.startswith("http"):
             url = full_url.split("://")[1]

--- a/moto/s3tables/models.py
+++ b/moto/s3tables/models.py
@@ -3,7 +3,7 @@
 import datetime
 import re
 from hashlib import md5
-from typing import Dict, List, Literal, Optional, Union
+from typing import Literal, Optional, Union
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.moto_api._internal import mock_random as random
@@ -154,7 +154,7 @@ class Namespace:
         self.account_id = account_id
         self.created_by = created_by
         self.creation_date = datetime.datetime.now(tz=datetime.timezone.utc)
-        self.tables: Dict[str, Table] = {}
+        self.tables: dict[str, Table] = {}
 
 
 class FakeTableBucket:
@@ -164,7 +164,7 @@ class FakeTableBucket:
         self.region_name = region_name
         self.partition = get_partition(region_name)
         self.creation_date = datetime.datetime.now(tz=datetime.timezone.utc)
-        self.namespaces: Dict[str, Namespace] = {}
+        self.namespaces: dict[str, Namespace] = {}
 
     @property
     def arn(self) -> str:
@@ -176,7 +176,7 @@ class S3TablesBackend(BaseBackend):
 
     def __init__(self, region_name: str, account_id: str) -> None:
         super().__init__(region_name, account_id)
-        self.table_buckets: Dict[str, FakeTableBucket] = {}
+        self.table_buckets: dict[str, FakeTableBucket] = {}
 
     def create_table_bucket(self, name: str) -> FakeTableBucket:
         _validate_table_bucket_name(name)
@@ -195,7 +195,7 @@ class S3TablesBackend(BaseBackend):
     def list_table_buckets(
         self,
         prefix: Optional[str] = None,
-    ) -> List[FakeTableBucket]:
+    ) -> list[FakeTableBucket]:
         all_buckets = list(
             bucket
             for bucket in self.table_buckets.values()
@@ -239,7 +239,7 @@ class S3TablesBackend(BaseBackend):
         self,
         table_bucket_arn: str,
         prefix: Optional[str] = None,
-    ) -> List[Namespace]:
+    ) -> list[Namespace]:
         bucket = self.get_table_bucket(table_bucket_arn)
 
         all_namespaces = list(
@@ -313,7 +313,7 @@ class S3TablesBackend(BaseBackend):
         table_bucket_arn: str,
         namespace: Optional[str] = None,
         prefix: Optional[str] = None,
-    ) -> List[Table]:
+    ) -> list[Table]:
         bucket = self.table_buckets.get(table_bucket_arn)
         if not bucket or (namespace and namespace not in bucket.namespaces):
             raise NotFoundException(

--- a/moto/s3tables/responses.py
+++ b/moto/s3tables/responses.py
@@ -1,7 +1,7 @@
 """Handles incoming s3tables requests, invokes methods, returns responses."""
 
 import json
-from typing import Any, Dict
+from typing import Any
 from urllib.parse import unquote
 
 from moto.core.common_types import TYPE_RESPONSE
@@ -40,7 +40,7 @@ class S3TablesResponse(BaseResponse):
             max_buckets=int(max_buckets) if max_buckets else None,
         )
 
-        body: Dict[str, Any] = {
+        body: dict[str, Any] = {
             "tableBuckets": [
                 {
                     "arn": b.arn,
@@ -117,7 +117,7 @@ class S3TablesResponse(BaseResponse):
             max_namespaces=int(max_namespaces) if max_namespaces else None,
         )
 
-        body: Dict[str, Any] = {
+        body: dict[str, Any] = {
             "namespaces": [
                 {
                     "namespace": [ns.name],
@@ -227,7 +227,7 @@ class S3TablesResponse(BaseResponse):
             continuation_token=continuation_token,
             max_tables=int(max_tables) if max_tables else None,
         )
-        body: Dict[str, Any] = {
+        body: dict[str, Any] = {
             "tables": [
                 {
                     "namespace": [table.namespace],

--- a/moto/sagemaker/models.py
+++ b/moto/sagemaker/models.py
@@ -4,8 +4,9 @@ import random
 import re
 import string
 from collections import defaultdict
+from collections.abc import Iterable
 from datetime import datetime
-from typing import Any, DefaultDict, Dict, Iterable, List, Optional, Union, cast
+from typing import Any, Optional, Union, cast
 
 from dateutil.tz import tzutc
 
@@ -163,8 +164,8 @@ PAGINATION_MODEL = {
     },
 }
 
-METRIC_INFO_TYPE = Dict[str, Union[str, int, float, datetime]]
-METRIC_STEP_TYPE = Dict[int, METRIC_INFO_TYPE]
+METRIC_INFO_TYPE = dict[str, Union[str, int, float, datetime]]
+METRIC_STEP_TYPE = dict[int, METRIC_INFO_TYPE]
 
 
 class BaseObject(BaseModel):
@@ -179,8 +180,8 @@ class BaseObject(BaseModel):
         for k in details.keys():
             setattr(self, k, details[k])
 
-    def gen_response_object(self) -> Dict[str, Any]:
-        response_object: Dict[str, Any] = dict()
+    def gen_response_object(self) -> dict[str, Any]:
+        response_object: dict[str, Any] = dict()
         for key, value in self.__dict__.items():
             if "_" in key:
                 response_object[self.camelCase(key)] = value
@@ -189,7 +190,7 @@ class BaseObject(BaseModel):
         return response_object
 
     @property
-    def response_object(self) -> Dict[str, Any]:  # type: ignore[misc]
+    def response_object(self) -> dict[str, Any]:  # type: ignore[misc]
         return self.gen_response_object()
 
 
@@ -198,9 +199,9 @@ class FakePipelineExecution(BaseObject):
         self,
         pipeline_execution_arn: str,
         pipeline_execution_display_name: str,
-        pipeline_parameters: List[Dict[str, str]],
+        pipeline_parameters: list[dict[str, str]],
         pipeline_execution_description: str,
-        parallelism_configuration: Dict[str, int],
+        parallelism_configuration: dict[str, int],
         pipeline_definition: str,
         client_request_token: str,
     ):
@@ -247,17 +248,17 @@ class FakePipeline(BaseObject):
         pipeline_definition: str,
         pipeline_description: str,
         role_arn: str,
-        tags: List[Dict[str, str]],
+        tags: list[dict[str, str]],
         account_id: str,
         region_name: str,
-        parallelism_configuration: Dict[str, int],
+        parallelism_configuration: dict[str, int],
     ):
         self.pipeline_name = pipeline_name
         self.arn = arn_formatter("pipeline", pipeline_name, account_id, region_name)
         self.pipeline_display_name = pipeline_display_name or pipeline_name
         self.pipeline_definition = pipeline_definition
         self.pipeline_description = pipeline_description
-        self.pipeline_executions: Dict[str, FakePipelineExecution] = dict()
+        self.pipeline_executions: dict[str, FakePipelineExecution] = dict()
         self.role_arn = role_arn
         self.tags = tags or []
         self.parallelism_configuration = parallelism_configuration
@@ -291,17 +292,17 @@ class FakePipeline(BaseObject):
 class FakeProcessingJob(BaseObject):
     def __init__(
         self,
-        app_specification: Dict[str, Any],
-        experiment_config: Dict[str, str],
-        network_config: Dict[str, Any],
-        processing_inputs: List[Dict[str, Any]],
+        app_specification: dict[str, Any],
+        experiment_config: dict[str, str],
+        network_config: dict[str, Any],
+        processing_inputs: list[dict[str, Any]],
         processing_job_name: str,
-        processing_output_config: Dict[str, Any],
+        processing_output_config: dict[str, Any],
         account_id: str,
         region_name: str,
         role_arn: str,
-        tags: List[Dict[str, str]],
-        stopping_condition: Dict[str, int],
+        tags: list[dict[str, str]],
+        stopping_condition: dict[str, int],
     ):
         self.processing_job_name = processing_job_name
         self.arn = FakeProcessingJob.arn_formatter(
@@ -322,7 +323,7 @@ class FakeProcessingJob(BaseObject):
         self.stopping_condition = stopping_condition
 
     @property
-    def response_object(self) -> Dict[str, Any]:  # type: ignore[misc]
+    def response_object(self) -> dict[str, Any]:  # type: ignore[misc]
         response_object = self.gen_response_object()
         response = {
             k: v for k, v in response_object.items() if v is not None and v != [None]
@@ -332,7 +333,7 @@ class FakeProcessingJob(BaseObject):
         return response
 
     @property
-    def response_create(self) -> Dict[str, str]:
+    def response_create(self) -> dict[str, str]:
         return {"ProcessingJobArn": self.arn}
 
     @staticmethod
@@ -346,23 +347,23 @@ class FakeTrainingJob(BaseObject):
         account_id: str,
         region_name: str,
         training_job_name: str,
-        hyper_parameters: Dict[str, str],
-        algorithm_specification: Dict[str, Any],
+        hyper_parameters: dict[str, str],
+        algorithm_specification: dict[str, Any],
         role_arn: str,
-        input_data_config: List[Dict[str, Any]],
-        output_data_config: Dict[str, str],
-        resource_config: Dict[str, Any],
-        vpc_config: Dict[str, List[str]],
-        stopping_condition: Dict[str, int],
-        tags: List[Dict[str, str]],
+        input_data_config: list[dict[str, Any]],
+        output_data_config: dict[str, str],
+        resource_config: dict[str, Any],
+        vpc_config: dict[str, list[str]],
+        stopping_condition: dict[str, int],
+        tags: list[dict[str, str]],
         enable_network_isolation: bool,
         enable_inter_container_traffic_encryption: bool,
         enable_managed_spot_training: bool,
-        checkpoint_config: Dict[str, str],
-        debug_hook_config: Dict[str, Any],
-        debug_rule_configurations: List[Dict[str, Any]],
-        tensor_board_output_config: Dict[str, str],
-        experiment_config: Dict[str, str],
+        checkpoint_config: dict[str, str],
+        debug_hook_config: dict[str, Any],
+        debug_rule_configurations: list[dict[str, Any]],
+        tensor_board_output_config: dict[str, str],
+        experiment_config: dict[str, str],
     ):
         self.training_job_name = training_job_name
         self.hyper_parameters = hyper_parameters
@@ -428,7 +429,7 @@ class FakeTrainingJob(BaseObject):
         ]
 
     @property
-    def response_object(self) -> Dict[str, Any]:  # type: ignore[misc]
+    def response_object(self) -> dict[str, Any]:  # type: ignore[misc]
         response_object = self.gen_response_object()
         response = {
             k: v for k, v in response_object.items() if v is not None and v != [None]
@@ -438,7 +439,7 @@ class FakeTrainingJob(BaseObject):
         return response
 
     @property
-    def response_create(self) -> Dict[str, str]:
+    def response_create(self) -> dict[str, str]:
         return {"TrainingJobArn": self.arn}
 
     @staticmethod
@@ -453,9 +454,9 @@ class FakeEndpoint(BaseObject, CloudFormationModel):
         region_name: str,
         endpoint_name: str,
         endpoint_config_name: str,
-        production_variants: List[Dict[str, Any]],
-        data_capture_config: Dict[str, Any],
-        tags: List[Dict[str, str]],
+        production_variants: list[dict[str, Any]],
+        data_capture_config: dict[str, Any],
+        tags: list[dict[str, str]],
     ):
         self.endpoint_name = endpoint_name
         self.arn = FakeEndpoint.arn_formatter(endpoint_name, account_id, region_name)
@@ -472,8 +473,8 @@ class FakeEndpoint(BaseObject, CloudFormationModel):
         )
 
     def _process_production_variants(
-        self, production_variants: List[Dict[str, Any]]
-    ) -> List[Dict[str, Any]]:
+        self, production_variants: list[dict[str, Any]]
+    ) -> list[dict[str, Any]]:
         endpoint_variants = []
         for production_variant in production_variants:
             temp_variant = {}
@@ -509,7 +510,7 @@ class FakeEndpoint(BaseObject, CloudFormationModel):
 
         return endpoint_variants
 
-    def summary(self) -> Dict[str, Any]:
+    def summary(self) -> dict[str, Any]:
         return {
             "EndpointName": self.endpoint_name,
             "EndpointArn": self.arn,
@@ -519,7 +520,7 @@ class FakeEndpoint(BaseObject, CloudFormationModel):
         }
 
     @property
-    def response_object(self) -> Dict[str, Any]:  # type: ignore[misc]
+    def response_object(self) -> dict[str, Any]:  # type: ignore[misc]
         response_object = self.gen_response_object()
         response = {
             k: v for k, v in response_object.items() if v is not None and v != [None]
@@ -529,7 +530,7 @@ class FakeEndpoint(BaseObject, CloudFormationModel):
         return response
 
     @property
-    def response_create(self) -> Dict[str, str]:
+    def response_create(self) -> dict[str, str]:
         return {"EndpointArn": self.arn}
 
     @staticmethod
@@ -626,10 +627,10 @@ class FakeEndpointConfig(BaseObject, CloudFormationModel):
         account_id: str,
         region_name: str,
         endpoint_config_name: str,
-        production_variants: List[Dict[str, Any]],
-        async_inference_config: Dict[str, Any],
-        data_capture_config: Dict[str, Any],
-        tags: List[Dict[str, Any]],
+        production_variants: list[dict[str, Any]],
+        async_inference_config: dict[str, Any],
+        data_capture_config: dict[str, Any],
+        tags: list[dict[str, Any]],
         kms_key_id: str,
     ):
         self.validate_production_variants(production_variants)
@@ -647,7 +648,7 @@ class FakeEndpointConfig(BaseObject, CloudFormationModel):
         self.creation_time = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
 
     def validate_production_variants(
-        self, production_variants: List[Dict[str, Any]]
+        self, production_variants: list[dict[str, Any]]
     ) -> None:
         for production_variant in production_variants:
             if "InstanceType" in production_variant.keys():
@@ -658,7 +659,7 @@ class FakeEndpointConfig(BaseObject, CloudFormationModel):
                 message = f"Invalid Keys for ProductionVariant: received {production_variant.keys()} but expected it to contain one of {['InstanceType', 'ServerlessConfig']}"
                 raise ValidationError(message=message)
 
-    def validate_serverless_config(self, serverless_config: Dict[str, Any]) -> None:
+    def validate_serverless_config(self, serverless_config: dict[str, Any]) -> None:
         VALID_SERVERLESS_MEMORY_SIZE = [1024, 2048, 3072, 4096, 5120, 6144]
         if not validators.is_one_of(
             serverless_config["MemorySizeInMB"], VALID_SERVERLESS_MEMORY_SIZE
@@ -739,7 +740,7 @@ class FakeEndpointConfig(BaseObject, CloudFormationModel):
             message = f"Value '{instance_type}' at 'instanceType' failed to satisfy constraint: Member must satisfy enum value set: {VALID_INSTANCE_TYPES}"
             raise ValidationError(message=message)
 
-    def summary(self) -> Dict[str, Any]:
+    def summary(self) -> dict[str, Any]:
         return {
             "EndpointConfigName": self.endpoint_config_name,
             "EndpointConfigArn": self.endpoint_config_arn,
@@ -747,14 +748,14 @@ class FakeEndpointConfig(BaseObject, CloudFormationModel):
         }
 
     @property
-    def response_object(self) -> Dict[str, Any]:  # type: ignore[misc]
+    def response_object(self) -> dict[str, Any]:  # type: ignore[misc]
         response_object = self.gen_response_object()
         return {
             k: v for k, v in response_object.items() if v is not None and v != [None]
         }
 
     @property
-    def response_create(self) -> Dict[str, str]:
+    def response_create(self) -> dict[str, str]:
         return {"EndpointConfigArn": self.endpoint_config_arn}
 
     @staticmethod
@@ -862,17 +863,17 @@ class FakeTransformJob(BaseObject):
         transform_job_name: str,
         model_name: str,
         max_concurrent_transforms: int,
-        model_client_config: Dict[str, int],
+        model_client_config: dict[str, int],
         max_payload_in_mb: int,
         batch_strategy: str,
-        environment: Dict[str, str],
-        transform_input: Dict[str, Union[Dict[str, str], str]],
-        transform_output: Dict[str, str],
-        data_capture_config: Dict[str, Union[str, bool]],
-        transform_resources: Dict[str, Union[str, int]],
-        data_processing: Dict[str, str],
-        tags: Dict[str, str],
-        experiment_config: Dict[str, str],
+        environment: dict[str, str],
+        transform_input: dict[str, Union[dict[str, str], str]],
+        transform_output: dict[str, str],
+        data_capture_config: dict[str, Union[str, bool]],
+        transform_resources: dict[str, Union[str, int]],
+        data_processing: dict[str, str],
+        tags: dict[str, str],
+        experiment_config: dict[str, str],
     ):
         self.transform_job_name = transform_job_name
         self.model_name = model_name
@@ -912,7 +913,7 @@ class FakeTransformJob(BaseObject):
         return "".join(words)
 
     @property
-    def response_object(self) -> Dict[str, Any]:  # type: ignore[misc]
+    def response_object(self) -> dict[str, Any]:  # type: ignore[misc]
         response_object = self.gen_response_object()
         response = {
             k: v for k, v in response_object.items() if v is not None and v != [None]
@@ -921,7 +922,7 @@ class FakeTransformJob(BaseObject):
         return response
 
     @property
-    def response_create(self) -> Dict[str, str]:
+    def response_create(self) -> dict[str, str]:
         return {"TransformJobArn": self.arn}
 
     @staticmethod
@@ -936,10 +937,10 @@ class Model(BaseObject, CloudFormationModel):
         region_name: str,
         model_name: str,
         execution_role_arn: str,
-        primary_container: Dict[str, Any],
-        vpc_config: Dict[str, Any],
-        containers: Optional[List[Dict[str, Any]]] = None,
-        tags: Optional[List[Dict[str, str]]] = None,
+        primary_container: dict[str, Any],
+        vpc_config: dict[str, Any],
+        containers: Optional[list[dict[str, Any]]] = None,
+        tags: Optional[list[dict[str, str]]] = None,
     ):
         self.model_name = model_name
         self.creation_time = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
@@ -952,7 +953,7 @@ class Model(BaseObject, CloudFormationModel):
         self.arn = arn_formatter("model", self.model_name, account_id, region_name)
 
     @property
-    def response_object(self) -> Dict[str, Any]:  # type: ignore[misc]
+    def response_object(self) -> dict[str, Any]:  # type: ignore[misc]
         response_object = self.gen_response_object()
         response = {
             k: v for k, v in response_object.items() if v is not None and v != [None]
@@ -962,7 +963,7 @@ class Model(BaseObject, CloudFormationModel):
         return response
 
     @property
-    def response_create(self) -> Dict[str, str]:
+    def response_create(self) -> dict[str, str]:
         return {"ModelArn": self.arn}
 
     @property
@@ -1057,7 +1058,7 @@ class ModelPackageGroup(BaseObject):
         model_package_group_description: str,
         account_id: str,
         region_name: str,
-        tags: Optional[List[Dict[str, str]]] = None,
+        tags: Optional[list[dict[str, str]]] = None,
     ) -> None:
         model_package_group_arn = arn_formatter(
             region_name=region_name,
@@ -1086,7 +1087,7 @@ class ModelPackageGroup(BaseObject):
         self.model_package_group_status = "Completed"
         self.tags = tags
 
-    def gen_response_object(self) -> Dict[str, Any]:
+    def gen_response_object(self) -> dict[str, Any]:
         response_object = super().gen_response_object()
         for k, v in response_object.items():
             if isinstance(v, datetime):
@@ -1114,8 +1115,8 @@ class FakeModelCard(BaseObject):
         model_card_version: int,
         content: str,
         model_card_status: str,
-        security_config: Optional[Dict[str, str]] = None,
-        tags: Optional[List[Dict[str, Any]]] = None,
+        security_config: Optional[dict[str, str]] = None,
+        tags: Optional[list[dict[str, Any]]] = None,
         creation_time: Optional[str] = None,
         last_modified_time: Optional[str] = None,
     ) -> None:
@@ -1132,7 +1133,7 @@ class FakeModelCard(BaseObject):
         self.security_config = security_config
         self.tags = tags
 
-    def describe(self) -> Dict[str, Any]:
+    def describe(self) -> dict[str, Any]:
         return {
             "ModelCardArn": self.arn,
             "ModelCardName": self.model_card_name,
@@ -1146,7 +1147,7 @@ class FakeModelCard(BaseObject):
             "LastModifiedBy": {},
         }
 
-    def summary(self) -> Dict[str, Any]:
+    def summary(self) -> dict[str, Any]:
         return {
             "ModelCardName": self.model_card_name,
             "ModelCardArn": self.arn,
@@ -1155,7 +1156,7 @@ class FakeModelCard(BaseObject):
             "LastModifiedTime": self.last_modified_time,
         }
 
-    def version_summary(self) -> Dict[str, Any]:
+    def version_summary(self) -> dict[str, Any]:
         return {
             "ModelCardName": self.model_card_name,
             "ModelCardArn": self.arn,
@@ -1174,10 +1175,10 @@ class FeatureGroup(BaseObject):
         feature_group_name: str,
         record_identifier_feature_name: str,
         event_time_feature_name: str,
-        feature_definitions: List[Dict[str, str]],
-        offline_store_config: Dict[str, Any],
+        feature_definitions: list[dict[str, str]],
+        offline_store_config: dict[str, Any],
         role_arn: str,
-        tags: Optional[List[Dict[str, str]]] = None,
+        tags: Optional[list[dict[str, str]]] = None,
     ) -> None:
         self.feature_group_name = feature_group_name
         self.record_identifier_feature_name = record_identifier_feature_name
@@ -1208,7 +1209,7 @@ class FeatureGroup(BaseObject):
         )
         self.tags = tags
 
-    def describe(self) -> Dict[str, Any]:
+    def describe(self) -> dict[str, Any]:
         return {
             "FeatureGroupArn": self.arn,
             "FeatureGroupName": self.feature_group_name,
@@ -1243,12 +1244,12 @@ class ModelPackage(BaseObject):
         domain: str,
         task: str,
         sample_payload_url: str,
-        additional_inference_specifications: List[Any],
+        additional_inference_specifications: list[Any],
         client_token: str,
         region_name: str,
         account_id: str,
         model_package_type: str,
-        tags: Optional[List[Dict[str, str]]] = None,
+        tags: Optional[list[dict[str, str]]] = None,
     ) -> None:
         fake_user_profile_name = "fake-user-profile-name"
         fake_domain_id = "fake-domain-id"
@@ -1310,16 +1311,16 @@ class ModelPackage(BaseObject):
         self.domain = domain
         self.task = task
         self.sample_payload_url = sample_payload_url
-        self.additional_inference_specifications: Optional[List[Any]] = None
+        self.additional_inference_specifications: Optional[list[Any]] = None
         self.add_additional_inference_specifications(
             additional_inference_specifications
         )
         self.tags = tags
         self.model_package_status = "Completed"
-        self.last_modified_by: Optional[Dict[str, str]] = None
+        self.last_modified_by: Optional[dict[str, str]] = None
         self.client_token = client_token
 
-    def gen_response_object(self) -> Dict[str, Any]:
+    def gen_response_object(self) -> dict[str, Any]:
         response_object = super().gen_response_object()
         for k, v in response_object.items():
             if isinstance(v, datetime):
@@ -1376,14 +1377,14 @@ class ModelPackage(BaseObject):
         self.model_approval_status = model_approval_status
 
     def remove_customer_metadata_property(
-        self, customer_metadata_properties_to_remove: List[str]
+        self, customer_metadata_properties_to_remove: list[str]
     ) -> None:
         if customer_metadata_properties_to_remove is not None:
             for customer_metadata_property in customer_metadata_properties_to_remove:
                 self.customer_metadata_properties.pop(customer_metadata_property, None)
 
     def add_additional_inference_specifications(
-        self, additional_inference_specifications_to_add: Optional[List[Any]]
+        self, additional_inference_specifications_to_add: Optional[list[Any]]
     ) -> None:
         self.validate_additional_inference_specifications(
             additional_inference_specifications_to_add
@@ -1401,7 +1402,7 @@ class ModelPackage(BaseObject):
             )
 
     def validate_additional_inference_specifications(
-        self, additional_inference_specifications: Optional[List[Dict[str, Any]]]
+        self, additional_inference_specifications: Optional[list[dict[str, Any]]]
     ) -> None:
         specifications_to_validate = additional_inference_specifications or []
         for additional_inference_specification in specifications_to_validate:
@@ -1422,7 +1423,7 @@ class ModelPackage(BaseObject):
                 )
 
     @staticmethod
-    def validate_supported_transform_instance_types(instance_types: List[str]) -> None:
+    def validate_supported_transform_instance_types(instance_types: list[str]) -> None:
         VALID_TRANSFORM_INSTANCE_TYPES = [
             "ml.m4.xlarge",
             "ml.m4.2xlarge",
@@ -1464,7 +1465,7 @@ class ModelPackage(BaseObject):
 
     @staticmethod
     def validate_supported_realtime_inference_instance_types(
-        instance_types: List[str],
+        instance_types: list[str],
     ) -> None:
         VALID_REALTIME_INFERENCE_INSTANCE_TYPES = [
             "ml.t2.medium",
@@ -1630,9 +1631,9 @@ class Cluster(BaseObject):
         cluster_name: str,
         region_name: str,
         account_id: str,
-        instance_groups: List[Dict[str, Any]],
-        vpc_config: Dict[str, List[str]],
-        tags: Optional[List[Dict[str, str]]] = None,
+        instance_groups: list[dict[str, Any]],
+        vpc_config: dict[str, list[str]],
+        tags: Optional[list[dict[str, str]]] = None,
     ):
         self.region_name = region_name
         self.account_id = account_id
@@ -1656,13 +1657,13 @@ class Cluster(BaseObject):
         self.status = "InService"
         self.creation_time = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
         self.failure_message = ""
-        self.nodes: Dict[str, ClusterNode] = {}
+        self.nodes: dict[str, ClusterNode] = {}
         for instance_group in self.instance_groups:
             instance_group["CurrentCount"] = instance_group["InstanceCount"]
             instance_group["TargetCount"] = instance_group["InstanceCount"]
             del instance_group["InstanceCount"]
 
-    def describe(self) -> Dict[str, Any]:
+    def describe(self) -> dict[str, Any]:
         return {
             "ClusterArn": self.arn,
             "ClusterName": self.cluster_name,
@@ -1673,7 +1674,7 @@ class Cluster(BaseObject):
             "VpcConfig": self.vpc_config,
         }
 
-    def summary(self) -> Dict[str, Any]:
+    def summary(self) -> dict[str, Any]:
         return {
             "ClusterArn": self.arn,
             "ClusterName": self.cluster_name,
@@ -1736,7 +1737,7 @@ class ClusterNode(BaseObject):
         cluster_name: str,
         instance_group_name: str,
         instance_type: str,
-        life_cycle_config: Dict[str, Any],
+        life_cycle_config: dict[str, Any],
         execution_role: str,
         node_id: str,
         threads_per_core: Optional[int] = None,
@@ -1755,7 +1756,7 @@ class ClusterNode(BaseObject):
         self.status = "Running"
         self.launch_time = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
 
-    def describe(self) -> Dict[str, Any]:
+    def describe(self) -> dict[str, Any]:
         return {
             "InstanceGroupName": self.instance_group_name,
             "InstanceId": self.instance_id,
@@ -1766,7 +1767,7 @@ class ClusterNode(BaseObject):
             "ThreadsPerCore": self.threads_per_core,
         }
 
-    def summary(self) -> Dict[str, Any]:
+    def summary(self) -> dict[str, Any]:
         return {
             "InstanceGroupName": self.instance_group_name,
             "InstanceId": self.instance_id,
@@ -1783,12 +1784,12 @@ class CompilationJob(BaseObject):
         role_arn: str,
         region_name: str,
         account_id: str,
-        output_config: Dict[str, Any],
-        stopping_condition: Dict[str, Any],
+        output_config: dict[str, Any],
+        stopping_condition: dict[str, Any],
         model_package_version_arn: Optional[str],
-        input_config: Optional[Dict[str, Any]],
-        vpc_config: Optional[Dict[str, Any]],
-        tags: Optional[List[Dict[str, str]]],
+        input_config: Optional[dict[str, Any]],
+        vpc_config: Optional[dict[str, Any]],
+        tags: Optional[list[dict[str, str]]],
     ):
         self.compilation_job_name = compilation_job_name
         if (
@@ -1829,7 +1830,7 @@ class CompilationJob(BaseObject):
         self.derived_information = {"DerivedDataInputConfig": "DerivedDataInputConfig"}
         self.tags = tags
 
-    def describe(self) -> Dict[str, Any]:
+    def describe(self) -> dict[str, Any]:
         return {
             "CompilationJobName": self.compilation_job_name,
             "CompilationJobArn": self.arn,
@@ -1851,7 +1852,7 @@ class CompilationJob(BaseObject):
             "DerivedInformation": self.derived_information,
         }
 
-    def summary(self) -> Dict[str, Any]:
+    def summary(self) -> dict[str, Any]:
         summary = {
             "CompilationJobName": self.compilation_job_name,
             "CompilationJobArn": self.arn,
@@ -1880,17 +1881,17 @@ class AutoMLJob(BaseObject):
     def __init__(
         self,
         auto_ml_job_name: str,
-        auto_ml_job_input_data_config: List[Dict[str, Any]],
-        output_data_config: Dict[str, Any],
-        auto_ml_problem_type_config: Dict[str, Any],
+        auto_ml_job_input_data_config: list[dict[str, Any]],
+        output_data_config: dict[str, Any],
+        auto_ml_problem_type_config: dict[str, Any],
         role_arn: str,
         region_name: str,
         account_id: str,
-        security_config: Optional[Dict[str, Any]],
-        auto_ml_job_objective: Optional[Dict[str, Any]],
-        model_deploy_config: Optional[Dict[str, Any]],
-        data_split_config: Optional[Dict[str, Any]],
-        tags: Optional[List[Dict[str, str]]] = None,
+        security_config: Optional[dict[str, Any]],
+        auto_ml_job_objective: Optional[dict[str, Any]],
+        model_deploy_config: Optional[dict[str, Any]],
+        data_split_config: Optional[dict[str, Any]],
+        tags: Optional[list[dict[str, str]]] = None,
     ):
         self.region_name = region_name
         self.account_id = account_id
@@ -2086,7 +2087,7 @@ class AutoMLJob(BaseObject):
             ),
         }
 
-    def describe(self) -> Dict[str, Any]:
+    def describe(self) -> dict[str, Any]:
         return {
             "AutoMLJobName": self.auto_ml_job_name,
             "AutoMLJobArn": self.arn,
@@ -2112,7 +2113,7 @@ class AutoMLJob(BaseObject):
             "SecurityConfig": self.security_config,
         }
 
-    def summary(self) -> Dict[str, Any]:
+    def summary(self) -> dict[str, Any]:
         return {
             "AutoMLJobName": self.auto_ml_job_name,
             "AutoMLJobArn": self.arn,
@@ -2131,18 +2132,18 @@ class Domain(BaseObject):
         self,
         domain_name: str,
         auth_mode: str,
-        default_user_settings: Dict[str, Any],
-        subnet_ids: List[str],
+        default_user_settings: dict[str, Any],
+        subnet_ids: list[str],
         vpc_id: str,
         account_id: str,
         region_name: str,
-        domain_settings: Optional[Dict[str, Any]],
-        tags: Optional[List[Dict[str, str]]],
+        domain_settings: Optional[dict[str, Any]],
+        tags: Optional[list[dict[str, str]]],
         app_network_access_type: Optional[str],
         home_efs_file_system_kms_key_id: Optional[str],
         kms_key_id: Optional[str],
         app_security_group_management: Optional[str],
-        default_space_settings: Optional[Dict[str, Any]],
+        default_space_settings: Optional[dict[str, Any]],
     ):
         self.domain_name = domain_name
         if domain_name in sagemaker_backends[account_id][region_name].domains:
@@ -2183,7 +2184,7 @@ class Domain(BaseObject):
         self.security_group_id_for_domain_boundary = f"sg-{domain_name}"
         self.url = f"{domain_name}.{region_name}.sagemaker.test.com"
 
-    def describe(self) -> Dict[str, Any]:
+    def describe(self) -> dict[str, Any]:
         return {
             "DomainArn": self.arn,
             "DomainId": self.id,
@@ -2209,7 +2210,7 @@ class Domain(BaseObject):
             "DefaultSpaceSettings": self.default_space_settings,
         }
 
-    def summary(self) -> Dict[str, Any]:
+    def summary(self) -> dict[str, Any]:
         return {
             "DomainArn": self.arn,
             "DomainId": self.id,
@@ -2225,17 +2226,17 @@ class ModelExplainabilityJobDefinition(BaseObject):
     def __init__(
         self,
         job_definition_name: str,
-        model_explainability_baseline_config: Optional[Dict[str, Any]],
-        model_explainability_app_specification: Dict[str, Any],
-        model_explainability_job_input: Dict[str, Any],
-        model_explainability_job_output_config: Dict[str, Any],
-        job_resources: Dict[str, Any],
-        network_config: Optional[Dict[str, Any]],
+        model_explainability_baseline_config: Optional[dict[str, Any]],
+        model_explainability_app_specification: dict[str, Any],
+        model_explainability_job_input: dict[str, Any],
+        model_explainability_job_output_config: dict[str, Any],
+        job_resources: dict[str, Any],
+        network_config: Optional[dict[str, Any]],
         role_arn: str,
-        stopping_condition: Optional[Dict[str, Any]],
+        stopping_condition: Optional[dict[str, Any]],
         region_name: str,
         account_id: str,
-        tags: Optional[List[Dict[str, str]]],
+        tags: Optional[list[dict[str, str]]],
     ):
         self.job_definition_name = job_definition_name
         if (
@@ -2274,7 +2275,7 @@ class ModelExplainabilityJobDefinition(BaseObject):
             "EndpointName"
         ]
 
-    def describe(self) -> Dict[str, Any]:
+    def describe(self) -> dict[str, Any]:
         return {
             "JobDefinitionArn": self.arn,
             "JobDefinitionName": self.job_definition_name,
@@ -2289,7 +2290,7 @@ class ModelExplainabilityJobDefinition(BaseObject):
             "StoppingConditions": self.stopping_condition,
         }
 
-    def summary(self) -> Dict[str, Any]:
+    def summary(self) -> dict[str, Any]:
         return {
             "MonitoringJobDefinitionName": self.job_definition_name,
             "MonitoringJobDefinitionArn": self.arn,
@@ -2302,14 +2303,14 @@ class HyperParameterTuningJob(BaseObject):
     def __init__(
         self,
         hyper_parameter_tuning_job_name: str,
-        hyper_parameter_tuning_job_config: Dict[str, Any],
+        hyper_parameter_tuning_job_config: dict[str, Any],
         region_name: str,
         account_id: str,
-        training_job_definition: Optional[Dict[str, Any]],
-        training_job_definitions: Optional[List[Dict[str, Any]]],
-        warm_start_config: Optional[Dict[str, Any]],
-        tags: Optional[List[Dict[str, str]]],
-        autotune: Optional[Dict[str, Any]],
+        training_job_definition: Optional[dict[str, Any]],
+        training_job_definitions: Optional[list[dict[str, Any]]],
+        warm_start_config: Optional[dict[str, Any]],
+        tags: Optional[list[dict[str, str]]],
+        autotune: Optional[dict[str, Any]],
     ):
         self.hyper_parameter_tuning_job_name = hyper_parameter_tuning_job_name
         if (
@@ -2394,7 +2395,7 @@ class HyperParameterTuningJob(BaseObject):
         self.tags = tags
         self.autotune = autotune
 
-    def describe(self) -> Dict[str, Any]:
+    def describe(self) -> dict[str, Any]:
         return {
             "HyperParameterTuningJobName": self.hyper_parameter_tuning_job_name,
             "HyperParameterTuningJobArn": self.arn,
@@ -2416,7 +2417,7 @@ class HyperParameterTuningJob(BaseObject):
             "ConsumedResources": self.consumed_resources,
         }
 
-    def summary(self) -> Dict[str, Any]:
+    def summary(self) -> dict[str, Any]:
         return {
             "HyperParameterTuningJobName": self.hyper_parameter_tuning_job_name,
             "HyperParameterTuningJobArn": self.arn,
@@ -2435,15 +2436,15 @@ class ModelQualityJobDefinition(BaseObject):
     def __init__(
         self,
         job_definition_name: str,
-        model_quality_baseline_config: Optional[Dict[str, Any]],
-        model_quality_app_specification: Dict[str, Any],
-        model_quality_job_input: Dict[str, Any],
-        model_quality_job_output_config: Dict[str, Any],
-        job_resources: Dict[str, Any],
-        network_config: Optional[Dict[str, Any]],
+        model_quality_baseline_config: Optional[dict[str, Any]],
+        model_quality_app_specification: dict[str, Any],
+        model_quality_job_input: dict[str, Any],
+        model_quality_job_output_config: dict[str, Any],
+        job_resources: dict[str, Any],
+        network_config: Optional[dict[str, Any]],
         role_arn: str,
-        stopping_condition: Optional[Dict[str, Any]],
-        tags: Optional[List[Dict[str, str]]],
+        stopping_condition: Optional[dict[str, Any]],
+        tags: Optional[list[dict[str, str]]],
         region_name: str,
         account_id: str,
     ):
@@ -2477,7 +2478,7 @@ class ModelQualityJobDefinition(BaseObject):
             "EndpointName"
         ]
 
-    def describe(self) -> Dict[str, Any]:
+    def describe(self) -> dict[str, Any]:
         return {
             "JobDefinitionArn": self.arn,
             "JobDefinitionName": self.job_definition_name,
@@ -2492,7 +2493,7 @@ class ModelQualityJobDefinition(BaseObject):
             "StoppingCondition": self.stopping_condition,
         }
 
-    def summary(self) -> Dict[str, Any]:
+    def summary(self) -> dict[str, Any]:
         return {
             "MonitoringJobDefinitionName": self.job_definition_name,
             "MonitoringJobDefinitionArn": self.arn,
@@ -2502,12 +2503,12 @@ class ModelQualityJobDefinition(BaseObject):
 
 
 class VpcConfig(BaseObject):
-    def __init__(self, security_group_ids: List[str], subnets: List[str]):
+    def __init__(self, security_group_ids: list[str], subnets: list[str]):
         self.security_group_ids = security_group_ids
         self.subnets = subnets
 
     @property
-    def response_object(self) -> Dict[str, List[str]]:
+    def response_object(self) -> dict[str, list[str]]:
         response_object = self.gen_response_object()
         return {
             k: v for k, v in response_object.items() if v is not None and v != [None]
@@ -2523,7 +2524,7 @@ class Container(BaseObject):
         self.environment = kwargs.get("environment", {})
 
     @property
-    def response_object(self) -> Dict[str, Any]:  # type: ignore[misc]
+    def response_object(self) -> dict[str, Any]:  # type: ignore[misc]
         response_object = self.gen_response_object()
         return {
             k: v for k, v in response_object.items() if v is not None and v != [None]
@@ -2539,15 +2540,15 @@ class FakeSagemakerNotebookInstance(CloudFormationModel):
         instance_type: str,
         role_arn: str,
         subnet_id: Optional[str],
-        security_group_ids: Optional[List[str]],
+        security_group_ids: Optional[list[str]],
         kms_key_id: Optional[str],
-        tags: Optional[List[Dict[str, str]]],
+        tags: Optional[list[dict[str, str]]],
         lifecycle_config_name: Optional[str],
         direct_internet_access: str,
         volume_size_in_gb: int,
-        accelerator_types: Optional[List[str]],
+        accelerator_types: Optional[list[str]],
         default_code_repository: Optional[str],
-        additional_code_repositories: Optional[List[str]],
+        additional_code_repositories: Optional[list[str]],
         root_access: Optional[str],
     ):
         self.validate_volume_size_in_gb(volume_size_in_gb)
@@ -2725,7 +2726,7 @@ class FakeSagemakerNotebookInstance(CloudFormationModel):
         backend.stop_notebook_instance(notebook_instance_name)
         backend.delete_notebook_instance(notebook_instance_name)
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         return {
             "NotebookInstanceArn": self.arn,
             "NotebookInstanceName": self.notebook_instance_name,
@@ -2755,8 +2756,8 @@ class FakeSageMakerNotebookInstanceLifecycleConfig(BaseObject, CloudFormationMod
         account_id: str,
         region_name: str,
         notebook_instance_lifecycle_config_name: str,
-        on_create: List[Dict[str, str]],
-        on_start: List[Dict[str, str]],
+        on_create: list[dict[str, str]],
+        on_start: list[dict[str, str]],
     ):
         self.region_name = region_name
         self.notebook_instance_lifecycle_config_name = (
@@ -2778,7 +2779,7 @@ class FakeSageMakerNotebookInstanceLifecycleConfig(BaseObject, CloudFormationMod
         )
 
     @property
-    def response_object(self) -> Dict[str, Any]:  # type: ignore[misc]
+    def response_object(self) -> dict[str, Any]:  # type: ignore[misc]
         response_object = self.gen_response_object()
         response = {
             k: v for k, v in response_object.items() if v is not None and v != [None]
@@ -2876,42 +2877,42 @@ class FakeSageMakerNotebookInstanceLifecycleConfig(BaseObject, CloudFormationMod
 class SageMakerModelBackend(BaseBackend):
     def __init__(self, region_name: str, account_id: str):
         super().__init__(region_name, account_id)
-        self._models: Dict[str, Model] = {}
-        self.notebook_instances: Dict[str, FakeSagemakerNotebookInstance] = {}
-        self.endpoint_configs: Dict[str, FakeEndpointConfig] = {}
-        self.endpoints: Dict[str, FakeEndpoint] = {}
-        self.experiments: Dict[str, FakeExperiment] = {}
-        self.pipelines: Dict[str, FakePipeline] = {}
-        self.pipeline_executions: Dict[str, FakePipelineExecution] = {}
-        self.processing_jobs: Dict[str, FakeProcessingJob] = {}
-        self.trials: Dict[str, FakeTrial] = {}
-        self.trial_components: Dict[str, FakeTrialComponent] = {}
-        self.training_jobs: Dict[str, FakeTrainingJob] = {}
-        self.transform_jobs: Dict[str, FakeTransformJob] = {}
-        self.notebook_instance_lifecycle_configurations: Dict[
+        self._models: dict[str, Model] = {}
+        self.notebook_instances: dict[str, FakeSagemakerNotebookInstance] = {}
+        self.endpoint_configs: dict[str, FakeEndpointConfig] = {}
+        self.endpoints: dict[str, FakeEndpoint] = {}
+        self.experiments: dict[str, FakeExperiment] = {}
+        self.pipelines: dict[str, FakePipeline] = {}
+        self.pipeline_executions: dict[str, FakePipelineExecution] = {}
+        self.processing_jobs: dict[str, FakeProcessingJob] = {}
+        self.trials: dict[str, FakeTrial] = {}
+        self.trial_components: dict[str, FakeTrialComponent] = {}
+        self.training_jobs: dict[str, FakeTrainingJob] = {}
+        self.transform_jobs: dict[str, FakeTransformJob] = {}
+        self.notebook_instance_lifecycle_configurations: dict[
             str, FakeSageMakerNotebookInstanceLifecycleConfig
         ] = {}
-        self.model_cards: DefaultDict[str, List[FakeModelCard]] = defaultdict(list)
-        self.model_package_groups: Dict[str, ModelPackageGroup] = {}
-        self.model_packages: Dict[str, ModelPackage] = {}
-        self.model_package_name_mapping: Dict[str, str] = {}
-        self.feature_groups: Dict[str, FeatureGroup] = {}
-        self.clusters: Dict[str, Cluster] = {}
-        self.data_quality_job_definitions: Dict[str, FakeDataQualityJobDefinition] = {}
-        self.model_bias_job_definitions: Dict[str, FakeModelBiasJobDefinition] = {}
-        self.auto_ml_jobs: Dict[str, AutoMLJob] = {}
-        self.compilation_jobs: Dict[str, CompilationJob] = {}
-        self.domains: Dict[str, Domain] = {}
-        self.model_explainability_job_definitions: Dict[
+        self.model_cards: defaultdict[str, list[FakeModelCard]] = defaultdict(list)
+        self.model_package_groups: dict[str, ModelPackageGroup] = {}
+        self.model_packages: dict[str, ModelPackage] = {}
+        self.model_package_name_mapping: dict[str, str] = {}
+        self.feature_groups: dict[str, FeatureGroup] = {}
+        self.clusters: dict[str, Cluster] = {}
+        self.data_quality_job_definitions: dict[str, FakeDataQualityJobDefinition] = {}
+        self.model_bias_job_definitions: dict[str, FakeModelBiasJobDefinition] = {}
+        self.auto_ml_jobs: dict[str, AutoMLJob] = {}
+        self.compilation_jobs: dict[str, CompilationJob] = {}
+        self.domains: dict[str, Domain] = {}
+        self.model_explainability_job_definitions: dict[
             str, ModelExplainabilityJobDefinition
         ] = {}
-        self.hyper_parameter_tuning_jobs: Dict[str, HyperParameterTuningJob] = {}
-        self.model_quality_job_definitions: Dict[str, ModelQualityJobDefinition] = {}
+        self.hyper_parameter_tuning_jobs: dict[str, HyperParameterTuningJob] = {}
+        self.model_quality_job_definitions: dict[str, ModelQualityJobDefinition] = {}
 
     @staticmethod
     def default_vpc_endpoint_service(
-        service_region: str, zones: List[str]
-    ) -> List[Dict[str, str]]:
+        service_region: str, zones: list[str]
+    ) -> list[dict[str, str]]:
         """Default VPC endpoint services."""
         api_service = BaseBackend.default_vpc_endpoint_service_factory(
             service_region, zones, "api.sagemaker", special_service_name="sagemaker.api"
@@ -2966,10 +2967,10 @@ class SageMakerModelBackend(BaseBackend):
         self,
         model_name: str,
         execution_role_arn: str,
-        primary_container: Optional[Dict[str, Any]],
-        vpc_config: Optional[Dict[str, Any]],
-        containers: Optional[List[Dict[str, Any]]],
-        tags: Optional[List[Dict[str, str]]],
+        primary_container: Optional[dict[str, Any]],
+        vpc_config: Optional[dict[str, Any]],
+        containers: Optional[list[dict[str, Any]]],
+        tags: Optional[list[dict[str, str]]],
     ) -> Model:
         model_obj = Model(
             account_id=self.account_id,
@@ -3003,7 +3004,7 @@ class SageMakerModelBackend(BaseBackend):
         else:
             raise MissingModel(model=model_name)
 
-    def create_experiment(self, experiment_name: str) -> Dict[str, str]:
+    def create_experiment(self, experiment_name: str) -> dict[str, str]:
         experiment = FakeExperiment(
             account_id=self.account_id,
             region_name=self.region_name,
@@ -3013,7 +3014,7 @@ class SageMakerModelBackend(BaseBackend):
         self.experiments[experiment_name] = experiment
         return experiment.response_create
 
-    def describe_experiment(self, experiment_name: str) -> Dict[str, Any]:
+    def describe_experiment(self, experiment_name: str) -> dict[str, Any]:
         experiment_data = self.experiments[experiment_name]
         return {
             "ExperimentName": experiment_data.experiment_name,
@@ -3057,22 +3058,22 @@ class SageMakerModelBackend(BaseBackend):
             return resource[0]
         return resource
 
-    def add_tags(self, arn: str, tags: List[Dict[str, str]]) -> List[Dict[str, str]]:
+    def add_tags(self, arn: str, tags: list[dict[str, str]]) -> list[dict[str, str]]:
         resource = self._get_resource_from_arn(arn)
         resource.tags.extend(tags)
         return resource.tags
 
     @paginate(pagination_model=PAGINATION_MODEL)
-    def list_tags(self, arn: str) -> List[Dict[str, str]]:
+    def list_tags(self, arn: str) -> list[dict[str, str]]:
         resource = self._get_resource_from_arn(arn)
         return resource.tags
 
-    def delete_tags(self, arn: str, tag_keys: List[str]) -> None:
+    def delete_tags(self, arn: str, tag_keys: list[str]) -> None:
         resource = self._get_resource_from_arn(arn)
         resource.tags = [tag for tag in resource.tags if tag["Key"] not in tag_keys]
 
     @paginate(pagination_model=PAGINATION_MODEL)
-    def list_experiments(self) -> List["FakeExperiment"]:
+    def list_experiments(self) -> list["FakeExperiment"]:
         return list(self.experiments.values())
 
     def search(self, resource: Any = None, search_expression: Any = None) -> Any:
@@ -3153,7 +3154,7 @@ class SageMakerModelBackend(BaseBackend):
 
             return True
 
-        result: Dict[str, Any] = {
+        result: dict[str, Any] = {
             "Results": [],
             "NextToken": str(next_index) if next_index is not None else None,
         }
@@ -3182,7 +3183,7 @@ class SageMakerModelBackend(BaseBackend):
                 message=f"Could not find experiment configuration '{arn}'."
             )
 
-    def create_trial(self, trial_name: str, experiment_name: str) -> Dict[str, str]:
+    def create_trial(self, trial_name: str, experiment_name: str) -> dict[str, str]:
         trial = FakeTrial(
             account_id=self.account_id,
             region_name=self.region_name,
@@ -3194,7 +3195,7 @@ class SageMakerModelBackend(BaseBackend):
         self.trials[trial_name] = trial
         return trial.response_create
 
-    def describe_trial(self, trial_name: str) -> Dict[str, Any]:
+    def describe_trial(self, trial_name: str) -> dict[str, Any]:
         try:
             return self.trials[trial_name].response_object
         except KeyError:
@@ -3215,7 +3216,7 @@ class SageMakerModelBackend(BaseBackend):
         self,
         experiment_name: Optional[str] = None,
         trial_component_name: Optional[str] = None,
-    ) -> List["FakeTrial"]:
+    ) -> list["FakeTrial"]:
         trials_fetched = list(self.trials.values())
 
         def evaluate_filter_expression(trial_data: FakeTrial) -> bool:
@@ -3239,15 +3240,15 @@ class SageMakerModelBackend(BaseBackend):
         self,
         trial_component_name: str,
         trial_name: str,
-        status: Dict[str, str],
+        status: dict[str, str],
         start_time: Optional[datetime],
         end_time: Optional[datetime],
         display_name: Optional[str],
-        parameters: Optional[Dict[str, Dict[str, Union[str, float]]]],
-        input_artifacts: Optional[Dict[str, Dict[str, str]]],
-        output_artifacts: Optional[Dict[str, Dict[str, str]]],
-        metadata_properties: Optional[Dict[str, str]],
-    ) -> Dict[str, Any]:
+        parameters: Optional[dict[str, dict[str, Union[str, float]]]],
+        input_artifacts: Optional[dict[str, dict[str, str]]],
+        output_artifacts: Optional[dict[str, dict[str, str]]],
+        metadata_properties: Optional[dict[str, str]],
+    ) -> dict[str, Any]:
         trial_component = FakeTrialComponent(
             account_id=self.account_id,
             region_name=self.region_name,
@@ -3277,7 +3278,7 @@ class SageMakerModelBackend(BaseBackend):
                 message=f"Could not find trial-component configuration '{arn}'."
             )
 
-    def describe_trial_component(self, trial_component_name: str) -> Dict[str, Any]:
+    def describe_trial_component(self, trial_component_name: str) -> dict[str, Any]:
         try:
             return self.trial_components[trial_component_name].response_object
         except KeyError:
@@ -3294,7 +3295,7 @@ class SageMakerModelBackend(BaseBackend):
     @paginate(pagination_model=PAGINATION_MODEL)
     def list_trial_components(
         self, trial_name: Optional[str] = None
-    ) -> List["FakeTrialComponent"]:
+    ) -> list["FakeTrialComponent"]:
         trial_components_fetched = list(self.trial_components.values())
 
         return [
@@ -3305,7 +3306,7 @@ class SageMakerModelBackend(BaseBackend):
 
     def associate_trial_component(
         self, trial_name: str, trial_component_name: str
-    ) -> Dict[str, str]:
+    ) -> dict[str, str]:
         if trial_name in self.trials.keys():
             self.trials[trial_name].trial_components.extend([trial_component_name])
         else:
@@ -3323,7 +3324,7 @@ class SageMakerModelBackend(BaseBackend):
 
     def disassociate_trial_component(
         self, trial_name: str, trial_component_name: str
-    ) -> Dict[str, str]:
+    ) -> dict[str, str]:
         if trial_component_name in self.trial_components.keys():
             self.trial_components[trial_component_name].trial_name = None
 
@@ -3343,17 +3344,17 @@ class SageMakerModelBackend(BaseBackend):
     def update_trial_component(
         self,
         trial_component_name: str,
-        status: Optional[Dict[str, str]],
+        status: Optional[dict[str, str]],
         display_name: Optional[str],
         start_time: Optional[datetime],
         end_time: Optional[datetime],
-        parameters: Optional[Dict[str, Dict[str, Union[str, float]]]],
-        parameters_to_remove: Optional[List[str]],
-        input_artifacts: Optional[Dict[str, Dict[str, str]]],
-        input_artifacts_to_remove: Optional[List[str]],
-        output_artifacts: Optional[Dict[str, Dict[str, str]]],
-        output_artifacts_to_remove: Optional[List[str]],
-    ) -> Dict[str, str]:
+        parameters: Optional[dict[str, dict[str, Union[str, float]]]],
+        parameters_to_remove: Optional[list[str]],
+        input_artifacts: Optional[dict[str, dict[str, str]]],
+        input_artifacts_to_remove: Optional[list[str]],
+        output_artifacts: Optional[dict[str, dict[str, str]]],
+        output_artifacts_to_remove: Optional[list[str]],
+    ) -> dict[str, str]:
         try:
             trial_component = self.trial_components[trial_component_name]
         except KeyError:
@@ -3402,15 +3403,15 @@ class SageMakerModelBackend(BaseBackend):
         instance_type: str,
         role_arn: str,
         subnet_id: Optional[str] = None,
-        security_group_ids: Optional[List[str]] = None,
+        security_group_ids: Optional[list[str]] = None,
         kms_key_id: Optional[str] = None,
-        tags: Optional[List[Dict[str, str]]] = None,
+        tags: Optional[list[dict[str, str]]] = None,
         lifecycle_config_name: Optional[str] = None,
         direct_internet_access: str = "Enabled",
         volume_size_in_gb: int = 5,
-        accelerator_types: Optional[List[str]] = None,
+        accelerator_types: Optional[list[str]] = None,
         default_code_repository: Optional[str] = None,
-        additional_code_repositories: Optional[List[str]] = None,
+        additional_code_repositories: Optional[list[str]] = None,
         root_access: Optional[str] = None,
     ) -> FakeSagemakerNotebookInstance:
         self._validate_unique_notebook_instance_name(notebook_instance_name)
@@ -3478,7 +3479,7 @@ class SageMakerModelBackend(BaseBackend):
         sort_order: str,
         name_contains: Optional[str],
         status: Optional[str],
-    ) -> List[FakeSagemakerNotebookInstance]:
+    ) -> list[FakeSagemakerNotebookInstance]:
         """
         The following parameters are not yet implemented:
         CreationTimeBefore, CreationTimeAfter, LastModifiedTimeBefore, LastModifiedTimeAfter, NotebookInstanceLifecycleConfigNameContains, DefaultCodeRepositoryContains, AdditionalCodeRepositoryEquals
@@ -3506,8 +3507,8 @@ class SageMakerModelBackend(BaseBackend):
     def create_notebook_instance_lifecycle_config(
         self,
         notebook_instance_lifecycle_config_name: str,
-        on_create: List[Dict[str, str]],
-        on_start: List[Dict[str, str]],
+        on_create: list[dict[str, str]],
+        on_start: list[dict[str, str]],
     ) -> FakeSageMakerNotebookInstanceLifecycleConfig:
         if (
             notebook_instance_lifecycle_config_name
@@ -3534,7 +3535,7 @@ class SageMakerModelBackend(BaseBackend):
 
     def describe_notebook_instance_lifecycle_config(
         self, notebook_instance_lifecycle_config_name: str
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         try:
             return self.notebook_instance_lifecycle_configurations[
                 notebook_instance_lifecycle_config_name
@@ -3567,10 +3568,10 @@ class SageMakerModelBackend(BaseBackend):
     def create_endpoint_config(
         self,
         endpoint_config_name: str,
-        production_variants: List[Dict[str, Any]],
-        data_capture_config: Dict[str, Any],
-        async_inference_config: Dict[str, Any],
-        tags: List[Dict[str, str]],
+        production_variants: list[dict[str, Any]],
+        data_capture_config: dict[str, Any],
+        async_inference_config: dict[str, Any],
+        tags: list[dict[str, str]],
         kms_key_id: str,
     ) -> FakeEndpointConfig:
         endpoint_config = FakeEndpointConfig(
@@ -3589,7 +3590,7 @@ class SageMakerModelBackend(BaseBackend):
         return endpoint_config
 
     def validate_production_variants(
-        self, production_variants: List[Dict[str, Any]]
+        self, production_variants: list[dict[str, Any]]
     ) -> None:
         for production_variant in production_variants:
             if production_variant["ModelName"] not in self._models:
@@ -3601,7 +3602,7 @@ class SageMakerModelBackend(BaseBackend):
                 )
                 raise ValidationError(message=f"Could not find model '{arn}'.")
 
-    def describe_endpoint_config(self, endpoint_config_name: str) -> Dict[str, Any]:
+    def describe_endpoint_config(self, endpoint_config_name: str) -> dict[str, Any]:
         try:
             return self.endpoint_configs[endpoint_config_name].response_object
         except KeyError:
@@ -3624,7 +3625,7 @@ class SageMakerModelBackend(BaseBackend):
             )
 
     def create_endpoint(
-        self, endpoint_name: str, endpoint_config_name: str, tags: List[Dict[str, str]]
+        self, endpoint_name: str, endpoint_config_name: str, tags: list[dict[str, str]]
     ) -> FakeEndpoint:
         try:
             endpoint_config = self.describe_endpoint_config(endpoint_config_name)
@@ -3647,7 +3648,7 @@ class SageMakerModelBackend(BaseBackend):
         self.endpoints[endpoint_name] = endpoint
         return endpoint
 
-    def describe_endpoint(self, endpoint_name: str) -> Dict[str, Any]:
+    def describe_endpoint(self, endpoint_name: str) -> dict[str, Any]:
         try:
             return self.endpoints[endpoint_name].response_object
         except KeyError:
@@ -3667,15 +3668,15 @@ class SageMakerModelBackend(BaseBackend):
 
     def create_processing_job(
         self,
-        app_specification: Dict[str, Any],
-        experiment_config: Dict[str, str],
-        network_config: Dict[str, Any],
-        processing_inputs: List[Dict[str, Any]],
+        app_specification: dict[str, Any],
+        experiment_config: dict[str, str],
+        network_config: dict[str, Any],
+        processing_inputs: list[dict[str, Any]],
         processing_job_name: str,
-        processing_output_config: Dict[str, Any],
+        processing_output_config: dict[str, Any],
         role_arn: str,
-        tags: List[Dict[str, str]],
-        stopping_condition: Dict[str, int],
+        tags: list[dict[str, str]],
+        stopping_condition: dict[str, int],
     ) -> FakeProcessingJob:
         processing_job = FakeProcessingJob(
             app_specification=app_specification,
@@ -3693,7 +3694,7 @@ class SageMakerModelBackend(BaseBackend):
         self.processing_jobs[processing_job_name] = processing_job
         return processing_job
 
-    def describe_processing_job(self, processing_job_name: str) -> Dict[str, Any]:
+    def describe_processing_job(self, processing_job_name: str) -> dict[str, Any]:
         try:
             return self.processing_jobs[processing_job_name].response_object
         except KeyError:
@@ -3707,11 +3708,11 @@ class SageMakerModelBackend(BaseBackend):
         pipeline_name: str,
         pipeline_display_name: str,
         pipeline_definition: str,
-        pipeline_definition_s3_location: Dict[str, Any],
+        pipeline_definition_s3_location: dict[str, Any],
         pipeline_description: str,
         role_arn: str,
-        tags: List[Dict[str, str]],
-        parallelism_configuration: Dict[str, int],
+        tags: list[dict[str, str]],
+        parallelism_configuration: dict[str, int],
     ) -> FakePipeline:
         if not any([pipeline_definition, pipeline_definition_s3_location]):
             raise ValidationError(
@@ -3789,11 +3790,11 @@ class SageMakerModelBackend(BaseBackend):
         self,
         pipeline_name: str,
         pipeline_execution_display_name: str,
-        pipeline_parameters: List[Dict[str, Any]],
+        pipeline_parameters: list[dict[str, Any]],
         pipeline_execution_description: str,
-        parallelism_configuration: Dict[str, int],
+        parallelism_configuration: dict[str, int],
         client_request_token: str,
-    ) -> Dict[str, str]:
+    ) -> dict[str, str]:
         pipeline = get_pipeline_from_name(self.pipelines, pipeline_name)
         execution_id = "".join(
             random.choices(string.ascii_lowercase + string.digits, k=12)
@@ -3825,7 +3826,7 @@ class SageMakerModelBackend(BaseBackend):
 
         return {"PipelineExecutionArn": pipeline_execution_arn}
 
-    def list_pipeline_executions(self, pipeline_name: str) -> Dict[str, Any]:
+    def list_pipeline_executions(self, pipeline_name: str) -> dict[str, Any]:
         pipeline = get_pipeline_from_name(self.pipelines, pipeline_name)
         return {
             "PipelineExecutionSummaries": [
@@ -3845,7 +3846,7 @@ class SageMakerModelBackend(BaseBackend):
 
     def describe_pipeline_definition_for_execution(
         self, pipeline_execution_arn: str
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         pipeline_execution = get_pipeline_execution_from_arn(
             self.pipelines, pipeline_execution_arn
         )
@@ -3858,7 +3859,7 @@ class SageMakerModelBackend(BaseBackend):
 
     def list_pipeline_parameters_for_execution(
         self, pipeline_execution_arn: str
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         pipeline_execution = get_pipeline_execution_from_arn(
             self.pipelines, pipeline_execution_arn
         )
@@ -3868,7 +3869,7 @@ class SageMakerModelBackend(BaseBackend):
 
     def describe_pipeline_execution(
         self, pipeline_execution_arn: str
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         pipeline_execution = get_pipeline_execution_from_arn(
             self.pipelines, pipeline_execution_arn
         )
@@ -3890,7 +3891,7 @@ class SageMakerModelBackend(BaseBackend):
             "ParallelismConfiguration": pipeline_execution.parallelism_configuration,
         }
 
-    def describe_pipeline(self, pipeline_name: str) -> Dict[str, Any]:
+    def describe_pipeline(self, pipeline_name: str) -> dict[str, Any]:
         pipeline = get_pipeline_from_name(self.pipelines, pipeline_name)
         return {
             "PipelineArn": pipeline.arn,
@@ -3917,7 +3918,7 @@ class SageMakerModelBackend(BaseBackend):
         max_results: int,
         sort_by: str,
         sort_order: str,
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         if next_token:
             try:
                 starting_index = int(next_token)
@@ -4002,7 +4003,7 @@ class SageMakerModelBackend(BaseBackend):
         last_modified_time_before: str,
         name_contains: str,
         status_equals: str,
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         if next_token:
             try:
                 starting_index = int(next_token)
@@ -4082,17 +4083,17 @@ class SageMakerModelBackend(BaseBackend):
         transform_job_name: str,
         model_name: str,
         max_concurrent_transforms: int,
-        model_client_config: Dict[str, int],
+        model_client_config: dict[str, int],
         max_payload_in_mb: int,
         batch_strategy: str,
-        environment: Dict[str, str],
-        transform_input: Dict[str, Union[Dict[str, str], str]],
-        transform_output: Dict[str, str],
-        data_capture_config: Dict[str, Union[str, bool]],
-        transform_resources: Dict[str, Union[str, int]],
-        data_processing: Dict[str, str],
-        tags: Dict[str, str],
-        experiment_config: Dict[str, str],
+        environment: dict[str, str],
+        transform_input: dict[str, Union[dict[str, str], str]],
+        transform_output: dict[str, str],
+        data_capture_config: dict[str, Union[str, bool]],
+        transform_resources: dict[str, Union[str, int]],
+        data_processing: dict[str, str],
+        tags: dict[str, str],
+        experiment_config: dict[str, str],
     ) -> FakeTransformJob:
         transform_job = FakeTransformJob(
             account_id=self.account_id,
@@ -4125,7 +4126,7 @@ class SageMakerModelBackend(BaseBackend):
         last_modified_time_before: str,
         name_contains: str,
         status_equals: str,
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         if next_token:
             try:
                 starting_index = int(next_token)
@@ -4198,7 +4199,7 @@ class SageMakerModelBackend(BaseBackend):
             "NextToken": str(next_index) if next_index is not None else None,
         }
 
-    def describe_transform_job(self, transform_job_name: str) -> Dict[str, Any]:
+    def describe_transform_job(self, transform_job_name: str) -> dict[str, Any]:
         try:
             return self.transform_jobs[transform_job_name].response_object
         except KeyError:
@@ -4211,23 +4212,23 @@ class SageMakerModelBackend(BaseBackend):
     def create_training_job(
         self,
         training_job_name: str,
-        hyper_parameters: Dict[str, str],
-        algorithm_specification: Dict[str, Any],
+        hyper_parameters: dict[str, str],
+        algorithm_specification: dict[str, Any],
         role_arn: str,
-        input_data_config: List[Dict[str, Any]],
-        output_data_config: Dict[str, str],
-        resource_config: Dict[str, Any],
-        vpc_config: Dict[str, List[str]],
-        stopping_condition: Dict[str, int],
-        tags: List[Dict[str, str]],
+        input_data_config: list[dict[str, Any]],
+        output_data_config: dict[str, str],
+        resource_config: dict[str, Any],
+        vpc_config: dict[str, list[str]],
+        stopping_condition: dict[str, int],
+        tags: list[dict[str, str]],
         enable_network_isolation: bool,
         enable_inter_container_traffic_encryption: bool,
         enable_managed_spot_training: bool,
-        checkpoint_config: Dict[str, str],
-        debug_hook_config: Dict[str, Any],
-        debug_rule_configurations: List[Dict[str, Any]],
-        tensor_board_output_config: Dict[str, str],
-        experiment_config: Dict[str, str],
+        checkpoint_config: dict[str, str],
+        debug_hook_config: dict[str, Any],
+        debug_rule_configurations: list[dict[str, Any]],
+        tensor_board_output_config: dict[str, str],
+        experiment_config: dict[str, str],
     ) -> FakeTrainingJob:
         training_job = FakeTrainingJob(
             account_id=self.account_id,
@@ -4254,7 +4255,7 @@ class SageMakerModelBackend(BaseBackend):
         self.training_jobs[training_job_name] = training_job
         return training_job
 
-    def describe_training_job(self, training_job_name: str) -> Dict[str, Any]:
+    def describe_training_job(self, training_job_name: str) -> dict[str, Any]:
         try:
             return self.training_jobs[training_job_name].response_object
         except KeyError:
@@ -4274,7 +4275,7 @@ class SageMakerModelBackend(BaseBackend):
         last_modified_time_before: str,
         name_contains: str,
         status_equals: str,
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         if next_token:
             try:
                 starting_index = int(next_token)
@@ -4347,7 +4348,7 @@ class SageMakerModelBackend(BaseBackend):
         }
 
     def update_endpoint_weights_and_capacities(
-        self, endpoint_name: str, desired_weights_and_capacities: List[Dict[str, Any]]
+        self, endpoint_name: str, desired_weights_and_capacities: list[dict[str, Any]]
     ) -> str:
         # Validate inputs
         endpoint = self.endpoints.get(endpoint_name, None)
@@ -4399,7 +4400,7 @@ class SageMakerModelBackend(BaseBackend):
         self,
         model_package_group_name: str,
         model_package_group_description: str,
-        tags: Optional[List[Dict[str, str]]] = None,
+        tags: Optional[list[dict[str, str]]] = None,
     ) -> str:
         self.model_package_groups[model_package_group_name] = ModelPackageGroup(
             model_package_group_name=model_package_group_name,
@@ -4429,7 +4430,7 @@ class SageMakerModelBackend(BaseBackend):
         name_contains: Optional[str],
         sort_by: Optional[str],
         sort_order: Optional[str],
-    ) -> List[ModelPackageGroup]:
+    ) -> list[ModelPackageGroup]:
         if isinstance(creation_time_before, int):
             creation_time_before_datetime = datetime.fromtimestamp(
                 creation_time_before, tz=tzutc()
@@ -4493,7 +4494,7 @@ class SageMakerModelBackend(BaseBackend):
         model_package_type: Optional[str],
         sort_by: Optional[str],
         sort_order: Optional[str],
-    ) -> List[ModelPackage]:
+    ) -> list[ModelPackage]:
         if isinstance(creation_time_before, int):
             creation_time_before_datetime = datetime.fromtimestamp(
                 creation_time_before, tz=tzutc()
@@ -4559,9 +4560,9 @@ class SageMakerModelBackend(BaseBackend):
         model_package_arn: str,
         model_approval_status: Optional[str],
         approval_description: Optional[str],
-        customer_metadata_properties: Optional[Dict[str, str]],
-        customer_metadata_properties_to_remove: List[str],
-        additional_inference_specifications_to_add: Optional[List[Any]],
+        customer_metadata_properties: Optional[dict[str, str]],
+        customer_metadata_properties_to_remove: list[str],
+        additional_inference_specifications_to_add: Optional[list[Any]],
     ) -> str:
         model_package_name_mapped = self.model_package_name_mapping.get(
             model_package_arn, model_package_arn
@@ -4667,8 +4668,8 @@ class SageMakerModelBackend(BaseBackend):
         feature_group_name: str,
         record_identifier_feature_name: str,
         event_time_feature_name: str,
-        feature_definitions: List[Dict[str, str]],
-        offline_store_config: Dict[str, Any],
+        feature_definitions: list[dict[str, str]],
+        offline_store_config: dict[str, Any],
         role_arn: str,
         tags: Any,
     ) -> str:
@@ -4700,7 +4701,7 @@ class SageMakerModelBackend(BaseBackend):
     def describe_feature_group(
         self,
         feature_group_name: str,
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         feature_group_arn = arn_formatter(
             region_name=self.region_name,
             account_id=self.account_id,
@@ -4714,8 +4715,8 @@ class SageMakerModelBackend(BaseBackend):
     def create_cluster(
         self,
         cluster_name: str,
-        instance_groups: List[Dict[str, Any]],
-        vpc_config: Dict[str, List[str]],
+        instance_groups: list[dict[str, Any]],
+        vpc_config: dict[str, list[str]],
         tags: Any,
     ) -> str:
         cluster = Cluster(
@@ -4747,7 +4748,7 @@ class SageMakerModelBackend(BaseBackend):
 
         return cluster.arn
 
-    def describe_cluster(self, cluster_name: str) -> Dict[str, Any]:
+    def describe_cluster(self, cluster_name: str) -> dict[str, Any]:
         if cluster_name.startswith(f"arn:{self.partition}:sagemaker:"):
             cluster_name = (cluster_name.split(":")[-1]).split("/")[-1]
         cluster = self.clusters.get(cluster_name)
@@ -4766,7 +4767,7 @@ class SageMakerModelBackend(BaseBackend):
         del self.clusters[cluster_name]
         return arn
 
-    def describe_cluster_node(self, cluster_name: str, node_id: str) -> Dict[str, Any]:
+    def describe_cluster_node(self, cluster_name: str, node_id: str) -> dict[str, Any]:
         if cluster_name.startswith(f"arn:{self.partition}:sagemaker:"):
             cluster_name = (cluster_name.split(":")[-1]).split("/")[-1]
         cluster = self.clusters.get(cluster_name)
@@ -4787,7 +4788,7 @@ class SageMakerModelBackend(BaseBackend):
         name_contains: Optional[str],
         sort_by: Optional[str],
         sort_order: Optional[str],
-    ) -> List[Cluster]:
+    ) -> list[Cluster]:
         clusters = list(self.clusters.values())
         if name_contains:
             clusters = [i for i in clusters if name_contains in i.cluster_name]
@@ -4815,7 +4816,7 @@ class SageMakerModelBackend(BaseBackend):
         instance_group_name_contains: Optional[str],
         sort_by: Optional[str],
         sort_order: Optional[str],
-    ) -> List[ClusterNode]:
+    ) -> list[ClusterNode]:
         if cluster_name.startswith(f"arn:{self.partition}:sagemaker:"):
             cluster_name = (cluster_name.split(":")[-1]).split("/")[-1]
         cluster = self.clusters.get(cluster_name)
@@ -4852,17 +4853,17 @@ class SageMakerModelBackend(BaseBackend):
         self,
         account_id: str,
         job_definition_name: str,
-        tags: Optional[List[Dict[str, str]]] = None,
+        tags: Optional[list[dict[str, str]]] = None,
         role_arn: str = "",
-        job_resources: Optional[Dict[str, Any]] = None,
-        stopping_condition: Optional[Dict[str, Any]] = None,
-        environment: Optional[Dict[str, str]] = None,
-        network_config: Optional[Dict[str, Any]] = None,
-        model_bias_baseline_config: Optional[Dict[str, Any]] = None,
-        model_bias_app_specification: Optional[Dict[str, Any]] = None,
-        model_bias_job_input: Optional[Dict[str, Any]] = None,
-        model_bias_job_output_config: Optional[Dict[str, Any]] = None,
-    ) -> Dict[str, str]:
+        job_resources: Optional[dict[str, Any]] = None,
+        stopping_condition: Optional[dict[str, Any]] = None,
+        environment: Optional[dict[str, str]] = None,
+        network_config: Optional[dict[str, Any]] = None,
+        model_bias_baseline_config: Optional[dict[str, Any]] = None,
+        model_bias_app_specification: Optional[dict[str, Any]] = None,
+        model_bias_job_input: Optional[dict[str, Any]] = None,
+        model_bias_job_output_config: Optional[dict[str, Any]] = None,
+    ) -> dict[str, str]:
         job_definition = FakeModelBiasJobDefinition(
             account_id=account_id,
             region_name=self.region_name,
@@ -4882,12 +4883,12 @@ class SageMakerModelBackend(BaseBackend):
         return job_definition.response_create
 
     @paginate(pagination_model=PAGINATION_MODEL)
-    def list_model_bias_job_definitions(self) -> List[Dict[str, str]]:
+    def list_model_bias_job_definitions(self) -> list[dict[str, str]]:
         return [job.summary_object for job in self.model_bias_job_definitions.values()]
 
     def describe_model_bias_job_definition(
         self, job_definition_name: str
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         job_definition = self.model_bias_job_definitions.get(job_definition_name)
         if job_definition is None:
             raise ResourceNotFound(f"Job definition {job_definition_name} not found")
@@ -4902,15 +4903,15 @@ class SageMakerModelBackend(BaseBackend):
     def create_auto_ml_job_v2(
         self,
         auto_ml_job_name: str,
-        auto_ml_job_input_data_config: List[Dict[str, Any]],
-        output_data_config: Dict[str, Any],
-        auto_ml_problem_type_config: Dict[str, Any],
+        auto_ml_job_input_data_config: list[dict[str, Any]],
+        output_data_config: dict[str, Any],
+        auto_ml_problem_type_config: dict[str, Any],
         role_arn: str,
-        tags: Optional[List[Dict[str, str]]],
-        security_config: Optional[Dict[str, Any]],
-        auto_ml_job_objective: Optional[Dict[str, str]],
-        model_deploy_config: Optional[Dict[str, Any]],
-        data_split_config: Optional[Dict[str, Any]],
+        tags: Optional[list[dict[str, str]]],
+        security_config: Optional[dict[str, Any]],
+        auto_ml_job_objective: Optional[dict[str, str]],
+        model_deploy_config: Optional[dict[str, Any]],
+        data_split_config: Optional[dict[str, Any]],
     ) -> str:
         auto_ml_job = AutoMLJob(
             auto_ml_job_name=auto_ml_job_name,
@@ -4930,7 +4931,7 @@ class SageMakerModelBackend(BaseBackend):
         self.auto_ml_jobs[auto_ml_job_name] = auto_ml_job
         return auto_ml_job.arn
 
-    def describe_auto_ml_job_v2(self, auto_ml_job_name: str) -> Dict[str, Any]:
+    def describe_auto_ml_job_v2(self, auto_ml_job_name: str) -> dict[str, Any]:
         if auto_ml_job_name not in self.auto_ml_jobs:
             raise ResourceNotFound(
                 f"Could not find AutoML job with name {auto_ml_job_name}."
@@ -4949,7 +4950,7 @@ class SageMakerModelBackend(BaseBackend):
         status_equals: Optional[str],
         sort_order: Optional[str],
         sort_by: Optional[str],
-    ) -> List[AutoMLJob]:
+    ) -> list[AutoMLJob]:
         auto_ml_jobs = list(self.auto_ml_jobs.values())
         if name_contains:
             auto_ml_jobs = [
@@ -5014,7 +5015,7 @@ class SageMakerModelBackend(BaseBackend):
         last_modified_time_before: Optional[str],
         last_modified_time_after: Optional[str],
         status_equals: Optional[str],
-    ) -> List[FakeEndpoint]:
+    ) -> list[FakeEndpoint]:
         endpoints = list(self.endpoints.values())
         if name_contains:
             endpoints = [i for i in endpoints if name_contains in i.endpoint_name]
@@ -5063,7 +5064,7 @@ class SageMakerModelBackend(BaseBackend):
         name_contains: Optional[str],
         creation_time_before: Optional[str],
         creation_time_after: Optional[str],
-    ) -> List[FakeEndpointConfig]:
+    ) -> list[FakeEndpointConfig]:
         endpoint_configs = list(self.endpoint_configs.values())
         if name_contains:
             endpoint_configs = [
@@ -5096,12 +5097,12 @@ class SageMakerModelBackend(BaseBackend):
         self,
         compilation_job_name: str,
         role_arn: str,
-        output_config: Dict[str, Any],
-        stopping_condition: Dict[str, Any],
+        output_config: dict[str, Any],
+        stopping_condition: dict[str, Any],
         model_package_version_arn: Optional[str],
-        input_config: Optional[Dict[str, Any]],
-        vpc_config: Optional[Dict[str, Any]],
-        tags: Optional[List[Dict[str, str]]],
+        input_config: Optional[dict[str, Any]],
+        vpc_config: Optional[dict[str, Any]],
+        tags: Optional[list[dict[str, str]]],
     ) -> str:
         compilation_job = CompilationJob(
             compilation_job_name=compilation_job_name,
@@ -5118,7 +5119,7 @@ class SageMakerModelBackend(BaseBackend):
         self.compilation_jobs[compilation_job_name] = compilation_job
         return compilation_job.arn
 
-    def describe_compilation_job(self, compilation_job_name: str) -> Dict[str, Any]:
+    def describe_compilation_job(self, compilation_job_name: str) -> dict[str, Any]:
         if compilation_job_name not in self.compilation_jobs:
             raise ResourceNotFound(
                 message=f"Could not find compilation job '{compilation_job_name}'."
@@ -5137,7 +5138,7 @@ class SageMakerModelBackend(BaseBackend):
         status_equals: Optional[str],
         sort_by: Optional[str],
         sort_order: Optional[str],
-    ) -> List[CompilationJob]:
+    ) -> list[CompilationJob]:
         compilation_jobs = list(self.compilation_jobs.values())
         if name_contains:
             compilation_jobs = [
@@ -5199,17 +5200,17 @@ class SageMakerModelBackend(BaseBackend):
         self,
         domain_name: str,
         auth_mode: str,
-        default_user_settings: Dict[str, Any],
-        subnet_ids: List[str],
+        default_user_settings: dict[str, Any],
+        subnet_ids: list[str],
         vpc_id: str,
-        domain_settings: Optional[Dict[str, Any]],
-        tags: Optional[List[Dict[str, str]]],
+        domain_settings: Optional[dict[str, Any]],
+        tags: Optional[list[dict[str, str]]],
         app_network_access_type: Optional[str],
         home_efs_file_system_kms_key_id: Optional[str],
         kms_key_id: Optional[str],
         app_security_group_management: Optional[str],
-        default_space_settings: Optional[Dict[str, Any]],
-    ) -> Dict[str, Any]:
+        default_space_settings: Optional[dict[str, Any]],
+    ) -> dict[str, Any]:
         domain = Domain(
             domain_name=domain_name,
             auth_mode=auth_mode,
@@ -5229,17 +5230,17 @@ class SageMakerModelBackend(BaseBackend):
         self.domains[domain.id] = domain
         return {"DomainArn": domain.arn, "Url": domain.url}
 
-    def describe_domain(self, domain_id: str) -> Dict[str, Any]:
+    def describe_domain(self, domain_id: str) -> dict[str, Any]:
         if domain_id not in self.domains:
             raise ValidationError(message=f"Could not find domain '{domain_id}'.")
         return self.domains[domain_id].describe()
 
     @paginate(pagination_model=PAGINATION_MODEL)
-    def list_domains(self) -> List[Domain]:
+    def list_domains(self) -> list[Domain]:
         return list(self.domains.values())
 
     def delete_domain(
-        self, domain_id: str, retention_policy: Optional[Dict[str, str]]
+        self, domain_id: str, retention_policy: Optional[dict[str, str]]
     ) -> None:
         # 'retention_policy' parameter is not used
         if domain_id not in self.domains:
@@ -5249,15 +5250,15 @@ class SageMakerModelBackend(BaseBackend):
     def create_model_explainability_job_definition(
         self,
         job_definition_name: str,
-        model_explainability_baseline_config: Optional[Dict[str, Any]],
-        model_explainability_app_specification: Dict[str, Any],
-        model_explainability_job_input: Dict[str, Any],
-        model_explainability_job_output_config: Dict[str, Any],
-        job_resources: Dict[str, Any],
-        network_config: Optional[Dict[str, Any]],
+        model_explainability_baseline_config: Optional[dict[str, Any]],
+        model_explainability_app_specification: dict[str, Any],
+        model_explainability_job_input: dict[str, Any],
+        model_explainability_job_output_config: dict[str, Any],
+        job_resources: dict[str, Any],
+        network_config: Optional[dict[str, Any]],
         role_arn: str,
-        stopping_condition: Optional[Dict[str, Any]],
-        tags: List[Dict[str, str]],
+        stopping_condition: Optional[dict[str, Any]],
+        tags: list[dict[str, str]],
     ) -> str:
         model_explainability_job_definition = ModelExplainabilityJobDefinition(
             job_definition_name=job_definition_name,
@@ -5280,7 +5281,7 @@ class SageMakerModelBackend(BaseBackend):
 
     def describe_model_explainability_job_definition(
         self, job_definition_name: str
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         if job_definition_name not in self.model_explainability_job_definitions:
             raise ResourceNotFound(
                 message=f"Could not find model explainability job definition with name '{job_definition_name}'."
@@ -5296,7 +5297,7 @@ class SageMakerModelBackend(BaseBackend):
         name_contains: Optional[str],
         creation_time_before: Optional[str],
         creation_time_after: Optional[str],
-    ) -> List[ModelExplainabilityJobDefinition]:
+    ) -> list[ModelExplainabilityJobDefinition]:
         model_explainability_job_definitions = list(
             self.model_explainability_job_definitions.values()
         )
@@ -5351,12 +5352,12 @@ class SageMakerModelBackend(BaseBackend):
     def create_hyper_parameter_tuning_job(
         self,
         hyper_parameter_tuning_job_name: str,
-        hyper_parameter_tuning_job_config: Dict[str, Any],
-        training_job_definition: Optional[Dict[str, Any]],
-        training_job_definitions: Optional[List[Dict[str, Any]]],
-        warm_start_config: Optional[Dict[str, Any]],
-        tags: Optional[List[Dict[str, str]]],
-        autotune: Optional[Dict[str, Any]],
+        hyper_parameter_tuning_job_config: dict[str, Any],
+        training_job_definition: Optional[dict[str, Any]],
+        training_job_definitions: Optional[list[dict[str, Any]]],
+        warm_start_config: Optional[dict[str, Any]],
+        tags: Optional[list[dict[str, str]]],
+        autotune: Optional[dict[str, Any]],
     ) -> str:
         hyper_parameter_tuning_job = HyperParameterTuningJob(
             hyper_parameter_tuning_job_name=hyper_parameter_tuning_job_name,
@@ -5377,7 +5378,7 @@ class SageMakerModelBackend(BaseBackend):
 
     def describe_hyper_parameter_tuning_job(
         self, hyper_parameter_tuning_job_name: str
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         if hyper_parameter_tuning_job_name not in self.hyper_parameter_tuning_jobs:
             raise ResourceNotFound(
                 message=f"Could not find hyper parameter tuning job '{hyper_parameter_tuning_job_name}'."
@@ -5397,7 +5398,7 @@ class SageMakerModelBackend(BaseBackend):
         last_modified_time_after: Optional[str],
         last_modified_time_before: Optional[str],
         status_equals: Optional[str],
-    ) -> List[HyperParameterTuningJob]:
+    ) -> list[HyperParameterTuningJob]:
         hyper_parameter_tuning_jobs = list(self.hyper_parameter_tuning_jobs.values())
         if name_contains:
             hyper_parameter_tuning_jobs = [
@@ -5468,15 +5469,15 @@ class SageMakerModelBackend(BaseBackend):
     def create_model_quality_job_definition(
         self,
         job_definition_name: str,
-        model_quality_baseline_config: Optional[Dict[str, Any]],
-        model_quality_app_specification: Dict[str, Any],
-        model_quality_job_input: Dict[str, Any],
-        model_quality_job_output_config: Dict[str, Any],
-        job_resources: Dict[str, Any],
-        network_config: Optional[Dict[str, Any]],
+        model_quality_baseline_config: Optional[dict[str, Any]],
+        model_quality_app_specification: dict[str, Any],
+        model_quality_job_input: dict[str, Any],
+        model_quality_job_output_config: dict[str, Any],
+        job_resources: dict[str, Any],
+        network_config: Optional[dict[str, Any]],
         role_arn: str,
-        stopping_condition: Optional[Dict[str, Any]],
-        tags: Optional[List[Dict[str, str]]],
+        stopping_condition: Optional[dict[str, Any]],
+        tags: Optional[list[dict[str, str]]],
     ) -> str:
         model_quality_job_definition = ModelQualityJobDefinition(
             job_definition_name=job_definition_name,
@@ -5499,7 +5500,7 @@ class SageMakerModelBackend(BaseBackend):
 
     def describe_model_quality_job_definition(
         self, job_definition_name: str
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         if job_definition_name not in self.model_quality_job_definitions:
             raise ResourceNotFound(
                 message=f"Could not find model quality job definition '{job_definition_name}'."
@@ -5515,7 +5516,7 @@ class SageMakerModelBackend(BaseBackend):
         name_contains: Optional[str],
         creation_time_before: Optional[str],
         creation_time_after: Optional[str],
-    ) -> List[ModelQualityJobDefinition]:
+    ) -> list[ModelQualityJobDefinition]:
         model_quality_job_definitions = list(
             self.model_quality_job_definitions.values()
         )
@@ -5568,10 +5569,10 @@ class SageMakerModelBackend(BaseBackend):
     def create_model_card(
         self,
         model_card_name: str,
-        security_config: Optional[Dict[str, str]],
+        security_config: Optional[dict[str, str]],
         content: str,
         model_card_status: str,
-        tags: Optional[List[Dict[str, str]]],
+        tags: Optional[list[dict[str, str]]],
         model_card_version: Optional[int] = None,
         creation_time: Optional[str] = None,
         last_modified_time: Optional[str] = None,
@@ -5638,7 +5639,7 @@ class SageMakerModelBackend(BaseBackend):
         model_card_status: Optional[str],
         sort_by: Optional[str],
         sort_order: Optional[str],
-    ) -> List[FakeModelCard]:
+    ) -> list[FakeModelCard]:
         model_cards = self.model_cards
 
         return filter_model_cards(
@@ -5660,7 +5661,7 @@ class SageMakerModelBackend(BaseBackend):
         model_card_status: Optional[str],
         sort_by: Optional[str],
         sort_order: Optional[str],
-    ) -> List[FakeModelCard]:
+    ) -> list[FakeModelCard]:
         if model_card_name not in self.model_cards:
             raise ResourceNotFound(f"Modelcard {model_card_name} does not exist")
 
@@ -5682,7 +5683,7 @@ class SageMakerModelBackend(BaseBackend):
 
     def describe_model_card(
         self, model_card_name: str, model_card_version: int
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         if model_card_name not in self.model_cards:
             raise ResourceNotFound(f"Modelcard {model_card_name} does not exist")
 
@@ -5710,17 +5711,17 @@ class SageMakerModelBackend(BaseBackend):
         self,
         account_id: str,
         job_definition_name: str,
-        tags: Optional[List[Dict[str, str]]] = None,
+        tags: Optional[list[dict[str, str]]] = None,
         role_arn: str = "",
-        job_resources: Optional[Dict[str, Any]] = None,
-        stopping_condition: Optional[Dict[str, Any]] = None,
-        environment: Optional[Dict[str, str]] = None,
-        network_config: Optional[Dict[str, Any]] = None,
-        data_quality_baseline_config: Optional[Dict[str, Any]] = None,
-        data_quality_app_specification: Optional[Dict[str, Any]] = None,
-        data_quality_job_input: Optional[Dict[str, Any]] = None,
-        data_quality_job_output_config: Optional[Dict[str, Any]] = None,
-    ) -> Dict[str, str]:
+        job_resources: Optional[dict[str, Any]] = None,
+        stopping_condition: Optional[dict[str, Any]] = None,
+        environment: Optional[dict[str, str]] = None,
+        network_config: Optional[dict[str, Any]] = None,
+        data_quality_baseline_config: Optional[dict[str, Any]] = None,
+        data_quality_app_specification: Optional[dict[str, Any]] = None,
+        data_quality_job_input: Optional[dict[str, Any]] = None,
+        data_quality_job_output_config: Optional[dict[str, Any]] = None,
+    ) -> dict[str, str]:
         job_definition = FakeDataQualityJobDefinition(
             account_id=account_id,
             region_name=self.region_name,
@@ -5740,14 +5741,14 @@ class SageMakerModelBackend(BaseBackend):
         return job_definition.response_create
 
     @paginate(pagination_model=PAGINATION_MODEL)
-    def list_data_quality_job_definitions(self) -> List[Dict[str, str]]:
+    def list_data_quality_job_definitions(self) -> list[dict[str, str]]:
         return [
             job.summary_object for job in self.data_quality_job_definitions.values()
         ]
 
     def describe_data_quality_job_definition(
         self, job_definition_name: str
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         job_definition = self.data_quality_job_definitions.get(job_definition_name)
         if job_definition is None:
             raise ResourceNotFound(f"Job definition {job_definition_name} not found")
@@ -5766,16 +5767,16 @@ class FakeDataQualityJobDefinition(BaseObject):
         account_id: str,
         region_name: str,
         job_definition_name: str,
-        tags: Optional[List[Dict[str, str]]] = None,
+        tags: Optional[list[dict[str, str]]] = None,
         role_arn: str = "",
-        job_resources: Optional[Dict[str, Any]] = None,
-        stopping_condition: Optional[Dict[str, Any]] = None,
-        environment: Optional[Dict[str, str]] = None,
-        network_config: Optional[Dict[str, Any]] = None,
-        data_quality_baseline_config: Optional[Dict[str, Any]] = None,
-        data_quality_app_specification: Optional[Dict[str, Any]] = None,
-        data_quality_job_input: Optional[Dict[str, Any]] = None,
-        data_quality_job_output_config: Optional[Dict[str, Any]] = None,
+        job_resources: Optional[dict[str, Any]] = None,
+        stopping_condition: Optional[dict[str, Any]] = None,
+        environment: Optional[dict[str, str]] = None,
+        network_config: Optional[dict[str, Any]] = None,
+        data_quality_baseline_config: Optional[dict[str, Any]] = None,
+        data_quality_app_specification: Optional[dict[str, Any]] = None,
+        data_quality_job_input: Optional[dict[str, Any]] = None,
+        data_quality_job_output_config: Optional[dict[str, Any]] = None,
     ):
         self.job_definition_name = job_definition_name
         self.arn = FakeDataQualityJobDefinition.arn_formatter(
@@ -5796,7 +5797,7 @@ class FakeDataQualityJobDefinition(BaseObject):
         )
 
     @property
-    def response_object(self) -> Dict[str, str]:
+    def response_object(self) -> dict[str, str]:
         response_object = self.gen_response_object()
         response = {
             k: v for k, v in response_object.items() if v is not None and v != [None]
@@ -5805,7 +5806,7 @@ class FakeDataQualityJobDefinition(BaseObject):
         return response
 
     @property
-    def response_create(self) -> Dict[str, str]:
+    def response_create(self) -> dict[str, str]:
         return {"JobDefinitionArn": self.arn}
 
     @staticmethod
@@ -5813,7 +5814,7 @@ class FakeDataQualityJobDefinition(BaseObject):
         return arn_formatter("data-quality-job-definition", name, account_id, region)
 
     @property
-    def summary_object(self) -> Dict[str, str]:
+    def summary_object(self) -> dict[str, str]:
         return {
             "MonitoringJobDefinitionName": self.job_definition_name,
             "MonitoringJobDefinitionArn": self.arn,
@@ -5828,7 +5829,7 @@ class FakeExperiment(BaseObject):
         account_id: str,
         region_name: str,
         experiment_name: str,
-        tags: List[Dict[str, str]],
+        tags: list[dict[str, str]],
     ):
         self.experiment_name = experiment_name
         self.arn = arn_formatter("experiment", experiment_name, account_id, region_name)
@@ -5838,14 +5839,14 @@ class FakeExperiment(BaseObject):
         )
 
     @property
-    def response_object(self) -> Dict[str, Any]:  # type: ignore[misc]
+    def response_object(self) -> dict[str, Any]:  # type: ignore[misc]
         response_object = self.gen_response_object()
         return {
             k: v for k, v in response_object.items() if v is not None and v != [None]
         }
 
     @property
-    def response_create(self) -> Dict[str, str]:
+    def response_create(self) -> dict[str, str]:
         return {"ExperimentArn": self.arn}
 
 
@@ -5856,8 +5857,8 @@ class FakeTrial(BaseObject):
         region_name: str,
         trial_name: str,
         experiment_name: str,
-        tags: List[Dict[str, str]],
-        trial_components: List[str],
+        tags: list[dict[str, str]],
+        trial_components: list[str],
     ):
         self.trial_name = trial_name
         self.arn = FakeTrial.arn_formatter(trial_name, account_id, region_name)
@@ -5869,7 +5870,7 @@ class FakeTrial(BaseObject):
         )
 
     @property
-    def response_object(self) -> Dict[str, Any]:  # type: ignore[misc]
+    def response_object(self) -> dict[str, Any]:  # type: ignore[misc]
         response_object = self.gen_response_object()
         response = {
             k: v for k, v in response_object.items() if v is not None and v != [None]
@@ -5879,7 +5880,7 @@ class FakeTrial(BaseObject):
         return response
 
     @property
-    def response_create(self) -> Dict[str, str]:
+    def response_create(self) -> dict[str, str]:
         return {"TrialArn": self.arn}
 
     @staticmethod
@@ -5896,13 +5897,13 @@ class FakeTrialComponent(BaseObject):
         display_name: Optional[str],
         start_time: Optional[datetime],
         end_time: Optional[datetime],
-        parameters: Optional[Dict[str, Dict[str, Union[str, float]]]],
-        input_artifacts: Optional[Dict[str, Dict[str, str]]],
-        output_artifacts: Optional[Dict[str, Dict[str, str]]],
-        metadata_properties: Optional[Dict[str, str]],
-        status: Optional[Dict[str, str]],
+        parameters: Optional[dict[str, dict[str, Union[str, float]]]],
+        input_artifacts: Optional[dict[str, dict[str, str]]],
+        output_artifacts: Optional[dict[str, dict[str, str]]],
+        metadata_properties: Optional[dict[str, str]],
+        status: Optional[dict[str, str]],
         trial_name: Optional[str],
-        tags: List[Dict[str, str]],
+        tags: list[dict[str, str]],
     ):
         self.trial_component_name = trial_component_name
         self.display_name = (
@@ -5918,17 +5919,17 @@ class FakeTrialComponent(BaseObject):
         self.end_time = end_time
         now_string = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
         self.creation_time = self.last_modified_time = now_string
-        self.created_by: Dict[str, Union[Dict[str, str], str]] = {}
-        self.last_modified_by: Dict[str, Union[Dict[str, str], str]] = {}
+        self.created_by: dict[str, Union[dict[str, str], str]] = {}
+        self.last_modified_by: dict[str, Union[dict[str, str], str]] = {}
         self.parameters = parameters if parameters is not None else {}
         self.input_artifacts = input_artifacts if input_artifacts is not None else {}
         self.output_artifacts = output_artifacts if output_artifacts is not None else {}
         self.metadata_properties = metadata_properties
-        self.metrics: Dict[str, Dict[str, Union[str, int, METRIC_STEP_TYPE]]] = {}
-        self.sources: List[Dict[str, str]] = []
+        self.metrics: dict[str, dict[str, Union[str, int, METRIC_STEP_TYPE]]] = {}
+        self.sources: list[dict[str, str]] = []
 
     @property
-    def response_object(self) -> Dict[str, Any]:  # type: ignore[misc]
+    def response_object(self) -> dict[str, Any]:  # type: ignore[misc]
         response_object = self.gen_response_object()
         response_object["Metrics"] = self.gen_metrics_response_object()
         response = {
@@ -5940,7 +5941,7 @@ class FakeTrialComponent(BaseObject):
 
     def gen_metrics_response_object(
         self,
-    ) -> List[Dict[str, Union[str, int, float, datetime]]]:
+    ) -> list[dict[str, Union[str, int, float, datetime]]]:
         metrics_names = self.metrics.keys()
         metrics_response_objects = []
         for metrics_name in metrics_names:
@@ -5948,7 +5949,7 @@ class FakeTrialComponent(BaseObject):
                 METRIC_STEP_TYPE, self.metrics[metrics_name]["Values"]
             )
             max_step = max(list(metrics_steps.keys()))
-            metrics_steps_values: List[float] = list(
+            metrics_steps_values: list[float] = list(
                 map(
                     lambda metric: cast(float, metric["Value"]),
                     list(metrics_steps.values()),
@@ -5978,7 +5979,7 @@ class FakeTrialComponent(BaseObject):
         return metrics_response_objects
 
     @property
-    def response_create(self) -> Dict[str, str]:
+    def response_create(self) -> dict[str, str]:
         return {"TrialComponentArn": self.arn}
 
     @staticmethod
@@ -5996,16 +5997,16 @@ class FakeModelBiasJobDefinition(BaseObject):
         account_id: str,
         region_name: str,
         job_definition_name: str,
-        tags: Optional[List[Dict[str, str]]] = None,
+        tags: Optional[list[dict[str, str]]] = None,
         role_arn: str = "",
-        job_resources: Optional[Dict[str, Any]] = None,
-        stopping_condition: Optional[Dict[str, Any]] = None,
-        environment: Optional[Dict[str, str]] = None,
-        network_config: Optional[Dict[str, Any]] = None,
-        model_bias_baseline_config: Optional[Dict[str, Any]] = None,
-        model_bias_app_specification: Optional[Dict[str, Any]] = None,
-        model_bias_job_input: Optional[Dict[str, Any]] = None,
-        model_bias_job_output_config: Optional[Dict[str, Any]] = None,
+        job_resources: Optional[dict[str, Any]] = None,
+        stopping_condition: Optional[dict[str, Any]] = None,
+        environment: Optional[dict[str, str]] = None,
+        network_config: Optional[dict[str, Any]] = None,
+        model_bias_baseline_config: Optional[dict[str, Any]] = None,
+        model_bias_app_specification: Optional[dict[str, Any]] = None,
+        model_bias_job_input: Optional[dict[str, Any]] = None,
+        model_bias_job_output_config: Optional[dict[str, Any]] = None,
     ):
         self.job_definition_name = job_definition_name
         self.arn = FakeModelBiasJobDefinition.arn_formatter(
@@ -6026,7 +6027,7 @@ class FakeModelBiasJobDefinition(BaseObject):
         )
 
     @property
-    def response_object(self) -> Dict[str, str]:
+    def response_object(self) -> dict[str, str]:
         response_object = self.gen_response_object()
         response = {
             k: v for k, v in response_object.items() if v is not None and v != [None]
@@ -6035,7 +6036,7 @@ class FakeModelBiasJobDefinition(BaseObject):
         return response
 
     @property
-    def response_create(self) -> Dict[str, str]:
+    def response_create(self) -> dict[str, str]:
         return {"JobDefinitionArn": self.arn}
 
     @staticmethod
@@ -6043,7 +6044,7 @@ class FakeModelBiasJobDefinition(BaseObject):
         return f"arn:{get_partition(region)}:sagemaker:{region}:{account_id}:model-bias-job-definition/{name}"
 
     @property
-    def summary_object(self) -> Dict[str, str]:
+    def summary_object(self) -> dict[str, str]:
         return {
             "MonitoringJobDefinitionName": self.job_definition_name,
             "MonitoringJobDefinitionArn": self.arn,

--- a/moto/sagemaker/utils.py
+++ b/moto/sagemaker/utils.py
@@ -1,7 +1,8 @@
 import json
 import typing
+from collections import defaultdict
 from datetime import datetime
-from typing import Any, DefaultDict, Dict, List, Optional
+from typing import Any, Optional
 
 from dateutil.tz import tzutc
 
@@ -15,7 +16,7 @@ if typing.TYPE_CHECKING:
 
 
 def get_pipeline_from_name(
-    pipelines: Dict[str, "FakePipeline"], pipeline_name: str
+    pipelines: dict[str, "FakePipeline"], pipeline_name: str
 ) -> "FakePipeline":
     try:
         return pipelines[pipeline_name]
@@ -30,7 +31,7 @@ def get_pipeline_name_from_execution_arn(pipeline_execution_arn: str) -> str:
 
 
 def get_pipeline_execution_from_arn(
-    pipelines: Dict[str, "FakePipeline"], pipeline_execution_arn: str
+    pipelines: dict[str, "FakePipeline"], pipeline_execution_arn: str
 ) -> "FakePipelineExecution":
     try:
         pipeline_name = get_pipeline_name_from_execution_arn(pipeline_execution_arn)
@@ -43,8 +44,8 @@ def get_pipeline_execution_from_arn(
 
 
 def load_pipeline_definition_from_s3(
-    pipeline_definition_s3_location: Dict[str, Any], account_id: str, partition: str
-) -> Dict[str, Any]:
+    pipeline_definition_s3_location: dict[str, Any], account_id: str, partition: str
+) -> dict[str, Any]:
     s3_backend = s3_backends[account_id][partition]
     result = s3_backend.get_object(
         bucket_name=pipeline_definition_s3_location["Bucket"],
@@ -70,14 +71,14 @@ def validate_model_approval_status(model_approval_status: typing.Optional[str]) 
 
 
 def filter_model_cards(
-    model_cards: DefaultDict[str, List["FakeModelCard"]],
+    model_cards: defaultdict[str, list["FakeModelCard"]],
     creation_time_after: Optional[datetime],
     creation_time_before: Optional[datetime],
     name_contains: Optional[str],
     model_card_status: Optional[str],
     sort_by: Optional[str],
     sort_order: Optional[str],
-) -> List["FakeModelCard"]:
+) -> list["FakeModelCard"]:
     reverse = sort_order == "Descending"
 
     if name_contains:
@@ -88,7 +89,7 @@ def filter_model_cards(
     else:
         filtered_cards = {k: v for k, v in model_cards.items()}
 
-    result: List[FakeModelCard] = []
+    result: list[FakeModelCard] = []
     for _, versions in filtered_cards.items():
         filtered_versions = versions
 

--- a/moto/sagemakermetrics/models.py
+++ b/moto/sagemakermetrics/models.py
@@ -1,13 +1,13 @@
 """SageMakerMetricsBackend class with methods for supported APIs."""
 
 from datetime import datetime
-from typing import Dict, List, Union, cast
+from typing import Union, cast
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.sagemaker import sagemaker_backends
 from moto.sagemaker.models import METRIC_STEP_TYPE
 
-RESPONSE_TYPE = Dict[str, List[Dict[str, Union[str, int]]]]
+RESPONSE_TYPE = dict[str, list[dict[str, Union[str, int]]]]
 
 
 class SageMakerMetricsBackend(BaseBackend):
@@ -20,7 +20,7 @@ class SageMakerMetricsBackend(BaseBackend):
     def batch_put_metrics(
         self,
         trial_component_name: str,
-        metric_data: List[Dict[str, Union[str, int, float, datetime]]],
+        metric_data: list[dict[str, Union[str, int, float, datetime]]],
     ) -> RESPONSE_TYPE:
         return_response: RESPONSE_TYPE = {"Errors": []}
 
@@ -36,8 +36,8 @@ class SageMakerMetricsBackend(BaseBackend):
             metric_name: str = cast(str, metric["MetricName"])
             if metric_name not in trial_component.metrics:
                 metric_timestamp: int = cast(int, metric["Timestamp"])
-                values_dict: Dict[int, Dict[str, Union[str, int, float, datetime]]] = {}
-                new_metric: Dict[str, Union[str, int, METRIC_STEP_TYPE]] = {
+                values_dict: dict[int, dict[str, Union[str, int, float, datetime]]] = {}
+                new_metric: dict[str, Union[str, int, METRIC_STEP_TYPE]] = {
                     "MetricName": metric_name,
                     "Timestamp": metric_timestamp,
                     "Values": values_dict,

--- a/moto/sagemakerruntime/models.py
+++ b/moto/sagemakerruntime/models.py
@@ -1,5 +1,4 @@
 import json
-from typing import Dict, List, Tuple
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.moto_api._internal import mock_random as random
@@ -10,14 +9,14 @@ class SageMakerRuntimeBackend(BaseBackend):
 
     def __init__(self, region_name: str, account_id: str):
         super().__init__(region_name, account_id)
-        self.async_results: Dict[str, Dict[str, Tuple[str, str]]] = {}
-        self.results: Dict[str, Dict[bytes, Tuple[str, str, str, str]]] = {}
-        self.results_queue: List[Tuple[str, str, str, str]] = []
-        self.async_results_queue: List[Tuple[bool, str]] = []
+        self.async_results: dict[str, dict[str, tuple[str, str]]] = {}
+        self.results: dict[str, dict[bytes, tuple[str, str, str, str]]] = {}
+        self.results_queue: list[tuple[str, str, str, str]] = []
+        self.async_results_queue: list[tuple[bool, str]] = []
 
     def invoke_endpoint(
         self, endpoint_name: str, unique_repr: bytes
-    ) -> Tuple[str, str, str, str]:
+    ) -> tuple[str, str, str, str]:
         """
         This call will return static data by default.
 
@@ -68,7 +67,7 @@ class SageMakerRuntimeBackend(BaseBackend):
 
     def invoke_endpoint_async(
         self, endpoint_name: str, input_location: str
-    ) -> Tuple[str, str]:
+    ) -> tuple[str, str]:
         """
         This call will return static data by default.
 

--- a/moto/scheduler/models.py
+++ b/moto/scheduler/models.py
@@ -1,7 +1,8 @@
 """EventBridgeSchedulerBackend class with methods for supported APIs."""
 
 import datetime
-from typing import Any, Dict, Iterable, List, Optional, cast
+from collections.abc import Iterable
+from typing import Any, Optional, cast
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
@@ -27,8 +28,8 @@ class Schedule(BaseModel):
         description: Optional[str],
         schedule_expression: str,
         schedule_expression_timezone: Optional[str],
-        flexible_time_window: Dict[str, Any],
-        target: Dict[str, Any],
+        flexible_time_window: dict[str, Any],
+        target: dict[str, Any],
         state: Optional[str],
         kms_key_arn: Optional[str],
         start_date: Optional[str],
@@ -51,7 +52,7 @@ class Schedule(BaseModel):
         self.creation_date = self.last_modified_date = unix_time()
 
     @staticmethod
-    def validate_target(target: Dict[str, Any]) -> Dict[str, Any]:  # type: ignore[misc]
+    def validate_target(target: dict[str, Any]) -> dict[str, Any]:  # type: ignore[misc]
         if "RetryPolicy" not in target:
             target["RetryPolicy"] = {
                 "MaximumEventAgeInSeconds": 86400,
@@ -75,8 +76,8 @@ class Schedule(BaseModel):
                     )
         return start_date
 
-    def to_dict(self, short: bool = False) -> Dict[str, Any]:
-        dct: Dict[str, Any] = {
+    def to_dict(self, short: bool = False) -> dict[str, Any]:
+        dct: dict[str, Any] = {
             "Arn": self.arn,
             "Name": self.name,
             "GroupName": self.group_name,
@@ -101,13 +102,13 @@ class Schedule(BaseModel):
         self,
         description: str,
         end_date: str,
-        flexible_time_window: Dict[str, Any],
+        flexible_time_window: dict[str, Any],
         kms_key_arn: str,
         schedule_expression: str,
         schedule_expression_timezone: str,
         start_date: str,
         state: str,
-        target: Dict[str, Any],
+        target: dict[str, Any],
     ) -> None:
         self.schedule_expression = schedule_expression
         self.schedule_expression_timezone = schedule_expression_timezone or "UTC"
@@ -125,7 +126,7 @@ class ScheduleGroup(BaseModel):
     def __init__(self, region: str, account_id: str, name: str):
         self.name = name
         self.arn = f"arn:{get_partition(region)}:scheduler:{region}:{account_id}:schedule-group/{name}"
-        self.schedules: Dict[str, Schedule] = dict()
+        self.schedules: dict[str, Schedule] = dict()
         self.created_on = None if self.name == "default" else unix_time()
         self.last_modified = None if self.name == "default" else unix_time()
 
@@ -142,7 +143,7 @@ class ScheduleGroup(BaseModel):
             raise ScheduleNotFound(name)
         self.schedules.pop(name)
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         return {
             "Arn": self.arn,
             "CreationDate": self.created_on,
@@ -157,7 +158,7 @@ class EventBridgeSchedulerBackend(BaseBackend):
 
     def __init__(self, region_name: str, account_id: str):
         super().__init__(region_name, account_id)
-        self.schedules: List[Schedule] = list()
+        self.schedules: list[Schedule] = list()
         self.schedule_groups = {
             "default": ScheduleGroup(
                 region=region_name, account_id=account_id, name="default"
@@ -169,7 +170,7 @@ class EventBridgeSchedulerBackend(BaseBackend):
         self,
         description: str,
         end_date: str,
-        flexible_time_window: Dict[str, Any],
+        flexible_time_window: dict[str, Any],
         group_name: str,
         kms_key_arn: str,
         name: str,
@@ -177,7 +178,7 @@ class EventBridgeSchedulerBackend(BaseBackend):
         schedule_expression_timezone: str,
         start_date: str,
         state: str,
-        target: Dict[str, Any],
+        target: dict[str, Any],
         action_after_completion: Optional[str],
     ) -> Schedule:
         """
@@ -217,7 +218,7 @@ class EventBridgeSchedulerBackend(BaseBackend):
         self,
         description: str,
         end_date: str,
-        flexible_time_window: Dict[str, Any],
+        flexible_time_window: dict[str, Any],
         group_name: str,
         kms_key_arn: str,
         name: str,
@@ -225,7 +226,7 @@ class EventBridgeSchedulerBackend(BaseBackend):
         schedule_expression_timezone: str,
         start_date: str,
         state: str,
-        target: Dict[str, Any],
+        target: dict[str, Any],
     ) -> Schedule:
         """
         The ClientToken is not yet implemented
@@ -259,7 +260,7 @@ class EventBridgeSchedulerBackend(BaseBackend):
         return results
 
     def create_schedule_group(
-        self, name: str, tags: List[Dict[str, str]]
+        self, name: str, tags: list[dict[str, str]]
     ) -> ScheduleGroup:
         """
         The ClientToken parameter is not yet implemented
@@ -287,13 +288,13 @@ class EventBridgeSchedulerBackend(BaseBackend):
 
     def list_tags_for_resource(
         self, resource_arn: str
-    ) -> Dict[str, List[Dict[str, str]]]:
+    ) -> dict[str, list[dict[str, str]]]:
         return self.tagger.list_tags_for_resource(resource_arn)
 
-    def tag_resource(self, resource_arn: str, tags: List[Dict[str, str]]) -> None:
+    def tag_resource(self, resource_arn: str, tags: list[dict[str, str]]) -> None:
         self.tagger.tag_resource(resource_arn, tags)
 
-    def untag_resource(self, resource_arn: str, tag_keys: List[str]) -> None:
+    def untag_resource(self, resource_arn: str, tag_keys: list[str]) -> None:
         self.tagger.untag_resource_using_names(resource_arn, tag_keys)
 
 

--- a/moto/sdb/models.py
+++ b/moto/sdb/models.py
@@ -2,8 +2,9 @@
 
 import re
 from collections import defaultdict
+from collections.abc import Iterable
 from threading import Lock
-from typing import Any, Dict, Iterable, List, Optional
+from typing import Any, Optional
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
@@ -13,15 +14,15 @@ from .exceptions import InvalidDomainName, UnknownDomainName
 
 class FakeItem(BaseModel):
     def __init__(self) -> None:
-        self.attributes: List[Dict[str, Any]] = []
+        self.attributes: list[dict[str, Any]] = []
         self.lock = Lock()
 
-    def get_attributes(self, names: Optional[List[str]]) -> List[Dict[str, Any]]:
+    def get_attributes(self, names: Optional[list[str]]) -> list[dict[str, Any]]:
         if not names:
             return self.attributes
         return [attr for attr in self.attributes if attr["Name"] in names]
 
-    def put_attributes(self, attributes: List[Dict[str, Any]]) -> None:
+    def put_attributes(self, attributes: list[dict[str, Any]]) -> None:
         # Replacing attributes involves quite a few loops
         # Lock this, so we know noone else touches this list while we're operating on it
         with self.lock:
@@ -37,13 +38,13 @@ class FakeItem(BaseModel):
 class FakeDomain(BaseModel):
     def __init__(self, name: str):
         self.name = name
-        self.items: Dict[str, FakeItem] = defaultdict(FakeItem)
+        self.items: dict[str, FakeItem] = defaultdict(FakeItem)
 
-    def get(self, item_name: str, attribute_names: List[str]) -> List[Dict[str, Any]]:
+    def get(self, item_name: str, attribute_names: list[str]) -> list[dict[str, Any]]:
         item = self.items[item_name]
         return item.get_attributes(attribute_names)
 
-    def put(self, item_name: str, attributes: List[Dict[str, Any]]) -> None:
+    def put(self, item_name: str, attributes: list[dict[str, Any]]) -> None:
         item = self.items[item_name]
         item.put_attributes(attributes)
 
@@ -51,7 +52,7 @@ class FakeDomain(BaseModel):
 class SimpleDBBackend(BaseBackend):
     def __init__(self, region_name: str, account_id: str):
         super().__init__(region_name, account_id)
-        self.domains: Dict[str, FakeDomain] = dict()
+        self.domains: dict[str, FakeDomain] = dict()
 
     def create_domain(self, domain_name: str) -> None:
         self._validate_domain_name(domain_name)
@@ -80,8 +81,8 @@ class SimpleDBBackend(BaseBackend):
         return self.domains[domain_name]
 
     def get_attributes(
-        self, domain_name: str, item_name: str, attribute_names: List[str]
-    ) -> List[Dict[str, Any]]:
+        self, domain_name: str, item_name: str, attribute_names: list[str]
+    ) -> list[dict[str, Any]]:
         """
         Behaviour for the consistent_read-attribute is not yet implemented
         """
@@ -90,7 +91,7 @@ class SimpleDBBackend(BaseBackend):
         return domain.get(item_name, attribute_names)
 
     def put_attributes(
-        self, domain_name: str, item_name: str, attributes: List[Dict[str, Any]]
+        self, domain_name: str, item_name: str, attributes: list[dict[str, Any]]
     ) -> None:
         """
         Behaviour for the expected-attribute is not yet implemented.

--- a/moto/secretsmanager/list_secrets/filters.py
+++ b/moto/secretsmanager/list_secrets/filters.py
@@ -1,15 +1,16 @@
 import re
-from typing import TYPE_CHECKING, Iterator, List, Union
+from collections.abc import Iterator
+from typing import TYPE_CHECKING, Union
 
 if TYPE_CHECKING:
     from ..models import FakeSecret, ReplicaSecret
 
 
-def name_filter(secret: "FakeSecret", names: List[str]) -> bool:
+def name_filter(secret: "FakeSecret", names: list[str]) -> bool:
     return _matcher(names, [secret.name])
 
 
-def description_filter(secret: "FakeSecret", descriptions: List[str]) -> bool:
+def description_filter(secret: "FakeSecret", descriptions: list[str]) -> bool:
     if not secret.description:
         return False
     # The documentation states that this search uses `Prefix match`
@@ -20,7 +21,7 @@ def description_filter(secret: "FakeSecret", descriptions: List[str]) -> bool:
     )
 
 
-def owning_service_filter(secret: "FakeSecret", owning_services: List[str]) -> bool:
+def owning_service_filter(secret: "FakeSecret", owning_services: list[str]) -> bool:
     return _matcher(
         owning_services,
         [secret.owning_service] if secret.owning_service else [],
@@ -29,21 +30,21 @@ def owning_service_filter(secret: "FakeSecret", owning_services: List[str]) -> b
     )
 
 
-def tag_key(secret: Union["FakeSecret", "ReplicaSecret"], tag_keys: List[str]) -> bool:
+def tag_key(secret: Union["FakeSecret", "ReplicaSecret"], tag_keys: list[str]) -> bool:
     if not secret.tags:
         return False
     return _matcher(tag_keys, [tag["Key"] for tag in secret.tags])
 
 
 def tag_value(
-    secret: Union["FakeSecret", "ReplicaSecret"], tag_values: List[str]
+    secret: Union["FakeSecret", "ReplicaSecret"], tag_values: list[str]
 ) -> bool:
     if not secret.tags:
         return False
     return _matcher(tag_values, [tag["Value"] for tag in secret.tags])
 
 
-def filter_all(secret: Union["FakeSecret", "ReplicaSecret"], values: List[str]) -> bool:
+def filter_all(secret: Union["FakeSecret", "ReplicaSecret"], values: list[str]) -> bool:
     attributes = [secret.name]
     if secret.description:
         attributes.append(secret.description)
@@ -56,8 +57,8 @@ def filter_all(secret: Union["FakeSecret", "ReplicaSecret"], values: List[str]) 
 
 
 def _matcher(
-    patterns: List[str],
-    strings: List[str],
+    patterns: list[str],
+    strings: list[str],
     match_prefix: bool = True,
     case_sensitive: bool = True,
 ) -> bool:
@@ -102,7 +103,7 @@ def _match_pattern(
     return True
 
 
-def split_words(s: str) -> List[str]:
+def split_words(s: str) -> list[str]:
     """
     Secrets are split by special characters first (/, +, _, etc)
     Partial results are then split again by UpperCasing
@@ -127,7 +128,7 @@ def split_words(s: str) -> List[str]:
     return list(split_by_uppercase(s))
 
 
-def split_by_uppercase(s: Union[str, List[str]]) -> Iterator[str]:
+def split_by_uppercase(s: Union[str, list[str]]) -> Iterator[str]:
     """
     Split a string into words. Words are recognized by upper case letters, i.e.:
     test   -> [test]

--- a/moto/secretsmanager/models.py
+++ b/moto/secretsmanager/models.py
@@ -1,7 +1,7 @@
 import datetime
 import json
 import time
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Optional, Union
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
@@ -37,7 +37,7 @@ MAX_RESULTS_DEFAULT = 100
 
 
 def filter_primary_region(
-    secret: Union["FakeSecret", "ReplicaSecret"], values: List[str]
+    secret: Union["FakeSecret", "ReplicaSecret"], values: list[str]
 ) -> bool:
     if isinstance(secret, FakeSecret):
         return len(secret.replicas) > 0 and secret.region in values
@@ -56,12 +56,12 @@ _filter_functions = {
 }
 
 
-def filter_keys() -> List[str]:
+def filter_keys() -> list[str]:
     return list(_filter_functions.keys())
 
 
 def _matches(
-    secret: Union["FakeSecret", "ReplicaSecret"], filters: List[Dict[str, Any]]
+    secret: Union["FakeSecret", "ReplicaSecret"], filters: list[dict[str, Any]]
 ) -> bool:
     is_match = True
 
@@ -79,17 +79,17 @@ class FakeSecret(BaseModel):
         account_id: str,
         region_name: str,
         secret_id: str,
-        secret_version: Dict[str, Any],
+        secret_version: dict[str, Any],
         version_id: str,
         secret_string: Optional[str] = None,
         secret_binary: Optional[str] = None,
         description: Optional[str] = None,
-        tags: Optional[List[Dict[str, str]]] = None,
+        tags: Optional[list[dict[str, str]]] = None,
         kms_key_id: Optional[str] = None,
-        version_stages: Optional[List[str]] = None,
+        version_stages: Optional[list[str]] = None,
         last_changed_date: Optional[int] = None,
         created_date: Optional[int] = None,
-        replica_regions: Optional[List[Dict[str, str]]] = None,
+        replica_regions: Optional[list[dict[str, str]]] = None,
         force_overwrite: bool = False,
     ):
         self.secret_id = secret_id
@@ -117,7 +117,7 @@ class FakeSecret(BaseModel):
         self.next_rotation_date: Optional[int] = None
         self.last_rotation_date: Optional[int] = None
 
-        self.versions: Dict[str, Dict[str, Any]] = {}
+        self.versions: dict[str, dict[str, Any]] = {}
         if secret_string or secret_binary:
             self.versions = {version_id: secret_version}
             self.set_default_version_id(version_id)
@@ -136,14 +136,14 @@ class FakeSecret(BaseModel):
         return None
 
     def create_replicas(
-        self, replica_regions: List[Dict[str, str]], force_overwrite: bool
-    ) -> List["ReplicaSecret"]:
+        self, replica_regions: list[dict[str, str]], force_overwrite: bool
+    ) -> list["ReplicaSecret"]:
         # Validate first, before we create anything
         for replica_config in replica_regions or []:
             if replica_config["Region"] == self.region:
                 raise InvalidParameterException("Invalid replica region.")
 
-        replicas: List[ReplicaSecret] = []
+        replicas: list[ReplicaSecret] = []
         for replica_config in replica_regions or []:
             replica_region = replica_config["Region"]
             backend = secretsmanager_backends[self.account_id][replica_region]
@@ -164,7 +164,7 @@ class FakeSecret(BaseModel):
     def update(
         self,
         description: Optional[str] = None,
-        tags: Optional[List[Dict[str, str]]] = None,
+        tags: Optional[list[dict[str, str]]] = None,
         kms_key_id: Optional[str] = None,
         last_changed_date: Optional[int] = None,
     ) -> None:
@@ -180,7 +180,7 @@ class FakeSecret(BaseModel):
         self.default_version_id = version_id
 
     def reset_default_version(
-        self, secret_version: Dict[str, Any], version_id: str
+        self, secret_version: dict[str, Any], version_id: str
     ) -> None:
         # remove all old AWSPREVIOUS stages
         for old_version in self.versions.values():
@@ -198,7 +198,7 @@ class FakeSecret(BaseModel):
         self.default_version_id = version_id
 
     def remove_version_stages_from_old_versions(
-        self, version_stages: List[str]
+        self, version_stages: list[str]
     ) -> None:
         for version_stage in version_stages:
             for old_version in self.versions.values():
@@ -222,7 +222,7 @@ class FakeSecret(BaseModel):
     ) -> str:
         if not version_id:
             version_id = self.default_version_id
-        dct: Dict[str, Any] = {
+        dct: dict[str, Any] = {
             "ARN": self.arn,
             "Name": self.name,
         }
@@ -234,10 +234,10 @@ class FakeSecret(BaseModel):
             dct["ReplicationStatus"] = [replica.config for replica in self.replicas]
         return json.dumps(dct)
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         version_id_to_stages = self._form_version_ids_to_stages()
 
-        dct: Dict[str, Any] = {
+        dct: dict[str, Any] = {
             "ARN": self.arn,
             "Name": self.name,
             "LastChangedDate": self.last_changed_date,
@@ -278,7 +278,7 @@ class FakeSecret(BaseModel):
             dct["ReplicationStatus"] = [replica.config for replica in self.replicas]
         return dct
 
-    def _form_version_ids_to_stages(self) -> Dict[str, str]:
+    def _form_version_ids_to_stages(self) -> dict[str, str]:
         version_id_to_stages = {}
         for key, value in self.versions.items():
             version_id_to_stages[key] = value["version_stages"]
@@ -310,7 +310,7 @@ class ReplicaSecret:
     def is_deleted(self) -> bool:
         return False
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         dct = self.source.to_dict()
         dct["ARN"] = self.arn
         dct["PrimaryRegion"] = self.source.region
@@ -321,7 +321,7 @@ class ReplicaSecret:
         return self.source.default_version_id
 
     @property
-    def versions(self) -> Dict[str, Dict[str, Any]]:  # type: ignore[misc]
+    def versions(self) -> dict[str, dict[str, Any]]:  # type: ignore[misc]
         return self.source.versions
 
     @property
@@ -337,7 +337,7 @@ class ReplicaSecret:
         return self.source.description
 
     @property
-    def tags(self) -> Optional[List[Dict[str, str]]]:
+    def tags(self) -> Optional[list[dict[str, str]]]:
         return self.source.tags
 
     @property
@@ -345,7 +345,7 @@ class ReplicaSecret:
         return self.source.owning_service
 
 
-class SecretsStore(Dict[str, Union[FakeSecret, ReplicaSecret]]):
+class SecretsStore(dict[str, Union[FakeSecret, ReplicaSecret]]):
     # Parameters to this dictionary can be three possible values:
     # names, full ARNs, and partial ARNs
     # Every retrieval method should check which type of input it receives
@@ -425,10 +425,8 @@ class SecretsManagerBackend(BaseBackend):
             # This response doesn't make much sense for  `CancelRotateSecret`, but this is what AWS has documented ...
             # https://docs.aws.amazon.com/secretsmanager/latest/apireference/API_CancelRotateSecret.html
             raise InvalidRequestException(
-                (
-                    "You tried to enable rotation on a secret that doesn't already have a Lambda function ARN configured"
-                    "and you didn't include such an ARN as a parameter in this call."
-                )
+                "You tried to enable rotation on a secret that doesn't already have a Lambda function ARN configured"
+                "and you didn't include such an ARN as a parameter in this call."
             )
 
         secret.rotation_enabled = False
@@ -436,7 +434,7 @@ class SecretsManagerBackend(BaseBackend):
 
     def get_secret_value(
         self, secret_id: str, version_id: str, version_stage: str
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         if not self._is_valid_identifier(secret_id):
             raise SecretNotFoundException()
 
@@ -500,13 +498,13 @@ class SecretsManagerBackend(BaseBackend):
 
     def batch_get_secret_value(
         self,
-        secret_id_list: Optional[List[str]] = None,
-        filters: Optional[List[Dict[str, Any]]] = None,
+        secret_id_list: Optional[list[str]] = None,
+        filters: Optional[list[dict[str, Any]]] = None,
         max_results: Optional[int] = None,
         next_token: Optional[str] = None,
-    ) -> Tuple[List[Dict[str, Any]], List[Any], Optional[str]]:
+    ) -> tuple[list[dict[str, Any]], list[Any], Optional[str]]:
         secret_list = []
-        errors: List[Any] = []
+        errors: list[Any] = []
         if secret_id_list and filters:
             raise InvalidParameterException(
                 "Either 'SecretIdList' or 'Filters' must be provided, but not both."
@@ -592,10 +590,10 @@ class SecretsManagerBackend(BaseBackend):
         secret_string: Optional[str],
         secret_binary: Optional[str],
         description: Optional[str],
-        tags: Optional[List[Dict[str, str]]],
+        tags: Optional[list[dict[str, str]]],
         kms_key_id: Optional[str],
         client_request_token: Optional[str],
-        replica_regions: List[Dict[str, str]],
+        replica_regions: list[dict[str, str]],
         force_overwrite: bool,
     ) -> str:
         existing_secret = self._check_with_existing_secrets_and_versions(
@@ -671,13 +669,13 @@ class SecretsManagerBackend(BaseBackend):
         secret_string: Optional[str] = None,
         secret_binary: Optional[str] = None,
         description: Optional[str] = None,
-        tags: Optional[List[Dict[str, str]]] = None,
+        tags: Optional[list[dict[str, str]]] = None,
         kms_key_id: Optional[str] = None,
         version_id: Optional[str] = None,
-        version_stages: Optional[List[str]] = None,
-        replica_regions: Optional[List[Dict[str, str]]] = None,
+        version_stages: Optional[list[str]] = None,
+        replica_regions: Optional[list[dict[str, str]]] = None,
         force_overwrite: bool = False,
-    ) -> Tuple[FakeSecret, bool]:
+    ) -> tuple[FakeSecret, bool]:
         if version_stages is None:
             version_stages = ["AWSCURRENT"]
 
@@ -738,10 +736,10 @@ class SecretsManagerBackend(BaseBackend):
         secret_string: Optional[str] = None,
         secret_binary: Optional[str] = None,
         description: Optional[str] = None,
-        tags: Optional[List[Dict[str, str]]] = None,
+        tags: Optional[list[dict[str, str]]] = None,
         kms_key_id: Optional[str] = None,
         version_id: Optional[str] = None,
-        replica_regions: Optional[List[Dict[str, str]]] = None,
+        replica_regions: Optional[list[dict[str, str]]] = None,
         force_overwrite: bool = False,
     ) -> FakeSecret:
         """Create an AWS managed secret for the specified service name."""
@@ -774,7 +772,7 @@ class SecretsManagerBackend(BaseBackend):
         secret_string: str,
         secret_binary: str,
         client_request_token: str,
-        version_stages: List[str],
+        version_stages: list[str],
     ) -> str:
         if not self._is_valid_identifier(secret_id):
             raise SecretNotFoundException()
@@ -816,7 +814,7 @@ class SecretsManagerBackend(BaseBackend):
         secret_id: str,
         client_request_token: Optional[str] = None,
         rotation_lambda_arn: Optional[str] = None,
-        rotation_rules: Optional[Dict[str, Any]] = None,
+        rotation_rules: Optional[dict[str, Any]] = None,
         rotate_immediately: bool = True,
     ) -> str:
         rotation_days = "AutomaticallyAfterDays"
@@ -909,8 +907,8 @@ class SecretsManagerBackend(BaseBackend):
 
             lambda_backend = get_backend(self.account_id, self.region_name)
 
-            request_headers: Dict[str, Any] = {}
-            response_headers: Dict[str, Any] = {}
+            request_headers: dict[str, Any] = {}
+            response_headers: dict[str, Any] = {}
 
             try:
                 lambda_backend.get_function(secret.rotation_lambda_arn)
@@ -1018,12 +1016,12 @@ class SecretsManagerBackend(BaseBackend):
 
     def list_secrets(
         self,
-        filters: List[Dict[str, Any]],
+        filters: list[dict[str, Any]],
         max_results: int = MAX_RESULTS_DEFAULT,
         next_token: Optional[str] = None,
         include_planned_deletion: bool = False,
-    ) -> Tuple[List[Dict[str, Any]], Optional[str]]:
-        secret_list: List[Dict[str, Any]] = []
+    ) -> tuple[list[dict[str, Any]], Optional[str]]:
+        secret_list: list[dict[str, Any]] = []
         for secret in self.secrets.values():
             if hasattr(secret, "deleted_date"):
                 if secret.deleted_date and not include_planned_deletion:
@@ -1040,7 +1038,7 @@ class SecretsManagerBackend(BaseBackend):
         secret_id: str,
         recovery_window_in_days: Optional[int],
         force_delete_without_recovery: bool,
-    ) -> Tuple[str, str, float]:
+    ) -> tuple[str, str, float]:
         if recovery_window_in_days is not None and (
             recovery_window_in_days < 7 or recovery_window_in_days > 30
         ):
@@ -1096,7 +1094,7 @@ class SecretsManagerBackend(BaseBackend):
 
             return arn, name, self._unix_time_secs(deletion_date)
 
-    def restore_secret(self, secret_id: str) -> Tuple[str, str]:
+    def restore_secret(self, secret_id: str) -> tuple[str, str]:
         if not self._is_valid_identifier(secret_id):
             raise SecretNotFoundException()
 
@@ -1107,7 +1105,7 @@ class SecretsManagerBackend(BaseBackend):
 
         return secret.arn, secret.name
 
-    def tag_resource(self, secret_id: str, tags: List[Dict[str, str]]) -> None:
+    def tag_resource(self, secret_id: str, tags: list[dict[str, str]]) -> None:
         if secret_id not in self.secrets:
             raise SecretNotFoundException()
 
@@ -1122,7 +1120,7 @@ class SecretsManagerBackend(BaseBackend):
 
         secret.tags = list(old_tags.values())
 
-    def untag_resource(self, secret_id: str, tag_keys: List[str]) -> None:
+    def untag_resource(self, secret_id: str, tag_keys: list[str]) -> None:
         if secret_id not in self.secrets:
             raise SecretNotFoundException()
 
@@ -1141,7 +1139,7 @@ class SecretsManagerBackend(BaseBackend):
         version_stage: str,
         remove_from_version_id: str,
         move_to_version_id: str,
-    ) -> Tuple[str, str]:
+    ) -> tuple[str, str]:
         if secret_id not in self.secrets:
             raise SecretNotFoundException()
 
@@ -1197,7 +1195,7 @@ class SecretsManagerBackend(BaseBackend):
 
         return secret.arn, secret.name
 
-    def put_resource_policy(self, secret_id: str, policy: str) -> Tuple[str, str]:
+    def put_resource_policy(self, secret_id: str, policy: str) -> tuple[str, str]:
         """
         The BlockPublicPolicy-parameter is not yet implemented
         """
@@ -1225,7 +1223,7 @@ class SecretsManagerBackend(BaseBackend):
             resp["ResourcePolicy"] = secret.policy
         return json.dumps(resp)
 
-    def delete_resource_policy(self, secret_id: str) -> Tuple[str, str]:
+    def delete_resource_policy(self, secret_id: str) -> tuple[str, str]:
         if not self._is_valid_identifier(secret_id):
             raise SecretNotFoundException()
 
@@ -1238,9 +1236,9 @@ class SecretsManagerBackend(BaseBackend):
     def replicate_secret_to_regions(
         self,
         secret_id: str,
-        replica_regions: List[Dict[str, str]],
+        replica_regions: list[dict[str, str]],
         force_overwrite: bool,
-    ) -> Tuple[str, List[Dict[str, Any]]]:
+    ) -> tuple[str, list[dict[str, Any]]]:
         secret = self.describe_secret(secret_id)
         if isinstance(secret, ReplicaSecret):
             raise OperationNotPermittedOnReplica
@@ -1251,8 +1249,8 @@ class SecretsManagerBackend(BaseBackend):
         return secret_id, statuses
 
     def remove_regions_from_replication(
-        self, secret_id: str, replica_regions: List[str]
-    ) -> Tuple[str, List[Dict[str, str]]]:
+        self, secret_id: str, replica_regions: list[str]
+    ) -> tuple[str, list[dict[str, str]]]:
         secret = self.describe_secret(secret_id)
         if isinstance(secret, ReplicaSecret):
             raise OperationNotPermittedOnReplica
@@ -1268,10 +1266,10 @@ class SecretsManagerBackend(BaseBackend):
 
     def _get_secret_values_page_and_next_token(
         self,
-        secret_list: List[Dict[str, Any]],
+        secret_list: list[dict[str, Any]],
         max_results: Optional[int],
         next_token: Optional[str],
-    ) -> Tuple[List[Dict[str, Any]], Optional[str]]:
+    ) -> tuple[list[dict[str, Any]], Optional[str]]:
         starting_point = int(next_token or 0)
         ending_point = starting_point + int(max_results or MAX_RESULTS_DEFAULT)
         secret_page = secret_list[starting_point:ending_point]

--- a/moto/secretsmanager/responses.py
+++ b/moto/secretsmanager/responses.py
@@ -1,5 +1,5 @@
 import json
-from typing import Any, Dict, List
+from typing import Any
 
 from moto.core.responses import BaseResponse
 from moto.secretsmanager.exceptions import (
@@ -11,7 +11,7 @@ from moto.secretsmanager.exceptions import (
 from .models import SecretsManagerBackend, filter_keys, secretsmanager_backends
 
 
-def _validate_filters(filters: List[Dict[str, Any]]) -> None:
+def _validate_filters(filters: list[dict[str, Any]]) -> None:
     for idx, f in enumerate(filters):
         filter_key = f.get("Key", None)
         filter_values = f.get("Values", None)

--- a/moto/securityhub/exceptions.py
+++ b/moto/securityhub/exceptions.py
@@ -11,8 +11,7 @@ class _InvalidOperationException(SecurityHubClientError):
     def __init__(self, error_type: str, op: str, msg: str):
         super().__init__(
             error_type,
-            "An error occurred (%s) when calling the %s operation: %s"
-            % (error_type, op, msg),
+            f"An error occurred ({error_type}) when calling the {op} operation: {msg}",
         )
 
 

--- a/moto/securityhub/models.py
+++ b/moto/securityhub/models.py
@@ -1,7 +1,7 @@
 """SecurityHubBackend class with methods for supported APIs."""
 
 import datetime
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Optional
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
@@ -13,11 +13,11 @@ from moto.utilities.paginator import paginate
 
 
 class Finding(BaseModel):
-    def __init__(self, finding_id: str, finding_data: Dict[str, Any]):
+    def __init__(self, finding_id: str, finding_data: dict[str, Any]):
         self.id = finding_id
         self.data = finding_data
 
-    def as_dict(self) -> Dict[str, Any]:
+    def as_dict(self) -> dict[str, Any]:
         return self.data
 
 
@@ -34,17 +34,17 @@ class SecurityHubBackend(BaseBackend):
         }
     }
 
-    _org_configs: Dict[str, Dict[str, Any]] = {}
+    _org_configs: dict[str, dict[str, Any]] = {}
 
     def __init__(self, region_name: str, account_id: str):
         super().__init__(region_name, account_id)
-        self.findings: List[Finding] = []
+        self.findings: list[Finding] = []
         self.region_name = region_name
         self.org_backend = organizations_backends[self.account_id]["aws"]
         self.enabled_at: Optional[str] = None
         self.enabled = False
 
-    def _get_org_config(self) -> Dict[str, Any]:
+    def _get_org_config(self) -> dict[str, Any]:
         """Get organization config for the current account."""
         try:
             org = self.org_backend.describe_organization()
@@ -68,8 +68,8 @@ class SecurityHubBackend(BaseBackend):
     def enable_security_hub(
         self,
         enable_default_standards: bool = True,
-        tags: Optional[Dict[str, str]] = None,
-    ) -> Dict[str, Any]:
+        tags: Optional[dict[str, str]] = None,
+    ) -> dict[str, Any]:
         if self.enabled:
             return {}
 
@@ -82,7 +82,7 @@ class SecurityHubBackend(BaseBackend):
 
         return {}
 
-    def disable_security_hub(self) -> Dict[str, Any]:
+    def disable_security_hub(self) -> dict[str, Any]:
         if not self.enabled:
             raise RESTError(
                 "InvalidAccessException",
@@ -95,7 +95,7 @@ class SecurityHubBackend(BaseBackend):
 
         return {}
 
-    def describe_hub(self, hub_arn: Optional[str] = None) -> Dict[str, Any]:
+    def describe_hub(self, hub_arn: Optional[str] = None) -> dict[str, Any]:
         if not self.enabled:
             raise RESTError(
                 "InvalidAccessException",
@@ -122,11 +122,11 @@ class SecurityHubBackend(BaseBackend):
     @paginate(pagination_model=PAGINATION_MODEL)
     def get_findings(
         self,
-        filters: Optional[Dict[str, Any]] = None,
-        sort_criteria: Optional[List[Dict[str, str]]] = None,
+        filters: Optional[dict[str, Any]] = None,
+        sort_criteria: Optional[list[dict[str, str]]] = None,
         max_results: Optional[int] = None,
         next_token: Optional[str] = None,
-    ) -> List[Dict[str, str]]:
+    ) -> list[dict[str, str]]:
         """
         Returns findings based on optional filters and sort criteria.
         """
@@ -151,8 +151,8 @@ class SecurityHubBackend(BaseBackend):
         return [f.as_dict() for f in findings]
 
     def batch_import_findings(
-        self, findings: List[Dict[str, Any]]
-    ) -> Tuple[int, int, List[Dict[str, Any]]]:
+        self, findings: list[dict[str, Any]]
+    ) -> tuple[int, int, list[dict[str, Any]]]:
         """
         Import findings in batch to SecurityHub.
 
@@ -234,7 +234,7 @@ class SecurityHubBackend(BaseBackend):
         self,
         auto_enable: bool,
         auto_enable_standards: Optional[str] = None,
-        organization_configuration: Optional[Dict[str, Any]] = None,
+        organization_configuration: Optional[dict[str, Any]] = None,
     ) -> None:
         try:
             self.org_backend.describe_organization()
@@ -304,7 +304,7 @@ class SecurityHubBackend(BaseBackend):
                 )
             org_config["auto_enable_standards"] = auto_enable_standards
 
-    def get_administrator_account(self) -> Dict[str, Any]:
+    def get_administrator_account(self) -> dict[str, Any]:
         try:
             org = self.org_backend.describe_organization()
             management_account_id = org["Organization"]["MasterAccountId"]
@@ -332,7 +332,7 @@ class SecurityHubBackend(BaseBackend):
             }
         }
 
-    def describe_organization_configuration(self) -> Dict[str, Any]:
+    def describe_organization_configuration(self) -> dict[str, Any]:
         try:
             self.org_backend.describe_organization()
         except RESTError:

--- a/moto/server.py
+++ b/moto/server.py
@@ -2,7 +2,7 @@ import argparse
 import os
 import signal
 import sys
-from typing import Any, List, Optional
+from typing import Any, Optional
 
 from werkzeug.serving import run_simple
 
@@ -20,7 +20,7 @@ def signal_handler(signum: Any, frame: Any) -> None:
     sys.exit(0)
 
 
-def main(argv: Optional[List[str]] = None) -> None:
+def main(argv: Optional[list[str]] = None) -> None:
     argv = argv or sys.argv[1:]
     parser = argparse.ArgumentParser()
 

--- a/moto/servicecatalog/models.py
+++ b/moto/servicecatalog/models.py
@@ -2,7 +2,7 @@
 
 import uuid
 from datetime import datetime
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Optional
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
@@ -28,7 +28,7 @@ class Portfolio(BaseModel):
         display_name: str,
         description: str,
         provider_name: str,
-        tags: List[Dict[str, str]],
+        tags: list[dict[str, str]],
         region_name: str,
         account_id: str,
     ) -> None:
@@ -45,7 +45,7 @@ class Portfolio(BaseModel):
     def arn(self) -> str:
         return f"arn:{get_partition(self.region_name)}:catalog:{self.region_name}:{self.account_id}:portfolio/{self.id}"
 
-    def to_dict(self) -> Dict[str, str]:
+    def to_dict(self) -> dict[str, str]:
         return {
             "Id": self.id,
             "ARN": self.arn,
@@ -61,10 +61,10 @@ class ServiceCatalogBackend(BaseBackend):
 
     def __init__(self, region_name: str, account_id: str) -> None:
         super().__init__(region_name, account_id)
-        self.portfolio_access: Dict[str, List[str]] = {}
-        self.portfolios: Dict[str, Portfolio] = {}
-        self.idempotency_tokens: Dict[str, str] = {}
-        self.portfolio_share_tokens: Dict[str, List[str]] = {}
+        self.portfolio_access: dict[str, list[str]] = {}
+        self.portfolios: dict[str, Portfolio] = {}
+        self.idempotency_tokens: dict[str, str] = {}
+        self.portfolio_share_tokens: dict[str, list[str]] = {}
 
     @paginate(pagination_model=PAGINATION_MODEL)
     def list_portfolio_access(
@@ -74,7 +74,7 @@ class ServiceCatalogBackend(BaseBackend):
         organization_parent_id: Optional[str],
         page_token: Optional[str],
         page_size: Optional[int] = None,
-    ) -> List[Dict[str, str]]:
+    ) -> list[dict[str, str]]:
         # TODO: Implement organization_parent_id and accept_language
 
         account_ids = self.portfolio_access.get(portfolio_id, [])
@@ -96,7 +96,7 @@ class ServiceCatalogBackend(BaseBackend):
         accept_language: Optional[str],
         portfolio_id: str,
         account_id: Optional[str],
-        organization_node: Optional[Dict[str, str]],
+        organization_node: Optional[dict[str, str]],
     ) -> Optional[str]:
         # TODO: Implement accept_language
 
@@ -133,9 +133,9 @@ class ServiceCatalogBackend(BaseBackend):
         display_name: str,
         description: Optional[str],
         provider_name: str,
-        tags: Optional[List[Dict[str, str]]],
+        tags: Optional[list[dict[str, str]]],
         idempotency_token: Optional[str],
-    ) -> Tuple[Dict[str, str], List[Dict[str, str]]]:
+    ) -> tuple[dict[str, str], list[dict[str, str]]]:
         # TODO: Implement accept_language
 
         if idempotency_token and idempotency_token in self.idempotency_tokens:
@@ -169,7 +169,7 @@ class ServiceCatalogBackend(BaseBackend):
         accept_language: Optional[str],
         portfolio_id: str,
         account_id: Optional[str],
-        organization_node: Optional[Dict[str, str]],
+        organization_node: Optional[dict[str, str]],
         share_tag_options: bool,
         share_principals: bool,
     ) -> Optional[str]:
@@ -213,7 +213,7 @@ class ServiceCatalogBackend(BaseBackend):
         accept_language: Optional[str] = None,
         page_token: Optional[str] = None,
         page_size: Optional[int] = None,
-    ) -> Tuple[List[Dict[str, str]], Optional[str]]:
+    ) -> tuple[list[dict[str, str]], Optional[str]]:
         """TODO: Implement pagination and accept_language"""
         portfolio_details = [
             portfolio.to_dict() for portfolio in self.portfolios.values()
@@ -226,7 +226,7 @@ class ServiceCatalogBackend(BaseBackend):
         type: str,
         page_token: Optional[str] = None,
         page_size: Optional[int] = None,
-    ) -> Tuple[Optional[str], List[Dict[str, Any]]]:
+    ) -> tuple[Optional[str], list[dict[str, Any]]]:
         """TODO: Implement pagination"""
 
         portfolio_share_details = []
@@ -277,8 +277,8 @@ class ServiceCatalogBackend(BaseBackend):
 
     def describe_portfolio(
         self, accept_language: Optional[str], id: str
-    ) -> Tuple[
-        Dict[str, Any], List[Dict[str, str]], List[Dict[str, Any]], List[Dict[str, str]]
+    ) -> tuple[
+        dict[str, Any], list[dict[str, str]], list[dict[str, Any]], list[dict[str, str]]
     ]:
         # TODO: Implement accept_language
 
@@ -290,8 +290,8 @@ class ServiceCatalogBackend(BaseBackend):
 
         tags = portfolio.tags
 
-        tag_options: List[Dict[str, Any]] = []
-        budgets: List[Dict[str, Any]] = []
+        tag_options: list[dict[str, Any]] = []
+        budgets: list[dict[str, Any]] = []
 
         return portfolio_detail, tags, tag_options, budgets
 

--- a/moto/servicecatalogappregistry/models.py
+++ b/moto/servicecatalogappregistry/models.py
@@ -2,7 +2,7 @@
 
 import datetime
 import re
-from typing import Any, Dict, List
+from typing import Any
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
@@ -32,12 +32,12 @@ class Application(BaseModel):
         self.description = description
         self.creationTime = datetime.datetime.now()
         self.lastUpdateTime = self.creationTime
-        self.tags: Dict[str, str] = dict()
-        self.applicationTag: Dict[str, str] = {"awsApplication": self.arn}
+        self.tags: dict[str, str] = dict()
+        self.applicationTag: dict[str, str] = {"awsApplication": self.arn}
 
-        self.associated_resources: Dict[str, AssociatedResource] = dict()
+        self.associated_resources: dict[str, AssociatedResource] = dict()
 
-    def to_json(self) -> Dict[str, Any]:
+    def to_json(self) -> dict[str, Any]:
         return {
             "id": self.id,
             "arn": self.arn,
@@ -55,7 +55,7 @@ class AssociatedResource(BaseBackend):
         self,
         resource_type: str,
         resource: str,
-        options: List[str],
+        options: list[str],
         application: Application,
         account_id: str,
         region_name: str,
@@ -103,7 +103,7 @@ class AssociatedResource(BaseBackend):
         self.resource_type = resource_type
         self.options = options
 
-    def to_json(self) -> Dict[str, Any]:
+    def to_json(self) -> dict[str, Any]:
         return_dict = {
             "name": self.name,
             "arn": self.resource,
@@ -120,12 +120,12 @@ class AppRegistryBackend(BaseBackend):
 
     def __init__(self, region_name: str, account_id: str):
         super().__init__(region_name, account_id)
-        self.applications: Dict[str, Application] = dict()
+        self.applications: dict[str, Application] = dict()
         self.tagger = TaggingService()
-        self.configuration: Dict[str, Any] = {"tagQueryConfiguration": {}}
+        self.configuration: dict[str, Any] = {"tagQueryConfiguration": {}}
 
     def create_application(
-        self, name: str, description: str, tags: Dict[str, str], client_token: str
+        self, name: str, description: str, tags: dict[str, str], client_token: str
     ) -> Application:
         app = Application(
             name,
@@ -137,12 +137,12 @@ class AppRegistryBackend(BaseBackend):
         self._tag_resource(app.arn, tags)
         return app
 
-    def list_applications(self) -> List[Application]:
+    def list_applications(self) -> list[Application]:
         return list(self.applications.values())
 
     def associate_resource(
-        self, application: str, resource_type: str, resource: str, options: List[str]
-    ) -> Dict[str, Any]:
+        self, application: str, resource_type: str, resource: str, options: list[str]
+    ) -> dict[str, Any]:
         app = self.applications[application]
         new_resource = AssociatedResource(
             resource_type, resource, options, app, self.account_id, self.region_name
@@ -150,21 +150,21 @@ class AppRegistryBackend(BaseBackend):
         app.associated_resources[new_resource.resource] = new_resource
         return {"applicationArn": app.arn, "resourceArn": resource, "options": options}
 
-    def _list_tags_for_resource(self, arn: str) -> Dict[str, str]:
+    def _list_tags_for_resource(self, arn: str) -> dict[str, str]:
         return self.tagger.get_tag_dict_for_resource(arn)
 
-    def _tag_resource(self, arn: str, tags: Dict[str, str]) -> None:
+    def _tag_resource(self, arn: str, tags: dict[str, str]) -> None:
         self.tagger.tag_resource(arn, TaggingService.convert_dict_to_tags_input(tags))
 
-    def _untag_resource(self, arn: str, tag_keys: List[str]) -> None:
+    def _untag_resource(self, arn: str, tag_keys: list[str]) -> None:
         self.tagger.untag_resource_using_names(arn, tag_keys)
 
-    def put_configuration(self, configuration: Dict[str, Any]) -> None:
+    def put_configuration(self, configuration: dict[str, Any]) -> None:
         self.configuration = configuration
 
     def get_configuration(
         self,
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         return self.configuration
 
 

--- a/moto/servicediscovery/models.py
+++ b/moto/servicediscovery/models.py
@@ -1,5 +1,6 @@
 import string
-from typing import Any, Dict, Iterable, List, Optional, Tuple
+from collections.abc import Iterable
+from typing import Any, Optional
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
@@ -35,8 +36,8 @@ class Namespace(BaseModel):
         ns_type: str,
         creator_request_id: str,
         description: str,
-        dns_properties: Dict[str, Any],
-        http_properties: Dict[str, Any],
+        dns_properties: dict[str, Any],
+        http_properties: dict[str, Any],
         vpc: Optional[str] = None,
     ):
         self.id = f"ns-{random_id(20)}"
@@ -51,7 +52,7 @@ class Namespace(BaseModel):
         self.created = unix_time()
         self.updated = unix_time()
 
-    def to_json(self) -> Dict[str, Any]:
+    def to_json(self) -> dict[str, Any]:
         return {
             "Arn": self.arn,
             "Id": self.id,
@@ -77,9 +78,9 @@ class Service(BaseModel):
         namespace_id: str,
         description: str,
         creator_request_id: str,
-        dns_config: Dict[str, Any],
-        health_check_config: Dict[str, Any],
-        health_check_custom_config: Dict[str, int],
+        dns_config: dict[str, Any],
+        health_check_config: dict[str, Any],
+        health_check_custom_config: dict[str, int],
         service_type: str,
     ):
         self.id = f"srv-{random_id(8)}"
@@ -88,15 +89,15 @@ class Service(BaseModel):
         self.namespace_id = namespace_id
         self.description = description
         self.creator_request_id = creator_request_id
-        self.dns_config: Optional[Dict[str, Any]] = dns_config
+        self.dns_config: Optional[dict[str, Any]] = dns_config
         self.health_check_config = health_check_config
         self.health_check_custom_config = health_check_custom_config
         self.service_type = service_type
         self.created = unix_time()
-        self.instances: List[ServiceInstance] = []
-        self.instances_revision: Dict[str, int] = {}
+        self.instances: list[ServiceInstance] = []
+        self.instances_revision: dict[str, int] = {}
 
-    def update(self, details: Dict[str, Any]) -> None:
+    def update(self, details: dict[str, Any]) -> None:
         if "Description" in details:
             self.description = details["Description"]
         if "DnsConfig" in details:
@@ -111,7 +112,7 @@ class Service(BaseModel):
         if "HealthCheckConfig" in details:
             self.health_check_config = details["HealthCheckConfig"]
 
-    def to_json(self) -> Dict[str, Any]:
+    def to_json(self) -> dict[str, Any]:
         return {
             "Arn": self.arn,
             "Id": self.id,
@@ -133,7 +134,7 @@ class ServiceInstance(BaseModel):
         service_id: str,
         instance_id: str,
         creator_request_id: Optional[str] = None,
-        attributes: Optional[Dict[str, str]] = None,
+        attributes: Optional[dict[str, str]] = None,
     ):
         self.service_id = service_id
         self.instance_id = instance_id
@@ -143,7 +144,7 @@ class ServiceInstance(BaseModel):
         )
         self.health_status = "HEALTHY"
 
-    def to_json(self) -> Dict[str, Any]:
+    def to_json(self) -> dict[str, Any]:
         return {
             "Id": self.instance_id,
             "CreatorRequestId": self.creator_request_id,
@@ -152,7 +153,7 @@ class ServiceInstance(BaseModel):
 
 
 class Operation(BaseModel):
-    def __init__(self, operation_type: str, targets: Dict[str, str]):
+    def __init__(self, operation_type: str, targets: dict[str, str]):
         super().__init__()
         self.id = f"{random_id(32)}-{random_id(8)}"
         self.status = "SUCCESS"
@@ -161,7 +162,7 @@ class Operation(BaseModel):
         self.updated = unix_time()
         self.targets = targets
 
-    def to_json(self, short: bool = False) -> Dict[str, Any]:
+    def to_json(self, short: bool = False) -> dict[str, Any]:
         if short:
             return {"Id": self.id, "Status": self.status}
         else:
@@ -180,9 +181,9 @@ class ServiceDiscoveryBackend(BaseBackend):
 
     def __init__(self, region_name: str, account_id: str):
         super().__init__(region_name, account_id)
-        self.operations: Dict[str, Operation] = dict()
-        self.namespaces: Dict[str, Namespace] = dict()
-        self.services: Dict[str, Service] = dict()
+        self.operations: dict[str, Operation] = dict()
+        self.namespaces: dict[str, Namespace] = dict()
+        self.services: dict[str, Service] = dict()
         self.tagger = TaggingService()
 
     def list_namespaces(self) -> Iterable[Namespace]:
@@ -196,7 +197,7 @@ class ServiceDiscoveryBackend(BaseBackend):
         name: str,
         creator_request_id: str,
         description: str,
-        tags: List[Dict[str, str]],
+        tags: list[dict[str, str]],
     ) -> str:
         namespace = Namespace(
             account_id=self.account_id,
@@ -216,7 +217,7 @@ class ServiceDiscoveryBackend(BaseBackend):
         )
         return operation_id
 
-    def _create_operation(self, op_type: str, targets: Dict[str, str]) -> str:
+    def _create_operation(self, op_type: str, targets: dict[str, str]) -> str:
         operation = Operation(operation_type=op_type, targets=targets)
         self.operations[operation.id] = operation
         return operation.id
@@ -252,15 +253,15 @@ class ServiceDiscoveryBackend(BaseBackend):
             raise OperationNotFound()
         return self.operations[operation_id]
 
-    def tag_resource(self, resource_arn: str, tags: List[Dict[str, str]]) -> None:
+    def tag_resource(self, resource_arn: str, tags: list[dict[str, str]]) -> None:
         self.tagger.tag_resource(resource_arn, tags)
 
-    def untag_resource(self, resource_arn: str, tag_keys: List[str]) -> None:
+    def untag_resource(self, resource_arn: str, tag_keys: list[str]) -> None:
         self.tagger.untag_resource_using_names(resource_arn, tag_keys)
 
     def list_tags_for_resource(
         self, resource_arn: str
-    ) -> Dict[str, List[Dict[str, str]]]:
+    ) -> dict[str, list[dict[str, str]]]:
         return self.tagger.list_tags_for_resource(resource_arn)
 
     def create_private_dns_namespace(
@@ -269,8 +270,8 @@ class ServiceDiscoveryBackend(BaseBackend):
         creator_request_id: str,
         description: str,
         vpc: str,
-        tags: List[Dict[str, str]],
-        properties: Dict[str, Any],
+        tags: list[dict[str, str]],
+        properties: dict[str, Any],
     ) -> str:
         for namespace in self.namespaces.values():
             if namespace.vpc == vpc:
@@ -311,8 +312,8 @@ class ServiceDiscoveryBackend(BaseBackend):
         name: str,
         creator_request_id: str,
         description: str,
-        tags: List[Dict[str, str]],
-        properties: Dict[str, Any],
+        tags: list[dict[str, str]],
+        properties: dict[str, Any],
     ) -> str:
         dns_properties = (properties or {}).get("DnsProperties", {})
 
@@ -350,10 +351,10 @@ class ServiceDiscoveryBackend(BaseBackend):
         namespace_id: str,
         creator_request_id: str,
         description: str,
-        dns_config: Dict[str, Any],
-        health_check_config: Dict[str, Any],
-        health_check_custom_config: Dict[str, Any],
-        tags: List[Dict[str, str]],
+        dns_config: dict[str, Any],
+        health_check_config: dict[str, Any],
+        health_check_custom_config: dict[str, Any],
+        tags: list[dict[str, str]],
         service_type: str,
     ) -> Service:
         service = Service(
@@ -387,7 +388,7 @@ class ServiceDiscoveryBackend(BaseBackend):
         """
         return self.services.values()
 
-    def update_service(self, service_id: str, details: Dict[str, Any]) -> str:
+    def update_service(self, service_id: str, details: dict[str, Any]) -> str:
         service = self.get_service(service_id)
         service.update(details=details)
         operation_id = self._create_operation(
@@ -398,7 +399,7 @@ class ServiceDiscoveryBackend(BaseBackend):
     def update_http_namespace(
         self,
         _id: str,
-        namespace_dict: Dict[str, Any],
+        namespace_dict: dict[str, Any],
         updater_request_id: Optional[str] = None,
     ) -> str:
         if "Description" not in namespace_dict:
@@ -420,7 +421,7 @@ class ServiceDiscoveryBackend(BaseBackend):
         return operation_id
 
     def update_private_dns_namespace(
-        self, _id: str, description: str, properties: Dict[str, Any]
+        self, _id: str, description: str, properties: dict[str, Any]
     ) -> str:
         namespace = self.get_namespace(namespace_id=_id)
         if description is not None:
@@ -433,7 +434,7 @@ class ServiceDiscoveryBackend(BaseBackend):
         return operation_id
 
     def update_public_dns_namespace(
-        self, _id: str, description: str, properties: Dict[str, Any]
+        self, _id: str, description: str, properties: dict[str, Any]
     ) -> str:
         namespace = self.get_namespace(namespace_id=_id)
         if description is not None:
@@ -450,7 +451,7 @@ class ServiceDiscoveryBackend(BaseBackend):
         service_id: str,
         instance_id: str,
         creator_request_id: str,
-        attributes: Dict[str, str],
+        attributes: dict[str, str],
     ) -> str:
         service = self.get_service(service_id)
         instance = ServiceInstance(
@@ -485,7 +486,7 @@ class ServiceDiscoveryBackend(BaseBackend):
             i += 1
         raise InstanceNotFound(instance_id)
 
-    def list_instances(self, service_id: str) -> List[ServiceInstance]:
+    def list_instances(self, service_id: str) -> list[ServiceInstance]:
         service = self.get_service(service_id)
         return service.instances
 
@@ -498,8 +499,8 @@ class ServiceDiscoveryBackend(BaseBackend):
     def get_instances_health_status(
         self,
         service_id: str,
-        instances: Optional[List[str]] = None,
-    ) -> List[Tuple[str, str]]:
+        instances: Optional[list[str]] = None,
+    ) -> list[tuple[str, str]]:
         service = self.get_service(service_id)
         status = []
         if instances is None:
@@ -525,11 +526,11 @@ class ServiceDiscoveryBackend(BaseBackend):
 
     def _filter_instances(
         self,
-        instances: List[ServiceInstance],
-        query_parameters: Optional[Dict[str, str]] = None,
-        optional_parameters: Optional[Dict[str, str]] = None,
+        instances: list[ServiceInstance],
+        query_parameters: Optional[dict[str, str]] = None,
+        optional_parameters: Optional[dict[str, str]] = None,
         health_status: Optional[str] = None,
-    ) -> List[ServiceInstance]:
+    ) -> list[ServiceInstance]:
         if query_parameters is None:
             query_parameters = {}
         if optional_parameters is None:
@@ -583,10 +584,10 @@ class ServiceDiscoveryBackend(BaseBackend):
         self,
         namespace_name: str,
         service_name: str,
-        query_parameters: Optional[Dict[str, str]] = None,
-        optional_parameters: Optional[Dict[str, str]] = None,
+        query_parameters: Optional[dict[str, str]] = None,
+        optional_parameters: Optional[dict[str, str]] = None,
         health_status: Optional[str] = None,
-    ) -> Tuple[List[ServiceInstance], Dict[str, int]]:
+    ) -> tuple[list[ServiceInstance], dict[str, int]]:
         if query_parameters is None:
             query_parameters = {}
         if optional_parameters is None:
@@ -630,10 +631,10 @@ class ServiceDiscoveryBackend(BaseBackend):
 
     def paginate(
         self,
-        items: List[Any],
+        items: list[Any],
         max_results: Optional[int] = None,
         next_token: Optional[str] = None,
-    ) -> Tuple[List[Any], Optional[str]]:
+    ) -> tuple[list[Any], Optional[str]]:
         """
         Paginates a list of items. If called without optional parameters, the entire list is returned as-is.
         """

--- a/moto/servicediscovery/responses.py
+++ b/moto/servicediscovery/responses.py
@@ -1,7 +1,7 @@
 """Handles incoming servicediscovery requests, invokes methods, returns responses."""
 
 import json
-from typing import Any, Dict, List
+from typing import Any
 
 from moto.core.common_types import TYPE_RESPONSE
 from moto.core.responses import BaseResponse
@@ -258,7 +258,7 @@ class ServiceDiscoveryResponse(BaseResponse):
         page, new_token = self.servicediscovery_backend.paginate(
             status_records, max_results=max_results, next_token=next_token
         )
-        result: Dict[str, Any] = {"Status": {}}
+        result: dict[str, Any] = {"Status": {}}
         for record in page:
             result["Status"][record[0]] = record[1]
         if new_token:
@@ -286,7 +286,7 @@ class ServiceDiscoveryResponse(BaseResponse):
         page, new_token = self.servicediscovery_backend.paginate(
             instances, max_results=max_results, next_token=next_token
         )
-        result: Dict[str, Any] = {"Instances": []}
+        result: dict[str, Any] = {"Instances": []}
         for instance in page:
             result["Instances"].append(instance.to_json())
         if new_token:
@@ -313,7 +313,7 @@ class ServiceDiscoveryResponse(BaseResponse):
         page, new_token = self.servicediscovery_backend.paginate(
             instances, max_results=max_results
         )
-        result_instances: List[Dict[str, Any]] = []
+        result_instances: list[dict[str, Any]] = []
         instances_revision_total = 0
         for instance in page:
             result_instances.append(

--- a/moto/servicequotas/models.py
+++ b/moto/servicequotas/models.py
@@ -1,6 +1,6 @@
 """ServiceQuotasBackend class with methods for supported APIs."""
 
-from typing import Any, Dict, List
+from typing import Any
 
 from moto.core.base_backend import BackendDict, BaseBackend
 
@@ -16,7 +16,7 @@ class ServiceQuotasBackend(BaseBackend):
 
     def list_aws_default_service_quotas(
         self, service_code: str
-    ) -> List[Dict[str, Any]]:
+    ) -> list[dict[str, Any]]:
         """
         The ServiceCodes that are currently implemented are: vpc
         Pagination is not yet implemented.
@@ -25,7 +25,7 @@ class ServiceQuotasBackend(BaseBackend):
             return VPC_DEFAULT_QUOTAS
         raise NoSuchResource
 
-    def get_service_quota(self, service_code: str, quota_code: str) -> Dict[str, Any]:
+    def get_service_quota(self, service_code: str, quota_code: str) -> dict[str, Any]:
         if service_code == "vpc":
             for quota in VPC_DEFAULT_QUOTAS:
                 if quota["QuotaCode"] == quota_code:

--- a/moto/ses/models.py
+++ b/moto/ses/models.py
@@ -7,7 +7,7 @@ from email.encoders import encode_7or8bit
 from email.mime.base import MIMEBase
 from email.mime.multipart import MIMEMultipart
 from email.utils import formataddr, getaddresses, parseaddr
-from typing import Any, Dict, List, Literal, Optional
+from typing import Any, Literal, Optional
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
@@ -67,8 +67,8 @@ class SESFeedback(BaseModel):
     FORWARDING_ENABLED = "feedback_forwarding_enabled"
 
     @staticmethod
-    def generate_message(account_id: str, msg_type: str) -> Dict[str, Any]:  # type: ignore[misc]
-        msg: Dict[str, Any] = dict(COMMON_MAIL)
+    def generate_message(account_id: str, msg_type: str) -> dict[str, Any]:  # type: ignore[misc]
+        msg: dict[str, Any] = dict(COMMON_MAIL)
         msg["mail"]["sendingAccountId"] = account_id
         if msg_type == SESFeedback.BOUNCE:
             msg["bounce"] = BOUNCE
@@ -87,7 +87,7 @@ class Message(BaseModel):
         source: str,
         subject: str,
         body: str,
-        destinations: Dict[str, List[str]],
+        destinations: dict[str, list[str]],
     ):
         self.id = message_id
         self.source = source
@@ -115,7 +115,7 @@ class TemplateMessage(BaseModel):
 class BulkTemplateMessage(BaseModel):
     def __init__(
         self,
-        message_ids: List[str],
+        message_ids: list[str],
         source: str,
         template: str,
         template_data: str,
@@ -130,7 +130,7 @@ class BulkTemplateMessage(BaseModel):
 
 class RawMessage(BaseModel):
     def __init__(
-        self, message_id: str, source: str, destinations: List[str], raw_data: str
+        self, message_id: str, source: str, destinations: list[str], raw_data: str
     ):
         self.id = message_id
         self.source = source
@@ -152,7 +152,7 @@ class ReceiptRuleSet(BaseModel):
             datetime.timezone.utc
         ).isoformat()
         self.is_active = False  # By default, during creation
-        self.rules: List[Dict[str, Any]] = []
+        self.rules: list[dict[str, Any]] = []
 
     @property
     def metadata(self) -> dict[str, str]:
@@ -166,13 +166,13 @@ class ConfigurationSet(BaseModel):
     def __init__(
         self,
         configuration_set_name: str,
-        tracking_options: Optional[Dict[str, str]] = None,
-        delivery_options: Optional[Dict[str, Any]] = None,
-        reputation_options: Optional[Dict[str, Any]] = None,
-        sending_options: Optional[Dict[str, bool]] = None,
-        tags: Optional[List[Dict[str, str]]] = None,
-        suppression_options: Optional[Dict[str, List[str]]] = None,
-        vdm_options: Optional[Dict[str, Dict[str, str]]] = None,
+        tracking_options: Optional[dict[str, str]] = None,
+        delivery_options: Optional[dict[str, Any]] = None,
+        reputation_options: Optional[dict[str, Any]] = None,
+        sending_options: Optional[dict[str, bool]] = None,
+        tags: Optional[list[dict[str, str]]] = None,
+        suppression_options: Optional[dict[str, list[str]]] = None,
+        vdm_options: Optional[dict[str, dict[str, str]]] = None,
     ) -> None:
         # Shared between SES and SESv2
         self.configuration_set_name = configuration_set_name
@@ -185,7 +185,7 @@ class ConfigurationSet(BaseModel):
         self.suppression_options = suppression_options or {}
         self.vdm_options = vdm_options or {}
 
-    def to_dict_v2(self) -> Dict[str, Any]:
+    def to_dict_v2(self) -> dict[str, Any]:
         return {
             "ConfigurationSetName": self.configuration_set_name,
             "TrackingOptions": self.tracking_options,
@@ -203,19 +203,19 @@ class Contact(BaseModel):
         self,
         contact_list_name: str,
         email_address: str,
-        topic_preferences: List[Dict[str, str]],
+        topic_preferences: list[dict[str, str]],
         unsubscribe_all: bool,
     ) -> None:
         self.contact_list_name = contact_list_name
         self.email_address = email_address
-        self.topic_default_preferences: List[Dict[str, str]] = []
+        self.topic_default_preferences: list[dict[str, str]] = []
         self.topic_preferences = topic_preferences
         self.unsubscribe_all = unsubscribe_all
         self.created_timestamp = iso_8601_datetime_with_milliseconds()
         self.last_updated_timestamp = iso_8601_datetime_with_milliseconds()
 
     @property
-    def response_object(self) -> Dict[str, Any]:  # type: ignore[misc]
+    def response_object(self) -> dict[str, Any]:  # type: ignore[misc]
         return {
             "ContactListName": self.contact_list_name,
             "EmailAddress": self.email_address,
@@ -232,16 +232,16 @@ class ContactList(BaseModel):
         self,
         contact_list_name: str,
         description: str,
-        topics: List[Dict[str, str]],
+        topics: list[dict[str, str]],
     ) -> None:
         self.contact_list_name = contact_list_name
         self.description = description
         self.topics = topics
         self.created_timestamp = iso_8601_datetime_with_milliseconds()
         self.last_updated_timestamp = iso_8601_datetime_with_milliseconds()
-        self.contacts: Dict[str, Contact] = {}
+        self.contacts: dict[str, Contact] = {}
 
-    def create_contact(self, contact_list_name: str, params: Dict[str, Any]) -> None:
+    def create_contact(self, contact_list_name: str, params: dict[str, Any]) -> None:
         email_address = params["EmailAddress"]
         topic_preferences = (
             [] if "TopicPreferences" not in params else params["TopicPreferences"]
@@ -254,7 +254,7 @@ class ContactList(BaseModel):
         )
         self.contacts[email_address] = new_contact
 
-    def list_contacts(self) -> List[Contact]:
+    def list_contacts(self) -> list[Contact]:
         return self.contacts.values()  # type: ignore[return-value]
 
     def get_contact(self, email: str) -> Contact:
@@ -269,7 +269,7 @@ class ContactList(BaseModel):
             del self.contacts[email]
 
     @property
-    def response_object(self) -> Dict[str, Any]:  # type: ignore[misc]
+    def response_object(self) -> dict[str, Any]:  # type: ignore[misc]
         return {
             "ContactListName": self.contact_list_name,
             "Description": self.description,
@@ -283,7 +283,7 @@ class EmailIdentity(BaseModel):
     def __init__(
         self,
         email_identity: str,
-        tags: Optional[Dict[str, str]],
+        tags: Optional[dict[str, str]],
         dkim_signing_attributes: Optional[object],
         configuration_set_name: Optional[str],
     ) -> None:
@@ -296,7 +296,7 @@ class EmailIdentity(BaseModel):
         self.feedback_forwarding_status = False
         self.verification_status = "SUCCESS"
         self.sending_enabled = True
-        self.dkim_attributes: Dict[str, Any] = {}
+        self.dkim_attributes: dict[str, Any] = {}
         if not self.dkim_signing_attributes or not isinstance(
             self.dkim_signing_attributes, dict
         ):
@@ -314,10 +314,10 @@ class EmailIdentity(BaseModel):
             self.dkim_attributes["LastKeyGenerationTimestamp"] = (
                 iso_8601_datetime_with_milliseconds()
             )
-        self.policies: Dict[str, Any] = {}
+        self.policies: dict[str, Any] = {}
 
     @property
-    def get_response_object(self) -> Dict[str, Any]:  # type: ignore[misc]
+    def get_response_object(self) -> dict[str, Any]:  # type: ignore[misc]
         return {
             "IdentityType": self.identity_type,
             "FeedbackForwardingStatus": self.feedback_forwarding_status,
@@ -330,7 +330,7 @@ class EmailIdentity(BaseModel):
         }
 
     @property
-    def list_response_object(self) -> Dict[str, Any]:  # type: ignore[misc]
+    def list_response_object(self) -> dict[str, Any]:  # type: ignore[misc]
         return {
             "IdentityType": self.identity_type,
             "IdentityName": self.email_identity,
@@ -341,13 +341,13 @@ class EmailIdentity(BaseModel):
 
 class DedicatedIpPool(BaseModel):
     def __init__(
-        self, pool_name: str, scaling_mode: str, tags: List[Dict[str, str]]
+        self, pool_name: str, scaling_mode: str, tags: list[dict[str, str]]
     ) -> None:
         self.pool_name = pool_name
         self.scaling_mode = scaling_mode
         self.tags = tags
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         return {
             "PoolName": self.pool_name,
             "Tags": self.tags,
@@ -377,21 +377,21 @@ class SESBackend(BaseBackend):
 
     def __init__(self, region_name: str, account_id: str):
         super().__init__(region_name, account_id)
-        self.sent_messages: List[Any] = []
+        self.sent_messages: list[Any] = []
         self.sent_message_count = 0
         self.rejected_messages_count = 0
-        self.sns_topics: Dict[str, Dict[str, Any]] = {}
-        self.config_sets: Dict[str, ConfigurationSet] = {}
-        self.config_set_event_destination: Dict[str, Dict[str, Any]] = {}
-        self.event_destinations: Dict[str, int] = {}
-        self.identity_mail_from_domains: Dict[str, Dict[str, Any]] = {}
-        self.templates: Dict[str, Dict[str, str]] = {}
-        self.receipt_rule_set: Dict[str, ReceiptRuleSet] = {}
-        self.dkim_tokens: Dict[str, List[str]] = {}
-        self.contacts: Dict[str, Contact] = {}
-        self.contacts_lists: Dict[str, ContactList] = {}
-        self.email_identities: Dict[str, EmailIdentity] = {}
-        self.dedicated_ip_pools: Dict[str, DedicatedIpPool] = {}
+        self.sns_topics: dict[str, dict[str, Any]] = {}
+        self.config_sets: dict[str, ConfigurationSet] = {}
+        self.config_set_event_destination: dict[str, dict[str, Any]] = {}
+        self.event_destinations: dict[str, int] = {}
+        self.identity_mail_from_domains: dict[str, dict[str, Any]] = {}
+        self.templates: dict[str, dict[str, str]] = {}
+        self.receipt_rule_set: dict[str, ReceiptRuleSet] = {}
+        self.dkim_tokens: dict[str, list[str]] = {}
+        self.contacts: dict[str, Contact] = {}
+        self.contacts_lists: dict[str, ContactList] = {}
+        self.email_identities: dict[str, EmailIdentity] = {}
+        self.dedicated_ip_pools: dict[str, DedicatedIpPool] = {}
 
     def _is_verified_address(self, source: str) -> bool:
         _, address = parseaddr(source)
@@ -417,7 +417,7 @@ class SESBackend(BaseBackend):
     def create_email_identity_v2(
         self,
         email_identity: str,
-        tags: Optional[Dict[str, str]],
+        tags: Optional[dict[str, str]],
         dkim_signing_attributes: Optional[object],
         configuration_set_name: Optional[str],
     ) -> EmailIdentity:
@@ -432,7 +432,7 @@ class SESBackend(BaseBackend):
 
     def list_identities(
         self, identity_type: Optional[Literal["EmailAddress", "Domain"]]
-    ) -> List[str]:
+    ) -> list[str]:
         if identity_type is not None:
             return [
                 (value.email_identity)
@@ -442,7 +442,7 @@ class SESBackend(BaseBackend):
             ]
         return [(value.email_identity) for _, value in self.email_identities.items()]
 
-    def list_verified_email_addresses(self) -> List[str]:
+    def list_verified_email_addresses(self) -> list[str]:
         x = [
             (value)
             for _, value in self.email_identities.items()
@@ -456,7 +456,7 @@ class SESBackend(BaseBackend):
             del self.email_identities[identity]
 
     def send_email(
-        self, source: str, subject: str, body: str, destinations: Dict[str, List[str]]
+        self, source: str, subject: str, body: str, destinations: dict[str, list[str]]
     ) -> Message:
         recipient_count = sum(map(len, destinations.values()))
         if recipient_count > RECIPIENT_LIMIT:
@@ -485,7 +485,7 @@ class SESBackend(BaseBackend):
         source: str,
         template: str,
         template_data: str,
-        destinations: List[Dict[str, Dict[str, List[str]]]],
+        destinations: list[dict[str, dict[str, list[str]]]],
     ) -> BulkTemplateMessage:
         recipient_count = len(destinations)
         if recipient_count > RECIPIENT_LIMIT:
@@ -521,7 +521,7 @@ class SESBackend(BaseBackend):
         source: str,
         template: str,
         template_data: str,
-        destinations: Dict[str, List[str]],
+        destinations: dict[str, list[str]],
     ) -> TemplateMessage:
         recipient_count = sum(map(len, destinations.values()))
         if recipient_count > RECIPIENT_LIMIT:
@@ -572,7 +572,7 @@ class SESBackend(BaseBackend):
 
         return None
 
-    def __generate_feedback__(self, msg_type: str) -> Dict[str, Any]:
+    def __generate_feedback__(self, msg_type: str) -> dict[str, Any]:
         """Generates the SNS message for the feedback"""
         return SESFeedback.generate_message(self.account_id, msg_type)
 
@@ -593,7 +593,7 @@ class SESBackend(BaseBackend):
                         )
 
     def send_raw_email(
-        self, source: str, destinations: List[str], raw_data: str
+        self, source: str, destinations: list[str], raw_data: str
     ) -> RawMessage:
         if source is not None:
             _, source_email_address = parseaddr(source)
@@ -640,9 +640,9 @@ class SESBackend(BaseBackend):
         return SESQuota(self.sent_message_count)
 
     def get_identity_notification_attributes(
-        self, identities: List[str]
-    ) -> Dict[str, Dict[str, Any]]:
-        response: Dict[str, Dict[str, Any]] = {}
+        self, identities: list[str]
+    ) -> dict[str, dict[str, Any]]:
+        response: dict[str, dict[str, Any]] = {}
         for identity in identities:
             config = self.sns_topics.get(identity, {})
             response[identity] = {
@@ -682,13 +682,13 @@ class SESBackend(BaseBackend):
     def create_configuration_set_v2(
         self,
         configuration_set_name: str,
-        tracking_options: Dict[str, str],
-        delivery_options: Dict[str, Any],
-        reputation_options: Dict[str, Any],
-        sending_options: Dict[str, bool],
-        tags: List[Dict[str, str]],
-        suppression_options: Dict[str, List[str]],
-        vdm_options: Dict[str, Dict[str, str]],
+        tracking_options: dict[str, str],
+        delivery_options: dict[str, Any],
+        reputation_options: dict[str, Any],
+        sending_options: dict[str, bool],
+        tags: list[dict[str, str]],
+        suppression_options: dict[str, list[str]],
+        vdm_options: dict[str, dict[str, str]],
     ) -> None:
         if configuration_set_name in self.config_sets:
             raise ConfigurationSetAlreadyExists(
@@ -719,14 +719,14 @@ class SESBackend(BaseBackend):
         self.config_sets.pop(configuration_set_name)
 
     @paginate(pagination_model=PAGINATION_MODEL)
-    def list_configuration_sets(self) -> List[ConfigurationSet]:
+    def list_configuration_sets(self) -> list[ConfigurationSet]:
         return list(self.config_sets.values())
 
-    def _list_all_configuration_sets(self) -> List[ConfigurationSet]:
+    def _list_all_configuration_sets(self) -> list[ConfigurationSet]:
         return list(self.config_sets.values())
 
     def create_configuration_set_event_destination(
-        self, configuration_set_name: str, event_destination: Dict[str, Any]
+        self, configuration_set_name: str, event_destination: dict[str, Any]
     ) -> None:
         if self.config_sets.get(configuration_set_name) is None:
             raise ConfigurationSetDoesNotExist("Invalid Configuration Set Name.")
@@ -737,7 +737,7 @@ class SESBackend(BaseBackend):
         self.config_set_event_destination[configuration_set_name] = event_destination
         self.event_destinations[event_destination["Name"]] = 1
 
-    def get_send_statistics(self) -> Dict[str, Any]:
+    def get_send_statistics(self) -> dict[str, Any]:
         return {
             "DeliveryAttempts": self.sent_message_count,
             "Rejects": self.rejected_messages_count,
@@ -746,7 +746,7 @@ class SESBackend(BaseBackend):
             "Timestamp": utcnow(),
         }
 
-    def add_template(self, template_info: Dict[str, str]) -> None:
+    def add_template(self, template_info: dict[str, str]) -> None:
         template_name = template_info["template_name"]
         if not template_name:
             raise ValidationError(
@@ -763,7 +763,7 @@ class SESBackend(BaseBackend):
             raise InvalidParameterValue("The subject must be specified.")
         self.templates[template_name] = template_info
 
-    def update_template(self, template_info: Dict[str, str]) -> None:
+    def update_template(self, template_info: dict[str, str]) -> None:
         template_name = template_info["template_name"]
         if not template_name:
             raise ValidationError(
@@ -780,15 +780,15 @@ class SESBackend(BaseBackend):
             raise InvalidParameterValue("The subject must be specified.")
         self.templates[template_name] = template_info
 
-    def get_template(self, template_name: str) -> Dict[str, str]:
+    def get_template(self, template_name: str) -> dict[str, str]:
         if not self.templates.get(template_name, None):
             raise TemplateDoesNotExist("Invalid Template Name.")
         return self.templates[template_name]
 
-    def list_templates(self) -> List[Dict[str, str]]:
+    def list_templates(self) -> list[dict[str, str]]:
         return list(self.templates.values())
 
-    def render_template(self, render_data: Dict[str, Any]) -> str:
+    def render_template(self, render_data: dict[str, Any]) -> str:
         template_name = render_data.get("name", "")
         template = self.templates.get(template_name, None)
         if not template:
@@ -846,7 +846,7 @@ class SESBackend(BaseBackend):
         self.receipt_rule_set[rule_set_name] = ReceiptRuleSet(name=rule_set_name)
 
     def create_receipt_rule(
-        self, rule_set_name: str, rule: Dict[str, Any], after: Optional[str]
+        self, rule_set_name: str, rule: dict[str, Any], after: Optional[str]
     ) -> None:
         # Validate ruleSetName
         self._validate_name_param(self.__RULE_SET_PARAM, rule_set_name)
@@ -932,7 +932,7 @@ class SESBackend(BaseBackend):
             raise CannotDelete(f"Cannot delete active rule set: {rule_set_name}")
         del self.receipt_rule_set[rule_set_name]
 
-    def list_receipt_rule_sets(self) -> List[ReceiptRuleSet]:
+    def list_receipt_rule_sets(self) -> list[ReceiptRuleSet]:
         # The receipt rule sets are ordered by name
         return sorted(self.receipt_rule_set.values(), key=lambda rs: rs.name)
 
@@ -951,7 +951,7 @@ class SESBackend(BaseBackend):
             raise ValidationError(f"Not a valid {param_name}: {name}")
         return
 
-    def _validate_receipt_rule_actions(self, rule: Dict[str, Any]) -> None:
+    def _validate_receipt_rule_actions(self, rule: dict[str, Any]) -> None:
         # Allowed to be empty
         actions = rule.get("Actions", [])
         for action in actions:
@@ -964,7 +964,7 @@ class SESBackend(BaseBackend):
             if "LambdaAction" in action:
                 self._validate_lambda_action(action["LambdaAction"])
 
-    def _validate_s3_action(self, s3_action: Dict[str, str]) -> None:
+    def _validate_s3_action(self, s3_action: dict[str, str]) -> None:
         from moto.s3.models import s3_backends
 
         # Raise an exception if the bucket does not exist
@@ -985,7 +985,7 @@ class SESBackend(BaseBackend):
         if s3_action.get("IamRoleArn"):
             self._validate_iam_role(s3_action["IamRoleArn"])
 
-    def _validate_lambda_action(self, lambda_action: Dict[str, str]) -> None:
+    def _validate_lambda_action(self, lambda_action: dict[str, str]) -> None:
         from moto.awslambda.models import lambda_backends
 
         # Raise an exception if the Lambda function does not exist
@@ -1043,7 +1043,7 @@ class SESBackend(BaseBackend):
 
     def describe_receipt_rule(
         self, rule_set_name: str, rule_name: str
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         rule_set = self.receipt_rule_set.get(rule_set_name)
 
         if rule_set is None:
@@ -1055,7 +1055,7 @@ class SESBackend(BaseBackend):
 
         raise RuleDoesNotExist(f"Rule does not exist: {rule_name}")
 
-    def update_receipt_rule(self, rule_set_name: str, rule: Dict[str, Any]) -> None:
+    def update_receipt_rule(self, rule_set_name: str, rule: dict[str, Any]) -> None:
         rule_set = self.receipt_rule_set.get(rule_set_name)
 
         if rule_set is None:
@@ -1101,8 +1101,8 @@ class SESBackend(BaseBackend):
         }
 
     def get_identity_mail_from_domain_attributes(
-        self, identities: Optional[List[str]] = None
-    ) -> Dict[str, Dict[str, str]]:
+        self, identities: Optional[list[str]] = None
+    ) -> dict[str, dict[str, str]]:
         if identities is None:
             actual_identities = []
         else:
@@ -1125,8 +1125,8 @@ class SESBackend(BaseBackend):
         return attributes_by_identity
 
     def get_identity_verification_attributes(
-        self, identities: Optional[List[str]] = None
-    ) -> Dict[str, Dict[str, str]]:
+        self, identities: Optional[list[str]] = None
+    ) -> dict[str, dict[str, str]]:
         if identities is None:
             actual_identities = []
         else:
@@ -1156,10 +1156,10 @@ class SESBackend(BaseBackend):
         config_set.reputation_options["ReputationMetricsEnabled"] = enabled
 
     def get_identity_dkim_attributes(
-        self, identities: List[str]
-    ) -> Dict[str, Dict[str, Any]]:
+        self, identities: list[str]
+    ) -> dict[str, dict[str, Any]]:
         result = {}
-        actual_identities: List[EmailIdentity] = []
+        actual_identities: list[EmailIdentity] = []
         for ident in identities:
             if ident in self.email_identities.keys():
                 actual_identities.append(self.email_identities[ident])

--- a/moto/ses/responses.py
+++ b/moto/ses/responses.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Optional
+from typing import Any, Optional
 
 from moto.core.responses import ActionResult, BaseResponse, EmptyResult
 from moto.core.utils import utcnow
@@ -151,7 +151,7 @@ class EmailResponse(BaseResponse):
 
         attribute_names = self._get_param("ConfigurationSetAttributeNames", [])
 
-        event_destination: Optional[Dict[str, Any]] = None
+        event_destination: Optional[dict[str, Any]] = None
         if "eventDestinations" in attribute_names:
             event_destination = self.backend.config_set_event_destination.get(
                 configuration_set_name

--- a/moto/ses/template.py
+++ b/moto/ses/template.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Optional, Type
+from typing import Any, Optional
 
 from moto.utilities.tokenizer import GenericTokenizer
 
@@ -7,7 +7,7 @@ from .exceptions import MissingRenderingAttributeException
 
 class BlockProcessor:
     def __init__(
-        self, template: str, template_data: Dict[str, Any], tokenizer: GenericTokenizer
+        self, template: str, template_data: dict[str, Any], tokenizer: GenericTokenizer
     ):
         self.template = template
         self.template_data = template_data
@@ -22,7 +22,7 @@ class BlockProcessor:
 
 class EachBlockProcessor(BlockProcessor):
     def __init__(
-        self, template: str, template_data: Dict[str, Any], tokenizer: GenericTokenizer
+        self, template: str, template_data: dict[str, Any], tokenizer: GenericTokenizer
     ):
         self.template = template
         self.tokenizer = tokenizer
@@ -65,7 +65,7 @@ class EachBlockProcessor(BlockProcessor):
 
 class EachEndBlockProcessor(BlockProcessor):
     def __init__(
-        self, template: str, template_data: Dict[str, Any], tokenizer: GenericTokenizer
+        self, template: str, template_data: dict[str, Any], tokenizer: GenericTokenizer
     ):
         super().__init__(template, template_data, tokenizer)
 
@@ -76,7 +76,7 @@ class EachEndBlockProcessor(BlockProcessor):
 
 class IfBlockProcessor(BlockProcessor):
     def __init__(
-        self, template: str, template_data: Dict[str, Any], tokenizer: GenericTokenizer
+        self, template: str, template_data: dict[str, Any], tokenizer: GenericTokenizer
     ):
         super().__init__(template, template_data, tokenizer)
 
@@ -115,7 +115,7 @@ class IfBlockProcessor(BlockProcessor):
 
 class IfEndBlockProcessor(BlockProcessor):
     def __init__(
-        self, template: str, template_data: Dict[str, Any], tokenizer: GenericTokenizer
+        self, template: str, template_data: dict[str, Any], tokenizer: GenericTokenizer
     ):
         super().__init__(template, template_data, tokenizer)
 
@@ -126,7 +126,7 @@ class IfEndBlockProcessor(BlockProcessor):
 
 class ElseBlockProcessor(BlockProcessor):
     def __init__(
-        self, template: str, template_data: Dict[str, Any], tokenizer: GenericTokenizer
+        self, template: str, template_data: dict[str, Any], tokenizer: GenericTokenizer
     ):
         super().__init__(template, template_data, tokenizer)
 
@@ -146,7 +146,7 @@ class VarBlockProcessor(BlockProcessor):
         return data
 
 
-def get_processor(tokenizer: GenericTokenizer) -> Type[BlockProcessor]:
+def get_processor(tokenizer: GenericTokenizer) -> type[BlockProcessor]:
     if tokenizer.peek(5) == "#each":
         return EachBlockProcessor
     if tokenizer.peek(5) == "/each":
@@ -162,7 +162,7 @@ def get_processor(tokenizer: GenericTokenizer) -> Type[BlockProcessor]:
 
 def parse_template(
     template: str,
-    template_data: Dict[str, Any],
+    template_data: dict[str, Any],
     tokenizer: Optional[GenericTokenizer] = None,
 ) -> str:
     tokenizer = tokenizer or GenericTokenizer(template)

--- a/moto/sesv2/models.py
+++ b/moto/sesv2/models.py
@@ -1,6 +1,6 @@
 """SESV2Backend class with methods for supported APIs."""
 
-from typing import Any, Dict, List, Optional
+from typing import Any, Optional
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.utilities.paginator import paginate
@@ -48,7 +48,7 @@ class SESV2Backend(BaseBackend):
         # Store local variables in v1 backend for interoperability
         self.core_backend = ses_backends[self.account_id][self.region_name]
 
-    def create_contact_list(self, params: Dict[str, Any]) -> None:
+    def create_contact_list(self, params: dict[str, Any]) -> None:
         name = params["ContactListName"]
         description = params.get("Description")
         topics = [] if "Topics" not in params else params["Topics"]
@@ -63,7 +63,7 @@ class SESV2Backend(BaseBackend):
                 f"List with name: {contact_list_name} doesn't exist."
             )
 
-    def list_contact_lists(self) -> List[ContactList]:
+    def list_contact_lists(self) -> list[ContactList]:
         return self.core_backend.contacts_lists.values()  # type: ignore[return-value]
 
     def delete_contact_list(self, name: str) -> None:
@@ -72,7 +72,7 @@ class SESV2Backend(BaseBackend):
         else:
             raise NotFoundException(f"List with name: {name} doesn't exist")
 
-    def create_contact(self, contact_list_name: str, params: Dict[str, Any]) -> None:
+    def create_contact(self, contact_list_name: str, params: dict[str, Any]) -> None:
         contact_list = self.get_contact_list(contact_list_name)
         contact_list.create_contact(contact_list_name, params)
         return
@@ -82,7 +82,7 @@ class SESV2Backend(BaseBackend):
         contact = contact_list.get_contact(email)
         return contact
 
-    def list_contacts(self, contact_list_name: str) -> List[Contact]:
+    def list_contacts(self, contact_list_name: str) -> list[Contact]:
         contact_list = self.get_contact_list(contact_list_name)
         contacts = contact_list.list_contacts()
         return contacts
@@ -93,7 +93,7 @@ class SESV2Backend(BaseBackend):
         return
 
     def send_email(
-        self, source: str, destinations: Dict[str, List[str]], subject: str, body: str
+        self, source: str, destinations: dict[str, list[str]], subject: str, body: str
     ) -> Message:
         message = self.core_backend.send_email(
             source=source,
@@ -104,7 +104,7 @@ class SESV2Backend(BaseBackend):
         return message
 
     def send_raw_email(
-        self, source: str, destinations: List[str], raw_data: str
+        self, source: str, destinations: list[str], raw_data: str
     ) -> RawMessage:
         message = self.core_backend.send_raw_email(
             source=source, destinations=destinations, raw_data=raw_data
@@ -114,7 +114,7 @@ class SESV2Backend(BaseBackend):
     def create_email_identity(
         self,
         email_identity: str,
-        tags: Optional[Dict[str, str]],
+        tags: Optional[dict[str, str]],
         dkim_signing_attributes: Optional[object],
         configuration_set_name: Optional[str],
     ) -> EmailIdentity:
@@ -129,20 +129,20 @@ class SESV2Backend(BaseBackend):
         self.core_backend.delete_identity(email_identity)
 
     @paginate(pagination_model=PAGINATION_MODEL)
-    def list_email_identities(self) -> List[EmailIdentity]:
+    def list_email_identities(self) -> list[EmailIdentity]:
         identities = list(self.core_backend.email_identities.values())
         return identities
 
     def create_configuration_set(
         self,
         configuration_set_name: str,
-        tracking_options: Dict[str, str],
-        delivery_options: Dict[str, Any],
-        reputation_options: Dict[str, Any],
-        sending_options: Dict[str, bool],
-        tags: List[Dict[str, str]],
-        suppression_options: Dict[str, List[str]],
-        vdm_options: Dict[str, Dict[str, str]],
+        tracking_options: dict[str, str],
+        delivery_options: dict[str, Any],
+        reputation_options: dict[str, Any],
+        sending_options: dict[str, bool],
+        tags: list[dict[str, str]],
+        suppression_options: dict[str, list[str]],
+        vdm_options: dict[str, dict[str, str]],
     ) -> None:
         self.core_backend.create_configuration_set_v2(
             configuration_set_name=configuration_set_name,
@@ -165,11 +165,11 @@ class SESV2Backend(BaseBackend):
         return config_set
 
     @paginate(pagination_model=PAGINATION_MODEL)
-    def list_configuration_sets(self) -> List[ConfigurationSet]:
+    def list_configuration_sets(self) -> list[ConfigurationSet]:
         return self.core_backend._list_all_configuration_sets()
 
     def create_dedicated_ip_pool(
-        self, pool_name: str, tags: List[Dict[str, str]], scaling_mode: str
+        self, pool_name: str, tags: list[dict[str, str]], scaling_mode: str
     ) -> None:
         if pool_name not in self.core_backend.dedicated_ip_pools:
             new_pool = DedicatedIpPool(
@@ -181,7 +181,7 @@ class SESV2Backend(BaseBackend):
         self.core_backend.dedicated_ip_pools.pop(pool_name)
 
     @paginate(pagination_model=PAGINATION_MODEL)
-    def list_dedicated_ip_pools(self) -> List[str]:
+    def list_dedicated_ip_pools(self) -> list[str]:
         return list(self.core_backend.dedicated_ip_pools.keys())
 
     def get_dedicated_ip_pool(self, pool_name: str) -> DedicatedIpPool:
@@ -228,7 +228,7 @@ class SESV2Backend(BaseBackend):
 
         return
 
-    def get_email_identity_policies(self, email_identity: str) -> Dict[str, Any]:
+    def get_email_identity_policies(self, email_identity: str) -> dict[str, Any]:
         email_id = self.get_email_identity(email_identity)
 
         return email_id.policies

--- a/moto/sesv2/responses.py
+++ b/moto/sesv2/responses.py
@@ -2,7 +2,6 @@
 
 import base64
 import json
-from typing import List
 from urllib.parse import unquote
 
 from moto.core.responses import BaseResponse
@@ -29,7 +28,7 @@ class SESV2Response(BaseResponse):
         destination = params.get("Destination", {})
         content = params.get("Content")
         if "Raw" in content:
-            all_destinations: List[str] = []
+            all_destinations: list[str] = []
             if "ToAddresses" in destination:
                 all_destinations = all_destinations + destination["ToAddresses"]
             if "CcAddresses" in destination:

--- a/moto/settings.py
+++ b/moto/settings.py
@@ -2,7 +2,7 @@ import json
 import os
 import pathlib
 from functools import lru_cache
-from typing import List, Optional
+from typing import Optional
 
 from moto.core.config import default_user_config
 
@@ -57,7 +57,7 @@ def get_sf_execution_history_type() -> str:
     return os.environ.get("SF_EXECUTION_HISTORY_TYPE", "SUCCESS")
 
 
-def get_s3_custom_endpoints() -> List[str]:
+def get_s3_custom_endpoints() -> list[str]:
     endpoints = os.environ.get("MOTO_S3_CUSTOM_ENDPOINTS")
     if endpoints:
         return endpoints.split(",")
@@ -116,7 +116,7 @@ def moto_proxy_port() -> str:
     return os.environ.get("MOTO_PROXY_PORT") or "5005"
 
 
-@lru_cache()
+@lru_cache
 def moto_server_host() -> str:
     if is_docker():
         return get_docker_host()

--- a/moto/signer/models.py
+++ b/moto/signer/models.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional
+from typing import Any, Optional
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
@@ -13,8 +13,8 @@ class SigningProfile(BaseModel):
         backend: "SignerBackend",
         name: str,
         platform_id: str,
-        signing_material: Dict[str, str],
-        signature_validity_period: Optional[Dict[str, Any]],
+        signing_material: dict[str, str],
+        signature_validity_period: Optional[dict[str, Any]],
     ):
         self.name = name
         self.platform_id = platform_id
@@ -33,8 +33,8 @@ class SigningProfile(BaseModel):
     def cancel(self) -> None:
         self.status = "Canceled"
 
-    def to_dict(self, full: bool = True) -> Dict[str, Any]:
-        small: Dict[str, Any] = {
+    def to_dict(self, full: bool = True) -> dict[str, Any]:
+        small: dict[str, Any] = {
             "arn": self.arn,
             "profileVersion": self.profile_version,
             "profileVersionArn": self.profile_version_arn,
@@ -163,7 +163,7 @@ class SignerBackend(BaseBackend):
 
     def __init__(self, region_name: str, account_id: str):
         super().__init__(region_name, account_id)
-        self.signing_profiles: Dict[str, SigningProfile] = dict()
+        self.signing_profiles: dict[str, SigningProfile] = dict()
         self.tagger = TaggingService()
 
     def cancel_signing_profile(self, profile_name: str) -> None:
@@ -175,10 +175,10 @@ class SignerBackend(BaseBackend):
     def put_signing_profile(
         self,
         profile_name: str,
-        signature_validity_period: Optional[Dict[str, Any]],
+        signature_validity_period: Optional[dict[str, Any]],
         platform_id: str,
-        signing_material: Dict[str, str],
-        tags: Dict[str, str],
+        signing_material: dict[str, str],
+        tags: dict[str, str],
     ) -> SigningProfile:
         """
         The following parameters are not yet implemented: Overrides, SigningParameters
@@ -194,21 +194,21 @@ class SignerBackend(BaseBackend):
         self.tag_resource(profile.arn, tags)
         return profile
 
-    def list_signing_platforms(self) -> List[Dict[str, Any]]:
+    def list_signing_platforms(self) -> list[dict[str, Any]]:
         """
         Pagination is not yet implemented. The parameters category, partner, target are not yet implemented
         """
         return SignerBackend.platforms
 
-    def list_tags_for_resource(self, resource_arn: str) -> Dict[str, str]:
+    def list_tags_for_resource(self, resource_arn: str) -> dict[str, str]:
         return self.tagger.get_tag_dict_for_resource(resource_arn)
 
-    def tag_resource(self, resource_arn: str, tags: Dict[str, str]) -> None:
+    def tag_resource(self, resource_arn: str, tags: dict[str, str]) -> None:
         self.tagger.tag_resource(
             resource_arn, TaggingService.convert_dict_to_tags_input(tags)
         )
 
-    def untag_resource(self, resource_arn: str, tag_keys: List[str]) -> None:
+    def untag_resource(self, resource_arn: str, tag_keys: list[str]) -> None:
         self.tagger.untag_resource_using_names(resource_arn, tag_keys)
 
 

--- a/moto/sns/config.py
+++ b/moto/sns/config.py
@@ -1,7 +1,7 @@
 """AWS Config integration for SNS resources."""
 
 import json
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Optional
 
 from moto.core.common_models import ConfigQueryModel
 from moto.sns import sns_backends
@@ -15,14 +15,14 @@ class SNSConfigQuery(ConfigQueryModel[SNSBackend]):
         self,
         account_id: str,
         partition: str,
-        resource_ids: Optional[List[str]],
+        resource_ids: Optional[list[str]],
         resource_name: Optional[str],
         limit: int,
         next_token: Optional[str],
         backend_region: Optional[str] = None,
         resource_region: Optional[str] = None,
-        aggregator: Optional[Dict[str, Any]] = None,
-    ) -> Tuple[List[Dict[str, Any]], Optional[str]]:
+        aggregator: Optional[dict[str, Any]] = None,
+    ) -> tuple[list[dict[str, Any]], Optional[str]]:
         region = resource_region or backend_region or "us-east-1"
         backend = self.backends[account_id][region]
 
@@ -43,7 +43,7 @@ class SNSConfigQuery(ConfigQueryModel[SNSBackend]):
         resource_name: Optional[str] = None,
         backend_region: Optional[str] = None,
         resource_region: Optional[str] = None,
-    ) -> Optional[Dict[str, Any]]:
+    ) -> Optional[dict[str, Any]]:
         region = resource_region or backend_region or "us-east-1"
         backend = self.backends[account_id][region]
 

--- a/moto/sns/models.py
+++ b/moto/sns/models.py
@@ -3,9 +3,10 @@ import contextlib
 import json
 import re
 from collections import OrderedDict
+from collections.abc import Iterable
 from datetime import timedelta
 from functools import lru_cache
-from typing import Any, Dict, Iterable, List, Optional, Set, Tuple, cast
+from typing import Any, Optional, cast
 
 import cryptography
 import requests
@@ -86,14 +87,14 @@ class Topic(CloudFormationModel):
         self.subscriptions_pending = 0
         self.subscriptions_confimed = 0
         self.subscriptions_deleted = 0
-        self.sent_notifications: List[
-            Tuple[str, str, Optional[str], Optional[Dict[str, Any]], Optional[str]]
+        self.sent_notifications: list[
+            tuple[str, str, Optional[str], Optional[dict[str, Any]], Optional[str]]
         ] = []
 
         self._policy_json = self._create_default_topic_policy(
             sns_backend.region_name, self.account_id, name
         )
-        self._tags: Dict[str, str] = {}
+        self._tags: dict[str, str] = {}
         self.fifo_topic = "false"
         self.content_based_deduplication = "false"
 
@@ -101,7 +102,7 @@ class Topic(CloudFormationModel):
         self,
         message: str,
         subject: Optional[str] = None,
-        message_attributes: Optional[Dict[str, Any]] = None,
+        message_attributes: Optional[dict[str, Any]] = None,
         group_id: Optional[str] = None,
         deduplication_id: Optional[str] = None,
         message_structure: Optional[str] = None,
@@ -197,7 +198,7 @@ class Topic(CloudFormationModel):
 
     def _create_default_topic_policy(
         self, region_name: str, account_id: str, name: str
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         return {
             "Version": "2008-10-17",
             "Id": "__default_policy_ID",
@@ -231,7 +232,7 @@ class Subscription(BaseModel):
         self.endpoint = endpoint
         self.protocol = protocol
         self.arn = make_arn_for_subscription(self.topic.arn)
-        self.attributes: Dict[str, Any] = {}
+        self.attributes: dict[str, Any] = {}
         self._filter_policy = None  # filter policy as a dict, not json.
         self._filter_policy_matcher: Optional[FilterPolicyMatcher] = None
         self.confirmed = False
@@ -245,7 +246,7 @@ class Subscription(BaseModel):
         message: str,
         message_id: str,
         subject: Optional[str] = None,
-        message_attributes: Optional[Dict[str, Any]] = None,
+        message_attributes: Optional[dict[str, Any]] = None,
         group_id: Optional[str] = None,
         deduplication_id: Optional[str] = None,
         message_structure: Optional[str] = None,
@@ -338,8 +339,8 @@ class Subscription(BaseModel):
         message: str,
         message_id: str,
         subject: Optional[str],
-        message_attributes: Optional[Dict[str, Any]] = None,
-    ) -> Dict[str, Any]:
+        message_attributes: Optional[dict[str, Any]] = None,
+    ) -> dict[str, Any]:
         key = self.private_key()
         cert_subject = [NameAttribute(NameOID.COMMON_NAME, "sns.amazonaws.com")]
         issuer = [
@@ -393,7 +394,7 @@ Notification
             serialization.Encoding.PEM
         )
 
-        post_data: Dict[str, Any] = {
+        post_data: dict[str, Any] = {
             "Type": "Notification",
             "MessageId": message_id,
             "TopicArn": self.topic.arn,
@@ -410,7 +411,7 @@ Notification
             post_data["MessageAttributes"] = message_attributes
         return post_data
 
-    @lru_cache()
+    @lru_cache
     def private_key(self) -> rsa.RSAPrivateKey:
         return rsa.generate_private_key(public_exponent=65537, key_size=2048)
 
@@ -439,7 +440,7 @@ class PlatformApplication(BaseModel):
         region: str,
         name: str,
         platform: str,
-        attributes: Dict[str, str],
+        attributes: dict[str, str],
     ):
         self.region = region
         self.name = name
@@ -456,7 +457,7 @@ class PlatformEndpoint(BaseModel):
         application: PlatformApplication,
         custom_user_data: str,
         token: str,
-        attributes: Dict[str, str],
+        attributes: dict[str, str],
     ):
         self.region = region
         self.application = application
@@ -465,7 +466,7 @@ class PlatformEndpoint(BaseModel):
         self.attributes = attributes
         self.id = mock_random.uuid4()
         self.arn = f"arn:{get_partition(region)}:sns:{region}:{account_id}:endpoint/{self.application.platform}/{self.application.name}/{self.id}"
-        self.messages: Dict[str, str] = OrderedDict()
+        self.messages: dict[str, str] = OrderedDict()
         self.__fixup_attributes()
 
     def __fixup_attributes(self) -> None:
@@ -513,16 +514,16 @@ class SNSBackend(BaseBackend):
 
     def __init__(self, region_name: str, account_id: str):
         super().__init__(region_name, account_id)
-        self.topics: Dict[str, Topic] = OrderedDict()
+        self.topics: dict[str, Topic] = OrderedDict()
         self.subscriptions: OrderedDict[str, Subscription] = OrderedDict()
-        self.applications: Dict[str, PlatformApplication] = {}
-        self.platform_endpoints: Dict[str, PlatformEndpoint] = {}
+        self.applications: dict[str, PlatformApplication] = {}
+        self.platform_endpoints: dict[str, PlatformEndpoint] = {}
         self.region_name = region_name
-        self.sms_attributes: Dict[str, str] = {}
+        self.sms_attributes: dict[str, str] = {}
         # We're storing the messages twice here
         # The tuple is for backwards compatibility; the object is to expose this data to the MotoAPI
         # We should combine these in a next major release, when we're allowed to break compatibility
-        self.sms_messages: Dict[str, Tuple[str, str]] = OrderedDict()
+        self.sms_messages: dict[str, tuple[str, str]] = OrderedDict()
         self.sms_message_objects: dict[str, SMS] = {}
         self.opt_out_numbers = [
             "+447420500600",
@@ -535,22 +536,22 @@ class SNSBackend(BaseBackend):
             "+447700900907",
         ]
 
-        self._message_public_keys: Dict[str, bytes] = {}
+        self._message_public_keys: dict[str, bytes] = {}
 
-    def get_sms_attributes(self, filter_list: Set[str]) -> Dict[str, str]:
+    def get_sms_attributes(self, filter_list: set[str]) -> dict[str, str]:
         if len(filter_list) > 0:
             return {k: v for k, v in self.sms_attributes.items() if k in filter_list}
         else:
             return self.sms_attributes
 
-    def set_sms_attributes(self, attrs: Dict[str, str]) -> None:
+    def set_sms_attributes(self, attrs: dict[str, str]) -> None:
         self.sms_attributes.update(attrs)
 
     def create_topic(
         self,
         name: str,
-        attributes: Optional[Dict[str, str]] = None,
-        tags: Optional[Dict[str, str]] = None,
+        attributes: Optional[dict[str, str]] = None,
+        tags: Optional[dict[str, str]] = None,
     ) -> Topic:
         if attributes is None:
             attributes = {}
@@ -582,8 +583,8 @@ class SNSBackend(BaseBackend):
             return candidate_topic
 
     def _get_values_nexttoken(
-        self, values_map: Dict[str, Any], next_token: Optional[str] = None
-    ) -> Tuple[List[Any], Optional[int]]:
+        self, values_map: dict[str, Any], next_token: Optional[str] = None
+    ) -> tuple[list[Any], Optional[int]]:
         i_next_token = int(next_token or "0")
         values = list(values_map.values())[
             i_next_token : i_next_token + DEFAULT_PAGE_SIZE
@@ -594,12 +595,12 @@ class SNSBackend(BaseBackend):
             i_next_token = None  # type: ignore
         return values, i_next_token
 
-    def _get_topic_subscriptions(self, topic: Topic) -> List[Subscription]:
+    def _get_topic_subscriptions(self, topic: Topic) -> list[Subscription]:
         return [sub for sub in self.subscriptions.values() if sub.topic == topic]
 
     def list_topics(
         self, next_token: Optional[str] = None
-    ) -> Tuple[List[Topic], Optional[int]]:
+    ) -> tuple[list[Topic], Optional[int]]:
         return self._get_values_nexttoken(self.topics, next_token)
 
     def delete_topic_subscriptions(self, topic: Topic) -> None:
@@ -710,12 +711,12 @@ class SNSBackend(BaseBackend):
 
     def list_subscriptions(
         self, next_token: Optional[str] = None
-    ) -> Tuple[List[Subscription], Optional[int]]:
+    ) -> tuple[list[Subscription], Optional[int]]:
         return self._get_values_nexttoken(self.subscriptions, next_token)
 
     def list_subscriptions_by_topic(
         self, topic_arn: str, next_token: Optional[str] = None
-    ) -> Tuple[List[Subscription], Optional[int]]:
+    ) -> tuple[list[Subscription], Optional[int]]:
         topic = self.get_topic(topic_arn)
         filtered = OrderedDict(
             [(sub.arn, sub) for sub in self._get_topic_subscriptions(topic)]
@@ -728,7 +729,7 @@ class SNSBackend(BaseBackend):
         arn: Optional[str],
         phone_number: Optional[str] = None,
         subject: Optional[str] = None,
-        message_attributes: Optional[Dict[str, Any]] = None,
+        message_attributes: Optional[dict[str, Any]] = None,
         group_id: Optional[str] = None,
         deduplication_id: Optional[str] = None,
         message_structure: Optional[str] = None,
@@ -792,7 +793,7 @@ class SNSBackend(BaseBackend):
         return message_id
 
     def create_platform_application(
-        self, name: str, platform: str, attributes: Dict[str, str]
+        self, name: str, platform: str, attributes: dict[str, str]
     ) -> PlatformApplication:
         application = PlatformApplication(
             self.account_id, self.region_name, name, platform, attributes
@@ -807,7 +808,7 @@ class SNSBackend(BaseBackend):
             raise SNSNotFoundError("PlatformApplication does not exist")
 
     def set_platform_application_attributes(
-        self, arn: str, attributes: Dict[str, Any]
+        self, arn: str, attributes: dict[str, Any]
     ) -> PlatformApplication:
         application = self.get_application(arn)
         application.attributes.update(attributes)
@@ -827,7 +828,7 @@ class SNSBackend(BaseBackend):
         application: PlatformApplication,
         custom_user_data: str,
         token: str,
-        attributes: Dict[str, str],
+        attributes: dict[str, str],
     ) -> PlatformEndpoint:
         for endpoint in self.platform_endpoints.values():
             if token == endpoint.token:
@@ -855,7 +856,7 @@ class SNSBackend(BaseBackend):
 
     def list_endpoints_by_platform_application(
         self, application_arn: str
-    ) -> List[PlatformEndpoint]:
+    ) -> list[PlatformEndpoint]:
         return [
             endpoint
             for endpoint in self.platform_endpoints.values()
@@ -869,7 +870,7 @@ class SNSBackend(BaseBackend):
             raise SNSNotFoundError("Endpoint does not exist")
 
     def set_endpoint_attributes(
-        self, arn: str, attributes: Dict[str, Any]
+        self, arn: str, attributes: dict[str, Any]
     ) -> PlatformEndpoint:
         endpoint = self.get_endpoint(arn)
         if "Enabled" in attributes:
@@ -883,7 +884,7 @@ class SNSBackend(BaseBackend):
         except KeyError:
             pass  # idempotent operation
 
-    def get_subscription_attributes(self, arn: str) -> Dict[str, Any]:
+    def get_subscription_attributes(self, arn: str) -> dict[str, Any]:
         subscription = self.subscriptions.get(arn)
 
         if not subscription:
@@ -938,8 +939,8 @@ class SNSBackend(BaseBackend):
         combinations = 1
 
         def aggregate_rules(
-            filter_policy: Dict[str, Any], depth: int = 1
-        ) -> List[List[Any]]:
+            filter_policy: dict[str, Any], depth: int = 1
+        ) -> list[list[Any]]:
             """
             This method evaluate the filter policy recursively, and returns only a list of lists of rules.
             It also calculates the combinations of rules, calculated depending on the nesting of the rules.
@@ -1113,8 +1114,8 @@ class SNSBackend(BaseBackend):
         region_name: str,
         topic_arn: str,
         label: str,
-        aws_account_ids: List[str],
-        action_names: List[str],
+        aws_account_ids: list[str],
+        action_names: list[str],
     ) -> None:
         topic = self.get_topic(topic_arn)
         policy = topic._policy_json
@@ -1158,13 +1159,13 @@ class SNSBackend(BaseBackend):
 
         topic._policy_json["Statement"] = statements
 
-    def list_tags_for_resource(self, resource_arn: str) -> Dict[str, str]:
+    def list_tags_for_resource(self, resource_arn: str) -> dict[str, str]:
         if resource_arn not in self.topics:
             raise ResourceNotFoundError
 
         return self.topics[resource_arn]._tags
 
-    def tag_resource(self, resource_arn: str, tags: Dict[str, str]) -> None:
+    def tag_resource(self, resource_arn: str, tags: dict[str, str]) -> None:
         if resource_arn not in self.topics:
             raise ResourceNotFoundError
 
@@ -1176,7 +1177,7 @@ class SNSBackend(BaseBackend):
 
         self.topics[resource_arn]._tags = updated_tags
 
-    def untag_resource(self, resource_arn: str, tag_keys: List[str]) -> None:
+    def untag_resource(self, resource_arn: str, tag_keys: list[str]) -> None:
         if resource_arn not in self.topics:
             raise ResourceNotFoundError
 
@@ -1184,8 +1185,8 @@ class SNSBackend(BaseBackend):
             self.topics[resource_arn]._tags.pop(key, None)
 
     def publish_batch(
-        self, topic_arn: str, publish_batch_request_entries: List[Dict[str, Any]]
-    ) -> Tuple[List[Dict[str, str]], List[Dict[str, Any]]]:
+        self, topic_arn: str, publish_batch_request_entries: list[dict[str, Any]]
+    ) -> tuple[list[dict[str, str]], list[dict[str, Any]]]:
         """
         The MessageDeduplicationId-parameter has not yet been implemented.
         """
@@ -1207,8 +1208,8 @@ class SNSBackend(BaseBackend):
                     "Invalid parameter: The MessageGroupId parameter is required for FIFO topics"
                 )
 
-        successful: List[Dict[str, str]] = []
-        failed: List[Dict[str, Any]] = []
+        successful: list[dict[str, str]] = []
+        failed: list[dict[str, Any]] = []
 
         for entry in publish_batch_request_entries:
             try:
@@ -1240,7 +1241,7 @@ class SNSBackend(BaseBackend):
         """
         return number.endswith("99")
 
-    def list_phone_numbers_opted_out(self) -> List[str]:
+    def list_phone_numbers_opted_out(self) -> list[str]:
         return self.opt_out_numbers
 
     def opt_in_phone_number(self, number: str) -> None:
@@ -1252,9 +1253,9 @@ class SNSBackend(BaseBackend):
     @paginate(pagination_model=PAGINATION_MODEL)  # type: ignore[misc]
     def list_config_service_resources(  # type: ignore[misc]
         self,
-        resource_ids: Optional[List[str]] = None,
+        resource_ids: Optional[list[str]] = None,
         resource_name: Optional[str] = None,
-    ) -> List[Dict[str, Any]]:
+    ) -> list[dict[str, Any]]:
         """List SNS topics for AWS Config."""
         topics = list(self.topics.values())
 
@@ -1277,7 +1278,7 @@ class SNSBackend(BaseBackend):
 
         return config_resources
 
-    def get_config_resource(self, resource_id: str) -> Optional[Dict[str, Any]]:
+    def get_config_resource(self, resource_id: str) -> Optional[dict[str, Any]]:
         """Get a specific SNS topic configuration for AWS Config."""
         if resource_id not in self.topics:
             return None
@@ -1313,7 +1314,7 @@ class SNSBackend(BaseBackend):
             },
             "configurationItemMD5Hash": "",
         }
-        configuration = cast(Dict[str, Any], config_item["configuration"])
+        configuration = cast(dict[str, Any], config_item["configuration"])
 
         if topic.kms_master_key_id:
             configuration["kmsMasterKeyId"] = topic.kms_master_key_id
@@ -1329,11 +1330,11 @@ class SNSBackend(BaseBackend):
     def confirm_subscription(self) -> None:
         pass
 
-    def get_endpoint_attributes(self, arn: str) -> Dict[str, str]:
+    def get_endpoint_attributes(self, arn: str) -> dict[str, str]:
         endpoint = self.get_endpoint(arn)
         return endpoint.attributes
 
-    def get_platform_application_attributes(self, arn: str) -> Dict[str, str]:
+    def get_platform_application_attributes(self, arn: str) -> dict[str, str]:
         application = self.get_application(arn)
         return application.attributes
 

--- a/moto/sns/responses.py
+++ b/moto/sns/responses.py
@@ -1,7 +1,7 @@
 import base64
 import re
 from collections import defaultdict
-from typing import Any, Dict
+from typing import Any
 
 from moto.core.responses import TYPE_RESPONSE, ActionResult, BaseResponse, EmptyResult
 from moto.core.utils import camelcase_to_underscores
@@ -32,21 +32,21 @@ class SNSResponse(BaseResponse):
     def backend(self) -> SNSBackend:
         return sns_backends[self.current_account][self.region]
 
-    def _get_attributes(self) -> Dict[str, Any]:
+    def _get_attributes(self) -> dict[str, Any]:
         attributes = self._get_param("Attributes", {})
         return attributes
 
-    def _get_tags(self) -> Dict[str, str]:
+    def _get_tags(self) -> dict[str, str]:
         tags = self._get_param("Tags", [])
         return {tag["Key"]: tag["Value"] for tag in tags}
 
-    def _parse_message_attributes(self) -> Dict[str, Any]:
+    def _parse_message_attributes(self) -> dict[str, Any]:
         message_attributes = self._get_param("MessageAttributes", {})
         return self._transform_message_attributes(message_attributes)
 
     def _transform_message_attributes(
-        self, message_attributes: Dict[str, Any]
-    ) -> Dict[str, Any]:
+        self, message_attributes: dict[str, Any]
+    ) -> dict[str, Any]:
         # SNS converts some key names before forwarding messages
         # DataType -> Type, StringValue -> Value, BinaryValue -> Value
         transformed_message_attributes = {}
@@ -342,7 +342,7 @@ class SNSResponse(BaseResponse):
         # attributes.entry.1.value
         # to
         # 1: {key:X, value:Y}
-        temp_dict: Dict[str, Any] = defaultdict(dict)
+        temp_dict: dict[str, Any] = defaultdict(dict)
         for key, value in self.querystring.items():
             match = self.SMS_ATTR_REGEX.match(key)
             if match is not None:

--- a/moto/sqs/models.py
+++ b/moto/sqs/models.py
@@ -5,7 +5,7 @@ import string
 import struct
 from copy import deepcopy
 from threading import Condition
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set, Tuple
+from typing import TYPE_CHECKING, Any, Optional
 from urllib.parse import ParseResult
 
 from moto.core.base_backend import BackendDict, BaseBackend
@@ -74,13 +74,13 @@ class Message(BaseModel):
         self,
         message_id: str,
         body: str,
-        system_attributes: Optional[Dict[str, Any]] = None,
+        system_attributes: Optional[dict[str, Any]] = None,
     ):
         self.id = message_id
         self.body = body
-        self.message_attributes: Dict[str, Any] = {}
+        self.message_attributes: dict[str, Any] = {}
         self.receipt_handle: Optional[str] = None
-        self._old_receipt_handles: List[str] = []
+        self._old_receipt_handles: list[str] = []
         self.sender_id = DEFAULT_SENDER_ID
         self.sent_timestamp = None
         self.approximate_first_receive_timestamp: Optional[int] = None
@@ -195,7 +195,7 @@ class Message(BaseModel):
         return False
 
     @property
-    def all_receipt_handles(self) -> List[Optional[str]]:
+    def all_receipt_handles(self) -> list[Optional[str]]:
         return [self.receipt_handle] + self._old_receipt_handles  # type: ignore
 
     def had_receipt_handle(self, receipt_handle: str) -> bool:
@@ -245,21 +245,21 @@ class Queue(CloudFormationModel):
         self.name = name
         self.region = region
         self.account_id = account_id
-        self.tags: Dict[str, str] = {}
-        self.permissions: Dict[str, Any] = {}
+        self.tags: dict[str, str] = {}
+        self.permissions: dict[str, Any] = {}
 
-        self._messages: List[Message] = []
-        self._pending_messages: Set[Message] = set()
-        self.deleted_messages: Set[str] = set()
+        self._messages: list[Message] = []
+        self._pending_messages: set[Message] = set()
+        self.deleted_messages: set[str] = set()
         self._messages_lock = Condition()
 
         now = unix_time()
         self.created_timestamp = now
         self.queue_arn = f"arn:{get_partition(region)}:sqs:{region}:{account_id}:{name}"
-        self.dead_letter_queue: Optional["Queue"] = None
+        self.dead_letter_queue: Optional[Queue] = None
         self.fifo_queue = False
 
-        self.lambda_event_source_mappings: Dict[str, "EventSourceMapping"] = {}
+        self.lambda_event_source_mappings: dict[str, EventSourceMapping] = {}
 
         # default settings for a non fifo queue
         defaults = {
@@ -308,11 +308,11 @@ class Queue(CloudFormationModel):
             )
 
     @property
-    def pending_messages(self) -> Set[Message]:
+    def pending_messages(self) -> set[Message]:
         return self._pending_messages
 
     @property
-    def pending_message_groups(self) -> Set[str]:
+    def pending_message_groups(self) -> set[str]:
         return set(
             message.group_id
             for message in self._pending_messages
@@ -320,7 +320,7 @@ class Queue(CloudFormationModel):
         )
 
     def _set_attributes(
-        self, attributes: Dict[str, Any], now: Optional[float] = None
+        self, attributes: dict[str, Any], now: Optional[float] = None
     ) -> None:
         if not now:
             now = unix_time()
@@ -504,8 +504,8 @@ class Queue(CloudFormationModel):
         return f"https://sqs.{self.region}.amazonaws.com/{self.account_id}/{self.name}"
 
     @property
-    def attributes(self) -> Dict[str, Any]:  # type: ignore[misc]
-        result: Dict[str, Any] = {}
+    def attributes(self) -> dict[str, Any]:  # type: ignore[misc]
+        result: dict[str, Any] = {}
 
         for attribute in self.BASE_ATTRIBUTES:
             attr = getattr(self, camelcase_to_underscores(attribute))
@@ -539,7 +539,7 @@ class Queue(CloudFormationModel):
         )
 
     @property
-    def messages(self) -> List[Message]:
+    def messages(self) -> list[Message]:
         # TODO: This can become very inefficient if a large number of messages are in-flight
         return [
             message
@@ -659,7 +659,7 @@ class Queue(CloudFormationModel):
 
 
 def _filter_message_attributes(
-    message: Message, input_message_attributes: List[str]
+    message: Message, input_message_attributes: list[str]
 ) -> None:
     filtered_message_attributes = {}
     return_all = "All" in input_message_attributes
@@ -672,10 +672,10 @@ def _filter_message_attributes(
 class SQSBackend(BaseBackend):
     def __init__(self, region_name: str, account_id: str):
         super().__init__(region_name, account_id)
-        self.queues: Dict[str, Queue] = {}
+        self.queues: dict[str, Queue] = {}
 
     def create_queue(
-        self, name: str, tags: Optional[Dict[str, str]] = None, **kwargs: Any
+        self, name: str, tags: Optional[dict[str, str]] = None, **kwargs: Any
     ) -> Queue:
         queue = self.queues.get(name)
         if queue:
@@ -714,7 +714,7 @@ class SQSBackend(BaseBackend):
     def get_queue_url(self, queue_name: str) -> Queue:
         return self.get_queue(queue_name)
 
-    def list_queues(self, queue_name_prefix: str) -> List[Queue]:
+    def list_queues(self, queue_name_prefix: str) -> list[Queue]:
         re_str = ".*"
         if queue_name_prefix:
             re_str = f"^{queue_name_prefix}.*"
@@ -737,8 +737,8 @@ class SQSBackend(BaseBackend):
         del self.queues[queue_name]
 
     def get_queue_attributes(
-        self, queue_name: str, attribute_names: List[str]
-    ) -> Dict[str, Any]:
+        self, queue_name: str, attribute_names: list[str]
+    ) -> dict[str, Any]:
         queue = self.get_queue(queue_name)
         if not attribute_names:
             return {}
@@ -768,7 +768,7 @@ class SQSBackend(BaseBackend):
         return attributes
 
     def set_queue_attributes(
-        self, queue_name: str, attributes: Dict[str, Any]
+        self, queue_name: str, attributes: dict[str, Any]
     ) -> Queue:
         queue = self.get_queue(queue_name)
         queue._set_attributes(attributes)
@@ -821,11 +821,11 @@ class SQSBackend(BaseBackend):
         self,
         queue_name: str,
         message_body: str,
-        message_attributes: Optional[Dict[str, Any]] = None,
+        message_attributes: Optional[dict[str, Any]] = None,
         delay_seconds: Optional[int] = None,
         deduplication_id: Optional[str] = None,
         group_id: Optional[str] = None,
-        system_attributes: Optional[Dict[str, Any]] = None,
+        system_attributes: Optional[dict[str, Any]] = None,
         validate_group_id: bool = True,
     ) -> Message:
         queue = self.get_queue(queue_name)
@@ -881,8 +881,8 @@ class SQSBackend(BaseBackend):
         return message
 
     def send_message_batch(
-        self, queue_name: str, entries: Dict[str, Dict[str, Any]]
-    ) -> Tuple[List[Message], List[Dict[str, Any]]]:
+        self, queue_name: str, entries: dict[str, dict[str, Any]]
+    ) -> tuple[list[Message], list[dict[str, Any]]]:
         queue = self.get_queue(queue_name)
 
         if any(
@@ -937,7 +937,7 @@ class SQSBackend(BaseBackend):
 
         return messages, failedInvalidDelay
 
-    def _get_first_duplicate_id(self, ids: List[str]) -> Optional[str]:
+    def _get_first_duplicate_id(self, ids: list[str]) -> Optional[str]:
         unique_ids = set()
         for _id in ids:
             if _id in unique_ids:
@@ -951,8 +951,8 @@ class SQSBackend(BaseBackend):
         count: int,
         wait_seconds_timeout: int,
         visibility_timeout: int,
-        message_attribute_names: Optional[List[str]] = None,
-    ) -> List[Message]:
+        message_attribute_names: Optional[list[str]] = None,
+    ) -> list[Message]:
         # Attempt to retrieve visible messages from a queue.
 
         # If a message was read by client and not deleted it is considered to be
@@ -963,7 +963,7 @@ class SQSBackend(BaseBackend):
         if message_attribute_names is None:
             message_attribute_names = []
         queue = self.get_queue(queue_name)
-        result: List[Message] = []
+        result: list[Message] = []
         previous_result_count = len(result)
 
         polling_end = unix_time() + wait_seconds_timeout
@@ -974,7 +974,7 @@ class SQSBackend(BaseBackend):
             if result or (wait_seconds_timeout and unix_time() > polling_end):
                 break
 
-            messages_to_dlq: List[Message] = []
+            messages_to_dlq: list[Message] = []
 
             for message in queue.messages:
                 if not message.visible:
@@ -1036,8 +1036,8 @@ class SQSBackend(BaseBackend):
         queue.delete_message(receipt_handle)
 
     def delete_message_batch(
-        self, queue_name: str, receipts: List[Dict[str, Any]]
-    ) -> Tuple[List[str], List[Dict[str, str]]]:
+        self, queue_name: str, receipts: list[dict[str, Any]]
+    ) -> tuple[list[str], list[dict[str, str]]]:
         success = []
         errors = []
         for receipt_and_id in receipts:
@@ -1078,8 +1078,8 @@ class SQSBackend(BaseBackend):
         raise ReceiptHandleIsInvalid
 
     def change_message_visibility_batch(
-        self, queue_name: str, entries: List[Dict[str, Any]]
-    ) -> Tuple[List[str], List[Dict[str, str]]]:
+        self, queue_name: str, entries: list[dict[str, Any]]
+    ) -> tuple[list[str], list[dict[str, str]]]:
         success = []
         error = []
         for entry in entries:
@@ -1120,10 +1120,10 @@ class SQSBackend(BaseBackend):
         queue._messages = []
         queue._pending_messages = set()
 
-    def list_dead_letter_source_queues(self, queue_name: str) -> List[Queue]:
+    def list_dead_letter_source_queues(self, queue_name: str) -> list[Queue]:
         dlq = self.get_queue(queue_name)
 
-        queues: List[Queue] = []
+        queues: list[Queue] = []
         for queue in self.queues.values():
             if queue.dead_letter_queue is dlq:
                 queues.append(queue)
@@ -1134,8 +1134,8 @@ class SQSBackend(BaseBackend):
         self,
         region_name: str,
         queue_name: str,
-        actions: List[str],
-        account_ids: List[str],
+        actions: list[str],
+        account_ids: list[str],
         label: str,
     ) -> None:
         queue = self.get_queue(queue_name)
@@ -1208,7 +1208,7 @@ class SQSBackend(BaseBackend):
 
         queue._policy_json["Statement"] = statements_new
 
-    def tag_queue(self, queue_name: str, tags: Dict[str, str]) -> None:
+    def tag_queue(self, queue_name: str, tags: dict[str, str]) -> None:
         queue = self.get_queue(queue_name)
 
         if not len(tags):
@@ -1219,7 +1219,7 @@ class SQSBackend(BaseBackend):
 
         queue.tags.update(tags)
 
-    def untag_queue(self, queue_name: str, tag_keys: List[str]) -> None:
+    def untag_queue(self, queue_name: str, tag_keys: list[str]) -> None:
         queue = self.get_queue(queue_name)
 
         if not len(tag_keys):

--- a/moto/sqs/responses.py
+++ b/moto/sqs/responses.py
@@ -1,5 +1,5 @@
 import re
-from typing import Any, Dict, Optional
+from typing import Any, Optional
 from urllib.parse import urlparse
 
 from moto.core.common_types import TYPE_RESPONSE
@@ -204,7 +204,7 @@ class SQSResponse(BaseResponse):
                 }
             )
 
-        resp: Dict[str, Any] = {"Successful": [], "Failed": errors}
+        resp: dict[str, Any] = {"Successful": [], "Failed": errors}
         for msg in messages:
             msg_dict = {
                 "Id": msg.user_id,  # type: ignore
@@ -310,7 +310,7 @@ class SQSResponse(BaseResponse):
 
         msgs = []
         for message in messages:
-            msg: Dict[str, Any] = {
+            msg: dict[str, Any] = {
                 "MessageId": message.id,
                 "ReceiptHandle": message.receipt_handle,
                 "MD5OfBody": message.body_md5,

--- a/moto/sqs/utils.py
+++ b/moto/sqs/utils.py
@@ -1,5 +1,5 @@
 import string
-from typing import Any, Dict
+from typing import Any
 
 from moto.moto_api._internal import mock_random as random
 
@@ -12,7 +12,7 @@ def generate_receipt_handle() -> str:
     return "".join(random.choice(string.ascii_lowercase) for x in range(length))
 
 
-def validate_message_attributes(message_attributes: Dict[str, Any]) -> None:
+def validate_message_attributes(message_attributes: dict[str, Any]) -> None:
     for name, value in (message_attributes or {}).items():
         data_type = value["DataType"]
 

--- a/moto/ssm/models.py
+++ b/moto/ssm/models.py
@@ -4,8 +4,9 @@ import json
 import re
 import time
 from collections import defaultdict
+from collections.abc import Iterator
 from dataclasses import dataclass
-from typing import Any, DefaultDict, Dict, Iterator, List, Optional, Tuple
+from typing import Any, Optional
 
 import yaml
 
@@ -48,7 +49,7 @@ from .exceptions import (
 from .utils import convert_to_params, parameter_arn
 
 
-class ParameterDict(DefaultDict[str, List["Parameter"]]):
+class ParameterDict(defaultdict[str, list["Parameter"]]):
     def __init__(self, account_id: str, region_name: str):
         # each value is a list of all the versions for a parameter
         # to get the current value, grab the last item of the list
@@ -133,7 +134,7 @@ class ParameterDict(DefaultDict[str, List["Parameter"]]):
                 )
             )
 
-    def _get_secretsmanager_parameter(self, secret_name: str) -> List["Parameter"]:
+    def _get_secretsmanager_parameter(self, secret_name: str) -> list["Parameter"]:
         secrets_backend = secretsmanager_backends[self.account_id][self.region_name]
         secret = secrets_backend.describe_secret(secret_name).to_dict()
         version_id_to_stage = secret["VersionIdsToStages"]
@@ -167,7 +168,7 @@ class ParameterDict(DefaultDict[str, List["Parameter"]]):
             for val in values
         ]
 
-    def __getitem__(self, item: str) -> List["Parameter"]:
+    def __getitem__(self, item: str) -> list["Parameter"]:
         if item.startswith("/aws/reference/secretsmanager/"):
             return self._get_secretsmanager_parameter("/".join(item.split("/")[4:]))
         self._check_loading_status(item)
@@ -223,7 +224,7 @@ class Parameter(CloudFormationModel):
         last_modified_date: float,
         version: int,
         data_type: str,
-        labels: Optional[List[str]] = None,
+        labels: Optional[list[str]] = None,
         source_result: Optional[str] = None,
         tier: Optional[str] = None,
         policies: Optional[str] = None,
@@ -264,8 +265,8 @@ class Parameter(CloudFormationModel):
 
     def response_object(
         self, decrypt: bool = False, region: Optional[str] = None
-    ) -> Dict[str, Any]:
-        r: Dict[str, Any] = {
+    ) -> dict[str, Any]:
+        r: dict[str, Any] = {
             "Name": self.name,
             "Type": self.parameter_type,
             "Value": self.decrypt(self.value) if decrypt else self.value,
@@ -293,8 +294,8 @@ class Parameter(CloudFormationModel):
 
     def describe_response_object(
         self, decrypt: bool = False, include_labels: bool = False
-    ) -> Dict[str, Any]:
-        r: Dict[str, Any] = self.response_object(decrypt)
+    ) -> dict[str, Any]:
+        r: dict[str, Any] = self.response_object(decrypt)
         r["LastModifiedDate"] = round(self.last_modified_date, 3)
         r["LastModifiedUser"] = "N/A"
 
@@ -389,8 +390,8 @@ MAX_TIMEOUT_SECONDS = 3600
 
 
 def generate_ssm_doc_param_list(
-    parameters: Dict[str, Any],
-) -> Optional[List[Dict[str, Any]]]:
+    parameters: dict[str, Any],
+) -> Optional[list[dict[str, Any]]]:
     if not parameters:
         return None
     param_list = []
@@ -431,7 +432,7 @@ class Documents(BaseModel):
         self.versions = {version: ssm_document}
         self.default_version = version
         self.latest_version = version
-        self.permissions: Dict[
+        self.permissions: dict[
             str, AccountPermission
         ] = {}  # {AccountID: AccountPermission }
 
@@ -473,7 +474,7 @@ class Documents(BaseModel):
         strict: bool = True,
     ) -> "Document":
         if document_version == "$LATEST":
-            ssm_document: Optional["Document"] = self.get_latest_version()
+            ssm_document: Optional[Document] = self.get_latest_version()
         elif version_name and document_version:
             ssm_document = self.find_by_version_and_version_name(
                 document_version, version_name
@@ -521,10 +522,10 @@ class Documents(BaseModel):
         self,
         document_version: Optional[str] = None,
         version_name: Optional[str] = None,
-        tags: Optional[List[Dict[str, str]]] = None,
-    ) -> Dict[str, Any]:
+        tags: Optional[list[dict[str, str]]] = None,
+    ) -> dict[str, Any]:
         document = self.find(document_version, version_name)
-        base: Dict[str, Any] = {
+        base: dict[str, Any] = {
             "Hash": document.hash,
             "HashType": "Sha256",
             "Name": document.name,
@@ -551,7 +552,7 @@ class Documents(BaseModel):
         return base
 
     def modify_permissions(
-        self, accounts_to_add: List[str], accounts_to_remove: List[str], version: str
+        self, accounts_to_add: list[str], accounts_to_remove: list[str], version: str
     ) -> None:
         version = version or "$DEFAULT"
         if accounts_to_add:
@@ -575,7 +576,7 @@ class Documents(BaseModel):
                 for account_id in accounts_to_remove:
                     self.permissions.pop(account_id, None)
 
-    def describe_permissions(self) -> Dict[str, Any]:
+    def describe_permissions(self) -> dict[str, Any]:
         permissions_ordered_by_date = sorted(
             self.permissions.values(), key=lambda p: p.created_at
         )
@@ -601,8 +602,8 @@ class Document(BaseModel):
         content: str,
         document_type: str,
         document_format: str,
-        requires: List[Dict[str, str]],
-        attachments: List[Dict[str, Any]],
+        requires: list[dict[str, str]],
+        attachments: list[dict[str, Any]],
         target_type: str,
         document_version: str = "1",
     ):
@@ -663,9 +664,9 @@ class Document(BaseModel):
         return hashlib.sha256(self.content.encode("utf-8")).hexdigest()
 
     def list_describe(
-        self, tags: Optional[List[Dict[str, str]]] = None
-    ) -> Dict[str, Any]:
-        base: Dict[str, Any] = {
+        self, tags: Optional[list[dict[str, str]]] = None
+    ) -> dict[str, Any]:
+        base: dict[str, Any] = {
             "Name": self.name,
             "Owner": self.owner,
             "DocumentVersion": self.document_version,
@@ -694,16 +695,16 @@ class Command(BaseModel):
         comment: str = "",
         document_name: Optional[str] = "",
         timeout_seconds: Optional[int] = MAX_TIMEOUT_SECONDS,
-        instance_ids: Optional[List[str]] = None,
+        instance_ids: Optional[list[str]] = None,
         max_concurrency: str = "",
         max_errors: str = "",
-        notification_config: Optional[Dict[str, Any]] = None,
+        notification_config: Optional[dict[str, Any]] = None,
         output_s3_bucket_name: str = "",
         output_s3_key_prefix: str = "",
         output_s3_region: str = "",
-        parameters: Optional[Dict[str, List[str]]] = None,
+        parameters: Optional[dict[str, list[str]]] = None,
         service_role_arn: str = "",
-        targets: Optional[List[Dict[str, Any]]] = None,
+        targets: Optional[list[dict[str, Any]]] = None,
         backend_region: str = "us-east-1",
     ):
         if instance_ids is None:
@@ -766,7 +767,7 @@ class Command(BaseModel):
                 self.invocation_response(instance_id, "aws:runShellScript")
             )
 
-    def _get_instance_ids_from_targets(self) -> List[str]:
+    def _get_instance_ids_from_targets(self) -> list[str]:
         target_instance_ids = []
         ec2_backend = ec2_backends[self.account_id][self.backend_region]
         ec2_filters = {target["Key"]: target["Values"] for target in self.targets}
@@ -776,7 +777,7 @@ class Command(BaseModel):
                 target_instance_ids.append(instance.id)
         return target_instance_ids
 
-    def response_object(self) -> Dict[str, Any]:
+    def response_object(self) -> dict[str, Any]:
         return {
             "CommandId": self.command_id,
             "Comment": self.comment,
@@ -802,7 +803,7 @@ class Command(BaseModel):
             "TimeoutSeconds": self.timeout_seconds,
         }
 
-    def invocation_response(self, instance_id: str, plugin_name: str) -> Dict[str, Any]:
+    def invocation_response(self, instance_id: str, plugin_name: str) -> dict[str, Any]:
         # Calculate elapsed time from requested time and now. Use a hardcoded
         # elapsed time since there is no easy way to convert a timedelta to
         # an ISO 8601 duration string.
@@ -829,7 +830,7 @@ class Command(BaseModel):
 
     def get_invocation(
         self, instance_id: str, plugin_name: Optional[str]
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         invocation = next(
             (
                 invocation
@@ -898,7 +899,7 @@ def _validate_document_info(
 
 
 def _document_filter_equal_comparator(
-    keyed_value: str, _filter: Dict[str, Any]
+    keyed_value: str, _filter: dict[str, Any]
 ) -> bool:
     for v in _filter["Values"]:
         if keyed_value == v:
@@ -907,7 +908,7 @@ def _document_filter_equal_comparator(
 
 
 def _document_filter_list_includes_comparator(
-    keyed_value_list: List[str], _filter: Dict[str, Any]
+    keyed_value_list: list[str], _filter: dict[str, Any]
 ) -> bool:
     for v in _filter["Values"]:
         if v in keyed_value_list:
@@ -916,7 +917,7 @@ def _document_filter_list_includes_comparator(
 
 
 def _document_filter_match(
-    account_id: str, filters: List[Dict[str, Any]], ssm_doc: Document
+    account_id: str, filters: list[dict[str, Any]], ssm_doc: Document
 ) -> bool:
     for _filter in filters:
         if _filter["Key"] == "Name" and not _document_filter_equal_comparator(
@@ -974,7 +975,7 @@ class FakeMaintenanceWindowTarget:
         self,
         window_id: str,
         resource_type: str,
-        targets: List[Dict[str, Any]],
+        targets: list[dict[str, Any]],
         owner_information: Optional[str],
         name: Optional[str],
         description: Optional[str],
@@ -987,7 +988,7 @@ class FakeMaintenanceWindowTarget:
         self.description = description
         self.owner_information = owner_information
 
-    def to_json(self) -> Dict[str, Any]:
+    def to_json(self) -> dict[str, Any]:
         return {
             "WindowId": self.window_id,
             "WindowTargetId": self.window_target_id,
@@ -1007,20 +1008,20 @@ class FakeMaintenanceWindowTask:
     def __init__(
         self,
         window_id: str,
-        targets: Optional[List[Dict[str, Any]]],
+        targets: Optional[list[dict[str, Any]]],
         task_arn: str,
         service_role_arn: Optional[str],
         task_type: str,
-        task_parameters: Optional[Dict[str, Any]],
-        task_invocation_parameters: Optional[Dict[str, Any]],
+        task_parameters: Optional[dict[str, Any]],
+        task_invocation_parameters: Optional[dict[str, Any]],
         priority: Optional[int],
         max_concurrency: Optional[str],
         max_errors: Optional[str],
-        logging_info: Optional[Dict[str, Any]],
+        logging_info: Optional[dict[str, Any]],
         name: Optional[str],
         description: Optional[str],
         cutoff_behavior: Optional[str],
-        alarm_configurations: Optional[Dict[str, Any]],
+        alarm_configurations: Optional[dict[str, Any]],
     ):
         self.window_task_id = FakeMaintenanceWindowTask.generate_id()
         self.window_id = window_id
@@ -1039,7 +1040,7 @@ class FakeMaintenanceWindowTask:
         self.cutoff_behavior = cutoff_behavior
         self.alarm_configurations = alarm_configurations
 
-    def to_json(self) -> Dict[str, Any]:
+    def to_json(self) -> dict[str, Any]:
         return {
             "WindowId": self.window_id,
             "WindowTaskId": self.window_task_id,
@@ -1063,7 +1064,7 @@ class FakeMaintenanceWindowTask:
 
 
 def _maintenance_window_target_filter_match(
-    filters: Optional[List[Dict[str, Any]]], target: FakeMaintenanceWindowTarget
+    filters: Optional[list[dict[str, Any]]], target: FakeMaintenanceWindowTarget
 ) -> bool:
     if not filters and target:
         return True
@@ -1071,7 +1072,7 @@ def _maintenance_window_target_filter_match(
 
 
 def _maintenance_window_task_filter_match(
-    filters: Optional[List[Dict[str, Any]]], task: FakeMaintenanceWindowTask
+    filters: Optional[list[dict[str, Any]]], task: FakeMaintenanceWindowTask
 ) -> bool:
     if not filters and task:
         return True
@@ -1101,10 +1102,10 @@ class FakeMaintenanceWindow:
         self.schedule_offset = schedule_offset
         self.start_date = start_date
         self.end_date = end_date
-        self.targets: Dict[str, FakeMaintenanceWindowTarget] = {}
-        self.tasks: Dict[str, FakeMaintenanceWindowTask] = {}
+        self.targets: dict[str, FakeMaintenanceWindowTarget] = {}
+        self.tasks: dict[str, FakeMaintenanceWindowTask] = {}
 
-    def to_json(self) -> Dict[str, Any]:
+    def to_json(self) -> dict[str, Any]:
         return {
             "WindowId": self.id,
             "Name": self.name,
@@ -1130,15 +1131,15 @@ class FakePatchBaseline:
         self,
         name: str,
         operating_system: str,
-        global_filters: Optional[Dict[str, Any]],
-        approval_rules: Optional[Dict[str, Any]],
-        approved_patches: Optional[List[str]],
+        global_filters: Optional[dict[str, Any]],
+        approval_rules: Optional[dict[str, Any]],
+        approved_patches: Optional[list[str]],
         approved_patches_compliance_level: Optional[str],
         approved_patches_enable_non_security: Optional[bool],
-        rejected_patches: Optional[List[str]],
+        rejected_patches: Optional[list[str]],
         rejected_patches_action: Optional[str],
         description: Optional[str],
-        sources: Optional[List[Dict[str, Any]]],
+        sources: Optional[list[dict[str, Any]]],
     ):
         self.id = FakePatchBaseline.generate_id()
         self.operating_system = operating_system
@@ -1154,7 +1155,7 @@ class FakePatchBaseline:
         self.sources = sources
         self.default_baseline = False
 
-    def to_json(self) -> Dict[str, Any]:
+    def to_json(self) -> dict[str, Any]:
         return {
             "BaselineId": self.id,
             "OperatingSystem": self.operating_system,
@@ -1210,25 +1211,25 @@ class SimpleSystemManagerBackend(BaseBackend):
         super().__init__(region_name, account_id)
         self._parameters = ParameterDict(account_id, region_name)
 
-        self._resource_tags: DefaultDict[str, DefaultDict[str, Dict[str, str]]] = (
+        self._resource_tags: defaultdict[str, defaultdict[str, dict[str, str]]] = (
             defaultdict(lambda: defaultdict(dict))
         )
-        self._commands: List[Command] = []
-        self._errors: List[str] = []
-        self._documents: Dict[str, Documents] = {}
+        self._commands: list[Command] = []
+        self._errors: list[str] = []
+        self._documents: dict[str, Documents] = {}
 
-        self.windows: Dict[str, FakeMaintenanceWindow] = dict()
-        self.baselines: Dict[str, FakePatchBaseline] = dict()
-        self.patch_groups: Dict[str, FakePatchGroup] = dict()
+        self.windows: dict[str, FakeMaintenanceWindow] = dict()
+        self.baselines: dict[str, FakePatchBaseline] = dict()
+        self.patch_groups: dict[str, FakePatchGroup] = dict()
         self.ssm_prefix = (
             f"arn:{self.partition}:ssm:{self.region_name}:{self.account_id}:parameter"
         )
 
     def _generate_document_information(
         self, ssm_document: Document, document_format: str
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         content = self._get_document_content(document_format, ssm_document)
-        base: Dict[str, Any] = {
+        base: dict[str, Any] = {
             "Name": ssm_document.name,
             "DocumentVersion": ssm_document.document_version,
             "Status": ssm_document.status,
@@ -1264,7 +1265,7 @@ class SimpleSystemManagerBackend(BaseBackend):
             raise InvalidDocument("The specified document does not exist.")
         return documents
 
-    def _get_documents_tags(self, name: str) -> List[Dict[str, str]]:
+    def _get_documents_tags(self, name: str) -> list[dict[str, str]]:
         docs_tags = self._resource_tags.get("Document")
         if docs_tags:
             document_tags = docs_tags.get(name, {})
@@ -1276,15 +1277,15 @@ class SimpleSystemManagerBackend(BaseBackend):
     def create_document(
         self,
         content: str,
-        requires: List[Dict[str, str]],
-        attachments: List[Dict[str, Any]],
+        requires: list[dict[str, str]],
+        attachments: list[dict[str, Any]],
         name: str,
         version_name: str,
         document_type: str,
         document_format: str,
         target_type: str,
-        tags: List[Dict[str, str]],
-    ) -> Dict[str, Any]:
+        tags: list[dict[str, str]],
+    ) -> dict[str, Any]:
         ssm_document = Document(
             account_id=self.account_id,
             name=name,
@@ -1372,7 +1373,7 @@ class SimpleSystemManagerBackend(BaseBackend):
 
     def get_document(
         self, name: str, document_version: str, version_name: str, document_format: str
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         documents = self._get_documents(name)
         ssm_document = documents.find(document_version, version_name)
 
@@ -1385,11 +1386,11 @@ class SimpleSystemManagerBackend(BaseBackend):
 
     def update_document_default_version(
         self, name: str, document_version: str
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         documents = self._get_documents(name)
         ssm_document = documents.update_default_version(document_version)
 
-        result: Dict[str, Any] = {
+        result: dict[str, Any] = {
             "Name": ssm_document.name,
             "DefaultVersion": document_version,
         }
@@ -1402,13 +1403,13 @@ class SimpleSystemManagerBackend(BaseBackend):
     def update_document(
         self,
         content: str,
-        attachments: List[Dict[str, Any]],
+        attachments: list[dict[str, Any]],
         name: str,
         version_name: str,
         document_version: str,
         document_format: str,
         target_type: str,
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         _validate_document_info(
             content=content,
             name=name,
@@ -1465,7 +1466,7 @@ class SimpleSystemManagerBackend(BaseBackend):
 
     def describe_document(
         self, name: str, document_version: str, version_name: str
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         documents = self._get_documents(name)
         tags = self._get_documents_tags(name)
         return documents.describe(document_version, version_name, tags=tags)
@@ -1473,17 +1474,17 @@ class SimpleSystemManagerBackend(BaseBackend):
     def list_documents(
         self,
         document_filter_list: Any,
-        filters: List[Dict[str, Any]],
+        filters: list[dict[str, Any]],
         max_results: int = 10,
         token: str = "0",
-    ) -> Tuple[List[Dict[str, Any]], str]:
+    ) -> tuple[list[dict[str, Any]], str]:
         if document_filter_list:
             raise ValidationException(
                 "DocumentFilterList is deprecated. Instead use Filters."
             )
 
         next_token = int(token or "0")
-        results: List[Dict[str, Any]] = []
+        results: list[dict[str, Any]] = []
         dummy_token_tracker = 0
         # Sort to maintain next token adjacency
         for _, documents in sorted(self._documents.items()):
@@ -1509,7 +1510,7 @@ class SimpleSystemManagerBackend(BaseBackend):
         # If we've fallen out of the loop, there are no more documents. No next token.
         return results, ""
 
-    def describe_document_permission(self, name: str) -> Dict[str, Any]:
+    def describe_document_permission(self, name: str) -> dict[str, Any]:
         """
         Parameters max_results, permission_type, and next_token not yet implemented
         """
@@ -1519,8 +1520,8 @@ class SimpleSystemManagerBackend(BaseBackend):
     def modify_document_permission(
         self,
         name: str,
-        account_ids_to_add: List[str],
-        account_ids_to_remove: List[str],
+        account_ids_to_add: list[str],
+        account_ids_to_remove: list[str],
         shared_document_version: str,
         permission_type: str,
     ) -> None:
@@ -1576,7 +1577,7 @@ class SimpleSystemManagerBackend(BaseBackend):
         self._resource_tags.get("Parameter", {}).pop(normalized_parameter_name, None)  # type: ignore
         return self._parameters.pop(normalized_parameter_name, None)  # type: ignore
 
-    def delete_parameters(self, names: List[str]) -> List[str]:
+    def delete_parameters(self, names: list[str]) -> list[str]:
         result = []
         for name in names:
             try:
@@ -1591,8 +1592,8 @@ class SimpleSystemManagerBackend(BaseBackend):
         return result
 
     def describe_parameters(
-        self, filters: List[Dict[str, Any]], parameter_filters: List[Dict[str, Any]]
-    ) -> List[Parameter]:
+        self, filters: list[dict[str, Any]], parameter_filters: list[dict[str, Any]]
+    ) -> list[Parameter]:
         if filters and parameter_filters:
             raise ValidationException(
                 "You can use either Filters or ParameterFilters in a single request."
@@ -1632,7 +1633,7 @@ class SimpleSystemManagerBackend(BaseBackend):
         return result
 
     def _validate_parameter_filters(
-        self, parameter_filters: Optional[List[Dict[str, Any]]], by_path: bool
+        self, parameter_filters: Optional[list[dict[str, Any]]], by_path: bool
     ) -> None:
         for index, filter_obj in enumerate(parameter_filters or []):
             key = filter_obj["Key"]
@@ -1793,7 +1794,7 @@ class SimpleSystemManagerBackend(BaseBackend):
                 f"{count} validation error{plural} detected: {errors}"
             )
 
-    def get_parameters(self, names: List[str]) -> Dict[str, Parameter]:
+    def get_parameters(self, names: list[str]) -> dict[str, Parameter]:
         result = {}
 
         if len(names) > 10:
@@ -1818,10 +1819,10 @@ class SimpleSystemManagerBackend(BaseBackend):
         self,
         path: str,
         recursive: bool,
-        filters: Optional[List[Dict[str, Any]]] = None,
+        filters: Optional[list[dict[str, Any]]] = None,
         next_token: Optional[str] = None,
         max_results: int = 10,
-    ) -> Tuple[List[Parameter], Optional[str]]:
+    ) -> tuple[list[Parameter], Optional[str]]:
         """Implement the get-parameters-by-path-API in the backend."""
         if max_results > PARAMETER_BY_PATH_MAX_RESULTS:
             raise ValidationException(
@@ -1832,7 +1833,7 @@ class SimpleSystemManagerBackend(BaseBackend):
 
         self._validate_parameter_filters(filters, by_path=True)
 
-        result: List[Parameter] = []
+        result: list[Parameter] = []
         # path could be with or without a trailing /. we handle this
         # difference here.
         path = path.rstrip("/") + "/"
@@ -1846,10 +1847,10 @@ class SimpleSystemManagerBackend(BaseBackend):
 
     def _get_values_nexttoken(
         self,
-        values_list: List[Parameter],
+        values_list: list[Parameter],
         max_results: int,
         token: Optional[str] = None,
-    ) -> Tuple[List[Parameter], Optional[str]]:
+    ) -> tuple[list[Parameter], Optional[str]]:
         next_token = int(token or "0")
         max_results = int(max_results)
         values = values_list[next_token : next_token + max_results]
@@ -1860,7 +1861,7 @@ class SimpleSystemManagerBackend(BaseBackend):
 
     def get_parameter_history(
         self, name: str, next_token: Optional[str], max_results: int = 50
-    ) -> Tuple[Optional[List[Parameter]], Optional[str]]:
+    ) -> tuple[Optional[list[Parameter]], Optional[str]]:
         if max_results > PARAMETER_HISTORY_MAX_RESULTS:
             raise ValidationException(
                 "1 validation error detected: "
@@ -1875,8 +1876,8 @@ class SimpleSystemManagerBackend(BaseBackend):
         return None, None
 
     def _get_history_nexttoken(
-        self, history: List[Parameter], token: Optional[str], max_results: int
-    ) -> Tuple[List[Parameter], Optional[str]]:
+        self, history: list[Parameter], token: Optional[str], max_results: int
+    ) -> tuple[list[Parameter], Optional[str]]:
         next_token = int(token or "0")
         max_results = int(max_results)
         history_to_return = history[next_token : next_token + max_results]
@@ -1889,7 +1890,7 @@ class SimpleSystemManagerBackend(BaseBackend):
         return history_to_return, None
 
     def _match_filters(
-        self, parameter: Parameter, filters: Optional[List[Dict[str, Any]]] = None
+        self, parameter: Parameter, filters: Optional[list[dict[str, Any]]] = None
     ) -> bool:
         """Return True if the given parameter matches all the filters"""
         parameter_tags = self.list_tags_for_resource("Parameter", parameter.name)
@@ -1997,9 +1998,8 @@ class SimpleSystemManagerBackend(BaseBackend):
                         return result[-1]
                     elif len(parameters) > 0:
                         raise ParameterVersionNotFound(
-                            "Systems Manager could not find version %s of %s. "
+                            f"Systems Manager could not find version {version_or_label} of {name_prefix}. "
                             "Verify the version and try again."
-                            % (version_or_label, name_prefix)
                         )
                 result = list(
                     filter(lambda x: version_or_label in x.labels, parameters)
@@ -2010,8 +2010,8 @@ class SimpleSystemManagerBackend(BaseBackend):
         return None
 
     def label_parameter_version(
-        self, name: str, version: int, labels: List[str]
-    ) -> Tuple[List[str], int]:
+        self, name: str, version: int, labels: list[str]
+    ) -> tuple[list[str], int]:
         previous_parameter_versions = self._parameters[name]
         if not previous_parameter_versions:
             raise ParameterNotFound(f"Parameter {name} not found.")
@@ -2047,10 +2047,9 @@ class SimpleSystemManagerBackend(BaseBackend):
             if len(label) > 100:
                 raise ValidationException(
                     "1 validation error detected: "
-                    "Value '[%s]' at 'labels' failed to satisfy constraint: "
+                    f"Value '[{label}]' at 'labels' failed to satisfy constraint: "
                     "Member must satisfy constraint: "
                     "[Member must have length less than or equal to 100, Member must have length greater than or equal to 1]"
-                    % label
                 )
                 continue
             if label not in found_parameter.labels:
@@ -2090,7 +2089,7 @@ class SimpleSystemManagerBackend(BaseBackend):
         allowed_pattern: str,
         keyid: str,
         overwrite: bool,
-        tags: List[Dict[str, str]],
+        tags: list[dict[str, str]],
         data_type: str,
         tier: Optional[str],
         policies: Optional[str],
@@ -2209,14 +2208,14 @@ class SimpleSystemManagerBackend(BaseBackend):
         return new_param
 
     def add_tags_to_resource(
-        self, resource_type: str, resource_id: str, tags: Dict[str, str]
+        self, resource_type: str, resource_id: str, tags: dict[str, str]
     ) -> None:
         resource_id = self._validate_resource_type_and_id(resource_type, resource_id)
         for key, value in tags.items():
             self._resource_tags[resource_type][resource_id][key] = value
 
     def remove_tags_from_resource(
-        self, resource_type: str, resource_id: str, keys: List[str]
+        self, resource_type: str, resource_id: str, keys: list[str]
     ) -> None:
         resource_id = self._validate_resource_type_and_id(resource_type, resource_id)
         tags = self._resource_tags[resource_type][resource_id]
@@ -2226,7 +2225,7 @@ class SimpleSystemManagerBackend(BaseBackend):
 
     def list_tags_for_resource(
         self, resource_type: str, resource_id: str
-    ) -> Dict[str, str]:
+    ) -> dict[str, str]:
         resource_id = self._validate_resource_type_and_id(resource_type, resource_id)
         return self._resource_tags[resource_type][resource_id]
 
@@ -2263,16 +2262,16 @@ class SimpleSystemManagerBackend(BaseBackend):
         comment: str,
         document_name: Optional[str],
         timeout_seconds: int,
-        instance_ids: List[str],
+        instance_ids: list[str],
         max_concurrency: str,
         max_errors: str,
-        notification_config: Optional[Dict[str, Any]],
+        notification_config: Optional[dict[str, Any]],
         output_s3_bucket_name: str,
         output_s3_key_prefix: str,
         output_s3_region: str,
-        parameters: Dict[str, List[str]],
+        parameters: dict[str, list[str]],
         service_role_arn: str,
-        targets: List[Dict[str, Any]],
+        targets: list[dict[str, Any]],
     ) -> Command:
         command = Command(
             account_id=self.account_id,
@@ -2297,7 +2296,7 @@ class SimpleSystemManagerBackend(BaseBackend):
 
     def list_commands(
         self, command_id: Optional[str], instance_id: Optional[str]
-    ) -> List[Command]:
+    ) -> list[Command]:
         """
         Pagination and the Filters-parameter is not yet implemented
         """
@@ -2319,14 +2318,14 @@ class SimpleSystemManagerBackend(BaseBackend):
 
         return command
 
-    def get_commands_by_instance_id(self, instance_id: str) -> List[Command]:
+    def get_commands_by_instance_id(self, instance_id: str) -> list[Command]:
         return [
             command for command in self._commands if instance_id in command.instance_ids
         ]
 
     def get_command_invocation(
         self, command_id: str, instance_id: str, plugin_name: Optional[str]
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         command = self.get_command_by_id(command_id)
         return command.get_invocation(instance_id, plugin_name)
 
@@ -2341,7 +2340,7 @@ class SimpleSystemManagerBackend(BaseBackend):
         schedule_offset: int,
         start_date: str,
         end_date: str,
-        tags: Optional[List[Dict[str, str]]],
+        tags: Optional[list[dict[str, str]]],
     ) -> str:
         """
         Creates a maintenance window. No error handling or input validation has been implemented yet.
@@ -2374,8 +2373,8 @@ class SimpleSystemManagerBackend(BaseBackend):
         return self.windows[window_id]
 
     def describe_maintenance_windows(
-        self, filters: Optional[List[Dict[str, Any]]]
-    ) -> List[FakeMaintenanceWindow]:
+        self, filters: Optional[list[dict[str, Any]]]
+    ) -> list[FakeMaintenanceWindow]:
         """
         Returns all windows. No pagination has been implemented yet. Only filtering for Name is supported.
         The NextExecutionTime-field is not returned.
@@ -2400,16 +2399,16 @@ class SimpleSystemManagerBackend(BaseBackend):
         self,
         name: str,
         operating_system: str,
-        global_filters: Optional[Dict[str, Any]],
-        approval_rules: Optional[Dict[str, Any]],
-        approved_patches: Optional[List[str]],
+        global_filters: Optional[dict[str, Any]],
+        approval_rules: Optional[dict[str, Any]],
+        approved_patches: Optional[list[str]],
         approved_patches_compliance_level: Optional[str],
         approved_patches_enable_non_security: Optional[bool],
-        rejected_patches: Optional[List[str]],
+        rejected_patches: Optional[list[str]],
         rejected_patches_action: Optional[str],
         description: Optional[str],
-        sources: Optional[List[Dict[str, Any]]],
-        tags: Optional[List[Dict[str, str]]],
+        sources: Optional[list[dict[str, Any]]],
+        tags: Optional[list[dict[str, str]]],
     ) -> str:
         """
         Registers a patch baseline. No error handling or input validation has been implemented yet.
@@ -2436,8 +2435,8 @@ class SimpleSystemManagerBackend(BaseBackend):
         return baseline.id
 
     def describe_patch_baselines(
-        self, filters: Optional[List[Dict[str, Any]]]
-    ) -> List[FakePatchBaseline]:
+        self, filters: Optional[list[dict[str, Any]]]
+    ) -> list[FakePatchBaseline]:
         """
         Returns all baselines. No pagination has been implemented yet.
         """
@@ -2462,7 +2461,7 @@ class SimpleSystemManagerBackend(BaseBackend):
         self,
         window_id: str,
         resource_type: str,
-        targets: List[Dict[str, Any]],
+        targets: list[dict[str, Any]],
         owner_information: Optional[str],
         name: Optional[str],
         description: Optional[str],
@@ -2493,8 +2492,8 @@ class SimpleSystemManagerBackend(BaseBackend):
         del window.targets[window_target_id]
 
     def describe_maintenance_window_targets(
-        self, window_id: str, filters: Optional[List[Dict[str, Any]]]
-    ) -> List[FakeMaintenanceWindowTarget]:
+        self, window_id: str, filters: Optional[list[dict[str, Any]]]
+    ) -> list[FakeMaintenanceWindowTarget]:
         """
         Describes all targets for a maintenance window. No error handling has been implemented yet.
         """
@@ -2509,20 +2508,20 @@ class SimpleSystemManagerBackend(BaseBackend):
     def register_task_with_maintenance_window(
         self,
         window_id: str,
-        targets: Optional[List[Dict[str, Any]]],
+        targets: Optional[list[dict[str, Any]]],
         task_arn: str,
         service_role_arn: Optional[str],
         task_type: str,
-        task_parameters: Optional[Dict[str, Any]],
-        task_invocation_parameters: Optional[Dict[str, Any]],
+        task_parameters: Optional[dict[str, Any]],
+        task_invocation_parameters: Optional[dict[str, Any]],
         priority: Optional[int],
         max_concurrency: Optional[str],
         max_errors: Optional[str],
-        logging_info: Optional[Dict[str, Any]],
+        logging_info: Optional[dict[str, Any]],
         name: Optional[str],
         description: Optional[str],
         cutoff_behavior: Optional[str],
-        alarm_configurations: Optional[Dict[str, Any]],
+        alarm_configurations: Optional[dict[str, Any]],
     ) -> str:
         window = self.get_maintenance_window(window_id)
         task = FakeMaintenanceWindowTask(
@@ -2546,8 +2545,8 @@ class SimpleSystemManagerBackend(BaseBackend):
         return task.window_task_id
 
     def describe_maintenance_window_tasks(
-        self, window_id: str, filters: List[Dict[str, Any]]
-    ) -> List[FakeMaintenanceWindowTask]:
+        self, window_id: str, filters: list[dict[str, Any]]
+    ) -> list[FakeMaintenanceWindowTask]:
         window = self.get_maintenance_window(window_id)
         tasks = [
             task
@@ -2564,7 +2563,7 @@ class SimpleSystemManagerBackend(BaseBackend):
 
     def register_patch_baseline_for_patch_group(
         self, baseline_id: str, patch_group: str
-    ) -> Tuple[str, str]:
+    ) -> tuple[str, str]:
         """register a patch group in ssm backend"""
         if baseline_id not in self.baselines.keys():
             raise DoesNotExistException(baseline_id)
@@ -2581,7 +2580,7 @@ class SimpleSystemManagerBackend(BaseBackend):
 
     def get_patch_baseline_for_patch_group(
         self, patch_group: str, operating_system: str
-    ) -> Tuple[str, str, str]:
+    ) -> tuple[str, str, str]:
         """get baselineid for patch group for operating system"""
         if patch_group not in self.patch_groups.keys():
             fake_patch_group = FakePatchGroup("Fake", self.region_name)
@@ -2592,7 +2591,7 @@ class SimpleSystemManagerBackend(BaseBackend):
 
     def deregister_patch_baseline_for_patch_group(
         self, baseline_id: str, patch_group: str
-    ) -> Tuple[str, str]:
+    ) -> tuple[str, str]:
         """deregister a patch baseline for os on patch group, set default"""
         if patch_group in self.patch_groups.keys():
             if baseline_id not in self.baselines.keys():

--- a/moto/ssm/responses.py
+++ b/moto/ssm/responses.py
@@ -1,5 +1,5 @@
 import json
-from typing import Any, Dict, Tuple, Union
+from typing import Any, Union
 
 from moto.core.responses import BaseResponse
 
@@ -147,7 +147,7 @@ class SimpleSystemManagerResponse(BaseResponse):
         )
         return "{}"
 
-    def delete_parameter(self) -> Union[str, Tuple[str, Dict[str, int]]]:
+    def delete_parameter(self) -> Union[str, tuple[str, dict[str, int]]]:
         name = self._get_param("Name")
         result = self.ssm_backend.delete_parameter(name)
         if result is None:
@@ -162,7 +162,7 @@ class SimpleSystemManagerResponse(BaseResponse):
         names = self._get_param("Names")
         result = self.ssm_backend.delete_parameters(names)
 
-        response: Dict[str, Any] = {"DeletedParameters": [], "InvalidParameters": []}
+        response: dict[str, Any] = {"DeletedParameters": [], "InvalidParameters": []}
 
         for name in names:
             if name in result:
@@ -171,7 +171,7 @@ class SimpleSystemManagerResponse(BaseResponse):
                 response["InvalidParameters"].append(name)
         return json.dumps(response)
 
-    def get_parameter(self) -> Union[str, Tuple[str, Dict[str, int]]]:
+    def get_parameter(self) -> Union[str, tuple[str, dict[str, int]]]:
         name = self._get_param("Name")
         with_decryption = self._get_param("WithDecryption")
 
@@ -201,7 +201,7 @@ class SimpleSystemManagerResponse(BaseResponse):
 
         result = self.ssm_backend.get_parameters(names)
 
-        response: Dict[str, Any] = {"Parameters": [], "InvalidParameters": []}
+        response: dict[str, Any] = {"Parameters": [], "InvalidParameters": []}
 
         for parameter in result.values():
             param_data = parameter.response_object(with_decryption, self.region)
@@ -229,7 +229,7 @@ class SimpleSystemManagerResponse(BaseResponse):
             max_results=max_results,
         )
 
-        response: Dict[str, Any] = {"Parameters": [], "NextToken": next_token}
+        response: dict[str, Any] = {"Parameters": [], "NextToken": next_token}
 
         for parameter in result:
             param_data = parameter.response_object(with_decryption, self.region)
@@ -250,7 +250,7 @@ class SimpleSystemManagerResponse(BaseResponse):
 
         result = self.ssm_backend.describe_parameters(filters, parameter_filters)
 
-        response: Dict[str, Any] = {"Parameters": []}
+        response: dict[str, Any] = {"Parameters": []}
 
         end = token + page_size
         for parameter in result[token:]:
@@ -263,7 +263,7 @@ class SimpleSystemManagerResponse(BaseResponse):
 
         return json.dumps(response)
 
-    def put_parameter(self) -> Union[str, Tuple[str, Dict[str, int]]]:
+    def put_parameter(self) -> Union[str, tuple[str, dict[str, int]]]:
         name = self._get_param("Name")
         description = self._get_param("Description")
         value = self._get_param("Value")
@@ -293,7 +293,7 @@ class SimpleSystemManagerResponse(BaseResponse):
         response = {"Version": param.version}
         return json.dumps(response)
 
-    def get_parameter_history(self) -> Union[str, Tuple[str, Dict[str, int]]]:
+    def get_parameter_history(self) -> Union[str, tuple[str, dict[str, int]]]:
         name = self._get_param("Name")
         with_decryption = self._get_param("WithDecryption")
         next_token = self._get_param("NextToken")

--- a/moto/ssm/utils.py
+++ b/moto/ssm/utils.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List
+from typing import Any
 
 from moto.utilities.utils import get_partition
 
@@ -9,13 +9,13 @@ def parameter_arn(account_id: str, region: str, parameter_name: str) -> str:
     return f"arn:{get_partition(region)}:ssm:{region}:{account_id}:parameter/{parameter_name}"
 
 
-def convert_to_tree(parameters: List[Dict[str, Any]]) -> Dict[str, Any]:
+def convert_to_tree(parameters: list[dict[str, Any]]) -> dict[str, Any]:
     """
     Convert input into a smaller, less redundant data set in tree form
     Input: [{"Name": "/a/b/c", "Value": "af-south-1", ...}, ..]
     Output: {"a": {"b": {"c": {"Value": af-south-1}, ..}, ..}, ..}
     """
-    tree_dict: Dict[str, Any] = {}
+    tree_dict: dict[str, Any] = {}
     for p in parameters:
         current_level = tree_dict
         for path in p["Name"].split("/"):
@@ -28,13 +28,13 @@ def convert_to_tree(parameters: List[Dict[str, Any]]) -> Dict[str, Any]:
     return tree_dict
 
 
-def convert_to_params(tree: Dict[str, Any]) -> List[Dict[str, Any]]:
+def convert_to_params(tree: dict[str, Any]) -> list[dict[str, Any]]:
     """
     Inverse of 'convert_to_tree'
     """
 
     def m(
-        tree: Dict[str, Any], params: List[Dict[str, Any]], current_path: str = ""
+        tree: dict[str, Any], params: list[dict[str, Any]], current_path: str = ""
     ) -> None:
         for key, value in tree.items():
             if key == "Value":
@@ -42,6 +42,6 @@ def convert_to_params(tree: Dict[str, Any]) -> List[Dict[str, Any]]:
             else:
                 m(value, params, current_path + "/" + key)
 
-    params: List[Dict[str, Any]] = []
+    params: list[dict[str, Any]] = []
     m(tree, params)
     return params

--- a/moto/ssoadmin/models.py
+++ b/moto/ssoadmin/models.py
@@ -1,5 +1,5 @@
 import json
-from typing import Any, Dict, List, Optional
+from typing import Any, Optional
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
@@ -41,8 +41,8 @@ class AccountAssignment(BaseModel):
 
     def to_json(
         self, include_creation_date: bool = False, include_request_id: bool = False
-    ) -> Dict[str, Any]:
-        summary: Dict[str, Any] = {
+    ) -> dict[str, Any]:
+        summary: dict[str, Any] = {
             "TargetId": self.target_id,
             "TargetType": self.target_type,
             "PermissionSetArn": self.permission_set_arn,
@@ -64,7 +64,7 @@ class PermissionSet(BaseModel):
         instance_arn: str,
         session_duration: str,
         relay_state: str,
-        tags: List[Dict[str, str]],
+        tags: list[dict[str, str]],
     ):
         self.name = name
         self.description = description
@@ -75,14 +75,14 @@ class PermissionSet(BaseModel):
         self.tags = tags
         self.created_date = unix_time()
         self.inline_policy = ""
-        self.managed_policies: List[ManagedPolicy] = list()
-        self.customer_managed_policies: List[CustomerManagedPolicy] = list()
+        self.managed_policies: list[ManagedPolicy] = list()
+        self.customer_managed_policies: list[CustomerManagedPolicy] = list()
         self.total_managed_policies_attached = (
             0  # this will also include customer managed policies
         )
 
-    def to_json(self, include_creation_date: bool = False) -> Dict[str, Any]:
-        summary: Dict[str, Any] = {
+    def to_json(self, include_creation_date: bool = False) -> dict[str, Any]:
+        summary: dict[str, Any] = {
             "Name": self.name,
             "Description": self.description,
             "PermissionSetArn": self.permission_set_arn,
@@ -131,9 +131,9 @@ class Instance:
         self.status = "ACTIVE"
         self.name: Optional[str] = None
 
-        self.provisioned_permission_sets: List[PermissionSet] = []
+        self.provisioned_permission_sets: list[PermissionSet] = []
 
-    def to_json(self) -> Dict[str, Any]:
+    def to_json(self) -> dict[str, Any]:
         return {
             "CreatedDate": self.created_date,
             "IdentityStoreId": self.identity_store_id,
@@ -149,11 +149,11 @@ class SSOAdminBackend(BaseBackend):
 
     def __init__(self, region_name: str, account_id: str):
         super().__init__(region_name, account_id)
-        self.account_assignments: List[AccountAssignment] = list()
-        self.deleted_account_assignments: List[AccountAssignment] = list()
-        self.permission_sets: List[PermissionSet] = list()
-        self.aws_managed_policies: Optional[Dict[str, Any]] = None
-        self.instances: List[Instance] = []
+        self.account_assignments: list[AccountAssignment] = list()
+        self.deleted_account_assignments: list[AccountAssignment] = list()
+        self.permission_sets: list[PermissionSet] = list()
+        self.aws_managed_policies: Optional[dict[str, Any]] = None
+        self.instances: list[Instance] = []
 
         self.instances.append(Instance(self.account_id, self.region_name))
 
@@ -165,7 +165,7 @@ class SSOAdminBackend(BaseBackend):
         permission_set_arn: str,
         principal_type: str,
         principal_id: str,
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         assignment = AccountAssignment(
             instance_arn,
             target_id,
@@ -185,7 +185,7 @@ class SSOAdminBackend(BaseBackend):
         permission_set_arn: str,
         principal_type: str,
         principal_id: str,
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         account = self._find_account(
             instance_arn,
             target_id,
@@ -249,7 +249,7 @@ class SSOAdminBackend(BaseBackend):
     @paginate(PAGINATION_MODEL)
     def list_account_assignments(
         self, instance_arn: str, account_id: str, permission_set_arn: str
-    ) -> List[Dict[str, str]]:
+    ) -> list[dict[str, str]]:
         account_assignments = []
         for assignment in self.account_assignments:
             if (
@@ -270,11 +270,11 @@ class SSOAdminBackend(BaseBackend):
     @paginate(PAGINATION_MODEL)
     def list_account_assignments_for_principal(
         self,
-        filter_: Dict[str, Any],
+        filter_: dict[str, Any],
         instance_arn: str,
         principal_id: str,
         principal_type: str,
-    ) -> List[Dict[str, str]]:
+    ) -> list[dict[str, str]]:
         return [
             {
                 "AccountId": account_assignment.target_id,
@@ -301,8 +301,8 @@ class SSOAdminBackend(BaseBackend):
         instance_arn: str,
         session_duration: str,
         relay_state: str,
-        tags: List[Dict[str, str]],
-    ) -> Dict[str, Any]:
+        tags: list[dict[str, str]],
+    ) -> dict[str, Any]:
         permission_set = PermissionSet(
             name,
             description,
@@ -321,7 +321,7 @@ class SSOAdminBackend(BaseBackend):
         description: str,
         session_duration: str,
         relay_state: str,
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         permission_set = self._find_permission_set(
             instance_arn,
             permission_set_arn,
@@ -335,7 +335,7 @@ class SSOAdminBackend(BaseBackend):
 
     def describe_permission_set(
         self, instance_arn: str, permission_set_arn: str
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         permission_set = self._find_permission_set(
             instance_arn,
             permission_set_arn,
@@ -344,7 +344,7 @@ class SSOAdminBackend(BaseBackend):
 
     def delete_permission_set(
         self, instance_arn: str, permission_set_arn: str
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         permission_set = self._find_permission_set(
             instance_arn,
             permission_set_arn,
@@ -375,7 +375,7 @@ class SSOAdminBackend(BaseBackend):
         )
 
     @paginate(pagination_model=PAGINATION_MODEL)
-    def list_permission_sets(self, instance_arn: str) -> List[PermissionSet]:
+    def list_permission_sets(self, instance_arn: str) -> list[PermissionSet]:
         permission_sets = []
         for permission_set in self.permission_sets:
             if permission_set.instance_arn == instance_arn:
@@ -441,7 +441,7 @@ class SSOAdminBackend(BaseBackend):
         self,
         instance_arn: str,
         permission_set_arn: str,
-    ) -> List[ManagedPolicy]:
+    ) -> list[ManagedPolicy]:
         permissionset = self._find_permission_set(
             instance_arn,
             permission_set_arn,
@@ -478,7 +478,7 @@ class SSOAdminBackend(BaseBackend):
         self,
         instance_arn: str,
         permission_set_arn: str,
-        customer_managed_policy_reference: Dict[str, str],
+        customer_managed_policy_reference: dict[str, str],
     ) -> None:
         permissionset = self._find_permission_set(
             permission_set_arn=permission_set_arn, instance_arn=instance_arn
@@ -507,7 +507,7 @@ class SSOAdminBackend(BaseBackend):
     @paginate(pagination_model=PAGINATION_MODEL)
     def list_customer_managed_policy_references_in_permission_set(
         self, instance_arn: str, permission_set_arn: str
-    ) -> List[CustomerManagedPolicy]:
+    ) -> list[CustomerManagedPolicy]:
         permissionset = self._find_permission_set(
             permission_set_arn=permission_set_arn, instance_arn=instance_arn
         )
@@ -517,7 +517,7 @@ class SSOAdminBackend(BaseBackend):
         self,
         instance_arn: str,
         permission_set_arn: str,
-        customer_managed_policy_reference: Dict[str, str],
+        customer_managed_policy_reference: dict[str, str],
     ) -> None:
         permissionset = self._find_permission_set(
             permission_set_arn=permission_set_arn, instance_arn=instance_arn
@@ -542,7 +542,7 @@ class SSOAdminBackend(BaseBackend):
         self,
         instance_arn: str,
         permission_set_arn: str,
-        customer_managed_policy_reference: Dict[str, str],
+        customer_managed_policy_reference: dict[str, str],
     ) -> None:
         self._detach_customer_managed_policy_from_permissionset(
             instance_arn=instance_arn,
@@ -552,7 +552,7 @@ class SSOAdminBackend(BaseBackend):
 
     def describe_account_assignment_creation_status(
         self, account_assignment_creation_request_id: str, instance_arn: str
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         for account in self.account_assignments:
             if account.request_id == account_assignment_creation_request_id:
                 return account.to_json(
@@ -563,7 +563,7 @@ class SSOAdminBackend(BaseBackend):
 
     def describe_account_assignment_deletion_status(
         self, account_assignment_deletion_request_id: str, instance_arn: str
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         for account in self.deleted_account_assignments:
             if account.request_id == account_assignment_deletion_request_id:
                 return account.to_json(
@@ -572,7 +572,7 @@ class SSOAdminBackend(BaseBackend):
 
         raise ResourceNotFoundException
 
-    def list_instances(self) -> List[Instance]:
+    def list_instances(self) -> list[Instance]:
         return self.instances
 
     def update_instance(self, instance_arn: str, name: str) -> None:
@@ -592,7 +592,7 @@ class SSOAdminBackend(BaseBackend):
 
     def list_permission_sets_provisioned_to_account(
         self, instance_arn: str
-    ) -> List[PermissionSet]:
+    ) -> list[PermissionSet]:
         """
         The following parameters are not yet implemented: AccountId, ProvisioningStatus, MaxResults, NextToken
         """
@@ -603,7 +603,7 @@ class SSOAdminBackend(BaseBackend):
 
     def list_accounts_for_provisioned_permission_set(
         self, instance_arn: str, permission_set_arn: str
-    ) -> List[str]:
+    ) -> list[str]:
         """
         The following parameters are not yet implemented: MaxResults, NextToken, ProvisioningStatus
         """

--- a/moto/stepfunctions/models.py
+++ b/moto/stepfunctions/models.py
@@ -1,7 +1,8 @@
 import json
 import re
 from datetime import datetime
-from typing import Any, Dict, List, Optional, Pattern
+from re import Pattern
+from typing import Any, Optional
 
 from dateutil.tz import tzlocal
 
@@ -38,9 +39,9 @@ class StateMachineInstance:
         name: str,
         definition: str,
         roleArn: str,
-        encryptionConfiguration: Optional[Dict[str, Any]] = None,
-        loggingConfiguration: Optional[Dict[str, Any]] = None,
-        tracingConfiguration: Optional[Dict[str, Any]] = None,
+        encryptionConfiguration: Optional[dict[str, Any]] = None,
+        loggingConfiguration: Optional[dict[str, Any]] = None,
+        tracingConfiguration: Optional[dict[str, Any]] = None,
     ):
         self.creation_date = iso_8601_datetime_with_milliseconds()
         self.update_date = self.creation_date
@@ -48,7 +49,7 @@ class StateMachineInstance:
         self.name = name
         self.definition = definition
         self.roleArn = roleArn
-        self.executions: List[Execution] = []
+        self.executions: list[Execution] = []
         self.type = "STANDARD"
         self.encryptionConfiguration = encryptionConfiguration or {
             "type": "AWS_OWNED_KEY"
@@ -87,9 +88,9 @@ class StateMachine(StateMachineInstance, CloudFormationModel):
         definition: str,
         roleArn: str,
         backend: "StepFunctionBackend",
-        encryptionConfiguration: Optional[Dict[str, Any]] = None,
-        loggingConfiguration: Optional[Dict[str, Any]] = None,
-        tracingConfiguration: Optional[Dict[str, Any]] = None,
+        encryptionConfiguration: Optional[dict[str, Any]] = None,
+        loggingConfiguration: Optional[dict[str, Any]] = None,
+        tracingConfiguration: Optional[dict[str, Any]] = None,
     ):
         StateMachineInstance.__init__(
             self,
@@ -102,7 +103,7 @@ class StateMachine(StateMachineInstance, CloudFormationModel):
             tracingConfiguration=tracingConfiguration,
         )
         self.latest_version_number = 0
-        self.versions: Dict[int, StateMachineVersion] = {}
+        self.versions: dict[int, StateMachineVersion] = {}
         self.latest_version: Optional[StateMachineVersion] = None
         self.backend = backend
 
@@ -171,7 +172,7 @@ class StateMachine(StateMachineInstance, CloudFormationModel):
     def physical_resource_id(self) -> str:
         return self.arn
 
-    def get_cfn_properties(self, prop_overrides: Dict[str, Any]) -> Dict[str, Any]:
+    def get_cfn_properties(self, prop_overrides: dict[str, Any]) -> dict[str, Any]:
         property_names = [
             "DefinitionString",
             "RoleArn",
@@ -327,7 +328,7 @@ class Execution:
         self.cause: Optional[str] = None
         self.error: Optional[str] = None
 
-    def get_execution_history(self, roleArn: str) -> List[Dict[str, Any]]:
+    def get_execution_history(self, roleArn: str) -> list[dict[str, Any]]:
         sf_execution_history_type = settings.get_sf_execution_history_type()
         if sf_execution_history_type == "SUCCESS":
             return [
@@ -436,7 +437,7 @@ class Activity:
         self,
         arn: str,
         name: str,
-        encryption_configuration: Optional[Dict[str, Any]] = None,
+        encryption_configuration: Optional[dict[str, Any]] = None,
     ):
         self.arn = arn
         self.name = name
@@ -585,8 +586,8 @@ class StepFunctionBackend(BaseBackend):
             tag_name="tags", key_name="key", value_name="value"
         )
 
-        self.state_machines: List[StateMachine] = []
-        self.activities: Dict[str, Activity] = {}
+        self.state_machines: list[StateMachine] = []
+        self.activities: dict[str, Activity] = {}
         self._account_id = None
 
     def create_state_machine(
@@ -594,11 +595,11 @@ class StepFunctionBackend(BaseBackend):
         name: str,
         definition: str,
         roleArn: str,
-        tags: Optional[List[Dict[str, str]]] = None,
+        tags: Optional[list[dict[str, str]]] = None,
         publish: Optional[bool] = None,
-        loggingConfiguration: Optional[Dict[str, Any]] = None,
-        tracingConfiguration: Optional[Dict[str, Any]] = None,
-        encryptionConfiguration: Optional[Dict[str, Any]] = None,
+        loggingConfiguration: Optional[dict[str, Any]] = None,
+        tracingConfiguration: Optional[dict[str, Any]] = None,
+        encryptionConfiguration: Optional[dict[str, Any]] = None,
         version_description: Optional[str] = None,
     ) -> StateMachine:
         self._validate_name(name)
@@ -627,7 +628,7 @@ class StepFunctionBackend(BaseBackend):
             return state_machine
 
     @paginate(pagination_model=PAGINATION_MODEL)
-    def list_state_machines(self) -> List[StateMachine]:
+    def list_state_machines(self) -> list[StateMachine]:
         return sorted(self.state_machines, key=lambda x: x.creation_date)
 
     def describe_state_machine(self, arn: str) -> StateMachine:
@@ -661,14 +662,14 @@ class StepFunctionBackend(BaseBackend):
         arn: str,
         definition: Optional[str] = None,
         role_arn: Optional[str] = None,
-        logging_configuration: Optional[Dict[str, bool]] = None,
-        tracing_configuration: Optional[Dict[str, bool]] = None,
-        encryption_configuration: Optional[Dict[str, Any]] = None,
+        logging_configuration: Optional[dict[str, bool]] = None,
+        tracing_configuration: Optional[dict[str, bool]] = None,
+        encryption_configuration: Optional[dict[str, Any]] = None,
         publish: Optional[bool] = None,
         version_description: Optional[str] = None,
     ) -> StateMachine:
         sm = self.describe_state_machine(arn)
-        updates: Dict[str, Any] = {
+        updates: dict[str, Any] = {
             "definition": definition,
             "roleArn": role_arn,
         }
@@ -704,7 +705,7 @@ class StepFunctionBackend(BaseBackend):
     @paginate(pagination_model=PAGINATION_MODEL)
     def list_executions(
         self, state_machine_arn: str, status_filter: Optional[str] = None
-    ) -> List[Execution]:
+    ) -> list[Execution]:
         executions = self.describe_state_machine(state_machine_arn).executions
 
         if status_filter:
@@ -725,7 +726,7 @@ class StepFunctionBackend(BaseBackend):
             )
         return exctn
 
-    def get_execution_history(self, execution_arn: str) -> Dict[str, Any]:
+    def get_execution_history(self, execution_arn: str) -> dict[str, Any]:
         self._validate_execution_arn(execution_arn)
         state_machine = self._get_state_machine_for_execution(execution_arn)
         execution = next(
@@ -745,16 +746,16 @@ class StepFunctionBackend(BaseBackend):
                     return sm
         raise ResourceNotFound(execution_arn)
 
-    def list_tags_for_resource(self, arn: str) -> Dict[str, List[Dict[str, str]]]:
+    def list_tags_for_resource(self, arn: str) -> dict[str, list[dict[str, str]]]:
         return self.tagger.list_tags_for_resource(arn)
 
-    def tag_resource(self, resource_arn: str, tags: List[Dict[str, str]]) -> None:
+    def tag_resource(self, resource_arn: str, tags: list[dict[str, str]]) -> None:
         self.tagger.tag_resource(resource_arn, tags)
 
-    def untag_resource(self, resource_arn: str, tag_keys: List[str]) -> None:
+    def untag_resource(self, resource_arn: str, tag_keys: list[str]) -> None:
         self.tagger.untag_resource_using_names(resource_arn, tag_keys)
 
-    def get_tags_list_for_state_machine(self, arn: str) -> List[Dict[str, str]]:
+    def get_tags_list_for_state_machine(self, arn: str) -> list[dict[str, str]]:
         return self.list_tags_for_resource(arn)[self.tagger.tag_name]
 
     def send_task_failure(self, task_token: str, error: Optional[str] = None) -> None:
@@ -766,7 +767,7 @@ class StepFunctionBackend(BaseBackend):
     def send_task_success(self, task_token: str, outcome: str) -> None:
         pass
 
-    def describe_map_run(self, map_run_arn: str) -> Dict[str, Any]:
+    def describe_map_run(self, map_run_arn: str) -> dict[str, Any]:
         return {}
 
     def list_map_runs(self, execution_arn: str) -> Any:
@@ -825,7 +826,7 @@ class StepFunctionBackend(BaseBackend):
             raise InvalidArn(invalid_msg)
 
     def _validate_encryption_configuration(
-        self, encryption_configuration: Dict[str, Any]
+        self, encryption_configuration: dict[str, Any]
     ) -> None:
         encryption_type = encryption_configuration.get("type")
         if not encryption_type:
@@ -857,8 +858,8 @@ class StepFunctionBackend(BaseBackend):
     def create_activity(
         self,
         name: str,
-        tags: Optional[List[Dict[str, str]]] = None,
-        encryption_configuration: Optional[Dict[str, Any]] = None,
+        tags: Optional[list[dict[str, str]]] = None,
+        encryption_configuration: Optional[dict[str, Any]] = None,
     ) -> Activity:
         self._validate_name(name)
 
@@ -895,7 +896,7 @@ class StepFunctionBackend(BaseBackend):
             del self.activities[activity_arn]
 
     @paginate(pagination_model=PAGINATION_MODEL)
-    def list_activities(self) -> List[Activity]:
+    def list_activities(self) -> list[Activity]:
         return sorted(self.activities.values(), key=lambda x: x.creation_date)
 
 

--- a/moto/stepfunctions/parser/api.py
+++ b/moto/stepfunctions/parser/api.py
@@ -1,6 +1,7 @@
+from collections.abc import Iterable
 from datetime import datetime
 from enum import Enum
-from typing import IO, Dict, Iterable, List, Optional, TypedDict, Union
+from typing import IO, Optional, TypedDict, Union
 
 from ..exceptions import AWSError as ServiceException
 
@@ -445,7 +446,7 @@ class ActivityListItem(TypedDict, total=False):
     creationDate: Timestamp
 
 
-ActivityList = List[ActivityListItem]
+ActivityList = list[ActivityListItem]
 
 
 class ActivityScheduleFailedEventDetails(TypedDict, total=False):
@@ -482,7 +483,7 @@ class ActivityTimedOutEventDetails(TypedDict, total=False):
     cause: Optional[SensitiveCause]
 
 
-AssignedVariables = Dict[VariableName, VariableValue]
+AssignedVariables = dict[VariableName, VariableValue]
 
 
 class AssignedVariablesDetails(TypedDict, total=False):
@@ -506,15 +507,10 @@ class CloudWatchLogsLogGroup(TypedDict, total=False):
     logGroupArn: Optional[Arn]
 
 
-EncryptionConfiguration = TypedDict(
-    "EncryptionConfiguration",
-    {
-        "kmsKeyId": Optional[KmsKeyId],
-        "kmsDataKeyReusePeriodSeconds": Optional[KmsDataKeyReusePeriodSeconds],
-        "type": EncryptionType,
-    },
-    total=False,
-)
+class EncryptionConfiguration(TypedDict, total=False):
+    kmsKeyId: Optional[KmsKeyId]
+    kmsDataKeyReusePeriodSeconds: Optional[KmsDataKeyReusePeriodSeconds]
+    type: EncryptionType
 
 
 class Tag(TypedDict, total=False):
@@ -522,7 +518,7 @@ class Tag(TypedDict, total=False):
     value: Optional[TagValue]
 
 
-TagList = List[Tag]
+TagList = list[Tag]
 
 
 class CreateActivityOutput(TypedDict, total=False):
@@ -535,7 +531,7 @@ class RoutingConfigurationListItem(TypedDict, total=False):
     weight: VersionWeight
 
 
-RoutingConfigurationList = List[RoutingConfigurationListItem]
+RoutingConfigurationList = list[RoutingConfigurationListItem]
 
 
 class CreateStateMachineAliasOutput(TypedDict, total=False):
@@ -551,7 +547,7 @@ class LogDestination(TypedDict, total=False):
     cloudWatchLogsLogGroup: Optional[CloudWatchLogsLogGroup]
 
 
-LogDestinationList = List[LogDestination]
+LogDestinationList = list[LogDestination]
 
 
 class LoggingConfiguration(TypedDict, total=False):
@@ -560,22 +556,17 @@ class LoggingConfiguration(TypedDict, total=False):
     destinations: Optional[LogDestinationList]
 
 
-CreateStateMachineInput = TypedDict(
-    "CreateStateMachineInput",
-    {
-        "name": Name,
-        "definition": Definition,
-        "roleArn": Arn,
-        "type": Optional[StateMachineType],
-        "loggingConfiguration": Optional[LoggingConfiguration],
-        "tags": Optional[TagList],
-        "tracingConfiguration": Optional[TracingConfiguration],
-        "publish": Optional[Publish],
-        "versionDescription": Optional[VersionDescription],
-        "encryptionConfiguration": Optional[EncryptionConfiguration],
-    },
-    total=False,
-)
+class CreateStateMachineInput(TypedDict, total=False):
+    name: Name
+    definition: Definition
+    roleArn: Arn
+    type: Optional[StateMachineType]
+    loggingConfiguration: Optional[LoggingConfiguration]
+    tags: Optional[TagList]
+    tracingConfiguration: Optional[TracingConfiguration]
+    publish: Optional[Publish]
+    versionDescription: Optional[VersionDescription]
+    encryptionConfiguration: Optional[EncryptionConfiguration]
 
 
 class CreateStateMachineOutput(TypedDict, total=False):
@@ -687,8 +678,8 @@ class DescribeStateMachineAliasOutput(TypedDict, total=False):
     updateDate: Optional[Timestamp]
 
 
-VariableNameList = List[VariableName]
-VariableReferences = Dict[StateName, VariableNameList]
+VariableNameList = list[VariableName]
+VariableReferences = dict[StateName, VariableNameList]
 
 
 class DescribeStateMachineForExecutionOutput(TypedDict, total=False):
@@ -706,26 +697,21 @@ class DescribeStateMachineForExecutionOutput(TypedDict, total=False):
     variableReferences: Optional[VariableReferences]
 
 
-DescribeStateMachineOutput = TypedDict(
-    "DescribeStateMachineOutput",
-    {
-        "stateMachineArn": Arn,
-        "name": Name,
-        "status": Optional[StateMachineStatus],
-        "definition": Definition,
-        "roleArn": Arn,
-        "type": StateMachineType,
-        "creationDate": Timestamp,
-        "loggingConfiguration": Optional[LoggingConfiguration],
-        "tracingConfiguration": Optional[TracingConfiguration],
-        "label": Optional[MapRunLabel],
-        "revisionId": Optional[RevisionId],
-        "description": Optional[VersionDescription],
-        "encryptionConfiguration": Optional[EncryptionConfiguration],
-        "variableReferences": Optional[VariableReferences],
-    },
-    total=False,
-)
+class DescribeStateMachineOutput(TypedDict, total=False):
+    stateMachineArn: Arn
+    name: Name
+    status: Optional[StateMachineStatus]
+    definition: Definition
+    roleArn: Arn
+    type: StateMachineType
+    creationDate: Timestamp
+    loggingConfiguration: Optional[LoggingConfiguration]
+    tracingConfiguration: Optional[TracingConfiguration]
+    label: Optional[MapRunLabel]
+    revisionId: Optional[RevisionId]
+    description: Optional[VersionDescription]
+    encryptionConfiguration: Optional[EncryptionConfiguration]
+    variableReferences: Optional[VariableReferences]
 
 
 class EvaluationFailedEventDetails(TypedDict, total=False):
@@ -763,7 +749,7 @@ class ExecutionListItem(TypedDict, total=False):
     redriveDate: Optional[Timestamp]
 
 
-ExecutionList = List[ExecutionListItem]
+ExecutionList = list[ExecutionListItem]
 
 
 class ExecutionRedrivenEventDetails(TypedDict, total=False):
@@ -924,66 +910,55 @@ class TaskFailedEventDetails(TypedDict, total=False):
     cause: Optional[SensitiveCause]
 
 
-HistoryEvent = TypedDict(
-    "HistoryEvent",
-    {
-        "timestamp": Timestamp,
-        "type": HistoryEventType,
-        "id": EventId,
-        "previousEventId": Optional[EventId],
-        "activityFailedEventDetails": Optional[ActivityFailedEventDetails],
-        "activityScheduleFailedEventDetails": Optional[
-            ActivityScheduleFailedEventDetails
-        ],
-        "activityScheduledEventDetails": Optional[ActivityScheduledEventDetails],
-        "activityStartedEventDetails": Optional[ActivityStartedEventDetails],
-        "activitySucceededEventDetails": Optional[ActivitySucceededEventDetails],
-        "activityTimedOutEventDetails": Optional[ActivityTimedOutEventDetails],
-        "taskFailedEventDetails": Optional[TaskFailedEventDetails],
-        "taskScheduledEventDetails": Optional[TaskScheduledEventDetails],
-        "taskStartFailedEventDetails": Optional[TaskStartFailedEventDetails],
-        "taskStartedEventDetails": Optional[TaskStartedEventDetails],
-        "taskSubmitFailedEventDetails": Optional[TaskSubmitFailedEventDetails],
-        "taskSubmittedEventDetails": Optional[TaskSubmittedEventDetails],
-        "taskSucceededEventDetails": Optional[TaskSucceededEventDetails],
-        "taskTimedOutEventDetails": Optional[TaskTimedOutEventDetails],
-        "executionFailedEventDetails": Optional[ExecutionFailedEventDetails],
-        "executionStartedEventDetails": Optional[ExecutionStartedEventDetails],
-        "executionSucceededEventDetails": Optional[ExecutionSucceededEventDetails],
-        "executionAbortedEventDetails": Optional[ExecutionAbortedEventDetails],
-        "executionTimedOutEventDetails": Optional[ExecutionTimedOutEventDetails],
-        "executionRedrivenEventDetails": Optional[ExecutionRedrivenEventDetails],
-        "mapStateStartedEventDetails": Optional[MapStateStartedEventDetails],
-        "mapIterationStartedEventDetails": Optional[MapIterationEventDetails],
-        "mapIterationSucceededEventDetails": Optional[MapIterationEventDetails],
-        "mapIterationFailedEventDetails": Optional[MapIterationEventDetails],
-        "mapIterationAbortedEventDetails": Optional[MapIterationEventDetails],
-        "lambdaFunctionFailedEventDetails": Optional[LambdaFunctionFailedEventDetails],
-        "lambdaFunctionScheduleFailedEventDetails": Optional[
-            LambdaFunctionScheduleFailedEventDetails
-        ],
-        "lambdaFunctionScheduledEventDetails": Optional[
-            LambdaFunctionScheduledEventDetails
-        ],
-        "lambdaFunctionStartFailedEventDetails": Optional[
-            LambdaFunctionStartFailedEventDetails
-        ],
-        "lambdaFunctionSucceededEventDetails": Optional[
-            LambdaFunctionSucceededEventDetails
-        ],
-        "lambdaFunctionTimedOutEventDetails": Optional[
-            LambdaFunctionTimedOutEventDetails
-        ],
-        "stateEnteredEventDetails": Optional[StateEnteredEventDetails],
-        "stateExitedEventDetails": Optional[StateExitedEventDetails],
-        "mapRunStartedEventDetails": Optional[MapRunStartedEventDetails],
-        "mapRunFailedEventDetails": Optional[MapRunFailedEventDetails],
-        "mapRunRedrivenEventDetails": Optional[MapRunRedrivenEventDetails],
-        "evaluationFailedEventDetails": Optional[EvaluationFailedEventDetails],
-    },
-    total=False,
-)
-HistoryEventList = List[HistoryEvent]
+class HistoryEvent(TypedDict, total=False):
+    timestamp: Timestamp
+    type: HistoryEventType
+    id: EventId
+    previousEventId: Optional[EventId]
+    activityFailedEventDetails: Optional[ActivityFailedEventDetails]
+    activityScheduleFailedEventDetails: Optional[ActivityScheduleFailedEventDetails]
+    activityScheduledEventDetails: Optional[ActivityScheduledEventDetails]
+    activityStartedEventDetails: Optional[ActivityStartedEventDetails]
+    activitySucceededEventDetails: Optional[ActivitySucceededEventDetails]
+    activityTimedOutEventDetails: Optional[ActivityTimedOutEventDetails]
+    taskFailedEventDetails: Optional[TaskFailedEventDetails]
+    taskScheduledEventDetails: Optional[TaskScheduledEventDetails]
+    taskStartFailedEventDetails: Optional[TaskStartFailedEventDetails]
+    taskStartedEventDetails: Optional[TaskStartedEventDetails]
+    taskSubmitFailedEventDetails: Optional[TaskSubmitFailedEventDetails]
+    taskSubmittedEventDetails: Optional[TaskSubmittedEventDetails]
+    taskSucceededEventDetails: Optional[TaskSucceededEventDetails]
+    taskTimedOutEventDetails: Optional[TaskTimedOutEventDetails]
+    executionFailedEventDetails: Optional[ExecutionFailedEventDetails]
+    executionStartedEventDetails: Optional[ExecutionStartedEventDetails]
+    executionSucceededEventDetails: Optional[ExecutionSucceededEventDetails]
+    executionAbortedEventDetails: Optional[ExecutionAbortedEventDetails]
+    executionTimedOutEventDetails: Optional[ExecutionTimedOutEventDetails]
+    executionRedrivenEventDetails: Optional[ExecutionRedrivenEventDetails]
+    mapStateStartedEventDetails: Optional[MapStateStartedEventDetails]
+    mapIterationStartedEventDetails: Optional[MapIterationEventDetails]
+    mapIterationSucceededEventDetails: Optional[MapIterationEventDetails]
+    mapIterationFailedEventDetails: Optional[MapIterationEventDetails]
+    mapIterationAbortedEventDetails: Optional[MapIterationEventDetails]
+    lambdaFunctionFailedEventDetails: Optional[LambdaFunctionFailedEventDetails]
+    lambdaFunctionScheduleFailedEventDetails: Optional[
+        LambdaFunctionScheduleFailedEventDetails
+    ]
+    lambdaFunctionScheduledEventDetails: Optional[LambdaFunctionScheduledEventDetails]
+    lambdaFunctionStartFailedEventDetails: Optional[
+        LambdaFunctionStartFailedEventDetails
+    ]
+    lambdaFunctionSucceededEventDetails: Optional[LambdaFunctionSucceededEventDetails]
+    lambdaFunctionTimedOutEventDetails: Optional[LambdaFunctionTimedOutEventDetails]
+    stateEnteredEventDetails: Optional[StateEnteredEventDetails]
+    stateExitedEventDetails: Optional[StateExitedEventDetails]
+    mapRunStartedEventDetails: Optional[MapRunStartedEventDetails]
+    mapRunFailedEventDetails: Optional[MapRunFailedEventDetails]
+    mapRunRedrivenEventDetails: Optional[MapRunRedrivenEventDetails]
+    evaluationFailedEventDetails: Optional[EvaluationFailedEventDetails]
+
+
+HistoryEventList = list[HistoryEvent]
 
 
 class GetExecutionHistoryOutput(TypedDict, total=False):
@@ -1028,7 +1003,7 @@ class MapRunListItem(TypedDict, total=False):
     stopDate: Optional[Timestamp]
 
 
-MapRunList = List[MapRunListItem]
+MapRunList = list[MapRunListItem]
 
 
 class ListMapRunsOutput(TypedDict, total=False):
@@ -1041,7 +1016,7 @@ class StateMachineAliasListItem(TypedDict, total=False):
     creationDate: Timestamp
 
 
-StateMachineAliasList = List[StateMachineAliasListItem]
+StateMachineAliasList = list[StateMachineAliasListItem]
 
 
 class ListStateMachineAliasesOutput(TypedDict, total=False):
@@ -1054,7 +1029,7 @@ class StateMachineVersionListItem(TypedDict, total=False):
     creationDate: Timestamp
 
 
-StateMachineVersionList = List[StateMachineVersionListItem]
+StateMachineVersionList = list[StateMachineVersionListItem]
 
 
 class ListStateMachineVersionsOutput(TypedDict, total=False):
@@ -1062,17 +1037,14 @@ class ListStateMachineVersionsOutput(TypedDict, total=False):
     nextToken: Optional[PageToken]
 
 
-StateMachineListItem = TypedDict(
-    "StateMachineListItem",
-    {
-        "stateMachineArn": Arn,
-        "name": Name,
-        "type": StateMachineType,
-        "creationDate": Timestamp,
-    },
-    total=False,
-)
-StateMachineList = List[StateMachineListItem]
+class StateMachineListItem(TypedDict, total=False):
+    stateMachineArn: Arn
+    name: Name
+    type: StateMachineType
+    creationDate: Timestamp
+
+
+StateMachineList = list[StateMachineListItem]
 
 
 class ListStateMachinesOutput(TypedDict, total=False):
@@ -1131,7 +1103,7 @@ class StopExecutionOutput(TypedDict, total=False):
     stopDate: Timestamp
 
 
-TagKeyList = List[TagKey]
+TagKeyList = list[TagKey]
 
 
 class TagResourceOutput(TypedDict, total=False):
@@ -1172,19 +1144,16 @@ class ValidateStateMachineDefinitionDiagnostic(TypedDict, total=False):
     location: Optional[ValidateStateMachineDefinitionLocation]
 
 
-ValidateStateMachineDefinitionDiagnosticList = List[
+ValidateStateMachineDefinitionDiagnosticList = list[
     ValidateStateMachineDefinitionDiagnostic
 ]
-ValidateStateMachineDefinitionInput = TypedDict(
-    "ValidateStateMachineDefinitionInput",
-    {
-        "definition": Definition,
-        "type": Optional[StateMachineType],
-        "severity": Optional[ValidateStateMachineDefinitionSeverity],
-        "maxResults": Optional[ValidateStateMachineDefinitionMaxResult],
-    },
-    total=False,
-)
+
+
+class ValidateStateMachineDefinitionInput(TypedDict, total=False):
+    definition: Definition
+    type: Optional[StateMachineType]
+    severity: Optional[ValidateStateMachineDefinitionSeverity]
+    maxResults: Optional[ValidateStateMachineDefinitionMaxResult]
 
 
 class ValidateStateMachineDefinitionOutput(TypedDict, total=False):

--- a/moto/stepfunctions/parser/asl/antlr/runtime/ASLIntrinsicParser.py
+++ b/moto/stepfunctions/parser/asl/antlr/runtime/ASLIntrinsicParser.py
@@ -1,5 +1,4 @@
 # Generated from ASLIntrinsicParser.g4 by ANTLR 4.13.2
-# encoding: utf-8
 import sys
 from typing import TextIO
 

--- a/moto/stepfunctions/parser/asl/antlr/runtime/ASLParser.py
+++ b/moto/stepfunctions/parser/asl/antlr/runtime/ASLParser.py
@@ -1,5 +1,4 @@
 # Generated from ASLParser.g4 by ANTLR 4.13.2
-# encoding: utf-8
 import sys
 from typing import TextIO
 

--- a/moto/stepfunctions/parser/asl/component/common/assign/assign_decl.py
+++ b/moto/stepfunctions/parser/asl/component/common/assign/assign_decl.py
@@ -1,4 +1,4 @@
-from typing import Any, Final, List
+from typing import Any, Final
 
 from moto.stepfunctions.parser.asl.component.common.assign.assign_decl_binding import (
     AssignDeclBinding,
@@ -8,9 +8,9 @@ from moto.stepfunctions.parser.asl.eval.environment import Environment
 
 
 class AssignDecl(EvalComponent):
-    declaration_bindings: Final[List[AssignDeclBinding]]
+    declaration_bindings: Final[list[AssignDeclBinding]]
 
-    def __init__(self, declaration_bindings: List[AssignDeclBinding]):
+    def __init__(self, declaration_bindings: list[AssignDeclBinding]):
         super().__init__()
         self.declaration_bindings = declaration_bindings
 

--- a/moto/stepfunctions/parser/asl/component/common/assign/assign_template_value_array.py
+++ b/moto/stepfunctions/parser/asl/component/common/assign/assign_template_value_array.py
@@ -1,4 +1,4 @@
-from typing import Final, List
+from typing import Final
 
 from moto.stepfunctions.parser.asl.component.common.assign.assign_template_value import (
     AssignTemplateValue,
@@ -7,9 +7,9 @@ from moto.stepfunctions.parser.asl.eval.environment import Environment
 
 
 class AssignTemplateValueArray(AssignTemplateValue):
-    values: Final[List[AssignTemplateValue]]
+    values: Final[list[AssignTemplateValue]]
 
-    def __init__(self, values: List[AssignTemplateValue]):
+    def __init__(self, values: list[AssignTemplateValue]):
         self.values = values
 
     def _eval_body(self, env: Environment) -> None:

--- a/moto/stepfunctions/parser/asl/component/common/assign/assign_template_value_object.py
+++ b/moto/stepfunctions/parser/asl/component/common/assign/assign_template_value_object.py
@@ -1,4 +1,4 @@
-from typing import Final, List
+from typing import Final
 
 from moto.stepfunctions.parser.asl.component.common.assign.assign_template_binding import (
     AssignTemplateBinding,
@@ -10,9 +10,9 @@ from moto.stepfunctions.parser.asl.eval.environment import Environment
 
 
 class AssignTemplateValueObject(AssignTemplateValue):
-    bindings: Final[List[AssignTemplateBinding]]
+    bindings: Final[list[AssignTemplateBinding]]
 
-    def __init__(self, bindings: List[AssignTemplateBinding]):
+    def __init__(self, bindings: list[AssignTemplateBinding]):
         self.bindings = bindings
 
     def _eval_body(self, env: Environment) -> None:

--- a/moto/stepfunctions/parser/asl/component/common/catch/catch_decl.py
+++ b/moto/stepfunctions/parser/asl/component/common/catch/catch_decl.py
@@ -1,4 +1,4 @@
-from typing import Final, List
+from typing import Final
 
 from moto.stepfunctions.parser.asl.component.common.catch.catch_outcome import (
     CatchOutcome,
@@ -15,8 +15,8 @@ from moto.stepfunctions.parser.asl.eval.environment import Environment
 
 
 class CatchDecl(EvalComponent):
-    def __init__(self, catchers: List[CatcherDecl]):
-        self.catchers: Final[List[CatcherDecl]] = catchers
+    def __init__(self, catchers: list[CatcherDecl]):
+        self.catchers: Final[list[CatcherDecl]] = catchers
 
     def _eval_body(self, env: Environment) -> None:
         for catcher in self.catchers:

--- a/moto/stepfunctions/parser/asl/component/common/error_name/error_equals_decl.py
+++ b/moto/stepfunctions/parser/asl/component/common/error_name/error_equals_decl.py
@@ -1,4 +1,4 @@
-from typing import Final, List
+from typing import Final
 
 from moto.stepfunctions.parser.asl.component.common.error_name.error_name import (
     ErrorName,
@@ -27,7 +27,7 @@ class ErrorEqualsDecl(EvalComponent):
         typ=StatesErrorNameType.StatesTaskFailed
     )
 
-    def __init__(self, error_names: List[ErrorName]):
+    def __init__(self, error_names: list[ErrorName]):
         # The reserved name "States.ALL" in a Retrier’s "ErrorEquals" field is a wildcard
         # and matches any Error Name. Such a value MUST appear alone in the "ErrorEquals"
         # array and MUST appear in the last Retrier in the "Retry" array.
@@ -37,7 +37,7 @@ class ErrorEqualsDecl(EvalComponent):
             )
 
         # TODO: how to handle duplicate ErrorName?
-        self.error_names: List[ErrorName] = error_names
+        self.error_names: list[ErrorName] = error_names
 
     def _eval_body(self, env: Environment) -> None:
         """

--- a/moto/stepfunctions/parser/asl/component/common/jsonata/jsonata_template_value_array.py
+++ b/moto/stepfunctions/parser/asl/component/common/jsonata/jsonata_template_value_array.py
@@ -1,4 +1,4 @@
-from typing import Final, List
+from typing import Final
 
 from moto.stepfunctions.parser.asl.component.common.jsonata.jsonata_template_value import (
     JSONataTemplateValue,
@@ -7,9 +7,9 @@ from moto.stepfunctions.parser.asl.eval.environment import Environment
 
 
 class JSONataTemplateValueArray(JSONataTemplateValue):
-    values: Final[List[JSONataTemplateValue]]
+    values: Final[list[JSONataTemplateValue]]
 
-    def __init__(self, values: List[JSONataTemplateValue]):
+    def __init__(self, values: list[JSONataTemplateValue]):
         self.values = values
 
     def _eval_body(self, env: Environment) -> None:

--- a/moto/stepfunctions/parser/asl/component/common/jsonata/jsonata_template_value_object.py
+++ b/moto/stepfunctions/parser/asl/component/common/jsonata/jsonata_template_value_object.py
@@ -1,4 +1,4 @@
-from typing import Final, List
+from typing import Final
 
 from moto.stepfunctions.parser.asl.component.common.jsonata.jsonata_template_binding import (
     JSONataTemplateBinding,
@@ -10,9 +10,9 @@ from moto.stepfunctions.parser.asl.eval.environment import Environment
 
 
 class JSONataTemplateValueObject(JSONataTemplateValue):
-    bindings: Final[List[JSONataTemplateBinding]]
+    bindings: Final[list[JSONataTemplateBinding]]
 
-    def __init__(self, bindings: List[JSONataTemplateBinding]):
+    def __init__(self, bindings: list[JSONataTemplateBinding]):
         self.bindings = bindings
 
     def _eval_body(self, env: Environment) -> None:

--- a/moto/stepfunctions/parser/asl/component/common/payload/payloadvalue/payloadarr/payload_arr.py
+++ b/moto/stepfunctions/parser/asl/component/common/payload/payloadvalue/payloadarr/payload_arr.py
@@ -1,4 +1,4 @@
-from typing import Final, List
+from typing import Final
 
 from moto.stepfunctions.parser.asl.component.common.payload.payloadvalue.payload_value import (
     PayloadValue,
@@ -7,8 +7,8 @@ from moto.stepfunctions.parser.asl.eval.environment import Environment
 
 
 class PayloadArr(PayloadValue):
-    def __init__(self, payload_values: List[PayloadValue]):
-        self.payload_values: Final[List[PayloadValue]] = payload_values
+    def __init__(self, payload_values: list[PayloadValue]):
+        self.payload_values: Final[list[PayloadValue]] = payload_values
 
     def _eval_body(self, env: Environment) -> None:
         arr = list()

--- a/moto/stepfunctions/parser/asl/component/common/payload/payloadvalue/payloadtmpl/payload_tmpl.py
+++ b/moto/stepfunctions/parser/asl/component/common/payload/payloadvalue/payloadtmpl/payload_tmpl.py
@@ -1,4 +1,4 @@
-from typing import Final, List
+from typing import Final
 
 from moto.stepfunctions.parser.asl.component.common.payload.payloadvalue.payload_value import (
     PayloadValue,
@@ -10,8 +10,8 @@ from moto.stepfunctions.parser.asl.eval.environment import Environment
 
 
 class PayloadTmpl(PayloadValue):
-    def __init__(self, payload_bindings: List[PayloadBinding]):
-        self.payload_bindings: Final[List[PayloadBinding]] = payload_bindings
+    def __init__(self, payload_bindings: list[PayloadBinding]):
+        self.payload_bindings: Final[list[PayloadBinding]] = payload_bindings
 
     def _eval_body(self, env: Environment) -> None:
         env.stack.append(dict())

--- a/moto/stepfunctions/parser/asl/component/common/retry/retry_decl.py
+++ b/moto/stepfunctions/parser/asl/component/common/retry/retry_decl.py
@@ -1,4 +1,4 @@
-from typing import Final, List
+from typing import Final
 
 from moto.stepfunctions.parser.asl.component.common.error_name.error_name import (
     ErrorName,
@@ -17,8 +17,8 @@ from moto.stepfunctions.parser.asl.eval.environment import Environment
 
 
 class RetryDecl(EvalComponent):
-    def __init__(self, retriers: List[RetrierDecl]):
-        self.retriers: Final[List[RetrierDecl]] = retriers
+    def __init__(self, retriers: list[RetrierDecl]):
+        self.retriers: Final[list[RetrierDecl]] = retriers
 
     def _eval_body(self, env: Environment) -> None:
         error_name: ErrorName = env.stack.pop()

--- a/moto/stepfunctions/parser/asl/component/intrinsic/argument/argument.py
+++ b/moto/stepfunctions/parser/asl/component/intrinsic/argument/argument.py
@@ -1,5 +1,5 @@
 import abc
-from typing import Any, Final, List, Optional
+from typing import Any, Final, Optional
 
 from moto.stepfunctions.parser.asl.component.common.string.string_expression import (
     StringVariableSample,
@@ -91,10 +91,10 @@ class ArgumentVar(Argument):
 
 
 class ArgumentList(Argument):
-    arguments: Final[List[Argument]]
+    arguments: Final[list[Argument]]
     size: Final[int]
 
-    def __init__(self, arguments: List[Argument]):
+    def __init__(self, arguments: list[Argument]):
         self.arguments = arguments
         self.size = len(arguments)
 

--- a/moto/stepfunctions/parser/asl/component/intrinsic/function/statesfunction/array/array.py
+++ b/moto/stepfunctions/parser/asl/component/intrinsic/function/statesfunction/array/array.py
@@ -1,4 +1,4 @@
-from typing import Any, List
+from typing import Any
 
 from moto.stepfunctions.parser.asl.component.intrinsic.argument.argument import (
     ArgumentList,
@@ -24,5 +24,5 @@ class Array(StatesFunction):
 
     def _eval_body(self, env: Environment) -> None:
         self.argument_list.eval(env=env)
-        values: List[Any] = env.stack.pop()
+        values: list[Any] = env.stack.pop()
         env.stack.append(values)

--- a/moto/stepfunctions/parser/asl/component/intrinsic/function/statesfunction/generic/string_format.py
+++ b/moto/stepfunctions/parser/asl/component/intrinsic/function/statesfunction/generic/string_format.py
@@ -1,5 +1,5 @@
 import json
-from typing import Any, Final, List
+from typing import Any, Final
 
 from moto.stepfunctions.parser.asl.component.intrinsic.argument.argument import (
     ArgumentContextPath,
@@ -71,7 +71,7 @@ class StringFormat(StatesFunction):
         args = env.stack.pop()
 
         string_format: str = args[0]
-        values: List[Any] = args[1:]
+        values: list[Any] = args[1:]
 
         values_str_repr = map(self._to_str_repr, values)
         string_result = string_format.format(*values_str_repr)
@@ -93,7 +93,7 @@ class StringFormat(StatesFunction):
         if isinstance(value, str):
             return value
         elif isinstance(value, list):
-            value_parts: List[str] = list(map(StringFormat._to_str_repr, value))
+            value_parts: list[str] = list(map(StringFormat._to_str_repr, value))
             return f"[{', '.join(value_parts)}]"
         elif isinstance(value, dict):
             dict_items = list()

--- a/moto/stepfunctions/parser/asl/component/intrinsic/function/statesfunction/states_function_array.py
+++ b/moto/stepfunctions/parser/asl/component/intrinsic/function/statesfunction/states_function_array.py
@@ -1,4 +1,4 @@
-from typing import Any, List
+from typing import Any
 
 from moto.stepfunctions.parser.asl.component.intrinsic.argument.argument import (
     ArgumentList,
@@ -24,7 +24,7 @@ class StatesFunctionArray(StatesFunction):
 
     def _eval_body(self, env: Environment) -> None:
         self.argument_list.eval(env=env)
-        values: List[Any] = list()
+        values: list[Any] = list()
         for _ in range(self.argument_list.size):
             values.append(env.stack.pop())
         values.reverse()

--- a/moto/stepfunctions/parser/asl/component/intrinsic/function/statesfunction/states_function_format.py
+++ b/moto/stepfunctions/parser/asl/component/intrinsic/function/statesfunction/states_function_format.py
@@ -1,4 +1,4 @@
-from typing import Any, Final, List
+from typing import Any, Final
 
 from moto.stepfunctions.parser.asl.component.intrinsic.argument.argument import (
     ArgumentList,
@@ -41,13 +41,13 @@ class StatesFunctionFormat(StatesFunction):
         # TODO: investigate behaviour for incorrect number of arguments in string format.
         self.argument_list.eval(env=env)
 
-        values: List[Any] = list()
+        values: list[Any] = list()
         for _ in range(self.argument_list.size):
             values.append(env.stack.pop())
         string_format: str = values.pop()
         values.reverse()
 
-        string_format_parts: List[str] = string_format.split(self._DELIMITER)
+        string_format_parts: list[str] = string_format.split(self._DELIMITER)
         string_result: str = ""
         for part in string_format_parts:
             string_result += part

--- a/moto/stepfunctions/parser/asl/component/intrinsic/jsonata.py
+++ b/moto/stepfunctions/parser/asl/component/intrinsic/jsonata.py
@@ -1,4 +1,4 @@
-from typing import Final, List, Optional
+from typing import Final, Optional
 
 from moto.stepfunctions.parser.asl.jsonata.jsonata import (
     VariableDeclarations,
@@ -75,7 +75,7 @@ _DECLARATION_BY_VARIABLE_REFERENCE: Final[dict[VariableReference, str]] = {
 def get_intrinsic_functions_declarations(
     variable_references: set[VariableReference],
 ) -> VariableDeclarations:
-    declarations: List[str] = list()
+    declarations: list[str] = list()
     for variable_reference in variable_references:
         declaration: Optional[VariableDeclarations] = (
             _DECLARATION_BY_VARIABLE_REFERENCE.get(variable_reference)

--- a/moto/stepfunctions/parser/asl/component/intrinsic/member.py
+++ b/moto/stepfunctions/parser/asl/component/intrinsic/member.py
@@ -13,4 +13,4 @@ class IdentifiedMember(Member):
 
 class DollarMember(IdentifiedMember):
     def __init__(self):
-        super(DollarMember, self).__init__(identifier="$")
+        super().__init__(identifier="$")

--- a/moto/stepfunctions/parser/asl/component/intrinsic/program.py
+++ b/moto/stepfunctions/parser/asl/component/intrinsic/program.py
@@ -1,8 +1,8 @@
-from typing import Final, List
+from typing import Final
 
 from moto.stepfunctions.parser.asl.component.intrinsic.component import Component
 
 
 class Program(Component):
     def __init__(self):
-        self.statements: Final[List[Component]] = []
+        self.statements: Final[list[Component]] = []

--- a/moto/stepfunctions/parser/asl/component/state/choice/choices_decl.py
+++ b/moto/stepfunctions/parser/asl/component/state/choice/choices_decl.py
@@ -1,4 +1,4 @@
-from typing import Final, List
+from typing import Final
 
 from moto.stepfunctions.parser.asl.component.component import Component
 from moto.stepfunctions.parser.asl.component.state.choice.choice_rule import (
@@ -7,5 +7,5 @@ from moto.stepfunctions.parser.asl.component.state.choice.choice_rule import (
 
 
 class ChoicesDecl(Component):
-    def __init__(self, rules: List[ChoiceRule]):
-        self.rules: Final[List[ChoiceRule]] = rules
+    def __init__(self, rules: list[ChoiceRule]):
+        self.rules: Final[list[ChoiceRule]] = rules

--- a/moto/stepfunctions/parser/asl/component/state/choice/comparison/comparison.py
+++ b/moto/stepfunctions/parser/asl/component/state/choice/comparison/comparison.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import abc
 from enum import Enum
-from typing import Any, Final, List
+from typing import Any, Final
 
 from moto.stepfunctions.parser.asl.antlr.runtime.ASLLexer import ASLLexer
 from moto.stepfunctions.parser.asl.component.common.string.string_expression import (
@@ -72,23 +72,21 @@ class ComparisonCompositeSingle(ComparisonComposite, abc.ABC):
     rule: Final[ChoiceRule]
 
     def __init__(self, operator: ComparisonComposite.ChoiceOp, rule: ChoiceRule):
-        super(ComparisonCompositeSingle, self).__init__(operator=operator)
+        super().__init__(operator=operator)
         self.rule = rule
 
 
 class ComparisonCompositeMulti(ComparisonComposite, abc.ABC):
-    rules: Final[List[ChoiceRule]]
+    rules: Final[list[ChoiceRule]]
 
-    def __init__(self, operator: ComparisonComposite.ChoiceOp, rules: List[ChoiceRule]):
-        super(ComparisonCompositeMulti, self).__init__(operator=operator)
+    def __init__(self, operator: ComparisonComposite.ChoiceOp, rules: list[ChoiceRule]):
+        super().__init__(operator=operator)
         self.rules = rules
 
 
 class ComparisonCompositeNot(ComparisonCompositeSingle):
     def __init__(self, rule: ChoiceRule):
-        super(ComparisonCompositeNot, self).__init__(
-            operator=ComparisonComposite.ChoiceOp.Not, rule=rule
-        )
+        super().__init__(operator=ComparisonComposite.ChoiceOp.Not, rule=rule)
 
     def _eval_body(self, env: Environment) -> None:
         self.rule.eval(env)
@@ -98,10 +96,8 @@ class ComparisonCompositeNot(ComparisonCompositeSingle):
 
 
 class ComparisonCompositeAnd(ComparisonCompositeMulti):
-    def __init__(self, rules: List[ChoiceRule]):
-        super(ComparisonCompositeAnd, self).__init__(
-            operator=ComparisonComposite.ChoiceOp.And, rules=rules
-        )
+    def __init__(self, rules: list[ChoiceRule]):
+        super().__init__(operator=ComparisonComposite.ChoiceOp.And, rules=rules)
 
     def _eval_body(self, env: Environment) -> None:
         res = True
@@ -115,10 +111,8 @@ class ComparisonCompositeAnd(ComparisonCompositeMulti):
 
 
 class ComparisonCompositeOr(ComparisonCompositeMulti):
-    def __init__(self, rules: List[ChoiceRule]):
-        super(ComparisonCompositeOr, self).__init__(
-            operator=ComparisonComposite.ChoiceOp.Or, rules=rules
-        )
+    def __init__(self, rules: list[ChoiceRule]):
+        super().__init__(operator=ComparisonComposite.ChoiceOp.Or, rules=rules)
 
     def _eval_body(self, env: Environment) -> None:
         res = False

--- a/moto/stepfunctions/parser/asl/component/state/choice/state_choice.py
+++ b/moto/stepfunctions/parser/asl/component/state/choice/state_choice.py
@@ -19,7 +19,7 @@ class StateChoice(CommonStateField):
     default_state: Optional[DefaultDecl]
 
     def __init__(self):
-        super(StateChoice, self).__init__(
+        super().__init__(
             state_entered_event_type=HistoryEventType.ChoiceStateEntered,
             state_exited_event_type=HistoryEventType.ChoiceStateExited,
         )
@@ -27,7 +27,7 @@ class StateChoice(CommonStateField):
         self._next_state_name = None
 
     def from_state_props(self, state_props: StateProps) -> None:
-        super(StateChoice, self).from_state_props(state_props)
+        super().from_state_props(state_props)
         self.choices_decl = state_props.get(ChoicesDecl)
         self.default_state = state_props.get(DefaultDecl)
 

--- a/moto/stepfunctions/parser/asl/component/state/exec/execute_state.py
+++ b/moto/stepfunctions/parser/asl/component/state/exec/execute_state.py
@@ -3,7 +3,7 @@ import copy
 import logging
 import threading
 from threading import Thread
-from typing import Any, List, Optional
+from typing import Any, Optional
 
 from moto.stepfunctions.parser.api import HistoryEventType, TaskFailedEventDetails
 from moto.stepfunctions.parser.asl.component.common.catch.catch_decl import CatchDecl
@@ -184,8 +184,8 @@ class ExecutionState(CommonStateField, abc.ABC):
         frame: Environment = env.open_frame()
         frame.states.reset(input_value=env.states.get_input())
         frame.stack = copy.deepcopy(env.stack)
-        execution_outputs: List[Any] = list()
-        execution_exceptions: List[Optional[Exception]] = [None]
+        execution_outputs: list[Any] = list()
+        execution_exceptions: list[Optional[Exception]] = [None]
         terminated_event = threading.Event()
 
         def _exec_and_notify():

--- a/moto/stepfunctions/parser/asl/component/state/exec/state_map/item_reader/reader_config/csv_headers.py
+++ b/moto/stepfunctions/parser/asl/component/state/exec/state_map/item_reader/reader_config/csv_headers.py
@@ -1,10 +1,10 @@
-from typing import Final, List
+from typing import Final
 
 from moto.stepfunctions.parser.asl.component.component import Component
 
 
 class CSVHeaders(Component):
-    header_names: Final[List[str]]
+    header_names: Final[list[str]]
 
-    def __init__(self, header_names: List[str]):
+    def __init__(self, header_names: list[str]):
         self.header_names = header_names

--- a/moto/stepfunctions/parser/asl/component/state/exec/state_map/iteration/distributed_iteration_component.py
+++ b/moto/stepfunctions/parser/asl/component/state/exec/state_map/iteration/distributed_iteration_component.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import abc
 import json
-from typing import Any, Final, List, Optional
+from typing import Any, Final, Optional
 
 from moto.stepfunctions.parser.api import (
     HistoryEventType,
@@ -58,7 +58,7 @@ class DistributedIterationComponentEvalInput(InlineIterationComponentEvalInput):
         self,
         state_name: str,
         max_concurrency: int,
-        input_items: List[json],
+        input_items: list[json],
         parameters: Optional[Parameters],
         item_selector: Optional[ItemSelector],
         item_reader: Optional[ItemReader],
@@ -101,7 +101,7 @@ class DistributedIterationComponent(InlineIterationComponent, abc.ABC):
     def _map_run(
         self, env: Environment, eval_input: DistributedIterationComponentEvalInput
     ) -> None:
-        input_items: List[json] = env.stack.pop()
+        input_items: list[json] = env.stack.pop()
 
         input_item_program: Final[Program] = self._get_iteration_program()
         job_pool = JobPool(job_program=input_item_program, job_inputs=input_items)
@@ -122,8 +122,8 @@ class DistributedIterationComponent(InlineIterationComponent, abc.ABC):
         if worker_exception is not None:
             raise worker_exception
 
-        closed_jobs: List[JobClosed] = job_pool.get_closed_jobs()
-        outputs: List[Any] = [closed_job.job_output for closed_job in closed_jobs]
+        closed_jobs: list[JobClosed] = job_pool.get_closed_jobs()
+        outputs: list[Any] = [closed_job.job_output for closed_job in closed_jobs]
 
         env.stack.append(outputs)
 

--- a/moto/stepfunctions/parser/asl/component/state/exec/state_map/iteration/inline_iteration_component.py
+++ b/moto/stepfunctions/parser/asl/component/state/exec/state_map/iteration/inline_iteration_component.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import abc
 import json
 import threading
-from typing import Any, Final, List, Optional
+from typing import Any, Final, Optional
 
 from moto.stepfunctions.parser.asl.component.common.comment import Comment
 from moto.stepfunctions.parser.asl.component.common.flow.start_at import StartAt
@@ -37,7 +37,7 @@ from moto.stepfunctions.parser.utils import TMP_THREADS
 class InlineIterationComponentEvalInput:
     state_name: Final[str]
     max_concurrency: Final[int]
-    input_items: Final[List[json]]
+    input_items: Final[list[json]]
     parameters: Final[Optional[Parameters]]
     item_selector: Final[Optional[ItemSelector]]
 
@@ -45,7 +45,7 @@ class InlineIterationComponentEvalInput:
         self,
         state_name: str,
         max_concurrency: int,
-        input_items: List[json],
+        input_items: list[json],
         parameters: Optional[Parameters],
         item_selector: Optional[ItemSelector],
     ):
@@ -99,7 +99,7 @@ class InlineIterationComponent(IterationComponent, abc.ABC):
         eval_input = env.stack.pop()
 
         max_concurrency: int = eval_input.max_concurrency
-        input_items: List[json] = eval_input.input_items
+        input_items: list[json] = eval_input.input_items
 
         input_item_program: Final[Program] = self._get_iteration_program()
         job_pool = JobPool(
@@ -120,7 +120,7 @@ class InlineIterationComponent(IterationComponent, abc.ABC):
         if worker_exception is not None:
             raise worker_exception
 
-        closed_jobs: List[JobClosed] = job_pool.get_closed_jobs()
-        outputs: List[Any] = [closed_job.job_output for closed_job in closed_jobs]
+        closed_jobs: list[JobClosed] = job_pool.get_closed_jobs()
+        outputs: list[Any] = [closed_job.job_output for closed_job in closed_jobs]
 
         env.stack.append(outputs)

--- a/moto/stepfunctions/parser/asl/component/state/exec/state_map/iteration/job.py
+++ b/moto/stepfunctions/parser/asl/component/state/exec/state_map/iteration/job.py
@@ -1,7 +1,7 @@
 import copy
 import logging
 import threading
-from typing import Any, Final, List, Optional
+from typing import Any, Final, Optional
 
 from moto.stepfunctions.parser.asl.component.program.program import Program
 from moto.stepfunctions.parser.asl.utils.encoding import to_json_str
@@ -40,10 +40,10 @@ class JobPool:
     _worker_exception: Optional[Exception]
 
     _jobs_number: Final[int]
-    _open_jobs: Final[List[Job]]
+    _open_jobs: Final[list[Job]]
     _closed_jobs: Final[set[JobClosed]]
 
-    def __init__(self, job_program: Program, job_inputs: List[Any]):
+    def __init__(self, job_program: Program, job_inputs: list[Any]):
         self._mutex = threading.Lock()
         self._termination_event = threading.Event()
         self._worker_exception = None

--- a/moto/stepfunctions/parser/asl/component/state/exec/state_map/state_map.py
+++ b/moto/stepfunctions/parser/asl/component/state/exec/state_map/state_map.py
@@ -122,13 +122,13 @@ class StateMap(ExecutionState):
     result_writer: Optional[ResultWriter]
 
     def __init__(self):
-        super(StateMap, self).__init__(
+        super().__init__(
             state_entered_event_type=HistoryEventType.MapStateEntered,
             state_exited_event_type=HistoryEventType.MapStateExited,
         )
 
     def from_state_props(self, state_props: StateProps) -> None:
-        super(StateMap, self).from_state_props(state_props)
+        super().from_state_props(state_props)
         if self._is_language_query_jsonpath():
             self.items = None
             self.items_path = state_props.get(ItemsPath) or ItemsPath(

--- a/moto/stepfunctions/parser/asl/component/state/exec/state_parallel/branches_decl.py
+++ b/moto/stepfunctions/parser/asl/component/state/exec/state_parallel/branches_decl.py
@@ -1,6 +1,6 @@
 import datetime
 import threading
-from typing import Final, List, Optional
+from typing import Final, Optional
 
 from moto.stepfunctions.parser.api import ExecutionFailedEventDetails, HistoryEventType
 from moto.stepfunctions.parser.asl.component.common.error_name.custom_error_name import (
@@ -59,8 +59,8 @@ class BranchWorkerPool(BranchWorker.BranchWorkerComm):
 
 
 class BranchesDecl(EvalComponent):
-    def __init__(self, programs: List[Program]):
-        self.programs: Final[List[Program]] = programs
+    def __init__(self, programs: list[Program]):
+        self.programs: Final[list[Program]] = programs
 
     def _eval_body(self, env: Environment) -> None:
         # Input value for every state_parallel process.
@@ -68,7 +68,7 @@ class BranchesDecl(EvalComponent):
 
         branch_worker_pool = BranchWorkerPool(workers_num=len(self.programs))
 
-        branch_workers: List[BranchWorker] = list()
+        branch_workers: list[BranchWorker] = list()
         for program in self.programs:
             # Environment frame for this sub process.
             env_frame: Environment = env.open_inner_frame()

--- a/moto/stepfunctions/parser/asl/component/state/exec/state_parallel/state_parallel.py
+++ b/moto/stepfunctions/parser/asl/component/state/exec/state_parallel/state_parallel.py
@@ -38,7 +38,7 @@ class StateParallel(ExecutionState):
         )
 
     def from_state_props(self, state_props: StateProps) -> None:
-        super(StateParallel, self).from_state_props(state_props)
+        super().from_state_props(state_props)
         self.branches = state_props.get(
             typ=BranchesDecl,
             raise_on_missing=ValueError(

--- a/moto/stepfunctions/parser/asl/component/state/exec/state_task/service/state_task_service.py
+++ b/moto/stepfunctions/parser/asl/component/state/exec/state_task/service/state_task_service.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import abc
 import copy
 import logging
-from typing import Any, Final, List, Optional
+from typing import Any, Final, Optional
 
 from botocore.model import ListShape, Shape, StringShape, StructureShape
 from botocore.response import StreamingBody
@@ -132,7 +132,7 @@ class StateTaskService(StateTask, abc.ABC):
             camel_to_snake_case(member_key): (member_key, member_value)
             for member_key, member_value in shape_members.items()
         }
-        parameters_bind_keys: List[str] = list(parameters.keys())
+        parameters_bind_keys: list[str] = list(parameters.keys())
         for parameter_key in parameters_bind_keys:
             norm_parameter_key = camel_to_snake_case(parameter_key)
             norm_member_bind: Optional[tuple[str, Optional[StructureShape]]] = (
@@ -176,7 +176,7 @@ class StateTaskService(StateTask, abc.ABC):
             return
 
         shape_members = structure_shape.members
-        response_bind_keys: List[str] = list(response.keys())
+        response_bind_keys: list[str] = list(response.keys())
         for response_key in response_bind_keys:
             norm_response_key = self._to_sfn_cased(response_key)
             if response_key in shape_members:

--- a/moto/stepfunctions/parser/asl/component/state/exec/state_task/service/state_task_service_api_gateway.py
+++ b/moto/stepfunctions/parser/asl/component/state/exec/state_task/service/state_task_service_api_gateway.py
@@ -4,7 +4,7 @@ import http
 import json
 import logging
 from json import JSONDecodeError
-from typing import Any, Dict, Final, Optional, Set, TypedDict, Union
+from typing import Any, Final, Optional, TypedDict, Union
 from urllib.parse import urlencode, urljoin
 
 import requests
@@ -30,7 +30,7 @@ from moto.stepfunctions.parser.asl.eval.event.event_detail import EventDetails
 
 LOG = logging.getLogger(__name__)
 
-_SUPPORTED_INTEGRATION_PATTERNS: Set[ResourceCondition] = {
+_SUPPORTED_INTEGRATION_PATTERNS: set[ResourceCondition] = {
     ResourceCondition.WaitForTaskToken,
 }
 
@@ -99,12 +99,12 @@ class SfnGatewayException(Exception):
 
 
 class StateTaskServiceApiGateway(StateTaskServiceCallback):
-    _SUPPORTED_API_PARAM_BINDINGS: Final[Dict[str, Set[str]]] = {
+    _SUPPORTED_API_PARAM_BINDINGS: Final[dict[str, set[str]]] = {
         SupportedApiCalls.invoke: {"ApiEndpoint", "Method"}
     }
 
-    _FORBIDDEN_HTTP_HEADERS_PREFIX: Final[Set[str]] = {"X-Forwarded", "X-Amz", "X-Amzn"}
-    _FORBIDDEN_HTTP_HEADERS: Final[Set[str]] = {
+    _FORBIDDEN_HTTP_HEADERS_PREFIX: Final[set[str]] = {"X-Forwarded", "X-Amz", "X-Amzn"}
+    _FORBIDDEN_HTTP_HEADERS: Final[set[str]] = {
         "Authorization",
         "Connection",
         "Content-md5",
@@ -124,12 +124,12 @@ class StateTaskServiceApiGateway(StateTaskServiceCallback):
     def __init__(self):
         super().__init__(supported_integration_patterns=_SUPPORTED_INTEGRATION_PATTERNS)
 
-    def _get_supported_parameters(self) -> Optional[Set[str]]:
+    def _get_supported_parameters(self) -> Optional[set[str]]:
         return self._SUPPORTED_API_PARAM_BINDINGS.get(self.resource.api_action.lower())
 
     def _normalise_parameters(
         self,
-        parameters: Dict[str, Any],
+        parameters: dict[str, Any],
         boto_service_name: Optional[str] = None,
         service_action_name: Optional[str] = None,
     ) -> None:

--- a/moto/stepfunctions/parser/asl/component/state/exec/state_task/state_task.py
+++ b/moto/stepfunctions/parser/asl/component/state/exec/state_task/state_task.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import abc
-from typing import List, Optional
+from typing import Optional
 
 from moto.stepfunctions.parser.api import HistoryEventType, TaskTimedOutEventDetails
 from moto.stepfunctions.parser.asl.component.common.error_name.failure_event import (
@@ -35,13 +35,13 @@ class StateTask(ExecutionState, abc.ABC):
     credentials: Optional[Credentials]
 
     def __init__(self):
-        super(StateTask, self).__init__(
+        super().__init__(
             state_entered_event_type=HistoryEventType.TaskStateEntered,
             state_exited_event_type=HistoryEventType.TaskStateExited,
         )
 
     def from_state_props(self, state_props: StateProps) -> None:
-        super(StateTask, self).from_state_props(state_props)
+        super().from_state_props(state_props)
         self.resource = state_props.get(Resource)
         self.parargs = state_props.get(Parargs)
         self.credentials = state_props.get(Credentials)
@@ -59,7 +59,7 @@ class StateTask(ExecutionState, abc.ABC):
         # Handle supported parameters.
         supported_parameters = self._get_supported_parameters()
         if supported_parameters:
-            unsupported_parameters: List[str] = [
+            unsupported_parameters: list[str] = [
                 parameter
                 for parameter in parameters.keys()
                 if parameter not in supported_parameters

--- a/moto/stepfunctions/parser/asl/component/state/fail/state_fail.py
+++ b/moto/stepfunctions/parser/asl/component/state/fail/state_fail.py
@@ -26,7 +26,7 @@ class StateFail(CommonStateField):
         self.error: Optional[ErrorDecl] = None
 
     def from_state_props(self, state_props: StateProps) -> None:
-        super(StateFail, self).from_state_props(state_props)
+        super().from_state_props(state_props)
         self.cause = state_props.get(CauseDecl)
         self.error = state_props.get(ErrorDecl)
 

--- a/moto/stepfunctions/parser/asl/component/state/state_pass/state_pass.py
+++ b/moto/stepfunctions/parser/asl/component/state/state_pass/state_pass.py
@@ -13,7 +13,7 @@ from moto.stepfunctions.parser.asl.eval.environment import Environment
 
 class StatePass(CommonStateField):
     def __init__(self):
-        super(StatePass, self).__init__(
+        super().__init__(
             state_entered_event_type=HistoryEventType.PassStateEntered,
             state_exited_event_type=HistoryEventType.PassStateExited,
         )
@@ -34,7 +34,7 @@ class StatePass(CommonStateField):
         self.parameters: Optional[Parameters] = None
 
     def from_state_props(self, state_props: StateProps) -> None:
-        super(StatePass, self).from_state_props(state_props)
+        super().from_state_props(state_props)
         self.result = state_props.get(Result)
         self.result_path = state_props.get(ResultPath) or ResultPath(
             result_path_src=ResultPath.DEFAULT_PATH

--- a/moto/stepfunctions/parser/asl/component/state/state_succeed/state_succeed.py
+++ b/moto/stepfunctions/parser/asl/component/state/state_succeed/state_succeed.py
@@ -17,7 +17,7 @@ class StateSucceed(CommonStateField):
         )
 
     def from_state_props(self, state_props: StateProps) -> None:
-        super(StateSucceed, self).from_state_props(state_props)
+        super().from_state_props(state_props)
         # TODO: assert all other fields are undefined?
 
         # No Next or End field: Succeed states are terminal states.

--- a/moto/stepfunctions/parser/asl/component/state/wait/state_wait.py
+++ b/moto/stepfunctions/parser/asl/component/state/wait/state_wait.py
@@ -19,7 +19,7 @@ class StateWait(CommonStateField):
         )
 
     def from_state_props(self, state_props: StateProps) -> None:
-        super(StateWait, self).from_state_props(state_props)
+        super().from_state_props(state_props)
         self.wait_function = state_props.get(
             typ=WaitFunction,
             raise_on_missing=ValueError(

--- a/moto/stepfunctions/parser/asl/component/test_state/state/test_state_state_props.py
+++ b/moto/stepfunctions/parser/asl/component/test_state/state/test_state_state_props.py
@@ -1,4 +1,4 @@
-from typing import Any, Final, List
+from typing import Any, Final
 
 from moto.stepfunctions.parser.asl.component.common.parargs import Parargs
 from moto.stepfunctions.parser.asl.component.common.path.input_path import InputPath
@@ -9,7 +9,7 @@ from moto.stepfunctions.parser.asl.component.common.result_selector import (
 from moto.stepfunctions.parser.asl.component.state.state_pass.result import Result
 from moto.stepfunctions.parser.asl.component.state.state_props import StateProps
 
-EQUAL_SUBTYPES: Final[List[type]] = [
+EQUAL_SUBTYPES: Final[list[type]] = [
     InputPath,
     Parargs,
     ResultSelector,

--- a/moto/stepfunctions/parser/asl/eval/environment.py
+++ b/moto/stepfunctions/parser/asl/eval/environment.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import copy
 import logging
 import threading
-from typing import Any, Final, List, Optional
+from typing import Any, Final, Optional
 
 from moto.stepfunctions.parser.api import (
     Arn,
@@ -54,11 +54,11 @@ class Environment:
     activity_store: Final[dict[Arn, Activity]]
     mock_test_case: Optional[MockTestCase] = None
 
-    _frames: Final[List[Environment]]
+    _frames: Final[list[Environment]]
     _is_frame: bool = False
 
     heap: dict[str, Any] = dict()
-    stack: List[Any] = list()
+    stack: list[Any] = list()
     states: Final[States]
     variable_store: Final[VariableStore]
 
@@ -73,7 +73,7 @@ class Environment:
         variable_store: Optional[VariableStore] = None,
         mock_test_case: Optional[MockTestCase] = None,
     ):
-        super(Environment, self).__init__()
+        super().__init__()
         self._state_mutex = threading.RLock()
         self._program_state = None
         self.program_state_event = threading.Event()

--- a/moto/stepfunctions/parser/asl/eval/event/logging.py
+++ b/moto/stepfunctions/parser/asl/eval/event/logging.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 from datetime import datetime
-from typing import Any, Final, List, Optional, TypedDict
+from typing import Any, Final, Optional, TypedDict
 
 from botocore.client import BaseClient
 from botocore.exceptions import ClientError
@@ -224,7 +224,7 @@ class CloudWatchLoggingSession:
         )
         self._publish_history_log_or_setup(log_events=log_events)
 
-    def _publish_history_log_or_setup(self, log_events: List[Any]):
+    def _publish_history_log_or_setup(self, log_events: list[Any]):
         # Attempts to put the events into the given log group and stream, and attempts to create the stream if
         # this does not already exist.
         is_events_put = self._put_events(log_events=log_events)
@@ -242,7 +242,7 @@ class CloudWatchLoggingSession:
 
         self._put_events(log_events=log_events)
 
-    def _put_events(self, log_events: List[Any]) -> bool:
+    def _put_events(self, log_events: list[Any]) -> bool:
         # Puts the events to the targe log group and stream, and returns false if the LogGroup or LogStream could
         # not be found, true otherwise.
         try:

--- a/moto/stepfunctions/parser/asl/jsonata/jsonata.py
+++ b/moto/stepfunctions/parser/asl/jsonata/jsonata.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import json
 import re
-from typing import Any, Callable, Final, List, Optional
+from typing import Any, Callable, Final, Optional
 
 from moto.stepfunctions.parser.asl.utils.encoding import to_json_str
 
@@ -106,7 +106,7 @@ def extract_jsonata_variable_references(
     if not jsonata_expression:
         return set()
     # Extract all recognised patterns.
-    all_references: List[Any] = _PATTERN_VARIABLE_REFERENCE.findall(jsonata_expression)
+    all_references: list[Any] = _PATTERN_VARIABLE_REFERENCE.findall(jsonata_expression)
     # Filter non-empty patterns (this includes consumed blocks such as jsonata
     # regular expressions, delimited between non-escaped slashes).
     variable_references: set[VariableReference] = {
@@ -123,7 +123,7 @@ def extract_jsonata_variable_references(
 def encode_jsonata_variable_declarations(
     bindings: dict[VariableReference, Any],
 ) -> VariableDeclarations:
-    declarations_parts: List[str] = list()
+    declarations_parts: list[str] = list()
     for variable_reference, value in bindings.items():
         if isinstance(value, str):
             value_str_lit = f'"{value}"'
@@ -142,7 +142,7 @@ def encode_jsonata_variable_declarations(
 
 def compose_jsonata_expression(
     final_jsonata_expression: JSONataExpression,
-    variable_declarations_list: List[VariableDeclarations],
+    variable_declarations_list: list[VariableDeclarations],
 ) -> JSONataExpression:
     variable_declarations = "".join(variable_declarations_list)
     expression = "".join(

--- a/moto/stepfunctions/parser/asl/parse/asl_parser.py
+++ b/moto/stepfunctions/parser/asl/parse/asl_parser.py
@@ -1,5 +1,5 @@
 import abc
-from typing import Final, List
+from typing import Final
 
 from antlr4 import CommonTokenStream, InputStream, ParserRuleContext
 from antlr4.error.ErrorListener import ErrorListener
@@ -11,7 +11,7 @@ from moto.stepfunctions.parser.asl.parse.preprocessor import Preprocessor
 
 
 class SyntaxErrorListener(ErrorListener):
-    errors: Final[List[str]]
+    errors: Final[list[str]]
 
     def __init__(self):
         super().__init__()
@@ -30,9 +30,9 @@ class SyntaxErrorListener(ErrorListener):
 
 
 class ASLParserException(Exception):
-    errors: Final[List[str]]
+    errors: Final[list[str]]
 
-    def __init__(self, errors: List[str]):
+    def __init__(self, errors: list[str]):
         self.errors = errors
 
     def __str__(self):

--- a/moto/stepfunctions/parser/asl/parse/intrinsic/preprocessor.py
+++ b/moto/stepfunctions/parser/asl/parse/intrinsic/preprocessor.py
@@ -1,5 +1,5 @@
 import re
-from typing import List, Optional
+from typing import Optional
 
 from antlr4.tree.Tree import ParseTree, TerminalNodeImpl
 
@@ -98,7 +98,7 @@ class Preprocessor(ASLIntrinsicParserVisitor):
     def visitFunc_arg_list(
         self, ctx: ASLIntrinsicParser.Func_arg_listContext
     ) -> ArgumentList:
-        arguments: List[Argument] = list()
+        arguments: list[Argument] = list()
         for child in ctx.children:
             cmp: Optional[Component] = self.visit(child)
             if isinstance(cmp, Argument):

--- a/moto/stepfunctions/parser/asl/parse/preprocessor.py
+++ b/moto/stepfunctions/parser/asl/parse/preprocessor.py
@@ -1,6 +1,6 @@
 import json
 import logging
-from typing import Any, List, Optional
+from typing import Any, Optional
 
 from antlr4 import ParserRuleContext
 from antlr4.tree.Tree import ParseTree, TerminalNodeImpl
@@ -336,7 +336,7 @@ LOG = logging.getLogger(__name__)
 
 
 class Preprocessor(ASLParserVisitor):
-    _query_language_per_scope: List[QueryLanguage] = list()
+    _query_language_per_scope: list[QueryLanguage] = list()
 
     def _get_current_query_language(self) -> QueryLanguage:
         return self._query_language_per_scope[-1]
@@ -557,7 +557,7 @@ class Preprocessor(ASLParserVisitor):
         return ResultSelector(payload_tmpl=payload_tmpl)
 
     def visitBranches_decl(self, ctx: ASLParser.Branches_declContext) -> BranchesDecl:
-        programs: List[Program] = []
+        programs: list[Program] = []
         for child in ctx.children:
             cmp: Optional[Component] = self.visit(child)
             if isinstance(cmp, Program):
@@ -706,7 +706,7 @@ class Preprocessor(ASLParserVisitor):
         self, ctx: ASLParser.Comparison_compositeContext
     ) -> ComparisonComposite:
         choice_op: ComparisonComposite.ChoiceOp = self.visit(ctx.choice_operator())
-        rules: List[ChoiceRule] = list()
+        rules: list[ChoiceRule] = list()
         for child in ctx.children[1:]:
             cmp: Optional[Component] = self.visit(child)
             if not cmp:
@@ -795,7 +795,7 @@ class Preprocessor(ASLParserVisitor):
             )
 
     def visitChoices_decl(self, ctx: ASLParser.Choices_declContext) -> ChoicesDecl:
-        rules: List[ChoiceRule] = list()
+        rules: list[ChoiceRule] = list()
         for child in ctx.children:
             cmp: Optional[Component] = self.visit(child)
             if not cmp:
@@ -1044,7 +1044,7 @@ class Preprocessor(ASLParserVisitor):
     def visitCsv_headers_decl(
         self, ctx: ASLParser.Csv_headers_declContext
     ) -> CSVHeaders:
-        csv_headers: List[str] = list()
+        csv_headers: list[str] = list()
         for child in ctx.children[3:-1]:
             maybe_str = is_production(
                 pt=child, rule_index=ASLParser.RULE_string_literal
@@ -1166,7 +1166,7 @@ class Preprocessor(ASLParserVisitor):
         return ResultWriter(resource=resource, parargs=parargs)
 
     def visitRetry_decl(self, ctx: ASLParser.Retry_declContext) -> RetryDecl:
-        retriers: List[RetrierDecl] = list()
+        retriers: list[RetrierDecl] = list()
         for child in ctx.children:
             cmp: Optional[Component] = self.visit(child)
             if isinstance(cmp, RetrierDecl):
@@ -1186,7 +1186,7 @@ class Preprocessor(ASLParserVisitor):
     def visitError_equals_decl(
         self, ctx: ASLParser.Error_equals_declContext
     ) -> ErrorEqualsDecl:
-        error_names: List[ErrorName] = list()
+        error_names: list[ErrorName] = list()
         for child in ctx.children:
             cmp = self.visit(child)
             if isinstance(cmp, ErrorName):
@@ -1246,7 +1246,7 @@ class Preprocessor(ASLParserVisitor):
         return JitterStrategyDecl(jitter_strategy=jitter_strategy)
 
     def visitCatch_decl(self, ctx: ASLParser.Catch_declContext) -> CatchDecl:
-        catchers: List[CatcherDecl] = list()
+        catchers: list[CatcherDecl] = list()
         for child in ctx.children:
             cmp: Optional[Component] = self.visit(child)
             if isinstance(cmp, CatcherDecl):
@@ -1328,7 +1328,7 @@ class Preprocessor(ASLParserVisitor):
     def visitPayload_arr_decl(
         self, ctx: ASLParser.Payload_arr_declContext
     ) -> PayloadArr:
-        payload_values: List[PayloadValue] = list()
+        payload_values: list[PayloadValue] = list()
         for child in ctx.children:
             cmp: Optional[Component] = self.visit(child)
             if isinstance(cmp, PayloadValue):
@@ -1338,7 +1338,7 @@ class Preprocessor(ASLParserVisitor):
     def visitPayload_tmpl_decl(
         self, ctx: ASLParser.Payload_tmpl_declContext
     ) -> PayloadTmpl:
-        payload_bindings: List[PayloadBinding] = list()
+        payload_bindings: list[PayloadBinding] = list()
         for child in ctx.children:
             cmp: Optional[Component] = self.visit(child)
             if isinstance(cmp, PayloadBinding):
@@ -1444,7 +1444,7 @@ class Preprocessor(ASLParserVisitor):
     def visitAssign_template_value_array(
         self, ctx: ASLParser.Assign_template_value_arrayContext
     ) -> AssignTemplateValueArray:
-        values: List[AssignTemplateValue] = list()
+        values: list[AssignTemplateValue] = list()
         for child in ctx.children:
             cmp: Optional[Component] = self.visit(child)
             if isinstance(cmp, AssignTemplateValue):
@@ -1454,7 +1454,7 @@ class Preprocessor(ASLParserVisitor):
     def visitAssign_template_value_object(
         self, ctx: ASLParser.Assign_template_value_objectContext
     ) -> AssignTemplateValueObject:
-        bindings: List[AssignTemplateBinding] = list()
+        bindings: list[AssignTemplateBinding] = list()
         for child in ctx.children:
             cmp: Optional[Component] = self.visit(child)
             if isinstance(cmp, AssignTemplateBinding):
@@ -1493,7 +1493,7 @@ class Preprocessor(ASLParserVisitor):
     def visitAssign_decl_body(
         self, ctx: ASLParser.Assign_decl_bodyContext
     ) -> list[AssignDeclBinding]:
-        bindings: List[AssignDeclBinding] = list()
+        bindings: list[AssignDeclBinding] = list()
         for child in ctx.children:
             cmp: Optional[Component] = self.visit(child)
             if isinstance(cmp, AssignDeclBinding):
@@ -1501,7 +1501,7 @@ class Preprocessor(ASLParserVisitor):
         return bindings
 
     def visitAssign_decl(self, ctx: ASLParser.Assign_declContext) -> AssignDecl:
-        declaration_bindings: List[AssignDeclBinding] = self.visit(
+        declaration_bindings: list[AssignDeclBinding] = self.visit(
             ctx.assign_decl_body()
         )
         return AssignDecl(declaration_bindings=declaration_bindings)
@@ -1550,7 +1550,7 @@ class Preprocessor(ASLParserVisitor):
     def visitJsonata_template_value_array(
         self, ctx: ASLParser.Jsonata_template_value_arrayContext
     ) -> JSONataTemplateValueArray:
-        values: List[JSONataTemplateValue] = list()
+        values: list[JSONataTemplateValue] = list()
         for child in ctx.children:
             cmp: Optional[Component] = self.visit(child)
             if isinstance(cmp, JSONataTemplateValue):
@@ -1560,7 +1560,7 @@ class Preprocessor(ASLParserVisitor):
     def visitJsonata_template_value_object(
         self, ctx: ASLParser.Jsonata_template_value_objectContext
     ) -> JSONataTemplateValueObject:
-        bindings: List[JSONataTemplateBinding] = list()
+        bindings: list[JSONataTemplateBinding] = list()
         for child in ctx.children:
             cmp: Optional[Component] = self.visit(child)
             if isinstance(cmp, JSONataTemplateBinding):

--- a/moto/stepfunctions/parser/asl/static_analyser/variable_references_static_analyser.py
+++ b/moto/stepfunctions/parser/asl/static_analyser/variable_references_static_analyser.py
@@ -1,5 +1,5 @@
 from collections import OrderedDict
-from typing import Final, List
+from typing import Final
 
 from moto.stepfunctions.parser.api import (
     StateName,
@@ -25,7 +25,7 @@ class VariableReferencesStaticAnalyser(StaticAnalyser):
         analyser.analyse(definition=definition)
         return analyser.get_variable_references()
 
-    _fringe_state_names: Final[List[StateName]]
+    _fringe_state_names: Final[list[StateName]]
     _variable_references: Final[VariableReferences]
 
     def __init__(self):

--- a/moto/stepfunctions/parser/asl/utils/encoding.py
+++ b/moto/stepfunctions/parser/asl/utils/encoding.py
@@ -1,7 +1,7 @@
 import datetime
 import json
 from json import JSONEncoder
-from typing import Any, Optional, Tuple
+from typing import Any, Optional
 
 
 class _DateTimeEncoder(JSONEncoder):
@@ -12,5 +12,5 @@ class _DateTimeEncoder(JSONEncoder):
             return str(o)
 
 
-def to_json_str(obj: Any, separators: Optional[Tuple[str, str]] = None) -> str:
+def to_json_str(obj: Any, separators: Optional[tuple[str, str]] = None) -> str:
     return json.dumps(obj, cls=_DateTimeEncoder, separators=separators)

--- a/moto/stepfunctions/parser/backend/execution.py
+++ b/moto/stepfunctions/parser/backend/execution.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import datetime
 import json
 import logging
-from typing import Dict, Optional
+from typing import Optional
 
 from moto.stepfunctions.parser.api import (
     Arn,
@@ -119,7 +119,7 @@ class Execution:
 
     exec_worker: Optional[ExecutionWorker]
 
-    _activity_store: Dict[Arn, Activity]
+    _activity_store: dict[Arn, Activity]
 
     def __init__(
         self,
@@ -132,7 +132,7 @@ class Execution:
         state_machine: StateMachineInstance,
         start_date: Timestamp,
         cloud_watch_logging_session: Optional[CloudWatchLoggingSession],
-        activity_store: Dict[Arn, Activity],
+        activity_store: dict[Arn, Activity],
         input_data: Optional[json] = None,
         trace_header: Optional[TraceHeader] = None,
     ):

--- a/moto/stepfunctions/parser/models.py
+++ b/moto/stepfunctions/parser/models.py
@@ -1,7 +1,7 @@
 import copy
 import datetime
 import json
-from typing import Any, Dict, List, Optional
+from typing import Any, Optional
 
 from moto.core.common_models import BackendDict
 from moto.stepfunctions.models import StateMachine, StepFunctionBackend
@@ -80,7 +80,7 @@ class StepFunctionsParserBackend(StepFunctionBackend):
         name: str,
         definition: str,
         roleArn: str,
-        tags: Optional[List[Dict[str, str]]] = None,
+        tags: Optional[list[dict[str, str]]] = None,
         publish: Optional[bool] = None,
         loggingConfiguration: Optional[LoggingConfiguration] = None,
         tracingConfiguration: Optional[TracingConfiguration] = None,
@@ -246,7 +246,7 @@ class StepFunctionsParserBackend(StepFunctionBackend):
             version_description=version_description,
         )
 
-    def describe_map_run(self, map_run_arn: str) -> Dict[str, Any]:
+    def describe_map_run(self, map_run_arn: str) -> dict[str, Any]:
         for execution in self._get_executions():
             map_run_record: Optional[MapRunRecord] = (
                 execution.exec_worker.env.map_run_record_pool_manager.get(map_run_arn)
@@ -255,12 +255,12 @@ class StepFunctionsParserBackend(StepFunctionBackend):
                 return map_run_record.describe()
         raise ResourceNotFound()
 
-    def list_map_runs(self, execution_arn: str) -> Dict[str, Any]:
+    def list_map_runs(self, execution_arn: str) -> dict[str, Any]:
         """
         Pagination is not yet implemented
         """
         execution = self.describe_execution(execution_arn=execution_arn)
-        map_run_records: List[MapRunRecord] = (
+        map_run_records: list[MapRunRecord] = (
             execution.exec_worker.env.map_run_record_pool_manager.get_all()
         )
         return dict(

--- a/moto/stepfunctions/parser/resource_providers/aws_stepfunctions_activity.py
+++ b/moto/stepfunctions/parser/resource_providers/aws_stepfunctions_activity.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import List, Optional, TypedDict
+from typing import Optional, TypedDict
 
 import localstack.services.cloudformation.provider_utils as util
 from localstack.services.cloudformation.resource_provider import (
@@ -16,7 +16,7 @@ from localstack.services.cloudformation.resource_provider import (
 class StepFunctionsActivityProperties(TypedDict):
     Name: Optional[str]
     Arn: Optional[str]
-    Tags: Optional[List[TagsEntry]]
+    Tags: Optional[list[TagsEntry]]
 
 
 class TagsEntry(TypedDict):

--- a/moto/stepfunctions/parser/resource_providers/aws_stepfunctions_activity_plugin.py
+++ b/moto/stepfunctions/parser/resource_providers/aws_stepfunctions_activity_plugin.py
@@ -1,4 +1,4 @@
-from typing import Optional, Type
+from typing import Optional
 
 from localstack.services.cloudformation.resource_provider import (
     CloudFormationResourceProviderPlugin,
@@ -10,7 +10,7 @@ class StepFunctionsActivityProviderPlugin(CloudFormationResourceProviderPlugin):
     name = "AWS::StepFunctions::Activity"
 
     def __init__(self):
-        self.factory: Optional[Type[ResourceProvider]] = None
+        self.factory: Optional[type[ResourceProvider]] = None
 
     def load(self):
         from localstack.services.stepfunctions.resource_providers.aws_stepfunctions_activity import (

--- a/moto/stepfunctions/parser/resource_providers/aws_stepfunctions_statemachine.py
+++ b/moto/stepfunctions/parser/resource_providers/aws_stepfunctions_statemachine.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import json
 import re
 from pathlib import Path
-from typing import Dict, List, Optional, TypedDict
+from typing import Optional, TypedDict
 
 import localstack.services.cloudformation.provider_utils as util
 from localstack.services.cloudformation.resource_provider import (
@@ -29,7 +29,7 @@ class StepFunctionsStateMachineProperties(TypedDict):
     StateMachineName: Optional[str]
     StateMachineRevisionId: Optional[str]
     StateMachineType: Optional[str]
-    Tags: Optional[List[TagsEntry]]
+    Tags: Optional[list[TagsEntry]]
     TracingConfiguration: Optional[TracingConfiguration]
     EncryptionConfiguration: Optional[EncryptionConfiguration]
 
@@ -43,7 +43,7 @@ class LogDestination(TypedDict):
 
 
 class LoggingConfiguration(TypedDict):
-    Destinations: Optional[List[LogDestination]]
+    Destinations: Optional[list[LogDestination]]
     IncludeExecutionData: Optional[bool]
     Level: Optional[str]
 
@@ -230,7 +230,7 @@ class StepFunctionsStateMachineProvider(
         )
 
 
-def _apply_substitutions(definition: str, substitutions: Dict[str, str]) -> str:
+def _apply_substitutions(definition: str, substitutions: dict[str, str]) -> str:
     substitution_regex = re.compile(
         "\\${[a-zA-Z0-9_]+}"
     )  # might be a bit too strict in some cases

--- a/moto/stepfunctions/parser/resource_providers/aws_stepfunctions_statemachine_plugin.py
+++ b/moto/stepfunctions/parser/resource_providers/aws_stepfunctions_statemachine_plugin.py
@@ -1,4 +1,4 @@
-from typing import Optional, Type
+from typing import Optional
 
 from localstack.services.cloudformation.resource_provider import (
     CloudFormationResourceProviderPlugin,
@@ -10,7 +10,7 @@ class StepFunctionsStateMachineProviderPlugin(CloudFormationResourceProviderPlug
     name = "AWS::StepFunctions::StateMachine"
 
     def __init__(self):
-        self.factory: Optional[Type[ResourceProvider]] = None
+        self.factory: Optional[type[ResourceProvider]] = None
 
     def load(self):
         from localstack.services.stepfunctions.resource_providers.aws_stepfunctions_statemachine import (

--- a/moto/stepfunctions/parser/stepfunctions_utils.py
+++ b/moto/stepfunctions/parser/stepfunctions_utils.py
@@ -1,6 +1,5 @@
 import base64
 import logging
-from typing import Tuple
 
 from moto.stepfunctions.parser.api import ValidationException
 from moto.stepfunctions.parser.utils import to_bytes, to_str
@@ -26,7 +25,7 @@ def assert_pagination_parameters_valid(
     next_token: str,
     next_token_length_limit: int = 1024,
     max_results_upper_limit: int = 1000,
-) -> Tuple[int, str]:
+) -> tuple[int, str]:
     validation_errors = []
 
     if isinstance(max_results, int) and max_results > max_results_upper_limit:

--- a/moto/stepfunctions/parser/utils.py
+++ b/moto/stepfunctions/parser/utils.py
@@ -1,6 +1,6 @@
 import base64
 import re
-from typing import Dict, List, Set, Type, Union
+from typing import Union
 from uuid import uuid4
 
 TMP_THREADS = []
@@ -10,7 +10,7 @@ def is_list_or_tuple(obj) -> bool:
     return isinstance(obj, (list, tuple))
 
 
-def select_attributes(obj: Dict, attributes: List[str]) -> Dict:
+def select_attributes(obj: dict, attributes: list[str]) -> dict:
     """Select a subset of attributes from the given dict (returns a copy)"""
     attributes = attributes if is_list_or_tuple(attributes) else [attributes]
     return {k: v for k, v in obj.items() if k in attributes}
@@ -20,7 +20,7 @@ class SubtypesInstanceManager:
     """Simple instance manager base class that scans the subclasses of a base type for concrete named
     implementations, and lazily creates and returns (singleton) instances on demand."""
 
-    _instances: Dict[str, "SubtypesInstanceManager"]
+    _instances: dict[str, "SubtypesInstanceManager"]
 
     @classmethod
     def get(cls, subtype_name: str, raise_if_missing: bool = False):
@@ -37,7 +37,7 @@ class SubtypesInstanceManager:
         return instance
 
     @classmethod
-    def instances(cls) -> Dict[str, "SubtypesInstanceManager"]:
+    def instances(cls) -> dict[str, "SubtypesInstanceManager"]:
         base_type = cls.get_base_type()
         if not hasattr(base_type, "_instances"):
             base_type._instances = {}
@@ -49,7 +49,7 @@ class SubtypesInstanceManager:
         raise NotImplementedError
 
     @classmethod
-    def get_base_type(cls) -> Type:
+    def get_base_type(cls) -> type:
         """Get the base class for which instances are being managed - can be customized by subtypes."""
         return cls
 
@@ -80,7 +80,7 @@ def snake_to_camel_case(string: str, capitalize_first: bool = True) -> str:
     return "".join(components)
 
 
-def get_all_subclasses(clazz: Type) -> Set[Type]:
+def get_all_subclasses(clazz: type) -> set[type]:
     """Recursively get all subclasses of the given class."""
     result = set()
     subs = clazz.__subclasses__()

--- a/moto/stepfunctions/utils.py
+++ b/moto/stepfunctions/utils.py
@@ -1,5 +1,3 @@
-from typing import Dict, List
-
 PAGINATION_MODEL = {
     "list_executions": {
         "input_token": "next_token",
@@ -22,9 +20,9 @@ PAGINATION_MODEL = {
 }
 
 
-def cfn_to_api_tags(cfn_tags_entry: List[Dict[str, str]]) -> List[Dict[str, str]]:
+def cfn_to_api_tags(cfn_tags_entry: list[dict[str, str]]) -> list[dict[str, str]]:
     return [{k.lower(): v for k, v in d.items()} for d in cfn_tags_entry]
 
 
-def api_to_cfn_tags(api_tags: List[Dict[str, str]]) -> List[Dict[str, str]]:
+def api_to_cfn_tags(api_tags: list[dict[str, str]]) -> list[dict[str, str]]:
     return [{k.capitalize(): v for k, v in d.items()} for d in api_tags]

--- a/moto/sts/models.py
+++ b/moto/sts/models.py
@@ -1,7 +1,7 @@
 import datetime
 import re
 from base64 import b64decode
-from typing import Any, List, Optional, Tuple
+from typing import Any, Optional
 
 import xmltodict
 
@@ -69,7 +69,7 @@ class AssumedRole(BaseModel):
 class STSBackend(BaseBackend):
     def __init__(self, region_name: str, account_id: str):
         super().__init__(region_name, account_id)
-        self.assumed_roles: List[AssumedRole] = []
+        self.assumed_roles: list[AssumedRole] = []
 
     def get_session_token(self, duration: int) -> Token:
         return Token(duration=duration)
@@ -167,7 +167,7 @@ class STSBackend(BaseBackend):
 
     def get_caller_identity(
         self, access_key_id: str, region: str
-    ) -> Tuple[str, str, str]:
+    ) -> tuple[str, str, str]:
         assumed_role = self.get_assumed_role_from_access_key(access_key_id)
         if assumed_role:
             return assumed_role.user_id, assumed_role.arn, assumed_role.account_id
@@ -183,7 +183,7 @@ class STSBackend(BaseBackend):
         arn = f"arn:{partition}:sts::{self.account_id}:user/moto"
         return user_id, arn, self.account_id
 
-    def _create_access_key(self, role: str) -> Tuple[str, AccessKey]:
+    def _create_access_key(self, role: str) -> tuple[str, AccessKey]:
         account_id_match = re.search(ARN_PARTITION_REGEX + r":iam::([0-9]+).+", role)
         if account_id_match:
             account_id = account_id_match.group(2)

--- a/moto/support/models.py
+++ b/moto/support/models.py
@@ -1,5 +1,5 @@
 import datetime
-from typing import Any, Dict, List, Optional
+from typing import Any, Optional
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.moto_api._internal import mock_random as random
@@ -63,10 +63,10 @@ class SupportCase(ManagedState):
 class SupportBackend(BaseBackend):
     def __init__(self, region_name: str, account_id: str):
         super().__init__(region_name, account_id)
-        self.check_status: Dict[str, str] = {}
-        self.cases: Dict[str, SupportCase] = {}
+        self.check_status: dict[str, str] = {}
+        self.cases: dict[str, SupportCase] = {}
 
-    def describe_trusted_advisor_checks(self) -> List[Dict[str, Any]]:
+    def describe_trusted_advisor_checks(self) -> list[dict[str, Any]]:
         """
         The Language-parameter is not yet implemented
         """
@@ -74,7 +74,7 @@ class SupportBackend(BaseBackend):
         checks = ADVISOR_CHECKS["checks"]
         return checks
 
-    def refresh_trusted_advisor_check(self, check_id: str) -> Dict[str, Any]:
+    def refresh_trusted_advisor_check(self, check_id: str) -> dict[str, Any]:
         self.advance_check_status(check_id)
         return {
             "status": {
@@ -131,7 +131,7 @@ class SupportBackend(BaseBackend):
         elif self.cases[case_id].severity_code == "critical":
             self.cases[case_id].severity_code = "low"
 
-    def resolve_case(self, case_id: str) -> Dict[str, Optional[str]]:
+    def resolve_case(self, case_id: str) -> dict[str, Optional[str]]:
         self.advance_case_status(case_id)
 
         return {
@@ -147,10 +147,10 @@ class SupportBackend(BaseBackend):
         severity_code: str,
         category_code: str,
         communication_body: str,
-        cc_email_addresses: List[str],
+        cc_email_addresses: list[str],
         language: str,
         attachment_set_id: str,
-    ) -> Dict[str, str]:
+    ) -> dict[str, str]:
         """
         The IssueType-parameter is not yet implemented
         """
@@ -176,11 +176,11 @@ class SupportBackend(BaseBackend):
 
     def describe_cases(
         self,
-        case_id_list: List[str],
+        case_id_list: list[str],
         include_resolved_cases: bool,
         next_token: Optional[str],
         include_communications: bool,
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         """
         The following parameters have not yet been implemented:
         DisplayID, AfterTime, BeforeTime, MaxResults, Language

--- a/moto/swf/exceptions.py
+++ b/moto/swf/exceptions.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, Dict, List, Optional
+from typing import TYPE_CHECKING, Any, Optional
 
 from moto.core.exceptions import JsonRESTError
 
@@ -83,7 +83,7 @@ class SWFValidationException(SWFClientError):
 
 
 class SWFDecisionValidationException(SWFClientError):
-    def __init__(self, problems: List[Dict[str, Any]]):
+    def __init__(self, problems: list[dict[str, Any]]):
         # messages
         messages = []
         for pb in problems:

--- a/moto/swf/models/__init__.py
+++ b/moto/swf/models/__init__.py
@@ -1,5 +1,5 @@
 from time import sleep
-from typing import Any, Dict, List, Optional
+from typing import Any, Optional
 
 from moto.core.base_backend import BackendDict, BaseBackend
 
@@ -28,7 +28,7 @@ KNOWN_SWF_TYPES = {"activity": ActivityType, "workflow": WorkflowType}
 class SWFBackend(BaseBackend):
     def __init__(self, region_name: str, account_id: str):
         super().__init__(region_name, account_id)
-        self.domains: List[Domain] = []
+        self.domains: list[Domain] = []
 
     def _get_domain(self, name: str, ignore_empty: bool = False) -> Domain:
         matching = [domain for domain in self.domains if domain.name == name]
@@ -45,7 +45,7 @@ class SWFBackend(BaseBackend):
 
     def list_domains(
         self, status: str, reverse_order: Optional[bool] = None
-    ) -> List[Domain]:
+    ) -> list[Domain]:
         domains = [domain for domain in self.domains if domain.status == status]
         domains = sorted(domains, key=lambda domain: domain.name)
         if reverse_order:
@@ -56,9 +56,9 @@ class SWFBackend(BaseBackend):
         self,
         domain_name: str,
         maximum_page_size: int,
-        tag_filter: Dict[str, str],
+        tag_filter: dict[str, str],
         reverse_order: bool,
-    ) -> List[WorkflowExecution]:
+    ) -> list[WorkflowExecution]:
         self._process_timeouts()
         domain = self._get_domain(domain_name)
         if domain.status == "DEPRECATED":
@@ -78,11 +78,11 @@ class SWFBackend(BaseBackend):
     def list_closed_workflow_executions(
         self,
         domain_name: str,
-        tag_filter: Dict[str, str],
-        close_status_filter: Dict[str, str],
+        tag_filter: dict[str, str],
+        close_status_filter: dict[str, str],
         maximum_page_size: int,
         reverse_order: bool,
-    ) -> List[WorkflowExecution]:
+    ) -> list[WorkflowExecution]:
         self._process_timeouts()
         domain = self._get_domain(domain_name)
         if domain.status == "DEPRECATED":
@@ -142,9 +142,9 @@ class SWFBackend(BaseBackend):
         domain_name: str,
         status: str,
         reverse_order: Optional[bool] = None,
-    ) -> List[GenericType]:
+    ) -> list[GenericType]:
         domain = self._get_domain(domain_name)
-        _types: List[GenericType] = domain.find_types(kind, status)
+        _types: list[GenericType] = domain.find_types(kind, status)
         _types = sorted(_types, key=lambda domain: domain.name)
         if reverse_order:
             _types = reversed(_types)  # type: ignore
@@ -191,7 +191,7 @@ class SWFBackend(BaseBackend):
         workflow_id: str,
         workflow_name: str,
         workflow_version: str,
-        tag_list: Optional[Dict[str, str]] = None,
+        tag_list: Optional[dict[str, str]] = None,
         workflow_input: Optional[str] = None,
         **kwargs: Any,
     ) -> WorkflowExecution:
@@ -223,7 +223,7 @@ class SWFBackend(BaseBackend):
         return domain.get_workflow_execution(workflow_id, run_id=run_id)
 
     def poll_for_decision_task(
-        self, domain_name: str, task_list: List[str], identity: Optional[str] = None
+        self, domain_name: str, task_list: list[str], identity: Optional[str] = None
     ) -> Optional[DecisionTask]:
         # process timeouts on all objects
         self._process_timeouts()
@@ -277,7 +277,7 @@ class SWFBackend(BaseBackend):
             return None
 
     def count_pending_decision_tasks(
-        self, domain_name: str, task_list: List[str]
+        self, domain_name: str, task_list: list[str]
     ) -> int:
         # process timeouts on all objects
         self._process_timeouts()
@@ -291,7 +291,7 @@ class SWFBackend(BaseBackend):
     def respond_decision_task_completed(
         self,
         task_token: str,
-        decisions: Optional[List[Dict[str, Any]]] = None,
+        decisions: Optional[list[dict[str, Any]]] = None,
         execution_context: Optional[str] = None,
     ) -> None:
         # process timeouts on all objects
@@ -345,7 +345,7 @@ class SWFBackend(BaseBackend):
             )
 
     def poll_for_activity_task(
-        self, domain_name: str, task_list: List[str], identity: Optional[str] = None
+        self, domain_name: str, task_list: list[str], identity: Optional[str] = None
     ) -> Optional[ActivityTask]:
         # process timeouts on all objects
         self._process_timeouts()
@@ -381,7 +381,7 @@ class SWFBackend(BaseBackend):
             return None
 
     def count_pending_activity_tasks(
-        self, domain_name: str, task_list: List[str]
+        self, domain_name: str, task_list: list[str]
     ) -> int:
         # process timeouts on all objects
         self._process_timeouts()

--- a/moto/swf/models/activity_task.py
+++ b/moto/swf/models/activity_task.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, Dict, Optional
+from typing import TYPE_CHECKING, Any, Optional
 
 from moto.core.common_models import BaseModel
 from moto.core.utils import unix_time, utcnow
@@ -19,7 +19,7 @@ class ActivityTask(BaseModel):
         activity_type: "ActivityType",
         scheduled_event_id: int,
         workflow_execution: "WorkflowExecution",
-        timeouts: Dict[str, Any],
+        timeouts: dict[str, Any],
         workflow_input: Any = None,
     ):
         self.activity_id = activity_id
@@ -46,8 +46,8 @@ class ActivityTask(BaseModel):
     def open(self) -> bool:
         return self.state in ["SCHEDULED", "STARTED"]
 
-    def to_full_dict(self) -> Dict[str, Any]:
-        hsh: Dict[str, Any] = {
+    def to_full_dict(self) -> dict[str, Any]:
+        hsh: dict[str, Any] = {
             "activityId": self.activity_id,
             "activityType": self.activity_type.to_short_dict(),
             "taskToken": self.task_token,

--- a/moto/swf/models/activity_type.py
+++ b/moto/swf/models/activity_type.py
@@ -1,11 +1,9 @@
-from typing import List
-
 from .generic_type import GenericType
 
 
 class ActivityType(GenericType):
     @property
-    def _configuration_keys(self) -> List[str]:
+    def _configuration_keys(self) -> list[str]:
         return [
             "defaultTaskHeartbeatTimeout",
             "defaultTaskScheduleToCloseTimeout",

--- a/moto/swf/models/decision_task.py
+++ b/moto/swf/models/decision_task.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, Dict, Optional
+from typing import TYPE_CHECKING, Any, Optional
 
 from moto.core.common_models import BaseModel
 from moto.core.utils import unix_time, utcnow
@@ -39,9 +39,9 @@ class DecisionTask(BaseModel):
         if not self.workflow_execution.open:
             raise SWFWorkflowExecutionClosedError()
 
-    def to_full_dict(self, reverse_order: bool = False) -> Dict[str, Any]:
+    def to_full_dict(self, reverse_order: bool = False) -> dict[str, Any]:
         events = self.workflow_execution.events(reverse_order=reverse_order)
-        hsh: Dict[str, Any] = {
+        hsh: dict[str, Any] = {
             "events": [evt.to_dict() for evt in events],
             "taskToken": self.task_token,
             "workflowExecution": self.workflow_execution.to_short_dict(),

--- a/moto/swf/models/domain.py
+++ b/moto/swf/models/domain.py
@@ -1,5 +1,5 @@
 from collections import defaultdict
-from typing import TYPE_CHECKING, Any, Dict, List, Optional
+from typing import TYPE_CHECKING, Any, Optional
 
 from moto.core.common_models import BaseModel
 from moto.utilities.utils import get_partition
@@ -31,7 +31,7 @@ class Domain(BaseModel):
         self.region_name = region_name
         self.description = description
         self.status = "REGISTERED"
-        self.types: Dict[str, Dict[str, Dict[str, GenericType]]] = {
+        self.types: dict[str, dict[str, dict[str, GenericType]]] = {
             "activity": defaultdict(dict),
             "workflow": defaultdict(dict),
         }
@@ -40,14 +40,14 @@ class Domain(BaseModel):
         # that against SWF API) ; hence the storage method as a dict
         # of "workflow_id (client determined)" => WorkflowExecution()
         # here.
-        self.workflow_executions: List["WorkflowExecution"] = []
-        self.activity_task_lists: Dict[List[str], List["ActivityTask"]] = {}
-        self.decision_task_lists: Dict[str, List["DecisionTask"]] = {}
+        self.workflow_executions: list[WorkflowExecution] = []
+        self.activity_task_lists: dict[list[str], list[ActivityTask]] = {}
+        self.decision_task_lists: dict[str, list[DecisionTask]] = {}
 
     def __repr__(self) -> str:
         return f"Domain(name: {self.name}, status: {self.status})"
 
-    def to_short_dict(self) -> Dict[str, str]:
+    def to_short_dict(self) -> dict[str, str]:
         hsh = {"name": self.name, "status": self.status}
         if self.description:
             hsh["description"] = self.description
@@ -56,7 +56,7 @@ class Domain(BaseModel):
         )
         return hsh
 
-    def to_full_dict(self) -> Dict[str, Any]:
+    def to_full_dict(self) -> dict[str, Any]:
         return {
             "domainInfo": self.to_short_dict(),
             "configuration": {"workflowExecutionRetentionPeriodInDays": self.retention},
@@ -77,7 +77,7 @@ class Domain(BaseModel):
     def add_type(self, _type: "TGenericType") -> None:
         self.types[_type.kind][_type.name][_type.version] = _type
 
-    def find_types(self, kind: str, status: str) -> List["GenericType"]:
+    def find_types(self, kind: str, status: str) -> list["GenericType"]:
         _all = []
         for family in self.types[kind].values():
             for _type in family.values():
@@ -129,15 +129,15 @@ class Domain(BaseModel):
         return wfe
 
     def add_to_activity_task_list(
-        self, task_list: List[str], obj: "ActivityTask"
+        self, task_list: list[str], obj: "ActivityTask"
     ) -> None:
         if task_list not in self.activity_task_lists:
             self.activity_task_lists[task_list] = []
         self.activity_task_lists[task_list].append(obj)
 
     @property
-    def activity_tasks(self) -> List["ActivityTask"]:
-        _all: List["ActivityTask"] = []
+    def activity_tasks(self) -> list["ActivityTask"]:
+        _all: list[ActivityTask] = []
         for tasks in self.activity_task_lists.values():
             _all += tasks
         return _all
@@ -148,8 +148,8 @@ class Domain(BaseModel):
         self.decision_task_lists[task_list].append(obj)
 
     @property
-    def decision_tasks(self) -> List["DecisionTask"]:
-        _all: List["DecisionTask"] = []
+    def decision_tasks(self) -> list["DecisionTask"]:
+        _all: list[DecisionTask] = []
         for tasks in self.decision_task_lists.values():
             _all += tasks
         return _all

--- a/moto/swf/models/generic_type.py
+++ b/moto/swf/models/generic_type.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, TypeVar
+from typing import Any, TypeVar
 
 from moto.core.common_models import BaseModel
 from moto.core.utils import camelcase_to_underscores
@@ -31,14 +31,14 @@ class GenericType(BaseModel):
         raise NotImplementedError()
 
     @property
-    def _configuration_keys(self) -> List[str]:
+    def _configuration_keys(self) -> list[str]:
         raise NotImplementedError()
 
-    def to_short_dict(self) -> Dict[str, str]:
+    def to_short_dict(self) -> dict[str, str]:
         return {"name": self.name, "version": self.version}
 
-    def to_medium_dict(self) -> Dict[str, Any]:
-        hsh: Dict[str, Any] = {
+    def to_medium_dict(self) -> dict[str, Any]:
+        hsh: dict[str, Any] = {
             f"{self.kind}Type": self.to_short_dict(),
             "creationDate": 1420066800,
             "status": self.status,
@@ -49,8 +49,8 @@ class GenericType(BaseModel):
             hsh["description"] = self.description
         return hsh
 
-    def to_full_dict(self) -> Dict[str, Any]:
-        hsh: Dict[str, Any] = {"typeInfo": self.to_medium_dict(), "configuration": {}}
+    def to_full_dict(self) -> dict[str, Any]:
+        hsh: dict[str, Any] = {"typeInfo": self.to_medium_dict(), "configuration": {}}
         if self.task_list:
             hsh["configuration"]["defaultTaskList"] = {"name": self.task_list}
         for key in self._configuration_keys:

--- a/moto/swf/models/history_event.py
+++ b/moto/swf/models/history_event.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Optional
+from typing import Any, Optional
 
 from moto.core.common_models import BaseModel
 from moto.core.utils import underscores_to_camelcase, unix_time
@@ -67,7 +67,7 @@ class HistoryEvent(BaseModel):
                     value = value.to_short_dict()
                 self.event_attributes[camel_key] = value
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         return {
             "eventId": self.event_id,
             "eventType": self.event_type,

--- a/moto/swf/models/workflow_type.py
+++ b/moto/swf/models/workflow_type.py
@@ -1,11 +1,9 @@
-from typing import List
-
 from .generic_type import GenericType
 
 
 class WorkflowType(GenericType):
     @property
-    def _configuration_keys(self) -> List[str]:
+    def _configuration_keys(self) -> list[str]:
         return [
             "defaultChildPolicy",
             "defaultExecutionStartToCloseTimeout",

--- a/moto/swf/responses.py
+++ b/moto/swf/responses.py
@@ -1,5 +1,5 @@
 import json
-from typing import Any, List
+from typing import Any
 
 from moto.core.responses import BaseResponse
 
@@ -64,7 +64,7 @@ class SWFResponse(BaseResponse):
         reverse_order = self._params.get("reverseOrder", None)
         self._check_string(domain_name)
         self._check_string(status)
-        types: List[GenericType] = self.swf_backend.list_types(
+        types: list[GenericType] = self.swf_backend.list_types(
             kind, domain_name, status, reverse_order=reverse_order
         )
         return json.dumps({"typeInfos": [_type.to_medium_dict() for _type in types]})

--- a/moto/synthetics/models.py
+++ b/moto/synthetics/models.py
@@ -2,7 +2,7 @@
 
 import datetime
 import uuid
-from typing import Dict, List, Optional
+from typing import Optional
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
@@ -17,20 +17,20 @@ class Canary(BaseModel):  # pylint: disable=too-many-instance-attributes,too-few
     def __init__(  # pylint: disable=too-many-arguments,too-many-positional-arguments,too-many-locals
         self,
         name: str,
-        code: Dict[str, object],
+        code: dict[str, object],
         artifact_s3_location: str,
         execution_role_arn: str,
-        schedule: Dict[str, object],
-        run_config: Dict[str, object],
+        schedule: dict[str, object],
+        run_config: dict[str, object],
         success_retention_period_in_days: int,
         failure_retention_period_in_days: int,
         runtime_version: str,
-        vpc_config: Optional[Dict[str, object]],
-        resources_to_replicate_tags: Optional[List[str]],
+        vpc_config: Optional[dict[str, object]],
+        resources_to_replicate_tags: Optional[list[str]],
         provisioned_resource_cleanup: Optional[str],
-        browser_configs: Optional[List[Dict[str, object]]],
-        tags: Optional[Dict[str, str]],
-        artifact_config: Optional[Dict[str, object]],
+        browser_configs: Optional[list[dict[str, object]]],
+        tags: Optional[dict[str, str]],
+        artifact_config: Optional[dict[str, object]],
     ):
         self.name = name
         self.id = str(uuid.uuid4())
@@ -58,7 +58,7 @@ class Canary(BaseModel):  # pylint: disable=too-many-instance-attributes,too-few
             "LastStopped": None,
         }
 
-    def to_dict(self) -> Dict[str, object]:
+    def to_dict(self) -> dict[str, object]:
         """
         Convert the Canary object to a dictionary representation.
         """
@@ -104,25 +104,25 @@ class SyntheticsBackend(BaseBackend):
         Initialize the SyntheticsBackend with region and account.
         """
         super().__init__(region_name, account_id)
-        self.canaries: Dict[str, Canary] = {}
+        self.canaries: dict[str, Canary] = {}
 
     def create_canary(  # pylint: disable=too-many-arguments,too-many-positional-arguments,too-many-locals
         self,
         name: str,
-        code: Dict[str, object],
+        code: dict[str, object],
         artifact_s3_location: str,
         execution_role_arn: str,
-        schedule: Dict[str, object],
-        run_config: Dict[str, object],
+        schedule: dict[str, object],
+        run_config: dict[str, object],
         success_retention_period_in_days: int,
         failure_retention_period_in_days: int,
         runtime_version: str,
-        vpc_config: Optional[Dict[str, object]],
-        resources_to_replicate_tags: Optional[List[str]],
+        vpc_config: Optional[dict[str, object]],
+        resources_to_replicate_tags: Optional[list[str]],
         provisioned_resource_cleanup: Optional[str],
-        browser_configs: Optional[List[Dict[str, object]]],
-        tags: Optional[Dict[str, str]],
-        artifact_config: Optional[Dict[str, object]],
+        browser_configs: Optional[list[dict[str, object]]],
+        tags: Optional[dict[str, str]],
+        artifact_config: Optional[dict[str, object]],
     ) -> Canary:
         canary = Canary(
             name,
@@ -155,7 +155,7 @@ class SyntheticsBackend(BaseBackend):
         self,
         next_token: Optional[str],  # pylint: disable=unused-argument
         max_results: Optional[int],  # pylint: disable=unused-argument
-        names: Optional[List[str]],
+        names: Optional[list[str]],
     ) -> tuple[list[Canary], None]:
         """
         Pagination is not yet supported
@@ -166,7 +166,7 @@ class SyntheticsBackend(BaseBackend):
 
         return canaries, None
 
-    def list_tags_for_resource(self, resource_arn: str) -> Dict[str, str]:
+    def list_tags_for_resource(self, resource_arn: str) -> dict[str, str]:
         # Simplified: assume resource_arn is actually the canary name
         canary = self.canaries.get(resource_arn)
         return canary.tags if canary else {}

--- a/moto/textract/models.py
+++ b/moto/textract/models.py
@@ -1,7 +1,7 @@
 import json
 import time
 from collections import defaultdict
-from typing import Any, Dict, List, Optional
+from typing import Any, Optional
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
@@ -21,17 +21,17 @@ class TextractJobStatus:
 
 class TextractJob(BaseModel):
     def __init__(
-        self, job: Dict[str, Any], notification_channel: Optional[Dict[str, str]] = None
+        self, job: dict[str, Any], notification_channel: Optional[dict[str, str]] = None
     ):
         self.job = job
         self.notification_channel = notification_channel
         self.job_id = str(mock_random.uuid4())
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         return self.job
 
     def send_completion_notification(
-        self, account_id: str, region_name: str, document_location: Dict[str, Any]
+        self, account_id: str, region_name: str, document_location: dict[str, Any]
     ) -> None:
         if not self.notification_channel:
             return
@@ -73,12 +73,12 @@ class TextractBackend(BaseBackend):
 
     JOB_STATUS = TextractJobStatus.succeeded
     PAGES = {"Pages": mock_random.randint(5, 500)}
-    BLOCKS: List[Dict[str, Any]] = []
+    BLOCKS: list[dict[str, Any]] = []
 
     def __init__(self, region_name: str, account_id: str):
         super().__init__(region_name, account_id)
-        self.async_text_detection_jobs: Dict[str, TextractJob] = defaultdict()
-        self.async_document_analysis_jobs: Dict[str, TextractJob] = defaultdict()
+        self.async_text_detection_jobs: dict[str, TextractJob] = defaultdict()
+        self.async_document_analysis_jobs: dict[str, TextractJob] = defaultdict()
 
     def get_document_text_detection(self, job_id: str) -> TextractJob:
         """
@@ -89,7 +89,7 @@ class TextractBackend(BaseBackend):
             raise InvalidJobIdException()
         return job
 
-    def detect_document_text(self) -> Dict[str, Any]:
+    def detect_document_text(self) -> dict[str, Any]:
         return {
             "Blocks": TextractBackend.BLOCKS,
             "DetectDocumentTextModelVersion": "1.0",
@@ -98,8 +98,8 @@ class TextractBackend(BaseBackend):
 
     def start_document_text_detection(
         self,
-        document_location: Dict[str, Any],
-        notification_channel: Optional[Dict[str, str]] = None,
+        document_location: dict[str, Any],
+        notification_channel: Optional[dict[str, str]] = None,
     ) -> str:
         """
         The following parameters have not yet been implemented: ClientRequestToken, JobTag, OutputConfig, KmsKeyID
@@ -127,7 +127,7 @@ class TextractBackend(BaseBackend):
         return job.job_id
 
     def start_document_analysis(
-        self, document_location: dict[str, Any], feature_types: List[str]
+        self, document_location: dict[str, Any], feature_types: list[str]
     ) -> str:
         """
         The following parameters have not yet been implemented: ClientRequestToken, JobTag, NotificationChannel, OutputConfig, KmsKeyID

--- a/moto/timestreaminfluxdb/models.py
+++ b/moto/timestreaminfluxdb/models.py
@@ -1,7 +1,7 @@
 """TimestreamInfluxDBBackend class with methods for supported APIs."""
 
 from enum import Enum
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Optional
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
@@ -75,7 +75,7 @@ class ParameterGroup(BaseModel):
         self,
         name: str,
         description: Optional[str] = None,
-        parameters: Optional[Dict[str, Any]] = None,
+        parameters: Optional[dict[str, Any]] = None,
         region_name: str = "",
         account_id: str = "",
     ):
@@ -85,7 +85,7 @@ class ParameterGroup(BaseModel):
         self.parameters = parameters or {}
         self.arn = f"arn:aws:timestream-influxdb:{region_name}:{account_id}:db-parameter-group/{self.id}"
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         return {
             "id": self.id,
             "name": self.name,
@@ -94,7 +94,7 @@ class ParameterGroup(BaseModel):
             "parameters": self.parameters,
         }
 
-    def to_summary_dict(self) -> Dict[str, str]:
+    def to_summary_dict(self) -> dict[str, str]:
         return {
             "id": self.id,
             "name": self.name,
@@ -118,11 +118,11 @@ class Cluster(BaseModel):
         allocated_storage: Optional[int] = None,
         network_type: Optional[str] = None,
         publicly_accessible: Optional[bool] = None,
-        vpc_subnet_ids: Optional[List[str]] = None,
-        vpc_security_group_ids: Optional[List[str]] = None,
+        vpc_subnet_ids: Optional[list[str]] = None,
+        vpc_security_group_ids: Optional[list[str]] = None,
         deployment_type: Optional[str] = None,
         failover_mode: Optional[str] = None,
-        log_delivery_configuration: Optional[Dict[str, Any]] = None,
+        log_delivery_configuration: Optional[dict[str, Any]] = None,
         region_name: str = "",
         account_id: str = "",
         endpoint_id: str = "",
@@ -155,7 +155,7 @@ class Cluster(BaseModel):
         self.influx_auth_parameters_secret_arn = f"arn:aws:secretsmanager:{region_name}:{account_id}:secret:timestream-influxdb/{self.id}/auth-params-{random_id(6)}"
         self.status = "CREATING"
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         return {
             "id": self.id,
             "name": self.name,
@@ -178,7 +178,7 @@ class Cluster(BaseModel):
             "failoverMode": self.failover_mode,
         }
 
-    def to_summary_dict(self) -> Dict[str, Any]:
+    def to_summary_dict(self) -> dict[str, Any]:
         return {
             "id": self.id,
             "name": self.name,
@@ -204,15 +204,15 @@ class DBInstance(BaseModel):
         organization: str,
         bucket: str,
         dbInstanceType: str,
-        vpcSubnetIds: List[str],
-        vpcSecurityGroupIds: List[str],
+        vpcSubnetIds: list[str],
+        vpcSecurityGroupIds: list[str],
         publiclyAccessible: bool,
         dbStorageType: str,
         allocatedStorage: int,
         dbParameterGroupIdentifier: Optional[str],
         deploymentType: str,
-        logDeliveryConfiguration: Optional[Dict[str, Any]],
-        tags: Optional[Dict[str, Any]],
+        logDeliveryConfiguration: Optional[dict[str, Any]],
+        tags: Optional[dict[str, Any]],
         port: int,
         networkType: str,
         region_name: str,
@@ -251,7 +251,7 @@ class DBInstance(BaseModel):
         self.availability_zone = ""  # TODO implement this
         self.secondary_availability_zone = ""  # TODO implement this
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         return {
             "id": self.id,
             "name": self.name,
@@ -284,9 +284,9 @@ class TimestreamInfluxDBBackend(BaseBackend):
         # the endpoint identifier is unique per account and per region
         # https://docs.aws.amazon.com/timestream/latest/developerguide/timestream-for-influxdb.html
         self.endpoint_id: str = random_id(10)
-        self.db_instances: Dict[str, DBInstance] = {}
-        self.db_parameter_groups: Dict[str, ParameterGroup] = {}
-        self.db_clusters: Dict[str, Cluster] = {}
+        self.db_instances: dict[str, DBInstance] = {}
+        self.db_parameter_groups: dict[str, ParameterGroup] = {}
+        self.db_clusters: dict[str, Cluster] = {}
         self.tagger = TaggingService()
 
     def create_db_instance(
@@ -297,15 +297,15 @@ class TimestreamInfluxDBBackend(BaseBackend):
         organization: str,
         bucket: str,
         db_instance_type: str,
-        vpc_subnet_ids: List[str],
-        vpc_security_group_ids: List[str],
+        vpc_subnet_ids: list[str],
+        vpc_security_group_ids: list[str],
         db_storage_type: str,
         publicly_accessible: bool,
         allocated_storage: int,
         db_parameter_group_identifier: str,
         deployment_type: str,
-        log_delivery_configuration: Optional[Dict[str, Any]],
-        tags: Optional[Dict[str, str]],
+        log_delivery_configuration: Optional[dict[str, Any]],
+        tags: Optional[dict[str, str]],
         port: int,
         network_type: str,
     ) -> DBInstance:
@@ -379,7 +379,7 @@ class TimestreamInfluxDBBackend(BaseBackend):
 
         return self.db_instances[id]
 
-    def list_db_instances(self) -> List[Dict[str, Any]]:
+    def list_db_instances(self) -> list[dict[str, Any]]:
         """
         Pagination is not yet implemented
         """
@@ -400,25 +400,25 @@ class TimestreamInfluxDBBackend(BaseBackend):
             for instance in self.db_instances.values()
         ]
 
-    def tag_resource(self, resource_arn: str, tags: Dict[str, str]) -> None:
+    def tag_resource(self, resource_arn: str, tags: dict[str, str]) -> None:
         tag_list = self.tagger.convert_dict_to_tags_input(tags)
         errmsg = self.tagger.validate_tags(tag_list)
         if errmsg:
             raise ValidationException(errmsg)
         self.tagger.tag_resource(resource_arn, tag_list)
 
-    def untag_resource(self, resource_arn: str, tag_keys: List[str]) -> None:
+    def untag_resource(self, resource_arn: str, tag_keys: list[str]) -> None:
         self.tagger.untag_resource_using_names(resource_arn, tag_keys)
 
-    def list_tags_for_resource(self, resource_arn: str) -> Dict[str, str]:
+    def list_tags_for_resource(self, resource_arn: str) -> dict[str, str]:
         return self.tagger.get_tag_dict_for_resource(resource_arn)
 
     def create_db_parameter_group(
         self,
         name: str,
         description: Optional[str] = None,
-        parameters: Optional[Dict[str, Any]] = None,
-        tags: Optional[Dict[str, str]] = None,
+        parameters: Optional[dict[str, Any]] = None,
+        tags: Optional[dict[str, str]] = None,
     ) -> ParameterGroup:
         validate_name(name)
 
@@ -453,7 +453,7 @@ class TimestreamInfluxDBBackend(BaseBackend):
         return param_group
 
     @paginate(pagination_model=PAGINATION_MODEL)
-    def list_db_parameter_groups(self) -> List[Dict[str, str]]:
+    def list_db_parameter_groups(self) -> list[dict[str, str]]:
         if not self.db_parameter_groups:
             return []
 
@@ -463,7 +463,7 @@ class TimestreamInfluxDBBackend(BaseBackend):
         ]
 
     @paginate(pagination_model=PAGINATION_MODEL)
-    def list_db_clusters(self) -> List[Dict[str, object]]:
+    def list_db_clusters(self) -> list[dict[str, object]]:
         if not self.db_clusters:
             return []
 
@@ -496,13 +496,13 @@ class TimestreamInfluxDBBackend(BaseBackend):
         allocated_storage: Optional[int] = None,
         network_type: Optional[str] = None,
         publicly_accessible: Optional[bool] = None,
-        vpc_subnet_ids: Optional[List[str]] = None,
-        vpc_security_group_ids: Optional[List[str]] = None,
+        vpc_subnet_ids: Optional[list[str]] = None,
+        vpc_security_group_ids: Optional[list[str]] = None,
         deployment_type: Optional[str] = None,
         failover_mode: Optional[str] = None,
-        log_delivery_configuration: Optional[Dict[str, Any]] = None,
-        tags: Optional[Dict[str, str]] = None,
-    ) -> Tuple[str, str]:
+        log_delivery_configuration: Optional[dict[str, Any]] = None,
+        tags: Optional[dict[str, str]] = None,
+    ) -> tuple[str, str]:
         validate_name(name)
 
         for cluster in self.db_clusters.values():

--- a/moto/timestreamquery/models.py
+++ b/moto/timestreamquery/models.py
@@ -1,6 +1,6 @@
 """TimestreamQueryBackend class with methods for supported APIs."""
 
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Optional, Union
 from uuid import uuid4
 
 from moto.core.base_backend import BackendDict, BaseBackend
@@ -18,13 +18,13 @@ class ScheduledQuery(BaseModel):
         region_name: str,
         name: str,
         query_string: str,
-        schedule_configuration: Dict[str, str],
-        notification_configuration: Dict[str, Dict[str, str]],
-        target_configuration: Optional[Dict[str, Any]],
+        schedule_configuration: dict[str, str],
+        notification_configuration: dict[str, dict[str, str]],
+        target_configuration: Optional[dict[str, Any]],
         scheduled_query_execution_role_arn: str,
-        tags: Optional[List[Dict[str, str]]],
+        tags: Optional[list[dict[str, str]]],
         kms_key_id: Optional[str],
-        error_report_configuration: Optional[Dict[str, Dict[str, str]]],
+        error_report_configuration: Optional[dict[str, dict[str, str]]],
     ):
         self.account_id = account_id
         self.region_name = region_name
@@ -44,7 +44,7 @@ class ScheduledQuery(BaseModel):
         self.arn = f"arn:{get_partition(region_name)}:timestream:{region_name}:{account_id}:scheduled-query/{name}"
         self.state = "ENABLED"
 
-    def description(self) -> Dict[str, Any]:
+    def description(self) -> dict[str, Any]:
         return {
             "Arn": self.arn,
             "Name": self.name,
@@ -65,22 +65,22 @@ class TimestreamQueryBackend(BaseBackend):
 
     def __init__(self, region_name: str, account_id: str):
         super().__init__(region_name, account_id)
-        self.scheduled_queries: Dict[str, ScheduledQuery] = {}
+        self.scheduled_queries: dict[str, ScheduledQuery] = {}
 
-        self.query_result_queue: Dict[Optional[str], List[Dict[str, Any]]] = {}
-        self.query_results: Dict[str, Dict[str, Any]] = {}
+        self.query_result_queue: dict[Optional[str], list[dict[str, Any]]] = {}
+        self.query_results: dict[str, dict[str, Any]] = {}
 
     def create_scheduled_query(
         self,
         name: str,
         query_string: str,
-        schedule_configuration: Dict[str, str],
-        notification_configuration: Dict[str, Dict[str, str]],
-        target_configuration: Optional[Dict[str, Any]],
+        schedule_configuration: dict[str, str],
+        notification_configuration: dict[str, dict[str, str]],
+        target_configuration: Optional[dict[str, Any]],
         scheduled_query_execution_role_arn: str,
-        tags: Optional[List[Dict[str, str]]],
+        tags: Optional[list[dict[str, str]]],
         kms_key_id: Optional[str],
-        error_report_configuration: Dict[str, Dict[str, str]],
+        error_report_configuration: dict[str, dict[str, str]],
     ) -> ScheduledQuery:
         query = ScheduledQuery(
             account_id=self.account_id,
@@ -110,7 +110,7 @@ class TimestreamQueryBackend(BaseBackend):
         query = self.scheduled_queries[scheduled_query_arn]
         query.state = state
 
-    def query(self, query_string: str) -> Dict[str, Any]:
+    def query(self, query_string: str) -> dict[str, Any]:
         """
         Moto does not have a builtin time-series Database, so calling this endpoint will return zero results by default.
 
@@ -165,7 +165,7 @@ class TimestreamQueryBackend(BaseBackend):
             return self.query_results[query_string]
         return {"QueryId": str(uuid4()), "Rows": [], "ColumnInfo": []}
 
-    def describe_endpoints(self) -> List[Dict[str, Union[str, int]]]:
+    def describe_endpoints(self) -> list[dict[str, Union[str, int]]]:
         # https://docs.aws.amazon.com/timestream/latest/developerguide/Using-API.endpoint-discovery.how-it-works.html
         # Usually, the address look like this:
         # query-cell1.timestream.us-east-1.amazonaws.com

--- a/moto/timestreamwrite/models.py
+++ b/moto/timestreamwrite/models.py
@@ -1,4 +1,5 @@
-from typing import Any, Dict, Iterable, List
+from collections.abc import Iterable
+from typing import Any
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
@@ -16,9 +17,9 @@ class TimestreamTable(BaseModel):
         region_name: str,
         table_name: str,
         db_name: str,
-        retention_properties: Dict[str, int],
-        magnetic_store_write_properties: Dict[str, Any],
-        schema: Dict[str, Any],
+        retention_properties: dict[str, int],
+        magnetic_store_write_properties: dict[str, Any],
+        schema: dict[str, Any],
     ):
         self.region_name = region_name
         self.name = table_name
@@ -37,14 +38,14 @@ class TimestreamTable(BaseModel):
                 }
             ]
         }
-        self.records: List[Dict[str, Any]] = []
+        self.records: list[dict[str, Any]] = []
         self.arn = f"arn:{get_partition(self.region_name)}:timestream:{self.region_name}:{account_id}:database/{self.db_name}/table/{self.name}"
 
     def update(
         self,
-        retention_properties: Dict[str, int],
-        magnetic_store_write_properties: Dict[str, Any],
-        schema: Dict[str, Any],
+        retention_properties: dict[str, int],
+        magnetic_store_write_properties: dict[str, Any],
+        schema: dict[str, Any],
     ) -> None:
         self.retention_properties = retention_properties
         if magnetic_store_write_properties is not None:
@@ -52,10 +53,10 @@ class TimestreamTable(BaseModel):
         if schema is not None:
             self.schema = schema
 
-    def write_records(self, records: List[Dict[str, Any]]) -> None:
+    def write_records(self, records: list[dict[str, Any]]) -> None:
         self.records.extend(records)
 
-    def description(self) -> Dict[str, Any]:
+    def description(self) -> dict[str, Any]:
         return {
             "Arn": self.arn,
             "TableName": self.name,
@@ -81,7 +82,7 @@ class TimestreamDatabase(BaseModel):
         self.arn = f"arn:{get_partition(self.region_name)}:timestream:{self.region_name}:{account_id}:database/{self.name}"
         self.created_on = unix_time()
         self.updated_on = unix_time()
-        self.tables: Dict[str, TimestreamTable] = dict()
+        self.tables: dict[str, TimestreamTable] = dict()
 
     def update(self, kms_key_id: str) -> None:
         self.kms_key_id = kms_key_id
@@ -89,9 +90,9 @@ class TimestreamDatabase(BaseModel):
     def create_table(
         self,
         table_name: str,
-        retention_properties: Dict[str, int],
-        magnetic_store_write_properties: Dict[str, Any],
-        schema: Dict[str, Any],
+        retention_properties: dict[str, int],
+        magnetic_store_write_properties: dict[str, Any],
+        schema: dict[str, Any],
     ) -> TimestreamTable:
         table = TimestreamTable(
             account_id=self.account_id,
@@ -108,9 +109,9 @@ class TimestreamDatabase(BaseModel):
     def update_table(
         self,
         table_name: str,
-        retention_properties: Dict[str, int],
-        magnetic_store_write_properties: Dict[str, Any],
-        schema: Dict[str, Any],
+        retention_properties: dict[str, int],
+        magnetic_store_write_properties: dict[str, Any],
+        schema: dict[str, Any],
     ) -> TimestreamTable:
         table = self.tables[table_name]
         table.update(
@@ -131,7 +132,7 @@ class TimestreamDatabase(BaseModel):
     def list_tables(self) -> Iterable[TimestreamTable]:
         return self.tables.values()
 
-    def description(self) -> Dict[str, Any]:
+    def description(self) -> dict[str, Any]:
         return {
             "Arn": self.arn,
             "DatabaseName": self.name,
@@ -158,11 +159,11 @@ class TimestreamWriteBackend(BaseBackend):
 
     def __init__(self, region_name: str, account_id: str):
         super().__init__(region_name, account_id)
-        self.databases: Dict[str, TimestreamDatabase] = dict()
+        self.databases: dict[str, TimestreamDatabase] = dict()
         self.tagging_service = TaggingService()
 
     def create_database(
-        self, database_name: str, kms_key_id: str, tags: List[Dict[str, str]]
+        self, database_name: str, kms_key_id: str, tags: list[dict[str, str]]
     ) -> TimestreamDatabase:
         database = TimestreamDatabase(
             self.account_id, self.region_name, database_name, kms_key_id
@@ -193,10 +194,10 @@ class TimestreamWriteBackend(BaseBackend):
         self,
         database_name: str,
         table_name: str,
-        retention_properties: Dict[str, int],
-        tags: List[Dict[str, str]],
-        magnetic_store_write_properties: Dict[str, Any],
-        schema: Dict[str, Any],
+        retention_properties: dict[str, int],
+        tags: list[dict[str, str]],
+        magnetic_store_write_properties: dict[str, Any],
+        schema: dict[str, Any],
     ) -> TimestreamTable:
         database = self.describe_database(database_name)
         table = database.create_table(
@@ -230,9 +231,9 @@ class TimestreamWriteBackend(BaseBackend):
         self,
         database_name: str,
         table_name: str,
-        retention_properties: Dict[str, int],
-        magnetic_store_write_properties: Dict[str, Any],
-        schema: Dict[str, Any],
+        retention_properties: dict[str, int],
+        magnetic_store_write_properties: dict[str, Any],
+        schema: dict[str, Any],
     ) -> TimestreamTable:
         database = self.describe_database(database_name)
         return database.update_table(
@@ -243,13 +244,13 @@ class TimestreamWriteBackend(BaseBackend):
         )
 
     def write_records(
-        self, database_name: str, table_name: str, records: List[Dict[str, Any]]
+        self, database_name: str, table_name: str, records: list[dict[str, Any]]
     ) -> None:
         database = self.describe_database(database_name)
         table = database.describe_table(table_name)
         table.write_records(records)
 
-    def describe_endpoints(self) -> Dict[str, List[Dict[str, Any]]]:
+    def describe_endpoints(self) -> dict[str, list[dict[str, Any]]]:
         # https://docs.aws.amazon.com/timestream/latest/developerguide/Using-API.endpoint-discovery.how-it-works.html
         # Usually, the address look like this:
         # ingest-cell1.timestream.us-east-1.amazonaws.com
@@ -266,13 +267,13 @@ class TimestreamWriteBackend(BaseBackend):
 
     def list_tags_for_resource(
         self, resource_arn: str
-    ) -> Dict[str, List[Dict[str, str]]]:
+    ) -> dict[str, list[dict[str, str]]]:
         return self.tagging_service.list_tags_for_resource(resource_arn)
 
-    def tag_resource(self, resource_arn: str, tags: List[Dict[str, str]]) -> None:
+    def tag_resource(self, resource_arn: str, tags: list[dict[str, str]]) -> None:
         self.tagging_service.tag_resource(resource_arn, tags)
 
-    def untag_resource(self, resource_arn: str, tag_keys: List[str]) -> None:
+    def untag_resource(self, resource_arn: str, tag_keys: list[str]) -> None:
         self.tagging_service.untag_resource_using_names(resource_arn, tag_keys)
 
 

--- a/moto/transcribe/models.py
+++ b/moto/transcribe/models.py
@@ -1,6 +1,6 @@
 import re
 from datetime import datetime, timedelta
-from typing import Any, Dict, List, Optional
+from typing import Any, Optional
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
@@ -17,8 +17,8 @@ class BaseObject(BaseModel):
             words.append(word.title())
         return "".join(words)
 
-    def gen_response_object(self) -> Dict[str, Any]:
-        response_object: Dict[str, Any] = dict()
+    def gen_response_object(self) -> dict[str, Any]:
+        response_object: dict[str, Any] = dict()
         for key, value in self.__dict__.items():
             if "_" in key:
                 response_object[self.camelCase(key)] = value
@@ -27,7 +27,7 @@ class BaseObject(BaseModel):
         return response_object
 
     @property
-    def response_object(self) -> Dict[str, Any]:  # type: ignore[misc]
+    def response_object(self) -> dict[str, Any]:  # type: ignore[misc]
         return self.gen_response_object()
 
 
@@ -40,18 +40,18 @@ class FakeTranscriptionJob(BaseObject, ManagedState):
         language_code: Optional[str],
         media_sample_rate_hertz: Optional[int],
         media_format: Optional[str],
-        media: Dict[str, str],
+        media: dict[str, str],
         output_bucket_name: Optional[str],
         output_key: Optional[str],
         output_encryption_kms_key_id: Optional[str],
-        settings: Optional[Dict[str, Any]],
-        model_settings: Optional[Dict[str, Optional[str]]],
-        job_execution_settings: Optional[Dict[str, Any]],
-        content_redaction: Optional[Dict[str, Any]],
+        settings: Optional[dict[str, Any]],
+        model_settings: Optional[dict[str, Optional[str]]],
+        job_execution_settings: Optional[dict[str, Any]],
+        content_redaction: Optional[dict[str, Any]],
         identify_language: Optional[bool],
         identify_multiple_languages: Optional[bool],
-        language_options: Optional[List[str]],
-        subtitles: Optional[Dict[str, Any]],
+        language_options: Optional[list[str]],
+        subtitles: Optional[dict[str, Any]],
     ):
         ManagedState.__init__(
             self,
@@ -66,11 +66,11 @@ class FakeTranscriptionJob(BaseObject, ManagedState):
         self._region_name = region_name
         self.transcription_job_name = transcription_job_name
         self.language_code = language_code
-        self.language_codes: Optional[List[Dict[str, Any]]] = None
+        self.language_codes: Optional[list[dict[str, Any]]] = None
         self.media_sample_rate_hertz = media_sample_rate_hertz
         self.media_format = media_format
         self.media = media
-        self.transcript: Optional[Dict[str, str]] = None
+        self.transcript: Optional[dict[str, str]] = None
         self.start_time: Optional[str] = None
         self.completion_time: Optional[str] = None
         self.creation_time = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
@@ -101,7 +101,7 @@ class FakeTranscriptionJob(BaseObject, ManagedState):
         )
         self.subtitles = subtitles or {"Formats": [], "OutputStartIndex": 0}
 
-    def response_object(self, response_type: str) -> Dict[str, Any]:  # type: ignore
+    def response_object(self, response_type: str) -> dict[str, Any]:  # type: ignore
         response_field_dict = {
             "CREATE": [
                 "TranscriptionJobName",
@@ -200,7 +200,7 @@ class FakeTranscriptionJob(BaseObject, ManagedState):
                 self.identified_language_score = 0.999645948
                 # Identify first two languages passed in language_options
                 # If none is set, default to "en-US"
-                self.language_codes: List[Dict[str, Any]] = []  # type: ignore[no-redef]
+                self.language_codes: list[dict[str, Any]] = []  # type: ignore[no-redef]
                 if self.language_options is None or len(self.language_options) == 0:
                     self.language_codes.append(
                         {"LanguageCode": "en-US", "DurationInSeconds": 123.0}
@@ -255,7 +255,7 @@ class FakeVocabulary(BaseObject, ManagedState):
         region_name: str,
         vocabulary_name: str,
         language_code: str,
-        phrases: Optional[List[str]],
+        phrases: Optional[list[str]],
         vocabulary_file_uri: Optional[str],
     ):
         # Configured ManagedState
@@ -273,7 +273,7 @@ class FakeVocabulary(BaseObject, ManagedState):
         self.failure_reason = None
         self.download_uri = f"https://s3.{region_name}.amazonaws.com/aws-transcribe-dictionary-model-{region_name}-prod/{account_id}/{vocabulary_name}/{mock_random.uuid4()}/input.txt"
 
-    def response_object(self, response_type: str) -> Dict[str, Any]:  # type: ignore
+    def response_object(self, response_type: str) -> dict[str, Any]:  # type: ignore
         response_field_dict = {
             "CREATE": [
                 "VocabularyName",
@@ -323,10 +323,10 @@ class FakeMedicalTranscriptionJob(BaseObject, ManagedState):
         language_code: str,
         media_sample_rate_hertz: Optional[int],
         media_format: Optional[str],
-        media: Dict[str, str],
+        media: dict[str, str],
         output_bucket_name: str,
         output_encryption_kms_key_id: Optional[str],
-        settings: Optional[Dict[str, Any]],
+        settings: Optional[dict[str, Any]],
         specialty: str,
         job_type: str,
     ):
@@ -345,7 +345,7 @@ class FakeMedicalTranscriptionJob(BaseObject, ManagedState):
         self.media_sample_rate_hertz = media_sample_rate_hertz
         self.media_format = media_format
         self.media = media
-        self.transcript: Optional[Dict[str, str]] = None
+        self.transcript: Optional[dict[str, str]] = None
         self.start_time: Optional[str] = None
         self.completion_time: Optional[str] = None
         self.creation_time = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
@@ -360,7 +360,7 @@ class FakeMedicalTranscriptionJob(BaseObject, ManagedState):
         self._output_encryption_kms_key_id = output_encryption_kms_key_id
         self.output_location_type = "CUSTOMER_BUCKET"
 
-    def response_object(self, response_type: str) -> Dict[str, Any]:  # type: ignore
+    def response_object(self, response_type: str) -> dict[str, Any]:  # type: ignore
         response_field_dict = {
             "CREATE": [
                 "MedicalTranscriptionJobName",
@@ -475,10 +475,10 @@ class FakeMedicalVocabulary(FakeVocabulary):
 class TranscribeBackend(BaseBackend):
     def __init__(self, region_name: str, account_id: str):
         super().__init__(region_name, account_id)
-        self.medical_transcriptions: Dict[str, FakeMedicalTranscriptionJob] = {}
-        self.transcriptions: Dict[str, FakeTranscriptionJob] = {}
-        self.medical_vocabularies: Dict[str, FakeMedicalVocabulary] = {}
-        self.vocabularies: Dict[str, FakeVocabulary] = {}
+        self.medical_transcriptions: dict[str, FakeMedicalTranscriptionJob] = {}
+        self.transcriptions: dict[str, FakeTranscriptionJob] = {}
+        self.medical_vocabularies: dict[str, FakeMedicalVocabulary] = {}
+        self.vocabularies: dict[str, FakeVocabulary] = {}
 
     def start_transcription_job(
         self,
@@ -486,19 +486,19 @@ class TranscribeBackend(BaseBackend):
         language_code: Optional[str],
         media_sample_rate_hertz: Optional[int],
         media_format: Optional[str],
-        media: Dict[str, str],
+        media: dict[str, str],
         output_bucket_name: Optional[str],
         output_key: Optional[str],
         output_encryption_kms_key_id: Optional[str],
-        settings: Optional[Dict[str, Any]],
-        model_settings: Optional[Dict[str, Optional[str]]],
-        job_execution_settings: Optional[Dict[str, Any]],
-        content_redaction: Optional[Dict[str, Any]],
+        settings: Optional[dict[str, Any]],
+        model_settings: Optional[dict[str, Optional[str]]],
+        job_execution_settings: Optional[dict[str, Any]],
+        content_redaction: Optional[dict[str, Any]],
         identify_language: Optional[bool],
         identify_multiple_languages: Optional[bool],
-        language_options: Optional[List[str]],
-        subtitles: Optional[Dict[str, Any]],
-    ) -> Dict[str, Any]:
+        language_options: Optional[list[str]],
+        subtitles: Optional[dict[str, Any]],
+    ) -> dict[str, Any]:
         if transcription_job_name in self.transcriptions:
             raise ConflictException(
                 message="The requested job name already exists. Use a different job name."
@@ -541,13 +541,13 @@ class TranscribeBackend(BaseBackend):
         language_code: str,
         media_sample_rate_hertz: Optional[int],
         media_format: Optional[str],
-        media: Dict[str, str],
+        media: dict[str, str],
         output_bucket_name: str,
         output_encryption_kms_key_id: Optional[str],
-        settings: Optional[Dict[str, Any]],
+        settings: Optional[dict[str, Any]],
         specialty: str,
         type_: str,
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         if medical_transcription_job_name in self.medical_transcriptions:
             raise ConflictException(
                 message="The requested job name already exists. Use a different job name."
@@ -580,7 +580,7 @@ class TranscribeBackend(BaseBackend):
 
         return transcription_job_object.response_object("CREATE")
 
-    def get_transcription_job(self, transcription_job_name: str) -> Dict[str, Any]:
+    def get_transcription_job(self, transcription_job_name: str) -> dict[str, Any]:
         try:
             job = self.transcriptions[transcription_job_name]
             job.advance()  # Fakes advancement through statuses.
@@ -593,7 +593,7 @@ class TranscribeBackend(BaseBackend):
 
     def get_medical_transcription_job(
         self, medical_transcription_job_name: str
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         try:
             job = self.medical_transcriptions[medical_transcription_job_name]
             job.advance()  # Fakes advancement through statuses.
@@ -630,7 +630,7 @@ class TranscribeBackend(BaseBackend):
         job_name_contains: str,
         next_token: str,
         max_results: int,
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         jobs = list(self.transcriptions.values())
 
         if state_equals:
@@ -647,7 +647,7 @@ class TranscribeBackend(BaseBackend):
         )  # Arbitrarily selected...
         jobs_paginated = jobs[start_offset:end_offset]
 
-        response: Dict[str, Any] = {
+        response: dict[str, Any] = {
             "TranscriptionJobSummaries": [
                 job.response_object("LIST") for job in jobs_paginated
             ]
@@ -660,7 +660,7 @@ class TranscribeBackend(BaseBackend):
 
     def list_medical_transcription_jobs(
         self, status: str, job_name_contains: str, next_token: str, max_results: int
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         jobs = list(self.medical_transcriptions.values())
 
         if status:
@@ -679,7 +679,7 @@ class TranscribeBackend(BaseBackend):
         )  # Arbitrarily selected...
         jobs_paginated = jobs[start_offset:end_offset]
 
-        response: Dict[str, Any] = {
+        response: dict[str, Any] = {
             "MedicalTranscriptionJobSummaries": [
                 job.response_object("LIST") for job in jobs_paginated
             ]
@@ -694,9 +694,9 @@ class TranscribeBackend(BaseBackend):
         self,
         vocabulary_name: str,
         language_code: str,
-        phrases: Optional[List[str]],
+        phrases: Optional[list[str]],
         vocabulary_file_uri: Optional[str],
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         if (
             phrases is not None
             and vocabulary_file_uri is not None
@@ -736,7 +736,7 @@ class TranscribeBackend(BaseBackend):
         vocabulary_name: str,
         language_code: str,
         vocabulary_file_uri: Optional[str],
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         if vocabulary_name in self.medical_vocabularies:
             raise ConflictException(
                 message="The requested vocabulary name already exists. "
@@ -755,7 +755,7 @@ class TranscribeBackend(BaseBackend):
 
         return medical_vocabulary_object.response_object("CREATE")
 
-    def get_vocabulary(self, vocabulary_name: str) -> Dict[str, Any]:
+    def get_vocabulary(self, vocabulary_name: str) -> dict[str, Any]:
         try:
             job = self.vocabularies[vocabulary_name]
             job.advance()  # Fakes advancement through statuses.
@@ -766,7 +766,7 @@ class TranscribeBackend(BaseBackend):
                 "Check the vocabulary name and try your request again."
             )
 
-    def get_medical_vocabulary(self, vocabulary_name: str) -> Dict[str, Any]:
+    def get_medical_vocabulary(self, vocabulary_name: str) -> dict[str, Any]:
         try:
             job = self.medical_vocabularies[vocabulary_name]
             job.advance()  # Fakes advancement through statuses.
@@ -795,7 +795,7 @@ class TranscribeBackend(BaseBackend):
 
     def list_vocabularies(
         self, state_equals: str, name_contains: str, next_token: str, max_results: int
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         vocabularies = list(self.vocabularies.values())
 
         if state_equals:
@@ -818,7 +818,7 @@ class TranscribeBackend(BaseBackend):
         )  # Arbitrarily selected...
         vocabularies_paginated = vocabularies[start_offset:end_offset]
 
-        response: Dict[str, Any] = {
+        response: dict[str, Any] = {
             "Vocabularies": [
                 vocabulary.response_object("LIST")
                 for vocabulary in vocabularies_paginated
@@ -832,7 +832,7 @@ class TranscribeBackend(BaseBackend):
 
     def list_medical_vocabularies(
         self, state_equals: str, name_contains: str, next_token: str, max_results: int
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         vocabularies = list(self.medical_vocabularies.values())
 
         if state_equals:
@@ -855,7 +855,7 @@ class TranscribeBackend(BaseBackend):
         )  # Arbitrarily selected...
         vocabularies_paginated = vocabularies[start_offset:end_offset]
 
-        response: Dict[str, Any] = {
+        response: dict[str, Any] = {
             "Vocabularies": [
                 vocabulary.response_object("LIST")
                 for vocabulary in vocabularies_paginated

--- a/moto/transfer/models.py
+++ b/moto/transfer/models.py
@@ -1,6 +1,6 @@
 """TransferBackend class with methods for supported APIs."""
 
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Optional
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.utils import unix_time
@@ -22,27 +22,27 @@ class TransferBackend(BaseBackend):
 
     def __init__(self, region_name: str, account_id: str) -> None:
         super().__init__(region_name, account_id)
-        self.servers: Dict[str, Server] = {}
+        self.servers: dict[str, Server] = {}
 
     def create_server(
         self,
         certificate: Optional[str],
         domain: Optional[ServerDomain],
-        endpoint_details: Optional[Dict[str, Any]],
+        endpoint_details: Optional[dict[str, Any]],
         endpoint_type: Optional[ServerEndpointType],
         host_key: str,
-        identity_provider_details: Optional[Dict[str, Any]],
+        identity_provider_details: Optional[dict[str, Any]],
         identity_provider_type: Optional[ServerIdentityProviderType],
         logging_role: Optional[str],
         post_authentication_login_banner: Optional[str],
         pre_authentication_login_banner: Optional[str],
-        protocols: Optional[List[ServerProtocols]],
-        protocol_details: Optional[Dict[str, Any]],
+        protocols: Optional[list[ServerProtocols]],
+        protocol_details: Optional[dict[str, Any]],
         security_policy_name: Optional[str],
-        tags: Optional[List[Dict[str, str]]],
-        workflow_details: Optional[Dict[str, Any]],
-        structured_log_destinations: Optional[List[str]],
-        s3_storage_options: Optional[Dict[str, Optional[str]]],
+        tags: Optional[list[dict[str, str]]],
+        workflow_details: Optional[dict[str, Any]],
+        structured_log_destinations: Optional[list[str]],
+        s3_storage_options: Optional[dict[str, Optional[str]]],
     ) -> str:
         server = Server(
             certificate=certificate,
@@ -131,15 +131,15 @@ class TransferBackend(BaseBackend):
         self,
         home_directory: Optional[str],
         home_directory_type: Optional[UserHomeDirectoryType],
-        home_directory_mappings: Optional[List[Dict[str, Optional[str]]]],
+        home_directory_mappings: Optional[list[dict[str, Optional[str]]]],
         policy: Optional[str],
-        posix_profile: Optional[Dict[str, Any]],
+        posix_profile: Optional[dict[str, Any]],
         role: str,
         server_id: str,
         ssh_public_key_body: Optional[str],
-        tags: Optional[List[Dict[str, str]]],
+        tags: Optional[list[dict[str, str]]],
         user_name: str,
-    ) -> Tuple[str, str]:
+    ) -> tuple[str, str]:
         if server_id not in self.servers:
             ServerNotFound(server_id=server_id)
         user = User(
@@ -180,7 +180,7 @@ class TransferBackend(BaseBackend):
         self.servers[server_id].user_count += 1
         return server_id, user_name
 
-    def describe_user(self, server_id: str, user_name: str) -> Tuple[str, User]:
+    def describe_user(self, server_id: str, user_name: str) -> tuple[str, User]:
         if server_id not in self.servers:
             raise ServerNotFound(server_id=server_id)
         for user in self.servers[server_id]._users:
@@ -200,7 +200,7 @@ class TransferBackend(BaseBackend):
 
     def import_ssh_public_key(
         self, server_id: str, ssh_public_key_body: str, user_name: str
-    ) -> Tuple[str, str, str]:
+    ) -> tuple[str, str, str]:
         if server_id not in self.servers:
             raise ServerNotFound(server_id=server_id)
         for user in self.servers[server_id]._users:

--- a/moto/transfer/types.py
+++ b/moto/transfer/types.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass, field
 from datetime import datetime
 from enum import Enum
-from typing import Any, Dict, List, Literal, Optional, Union
+from typing import Any, Literal, Optional, Union
 
 from moto.core.common_models import BaseModel
 
@@ -24,20 +24,20 @@ class User(BaseModel):
     role: str
     user_name: str
     arn: str = field(default="", init=False)
-    home_directory_mappings: List[Dict[str, Optional[str]]] = field(
+    home_directory_mappings: list[dict[str, Optional[str]]] = field(
         default_factory=list
     )
-    posix_profile: Dict[str, Optional[Union[str, List[str]]]] = field(
+    posix_profile: dict[str, Optional[Union[str, list[str]]]] = field(
         default_factory=dict
     )
-    ssh_public_keys: List[Dict[str, str]] = field(default_factory=list)
-    tags: List[Dict[str, str]] = field(default_factory=list)
+    ssh_public_keys: list[dict[str, str]] = field(default_factory=list)
+    tags: list[dict[str, str]] = field(default_factory=list)
 
     def __post_init__(self) -> None:
         if self.arn == "":
             self.arn = f"arn:aws:transfer:{self.user_name}:{datetime.now().strftime('%Y%m%d%H%M%S')}"
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         user = {
             "HomeDirectory": self.home_directory,
             "HomeDirectoryType": self.home_directory_type,
@@ -113,7 +113,7 @@ class ServerState(str, Enum):
     STOP_FAILED = "STOP_FAILED"
 
 
-AS2_TRANSPORTS_TYPE = List[Literal["HTTP"]]
+AS2_TRANSPORTS_TYPE = list[Literal["HTTP"]]
 
 
 @dataclass
@@ -126,21 +126,21 @@ class Server(BaseModel):
     logging_role: Optional[str]
     post_authentication_login_banner: Optional[str]
     pre_authentication_login_banner: Optional[str]
-    protocols: Optional[List[ServerProtocols]]
+    protocols: Optional[list[ServerProtocols]]
     security_policy_name: Optional[str]
-    structured_log_destinations: Optional[List[str]]
+    structured_log_destinations: Optional[list[str]]
     arn: str = field(default="", init=False)
-    as2_service_managed_egress_ip_addresses: List[str] = field(default_factory=list)
-    endpoint_details: Dict[str, str] = field(default_factory=dict)
-    identity_provider_details: Dict[str, str] = field(default_factory=dict)
-    protocol_details: Dict[str, str] = field(default_factory=dict)
-    s3_storage_options: Dict[str, Optional[str]] = field(default_factory=dict)
+    as2_service_managed_egress_ip_addresses: list[str] = field(default_factory=list)
+    endpoint_details: dict[str, str] = field(default_factory=dict)
+    identity_provider_details: dict[str, str] = field(default_factory=dict)
+    protocol_details: dict[str, str] = field(default_factory=dict)
+    s3_storage_options: dict[str, Optional[str]] = field(default_factory=dict)
     server_id: str = field(default="", init=False)
     state: Optional[ServerState] = ServerState.ONLINE
-    tags: List[Dict[str, str]] = field(default_factory=list)
+    tags: list[dict[str, str]] = field(default_factory=list)
     user_count: int = field(default=0)
-    workflow_details: Dict[str, List[Dict[str, str]]] = field(default_factory=dict)
-    _users: List[User] = field(default_factory=list, repr=False)
+    workflow_details: dict[str, list[dict[str, str]]] = field(default_factory=dict)
+    _users: list[User] = field(default_factory=list, repr=False)
 
     def __post_init__(self) -> None:
         if self.arn == "":
@@ -150,7 +150,7 @@ class Server(BaseModel):
         if self.as2_service_managed_egress_ip_addresses == []:
             self.as2_service_managed_egress_ip_addresses.append("0.0.0.0/0")
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         on_upload = []
         on_partial_upload = []
         if self.workflow_details is not None:

--- a/moto/utilities/aws_headers.py
+++ b/moto/utilities/aws_headers.py
@@ -1,5 +1,5 @@
 from functools import wraps
-from typing import TYPE_CHECKING, Any, Callable, Dict, Optional, TypeVar
+from typing import TYPE_CHECKING, Any, Callable, Optional, TypeVar
 
 if TYPE_CHECKING:
     from typing_extensions import Protocol
@@ -15,7 +15,7 @@ class GenericFunction(Protocol):
     def __call__(self, *args: Any, **kwargs: Any) -> Any: ...
 
 
-def gen_amz_crc32(response: Any, headerdict: Optional[Dict[str, Any]] = None) -> int:
+def gen_amz_crc32(response: Any, headerdict: Optional[dict[str, Any]] = None) -> int:
     if not isinstance(response, bytes):
         response = response.encode("utf-8")
 
@@ -27,7 +27,7 @@ def gen_amz_crc32(response: Any, headerdict: Optional[Dict[str, Any]] = None) ->
     return crc
 
 
-def gen_amzn_requestid_long(headerdict: Optional[Dict[str, Any]] = None) -> str:
+def gen_amzn_requestid_long(headerdict: Optional[dict[str, Any]] = None) -> str:
     from moto.moto_api._internal import mock_random as random
 
     req_id = random.get_random_string(length=52)

--- a/moto/utilities/collections.py
+++ b/moto/utilities/collections.py
@@ -1,7 +1,7 @@
-from typing import Any, List
+from typing import Any
 
 
-def select_attributes(obj: Any, attributes: List[str]) -> Any:
+def select_attributes(obj: Any, attributes: list[str]) -> Any:
     """Select a subset of attributes from the given dict (returns a copy)"""
     attributes = attributes if isinstance(attributes, (list, tuple)) else [attributes]  # type: ignore
     return {k: v for k, v in obj.items() if k in attributes}

--- a/moto/utilities/docker_utilities.py
+++ b/moto/utilities/docker_utilities.py
@@ -1,5 +1,5 @@
 import functools
-from typing import TYPE_CHECKING, Any, Tuple
+from typing import TYPE_CHECKING, Any
 
 import requests.adapters
 
@@ -48,7 +48,7 @@ class DockerModel:
             self.docker_client.images.pull(full_name)
 
 
-def parse_image_ref(image_name: str) -> Tuple[str, str]:
+def parse_image_ref(image_name: str) -> tuple[str, str]:
     # podman does not support short container image name out of box - try to make a full name
     # See ParseDockerRef() in https://github.com/distribution/distribution/blob/main/reference/normalize.go
     parts = image_name.split("/")

--- a/moto/utilities/id_generator.py
+++ b/moto/utilities/id_generator.py
@@ -1,14 +1,14 @@
 import abc
 import logging
 import threading
-from typing import Any, Callable, Dict, List, TypedDict, Union
+from typing import Any, Callable, TypedDict, Union
 
 from moto.moto_api._internal import mock_random
 
 log = logging.getLogger(__name__)
 
-ExistingIds = Union[List[str], None]
-Tags = Union[Dict[str, str], List[Dict[str, str]], None]
+ExistingIds = Union[list[str], None]
+Tags = Union[dict[str, str], list[dict[str, str]], None]
 
 # Custom resource tag to override the generated resource ID.
 TAG_KEY_CUSTOM_ID = "_custom_id_"
@@ -55,8 +55,8 @@ class MotoIdManager:
     """class to manage custom ids. Do not create instance and instead
     use the `id_manager` instance created below."""
 
-    _custom_ids: Dict[str, str]
-    _id_sources: List[Callable[[IdSourceContext], Union[str, None]]]
+    _custom_ids: dict[str, str]
+    _id_sources: list[Callable[[IdSourceContext], Union[str, None]]]
 
     _lock: threading.RLock
 
@@ -157,7 +157,7 @@ def moto_id(fn: Callable[..., str]) -> Callable[..., str]:
         resource_identifier: ResourceIdentifier,
         existing_ids: ExistingIds = None,
         tags: Tags = None,
-        **kwargs: Dict[str, Any],
+        **kwargs: dict[str, Any],
     ) -> str:
         if resource_identifier and (
             found_id := moto_id_manager.find_id_from_sources(

--- a/moto/utilities/paginator.py
+++ b/moto/utilities/paginator.py
@@ -1,7 +1,7 @@
 import inspect
 from copy import deepcopy
 from functools import wraps
-from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple, TypeVar
+from typing import TYPE_CHECKING, Any, Callable, Optional, TypeVar
 
 from botocore.paginate import TokenDecoder, TokenEncoder
 
@@ -20,14 +20,14 @@ T = TypeVar("T")
 
 class GenericFunction(Protocol):
     def __call__(
-        self, func: "Callable[P1, List[T]]"
-    ) -> "Callable[P2, Tuple[List[T], Optional[str]]]": ...
+        self, func: "Callable[P1, list[T]]"
+    ) -> "Callable[P2, tuple[list[T], Optional[str]]]": ...
 
 
-def paginate(pagination_model: Dict[str, Any]) -> GenericFunction:
+def paginate(pagination_model: dict[str, Any]) -> GenericFunction:
     def pagination_decorator(
-        func: Callable[..., List[T]],
-    ) -> Callable[..., Tuple[List[T], Optional[str]]]:
+        func: Callable[..., list[T]],
+    ) -> Callable[..., tuple[list[T], Optional[str]]]:
         @wraps(func)
         def pagination_wrapper(*args: Any, **kwargs: Any) -> Any:  # type: ignore
             method = func.__name__
@@ -100,7 +100,7 @@ class Paginator:
         self._param_checksum = self._calculate_parameter_checksum()
         self._parsed_token = self._parse_starting_token()
 
-    def _parse_starting_token(self) -> Optional[Dict[str, Any]]:
+    def _parse_starting_token(self) -> Optional[dict[str, Any]]:
         if self._starting_token is None:
             return None
         # The starting token is a dict passed as a base64 encoded string.
@@ -157,7 +157,7 @@ class Paginator:
         return True
 
     def _build_next_token(self, next_item: Any) -> str:
-        token_dict: Dict[str, Any] = {}
+        token_dict: dict[str, Any] = {}
         if self._param_checksum:
             token_dict["parameterChecksum"] = self._param_checksum
         range_keys = []
@@ -169,7 +169,7 @@ class Paginator:
         token_dict["uniqueAttributes"] = "|".join(range_keys)
         return self._token_encoder.encode(token_dict)
 
-    def paginate(self, results: List[Any]) -> Tuple[List[Any], Optional[str]]:
+    def paginate(self, results: list[Any]) -> tuple[list[Any], Optional[str]]:
         index_start = 0
         if self._starting_token:
             try:

--- a/moto/utilities/tagging_service.py
+++ b/moto/utilities/tagging_service.py
@@ -1,7 +1,7 @@
 """Tag functionality contained in class TaggingService."""
 
 import re
-from typing import Dict, List, Optional
+from typing import Optional
 
 
 class TaggingService:
@@ -13,9 +13,9 @@ class TaggingService:
         self.tag_name = tag_name
         self.key_name = key_name
         self.value_name = value_name
-        self.tags: Dict[str, Dict[str, Optional[str]]] = {}
+        self.tags: dict[str, dict[str, Optional[str]]] = {}
 
-    def get_tag_dict_for_resource(self, arn: str) -> Dict[str, str]:
+    def get_tag_dict_for_resource(self, arn: str) -> dict[str, str]:
         """Return dict of key/value pairs vs. list of key/values dicts."""
         result = {}
         if self.has_tags(arn):
@@ -23,7 +23,7 @@ class TaggingService:
                 result[key] = val
         return result  # type: ignore
 
-    def list_tags_for_resource(self, arn: str) -> Dict[str, List[Dict[str, str]]]:
+    def list_tags_for_resource(self, arn: str) -> dict[str, list[dict[str, str]]]:
         """Return list of tags inside dict with key of "tag_name".
 
         Useful for describe functions; this return value can be added to
@@ -44,7 +44,7 @@ class TaggingService:
         """Return True if the ARN has any associated tags, False otherwise."""
         return arn in self.tags
 
-    def tag_resource(self, arn: str, tags: Optional[List[Dict[str, str]]]) -> None:
+    def tag_resource(self, arn: str, tags: Optional[list[dict[str, str]]]) -> None:
         """Store associated list of dicts with ARN.
 
         Note: the storage is internal to this class instance.
@@ -69,13 +69,13 @@ class TaggingService:
                 to_arn, self.list_tags_for_resource(from_arn)[self.tag_name]
             )
 
-    def untag_resource_using_names(self, arn: str, tag_names: List[str]) -> None:
+    def untag_resource_using_names(self, arn: str, tag_names: list[str]) -> None:
         """Remove tags associated with ARN using key names in 'tag_names'."""
         for name in tag_names:
             if name in self.tags.get(arn, {}):
                 del self.tags[arn][name]
 
-    def untag_resource_using_tags(self, arn: str, tags: List[Dict[str, str]]) -> None:
+    def untag_resource_using_tags(self, arn: str, tags: list[dict[str, str]]) -> None:
         """Remove tags associated with ARN using key/value pairs in 'tags'."""
         current_tags = self.tags.get(arn, {})
         for tag in tags:
@@ -87,9 +87,9 @@ class TaggingService:
                     # If both key and value are provided, match both before deletion
                     del current_tags[tag[self.key_name]]
 
-    def extract_tag_names(self, tags: List[Dict[str, str]]) -> List[str]:
+    def extract_tag_names(self, tags: list[dict[str, str]]) -> list[str]:
         """Return list of key names in list of 'tags' key/value dicts."""
-        results: List[str] = []
+        results: list[str] = []
         if len(tags) == 0:
             return results
         for tag in tags:
@@ -97,9 +97,9 @@ class TaggingService:
                 results.append(tag[self.key_name])
         return results
 
-    def flatten_tag_list(self, tags: List[Dict[str, str]]) -> Dict[str, Optional[str]]:
+    def flatten_tag_list(self, tags: list[dict[str, str]]) -> dict[str, Optional[str]]:
         """Return dict of key/value pairs with 'tag_name', 'value_name'."""
-        result: Dict[str, Optional[str]] = {}
+        result: dict[str, Optional[str]] = {}
         for tag in tags:
             if self.value_name in tag:
                 result[tag[self.key_name]] = tag[self.value_name]
@@ -107,7 +107,7 @@ class TaggingService:
                 result[tag[self.key_name]] = None
         return result
 
-    def validate_tags(self, tags: List[Dict[str, str]], limit: int = 0) -> str:
+    def validate_tags(self, tags: list[dict[str, str]], limit: int = 0) -> str:
         """Returns error message if tags in 'tags' list of dicts are invalid.
 
         The validation does not include a check for duplicate keys.
@@ -173,8 +173,8 @@ class TaggingService:
 
     @staticmethod
     def convert_dict_to_tags_input(
-        tags: Optional[Dict[str, str]],
-    ) -> List[Dict[str, str]]:
+        tags: Optional[dict[str, str]],
+    ) -> list[dict[str, str]]:
         """Given a dictionary, return generic boto params for tags"""
         if not tags:
             return []

--- a/moto/utilities/utils.py
+++ b/moto/utilities/utils.py
@@ -2,7 +2,8 @@ import gzip
 import hashlib
 import json
 import pkgutil
-from typing import Any, Dict, Iterator, List, MutableMapping, Optional, Tuple, TypeVar
+from collections.abc import Iterator, MutableMapping
+from typing import Any, Optional, TypeVar
 from uuid import UUID
 
 from requests.structures import CaseInsensitiveDict as _CaseInsensitiveDict
@@ -63,7 +64,7 @@ def load_resource_as_bytes(package: str, resource: str) -> bytes:
     return pkgutil.get_data(package, resource)  # type: ignore
 
 
-def merge_multiple_dicts(*args: Any) -> Dict[str, Any]:
+def merge_multiple_dicts(*args: Any) -> dict[str, Any]:
     result = {}
     for d in args:
         result.update(d)
@@ -82,10 +83,10 @@ RESOURCE_TYPE = TypeVar("RESOURCE_TYPE")
 
 
 def filter_resources(
-    resources: List[RESOURCE_TYPE],
+    resources: list[RESOURCE_TYPE],
     filters: Any,
-    attr_pairs: Tuple[Tuple[str, ...], ...],
-) -> List[RESOURCE_TYPE]:
+    attr_pairs: tuple[tuple[str, ...], ...],
+) -> list[RESOURCE_TYPE]:
     """
     Used to filter resources. Usually in get and describe apis.
     """
@@ -120,7 +121,7 @@ class LowercaseDict(MutableMapping[str, Any]):
     """A dictionary that lowercases all keys"""
 
     def __init__(self, *args: Any, **kwargs: Any):
-        self.store: Dict[str, Any] = dict()
+        self.store: dict[str, Any] = dict()
         self.update(dict(*args, **kwargs))  # use the free update to set keys
 
     def __getitem__(self, key: str) -> Any:
@@ -158,7 +159,7 @@ class CamelToUnderscoresWalker:
             return CamelToUnderscoresWalker.parse_scalar(x)
 
     @staticmethod
-    def parse_dict(x: Dict[str, Any]) -> Dict[str, Any]:  # type: ignore[misc]
+    def parse_dict(x: dict[str, Any]) -> dict[str, Any]:  # type: ignore[misc]
         from moto.core.utils import camelcase_to_underscores
 
         temp = {}

--- a/moto/vpclattice/models.py
+++ b/moto/vpclattice/models.py
@@ -1,7 +1,7 @@
 import random
 import uuid
 from datetime import datetime, timezone
-from typing import Any, Dict, List, Optional
+from typing import Any, Optional
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
@@ -23,7 +23,7 @@ class VPCLatticeService(BaseModel):
         client_token: str,
         custom_domain_name: Optional[str],
         name: str,
-        tags: Optional[Dict[str, str]],
+        tags: Optional[dict[str, str]],
     ) -> None:
         self.id: str = f"svc-{str(uuid.uuid4())[:17]}"
         self.auth_type: str = auth_type
@@ -36,9 +36,9 @@ class VPCLatticeService(BaseModel):
         self.name: str = name
         self.arn: str = f"arn:aws:vpc-lattice:{region}:{account_id}:service/{self.id}"
         self.status: str = "ACTIVE"
-        self.tags: Dict[str, str] = tags or {}
+        self.tags: dict[str, str] = tags or {}
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         return {
             "arn": self.arn,
             "authType": self.auth_type,
@@ -59,8 +59,8 @@ class VPCLatticeServiceNetwork(BaseModel):
         auth_type: str,
         client_token: str,
         name: str,
-        sharing_config: Optional[Dict[str, Any]],
-        tags: Optional[Dict[str, str]],
+        sharing_config: Optional[dict[str, Any]],
+        tags: Optional[dict[str, str]],
     ) -> None:
         self.auth_type: str = auth_type
         self.client_token: str = client_token
@@ -69,10 +69,10 @@ class VPCLatticeServiceNetwork(BaseModel):
         self.arn: str = (
             f"arn:aws:vpc-lattice:{region}:{account_id}:servicenetwork/{self.id}"
         )
-        self.sharing_config: Dict[str, Any] = sharing_config or {}
-        self.tags: Dict[str, str] = tags or {}
+        self.sharing_config: dict[str, Any] = sharing_config or {}
+        self.tags: dict[str, str] = tags or {}
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         return {
             "arn": self.arn,
             "authType": self.auth_type,
@@ -88,19 +88,19 @@ class VPCLatticeServiceNetworkVpcAssociation(BaseModel):
         region: str,
         account_id: str,
         client_token: str,
-        security_group_ids: Optional[List[str]],
+        security_group_ids: Optional[list[str]],
         service_network_identifier: str,
-        tags: Optional[Dict[str, str]],
+        tags: Optional[dict[str, str]],
         vpc_identifier: str,
     ) -> None:
         self.id: str = f"snva-{service_network_identifier[:4]}-{vpc_identifier[:4]}"
         self.arn: str = f"arn:aws:vpc-lattice:{region}:{account_id}:servicenetworkvpcassociation/{self.id}"
         self.created_by: str = "user"
-        self.security_group_ids: List[str] = security_group_ids or []
+        self.security_group_ids: list[str] = security_group_ids or []
         self.status: str = "ACTIVE"
-        self.tags: Dict[str, str] = tags or {}
+        self.tags: dict[str, str] = tags or {}
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         return {
             "arn": self.arn,
             "createdBy": self.created_by,
@@ -116,16 +116,16 @@ class VPCLatticeRule(BaseModel):
         self,
         region: str,
         account_id: str,
-        action: Dict[str, Any],
+        action: dict[str, Any],
         client_token: str,
         listener_identifier: str,
-        match: Dict[str, Any],
+        match: dict[str, Any],
         name: str,
         priority: int,
         service_identifier: str,
-        tags: Dict[str, str],
+        tags: dict[str, str],
     ) -> None:
-        self.action: Dict[str, Any] = action or {}
+        self.action: dict[str, Any] = action or {}
         self.id: str = f"rule-[0-9a-z]{17}"
         self.arn: str = (
             f"arn:aws:vpc-lattice:{region}:{account_id}:service/{service_identifier}"
@@ -133,13 +133,13 @@ class VPCLatticeRule(BaseModel):
         )
         self.client_token: str = client_token
         self.listener_identifier: str = listener_identifier
-        self.match: Dict[str, Any] = match or {}
+        self.match: dict[str, Any] = match or {}
         self.name: str = name
         self.priority: int = priority
         self.service_identifier: str = service_identifier
-        self.tags: Dict[str, str] = tags or {}
+        self.tags: dict[str, str] = tags or {}
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         return {
             "arn": self.arn,
             "id": self.id,
@@ -165,7 +165,7 @@ class VPCLatticeDNSEntry:
         )
         self.hosted_zone_id: str = f"Z{random.randint(100000, 999999)}XYZ"
 
-    def to_dict(self) -> Dict[str, str]:
+    def to_dict(self) -> dict[str, str]:
         return {"domainName": self.domain_name, "hostedZoneId": self.hosted_zone_id}
 
 
@@ -178,7 +178,7 @@ class VPCLatticeAccessLogSubscription(BaseModel):
         resourceArn: str,
         resourceId: str,  # resourceIdentifier
         serviceNetworkLogType: Optional[str],
-        tags: Optional[Dict[str, str]],
+        tags: Optional[dict[str, str]],
     ) -> None:
         self.id: str = f"als-{str(uuid.uuid4())[:17]}"
         self.arn: str = (
@@ -192,7 +192,7 @@ class VPCLatticeAccessLogSubscription(BaseModel):
         self.serviceNetworkLogType = serviceNetworkLogType or "SERVICE"
         self.tags = tags or {}
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         return {
             "arn": self.arn,
             "createdAt": self.created_at,
@@ -224,14 +224,14 @@ class VPCLatticeBackend(BaseBackend):
 
     def __init__(self, region_name: str, account_id: str) -> None:
         super().__init__(region_name, account_id)
-        self.services: Dict[str, VPCLatticeService] = {}
-        self.service_networks: Dict[str, VPCLatticeServiceNetwork] = {}
-        self.service_network_vpc_associations: Dict[
+        self.services: dict[str, VPCLatticeService] = {}
+        self.service_networks: dict[str, VPCLatticeServiceNetwork] = {}
+        self.service_network_vpc_associations: dict[
             str, VPCLatticeServiceNetworkVpcAssociation
         ] = {}
-        self.rules: Dict[str, VPCLatticeRule] = {}
+        self.rules: dict[str, VPCLatticeRule] = {}
         self.tagger: TaggingService = TaggingService()
-        self.access_log_subscriptions: Dict[str, VPCLatticeAccessLogSubscription] = {}
+        self.access_log_subscriptions: dict[str, VPCLatticeAccessLogSubscription] = {}
 
     def create_service(
         self,
@@ -240,7 +240,7 @@ class VPCLatticeBackend(BaseBackend):
         client_token: str,
         custom_domain_name: Optional[str],
         name: str,
-        tags: Optional[Dict[str, str]],
+        tags: Optional[dict[str, str]],
     ) -> VPCLatticeService:
         service = VPCLatticeService(
             self.region_name,
@@ -263,7 +263,7 @@ class VPCLatticeBackend(BaseBackend):
         return service
 
     @paginate(pagination_model=PAGINATION_MODEL)
-    def list_services(self) -> List[VPCLatticeService]:
+    def list_services(self) -> list[VPCLatticeService]:
         return [service for service in self.services.values()]
 
     def create_service_network(
@@ -271,8 +271,8 @@ class VPCLatticeBackend(BaseBackend):
         auth_type: str,
         client_token: str,
         name: str,
-        sharing_config: Optional[Dict[str, Any]],
-        tags: Optional[Dict[str, str]],
+        sharing_config: Optional[dict[str, Any]],
+        tags: Optional[dict[str, str]],
     ) -> VPCLatticeServiceNetwork:
         """
         WARNING: This method currently does NOT fail if there is a disassociation in progress.
@@ -299,15 +299,15 @@ class VPCLatticeBackend(BaseBackend):
         return service_network
 
     @paginate(pagination_model=PAGINATION_MODEL)
-    def list_service_networks(self) -> List[VPCLatticeServiceNetwork]:
+    def list_service_networks(self) -> list[VPCLatticeServiceNetwork]:
         return [service_network for service_network in self.service_networks.values()]
 
     def create_service_network_vpc_association(
         self,
         client_token: str,
-        security_group_ids: Optional[List[str]],
+        security_group_ids: Optional[list[str]],
         service_network_identifier: str,
-        tags: Optional[Dict[str, str]],
+        tags: Optional[dict[str, str]],
         vpc_identifier: str,
     ) -> VPCLatticeServiceNetworkVpcAssociation:
         assoc = VPCLatticeServiceNetworkVpcAssociation(
@@ -325,14 +325,14 @@ class VPCLatticeBackend(BaseBackend):
 
     def create_rule(
         self,
-        action: Dict[str, Any],
+        action: dict[str, Any],
         client_token: str,
         listener_identifier: str,
-        match: Dict[str, Any],
+        match: dict[str, Any],
         name: str,
         priority: int,
         service_identifier: str,
-        tags: Dict[str, str],
+        tags: dict[str, str],
     ) -> VPCLatticeRule:
         rule = VPCLatticeRule(
             self.region_name,
@@ -350,14 +350,14 @@ class VPCLatticeBackend(BaseBackend):
         self.tag_resource(rule.arn, tags or {})
         return rule
 
-    def tag_resource(self, resource_arn: str, tags: Dict[str, str]) -> None:
+    def tag_resource(self, resource_arn: str, tags: dict[str, str]) -> None:
         tags_input = self.tagger.convert_dict_to_tags_input(tags or {})
         self.tagger.tag_resource(resource_arn, tags_input)
 
-    def list_tags_for_resource(self, resource_arn: str) -> Dict[str, str]:
+    def list_tags_for_resource(self, resource_arn: str) -> dict[str, str]:
         return self.tagger.get_tag_dict_for_resource(resource_arn)
 
-    def untag_resource(self, resource_arn: str, tag_keys: List[str]) -> None:
+    def untag_resource(self, resource_arn: str, tag_keys: list[str]) -> None:
         if not isinstance(tag_keys, list):
             tag_keys = [tag_keys]
         self.tagger.untag_resource_using_names(resource_arn, tag_keys)
@@ -368,7 +368,7 @@ class VPCLatticeBackend(BaseBackend):
         destinationArn: str,
         client_token: Optional[str],
         serviceNetworkLogType: Optional[str],
-        tags: Optional[Dict[str, str]],
+        tags: Optional[dict[str, str]],
     ) -> VPCLatticeAccessLogSubscription:
         resource: Any = None
         if resourceIdentifier.startswith("sn-"):
@@ -411,7 +411,7 @@ class VPCLatticeBackend(BaseBackend):
         resourceIdentifier: str,
         maxResults: Optional[int] = None,
         nextToken: Optional[str] = None,
-    ) -> List[VPCLatticeAccessLogSubscription]:
+    ) -> list[VPCLatticeAccessLogSubscription]:
         return [
             sub
             for sub in self.access_log_subscriptions.values()

--- a/moto/wafv2/models.py
+++ b/moto/wafv2/models.py
@@ -1,6 +1,6 @@
 import re
 from collections import OrderedDict
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
+from typing import TYPE_CHECKING, Any, Optional, Union
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
@@ -82,13 +82,13 @@ class FakeRule(BaseModel):
         self,
         name: str,
         priority: int,
-        statement: Dict[str, Any],
-        visibility_config: Dict[str, Union[str, bool]],
-        action: Optional[Dict[str, Any]] = None,
-        captcha_config: Optional[Dict[str, Dict[str, int]]] = None,
-        challenge_config: Optional[Dict[str, Dict[str, int]]] = None,
-        override_action: Optional[Dict[str, Any]] = None,
-        rule_labels: Optional[List[Dict[str, str]]] = None,
+        statement: dict[str, Any],
+        visibility_config: dict[str, Union[str, bool]],
+        action: Optional[dict[str, Any]] = None,
+        captcha_config: Optional[dict[str, dict[str, int]]] = None,
+        challenge_config: Optional[dict[str, dict[str, int]]] = None,
+        override_action: Optional[dict[str, Any]] = None,
+        rule_labels: Optional[list[dict[str, str]]] = None,
     ):
         self.name = name
         self.priority = priority
@@ -103,10 +103,10 @@ class FakeRule(BaseModel):
     def get_consumed_label(self) -> Optional[str]:
         return self.statement.get("LabelMatchStatement", {}).get("Key")
 
-    def get_available_labels(self) -> Optional[List[str]]:
+    def get_available_labels(self) -> Optional[list[str]]:
         return [r["Name"] for r in self.rule_labels] if self.rule_labels else None
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         return {
             "Name": self.name,
             "Action": self.action,
@@ -131,15 +131,15 @@ class FakeWebACL(BaseModel):
         account: str,
         arn: str,
         wacl_id: str,
-        visibility_config: Dict[str, Any],
-        default_action: Dict[str, Any],
+        visibility_config: dict[str, Any],
+        default_action: dict[str, Any],
         description: Optional[str],
-        rules: Optional[List[FakeRule]],
-        association_config: Optional[Dict[str, Any]] = None,
-        captcha_config: Optional[Dict[str, Any]] = None,
-        challenge_config: Optional[Dict[str, Any]] = None,
-        custom_response_bodies: Optional[Dict[str, Any]] = None,
-        token_domains: Optional[List[str]] = None,
+        rules: Optional[list[FakeRule]],
+        association_config: Optional[dict[str, Any]] = None,
+        captcha_config: Optional[dict[str, Any]] = None,
+        challenge_config: Optional[dict[str, Any]] = None,
+        custom_response_bodies: Optional[dict[str, Any]] = None,
+        token_domains: Optional[list[str]] = None,
     ):
         self.name = name
         self.account = account
@@ -152,7 +152,7 @@ class FakeWebACL(BaseModel):
         self.visibility_config = visibility_config
         self.default_action = default_action
         self.lock_token = self._generate_lock_token()
-        self.associated_resources: List[str] = []
+        self.associated_resources: list[str] = []
         self.association_config = association_config
         self.captcha_config = captcha_config
         self.challenge_config = challenge_config
@@ -168,15 +168,15 @@ class FakeWebACL(BaseModel):
 
     def update(
         self,
-        default_action: Optional[Dict[str, Any]],
-        rules: Optional[List[FakeRule]],
+        default_action: Optional[dict[str, Any]],
+        rules: Optional[list[FakeRule]],
         description: Optional[str],
-        visibility_config: Optional[Dict[str, Any]],
-        custom_response_bodies: Optional[Dict[str, Any]],
-        captcha_config: Optional[Dict[str, Any]],
-        challenge_config: Optional[Dict[str, Any]],
-        token_domains: Optional[List[str]],
-        association_config: Optional[Dict[str, Any]],
+        visibility_config: Optional[dict[str, Any]],
+        custom_response_bodies: Optional[dict[str, Any]],
+        captcha_config: Optional[dict[str, Any]],
+        challenge_config: Optional[dict[str, Any]],
+        token_domains: Optional[list[str]],
+        association_config: Optional[dict[str, Any]],
     ) -> None:
         if default_action is not None:
             self.default_action = default_action
@@ -198,7 +198,7 @@ class FakeWebACL(BaseModel):
             self.association_config = association_config
         self.lock_token = self._generate_lock_token()
 
-    def to_short_dict(self) -> Dict[str, Any]:
+    def to_short_dict(self) -> dict[str, Any]:
         # Format for summary https://docs.aws.amazon.com/waf/latest/APIReference/API_CreateWebACL.html (response syntax section)
         return {
             "ARN": self.arn,
@@ -208,7 +208,7 @@ class FakeWebACL(BaseModel):
             "LockToken": self.lock_token,
         }
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         return {
             "Name": self.name,
             "Id": self.id,
@@ -238,7 +238,7 @@ class FakeIPSet(BaseModel):
         arn: str,
         ip_set_id: str,
         ip_address_version: str,
-        addresses: List[str],
+        addresses: list[str],
         name: str,
         description: str,
         scope: str,
@@ -253,14 +253,14 @@ class FakeIPSet(BaseModel):
 
         self.lock_token = str(mock_random.uuid4())[0:6]
 
-    def update(self, description: Optional[str], addresses: List[str]) -> None:
+    def update(self, description: Optional[str], addresses: list[str]) -> None:
         if description is not None:
             self.description = description
         self.addresses = addresses
 
         self.lock_token = str(mock_random.uuid4())[0:6]
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         return {
             "Name": self.name,
             "Id": self.ip_set_id,
@@ -276,10 +276,10 @@ class FakeLoggingConfiguration(BaseModel):
     def __init__(
         self,
         arn: str,
-        log_destination_configs: List[str],
-        redacted_fields: Optional[Dict[str, Any]],
+        log_destination_configs: list[str],
+        redacted_fields: Optional[dict[str, Any]],
         managed_gy_firewall_manager: Optional[bool],
-        logging_filter: Optional[Dict[str, Any]],
+        logging_filter: Optional[dict[str, Any]],
     ):
         self.arn = arn
         self.log_destination_configs = log_destination_configs
@@ -287,7 +287,7 @@ class FakeLoggingConfiguration(BaseModel):
         self.managed_by_firewall_manager = managed_gy_firewall_manager or False
         self.logging_filter = logging_filter
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         return {
             "ResourceArn": self.arn,
             "LogDestinationConfigs": self.log_destination_configs,
@@ -306,10 +306,10 @@ class FakeRuleGroup(BaseModel):
         arn: str,
         scope: str,
         capacity: int,
-        visibility_config: Dict[str, Any],
+        visibility_config: dict[str, Any],
         description: Optional[str],
-        rules: Optional[List[FakeRule]],
-        custom_response_bodies: Optional[Dict[str, Any]] = None,
+        rules: Optional[list[FakeRule]],
+        custom_response_bodies: Optional[dict[str, Any]] = None,
     ):
         self.account = account
         self.name = name
@@ -329,7 +329,7 @@ class FakeRuleGroup(BaseModel):
     def _generate_lock_token(self) -> str:
         return str(mock_random.uuid4())
 
-    def _get_available_labels(self) -> Optional[List[Dict[str, str]]]:
+    def _get_available_labels(self) -> Optional[list[dict[str, str]]]:
         return (
             [
                 {"Name": f"{self.label_namespace}{label}"}
@@ -340,7 +340,7 @@ class FakeRuleGroup(BaseModel):
             else None
         )
 
-    def _get_consumed_labels(self) -> Optional[List[Dict[str, str]]]:
+    def _get_consumed_labels(self) -> Optional[list[dict[str, str]]]:
         return (
             [
                 {"Name": f"{self.label_namespace}{label}"}
@@ -357,9 +357,9 @@ class FakeRuleGroup(BaseModel):
     def update(
         self,
         description: Optional[str],
-        rules: Optional[List[FakeRule]],
-        visibility_config: Optional[Dict[str, Any]],
-        custom_response_bodies: Optional[Dict[str, Any]],
+        rules: Optional[list[FakeRule]],
+        visibility_config: Optional[dict[str, Any]],
+        custom_response_bodies: Optional[dict[str, Any]],
     ) -> str:
         if description is not None:
             self.description = description
@@ -373,7 +373,7 @@ class FakeRuleGroup(BaseModel):
         self.lock_token = self._generate_lock_token()
         return self.lock_token
 
-    def to_short_dict(self) -> Dict[str, Any]:
+    def to_short_dict(self) -> dict[str, Any]:
         return {
             "Name": self.name,
             "Id": self.id,
@@ -382,7 +382,7 @@ class FakeRuleGroup(BaseModel):
             "ARN": self.arn,
         }
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         return {
             "Name": self.name,
             "Id": self.id,
@@ -411,7 +411,7 @@ class FakeRegexPatternSet(BaseModel):
         id: str,
         arn: str,
         description: str,
-        regular_expressions: List[Dict[str, str]],
+        regular_expressions: list[dict[str, str]],
         scope: str,
     ):
         self.name = name
@@ -426,7 +426,7 @@ class FakeRegexPatternSet(BaseModel):
     def update(
         self,
         description: Optional[str],
-        regular_expressions: Optional[List[Dict[str, str]]],
+        regular_expressions: Optional[list[dict[str, str]]],
     ) -> None:
         if description is not None:
             self.description = description
@@ -434,7 +434,7 @@ class FakeRegexPatternSet(BaseModel):
             self.regular_expressions = regular_expressions
         self.lock_token = str(mock_random.uuid4())
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         return {
             "Name": self.name,
             "Id": self.id,
@@ -444,7 +444,7 @@ class FakeRegexPatternSet(BaseModel):
             "LockToken": self.lock_token,
         }
 
-    def to_short_dict(self) -> Dict[str, Any]:
+    def to_short_dict(self) -> dict[str, Any]:
         return {
             "Name": self.name,
             "Id": self.id,
@@ -461,11 +461,11 @@ class WAFV2Backend(BaseBackend):
 
     def __init__(self, region_name: str, account_id: str):
         super().__init__(region_name, account_id)
-        self.wacls: Dict[str, FakeWebACL] = OrderedDict()
-        self.ip_sets: Dict[str, FakeIPSet] = OrderedDict()
-        self.logging_configurations: Dict[str, FakeLoggingConfiguration] = OrderedDict()
-        self.rule_groups: Dict[str, FakeRuleGroup] = OrderedDict()
-        self.regex_pattern_sets: Dict[str, FakeRegexPatternSet] = OrderedDict()
+        self.wacls: dict[str, FakeWebACL] = OrderedDict()
+        self.ip_sets: dict[str, FakeIPSet] = OrderedDict()
+        self.logging_configurations: dict[str, FakeLoggingConfiguration] = OrderedDict()
+        self.rule_groups: dict[str, FakeRuleGroup] = OrderedDict()
+        self.regex_pattern_sets: dict[str, FakeRegexPatternSet] = OrderedDict()
         self.tagging_service = TaggingService()
         # TODO: self.load_balancers = OrderedDict()
 
@@ -514,17 +514,17 @@ class WAFV2Backend(BaseBackend):
     def create_web_acl(
         self,
         name: str,
-        visibility_config: Dict[str, Any],
-        default_action: Dict[str, Any],
+        visibility_config: dict[str, Any],
+        default_action: dict[str, Any],
         scope: str,
         description: str,
-        tags: List[Dict[str, str]],
-        rules: List[Dict[str, Any]],
-        association_config: Optional[Dict[str, Any]],
-        captcha_config: Optional[Dict[str, Any]],
-        challenge_config: Optional[Dict[str, Any]],
-        custom_response_bodies: Optional[Dict[str, Any]],
-        token_domains: Optional[List[str]],
+        tags: list[dict[str, str]],
+        rules: list[dict[str, Any]],
+        association_config: Optional[dict[str, Any]],
+        captcha_config: Optional[dict[str, Any]],
+        challenge_config: Optional[dict[str, Any]],
+        custom_response_bodies: Optional[dict[str, Any]],
+        token_domains: Optional[list[str]],
     ) -> FakeWebACL:
         wacl_id = self._generate_id()
         arn = make_arn_for_wacl(
@@ -581,7 +581,7 @@ class WAFV2Backend(BaseBackend):
         raise WAFNonexistentItemException
 
     @paginate(PAGINATION_MODEL)  # type: ignore
-    def list_web_acls(self) -> List[FakeWebACL]:
+    def list_web_acls(self) -> list[FakeWebACL]:
         return [wacl for wacl in self.wacls.values()]
 
     def _is_duplicate_name(self, name: str) -> bool:
@@ -589,36 +589,36 @@ class WAFV2Backend(BaseBackend):
         return name in all_wacl_names
 
     @paginate(PAGINATION_MODEL)  # type: ignore
-    def list_rule_groups(self, scope: str) -> List[FakeRuleGroup]:
+    def list_rule_groups(self, scope: str) -> list[FakeRuleGroup]:
         rule_groups = [
             group for group in self.rule_groups.values() if group.scope == scope
         ]
         return rule_groups
 
     @paginate(PAGINATION_MODEL)  # type: ignore
-    def list_tags_for_resource(self, arn: str) -> List[Dict[str, str]]:
+    def list_tags_for_resource(self, arn: str) -> list[dict[str, str]]:
         return self.tagging_service.list_tags_for_resource(arn)["Tags"]
 
-    def tag_resource(self, arn: str, tags: List[Dict[str, str]]) -> None:
+    def tag_resource(self, arn: str, tags: list[dict[str, str]]) -> None:
         self.tagging_service.tag_resource(arn, tags)
 
-    def untag_resource(self, arn: str, tag_keys: List[str]) -> None:
+    def untag_resource(self, arn: str, tag_keys: list[str]) -> None:
         self.tagging_service.untag_resource_using_names(arn, tag_keys)
 
     def update_web_acl(
         self,
         name: str,
         _id: str,
-        default_action: Optional[Dict[str, Any]],
-        rules: Optional[List[Dict[str, Any]]],
+        default_action: Optional[dict[str, Any]],
+        rules: Optional[list[dict[str, Any]]],
         description: Optional[str],
-        visibility_config: Optional[Dict[str, Any]],
+        visibility_config: Optional[dict[str, Any]],
         lock_token: str,
-        custom_response_bodies: Optional[Dict[str, Any]],
-        captcha_config: Optional[Dict[str, Any]],
-        challenge_config: Optional[Dict[str, Any]],
-        token_domains: Optional[List[str]],
-        association_config: Optional[Dict[str, Any]],
+        custom_response_bodies: Optional[dict[str, Any]],
+        captcha_config: Optional[dict[str, Any]],
+        challenge_config: Optional[dict[str, Any]],
+        token_domains: Optional[list[str]],
+        association_config: Optional[dict[str, Any]],
     ) -> str:
         acl = self.get_web_acl(name, _id)
         if acl.lock_token != lock_token:
@@ -650,8 +650,8 @@ class WAFV2Backend(BaseBackend):
         scope: str,
         description: str,
         ip_address_version: str,
-        addresses: List[str],
-        tags: List[Dict[str, str]],
+        addresses: list[str],
+        tags: list[dict[str, str]],
     ) -> FakeIPSet:
         ip_set_id = self._generate_id()
         arn = make_arn_for_ip_set(
@@ -693,7 +693,7 @@ class WAFV2Backend(BaseBackend):
         self.ip_sets.pop(arn)
 
     @paginate(PAGINATION_MODEL)  # type: ignore
-    def list_ip_sets(self, scope: str) -> List[FakeIPSet]:
+    def list_ip_sets(self, scope: str) -> list[FakeIPSet]:
         ip_sets = [
             ip_set for arn, ip_set in self.ip_sets.items() if ip_set.scope == scope
         ]
@@ -718,7 +718,7 @@ class WAFV2Backend(BaseBackend):
         scope: str,
         _id: str,
         description: Optional[str],
-        addresses: List[str],
+        addresses: list[str],
         lock_token: str,
     ) -> FakeIPSet:
         arn = make_arn_for_ip_set(
@@ -742,10 +742,10 @@ class WAFV2Backend(BaseBackend):
     def put_logging_configuration(
         self,
         arn: str,
-        log_destination_configs: List[str],
-        redacted_fields: Optional[Dict[str, Any]],
+        log_destination_configs: list[str],
+        redacted_fields: Optional[dict[str, Any]],
         managed_gy_firewall_manager: bool,
-        logging_filter: Dict[str, Any],
+        logging_filter: dict[str, Any],
     ) -> FakeLoggingConfiguration:
         logging_configuration = FakeLoggingConfiguration(
             arn,
@@ -768,7 +768,7 @@ class WAFV2Backend(BaseBackend):
         return logging_configuration
 
     @paginate(PAGINATION_MODEL)  # type: ignore
-    def list_logging_configurations(self, scope: str) -> List[FakeLoggingConfiguration]:
+    def list_logging_configurations(self, scope: str) -> list[FakeLoggingConfiguration]:
         if scope == "CLOUDFRONT":
             scope = "global"
         else:
@@ -786,10 +786,10 @@ class WAFV2Backend(BaseBackend):
         scope: str,
         capacity: int,
         description: Optional[str],
-        rules: Optional[List[Dict[str, Any]]],
-        visibility_config: Dict[str, Union[bool, str]],
-        tags: Optional[List[Dict[str, str]]],
-        custom_response_bodies: Optional[Dict[str, str]],
+        rules: Optional[list[dict[str, Any]]],
+        visibility_config: dict[str, Union[bool, str]],
+        tags: Optional[list[dict[str, str]]],
+        custom_response_bodies: Optional[dict[str, str]],
     ) -> FakeRuleGroup:
         id = self._generate_id()
         arn = make_arn_for_rule_group(
@@ -827,10 +827,10 @@ class WAFV2Backend(BaseBackend):
         scope: str,
         id: str,
         description: Optional[str],
-        rules: Optional[List[Dict[str, Any]]],
-        visibility_config: Dict[str, Any],
+        rules: Optional[list[dict[str, Any]]],
+        visibility_config: dict[str, Any],
         lock_token: str,
-        custom_response_bodies: Optional[Dict[str, Any]],
+        custom_response_bodies: Optional[dict[str, Any]],
     ) -> FakeRuleGroup:
         arn = make_arn_for_rule_group(
             name, self.account_id, self.region_name, id, scope
@@ -897,8 +897,8 @@ class WAFV2Backend(BaseBackend):
         name: str,
         scope: str,
         description: str,
-        regular_expressions: List[Dict[str, str]],
-        tags: List[Dict[str, str]],
+        regular_expressions: list[dict[str, str]],
+        tags: list[dict[str, str]],
     ) -> FakeRegexPatternSet:
         regex_pattern_set_id = self._generate_id()
         arn = make_arn_for_regex_pattern_set(
@@ -948,7 +948,7 @@ class WAFV2Backend(BaseBackend):
         scope: str,
         id: str,
         description: Optional[str],
-        regular_expressions: Optional[List[Dict[str, str]]],
+        regular_expressions: Optional[list[dict[str, str]]],
         lock_token: str,
     ) -> FakeRegexPatternSet:
         arn = make_arn_for_regex_pattern_set(
@@ -986,7 +986,7 @@ class WAFV2Backend(BaseBackend):
         self.regex_pattern_sets.pop(arn)
 
     @paginate(PAGINATION_MODEL)
-    def list_regex_pattern_sets(self, scope: str) -> List[FakeRegexPatternSet]:
+    def list_regex_pattern_sets(self, scope: str) -> list[FakeRegexPatternSet]:
         return [
             pattern_set
             for pattern_set in self.regex_pattern_sets.values()

--- a/moto/workspaces/models.py
+++ b/moto/workspaces/models.py
@@ -2,7 +2,7 @@
 
 import re
 from collections.abc import Mapping
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Optional
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
@@ -23,12 +23,12 @@ from moto.workspaces.exceptions import (
 class Workspace(BaseModel):
     def __init__(
         self,
-        workspace: Dict[str, Any],
+        workspace: dict[str, Any],
         running_mode: str,
         error_code: str,
         error_msg: str,
     ):
-        self.workspace_properties: Dict[str, Any]
+        self.workspace_properties: dict[str, Any]
         self.workspace = workspace
         self.workspace_id = f"ws-{mock_random.get_random_hex(9)}"
         # Create_workspaces operation is asynchronous and returns before the WorkSpaces are created.
@@ -56,17 +56,17 @@ class Workspace(BaseModel):
             self.workspace_properties = workspace_properties
 
         self.computer_name = ""  # Workspace Bundle
-        self.modification_states: List[
-            Dict[str, str]
+        self.modification_states: list[
+            dict[str, str]
         ] = []  # modify_workspace_properties
         # create_standy_workspace
-        self.related_workspaces: List[Dict[str, str]] = []
-        self.data_replication_settings: Dict[str, Any] = {}
+        self.related_workspaces: list[dict[str, str]] = []
+        self.data_replication_settings: dict[str, Any] = {}
         # The properties of the standby WorkSpace related to related_workspaces
-        self.standby_workspaces_properties: List[Dict[str, Any]] = []
+        self.standby_workspaces_properties: list[dict[str, Any]] = []
         self.tags = workspace.get("Tags", [])
 
-    def to_dict_pending(self) -> Dict[str, Any]:
+    def to_dict_pending(self) -> dict[str, Any]:
         dct = {
             "WorkspaceId": self.workspace_id,
             "DirectoryId": self.directory_id,
@@ -89,13 +89,13 @@ class Workspace(BaseModel):
         }
         return {k: v for k, v in dct.items() if v}
 
-    def filter_empty_values(self, d: Dict[str, Any]) -> Dict[str, Any]:
+    def filter_empty_values(self, d: dict[str, Any]) -> dict[str, Any]:
         if isinstance(d, Mapping):
             return dict((k, self.filter_empty_values(v)) for k, v in d.items() if v)
         else:
             return d
 
-    def to_dict_failed(self) -> Dict[str, Any]:
+    def to_dict_failed(self) -> dict[str, Any]:
         dct = {
             "WorkspaceRequest": {
                 "DirectoryId": self.workspace["DirectoryId"],
@@ -122,10 +122,10 @@ class WorkSpaceDirectory(BaseModel):
         directory: Directory,
         registration_code: str,
         security_group_id: str,
-        subnet_ids: List[str],
+        subnet_ids: list[str],
         enable_self_service: bool,
         tenancy: str,
-        tags: List[Dict[str, str]],
+        tags: list[dict[str, str]],
     ):
         self.account_id = account_id
         self.region = region
@@ -223,7 +223,7 @@ class WorkSpaceDirectory(BaseModel):
             group_id=self.workspace_security_group_id
         )
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         dct = {
             "DirectoryId": self.directory_id,
             "Alias": self.alias,
@@ -252,13 +252,13 @@ class WorkspaceImage(BaseModel):
         self,
         name: str,
         description: str,
-        tags: List[Dict[str, str]],
+        tags: list[dict[str, str]],
         account_id: str,
     ):
         self.image_id = f"wsi-{mock_random.get_random_hex(9)}"
         self.name = name
         self.description = description
-        self.operating_system: Dict[str, str] = {}  # Unknown
+        self.operating_system: dict[str, str] = {}  # Unknown
         # Initially the 'state' is 'PENDING', but here the 'state' will be set as 'AVAILABLE' since
         # this operation is being mocked.
         self.state = "AVAILABLE"
@@ -267,7 +267,7 @@ class WorkspaceImage(BaseModel):
         self.owner_account = account_id
         self.error_code = ""
         self.error_message = ""
-        self.image_permissions: List[Dict[str, str]] = []
+        self.image_permissions: list[dict[str, str]] = []
         self.tags = tags
 
         # Default updates
@@ -275,9 +275,9 @@ class WorkspaceImage(BaseModel):
             "UpdateAvailable": False,
             "Description": "This WorkSpace image does not have updates available",
         }
-        self.error_details: List[Dict[str, str]] = []
+        self.error_details: list[dict[str, str]] = []
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         dct = {
             "ImageId": self.image_id,
             "Name": self.name,
@@ -290,7 +290,7 @@ class WorkspaceImage(BaseModel):
         }
         return {k: v for k, v in dct.items() if v}
 
-    def to_desc_dict(self) -> Dict[str, Any]:
+    def to_desc_dict(self) -> dict[str, Any]:
         dct = self.to_dict()
         dct_options = {
             "ErrorCode": self.error_code,
@@ -312,10 +312,10 @@ class WorkSpacesBackend(BaseBackend):
 
     def __init__(self, region_name: str, account_id: str):
         super().__init__(region_name, account_id)
-        self.workspaces: Dict[str, Workspace] = dict()
-        self.workspace_directories: Dict[str, WorkSpaceDirectory] = dict()
-        self.workspace_images: Dict[str, WorkspaceImage] = dict()
-        self.directories: List[Directory]
+        self.workspaces: dict[str, Workspace] = dict()
+        self.workspace_directories: dict[str, WorkSpaceDirectory] = dict()
+        self.workspace_images: dict[str, WorkspaceImage] = dict()
+        self.directories: list[Directory]
 
     def validate_directory_id(self, value: str, msg: str) -> None:
         """Raise exception if the directory id is invalid."""
@@ -341,8 +341,8 @@ class WorkSpacesBackend(BaseBackend):
         return security_group_info.id
 
     def create_workspaces(
-        self, workspaces: List[Dict[str, Any]]
-    ) -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]]]:
+        self, workspaces: list[dict[str, Any]]
+    ) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
         failed_requests = []
         pending_requests = []
 
@@ -391,11 +391,11 @@ class WorkSpacesBackend(BaseBackend):
 
     def describe_workspaces(
         self,
-        workspace_ids: List[str],
+        workspace_ids: list[str],
         directory_id: str,
         user_name: str,
         bundle_id: str,
-    ) -> List[Workspace]:
+    ) -> list[Workspace]:
         # Pagination not yet implemented
 
         # Only one of the following are allowed to be specified: BundleId, DirectoryId, WorkSpaceIds.
@@ -429,8 +429,8 @@ class WorkSpacesBackend(BaseBackend):
         return workspaces
 
     def terminate_workspaces(
-        self, terminate_workspace_requests: List[Dict[str, Any]]
-    ) -> Dict[str, List[Dict[str, Any]]]:
+        self, terminate_workspace_requests: list[dict[str, Any]]
+    ) -> dict[str, list[dict[str, Any]]]:
         failed_requests = []
         terminated_workspaces = []
 
@@ -457,10 +457,10 @@ class WorkSpacesBackend(BaseBackend):
     def register_workspace_directory(
         self,
         directory_id: str,
-        subnet_ids: List[str],
+        subnet_ids: list[str],
         enable_self_service: bool,
         tenancy: str,
-        tags: List[Dict[str, str]],
+        tags: list[dict[str, str]],
     ) -> None:
         ran_str = mock_random.get_random_string(length=6)
         registration_code = f"SLiad+{ran_str.upper()}"
@@ -493,8 +493,8 @@ class WorkSpacesBackend(BaseBackend):
         )
 
     def describe_workspace_directories(
-        self, directory_ids: Optional[List[str]] = None
-    ) -> List[WorkSpaceDirectory]:
+        self, directory_ids: Optional[list[str]] = None
+    ) -> list[WorkSpaceDirectory]:
         """Return info on all directories or directories with matching IDs."""
         # Pagination not yet implemented
 
@@ -510,7 +510,7 @@ class WorkSpacesBackend(BaseBackend):
         return sorted(workspace_directories, key=lambda x: x.launch_time)
 
     def modify_workspace_creation_properties(
-        self, resource_id: str, workspace_creation_properties: Dict[str, Any]
+        self, resource_id: str, workspace_creation_properties: dict[str, Any]
     ) -> None:
         # Raise Exception if Directory doesnot exist.
         if resource_id not in self.workspace_directories:
@@ -519,7 +519,7 @@ class WorkSpacesBackend(BaseBackend):
         res = self.workspace_directories[resource_id]
         res.workspace_creation_properties = workspace_creation_properties
 
-    def create_tags(self, resource_id: str, tags: List[Dict[str, str]]) -> None:
+    def create_tags(self, resource_id: str, tags: list[dict[str, str]]) -> None:
         if resource_id.startswith("d-"):
             ds = self.workspace_directories[resource_id]
             ds.tags.extend(tags)
@@ -527,7 +527,7 @@ class WorkSpacesBackend(BaseBackend):
             ws = self.workspaces[resource_id]
             ws.tags.extend(tags)
 
-    def describe_tags(self, resource_id: str) -> List[Dict[str, str]]:
+    def describe_tags(self, resource_id: str) -> list[dict[str, str]]:
         if resource_id.startswith("d-"):
             ds = self.workspace_directories[resource_id]
             tag_list = ds.tags
@@ -539,7 +539,7 @@ class WorkSpacesBackend(BaseBackend):
             tag_list = wsi.tags
         return tag_list
 
-    def describe_client_properties(self, resource_ids: str) -> List[Dict[str, Any]]:
+    def describe_client_properties(self, resource_ids: str) -> list[dict[str, Any]]:
         workspace_directories = list(self.workspace_directories.values())
         workspace_directories = [
             x for x in workspace_directories if x.directory_id in resource_ids
@@ -554,14 +554,14 @@ class WorkSpacesBackend(BaseBackend):
         return client_properties_list
 
     def modify_client_properties(
-        self, resource_id: str, client_properties: Dict[str, str]
+        self, resource_id: str, client_properties: dict[str, str]
     ) -> None:
         res = self.workspace_directories[resource_id]
         res.client_properties = client_properties
 
     def create_workspace_image(
-        self, name: str, description: str, workspace_id: str, tags: List[Dict[str, str]]
-    ) -> Dict[str, Any]:
+        self, name: str, description: str, workspace_id: str, tags: list[dict[str, str]]
+    ) -> dict[str, Any]:
         # Check if workspace exists.
         if workspace_id not in self.workspaces:
             raise ResourceNotFoundException(
@@ -583,8 +583,8 @@ class WorkSpacesBackend(BaseBackend):
         return workspace_image.to_dict()
 
     def describe_workspace_images(
-        self, image_ids: Optional[List[str]], image_type: Optional[str]
-    ) -> List[Dict[str, Any]]:
+        self, image_ids: Optional[list[str]], image_type: Optional[str]
+    ) -> list[dict[str, Any]]:
         # Pagination not yet implemented
         workspace_images = list(self.workspace_images.values())
         if image_type == "OWNED":
@@ -616,7 +616,7 @@ class WorkSpacesBackend(BaseBackend):
 
     def describe_workspace_image_permissions(
         self, image_id: str
-    ) -> Tuple[str, List[Dict[str, str]]]:
+    ) -> tuple[str, list[dict[str, str]]]:
         # Pagination not yet implemented
 
         msg = f"The Image ID {image_id} in the request is invalid"
@@ -635,7 +635,7 @@ class WorkSpacesBackend(BaseBackend):
         self.workspace_directories.pop(directory_id)
 
     def modify_selfservice_permissions(
-        self, resource_id: str, selfservice_permissions: Dict[str, str]
+        self, resource_id: str, selfservice_permissions: dict[str, str]
     ) -> None:
         res = self.workspace_directories[resource_id]
         res.self_service_permissions = selfservice_permissions

--- a/moto/workspacesweb/models.py
+++ b/moto/workspacesweb/models.py
@@ -2,7 +2,7 @@
 
 import datetime
 import uuid
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Optional
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
@@ -43,12 +43,12 @@ class FakeUserSettings(BaseModel):
         self.paste_allowed = paste_allowed if paste_allowed else "Disabled"
         self.print_allowed = print_allowed if print_allowed else "Disabled"
         self.upload_allowed = upload_allowed if upload_allowed else "Disabled"
-        self.associated_portal_arns: List[str] = []
+        self.associated_portal_arns: list[str] = []
 
     def arn_formatter(self, _id: str, account_id: str, region_name: str) -> str:
         return f"arn:{get_partition(region_name)}:workspaces-web:{region_name}:{account_id}:user-settings/{_id}"
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         return {
             "associatedPortalArns": self.associated_portal_arns,
             "additionalEncryptionContext": self.additional_encryption_context,
@@ -81,12 +81,12 @@ class FakeUserAccessLoggingSettings(BaseModel):
         )
         self.client_token = client_token
         self.kinesis_stream_arn = kinesis_stream_arn
-        self.associated_portal_arns: List[str] = []
+        self.associated_portal_arns: list[str] = []
 
     def arn_formatter(self, _id: str, account_id: str, region_name: str) -> str:
         return f"arn:{get_partition(region_name)}:workspaces-web:{region_name}:{account_id}:user-access-logging-settings/{_id}"
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         return {
             "associatedPortalArns": self.associated_portal_arns,
             "kinesisStreamArn": self.kinesis_stream_arn,
@@ -97,8 +97,8 @@ class FakeUserAccessLoggingSettings(BaseModel):
 class FakeNetworkSettings(BaseModel):
     def __init__(
         self,
-        security_group_ids: List[str],
-        subnet_ids: List[str],
+        security_group_ids: list[str],
+        subnet_ids: list[str],
         vpc_id: str,
         region_name: str,
         account_id: str,
@@ -108,12 +108,12 @@ class FakeNetworkSettings(BaseModel):
         self.security_group_ids = security_group_ids
         self.subnet_ids = subnet_ids
         self.vpc_id = vpc_id
-        self.associated_portal_arns: List[str] = []
+        self.associated_portal_arns: list[str] = []
 
     def arn_formatter(self, _id: str, account_id: str, region_name: str) -> str:
         return f"arn:{get_partition(region_name)}:workspaces-web:{region_name}:{account_id}:network-settings/{_id}"
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         return {
             "associatedPortalArns": self.associated_portal_arns,
             "networkSettingsArn": self.arn,
@@ -139,12 +139,12 @@ class FakeBrowserSettings(BaseModel):
         self.browser_policy = browser_policy
         self.client_token = client_token
         self.customer_managed_key = customer_managed_key
-        self.associated_portal_arns: List[str] = []
+        self.associated_portal_arns: list[str] = []
 
     def arn_formatter(self, _id: str, account_id: str, region_name: str) -> str:
         return f"arn:{get_partition(region_name)}:workspaces-web:{region_name}:{account_id}:browser-settings/{_id}"
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         return {
             "associatedPortalArns": self.associated_portal_arns,
             "browserSettingsArn": self.arn,
@@ -192,7 +192,7 @@ class FakePortal(BaseModel):
     def arn_formatter(self, _id: str, account_id: str, region_name: str) -> str:
         return f"arn:{get_partition(region_name)}:workspaces-web:{region_name}:{account_id}:portal/{_id}"
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         return {
             "additionalEncryptionContext": self.additional_encryption_context,
             "authenticationType": self.authentication_type,
@@ -221,18 +221,18 @@ class WorkSpacesWebBackend(BaseBackend):
 
     def __init__(self, region_name: str, account_id: str):
         super().__init__(region_name, account_id)
-        self.network_settings: Dict[str, FakeNetworkSettings] = {}
-        self.browser_settings: Dict[str, FakeBrowserSettings] = {}
-        self.user_settings: Dict[str, FakeUserSettings] = {}
-        self.user_access_logging_settings: Dict[str, FakeUserAccessLoggingSettings] = {}
-        self.portals: Dict[str, FakePortal] = {}
+        self.network_settings: dict[str, FakeNetworkSettings] = {}
+        self.browser_settings: dict[str, FakeBrowserSettings] = {}
+        self.user_settings: dict[str, FakeUserSettings] = {}
+        self.user_access_logging_settings: dict[str, FakeUserAccessLoggingSettings] = {}
+        self.portals: dict[str, FakePortal] = {}
         self.tagger = TaggingService()
 
     def create_network_settings(
         self,
-        security_group_ids: List[str],
-        subnet_ids: List[str],
-        tags: Dict[str, str],
+        security_group_ids: list[str],
+        subnet_ids: list[str],
+        tags: dict[str, str],
         vpc_id: str,
     ) -> str:
         network_settings_object = FakeNetworkSettings(
@@ -247,13 +247,13 @@ class WorkSpacesWebBackend(BaseBackend):
             self.tag_resource("TEMP_CLIENT_TOKEN", network_settings_object.arn, tags)
         return network_settings_object.arn
 
-    def list_network_settings(self) -> List[Dict[str, str]]:
+    def list_network_settings(self) -> list[dict[str, str]]:
         return [
             {"networkSettingsArn": network_setting.arn, "vpcId": network_setting.vpc_id}
             for network_setting in self.network_settings.values()
         ]
 
-    def get_network_settings(self, network_settings_arn: str) -> Dict[str, Any]:
+    def get_network_settings(self, network_settings_arn: str) -> dict[str, Any]:
         return self.network_settings[network_settings_arn].to_dict()
 
     def delete_network_settings(self, network_settings_arn: str) -> None:
@@ -265,7 +265,7 @@ class WorkSpacesWebBackend(BaseBackend):
         browser_policy: str,
         client_token: str,
         customer_managed_key: str,
-        tags: Optional[List[Dict[str, str]]] = None,
+        tags: Optional[list[dict[str, str]]] = None,
     ) -> str:
         browser_settings_object = FakeBrowserSettings(
             additional_encryption_context,
@@ -280,13 +280,13 @@ class WorkSpacesWebBackend(BaseBackend):
             self.tag_resource(client_token, browser_settings_object.arn, tags)
         return browser_settings_object.arn
 
-    def list_browser_settings(self) -> List[Dict[str, str]]:
+    def list_browser_settings(self) -> list[dict[str, str]]:
         return [
             {"browserSettingsArn": browser_setting.arn}
             for browser_setting in self.browser_settings.values()
         ]
 
-    def get_browser_settings(self, browser_settings_arn: str) -> Dict[str, Any]:
+    def get_browser_settings(self, browser_settings_arn: str) -> dict[str, Any]:
         return self.browser_settings[browser_settings_arn].to_dict()
 
     def delete_browser_settings(self, browser_settings_arn: str) -> None:
@@ -301,8 +301,8 @@ class WorkSpacesWebBackend(BaseBackend):
         display_name: str,
         instance_type: str,
         max_concurrent_sessions: str,
-        tags: Optional[List[Dict[str, str]]] = None,
-    ) -> Tuple[str, str]:
+        tags: Optional[list[dict[str, str]]] = None,
+    ) -> tuple[str, str]:
         portal_object = FakePortal(
             additional_encryption_context,
             authentication_type,
@@ -319,7 +319,7 @@ class WorkSpacesWebBackend(BaseBackend):
             self.tag_resource(client_token, portal_object.arn, tags)
         return portal_object.arn, portal_object.portal_endpoint
 
-    def list_portals(self) -> List[Dict[str, Any]]:
+    def list_portals(self) -> list[dict[str, Any]]:
         return [
             {
                 "authenticationType": portal.authentication_type,
@@ -344,7 +344,7 @@ class WorkSpacesWebBackend(BaseBackend):
             for portal in self.portals.values()
         ]
 
-    def get_portal(self, portal_arn: str) -> Dict[str, Any]:
+    def get_portal(self, portal_arn: str) -> dict[str, Any]:
         return self.portals[portal_arn].to_dict()
 
     def delete_portal(self, portal_arn: str) -> None:
@@ -352,7 +352,7 @@ class WorkSpacesWebBackend(BaseBackend):
 
     def associate_browser_settings(
         self, browser_settings_arn: str, portal_arn: str
-    ) -> Tuple[str, str]:
+    ) -> tuple[str, str]:
         browser_settings_object = self.browser_settings[browser_settings_arn]
         portal_object = self.portals[portal_arn]
         browser_settings_object.associated_portal_arns.append(portal_arn)
@@ -361,7 +361,7 @@ class WorkSpacesWebBackend(BaseBackend):
 
     def associate_network_settings(
         self, network_settings_arn: str, portal_arn: str
-    ) -> Tuple[str, str]:
+    ) -> tuple[str, str]:
         network_settings_object = self.network_settings[network_settings_arn]
         portal_object = self.portals[portal_arn]
         network_settings_object.associated_portal_arns.append(portal_arn)
@@ -405,7 +405,7 @@ class WorkSpacesWebBackend(BaseBackend):
             self.tag_resource(client_token, user_settings_object.arn, tags)
         return user_settings_object.arn
 
-    def get_user_settings(self, user_settings_arn: str) -> Dict[str, Any]:
+    def get_user_settings(self, user_settings_arn: str) -> dict[str, Any]:
         return self.user_settings[user_settings_arn].to_dict()
 
     def delete_user_settings(self, user_settings_arn: str) -> None:
@@ -428,7 +428,7 @@ class WorkSpacesWebBackend(BaseBackend):
 
     def get_user_access_logging_settings(
         self, user_access_logging_settings_arn: str
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         return self.user_access_logging_settings[
             user_access_logging_settings_arn
         ].to_dict()
@@ -440,7 +440,7 @@ class WorkSpacesWebBackend(BaseBackend):
 
     def associate_user_settings(
         self, portal_arn: str, user_settings_arn: str
-    ) -> Tuple[str, str]:
+    ) -> tuple[str, str]:
         user_settings_object = self.user_settings[user_settings_arn]
         portal_object = self.portals[portal_arn]
         user_settings_object.associated_portal_arns.append(portal_arn)
@@ -449,7 +449,7 @@ class WorkSpacesWebBackend(BaseBackend):
 
     def associate_user_access_logging_settings(
         self, portal_arn: str, user_access_logging_settings_arn: str
-    ) -> Tuple[str, str]:
+    ) -> tuple[str, str]:
         user_access_logging_settings_object = self.user_access_logging_settings[
             user_access_logging_settings_arn
         ]
@@ -460,13 +460,13 @@ class WorkSpacesWebBackend(BaseBackend):
         )
         return portal_arn, user_access_logging_settings_arn
 
-    def list_user_settings(self) -> List[Dict[str, str]]:
+    def list_user_settings(self) -> list[dict[str, str]]:
         return [
             {"userSettingsArn": user_settings.arn}
             for user_settings in self.user_settings.values()
         ]
 
-    def list_user_access_logging_settings(self) -> List[Dict[str, str]]:
+    def list_user_access_logging_settings(self) -> list[dict[str, str]]:
         return [
             {"userAccessLoggingSettingsArn": user_access_logging_settings.arn}
             for user_access_logging_settings in self.user_access_logging_settings.values()
@@ -478,7 +478,7 @@ class WorkSpacesWebBackend(BaseBackend):
     def untag_resource(self, resource_arn: str, tag_keys: Any) -> None:
         self.tagger.untag_resource_using_names(resource_arn, tag_keys)
 
-    def list_tags_for_resource(self, resource_arn: str) -> List[Dict[str, str]]:
+    def list_tags_for_resource(self, resource_arn: str) -> list[dict[str, str]]:
         tags = self.tagger.get_tag_dict_for_resource(resource_arn)
         Tags = []
         for key, value in tags.items():

--- a/moto/xray/exceptions.py
+++ b/moto/xray/exceptions.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Optional
+from typing import Any, Optional
 
 
 class BadSegmentException(Exception):
@@ -15,8 +15,8 @@ class BadSegmentException(Exception):
     def __repr__(self) -> str:
         return f"<BadSegment {self.id}-{self.code}-{self.message}>"
 
-    def to_dict(self) -> Dict[str, Any]:
-        result: Dict[str, Any] = {}
+    def to_dict(self) -> dict[str, Any]:
+        result: dict[str, Any] = {}
         if self.id is not None:
             result["Id"] = self.id
         if self.code is not None:

--- a/moto/xray/mock_client.py
+++ b/moto/xray/mock_client.py
@@ -84,7 +84,7 @@ class MockXrayClient:
         self.stop()
 
 
-class XRaySegment(object):
+class XRaySegment:
     """
     XRay is request oriented, when a request comes in, normally middleware like django (or automatically in lambda) will mark
     the start of a segment, this stay open during the lifetime of the request. During that time subsegments may be generated

--- a/moto/xray/models.py
+++ b/moto/xray/models.py
@@ -2,7 +2,7 @@ import bisect
 import datetime
 import json
 from collections import defaultdict
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Optional
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
@@ -17,7 +17,7 @@ class TelemetryRecords(BaseModel):
         instance_id: str,
         hostname: str,
         resource_arn: str,
-        records: List[Dict[str, Any]],
+        records: list[dict[str, Any]],
     ):
         self.instance_id = instance_id
         self.hostname = hostname
@@ -25,7 +25,7 @@ class TelemetryRecords(BaseModel):
         self.records = records
 
     @classmethod
-    def from_json(cls, src: Dict[str, Any]) -> "TelemetryRecords":  # type: ignore[misc]
+    def from_json(cls, src: dict[str, Any]) -> "TelemetryRecords":  # type: ignore[misc]
         instance_id = src.get("EC2InstanceId", None)
         hostname = src.get("Hostname")
         resource_arn = src.get("ResourceARN")
@@ -112,7 +112,7 @@ class TraceSegment(BaseModel):
         return self._end_date
 
     @classmethod
-    def from_dict(cls, data: Dict[str, Any], raw: Any) -> "TraceSegment":  # type: ignore[misc]
+    def from_dict(cls, data: dict[str, Any], raw: Any) -> "TraceSegment":  # type: ignore[misc]
         # Check manditory args
         if "id" not in data:
             raise BadSegmentException(code="MissingParam", message="Missing segment ID")
@@ -139,12 +139,12 @@ class TraceSegment(BaseModel):
         return cls(raw=raw, **data)
 
 
-class SegmentCollection(object):
+class SegmentCollection:
     def __init__(self) -> None:
-        self._traces: Dict[str, Dict[str, Any]] = defaultdict(self._new_trace_item)
+        self._traces: dict[str, dict[str, Any]] = defaultdict(self._new_trace_item)
 
     @staticmethod
-    def _new_trace_item() -> Dict[str, Any]:  # type: ignore[misc]
+    def _new_trace_item() -> dict[str, Any]:  # type: ignore[misc]
         return {
             "start_date": datetime.datetime(1970, 1, 1),
             "end_date": datetime.datetime(1970, 1, 1),
@@ -172,7 +172,7 @@ class SegmentCollection(object):
 
     def summary(
         self, start_time: str, end_time: str, filter_expression: Any = None
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         # This beast https://docs.aws.amazon.com/xray/latest/api/API_GetTraceSummaries.html#API_GetTraceSummaries_ResponseSyntax
         if filter_expression is not None:
             raise AWSError(
@@ -228,8 +228,8 @@ class SegmentCollection(object):
         return result
 
     def get_trace_ids(
-        self, trace_ids: List[str]
-    ) -> Tuple[List[Dict[str, Any]], List[str]]:
+        self, trace_ids: list[str]
+    ) -> tuple[list[dict[str, Any]], list[str]]:
         traces = []
         unprocessed = []
 
@@ -247,7 +247,7 @@ class SegmentCollection(object):
 class XRayBackend(BaseBackend):
     def __init__(self, region_name: str, account_id: str):
         super().__init__(region_name, account_id)
-        self._telemetry_records: List[TelemetryRecords] = []
+        self._telemetry_records: list[TelemetryRecords] = []
         self._segment_collection = SegmentCollection()
 
     def add_telemetry_records(self, src: Any) -> None:
@@ -275,13 +275,13 @@ class XRayBackend(BaseBackend):
 
     def get_trace_summary(
         self, start_time: str, end_time: str, filter_expression: Any
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         return self._segment_collection.summary(start_time, end_time, filter_expression)
 
-    def get_trace_ids(self, trace_ids: List[str]) -> Dict[str, Any]:
+    def get_trace_ids(self, trace_ids: list[str]) -> dict[str, Any]:
         traces, unprocessed_ids = self._segment_collection.get_trace_ids(trace_ids)
 
-        result: Dict[str, Any] = {"Traces": [], "UnprocessedTraceIds": unprocessed_ids}
+        result: dict[str, Any] = {"Traces": [], "UnprocessedTraceIds": unprocessed_ids}
 
         for trace in traces:
             segments = []

--- a/moto/xray/responses.py
+++ b/moto/xray/responses.py
@@ -1,6 +1,6 @@
 import datetime
 import json
-from typing import Any, Dict, Tuple, Union
+from typing import Any, Union
 from urllib.parse import urlsplit
 
 from moto.core.exceptions import AWSError
@@ -14,7 +14,7 @@ class XRayResponse(BaseResponse):
     def __init__(self) -> None:
         super().__init__(service_name="xray")
 
-    def _error(self, code: str, message: str) -> Tuple[str, Dict[str, int]]:
+    def _error(self, code: str, message: str) -> tuple[str, dict[str, int]]:
         return json.dumps({"__type": code, "message": message}), dict(status=400)
 
     @property
@@ -44,7 +44,7 @@ class XRayResponse(BaseResponse):
         return ""
 
     # PutTraceSegments
-    def trace_segments(self) -> Union[str, Tuple[str, Dict[str, int]]]:
+    def trace_segments(self) -> Union[str, tuple[str, dict[str, int]]]:
         docs = self._get_param("TraceSegmentDocuments")
 
         if docs is None:
@@ -72,7 +72,7 @@ class XRayResponse(BaseResponse):
         return json.dumps(result)
 
     # GetTraceSummaries
-    def trace_summaries(self) -> Union[str, Tuple[str, Dict[str, int]]]:
+    def trace_summaries(self) -> Union[str, tuple[str, dict[str, int]]]:
         start_time = self._get_param("StartTime")
         end_time = self._get_param("EndTime")
         if start_time is None:
@@ -122,7 +122,7 @@ class XRayResponse(BaseResponse):
         return json.dumps(result)
 
     # BatchGetTraces
-    def traces(self) -> Union[str, Tuple[str, Dict[str, int]]]:
+    def traces(self) -> Union[str, tuple[str, dict[str, int]]]:
         trace_ids = self._get_param("TraceIds")
 
         if trace_ids is None:
@@ -145,7 +145,7 @@ class XRayResponse(BaseResponse):
         return json.dumps(result)
 
     # GetServiceGraph - just a dummy response for now
-    def service_graph(self) -> Union[str, Tuple[str, Dict[str, int]]]:
+    def service_graph(self) -> Union[str, tuple[str, dict[str, int]]]:
         start_time = self._get_param("StartTime")
         end_time = self._get_param("EndTime")
         # next_token = self._get_param('NextToken')  # not implemented yet
@@ -167,7 +167,7 @@ class XRayResponse(BaseResponse):
         return json.dumps(result)
 
     # GetTraceGraph - just a dummy response for now
-    def trace_graph(self) -> Union[str, Tuple[str, Dict[str, int]]]:
+    def trace_graph(self) -> Union[str, tuple[str, dict[str, int]]]:
         trace_ids = self._get_param("TraceIds")
         # next_token = self._get_param('NextToken')  # not implemented yet
 
@@ -178,5 +178,5 @@ class XRayResponse(BaseResponse):
                 dict(status=400),
             )
 
-        result: Dict[str, Any] = {"Services": []}
+        result: dict[str, Any] = {"Services": []}
         return json.dumps(result)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ ignore = [
     "B027",  # `ResourceEval.eval_resource` is an empty method in an abstract base class, but has no abstract decorator
     "B904",  # Within an `except` clause, raise exceptions with `raise ... from err` or `raise ... from None` to distinguish them from errors in exception handling
     "E501",  # Line length
+    "UP007",  # Use X | Y for type annotations - should only be enabled when we support Python >= 3.10
 ]
-extend-select = ["B", "I", "T201", "T203"]
+extend-select = ["B", "I", "T201", "T203", "UP"]
 

--- a/tests/test_batch/__init__.py
+++ b/tests/test_batch/__init__.py
@@ -1,5 +1,5 @@
 import json
-from typing import Any, Tuple
+from typing import Any
 from uuid import uuid4
 
 import boto3
@@ -7,7 +7,7 @@ import boto3
 DEFAULT_REGION = "eu-central-1"
 
 
-def _get_clients() -> Tuple[Any, Any, Any, Any, Any]:
+def _get_clients() -> tuple[Any, Any, Any, Any, Any]:
     return (
         boto3.client("ec2", region_name=DEFAULT_REGION),
         boto3.client("iam", region_name=DEFAULT_REGION),
@@ -17,7 +17,7 @@ def _get_clients() -> Tuple[Any, Any, Any, Any, Any]:
     )
 
 
-def _setup(ec2_client: Any, iam_client: Any) -> Tuple[str, str, str, str]:
+def _setup(ec2_client: Any, iam_client: Any) -> tuple[str, str, str, str]:
     """
     Do prerequisite setup
     :return: VPC ID, Subnet ID, Security group ID, IAM Role ARN

--- a/tests/test_batch_simple/test_batch_jobs.py
+++ b/tests/test_batch_simple/test_batch_jobs.py
@@ -1,5 +1,5 @@
 import os
-from typing import Any, Tuple
+from typing import Any
 from unittest import SkipTest, mock
 from uuid import uuid4
 
@@ -191,7 +191,7 @@ def test_submit_job_fail_bad_int() -> None:
         assert job["status"] == "FAILED"
 
 
-def setup_common_batch_simple(job_definition_name: str) -> Tuple[Any, str, str]:
+def setup_common_batch_simple(job_definition_name: str) -> tuple[Any, str, str]:
     if settings.TEST_SERVER_MODE:
         raise SkipTest("No point in testing batch_simple in ServerMode")
 

--- a/tests/test_core/test_account_id_resolution.py
+++ b/tests/test_core/test_account_id_resolution.py
@@ -1,5 +1,5 @@
 import os
-from typing import Dict, Optional
+from typing import Optional
 from unittest import SkipTest
 
 import requests
@@ -53,7 +53,7 @@ class TestAccountIdResolution:
         assert self._get_account_id(resp) == ACCOUNT_ID
 
     def _get_caller_identity(
-        self, extra_headers: Optional[Dict[str, str]] = None
+        self, extra_headers: Optional[dict[str, str]] = None
     ) -> requests.Response:
         data = "Action=GetCallerIdentity&Version=2011-06-15"
         headers = {

--- a/tests/test_core/test_auth.py
+++ b/tests/test_core/test_auth.py
@@ -1,6 +1,6 @@
 import json
 import sys
-from typing import Any, Dict, Optional
+from typing import Any, Optional
 from unittest import SkipTest
 from uuid import uuid4
 
@@ -17,7 +17,7 @@ boto3_version = sys.modules["botocore"].__version__
 
 
 @mock_aws
-def create_user_with_access_key(user_name: str = "test-user") -> Dict[str, str]:
+def create_user_with_access_key(user_name: str = "test-user") -> dict[str, str]:
     client = boto3.client("iam", region_name="us-east-1")
     client.create_user(UserName=user_name)
     return client.create_access_key(UserName=user_name)["AccessKey"]
@@ -26,10 +26,10 @@ def create_user_with_access_key(user_name: str = "test-user") -> Dict[str, str]:
 @mock_aws
 def create_user_with_access_key_and_inline_policy(  # type: ignore[misc]
     user_name: str,
-    policy_document: Dict[str, Any],
+    policy_document: dict[str, Any],
     policy_name: str = "policy1",
     region_name: str = "us-east-1",
-) -> Dict[str, str]:
+) -> dict[str, str]:
     client = boto3.client("iam", region_name=region_name)
     client.create_user(UserName=user_name)
     client.put_user_policy(
@@ -42,8 +42,8 @@ def create_user_with_access_key_and_inline_policy(  # type: ignore[misc]
 
 @mock_aws
 def create_user_with_access_key_and_attached_policy(  # type: ignore[misc]
-    user_name: str, policy_document: Dict[str, Any], policy_name: str = "policy1"
-) -> Dict[str, str]:
+    user_name: str, policy_document: dict[str, Any], policy_name: str = "policy1"
+) -> dict[str, str]:
     client = boto3.client("iam", region_name="us-east-1")
     client.create_user(UserName=user_name)
     policy_arn = client.create_policy(
@@ -56,11 +56,11 @@ def create_user_with_access_key_and_attached_policy(  # type: ignore[misc]
 @mock_aws
 def create_user_with_access_key_and_multiple_policies(  # type: ignore[misc]
     user_name: str,
-    inline_policy_document: Dict[str, Any],
-    attached_policy_document: Dict[str, Any],
+    inline_policy_document: dict[str, Any],
+    attached_policy_document: dict[str, Any],
     inline_policy_name: str = "policy1",
     attached_policy_name: str = "policy1",
-) -> Dict[str, str]:
+) -> dict[str, str]:
     client = boto3.client("iam", region_name="us-east-1")
     client.create_user(UserName=user_name)
     policy_arn = client.create_policy(
@@ -78,7 +78,7 @@ def create_user_with_access_key_and_multiple_policies(  # type: ignore[misc]
 
 def create_group_with_attached_policy_and_add_user(
     user_name: str,
-    policy_document: Dict[str, Any],
+    policy_document: dict[str, Any],
     group_name: str = "test-group",
     policy_name: Optional[str] = None,
 ) -> None:
@@ -95,7 +95,7 @@ def create_group_with_attached_policy_and_add_user(
 
 def create_group_with_inline_policy_and_add_user(
     user_name: str,
-    policy_document: Dict[str, Any],
+    policy_document: dict[str, Any],
     group_name: str = "test-group",
     policy_name: str = "policy1",
 ) -> None:
@@ -111,8 +111,8 @@ def create_group_with_inline_policy_and_add_user(
 
 def create_group_with_multiple_policies_and_add_user(
     user_name: str,
-    inline_policy_document: Dict[str, Any],
-    attached_policy_document: Dict[str, Any],
+    inline_policy_document: dict[str, Any],
+    attached_policy_document: dict[str, Any],
     group_name: str = "test-group",
     inline_policy_name: str = "policy1",
     attached_policy_name: Optional[str] = None,
@@ -137,11 +137,11 @@ def create_group_with_multiple_policies_and_add_user(
 @mock_aws
 def create_role_with_attached_policy_and_assume_it(  # type: ignore[misc]
     role_name: str,
-    trust_policy_document: Dict[str, Any],
-    policy_document: Dict[str, Any],
+    trust_policy_document: dict[str, Any],
+    policy_document: dict[str, Any],
     session_name: str = "session1",
     policy_name: str = "policy1",
-) -> Dict[str, str]:
+) -> dict[str, str]:
     iam_client = boto3.client("iam", region_name="us-east-1")
     sts_client = boto3.client("sts", region_name="us-east-1")
     role_arn = iam_client.create_role(
@@ -159,11 +159,11 @@ def create_role_with_attached_policy_and_assume_it(  # type: ignore[misc]
 @mock_aws
 def create_role_with_inline_policy_and_assume_it(  # type: ignore[misc]
     role_name: str,
-    trust_policy_document: Dict[str, Any],
-    policy_document: Dict[str, Any],
+    trust_policy_document: dict[str, Any],
+    policy_document: dict[str, Any],
     session_name: str = "session1",
     policy_name: str = "policy1",
-) -> Dict[str, str]:
+) -> dict[str, str]:
     iam_client = boto3.client("iam", region_name="us-east-1")
     sts_client = boto3.client("sts", region_name="us-east-1")
     role_arn = iam_client.create_role(
@@ -182,7 +182,7 @@ def create_role_with_inline_policy_and_assume_it(  # type: ignore[misc]
 @mock_aws
 def create_role(  # type: ignore[misc]
     role_name: str,
-    trust_policy_document: Dict[str, Any],
+    trust_policy_document: dict[str, Any],
 ) -> None:
     iam_client = boto3.client("iam", region_name="us-east-1")
     iam_client.create_role(
@@ -193,8 +193,8 @@ def create_role(  # type: ignore[misc]
 @mock_aws
 def create_role_with_attached_policy(  # type: ignore[misc]
     role_name: str,
-    trust_policy_document: Dict[str, Any],
-    policy_document: Dict[str, Any],
+    trust_policy_document: dict[str, Any],
+    policy_document: dict[str, Any],
     policy_name: str = "policy1",
 ) -> None:
     iam_client = boto3.client("iam", region_name="us-east-1")

--- a/tests/test_core/test_backenddict.py
+++ b/tests/test_core/test_backenddict.py
@@ -1,7 +1,7 @@
 import random
 import time
 from threading import Thread
-from typing import Any, List, Optional
+from typing import Any, Optional
 
 import pytest
 
@@ -79,7 +79,7 @@ class TestMultiThreadedAccess:
         def __init__(self, region_name: str, account_id: str):
             super().__init__(region_name, account_id)
             time.sleep(0.1)
-            self.data: List[int] = []
+            self.data: list[int] = []
 
     def setup_method(self) -> None:
         self.backend = BackendDict(TestMultiThreadedAccess.SlowExampleBackend, "ec2")
@@ -143,7 +143,7 @@ def _create_asb(
     account_id: str,
     backend: Any = None,
     use_boto3_regions: bool = False,
-    regions: Optional[List[str]] = None,
+    regions: Optional[list[str]] = None,
 ) -> Any:
     return AccountSpecificBackend(
         service_name="ec2",

--- a/tests/test_core/test_importorder.py
+++ b/tests/test_core/test_importorder.py
@@ -1,5 +1,5 @@
 import sys
-from typing import Any, List
+from typing import Any
 from unittest import SkipTest
 
 import boto3
@@ -117,7 +117,7 @@ class ImportantBusinessLogic:
     def __init__(self) -> None:
         self._s3 = boto3.client("s3", region_name="us-east-1")
 
-    def do_important_things(self) -> List[str]:
+    def do_important_things(self) -> list[str]:
         return self._s3.list_buckets()["Buckets"]
 
 

--- a/tests/test_core/test_server.py
+++ b/tests/test_core/test_server.py
@@ -1,5 +1,5 @@
 import gzip
-from typing import Iterable
+from collections.abc import Iterable
 from unittest.mock import Mock, patch
 
 import boto3

--- a/tests/test_core/utilities.py
+++ b/tests/test_core/utilities.py
@@ -1,6 +1,6 @@
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from threading import Event, Thread
-from typing import Optional, Tuple
+from typing import Optional
 
 
 class SimpleServer:
@@ -23,7 +23,7 @@ class SimpleServer:
         self._thread.start()
         self._server_ready_event.wait()
 
-    def get_host_and_port(self) -> Tuple[str, int]:
+    def get_host_and_port(self) -> tuple[str, int]:
         assert self._server
         host, port = self._server.server_address[:2]
         return str(host), port

--- a/tests/test_ecr/test_ecr_helpers.py
+++ b/tests/test_ecr/test_ecr_helpers.py
@@ -5,7 +5,7 @@ import random
 
 
 def _generate_random_sha():
-    random_sha = hashlib.sha256(f"{random.randint(0, 100)}".encode("utf-8")).hexdigest()
+    random_sha = hashlib.sha256(f"{random.randint(0, 100)}".encode()).hexdigest()
     return f"sha256:{random_sha}"
 
 
@@ -24,7 +24,7 @@ def _create_image_layers(n):
 
 def _create_image_digest(layers):
     layer_digests = "".join([layer["digest"] for layer in layers])
-    summed_digest = hashlib.sha256(f"{layer_digests}".encode("utf-8")).hexdigest()
+    summed_digest = hashlib.sha256(f"{layer_digests}".encode()).hexdigest()
     return f"sha256:{summed_digest}"
 
 

--- a/tests/test_events/test_events_cloudformation.py
+++ b/tests/test_events/test_events_cloudformation.py
@@ -275,7 +275,7 @@ def test_create_rule_with_targets():
         resources = cfn_client.list_stack_resources(StackName=stack_name)[
             "StackResourceSummaries"
         ]
-        queue = next((r for r in resources if r["LogicalResourceId"] == "DestQueue"))
+        queue = next(r for r in resources if r["LogicalResourceId"] == "DestQueue")
         q_url = queue["PhysicalResourceId"]
 
         entry = dict(

--- a/tests/test_iotdata/test_iotdata.py
+++ b/tests/test_iotdata/test_iotdata.py
@@ -1,6 +1,6 @@
 import json
 import sys
-from typing import Dict, Optional
+from typing import Optional
 from unittest import SkipTest
 
 import boto3
@@ -322,10 +322,10 @@ def test_delete_field_from_device_shadow(name: Optional[str] = None) -> None:
     ],
 )
 def test_delta_calculation(
-    desired: Dict[str, Dict[str, Optional[bool]]],
-    initial_delta: Dict[str, Dict[str, Optional[bool]]],
-    reported: Dict[str, Dict[str, Optional[bool]]],
-    delta_after_report: Dict[str, Dict[str, Optional[bool]]],
+    desired: dict[str, dict[str, Optional[bool]]],
+    initial_delta: dict[str, dict[str, Optional[bool]]],
+    reported: dict[str, dict[str, Optional[bool]]],
+    delta_after_report: dict[str, dict[str, Optional[bool]]],
     name: Optional[str] = None,
 ) -> None:
     client = boto3.client("iot-data", region_name="ap-northeast-1")

--- a/tests/test_kinesis/test_kinesis.py
+++ b/tests/test_kinesis/test_kinesis.py
@@ -293,7 +293,7 @@ def test_get_records_at_sequence_number():
     for index in range(1, 5):
         client.put_record(
             StreamName=stream_name,
-            Data=f"data_{index}".encode("utf-8"),
+            Data=f"data_{index}".encode(),
             PartitionKey=str(index),
         )
 
@@ -332,7 +332,7 @@ def test_get_records_after_sequence_number():
     for index in range(1, 5):
         client.put_record(
             StreamName=stream_name,
-            Data=f"data_{index}".encode("utf-8"),
+            Data=f"data_{index}".encode(),
             PartitionKey=str(index),
         )
 
@@ -372,7 +372,7 @@ def test_get_records_latest():
     for index in range(1, 5):
         client.put_record(
             StreamName=stream_name,
-            Data=f"data_{index}".encode("utf-8"),
+            Data=f"data_{index}".encode(),
             PartitionKey=str(index),
         )
 
@@ -802,13 +802,13 @@ def test_merge_shards():
     for index in range(1, 50):
         client.put_record(
             StreamName=stream_name,
-            Data=f"data_{index}".encode("utf-8"),
+            Data=f"data_{index}".encode(),
             PartitionKey=str(index),
         )
     for index in range(51, 100):
         client.put_record(
             StreamARN=stream_arn,
-            Data=f"data_{index}".encode("utf-8"),
+            Data=f"data_{index}".encode(),
             PartitionKey=str(index),
         )
 

--- a/tests/test_kinesis/test_kinesis_boto3.py
+++ b/tests/test_kinesis/test_kinesis_boto3.py
@@ -233,7 +233,7 @@ def test_split_shard():
     for index in range(1, 100):
         client.put_record(
             StreamName=stream_name,
-            Data=f"data_{index}".encode("utf-8"),
+            Data=f"data_{index}".encode(),
             PartitionKey=str(index),
         )
 

--- a/tests/test_kms/test_kms.py
+++ b/tests/test_kms/test_kms.py
@@ -52,10 +52,10 @@ def test_create_key_with_invalid_key_spec():
     err = ex.value.response["Error"]
     assert err["Code"] == "ValidationException"
     assert err["Message"] == (
-        "1 validation error detected: Value '{key_spec}' at 'KeySpec' failed "
+        f"1 validation error detected: Value '{unsupported_key_spec}' at 'KeySpec' failed "
         "to satisfy constraint: Member must satisfy enum value set: "
         "['ECC_NIST_P256', 'ECC_NIST_P384', 'ECC_NIST_P521', 'ECC_SECG_P256K1', 'HMAC_224', 'HMAC_256', 'HMAC_384', 'HMAC_512', 'RSA_2048', 'RSA_3072', 'RSA_4096', 'SM2', 'SYMMETRIC_DEFAULT']"
-    ).format(key_spec=unsupported_key_spec)
+    )
 
 
 @mock_aws
@@ -1451,12 +1451,9 @@ def test_invalid_signing_algorithm_for_key_spec_type_ECDSA(
     err = ex.value.response["Error"]
     assert err["Code"] == "ValidationException"
     assert err["Message"] == (
-        "1 validation error detected: Value '{signing_algorithm}' at 'SigningAlgorithm' failed "
+        f"1 validation error detected: Value '{signing_algorithm}' at 'SigningAlgorithm' failed "
         "to satisfy constraint: Member must satisfy enum value set: "
-        "{valid_sign_algorithms}"
-    ).format(
-        signing_algorithm=signing_algorithm,
-        valid_sign_algorithms=valid_signing_algorithms,
+        f"{valid_signing_algorithms}"
     )
 
 

--- a/tests/test_kms/test_kms_mac.py
+++ b/tests/test_kms/test_kms_mac.py
@@ -31,7 +31,7 @@ def test_generate_mac():
     resp = client.generate_mac(
         KeyId=key_id,
         MacAlgorithm="HMAC_SHA_512",
-        Message=base64.b64encode("Hello World".encode("utf-8")),
+        Message=base64.b64encode(b"Hello World"),
     )
 
     # Assert
@@ -50,7 +50,7 @@ def test_generate_fails_for_non_existent_key():
         client.generate_mac(
             KeyId="some-key",
             MacAlgorithm="HMAC_SHA_512",
-            Message=base64.b64encode("Hello World".encode("utf-8")),
+            Message=base64.b64encode(b"Hello World"),
         )
 
 
@@ -67,7 +67,7 @@ def test_generate_fails_for_invalid_key_usage():
         client.generate_mac(
             KeyId=key_id,
             MacAlgorithm="HMAC_SHA_512",
-            Message=base64.b64encode("Hello World".encode("utf-8")),
+            Message=base64.b64encode(b"Hello World"),
         )
 
 
@@ -84,7 +84,7 @@ def test_generate_fails_for_invalid_key_spec():
         client.generate_mac(
             KeyId=key_id,
             MacAlgorithm="HMAC_SHA_512",
-            Message=base64.b64encode("Hello World".encode("utf-8")),
+            Message=base64.b64encode(b"Hello World"),
         )
 
 
@@ -96,14 +96,14 @@ def test_verify_mac():
     mac = client.generate_mac(
         KeyId=key_id,
         MacAlgorithm="HMAC_SHA_512",
-        Message=base64.b64encode("Hello World".encode("utf-8")),
+        Message=base64.b64encode(b"Hello World"),
     )["Mac"]
 
     # Act
     resp = client.verify_mac(
         KeyId=key_id,
         MacAlgorithm="HMAC_SHA_512",
-        Message=base64.b64encode("Hello World".encode("utf-8")),
+        Message=base64.b64encode(b"Hello World"),
         Mac=mac,
     )
 
@@ -122,7 +122,7 @@ def test_verify_mac_fails_for_another_key_id():
     mac = client.generate_mac(
         KeyId=key_id,
         MacAlgorithm="HMAC_SHA_512",
-        Message=base64.b64encode("Hello World".encode("utf-8")),
+        Message=base64.b64encode(b"Hello World"),
     )["Mac"]
 
     # Act + Assert
@@ -130,6 +130,6 @@ def test_verify_mac_fails_for_another_key_id():
         client.verify_mac(
             KeyId=other_key_id,
             MacAlgorithm="HMAC_SHA_512",
-            Message=base64.b64encode("Hello World".encode("utf-8")),
+            Message=base64.b64encode(b"Hello World"),
             Mac=mac,
         )

--- a/tests/test_lakeformation/test_lakeformation.py
+++ b/tests/test_lakeformation/test_lakeformation.py
@@ -1,6 +1,6 @@
 """Unit tests for lakeformation-supported APIs."""
 
-from typing import Dict, Optional
+from typing import Optional
 
 import boto3
 import pytest
@@ -257,7 +257,7 @@ def grant_data_location_permissions(
     )
 
 
-def db_response(principal: str, catalog_id: str, db: str) -> Dict:
+def db_response(principal: str, catalog_id: str, db: str) -> dict:
     return {
         "Principal": {"DataLakePrincipalIdentifier": principal},
         "Resource": {
@@ -271,7 +271,7 @@ def db_response(principal: str, catalog_id: str, db: str) -> Dict:
     }
 
 
-def table_response(principal: str, catalog_id: str, db: str, table: str) -> Dict:
+def table_response(principal: str, catalog_id: str, db: str, table: str) -> dict:
     return {
         "Principal": {"DataLakePrincipalIdentifier": principal},
         "Resource": {
@@ -287,7 +287,7 @@ def table_response(principal: str, catalog_id: str, db: str, table: str) -> Dict
     }
 
 
-def catalog_response(principal: str) -> Dict:
+def catalog_response(principal: str) -> dict:
     return {
         "Principal": {"DataLakePrincipalIdentifier": principal},
         "Resource": {"Catalog": {}},
@@ -298,7 +298,7 @@ def catalog_response(principal: str) -> Dict:
 
 def data_location_response(
     principal: str, resource_arn: str, catalog_id: Optional[str] = None
-) -> Dict:
+) -> dict:
     response = {
         "Principal": {"DataLakePrincipalIdentifier": principal},
         "Resource": {"DataLocation": {"ResourceArn": resource_arn}},

--- a/tests/test_panorama/test_panorama_device.py
+++ b/tests/test_panorama/test_panorama_device.py
@@ -1,5 +1,4 @@
 from datetime import datetime
-from typing import List
 from unittest import SkipTest
 
 import boto3
@@ -315,7 +314,7 @@ def test_list_device_max_result_and_next_token() -> None:
     ],
 )
 @mock_aws
-def test_list_devices_sort_order(sort_order: str, indexes: List[int]) -> None:
+def test_list_devices_sort_order(sort_order: str, indexes: list[int]) -> None:
     client = boto3.client("panorama", region_name="eu-west-1")
     resp_1 = client.provision_device(
         Description="test device description 1",
@@ -345,7 +344,7 @@ def test_list_devices_sort_order(sort_order: str, indexes: List[int]) -> None:
     ],
 )
 @mock_aws
-def test_list_devices_sort_by(sort_by: str, indexes: List[int]) -> None:
+def test_list_devices_sort_by(sort_by: str, indexes: list[int]) -> None:
     if settings.TEST_SERVER_MODE:
         raise SkipTest("Can't freeze time in ServerMode")
     client = boto3.client("panorama", region_name="eu-west-1")

--- a/tests/test_resourcegroupstaggingapi/test_resourcegroupstaggingapi.py
+++ b/tests/test_resourcegroupstaggingapi/test_resourcegroupstaggingapi.py
@@ -1,5 +1,4 @@
 import json
-import typing
 
 import boto3
 import pytest
@@ -1829,7 +1828,7 @@ def test_get_resources_workspacesweb():
 @pytest.mark.parametrize("resource_type", ["secretsmanager", "secretsmanager:secret"])
 @mock_aws
 def test_get_resources_secretsmanager(resource_type):
-    def assert_tagging_works(region_name: str, regional_response_keys: typing.Set[str]):
+    def assert_tagging_works(region_name: str, regional_response_keys: set[str]):
         rtapi = boto3.client("resourcegroupstaggingapi", region_name=region_name)
         resp = rtapi.get_resources(
             ResourcesPerPage=2, ResourceTypeFilters=[resource_type]

--- a/tests/test_route53/test_route53_query_logging_config.py
+++ b/tests/test_route53/test_route53_query_logging_config.py
@@ -1,4 +1,5 @@
-from typing import Callable, Iterable
+from collections.abc import Iterable
+from typing import Callable
 from unittest import SkipTest
 
 import boto3

--- a/tests/test_route53domains/test_route53domains_domain.py
+++ b/tests/test_route53domains/test_route53domains_domain.py
@@ -1,5 +1,4 @@
 from datetime import datetime, timedelta, timezone
-from typing import Dict, List
 
 import boto3
 import pytest
@@ -9,7 +8,7 @@ from moto import mock_aws
 
 
 @pytest.fixture(name="domain_parameters")
-def generate_domain_parameters() -> Dict:
+def generate_domain_parameters() -> dict:
     return {
         "DomainName": "domain.com",
         "DurationInYears": 3,
@@ -57,14 +56,14 @@ def generate_domain_parameters() -> Dict:
 
 
 @pytest.fixture(name="invalid_domain_parameters")
-def generate_invalid_domain_parameters(domain_parameters: Dict) -> Dict:
+def generate_invalid_domain_parameters(domain_parameters: dict) -> dict:
     domain_parameters["DomainName"] = "a"
     domain_parameters["DurationInYears"] = 500
     return domain_parameters
 
 
 @mock_aws
-def test_register_domain(domain_parameters: Dict):
+def test_register_domain(domain_parameters: dict):
     route53domains_client = boto3.client("route53domains", region_name="global")
     res = route53domains_client.register_domain(**domain_parameters)
 
@@ -84,7 +83,7 @@ def test_register_domain(domain_parameters: Dict):
 
 @mock_aws
 def test_register_domain_creates_hosted_zone(
-    domain_parameters: Dict,
+    domain_parameters: dict,
 ):
     """Test good register domain API calls."""
     route53domains_client = boto3.client("route53domains", region_name="global")
@@ -99,7 +98,7 @@ def test_register_domain_creates_hosted_zone(
 
 @mock_aws
 def test_register_domain_fails_on_invalid_input(
-    invalid_domain_parameters: Dict,
+    invalid_domain_parameters: dict,
 ):
     route53domains_client = boto3.client("route53domains", region_name="global")
     route53_client = boto3.client("route53", region_name="global")
@@ -114,7 +113,7 @@ def test_register_domain_fails_on_invalid_input(
 
 
 @mock_aws
-def test_register_domain_fails_on_invalid_tld(domain_parameters: Dict):
+def test_register_domain_fails_on_invalid_tld(domain_parameters: dict):
     route53domains_client = boto3.client("route53domains", region_name="global")
     route53_client = boto3.client("route53", region_name="global")
 
@@ -131,7 +130,7 @@ def test_register_domain_fails_on_invalid_tld(domain_parameters: Dict):
 
 
 @mock_aws
-def test_list_operations(domain_parameters: Dict):
+def test_list_operations(domain_parameters: dict):
     route53domains_client = boto3.client("route53domains", region_name="global")
     route53domains_client.register_domain(**domain_parameters)
     operations = route53domains_client.list_operations()["Operations"]
@@ -182,7 +181,7 @@ def test_list_operations_invalid_input():
 
 
 @mock_aws
-def test_get_operation_detail(domain_parameters: Dict):
+def test_get_operation_detail(domain_parameters: dict):
     route53domains_client = boto3.client("route53domains", region_name="global")
     res = route53domains_client.register_domain(**domain_parameters)
     expected_operation_id = res["OperationId"]
@@ -207,7 +206,7 @@ def test_get_nonexistent_operation_detail():
 
 
 @mock_aws
-def test_duplicate_requests(domain_parameters: Dict):
+def test_duplicate_requests(domain_parameters: dict):
     route53domains_client = boto3.client("route53domains", region_name="global")
     route53domains_client.register_domain(**domain_parameters)
     with pytest.raises(ClientError) as exc:
@@ -217,7 +216,7 @@ def test_duplicate_requests(domain_parameters: Dict):
 
 
 @mock_aws
-def test_domain_limit(domain_parameters: Dict):
+def test_domain_limit(domain_parameters: dict):
     route53domains_client = boto3.client("route53domains", region_name="global")
     params = domain_parameters.copy()
     for i in range(20):
@@ -233,7 +232,7 @@ def test_domain_limit(domain_parameters: Dict):
 
 
 @mock_aws
-def test_get_domain_detail(domain_parameters: Dict):
+def test_get_domain_detail(domain_parameters: dict):
     route53domains_client = boto3.client("route53domains", region_name="global")
     route53domains_client.register_domain(**domain_parameters)
     res = route53domains_client.get_domain_detail(
@@ -261,7 +260,7 @@ def test_get_invalid_domain_detail(domain_parameters):
 
 
 @mock_aws
-def test_list_domains(domain_parameters: Dict):
+def test_list_domains(domain_parameters: dict):
     route53domains_client = boto3.client("route53domains", region_name="global")
     route53domains_client.register_domain(**domain_parameters)
     res = route53domains_client.list_domains()
@@ -333,7 +332,7 @@ def test_list_domains(domain_parameters: Dict):
     ],
 )
 def test_list_domains_filters(
-    domain_parameters: Dict, filters: List[Dict], expected_domains_len: int
+    domain_parameters: dict, filters: list[dict], expected_domains_len: int
 ):
     route53domains_client = boto3.client("route53domains", region_name="global")
     route53domains_client.register_domain(**domain_parameters)
@@ -342,7 +341,7 @@ def test_list_domains_filters(
 
 
 @mock_aws
-def test_list_domains_sort_condition(domain_parameters: Dict):
+def test_list_domains_sort_condition(domain_parameters: dict):
     route53domains_client = boto3.client("route53domains", region_name="global")
     params = domain_parameters.copy()
     params["DomainName"] = "adomain.com"
@@ -363,7 +362,7 @@ def test_list_domains_sort_condition(domain_parameters: Dict):
 
 
 @mock_aws
-def test_list_domains_invalid_filter(domain_parameters: Dict):
+def test_list_domains_invalid_filter(domain_parameters: dict):
     route53domains_client = boto3.client("route53domains", region_name="global")
     route53domains_client.register_domain(**domain_parameters)
     filters = [
@@ -382,7 +381,7 @@ def test_list_domains_invalid_filter(domain_parameters: Dict):
 
 
 @mock_aws
-def test_list_domains_invalid_sort_condition(domain_parameters: Dict):
+def test_list_domains_invalid_sort_condition(domain_parameters: dict):
     route53domains_client = boto3.client("route53domains", region_name="global")
     route53domains_client.register_domain(**domain_parameters)
     sort = {
@@ -399,7 +398,7 @@ def test_list_domains_invalid_sort_condition(domain_parameters: Dict):
 
 @mock_aws
 def test_list_domains_sort_condition_not_the_same_as_filter_condition(
-    domain_parameters: Dict,
+    domain_parameters: dict,
 ):
     route53domains_client = boto3.client("route53domains", region_name="global")
     route53domains_client.register_domain(**domain_parameters)
@@ -423,7 +422,7 @@ def test_list_domains_sort_condition_not_the_same_as_filter_condition(
 
 
 @mock_aws
-def test_delete_domain(domain_parameters: Dict):
+def test_delete_domain(domain_parameters: dict):
     route53domains_client = boto3.client("route53domains", region_name="global")
     route53domains_client.register_domain(**domain_parameters)
     domains = route53domains_client.list_domains()["Domains"]
@@ -438,7 +437,7 @@ def test_delete_domain(domain_parameters: Dict):
 
 
 @mock_aws
-def test_delete_invalid_domain(domain_parameters: Dict):
+def test_delete_invalid_domain(domain_parameters: dict):
     route53domains_client = boto3.client("route53domains", region_name="global")
     domains = route53domains_client.list_domains()["Domains"]
     assert len(domains) == 0
@@ -460,7 +459,7 @@ def test_delete_invalid_domain(domain_parameters: Dict):
         ],
     ],
 )
-def test_update_domain_nameservers(domain_parameters: Dict, nameservers: List[Dict]):
+def test_update_domain_nameservers(domain_parameters: dict, nameservers: list[dict]):
     route53domains_client = boto3.client("route53domains", region_name="global")
     route53domains_client.register_domain(**domain_parameters)
     operation_id = route53domains_client.update_domain_nameservers(
@@ -523,7 +522,7 @@ def test_update_domain_nameservers(domain_parameters: Dict, nameservers: List[Di
     ],
 )
 def test_update_domain_nameservers_with_multiple_glue_ips(
-    domain_parameters: Dict, nameservers: List[Dict]
+    domain_parameters: dict, nameservers: list[dict]
 ):
     route53domains_client = boto3.client("route53domains", region_name="global")
     route53domains_client.register_domain(**domain_parameters)
@@ -536,7 +535,7 @@ def test_update_domain_nameservers_with_multiple_glue_ips(
 
 
 @mock_aws
-def test_update_domain_nameservers_requires_glue_ips(domain_parameters: Dict):
+def test_update_domain_nameservers_requires_glue_ips(domain_parameters: dict):
     route53domains_client = boto3.client("route53domains", region_name="global")
     route53domains_client.register_domain(**domain_parameters)
     domain_name = domain_parameters["DomainName"]

--- a/tests/test_s3/test_s3_eventbridge_integration.py
+++ b/tests/test_s3/test_s3_eventbridge_integration.py
@@ -1,6 +1,6 @@
 import json
 from io import BytesIO
-from typing import Any, Dict, List
+from typing import Any
 from unittest import SkipTest
 from uuid import uuid4
 
@@ -26,7 +26,7 @@ def _seteup_bucket_notification_eventbridge(
     rule_name: str = "test-rule",
     log_group_name: str = "/test-group",
     region: str = REGION_NAME,
-) -> Dict[str, str]:
+) -> dict[str, str]:
     """Setups S3, EventBridge and CloudWatchLogs"""
     # Setup S3
     s3_res = boto3.resource("s3", region_name=region)
@@ -72,7 +72,7 @@ def _seteup_bucket_notification_eventbridge(
 
 def _get_send_events(
     log_group_name: str = "/test-group", region: str = REGION_NAME
-) -> List[Dict[str, Any]]:
+) -> list[dict[str, Any]]:
     logs_client = boto3.client("logs", region_name=region)
     return sorted(
         logs_client.filter_log_events(logGroupName=log_group_name)["events"],
@@ -108,7 +108,7 @@ def test_put_object_notification_ObjectCreated_PUT(region, partition):
 @reduced_min_part_size
 def test_put_object_notification_ObjectCreated_POST():
     if not settings.TEST_DECORATOR_MODE:
-        raise SkipTest(("Doesn't quite work right with the Proxy or Server"))
+        raise SkipTest("Doesn't quite work right with the Proxy or Server")
 
     resource_names = _seteup_bucket_notification_eventbridge()
     bucket_name = resource_names["bucket_name"]

--- a/tests/test_s3/test_s3_list_object_versions.py
+++ b/tests/test_s3/test_s3_list_object_versions.py
@@ -86,7 +86,7 @@ def test_list_object_versions_with_delimiter(bucket_name=None):
     enable_versioning(bucket_name, s3_client)
     for key_index in list(range(1, 5)) + list(range(10, 14)):
         for version_index in range(1, 4):
-            body = f"data-{version_index}".encode("UTF-8")
+            body = f"data-{version_index}".encode()
             s3_client.put_object(
                 Bucket=bucket_name, Key=f"key{key_index}-with-data", Body=body
             )
@@ -206,27 +206,27 @@ def test_list_object_versions_with_delimiter_for_deleted_objects():
     # Create a history of objects
     for pos in range(2):
         client.put_object(
-            Bucket=bucket_name, Key=f"obj_{pos}", Body=f"object {pos}".encode("utf-8")
+            Bucket=bucket_name, Key=f"obj_{pos}", Body=f"object {pos}".encode()
         )
 
     for pos in range(2):
         client.put_object(
             Bucket=bucket_name,
             Key=f"hist_obj_{pos}",
-            Body=f"history object {pos}".encode("utf-8"),
+            Body=f"history object {pos}".encode(),
         )
         for hist_pos in range(2):
             client.put_object(
                 Bucket=bucket_name,
                 Key=f"hist_obj_{pos}",
-                Body=f"object {pos} {hist_pos}".encode("utf-8"),
+                Body=f"object {pos} {hist_pos}".encode(),
             )
 
     for pos in range(2):
         client.put_object(
             Bucket=bucket_name,
             Key=f"del_obj_{pos}",
-            Body=f"deleted object {pos}".encode("utf-8"),
+            Body=f"deleted object {pos}".encode(),
         )
         client.delete_object(Bucket=bucket_name, Key=f"del_obj_{pos}")
 
@@ -440,7 +440,7 @@ def test_list_object_versions_with_paging_and_delimiter(bucket_name=None):
     # Copied from test_list_object_versions_with_delimiter.
     for key_index in list(range(1, 5)) + list(range(10, 14)):
         for version_index in range(1, 4):
-            body = f"data-{version_index}".encode("UTF-8")
+            body = f"data-{version_index}".encode()
             s3_client.put_object(
                 Bucket=bucket_name, Key=f"key{key_index}-with-data", Body=body
             )

--- a/tests/test_s3/test_s3_notifications.py
+++ b/tests/test_s3/test_s3_notifications.py
@@ -1,5 +1,4 @@
 import json
-from typing import List
 from unittest import SkipTest
 from uuid import uuid4
 
@@ -56,7 +55,7 @@ REGION_NAME = "us-east-1"
         ([S3NotificationEvent.OBJECT_TAGGING_DELETE_EVENT], "Object Tags Deleted"),
     ],
 )
-def test_detail_type(event_names: List[str], expected_event_message: str):
+def test_detail_type(event_names: list[str], expected_event_message: str):
     for event_name in event_names:
         assert _detail_type(event_name) == expected_event_message
 
@@ -117,7 +116,7 @@ def test_send_event_bridge_message():
     )
 
     if not settings.TEST_DECORATOR_MODE:
-        raise SkipTest(("Doesn't quite work right with the Proxy or Server"))
+        raise SkipTest("Doesn't quite work right with the Proxy or Server")
     # an event is correctly sent to the log group.
     _send_event_bridge_message(
         ACCOUNT_ID,

--- a/tests/test_s3/test_server.py
+++ b/tests/test_s3/test_server.py
@@ -224,7 +224,7 @@ def test_s3_server_post_unicode_bucket_key():
     backend_app = dispatcher.get_application(
         {
             "HTTP_HOST": "s3.amazonaws.com",
-            "PATH_INFO": "/test-bucket/test-object-てすと".encode("utf-8"),
+            "PATH_INFO": "/test-bucket/test-object-てすと".encode(),
         }
     )
     assert backend_app

--- a/tests/test_scheduler/__init__.py
+++ b/tests/test_scheduler/__init__.py
@@ -1,11 +1,10 @@
 from datetime import datetime, timedelta
-from typing import List, Tuple
 
 from moto.core.utils import utcnow
 
 
-def pytest_parametrize_test_create_get_schedule__with_start_date() -> List[
-    Tuple[datetime, datetime]
+def pytest_parametrize_test_create_get_schedule__with_start_date() -> list[
+    tuple[datetime, datetime]
 ]:
     now = utcnow()
     timedelta_kwargs = {"days": 1, "hours": 1, "weeks": 1}
@@ -19,7 +18,7 @@ def pytest_parametrize_test_create_get_schedule__with_start_date() -> List[
     return return_
 
 
-def pytest_parametrize_test_create_schedule__exception_with_start_date() -> List[
+def pytest_parametrize_test_create_schedule__exception_with_start_date() -> list[
     datetime
 ]:
     now = utcnow()

--- a/tests/test_sqs/test_sqs.py
+++ b/tests/test_sqs/test_sqs.py
@@ -2999,7 +2999,7 @@ def test_fifo_queue_send_deduplicationid_same_as_sha256_of_old_message():
     msg_queue.send_message(MessageBody="first", MessageGroupId="1")
 
     sha256 = hashlib.sha256()
-    sha256.update("first".encode("utf-8"))
+    sha256.update(b"first")
     deduplicationid = sha256.hexdigest()
 
     msg_queue.send_message(

--- a/tests/test_stepfunctions/parser/templates/templates.py
+++ b/tests/test_stepfunctions/parser/templates/templates.py
@@ -6,6 +6,6 @@ folder = os.path.dirname(os.path.realpath(__file__))
 
 def load_template(name: str):
     template = None
-    with open(os.path.join(folder, name + ".json"), "r") as df:
+    with open(os.path.join(folder, name + ".json")) as df:
         template = json.load(df)
     return template


### PR DESCRIPTION
Ruff's documentation: https://docs.astral.sh/ruff/rules/#pyupgrade-up

Most important rules in terms of impact:
 - Use `list` instead of `typing.List` - same for `dict`/`set`/etc.

Note that this syntax was only introduced in Python 3.9, so this makes everything officially incompatible with Python 3.8