### PR TITLE
ELB and ELBv2 certificate fixes

### DIFF
--- a/moto/elb/models.py
+++ b/moto/elb/models.py
@@ -530,7 +530,9 @@ class ELBBackend(BaseBackend):
             for idx, listener in enumerate(balancer.listeners):
                 if lb_port == listener.load_balancer_port:
                     balancer.listeners[idx].ssl_certificate_id = ssl_certificate_id
-                    if ssl_certificate_id:
+                    if ssl_certificate_id and not re.search(
+                        f"{ARN_PARTITION_REGEX}:iam:", ssl_certificate_id
+                    ):
                         register_certificate(
                             self.account_id,
                             self.region_name,

--- a/moto/elbv2/responses.py
+++ b/moto/elbv2/responses.py
@@ -797,7 +797,13 @@ class ELBV2Response(BaseResponse):
     def describe_listener_certificates(self) -> ActionResult:
         arn = self._get_param("ListenerArn")
         certificates = self.elbv2_backend.describe_listener_certificates(arn)
-        result = {"Certificates": [{"CertificateArn": arn} for arn in certificates]}
+        # The first certificate is the default, others are SNI certificates
+        result = {
+            "Certificates": [
+                {"CertificateArn": cert_arn, "IsDefault": idx == 0}
+                for idx, cert_arn in enumerate(certificates)
+            ]
+        }
         return ActionResult(result)
 
     def remove_listener_certificates(self) -> ActionResult:


### PR DESCRIPTION
Fixes two issues in ELB/ELBv2 certificate management:

1. Updating IAM certificates on ELB -- IAM certs should skip ACM registration (consistent with other parts of the ELB model)
2. ELBv2 certificates now support the IsDefault attribute