### PR TITLE
DynamoDB: Run tests in parallel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ markers = [
     "network: requires network connection",
     "requires_docker: requires running docker",
     "aws_verified: Verified against AWS, and should be able to run against AWS",
+    "requires_clean_slate: requires a clean slate, so no parallel testing",
 ]
 
 [tool.ruff.lint]

--- a/setup.cfg
+++ b/setup.cfg
@@ -255,6 +255,7 @@ markers =
     network: requires network connection
     requires_docker: requires running docker
     aws_verified: Verified against AWS, and should be able to run against AWS
+    requires_clean_slate: requires a clean slate, so no parallel testing
 
 [coverage:run]
 relative_files = True

--- a/tests/test_dynamodb/conftest.py
+++ b/tests/test_dynamodb/conftest.py
@@ -1,4 +1,5 @@
 import os
+from uuid import uuid4
 
 import boto3
 import pytest
@@ -31,28 +32,17 @@ def ddb_resource(aws_credentials):
 
 
 @pytest.fixture
-def users_table_name():
-    return "users"
-
-
-@pytest.fixture
-def create_user_table(ddb_client, users_table_name):
-    ddb_client.create_table(
-        TableName=users_table_name,
+def user_table(ddb_resource):
+    table = ddb_resource.create_table(
+        TableName=f"T{uuid4()}",
         KeySchema=[{"AttributeName": "username", "KeyType": "HASH"}],
         AttributeDefinitions=[{"AttributeName": "username", "AttributeType": "S"}],
         ProvisionedThroughput={"ReadCapacityUnits": 5, "WriteCapacityUnits": 5},
     )
-    ddb_client.put_item(
-        TableName="users", Item={"username": {"S": "user1"}, "binaryfoo": {"B": b"bar"}}
-    )
-    ddb_client.put_item(
-        TableName="users", Item={"username": {"S": "user2"}, "foo": {"S": "bar"}}
-    )
-    ddb_client.put_item(
-        TableName="users", Item={"username": {"S": "user3"}, "foo": {"S": "bar"}}
-    )
-    return ddb_client
+    table.put_item(Item={"username": "user1", "binaryfoo": b"bar"})
+    table.put_item(Item={"username": "user2", "foo": "bar"})
+    table.put_item(Item={"username": "user3", "foo": "bar"})
+    return table
 
 
 @pytest.fixture

--- a/tests/test_dynamodb/exceptions/test_dynamodb_exceptions.py
+++ b/tests/test_dynamodb/exceptions/test_dynamodb_exceptions.py
@@ -39,7 +39,7 @@ class BaseTest:
             cls.mock = mock_aws()
             cls.mock.start()
         cls.client = boto3.client("dynamodb", region_name="us-east-1")
-        cls.table_name = "T" + str(uuid4())[0:6]
+        cls.table_name = "T" + str(uuid4())
         cls.has_range_key = add_range
 
         dynamodb = boto3.resource("dynamodb", region_name="us-east-1")
@@ -60,7 +60,8 @@ class BaseTest:
         waiter.wait(TableName=cls.table_name)
         cls.table = dynamodb.Table(cls.table_name)
 
-    def setup_method(self):
+    @classmethod
+    def empty_table(self):
         # Empty table between runs
         items = self.table.scan()["Items"]
         for item in items:
@@ -86,10 +87,9 @@ def test_query_gsi_with_wrong_key_attribute_names_throws_exception():
     }
 
     dynamodb = boto3.resource("dynamodb", region_name="us-east-1")
-    dynamodb.create_table(
-        TableName="test-table", BillingMode="PAY_PER_REQUEST", **table_schema
+    table = dynamodb.create_table(
+        TableName=f"T{uuid4()}", BillingMode="PAY_PER_REQUEST", **table_schema
     )
-    table = dynamodb.Table("test-table")
     table.put_item(Item=item)
 
     # check using wrong name for sort key throws exception
@@ -239,10 +239,9 @@ def test_empty_expressionattributenames(table_name=None):
 @mock_aws
 def test_empty_expressionattributenames_with_empty_projection():
     ddb = boto3.resource("dynamodb", region_name="us-east-1")
-    ddb.create_table(
-        TableName="test-table", BillingMode="PAY_PER_REQUEST", **table_schema
+    table = ddb.create_table(
+        TableName=f"T{uuid4()}", BillingMode="PAY_PER_REQUEST", **table_schema
     )
-    table = ddb.Table("test-table")
     with pytest.raises(ClientError) as exc:
         table.get_item(
             Key={"id": "my_id"}, ProjectionExpression="a", ExpressionAttributeNames={}
@@ -255,10 +254,9 @@ def test_empty_expressionattributenames_with_empty_projection():
 @mock_aws
 def test_empty_expressionattributenames_with_projection():
     ddb = boto3.resource("dynamodb", region_name="us-east-1")
-    ddb.create_table(
-        TableName="test-table", BillingMode="PAY_PER_REQUEST", **table_schema
+    table = ddb.create_table(
+        TableName=f"T{uuid4()}", BillingMode="PAY_PER_REQUEST", **table_schema
     )
-    table = ddb.Table("test-table")
     with pytest.raises(ClientError) as exc:
         table.get_item(
             Key={"id": "my_id"}, ProjectionExpression="id", ExpressionAttributeNames={}
@@ -829,7 +827,7 @@ def test_create_table_with_redundant_attributes():
 
     with pytest.raises(ClientError) as exc:
         dynamodb.create_table(
-            TableName="test-table",
+            TableName=f"T{uuid4()}",
             AttributeDefinitions=[
                 {"AttributeName": "id", "AttributeType": "S"},
                 {"AttributeName": "created_at", "AttributeType": "N"},
@@ -847,7 +845,7 @@ def test_create_table_with_redundant_attributes():
 
     with pytest.raises(ClientError) as exc:
         dynamodb.create_table(
-            TableName="test-table",
+            TableName=f"T{uuid4()}",
             AttributeDefinitions=[
                 {"AttributeName": "id", "AttributeType": "S"},
                 {"AttributeName": "user", "AttributeType": "S"},
@@ -878,7 +876,7 @@ def test_create_table_with_missing_attributes():
 
     with pytest.raises(ClientError) as exc:
         dynamodb.create_table(
-            TableName="test-table",
+            TableName=f"T{uuid4()}",
             AttributeDefinitions=[{"AttributeName": "id", "AttributeType": "S"}],
             KeySchema=[
                 {"AttributeName": "id", "KeyType": "HASH"},
@@ -896,7 +894,7 @@ def test_create_table_with_missing_attributes():
 
     with pytest.raises(ClientError) as exc:
         dynamodb.create_table(
-            TableName="test-table",
+            TableName=f"T{uuid4()}",
             AttributeDefinitions=[{"AttributeName": "id", "AttributeType": "S"}],
             KeySchema=[{"AttributeName": "id", "KeyType": "HASH"}],
             GlobalSecondaryIndexes=[
@@ -923,7 +921,7 @@ def test_create_table_with_redundant_and_missing_attributes():
 
     with pytest.raises(ClientError) as exc:
         dynamodb.create_table(
-            TableName="test-table",
+            TableName=f"T{uuid4()}",
             AttributeDefinitions=[
                 {"AttributeName": "created_at", "AttributeType": "N"}
             ],
@@ -939,7 +937,7 @@ def test_create_table_with_redundant_and_missing_attributes():
 
     with pytest.raises(ClientError) as exc:
         dynamodb.create_table(
-            TableName="test-table",
+            TableName=f"T{uuid4()}",
             AttributeDefinitions=[
                 {"AttributeName": "id", "AttributeType": "S"},
                 {"AttributeName": "created_at", "AttributeType": "N"},
@@ -965,9 +963,10 @@ def test_create_table_with_redundant_and_missing_attributes():
 @mock_aws
 def test_put_item_wrong_attribute_type():
     dynamodb = boto3.client("dynamodb", region_name="us-east-1")
+    table_name = f"T{uuid4()}"
 
     dynamodb.create_table(
-        TableName="test-table",
+        TableName=table_name,
         AttributeDefinitions=[
             {"AttributeName": "id", "AttributeType": "S"},
             {"AttributeName": "created_at", "AttributeType": "N"},
@@ -986,7 +985,7 @@ def test_put_item_wrong_attribute_type():
     }
 
     with pytest.raises(ClientError) as exc:
-        dynamodb.put_item(TableName="test-table", Item=item)
+        dynamodb.put_item(TableName=table_name, Item=item)
     err = exc.value.response["Error"]
     assert err["Code"] == "ValidationException"
     assert (
@@ -1001,7 +1000,7 @@ def test_put_item_wrong_attribute_type():
     }
 
     with pytest.raises(ClientError) as exc:
-        dynamodb.put_item(TableName="test-table", Item=item)
+        dynamodb.put_item(TableName=table_name, Item=item)
     err = exc.value.response["Error"]
     assert err["Code"] == "ValidationException"
     assert (
@@ -1015,7 +1014,7 @@ def test_put_item_wrong_attribute_type():
 def test_hash_key_cannot_use_begins_with_operations():
     dynamodb = boto3.resource("dynamodb", region_name="us-east-1")
     table = dynamodb.create_table(
-        TableName="test-table",
+        TableName=f"T{uuid4()}",
         KeySchema=[{"AttributeName": "key", "KeyType": "HASH"}],
         AttributeDefinitions=[{"AttributeName": "key", "AttributeType": "S"}],
         ProvisionedThroughput={"ReadCapacityUnits": 1, "WriteCapacityUnits": 1},
@@ -1031,7 +1030,6 @@ def test_hash_key_cannot_use_begins_with_operations():
         for item in items:
             batch.put_item(Item=item)
 
-    table = dynamodb.Table("test-table")
     with pytest.raises(ClientError) as ex:
         table.query(KeyConditionExpression=Key("key").begins_with("prefix-"))
     assert ex.value.response["Error"]["Code"] == "ValidationException"
@@ -1043,13 +1041,12 @@ def test_hash_key_cannot_use_begins_with_operations():
 @pytest.mark.parametrize("operator", ["<", "<=", ">", ">="])
 def test_hash_key_can_only_use_equals_operations(operator):
     dynamodb = boto3.resource("dynamodb", region_name="us-east-1")
-    dynamodb.create_table(
-        TableName="test-table",
+    table = dynamodb.create_table(
+        TableName=f"T{uuid4()}",
         KeySchema=[{"AttributeName": "pk", "KeyType": "HASH"}],
         AttributeDefinitions=[{"AttributeName": "pk", "AttributeType": "S"}],
         ProvisionedThroughput={"ReadCapacityUnits": 1, "WriteCapacityUnits": 1},
     )
-    table = dynamodb.Table("test-table")
 
     with pytest.raises(ClientError) as exc:
         table.query(
@@ -1067,7 +1064,7 @@ def test_creating_table_with_0_local_indexes():
 
     with pytest.raises(ClientError) as exc:
         dynamodb.create_table(
-            TableName="test-table",
+            TableName=f"T{uuid4()}",
             KeySchema=[{"AttributeName": "pk", "KeyType": "HASH"}],
             AttributeDefinitions=[{"AttributeName": "pk", "AttributeType": "S"}],
             ProvisionedThroughput={"ReadCapacityUnits": 1, "WriteCapacityUnits": 1},
@@ -1087,7 +1084,7 @@ def test_creating_table_with_0_global_indexes():
 
     with pytest.raises(ClientError) as exc:
         dynamodb.create_table(
-            TableName="test-table",
+            TableName=f"T{uuid4()}",
             KeySchema=[{"AttributeName": "pk", "KeyType": "HASH"}],
             AttributeDefinitions=[{"AttributeName": "pk", "AttributeType": "S"}],
             ProvisionedThroughput={"ReadCapacityUnits": 1, "WriteCapacityUnits": 1},
@@ -1103,22 +1100,21 @@ def test_creating_table_with_0_global_indexes():
 
 @mock_aws
 def test_multiple_transactions_on_same_item():
+    table_name = f"T{uuid4()}"
     schema = {
         "KeySchema": [{"AttributeName": "id", "KeyType": "HASH"}],
         "AttributeDefinitions": [{"AttributeName": "id", "AttributeType": "S"}],
     }
     dynamodb = boto3.client("dynamodb", region_name="us-east-1")
-    dynamodb.create_table(
-        TableName="test-table", BillingMode="PAY_PER_REQUEST", **schema
-    )
+    dynamodb.create_table(TableName=table_name, BillingMode="PAY_PER_REQUEST", **schema)
     # Insert an item
-    dynamodb.put_item(TableName="test-table", Item={"id": {"S": "foo"}})
+    dynamodb.put_item(TableName=table_name, Item={"id": {"S": "foo"}})
 
     def update_email_transact(email):
         return {
             "Update": {
                 "Key": {"id": {"S": "foo"}},
-                "TableName": "test-table",
+                "TableName": table_name,
                 "UpdateExpression": "SET #e = :v",
                 "ExpressionAttributeNames": {"#e": "email_address"},
                 "ExpressionAttributeValues": {":v": {"S": email}},
@@ -1142,19 +1138,18 @@ def test_multiple_transactions_on_same_item():
 
 @mock_aws
 def test_transact_write_items__too_many_transactions():
+    table_name = f"T{uuid4()}"
     schema = {
         "KeySchema": [{"AttributeName": "pk", "KeyType": "HASH"}],
         "AttributeDefinitions": [{"AttributeName": "pk", "AttributeType": "S"}],
     }
     dynamodb = boto3.client("dynamodb", region_name="us-east-1")
-    dynamodb.create_table(
-        TableName="test-table", BillingMode="PAY_PER_REQUEST", **schema
-    )
+    dynamodb.create_table(TableName=table_name, BillingMode="PAY_PER_REQUEST", **schema)
 
     def update_email_transact(email):
         return {
             "Put": {
-                "TableName": "test-table",
+                "TableName": table_name,
                 "Item": {"pk": {"S": ":v"}},
                 "ExpressionAttributeValues": {":v": {"S": email}},
             }
@@ -1234,15 +1229,16 @@ def test_put_item_wrong_datatype():
         raise SkipTest("Unable to mock a session with Config in ServerMode")
     session = botocore.session.Session()
     config = botocore.client.Config(parameter_validation=False)
+    table_name = f"T{uuid4()}"
     client = session.create_client("dynamodb", region_name="us-east-1", config=config)
     client.create_table(
-        TableName="test2",
+        TableName=table_name,
         KeySchema=[{"AttributeName": "mykey", "KeyType": "HASH"}],
         AttributeDefinitions=[{"AttributeName": "mykey", "AttributeType": "N"}],
         BillingMode="PAY_PER_REQUEST",
     )
     with pytest.raises(ClientError) as exc:
-        client.put_item(TableName="test2", Item={"mykey": {"N": 123}})
+        client.put_item(TableName=table_name, Item={"mykey": {"N": 123}})
     err = exc.value.response["Error"]
     assert err["Code"] == "SerializationException"
     assert err["Message"] == "NUMBER_VALUE cannot be converted to String"
@@ -1250,7 +1246,7 @@ def test_put_item_wrong_datatype():
     # Same thing - but with a non-key, and nested
     with pytest.raises(ClientError) as exc:
         client.put_item(
-            TableName="test2",
+            TableName=table_name,
             Item={"mykey": {"N": "123"}, "nested": {"M": {"sth": {"N": 5}}}},
         )
     err = exc.value.response["Error"]
@@ -1290,7 +1286,7 @@ def test_put_item_empty_set(table_name=None):
 def test_update_expression_with_trailing_comma():
     resource = boto3.resource(service_name="dynamodb", region_name="us-east-1")
     table = resource.create_table(
-        TableName="test-table",
+        TableName=f"T{uuid4()}",
         KeySchema=[{"AttributeName": "pk", "KeyType": "HASH"}],
         AttributeDefinitions=[{"AttributeName": "pk", "AttributeType": "S"}],
         ProvisionedThroughput={"ReadCapacityUnits": 1, "WriteCapacityUnits": 1},
@@ -1315,20 +1311,19 @@ def test_update_expression_with_trailing_comma():
 
 @mock_aws
 def test_batch_items_should_throw_exception_for_duplicate_request(
-    ddb_resource, create_user_table, users_table_name
+    ddb_resource, user_table
 ):
     # Setup
-    table = ddb_resource.Table(users_table_name)
     test_item = {"forum_name": "test_dupe", "subject": "test1"}
 
     # Execute
     with pytest.raises(ClientError) as ex:
-        with table.batch_writer() as batch:
+        with user_table.batch_writer() as batch:
             batch.put_item(Item=test_item)
             batch.put_item(Item=test_item)
 
     with pytest.raises(ClientError) as ex2:
-        with table.batch_writer() as batch:
+        with user_table.batch_writer() as batch:
             batch.delete_item(Key=test_item)
             batch.delete_item(Key=test_item)
 
@@ -1345,19 +1340,18 @@ def test_batch_items_should_throw_exception_for_duplicate_request(
 @mock_aws
 def test_batch_put_item_with_empty_value():
     ddb = boto3.resource("dynamodb", region_name="us-east-1")
-    ddb.create_table(
+    table = ddb.create_table(
         AttributeDefinitions=[
             {"AttributeName": "pk", "AttributeType": "S"},
             {"AttributeName": "sk", "AttributeType": "S"},
         ],
-        TableName="test-table",
+        TableName=f"T{uuid4()}",
         KeySchema=[
             {"AttributeName": "pk", "KeyType": "HASH"},
             {"AttributeName": "sk", "KeyType": "RANGE"},
         ],
         ProvisionedThroughput={"ReadCapacityUnits": 5, "WriteCapacityUnits": 5},
     )
-    table = ddb.Table("test-table")
 
     # Empty Partition Key throws an error
     with pytest.raises(botocore.exceptions.ClientError) as exc:
@@ -1389,8 +1383,9 @@ def test_batch_put_item_with_empty_value():
 @mock_aws
 def test_query_begins_with_without_brackets():
     client = boto3.client("dynamodb", region_name="us-east-1")
+    table_name = f"T{uuid4()}"
     client.create_table(
-        TableName="test-table",
+        TableName=table_name,
         AttributeDefinitions=[
             {"AttributeName": "pk", "AttributeType": "S"},
             {"AttributeName": "sk", "AttributeType": "S"},
@@ -1403,7 +1398,7 @@ def test_query_begins_with_without_brackets():
     )
     with pytest.raises(ClientError) as exc:
         client.query(
-            TableName="test-table",
+            TableName=table_name,
             KeyConditionExpression="pk=:pk AND begins_with sk, :sk ",
             ExpressionAttributeValues={":pk": {"S": "test1"}, ":sk": {"S": "test2"}},
         )
@@ -1420,7 +1415,7 @@ def test_transact_write_items_multiple_operations_fail():
         "AttributeDefinitions": [{"AttributeName": "id", "AttributeType": "S"}],
     }
     dynamodb = boto3.client("dynamodb", region_name="us-east-1")
-    table_name = "test-table"
+    table_name = f"T{uuid4()}"
     dynamodb.create_table(TableName=table_name, BillingMode="PAY_PER_REQUEST", **schema)
 
     # Execute
@@ -1451,9 +1446,10 @@ def test_transact_write_items_multiple_operations_fail():
 @mock_aws
 def test_transact_write_items_with_empty_gsi_key():
     client = boto3.client("dynamodb", "us-east-2")
+    table_name = f"T{uuid4()}"
 
     client.create_table(
-        TableName="test_table",
+        TableName=table_name,
         KeySchema=[{"AttributeName": "unique_code", "KeyType": "HASH"}],
         AttributeDefinitions=[
             {"AttributeName": "unique_code", "AttributeType": "S"},
@@ -1473,7 +1469,7 @@ def test_transact_write_items_with_empty_gsi_key():
         {
             "Put": {
                 "Item": {"unique_code": {"S": "some code"}, "unique_id": {"S": ""}},
-                "TableName": "test_table",
+                "TableName": table_name,
             }
         }
     ]
@@ -1501,11 +1497,10 @@ def test_update_primary_key_with_sortkey():
             {"AttributeName": "sk", "AttributeType": "S"},
         ],
     }
-    dynamodb.create_table(
-        TableName="test-table", BillingMode="PAY_PER_REQUEST", **schema
+    table = dynamodb.create_table(
+        TableName=f"T{uuid4()}", BillingMode="PAY_PER_REQUEST", **schema
     )
 
-    table = dynamodb.Table("test-table")
     base_item = {"pk": "testchangepk", "sk": "else"}
     table.put_item(Item=base_item)
 
@@ -1534,11 +1529,10 @@ def test_update_primary_key():
         "KeySchema": [{"AttributeName": "pk", "KeyType": "HASH"}],
         "AttributeDefinitions": [{"AttributeName": "pk", "AttributeType": "S"}],
     }
-    dynamodb.create_table(
-        TableName="without_sk", BillingMode="PAY_PER_REQUEST", **schema
+    table = dynamodb.create_table(
+        TableName=f"T{uuid4()}", BillingMode="PAY_PER_REQUEST", **schema
     )
 
-    table = dynamodb.Table("without_sk")
     base_item = {"pk": "testchangepk"}
     table.put_item(Item=base_item)
 
@@ -1564,34 +1558,32 @@ def test_update_primary_key():
 def test_put_item__string_as_integer_value():
     if settings.TEST_SERVER_MODE:
         raise SkipTest("Unable to mock a session with Config in ServerMode")
-    session = botocore.session.Session()
     config = botocore.client.Config(parameter_validation=False)
-    client = session.create_client("dynamodb", region_name="us-east-1", config=config)
+    client = boto3.client("dynamodb", region_name="us-east-1", config=config)
+    table_name = f"T{uuid4()}"
     client.create_table(
-        TableName="without_sk",
+        TableName=table_name,
         KeySchema=[{"AttributeName": "pk", "KeyType": "HASH"}],
         AttributeDefinitions=[{"AttributeName": "pk", "AttributeType": "S"}],
         ProvisionedThroughput={"ReadCapacityUnits": 10, "WriteCapacityUnits": 10},
     )
     with pytest.raises(ClientError) as exc:
-        client.put_item(TableName="without_sk", Item={"pk": {"S": 123}})
+        client.put_item(TableName=table_name, Item={"pk": {"S": 123}})
     err = exc.value.response["Error"]
     assert err["Code"] == "SerializationException"
     assert err["Message"] == "NUMBER_VALUE cannot be converted to String"
 
     # A primary key cannot be of type S, but then point to a dictionary
     with pytest.raises(ClientError) as exc:
-        client.put_item(TableName="without_sk", Item={"pk": {"S": {"S": "asdf"}}})
+        client.put_item(TableName=table_name, Item={"pk": {"S": {"S": "asdf"}}})
     err = exc.value.response["Error"]
     assert err["Code"] == "SerializationException"
     assert err["Message"] == "Start of structure or map found where not expected"
 
     # Note that a normal attribute name can be an 'S', which follows the same pattern
     # Nested 'S'-s like this are allowed for non-key attributes
-    client.put_item(
-        TableName="without_sk", Item={"pk": {"S": "val"}, "S": {"S": "asdf"}}
-    )
-    item = client.get_item(TableName="without_sk", Key={"pk": {"S": "val"}})["Item"]
+    client.put_item(TableName=table_name, Item={"pk": {"S": "val"}, "S": {"S": "asdf"}})
+    item = client.get_item(TableName=table_name, Key={"pk": {"S": "val"}})["Item"]
     assert item == {"pk": {"S": "val"}, "S": {"S": "asdf"}}
 
 
@@ -1603,7 +1595,7 @@ def test_gsi_key_cannot_be_empty():
         "KeySchema": [{"AttributeName": "hello", "KeyType": "HASH"}],
         "Projection": {"ProjectionType": "ALL"},
     }
-    table_name = "lilja-test"
+    table_name = f"T{uuid4()}"
 
     # Let's create a table with [id: str, hello: str], with an index to hello
     dynamodb.create_table(
@@ -1640,22 +1632,23 @@ def test_gsi_key_cannot_be_empty():
 def test_list_append_errors_for_unknown_attribute_value():
     # Verify whether the list_append operation works as expected
     client = boto3.client("dynamodb", region_name="us-east-1")
+    table_name = f"T{uuid4()}"
 
     client.create_table(
         AttributeDefinitions=[{"AttributeName": "key", "AttributeType": "S"}],
-        TableName="table2",
+        TableName=table_name,
         KeySchema=[{"AttributeName": "key", "KeyType": "HASH"}],
         ProvisionedThroughput={"ReadCapacityUnits": 5, "WriteCapacityUnits": 5},
     )
     client.put_item(
-        TableName="table2",
+        TableName=table_name,
         Item={"key": {"S": "sha-of-file"}, "crontab": {"L": [{"S": "bar1"}]}},
     )
 
     # append to unknown list directly
     with pytest.raises(ClientError) as exc:
         client.update_item(
-            TableName="table2",
+            TableName=table_name,
             Key={"key": {"S": "sha-of-file"}},
             UpdateExpression="SET uk = list_append(uk, :i)",
             ExpressionAttributeValues={":i": {"L": [{"S": "bar2"}]}},
@@ -1671,7 +1664,7 @@ def test_list_append_errors_for_unknown_attribute_value():
     # append to unknown list via ExpressionAttributeNames
     with pytest.raises(ClientError) as exc:
         client.update_item(
-            TableName="table2",
+            TableName=table_name,
             Key={"key": {"S": "sha-of-file"}},
             UpdateExpression="SET #0 = list_append(#0, :i)",
             ExpressionAttributeNames={"#0": "uk"},
@@ -1688,7 +1681,7 @@ def test_list_append_errors_for_unknown_attribute_value():
     # append to unknown list, even though end result is known
     with pytest.raises(ClientError) as exc:
         client.update_item(
-            TableName="table2",
+            TableName=table_name,
             Key={"key": {"S": "sha-of-file"}},
             UpdateExpression="SET crontab = list_append(uk, :i)",
             ExpressionAttributeValues={":i": {"L": [{"S": "bar2"}]}},
@@ -1703,7 +1696,7 @@ def test_list_append_errors_for_unknown_attribute_value():
 
     # We can append to a known list, into an unknown/new list
     client.update_item(
-        TableName="table2",
+        TableName=table_name,
         Key={"key": {"S": "sha-of-file"}},
         UpdateExpression="SET uk = list_append(crontab, :i)",
         ExpressionAttributeValues={":i": {"L": [{"S": "bar2"}]}},
@@ -1714,10 +1707,9 @@ def test_list_append_errors_for_unknown_attribute_value():
 @mock_aws
 def test_query_with_empty_filter_expression():
     ddb = boto3.resource("dynamodb", region_name="us-east-1")
-    ddb.create_table(
-        TableName="test-table", BillingMode="PAY_PER_REQUEST", **table_schema
+    table = ddb.create_table(
+        TableName=f"T{uuid4()}", BillingMode="PAY_PER_REQUEST", **table_schema
     )
-    table = ddb.Table("test-table")
     with pytest.raises(ClientError) as exc:
         table.query(
             KeyConditionExpression="partitionKey = sth", ProjectionExpression=""
@@ -1741,11 +1733,14 @@ def test_query_with_empty_filter_expression():
 @mock_aws
 def test_query_with_missing_expression_attribute():
     ddb = boto3.resource("dynamodb", region_name="us-west-2")
-    ddb.create_table(TableName="test", BillingMode="PAY_PER_REQUEST", **table_schema)
+    table_name = f"T{uuid4()}"
+    ddb.create_table(
+        TableName=table_name, BillingMode="PAY_PER_REQUEST", **table_schema
+    )
     client = boto3.client("dynamodb", region_name="us-west-2")
     with pytest.raises(ClientError) as exc:
         client.query(
-            TableName="test",
+            TableName=table_name,
             KeyConditionExpression="#part_key=some_value",
             ExpressionAttributeNames={"#part_key": "partitionKey"},
         )
@@ -1760,7 +1755,6 @@ def test_query_with_missing_expression_attribute():
 @pytest.mark.aws_verified
 class TestReturnValuesOnConditionCheckFailure(BaseTest):
     def setup_method(self):
-        super().setup_method()
         self.table.put_item(
             Item={"pk": "the-key", "subject": "123", "body": "some test msg"}
         )
@@ -1922,8 +1916,9 @@ def test_too_many_key_schema_attributes():
 @mock_aws
 def test_cannot_query_gsi_with_consistent_read():
     dynamodb = boto3.client("dynamodb", region_name="us-east-1")
+    table_name = f"T{uuid4()}"
     dynamodb.create_table(
-        TableName="test",
+        TableName=table_name,
         KeySchema=[{"AttributeName": "id", "KeyType": "HASH"}],
         AttributeDefinitions=[
             {"AttributeName": "id", "AttributeType": "S"},
@@ -1949,7 +1944,7 @@ def test_cannot_query_gsi_with_consistent_read():
 
     with pytest.raises(ClientError) as exc:
         dynamodb.query(
-            TableName="test",
+            TableName=table_name,
             IndexName="test_gsi",
             KeyConditionExpression="gsi_hash_key = :gsi_hash_key and gsi_range_key = :gsi_range_key",
             ExpressionAttributeValues={
@@ -1968,8 +1963,9 @@ def test_cannot_query_gsi_with_consistent_read():
 @mock_aws
 def test_cannot_scan_gsi_with_consistent_read():
     dynamodb = boto3.client("dynamodb", region_name="us-east-1")
+    table_name = f"T{uuid4()}"
     dynamodb.create_table(
-        TableName="test",
+        TableName=table_name,
         KeySchema=[{"AttributeName": "id", "KeyType": "HASH"}],
         AttributeDefinitions=[
             {"AttributeName": "id", "AttributeType": "S"},
@@ -1995,7 +1991,7 @@ def test_cannot_scan_gsi_with_consistent_read():
 
     with pytest.raises(ClientError) as exc:
         dynamodb.scan(
-            TableName="test",
+            TableName=table_name,
             IndexName="test_gsi",
             ConsistentRead=True,
         )
@@ -2009,10 +2005,11 @@ def test_cannot_scan_gsi_with_consistent_read():
 @mock_aws
 def test_delete_table():
     client = boto3.client("dynamodb", region_name="us-east-1")
+    table_name = f"T{uuid4()}"
 
     # Create the DynamoDB table.
     client.create_table(
-        TableName="test1",
+        TableName=table_name,
         AttributeDefinitions=[
             {"AttributeName": "client", "AttributeType": "S"},
             {"AttributeName": "app", "AttributeType": "S"},
@@ -2026,11 +2023,11 @@ def test_delete_table():
     )
 
     with pytest.raises(ClientError) as err:
-        client.delete_table(TableName="test1")
+        client.delete_table(TableName=table_name)
     assert err.value.response["Error"]["Code"] == "ValidationException"
     assert (
         err.value.response["Error"]["Message"]
-        == "1 validation error detected: Table 'test1' can't be deleted while DeletionProtectionEnabled is set to True"
+        == f"1 validation error detected: Table '{table_name}' can't be deleted while DeletionProtectionEnabled is set to True"
     )
 
 

--- a/tests/test_dynamodb/exceptions/test_key_length_exceptions.py
+++ b/tests/test_dynamodb/exceptions/test_key_length_exceptions.py
@@ -1,3 +1,5 @@
+from uuid import uuid4
+
 import boto3
 import pytest
 from boto3.dynamodb.conditions import Key
@@ -10,7 +12,7 @@ from tests.test_dynamodb import dynamodb_aws_verified
 
 @mock_aws
 def test_item_add_long_string_hash_key_exception():
-    name = "TestTable"
+    name = f"T{uuid4()}"
     conn = boto3.client("dynamodb", region_name="us-west-2")
     conn.create_table(
         TableName=name,
@@ -52,7 +54,7 @@ def test_item_add_long_string_hash_key_exception():
 
 @mock_aws
 def test_item_add_long_string_nonascii_hash_key_exception():
-    name = "TestTable"
+    name = f"T{uuid4()}"
     conn = boto3.client("dynamodb", region_name="us-west-2")
     conn.create_table(
         TableName=name,
@@ -100,7 +102,7 @@ def test_item_add_long_string_nonascii_hash_key_exception():
 
 @mock_aws
 def test_item_add_long_string_range_key_exception():
-    name = "TestTable"
+    name = f"T{uuid4()}"
     conn = boto3.client("dynamodb", region_name="us-west-2")
     conn.create_table(
         TableName=name,
@@ -148,7 +150,7 @@ def test_item_add_long_string_range_key_exception():
 
 @mock_aws
 def test_put_long_string_gsi_range_key_exception():
-    name = "TestTable"
+    name = f"T{uuid4()}"
     conn = boto3.client("dynamodb", region_name="us-west-2")
     conn.create_table(
         TableName=name,
@@ -247,7 +249,7 @@ def test_update_item_with_long_string_hash_key_exception(table_name=None):
 
 @mock_aws
 def test_update_item_with_long_string_range_key_exception():
-    name = "TestTable"
+    name = f"T{uuid4()}"
     conn = boto3.client("dynamodb", region_name="us-west-2")
     conn.create_table(
         TableName=name,
@@ -293,7 +295,7 @@ def test_update_item_with_long_string_range_key_exception():
 
 @mock_aws
 def test_item_add_empty_key_exception():
-    name = "TestTable"
+    name = f"T{uuid4()}"
     conn = boto3.client("dynamodb", region_name="us-west-2")
     conn.create_table(
         TableName=name,
@@ -317,7 +319,7 @@ def test_item_add_empty_key_exception():
 
 @mock_aws
 def test_query_empty_key_exception():
-    name = "TestTable"
+    name = f"T{uuid4()}"
     conn = boto3.client("dynamodb", region_name="us-west-2")
     conn.create_table(
         TableName=name,

--- a/tests/test_dynamodb/test_dynamodb.py
+++ b/tests/test_dynamodb/test_dynamodb.py
@@ -1,8 +1,7 @@
 import copy
-import re
-import uuid
 from datetime import datetime
 from decimal import Decimal
+from uuid import uuid4
 
 import boto3
 import pytest
@@ -20,9 +19,10 @@ from . import dynamodb_aws_verified
 
 
 @mock_aws
+@pytest.mark.requires_clean_slate
 @pytest.mark.parametrize(
     "names",
-    [[], ["TestTable"], ["TestTable1", "TestTable2"]],
+    [[], [f"T{uuid4()}"], [f"T{uuid4()}", f"T{uuid4()}"]],
     ids=["no-table", "one-table", "multiple-tables"],
 )
 def test_list_tables(names):
@@ -38,6 +38,7 @@ def test_list_tables(names):
 
 
 @mock_aws
+@pytest.mark.requires_clean_slate
 def test_list_tables_paginated():
     conn = boto3.client("dynamodb", region_name="us-west-2")
     for name in ["name1", "name2", "name3"]:
@@ -64,19 +65,20 @@ def test_list_tables_paginated():
 @mock_aws
 def test_describe_missing_table():
     conn = boto3.client("dynamodb", region_name="us-west-2")
+    table_name = f"T{uuid4()}"
     with pytest.raises(ClientError) as ex:
-        conn.describe_table(TableName="messages")
+        conn.describe_table(TableName=table_name)
     assert ex.value.response["Error"]["Code"] == "ResourceNotFoundException"
     assert ex.value.response["ResponseMetadata"]["HTTPStatusCode"] == 400
     assert (
         ex.value.response["Error"]["Message"]
-        == "Requested resource not found: Table: messages not found"
+        == f"Requested resource not found: Table: {table_name} not found"
     )
 
 
 @mock_aws
 def test_describe_table_using_arn():
-    name = "TestTable"
+    name = f"T{uuid4()}"
     conn = boto3.client("dynamodb", region_name="us-west-2")
     table_arn = conn.create_table(
         TableName=name,
@@ -115,7 +117,7 @@ def test_describe_table_using_arn():
 
 @mock_aws
 def test_list_table_tags():
-    name = "TestTable"
+    name = f"T{uuid4()}"
     conn = boto3.client(
         "dynamodb",
         region_name="us-west-2",
@@ -152,7 +154,7 @@ def test_list_table_tags():
 
 @mock_aws
 def test_list_table_tags_empty():
-    name = "TestTable"
+    name = f"T{uuid4()}"
     conn = boto3.client(
         "dynamodb",
         region_name="us-west-2",
@@ -173,7 +175,7 @@ def test_list_table_tags_empty():
 
 @mock_aws
 def test_list_table_tags_paginated():
-    name = "TestTable"
+    name = f"T{uuid4()}"
     conn = boto3.client(
         "dynamodb",
         region_name="us-west-2",
@@ -216,7 +218,7 @@ def test_list_not_found_table_tags():
 
 @mock_aws
 def test_item_add_empty_string_hash_key_exception():
-    name = "TestTable"
+    name = f"T{uuid4()}"
     conn = boto3.client(
         "dynamodb",
         region_name="us-west-2",
@@ -252,7 +254,7 @@ def test_item_add_empty_string_hash_key_exception():
 
 @mock_aws
 def test_item_add_empty_string_range_key_exception():
-    name = "TestTable"
+    name = f"T{uuid4()}"
     conn = boto3.client(
         "dynamodb",
         region_name="us-west-2",
@@ -294,7 +296,7 @@ def test_item_add_empty_string_range_key_exception():
 
 @mock_aws
 def test_item_add_empty_string_attr_no_exception():
-    name = "TestTable"
+    name = f"T{uuid4()}"
     conn = boto3.client(
         "dynamodb",
         region_name="us-west-2",
@@ -322,7 +324,7 @@ def test_item_add_empty_string_attr_no_exception():
 
 @mock_aws
 def test_update_item_with_empty_string_attr_no_exception():
-    name = "TestTable"
+    name = f"T{uuid4()}"
     conn = boto3.client(
         "dynamodb",
         region_name="us-west-2",
@@ -357,25 +359,20 @@ def test_update_item_with_empty_string_attr_no_exception():
 
 @mock_aws
 def test_query_invalid_table():
-    conn = boto3.client(
-        "dynamodb",
-        region_name="us-west-2",
-        aws_access_key_id="ak",
-        aws_secret_access_key="sk",
-    )
-    try:
+    conn = boto3.client("dynamodb", region_name="us-west-2")
+    with pytest.raises(ClientError) as exc:
         conn.query(
-            TableName="invalid_table",
+            TableName=f"T{uuid4()}",
             KeyConditionExpression="index1 = :partitionkeyval",
             ExpressionAttributeValues={":partitionkeyval": {"S": "test"}},
         )
-    except ClientError as exception:
-        assert exception.response["Error"]["Code"] == "ResourceNotFoundException"
+    err = exc.value.response["Error"]
+    assert err["Code"] == "ResourceNotFoundException"
 
 
 @mock_aws
 def test_put_item_with_special_chars():
-    name = "TestTable"
+    name = f"T{uuid4()}"
     conn = boto3.client(
         "dynamodb",
         region_name="us-west-2",
@@ -405,7 +402,7 @@ def test_put_item_with_special_chars():
 
 @mock_aws
 def test_put_item_with_streams():
-    name = "TestTable"
+    name = f"T{uuid4()}"
     conn = boto3.client(
         "dynamodb",
         region_name="us-west-2",
@@ -460,7 +457,7 @@ def test_basic_projection_expression_using_get_item():
 
     # Create the DynamoDB table.
     table = dynamodb.create_table(
-        TableName="users",
+        TableName=f"T{uuid4()}",
         KeySchema=[
             {"AttributeName": "forum_name", "KeyType": "HASH"},
             {"AttributeName": "subject", "KeyType": "RANGE"},
@@ -471,7 +468,6 @@ def test_basic_projection_expression_using_get_item():
         ],
         ProvisionedThroughput={"ReadCapacityUnits": 5, "WriteCapacityUnits": 5},
     )
-    table = dynamodb.Table("users")
 
     table.put_item(
         Item={"forum_name": "the-key", "subject": "123", "body": "some test message"}
@@ -517,8 +513,8 @@ def test_basic_projection_expressions_using_scan():
     dynamodb = boto3.resource("dynamodb", region_name="us-east-1")
 
     # Create the DynamoDB table.
-    dynamodb.create_table(
-        TableName="users",
+    table = dynamodb.create_table(
+        TableName=f"T{uuid4()}",
         KeySchema=[
             {"AttributeName": "forum_name", "KeyType": "HASH"},
             {"AttributeName": "subject", "KeyType": "RANGE"},
@@ -529,7 +525,6 @@ def test_basic_projection_expressions_using_scan():
         ],
         ProvisionedThroughput={"ReadCapacityUnits": 5, "WriteCapacityUnits": 5},
     )
-    table = dynamodb.Table("users")
 
     table.put_item(
         Item={"forum_name": "the-key", "subject": "123", "body": "some test message"}
@@ -584,13 +579,12 @@ def test_nested_projection_expression_using_get_item():
     dynamodb = boto3.resource("dynamodb", region_name="us-east-1")
 
     # Create the DynamoDB table.
-    dynamodb.create_table(
-        TableName="users",
+    table = dynamodb.create_table(
+        TableName=f"T{uuid4()}",
         KeySchema=[{"AttributeName": "forum_name", "KeyType": "HASH"}],
         AttributeDefinitions=[{"AttributeName": "forum_name", "AttributeType": "S"}],
         ProvisionedThroughput={"ReadCapacityUnits": 5, "WriteCapacityUnits": 5},
     )
-    table = dynamodb.Table("users")
     table.put_item(
         Item={
             "forum_name": "key1",
@@ -636,8 +630,8 @@ def test_basic_projection_expressions_using_query():
     dynamodb = boto3.resource("dynamodb", region_name="us-east-1")
 
     # Create the DynamoDB table.
-    dynamodb.create_table(
-        TableName="users",
+    table = dynamodb.create_table(
+        TableName=f"T{uuid4()}",
         KeySchema=[
             {"AttributeName": "forum_name", "KeyType": "HASH"},
             {"AttributeName": "subject", "KeyType": "RANGE"},
@@ -648,7 +642,6 @@ def test_basic_projection_expressions_using_query():
         ],
         ProvisionedThroughput={"ReadCapacityUnits": 5, "WriteCapacityUnits": 5},
     )
-    table = dynamodb.Table("users")
     table.put_item(
         Item={"forum_name": "the-key", "subject": "123", "body": "some test message"}
     )
@@ -703,13 +696,12 @@ def test_nested_projection_expression_using_query():
     dynamodb = boto3.resource("dynamodb", region_name="us-east-1")
 
     # Create the DynamoDB table.
-    dynamodb.create_table(
-        TableName="users",
+    table = dynamodb.create_table(
+        TableName=f"T{uuid4()}",
         KeySchema=[{"AttributeName": "name", "KeyType": "HASH"}],
         AttributeDefinitions=[{"AttributeName": "name", "AttributeType": "S"}],
         ProvisionedThroughput={"ReadCapacityUnits": 5, "WriteCapacityUnits": 5},
     )
-    table = dynamodb.Table("users")
     table.put_item(
         Item={
             "name": "key1",
@@ -762,13 +754,12 @@ def test_nested_projection_expression_using_scan():
     dynamodb = boto3.resource("dynamodb", region_name="us-east-1")
 
     # Create the DynamoDB table.
-    dynamodb.create_table(
-        TableName="users",
+    table = dynamodb.create_table(
+        TableName=f"T{uuid4()}",
         KeySchema=[{"AttributeName": "forum_name", "KeyType": "HASH"}],
         AttributeDefinitions=[{"AttributeName": "forum_name", "AttributeType": "S"}],
         ProvisionedThroughput={"ReadCapacityUnits": 5, "WriteCapacityUnits": 5},
     )
-    table = dynamodb.Table("users")
     table.put_item(
         Item={
             "forum_name": "key1",
@@ -822,7 +813,7 @@ def test_basic_projection_expression_using_get_item_with_attr_expression_names()
 
     # Create the DynamoDB table.
     table = dynamodb.create_table(
-        TableName="users",
+        TableName=f"T{uuid4()}",
         KeySchema=[
             {"AttributeName": "forum_name", "KeyType": "HASH"},
             {"AttributeName": "subject", "KeyType": "RANGE"},
@@ -833,7 +824,6 @@ def test_basic_projection_expression_using_get_item_with_attr_expression_names()
         ],
         ProvisionedThroughput={"ReadCapacityUnits": 5, "WriteCapacityUnits": 5},
     )
-    table = dynamodb.Table("users")
 
     table.put_item(
         Item={
@@ -871,7 +861,7 @@ def test_basic_projection_expressions_using_query_with_attr_expression_names():
 
     # Create the DynamoDB table.
     table = dynamodb.create_table(
-        TableName="users",
+        TableName=f"T{uuid4()}",
         KeySchema=[
             {"AttributeName": "forum_name", "KeyType": "HASH"},
             {"AttributeName": "subject", "KeyType": "RANGE"},
@@ -882,7 +872,6 @@ def test_basic_projection_expressions_using_query_with_attr_expression_names():
         ],
         ProvisionedThroughput={"ReadCapacityUnits": 5, "WriteCapacityUnits": 5},
     )
-    table = dynamodb.Table("users")
 
     table.put_item(
         Item={
@@ -919,13 +908,12 @@ def test_nested_projection_expression_using_get_item_with_attr_expression():
     dynamodb = boto3.resource("dynamodb", region_name="us-east-1")
 
     # Create the DynamoDB table.
-    dynamodb.create_table(
-        TableName="users",
+    table = dynamodb.create_table(
+        TableName=f"T{uuid4()}",
         KeySchema=[{"AttributeName": "forum_name", "KeyType": "HASH"}],
         AttributeDefinitions=[{"AttributeName": "forum_name", "AttributeType": "S"}],
         ProvisionedThroughput={"ReadCapacityUnits": 5, "WriteCapacityUnits": 5},
     )
-    table = dynamodb.Table("users")
     table.put_item(
         Item={
             "forum_name": "key1",
@@ -985,13 +973,12 @@ def test_nested_projection_expression_using_query_with_attr_expression_names():
     dynamodb = boto3.resource("dynamodb", region_name="us-east-1")
 
     # Create the DynamoDB table.
-    dynamodb.create_table(
-        TableName="users",
+    table = dynamodb.create_table(
+        TableName=f"T{uuid4()}",
         KeySchema=[{"AttributeName": "name", "KeyType": "HASH"}],
         AttributeDefinitions=[{"AttributeName": "name", "AttributeType": "S"}],
         ProvisionedThroughput={"ReadCapacityUnits": 5, "WriteCapacityUnits": 5},
     )
-    table = dynamodb.Table("users")
     table.put_item(
         Item={
             "name": "key1",
@@ -1042,7 +1029,7 @@ def test_basic_projection_expressions_using_scan_with_attr_expression_names():
 
     # Create the DynamoDB table.
     table = dynamodb.create_table(
-        TableName="users",
+        TableName=f"T{uuid4()}",
         KeySchema=[
             {"AttributeName": "forum_name", "KeyType": "HASH"},
             {"AttributeName": "subject", "KeyType": "RANGE"},
@@ -1053,7 +1040,6 @@ def test_basic_projection_expressions_using_scan_with_attr_expression_names():
         ],
         ProvisionedThroughput={"ReadCapacityUnits": 5, "WriteCapacityUnits": 5},
     )
-    table = dynamodb.Table("users")
 
     table.put_item(
         Item={
@@ -1102,13 +1088,12 @@ def test_nested_projection_expression_using_scan_with_attr_expression_names():
     dynamodb = boto3.resource("dynamodb", region_name="us-east-1")
 
     # Create the DynamoDB table.
-    dynamodb.create_table(
-        TableName="users",
+    table = dynamodb.create_table(
+        TableName=f"T{uuid4()}",
         KeySchema=[{"AttributeName": "forum_name", "KeyType": "HASH"}],
         AttributeDefinitions=[{"AttributeName": "forum_name", "AttributeType": "S"}],
         ProvisionedThroughput={"ReadCapacityUnits": 5, "WriteCapacityUnits": 5},
     )
-    table = dynamodb.Table("users")
     table.put_item(
         Item={
             "forum_name": "key1",
@@ -1160,13 +1145,12 @@ def test_nested_projection_expression_using_scan_with_attr_expression_names():
 @mock_aws
 def test_put_empty_item():
     dynamodb = boto3.resource("dynamodb", region_name="us-east-1")
-    dynamodb.create_table(
+    table = dynamodb.create_table(
         AttributeDefinitions=[{"AttributeName": "structure_id", "AttributeType": "S"}],
-        TableName="test",
+        TableName=f"T{uuid4()}",
         KeySchema=[{"AttributeName": "structure_id", "KeyType": "HASH"}],
         ProvisionedThroughput={"ReadCapacityUnits": 123, "WriteCapacityUnits": 123},
     )
-    table = dynamodb.Table("test")
 
     with pytest.raises(ClientError) as ex:
         table.put_item(Item={})
@@ -1180,13 +1164,12 @@ def test_put_empty_item():
 @mock_aws
 def test_put_item_nonexisting_hash_key():
     dynamodb = boto3.resource("dynamodb", region_name="us-east-1")
-    dynamodb.create_table(
+    table = dynamodb.create_table(
         AttributeDefinitions=[{"AttributeName": "structure_id", "AttributeType": "S"}],
-        TableName="test",
+        TableName=f"T{uuid4()}",
         KeySchema=[{"AttributeName": "structure_id", "KeyType": "HASH"}],
         ProvisionedThroughput={"ReadCapacityUnits": 123, "WriteCapacityUnits": 123},
     )
-    table = dynamodb.Table("test")
 
     with pytest.raises(ClientError) as ex:
         table.put_item(Item={"a_terribly_misguided_id_attribute": "abcdef"})
@@ -1200,19 +1183,18 @@ def test_put_item_nonexisting_hash_key():
 @mock_aws
 def test_put_item_nonexisting_range_key():
     dynamodb = boto3.resource("dynamodb", region_name="us-east-1")
-    dynamodb.create_table(
+    table = dynamodb.create_table(
         AttributeDefinitions=[
             {"AttributeName": "structure_id", "AttributeType": "S"},
             {"AttributeName": "added_at", "AttributeType": "N"},
         ],
-        TableName="test",
+        TableName=f"T{uuid4()}",
         KeySchema=[
             {"AttributeName": "structure_id", "KeyType": "HASH"},
             {"AttributeName": "added_at", "KeyType": "RANGE"},
         ],
         ProvisionedThroughput={"ReadCapacityUnits": 123, "WriteCapacityUnits": 123},
     )
-    table = dynamodb.Table("test")
 
     with pytest.raises(ClientError) as ex:
         table.put_item(Item={"structure_id": "abcdef"})
@@ -1354,10 +1336,11 @@ def test_filter_expression():
 @mock_aws
 def test_duplicate_create():
     client = boto3.client("dynamodb", region_name="us-east-1")
+    table_name = f"T{uuid4()}"
 
     # Create the DynamoDB table.
     client.create_table(
-        TableName="test1",
+        TableName=table_name,
         AttributeDefinitions=[
             {"AttributeName": "client", "AttributeType": "S"},
             {"AttributeName": "app", "AttributeType": "S"},
@@ -1371,7 +1354,7 @@ def test_duplicate_create():
 
     with pytest.raises(ClientError) as exc:
         client.create_table(
-            TableName="test1",
+            TableName=table_name,
             AttributeDefinitions=[
                 {"AttributeName": "client", "AttributeType": "S"},
                 {"AttributeName": "app", "AttributeType": "S"},
@@ -1387,12 +1370,14 @@ def test_duplicate_create():
 
 
 @mock_aws
+@pytest.mark.requires_clean_slate
 def test_delete_table():
     client = boto3.client("dynamodb", region_name="us-east-1")
+    table_name = f"T{uuid4()}"
 
     # Create the DynamoDB table.
     client.create_table(
-        TableName="test1",
+        TableName=table_name,
         AttributeDefinitions=[
             {"AttributeName": "client", "AttributeType": "S"},
             {"AttributeName": "app", "AttributeType": "S"},
@@ -1404,13 +1389,13 @@ def test_delete_table():
         ProvisionedThroughput={"ReadCapacityUnits": 123, "WriteCapacityUnits": 123},
     )
 
-    client.delete_table(TableName="test1")
+    client.delete_table(TableName=table_name)
 
     resp = client.list_tables()
     assert len(resp["TableNames"]) == 0
 
     with pytest.raises(ClientError) as err:
-        client.delete_table(TableName="test1")
+        client.delete_table(TableName=table_name)
     assert err.value.response["Error"]["Code"] == "ResourceNotFoundException"
 
 
@@ -1418,10 +1403,11 @@ def test_delete_table():
 def test_delete_item():
     client = boto3.client("dynamodb", region_name="us-east-1")
     dynamodb = boto3.resource("dynamodb", region_name="us-east-1")
+    table_name = f"T{uuid4()}"
 
     # Create the DynamoDB table.
     client.create_table(
-        TableName="test1",
+        TableName=table_name,
         AttributeDefinitions=[
             {"AttributeName": "client", "AttributeType": "S"},
             {"AttributeName": "app", "AttributeType": "S"},
@@ -1433,13 +1419,13 @@ def test_delete_item():
         ProvisionedThroughput={"ReadCapacityUnits": 123, "WriteCapacityUnits": 123},
     )
     client.put_item(
-        TableName="test1", Item={"client": {"S": "client1"}, "app": {"S": "app1"}}
+        TableName=table_name, Item={"client": {"S": "client1"}, "app": {"S": "app1"}}
     )
     client.put_item(
-        TableName="test1", Item={"client": {"S": "client1"}, "app": {"S": "app2"}}
+        TableName=table_name, Item={"client": {"S": "client1"}, "app": {"S": "app2"}}
     )
 
-    table = dynamodb.Table("test1")
+    table = dynamodb.Table(table_name)
     response = table.scan()
     assert response["Count"] == 2
 
@@ -1475,8 +1461,8 @@ def test_delete_item_error():
     # Setup
     client = boto3.resource("dynamodb", region_name="us-east-1")
     # Create the DynamoDB table.
-    client.create_table(
-        TableName="test1",
+    table = client.create_table(
+        TableName=f"T{uuid4()}",
         AttributeDefinitions=[
             {"AttributeName": "client", "AttributeType": "S"},
             {"AttributeName": "app", "AttributeType": "S"},
@@ -1487,7 +1473,6 @@ def test_delete_item_error():
         ],
         BillingMode="PAY_PER_REQUEST",
     )
-    table = client.Table("test1")
     table.delete()
 
     # Execute
@@ -1516,10 +1501,11 @@ def test_describe_limits():
 @mock_aws
 def test_set_ttl():
     client = boto3.client("dynamodb", region_name="us-east-1")
+    table_name = f"T{uuid4()}"
 
     # Create the DynamoDB table.
     client.create_table(
-        TableName="test1",
+        TableName=table_name,
         AttributeDefinitions=[
             {"AttributeName": "client", "AttributeType": "S"},
             {"AttributeName": "app", "AttributeType": "S"},
@@ -1532,20 +1518,20 @@ def test_set_ttl():
     )
 
     client.update_time_to_live(
-        TableName="test1",
+        TableName=table_name,
         TimeToLiveSpecification={"Enabled": True, "AttributeName": "expire"},
     )
 
-    resp = client.describe_time_to_live(TableName="test1")
+    resp = client.describe_time_to_live(TableName=table_name)
     assert resp["TimeToLiveDescription"]["TimeToLiveStatus"] == "ENABLED"
     assert resp["TimeToLiveDescription"]["AttributeName"] == "expire"
 
     client.update_time_to_live(
-        TableName="test1",
+        TableName=table_name,
         TimeToLiveSpecification={"Enabled": False, "AttributeName": "expire"},
     )
 
-    resp = client.describe_time_to_live(TableName="test1")
+    resp = client.describe_time_to_live(TableName=table_name)
     assert resp["TimeToLiveDescription"]["TimeToLiveStatus"] == "DISABLED"
 
 
@@ -1554,7 +1540,7 @@ def test_describe_continuous_backups():
     # given
     client = boto3.client("dynamodb", region_name="us-east-1")
     table_name = client.create_table(
-        TableName="test",
+        TableName=f"T{uuid4()}",
         AttributeDefinitions=[
             {"AttributeName": "client", "AttributeType": "S"},
             {"AttributeName": "app", "AttributeType": "S"},
@@ -1580,17 +1566,18 @@ def test_describe_continuous_backups():
 def test_describe_continuous_backups_errors():
     # given
     client = boto3.client("dynamodb", region_name="us-east-1")
+    table_name = f"T{uuid4()}"
 
     # when
     with pytest.raises(ClientError) as e:
-        client.describe_continuous_backups(TableName="not-existing-table")
+        client.describe_continuous_backups(TableName=table_name)
 
     # then
     ex = e.value
     assert ex.operation_name == "DescribeContinuousBackups"
     assert ex.response["ResponseMetadata"]["HTTPStatusCode"] == 400
     assert ex.response["Error"]["Code"] == "TableNotFoundException"
-    assert ex.response["Error"]["Message"] == "Table not found: not-existing-table"
+    assert ex.response["Error"]["Message"] == f"Table not found: {table_name}"
 
 
 @mock_aws
@@ -1598,7 +1585,7 @@ def test_update_continuous_backups():
     # given
     client = boto3.client("dynamodb", region_name="us-east-1")
     table_name = client.create_table(
-        TableName="test",
+        TableName=f"T{uuid4()}",
         AttributeDefinitions=[
             {"AttributeName": "client", "AttributeType": "S"},
             {"AttributeName": "app", "AttributeType": "S"},
@@ -1664,11 +1651,12 @@ def test_update_continuous_backups():
 def test_update_continuous_backups_errors():
     # given
     client = boto3.client("dynamodb", region_name="us-east-1")
+    table_name = f"T{uuid4()}"
 
     # when
     with pytest.raises(ClientError) as e:
         client.update_continuous_backups(
-            TableName="not-existing-table",
+            TableName=table_name,
             PointInTimeRecoverySpecification={"PointInTimeRecoveryEnabled": True},
         )
 
@@ -1677,17 +1665,18 @@ def test_update_continuous_backups_errors():
     assert ex.operation_name == "UpdateContinuousBackups"
     assert ex.response["ResponseMetadata"]["HTTPStatusCode"] == 400
     assert ex.response["Error"]["Code"] == "TableNotFoundException"
-    assert ex.response["Error"]["Message"] == "Table not found: not-existing-table"
+    assert ex.response["Error"]["Message"] == f"Table not found: {table_name}"
 
 
 # https://github.com/getmoto/moto/issues/1043
 @mock_aws
 def test_query_missing_expr_names():
     client = boto3.client("dynamodb", region_name="us-east-1")
+    table_name = f"T{uuid4()}"
 
     # Create the DynamoDB table.
     client.create_table(
-        TableName="test1",
+        TableName=table_name,
         AttributeDefinitions=[
             {"AttributeName": "client", "AttributeType": "S"},
             {"AttributeName": "app", "AttributeType": "S"},
@@ -1699,14 +1688,14 @@ def test_query_missing_expr_names():
         ProvisionedThroughput={"ReadCapacityUnits": 123, "WriteCapacityUnits": 123},
     )
     client.put_item(
-        TableName="test1", Item={"client": {"S": "test1"}, "app": {"S": "test1"}}
+        TableName=table_name, Item={"client": {"S": "test1"}, "app": {"S": "test1"}}
     )
     client.put_item(
-        TableName="test1", Item={"client": {"S": "test2"}, "app": {"S": "test2"}}
+        TableName=table_name, Item={"client": {"S": "test2"}, "app": {"S": "test2"}}
     )
 
     resp = client.query(
-        TableName="test1",
+        TableName=table_name,
         KeyConditionExpression="client=:client",
         ExpressionAttributeValues={":client": {"S": "test1"}},
     )
@@ -1721,13 +1710,12 @@ def test_update_item_with_list():
     dynamodb = boto3.resource("dynamodb", region_name="us-east-1")
 
     # Create the DynamoDB table.
-    dynamodb.create_table(
-        TableName="Table",
+    table = dynamodb.create_table(
+        TableName=f"T{uuid4()}",
         KeySchema=[{"AttributeName": "key", "KeyType": "HASH"}],
         AttributeDefinitions=[{"AttributeName": "key", "AttributeType": "S"}],
         ProvisionedThroughput={"ReadCapacityUnits": 1, "WriteCapacityUnits": 1},
     )
-    table = dynamodb.Table("Table")
     table.update_item(
         Key={"key": "the-key"},
         AttributeUpdates={"list": {"Value": [1, 2], "Action": "PUT"}},
@@ -1743,13 +1731,12 @@ def test_update_item_with_no_action_passed_with_list():
     dynamodb = boto3.resource("dynamodb", region_name="us-east-1")
 
     # Create the DynamoDB table.
-    dynamodb.create_table(
-        TableName="Table",
+    table = dynamodb.create_table(
+        TableName=f"T{uuid4()}",
         KeySchema=[{"AttributeName": "key", "KeyType": "HASH"}],
         AttributeDefinitions=[{"AttributeName": "key", "AttributeType": "S"}],
         ProvisionedThroughput={"ReadCapacityUnits": 1, "WriteCapacityUnits": 1},
     )
-    table = dynamodb.Table("Table")
     table.update_item(
         Key={"key": "the-key"},
         # Do not pass 'Action' key, in order to check that the
@@ -1768,8 +1755,8 @@ def test_update_item_on_map():
     client = boto3.client("dynamodb", region_name="us-east-1")
 
     # Create the DynamoDB table.
-    dynamodb.create_table(
-        TableName="users",
+    table = dynamodb.create_table(
+        TableName=f"T{uuid4()}",
         KeySchema=[
             {"AttributeName": "forum_name", "KeyType": "HASH"},
             {"AttributeName": "subject", "KeyType": "RANGE"},
@@ -1780,7 +1767,6 @@ def test_update_item_on_map():
         ],
         ProvisionedThroughput={"ReadCapacityUnits": 5, "WriteCapacityUnits": 5},
     )
-    table = dynamodb.Table("users")
 
     table.put_item(
         Item={
@@ -1846,8 +1832,8 @@ def test_update_if_not_exists():
     dynamodb = boto3.resource("dynamodb", region_name="us-east-1")
 
     # Create the DynamoDB table.
-    dynamodb.create_table(
-        TableName="users",
+    table = dynamodb.create_table(
+        TableName=f"T{uuid4()}",
         KeySchema=[
             {"AttributeName": "forum_name", "KeyType": "HASH"},
             {"AttributeName": "subject", "KeyType": "RANGE"},
@@ -1858,7 +1844,6 @@ def test_update_if_not_exists():
         ],
         ProvisionedThroughput={"ReadCapacityUnits": 5, "WriteCapacityUnits": 5},
     )
-    table = dynamodb.Table("users")
 
     table.put_item(Item={"forum_name": "the-key", "subject": "123"})
 
@@ -1888,9 +1873,10 @@ def test_update_if_not_exists():
 @mock_aws
 def test_update_return_attributes():
     dynamodb = boto3.client("dynamodb", region_name="us-east-1")
+    table_name = f"T{uuid4()}"
 
     dynamodb.create_table(
-        TableName="moto-test",
+        TableName=table_name,
         KeySchema=[{"AttributeName": "id", "KeyType": "HASH"}],
         AttributeDefinitions=[{"AttributeName": "id", "AttributeType": "S"}],
         ProvisionedThroughput={"ReadCapacityUnits": 1, "WriteCapacityUnits": 1},
@@ -1898,7 +1884,7 @@ def test_update_return_attributes():
 
     def update(col, to, rv):
         return dynamodb.update_item(
-            TableName="moto-test",
+            TableName=table_name,
             Key={"id": {"S": "foo"}},
             AttributeUpdates={col: {"Value": {"S": to}, "Action": "PUT"}},
             ReturnValues=rv,
@@ -1930,21 +1916,21 @@ def test_update_return_attributes():
 @mock_aws
 def test_update_return_updated_new_attributes_when_same():
     dynamo_client = boto3.resource("dynamodb", region_name="us-east-1")
-    dynamo_client.create_table(
-        TableName="moto-test",
+    table_name = f"T{uuid4()}"
+    dynamodb_table = dynamo_client.create_table(
+        TableName=table_name,
         KeySchema=[{"AttributeName": "HashKey1", "KeyType": "HASH"}],
         AttributeDefinitions=[{"AttributeName": "HashKey1", "AttributeType": "S"}],
         ProvisionedThroughput={"ReadCapacityUnits": 1, "WriteCapacityUnits": 1},
     )
 
-    dynamodb_table = dynamo_client.Table("moto-test")
     dynamodb_table.put_item(
         Item={"HashKey1": "HashKeyValue1", "listValuedAttribute1": ["a", "b"]}
     )
 
     def update(col, to, rv):
         return dynamodb_table.update_item(
-            TableName="moto-test",
+            TableName=table_name,
             Key={"HashKey1": "HashKeyValue1"},
             UpdateExpression="SET listValuedAttribute1=:" + col,
             ExpressionAttributeValues={":" + col: to},
@@ -1970,23 +1956,24 @@ def test_update_return_updated_new_attributes_when_same():
 @mock_aws
 def test_put_return_attributes():
     dynamodb = boto3.client("dynamodb", region_name="us-east-1")
+    table_name = f"T{uuid4()}"
 
     dynamodb.create_table(
-        TableName="moto-test",
+        TableName=table_name,
         KeySchema=[{"AttributeName": "id", "KeyType": "HASH"}],
         AttributeDefinitions=[{"AttributeName": "id", "AttributeType": "S"}],
         ProvisionedThroughput={"ReadCapacityUnits": 1, "WriteCapacityUnits": 1},
     )
 
     r = dynamodb.put_item(
-        TableName="moto-test",
+        TableName=table_name,
         Item={"id": {"S": "foo"}, "col1": {"S": "val1"}},
         ReturnValues="NONE",
     )
     assert "Attributes" not in r
 
     r = dynamodb.put_item(
-        TableName="moto-test",
+        TableName=table_name,
         Item={"id": {"S": "foo"}, "col1": {"S": "val2"}},
         ReturnValues="ALL_OLD",
     )
@@ -1994,7 +1981,7 @@ def test_put_return_attributes():
 
     with pytest.raises(ClientError) as ex:
         dynamodb.put_item(
-            TableName="moto-test",
+            TableName=table_name,
             Item={"id": {"S": "foo"}, "col1": {"S": "val3"}},
             ReturnValues="ALL_NEW",
         )
@@ -2008,13 +1995,12 @@ def test_query_global_secondary_index_when_created_via_update_table_resource():
     dynamodb = boto3.resource("dynamodb", region_name="us-east-1")
 
     # Create the DynamoDB table.
-    dynamodb.create_table(
-        TableName="users",
+    table = dynamodb.create_table(
+        TableName=f"T{uuid4()}",
         KeySchema=[{"AttributeName": "user_id", "KeyType": "HASH"}],
         AttributeDefinitions=[{"AttributeName": "user_id", "AttributeType": "N"}],
         ProvisionedThroughput={"ReadCapacityUnits": 5, "WriteCapacityUnits": 5},
     )
-    table = dynamodb.Table("users")
     table.update(
         AttributeDefinitions=[{"AttributeName": "forum_name", "AttributeType": "S"}],
         GlobalSecondaryIndexUpdates=[
@@ -2078,9 +2064,10 @@ def test_query_global_secondary_index_when_created_via_update_table_resource():
 @mock_aws
 def test_scan_by_non_exists_index():
     dynamodb = boto3.client("dynamodb", region_name="us-east-1")
+    table_name = f"T{uuid4()}"
 
     dynamodb.create_table(
-        TableName="test",
+        TableName=table_name,
         KeySchema=[{"AttributeName": "id", "KeyType": "HASH"}],
         AttributeDefinitions=[
             {"AttributeName": "id", "AttributeType": "S"},
@@ -2101,7 +2088,7 @@ def test_scan_by_non_exists_index():
     )
 
     with pytest.raises(ClientError) as ex:
-        dynamodb.scan(TableName="test", IndexName="non_exists_index")
+        dynamodb.scan(TableName=table_name, IndexName="non_exists_index")
 
     assert ex.value.response["Error"]["Code"] == "ValidationException"
     assert ex.value.response["ResponseMetadata"]["HTTPStatusCode"] == 400
@@ -2114,9 +2101,10 @@ def test_scan_by_non_exists_index():
 @mock_aws
 def test_query_by_non_exists_index():
     dynamodb = boto3.client("dynamodb", region_name="us-east-1")
+    table_name = f"T{uuid4()}"
 
     dynamodb.create_table(
-        TableName="test",
+        TableName=table_name,
         KeySchema=[{"AttributeName": "id", "KeyType": "HASH"}],
         AttributeDefinitions=[
             {"AttributeName": "id", "AttributeType": "S"},
@@ -2138,7 +2126,7 @@ def test_query_by_non_exists_index():
 
     with pytest.raises(ClientError) as ex:
         dynamodb.query(
-            TableName="test",
+            TableName=table_name,
             IndexName="non_exists_index",
             KeyConditionExpression="CarModel=M",
         )
@@ -2146,7 +2134,7 @@ def test_query_by_non_exists_index():
     assert ex.value.response["Error"]["Code"] == "ResourceNotFoundException"
     assert (
         ex.value.response["Error"]["Message"]
-        == "Invalid index: non_exists_index for table: test. Available indexes are: test_gsi"
+        == f"Invalid index: non_exists_index for table: {table_name}. Available indexes are: test_gsi"
     )
 
 
@@ -2154,17 +2142,13 @@ def test_query_by_non_exists_index():
 def test_index_with_unknown_attributes_should_fail():
     dynamodb = boto3.client("dynamodb", region_name="us-east-1")
 
-    expected_exception = (
-        "Some index key attributes are not defined in AttributeDefinitions."
-    )
-
-    with pytest.raises(ClientError) as ex:
+    with pytest.raises(ClientError) as exc:
         dynamodb.create_table(
             AttributeDefinitions=[
                 {"AttributeName": "customer_nr", "AttributeType": "S"},
                 {"AttributeName": "last_name", "AttributeType": "S"},
             ],
-            TableName="table_with_missing_attribute_definitions",
+            TableName=f"T{uuid4()}",
             KeySchema=[
                 {"AttributeName": "customer_nr", "KeyType": "HASH"},
                 {"AttributeName": "last_name", "KeyType": "RANGE"},
@@ -2181,14 +2165,17 @@ def test_index_with_unknown_attributes_should_fail():
             ],
             BillingMode="PAY_PER_REQUEST",
         )
-
-    assert ex.value.response["Error"]["Code"] == "ValidationException"
-    assert expected_exception in ex.value.response["Error"]["Message"]
+    err = exc.value.response["Error"]
+    assert err["Code"] == "ValidationException"
+    assert (
+        "Some index key attributes are not defined in AttributeDefinitions."
+        in err["Message"]
+    )
 
 
 @mock_aws
 def test_update_list_index__set_existing_index():
-    table_name = "test_list_index_access"
+    table_name = f"T{uuid4()}"
     client = create_table_with_list(table_name)
     client.put_item(
         TableName=table_name,
@@ -2213,7 +2200,7 @@ def test_update_list_index__set_existing_index():
 
 @mock_aws
 def test_update_list_index__set_existing_nested_index():
-    table_name = "test_list_index_access"
+    table_name = f"T{uuid4()}"
     client = create_table_with_list(table_name)
     client.put_item(
         TableName=table_name,
@@ -2242,7 +2229,7 @@ def test_update_list_index__set_existing_nested_index():
 
 @mock_aws
 def test_update_list_index__set_index_out_of_range():
-    table_name = "test_list_index_access"
+    table_name = f"T{uuid4()}"
     client = create_table_with_list(table_name)
     client.put_item(
         TableName=table_name,
@@ -2267,7 +2254,7 @@ def test_update_list_index__set_index_out_of_range():
 
 @mock_aws
 def test_update_list_index__set_nested_index_out_of_range():
-    table_name = "test_list_index_access"
+    table_name = f"T{uuid4()}"
     client = create_table_with_list(table_name)
     client.put_item(
         TableName=table_name,
@@ -2297,7 +2284,7 @@ def test_update_list_index__set_nested_index_out_of_range():
 
 @mock_aws
 def test_update_list_index__set_double_nested_index():
-    table_name = "test_list_index_access"
+    table_name = f"T{uuid4()}"
     client = create_table_with_list(table_name)
     client.put_item(
         TableName=table_name,
@@ -2335,7 +2322,7 @@ def test_update_list_index__set_double_nested_index():
 
 @mock_aws
 def test_update_list_index__set_index_of_a_string():
-    table_name = "test_list_index_access"
+    table_name = f"T{uuid4()}"
     client = create_table_with_list(table_name)
     client.put_item(
         TableName=table_name, Item={"id": {"S": "foo2"}, "itemstr": {"S": "somestring"}}
@@ -2358,7 +2345,7 @@ def test_update_list_index__set_index_of_a_string():
 
 @mock_aws
 def test_remove_top_level_attribute():
-    table_name = "test_remove"
+    table_name = f"T{uuid4()}"
     client = create_table_with_list(table_name)
     client.put_item(
         TableName=table_name, Item={"id": {"S": "foo"}, "item": {"S": "bar"}}
@@ -2394,7 +2381,7 @@ def test_remove_top_level_attribute_non_existent(table_name=None):
 
 @mock_aws
 def test_remove_list_index__remove_existing_index():
-    table_name = "test_list_index_access"
+    table_name = f"T{uuid4()}"
     client = create_table_with_list(table_name)
     client.put_item(
         TableName=table_name,
@@ -2439,7 +2426,7 @@ def test_remove_list_index__remove_multiple_indexes():
 
 @mock_aws
 def test_remove_list_index__remove_existing_nested_index():
-    table_name = "test_list_index_access"
+    table_name = f"T{uuid4()}"
     client = create_table_with_list(table_name)
     client.put_item(
         TableName=table_name,
@@ -2461,7 +2448,7 @@ def test_remove_list_index__remove_existing_nested_index():
 
 @mock_aws
 def test_remove_list_index__remove_existing_double_nested_index():
-    table_name = "test_list_index_access"
+    table_name = f"T{uuid4()}"
     client = create_table_with_list(table_name)
     client.put_item(
         TableName=table_name,
@@ -2498,7 +2485,7 @@ def test_remove_list_index__remove_existing_double_nested_index():
 
 @mock_aws
 def test_remove_list_index__remove_index_out_of_range():
-    table_name = "test_list_index_access"
+    table_name = f"T{uuid4()}"
     client = create_table_with_list(table_name)
     client.put_item(
         TableName=table_name,
@@ -2534,19 +2521,19 @@ def create_table_with_list(table_name):
 def test_item_size_is_under_400KB():
     dynamodb = boto3.resource("dynamodb", region_name="us-east-1")
     client = boto3.client("dynamodb", region_name="us-east-1")
+    table_name = f"T{uuid4()}"
 
-    dynamodb.create_table(
-        TableName="moto-test",
+    table = dynamodb.create_table(
+        TableName=table_name,
         KeySchema=[{"AttributeName": "id", "KeyType": "HASH"}],
         AttributeDefinitions=[{"AttributeName": "id", "AttributeType": "S"}],
         ProvisionedThroughput={"ReadCapacityUnits": 1, "WriteCapacityUnits": 1},
     )
-    table = dynamodb.Table("moto-test")
 
     large_item = "x" * 410 * 1000
     assert_failure_due_to_item_size(
         func=client.put_item,
-        TableName="moto-test",
+        TableName=table_name,
         Item={"id": {"S": "foo"}, "cont": {"S": large_item}},
     )
     assert_failure_due_to_item_size(
@@ -2554,7 +2541,7 @@ def test_item_size_is_under_400KB():
     )
     assert_failure_due_to_item_size_to_update(
         func=client.update_item,
-        TableName="moto-test",
+        TableName=table_name,
         Key={"id": {"S": "foo2"}},
         UpdateExpression="set cont=:Item",
         ExpressionAttributeValues={":Item": {"S": large_item}},
@@ -2565,7 +2552,7 @@ def test_item_size_is_under_400KB():
     )
     assert_failure_due_to_item_size(
         func=client.put_item,
-        TableName="moto-test",
+        TableName=table_name,
         Item={
             "id": {"S": "foo"},
             "itemlist": {"L": [{"M": {"item1": {"S": large_item}}}]},
@@ -2592,16 +2579,17 @@ def assert_failure_due_to_item_size_to_update(func, **kwargs):
 @mock_aws
 def test_update_supports_complex_expression_attribute_values():
     client = boto3.client("dynamodb", region_name="us-east-1")
+    table_name = f"T{uuid4()}"
 
     client.create_table(
         AttributeDefinitions=[{"AttributeName": "SHA256", "AttributeType": "S"}],
-        TableName="TestTable",
+        TableName=table_name,
         KeySchema=[{"AttributeName": "SHA256", "KeyType": "HASH"}],
         ProvisionedThroughput={"ReadCapacityUnits": 5, "WriteCapacityUnits": 5},
     )
 
     client.update_item(
-        TableName="TestTable",
+        TableName=table_name,
         Key={"SHA256": {"S": "sha-of-file"}},
         UpdateExpression=("SET MD5 = :md5,MyStringSet = :string_set,MyMap = :map"),
         ExpressionAttributeValues={
@@ -2611,7 +2599,7 @@ def test_update_supports_complex_expression_attribute_values():
         },
     )
     result = client.get_item(
-        TableName="TestTable", Key={"SHA256": {"S": "sha-of-file"}}
+        TableName=table_name, Key={"SHA256": {"S": "sha-of-file"}}
     )["Item"]
     assert result == {
         "MyStringSet": {"SS": ["string1", "string2"]},
@@ -2625,21 +2613,22 @@ def test_update_supports_complex_expression_attribute_values():
 def test_update_supports_list_append():
     # Verify whether the list_append operation works as expected
     client = boto3.client("dynamodb", region_name="us-east-1")
+    table_name = f"T{uuid4()}"
 
     client.create_table(
         AttributeDefinitions=[{"AttributeName": "SHA256", "AttributeType": "S"}],
-        TableName="TestTable",
+        TableName=table_name,
         KeySchema=[{"AttributeName": "SHA256", "KeyType": "HASH"}],
         ProvisionedThroughput={"ReadCapacityUnits": 5, "WriteCapacityUnits": 5},
     )
     client.put_item(
-        TableName="TestTable",
+        TableName=table_name,
         Item={"SHA256": {"S": "sha-of-file"}, "crontab": {"L": [{"S": "bar1"}]}},
     )
 
     # Update item using list_append expression
     updated_item = client.update_item(
-        TableName="TestTable",
+        TableName=table_name,
         Key={"SHA256": {"S": "sha-of-file"}},
         UpdateExpression="SET crontab = list_append(crontab, :i)",
         ExpressionAttributeValues={":i": {"L": [{"S": "bar2"}]}},
@@ -2652,7 +2641,7 @@ def test_update_supports_list_append():
     }
     # Verify item is appended to the existing list
     result = client.get_item(
-        TableName="TestTable", Key={"SHA256": {"S": "sha-of-file"}}
+        TableName=table_name, Key={"SHA256": {"S": "sha-of-file"}}
     )["Item"]
     assert result == {
         "SHA256": {"S": "sha-of-file"},
@@ -2664,15 +2653,16 @@ def test_update_supports_list_append():
 def test_update_supports_nested_list_append():
     # Verify whether we can append a list that's inside a map
     client = boto3.client("dynamodb", region_name="us-east-1")
+    name = f"T{uuid4()}"
 
     client.create_table(
         AttributeDefinitions=[{"AttributeName": "id", "AttributeType": "S"}],
-        TableName="TestTable",
+        TableName=name,
         KeySchema=[{"AttributeName": "id", "KeyType": "HASH"}],
         ProvisionedThroughput={"ReadCapacityUnits": 5, "WriteCapacityUnits": 5},
     )
     client.put_item(
-        TableName="TestTable",
+        TableName=name,
         Item={
             "id": {"S": "nested_list_append"},
             "a": {"M": {"b": {"L": [{"S": "bar1"}]}}},
@@ -2681,7 +2671,7 @@ def test_update_supports_nested_list_append():
 
     # Update item using list_append expression
     updated_item = client.update_item(
-        TableName="TestTable",
+        TableName=name,
         Key={"id": {"S": "nested_list_append"}},
         UpdateExpression="SET a.#b = list_append(a.#b, :i)",
         ExpressionAttributeValues={":i": {"L": [{"S": "bar2"}]}},
@@ -2693,9 +2683,9 @@ def test_update_supports_nested_list_append():
     assert updated_item["Attributes"] == {
         "a": {"M": {"b": {"L": [{"S": "bar1"}, {"S": "bar2"}]}}}
     }
-    result = client.get_item(
-        TableName="TestTable", Key={"id": {"S": "nested_list_append"}}
-    )["Item"]
+    result = client.get_item(TableName=name, Key={"id": {"S": "nested_list_append"}})[
+        "Item"
+    ]
     assert result == {
         "id": {"S": "nested_list_append"},
         "a": {"M": {"b": {"L": [{"S": "bar1"}, {"S": "bar2"}]}}},
@@ -2706,15 +2696,16 @@ def test_update_supports_nested_list_append():
 def test_update_supports_multiple_levels_nested_list_append():
     # Verify whether we can append a list that's inside a map that's inside a map  (Inception!)
     client = boto3.client("dynamodb", region_name="us-east-1")
+    name = f"T{uuid4()}"
 
     client.create_table(
         AttributeDefinitions=[{"AttributeName": "id", "AttributeType": "S"}],
-        TableName="TestTable",
+        TableName=name,
         KeySchema=[{"AttributeName": "id", "KeyType": "HASH"}],
         ProvisionedThroughput={"ReadCapacityUnits": 5, "WriteCapacityUnits": 5},
     )
     client.put_item(
-        TableName="TestTable",
+        TableName=name,
         Item={
             "id": {"S": "nested_list_append"},
             "a": {"M": {"b": {"M": {"c": {"L": [{"S": "bar1"}]}}}}},
@@ -2723,7 +2714,7 @@ def test_update_supports_multiple_levels_nested_list_append():
 
     # Update item using list_append expression
     updated_item = client.update_item(
-        TableName="TestTable",
+        TableName=name,
         Key={"id": {"S": "nested_list_append"}},
         UpdateExpression="SET a.#b.c = list_append(a.#b.#c, :i)",
         ExpressionAttributeValues={":i": {"L": [{"S": "bar2"}]}},
@@ -2736,9 +2727,9 @@ def test_update_supports_multiple_levels_nested_list_append():
         "a": {"M": {"b": {"M": {"c": {"L": [{"S": "bar1"}, {"S": "bar2"}]}}}}}
     }
     # Verify item is appended to the existing list
-    result = client.get_item(
-        TableName="TestTable", Key={"id": {"S": "nested_list_append"}}
-    )["Item"]
+    result = client.get_item(TableName=name, Key={"id": {"S": "nested_list_append"}})[
+        "Item"
+    ]
     assert result == {
         "id": {"S": "nested_list_append"},
         "a": {"M": {"b": {"M": {"c": {"L": [{"S": "bar1"}, {"S": "bar2"}]}}}}},
@@ -2750,15 +2741,16 @@ def test_update_supports_nested_list_append_onto_another_list():
     # Verify whether we can take the contents of one list, and use that to fill another list
     # Note that the contents of the other list is completely overwritten
     client = boto3.client("dynamodb", region_name="us-east-1")
+    name = f"T{uuid4()}"
 
     client.create_table(
         AttributeDefinitions=[{"AttributeName": "id", "AttributeType": "S"}],
-        TableName="TestTable",
+        TableName=name,
         KeySchema=[{"AttributeName": "id", "KeyType": "HASH"}],
         ProvisionedThroughput={"ReadCapacityUnits": 5, "WriteCapacityUnits": 5},
     )
     client.put_item(
-        TableName="TestTable",
+        TableName=name,
         Item={
             "id": {"S": "list_append_another"},
             "a": {"M": {"b": {"L": [{"S": "bar1"}]}, "c": {"L": [{"S": "car1"}]}}},
@@ -2767,7 +2759,7 @@ def test_update_supports_nested_list_append_onto_another_list():
 
     # Update item using list_append expression
     updated_item = client.update_item(
-        TableName="TestTable",
+        TableName=name,
         Key={"id": {"S": "list_append_another"}},
         UpdateExpression="SET a.#c = list_append(a.#b, :i)",
         ExpressionAttributeValues={":i": {"L": [{"S": "bar2"}]}},
@@ -2780,9 +2772,9 @@ def test_update_supports_nested_list_append_onto_another_list():
         "a": {"M": {"c": {"L": [{"S": "bar1"}, {"S": "bar2"}]}}}
     }
     # Verify item is appended to the existing list
-    result = client.get_item(
-        TableName="TestTable", Key={"id": {"S": "list_append_another"}}
-    )["Item"]
+    result = client.get_item(TableName=name, Key={"id": {"S": "list_append_another"}})[
+        "Item"
+    ]
     assert result == {
         "id": {"S": "list_append_another"},
         "a": {
@@ -2797,12 +2789,13 @@ def test_update_supports_nested_list_append_onto_another_list():
 @mock_aws
 def test_update_supports_list_append_maps():
     client = boto3.client("dynamodb", region_name="us-west-1")
+    name = f"T{uuid4()}"
     client.create_table(
         AttributeDefinitions=[
             {"AttributeName": "id", "AttributeType": "S"},
             {"AttributeName": "rid", "AttributeType": "S"},
         ],
-        TableName="TestTable",
+        TableName=name,
         KeySchema=[
             {"AttributeName": "id", "KeyType": "HASH"},
             {"AttributeName": "rid", "KeyType": "RANGE"},
@@ -2810,7 +2803,7 @@ def test_update_supports_list_append_maps():
         ProvisionedThroughput={"ReadCapacityUnits": 5, "WriteCapacityUnits": 5},
     )
     client.put_item(
-        TableName="TestTable",
+        TableName=name,
         Item={
             "id": {"S": "nested_list_append"},
             "rid": {"S": "range_key"},
@@ -2820,7 +2813,7 @@ def test_update_supports_list_append_maps():
 
     # Update item using list_append expression
     updated_item = client.update_item(
-        TableName="TestTable",
+        TableName=name,
         Key={"id": {"S": "nested_list_append"}, "rid": {"S": "range_key"}},
         UpdateExpression="SET a = list_append(a, :i)",
         ExpressionAttributeValues={":i": {"L": [{"M": {"b": {"S": "bar2"}}}]}},
@@ -2833,7 +2826,7 @@ def test_update_supports_list_append_maps():
     }
     # Verify item is appended to the existing list
     result = client.query(
-        TableName="TestTable",
+        TableName=name,
         KeyConditionExpression="id = :i AND begins_with(rid, :r)",
         ExpressionAttributeValues={
             ":i": {"S": "nested_list_append"},
@@ -2852,7 +2845,7 @@ def test_update_supports_list_append_maps():
 @mock_aws
 def test_update_supports_nested_update_if_nested_value_not_exists():
     dynamodb = boto3.resource("dynamodb", region_name="us-east-1")
-    name = "TestTable"
+    name = f"T{uuid4()}"
 
     dynamodb.create_table(
         TableName=name,
@@ -2882,7 +2875,7 @@ def test_update_supports_nested_update_if_nested_value_not_exists():
 @mock_aws
 def test_update_supports_list_append_with_nested_if_not_exists_operation():
     dynamo = boto3.resource("dynamodb", region_name="us-west-1")
-    table_name = "test"
+    table_name = f"T{uuid4()}"
 
     dynamo.create_table(
         TableName=table_name,
@@ -2915,7 +2908,7 @@ def test_update_supports_list_append_with_nested_if_not_exists_operation():
 @mock_aws
 def test_update_supports_list_append_with_nested_if_not_exists_operation_and_property_already_exists():
     dynamo = boto3.resource("dynamodb", region_name="us-west-1")
-    table_name = "test"
+    table_name = f"T{uuid4()}"
 
     dynamo.create_table(
         TableName=table_name,
@@ -2948,13 +2941,12 @@ def test_update_supports_list_append_with_nested_if_not_exists_operation_and_pro
 @mock_aws
 def test_update_item_if_original_value_is_none():
     dynamo = boto3.resource("dynamodb", region_name="eu-central-1")
-    dynamo.create_table(
+    table = dynamo.create_table(
         AttributeDefinitions=[{"AttributeName": "job_id", "AttributeType": "S"}],
-        TableName="origin-rbu-dev",
+        TableName=f"T{uuid4()}",
         KeySchema=[{"AttributeName": "job_id", "KeyType": "HASH"}],
         ProvisionedThroughput={"ReadCapacityUnits": 1, "WriteCapacityUnits": 1},
     )
-    table = dynamo.Table("origin-rbu-dev")
     table.put_item(Item={"job_id": "a", "job_name": None})
     table.update_item(
         Key={"job_id": "a"},
@@ -2967,13 +2959,12 @@ def test_update_item_if_original_value_is_none():
 @mock_aws
 def test_update_nested_item_if_original_value_is_none():
     dynamo = boto3.resource("dynamodb", region_name="eu-central-1")
-    dynamo.create_table(
+    table = dynamo.create_table(
         AttributeDefinitions=[{"AttributeName": "job_id", "AttributeType": "S"}],
-        TableName="origin-rbu-dev",
+        TableName=f"T{uuid4()}",
         KeySchema=[{"AttributeName": "job_id", "KeyType": "HASH"}],
         ProvisionedThroughput={"ReadCapacityUnits": 1, "WriteCapacityUnits": 1},
     )
-    table = dynamo.Table("origin-rbu-dev")
     table.put_item(Item={"job_id": "a", "job_details": {"job_name": None}})
     updated_item = table.update_item(
         Key={"job_id": "a"},
@@ -2991,13 +2982,12 @@ def test_update_nested_item_if_original_value_is_none():
 @mock_aws
 def test_allow_update_to_item_with_different_type():
     dynamo = boto3.resource("dynamodb", region_name="eu-central-1")
-    dynamo.create_table(
+    table = dynamo.create_table(
         AttributeDefinitions=[{"AttributeName": "job_id", "AttributeType": "S"}],
-        TableName="origin-rbu-dev",
+        TableName=f"T{uuid4()}",
         KeySchema=[{"AttributeName": "job_id", "KeyType": "HASH"}],
         ProvisionedThroughput={"ReadCapacityUnits": 1, "WriteCapacityUnits": 1},
     )
-    table = dynamo.Table("origin-rbu-dev")
     table.put_item(Item={"job_id": "a", "job_details": {"job_name": {"nested": "yes"}}})
     table.put_item(Item={"job_id": "b", "job_details": {"job_name": {"nested": "yes"}}})
     updated_item = table.update_item(
@@ -3022,16 +3012,15 @@ def test_allow_update_to_item_with_different_type():
 @mock_aws
 def test_query_catches_when_no_filters():
     dynamo = boto3.resource("dynamodb", region_name="eu-central-1")
-    dynamo.create_table(
+    table = dynamo.create_table(
         AttributeDefinitions=[{"AttributeName": "job_id", "AttributeType": "S"}],
-        TableName="origin-rbu-dev",
+        TableName=f"T{uuid4()}",
         KeySchema=[{"AttributeName": "job_id", "KeyType": "HASH"}],
         ProvisionedThroughput={"ReadCapacityUnits": 1, "WriteCapacityUnits": 1},
     )
-    table = dynamo.Table("origin-rbu-dev")
 
     with pytest.raises(ClientError) as ex:
-        table.query(TableName="original-rbu-dev")
+        table.query()
 
     assert ex.value.response["Error"]["Code"] == "ValidationException"
     assert ex.value.response["ResponseMetadata"]["HTTPStatusCode"] == 400
@@ -3045,7 +3034,7 @@ def test_query_catches_when_no_filters():
 def test_dynamodb_max_1mb_limit():
     ddb = boto3.resource("dynamodb", region_name="eu-west-1")
 
-    table_name = "populated-mock-table"
+    table_name = f"T{uuid4()}"
     table = ddb.create_table(
         TableName=table_name,
         KeySchema=[
@@ -3104,9 +3093,10 @@ def test_update_expression_with_numeric_literal_instead_of_value():
     be raised
     """
     dynamodb = boto3.client("dynamodb", region_name="eu-west-1")
+    table_name = f"T{uuid4()}"
 
     dynamodb.create_table(
-        TableName="moto-test",
+        TableName=table_name,
         KeySchema=[{"AttributeName": "id", "KeyType": "HASH"}],
         AttributeDefinitions=[{"AttributeName": "id", "AttributeType": "S"}],
         BillingMode="PAY_PER_REQUEST",
@@ -3114,7 +3104,7 @@ def test_update_expression_with_numeric_literal_instead_of_value():
 
     with pytest.raises(ClientError) as exc:
         dynamodb.update_item(
-            TableName="moto-test",
+            TableName=table_name,
             Key={"id": {"S": "1"}},
             UpdateExpression="SET MyStr = myNum + 1",
         )
@@ -3128,9 +3118,10 @@ def test_update_expression_with_multiple_set_clauses_must_be_comma_separated():
     An UpdateExpression can have multiple set clauses but if they are passed in without the separating comma.
     """
     dynamodb = boto3.client("dynamodb", region_name="eu-west-1")
+    table_name = f"T{uuid4()}"
 
     dynamodb.create_table(
-        TableName="moto-test",
+        TableName=table_name,
         KeySchema=[{"AttributeName": "id", "KeyType": "HASH"}],
         AttributeDefinitions=[{"AttributeName": "id", "AttributeType": "S"}],
         BillingMode="PAY_PER_REQUEST",
@@ -3138,7 +3129,7 @@ def test_update_expression_with_multiple_set_clauses_must_be_comma_separated():
 
     with pytest.raises(ClientError) as exc:
         dynamodb.update_item(
-            TableName="moto-test",
+            TableName=table_name,
             Key={"id": {"S": "1"}},
             UpdateExpression="SET MyStr = myNum Mystr2 myNum2",
         )
@@ -3155,51 +3146,20 @@ def test_list_tables_exclusive_start_table_name_empty():
     assert len(resp["TableNames"]) == 0
 
 
-def assert_correct_client_error(
-    client_error, code, message_template, message_values=None, braces=None
-):
-    """
-    Assert whether a client_error is as expected. Allow for a list of values to be passed into the message
-
-    Args:
-        client_error(ClientError): The ClientError exception that was raised
-        code(str): The code for the error (e.g. ValidationException)
-        message_template(str): Error message template. if message_values is not None then this template has a {values}
-            as placeholder. For example:
-            'Value provided in ExpressionAttributeValues unused in expressions: keys: {values}'
-        message_values(list of str|None): The values that are passed in the error message
-        braces(list of str|None): List of length 2 with opening and closing brace for the values. By default it will be
-                                  surrounded by curly brackets
-    """
-    braces = braces or ["{", "}"]
-    assert client_error.response["Error"]["Code"] == code
-    if message_values is not None:
-        values_string = f"{braces[0]}(?P<values>.*){braces[1]}"
-        re_msg = re.compile(message_template.format(values=values_string))
-        match_result = re_msg.match(client_error.response["Error"]["Message"])
-        assert match_result is not None
-        values_string = match_result.groupdict()["values"]
-        values = list(values_string.split(", "))
-        assert len(message_values) == len(values)
-        for value in message_values:
-            assert value in values
-    else:
-        assert client_error.response["Error"]["Message"] == message_template
-
-
 def create_simple_table_and_return_client():
     dynamodb = boto3.client("dynamodb", region_name="eu-west-1")
+    table_name = f"T{uuid4()}"
     dynamodb.create_table(
-        TableName="moto-test",
+        TableName=table_name,
         KeySchema=[{"AttributeName": "id", "KeyType": "HASH"}],
         AttributeDefinitions=[{"AttributeName": "id", "AttributeType": "S"}],
         ProvisionedThroughput={"ReadCapacityUnits": 1, "WriteCapacityUnits": 1},
     )
     dynamodb.put_item(
-        TableName="moto-test",
+        TableName=table_name,
         Item={"id": {"S": "1"}, "myNum": {"N": "1"}, "MyStr": {"S": "1"}},
     )
-    return dynamodb
+    return dynamodb, table_name
 
 
 # https://github.com/getmoto/moto/issues/2806
@@ -3207,25 +3167,25 @@ def create_simple_table_and_return_client():
 #       #DDB-UpdateItem-request-UpdateExpression
 @mock_aws
 def test_update_item_with_attribute_in_right_hand_side_and_operation():
-    dynamodb = create_simple_table_and_return_client()
+    dynamodb, table_name = create_simple_table_and_return_client()
 
     dynamodb.update_item(
-        TableName="moto-test",
+        TableName=table_name,
         Key={"id": {"S": "1"}},
         UpdateExpression="SET myNum = myNum+:val",
         ExpressionAttributeValues={":val": {"N": "3"}},
     )
 
-    result = dynamodb.get_item(TableName="moto-test", Key={"id": {"S": "1"}})
+    result = dynamodb.get_item(TableName=table_name, Key={"id": {"S": "1"}})
     assert result["Item"]["myNum"]["N"] == "4"
 
     dynamodb.update_item(
-        TableName="moto-test",
+        TableName=table_name,
         Key={"id": {"S": "1"}},
         UpdateExpression="SET myNum = myNum - :val",
         ExpressionAttributeValues={":val": {"N": "1"}},
     )
-    result = dynamodb.get_item(TableName="moto-test", Key={"id": {"S": "1"}})
+    result = dynamodb.get_item(TableName=table_name, Key={"id": {"S": "1"}})
     assert result["Item"]["myNum"]["N"] == "3"
 
 
@@ -3234,48 +3194,46 @@ def test_non_existing_attribute_should_raise_exception():
     """
     Does error message get correctly raised if attribute is referenced but it does not exist for the item.
     """
-    dynamodb = create_simple_table_and_return_client()
+    dynamodb, table_name = create_simple_table_and_return_client()
 
-    try:
+    with pytest.raises(ClientError) as exc:
         dynamodb.update_item(
-            TableName="moto-test",
+            TableName=table_name,
             Key={"id": {"S": "1"}},
             UpdateExpression="SET MyStr = no_attr + MyStr",
         )
-        raise AssertionError("Validation exception not thrown")
-    except dynamodb.exceptions.ClientError as e:
-        assert_correct_client_error(
-            e,
-            "ValidationException",
-            "The provided expression refers to an attribute that does not exist in the item",
-        )
+    err = exc.value.response["Error"]
+    assert err["Code"] == "ValidationException"
+    assert (
+        err["Message"]
+        == "The provided expression refers to an attribute that does not exist in the item"
+    )
 
 
 @mock_aws
 def test_update_expression_with_plus_in_attribute_name():
     """
     Does error message get correctly raised if attribute contains a plus and is passed in without an AttributeName. And
-    lhs & rhs are not attribute IDs by themselve.
+    lhs & rhs are not attribute IDs by themselves.
     """
-    dynamodb = create_simple_table_and_return_client()
+    dynamodb, table_name = create_simple_table_and_return_client()
 
     dynamodb.put_item(
-        TableName="moto-test",
+        TableName=table_name,
         Item={"id": {"S": "1"}, "my+Num": {"S": "1"}, "MyStr": {"S": "aaa"}},
     )
-    try:
+    with pytest.raises(ClientError) as exc:
         dynamodb.update_item(
-            TableName="moto-test",
+            TableName=table_name,
             Key={"id": {"S": "1"}},
             UpdateExpression="SET MyStr = my+Num",
         )
-        raise AssertionError("Validation exception not thrown")
-    except dynamodb.exceptions.ClientError as e:
-        assert_correct_client_error(
-            e,
-            "ValidationException",
-            "The provided expression refers to an attribute that does not exist in the item",
-        )
+    err = exc.value.response["Error"]
+    assert err["Code"] == "ValidationException"
+    assert (
+        err["Message"]
+        == "The provided expression refers to an attribute that does not exist in the item"
+    )
 
 
 @mock_aws
@@ -3284,25 +3242,24 @@ def test_update_expression_with_minus_in_attribute_name():
     Does error message get correctly raised if attribute contains a minus and is passed in without an AttributeName. And
     lhs & rhs are not attribute IDs by themselve.
     """
-    dynamodb = create_simple_table_and_return_client()
+    dynamodb, table_name = create_simple_table_and_return_client()
 
     dynamodb.put_item(
-        TableName="moto-test",
+        TableName=table_name,
         Item={"id": {"S": "1"}, "my-Num": {"S": "1"}, "MyStr": {"S": "aaa"}},
     )
-    try:
+    with pytest.raises(ClientError) as exc:
         dynamodb.update_item(
-            TableName="moto-test",
+            TableName=table_name,
             Key={"id": {"S": "1"}},
             UpdateExpression="SET MyStr = my-Num",
         )
-        raise AssertionError("Validation exception not thrown")
-    except dynamodb.exceptions.ClientError as e:
-        assert_correct_client_error(
-            e,
-            "ValidationException",
-            "The provided expression refers to an attribute that does not exist in the item",
-        )
+    err = exc.value.response["Error"]
+    assert err["Code"] == "ValidationException"
+    assert (
+        err["Message"]
+        == "The provided expression refers to an attribute that does not exist in the item"
+    )
 
 
 @mock_aws
@@ -3311,16 +3268,16 @@ def test_update_expression_with_space_in_attribute_name():
     Does error message get correctly raised if attribute contains a space and is passed in without an AttributeName. And
     lhs & rhs are not attribute IDs by themselves.
     """
-    dynamodb = create_simple_table_and_return_client()
+    dynamodb, table_name = create_simple_table_and_return_client()
 
     dynamodb.put_item(
-        TableName="moto-test",
+        TableName=table_name,
         Item={"id": {"S": "1"}, "my Num": {"S": "1"}, "MyStr": {"S": "aaa"}},
     )
 
     with pytest.raises(ClientError) as exc:
         dynamodb.update_item(
-            TableName="moto-test",
+            TableName=table_name,
             Key={"id": {"S": "1"}},
             UpdateExpression="SET MyStr = my Num",
         )
@@ -3335,21 +3292,20 @@ def test_summing_up_2_strings_raises_exception():
     raises an exception.  It results in ClientError with code ValidationException:
         Saying An operand in the update expression has an incorrect data type
     """
-    dynamodb = create_simple_table_and_return_client()
+    dynamodb, table_name = create_simple_table_and_return_client()
 
-    try:
+    with pytest.raises(ClientError) as exc:
         dynamodb.update_item(
-            TableName="moto-test",
+            TableName=table_name,
             Key={"id": {"S": "1"}},
             UpdateExpression="SET MyStr = MyStr + MyStr",
         )
-        raise AssertionError("Validation exception not thrown")
-    except dynamodb.exceptions.ClientError as e:
-        assert_correct_client_error(
-            e,
-            "ValidationException",
-            "An operand in the update expression has an incorrect data type",
-        )
+    err = exc.value.response["Error"]
+    assert err["Code"] == "ValidationException"
+    assert (
+        err["Message"]
+        == "An operand in the update expression has an incorrect data type"
+    )
 
 
 # https://github.com/getmoto/moto/issues/2806
@@ -3358,39 +3314,39 @@ def test_update_item_with_attribute_in_right_hand_side():
     """
     After tokenization and building expression make sure referenced attributes are replaced with their current value
     """
-    dynamodb = create_simple_table_and_return_client()
+    dynamodb, table_name = create_simple_table_and_return_client()
 
     # Make sure there are 2 values
     dynamodb.put_item(
-        TableName="moto-test",
+        TableName=table_name,
         Item={"id": {"S": "1"}, "myVal1": {"S": "Value1"}, "myVal2": {"S": "Value2"}},
     )
 
     dynamodb.update_item(
-        TableName="moto-test",
+        TableName=table_name,
         Key={"id": {"S": "1"}},
         UpdateExpression="SET myVal1 = myVal2",
     )
 
-    result = dynamodb.get_item(TableName="moto-test", Key={"id": {"S": "1"}})
+    result = dynamodb.get_item(TableName=table_name, Key={"id": {"S": "1"}})
     assert result["Item"]["myVal1"]["S"] == result["Item"]["myVal2"]["S"] == "Value2"
 
 
 @mock_aws
 def test_multiple_updates():
-    dynamodb = create_simple_table_and_return_client()
+    dynamodb, table_name = create_simple_table_and_return_client()
     dynamodb.put_item(
-        TableName="moto-test",
+        TableName=table_name,
         Item={"id": {"S": "1"}, "myNum": {"N": "1"}, "path": {"N": "6"}},
     )
     dynamodb.update_item(
-        TableName="moto-test",
+        TableName=table_name,
         Key={"id": {"S": "1"}},
         UpdateExpression="SET myNum = #p + :val, newAttr = myNum",
         ExpressionAttributeValues={":val": {"N": "1"}},
         ExpressionAttributeNames={"#p": "path"},
     )
-    result = dynamodb.get_item(TableName="moto-test", Key={"id": {"S": "1"}})["Item"]
+    result = dynamodb.get_item(TableName=table_name, Key={"id": {"S": "1"}})["Item"]
     expected_result = {
         "myNum": {"N": "7"},
         "newAttr": {"N": "1"},
@@ -3402,7 +3358,7 @@ def test_multiple_updates():
 
 @mock_aws
 def test_update_item_atomic_counter():
-    table = "table_t"
+    table = f"T{uuid4()}"
     ddb_mock = boto3.client("dynamodb", region_name="eu-west-3")
     ddb_mock.create_table(
         TableName=table,
@@ -3431,7 +3387,7 @@ def test_update_item_atomic_counter():
 
 @mock_aws
 def test_update_item_atomic_counter_return_values():
-    table = "table_t"
+    table = f"T{uuid4()}"
     ddb_mock = boto3.client("dynamodb", region_name="eu-west-3")
     ddb_mock.create_table(
         TableName=table,
@@ -3479,7 +3435,7 @@ def test_update_item_atomic_counter_return_values():
 
 @mock_aws
 def test_update_item_atomic_counter_from_zero():
-    table = "table_t"
+    table = f"T{uuid4()}"
     ddb_mock = boto3.client("dynamodb", region_name="eu-west-1")
     ddb_mock.create_table(
         TableName=table,
@@ -3505,7 +3461,7 @@ def test_update_item_atomic_counter_from_zero():
 
 @mock_aws
 def test_update_item_add_to_non_existent_set():
-    table = "table_t"
+    table = f"T{uuid4()}"
     ddb_mock = boto3.client("dynamodb", region_name="eu-west-1")
     ddb_mock.create_table(
         TableName=table,
@@ -3528,7 +3484,7 @@ def test_update_item_add_to_non_existent_set():
 
 @mock_aws
 def test_update_item_add_to_non_existent_number_set():
-    table = "table_t"
+    table = f"T{uuid4()}"
     ddb_mock = boto3.client("dynamodb", region_name="eu-west-1")
     ddb_mock.create_table(
         TableName=table,
@@ -3578,6 +3534,7 @@ def test_gsi_projection_type_keys_only(table_name=None):
 
 @mock_aws
 def test_gsi_projection_type_include():
+    table_name = f"T{uuid4()}"
     table_schema = {
         "KeySchema": [{"AttributeName": "partitionKey", "KeyType": "HASH"}],
         "GlobalSecondaryIndexes": [
@@ -3609,10 +3566,9 @@ def test_gsi_projection_type_include():
     }
 
     dynamodb = boto3.resource("dynamodb", region_name="us-east-1")
-    dynamodb.create_table(
-        TableName="test-table", BillingMode="PAY_PER_REQUEST", **table_schema
+    table = dynamodb.create_table(
+        TableName=table_name, BillingMode="PAY_PER_REQUEST", **table_schema
     )
-    table = dynamodb.Table("test-table")
     table.put_item(Item=item)
 
     items = table.query(
@@ -3700,18 +3656,19 @@ def test_set_attribute_is_dropped_if_empty_after_update_expression(table_name=No
 def test_dynamodb_update_item_fails_on_string_sets():
     dynamodb = boto3.resource("dynamodb", region_name="eu-west-1")
     client = boto3.client("dynamodb", region_name="eu-west-1")
+    table_name = f"T{uuid4()}"
 
     table = dynamodb.create_table(
-        TableName="test",
+        TableName=table_name,
         KeySchema=[{"AttributeName": "record_id", "KeyType": "HASH"}],
         AttributeDefinitions=[{"AttributeName": "record_id", "AttributeType": "S"}],
         BillingMode="PAY_PER_REQUEST",
     )
-    table.meta.client.get_waiter("table_exists").wait(TableName="test")
+    table.meta.client.get_waiter("table_exists").wait(TableName=table_name)
     attribute = {"test_field": {"Value": {"SS": ["test1", "test2"]}, "Action": "PUT"}}
 
     client.update_item(
-        TableName="test",
+        TableName=table_name,
         Key={"record_id": {"S": "testrecord"}},
         AttributeUpdates=attribute,
     )
@@ -3720,18 +3677,17 @@ def test_dynamodb_update_item_fails_on_string_sets():
 @mock_aws
 def test_update_item_add_to_list_using_legacy_attribute_updates():
     resource = boto3.resource("dynamodb", region_name="us-west-2")
-    resource.create_table(
+    name = f"T{uuid4()}"
+    table = resource.create_table(
         AttributeDefinitions=[{"AttributeName": "id", "AttributeType": "S"}],
-        TableName="TestTable",
+        TableName=name,
         KeySchema=[{"AttributeName": "id", "KeyType": "HASH"}],
         ProvisionedThroughput={"ReadCapacityUnits": 5, "WriteCapacityUnits": 5},
     )
-    table = resource.Table("TestTable")
     table.wait_until_exists()
     table.put_item(Item={"id": "list_add", "attr": ["a", "b", "c"]})
 
     table.update_item(
-        TableName="TestTable",
         Key={"id": "list_add"},
         AttributeUpdates={"attr": {"Action": "ADD", "Value": ["d", "e"]}},
     )
@@ -3743,24 +3699,21 @@ def test_update_item_add_to_list_using_legacy_attribute_updates():
 @mock_aws
 def test_update_item_add_to_num_set_using_legacy_attribute_updates():
     resource = boto3.resource("dynamodb", region_name="us-west-2")
-    resource.create_table(
+    table = resource.create_table(
         AttributeDefinitions=[{"AttributeName": "id", "AttributeType": "S"}],
-        TableName="TestTable",
+        TableName=f"T{uuid4()}",
         KeySchema=[{"AttributeName": "id", "KeyType": "HASH"}],
         ProvisionedThroughput={"ReadCapacityUnits": 5, "WriteCapacityUnits": 5},
     )
-    table = resource.Table("TestTable")
     table.wait_until_exists()
     table.put_item(Item={"id": "set_add", "attr": {1, 2}})
 
     table.update_item(
-        TableName="TestTable",
         Key={"id": "set_add"},
         AttributeUpdates={"attr": {"Action": "PUT", "Value": {1, 2, 3}}},
     )
 
     table.update_item(
-        TableName="TestTable",
         Key={"id": "set_add"},
         AttributeUpdates={"attr": {"Action": "ADD", "Value": {4, 5}}},
     )
@@ -3769,7 +3722,6 @@ def test_update_item_add_to_num_set_using_legacy_attribute_updates():
     assert resp["Item"]["attr"] == {1, 2, 3, 4, 5}
 
     table.update_item(
-        TableName="TestTable",
         Key={"id": "set_add"},
         AttributeUpdates={"attr": {"Action": "DELETE", "Value": {2, 3}}},
     )
@@ -3782,7 +3734,7 @@ def test_update_item_add_to_num_set_using_legacy_attribute_updates():
 def test_get_item_for_non_existent_table_raises_error():
     client = boto3.client("dynamodb", "us-east-1")
     with pytest.raises(ClientError) as ex:
-        client.get_item(TableName="non-existent", Key={"site-id": {"S": "foo"}})
+        client.get_item(TableName=f"T{uuid4()}", Key={"site-id": {"S": "foo"}})
     assert ex.value.response["Error"]["Code"] == "ResourceNotFoundException"
     assert ex.value.response["Error"]["Message"] == "Requested resource not found"
 
@@ -3790,7 +3742,7 @@ def test_get_item_for_non_existent_table_raises_error():
 @mock_aws
 def test_error_when_providing_expression_and_nonexpression_params():
     client = boto3.client("dynamodb", "eu-central-1")
-    table_name = "testtable"
+    table_name = f"T{uuid4()}"
     client.create_table(
         TableName=table_name,
         KeySchema=[{"AttributeName": "pkey", "KeyType": "HASH"}],
@@ -3819,7 +3771,7 @@ def test_error_when_providing_expression_and_nonexpression_params():
 @mock_aws
 def test_error_when_providing_empty_update_expression():
     client = boto3.client("dynamodb", "eu-central-1")
-    table_name = "testtable"
+    table_name = f"T{uuid4()}"
     client.create_table(
         TableName=table_name,
         KeySchema=[{"AttributeName": "pkey", "KeyType": "HASH"}],
@@ -3843,7 +3795,7 @@ def test_error_when_providing_empty_update_expression():
 
 @mock_aws
 def test_attribute_item_delete():
-    name = "TestTable"
+    name = f"T{uuid4()}"
     conn = boto3.client("dynamodb", region_name="eu-west-1")
     conn.create_table(
         TableName=name,
@@ -3868,7 +3820,7 @@ def test_attribute_item_delete():
 
 @mock_aws
 def test_gsi_key_can_be_updated():
-    name = "TestTable"
+    name = f"T{uuid4()}"
     conn = boto3.client("dynamodb", region_name="eu-west-2")
     conn.create_table(
         TableName=name,
@@ -3914,7 +3866,7 @@ def test_gsi_key_can_be_updated():
 
 @mock_aws
 def test_gsi_key_cannot_be_empty():
-    name = "TestTable"
+    name = f"T{uuid4()}"
     conn = boto3.client("dynamodb", region_name="eu-west-2")
     conn.create_table(
         TableName=name,
@@ -3964,24 +3916,25 @@ def test_gsi_key_cannot_be_empty():
 @mock_aws
 def test_create_backup_for_non_existent_table_raises_error():
     client = boto3.client("dynamodb", "us-east-1")
+    table_name = f"T{uuid4()}"
     with pytest.raises(ClientError) as ex:
-        client.create_backup(TableName="non-existent", BackupName="backup")
+        client.create_backup(TableName=table_name, BackupName="backup")
     error = ex.value.response["Error"]
     assert error["Code"] == "TableNotFoundException"
-    assert error["Message"] == "Table not found: non-existent"
+    assert error["Message"] == f"Table not found: {table_name}"
 
 
 @mock_aws
 def test_create_backup():
     client = boto3.client("dynamodb", "us-east-1")
-    table_name = "test-table"
+    table_name = f"T{uuid4()}"
     client.create_table(
         TableName=table_name,
         KeySchema=[{"AttributeName": "id", "KeyType": "HASH"}],
         AttributeDefinitions=[{"AttributeName": "id", "AttributeType": "S"}],
         ProvisionedThroughput={"ReadCapacityUnits": 5, "WriteCapacityUnits": 5},
     )
-    backup_name = "backup-test-table"
+    backup_name = f"T{uuid4()}"
     resp = client.create_backup(TableName=table_name, BackupName=backup_name)
     details = resp.get("BackupDetails")
     assert table_name in details["BackupArn"]
@@ -3996,7 +3949,7 @@ def test_create_backup():
 def test_create_backup_using_arn():
     client = boto3.client("dynamodb", "us-east-1")
     table_arn = client.create_table(
-        TableName="test-table",
+        TableName=f"T{uuid4()}",
         KeySchema=[{"AttributeName": "id", "KeyType": "HASH"}],
         AttributeDefinitions=[{"AttributeName": "id", "AttributeType": "S"}],
         ProvisionedThroughput={"ReadCapacityUnits": 5, "WriteCapacityUnits": 5},
@@ -4010,14 +3963,14 @@ def test_create_backup_using_arn():
 @mock_aws
 def test_create_multiple_backups_with_same_name():
     client = boto3.client("dynamodb", "us-east-1")
-    table_name = "test-table"
+    table_name = f"T{uuid4()}"
     client.create_table(
         TableName=table_name,
         KeySchema=[{"AttributeName": "id", "KeyType": "HASH"}],
         AttributeDefinitions=[{"AttributeName": "id", "AttributeType": "S"}],
         ProvisionedThroughput={"ReadCapacityUnits": 5, "WriteCapacityUnits": 5},
     )
-    backup_name = "backup-test-table"
+    backup_name = f"T{uuid4()}"
     backup_arns = []
     for _ in range(4):
         backup = client.create_backup(TableName=table_name, BackupName=backup_name).get(
@@ -4042,14 +3995,14 @@ def test_describe_backup_for_non_existent_backup_raises_error():
 @mock_aws
 def test_describe_backup():
     client = boto3.client("dynamodb", "us-east-1")
-    table_name = "test-table"
+    table_name = f"T{uuid4()}"
     table = client.create_table(
         TableName=table_name,
         KeySchema=[{"AttributeName": "id", "KeyType": "HASH"}],
         AttributeDefinitions=[{"AttributeName": "id", "AttributeType": "S"}],
         ProvisionedThroughput={"ReadCapacityUnits": 5, "WriteCapacityUnits": 5},
     ).get("TableDescription")
-    backup_name = "backup-test-table"
+    backup_name = f"T{uuid4()}"
     backup_arn = (
         client.create_backup(TableName=table_name, BackupName=backup_name)
         .get("BackupDetails")
@@ -4077,14 +4030,15 @@ def test_describe_backup():
 @mock_aws
 def test_list_backups_for_non_existent_table():
     client = boto3.client("dynamodb", "us-east-1")
-    resp = client.list_backups(TableName="non-existent")
+    resp = client.list_backups(TableName=f"T{uuid4()}")
     assert len(resp["BackupSummaries"]) == 0
 
 
 @mock_aws
+@pytest.mark.requires_clean_slate
 def test_list_backups():
     client = boto3.client("dynamodb", "us-east-1")
-    table_names = ["test-table-1", "test-table-2"]
+    table_names = [f"T{uuid4()}", f"T{uuid4()}"]
     backup_names = ["backup-1", "backup-2"]
     for table_name in table_names:
         client.create_table(
@@ -4127,7 +4081,7 @@ def test_restore_table_from_non_existent_backup_raises_error():
 @mock_aws
 def test_restore_table_from_backup_raises_error_when_table_already_exists():
     client = boto3.client("dynamodb", "us-east-1")
-    table_name = "test-table"
+    table_name = f"T{uuid4()}"
     client.create_table(
         TableName=table_name,
         KeySchema=[{"AttributeName": "id", "KeyType": "HASH"}],
@@ -4148,7 +4102,7 @@ def test_restore_table_from_backup_raises_error_when_table_already_exists():
 @mock_aws
 def test_restore_table_from_backup():
     client = boto3.client("dynamodb", "us-east-1")
-    table_name = "test-table"
+    table_name = f"T{uuid4()}"
     resp = client.create_table(
         TableName=table_name,
         KeySchema=[{"AttributeName": "id", "KeyType": "HASH"}],
@@ -4165,7 +4119,7 @@ def test_restore_table_from_backup():
         .get("BackupArn")
     )
 
-    restored_table_name = "restored-from-backup"
+    restored_table_name = f"T{uuid4()}"
     restored = client.restore_table_from_backup(
         TargetTableName=restored_table_name, BackupArn=backup_arn
     ).get("TableDescription")
@@ -4186,7 +4140,7 @@ def test_restore_table_from_backup():
 @mock_aws
 def test_restore_table_to_point_in_time():
     client = boto3.client("dynamodb", "us-east-1")
-    table_name = "test-table"
+    table_name = f"T{uuid4()}"
     resp = client.create_table(
         TableName=table_name,
         KeySchema=[{"AttributeName": "id", "KeyType": "HASH"}],
@@ -4197,7 +4151,7 @@ def test_restore_table_to_point_in_time():
     for i in range(5):
         client.put_item(TableName=table_name, Item={"id": {"S": f"item {i}"}})
 
-    restored_table_name = "restored-from-pit"
+    restored_table_name = f"T{uuid4()}"
     restored = client.restore_table_to_point_in_time(
         TargetTableName=restored_table_name, SourceTableName=table_name
     ).get("TableDescription")
@@ -4216,8 +4170,8 @@ def test_restore_table_to_point_in_time():
 @mock_aws
 def test_restore_table_to_point_in_time_raises_error_when_source_not_exist():
     client = boto3.client("dynamodb", "us-east-1")
-    table_name = "test-table"
-    restored_table_name = "restored-from-pit"
+    table_name = f"T{uuid4()}"
+    restored_table_name = f"T{uuid4()}"
     with pytest.raises(ClientError) as ex:
         client.restore_table_to_point_in_time(
             TargetTableName=restored_table_name, SourceTableName=table_name
@@ -4230,8 +4184,8 @@ def test_restore_table_to_point_in_time_raises_error_when_source_not_exist():
 @mock_aws
 def test_restore_table_to_point_in_time_raises_error_when_dest_exist():
     client = boto3.client("dynamodb", "us-east-1")
-    table_name = "test-table"
-    restored_table_name = "restored-from-pit"
+    table_name = f"T{uuid4()}"
+    restored_table_name = f"T{uuid4()}"
     client.create_table(
         TableName=table_name,
         KeySchema=[{"AttributeName": "id", "KeyType": "HASH"}],
@@ -4267,7 +4221,7 @@ def test_delete_non_existent_backup_raises_error():
 @mock_aws
 def test_delete_backup():
     client = boto3.client("dynamodb", "us-east-1")
-    table_name = "test-table-1"
+    table_name = f"T{uuid4()}"
     backup_names = ["backup-1", "backup-2"]
     client.create_table(
         TableName=table_name,
@@ -4300,7 +4254,7 @@ def test_source_and_restored_table_items_are_not_linked():
     def add_guids_to_table(table, num_items):
         guids = []
         for _ in range(num_items):
-            guid = str(uuid.uuid4())
+            guid = str(uuid4())
             client.put_item(TableName=table, Item={"id": {"S": guid}})
             guids.append(guid)
         return guids
@@ -4321,7 +4275,7 @@ def test_source_and_restored_table_items_are_not_linked():
     )
     guids_added_after_backup = add_guids_to_table(source_table_name, 5)
 
-    restored_table_name = "restored-from-backup"
+    restored_table_name = f"T{uuid4()}"
     client.restore_table_from_backup(
         TargetTableName=restored_table_name, BackupArn=backup_arn
     )
@@ -4363,7 +4317,7 @@ def test_update_non_existing_item_raises_error_and_does_not_contain_item_afterwa
     Happened because we would create a placeholder, before validating/executing the UpdateExpression
     :return:
     """
-    name = "TestTable"
+    name = f"T{uuid4()}"
     conn = boto3.client("dynamodb", region_name="us-west-2")
     hkey = "primary_partition_key"
     conn.create_table(
@@ -4391,7 +4345,7 @@ def test_update_non_existing_item_raises_error_and_does_not_contain_item_afterwa
 def test_gsi_lastevaluatedkey():
     # github.com/getmoto/moto/issues/3968
     conn = boto3.resource("dynamodb", region_name="us-west-2")
-    name = "test-table"
+    name = f"T{uuid4()}"
     table = conn.Table(name)
 
     conn.create_table(
@@ -4461,7 +4415,7 @@ def test_filter_expression_execution_order():
     # then we should get no items in response.
 
     conn = boto3.resource("dynamodb", region_name="us-west-2")
-    name = "test-filter-expression-table"
+    name = f"T{uuid4()}"
     table = conn.Table(name)
 
     conn.create_table(
@@ -4546,7 +4500,7 @@ def test_projection_expression_execution_order():
     # include attributes which are not projected.
 
     conn = boto3.resource("dynamodb", region_name="us-west-2")
-    name = "test-projection-expression-with-gsi"
+    name = f"T{uuid4()}"
     table = conn.Table(name)
 
     conn.create_table(
@@ -4601,8 +4555,8 @@ def test_projection_expression_execution_order():
 @mock_aws
 def test_projection_expression_with_binary_attr():
     dynamo_resource = boto3.resource("dynamodb", region_name="us-east-1")
-    dynamo_resource.create_table(
-        TableName="test",
+    table = dynamo_resource.create_table(
+        TableName=f"T{uuid4()}",
         AttributeDefinitions=[
             {"AttributeName": "pk", "AttributeType": "S"},
             {"AttributeName": "sk", "AttributeType": "S"},
@@ -4613,7 +4567,6 @@ def test_projection_expression_with_binary_attr():
         ],
         BillingMode="PAY_PER_REQUEST",
     )
-    table = dynamo_resource.Table("test")
     table.put_item(Item={"pk": "pk", "sk": "sk", "key": b"value\xbf"})
 
     item = table.get_item(
@@ -4632,7 +4585,7 @@ def test_projection_expression_with_binary_attr():
 
 @mock_aws
 def test_invalid_projection_expressions():
-    table_name = "test-projection-expressions-table"
+    table_name = f"T{uuid4()}"
     client = boto3.client("dynamodb", region_name="us-east-1")
     client.create_table(
         TableName=table_name,
@@ -4695,8 +4648,8 @@ def test_update_item_with_global_secondary_index():
     dynamodb = boto3.resource("dynamodb", region_name="us-east-1")
 
     # Create the DynamoDB table
-    dynamodb.create_table(
-        TableName="test",
+    table = dynamodb.create_table(
+        TableName=f"T{uuid4()}",
         KeySchema=[{"AttributeName": "id", "KeyType": "HASH"}],
         AttributeDefinitions=[
             {"AttributeName": "id", "AttributeType": "S"},
@@ -4741,7 +4694,6 @@ def test_update_item_with_global_secondary_index():
             },
         ],
     )
-    table = dynamodb.Table("test")
 
     table.put_item(
         Item={"id": "test1"},
@@ -4831,7 +4783,7 @@ def test_query_with_unknown_last_evaluated_key(table_name=None):
 @mock_aws
 def test_query_with_gsi_reverse_paginated():
     client = boto3.client("dynamodb", region_name="us-west-2")
-    table_name = "unit-test-table"
+    table_name = f"T{uuid4()}"
     index_name = "alternate"
 
     # Create table - GSI has dissimilar attributes from the main table

--- a/tests/test_dynamodb/test_dynamodb_account_mode.py
+++ b/tests/test_dynamodb/test_dynamodb_account_mode.py
@@ -1,3 +1,5 @@
+from uuid import uuid4
+
 import boto3
 import pytest
 from botocore.config import Config
@@ -19,7 +21,7 @@ def test_dynamodb_with_account_id_routing(endpoint_mode):
         config=endpoint_config,
     )
     client.create_table(
-        TableName="test",
+        TableName=f"T{uuid4()}",
         KeySchema=[{"AttributeName": "id", "KeyType": "HASH"}],
         AttributeDefinitions=[{"AttributeName": "id", "AttributeType": "S"}],
         ProvisionedThroughput={"ReadCapacityUnits": 5, "WriteCapacityUnits": 5},

--- a/tests/test_dynamodb/test_dynamodb_batch_write.py
+++ b/tests/test_dynamodb/test_dynamodb_batch_write.py
@@ -33,7 +33,7 @@ def test_batch_write_single_set(table_name=None):
 @dynamodb_aws_verified(create_table=False)
 def test_batch_write_item_to_multiple_tables():
     conn = boto3.resource("dynamodb", region_name="us-west-2")
-    tables = [f"table-{str(uuid4())[0:6]}-{i}" for i in range(3)]
+    tables = [f"table-{str(uuid4())}-{i}" for i in range(3)]
     for name in tables:
         conn.create_table(
             TableName=name,

--- a/tests/test_dynamodb/test_dynamodb_cloudformation.py
+++ b/tests/test_dynamodb/test_dynamodb_cloudformation.py
@@ -2,6 +2,7 @@ import json
 from copy import deepcopy
 
 import boto3
+import pytest
 
 from moto import mock_aws
 
@@ -31,6 +32,7 @@ template_create_table = {
 
 
 @mock_aws
+@pytest.mark.requires_clean_slate
 def test_create_stack_pay_per_request():
     conn = boto3.client("cloudformation", region_name="us-east-1")
     dynamodb_client = boto3.client("dynamodb", region_name="us-east-1")
@@ -49,6 +51,7 @@ def test_create_stack_pay_per_request():
 
 
 @mock_aws
+@pytest.mark.requires_clean_slate
 def test_create_stack_with_indexes():
     conn = boto3.client("cloudformation", region_name="us-east-1")
     dynamodb_client = boto3.client("dynamodb", region_name="us-east-1")
@@ -80,6 +83,7 @@ def test_create_stack_with_indexes():
 
 
 @mock_aws
+@pytest.mark.requires_clean_slate
 def test_delete_stack_dynamo_template():
     conn = boto3.client("cloudformation", region_name="us-east-1")
     dynamodb_client = boto3.client("dynamodb", region_name="us-east-1")

--- a/tests/test_dynamodb/test_dynamodb_condition_expressions.py
+++ b/tests/test_dynamodb/test_dynamodb_condition_expressions.py
@@ -1,5 +1,6 @@
 import re
 from decimal import Decimal
+from uuid import uuid4
 
 import boto3
 import pytest
@@ -11,7 +12,7 @@ from moto import mock_aws
 @mock_aws
 def test_condition_expression_with_dot_in_attr_name():
     dynamodb = boto3.resource("dynamodb", region_name="us-east-2")
-    table_name = "Test"
+    table_name = f"T{uuid4()}"
     dynamodb.create_table(
         TableName=table_name,
         KeySchema=[{"AttributeName": "id", "KeyType": "HASH"}],
@@ -45,10 +46,11 @@ def test_condition_expression_with_dot_in_attr_name():
 @mock_aws
 def test_condition_expressions():
     client = boto3.client("dynamodb", region_name="us-east-1")
+    table_name = f"T{uuid4()}"
 
     # Create the DynamoDB table.
     client.create_table(
-        TableName="test1",
+        TableName=table_name,
         AttributeDefinitions=[
             {"AttributeName": "client", "AttributeType": "S"},
             {"AttributeName": "app", "AttributeType": "S"},
@@ -60,7 +62,7 @@ def test_condition_expressions():
         ProvisionedThroughput={"ReadCapacityUnits": 123, "WriteCapacityUnits": 123},
     )
     client.put_item(
-        TableName="test1",
+        TableName=table_name,
         Item={
             "client": {"S": "client1"},
             "app": {"S": "app1"},
@@ -70,7 +72,7 @@ def test_condition_expressions():
     )
 
     client.put_item(
-        TableName="test1",
+        TableName=table_name,
         Item={
             "client": {"S": "client1"},
             "app": {"S": "app1"},
@@ -87,7 +89,7 @@ def test_condition_expressions():
     )
 
     client.put_item(
-        TableName="test1",
+        TableName=table_name,
         Item={
             "client": {"S": "client1"},
             "app": {"S": "app1"},
@@ -99,7 +101,7 @@ def test_condition_expressions():
     )
 
     client.put_item(
-        TableName="test1",
+        TableName=table_name,
         Item={
             "client": {"S": "client1"},
             "app": {"S": "app1"},
@@ -111,7 +113,7 @@ def test_condition_expressions():
     )
 
     client.put_item(
-        TableName="test1",
+        TableName=table_name,
         Item={
             "client": {"S": "client1"},
             "app": {"S": "app1"},
@@ -124,7 +126,7 @@ def test_condition_expressions():
     )
 
     client.put_item(
-        TableName="test1",
+        TableName=table_name,
         Item={
             "client": {"S": "client1"},
             "app": {"S": "app1"},
@@ -141,7 +143,7 @@ def test_condition_expressions():
 
     with pytest.raises(client.exceptions.ConditionalCheckFailedException):
         client.put_item(
-            TableName="test1",
+            TableName=table_name,
             Item={
                 "client": {"S": "client1"},
                 "app": {"S": "app1"},
@@ -157,7 +159,7 @@ def test_condition_expressions():
 
     with pytest.raises(client.exceptions.ConditionalCheckFailedException):
         client.put_item(
-            TableName="test1",
+            TableName=table_name,
             Item={
                 "client": {"S": "client1"},
                 "app": {"S": "app1"},
@@ -173,7 +175,7 @@ def test_condition_expressions():
 
     with pytest.raises(client.exceptions.ConditionalCheckFailedException):
         client.put_item(
-            TableName="test1",
+            TableName=table_name,
             Item={
                 "client": {"S": "client1"},
                 "app": {"S": "app1"},
@@ -191,7 +193,7 @@ def test_condition_expressions():
 
     # Make sure update_item honors ConditionExpression as well
     client.update_item(
-        TableName="test1",
+        TableName=table_name,
         Key={"client": {"S": "client1"}, "app": {"S": "app1"}},
         UpdateExpression="set #match=:match",
         ConditionExpression="attribute_exists(#existing)",
@@ -201,7 +203,7 @@ def test_condition_expressions():
 
     with pytest.raises(client.exceptions.ConditionalCheckFailedException) as exc:
         client.update_item(
-            TableName="test1",
+            TableName=table_name,
             Key={"client": {"S": "client1"}, "app": {"S": "app1"}},
             UpdateExpression="set #match=:match",
             ConditionExpression="attribute_not_exists(#existing)",
@@ -212,7 +214,7 @@ def test_condition_expressions():
 
     with pytest.raises(client.exceptions.ConditionalCheckFailedException) as exc:
         client.update_item(
-            TableName="test1",
+            TableName=table_name,
             Key={"client": {"S": "client2"}, "app": {"S": "app1"}},
             UpdateExpression="set #match=:match",
             ConditionExpression="attribute_exists(#existing)",
@@ -223,7 +225,7 @@ def test_condition_expressions():
 
     with pytest.raises(client.exceptions.ConditionalCheckFailedException):
         client.delete_item(
-            TableName="test1",
+            TableName=table_name,
             Key={"client": {"S": "client1"}, "app": {"S": "app1"}},
             ConditionExpression="attribute_not_exists(#existing)",
             ExpressionAttributeValues={":match": {"S": "match"}},
@@ -240,13 +242,12 @@ def _assert_conditional_check_failed_exception(exc):
 @mock_aws
 def test_condition_expression_numerical_attribute():
     dynamodb = boto3.resource("dynamodb", region_name="us-east-1")
-    dynamodb.create_table(
-        TableName="my-table",
+    table = dynamodb.create_table(
+        TableName=f"T{uuid4()}",
         KeySchema=[{"AttributeName": "partitionKey", "KeyType": "HASH"}],
         AttributeDefinitions=[{"AttributeName": "partitionKey", "AttributeType": "S"}],
         BillingMode="PAY_PER_REQUEST",
     )
-    table = dynamodb.Table("my-table")
     table.put_item(Item={"partitionKey": "pk-pos", "myAttr": 5})
     table.put_item(Item={"partitionKey": "pk-neg", "myAttr": -5})
 
@@ -281,22 +282,23 @@ def update_numerical_con_expr(key, con_expr, res, table):
 @mock_aws
 def test_condition_expression__attr_doesnt_exist():
     client = boto3.client("dynamodb", region_name="us-east-1")
+    table_name = f"T{uuid4()}"
 
     client.create_table(
-        TableName="test",
+        TableName=table_name,
         KeySchema=[{"AttributeName": "forum_name", "KeyType": "HASH"}],
         AttributeDefinitions=[{"AttributeName": "forum_name", "AttributeType": "S"}],
         ProvisionedThroughput={"ReadCapacityUnits": 1, "WriteCapacityUnits": 1},
     )
 
     client.put_item(
-        TableName="test", Item={"forum_name": {"S": "foo"}, "ttl": {"N": "bar"}}
+        TableName=table_name, Item={"forum_name": {"S": "foo"}, "ttl": {"N": "bar"}}
     )
 
     def update_if_attr_doesnt_exist():
         # Test nonexistent top-level attribute.
         client.update_item(
-            TableName="test",
+            TableName=table_name,
             Key={"forum_name": {"S": "the-key"}},
             UpdateExpression="set #new_state=:new_state, #ttl=:ttl",
             ConditionExpression="attribute_not_exists(#new_state)",
@@ -319,9 +321,10 @@ def test_condition_expression__attr_doesnt_exist():
 @mock_aws
 def test_condition_expression__or_order():
     client = boto3.client("dynamodb", region_name="us-east-1")
+    table_name = f"T{uuid4()}"
 
     client.create_table(
-        TableName="test",
+        TableName=table_name,
         KeySchema=[{"AttributeName": "forum_name", "KeyType": "HASH"}],
         AttributeDefinitions=[{"AttributeName": "forum_name", "AttributeType": "S"}],
         ProvisionedThroughput={"ReadCapacityUnits": 1, "WriteCapacityUnits": 1},
@@ -330,7 +333,7 @@ def test_condition_expression__or_order():
     # ensure that the RHS of the OR expression is not evaluated if the LHS
     # returns true (as it would result an error)
     client.update_item(
-        TableName="test",
+        TableName=table_name,
         Key={"forum_name": {"S": "the-key"}},
         UpdateExpression="set #ttl=:ttl",
         ConditionExpression="attribute_not_exists(#ttl) OR #ttl <= :old_ttl",
@@ -342,9 +345,10 @@ def test_condition_expression__or_order():
 @mock_aws
 def test_condition_expression__and_order():
     client = boto3.client("dynamodb", region_name="us-east-1")
+    table_name = f"T{uuid4()}"
 
     client.create_table(
-        TableName="test",
+        TableName=table_name,
         KeySchema=[{"AttributeName": "forum_name", "KeyType": "HASH"}],
         AttributeDefinitions=[{"AttributeName": "forum_name", "AttributeType": "S"}],
         ProvisionedThroughput={"ReadCapacityUnits": 1, "WriteCapacityUnits": 1},
@@ -354,7 +358,7 @@ def test_condition_expression__and_order():
     # returns true (as it would result an error)
     with pytest.raises(client.exceptions.ConditionalCheckFailedException) as exc:
         client.update_item(
-            TableName="test",
+            TableName=table_name,
             Key={"forum_name": {"S": "the-key"}},
             UpdateExpression="set #ttl=:ttl",
             ConditionExpression="attribute_exists(#ttl) AND #ttl <= :old_ttl",
@@ -367,7 +371,7 @@ def test_condition_expression__and_order():
 @mock_aws
 def test_condition_expression_with_reserved_keyword_as_attr_name():
     dynamodb = boto3.resource("dynamodb", region_name="us-east-2")
-    table_name = "Test"
+    table_name = f"T{uuid4()}"
     dynamodb.create_table(
         TableName=table_name,
         KeySchema=[{"AttributeName": "id", "KeyType": "HASH"}],
@@ -432,8 +436,9 @@ def test_condition_check_failure_exception_is_raised_when_values_are_returned_fo
     # TypeError: Object of type DynamoType is not JSON serializable
 
     dynamodb_client = boto3.client("dynamodb", region_name="us-east-1")
+    table_name = f"T{uuid4()}"
     dynamodb_client.create_table(
-        TableName="example_table",
+        TableName=table_name,
         KeySchema=[{"AttributeName": "id", "KeyType": "HASH"}],
         AttributeDefinitions=[
             {"AttributeName": "id", "AttributeType": "S"},
@@ -445,13 +450,13 @@ def test_condition_check_failure_exception_is_raised_when_values_are_returned_fo
         "some_list": {"L": [{"M": {"hello": {"S": "h"}}}]},
     }
     dynamodb_client.put_item(
-        TableName="example_table",
+        TableName=table_name,
         Item=record,
     )
 
     with pytest.raises(ClientError) as error:
         dynamodb_client.update_item(
-            TableName="example_table",
+            TableName=table_name,
             Key={"id": {"S": "example_id"}},
             UpdateExpression="set some_list=list_append(some_list, :w)",
             ExpressionAttributeValues={
@@ -482,8 +487,9 @@ def test_condition_check_failure_exception_is_raised_when_values_are_returned_fo
     # AttributeError: 'str' object has no attribute 'to_regular_json'
 
     dynamodb_client = boto3.client("dynamodb", region_name="us-east-1")
+    table_name = f"T{uuid4()}"
     dynamodb_client.create_table(
-        TableName="example_table",
+        TableName=table_name,
         KeySchema=[{"AttributeName": "id", "KeyType": "HASH"}],
         AttributeDefinitions=[
             {"AttributeName": "id", "AttributeType": "S"},
@@ -495,13 +501,13 @@ def test_condition_check_failure_exception_is_raised_when_values_are_returned_fo
         "some_list": {"SS": ["hello"]},
     }
     dynamodb_client.put_item(
-        TableName="example_table",
+        TableName=table_name,
         Item=record,
     )
 
     with pytest.raises(ClientError) as error:
         dynamodb_client.update_item(
-            TableName="example_table",
+            TableName=table_name,
             Key={"id": {"S": "example_id"}},
             UpdateExpression="set some_list=list_append(some_list, :w)",
             ExpressionAttributeValues={
@@ -529,8 +535,9 @@ def test_condition_check_failure_exception_is_raised_when_values_are_returned_fo
     # when lists are inside a map
 
     dynamodb_client = boto3.client("dynamodb", region_name="us-east-1")
+    table_name = f"T{uuid4()}"
     dynamodb_client.create_table(
-        TableName="example_table",
+        TableName=table_name,
         KeySchema=[{"AttributeName": "id", "KeyType": "HASH"}],
         AttributeDefinitions=[
             {"AttributeName": "id", "AttributeType": "S"},
@@ -543,14 +550,11 @@ def test_condition_check_failure_exception_is_raised_when_values_are_returned_fo
             "M": {"some_list": {"L": [{"M": {"hello": {"S": "h"}}}]}}
         },
     }
-    dynamodb_client.put_item(
-        TableName="example_table",
-        Item=record,
-    )
+    dynamodb_client.put_item(TableName=table_name, Item=record)
 
     with pytest.raises(ClientError) as error:
         dynamodb_client.update_item(
-            TableName="example_table",
+            TableName=table_name,
             Key={"id": {"S": "example_id"}},
             UpdateExpression="set some_list_in_a_map.some_list=list_append(some_list_in_a_map.some_list, :w)",
             ExpressionAttributeValues={

--- a/tests/test_dynamodb/test_dynamodb_consumedcapacity.py
+++ b/tests/test_dynamodb/test_dynamodb_consumedcapacity.py
@@ -1,3 +1,5 @@
+from uuid import uuid4
+
 import boto3
 import pytest
 from botocore.exceptions import ClientError
@@ -8,15 +10,13 @@ from moto import mock_aws
 @mock_aws
 def test_error_on_wrong_value_for_consumed_capacity():
     resource = boto3.resource("dynamodb", region_name="ap-northeast-3")
-    client = boto3.client("dynamodb", region_name="ap-northeast-3")
-    client.create_table(
-        TableName="jobs",
+    table = resource.create_table(
+        TableName=f"T{uuid4()}",
         KeySchema=[{"AttributeName": "job_id", "KeyType": "HASH"}],
         AttributeDefinitions=[{"AttributeName": "job_id", "AttributeType": "S"}],
         ProvisionedThroughput={"ReadCapacityUnits": 5, "WriteCapacityUnits": 5},
     )
 
-    table = resource.Table("jobs")
     item = {"job_id": "asdasdasd", "expires_at": "1"}
 
     # PUT_ITEM
@@ -33,21 +33,22 @@ def test_error_on_wrong_value_for_consumed_capacity():
 @mock_aws
 def test_consumed_capacity_get_unknown_item():
     conn = boto3.client("dynamodb", region_name="us-east-1")
+    table_name = f"T{uuid4()}"
     conn.create_table(
-        TableName="test_table",
+        TableName=table_name,
         KeySchema=[{"AttributeName": "u", "KeyType": "HASH"}],
         AttributeDefinitions=[{"AttributeName": "u", "AttributeType": "S"}],
         BillingMode="PAY_PER_REQUEST",
     )
     response = conn.get_item(
-        TableName="test_table",
+        TableName=table_name,
         Key={"u": {"S": "does_not_exist"}},
         ReturnConsumedCapacity="TOTAL",
     )
 
     # Should still return ConsumedCapacity, even if it does not return an item
     assert response["ConsumedCapacity"] == {
-        "TableName": "test_table",
+        "TableName": table_name,
         "CapacityUnits": 0.5,
     }
 
@@ -67,8 +68,8 @@ def test_only_return_consumed_capacity_when_required(
 ):
     resource = boto3.resource("dynamodb", region_name="ap-northeast-3")
     client = boto3.client("dynamodb", region_name="ap-northeast-3")
-    client.create_table(
-        TableName="jobs",
+    table = resource.create_table(
+        TableName=f"T{uuid4()}",
         KeySchema=[{"AttributeName": "job_id", "KeyType": "HASH"}],
         LocalSecondaryIndexes=[
             {
@@ -84,7 +85,6 @@ def test_only_return_consumed_capacity_when_required(
         ProvisionedThroughput={"ReadCapacityUnits": 5, "WriteCapacityUnits": 5},
     )
 
-    table = resource.Table("jobs")
     item = {"job_id": "asdasdasd", "expires_at": "1"}
 
     # PUT_ITEM
@@ -102,7 +102,7 @@ def test_only_return_consumed_capacity_when_required(
     validate_response(response, should_have_capacity, should_have_table, value=0.5)
 
     # SCAN
-    args = {"TableName": "jobs"}
+    args = {"TableName": table.name}
     if capacity:
         args["ReturnConsumedCapacity"] = capacity
     response = client.scan(**args)
@@ -115,7 +115,7 @@ def test_only_return_consumed_capacity_when_required(
 
     # QUERY
     args = {
-        "TableName": "jobs",
+        "TableName": table.name,
         "KeyConditionExpression": "job_id = :id",
         "ExpressionAttributeValues": {":id": {"S": "asdasdasd"}},
     }
@@ -136,7 +136,6 @@ def validate_response(
 ):
     if should_have_capacity:
         capacity = response["ConsumedCapacity"]
-        assert capacity["TableName"] == "jobs"
         assert capacity["CapacityUnits"] == value
         if should_have_table:
             assert capacity["Table"] == {"CapacityUnits": value}

--- a/tests/test_dynamodb/test_dynamodb_export_table.py
+++ b/tests/test_dynamodb/test_dynamodb_export_table.py
@@ -26,7 +26,7 @@ def test_export_from_missing_table(table_name=None, bucket_name=None):
     account_id = sts.get_caller_identity()["Account"]
 
     s3_prefix = "prefix"
-    table_arn = f"arn:aws:dynamodb:us-east-1:{account_id}:table/{str(uuid4())[0:6]}"
+    table_arn = f"arn:aws:dynamodb:us-east-1:{account_id}:table/{str(uuid4())}"
 
     with pytest.raises(ClientError) as exc:
         client.export_table_to_point_in_time(

--- a/tests/test_dynamodb/test_dynamodb_import_table.py
+++ b/tests/test_dynamodb/test_dynamodb_import_table.py
@@ -15,7 +15,7 @@ from . import dynamodb_aws_verified
 def test_import_from_missing_s3_table(table_name=None):
     client = boto3.client("dynamodb", region_name="us-east-1")
 
-    table_name = "t" + str(uuid4())[0:6]
+    table_name = "t" + str(uuid4())
 
     import_description = client.import_table(
         S3BucketSource={"S3Bucket": f"{uuid4()}"},
@@ -48,7 +48,7 @@ def test_import_from_missing_s3_table(table_name=None):
 def test_import_has_regular_validation(table_name=None):
     client = boto3.client("dynamodb", region_name="us-east-1")
 
-    table_name = "t" + str(uuid4())[0:6]
+    table_name = "t" + str(uuid4())
 
     with pytest.raises(ClientError) as exc:
         client.import_table(
@@ -83,7 +83,8 @@ def test_import_from_empty_s3_bucket(table_name=None):
     s3 = boto3.client("s3", region_name="us-east-1")
 
     s3_bucket_name = f"inttest{uuid4()}"
-    table_name = "moto_test_" + str(uuid4())[0:6]
+    table_name = "moto_test_" + str(uuid4())
+    key_schema = [{"AttributeName": "pk", "KeyType": "HASH"}]
 
     s3.create_bucket(Bucket=s3_bucket_name)
 
@@ -93,12 +94,8 @@ def test_import_from_empty_s3_bucket(table_name=None):
         InputCompressionType="NONE",
         TableCreationParameters={
             "TableName": table_name,
-            "AttributeDefinitions": [
-                {"AttributeName": "pk", "AttributeType": "S"},
-            ],
-            "KeySchema": [
-                {"AttributeName": "pk", "KeyType": "HASH"},
-            ],
+            "AttributeDefinitions": [{"AttributeName": "pk", "AttributeType": "S"}],
+            "KeySchema": key_schema,
             "BillingMode": "PAY_PER_REQUEST",
         },
     )["ImportTableDescription"]
@@ -111,7 +108,9 @@ def test_import_from_empty_s3_bucket(table_name=None):
     assert import_details["ImportedItemCount"] == 0
     assert import_details["ProcessedSizeBytes"] == 0
 
-    assert table_name in client.list_tables()["TableNames"]
+    assert (
+        client.describe_table(TableName=table_name)["Table"]["KeySchema"] == key_schema
+    )
 
     assert client.scan(TableName=table_name)["Items"] == []
 
@@ -127,7 +126,7 @@ def test_import_table_single_file_with_multiple_items():
     s3 = boto3.client("s3", region_name="us-east-1")
 
     s3_bucket_name = f"inttest{uuid4()}"
-    table_name = "moto_test_" + str(uuid4())[0:6]
+    table_name = "moto_test_" + str(uuid4())
 
     s3.create_bucket(Bucket=s3_bucket_name)
 
@@ -203,7 +202,7 @@ def test_import_table_multiple_files():
     s3 = boto3.client("s3", region_name="us-east-1")
 
     s3_bucket_name = f"inttest{uuid4()}"
-    table_name = "moto_test_" + str(uuid4())[0:6]
+    table_name = "moto_test_" + str(uuid4())
 
     s3.create_bucket(Bucket=s3_bucket_name)
 
@@ -268,7 +267,7 @@ def test_some_successfull_files_and_some_with_unknown_data():
     s3 = boto3.client("s3", region_name="us-east-1")
 
     s3_bucket_name = f"inttest{uuid4()}"
-    table_name = "moto_test_" + str(uuid4())[0:6]
+    table_name = "moto_test_" + str(uuid4())
 
     s3.create_bucket(Bucket=s3_bucket_name)
 
@@ -332,7 +331,7 @@ def test_only_process_file_with_prefix():
     s3 = boto3.client("s3", region_name="us-east-1")
 
     s3_bucket_name = f"inttest{uuid4()}"
-    table_name = "moto_test_" + str(uuid4())[0:6]
+    table_name = "moto_test_" + str(uuid4())
 
     s3.create_bucket(Bucket=s3_bucket_name)
 
@@ -396,7 +395,7 @@ def test_process_gzipped_file():
     s3 = boto3.client("s3", region_name="us-east-1")
 
     s3_bucket_name = f"inttest{uuid4()}"
-    table_name = "moto_test_" + str(uuid4())[0:6]
+    table_name = "moto_test_" + str(uuid4())
 
     s3.create_bucket(Bucket=s3_bucket_name)
 

--- a/tests/test_dynamodb/test_dynamodb_query.py
+++ b/tests/test_dynamodb/test_dynamodb_query.py
@@ -1,4 +1,5 @@
 from decimal import Decimal
+from uuid import uuid4
 
 import boto3
 import pytest
@@ -84,8 +85,8 @@ def test_key_condition_expressions():
     dynamodb = boto3.resource("dynamodb", region_name="us-east-1")
 
     # Create the DynamoDB table.
-    dynamodb.create_table(
-        TableName="users",
+    table = dynamodb.create_table(
+        TableName=f"T{uuid4()}",
         KeySchema=[
             {"AttributeName": "forum_name", "KeyType": "HASH"},
             {"AttributeName": "subject", "KeyType": "RANGE"},
@@ -96,7 +97,6 @@ def test_key_condition_expressions():
         ],
         ProvisionedThroughput={"ReadCapacityUnits": 5, "WriteCapacityUnits": 5},
     )
-    table = dynamodb.Table("users")
 
     table.put_item(Item={"forum_name": "the-key", "subject": "123"})
     table.put_item(Item={"forum_name": "the-key", "subject": "456"})
@@ -331,8 +331,8 @@ def test_query_gsi_pagination_with_opposite_pk_order():
     dynamodb = boto3.resource("dynamodb", region_name="us-east-1")
 
     # Create the DynamoDB table.
-    dynamodb.create_table(
-        TableName="users",
+    table = dynamodb.create_table(
+        TableName=f"T{uuid4()}",
         KeySchema=[
             {"AttributeName": "pk", "KeyType": "HASH"},
         ],
@@ -353,7 +353,6 @@ def test_query_gsi_pagination_with_opposite_pk_order():
             }
         ],
     )
-    table = dynamodb.Table("users")
 
     table.put_item(Item={"pk": "b", "gsi_hash": "a", "gsi_sort": "a"})
     table.put_item(Item={"pk": "a", "gsi_hash": "a", "gsi_sort": "b"})
@@ -693,9 +692,11 @@ class TestFilterExpression:
         client = boto3.client("dynamodb", region_name="us-east-1")
         dynamodb = boto3.resource("dynamodb", region_name="us-east-1")
 
+        table_name = f"T{str(uuid4())}"
+
         # Create the DynamoDB table.
         client.create_table(
-            TableName="test1",
+            TableName=table_name,
             AttributeDefinitions=[
                 {"AttributeName": "client", "AttributeType": "S"},
                 {"AttributeName": "app", "AttributeType": "S"},
@@ -707,7 +708,7 @@ class TestFilterExpression:
             ProvisionedThroughput={"ReadCapacityUnits": 123, "WriteCapacityUnits": 123},
         )
         client.put_item(
-            TableName="test1",
+            TableName=table_name,
             Item={
                 "client": {"S": "client1"},
                 "app": {"S": "app1"},
@@ -720,7 +721,7 @@ class TestFilterExpression:
             },
         )
         client.put_item(
-            TableName="test1",
+            TableName=table_name,
             Item={
                 "client": {"S": "client1"},
                 "app": {"S": "app2"},
@@ -733,7 +734,7 @@ class TestFilterExpression:
             },
         )
 
-        table = dynamodb.Table("test1")
+        table = dynamodb.Table(table_name)
         response = table.query(KeyConditionExpression=Key("client").eq("client1"))
         assert response["Count"] == 2
         assert response["ScannedCount"] == 2
@@ -786,9 +787,11 @@ class TestFilterExpression:
         client = boto3.client("dynamodb", region_name="us-east-1")
         dynamodb = boto3.resource("dynamodb", region_name="us-east-1")
 
+        table_name = f"T{str(uuid4())}"
+
         # Create the DynamoDB table.
         client.create_table(
-            TableName="test1",
+            TableName=table_name,
             AttributeDefinitions=[
                 {"AttributeName": "client", "AttributeType": "S"},
                 {"AttributeName": "app", "AttributeType": "S"},
@@ -801,7 +804,7 @@ class TestFilterExpression:
         )
 
         client.put_item(
-            TableName="test1",
+            TableName=table_name,
             Item={
                 "client": {"S": "client1"},
                 "app": {"S": "app1"},
@@ -814,7 +817,7 @@ class TestFilterExpression:
             },
         )
 
-        table = dynamodb.Table("test1")
+        table = dynamodb.Table(table_name)
         response = table.query(
             KeyConditionExpression=Key("client").eq("client1") & Key("app").eq("app1"),
             ProjectionExpression="#1, #10, nested",

--- a/tests/test_dynamodb/test_dynamodb_scan.py
+++ b/tests/test_dynamodb/test_dynamodb_scan.py
@@ -1,5 +1,6 @@
 import copy
 from decimal import Decimal as dec
+from uuid import uuid4
 
 import boto3
 import pytest
@@ -234,9 +235,10 @@ def test_scan_by_global_index(table_name=None):
 @mock_aws
 def test_scan_by_global_and_local_index():
     dynamodb = boto3.client("dynamodb", region_name="us-east-1")
+    table_name = f"T{uuid4()}"
 
     dynamodb.create_table(
-        TableName="test",
+        TableName=table_name,
         KeySchema=[
             {"AttributeName": "id", "KeyType": "HASH"},
             {"AttributeName": "range_key", "KeyType": "RANGE"},
@@ -276,7 +278,7 @@ def test_scan_by_global_and_local_index():
     )
 
     dynamodb.put_item(
-        TableName="test",
+        TableName=table_name,
         Item={
             "id": {"S": "1"},
             "range_key": {"S": "1"},
@@ -288,7 +290,7 @@ def test_scan_by_global_and_local_index():
     )
 
     dynamodb.put_item(
-        TableName="test",
+        TableName=table_name,
         Item={
             "id": {"S": "1"},
             "range_key": {"S": "2"},
@@ -300,28 +302,28 @@ def test_scan_by_global_and_local_index():
     )
 
     dynamodb.put_item(
-        TableName="test",
+        TableName=table_name,
         Item={"id": {"S": "3"}, "range_key": {"S": "1"}, "col1": {"S": "val3"}},
     )
 
-    res = dynamodb.scan(TableName="test")
+    res = dynamodb.scan(TableName=table_name)
     assert res["Count"] == 3
     assert len(res["Items"]) == 3
 
-    res = dynamodb.scan(TableName="test", Limit=1)
+    res = dynamodb.scan(TableName=table_name, Limit=1)
     assert res["Count"] == 1
     assert res["ScannedCount"] == 1
 
-    res = dynamodb.scan(TableName="test", ExclusiveStartKey=res["LastEvaluatedKey"])
+    res = dynamodb.scan(TableName=table_name, ExclusiveStartKey=res["LastEvaluatedKey"])
     assert res["Count"] == 2
     assert res["ScannedCount"] == 2
 
-    res = dynamodb.scan(TableName="test", IndexName="test_gsi")
+    res = dynamodb.scan(TableName=table_name, IndexName="test_gsi")
     assert res["Count"] == 2
     assert res["ScannedCount"] == 2
     assert len(res["Items"]) == 2
 
-    res = dynamodb.scan(TableName="test", IndexName="test_gsi", Limit=1)
+    res = dynamodb.scan(TableName=table_name, IndexName="test_gsi", Limit=1)
     assert res["Count"] == 1
     assert res["ScannedCount"] == 1
     assert len(res["Items"]) == 1
@@ -331,22 +333,22 @@ def test_scan_by_global_and_local_index():
     assert last_eval_key["gsi_range_key"]["S"] == "1"
 
     res = dynamodb.scan(
-        TableName="test", IndexName="test_gsi", ExclusiveStartKey=last_eval_key
+        TableName=table_name, IndexName="test_gsi", ExclusiveStartKey=last_eval_key
     )
     assert res["Count"] == 1
     assert res["ScannedCount"] == 1
 
-    res = dynamodb.scan(TableName="test", IndexName="test_lsi")
+    res = dynamodb.scan(TableName=table_name, IndexName="test_lsi")
     assert res["Count"] == 2
     assert res["ScannedCount"] == 2
     assert len(res["Items"]) == 2
 
-    res = dynamodb.scan(TableName="test", IndexName="test_lsi", ConsistentRead=True)
+    res = dynamodb.scan(TableName=table_name, IndexName="test_lsi", ConsistentRead=True)
     assert res["Count"] == 2
     assert res["ScannedCount"] == 2
     assert len(res["Items"]) == 2
 
-    res = dynamodb.scan(TableName="test", IndexName="test_lsi", Limit=1)
+    res = dynamodb.scan(TableName=table_name, IndexName="test_lsi", Limit=1)
     assert res["Count"] == 1
     assert res["ScannedCount"] == 1
     assert len(res["Items"]) == 1
@@ -550,10 +552,11 @@ class TestFilterExpression:
     def test_scan_filter(self):
         client = boto3.client("dynamodb", region_name="us-east-1")
         dynamodb = boto3.resource("dynamodb", region_name="us-east-1")
+        table_name = f"T{uuid4()}"
 
         # Create the DynamoDB table.
         client.create_table(
-            TableName="test1",
+            TableName=table_name,
             AttributeDefinitions=[
                 {"AttributeName": "client", "AttributeType": "S"},
                 {"AttributeName": "app", "AttributeType": "S"},
@@ -565,10 +568,11 @@ class TestFilterExpression:
             ProvisionedThroughput={"ReadCapacityUnits": 123, "WriteCapacityUnits": 123},
         )
         client.put_item(
-            TableName="test1", Item={"client": {"S": "client1"}, "app": {"S": "app1"}}
+            TableName=table_name,
+            Item={"client": {"S": "client1"}, "app": {"S": "app1"}},
         )
 
-        table = dynamodb.Table("test1")
+        table = dynamodb.Table(table_name)
         response = table.scan(FilterExpression=Attr("app").eq("app2"))
         assert response["Count"] == 0
 
@@ -583,10 +587,11 @@ class TestFilterExpression:
 
     def test_scan_filter2(self):
         client = boto3.client("dynamodb", region_name="us-east-1")
+        table_name = f"T{uuid4()}"
 
         # Create the DynamoDB table.
         client.create_table(
-            TableName="test1",
+            TableName=table_name,
             AttributeDefinitions=[
                 {"AttributeName": "client", "AttributeType": "S"},
                 {"AttributeName": "app", "AttributeType": "N"},
@@ -598,11 +603,11 @@ class TestFilterExpression:
             ProvisionedThroughput={"ReadCapacityUnits": 123, "WriteCapacityUnits": 123},
         )
         client.put_item(
-            TableName="test1", Item={"client": {"S": "client1"}, "app": {"N": "1"}}
+            TableName=table_name, Item={"client": {"S": "client1"}, "app": {"N": "1"}}
         )
 
         response = client.scan(
-            TableName="test1",
+            TableName=table_name,
             Select="ALL_ATTRIBUTES",
             FilterExpression="#tb >= :dt",
             ExpressionAttributeNames={"#tb": "app"},
@@ -613,10 +618,11 @@ class TestFilterExpression:
     def test_scan_filter3(self):
         client = boto3.client("dynamodb", region_name="us-east-1")
         dynamodb = boto3.resource("dynamodb", region_name="us-east-1")
+        table_name = f"T{uuid4()}"
 
         # Create the DynamoDB table.
         client.create_table(
-            TableName="test1",
+            TableName=table_name,
             AttributeDefinitions=[
                 {"AttributeName": "client", "AttributeType": "S"},
                 {"AttributeName": "app", "AttributeType": "N"},
@@ -628,7 +634,7 @@ class TestFilterExpression:
             ProvisionedThroughput={"ReadCapacityUnits": 123, "WriteCapacityUnits": 123},
         )
         client.put_item(
-            TableName="test1",
+            TableName=table_name,
             Item={
                 "client": {"S": "client1"},
                 "app": {"N": "1"},
@@ -636,7 +642,7 @@ class TestFilterExpression:
             },
         )
 
-        table = dynamodb.Table("test1")
+        table = dynamodb.Table(table_name)
         response = table.scan(FilterExpression=Attr("active").eq(True))
         assert response["Count"] == 1
 
@@ -655,10 +661,11 @@ class TestFilterExpression:
     def test_scan_filter4(self):
         client = boto3.client("dynamodb", region_name="us-east-1")
         dynamodb = boto3.resource("dynamodb", region_name="us-east-1")
+        table_name = f"T{uuid4()}"
 
         # Create the DynamoDB table.
         client.create_table(
-            TableName="test1",
+            TableName=table_name,
             AttributeDefinitions=[
                 {"AttributeName": "client", "AttributeType": "S"},
                 {"AttributeName": "app", "AttributeType": "N"},
@@ -670,7 +677,7 @@ class TestFilterExpression:
             ProvisionedThroughput={"ReadCapacityUnits": 123, "WriteCapacityUnits": 123},
         )
 
-        table = dynamodb.Table("test1")
+        table = dynamodb.Table(table_name)
         response = table.scan(
             FilterExpression=Attr("epoch_ts").lt(7) & Attr("fanout_ts").not_exists()
         )
@@ -678,7 +685,7 @@ class TestFilterExpression:
         assert response["Count"] == 0
 
     def test_filter_should_not_return_non_existing_attributes(self):
-        table_name = "my-table"
+        table_name = f"T{uuid4()}"
         item = {"partitionKey": "pk-2", "my-attr": 42}
         # Create table
         res = boto3.resource("dynamodb", region_name="us-east-1")
@@ -706,10 +713,11 @@ class TestFilterExpression:
     def test_bad_scan_filter(self):
         client = boto3.client("dynamodb", region_name="us-east-1")
         dynamodb = boto3.resource("dynamodb", region_name="us-east-1")
+        table_name = f"T{uuid4()}"
 
         # Create the DynamoDB table.
         client.create_table(
-            TableName="test1",
+            TableName=table_name,
             AttributeDefinitions=[
                 {"AttributeName": "client", "AttributeType": "S"},
                 {"AttributeName": "app", "AttributeType": "S"},
@@ -720,7 +728,7 @@ class TestFilterExpression:
             ],
             ProvisionedThroughput={"ReadCapacityUnits": 123, "WriteCapacityUnits": 123},
         )
-        table = dynamodb.Table("test1")
+        table = dynamodb.Table(table_name)
 
         # Bad expression
         with pytest.raises(ClientError) as exc:
@@ -779,6 +787,10 @@ class TestFilterExpression:
 
 @pytest.mark.aws_verified
 class TestParallelScan(BaseTest):
+    @classmethod
+    def setup_method(cls):
+        cls.empty_table()
+
     @staticmethod
     def setup_class(cls):
         super().setup_class(add_range=True)

--- a/tests/test_dynamodb/test_dynamodb_transact.py
+++ b/tests/test_dynamodb/test_dynamodb_transact.py
@@ -1,3 +1,5 @@
+from uuid import uuid4
+
 import boto3
 import pytest
 from botocore.exceptions import ClientError
@@ -10,13 +12,12 @@ from . import dynamodb_aws_verified
 @mock_aws
 def test_invalid_transact_get_items():
     dynamodb = boto3.resource("dynamodb", region_name="us-east-1")
-    dynamodb.create_table(
-        TableName="test1",
+    table = dynamodb.create_table(
+        TableName=f"T{uuid4()}",
         KeySchema=[{"AttributeName": "id", "KeyType": "HASH"}],
         AttributeDefinitions=[{"AttributeName": "id", "AttributeType": "S"}],
         ProvisionedThroughput={"ReadCapacityUnits": 5, "WriteCapacityUnits": 5},
     )
-    table = dynamodb.Table("test1")
     table.put_item(Item={"id": "1", "val": "1"})
     table.put_item(Item={"id": "1", "val": "2"})
 
@@ -25,7 +26,7 @@ def test_invalid_transact_get_items():
     with pytest.raises(ClientError) as ex:
         client.transact_get_items(
             TransactItems=[
-                {"Get": {"Key": {"id": {"S": "1"}}, "TableName": "test1"}}
+                {"Get": {"Key": {"id": {"S": "1"}}, "TableName": table.name}}
                 for i in range(26)
             ]
         )
@@ -39,8 +40,8 @@ def test_invalid_transact_get_items():
     with pytest.raises(ClientError) as ex:
         client.transact_get_items(
             TransactItems=[
-                {"Get": {"Key": {"id": {"S": "1"}}, "TableName": "test1"}},
-                {"Get": {"Key": {"id": {"S": "1"}}, "TableName": "non_exists_table"}},
+                {"Get": {"Key": {"id": {"S": "1"}}, "TableName": table.name}},
+                {"Get": {"Key": {"id": {"S": "1"}}, "TableName": f"T{uuid4()}"}},
             ]
         )
 
@@ -52,7 +53,7 @@ def test_invalid_transact_get_items():
 @mock_aws
 def test_transact_get_items_should_return_empty_map_for_non_existent_item():
     client = boto3.client("dynamodb", region_name="us-west-2")
-    table_name = "test-table"
+    table_name = f"T{uuid4()}"
     key_schema = [{"AttributeName": "id", "KeyType": "HASH"}]
     attribute_definitions = [{"AttributeName": "id", "AttributeType": "S"}]
     client.create_table(
@@ -77,8 +78,8 @@ def test_transact_get_items_should_return_empty_map_for_non_existent_item():
 @mock_aws
 def test_valid_transact_get_items():
     dynamodb = boto3.resource("dynamodb", region_name="us-east-1")
-    dynamodb.create_table(
-        TableName="test1",
+    table1 = dynamodb.create_table(
+        TableName=f"T{uuid4()}",
         KeySchema=[
             {"AttributeName": "id", "KeyType": "HASH"},
             {"AttributeName": "sort_key", "KeyType": "RANGE"},
@@ -89,12 +90,11 @@ def test_valid_transact_get_items():
         ],
         ProvisionedThroughput={"ReadCapacityUnits": 5, "WriteCapacityUnits": 5},
     )
-    table1 = dynamodb.Table("test1")
     table1.put_item(Item={"id": "1", "sort_key": "1"})
     table1.put_item(Item={"id": "1", "sort_key": "2"})
 
-    dynamodb.create_table(
-        TableName="test2",
+    table2 = dynamodb.create_table(
+        TableName=f"T{uuid4()}",
         KeySchema=[
             {"AttributeName": "id", "KeyType": "HASH"},
             {"AttributeName": "sort_key", "KeyType": "RANGE"},
@@ -105,7 +105,6 @@ def test_valid_transact_get_items():
         ],
         ProvisionedThroughput={"ReadCapacityUnits": 5, "WriteCapacityUnits": 5},
     )
-    table2 = dynamodb.Table("test2")
     table2.put_item(Item={"id": "1", "sort_key": "1"})
 
     client = boto3.client("dynamodb", region_name="us-east-1")
@@ -114,13 +113,13 @@ def test_valid_transact_get_items():
             {
                 "Get": {
                     "Key": {"id": {"S": "1"}, "sort_key": {"S": "1"}},
-                    "TableName": "test1",
+                    "TableName": table1.name,
                 }
             },
             {
                 "Get": {
                     "Key": {"id": {"S": "non_exists_key"}, "sort_key": {"S": "2"}},
-                    "TableName": "test1",
+                    "TableName": table1.name,
                 }
             },
         ]
@@ -134,28 +133,26 @@ def test_valid_transact_get_items():
             {
                 "Get": {
                     "Key": {"id": {"S": "1"}, "sort_key": {"S": "1"}},
-                    "TableName": "test1",
+                    "TableName": table1.name,
                 }
             },
             {
                 "Get": {
                     "Key": {"id": {"S": "1"}, "sort_key": {"S": "2"}},
-                    "TableName": "test1",
+                    "TableName": table1.name,
                 }
             },
             {
                 "Get": {
                     "Key": {"id": {"S": "1"}, "sort_key": {"S": "1"}},
-                    "TableName": "test2",
+                    "TableName": table2.name,
                 }
             },
         ]
     )
 
     assert res["Responses"][0]["Item"] == {"id": {"S": "1"}, "sort_key": {"S": "1"}}
-
     assert res["Responses"][1]["Item"] == {"id": {"S": "1"}, "sort_key": {"S": "2"}}
-
     assert res["Responses"][2]["Item"] == {"id": {"S": "1"}, "sort_key": {"S": "1"}}
 
     res = client.transact_get_items(
@@ -163,19 +160,19 @@ def test_valid_transact_get_items():
             {
                 "Get": {
                     "Key": {"id": {"S": "1"}, "sort_key": {"S": "1"}},
-                    "TableName": "test1",
+                    "TableName": table1.name,
                 }
             },
             {
                 "Get": {
                     "Key": {"id": {"S": "1"}, "sort_key": {"S": "2"}},
-                    "TableName": "test1",
+                    "TableName": table1.name,
                 }
             },
             {
                 "Get": {
                     "Key": {"id": {"S": "1"}, "sort_key": {"S": "1"}},
-                    "TableName": "test2",
+                    "TableName": table2.name,
                 }
             },
         ],
@@ -183,13 +180,13 @@ def test_valid_transact_get_items():
     )
 
     assert res["ConsumedCapacity"][0] == {
-        "TableName": "test1",
+        "TableName": table1.name,
         "CapacityUnits": 4.0,
         "ReadCapacityUnits": 4.0,
     }
 
     assert res["ConsumedCapacity"][1] == {
-        "TableName": "test2",
+        "TableName": table2.name,
         "CapacityUnits": 2.0,
         "ReadCapacityUnits": 2.0,
     }
@@ -199,19 +196,19 @@ def test_valid_transact_get_items():
             {
                 "Get": {
                     "Key": {"id": {"S": "1"}, "sort_key": {"S": "1"}},
-                    "TableName": "test1",
+                    "TableName": table1.name,
                 }
             },
             {
                 "Get": {
                     "Key": {"id": {"S": "1"}, "sort_key": {"S": "2"}},
-                    "TableName": "test1",
+                    "TableName": table1.name,
                 }
             },
             {
                 "Get": {
                     "Key": {"id": {"S": "1"}, "sort_key": {"S": "1"}},
-                    "TableName": "test2",
+                    "TableName": table2.name,
                 }
             },
         ],
@@ -219,14 +216,14 @@ def test_valid_transact_get_items():
     )
 
     assert res["ConsumedCapacity"][0] == {
-        "TableName": "test1",
+        "TableName": table1.name,
         "CapacityUnits": 4.0,
         "ReadCapacityUnits": 4.0,
         "Table": {"CapacityUnits": 4.0, "ReadCapacityUnits": 4.0},
     }
 
     assert res["ConsumedCapacity"][1] == {
-        "TableName": "test2",
+        "TableName": table2.name,
         "CapacityUnits": 2.0,
         "ReadCapacityUnits": 2.0,
         "Table": {"CapacityUnits": 2.0, "ReadCapacityUnits": 2.0},
@@ -235,13 +232,14 @@ def test_valid_transact_get_items():
 
 @mock_aws
 def test_transact_write_items_put():
+    table_name = f"T{uuid4()}"
     table_schema = {
         "KeySchema": [{"AttributeName": "id", "KeyType": "HASH"}],
         "AttributeDefinitions": [{"AttributeName": "id", "AttributeType": "S"}],
     }
     dynamodb = boto3.client("dynamodb", region_name="us-east-1")
     dynamodb.create_table(
-        TableName="test-table", BillingMode="PAY_PER_REQUEST", **table_schema
+        TableName=table_name, BillingMode="PAY_PER_REQUEST", **table_schema
     )
     # Put multiple items
     dynamodb.transact_write_items(
@@ -249,14 +247,14 @@ def test_transact_write_items_put():
             {
                 "Put": {
                     "Item": {"id": {"S": f"foo{str(i)}"}, "foo": {"S": "bar"}},
-                    "TableName": "test-table",
+                    "TableName": table_name,
                 }
             }
             for i in range(0, 5)
         ]
     )
     # Assert all are present
-    items = dynamodb.scan(TableName="test-table")["Items"]
+    items = dynamodb.scan(TableName=table_name)["Items"]
     assert len(items) == 5
 
 
@@ -358,17 +356,18 @@ def test_transact_write_items_failure__return_item(operation: str, table_name=No
 
 @mock_aws
 def test_transact_write_items_conditioncheck_passes():
+    table_name = f"T{uuid4()}"
     table_schema = {
         "KeySchema": [{"AttributeName": "id", "KeyType": "HASH"}],
         "AttributeDefinitions": [{"AttributeName": "id", "AttributeType": "S"}],
     }
     dynamodb = boto3.client("dynamodb", region_name="us-east-1")
     dynamodb.create_table(
-        TableName="test-table", BillingMode="PAY_PER_REQUEST", **table_schema
+        TableName=table_name, BillingMode="PAY_PER_REQUEST", **table_schema
     )
     # Insert an item with email address
     dynamodb.put_item(
-        TableName="test-table",
+        TableName=table_name,
         Item={"id": {"S": "foo"}, "email_address": {"S": "foo@moto.com"}},
     )
     # Put a new item, after verifying the exising item also has email address
@@ -377,7 +376,7 @@ def test_transact_write_items_conditioncheck_passes():
             {
                 "ConditionCheck": {
                     "Key": {"id": {"S": "foo"}},
-                    "TableName": "test-table",
+                    "TableName": table_name,
                     "ConditionExpression": "attribute_exists(#e)",
                     "ExpressionAttributeNames": {"#e": "email_address"},
                 }
@@ -388,13 +387,13 @@ def test_transact_write_items_conditioncheck_passes():
                         "id": {"S": "bar"},
                         "email_address": {"S": "bar@moto.com"},
                     },
-                    "TableName": "test-table",
+                    "TableName": table_name,
                 }
             },
         ]
     )
     # Assert all are present
-    items = dynamodb.scan(TableName="test-table")["Items"]
+    items = dynamodb.scan(TableName=table_name)["Items"]
     assert len(items) == 2
     assert {"email_address": {"S": "foo@moto.com"}, "id": {"S": "foo"}} in items
     assert {"email_address": {"S": "bar@moto.com"}, "id": {"S": "bar"}} in items
@@ -402,19 +401,17 @@ def test_transact_write_items_conditioncheck_passes():
 
 @mock_aws
 def test_transact_write_items_conditioncheck_fails():
+    table_name = f"T{uuid4()}"
     table_schema = {
         "KeySchema": [{"AttributeName": "id", "KeyType": "HASH"}],
         "AttributeDefinitions": [{"AttributeName": "id", "AttributeType": "S"}],
     }
     dynamodb = boto3.client("dynamodb", region_name="us-east-1")
     dynamodb.create_table(
-        TableName="test-table", BillingMode="PAY_PER_REQUEST", **table_schema
+        TableName=table_name, BillingMode="PAY_PER_REQUEST", **table_schema
     )
     # Insert an item without email address
-    dynamodb.put_item(
-        TableName="test-table",
-        Item={"id": {"S": "foo"}},
-    )
+    dynamodb.put_item(TableName=table_name, Item={"id": {"S": "foo"}})
     # Try putting a new item, after verifying the exising item also has email address
     # ConditionCheck should fail
     with pytest.raises(ClientError) as ex:
@@ -423,7 +420,7 @@ def test_transact_write_items_conditioncheck_fails():
                 {
                     "ConditionCheck": {
                         "Key": {"id": {"S": "foo"}},
-                        "TableName": "test-table",
+                        "TableName": table_name,
                         "ConditionExpression": "attribute_exists(#e)",
                         "ExpressionAttributeNames": {"#e": "email_address"},
                     }
@@ -434,7 +431,7 @@ def test_transact_write_items_conditioncheck_fails():
                             "id": {"S": "bar"},
                             "email_address": {"S": "bar@moto.com"},
                         },
-                        "TableName": "test-table",
+                        "TableName": table_name,
                     }
                 },
             ]
@@ -444,53 +441,55 @@ def test_transact_write_items_conditioncheck_fails():
     assert ex.value.response["ResponseMetadata"]["HTTPStatusCode"] == 400
 
     # Assert the original item is still present
-    items = dynamodb.scan(TableName="test-table")["Items"]
+    items = dynamodb.scan(TableName=table_name)["Items"]
     assert len(items) == 1
     assert items[0] == {"id": {"S": "foo"}}
 
 
 @mock_aws
 def test_transact_write_items_delete():
+    table_name = f"T{uuid4()}"
     table_schema = {
         "KeySchema": [{"AttributeName": "id", "KeyType": "HASH"}],
         "AttributeDefinitions": [{"AttributeName": "id", "AttributeType": "S"}],
     }
     dynamodb = boto3.client("dynamodb", region_name="us-east-1")
     dynamodb.create_table(
-        TableName="test-table", BillingMode="PAY_PER_REQUEST", **table_schema
+        TableName=table_name, BillingMode="PAY_PER_REQUEST", **table_schema
     )
     # Insert an item
-    dynamodb.put_item(TableName="test-table", Item={"id": {"S": "foo"}})
+    dynamodb.put_item(TableName=table_name, Item={"id": {"S": "foo"}})
     # Delete the item
     dynamodb.transact_write_items(
         TransactItems=[
-            {"Delete": {"Key": {"id": {"S": "foo"}}, "TableName": "test-table"}}
+            {"Delete": {"Key": {"id": {"S": "foo"}}, "TableName": table_name}}
         ]
     )
     # Assert the item is deleted
-    items = dynamodb.scan(TableName="test-table")["Items"]
+    items = dynamodb.scan(TableName=table_name)["Items"]
     assert len(items) == 0
 
 
 @mock_aws
 def test_transact_write_items_delete_with_successful_condition_expression():
+    table_name = f"T{uuid4()}"
     table_schema = {
         "KeySchema": [{"AttributeName": "id", "KeyType": "HASH"}],
         "AttributeDefinitions": [{"AttributeName": "id", "AttributeType": "S"}],
     }
     dynamodb = boto3.client("dynamodb", region_name="us-east-1")
     dynamodb.create_table(
-        TableName="test-table", BillingMode="PAY_PER_REQUEST", **table_schema
+        TableName=table_name, BillingMode="PAY_PER_REQUEST", **table_schema
     )
     # Insert an item without email address
-    dynamodb.put_item(TableName="test-table", Item={"id": {"S": "foo"}})
+    dynamodb.put_item(TableName=table_name, Item={"id": {"S": "foo"}})
     # ConditionExpression will pass - no email address has been specified yet
     dynamodb.transact_write_items(
         TransactItems=[
             {
                 "Delete": {
                     "Key": {"id": {"S": "foo"}},
-                    "TableName": "test-table",
+                    "TableName": table_name,
                     "ConditionExpression": "attribute_not_exists(#e)",
                     "ExpressionAttributeNames": {"#e": "email_address"},
                 }
@@ -498,23 +497,24 @@ def test_transact_write_items_delete_with_successful_condition_expression():
         ]
     )
     # Assert the item is deleted
-    items = dynamodb.scan(TableName="test-table")["Items"]
+    items = dynamodb.scan(TableName=table_name)["Items"]
     assert len(items) == 0
 
 
 @mock_aws
 def test_transact_write_items_delete_with_failed_condition_expression():
+    table_name = f"T{uuid4()}"
     table_schema = {
         "KeySchema": [{"AttributeName": "id", "KeyType": "HASH"}],
         "AttributeDefinitions": [{"AttributeName": "id", "AttributeType": "S"}],
     }
     dynamodb = boto3.client("dynamodb", region_name="us-east-1")
     dynamodb.create_table(
-        TableName="test-table", BillingMode="PAY_PER_REQUEST", **table_schema
+        TableName=table_name, BillingMode="PAY_PER_REQUEST", **table_schema
     )
     # Insert an item with email address
     dynamodb.put_item(
-        TableName="test-table",
+        TableName=table_name,
         Item={"id": {"S": "foo"}, "email_address": {"S": "test@moto.com"}},
     )
     # Try to delete an item that does not have an email address
@@ -525,7 +525,7 @@ def test_transact_write_items_delete_with_failed_condition_expression():
                 {
                     "Delete": {
                         "Key": {"id": {"S": "foo"}},
-                        "TableName": "test-table",
+                        "TableName": table_name,
                         "ConditionExpression": "attribute_not_exists(#e)",
                         "ExpressionAttributeNames": {"#e": "email_address"},
                     }
@@ -536,30 +536,31 @@ def test_transact_write_items_delete_with_failed_condition_expression():
     assert ex.value.response["Error"]["Code"] == "TransactionCanceledException"
     assert ex.value.response["ResponseMetadata"]["HTTPStatusCode"] == 400
     # Assert the original item is still present
-    items = dynamodb.scan(TableName="test-table")["Items"]
+    items = dynamodb.scan(TableName=table_name)["Items"]
     assert len(items) == 1
     assert items[0] == {"email_address": {"S": "test@moto.com"}, "id": {"S": "foo"}}
 
 
 @mock_aws
 def test_transact_write_items_update():
+    table_name = f"T{uuid4()}"
     table_schema = {
         "KeySchema": [{"AttributeName": "id", "KeyType": "HASH"}],
         "AttributeDefinitions": [{"AttributeName": "id", "AttributeType": "S"}],
     }
     dynamodb = boto3.client("dynamodb", region_name="us-east-1")
     dynamodb.create_table(
-        TableName="test-table", BillingMode="PAY_PER_REQUEST", **table_schema
+        TableName=table_name, BillingMode="PAY_PER_REQUEST", **table_schema
     )
     # Insert an item
-    dynamodb.put_item(TableName="test-table", Item={"id": {"S": "foo"}})
+    dynamodb.put_item(TableName=table_name, Item={"id": {"S": "foo"}})
     # Update the item
     dynamodb.transact_write_items(
         TransactItems=[
             {
                 "Update": {
                     "Key": {"id": {"S": "foo"}},
-                    "TableName": "test-table",
+                    "TableName": table_name,
                     "UpdateExpression": "SET #e = :v",
                     "ExpressionAttributeNames": {"#e": "email_address"},
                     "ExpressionAttributeValues": {":v": {"S": "test@moto.com"}},
@@ -568,24 +569,25 @@ def test_transact_write_items_update():
         ]
     )
     # Assert the item is updated
-    items = dynamodb.scan(TableName="test-table")["Items"]
+    items = dynamodb.scan(TableName=table_name)["Items"]
     assert len(items) == 1
     assert items[0] == {"id": {"S": "foo"}, "email_address": {"S": "test@moto.com"}}
 
 
 @mock_aws
 def test_transact_write_items_update_with_failed_condition_expression():
+    table_name = f"T{uuid4()}"
     table_schema = {
         "KeySchema": [{"AttributeName": "id", "KeyType": "HASH"}],
         "AttributeDefinitions": [{"AttributeName": "id", "AttributeType": "S"}],
     }
     dynamodb = boto3.client("dynamodb", region_name="us-east-1")
     dynamodb.create_table(
-        TableName="test-table", BillingMode="PAY_PER_REQUEST", **table_schema
+        TableName=table_name, BillingMode="PAY_PER_REQUEST", **table_schema
     )
     # Insert an item with email address
     dynamodb.put_item(
-        TableName="test-table",
+        TableName=table_name,
         Item={"id": {"S": "foo"}, "email_address": {"S": "test@moto.com"}},
     )
     # Try to update an item that does not have an email address
@@ -596,7 +598,7 @@ def test_transact_write_items_update_with_failed_condition_expression():
                 {
                     "Update": {
                         "Key": {"id": {"S": "foo"}},
-                        "TableName": "test-table",
+                        "TableName": table_name,
                         "UpdateExpression": "SET #e = :v",
                         "ConditionExpression": "attribute_not_exists(#e)",
                         "ExpressionAttributeNames": {"#e": "email_address"},
@@ -609,23 +611,24 @@ def test_transact_write_items_update_with_failed_condition_expression():
     assert ex.value.response["Error"]["Code"] == "TransactionCanceledException"
     assert ex.value.response["ResponseMetadata"]["HTTPStatusCode"] == 400
     # Assert the original item is still present
-    items = dynamodb.scan(TableName="test-table")["Items"]
+    items = dynamodb.scan(TableName=table_name)["Items"]
     assert len(items) == 1
     assert items[0] == {"email_address": {"S": "test@moto.com"}, "id": {"S": "foo"}}
 
 
 @mock_aws
 def test_transact_write_items_fails_with_transaction_canceled_exception():
+    table_name = f"T{uuid4()}"
     table_schema = {
         "KeySchema": [{"AttributeName": "id", "KeyType": "HASH"}],
         "AttributeDefinitions": [{"AttributeName": "id", "AttributeType": "S"}],
     }
     dynamodb = boto3.client("dynamodb", region_name="us-east-1")
     dynamodb.create_table(
-        TableName="test-table", BillingMode="PAY_PER_REQUEST", **table_schema
+        TableName=table_name, BillingMode="PAY_PER_REQUEST", **table_schema
     )
     # Insert one item
-    dynamodb.put_item(TableName="test-table", Item={"id": {"S": "foo"}})
+    dynamodb.put_item(TableName=table_name, Item={"id": {"S": "foo"}})
     # Update two items, the one that exists and another that doesn't
     with pytest.raises(ClientError) as ex:
         dynamodb.transact_write_items(
@@ -633,7 +636,7 @@ def test_transact_write_items_fails_with_transaction_canceled_exception():
                 {
                     "Update": {
                         "Key": {"id": {"S": "foo"}},
-                        "TableName": "test-table",
+                        "TableName": table_name,
                         "UpdateExpression": "SET #k = :v",
                         "ConditionExpression": "attribute_exists(id)",
                         "ExpressionAttributeNames": {"#k": "key"},
@@ -643,7 +646,7 @@ def test_transact_write_items_fails_with_transaction_canceled_exception():
                 {
                     "Update": {
                         "Key": {"id": {"S": "doesnotexist"}},
-                        "TableName": "test-table",
+                        "TableName": table_name,
                         "UpdateExpression": "SET #e = :v",
                         "ConditionExpression": "attribute_exists(id)",
                         "ExpressionAttributeNames": {"#e": "key"},
@@ -668,7 +671,7 @@ def test_transact_using_arns():
     }
     dynamodb = boto3.client("dynamodb", region_name="us-east-1")
     table_arn = dynamodb.create_table(
-        TableName="test-table", BillingMode="PAY_PER_REQUEST", **table_schema
+        TableName=f"T{uuid4()}", BillingMode="PAY_PER_REQUEST", **table_schema
     )["TableDescription"]["TableArn"]
 
     dynamodb.transact_write_items(

--- a/tests/test_networkmanager/test_networkmanager.py
+++ b/tests/test_networkmanager/test_networkmanager.py
@@ -20,7 +20,7 @@ def create_global_network(client) -> str:
 
 @mock_aws
 def test_create_global_network():
-    client = boto3.client("networkmanager")
+    client = boto3.client("networkmanager", "us-east-1")
     resp = client.create_global_network(
         Description="Test global network",
         Tags=[
@@ -44,7 +44,7 @@ def test_create_global_network():
 
 @mock_aws
 def test_create_core_network():
-    client = boto3.client("networkmanager")
+    client = boto3.client("networkmanager", "us-east-1")
     # Create a global network
     global_network_id = client.create_global_network(
         Description="Test global network",
@@ -75,7 +75,7 @@ def test_create_core_network():
 
 @mock_aws
 def test_delete_core_network():
-    client = boto3.client("networkmanager")
+    client = boto3.client("networkmanager", "us-east-1")
     gn_id = create_global_network(client)
     core_network = client.create_core_network(GlobalNetworkId=gn_id)
     cn_id = core_network["CoreNetwork"]["CoreNetworkId"]
@@ -92,7 +92,7 @@ def test_tag_resource():
         {"Key": "Moto", "Value": "TestTag"},
         {"Key": "Owner", "Value": "Alice"},
     ]
-    client = boto3.client("networkmanager")
+    client = boto3.client("networkmanager", "us-east-1")
     gn_id = create_global_network(client)
     cn = client.create_core_network(GlobalNetworkId=gn_id)["CoreNetwork"]
 
@@ -136,7 +136,7 @@ def test_tag_resource():
 
 @mock_aws
 def test_untag_resource():
-    client = boto3.client("networkmanager")
+    client = boto3.client("networkmanager", "us-east-1")
     gn_id = create_global_network(client)
     cn = client.create_core_network(
         GlobalNetworkId=gn_id,
@@ -159,7 +159,7 @@ def test_untag_resource():
 @mock_aws
 def test_list_core_networks():
     NUM_CORE_NETWORKS = 3
-    client = boto3.client("networkmanager")
+    client = boto3.client("networkmanager", "us-east-1")
     for _ in range(NUM_CORE_NETWORKS):
         gn_id = create_global_network(client)
         client.create_core_network(GlobalNetworkId=gn_id)
@@ -182,7 +182,7 @@ def test_list_core_networks():
 
 @mock_aws
 def test_get_core_network():
-    client = boto3.client("networkmanager")
+    client = boto3.client("networkmanager", "us-east-1")
     gn_id = create_global_network(client)
     cn_id = client.create_core_network(
         GlobalNetworkId=gn_id,
@@ -203,7 +203,7 @@ def test_get_core_network():
 @mock_aws
 def test_describe_global_networks():
     NUM_NETWORKS = 3
-    client = boto3.client("networkmanager")
+    client = boto3.client("networkmanager", "us-east-1")
     global_ids = []
     for idx in range(NUM_NETWORKS):
         global_id = client.create_global_network(
@@ -226,7 +226,7 @@ def test_describe_global_networks():
 
 @mock_aws
 def test_create_site():
-    client = boto3.client("networkmanager")
+    client = boto3.client("networkmanager", "us-east-1")
     gn_id = create_global_network(client)
     site = client.create_site(
         GlobalNetworkId=gn_id,
@@ -247,7 +247,7 @@ def test_create_site():
 
 @mock_aws
 def test_delete_site():
-    client = boto3.client("networkmanager")
+    client = boto3.client("networkmanager", "us-east-1")
     gn_id = create_global_network(client)
     site_id = client.create_site(
         GlobalNetworkId=gn_id, Description="Test site to be deleted"
@@ -261,7 +261,7 @@ def test_delete_site():
 def test_get_sites():
     NUM_SITES = 4
     NUM_TO_TEST = 2
-    client = boto3.client("networkmanager")
+    client = boto3.client("networkmanager", "us-east-1")
     gn_id = create_global_network(client)
     site_ids = []
     for _ in range(NUM_SITES):
@@ -290,7 +290,7 @@ def test_get_sites():
 
 @mock_aws
 def test_create_link():
-    client = boto3.client("networkmanager")
+    client = boto3.client("networkmanager", "us-east-1")
     gn_id = create_global_network(client)
     link = client.create_link(
         GlobalNetworkId=gn_id,
@@ -315,7 +315,7 @@ def test_create_link():
 def test_get_links():
     NUM_LINKS = 4
     NUM_TO_TEST = 2
-    client = boto3.client("networkmanager")
+    client = boto3.client("networkmanager", "us-east-1")
     gn_id = create_global_network(client)
     ids = []
     for _ in range(NUM_LINKS):
@@ -341,7 +341,7 @@ def test_get_links():
 
 @mock_aws
 def test_delete_link():
-    client = boto3.client("networkmanager")
+    client = boto3.client("networkmanager", "us-east-1")
     gn_id = create_global_network(client)
     link_id = client.create_link(
         GlobalNetworkId=gn_id,
@@ -357,7 +357,7 @@ def test_delete_link():
 
 @mock_aws
 def test_create_device():
-    client = boto3.client("networkmanager")
+    client = boto3.client("networkmanager", "us-east-1")
     gn_id = create_global_network(client)
     device = client.create_device(
         GlobalNetworkId=gn_id,
@@ -374,7 +374,7 @@ def test_create_device():
 def test_get_devices():
     NUM_DEVICES = 4
     NUM_TO_TEST = 2
-    client = boto3.client("networkmanager")
+    client = boto3.client("networkmanager", "us-east-1")
     gn_id = create_global_network(client)
     ids = []
     for idx in range(NUM_DEVICES):
@@ -404,7 +404,7 @@ def test_get_devices():
 
 @mock_aws
 def test_delete_device():
-    client = boto3.client("networkmanager")
+    client = boto3.client("networkmanager", "us-east-1")
     gn_id = create_global_network(client)
     device_id = client.create_device(
         GlobalNetworkId=gn_id,
@@ -429,7 +429,7 @@ def test_list_tags_for_resource():
         {"Key": "Moto", "Value": "TestTag"},
         {"Key": "Owner", "Value": "Alice"},
     ]
-    client = boto3.client("networkmanager")
+    client = boto3.client("networkmanager", "us-east-1")
 
     # Global Network
     g_network = client.create_global_network(
@@ -484,7 +484,7 @@ def test_list_tags_for_resource():
 
 @mock_aws
 def test_device_exceptions():
-    client = boto3.client("networkmanager")
+    client = boto3.client("networkmanager", "us-east-1")
     gn_id = create_global_network(client)
     device_id = client.create_device(
         GlobalNetworkId=gn_id,
@@ -519,7 +519,7 @@ def test_device_exceptions():
 
 @mock_aws
 def test_site_exceptions():
-    client = boto3.client("networkmanager")
+    client = boto3.client("networkmanager", "us-east-1")
 
     # Test invalid global_network_id for create resource
     with pytest.raises(ClientError) as exc:
@@ -540,7 +540,7 @@ def test_site_exceptions():
 
 @mock_aws
 def test_link_exceptions():
-    client = boto3.client("networkmanager")
+    client = boto3.client("networkmanager", "us-east-1")
 
     # Test invalid global_network_id for create resource
     with pytest.raises(ClientError) as exc:

--- a/tests/test_shield/test_shield.py
+++ b/tests/test_shield/test_shield.py
@@ -13,7 +13,7 @@ from tests import aws_verified
 
 @mock_aws
 def test_create_protection():
-    client = boto3.client("shield")
+    client = boto3.client("shield", "us-east-1")
     resp = client.create_protection(
         Name="foobar",
         ResourceArn="arn:aws:cloudfront::123456789012:distribution/foobar",
@@ -26,7 +26,7 @@ def test_create_protection():
 
 @mock_aws
 def test_create_protection_resource_already_exists():
-    client = boto3.client("shield")
+    client = boto3.client("shield", "us-east-1")
     client.create_protection(
         Name="foobar",
         ResourceArn="arn:aws:cloudfront::123456789012:distribution/foobar",
@@ -82,7 +82,7 @@ def test_protect_elastic_ip(account_id):
 
 @mock_aws
 def test_describe_protection_with_resource_arn():
-    client = boto3.client("shield")
+    client = boto3.client("shield", "us-east-1")
     client.create_protection(
         Name="foobar",
         ResourceArn="arn:aws:cloudfront::123456789012:distribution/foobar",
@@ -99,7 +99,7 @@ def test_describe_protection_with_resource_arn():
 
 @mock_aws
 def test_describe_protection_with_protection_id():
-    client = boto3.client("shield")
+    client = boto3.client("shield", "us-east-1")
     protection = client.create_protection(
         Name="foobar",
         ResourceArn="arn:aws:cloudfront::123456789012:distribution/foobar",
@@ -115,7 +115,7 @@ def test_describe_protection_with_protection_id():
 
 @mock_aws
 def test_describe_protection_with_both_resource_and_protection_id():
-    client = boto3.client("shield")
+    client = boto3.client("shield", "us-east-1")
     with pytest.raises(ClientError) as exc:
         client.describe_protection(
             ResourceArn="arn:aws:cloudfront::123456789012:distribution/foobar",
@@ -127,7 +127,7 @@ def test_describe_protection_with_both_resource_and_protection_id():
 
 @mock_aws
 def test_describe_protection_resource_doesnot_exist():
-    client = boto3.client("shield")
+    client = boto3.client("shield", "us-east-1")
     with pytest.raises(ClientError) as exc:
         client.describe_protection(
             ResourceArn="arn:aws:cloudfront::123456789012:distribution/donotexist"
@@ -138,7 +138,7 @@ def test_describe_protection_resource_doesnot_exist():
 
 @mock_aws
 def test_describe_protection_doesnot_exist():
-    client = boto3.client("shield")
+    client = boto3.client("shield", "us-east-1")
     with pytest.raises(ClientError) as exc:
         client.describe_protection(ProtectionId="aaaaaaaa-bbbb-cccc-dddd-aaa221177777")
     err = exc.value.response["Error"]
@@ -147,7 +147,7 @@ def test_describe_protection_doesnot_exist():
 
 @mock_aws
 def test_list_protections():
-    client = boto3.client("shield")
+    client = boto3.client("shield", "us-east-1")
     client.create_protection(
         Name="shield1",
         ResourceArn="arn:aws:cloudfront::123456789012:distribution/foobar",
@@ -163,7 +163,7 @@ def test_list_protections():
 
 @mock_aws
 def test_list_protections_with_only_resource_arn():
-    client = boto3.client("shield")
+    client = boto3.client("shield", "us-east-1")
     client.create_protection(
         Name="shield1",
         ResourceArn="arn:aws:cloudfront::123456789012:distribution/foobar",
@@ -183,7 +183,7 @@ def test_list_protections_with_only_resource_arn():
 
 @mock_aws
 def test_list_protections_with_only_protection_name():
-    client = boto3.client("shield")
+    client = boto3.client("shield", "us-east-1")
     client.create_protection(
         Name="shield1",
         ResourceArn="arn:aws:cloudfront::123456789012:distribution/foobar",
@@ -203,7 +203,7 @@ def test_list_protections_with_only_protection_name():
 
 @mock_aws
 def test_list_protections_with_only_resource_type():
-    client = boto3.client("shield")
+    client = boto3.client("shield", "us-east-1")
     client.create_protection(
         Name="shield1",
         ResourceArn="arn:aws:cloudfront::123456789012:distribution/foobar",
@@ -233,7 +233,7 @@ def test_list_protections_with_only_resource_type():
 
 @mock_aws
 def test_list_protections_with_resource_arn_and_protection_name():
-    client = boto3.client("shield")
+    client = boto3.client("shield", "us-east-1")
     client.create_protection(
         Name="shield1",
         ResourceArn="arn:aws:cloudfront::123456789012:distribution/foobar",
@@ -254,7 +254,7 @@ def test_list_protections_with_resource_arn_and_protection_name():
 
 @mock_aws
 def test_list_protections_invalid_resource_arn():
-    client = boto3.client("shield")
+    client = boto3.client("shield", "us-east-1")
     with pytest.raises(ClientError) as exc:
         client.list_protections(
             InclusionFilters={
@@ -270,7 +270,7 @@ def test_list_protections_invalid_resource_arn():
 
 @mock_aws
 def test_list_protections_invalid_protection_names():
-    client = boto3.client("shield")
+    client = boto3.client("shield", "us-east-1")
     with pytest.raises(ClientError) as exc:
         client.list_protections(
             InclusionFilters={
@@ -283,7 +283,7 @@ def test_list_protections_invalid_protection_names():
 
 @mock_aws
 def test_list_protections_invalid_resource_types():
-    client = boto3.client("shield")
+    client = boto3.client("shield", "us-east-1")
     with pytest.raises(ClientError) as exc:
         client.list_protections(
             InclusionFilters={
@@ -296,7 +296,7 @@ def test_list_protections_invalid_resource_types():
 
 @mock_aws
 def test_delete_protection():
-    client = boto3.client("shield")
+    client = boto3.client("shield", "us-east-1")
     protection = client.create_protection(
         Name="shield1",
         ResourceArn="arn:aws:elasticloadbalancing:us-east-1:123456789012:loadbalancer/foobar",
@@ -316,7 +316,7 @@ def test_delete_protection():
 
 @mock_aws
 def test_delete_protection_invalid_protection_id():
-    client = boto3.client("shield")
+    client = boto3.client("shield", "us-east-1")
     with pytest.raises(ClientError) as exc:
         client.delete_protection(ProtectionId="aaaaaaaa-bbbb-cccc-dddd-aaa221177777")
     err = exc.value.response["Error"]
@@ -325,7 +325,7 @@ def test_delete_protection_invalid_protection_id():
 
 @mock_aws
 def test_list_tags_for_resource():
-    client = boto3.client("shield")
+    client = boto3.client("shield", "us-east-1")
     protection = client.create_protection(
         Name="shield1",
         ResourceArn="arn:aws:cloudfront::123456789012:distribution/foobar",
@@ -345,7 +345,7 @@ def test_list_tags_for_resource():
 
 @mock_aws
 def test_tag_resource():
-    client = boto3.client("shield")
+    client = boto3.client("shield", "us-east-1")
     protection = client.create_protection(
         Name="shield1",
         ResourceArn="arn:aws:cloudfront::123456789012:distribution/foobar",
@@ -367,7 +367,7 @@ def test_tag_resource():
 
 @mock_aws
 def test_untag_resource():
-    client = boto3.client("shield")
+    client = boto3.client("shield", "us-east-1")
     protection = client.create_protection(
         Name="shield1",
         ResourceArn="arn:aws:cloudfront::123456789012:distribution/foobar",


### PR DESCRIPTION
We already had a few tests running in parallel, for instance the EC2, SQS and SNS tests - this PR adds the DynamoDB tests to that list.

This has two advantages:
 - Tests should be completed slightly faster
 - We have more confidence that there are no concurrency bugs in Moto

Changes to the DynamoDB implementation:
 - Searching for a table by name is now a `O(1)` implementation. Searching by ARN is still `O(n)`
 - Calling the `transact_write_items()` method would always keep a copy of the old state and reset it if anything failed, mimicking a transaction. We now only keep a copy of the tables that are actually updated - unrelated tables are not touched.

Changes to the tests:
 - All tests now use a unique table name

Changes to the test setup:
 - We now have a new marker, `requires_clean_slate`. This should be used specifically for tests that can *not* be run alongside other tests. For instance: if you want to verify that a `list_resources()` method works correctly, it is much easier to run this against an 'empty' instance, so we know exactly how many resources exist and how many we should exist when calling the `list_resources()` method.