### PR TITLE
[ResourceGroupsTaggingAPI] Add RDS resource types to untag_resources

### DIFF
--- a/moto/resourcegroupstaggingapi/models.py
+++ b/moto/resourcegroupstaggingapi/models.py
@@ -1602,6 +1602,8 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
                 self.quicksight_backend.untag_resource(arn, tag_keys)
             elif arn.startswith(f"arn:{get_partition(self.region_name)}:elasticache:"):
                 self.elasticache_backend.remove_tags_from_resource(arn, tag_keys)
+            elif arn.startswith(f"arn:{get_partition(self.region_name)}:rds:"):
+                self.rds_backend.remove_tags_from_resource(arn, tag_keys)
             else:
                 missing_resources.append(arn)
 

--- a/tests/test_resourcegroupstaggingapi/test_resourcegroupstagging_rds.py
+++ b/tests/test_resourcegroupstaggingapi/test_resourcegroupstagging_rds.py
@@ -79,3 +79,28 @@ class TestRdsTagging(unittest.TestCase):
             assert {"Key": "key2", "Value": "value2"} in get_tags(arn)
         for arn in self.resources_untagged:
             assert get_tags(arn) == []
+
+    def test_untag_resources_rds(self):
+        for arn in self.resources_tagged:
+            self.rds.add_tags_to_resource(
+                ResourceName=arn,
+                Tags=[
+                    {"Key": "key1", "Value": "value1"},
+                    {"Key": "key2", "Value": "value2"},
+                ],
+            )
+
+        response = self.rtapi.untag_resources(
+            ResourceARNList=self.resources_tagged,
+            TagKeys=["key2"],
+        )
+
+        assert response["FailedResourcesMap"] == {}
+
+        def get_tags(arn):
+            return self.rds.list_tags_for_resource(ResourceName=arn)["TagList"]
+
+        for arn in self.resources_tagged:
+            tags = get_tags(arn)
+            assert {"Key": "key1", "Value": "value1"} in tags
+            assert {"Key": "key2", "Value": "value2"} not in tags


### PR DESCRIPTION
Summary
This small PR introduces support for using the ResourceGroupsTaggingAPI untag_resources for RDS resources.

Tests in tests/test_resourcegroupstaggingapi/test_resourcegroupstagging_rds.py to validate the untagging functionality.