### PR TITLE
S3: put_object_tagging() now throws MethodNotAllowed when passing a DeleteMarker

### DIFF
--- a/moto/s3/exceptions.py
+++ b/moto/s3/exceptions.py
@@ -16,6 +16,14 @@ ERROR_WITH_KEY_NAME = """{% extends 'single_error' %}
 {% block extra %}<Key>{{ key }}</Key>{% endblock %}
 """
 
+ERROR_WITH_KEY_AND_VERSION = """{% extends 'single_error' %}
+{% block extra %}<Key>{{ key }}</Key><VersionId>{{ version_id }}</VersionId>{% endblock %}
+"""
+
+ERROR_WITH_METHOD_AND_RESOURCE = """{% extends 'single_error' %}
+{% block extra %}{% if method %}<Method>{{ method }}</Method>{% endif %}{% if resource_type %}<ResourceType>{{ resource_type }}</ResourceType>{% endif %}{% endblock %}
+"""
+
 ERROR_WITH_ARGUMENT = """{% extends 'single_error' %}
 {% block extra %}<ArgumentName>{{ name }}</ArgumentName>
 <ArgumentValue>{{ value }}</ArgumentValue>{% endblock %}
@@ -46,6 +54,8 @@ class S3ClientError(RESTError):
     extended_templates = {
         "bucket_error": ERROR_WITH_BUCKET_NAME,
         "key_error": ERROR_WITH_KEY_NAME,
+        "key_version_error": ERROR_WITH_KEY_AND_VERSION,
+        "method_resource_error": ERROR_WITH_METHOD_AND_RESOURCE,
         "argument_error": ERROR_WITH_ARGUMENT,
         "error_uploadid": ERROR_WITH_UPLOADID,
         "condition_error": ERROR_WITH_CONDITION_NAME,
@@ -126,8 +136,11 @@ class MissingKey(S3ClientError):
 class MissingVersion(S3ClientError):
     code = 404
 
-    def __init__(self) -> None:
-        super().__init__("NoSuchVersion", "The specified version does not exist.")
+    def __init__(self, **kwargs: Any) -> None:
+        kwargs.setdefault("template", "key_version_error")
+        super().__init__(
+            "NoSuchVersion", "The specified version does not exist.", **kwargs
+        )
 
 
 class MissingInventoryConfig(S3ClientError):
@@ -633,8 +646,10 @@ class HeadOnDeleteMarker(Exception):
 class MethodNotAllowed(S3ClientError):
     code = 405
 
-    def __init__(self) -> None:
+    def __init__(self, **kwargs: Any):
+        kwargs.setdefault("template", "method_resource_error")
         super().__init__(
             "MethodNotAllowed",
             "The specified method is not allowed against this resource.",
+            **kwargs,
         )

--- a/moto/s3/models.py
+++ b/moto/s3/models.py
@@ -2430,13 +2430,9 @@ class S3Backend(BaseBackend, CloudWatchMetricProvider):
 
     def put_object_tagging(
         self,
-        key: Optional[FakeKey],
+        key: FakeKey,
         tags: Optional[dict[str, str]],
-        key_name: Optional[str] = None,
     ) -> FakeKey:
-        if key is None:
-            raise MissingKey(key=key_name)
-
         # get bucket for eventbridge notification
         # we can assume that the key has its bucket
         bucket = self.get_bucket(key.bucket_name)  # type: ignore


### PR DESCRIPTION
Fixes #9401 

Additional improvements:
 - `put_object_tagging()` now returns a MissingVersion, instead of `NoSuchKey`, when appropriate
 - Improves the error handling a bit, by returning additional fields when throwing an error.
 - Improves the tests by splitting separate scenarios into standalone tests
