### PR TITLE
Tests: Use pytest.skip instead of unittest.SkipTest, now that's broken in pytest 9.0

### DIFF
--- a/tests/test_acm/test_acm.py
+++ b/tests/test_acm/test_acm.py
@@ -2,7 +2,7 @@ import datetime
 import os
 import uuid
 from ipaddress import IPv4Address
-from unittest import SkipTest, mock
+from unittest import mock
 
 import boto3
 import pytest
@@ -477,7 +477,7 @@ def test_request_certificate():
 @mock.patch("moto.settings.ACM_VALIDATION_WAIT", 1)
 def test_request_exportable_certificate():
     if not settings.TEST_DECORATOR_MODE:
-        raise SkipTest("Can only change setting in DecoratorMode")
+        raise pytest.skip("Can only change setting in DecoratorMode")
     client = boto3.client("acm", region_name="eu-central-1")
 
     resp = client.request_certificate(
@@ -555,7 +555,7 @@ def test_list_certificates_with_key_types_filter():
 @mock.patch("moto.settings.ACM_VALIDATION_WAIT", 1)
 def test_request_certificate_with_optional_arguments():
     if not settings.TEST_DECORATOR_MODE:
-        raise SkipTest("Can only change setting in DecoratorMode")
+        raise pytest.skip("Can only change setting in DecoratorMode")
     client = boto3.client("acm", region_name="eu-central-1")
 
     token = str(uuid.uuid4())
@@ -793,7 +793,7 @@ def test_request_certificate_issued_status():
 def test_request_certificate_issued_status_with_wait_in_envvar():
     # After requesting a certificate, it should then auto-validate after 3 seconds
     if not settings.TEST_DECORATOR_MODE:
-        raise SkipTest("Cant manipulate time in server mode")
+        raise pytest.skip("Cant manipulate time in server mode")
 
     client = boto3.client("acm", region_name="eu-central-1")
 
@@ -821,7 +821,7 @@ def test_request_certificate_issued_status_with_wait_in_envvar():
 @mock_aws
 def test_request_certificate_with_multiple_times():
     if not settings.TEST_DECORATOR_MODE:
-        raise SkipTest("Cant manipulate time in server mode")
+        raise pytest.skip("Cant manipulate time in server mode")
 
     # After requesting a certificate, it should then auto-validate after 1 minute
     # Some sneaky programming for that ;-)
@@ -944,7 +944,7 @@ def test_elbv2_acm_in_use_by():
 @mock_aws
 def test_certificate_expiration_status():
     if not settings.TEST_DECORATOR_MODE:
-        raise SkipTest("Cant manipulate time in server mode")
+        raise pytest.skip("Cant manipulate time in server mode")
     client = boto3.client("acm", region_name="eu-central-1")
     arn = _import_cert(client)
 

--- a/tests/test_acmpca/test_acmpca.py
+++ b/tests/test_acmpca/test_acmpca.py
@@ -1,7 +1,6 @@
 import datetime
 import json
 import pickle
-from unittest import SkipTest
 
 import boto3
 import cryptography.hazmat.primitives.asymmetric.rsa
@@ -733,7 +732,7 @@ def test_policy_operations():
 @mock_aws
 def test_list_certificate_authorities():
     if settings.TEST_SERVER_MODE:
-        raise SkipTest("Cannot verify backend state in server mode")
+        raise pytest.skip("Cannot verify backend state in server mode")
 
     client = boto3.client("acm-pca", region_name="us-east-1")
 

--- a/tests/test_apigateway/test_apigateway_integration.py
+++ b/tests/test_apigateway/test_apigateway_integration.py
@@ -1,7 +1,7 @@
 import json
-from unittest import SkipTest
 
 import boto3
+import pytest
 import requests
 
 from moto import mock_aws, settings
@@ -12,9 +12,9 @@ from moto.core.versions import is_responses_0_17_x
 @mock_aws
 def test_http_integration():
     if not settings.TEST_DECORATOR_MODE:
-        raise SkipTest("Cannot test mock of execute-api.apigateway in ServerMode")
+        raise pytest.skip("Cannot test mock of execute-api.apigateway in ServerMode")
     if not is_responses_0_17_x():
-        raise SkipTest("Not supported in older requests-version")
+        raise pytest.skip("Not supported in older requests-version")
 
     responses_mock.add(
         responses_mock.GET, "http://httpbin.org/robots.txt", body="a fake response"
@@ -62,9 +62,9 @@ def test_http_integration():
 @mock_aws
 def test_aws_integration_dynamodb():
     if not settings.TEST_DECORATOR_MODE:
-        raise SkipTest("Cannot test mock of execute-api.apigateway in ServerMode")
+        raise pytest.skip("Cannot test mock of execute-api.apigateway in ServerMode")
     if not is_responses_0_17_x():
-        raise SkipTest("Not supported in older requests-version")
+        raise pytest.skip("Not supported in older requests-version")
 
     client = boto3.client("apigateway", region_name="us-west-2")
     dynamodb = boto3.client("dynamodb", region_name="us-west-2")
@@ -88,9 +88,9 @@ def test_aws_integration_dynamodb():
 @mock_aws
 def test_aws_integration_dynamodb_multiple_stages():
     if not settings.TEST_DECORATOR_MODE:
-        raise SkipTest("Cannot test mock of execute-api.apigateway in ServerMode")
+        raise pytest.skip("Cannot test mock of execute-api.apigateway in ServerMode")
     if not is_responses_0_17_x():
-        raise SkipTest("Not supported in older requests-version")
+        raise pytest.skip("Not supported in older requests-version")
 
     client = boto3.client("apigateway", region_name="us-west-2")
     dynamodb = boto3.client("dynamodb", region_name="us-west-2")
@@ -126,9 +126,9 @@ def test_aws_integration_dynamodb_multiple_stages():
 @mock_aws
 def test_aws_integration_dynamodb_multiple_resources():
     if not settings.TEST_DECORATOR_MODE:
-        raise SkipTest("Cannot test mock of execute-api.apigateway in ServerMode")
+        raise pytest.skip("Cannot test mock of execute-api.apigateway in ServerMode")
     if not is_responses_0_17_x():
-        raise SkipTest("Not supported in older requests-version")
+        raise pytest.skip("Not supported in older requests-version")
 
     client = boto3.client("apigateway", region_name="us-west-2")
     dynamodb = boto3.client("dynamodb", region_name="us-west-2")

--- a/tests/test_apigatewaymanagementapi/test_apigatewaymanagementapi.py
+++ b/tests/test_apigatewaymanagementapi/test_apigatewaymanagementapi.py
@@ -1,6 +1,5 @@
-from unittest import SkipTest
-
 import boto3
+import pytest
 
 from moto import mock_aws, settings
 from moto.apigatewaymanagementapi.models import apigatewaymanagementapi_backends
@@ -17,7 +16,7 @@ def test_delete_connection():
         # URL matching changed in 2.2.x - the root path '/@connections' cannot be found
         # 2.1.x works, 2.2.x is broken, and 2.3.x (and 3.x) works again
         # We could only skip 2.2.x - but only supporting >= 2.3.x is easier
-        raise SkipTest("Can't test this in older werkzeug versions")
+        raise pytest.skip("Can't test this in older werkzeug versions")
     client = boto3.client("apigatewaymanagementapi", region_name="eu-west-1")
     # NO-OP
     client.delete_connection(ConnectionId="anything")
@@ -28,7 +27,7 @@ def test_get_connection():
     if settings.TEST_SERVER_MODE and not is_werkzeug_2_3_x():
         # URL matching changed between 2.2.x and 2.3.x
         # 2.3.x has no problem matching the root path '/@connections', but 2.2.x refuses
-        raise SkipTest("Can't test this in older werkzeug versions")
+        raise pytest.skip("Can't test this in older werkzeug versions")
     client = boto3.client("apigatewaymanagementapi", region_name="us-east-2")
     conn = client.get_connection(ConnectionId="anything")
 
@@ -42,7 +41,7 @@ def test_post_to_connection():
     if settings.TEST_SERVER_MODE and not is_werkzeug_2_3_x():
         # URL matching changed between 2.2.x and 2.3.x
         # 2.3.x has no problem matching the root path '/@connections', but 2.2.x refuses
-        raise SkipTest("Can't test this in older werkzeug versions")
+        raise pytest.skip("Can't test this in older werkzeug versions")
     client = boto3.client("apigatewaymanagementapi", region_name="ap-southeast-1")
     client.post_to_connection(ConnectionId="anything", Data=b"my first bytes")
 
@@ -60,7 +59,7 @@ def test_post_to_connection():
 @mock_aws
 def test_post_to_connection_using_endpoint_url():
     if not settings.TEST_DECORATOR_MODE:
-        raise SkipTest("Can only test this with decorators")
+        raise pytest.skip("Can only test this with decorators")
     client = boto3.client(
         "apigatewaymanagementapi",
         "us-west-2",

--- a/tests/test_appsync/test_appsync.py
+++ b/tests/test_appsync/test_appsync.py
@@ -1,6 +1,5 @@
 import json
 from datetime import datetime, timedelta
-from unittest import SkipTest
 
 import boto3
 import pytest
@@ -695,7 +694,7 @@ def test_get_api():
 @mock_aws
 def test_events_api_direct_http_request_e2e():
     if not settings.TEST_DECORATOR_MODE:
-        raise SkipTest("Can only test this flow in DecoratorMode")
+        raise pytest.skip("Can only test this flow in DecoratorMode")
     client = boto3.client("appsync", region_name="us-east-1")
     api_resp = client.create_api(
         name="events-api",

--- a/tests/test_athena/test_athena_execution_state.py
+++ b/tests/test_athena/test_athena_execution_state.py
@@ -1,5 +1,3 @@
-from unittest import SkipTest
-
 import boto3
 import pytest
 from botocore.exceptions import ClientError
@@ -24,7 +22,7 @@ def execution_state_transition():
 def test_execution_with_manual_transition(execution_state_transition):
     if not settings.TEST_DECORATOR_MODE:
         # We already test the state transitions in ServerMode in other tests
-        raise SkipTest(
+        raise pytest.skip(
             "NO point in verifying state transitions when not using the decorator"
         )
 

--- a/tests/test_athena/test_athena_integration.py
+++ b/tests/test_athena/test_athena_integration.py
@@ -1,5 +1,4 @@
 import json
-from unittest import SkipTest
 from uuid import uuid4
 
 import boto3
@@ -77,7 +76,7 @@ COLUMN_INFO = [
 @pytest.mark.aws_verified
 def test_athena_csv_result(bucket_name=None):
     if not settings.TEST_DECORATOR_MODE:
-        raise SkipTest("No point in testing this outside of decorators")
+        raise pytest.skip("No point in testing this outside of decorators")
 
     s3 = boto3.client("s3", "us-east-1")
     s3.put_object(Bucket=bucket_name, Key="input/data1.json", Body=DATA.encode("utf-8"))

--- a/tests/test_athena/test_athena_server_api.py
+++ b/tests/test_athena/test_athena_server_api.py
@@ -1,7 +1,7 @@
 import os
-from unittest import SkipTest
 
 import boto3
+import pytest
 import requests
 from botocore.config import Config
 
@@ -26,7 +26,7 @@ DEFAULT_COLUMN_INFO = [
 @mock_aws
 def test_set_athena_result():
     if settings.is_test_proxy_mode():
-        raise SkipTest("Proxy requires more config, done in separate test")
+        raise pytest.skip("Proxy requires more config, done in separate test")
     base_url = (
         "localhost:5000" if settings.TEST_SERVER_MODE else "motoapi.amazonaws.com"
     )
@@ -60,7 +60,7 @@ def test_set_athena_result():
 
 def test_set_athena_result_using_proxy():
     if not settings.is_test_proxy_mode():
-        raise SkipTest("Specifically testing the proxy here")
+        raise pytest.skip("Specifically testing the proxy here")
     os.environ["AWS_ACCESS_KEY_ID"] = "testing"
     os.environ["AWS_SECRET_ACCESS_KEY"] = "testing"
     athena_result = {

--- a/tests/test_autoscaling/test_launch_configurations.py
+++ b/tests/test_autoscaling/test_launch_configurations.py
@@ -1,6 +1,6 @@
 import base64
 import os
-from unittest import SkipTest, mock
+from unittest import mock
 
 import boto3
 import pytest
@@ -138,7 +138,7 @@ def test_create_launch_configuration_additional_parameters():
 @mock_aws
 def test_create_launch_configuration_without_public_ip():
     if settings.TEST_SERVER_MODE:
-        raise SkipTest("Can't set environment variables in ServerMode")
+        raise pytest.skip("Can't set environment variables in ServerMode")
     ec2 = boto3.resource("ec2", "us-east-1")
     vpc = ec2.create_vpc(CidrBlock="10.0.0.0/16")
     subnet = ec2.create_subnet(VpcId=vpc.id, CidrBlock="10.0.0.0/27")
@@ -298,7 +298,7 @@ def test_invalid_launch_configuration_request_raises_error(request_params):
 @mock_aws
 def test_launch_config_with_block_device_mappings__volumes_are_created():
     if settings.TEST_SERVER_MODE:
-        raise SkipTest("Can't set environment variables in ServerMode")
+        raise pytest.skip("Can't set environment variables in ServerMode")
     as_client = boto3.client("autoscaling", "us-east-2")
     ec2_client = boto3.client("ec2", "us-east-2")
     random_image_id = ec2_client.describe_images()["Images"][0]["ImageId"]

--- a/tests/test_awslambda/test_lambda.py
+++ b/tests/test_awslambda/test_lambda.py
@@ -3,7 +3,7 @@ import hashlib
 import json
 import os
 import sys
-from unittest import SkipTest, mock
+from unittest import mock
 from uuid import uuid4
 
 import boto3
@@ -38,9 +38,9 @@ boto3_version = sys.modules["botocore"].__version__
 @mock_aws
 def test_lambda_regions(region):
     if not settings.TEST_DECORATOR_MODE:
-        raise SkipTest("Can only set EnvironVars in DecoratorMode")
+        raise pytest.skip("Can only set EnvironVars in DecoratorMode")
     if LooseVersion(boto3_version) < LooseVersion("1.29.0"):
-        raise SkipTest("ISO-region not available in older versions")
+        raise pytest.skip("ISO-region not available in older versions")
     client = boto3.client("lambda", region_name=region)
     resp = client.list_functions()
     assert resp["ResponseMetadata"]["HTTPStatusCode"] == 200
@@ -74,7 +74,7 @@ def test_lambda_regions(region):
 @lambda_aws_verified
 def test_list_functions(iam_role_arn=None):
     if LooseVersion(boto3_version) < LooseVersion("1.29.0"):
-        raise SkipTest("Parameters only available in newer versions")
+        raise pytest.skip("Parameters only available in newer versions")
     sts = boto3.client("sts", "eu-west-2")
     account_id = sts.get_caller_identity()["Account"]
 
@@ -162,7 +162,7 @@ def test_create_based_on_s3_with_missing_bucket():
 @freeze_time("2015-01-01 00:00:00")
 def test_create_function_from_aws_bucket():
     if LooseVersion(boto3_version) < LooseVersion("1.29.0"):
-        raise SkipTest("Parameters only available in newer versions")
+        raise pytest.skip("Parameters only available in newer versions")
     bucket_name = str(uuid4())
     s3_conn = boto3.client("s3", _lambda_region)
     s3_conn.create_bucket(
@@ -206,7 +206,7 @@ def test_create_function_from_aws_bucket():
 @freeze_time("2015-01-01 00:00:00")
 def test_create_function_from_zipfile():
     if LooseVersion(boto3_version) < LooseVersion("1.29.0"):
-        raise SkipTest("Parameters only available in newer versions")
+        raise pytest.skip("Parameters only available in newer versions")
     conn = boto3.client("lambda", _lambda_region)
     zip_content = get_test_zip_file1()
     function_name = str(uuid4())[0:6]
@@ -256,7 +256,7 @@ def test_create_function_from_zipfile():
 @mock_aws
 def test_create_function_from_image():
     if LooseVersion(boto3_version) < LooseVersion("1.29.0"):
-        raise SkipTest("Parameters only available in newer versions")
+        raise pytest.skip("Parameters only available in newer versions")
     conn = boto3.client("lambda", _lambda_region)
     function_name = str(uuid4())[0:6]
     image_uri = f"{ACCOUNT_ID}.dkr.ecr.us-east-1.amazonaws.com/testlambdaecr:prod"
@@ -287,7 +287,7 @@ def test_create_function_from_image():
 @mock_aws
 def test_create_function_from_image_default_working_directory():
     if LooseVersion(boto3_version) < LooseVersion("1.29.0"):
-        raise SkipTest("Parameters only available in newer versions")
+        raise pytest.skip("Parameters only available in newer versions")
     conn = boto3.client("lambda", _lambda_region)
     function_name = str(uuid4())[0:6]
     image_uri = f"{ACCOUNT_ID}.dkr.ecr.us-east-1.amazonaws.com/testlambdaecr:prod"
@@ -317,7 +317,7 @@ def test_create_function_from_image_default_working_directory():
 @mock_aws
 def test_create_function_error_bad_architecture():
     if LooseVersion(boto3_version) < LooseVersion("1.29.0"):
-        raise SkipTest("Parameters only available in newer versions")
+        raise pytest.skip("Parameters only available in newer versions")
     conn = boto3.client("lambda", _lambda_region)
     function_name = str(uuid4())[0:6]
     image_uri = f"{ACCOUNT_ID}.dkr.ecr.us-east-1.amazonaws.com/testlambdaecr:prod"
@@ -344,7 +344,7 @@ def test_create_function_error_bad_architecture():
 @mock_aws
 def test_create_function_error_ephemeral_too_big():
     if LooseVersion(boto3_version) < LooseVersion("1.29.0"):
-        raise SkipTest("Parameters only available in newer versions")
+        raise pytest.skip("Parameters only available in newer versions")
     conn = boto3.client("lambda", _lambda_region)
     function_name = str(uuid4())[0:6]
     image_uri = f"{ACCOUNT_ID}.dkr.ecr.us-east-1.amazonaws.com/testlambdaecr:prod"
@@ -419,7 +419,7 @@ def ecr_repo_fixture():
 @mock_aws
 def test_create_function_from_stubbed_ecr():
     if LooseVersion(boto3_version) < LooseVersion("1.29.0"):
-        raise SkipTest("Parameters only available in newer versions")
+        raise pytest.skip("Parameters only available in newer versions")
     lambda_client = boto3.client("lambda", "us-east-1")
     fn_name = str(uuid4())[0:6]
     image_uri = "111122223333.dkr.ecr.us-east-1.amazonaws.com/testlambda:latest"
@@ -456,9 +456,9 @@ def test_create_function_from_mocked_ecr_image_tag(
     with_ecr_mock,
 ):
     if LooseVersion(boto3_version) < LooseVersion("1.29.0"):
-        raise SkipTest("Parameters only available in newer versions")
+        raise pytest.skip("Parameters only available in newer versions")
     if not settings.TEST_DECORATOR_MODE:
-        raise SkipTest(
+        raise pytest.skip(
             "Envars not easily set in server mode, feature off by default, skipping..."
         )
 
@@ -500,9 +500,9 @@ def test_create_function_from_mocked_ecr_image_digest(
     with_ecr_mock,
 ):
     if LooseVersion(boto3_version) < LooseVersion("1.29.0"):
-        raise SkipTest("Parameters only available in newer versions")
+        raise pytest.skip("Parameters only available in newer versions")
     if not settings.TEST_DECORATOR_MODE:
-        raise SkipTest(
+        raise pytest.skip(
             "Envars not easily set in server mode, feature off by default, skipping..."
         )
     lambda_client = boto3.client("lambda", "us-east-1")
@@ -529,9 +529,9 @@ def test_create_function_from_mocked_ecr_missing_image(
     with_ecr_mock,
 ):
     if LooseVersion(boto3_version) < LooseVersion("1.29.0"):
-        raise SkipTest("Parameters only available in newer versions")
+        raise pytest.skip("Parameters only available in newer versions")
     if not settings.TEST_DECORATOR_MODE:
-        raise SkipTest(
+        raise pytest.skip(
             "Envars not easily set in server mode, feature off by default, skipping..."
         )
 
@@ -712,7 +712,7 @@ def test_get_function_configuration(key):
 @mock_aws
 def test_get_function_code_signing_config(key):
     if LooseVersion(boto3_version) < LooseVersion("1.29.0"):
-        raise SkipTest("Parameters only available in newer versions")
+        raise pytest.skip("Parameters only available in newer versions")
     bucket_name = str(uuid4())
     s3_conn = boto3.client("s3", _lambda_region)
     s3_conn.create_bucket(
@@ -941,7 +941,7 @@ def test_list_create_list_get_delete_list():
 
     """
     if LooseVersion(boto3_version) < LooseVersion("1.29.0"):
-        raise SkipTest("Parameters only available in newer versions")
+        raise pytest.skip("Parameters only available in newer versions")
     bucket_name = str(uuid4())
     s3_conn = boto3.client("s3", _lambda_region)
     s3_conn.create_bucket(
@@ -1536,7 +1536,7 @@ def test_update_function_s3():
 @mock_aws
 def test_update_function_ecr():
     if LooseVersion(boto3_version) < LooseVersion("1.29.0"):
-        raise SkipTest("Parameters only available in newer versions")
+        raise pytest.skip("Parameters only available in newer versions")
     conn = boto3.client("lambda", _lambda_region)
     function_name = str(uuid4())[0:6]
     image_uri = f"{ACCOUNT_ID}.dkr.ecr.us-east-1.amazonaws.com/testlambdaecr:prod"
@@ -1741,7 +1741,7 @@ def test_get_role_name_utility_race_condition():
 @mock.patch.dict(os.environ, {"MOTO_LAMBDA_CONCURRENCY_QUOTA": "1000"})
 def test_put_function_concurrency_success():
     if not settings.TEST_DECORATOR_MODE:
-        raise SkipTest(
+        raise pytest.skip(
             "Envars not easily set in server mode, feature off by default, skipping..."
         )
     conn = boto3.client("lambda", _lambda_region)
@@ -1795,7 +1795,7 @@ def test_put_function_concurrency_not_enforced():
 @mock.patch.dict(os.environ, {"MOTO_LAMBDA_CONCURRENCY_QUOTA": "1000"})
 def test_put_function_concurrency_failure():
     if not settings.TEST_DECORATOR_MODE:
-        raise SkipTest(
+        raise pytest.skip(
             "Envars not easily set in server mode, feature off by default, skipping..."
         )
     conn = boto3.client("lambda", _lambda_region)
@@ -1829,7 +1829,7 @@ def test_put_function_concurrency_failure():
 @mock.patch.dict(os.environ, {"MOTO_LAMBDA_CONCURRENCY_QUOTA": "1000"})
 def test_put_function_concurrency_i_can_has_math():
     if not settings.TEST_DECORATOR_MODE:
-        raise SkipTest(
+        raise pytest.skip(
             "Envars not easily set in server mode, feature off by default, skipping..."
         )
     conn = boto3.client("lambda", _lambda_region)

--- a/tests/test_awslambda/test_lambda_eventsourcemapping.py
+++ b/tests/test_awslambda/test_lambda_eventsourcemapping.py
@@ -2,7 +2,6 @@ import json
 import sys
 import time
 import uuid
-from unittest import SkipTest
 
 import boto3
 import pytest
@@ -28,7 +27,7 @@ botocore_version = sys.modules["botocore"].__version__
 @mock_aws
 def test_create_event_source_mapping():
     if LooseVersion(botocore_version) < LooseVersion("1.23.12"):
-        raise SkipTest("Parameter FilterCriteria is not available in older versions")
+        raise pytest.skip("Parameter FilterCriteria is not available in older versions")
 
     function_name = str(uuid.uuid4())[0:6]
     sqs = boto3.resource("sqs", region_name="us-east-1")
@@ -531,7 +530,7 @@ def test_get_event_source_mapping():
 @mock_aws
 def test_update_event_source_mapping():
     if LooseVersion(botocore_version) < LooseVersion("1.23.12"):
-        raise SkipTest("Parameter FilterCriteria is not available in older versions")
+        raise pytest.skip("Parameter FilterCriteria is not available in older versions")
 
     function_name = str(uuid.uuid4())[0:6]
     sqs = boto3.resource("sqs", region_name="us-east-1")
@@ -667,7 +666,7 @@ def test_delete_event_source_mapping():
 @mock_aws
 def test_event_source_mapping_tagging_lifecycle():
     if LooseVersion(botocore_version) < LooseVersion("1.35.23"):
-        raise SkipTest(
+        raise pytest.skip(
             "Tagging support for Lambda event source mapping is not available in older Botocore versions"
         )
 

--- a/tests/test_awslambda/test_lambda_function_urls.py
+++ b/tests/test_awslambda/test_lambda_function_urls.py
@@ -1,5 +1,4 @@
 import sys
-from unittest import SkipTest
 from uuid import uuid4
 
 import boto3
@@ -20,7 +19,7 @@ boto3_version = sys.modules["botocore"].__version__
 @pytest.mark.parametrize("key", ["FunctionName", "FunctionArn"])
 def test_create_function_url_config(key):
     if LooseVersion(boto3_version) < LooseVersion("1.29.0"):
-        raise SkipTest("Parameters only available in newer versions")
+        raise pytest.skip("Parameters only available in newer versions")
     client = boto3.client("lambda", "us-east-2")
     function_name = str(uuid4())[0:6]
     fxn = client.create_function(
@@ -48,7 +47,7 @@ def test_create_function_url_config(key):
 @mock_aws
 def test_create_function_url_config_with_cors():
     if LooseVersion(boto3_version) < LooseVersion("1.29.0"):
-        raise SkipTest("Parameters only available in newer versions")
+        raise pytest.skip("Parameters only available in newer versions")
     client = boto3.client("lambda", "us-east-2")
     function_name = str(uuid4())[0:6]
     fxn = client.create_function(
@@ -85,7 +84,7 @@ def test_create_function_url_config_with_cors():
 @mock_aws
 def test_update_function_url_config_with_cors():
     if LooseVersion(boto3_version) < LooseVersion("1.29.0"):
-        raise SkipTest("Parameters only available in newer versions")
+        raise pytest.skip("Parameters only available in newer versions")
     client = boto3.client("lambda", "us-east-2")
     function_name = str(uuid4())[0:6]
     fxn = client.create_function(
@@ -120,7 +119,7 @@ def test_update_function_url_config_with_cors():
 @pytest.mark.parametrize("key", ["FunctionName", "FunctionArn"])
 def test_delete_function_url_config(key):
     if LooseVersion(boto3_version) < LooseVersion("1.29.0"):
-        raise SkipTest("Parameters only available in newer versions")
+        raise pytest.skip("Parameters only available in newer versions")
     client = boto3.client("lambda", "us-east-2")
     function_name = str(uuid4())[0:6]
     fxn = client.create_function(

--- a/tests/test_awslambda/test_lambda_invoke.py
+++ b/tests/test_awslambda/test_lambda_invoke.py
@@ -1,6 +1,5 @@
 import base64
 import json
-from unittest import SkipTest
 from uuid import uuid4
 
 import boto3
@@ -191,7 +190,7 @@ class TestLambdaInvocations:
 @mock_aws
 def test_invoke_lambda_using_environment_port():
     if not settings.TEST_SERVER_MODE:
-        raise SkipTest("Can only test environment variables in server mode")
+        raise pytest.skip("Can only test environment variables in server mode")
     conn = boto3.client("lambda", _lambda_region)
     function_name = str(uuid4())[0:6]
     conn.create_function(
@@ -230,7 +229,7 @@ def test_invoke_lambda_using_networkmode():
     Test is only run in our CI (for now)
     """
     if not settings.moto_network_mode():
-        raise SkipTest("Can only test this when NETWORK_MODE is specified")
+        raise pytest.skip("Can only test this when NETWORK_MODE is specified")
     conn = boto3.client("lambda", _lambda_region)
     function_name = str(uuid4())[0:6]
     conn.create_function(
@@ -348,7 +347,7 @@ def test_invoke_function_large_response():
 @mock_aws
 def test_invoke_lambda_with_proxy():
     if not settings.is_test_proxy_mode():
-        raise SkipTest("We only want to test this in ProxyMode")
+        raise pytest.skip("We only want to test this in ProxyMode")
 
     conn = boto3.resource("ec2", _lambda_region)
     vol = conn.create_volume(Size=99, AvailabilityZone=_lambda_region)
@@ -386,7 +385,7 @@ def test_invoke_lambda_with_proxy():
 @requires_docker
 def test_invoke_lambda_with_entrypoint():
     if LooseVersion(boto3_version) < LooseVersion("1.29.0"):
-        raise SkipTest("ImageConfig parameter not available in older versions")
+        raise pytest.skip("ImageConfig parameter not available in older versions")
     conn = boto3.client("lambda", _lambda_region)
     function_name = str(uuid4())[0:6]
     conn.create_function(
@@ -425,7 +424,7 @@ def test_invoke_lambda_with_entrypoint():
 @mock_aws
 def test_lambda_request_unauthorized_user():
     if not settings.TEST_DECORATOR_MODE:
-        raise SkipTest("Auth decorator does not work in server mode")
+        raise pytest.skip("Auth decorator does not work in server mode")
     iam = boto3.client("iam", region_name="us-west-2")
     user_name = "test-user"
     iam.create_user(UserName=user_name)

--- a/tests/test_awslambda/test_lambda_layers.py
+++ b/tests/test_awslambda/test_lambda_layers.py
@@ -1,7 +1,7 @@
 import json
 import os
 import sys
-from unittest import SkipTest, mock
+from unittest import mock
 from uuid import uuid4
 
 import boto3
@@ -43,7 +43,7 @@ def test_publish_lambda_layers__without_content():
 @mock.patch.dict(os.environ, {"VALIDATE_LAMBDA_S3": "false"})
 def test_publish_layer_with_unknown_s3_file():
     if not settings.TEST_DECORATOR_MODE:
-        raise SkipTest("Can only set env var in DecoratorMode")
+        raise pytest.skip("Can only set env var in DecoratorMode")
     conn = boto3.client("lambda", _lambda_region)
     content = conn.publish_layer_version(
         LayerName=str(uuid4())[0:6],
@@ -56,7 +56,7 @@ def test_publish_layer_with_unknown_s3_file():
 @s3_aws_verified
 def test_list_lambda_layers(account_id, bucket_name=None):
     if LooseVersion(boto3_version) < LooseVersion("1.29.0"):
-        raise SkipTest("Parameters only available in newer versions")
+        raise pytest.skip("Parameters only available in newer versions")
     s3_conn = boto3.client("s3", "us-east-1")
 
     zip_content = get_test_zip_file1()
@@ -117,7 +117,7 @@ def test_list_lambda_layers(account_id, bucket_name=None):
 @mock_aws
 def test_create_function_with_layer():
     if LooseVersion(boto3_version) < LooseVersion("1.29.0"):
-        raise SkipTest("Parameters only available in newer versions")
+        raise pytest.skip("Parameters only available in newer versions")
     bucket_name = str(uuid4())
     s3_conn = boto3.client("s3", _lambda_region)
     s3_conn.create_bucket(
@@ -179,7 +179,7 @@ def test_list_lambda_layers_with_unknown_name():
 @mock_aws
 def test_create_function_with_unknown_layer():
     if LooseVersion(boto3_version) < LooseVersion("1.29.0"):
-        raise SkipTest("Parameters only available in newer versions")
+        raise pytest.skip("Parameters only available in newer versions")
     bucket_name = str(uuid4())
 
     conn = boto3.client("lambda", _lambda_region)
@@ -208,7 +208,7 @@ def test_create_function_with_unknown_layer():
 @mock_aws
 def test_get_layer_version():
     if LooseVersion(boto3_version) < LooseVersion("1.29.0"):
-        raise SkipTest("Parameters only available in newer versions")
+        raise pytest.skip("Parameters only available in newer versions")
     bucket_name = str(uuid4())
     s3_conn = boto3.client("s3", _lambda_region)
     s3_conn.create_bucket(
@@ -374,7 +374,7 @@ def test_get_layer_with_no_layer_versions():
 @mock_aws
 def test_add_layer_version_permission():
     if LooseVersion(boto3_version) < LooseVersion("1.29.0"):
-        raise SkipTest("Parameters only available in newer versions")
+        raise pytest.skip("Parameters only available in newer versions")
     bucket_name = str(uuid4())
     s3_conn = boto3.client("s3", _lambda_region)
     s3_conn.create_bucket(
@@ -412,7 +412,7 @@ def test_add_layer_version_permission():
 @mock_aws
 def test_get_layer_version_policy():
     if LooseVersion(boto3_version) < LooseVersion("1.29.0"):
-        raise SkipTest("Parameters only available in newer versions")
+        raise pytest.skip("Parameters only available in newer versions")
     bucket_name = str(uuid4())
     s3_conn = boto3.client("s3", _lambda_region)
     s3_conn.create_bucket(
@@ -456,7 +456,7 @@ def test_get_layer_version_policy():
 @mock_aws
 def test_remove_layer_version_permission():
     if LooseVersion(boto3_version) < LooseVersion("1.29.0"):
-        raise SkipTest("Parameters only available in newer versions")
+        raise pytest.skip("Parameters only available in newer versions")
     bucket_name = str(uuid4())
     s3_conn = boto3.client("s3", _lambda_region)
     s3_conn.create_bucket(

--- a/tests/test_awslambda/test_lambda_policy.py
+++ b/tests/test_awslambda/test_lambda_policy.py
@@ -1,6 +1,5 @@
 import json
 import sys
-from unittest import SkipTest
 from uuid import uuid4
 
 import boto3
@@ -57,7 +56,7 @@ def test_add_function_permission(key):
 @mock_aws
 def test_add_permission_with_principalorgid():
     if LooseVersion(boto3_version) < LooseVersion("1.29.0"):
-        raise SkipTest("Parameters only available in newer versions")
+        raise pytest.skip("Parameters only available in newer versions")
     conn = boto3.client("lambda", _lambda_region)
     zip_content = get_test_zip_file1()
     function_name = str(uuid4())[0:6]

--- a/tests/test_awslambda_simple/test_lambda_simple.py
+++ b/tests/test_awslambda_simple/test_lambda_simple.py
@@ -1,7 +1,7 @@
 import json
-from unittest import SkipTest
 
 import boto3
+import pytest
 import requests
 
 from moto import mock_aws, settings
@@ -11,9 +11,6 @@ from ..test_awslambda.utilities import get_role_name, get_test_zip_file1
 LAMBDA_REGION = "us-west-2"
 PYTHON_VERSION = "3.11"
 FUNCTION_NAME = "test-function-123"
-
-if settings.TEST_SERVER_MODE:
-    raise SkipTest("No point in testing batch_simple in ServerMode")
 
 
 @mock_aws(config={"lambda": {"use_docker": False}})
@@ -56,11 +53,7 @@ def test_run_function_no_log():
 @mock_aws(config={"lambda": {"use_docker": False}})
 def test_set_lambda_simple_query_results():
     # Setup
-    base_url = (
-        settings.test_server_mode_endpoint()
-        if settings.TEST_SERVER_MODE
-        else "http://motoapi.amazonaws.com"
-    )
+    base_url = "http://motoapi.amazonaws.com"
     results = {"results": ["test", "test 2"], "region": LAMBDA_REGION}
     resp = requests.post(
         f"{base_url}/moto-api/static/lambda-simple/response",
@@ -91,6 +84,9 @@ def test_set_lambda_simple_query_results():
 
 
 def setup_lambda():
+    if settings.TEST_SERVER_MODE:
+        raise pytest.skip("No point in testing awslambda_simple in ServerMode")
+
     client = boto3.client("lambda", LAMBDA_REGION)
     zip_content = get_test_zip_file1()
     function_name = FUNCTION_NAME

--- a/tests/test_batch/test_batch_jobs.py
+++ b/tests/test_batch/test_batch_jobs.py
@@ -1,6 +1,5 @@
 import datetime
 import time
-from unittest import SkipTest
 from uuid import uuid4
 
 import botocore.exceptions
@@ -142,7 +141,7 @@ def test_submit_job_array_size():
 @requires_docker
 def test_submit_job_array_size__reset_while_job_is_running():
     if settings.TEST_SERVER_MODE:
-        raise SkipTest("No point testing this in ServerMode")
+        raise pytest.skip("No point testing this in ServerMode")
 
     # Setup
     job_definition_name = f"echo_{str(uuid4())[0:6]}"

--- a/tests/test_batch_simple/test_batch_jobs.py
+++ b/tests/test_batch_simple/test_batch_jobs.py
@@ -1,7 +1,9 @@
 import os
 from typing import Any
-from unittest import SkipTest, mock
+from unittest import mock
 from uuid import uuid4
+
+import pytest
 
 from moto import mock_aws, settings
 
@@ -193,7 +195,7 @@ def test_submit_job_fail_bad_int() -> None:
 
 def setup_common_batch_simple(job_definition_name: str) -> tuple[Any, str, str]:
     if settings.TEST_SERVER_MODE:
-        raise SkipTest("No point in testing batch_simple in ServerMode")
+        raise pytest.skip("No point in testing batch_simple in ServerMode")
 
     ec2_client, iam_client, _, _, batch_client = _get_clients()
     _, _, _, iam_arn = _setup(ec2_client, iam_client)

--- a/tests/test_bedrock/test_bedrock.py
+++ b/tests/test_bedrock/test_bedrock.py
@@ -1,7 +1,6 @@
 """Unit tests for bedrock-supported APIs."""
 
 from datetime import datetime
-from unittest import SkipTest
 
 import boto3
 import pytest
@@ -666,7 +665,7 @@ def test_list_model_customization_jobs_name_contains():
 @mock_aws
 def test_list_model_customization_jobs_creation_time_before():
     if settings.TEST_SERVER_MODE:
-        raise SkipTest("Can't freeze time in ServerMode")
+        raise pytest.skip("Can't freeze time in ServerMode")
     client = boto3.client("bedrock", region_name=DEFAULT_REGION)
     with freeze_time("2022-01-01 12:00:00"):
         client.create_model_customization_job(
@@ -700,7 +699,7 @@ def test_list_model_customization_jobs_creation_time_before():
 @mock_aws
 def test_list_model_customization_jobs_creation_time_after():
     if settings.TEST_SERVER_MODE:
-        raise SkipTest("Can't freeze time in ServerMode")
+        raise pytest.skip("Can't freeze time in ServerMode")
     client = boto3.client("bedrock", region_name=DEFAULT_REGION)
     with freeze_time("2022-01-01 12:00:00"):
         client.create_model_customization_job(
@@ -767,7 +766,7 @@ def test_list_model_customization_jobs_status():
 @mock_aws
 def test_list_model_customization_jobs_ascending_sort():
     if settings.TEST_SERVER_MODE:
-        raise SkipTest("Can't freeze time in ServerMode")
+        raise pytest.skip("Can't freeze time in ServerMode")
     client = boto3.client("bedrock", region_name=DEFAULT_REGION)
     with freeze_time("2022-01-01 12:00:00"):
         client.create_model_customization_job(
@@ -819,7 +818,7 @@ def test_list_model_customization_jobs_ascending_sort():
 @mock_aws
 def test_list_model_customization_jobs_descending_sort():
     if settings.TEST_SERVER_MODE:
-        raise SkipTest("Can't freeze time in ServerMode")
+        raise pytest.skip("Can't freeze time in ServerMode")
     client = boto3.client("bedrock", region_name=DEFAULT_REGION)
     with freeze_time("2022-01-01 12:00:00"):
         client.create_model_customization_job(
@@ -881,7 +880,7 @@ def test_list_model_customization_jobs_bad_sort_order():
 @mock_aws
 def test_list_model_customization_jobs_bad_sort_by():
     if settings.TEST_SERVER_MODE:
-        raise SkipTest("Can't freeze time in ServerMode")
+        raise pytest.skip("Can't freeze time in ServerMode")
     client = boto3.client("bedrock", region_name=DEFAULT_REGION)
     with freeze_time("2022-01-01 12:00:00"):
         client.create_model_customization_job(
@@ -987,7 +986,7 @@ def test_list_custom_models_name_contains():
 @mock_aws
 def test_list_custom_models_creation_time_before():
     if settings.TEST_SERVER_MODE:
-        raise SkipTest("Can't freeze time in ServerMode")
+        raise pytest.skip("Can't freeze time in ServerMode")
     client = boto3.client("bedrock", region_name=DEFAULT_REGION)
     with freeze_time("2022-01-01 12:00:00"):
         client.create_model_customization_job(
@@ -1019,7 +1018,7 @@ def test_list_custom_models_creation_time_before():
 @mock_aws
 def test_list_custom_models_creation_time_after():
     if settings.TEST_SERVER_MODE:
-        raise SkipTest("Can't freeze time in ServerMode")
+        raise pytest.skip("Can't freeze time in ServerMode")
     client = boto3.client("bedrock", region_name=DEFAULT_REGION)
     with freeze_time("2022-01-01 12:00:00"):
         client.create_model_customization_job(
@@ -1051,7 +1050,7 @@ def test_list_custom_models_creation_time_after():
 @mock_aws
 def test_list_custom_models_ascending_sort():
     if settings.TEST_SERVER_MODE:
-        raise SkipTest("Can't freeze time in ServerMode")
+        raise pytest.skip("Can't freeze time in ServerMode")
     client = boto3.client("bedrock", region_name=DEFAULT_REGION)
     with freeze_time("2022-01-01 12:00:00"):
         client.create_model_customization_job(
@@ -1101,7 +1100,7 @@ def test_list_custom_models_ascending_sort():
 @mock_aws
 def test_list_custom_models_descending_sort():
     if settings.TEST_SERVER_MODE:
-        raise SkipTest("Can't freeze time in ServerMode")
+        raise pytest.skip("Can't freeze time in ServerMode")
     client = boto3.client("bedrock", region_name=DEFAULT_REGION)
     with freeze_time("2022-01-01 12:00:00"):
         client.create_model_customization_job(
@@ -1151,7 +1150,7 @@ def test_list_custom_models_descending_sort():
 @mock_aws
 def test_list_custom_models_bad_sort_order():
     if settings.TEST_SERVER_MODE:
-        raise SkipTest("Can't freeze time in ServerMode")
+        raise pytest.skip("Can't freeze time in ServerMode")
     client = boto3.client("bedrock", region_name=DEFAULT_REGION)
     with freeze_time("2022-01-01 12:00:00"):
         client.create_model_customization_job(
@@ -1190,7 +1189,7 @@ def test_list_custom_models_bad_sort_order():
 @mock_aws
 def test_list_custom_models_bad_sort_by():
     if settings.TEST_SERVER_MODE:
-        raise SkipTest("Can't freeze time in ServerMode")
+        raise pytest.skip("Can't freeze time in ServerMode")
     client = boto3.client("bedrock", region_name=DEFAULT_REGION)
     with freeze_time("2022-01-01 12:00:00"):
         client.create_model_customization_job(

--- a/tests/test_cloudformation/test_cloudformation_custom_resources.py
+++ b/tests/test_cloudformation/test_cloudformation_custom_resources.py
@@ -1,6 +1,5 @@
 import json
 import time
-from unittest import SkipTest
 from uuid import uuid4
 
 import boto3
@@ -46,7 +45,7 @@ def test_create_custom_lambda_resource():
     # TEST: verify that this output is persisted
     ##########
     if not settings.TEST_SERVER_MODE:
-        raise SkipTest(
+        raise pytest.skip(
             "Needs a standalone MotoServer, as cfnresponse needs to connect to something"
         )
     # Create cloudformation stack
@@ -84,7 +83,7 @@ def test_create_custom_lambda_resource__verify_cfnresponse_failed():
     # TEST: verify that a failure message appears in the CloudwatchLogs
     ##########
     if settings.TEST_SERVER_MODE:
-        raise SkipTest("Verify this fails if MotoServer is not running")
+        raise pytest.skip("Verify this fails if MotoServer is not running")
     # Create cloudformation stack
     stack_name = f"stack{str(uuid4())[0:6]}"
     template_body = get_template(get_lambda_code())
@@ -135,7 +134,7 @@ def test_create_custom_lambda_resource__verify_manual_request():
     # TEST: verify that the stack has a CREATE_COMPLETE status afterwards
     ##########
     if settings.TEST_SERVER_MODE:
-        raise SkipTest(
+        raise pytest.skip(
             "Verify HTTP request can be made manually if MotoServer is not running"
         )
     # Create cloudformation stack

--- a/tests/test_cloudformation/test_cloudformation_multi_accounts.py
+++ b/tests/test_cloudformation/test_cloudformation_multi_accounts.py
@@ -1,5 +1,5 @@
 import json
-from unittest import SkipTest, TestCase
+from unittest import TestCase
 from uuid import uuid4
 
 import boto3
@@ -37,7 +37,7 @@ class TestStackSetMultipleAccounts(TestCase):
         #                     [acct21]      [acct22]
         #
         if settings.TEST_SERVER_MODE:
-            raise SkipTest(
+            raise pytest.skip(
                 "These tests directly access the backend, which is not possible in ServerMode"
             )
         mockname = "mock-account"

--- a/tests/test_cloudformation/test_cloudformation_stack_crud.py
+++ b/tests/test_cloudformation/test_cloudformation_stack_crud.py
@@ -6,7 +6,6 @@ import sys
 import uuid
 from collections import OrderedDict
 from datetime import datetime, timedelta, timezone
-from unittest import SkipTest
 from uuid import uuid4
 
 import boto3
@@ -1926,7 +1925,7 @@ def test_delete_change_set():
 @mock_aws
 def test_create_change_set_twice__no_changes():
     if LooseVersion(boto3_version) < LooseVersion("1.29.0"):
-        raise SkipTest("Parameters only available in newer versions")
+        raise pytest.skip("Parameters only available in newer versions")
     cf_client = boto3.client("cloudformation", region_name=REGION_NAME)
 
     # Execute once
@@ -1959,7 +1958,7 @@ def test_create_change_set_twice__no_changes():
 @mock_aws
 def test_create_change_set_twice__using_s3__no_changes():
     if LooseVersion(boto3_version) < LooseVersion("1.29.0"):
-        raise SkipTest("Parameters only available in newer versions")
+        raise pytest.skip("Parameters only available in newer versions")
     cf_client = boto3.client("cloudformation", region_name=REGION_NAME)
     s3 = boto3.client("s3", region_name=REGION_NAME)
     s3_conn = boto3.resource("s3", region_name=REGION_NAME)
@@ -2263,7 +2262,7 @@ def test_update_stack_replace_tags():
 @mock_aws
 def test_update_stack_when_rolled_back():
     if settings.TEST_SERVER_MODE:
-        raise SkipTest("Cant manipulate backend in server mode")
+        raise pytest.skip("Cant manipulate backend in server mode")
     cf = boto3.client("cloudformation", region_name=REGION_NAME)
     stack = cf.create_stack(StackName=TEST_STACK_NAME, TemplateBody=dummy_template_json)
     stack_id = stack["StackId"]
@@ -2550,7 +2549,7 @@ def test_delete_stack_dynamo_template():
 @mock_aws
 def test_create_stack_lambda_and_dynamodb():
     if settings.TEST_SERVER_MODE:
-        raise SkipTest("Cant set environment variables in server mode")
+        raise pytest.skip("Cant set environment variables in server mode")
     cf = boto3.client("cloudformation", region_name=REGION_NAME)
     template = {
         "AWSTemplateFormatVersion": "2010-09-09",

--- a/tests/test_cognitoidentity/test_cognitoidentity.py
+++ b/tests/test_cognitoidentity/test_cognitoidentity.py
@@ -1,6 +1,6 @@
 import os
 from datetime import datetime
-from unittest import SkipTest, mock
+from unittest import mock
 from uuid import UUID
 
 import boto3
@@ -174,7 +174,7 @@ def test_get_id():
 @mock.patch.dict(os.environ, {"MOTO_ALLOW_NONEXISTENT_REGION": "trUe"})
 def test_get_id__unknown_region():
     if settings.TEST_SERVER_MODE:
-        raise SkipTest("Cannot set environemnt variables in ServerMode")
+        raise pytest.skip("Cannot set environemnt variables in ServerMode")
     conn = boto3.client("cognito-identity")
     identity_pool_data = conn.create_identity_pool(
         IdentityPoolName="test_identity_pool", AllowUnauthenticatedIdentities=True

--- a/tests/test_cognitoidp/test_cognitoidp.py
+++ b/tests/test_cognitoidp/test_cognitoidp.py
@@ -7,7 +7,7 @@ import random
 import re
 import time
 import uuid
-from unittest import SkipTest, mock
+from unittest import mock
 from uuid import UUID
 
 import boto3
@@ -536,7 +536,7 @@ def test_create_user_pool_default_id_strategy():
 @mock.patch.dict(os.environ, {"MOTO_COGNITO_IDP_USER_POOL_ID_STRATEGY": "HASH"})
 def test_create_user_pool_hash_id_strategy_with_equal_pool_name():
     if settings.TEST_SERVER_MODE:
-        raise SkipTest("Cannot set environemnt variables in ServerMode")
+        raise pytest.skip("Cannot set environemnt variables in ServerMode")
 
     conn = boto3.client("cognito-idp", "us-west-2")
 
@@ -550,7 +550,7 @@ def test_create_user_pool_hash_id_strategy_with_equal_pool_name():
 @mock.patch.dict(os.environ, {"MOTO_COGNITO_IDP_USER_POOL_ID_STRATEGY": "HASH"})
 def test_create_user_pool_hash_id_strategy_with_different_pool_name():
     if settings.TEST_SERVER_MODE:
-        raise SkipTest("Cannot set environemnt variables in ServerMode")
+        raise pytest.skip("Cannot set environemnt variables in ServerMode")
 
     conn = boto3.client("cognito-idp", "us-west-2")
 
@@ -564,7 +564,7 @@ def test_create_user_pool_hash_id_strategy_with_different_pool_name():
 @mock.patch.dict(os.environ, {"MOTO_COGNITO_IDP_USER_POOL_ID_STRATEGY": "HASH"})
 def test_create_user_pool_hash_id_strategy_with_different_attributes():
     if settings.TEST_SERVER_MODE:
-        raise SkipTest("Cannot set environemnt variables in ServerMode")
+        raise pytest.skip("Cannot set environemnt variables in ServerMode")
 
     conn = boto3.client("cognito-idp", "us-west-2")
 
@@ -1002,7 +1002,7 @@ def test_create_user_pool_client_default_id_strategy():
 @mock.patch.dict(os.environ, {"MOTO_COGNITO_IDP_USER_POOL_CLIENT_ID_STRATEGY": "HASH"})
 def test_create_user_pool_client_hash_id_strategy_with_equal_args():
     if settings.TEST_SERVER_MODE:
-        raise SkipTest("Cannot set environemnt variables in ServerMode")
+        raise pytest.skip("Cannot set environemnt variables in ServerMode")
 
     conn = boto3.client("cognito-idp", "us-west-2")
 
@@ -1024,7 +1024,7 @@ def test_create_user_pool_client_hash_id_strategy_with_equal_args():
 @mock.patch.dict(os.environ, {"MOTO_COGNITO_IDP_USER_POOL_CLIENT_ID_STRATEGY": "HASH"})
 def test_create_user_pool_client_hash_id_strategy_with_different_args():
     if settings.TEST_SERVER_MODE:
-        raise SkipTest("Cannot set environemnt variables in ServerMode")
+        raise pytest.skip("Cannot set environemnt variables in ServerMode")
 
     conn = boto3.client("cognito-idp", "us-west-2")
 
@@ -2860,7 +2860,7 @@ def test_list_users_inherent_attributes():
 @mock_aws
 def test_get_user_unconfirmed():
     if settings.TEST_SERVER_MODE:
-        raise SkipTest("Cant patch attributes in server mode.")
+        raise pytest.skip("Cant patch attributes in server mode.")
     conn = boto3.client("cognito-idp", "us-west-2")
     outputs = authentication_flow(conn, "ADMIN_NO_SRP_AUTH")
 

--- a/tests/test_config/test_config.py
+++ b/tests/test_config/test_config.py
@@ -2,7 +2,6 @@ import json
 import os
 import time
 from datetime import datetime, timedelta
-from unittest import SkipTest
 
 import boto3
 import pytest
@@ -1952,7 +1951,7 @@ def test_put_evaluations():
     assert ce.value.response["Error"]["Code"] == "InvalidResultTokenException"
 
     if os.environ.get("TEST_SERVER_MODE", "false").lower() == "true":
-        raise SkipTest("Does not work in server mode due to error in Workzeug")
+        raise pytest.skip("Does not work in server mode due to error in Workzeug")
     else:
         # Try without TestMode supplied:
         with pytest.raises(NotImplementedError):
@@ -2509,7 +2508,7 @@ def test_put_resource_config():
 @mock_aws
 def test_delete_resource_config():
     if not settings.TEST_DECORATOR_MODE:
-        raise SkipTest(
+        raise pytest.skip(
             "Test fails in server mode because the backend reference doesn't access the same instance that the client uses"
         )
 
@@ -2561,7 +2560,7 @@ def test_delete_resource_config():
 @mock_aws
 def test_select_resource_config_with_query_results_queue():
     if not settings.TEST_DECORATOR_MODE:
-        raise SkipTest(
+        raise pytest.skip(
             "Test fails in server mode because the backend reference doesn't access the same instance that the client uses"
         )
 
@@ -2602,7 +2601,7 @@ def test_select_resource_config_with_query_results_queue():
 @mock_aws
 def test_select_resource_config_with_expression_results():
     if not settings.TEST_DECORATOR_MODE:
-        raise SkipTest(
+        raise pytest.skip(
             "Test fails in server mode because the backend reference doesn't access the same instance that the client uses"
         )
 

--- a/tests/test_core/test_account_id_resolution.py
+++ b/tests/test_core/test_account_id_resolution.py
@@ -1,7 +1,7 @@
 import os
 from typing import Optional
-from unittest import SkipTest
 
+import pytest
 import requests
 import xmltodict
 
@@ -16,7 +16,7 @@ BASE_URL = f"http://localhost:{SERVER_PORT}/"
 class TestAccountIdResolution:
     def setup_method(self) -> None:
         if settings.TEST_SERVER_MODE:
-            raise SkipTest(
+            raise pytest.skip(
                 "No point in testing this in ServerMode, as we already start our own server"
             )
         self.server = ThreadedMotoServer(port=SERVER_PORT, verbose=False)

--- a/tests/test_core/test_auth.py
+++ b/tests/test_core/test_auth.py
@@ -1,7 +1,6 @@
 import json
 import sys
 from typing import Any, Optional
-from unittest import SkipTest
 from uuid import uuid4
 
 import boto3
@@ -228,7 +227,7 @@ def test_invalid_client_token_id() -> None:
 @mock_aws
 def test_auth_failure() -> None:
     if LooseVersion(boto3_version) < LooseVersion("1.29.0"):
-        raise SkipTest("Error handling is different in newer versions")
+        raise pytest.skip("Error handling is different in newer versions")
     client = boto3.client(
         "ec2",
         region_name="us-east-1",
@@ -269,7 +268,7 @@ def test_signature_does_not_match() -> None:
 @mock_aws
 def test_auth_failure_with_valid_access_key_id() -> None:
     if LooseVersion(boto3_version) < LooseVersion("1.29.0"):
-        raise SkipTest("Error handling is different in newer versions")
+        raise pytest.skip("Error handling is different in newer versions")
     access_key = create_user_with_access_key()
     client = boto3.client(
         "ec2",
@@ -291,7 +290,7 @@ def test_auth_failure_with_valid_access_key_id() -> None:
 @mock_aws
 def test_access_denied_with_no_policy() -> None:
     if LooseVersion(boto3_version) < LooseVersion("1.29.0"):
-        raise SkipTest("Error handling is different in newer versions")
+        raise pytest.skip("Error handling is different in newer versions")
     user_name = "test-user"
     access_key = create_user_with_access_key(user_name)
     client = boto3.client(
@@ -314,7 +313,7 @@ def test_access_denied_with_no_policy() -> None:
 @mock_aws
 def test_access_denied_with_not_allowing_policy() -> None:
     if LooseVersion(boto3_version) < LooseVersion("1.29.0"):
-        raise SkipTest("Error handling is different in newer versions")
+        raise pytest.skip("Error handling is different in newer versions")
     user_name = "test-user"
     inline_policy_document = {
         "Version": "2012-10-17",
@@ -384,7 +383,7 @@ def test_access_denied_explicitly_on_specific_resource() -> None:
 @mock_aws
 def test_access_denied_for_run_instances() -> None:
     if LooseVersion(boto3_version) < LooseVersion("1.29.0"):
-        raise SkipTest("Error handling is different in newer versions")
+        raise pytest.skip("Error handling is different in newer versions")
     # https://github.com/getmoto/moto/issues/2774
     # The run-instances method was broken between botocore versions 1.15.8 and 1.15.12
     # This was due to the inclusion of '"idempotencyToken":true' in the response, somehow altering the signature and breaking the authentication
@@ -419,7 +418,7 @@ def test_access_denied_for_run_instances() -> None:
 @mock_aws
 def test_access_denied_with_denying_policy() -> None:
     if LooseVersion(boto3_version) < LooseVersion("1.29.0"):
-        raise SkipTest("Error handling is different in newer versions")
+        raise pytest.skip("Error handling is different in newer versions")
     user_name = "test-user"
     inline_policy_document = {
         "Version": "2012-10-17",
@@ -582,7 +581,7 @@ def test_s3_access_denied_with_denying_inline_group_policy() -> None:
 @mock_aws
 def test_access_denied_with_many_irrelevant_policies() -> None:
     if LooseVersion(boto3_version) < LooseVersion("1.29.0"):
-        raise SkipTest("Error handling is different in newer versions")
+        raise pytest.skip("Error handling is different in newer versions")
     user_name = "test-user"
     inline_policy_document = {
         "Version": "2012-10-17",

--- a/tests/test_core/test_config.py
+++ b/tests/test_core/test_config.py
@@ -1,5 +1,3 @@
-from unittest import SkipTest
-
 import boto3
 import pytest
 import requests
@@ -59,7 +57,7 @@ def test_change_configuration_using_api() -> None:
 
 def test_whitelist() -> None:
     if not settings.TEST_DECORATOR_MODE:
-        raise SkipTest("No point in testing this anywhere else")
+        raise pytest.skip("No point in testing this anywhere else")
 
     with mock_aws(config={"core": {"service_whitelist": ["s3"]}}):
         dynamodb = boto3.client("dynamodb", "us-east-1")

--- a/tests/test_core/test_decorator_calls.py
+++ b/tests/test_core/test_decorator_calls.py
@@ -2,7 +2,7 @@ import inspect
 import os
 import unittest
 from typing import Any
-from unittest import SkipTest, mock
+from unittest import mock
 
 import boto3
 import pytest
@@ -63,7 +63,7 @@ def test_context_decorator_exposes_bare_essentials(mock_class: Any) -> None:  # 
 @pytest.mark.network
 def test_decorator_start_and_stop() -> None:
     if settings.TEST_SERVER_MODE:
-        raise SkipTest("Authentication always works in ServerMode")
+        raise pytest.skip("Authentication always works in ServerMode")
     my_mock = mock_aws()
     my_mock.start()
     client = boto3.client("ec2", region_name="us-west-1")

--- a/tests/test_core/test_importorder.py
+++ b/tests/test_core/test_importorder.py
@@ -1,6 +1,5 @@
 import sys
 from typing import Any
-from unittest import SkipTest
 
 import boto3
 import pytest
@@ -15,7 +14,7 @@ boto3_version = sys.modules["botocore"].__version__
 def fixture_aws_credentials(monkeypatch: Any) -> None:  # type: ignore[misc]
     """Mocked AWS Credentials for moto."""
     if settings.TEST_SERVER_MODE:
-        raise SkipTest("No point in testing this in ServerMode.")
+        raise pytest.skip("No point in testing this in ServerMode.")
     monkeypatch.setenv("AWS_ACCESS_KEY_ID", "testing")
     monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "testing")
     monkeypatch.setenv("AWS_SECURITY_TOKEN", "testing")
@@ -75,7 +74,7 @@ def test_mock_works_with_resource_created_outside(
 
 def test_patch_can_be_called_on_a_mocked_client() -> None:
     if LooseVersion(boto3_version) < LooseVersion("1.29.0"):
-        raise SkipTest("Error handling is different in newer versions")
+        raise pytest.skip("Error handling is different in newer versions")
     # start S3 after the mock, ensuring that the client contains our event-handler
     m = mock_aws()
     m.start()
@@ -125,7 +124,7 @@ def test_mock_works_when_replacing_client(
     aws_credentials: Any,
 ) -> None:
     if LooseVersion(boto3_version) < LooseVersion("1.29.0"):
-        raise SkipTest("Error handling is different in newer versions")
+        raise pytest.skip("Error handling is different in newer versions")
     logic = ImportantBusinessLogic()
 
     m = mock_aws()

--- a/tests/test_core/test_mock_regions.py
+++ b/tests/test_core/test_mock_regions.py
@@ -1,5 +1,5 @@
 import os
-from unittest import SkipTest, mock
+from unittest import mock
 
 import boto3
 import pytest
@@ -10,7 +10,7 @@ from moto import mock_aws, settings
 @mock_aws
 def test_use_invalid_region() -> None:
     if settings.TEST_SERVER_MODE:
-        raise SkipTest("ServerMode will throw different errors")
+        raise pytest.skip("ServerMode will throw different errors")
     client = boto3.client("sns", region_name="any-region")
     with pytest.raises(KeyError) as exc:
         client.list_platform_applications()
@@ -28,7 +28,7 @@ def test_use_region_from_env() -> None:  # type: ignore[misc]
 @mock.patch.dict(os.environ, {"AWS_DEFAULT_REGION": "any-region"})
 def test_use_unknown_region_from_env() -> None:  # type: ignore[misc]
     if settings.TEST_SERVER_MODE:
-        raise SkipTest("Cannot set environment variables in ServerMode")
+        raise pytest.skip("Cannot set environment variables in ServerMode")
     client = boto3.client("sns")
     with pytest.raises(KeyError) as exc:
         client.list_platform_applications()
@@ -40,7 +40,7 @@ def test_use_unknown_region_from_env() -> None:  # type: ignore[misc]
 @mock.patch.dict(os.environ, {"MOTO_ALLOW_NONEXISTENT_REGION": "trUe"})
 def test_use_unknown_region_from_env_but_allow_it() -> None:  # type: ignore[misc]
     if settings.TEST_SERVER_MODE:
-        raise SkipTest("Cannot set environemnt variables in ServerMode")
+        raise pytest.skip("Cannot set environemnt variables in ServerMode")
     client = boto3.client("sns")
     assert client.list_platform_applications()["PlatformApplications"] == []
 
@@ -49,7 +49,7 @@ def test_use_unknown_region_from_env_but_allow_it() -> None:  # type: ignore[mis
 @mock.patch.dict(os.environ, {"MOTO_ALLOW_NONEXISTENT_REGION": "trUe"})
 def test_use_unknown_region_from_env_but_allow_it__dynamo() -> None:  # type: ignore[misc]
     if settings.TEST_SERVER_MODE:
-        raise SkipTest("Cannot set environemnt variables in ServerMode")
+        raise pytest.skip("Cannot set environemnt variables in ServerMode")
     dynamo_db = boto3.resource("dynamodb", region_name="test")
     dynamo_db.create_table(
         TableName="test_table",

--- a/tests/test_core/test_moto_api.py
+++ b/tests/test_core/test_moto_api.py
@@ -1,5 +1,5 @@
 import json
-from unittest import SkipTest, TestCase
+from unittest import TestCase
 
 import boto3
 import pytest
@@ -43,7 +43,7 @@ def test_data_api() -> None:
 @mock_aws
 def test_overwriting_s3_object_still_returns_data() -> None:
     if settings.TEST_SERVER_MODE:
-        raise SkipTest("No point in testing this behaves the same in ServerMode")
+        raise pytest.skip("No point in testing this behaves the same in ServerMode")
     s3 = boto3.client("s3", region_name="us-east-1")
     s3.create_bucket(Bucket="test")
     s3.put_object(Bucket="test", Body=b"t", Key="file.txt")
@@ -55,7 +55,7 @@ def test_overwriting_s3_object_still_returns_data() -> None:
 @mock_aws
 def test_creation_error__data_api_still_returns_thing() -> None:
     if settings.TEST_SERVER_MODE:
-        raise SkipTest("No point in testing this behaves the same in ServerMode")
+        raise pytest.skip("No point in testing this behaves the same in ServerMode")
     # Timeline:
     #
     # When calling BaseModel.__new__, the created instance (of type FakeAutoScalingGroup) is stored in `model_data`
@@ -89,7 +89,7 @@ def test_creation_error__data_api_still_returns_thing() -> None:
 
 def test_model_data_is_emptied_as_necessary() -> None:
     if settings.TEST_SERVER_MODE:
-        raise SkipTest("We're only interested in the decorator performance here")
+        raise pytest.skip("We're only interested in the decorator performance here")
 
     # Reset any residual data
     reset_model_data()
@@ -133,7 +133,7 @@ def test_model_data_is_emptied_as_necessary() -> None:
 class TestModelDataResetForClassDecorator(TestCase):
     def setUp(self) -> None:
         if settings.TEST_SERVER_MODE:
-            raise SkipTest("We're only interested in the decorator performance here")
+            raise pytest.skip("We're only interested in the decorator performance here")
 
         # No data is present at the beginning
         for classes_per_service in model_data.values():

--- a/tests/test_core/test_proxy.py
+++ b/tests/test_core/test_proxy.py
@@ -1,6 +1,5 @@
 from http.server import BaseHTTPRequestHandler
 from typing import Any
-from unittest import SkipTest
 
 import pytest
 import requests
@@ -29,7 +28,7 @@ def server() -> Any:  # type: ignore[misc]
 
 def test_real_request_errors() -> None:
     if not settings.is_test_proxy_mode():
-        raise SkipTest("Can only be tested in ProxyMode")
+        raise pytest.skip("Can only be tested in ProxyMode")
 
     http_proxy = settings.test_proxy_mode_endpoint()
     https_proxy = settings.test_proxy_mode_endpoint()
@@ -45,7 +44,7 @@ def test_real_request_errors() -> None:
 
 def test_configure_passedthrough_urls() -> None:
     if not settings.is_test_proxy_mode():
-        raise SkipTest("Can only be tested in ProxyMode")
+        raise pytest.skip("Can only be tested in ProxyMode")
 
     http_proxy = settings.test_proxy_mode_endpoint()
     https_proxy = settings.test_proxy_mode_endpoint()
@@ -90,7 +89,7 @@ def test_configure_passedthrough_urls() -> None:
 
 def test_http_get_request_can_be_passed_through(server: Any) -> None:
     if not settings.is_test_proxy_mode():
-        raise SkipTest("Can only be tested in ProxyMode")
+        raise pytest.skip("Can only be tested in ProxyMode")
 
     http_proxy = settings.test_proxy_mode_endpoint()
     https_proxy = settings.test_proxy_mode_endpoint()
@@ -110,9 +109,9 @@ def test_http_get_request_can_be_passed_through(server: Any) -> None:
 
 
 def test_https_request_can_be_passed_through() -> None:
-    raise SkipTest("Times out regularly")
+    raise pytest.skip("Times out regularly")
     if not settings.is_test_proxy_mode():
-        raise SkipTest("Can only be tested in ProxyMode")
+        raise pytest.skip("Can only be tested in ProxyMode")
 
     http_proxy = settings.test_proxy_mode_endpoint()
     https_proxy = settings.test_proxy_mode_endpoint()

--- a/tests/test_core/test_request_mocking.py
+++ b/tests/test_core/test_request_mocking.py
@@ -1,5 +1,3 @@
-from unittest import SkipTest
-
 import boto3
 import pytest
 import requests
@@ -57,7 +55,7 @@ def test_decorator_ordering() -> None:
 @mock_aws()
 def test_replace_and_remove_mock() -> None:
     if not settings.TEST_DECORATOR_MODE:
-        raise SkipTest("Only need to test responses mock in decorator mode")
+        raise pytest.skip("Only need to test responses mock in decorator mode")
     rsp1 = Response(method="GET", url="http://example.com", body="test")
     responses_mock.add(rsp1)
 

--- a/tests/test_core/test_request_passthrough.py
+++ b/tests/test_core/test_request_passthrough.py
@@ -1,5 +1,4 @@
 import os
-from unittest import SkipTest
 from unittest.mock import patch
 
 import boto3
@@ -13,9 +12,9 @@ from moto.core.versions import is_werkzeug_2_0_x_or_older
 
 def test_passthrough_calls_for_entire_service() -> None:
     if not settings.TEST_DECORATOR_MODE:
-        raise SkipTest("Can only test config when using decorators")
+        raise pytest.skip("Can only test config when using decorators")
     if is_werkzeug_2_0_x_or_older():
-        raise SkipTest(
+        raise pytest.skip(
             "Bug in old werkzeug versions where headers with byte-values throw errors"
         )
     # Still mock the credentials ourselves, we don't want to reach out to AWS for real
@@ -54,9 +53,9 @@ def test_passthrough_calls_for_entire_service() -> None:
 
 def test_passthrough_calls_for_specific_url() -> None:
     if not settings.TEST_DECORATOR_MODE:
-        raise SkipTest("Can only test config when using decorators")
+        raise pytest.skip("Can only test config when using decorators")
     if is_werkzeug_2_0_x_or_older():
-        raise SkipTest(
+        raise pytest.skip(
             "Bug in old werkzeug versions where headers with byte-values throw errors"
         )
     # Still mock the credentials ourselves, we don't want to reach out to AWS for real
@@ -94,7 +93,7 @@ def test_passthrough_calls_for_specific_url() -> None:
 
 def test_passthrough_calls_for_wildcard_urls() -> None:
     if not settings.TEST_DECORATOR_MODE:
-        raise SkipTest("Can only test config when using decorators")
+        raise pytest.skip("Can only test config when using decorators")
     # Still mock the credentials ourselves, we don't want to reach out to AWS for real
     with patch.dict(
         os.environ, {"AWS_ACCESS_KEY_ID": "a", "AWS_SECRET_ACCESS_KEY": "b"}
@@ -130,7 +129,7 @@ def test_passthrough_calls_for_wildcard_urls() -> None:
 
 def test_passthrough__using_unsupported_service() -> None:
     if not settings.TEST_DECORATOR_MODE:
-        raise SkipTest("Can only test config when using decorators")
+        raise pytest.skip("Can only test config when using decorators")
     with patch.dict(
         os.environ, {"AWS_ACCESS_KEY_ID": "a", "AWS_SECRET_ACCESS_KEY": "b"}
     ):

--- a/tests/test_core/test_responses.py
+++ b/tests/test_core/test_responses.py
@@ -2,8 +2,9 @@ import datetime
 from collections import OrderedDict
 from gzip import compress as gzip_compress
 from typing import Any
-from unittest import SkipTest, mock
+from unittest import mock
 
+import pytest
 from botocore.awsrequest import AWSPreparedRequest, HTTPHeaders
 from freezegun import freeze_time
 
@@ -119,7 +120,7 @@ def test_response_environment_preserved_by_type() -> None:
 )
 def test_jinja_render_prettify(m_env_var: Any) -> None:  # type: ignore[misc]
     if settings.TEST_SERVER_MODE:
-        raise SkipTest(
+        raise pytest.skip(
             "It is not possible to set the environment variable in server mode"
         )
     response = BaseResponse()

--- a/tests/test_core/test_responses_module.py
+++ b/tests/test_core/test_responses_module.py
@@ -3,9 +3,10 @@ Ensure that the responses module plays nice with our mocks
 """
 
 from http.server import BaseHTTPRequestHandler
-from unittest import SkipTest, TestCase
+from unittest import TestCase
 
 import boto3
+import pytest
 import requests
 import responses
 
@@ -20,7 +21,7 @@ from .utilities import SimpleServer
 class TestResponsesModule(TestCase):
     def setUp(self) -> None:
         if settings.TEST_SERVER_MODE:
-            raise SkipTest("No point in testing responses-decorator in ServerMode")
+            raise pytest.skip("No point in testing responses-decorator in ServerMode")
 
     @mock_aws
     @responses.activate
@@ -86,7 +87,7 @@ class TestResponsesMockWithPassThru(TestCase):
 
     def setUp(self) -> None:
         if RESPONSES_VERSION < LooseVersion("0.24.0"):
-            raise SkipTest("Can only test this with responses >= 0.24.0")
+            raise pytest.skip("Can only test this with responses >= 0.24.0")
 
         self.server = SimpleServer(WebRequestHandler)
         self.server.start()

--- a/tests/test_dynamodb/exceptions/test_dynamodb_exceptions.py
+++ b/tests/test_dynamodb/exceptions/test_dynamodb_exceptions.py
@@ -1,5 +1,4 @@
 from decimal import Decimal
-from unittest import SkipTest
 from uuid import uuid4
 
 import boto3
@@ -1226,7 +1225,7 @@ class TestDuplicateProjectionExpressions(BaseTest):
 @mock_aws
 def test_put_item_wrong_datatype():
     if settings.TEST_SERVER_MODE:
-        raise SkipTest("Unable to mock a session with Config in ServerMode")
+        raise pytest.skip("Unable to mock a session with Config in ServerMode")
     session = botocore.session.Session()
     config = botocore.client.Config(parameter_validation=False)
     table_name = f"T{uuid4()}"
@@ -1557,7 +1556,7 @@ def test_update_primary_key():
 @mock_aws
 def test_put_item__string_as_integer_value():
     if settings.TEST_SERVER_MODE:
-        raise SkipTest("Unable to mock a session with Config in ServerMode")
+        raise pytest.skip("Unable to mock a session with Config in ServerMode")
     config = botocore.client.Config(parameter_validation=False)
     client = boto3.client("dynamodb", region_name="us-east-1", config=config)
     table_name = f"T{uuid4()}"

--- a/tests/test_dynamodb/test_dynamodb_export_table.py
+++ b/tests/test_dynamodb/test_dynamodb_export_table.py
@@ -2,7 +2,7 @@ import gzip
 import json
 import os
 from time import sleep
-from unittest import SkipTest, mock
+from unittest import mock
 from uuid import uuid4
 
 import boto3
@@ -97,7 +97,7 @@ def test_export_backup_to_s3_error(table_name=None, bucket_name=None):
         os.environ.get("MOTO_TEST_ALLOW_AWS_REQUEST", "false").lower() == "true"
     )
     if not settings.TEST_DECORATOR_MODE or aws_request:
-        raise SkipTest("Can't mock backup to s3 error in ServerMode/against AWS")
+        raise pytest.skip("Can't mock backup to s3 error in ServerMode/against AWS")
 
     client = boto3.client("dynamodb", region_name="us-east-1")
 

--- a/tests/test_dynamodb_v20111205/test_servermode.py
+++ b/tests/test_dynamodb_v20111205/test_servermode.py
@@ -1,7 +1,7 @@
 import json
-from unittest import SkipTest
 from uuid import uuid4
 
+import pytest
 import requests
 
 from moto import settings
@@ -15,7 +15,7 @@ https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Appendix.APIv20
 
 def test_table_list():
     if not settings.TEST_SERVER_MODE:
-        raise SkipTest("Only run test with external server")
+        raise pytest.skip("Only run test with external server")
     headers = {
         "X-Amz-Target": "DynamoDB_20111205.ListTables",
         "AUTHORIZATION": "AWS4-HMAC-SHA256 Credential=ACCESS_KEY/20220226/us-east-1/dynamodb/aws4_request, SignedHeaders=content-type;host;x-amz-date;x-amz-target, Signature=sig",
@@ -28,7 +28,7 @@ def test_table_list():
 
 def test_create_table():
     if not settings.TEST_SERVER_MODE:
-        raise SkipTest("Only run test with external server")
+        raise pytest.skip("Only run test with external server")
 
     table_name = str(uuid4())
 

--- a/tests/test_ec2/test_amis.py
+++ b/tests/test_ec2/test_amis.py
@@ -1,6 +1,6 @@
 import os
 import random
-from unittest import SkipTest, mock
+from unittest import mock
 from uuid import uuid4
 
 import boto3
@@ -20,7 +20,7 @@ from tests import EXAMPLE_AMI_ID, EXAMPLE_AMI_PARAVIRTUAL
 @mock_aws
 def test_snapshots_for_initial_amis():
     if settings.TEST_SERVER_MODE:
-        raise SkipTest("Can't set environment variables in ServerMode")
+        raise pytest.skip("Can't set environment variables in ServerMode")
     ec2 = boto3.client("ec2", region_name="us-east-1")
 
     snapshots = ec2.describe_snapshots()["Snapshots"]
@@ -41,7 +41,7 @@ def test_snapshots_for_initial_amis():
 @mock_aws
 def test_ami_create_and_delete():
     if settings.TEST_SERVER_MODE:
-        raise SkipTest("Can't set environment variables in ServerMode")
+        raise pytest.skip("Can't set environment variables in ServerMode")
     ec2 = boto3.client("ec2", region_name="us-east-1")
 
     reservation = ec2.run_instances(ImageId=EXAMPLE_AMI_ID, MinCount=1, MaxCount=1)
@@ -196,7 +196,7 @@ def test_ami_copy_dryrun():
 @mock_aws
 def test_ami_copy():
     if settings.TEST_SERVER_MODE:
-        raise SkipTest("Can't set environment variables in ServerMode")
+        raise pytest.skip("Can't set environment variables in ServerMode")
     ec2 = boto3.client("ec2", region_name="us-west-1")
 
     reservation = ec2.run_instances(ImageId=EXAMPLE_AMI_ID, MinCount=1, MaxCount=1)
@@ -287,7 +287,7 @@ def test_ami_copy_nonexisting_source_region():
 @mock_aws
 def test_copy_image_changes_owner_id():
     if settings.TEST_SERVER_MODE:
-        raise SkipTest("Can't set environment variables in ServerMode")
+        raise pytest.skip("Can't set environment variables in ServerMode")
     conn = boto3.client("ec2", region_name="us-east-1")
 
     # this source AMI ID is from moto/ec2/resources/amis.json
@@ -396,7 +396,7 @@ def test_ami_uses_account_id_if_valid_access_key_is_supplied():
 @mock_aws
 def test_ami_filters():
     if settings.TEST_SERVER_MODE:
-        raise SkipTest("Can't set environment variables in ServerMode")
+        raise pytest.skip("Can't set environment variables in ServerMode")
     image_name_A = f"test-ami-{str(uuid4())[0:6]}"
     kernel_value_A = f"k-{str(uuid4())[0:6]}"
     kernel_value_B = f"k-{str(uuid4())[0:6]}"
@@ -978,7 +978,7 @@ def test_ami_attribute_user_and_group_permissions():
 @mock_aws
 def test_filter_description():
     if settings.TEST_SERVER_MODE:
-        raise SkipTest("Can't set environment variables in ServerMode")
+        raise pytest.skip("Can't set environment variables in ServerMode")
     # https://github.com/getmoto/moto/issues/4460
     client = boto3.client("ec2", region_name="us-west-2")
 
@@ -1153,7 +1153,7 @@ def test_ami_filter_wildcard():
 @mock_aws
 def test_ami_filter_by_owner_id():
     if settings.TEST_SERVER_MODE:
-        raise SkipTest("Can't set environment variables in ServerMode")
+        raise pytest.skip("Can't set environment variables in ServerMode")
     client = boto3.client("ec2", region_name="us-east-1")
 
     ubuntu_id = "099720109477"
@@ -1342,7 +1342,7 @@ def test_ami_filter_by_source_instance_id():
 @mock_aws
 def test_ami_filter_by_ownerid():
     if settings.TEST_SERVER_MODE:
-        raise SkipTest("Can't set environment variables in ServerMode")
+        raise pytest.skip("Can't set environment variables in ServerMode")
     ec2_connection = boto3.client("ec2", region_name="us-east-1")
 
     images = ec2_connection.describe_images(
@@ -1444,7 +1444,7 @@ def test_delete_snapshot_from_create_image():
 @mock_aws
 def test_ami_describe_image_attribute_product_codes():
     if settings.TEST_SERVER_MODE:
-        raise SkipTest("Can't set environment variables in ServerMode")
+        raise pytest.skip("Can't set environment variables in ServerMode")
     # Setup
     conn = boto3.client("ec2", region_name="us-east-1")
 
@@ -1472,7 +1472,7 @@ def test_ami_describe_image_attribute_product_codes():
 @mock_aws
 def test_ami_describe_image_attribute():
     if settings.TEST_SERVER_MODE:
-        raise SkipTest("Can't set environment variables in ServerMode")
+        raise pytest.skip("Can't set environment variables in ServerMode")
     # Setup
     conn = boto3.client("ec2", region_name="us-east-1")
 
@@ -1506,7 +1506,7 @@ def test_ami_describe_image_attribute():
 @mock_aws
 def test_ami_describe_image_attribute_block_device_fail():
     if settings.TEST_SERVER_MODE:
-        raise SkipTest("Can't set environment variables in ServerMode")
+        raise pytest.skip("Can't set environment variables in ServerMode")
     # Setup
     conn = boto3.client("ec2", region_name="us-east-1")
     test_image = conn.describe_images()
@@ -1530,7 +1530,7 @@ def test_ami_describe_image_attribute_block_device_fail():
 @mock_aws
 def test_ami_describe_image_attribute_invalid_param():
     if settings.TEST_SERVER_MODE:
-        raise SkipTest("Can't set environment variables in ServerMode")
+        raise pytest.skip("Can't set environment variables in ServerMode")
     # Setup
     conn = boto3.client("ec2", region_name="us-east-1")
     test_image = conn.describe_images()

--- a/tests/test_ec2/test_carrier_gateways.py
+++ b/tests/test_ec2/test_carrier_gateways.py
@@ -1,5 +1,3 @@
-from unittest import SkipTest
-
 import boto3
 import pytest
 from botocore.exceptions import ClientError
@@ -11,7 +9,7 @@ from moto.core import DEFAULT_ACCOUNT_ID as ACCOUNT_ID
 @mock_aws
 def test_describe_carrier_gateways_none():
     if settings.TEST_SERVER_MODE:
-        raise SkipTest("ServerMode is not guaranteed to be empty")
+        raise pytest.skip("ServerMode is not guaranteed to be empty")
     ec2 = boto3.client("ec2", region_name="us-east-1")
     assert ec2.describe_carrier_gateways()["CarrierGateways"] == []
 

--- a/tests/test_ec2/test_dhcp_options.py
+++ b/tests/test_ec2/test_dhcp_options.py
@@ -1,6 +1,5 @@
 import random
 import uuid
-from unittest import SkipTest
 
 import boto3
 import pytest
@@ -477,7 +476,7 @@ def test_dhcp_options_get_by_key_filter():
 @mock_aws
 def test_dhcp_options_get_by_invalid_filter():
     if settings.TEST_SERVER_MODE:
-        raise SkipTest("Will throw a generic 500 in ServerMode")
+        raise pytest.skip("Will throw a generic 500 in ServerMode")
     ec2 = boto3.resource("ec2", region_name="us-west-1")
 
     client = boto3.client("ec2", region_name="us-west-1")

--- a/tests/test_ec2/test_elastic_block_store.py
+++ b/tests/test_ec2/test_elastic_block_store.py
@@ -1,5 +1,5 @@
 import os
-from unittest import SkipTest, mock
+from unittest import mock
 from uuid import uuid4
 
 import boto3
@@ -1131,7 +1131,7 @@ def test_create_snapshots_multiple_volumes():
 @mock_aws
 def test_create_snapshots_multiple_volumes_without_boot():
     if settings.TEST_SERVER_MODE:
-        raise SkipTest("Can't set environment variables in ServerMode")
+        raise pytest.skip("Can't set environment variables in ServerMode")
     client = boto3.client("ec2", region_name="us-east-1")
     ec2 = boto3.resource("ec2", region_name="us-east-1")
 

--- a/tests/test_ec2/test_instances.py
+++ b/tests/test_ec2/test_instances.py
@@ -3,7 +3,7 @@ import ipaddress
 import json
 import os
 import warnings
-from unittest import SkipTest, mock
+from unittest import mock
 from uuid import uuid4
 
 import boto3
@@ -1229,7 +1229,7 @@ def test_run_instance_with_default_placement():
 )
 def test_run_instance_with_invalid_instance_type(m_flag):
     if settings.TEST_SERVER_MODE:
-        raise SkipTest(
+        raise pytest.skip(
             "It is not possible to set the environment variable in server mode"
         )
     ec2 = boto3.resource("ec2", region_name="us-east-1")
@@ -1672,7 +1672,7 @@ def test_describe_instances_with_keypair_filter():
 )
 def test_run_instance_with_invalid_keypair(m_flag):
     if settings.TEST_SERVER_MODE:
-        raise SkipTest(
+        raise pytest.skip(
             "It is not possible to set the environment variable in server mode"
         )
     ec2 = boto3.resource("ec2", region_name="us-east-1")
@@ -1836,7 +1836,7 @@ def test_run_instance_with_block_device_mappings_from_snapshot():
 @mock_aws
 def test_describe_instance_status_no_instances():
     if settings.TEST_SERVER_MODE:
-        raise SkipTest("ServerMode is not guaranteed to be empty")
+        raise pytest.skip("ServerMode is not guaranteed to be empty")
     client = boto3.client("ec2", region_name="us-east-1")
     all_status = client.describe_instance_status()["InstanceStatuses"]
     assert len(all_status) == 0
@@ -2302,7 +2302,7 @@ def test_describe_instance_attribute():
 )
 def test_error_on_invalid_ami(m_flag):
     if settings.TEST_SERVER_MODE:
-        raise SkipTest("Can't capture warnings in server mode.")
+        raise pytest.skip("Can't capture warnings in server mode.")
     ec2 = boto3.resource("ec2", "us-east-1")
     with pytest.raises(ClientError) as ex:
         ec2.create_instances(ImageId="ami-invalid", MinCount=1, MaxCount=1)
@@ -2323,7 +2323,7 @@ def test_error_on_invalid_ami(m_flag):
 )
 def test_error_on_invalid_ami_format(m_flag):
     if settings.TEST_SERVER_MODE:
-        raise SkipTest(
+        raise pytest.skip(
             "It is not possible to set the environment variable in server mode"
         )
     ec2 = boto3.resource("ec2", "us-east-1")
@@ -2533,7 +2533,7 @@ def test_create_instance_with_launch_template_id_produces_no_warning(
     launch_template_kind,
 ):
     if settings.TEST_SERVER_MODE:
-        raise SkipTest("Can't set environment variables in ServerMode")
+        raise pytest.skip("Can't set environment variables in ServerMode")
     client, resource = (
         boto3.client("ec2", region_name="us-west-1"),
         boto3.resource("ec2", region_name="us-west-1"),

--- a/tests/test_ec2/test_key_pairs.py
+++ b/tests/test_ec2/test_key_pairs.py
@@ -1,5 +1,4 @@
 from datetime import datetime
-from unittest import SkipTest
 from uuid import uuid4
 
 import boto3
@@ -94,7 +93,7 @@ moto@github.com"""
 @mock_aws
 def test_key_pairs_empty():
     if settings.TEST_SERVER_MODE:
-        raise SkipTest("ServerMode is not guaranteed to be empty")
+        raise pytest.skip("ServerMode is not guaranteed to be empty")
     client = boto3.client("ec2", "us-west-1")
     assert client.describe_key_pairs()["KeyPairs"] == []
 

--- a/tests/test_ec2/test_nat_gateway.py
+++ b/tests/test_ec2/test_nat_gateway.py
@@ -1,6 +1,5 @@
-from unittest import SkipTest
-
 import boto3
+import pytest
 
 from moto import mock_aws, settings
 
@@ -8,7 +7,7 @@ from moto import mock_aws, settings
 @mock_aws
 def test_describe_nat_gateways():
     if settings.TEST_SERVER_MODE:
-        raise SkipTest("ServerMode is not guaranteed to have no resources")
+        raise pytest.skip("ServerMode is not guaranteed to have no resources")
     conn = boto3.client("ec2", "us-east-1")
 
     response = conn.describe_nat_gateways()

--- a/tests/test_ec2/test_network_acls.py
+++ b/tests/test_ec2/test_network_acls.py
@@ -1,5 +1,4 @@
 from random import randint
-from unittest import SkipTest
 
 import boto3
 import pytest
@@ -41,7 +40,7 @@ def test_network_create_and_list_acls():
 @mock_aws
 def test_new_subnet_associates_with_default_network_acl():
     if settings.TEST_SERVER_MODE:
-        raise SkipTest("ServerMode will have conflicting CidrBlocks")
+        raise pytest.skip("ServerMode will have conflicting CidrBlocks")
     client = boto3.client("ec2", region_name="us-east-1")
     ec2 = boto3.resource("ec2", region_name="us-east-1")
     default_vpc = client.describe_vpcs()["Vpcs"][0]
@@ -265,7 +264,7 @@ def test_default_network_acl_default_entries():
 @mock_aws
 def test_delete_default_network_acl_default_entry():
     if settings.TEST_SERVER_MODE:
-        raise SkipTest(
+        raise pytest.skip(
             "Don't want to mess with default ACLs in ServerMode, as other tests may need them"
         )
     ec2 = boto3.resource("ec2", region_name="us-west-1")

--- a/tests/test_ec2/test_security_groups.py
+++ b/tests/test_ec2/test_security_groups.py
@@ -2,7 +2,6 @@ import copy
 import json
 import unittest
 from random import randint
-from unittest import SkipTest
 from uuid import uuid4
 
 import boto3
@@ -1850,7 +1849,7 @@ def test_filter_description():
 @mock_aws
 def test_filter_ip_permission__cidr():
     if settings.TEST_SERVER_MODE:
-        raise SkipTest(
+        raise pytest.skip(
             "CIDR's might already exist due to other tests creating IP ranges"
         )
     ec2r = boto3.resource("ec2", region_name=REGION)
@@ -1897,7 +1896,7 @@ def test_filter_ip_permission__cidr():
 @mock_aws
 def test_filter_egress__ip_permission__cidr():
     if settings.TEST_SERVER_MODE:
-        raise SkipTest(
+        raise pytest.skip(
             "CIDR's might already exist due to other tests creating IP ranges"
         )
     ec2r = boto3.resource("ec2", region_name=REGION)

--- a/tests/test_ec2/test_spot_instances.py
+++ b/tests/test_ec2/test_spot_instances.py
@@ -1,5 +1,4 @@
 import datetime
-from unittest import SkipTest
 from uuid import uuid4
 
 import boto3
@@ -302,7 +301,7 @@ def test_request_spot_instances_instance_lifecycle():
     if settings.TEST_SERVER_MODE:
         # Currently no easy way to check which instance was created by request_spot_instance
         # And we can't just pick the first instance in ServerMode and expect it to be the right one
-        raise SkipTest("ServerMode is not guaranteed to be empty")
+        raise pytest.skip("ServerMode is not guaranteed to be empty")
     client = boto3.client("ec2", region_name="us-east-1")
     client.request_spot_instances(SpotPrice="0.5")
 

--- a/tests/test_ec2/test_subnets.py
+++ b/tests/test_ec2/test_subnets.py
@@ -1,5 +1,4 @@
 import random
-from unittest import SkipTest
 from uuid import uuid4
 
 import boto3
@@ -183,7 +182,7 @@ def test_availability_zone_in_create_subnet():
 @mock_aws
 def test_default_subnet():
     if settings.TEST_SERVER_MODE:
-        raise SkipTest("ServerMode will have conflicting CidrBlocks")
+        raise pytest.skip("ServerMode will have conflicting CidrBlocks")
     ec2 = boto3.resource("ec2", region_name="us-west-1")
 
     default_vpc = list(ec2.vpcs.all())[0]
@@ -651,7 +650,7 @@ def test_create_subnet_with_tags():
 @mock_aws
 def test_available_ip_addresses_in_subnet():
     if settings.TEST_SERVER_MODE:
-        raise SkipTest(
+        raise pytest.skip(
             "ServerMode is not guaranteed to be empty - other subnets will affect the count"
         )
     ec2 = boto3.resource("ec2", region_name="us-west-1")
@@ -680,7 +679,7 @@ def test_available_ip_addresses_in_subnet():
 @mock_aws
 def test_available_ip_addresses_in_subnet_with_enis():
     if settings.TEST_SERVER_MODE:
-        raise SkipTest(
+        raise pytest.skip(
             "ServerMode is not guaranteed to be empty - other ENI's will affect the count"
         )
     ec2 = boto3.resource("ec2", region_name="us-west-1")

--- a/tests/test_ec2/test_transit_gateway.py
+++ b/tests/test_ec2/test_transit_gateway.py
@@ -1,5 +1,4 @@
 from time import sleep
-from unittest import SkipTest
 
 import boto3
 import pytest
@@ -18,7 +17,7 @@ from tests.test_ec2 import (
 @mock_aws
 def test_describe_transit_gateways():
     if settings.TEST_SERVER_MODE:
-        raise SkipTest("ServerMode is not guaranteed to be empty")
+        raise pytest.skip("ServerMode is not guaranteed to be empty")
     ec2 = boto3.client("ec2", region_name="us-west-1")
     response = ec2.describe_transit_gateways()
     assert response["TransitGateways"] == []
@@ -192,7 +191,7 @@ def test_modify_transit_gateway():
 @mock_aws
 def test_describe_transit_gateway_vpc_attachments():
     if settings.TEST_SERVER_MODE:
-        raise SkipTest("ServerMode is not guaranteed to be empty")
+        raise pytest.skip("ServerMode is not guaranteed to be empty")
     ec2 = boto3.client("ec2", region_name="us-west-1")
     response = ec2.describe_transit_gateway_vpc_attachments()
     assert response["TransitGatewayVpcAttachments"] == []
@@ -201,7 +200,7 @@ def test_describe_transit_gateway_vpc_attachments():
 @mock_aws
 def test_describe_transit_gateway_attachments():
     if settings.TEST_SERVER_MODE:
-        raise SkipTest("ServerMode is not guaranteed to be empty")
+        raise pytest.skip("ServerMode is not guaranteed to be empty")
     ec2 = boto3.client("ec2", region_name="us-west-1")
     response = ec2.describe_transit_gateway_attachments()
     assert response["TransitGatewayAttachments"] == []
@@ -343,7 +342,7 @@ def test_create_and_describe_transit_gateway_vpc_attachment(
 @mock_aws
 def test_describe_transit_gateway_route_tables():
     if settings.TEST_SERVER_MODE:
-        raise SkipTest("ServerMode is not guaranteed to be empty")
+        raise pytest.skip("ServerMode is not guaranteed to be empty")
     ec2 = boto3.client("ec2", region_name="us-west-1")
     response = ec2.describe_transit_gateway_route_tables()
     assert response["TransitGatewayRouteTables"] == []

--- a/tests/test_ec2/test_transit_gateway_peering_attachments.py
+++ b/tests/test_ec2/test_transit_gateway_peering_attachments.py
@@ -1,5 +1,5 @@
 import os
-from unittest import SkipTest, mock
+from unittest import mock
 
 import boto3
 import pytest
@@ -12,7 +12,7 @@ from moto.core import DEFAULT_ACCOUNT_ID as ACCOUNT_ID
 @mock_aws
 def test_describe_transit_gateway_peering_attachment_empty():
     if settings.TEST_SERVER_MODE:
-        raise SkipTest("ServerMode is not guaranteed to be empty")
+        raise pytest.skip("ServerMode is not guaranteed to be empty")
     ec2 = boto3.client("ec2", region_name="us-west-1")
 
     all_attachments = ec2.describe_transit_gateway_peering_attachments()[

--- a/tests/test_ec2/test_vpcs.py
+++ b/tests/test_ec2/test_vpcs.py
@@ -1,6 +1,5 @@
 import json
 import random
-from unittest import SkipTest
 from uuid import uuid4
 
 import boto3
@@ -19,7 +18,9 @@ SAMPLE_NAME_SERVERS = ["10.0.0.6", "10.0.0.7"]
 @mock_aws
 def test_creating_a_vpc_in_empty_region_does_not_make_this_vpc_the_default():
     if settings.TEST_SERVER_MODE:
-        raise SkipTest("Lets not start deleting VPC's while other tests are using it")
+        raise pytest.skip(
+            "Lets not start deleting VPC's while other tests are using it"
+        )
     # Delete VPC that's created by default
     client = boto3.client("ec2", region_name="eu-north-1")
     all_vpcs = retrieve_all_vpcs(client)
@@ -41,7 +42,9 @@ def test_creating_a_vpc_in_empty_region_does_not_make_this_vpc_the_default():
 @mock_aws
 def test_create_default_vpc():
     if settings.TEST_SERVER_MODE:
-        raise SkipTest("Lets not start deleting VPC's while other tests are using it")
+        raise pytest.skip(
+            "Lets not start deleting VPC's while other tests are using it"
+        )
     # Delete VPC that's created by default
     client = boto3.client("ec2", region_name="eu-north-1")
     all_vpcs = retrieve_all_vpcs(client)

--- a/tests/test_ec2/test_windows.py
+++ b/tests/test_ec2/test_windows.py
@@ -1,7 +1,8 @@
 import os
-from unittest import SkipTest, mock
+from unittest import mock
 
 import boto3
+import pytest
 
 from moto import mock_aws, settings
 from tests import EXAMPLE_AMI_PARAVIRTUAL, EXAMPLE_AMI_WINDOWS
@@ -13,7 +14,7 @@ from tests import EXAMPLE_AMI_PARAVIRTUAL, EXAMPLE_AMI_WINDOWS
 @mock_aws
 def test_get_password_data():
     if settings.TEST_SERVER_MODE:
-        raise SkipTest("Can't set environment variables in ServerMode")
+        raise pytest.skip("Can't set environment variables in ServerMode")
     client = boto3.client("ec2", region_name="us-east-1")
 
     # Ensure non-windows instances return empty password data

--- a/tests/test_ecr/test_ecr.py
+++ b/tests/test_ecr/test_ecr.py
@@ -1,6 +1,5 @@
 import json
 from datetime import datetime
-from unittest import SkipTest
 
 import boto3
 import pytest
@@ -444,7 +443,7 @@ def test_put_manifest_list():
 @mock_aws
 def test_put_image_with_push_date():
     if settings.TEST_SERVER_MODE:
-        raise SkipTest("Cant manipulate time in server mode")
+        raise pytest.skip("Cant manipulate time in server mode")
 
     client = boto3.client("ecr", region_name=ECR_REGION)
     _ = client.create_repository(repositoryName="test_repository")

--- a/tests/test_ecs/test_ecs.py
+++ b/tests/test_ecs/test_ecs.py
@@ -1,7 +1,7 @@
 import json
 import os
 from datetime import datetime
-from unittest import SkipTest, mock
+from unittest import mock
 from uuid import UUID
 
 import boto3
@@ -757,7 +757,7 @@ def test_create_service():
 @mock_aws
 def test_create_running_service():
     if settings.TEST_SERVER_MODE:
-        raise SkipTest(
+        raise pytest.skip(
             "Can't set environment variables in server mode for a single test"
         )
     running_service_count = 3
@@ -1096,7 +1096,7 @@ def test_describe_services():
 @mock.patch.dict(os.environ, {"MOTO_ECS_NEW_ARN": "TrUe"})
 def test_describe_services_new_arn():
     if settings.TEST_SERVER_MODE:
-        raise SkipTest(
+        raise pytest.skip(
             "Can't set environment variables in server mode for a single test"
         )
     client = boto3.client("ecs", region_name=ECS_REGION)
@@ -1605,7 +1605,7 @@ def test_register_container_instance():
 @mock.patch.dict(os.environ, {"MOTO_ECS_NEW_ARN": "TrUe"})
 def test_register_container_instance_new_arn_format():
     if settings.TEST_SERVER_MODE:
-        raise SkipTest(
+        raise pytest.skip(
             "Can't set environment variables in server mode for a single test"
         )
     ecs_client = boto3.client("ecs", region_name=ECS_REGION)
@@ -2027,7 +2027,7 @@ def test_run_task():
 @mock_aws
 def test_wait_tasks_stopped():
     if settings.TEST_SERVER_MODE:
-        raise SkipTest("Can't set transition directly in ServerMode")
+        raise pytest.skip("Can't set transition directly in ServerMode")
 
     state_manager.set_transition(
         model_name="ecs::task",
@@ -2093,7 +2093,7 @@ def test_wait_tasks_stopped():
 @mock_aws
 def test_task_state_transitions():
     if settings.TEST_SERVER_MODE:
-        raise SkipTest("Can't set transition directly in ServerMode")
+        raise pytest.skip("Can't set transition directly in ServerMode")
 
     state_manager.set_transition(
         model_name="ecs::task",
@@ -2325,7 +2325,7 @@ def test_run_task_default_cluster():
 @mock.patch.dict(os.environ, {"MOTO_ECS_NEW_ARN": "TrUe"})
 def test_run_task_default_cluster_new_arn_format():
     if settings.TEST_SERVER_MODE:
-        raise SkipTest(
+        raise pytest.skip(
             "Can't set environment variables in server mode for a single test"
         )
     client = boto3.client("ecs", region_name=ECS_REGION)

--- a/tests/test_efs/test_server.py
+++ b/tests/test_efs/test_server.py
@@ -1,5 +1,4 @@
 import re
-from unittest import SkipTest
 
 import pytest
 
@@ -22,7 +21,7 @@ def fixture_aws_credentials(monkeypatch):
 @pytest.fixture(scope="function", name="efs_client")
 def fixture_efs_client(aws_credentials):
     if not settings.TEST_DECORATOR_MODE:
-        raise SkipTest("Using server directly - no point in testing ServerMode")
+        raise pytest.skip("Using server directly - no point in testing ServerMode")
 
     with mock_aws():
         yield server.create_backend_app("efs").test_client()

--- a/tests/test_eks/test_eks.py
+++ b/tests/test_eks/test_eks.py
@@ -1,6 +1,6 @@
 import datetime
 from copy import deepcopy
-from unittest import SkipTest, mock
+from unittest import mock
 from unittest.mock import PropertyMock
 
 import boto3
@@ -556,7 +556,7 @@ def test_create_nodegroup_throws_exception_when_nodegroup_already_exists(
 @mock_aws
 def test_create_nodegroup_throws_exception_when_cluster_not_active(NodegroupBuilder):
     if settings.TEST_SERVER_MODE:
-        raise SkipTest("Cant patch Cluster attributes in server mode.")
+        raise pytest.skip("Cant patch Cluster attributes in server mode.")
     client, generated_test_data = NodegroupBuilder(BatchCountSize.SMALL)
     expected_exception = InvalidRequestException
     expected_msg = CLUSTER_NOT_READY_MSG.format(
@@ -1004,7 +1004,7 @@ def test_create_fargate_profile_throws_exception_when_cluster_not_active(
     FargateProfileBuilder,
 ):
     if settings.TEST_SERVER_MODE:
-        raise SkipTest("Cant patch Cluster attributes in server mode.")
+        raise pytest.skip("Cant patch Cluster attributes in server mode.")
     client, generated_test_data = FargateProfileBuilder(BatchCountSize.SMALL)
     expected_exception = InvalidRequestException
     expected_msg = CLUSTER_NOT_READY_MSG.format(

--- a/tests/test_emrcontainers/test_emrcontainers.py
+++ b/tests/test_emrcontainers/test_emrcontainers.py
@@ -1,6 +1,5 @@
 import re
 from datetime import datetime, timedelta, timezone
-from unittest import SkipTest
 from unittest.mock import patch
 
 import boto3
@@ -22,7 +21,7 @@ def fixture_client():
 @pytest.fixture(scope="function", name="virtual_cluster_factory")
 def fixture_virtual_cluster_factory(client):
     if settings.TEST_SERVER_MODE:
-        raise SkipTest("Cant manipulate time in server mode")
+        raise pytest.skip("Cant manipulate time in server mode")
 
     cluster_state = ["RUNNING", "TERMINATING", "TERMINATED", "ARRESTED"]
 

--- a/tests/test_events/test_events_http_integration.py
+++ b/tests/test_events/test_events_http_integration.py
@@ -1,8 +1,9 @@
 import json
 import os
-from unittest import SkipTest, mock
+from unittest import mock
 
 import boto3
+import pytest
 import responses
 
 from moto import mock_aws, settings
@@ -12,7 +13,7 @@ from moto import mock_aws, settings
 @mock.patch.dict(os.environ, {"MOTO_EVENTS_INVOKE_HTTP": "true"})
 def test_invoke_http_request_on_event():
     if settings.TEST_SERVER_MODE:
-        raise SkipTest("Can't intercept HTTP requests in ServerMode")
+        raise pytest.skip("Can't intercept HTTP requests in ServerMode")
     events = boto3.client("events", region_name="eu-west-1")
 
     #

--- a/tests/test_events/test_events_integration.py
+++ b/tests/test_events/test_events_integration.py
@@ -2,7 +2,7 @@ import contextlib
 import json
 import os
 from datetime import datetime
-from unittest import SkipTest, mock
+from unittest import mock
 
 import boto3
 import pytest
@@ -324,7 +324,7 @@ def test_moto_matches_none_value_with_exists_filter():
 @mock_aws
 def test_put_events_event_bus_forwarding_rules():
     if settings.TEST_SERVER_MODE:
-        raise SkipTest("Cross-account test - easiest to just test in DecoratorMode")
+        raise pytest.skip("Cross-account test - easiest to just test in DecoratorMode")
 
     # EventBus1 --> EventBus2 --> SQS
     account1 = ACCOUNT_ID

--- a/tests/test_events/test_events_partners_integration.py
+++ b/tests/test_events/test_events_partners_integration.py
@@ -1,9 +1,10 @@
 import json
 import os
 from datetime import datetime
-from unittest import SkipTest, mock
+from unittest import mock
 
 import boto3
+import pytest
 
 from moto import mock_aws, settings
 
@@ -26,7 +27,7 @@ def test_create_partner_event_bus():
 @mock_aws
 def test_describe_partner_event_busses():
     if settings.TEST_SERVER_MODE:
-        raise SkipTest("Can't change accounts easily in ServerMode")
+        raise pytest.skip("Can't change accounts easily in ServerMode")
     # Having a separate partner account isn't 'strictly necessary - we could do that from the main account
     # But it makes it more obvious for the reader that we're accessing different accounts IMO
     partner_account = "111122223333"
@@ -57,7 +58,7 @@ def test_describe_partner_event_busses():
 @mock_aws
 def test_put_partner_events():
     if settings.TEST_SERVER_MODE:
-        raise SkipTest("Can't change accounts easily in ServerMode")
+        raise pytest.skip("Can't change accounts easily in ServerMode")
 
     partner_account = "111122223333"
     client_account = "444455556666"

--- a/tests/test_firehose/test_firehose.py
+++ b/tests/test_firehose/test_firehose.py
@@ -1,5 +1,4 @@
 import warnings
-from unittest import SkipTest
 
 import boto3
 import pytest
@@ -25,7 +24,7 @@ def sample_s3_dest_config():
 def test_warnings():
     """Test features that raise a warning as they're unimplemented."""
     if settings.TEST_SERVER_MODE:
-        raise SkipTest("Can't capture warnings in server mode")
+        raise pytest.skip("Can't capture warnings in server mode")
 
     client = boto3.client("firehose", region_name=TEST_REGION)
     s3_dest_config = sample_s3_dest_config()
@@ -499,7 +498,7 @@ def test_lookup_name_from_arn():
     to 'firehose_backends'.
     """
     if settings.TEST_SERVER_MODE:
-        raise SkipTest("Can't access firehose_backend in server mode")
+        raise pytest.skip("Can't access firehose_backend in server mode")
 
     client = boto3.client("firehose", region_name=TEST_REGION)
     s3_dest_config = sample_s3_dest_config()

--- a/tests/test_glue/test_glue_job_runs.py
+++ b/tests/test_glue/test_glue_job_runs.py
@@ -1,5 +1,3 @@
-from unittest import SkipTest
-
 import pytest
 from botocore.client import ClientError
 
@@ -20,7 +18,7 @@ def test_start_job_run():
 @mock_aws
 def test_start_job_run__multiple_runs_allowed():
     if settings.TEST_SERVER_MODE:
-        raise SkipTest("Can't set transition directly in ServerMode")
+        raise pytest.skip("Can't set transition directly in ServerMode")
 
     state_manager.set_transition(
         model_name="glue::job_run", transition={"progression": "manual", "times": 2}
@@ -53,7 +51,7 @@ def test_start_job_run__multiple_runs_allowed():
 @mock_aws
 def test_start_job_run__single_run_allowed():
     if settings.TEST_SERVER_MODE:
-        raise SkipTest("Can't set transition directly in ServerMode")
+        raise pytest.skip("Can't set transition directly in ServerMode")
 
     state_manager.set_transition(
         model_name="glue::job_run", transition={"progression": "manual", "times": 2}
@@ -143,7 +141,7 @@ def test_get_job_runs_job_exists_but_no_runs():
 @mock_aws
 def test_job_run_transition():
     if settings.TEST_SERVER_MODE:
-        raise SkipTest("Can't set transition directly in ServerMode")
+        raise pytest.skip("Can't set transition directly in ServerMode")
 
     state_manager.set_transition(
         model_name="glue::job_run", transition={"progression": "manual", "times": 2}

--- a/tests/test_glue/test_partition_filter.py
+++ b/tests/test_glue/test_partition_filter.py
@@ -1,5 +1,3 @@
-from unittest import SkipTest
-
 import boto3
 import pytest
 from botocore.client import ClientError
@@ -330,7 +328,7 @@ def test_get_partitions_expression_timestamp_column():
 @mock_aws
 def test_get_partition_expression_warnings_and_exceptions():
     if settings.TEST_SERVER_MODE:
-        raise SkipTest("Cannot catch warnings in server mode")
+        raise pytest.skip("Cannot catch warnings in server mode")
 
     client = boto3.client("glue", region_name="us-east-1")
     database_name = "myspecialdatabase"

--- a/tests/test_iam/test_iam.py
+++ b/tests/test_iam/test_iam.py
@@ -1,7 +1,6 @@
 import csv
 import json
 from datetime import datetime
-from unittest import SkipTest
 from urllib import parse
 from uuid import uuid4
 
@@ -792,7 +791,7 @@ def test_get_policy():
 )
 def test_get_aws_managed_policy(region, partition):
     if settings.TEST_SERVER_MODE:
-        raise SkipTest("Policies not loaded in ServerMode")
+        raise pytest.skip("Policies not loaded in ServerMode")
     conn = boto3.client("iam", region_name=region)
     managed_policy_arn = f"arn:{partition}:iam::aws:policy/IAMUserChangePassword"
     managed_policy_create_date = datetime.strptime(
@@ -830,7 +829,7 @@ def test_get_policy_version():
 @mock_aws(config={"iam": {"load_aws_managed_policies": True}})
 def test_get_aws_managed_policy_version():
     if settings.TEST_SERVER_MODE:
-        raise SkipTest("Policies not loaded in ServerMode")
+        raise pytest.skip("Policies not loaded in ServerMode")
     conn = boto3.client("iam", region_name="us-east-1")
     managed_policy_arn = (
         "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
@@ -853,7 +852,7 @@ def test_get_aws_managed_policy_version():
 @mock_aws(config={"iam": {"load_aws_managed_policies": True}})
 def test_get_aws_managed_policy_v8_version():
     if settings.TEST_SERVER_MODE:
-        raise SkipTest("Policies not loaded in ServerMode")
+        raise pytest.skip("Policies not loaded in ServerMode")
     conn = boto3.client("iam", region_name="us-east-1")
     managed_policy_arn = "arn:aws:iam::aws:policy/job-function/SystemAdministrator"
     with pytest.raises(ClientError):
@@ -2036,7 +2035,7 @@ def test_get_access_key_last_used_when_used():
 @mock_aws(config={"iam": {"load_aws_managed_policies": True}})
 def test_managed_policy():
     if settings.TEST_SERVER_MODE:
-        raise SkipTest("Policies not loaded in ServerMode")
+        raise pytest.skip("Policies not loaded in ServerMode")
     conn = boto3.client("iam", region_name="us-west-1")
 
     conn.create_policy(
@@ -2449,7 +2448,7 @@ def test_delete_ssh_public_key():
 @mock_aws(config={"iam": {"load_aws_managed_policies": True}})
 def test_get_account_authorization_details():
     if settings.TEST_SERVER_MODE:
-        raise SkipTest("Policies not loaded in ServerMode")
+        raise pytest.skip("Policies not loaded in ServerMode")
     test_policy = json.dumps(
         {
             "Version": "2012-10-17",
@@ -3736,7 +3735,7 @@ def test_role_list_config_discovered_resources():
 @mock_aws
 def test_role_config_dict():
     if not settings.TEST_DECORATOR_MODE:
-        raise SkipTest("Using backend directly - no point in testing ServerMode")
+        raise pytest.skip("Using backend directly - no point in testing ServerMode")
     from moto.iam.config import policy_config_query, role_config_query
     from moto.iam.utils import random_policy_id, random_role_id
 
@@ -4358,7 +4357,7 @@ def test_policy_list_config_discovered_resources():
 @mock_aws
 def test_policy_config_dict():
     if not settings.TEST_DECORATOR_MODE:
-        raise SkipTest("Using backend directly - no point in testing ServerMode")
+        raise pytest.skip("Using backend directly - no point in testing ServerMode")
     from moto.iam.config import policy_config_query, role_config_query
     from moto.iam.utils import random_policy_id
 

--- a/tests/test_iam/test_iam_access_integration.py
+++ b/tests/test_iam/test_iam_access_integration.py
@@ -1,8 +1,8 @@
 import csv
 import datetime
-from unittest import SkipTest
 
 import boto3
+import pytest
 from dateutil.parser import parse
 
 from moto import mock_aws, settings
@@ -67,7 +67,7 @@ def test_mark_role_as_last_used():
 @mock_aws
 def test_get_credential_report_content__set_last_used_automatically():
     if not settings.TEST_DECORATOR_MODE:
-        raise SkipTest("No point testing this in ServerMode")
+        raise pytest.skip("No point testing this in ServerMode")
     # Ensure LAST_USED field is set
     c_iam = boto3.client("iam", region_name="us-east-1")
     c_iam.create_user(Path="my/path", UserName="fakeUser")

--- a/tests/test_iam/test_iam_groups.py
+++ b/tests/test_iam/test_iam_groups.py
@@ -1,6 +1,5 @@
 import json
 from datetime import datetime
-from unittest import SkipTest
 
 import boto3
 import pytest
@@ -217,7 +216,7 @@ def test_put_group_policy():
 @mock_aws(config={"iam": {"load_aws_managed_policies": True}})
 def test_attach_group_policies():
     if settings.TEST_SERVER_MODE:
-        raise SkipTest("Policies not loaded in ServerMode")
+        raise pytest.skip("Policies not loaded in ServerMode")
     conn = boto3.client("iam", region_name="us-east-1")
     conn.create_group(GroupName="my-group")
     assert (

--- a/tests/test_iam/test_iam_password_last_used.py
+++ b/tests/test_iam/test_iam_password_last_used.py
@@ -1,6 +1,5 @@
-from unittest import SkipTest
-
 import boto3
+import pytest
 
 from moto import mock_aws, settings
 from moto.backends import get_backend
@@ -11,7 +10,7 @@ from moto.core.utils import utcnow
 @mock_aws
 def test_password_last_used():
     if settings.TEST_SERVER_MODE:
-        raise SkipTest("Can't set password_last_used in ServerMode")
+        raise pytest.skip("Can't set password_last_used in ServerMode")
     client = boto3.client("iam", "us-east-1")
     username = "test.user"
     client.create_user(Path="/staff/", UserName=username)["User"]

--- a/tests/test_iam/test_iam_resets.py
+++ b/tests/test_iam/test_iam_resets.py
@@ -1,8 +1,9 @@
 import json
 import os
-from unittest import SkipTest, mock
+from unittest import mock
 
 import boto3
+import pytest
 
 from moto import mock_aws, settings
 
@@ -10,7 +11,7 @@ from moto import mock_aws, settings
 # Test IAM User Inline Policy
 def test_policies_are_not_kept_after_mock_ends():
     if settings.TEST_SERVER_MODE:
-        raise SkipTest("Policies not loaded in ServerMode")
+        raise pytest.skip("Policies not loaded in ServerMode")
     with mock_aws(config={"iam": {"load_aws_managed_policies": True}}):
         iam_client = boto3.client("iam", "us-east-1")
         role_name = "test"
@@ -45,7 +46,7 @@ def test_policies_are_not_kept_after_mock_ends():
 
 def test_policies_are_loaded_when_using_env_variable():
     if settings.TEST_SERVER_MODE:
-        raise SkipTest("EnvVar not loaded in ServerMode")
+        raise pytest.skip("EnvVar not loaded in ServerMode")
     with mock.patch.dict(os.environ, {"MOTO_IAM_LOAD_MANAGED_POLICIES": "true"}):
         with mock_aws():
             iam_client = boto3.client("iam", "us-east-1")

--- a/tests/test_iot/test_iot_ca_certificates.py
+++ b/tests/test_iot/test_iot_ca_certificates.py
@@ -1,5 +1,3 @@
-from unittest import SkipTest
-
 import boto3
 import pytest
 from botocore.exceptions import ClientError
@@ -40,7 +38,7 @@ def test_register_ca_certificate_simple(make_cert):
         # in ServerMode the config is not set, so we'll compute the cert the old/invalid way
         # But there are no assertions to actually verify the value of the computed cert
         # This is just added here as a warning/reminder if this ever changes
-        raise SkipTest("Config cannot be easily set in ServerMode")
+        raise pytest.skip("Config cannot be easily set in ServerMode")
 
     client = boto3.client("iot", region_name="us-east-1")
     certInfo = make_cert

--- a/tests/test_iotdata/test_iotdata.py
+++ b/tests/test_iotdata/test_iotdata.py
@@ -1,7 +1,6 @@
 import json
 import sys
 from typing import Optional
-from unittest import SkipTest
 
 import boto3
 import pytest
@@ -101,7 +100,7 @@ def test_update(name: Optional[str] = None) -> None:
 @pytest.mark.aws_verified
 def test_create_named_shadows(name: Optional[str] = None) -> None:
     if LooseVersion(boto3_version) < LooseVersion("1.29.0"):
-        raise SkipTest("Parameter only available in newer versions")
+        raise pytest.skip("Parameter only available in newer versions")
     client = boto3.client("iot-data", region_name="ap-northeast-1")
     thing_name = name
 

--- a/tests/test_kinesisvideoarchivedmedia/test_kinesisvideoarchivedmedia.py
+++ b/tests/test_kinesisvideoarchivedmedia/test_kinesisvideoarchivedmedia.py
@@ -1,7 +1,7 @@
 from datetime import timedelta
-from unittest import SkipTest
 
 import boto3
+import pytest
 
 from moto import mock_aws, settings
 from moto.core.utils import utcnow
@@ -10,7 +10,7 @@ from moto.core.utils import utcnow
 @mock_aws
 def test_get_hls_streaming_session_url():
     if settings.TEST_SERVER_MODE:
-        raise SkipTest("Can't mock KinesisVideo, as DataEndpoint is set to real URL")
+        raise pytest.skip("Can't mock KinesisVideo, as DataEndpoint is set to real URL")
     region_name = "ap-northeast-1"
     kvs_client = boto3.client("kinesisvideo", region_name=region_name)
     stream_name = "my-stream"
@@ -34,7 +34,7 @@ def test_get_hls_streaming_session_url():
 @mock_aws
 def test_get_dash_streaming_session_url():
     if settings.TEST_SERVER_MODE:
-        raise SkipTest("Can't mock KinesisVideo, as DataEndpoint is set to real URL")
+        raise pytest.skip("Can't mock KinesisVideo, as DataEndpoint is set to real URL")
     region_name = "ap-northeast-1"
     kvs_client = boto3.client("kinesisvideo", region_name=region_name)
     stream_name = "my-stream"
@@ -58,7 +58,7 @@ def test_get_dash_streaming_session_url():
 @mock_aws
 def test_get_clip():
     if settings.TEST_SERVER_MODE:
-        raise SkipTest("Can't mock KinesisVideo, as DataEndpoint is set to real URL")
+        raise pytest.skip("Can't mock KinesisVideo, as DataEndpoint is set to real URL")
     region_name = "ap-northeast-1"
     kvs_client = boto3.client("kinesisvideo", region_name=region_name)
     stream_name = "my-stream"

--- a/tests/test_managedblockchain/test_managedblockchain_proposalvotes.py
+++ b/tests/test_managedblockchain/test_managedblockchain_proposalvotes.py
@@ -1,5 +1,4 @@
 import os
-from unittest import SkipTest
 
 import boto3
 import pytest
@@ -256,7 +255,7 @@ def test_vote_on_proposal_no_greater_than():
 @mock_aws
 def test_vote_on_proposal_expiredproposal():
     if os.environ.get("TEST_SERVER_MODE", "false").lower() == "true":
-        raise SkipTest("Cant manipulate time in server mode")
+        raise pytest.skip("Cant manipulate time in server mode")
 
     votingpolicy = {
         "ApprovalThresholdPolicy": {

--- a/tests/test_moto_api/recorder/test_recorder.py
+++ b/tests/test_moto_api/recorder/test_recorder.py
@@ -1,9 +1,10 @@
 import base64
 import json
 import os
-from unittest import SkipTest, TestCase
+from unittest import TestCase
 
 import boto3
+import pytest
 import requests
 
 from moto import mock_aws, settings
@@ -232,7 +233,7 @@ class TestRecorder(TestCase):
 class TestThreadedMotoServer(TestCase):
     def setUp(self) -> None:
         if settings.TEST_SERVER_MODE:
-            raise SkipTest("No point in testing ServerMode within ServerMode")
+            raise pytest.skip("No point in testing ServerMode within ServerMode")
 
         self.port_1 = 5678
         self.port_2 = 5679

--- a/tests/test_moto_api/state_manager/servermode/test_state_manager.py
+++ b/tests/test_moto_api/state_manager/servermode/test_state_manager.py
@@ -1,6 +1,6 @@
 import json
-from unittest import SkipTest
 
+import pytest
 import requests
 
 from moto import settings
@@ -8,7 +8,7 @@ from moto import settings
 
 def test_set_transition():
     if not settings.TEST_SERVER_MODE:
-        raise SkipTest("We only want to test ServerMode here")
+        raise pytest.skip("We only want to test ServerMode here")
 
     post_body = {
         "model_name": "test_model0",
@@ -29,7 +29,7 @@ def test_set_transition():
 
 def test_unset_transition():
     if not settings.TEST_SERVER_MODE:
-        raise SkipTest("We only want to test ServerMode here")
+        raise pytest.skip("We only want to test ServerMode here")
 
     post_body = {
         "model_name": "test::model1",
@@ -55,7 +55,7 @@ def test_unset_transition():
 
 def test_get_default_transition():
     if not settings.TEST_SERVER_MODE:
-        raise SkipTest("We only want to test ServerMode here")
+        raise pytest.skip("We only want to test ServerMode here")
 
     resp = requests.get(
         "http://localhost:5000/moto-api/state-manager/get-transition?model_name=unknown"

--- a/tests/test_moto_api/state_manager/test_batch_integration.py
+++ b/tests/test_moto_api/state_manager/test_batch_integration.py
@@ -1,4 +1,4 @@
-from unittest import SkipTest
+import pytest
 
 from moto import mock_aws, settings
 from moto.moto_api import state_manager
@@ -11,7 +11,7 @@ from tests.test_batch.test_batch_jobs import _wait_for_job_status, prepare_job
 @requires_docker
 def test_cancel_pending_job():
     if settings.TEST_SERVER_MODE:
-        raise SkipTest("Can't use state_manager in ServerMode directly")
+        raise pytest.skip("Can't use state_manager in ServerMode directly")
 
     ec2_client, iam_client, _, _, batch_client = _get_clients()
     _, _, _, iam_arn = _setup(ec2_client, iam_client)

--- a/tests/test_organizations/test_organizations.py
+++ b/tests/test_organizations/test_organizations.py
@@ -2,7 +2,7 @@ import json
 import os
 import re
 from datetime import datetime
-from unittest import SkipTest, mock
+from unittest import mock
 
 import boto3
 import pytest
@@ -44,7 +44,7 @@ mockemail = "@".join([mockname, mockdomain])
 )
 def test_create_organization(region, partition):
     if not settings.TEST_DECORATOR_MODE:
-        raise SkipTest("Involves changing account using env variable")
+        raise pytest.skip("Involves changing account using env variable")
 
     client = boto3.client("organizations", region_name=region)
     response = client.create_organization(FeatureSet="ALL")
@@ -111,7 +111,7 @@ def test_create_organization_without_feature_set():
 @mock_aws
 def test_create_account_creates_role():
     if not settings.TEST_DECORATOR_MODE:
-        raise SkipTest("Involves changing account using env variable")
+        raise pytest.skip("Involves changing account using env variable")
     orgs_client = boto3.client("organizations", region_name="us-west-2")
     orgs_client.create_organization()
     account = orgs_client.create_account(AccountName="test", Email="test@test.xyz")
@@ -125,7 +125,7 @@ def test_create_account_creates_role():
 @mock_aws
 def test_create_account_creates_custom_role():
     if not settings.TEST_DECORATOR_MODE:
-        raise SkipTest("Involves changing account using env variable")
+        raise pytest.skip("Involves changing account using env variable")
 
     orgs_client = boto3.client("organizations", region_name="us-west-2")
     _ = orgs_client.create_organization()
@@ -144,7 +144,7 @@ def test_create_account_creates_custom_role():
 @mock_aws
 def test_describe_organization():
     if not settings.TEST_DECORATOR_MODE:
-        raise SkipTest("Involves changing account using env variable")
+        raise pytest.skip("Involves changing account using env variable")
 
     client = boto3.client("organizations", region_name="us-east-1")
     client.create_organization(FeatureSet="ALL")
@@ -192,7 +192,7 @@ def test_list_roots():
 @mock_aws
 def test_list_roots_for_new_account_in_organization():
     if not settings.TEST_DECORATOR_MODE:
-        raise SkipTest("Involves changing account using env variable")
+        raise pytest.skip("Involves changing account using env variable")
     client = boto3.client("organizations", region_name="us-east-1")
     org = client.create_organization()["Organization"]
     org_roots = client.list_roots()
@@ -714,7 +714,7 @@ def test_get_paginated_list_create_account_status():
 @mock_aws
 def test_remove_account_from_organization():
     if not settings.TEST_DECORATOR_MODE:
-        raise SkipTest("Involves changing account using env variable")
+        raise pytest.skip("Involves changing account using env variable")
 
     client = boto3.client("organizations", region_name="us-east-1")
     _ = client.create_organization(FeatureSet="ALL")["Organization"]

--- a/tests/test_panorama/test_application_instance.py
+++ b/tests/test_panorama/test_application_instance.py
@@ -1,8 +1,8 @@
 import datetime
-from unittest import SkipTest
 from unittest.mock import ANY
 
 import boto3
+import pytest
 from dateutil.tz import tzutc
 from freezegun import freeze_time
 
@@ -125,7 +125,7 @@ def test_describe_application_instance() -> None:
 def test_create_application_instance_should_set_created_time() -> None:
     # Given
     if settings.TEST_SERVER_MODE:
-        raise SkipTest("Can't use ManagedState in ServerMode")
+        raise pytest.skip("Can't use ManagedState in ServerMode")
     panorama_client = boto3.client("panorama", "eu-west-1")
     response_device_creation = panorama_client.provision_device(
         **PROVISION_DEVICE_PARAMS

--- a/tests/test_panorama/test_panorama_device.py
+++ b/tests/test_panorama/test_panorama_device.py
@@ -1,5 +1,4 @@
 from datetime import datetime
-from unittest import SkipTest
 
 import boto3
 import pytest
@@ -14,7 +13,7 @@ from moto.moto_api import state_manager
 @mock_aws
 def test_provision_device() -> None:
     if settings.TEST_SERVER_MODE:
-        raise SkipTest("Can't use ManagedState in ServerMode")
+        raise pytest.skip("Can't use ManagedState in ServerMode")
     client = boto3.client("panorama", region_name="eu-west-1")
     given_device_name = "test-device-name"
     state_manager.set_transition(
@@ -61,7 +60,7 @@ def test_provision_device() -> None:
 @mock_aws
 def test_describe_device() -> None:
     if settings.TEST_SERVER_MODE:
-        raise SkipTest("Can't freeze time in ServerMode")
+        raise pytest.skip("Can't freeze time in ServerMode")
     client = boto3.client("panorama", region_name="eu-west-1")
     given_device_name = "test-device-name"
     state_manager.set_transition(
@@ -142,7 +141,7 @@ def test_describe_device() -> None:
 @mock_aws
 def test_provision_device_aggregated_status_lifecycle() -> None:
     if settings.TEST_SERVER_MODE:
-        raise SkipTest("Can't use ManagedState in ServerMode")
+        raise pytest.skip("Can't use ManagedState in ServerMode")
     client = boto3.client("panorama", region_name="eu-west-1")
     given_device_name = "test-device-name"
     state_manager.set_transition(
@@ -346,7 +345,7 @@ def test_list_devices_sort_order(sort_order: str, indexes: list[int]) -> None:
 @mock_aws
 def test_list_devices_sort_by(sort_by: str, indexes: list[int]) -> None:
     if settings.TEST_SERVER_MODE:
-        raise SkipTest("Can't freeze time in ServerMode")
+        raise pytest.skip("Can't freeze time in ServerMode")
     client = boto3.client("panorama", region_name="eu-west-1")
     state_manager.set_transition(
         model_name="panorama::device_test-device-name-2_aggregated_status",
@@ -375,7 +374,7 @@ def test_list_devices_sort_by(sort_by: str, indexes: list[int]) -> None:
 @mock_aws
 def test_list_devices_device_aggregated_status_filter() -> None:
     if settings.TEST_SERVER_MODE:
-        raise SkipTest("Can't use ManagedState in ServerMode")
+        raise pytest.skip("Can't use ManagedState in ServerMode")
     client = boto3.client("panorama", region_name="eu-west-1")
     state_manager.set_transition(
         model_name="panorama::device_test-device-name-2_aggregated_status",

--- a/tests/test_route53/test_route53_query_logging_config.py
+++ b/tests/test_route53/test_route53_query_logging_config.py
@@ -1,6 +1,5 @@
 from collections.abc import Iterable
 from typing import Callable
-from unittest import SkipTest
 
 import boto3
 import pytest
@@ -19,7 +18,7 @@ def moto_server() -> Iterable[Callable[[], str]]:
     try:
         from moto.moto_server.threaded_moto_server import ThreadedMotoServer
     except ImportError as e:
-        raise SkipTest(str(e))
+        raise pytest.skip(str(e))
 
     servers = []
     """Fixture to run a mocked AWS server for testing."""

--- a/tests/test_s3/test_multiple_accounts_server.py
+++ b/tests/test_s3/test_multiple_accounts_server.py
@@ -1,5 +1,4 @@
-from unittest import SkipTest
-
+import pytest
 import requests
 
 from moto import settings
@@ -12,7 +11,7 @@ BASE_URL = f"http://localhost:{SERVER_PORT}/"
 class TestAccountIdResolution:
     def setup_method(self):
         if not settings.TEST_DECORATOR_MODE:
-            raise SkipTest(
+            raise pytest.skip(
                 "No point in testing this in ServerMode, as we already start our own server"
             )
         self.server = ThreadedMotoServer(port=SERVER_PORT, verbose=False)

--- a/tests/test_s3/test_s3.py
+++ b/tests/test_s3/test_s3.py
@@ -7,7 +7,6 @@ import zlib
 from gzip import GzipFile
 from io import BytesIO
 from time import sleep
-from unittest import SkipTest
 from urllib.parse import parse_qs, urlparse
 
 import boto3
@@ -123,7 +122,7 @@ def test_key_save_to_missing_bucket():
 @mock_aws
 def test_missing_key_request():
     if not settings.TEST_DECORATOR_MODE:
-        raise SkipTest("Only test status code in DecoratorMode")
+        raise pytest.skip("Only test status code in DecoratorMode")
     s3_client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
     s3_client.create_bucket(Bucket="foobar")
 
@@ -364,7 +363,7 @@ def test_get_all_buckets():
 def test_post_to_bucket():
     if not settings.TEST_DECORATOR_MODE:
         # ServerMode does not allow unauthorized requests
-        raise SkipTest()
+        raise pytest.skip()
 
     client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
     client.create_bucket(Bucket="foobar")
@@ -381,7 +380,7 @@ def test_post_to_bucket():
 def test_post_with_metadata_to_bucket():
     if not settings.TEST_DECORATOR_MODE:
         # ServerMode does not allow unauthorized requests
-        raise SkipTest()
+        raise pytest.skip()
     client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
     client.create_bucket(Bucket="foobar")
 
@@ -510,7 +509,7 @@ def test_bucket_name_with_special_chars(name):
 @mock_aws
 def test_key_with_special_characters(key):
     if settings.is_test_proxy_mode():
-        raise SkipTest("Keys starting with a / don't work well in ProxyMode")
+        raise pytest.skip("Keys starting with a / don't work well in ProxyMode")
     s3_resource = boto3.resource("s3", region_name=DEFAULT_REGION_NAME)
     client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
     bucket = s3_resource.Bucket("testname")
@@ -620,7 +619,7 @@ def test_restore_key():
 @mock_aws
 def test_restore_key_transition():
     if not settings.TEST_DECORATOR_MODE:
-        raise SkipTest("Can't set transition directly in ServerMode")
+        raise pytest.skip("Can't set transition directly in ServerMode")
 
     state_manager.set_transition(
         model_name="s3::keyrestore", transition={"progression": "manual", "times": 1}
@@ -1565,7 +1564,7 @@ def test_list_objects_v2_truncate_combined_keys_and_folders():
 def test_list_objects_v2__more_than_1000():
     # Verify that the default pagination size (1000) works
     if not settings.TEST_DECORATOR_MODE:
-        raise SkipTest("Accessing backends directly")
+        raise pytest.skip("Accessing backends directly")
     s3_client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
     s3_client.create_bucket(Bucket="mybucket")
 
@@ -2630,7 +2629,7 @@ def test_paths_with_leading_slashes_work():
 @mock_aws
 def test_root_dir_with_empty_name_works():
     if not settings.TEST_DECORATOR_MODE:
-        raise SkipTest("Does not work in server mode due to error in Workzeug")
+        raise pytest.skip("Does not work in server mode due to error in Workzeug")
     store_and_read_back_a_key("/")
 
 
@@ -2639,7 +2638,7 @@ def test_root_dir_with_empty_name_works():
 def test_leading_slashes_not_removed(bucket_name):
     """Make sure that leading slashes are not removed internally."""
     if settings.is_test_proxy_mode():
-        raise SkipTest("Doesn't quite work right with the Proxy")
+        raise pytest.skip("Doesn't quite work right with the Proxy")
     s3_client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
     s3_client.create_bucket(Bucket=bucket_name)
 

--- a/tests/test_s3/test_s3_auth.py
+++ b/tests/test_s3/test_s3_auth.py
@@ -1,5 +1,4 @@
 import json
-from unittest import SkipTest
 
 import boto3
 import pytest
@@ -16,7 +15,7 @@ DEFAULT_REGION_NAME = "us-east-1"
 @set_initial_no_auth_action_count(0)
 def test_load_unexisting_object_without_auth_should_return_403():
     if not settings.TEST_DECORATOR_MODE:
-        raise SkipTest("Auth decorator does not work in server mode")
+        raise pytest.skip("Auth decorator does not work in server mode")
 
     # Head an S3 object we should have no access to.
     resource = boto3.resource("s3", region_name="us-east-1")
@@ -35,7 +34,7 @@ def test_load_unexisting_object_without_auth_should_return_403():
 @mock_aws
 def test_head_bucket_with_correct_credentials():
     if not settings.TEST_DECORATOR_MODE:
-        raise SkipTest("Auth decorator does not work in server mode")
+        raise pytest.skip("Auth decorator does not work in server mode")
 
     # These calls are all unauthenticated
     iam_keys = create_user_with_access_key_and_policy()
@@ -67,7 +66,7 @@ def test_head_bucket_with_correct_credentials():
 @mock_aws
 def test_head_bucket_with_incorrect_credentials():
     if not settings.TEST_DECORATOR_MODE:
-        raise SkipTest("Auth decorator does not work in server mode")
+        raise pytest.skip("Auth decorator does not work in server mode")
 
     # These calls are all authenticated
     iam_keys = create_user_with_access_key_and_policy()
@@ -153,7 +152,7 @@ def create_role_with_attached_policy_and_assume_it(
 @mock_aws
 def test_delete_objects_without_access_throws_custom_error():
     if not settings.TEST_DECORATOR_MODE:
-        raise SkipTest("Auth decorator does not work in server mode")
+        raise pytest.skip("Auth decorator does not work in server mode")
 
     role_name = "some-test-role"
     bucket_name = "some-test-bucket"

--- a/tests/test_s3/test_s3_bucket_policy.py
+++ b/tests/test_s3/test_s3_bucket_policy.py
@@ -1,5 +1,4 @@
 import json
-from unittest import SkipTest
 
 import boto3
 import pytest
@@ -15,7 +14,9 @@ class TestBucketPolicy:
     @classmethod
     def setup_class(cls):
         if not settings.TEST_DECORATOR_MODE:
-            raise SkipTest("No point testing the ThreadedServer in Server/Proxy-mode")
+            raise pytest.skip(
+                "No point testing the ThreadedServer in Server/Proxy-mode"
+            )
         cls.server = ThreadedMotoServer(port="6000", verbose=False)
         cls.server.start()
 

--- a/tests/test_s3/test_s3_cross_account.py
+++ b/tests/test_s3/test_s3_cross_account.py
@@ -1,5 +1,5 @@
 import os
-from unittest import SkipTest, mock
+from unittest import mock
 
 import boto3
 import pytest
@@ -12,7 +12,7 @@ from moto.s3.responses import DEFAULT_REGION_NAME
 @mock_aws
 def test_cross_account_region_access():
     if not settings.TEST_DECORATOR_MODE:
-        raise SkipTest("Multi-accounts env config only works serverside")
+        raise pytest.skip("Multi-accounts env config only works serverside")
 
     client1 = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
     client2 = boto3.client("s3", region_name=DEFAULT_REGION_NAME)

--- a/tests/test_s3/test_s3_custom_endpoint.py
+++ b/tests/test_s3/test_s3_custom_endpoint.py
@@ -1,5 +1,4 @@
 import os
-from unittest import SkipTest
 from unittest.mock import patch
 
 import boto3
@@ -16,7 +15,7 @@ CUSTOM_ENDPOINT_2 = "https://caf-o.s3-ext.jc.rl.ac.uk"
 @pytest.mark.parametrize("url", [CUSTOM_ENDPOINT, CUSTOM_ENDPOINT_2])
 def test_create_and_list_buckets(url):
     if not settings.TEST_DECORATOR_MODE:
-        raise SkipTest("Unable to set ENV VAR in ServerMode")
+        raise pytest.skip("Unable to set ENV VAR in ServerMode")
     # Have to inline this, as the URL-param is not available as a context decorator
     with patch.dict(os.environ, {"MOTO_S3_CUSTOM_ENDPOINTS": url}):
         # Mock needs to be started after the environment variable is patched in
@@ -35,7 +34,7 @@ def test_create_and_list_buckets(url):
 @pytest.mark.parametrize("url", [CUSTOM_ENDPOINT, CUSTOM_ENDPOINT_2])
 def test_create_and_list_buckets_with_multiple_supported_endpoints(url):
     if not settings.TEST_DECORATOR_MODE:
-        raise SkipTest("Unable to set ENV VAR in ServerMode")
+        raise pytest.skip("Unable to set ENV VAR in ServerMode")
     # Have to inline this, as the URL-param is not available as a context decorator
     with patch.dict(
         os.environ,
@@ -58,7 +57,7 @@ def test_create_and_list_buckets_with_multiple_supported_endpoints(url):
 @mock_aws
 def test_put_and_get_object(url):
     if not settings.TEST_DECORATOR_MODE:
-        raise SkipTest("Unable to set ENV VAR in ServerMode")
+        raise pytest.skip("Unable to set ENV VAR in ServerMode")
     with patch.dict(os.environ, {"MOTO_S3_CUSTOM_ENDPOINTS": url}):
         with mock_aws():
             bucket = "mybucket"
@@ -81,7 +80,7 @@ def test_put_and_get_object(url):
 @mock_aws
 def test_put_and_list_objects(url):
     if not settings.TEST_DECORATOR_MODE:
-        raise SkipTest("Unable to set ENV VAR in ServerMode")
+        raise pytest.skip("Unable to set ENV VAR in ServerMode")
     with patch.dict(os.environ, {"MOTO_S3_CUSTOM_ENDPOINTS": url}):
         with mock_aws():
             bucket = "mybucket"
@@ -102,7 +101,7 @@ def test_put_and_list_objects(url):
 @pytest.mark.parametrize("url", [CUSTOM_ENDPOINT, CUSTOM_ENDPOINT_2])
 def test_get_presigned_url(url):
     if not settings.TEST_DECORATOR_MODE:
-        raise SkipTest("Unable to set ENV VAR in ServerMode")
+        raise pytest.skip("Unable to set ENV VAR in ServerMode")
     with patch.dict(os.environ, {"MOTO_S3_CUSTOM_ENDPOINTS": url}):
         with mock_aws():
             bucket = "mybucket"

--- a/tests/test_s3/test_s3_eventbridge_integration.py
+++ b/tests/test_s3/test_s3_eventbridge_integration.py
@@ -1,7 +1,6 @@
 import json
 from io import BytesIO
 from typing import Any
-from unittest import SkipTest
 from uuid import uuid4
 
 import boto3
@@ -108,7 +107,7 @@ def test_put_object_notification_ObjectCreated_PUT(region, partition):
 @reduced_min_part_size
 def test_put_object_notification_ObjectCreated_POST():
     if not settings.TEST_DECORATOR_MODE:
-        raise SkipTest("Doesn't quite work right with the Proxy or Server")
+        raise pytest.skip("Doesn't quite work right with the Proxy or Server")
 
     resource_names = _seteup_bucket_notification_eventbridge()
     bucket_name = resource_names["bucket_name"]

--- a/tests/test_s3/test_s3_file_handles.py
+++ b/tests/test_s3/test_s3_file_handles.py
@@ -2,9 +2,10 @@ import copy
 import gc
 import warnings
 from functools import wraps
-from unittest import SkipTest, TestCase
+from unittest import TestCase
 
 import boto3
+import pytest
 import requests
 
 from moto import mock_aws, settings
@@ -49,7 +50,7 @@ class TestS3FileHandleClosures(TestCase):
 
     def setUp(self) -> None:
         if not settings.TEST_DECORATOR_MODE:
-            raise SkipTest("No point in testing ServerMode, we're not using boto3")
+            raise pytest.skip("No point in testing ServerMode, we're not using boto3")
         self.s3_client = s3_backends[DEFAULT_ACCOUNT_ID]["global"]
         self.s3_client.create_bucket(TEST_BUCKET, "us-west-1")
         self.s3_client.create_bucket(TEST_BUCKET_VERSIONED, "us-west-1")
@@ -231,7 +232,7 @@ class TestS3FileHandleClosures(TestCase):
 class TestS3FileHandleClosuresUsingMocks(TestCase):
     def setUp(self) -> None:
         if not settings.TEST_DECORATOR_MODE:
-            raise SkipTest("No point in testing ServerMode, we're not using boto3")
+            raise pytest.skip("No point in testing ServerMode, we're not using boto3")
         self.s3_client = boto3.client("s3", "us-east-1")
 
     @verify_zero_warnings

--- a/tests/test_s3/test_s3_list_object_versions.py
+++ b/tests/test_s3/test_s3_list_object_versions.py
@@ -1,4 +1,4 @@
-from unittest import SkipTest, mock
+from unittest import mock
 from uuid import uuid4
 
 import boto3
@@ -635,7 +635,7 @@ def test_list_object_versions__sort_order(bucket_name=None):
 @mock.patch.dict("os.environ", {"MOTO_S3_DEFAULT_MAX_KEYS": "5"})
 def test_list_object_versions_with_custom_limit():
     if not settings.TEST_DECORATOR_MODE:
-        raise SkipTest("Can only set env var in DecoratorMode")
+        raise pytest.skip("Can only set env var in DecoratorMode")
     s3_client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
     s3_resource = boto3.resource("s3", region_name=DEFAULT_REGION_NAME)
     bucket_name = "foobar"

--- a/tests/test_s3/test_s3_list_objects.py
+++ b/tests/test_s3/test_s3_list_objects.py
@@ -1,4 +1,4 @@
-from unittest import SkipTest, mock
+from unittest import mock
 
 import boto3
 import pytest
@@ -60,7 +60,7 @@ def test_s3_filter_with_manual_marker(bucket_name=None) -> None:
 @mock.patch.dict("os.environ", {"MOTO_S3_DEFAULT_MAX_KEYS": "5"})
 def test_list_object_versions_with_custom_limit():
     if not settings.TEST_DECORATOR_MODE:
-        raise SkipTest("Can only set env var in DecoratorMode")
+        raise pytest.skip("Can only set env var in DecoratorMode")
     s3_client = boto3.client("s3", region_name="us-east-1")
     s3_resource = boto3.resource("s3", region_name="us-east-1")
     bucket_name = "foobar"

--- a/tests/test_s3/test_s3_locales.py
+++ b/tests/test_s3/test_s3_locales.py
@@ -1,7 +1,7 @@
 from datetime import datetime
-from unittest import SkipTest
 
 import boto3
+import pytest
 from freezegun import freeze_time
 
 from moto import mock_aws, settings
@@ -10,7 +10,7 @@ from moto import mock_aws, settings
 @mock_aws
 def test_rfc_returns_valid_date_for_every_possible_weekday_and_month():
     if not settings.TEST_DECORATOR_MODE:
-        raise SkipTest("Freezing time only possible in DecoratorMode")
+        raise pytest.skip("Freezing time only possible in DecoratorMode")
     client = boto3.client("s3", region_name="us-east-1")
     client.create_bucket(Bucket="bucket_")
     for weekday in range(1, 8):

--- a/tests/test_s3/test_s3_logging.py
+++ b/tests/test_s3/test_s3_logging.py
@@ -1,6 +1,5 @@
 import json
 from time import sleep
-from unittest import SkipTest
 from unittest.mock import patch
 from uuid import uuid4
 
@@ -277,7 +276,7 @@ def test_log_file_is_created():
 @mock_aws
 def test_invalid_bucket_logging_when_permissions_are_false():
     if not settings.TEST_DECORATOR_MODE:
-        raise SkipTest("Can't patch permission logic in ServerMode")
+        raise pytest.skip("Can't patch permission logic in ServerMode")
 
     s3_client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
     bucket_name = "mybucket"
@@ -307,7 +306,7 @@ def test_invalid_bucket_logging_when_permissions_are_false():
 @mock_aws
 def test_valid_bucket_logging_when_permissions_are_true():
     if not settings.TEST_DECORATOR_MODE:
-        raise SkipTest("Can't patch permission logic in ServerMode")
+        raise pytest.skip("Can't patch permission logic in ServerMode")
 
     s3_client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
     bucket_name = "mybucket"
@@ -340,7 +339,7 @@ def test_valid_bucket_logging_when_permissions_are_true():
 @mock_aws
 def test_bucket_policy_not_set():
     if not settings.TEST_DECORATOR_MODE:
-        raise SkipTest("Can't patch permission logic in ServerMode")
+        raise pytest.skip("Can't patch permission logic in ServerMode")
 
     s3_client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
     s3_backend = s3_backends[DEFAULT_ACCOUNT_ID]["global"]
@@ -360,7 +359,7 @@ def test_bucket_policy_not_set():
 @mock_aws
 def test_bucket_policy_principal():
     if not settings.TEST_DECORATOR_MODE:
-        raise SkipTest("Can't patch permission logic in ServerMode")
+        raise pytest.skip("Can't patch permission logic in ServerMode")
 
     s3_client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
     s3_backend = s3_backends[DEFAULT_ACCOUNT_ID]["global"]
@@ -415,7 +414,7 @@ def test_bucket_policy_principal():
 @mock_aws
 def test_bucket_policy_effect():
     if not settings.TEST_DECORATOR_MODE:
-        raise SkipTest("Can't patch permission logic in ServerMode")
+        raise pytest.skip("Can't patch permission logic in ServerMode")
 
     s3_client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
     s3_backend = s3_backends[DEFAULT_ACCOUNT_ID]["global"]
@@ -469,7 +468,7 @@ def test_bucket_policy_effect():
 @mock_aws
 def test_bucket_policy_action():
     if not settings.TEST_DECORATOR_MODE:
-        raise SkipTest("Can't patch permission logic in ServerMode")
+        raise pytest.skip("Can't patch permission logic in ServerMode")
 
     s3_client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
     s3_backend = s3_backends[DEFAULT_ACCOUNT_ID]["global"]
@@ -521,7 +520,7 @@ def test_bucket_policy_action():
 @mock_aws
 def test_bucket_policy_resource():
     if not settings.TEST_DECORATOR_MODE:
-        raise SkipTest("Can't patch permission logic in ServerMode")
+        raise pytest.skip("Can't patch permission logic in ServerMode")
 
     s3_client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
     s3_backend = s3_backends[DEFAULT_ACCOUNT_ID]["global"]

--- a/tests/test_s3/test_s3_multipart.py
+++ b/tests/test_s3/test_s3_multipart.py
@@ -2,7 +2,6 @@ import os
 import re
 from functools import wraps
 from io import BytesIO
-from unittest import SkipTest
 
 import boto3
 import pytest
@@ -1078,7 +1077,7 @@ def test_head_object_returns_part_count():
 @reduced_min_part_size
 def test_generate_presigned_url_for_multipart_upload():
     if not settings.TEST_DECORATOR_MODE:
-        raise SkipTest("No point in testing this outside decorator mode")
+        raise pytest.skip("No point in testing this outside decorator mode")
     bucket_name = "mock-bucket"
     file_name = "mock-file"
     s3_client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)

--- a/tests/test_s3/test_s3_notifications.py
+++ b/tests/test_s3/test_s3_notifications.py
@@ -1,5 +1,4 @@
 import json
-from unittest import SkipTest
 from uuid import uuid4
 
 import boto3
@@ -116,7 +115,7 @@ def test_send_event_bridge_message():
     )
 
     if not settings.TEST_DECORATOR_MODE:
-        raise SkipTest("Doesn't quite work right with the Proxy or Server")
+        raise pytest.skip("Doesn't quite work right with the Proxy or Server")
     # an event is correctly sent to the log group.
     _send_event_bridge_message(
         ACCOUNT_ID,

--- a/tests/test_sagemaker/test_sagemaker_model_package_groups.py
+++ b/tests/test_sagemaker/test_sagemaker_model_package_groups.py
@@ -1,6 +1,5 @@
 import uuid
 from datetime import datetime
-from unittest import SkipTest
 
 import boto3
 import pytest
@@ -66,7 +65,7 @@ def test_list_model_package_groups():
 @mock_aws
 def test_list_model_package_groups_creation_time_before():
     if settings.TEST_SERVER_MODE:
-        raise SkipTest("Can't freeze time in ServerMode")
+        raise pytest.skip("Can't freeze time in ServerMode")
     client = boto3.client("sagemaker", region_name="eu-west-1")
     with freeze_time("2020-01-01 00:00:00"):
         client.create_model_package_group(
@@ -86,7 +85,7 @@ def test_list_model_package_groups_creation_time_before():
 @mock_aws
 def test_list_model_package_groups_creation_time_after():
     if settings.TEST_SERVER_MODE:
-        raise SkipTest("Can't freeze time in ServerMode")
+        raise pytest.skip("Can't freeze time in ServerMode")
     client = boto3.client("sagemaker", region_name="eu-west-1")
     with freeze_time("2020-01-01 00:00:00"):
         client.create_model_package_group(
@@ -172,7 +171,7 @@ def test_list_model_package_groups_sort_order():
 @mock_aws
 def test_describe_model_package_group():
     if settings.TEST_SERVER_MODE:
-        raise SkipTest("Can't freeze time in ServerMode")
+        raise pytest.skip("Can't freeze time in ServerMode")
     client = boto3.client("sagemaker", region_name="eu-west-1")
     with freeze_time("2020-01-01 00:00:00"):
         client.create_model_package_group(
@@ -197,7 +196,7 @@ def test_describe_model_package_group():
 @mock_aws
 def test_describe_model_package_group_not_exists():
     if settings.TEST_SERVER_MODE:
-        raise SkipTest("Can't freeze time in ServerMode")
+        raise pytest.skip("Can't freeze time in ServerMode")
     client = boto3.client("sagemaker", region_name="eu-west-1")
 
     with pytest.raises(ClientError) as e:

--- a/tests/test_sagemaker/test_sagemaker_model_packages.py
+++ b/tests/test_sagemaker/test_sagemaker_model_packages.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from unittest import SkipTest, TestCase
+from unittest import TestCase
 
 import boto3
 import pytest
@@ -54,7 +54,7 @@ def test_list_model_packages():
 @mock_aws
 def test_list_model_packages_creation_time_before():
     if settings.TEST_SERVER_MODE:
-        raise SkipTest("Can't freeze time in ServerMode")
+        raise pytest.skip("Can't freeze time in ServerMode")
     client = boto3.client("sagemaker", region_name="eu-west-1")
     with freeze_time("2020-01-01 00:00:00"):
         client.create_model_package(
@@ -74,7 +74,7 @@ def test_list_model_packages_creation_time_before():
 @mock_aws
 def test_list_model_packages_creation_time_after():
     if settings.TEST_SERVER_MODE:
-        raise SkipTest("Can't freeze time in ServerMode")
+        raise pytest.skip("Can't freeze time in ServerMode")
     client = boto3.client("sagemaker", region_name="eu-west-1")
     with freeze_time("2020-01-01 00:00:00"):
         client.create_model_package(
@@ -227,7 +227,7 @@ def test_list_model_packages_sort_order():
 @mock_aws
 def test_describe_model_package_default():
     if settings.TEST_SERVER_MODE:
-        raise SkipTest("Can't freeze time in ServerMode")
+        raise pytest.skip("Can't freeze time in ServerMode")
     client = boto3.client("sagemaker", region_name="eu-west-1")
     client.create_model_package_group(ModelPackageGroupName="test-model-package-group")
     with freeze_time("2015-01-01 00:00:00"):
@@ -369,7 +369,7 @@ def test_update_model_package_given_additional_inference_specifications_to_add()
 @mock_aws
 def test_update_model_package_should_update_last_modified_information():
     if settings.TEST_SERVER_MODE:
-        raise SkipTest("Can't freeze time in ServerMode")
+        raise pytest.skip("Can't freeze time in ServerMode")
     client = boto3.client("sagemaker", region_name="eu-west-1")
     client.create_model_package_group(ModelPackageGroupName="test-model-package-group")
     model_package_arn = client.create_model_package(

--- a/tests/test_sagemaker/test_sagemaker_pipeline.py
+++ b/tests/test_sagemaker/test_sagemaker_pipeline.py
@@ -2,7 +2,6 @@ import json
 from contextlib import contextmanager
 from datetime import datetime
 from time import sleep
-from unittest import SkipTest
 
 import boto3
 import botocore
@@ -208,7 +207,7 @@ def test_start_pipeline_execution(sagemaker_client):
 
 def test_start_pipeline_execution_contains_client_request_token(sagemaker_client):
     if settings.TEST_SERVER_MODE:
-        raise SkipTest(
+        raise pytest.skip(
             "Skipping test in server mode due to lack of access to sagemaker_backends."
         )
 
@@ -274,7 +273,7 @@ def test_describe_pipeline_execution(sagemaker_client):
 
 def test_load_pipeline_definition_from_s3():
     if settings.TEST_SERVER_MODE:
-        raise SkipTest(
+        raise pytest.skip(
             "Skipping test in server mode due to lack of access to s3_backend."
         )
 

--- a/tests/test_secretsmanager/test_rotate_simple_lambda.py
+++ b/tests/test_secretsmanager/test_rotate_simple_lambda.py
@@ -1,10 +1,10 @@
 import io
 import json
 import zipfile
-from unittest import SkipTest
 from unittest.mock import patch
 
 import boto3
+import pytest
 from botocore.exceptions import ClientError
 
 from moto import mock_aws, settings
@@ -23,7 +23,7 @@ def mock_lambda_invoke(*args, **kwarg):
 )
 def test_simple_lambda_is_invoked():
     if not settings.TEST_DECORATOR_MODE:
-        raise SkipTest("Can only test patched code in DecoratorMode")
+        raise pytest.skip("Can only test patched code in DecoratorMode")
     sm_client = boto3.client("secretsmanager", region_name="us-east-1")
     secret_arn = sm_client.create_secret(Name="some", SecretString="secret")["ARN"]
 
@@ -44,7 +44,7 @@ def test_simple_lambda_is_invoked():
 )
 def test_simple_lambda_is_invoked__do_not_rotate_immediately():
     if not settings.TEST_DECORATOR_MODE:
-        raise SkipTest("Can only test patched code in DecoratorMode")
+        raise pytest.skip("Can only test patched code in DecoratorMode")
     sm_client = boto3.client("secretsmanager", region_name="us-east-1")
     secret_arn = sm_client.create_secret(Name="some", SecretString="secret")["ARN"]
 

--- a/tests/test_secretsmanager/test_secretsmanager.py
+++ b/tests/test_secretsmanager/test_secretsmanager.py
@@ -3,7 +3,6 @@ import re
 import string
 from datetime import datetime, timedelta, timezone
 from time import sleep
-from unittest import SkipTest
 from uuid import uuid4
 
 import boto3
@@ -928,7 +927,7 @@ def test_cancel_rotate_secret_before_enable():
 @mock_aws
 def test_cancel_rotate_secret():
     if not settings.TEST_SERVER_MODE:
-        raise SkipTest("rotation requires a server to be running")
+        raise pytest.skip("rotation requires a server to be running")
     from tests.test_awslambda.utilities import get_role_name
 
     lambda_conn = boto3.client(
@@ -1251,7 +1250,7 @@ def lambda_handler(event, context):
 def test_rotate_secret_using_lambda(secret=None, iam_role_arn=None, table_name=None):
     role_name = iam_role_arn.split("/")[-1]
     if not allow_aws_request() and not settings.TEST_SERVER_MODE:
-        raise SkipTest("Can only test this in ServerMode")
+        raise pytest.skip("Can only test this in ServerMode")
 
     iam = boto3.client("iam", "us-east-1")
     if allow_aws_request():
@@ -1350,7 +1349,7 @@ def test_rotate_secret_using_lambda_dont_rotate_immediately(
 ):
     role_name = iam_role_arn.split("/")[-1]
     if not allow_aws_request() and not settings.TEST_SERVER_MODE:
-        raise SkipTest("Can only test this in ServerMode")
+        raise pytest.skip("Can only test this in ServerMode")
 
     iam = boto3.client("iam", "us-east-1")
     if allow_aws_request():

--- a/tests/test_servicediscovery/test_servicediscovery_instance.py
+++ b/tests/test_servicediscovery/test_servicediscovery_instance.py
@@ -1,5 +1,3 @@
-from unittest import SkipTest
-
 import boto3
 import pytest
 from botocore.exceptions import ClientError
@@ -184,7 +182,7 @@ def test_update_instance_custom_health_status(client, ns_resp, srv_resp):
 @mock_aws
 def test_discover_instances_formatting(client, ns_resp, srv_resp):
     if not settings.TEST_DECORATOR_MODE:
-        raise SkipTest(
+        raise pytest.skip(
             "Endpoint for discovering instances is prefixed with 'data-', and we can't intercept calls to 'data-localhost'"
         )
 
@@ -211,7 +209,7 @@ def test_discover_instances_formatting(client, ns_resp, srv_resp):
 @mock_aws
 def test_discover_instances_attr_filters(client, ns_resp, srv_resp):
     if not settings.TEST_DECORATOR_MODE:
-        raise SkipTest(
+        raise pytest.skip(
             "Endpoint for discovering instances is prefixed with 'data-', and we can't intercept calls to 'data-localhost'"
         )
 
@@ -276,7 +274,7 @@ def test_discover_instances_attr_filters(client, ns_resp, srv_resp):
 @mock_aws
 def test_discover_instances_health_filters(client, ns_resp, srv_resp):
     if not settings.TEST_DECORATOR_MODE:
-        raise SkipTest(
+        raise pytest.skip(
             "Endpoint for discovering instances is prefixed with 'data-', and we can't intercept calls to 'data-localhost'"
         )
 
@@ -372,7 +370,7 @@ def test_discover_instances_health_filters(client, ns_resp, srv_resp):
 @mock_aws
 def test_max_results_discover_instances(client, ns_resp, srv_resp):
     if not settings.TEST_DECORATOR_MODE:
-        raise SkipTest(
+        raise pytest.skip(
             "Endpoint for discovering instances is prefixed with 'data-', and we can't intercept calls to 'data-localhost'"
         )
 
@@ -396,7 +394,7 @@ def test_max_results_discover_instances(client, ns_resp, srv_resp):
 @mock_aws
 def test_discover_instances_revision(client, ns_resp, srv_resp):
     if not settings.TEST_DECORATOR_MODE:
-        raise SkipTest(
+        raise pytest.skip(
             "Endpoint for discovering instances is prefixed with 'data-', and we can't intercept calls to 'data-localhost'"
         )
 

--- a/tests/test_sns/__init__.py
+++ b/tests/test_sns/__init__.py
@@ -1,11 +1,10 @@
 import json
-import os
 from functools import wraps
-from unittest import SkipTest
 from uuid import uuid4
 
 import boto3
 import botocore
+import pytest
 
 from moto import mock_aws
 from tests import allow_aws_request
@@ -22,11 +21,7 @@ def sns_aws_verified(func):
 
     @wraps(func)
     def pagination_wrapper():
-        allow_aws_request = (
-            os.environ.get("MOTO_TEST_ALLOW_AWS_REQUEST", "false").lower() == "true"
-        )
-
-        if allow_aws_request:
+        if allow_aws_request():
             ssm = boto3.client("ssm", "us-east-1")
             try:
                 param = ssm.get_parameter(
@@ -44,7 +39,7 @@ def sns_aws_verified(func):
                 # AWS calls it 'API key', but Firebase calls it Server Key
                 #
                 # https://stackoverflow.com/a/75896532/13245310
-                raise SkipTest("Can't execute SNS tests without Firebase API key")
+                raise pytest.skip("Can't execute SNS tests without Firebase API key")
         else:
             with mock_aws():
                 resp = func("mock_api_key")

--- a/tests/test_sns/test_http_message_verification.py
+++ b/tests/test_sns/test_http_message_verification.py
@@ -1,10 +1,10 @@
 import base64
 import json
 from http.server import BaseHTTPRequestHandler
-from unittest import SkipTest
 from uuid import uuid4
 
 import boto3
+import pytest
 import requests
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.asymmetric import padding
@@ -46,7 +46,7 @@ class TestHTTPMessageVerification:
 
     def setup_method(self, *args):
         if not settings.TEST_DECORATOR_MODE:
-            raise SkipTest("Can only be tested using decorators")
+            raise pytest.skip("Can only be tested using decorators")
         self.server = SimpleServer(WebRequestHandler)
         self.server.start()
 

--- a/tests/test_sns/test_publishing.py
+++ b/tests/test_sns/test_publishing.py
@@ -1,6 +1,5 @@
 import base64
 import json
-from unittest import SkipTest
 
 import boto3
 import pytest
@@ -483,7 +482,7 @@ def test_publish_to_sqs_in_different_region():
 @mock_aws
 def test_publish_to_http():
     if settings.TEST_SERVER_MODE:
-        raise SkipTest("Can't mock requests in ServerMode")
+        raise pytest.skip("Can't mock requests in ServerMode")
 
     def callback(request):
         assert request.headers["Content-Type"] == "text/plain; charset=UTF-8"

--- a/tests/test_special_cases/test_custom_amis.py
+++ b/tests/test_special_cases/test_custom_amis.py
@@ -7,9 +7,10 @@ import importlib
 import json
 import os
 from pathlib import Path
-from unittest import SkipTest, TestCase, mock
+from unittest import TestCase, mock
 
 import boto3
+import pytest
 
 import moto
 from moto import mock_aws, settings
@@ -54,7 +55,7 @@ class TestEC2CustomAMIs(TestCase):
 
     def setUp(self) -> None:
         if settings.TEST_SERVER_MODE:
-            raise SkipTest("Only test status code in non-ServerMode")
+            raise pytest.skip("Only test status code in non-ServerMode")
         self.test_ami_path = self.setup_amis()
         os.environ["MOTO_AMIS_PATH"] = str(self.test_ami_path)
 

--- a/tests/test_sqs/test_sqs.py
+++ b/tests/test_sqs/test_sqs.py
@@ -4,7 +4,7 @@ import os
 import re
 import sys
 import time
-from unittest import SkipTest, mock
+from unittest import mock
 from uuid import uuid4
 
 import boto3
@@ -987,7 +987,7 @@ def test_receive_message_with_xml_content():
 @mock_aws
 def test_change_message_visibility_than_permitted():
     if settings.TEST_SERVER_MODE:
-        raise SkipTest("Cant manipulate time in server mode")
+        raise pytest.skip("Cant manipulate time in server mode")
 
     sqs = boto3.resource("sqs", region_name=REGION)
     conn = boto3.client("sqs", region_name=REGION)
@@ -2105,7 +2105,7 @@ def test_send_message_batch_with_empty_list():
 @mock_aws
 def test_batch_change_message_visibility():
     if settings.TEST_SERVER_MODE:
-        raise SkipTest("Cant manipulate time in server mode")
+        raise pytest.skip("Cant manipulate time in server mode")
 
     with freeze_time("2015-01-01 12:00:00"):
         sqs = boto3.client("sqs", region_name=REGION)
@@ -2549,7 +2549,7 @@ def test_create_fifo_queue_with_dlq():
 @mock_aws
 def test_queue_with_dlq():
     if settings.TEST_SERVER_MODE:
-        raise SkipTest("Cant manipulate time in server mode")
+        raise pytest.skip("Cant manipulate time in server mode")
 
     sqs = boto3.client("sqs", region_name=REGION)
 
@@ -2772,7 +2772,7 @@ def test_receive_messages_with_message_group_id_on_requeue():
 @mock_aws
 def test_receive_messages_with_message_group_id_on_visibility_timeout():
     if settings.TEST_SERVER_MODE:
-        raise SkipTest("Cant manipulate time in server mode")
+        raise pytest.skip("Cant manipulate time in server mode")
 
     with freeze_time("2015-01-01 12:00:00"):
         sqs = boto3.resource("sqs", region_name=REGION)
@@ -2822,7 +2822,7 @@ def test_receive_message_for_queue_with_receive_message_wait_time_seconds_set():
 def test_list_queues_limits_to_1000_queues():
     if settings.TEST_SERVER_MODE:
         # Re-visit once we have a NextToken-implementation for list_queues
-        raise SkipTest("Too many queues for a persistent mode")
+        raise pytest.skip("Too many queues for a persistent mode")
     client = boto3.client("sqs", region_name=REGION)
 
     prefix_name = str(uuid4())[0:6]
@@ -2972,7 +2972,7 @@ def test_fifo_queue_deduplication_withoutid(msg_1, msg_2, expected_count):
 @mock_aws
 def test_fifo_queue_send_duplicate_messages_after_deduplication_time_limit():
     if settings.TEST_SERVER_MODE:
-        raise SkipTest("Cant patch env variables in server mode")
+        raise pytest.skip("Cant patch env variables in server mode")
 
     sqs = boto3.resource("sqs", region_name=REGION)
     msg_queue = sqs.create_queue(

--- a/tests/test_sqs/test_sqs_integration.py
+++ b/tests/test_sqs/test_sqs_integration.py
@@ -1,7 +1,6 @@
 import json
 import time
 import uuid
-from unittest import SkipTest
 
 import boto3
 import pytest
@@ -75,7 +74,7 @@ def test_invoke_function_from_sqs_queue():
 @mock_aws(config={"lambda": {"use_docker": False}})
 def test_invoke_fake_function_from_sqs_queue():
     if not settings.TEST_DECORATOR_MODE:
-        raise SkipTest("Can only set Config in DecoratorMode")
+        raise pytest.skip("Can only set Config in DecoratorMode")
     logs_conn = boto3.client("logs", region_name="us-east-1")
     sqs = boto3.resource("sqs", region_name="us-east-1")
     queue_name = str(uuid.uuid4())[0:6]

--- a/tests/test_ssm/test_ssm_ec2_integration.py
+++ b/tests/test_ssm/test_ssm_ec2_integration.py
@@ -1,7 +1,8 @@
 import os
-from unittest import SkipTest, mock
+from unittest import mock
 
 import boto3
+import pytest
 
 from moto import mock_aws, settings
 
@@ -14,7 +15,7 @@ test_ami = "/aws/service/ami-amazon-linux-latest/al2023-ami-kernel-default-x86_6
 @mock_aws
 def test_ssm_get_latest_ami_by_path():
     if settings.TEST_SERVER_MODE:
-        raise SkipTest("Can't set environment variables in ServerMode")
+        raise pytest.skip("Can't set environment variables in ServerMode")
     ssm = boto3.client("ssm", region_name="us-east-1")
     ami = ssm.get_parameter(Name=test_ami)["Parameter"]["Value"]
 

--- a/tests/test_ssm/test_ssm_ecs_images.py
+++ b/tests/test_ssm/test_ssm_ecs_images.py
@@ -1,7 +1,8 @@
 import os
-from unittest import SkipTest, mock
+from unittest import mock
 
 import boto3
+import pytest
 
 from moto import mock_aws, settings
 
@@ -12,7 +13,7 @@ from moto import mock_aws, settings
 @mock_aws
 def test_ssm_get_latest_ami_by_path():
     if settings.TEST_SERVER_MODE:
-        raise SkipTest("Can't set environment variables in ServerMode")
+        raise pytest.skip("Can't set environment variables in ServerMode")
     ssm = boto3.client("ssm", region_name="us-east-1")
     path = "/aws/service/ecs/optimized-ami"
     params = ssm.get_parameters_by_path(Path=path, Recursive=True)["Parameters"]

--- a/tests/test_stepfunctions/parser/test_choice_state.py
+++ b/tests/test_stepfunctions/parser/test_choice_state.py
@@ -1,5 +1,6 @@
 import json
-from unittest import SkipTest
+
+import pytest
 
 from moto import mock_aws, settings
 
@@ -9,7 +10,7 @@ from . import aws_verified, verify_execution_result
 @mock_aws(config={"stepfunctions": {"execute_state_machine": True}})
 def test_state_machine_with_choice():
     if settings.TEST_SERVER_MODE:
-        raise SkipTest("Don't need to test this in ServerMode")
+        raise pytest.skip("Don't need to test this in ServerMode")
     tmpl_name = "choice_state_singleton"
     exec_input = {"type": "Public"}
 
@@ -24,7 +25,7 @@ def test_state_machine_with_choice():
 @aws_verified
 def test_state_machine_with_choice_miss():
     if settings.TEST_SERVER_MODE:
-        raise SkipTest("Don't need to test this in ServerMode")
+        raise pytest.skip("Don't need to test this in ServerMode")
     tmpl_name = "choice_state_singleton"
     exec_input = {"type": "Private"}
 

--- a/tests/test_stepfunctions/parser/test_comments.py
+++ b/tests/test_stepfunctions/parser/test_comments.py
@@ -1,5 +1,6 @@
 import json
-from unittest import SkipTest
+
+import pytest
 
 from moto import mock_aws, settings
 
@@ -9,7 +10,7 @@ from . import verify_execution_result
 @mock_aws(config={"stepfunctions": {"execute_state_machine": True}})
 def test_comments_in_parameters():
     if settings.TEST_SERVER_MODE:
-        raise SkipTest("Don't need to test this in ServerMode")
+        raise pytest.skip("Don't need to test this in ServerMode")
     tmpl_name = "comments/comments_in_parameters"
     exec_input = {"type": "Public"}
 

--- a/tests/test_stepfunctions/parser/test_map_item.py
+++ b/tests/test_stepfunctions/parser/test_map_item.py
@@ -1,7 +1,7 @@
 import json
-from unittest import SkipTest
 
 import boto3
+import pytest
 
 from moto import mock_aws, settings
 
@@ -11,7 +11,7 @@ from . import verify_execution_result
 @mock_aws(config={"stepfunctions": {"execute_state_machine": True}})
 def test_state_machine_with_map_reader_csv():
     if settings.TEST_SERVER_MODE:
-        raise SkipTest("Don't need to test this in ServerMode")
+        raise pytest.skip("Don't need to test this in ServerMode")
 
     # Prepare CSV
     s3 = boto3.client("s3", "us-east-1")
@@ -48,7 +48,7 @@ def test_state_machine_with_map_reader_csv():
 @mock_aws(config={"stepfunctions": {"execute_state_machine": True}})
 def test_state_machine_with_map_reader_csv_with_header():
     if settings.TEST_SERVER_MODE:
-        raise SkipTest("Don't need to test this in ServerMode")
+        raise pytest.skip("Don't need to test this in ServerMode")
 
     # Prepare CSV
     s3 = boto3.client("s3", "us-east-1")

--- a/tests/test_stepfunctions/parser/test_parallel_states.py
+++ b/tests/test_stepfunctions/parser/test_parallel_states.py
@@ -1,5 +1,6 @@
 import json
-from unittest import SkipTest
+
+import pytest
 
 from moto import mock_aws, settings
 
@@ -9,7 +10,7 @@ from . import verify_execution_result
 @mock_aws(config={"stepfunctions": {"execute_state_machine": True}})
 def test_state_machine_with_parallel_states():
     if settings.TEST_SERVER_MODE:
-        raise SkipTest("Don't need to test this in ServerMode")
+        raise pytest.skip("Don't need to test this in ServerMode")
     tmpl_name = "parallel_states"
 
     def _verify_result(client, execution, execution_arn):
@@ -32,7 +33,7 @@ def test_state_machine_with_parallel_states():
 @mock_aws(config={"stepfunctions": {"execute_state_machine": True}})
 def test_state_machine_with_parallel_states_catch_error():
     if settings.TEST_SERVER_MODE:
-        raise SkipTest("Don't need to test this in ServerMode")
+        raise pytest.skip("Don't need to test this in ServerMode")
     expected_status = "SUCCEEDED"
     tmpl_name = "parallel_states_catch"
 
@@ -51,7 +52,7 @@ def test_state_machine_with_parallel_states_catch_error():
 @mock_aws(config={"stepfunctions": {"execute_state_machine": True}})
 def test_state_machine_with_parallel_states_error():
     if settings.TEST_SERVER_MODE:
-        raise SkipTest("Don't need to test this in ServerMode")
+        raise pytest.skip("Don't need to test this in ServerMode")
 
     def _verify_result(client, execution, execution_arn):
         assert "stopDate" in execution
@@ -63,7 +64,7 @@ def test_state_machine_with_parallel_states_error():
 @mock_aws(config={"stepfunctions": {"execute_state_machine": True}})
 def test_state_machine_with_parallel_states_order():
     if settings.TEST_SERVER_MODE:
-        raise SkipTest("Don't need to test this in ServerMode")
+        raise pytest.skip("Don't need to test this in ServerMode")
 
     def _verify_result(client, execution, execution_arn):
         assert json.loads(execution["output"]) == [

--- a/tests/test_stepfunctions/parser/test_stepfunctions.py
+++ b/tests/test_stepfunctions/parser/test_stepfunctions.py
@@ -1,6 +1,5 @@
 import json
 from time import sleep
-from unittest import SkipTest
 from uuid import uuid4
 
 import boto3
@@ -21,7 +20,7 @@ from . import (
 @pytest.mark.aws_verified
 def test_state_machine_with_simple_failure_state():
     if settings.TEST_SERVER_MODE:
-        raise SkipTest("Don't need to test this in ServerMode")
+        raise pytest.skip("Don't need to test this in ServerMode")
 
     def _verify_result(client, execution, execution_arn):
         assert "stopDate" in execution
@@ -55,7 +54,7 @@ def test_state_machine_with_simple_failure_state():
 @pytest.mark.aws_verified
 def test_state_machine_with_input():
     if settings.TEST_SERVER_MODE:
-        raise SkipTest("Don't need to test this in ServerMode")
+        raise pytest.skip("Don't need to test this in ServerMode")
 
     _input = {"my": "data"}
 
@@ -74,7 +73,7 @@ def test_state_machine_with_input():
 @pytest.mark.aws_verified
 def test_state_machine_with_json_regex():
     if settings.TEST_SERVER_MODE:
-        raise SkipTest("Don't need to test this in ServerMode")
+        raise pytest.skip("Don't need to test this in ServerMode")
 
     _input = {"Parameters": [{"Name": "/eggs/cooked/like", "Value": "poached"}]}
     _output = {
@@ -172,7 +171,7 @@ def test_version_is_only_available_when_published():
 @mock_aws(config={"stepfunctions": {"execute_state_machine": True}})
 def test_verify_template_with_credentials():
     if settings.TEST_SERVER_MODE:
-        raise SkipTest("Don't need to test this in ServerMode")
+        raise pytest.skip("Don't need to test this in ServerMode")
 
     def _verify_result(client, execution, execution_arn):
         output = json.loads(execution["output"])

--- a/tests/test_stepfunctions/parser/test_stepfunctions_sns_integration.py
+++ b/tests/test_stepfunctions/parser/test_stepfunctions_sns_integration.py
@@ -1,7 +1,7 @@
 import json
-from unittest import SkipTest
 
 import boto3
+import pytest
 
 from moto import mock_aws, settings
 from moto.sns.models import sns_backends
@@ -13,7 +13,7 @@ from . import verify_execution_result
 @mock_aws(config={"stepfunctions": {"execute_state_machine": True}})
 def test_state_machine_calling_sns_publish():
     if not settings.TEST_DECORATOR_MODE:
-        raise SkipTest("No point in testing this in ServerMode")
+        raise pytest.skip("No point in testing this in ServerMode")
     sns = boto3.client("sns", "us-east-1")
     topic_arn = sns.create_topic(Name="mytopic")["TopicArn"]
 

--- a/tests/test_stepfunctions/parser/test_stepfunctions_sqs_integration.py
+++ b/tests/test_stepfunctions/parser/test_stepfunctions_sqs_integration.py
@@ -1,8 +1,8 @@
 import json
-from unittest import SkipTest
 from uuid import uuid4
 
 import boto3
+import pytest
 
 from moto import mock_aws, settings
 
@@ -12,7 +12,7 @@ from . import verify_execution_result
 @mock_aws(config={"stepfunctions": {"execute_state_machine": True}})
 def test_state_machine_calling_sqs_with_heartbeat():
     if not settings.TEST_DECORATOR_MODE:
-        raise SkipTest("No point in testing this in ServerMode")
+        raise pytest.skip("No point in testing this in ServerMode")
     sqs = boto3.client("sqs", "us-east-1")
     sfn = boto3.client("stepfunctions", "us-east-1")
     queue_name = f"queue{uuid4()}"
@@ -43,7 +43,7 @@ def test_state_machine_calling_sqs_with_heartbeat():
 @mock_aws(config={"stepfunctions": {"execute_state_machine": True}})
 def test_state_machine_calling_sqs_with_task_success():
     if not settings.TEST_DECORATOR_MODE:
-        raise SkipTest("No point in testing this in ServerMode")
+        raise pytest.skip("No point in testing this in ServerMode")
     sqs = boto3.client("sqs", "us-east-1")
     sfn = boto3.client("stepfunctions", "us-east-1")
     queue_name = f"queue{uuid4()}"

--- a/tests/test_stepfunctions/test_stepfunctions.py
+++ b/tests/test_stepfunctions/test_stepfunctions.py
@@ -2,7 +2,7 @@ import json
 import os
 import re
 from datetime import datetime
-from unittest import SkipTest, mock
+from unittest import mock
 from uuid import uuid4
 
 import boto3
@@ -919,7 +919,7 @@ def test_stepfunction_regions(test_region):
 @mock.patch.dict(os.environ, {"SF_EXECUTION_HISTORY_TYPE": "FAILURE"})
 def test_state_machine_get_execution_history_contains_expected_failure_events_when_started():
     if os.environ.get("TEST_SERVER_MODE", "false").lower() == "true":
-        raise SkipTest("Cant pass environment variable in server mode")
+        raise pytest.skip("Cant pass environment variable in server mode")
     expected_events = [
         {
             "timestamp": datetime(2020, 1, 1, 0, 0, 0, tzinfo=tzutc()),

--- a/tests/test_swf/responses/test_activity_tasks.py
+++ b/tests/test_swf/responses/test_activity_tasks.py
@@ -1,5 +1,4 @@
 import re
-from unittest import SkipTest
 
 import pytest
 from botocore.exceptions import ClientError
@@ -254,7 +253,7 @@ def test_record_activity_task_heartbeat_with_wrong_token():
 @mock_aws
 def test_record_activity_task_heartbeat_sets_details_in_case_of_timeout():
     if settings.TEST_SERVER_MODE:
-        raise SkipTest("Unable to manipulate time in ServerMode")
+        raise pytest.skip("Unable to manipulate time in ServerMode")
     client = setup_workflow()
     decision_token = client.poll_for_decision_task(
         domain="test-domain", taskList={"name": "queue"}

--- a/tests/test_swf/responses/test_timeouts.py
+++ b/tests/test_swf/responses/test_timeouts.py
@@ -1,6 +1,6 @@
 from datetime import datetime
-from unittest import SkipTest
 
+import pytest
 from dateutil.parser import parse as dtparse
 from freezegun import freeze_time
 
@@ -14,7 +14,7 @@ from ..utils import SCHEDULE_ACTIVITY_TASK_DECISION, setup_workflow
 @mock_aws
 def test_activity_task_heartbeat_timeout():
     if settings.TEST_SERVER_MODE:
-        raise SkipTest("Unable to manipulate time in ServerMode")
+        raise pytest.skip("Unable to manipulate time in ServerMode")
     with freeze_time("2015-01-01 12:00:00"):
         client = setup_workflow()
         decision_token = client.poll_for_decision_task(
@@ -57,7 +57,7 @@ def test_activity_task_heartbeat_timeout():
 @mock_aws
 def test_decision_task_start_to_close_timeout():
     if settings.TEST_SERVER_MODE:
-        raise SkipTest("Unable to manipulate time in ServerMode")
+        raise pytest.skip("Unable to manipulate time in ServerMode")
 
     with freeze_time("2015-01-01 12:00:00 UTC"):
         client = setup_workflow()
@@ -108,7 +108,7 @@ def test_decision_task_start_to_close_timeout():
 @mock_aws
 def test_workflow_execution_start_to_close_timeout():
     if settings.TEST_SERVER_MODE:
-        raise SkipTest("Unable to manipulate time in ServerMode")
+        raise pytest.skip("Unable to manipulate time in ServerMode")
     with freeze_time("2015-01-01 12:00:00 UTC"):
         client = setup_workflow()
 

--- a/tests/test_textract/test_textract.py
+++ b/tests/test_textract/test_textract.py
@@ -1,6 +1,5 @@
 import json
 from random import randint
-from unittest import SkipTest
 
 import boto3
 import pytest
@@ -16,7 +15,7 @@ from moto.textract.models import TextractBackend
 @mock_aws
 def test_get_document_text_detection():
     if settings.TEST_SERVER_MODE:
-        raise SkipTest("Cannot set textract backend values in server mode")
+        raise pytest.skip("Cannot set textract backend values in server mode")
 
     TextractBackend.JOB_STATUS = "SUCCEEDED"
     TextractBackend.PAGES = randint(5, 500)
@@ -146,7 +145,7 @@ def test_start_document_text_detection_with_sns_notification():
 @mock_aws
 def test_get_document_analysis():
     if settings.TEST_SERVER_MODE:
-        raise SkipTest("Cannot set textract backend values in server mode")
+        raise pytest.skip("Cannot set textract backend values in server mode")
 
     TextractBackend.JOB_STATUS = "SUCCEEDED"
     TextractBackend.PAGES = randint(5, 500)

--- a/tests/test_utilities/test_threaded_server.py
+++ b/tests/test_utilities/test_threaded_server.py
@@ -1,7 +1,7 @@
 import unittest
-from unittest import SkipTest
 
 import boto3
+import pytest
 import requests
 
 from moto import mock_aws, settings
@@ -11,7 +11,7 @@ from moto.server import ThreadedMotoServer
 class TestThreadedMotoServer(unittest.TestCase):
     def setUp(self):
         if settings.TEST_SERVER_MODE:
-            raise SkipTest("No point in testing ServerMode within ServerMode")
+            raise pytest.skip("No point in testing ServerMode within ServerMode")
         self.server = ThreadedMotoServer(ip_address="127.0.0.1")
         self.server.start()
         requests.post("http://localhost:5000/moto-api/reset")
@@ -58,7 +58,7 @@ class TestThreadedMotoServer(unittest.TestCase):
 
 def test_threaded_moto_server__different_port():
     if settings.TEST_SERVER_MODE:
-        raise SkipTest("No point in testing ServerMode within ServerMode")
+        raise pytest.skip("No point in testing ServerMode within ServerMode")
     server = ThreadedMotoServer(port=5001)
     server.start()
     requests.post("http://localhost:5001/moto-api/reset")
@@ -79,7 +79,7 @@ def test_threaded_moto_server__different_port():
 
 def test_threaded_moto_server__using_requests():
     if settings.TEST_SERVER_MODE:
-        raise SkipTest("No point in testing ServerMode within ServerMode")
+        raise pytest.skip("No point in testing ServerMode within ServerMode")
     server = ThreadedMotoServer(port=5001)
     server.start()
     requests.post("http://localhost:5001/moto-api/reset")

--- a/tests/test_xray/test_xray_client.py
+++ b/tests/test_xray/test_xray_client.py
@@ -1,12 +1,12 @@
 import os
 import sys
-from unittest import SkipTest
 
 import aws_xray_sdk.core as xray_core
 import aws_xray_sdk.core.patcher as xray_core_patcher
 import boto3
 import botocore.client
 import botocore.endpoint
+import pytest
 import requests
 
 from moto import mock_aws
@@ -35,7 +35,7 @@ def check_coverage_status():
     # If Coverage is not enabled in this test run, we're fine
     if "COV_CORE_SOURCE" not in os.environ:
         return
-    raise SkipTest("Can't run this test with Coverage 5.x")
+    raise pytest.skip("Can't run this test with Coverage 5.x")
 
 
 @mock_aws


### PR DESCRIPTION
Relevant bug report: https://github.com/pytest-dev/pytest/issues/13895

It looks like it may be reverted, but that's still under discussion, and 200+ of our tests break because of it. So I'll probably just merge anyway.
