### PR TITLE
Admin: Skip pytest 9.0.0

### DIFF
--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -1,6 +1,7 @@
 coverage
 pycognito
-pytest
+# Pytest 9.0.0 fails SkipTest, instead of skipping - see https://github.com/pytest-dev/pytest/issues/13895
+pytest!=9.0.0
 pytest-cov
 pytest-order
 pytest-xdist


### PR DESCRIPTION
Fixes the build, as that's currently broken with `pytest==9.0.0`.

This is [already fixed](https://github.com/pytest-dev/pytest/pull/13912) in pytest main, so I expect this to work again with 9.0.1. 

Supercedes #9459 