### PR TITLE
EC2: Fix type for key pair public key material

### DIFF
--- a/moto/ec2/responses/key_pairs.py
+++ b/moto/ec2/responses/key_pairs.py
@@ -26,7 +26,7 @@ class KeyPairs(EC2BaseResponse):
 
     def import_key_pair(self) -> str:
         name = self._get_param("KeyName")
-        material = self._get_param("PublicKeyMaterial")
+        material = self._get_param("PublicKeyMaterial").decode("utf-8")  # type: str
         tags = self._parse_tag_specification("key-pair").get("key-pair", {})
         self.error_on_dryrun()
 


### PR DESCRIPTION
This PR fixes a bug in the `KeyPair` resource, where the `KeyPair.material_public` attribute is expected to be `str` but held `byte` instead.