### PR TITLE
fix: Optimize request parsing.

### DIFF
--- a/moto/core/utils.py
+++ b/moto/core/utils.py
@@ -378,6 +378,10 @@ def extract_region_from_aws_authorization(string: str) -> Optional[str]:
     return region
 
 
+# Match: "member." followed by digits
+_PARAMS_SORT_REGEX = re.compile(r"member\.(\d+)")
+
+
 def params_sort_function(item: tuple[str, Any]) -> tuple[str, int, str]:
     """
     sort by <string-prefix>.member.<integer>.<string-postfix>:
@@ -387,9 +391,9 @@ def params_sort_function(item: tuple[str, Any]) -> tuple[str, int, str]:
     """
     key, _ = item
 
-    match = re.search(r"(.*?member)\.(\d+)(.*)", key)
+    match = _PARAMS_SORT_REGEX.search(key)
     if match:
-        return (match.group(1), int(match.group(2)), match.group(3))
+        return (key[: match.start() + 7], int(match.group(1)), key[match.end() :])
     return (key, 0, "")
 
 


### PR DESCRIPTION
When sending a large `Body` to `sagemaker_runtime.invoke_endpoint` the
response times would just explode. The regular expression used for
sorting the keys had some bad backtracking and performance behavior.

To improve the situation, we can simplify the regex and make use of the
Match object returned from the search to do the splitting. This
implementation is intended to retain the existing behavior but if the
`member` suffix in the first element of the tuple isn't needed then the
magic `+7` could be dropped.
