### PR TITLE
EC2: add assertions for default RunInstances response

### DIFF
--- a/tests/test_ec2/test_instances.py
+++ b/tests/test_ec2/test_instances.py
@@ -3033,7 +3033,7 @@ def test_run_instances_default_response():
     assert mo["HttpTokens"] == "optional"
     assert mo["InstanceMetadataTags"] == "disabled"
     monitoring = instance["Monitoring"]
-    assert monitoring["State"] == " disabled "
+    assert monitoring["State"] == "disabled"
     assert len(instance["NetworkInterfaces"]) == 1
     nif = instance["NetworkInterfaces"][0]
     assert nif["Association"]["IpOwnerId"] == ACCOUNT_ID


### PR DESCRIPTION
This PR adds a test to capture Moto's default ec2:RunInstances response as it exists today to help minimize potential regressions when integrating with the new serialization pipeline.
