### PR TITLE
EC2: standardize default `timestamp` response attribute serialization format 

### DIFF
--- a/moto/core/serialize.py
+++ b/moto/core/serialize.py
@@ -100,11 +100,13 @@ class SerializationContext:
 
 class TimestampSerializer:
     TIMESTAMP_FORMAT_ISO8601 = "iso8601"
+    TIMESTAMP_FORMAT_ISO8601_ZEROED = "iso8601_zeroed"
     TIMESTAMP_FORMAT_RFC822 = "rfc822"
     TIMESTAMP_FORMAT_UNIX = "unixtimestamp"
 
     ISO8601 = "%Y-%m-%dT%H:%M:%SZ"
     ISO8601_MICRO = "%Y-%m-%dT%H:%M:%S.%fZ"
+    ISO8601_MICRO_ZEROED = "%Y-%m-%dT%H:%M:%S.000Z"
 
     def __init__(self, default_format: str) -> None:
         self.default_format = default_format
@@ -124,6 +126,9 @@ class TimestampSerializer:
         else:
             timestamp_format = self.ISO8601
         return value.strftime(timestamp_format)
+
+    def _timestamp_iso8601_zeroed(self, value: datetime) -> str:
+        return value.strftime(self.ISO8601_MICRO_ZEROED)
 
     @staticmethod
     def _timestamp_unixtimestamp(value: datetime) -> float:
@@ -888,6 +893,8 @@ class QueryJSONSerializer(QuerySerializer):
 
 
 class EC2Serializer(QuerySerializer):
+    DEFAULT_TIMESTAMP_FORMAT = TimestampSerializer.TIMESTAMP_FORMAT_ISO8601_ZEROED
+
     def _serialize_body(self, body: Mapping[str, Any]) -> str:
         body_serialized = xmltodict.unparse(
             body,

--- a/tests/test_core/protocols/output/ec2.json
+++ b/tests/test_core/protocols/output/ec2.json
@@ -514,7 +514,7 @@
         "response": {
           "status_code": 200,
           "headers": {},
-          "body": "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<OperationNameResponse><TimeArg>2014-04-29T18:30:38Z</TimeArg><TimeCustom>Tue, 29 Apr 2014 18:30:38 GMT</TimeCustom><TimeFormat>1398796238</TimeFormat><StructMember><foo>2014-04-29T18:30:38Z</foo><bar>1398796238</bar></StructMember><requestId>request-id</requestId></OperationNameResponse>"
+          "body": "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<OperationNameResponse><TimeArg>2014-04-29T18:30:38.000Z</TimeArg><TimeCustom>Tue, 29 Apr 2014 18:30:38 GMT</TimeCustom><TimeFormat>1398796238</TimeFormat><StructMember><foo>2014-04-29T18:30:38.000Z</foo><bar>1398796238</bar></StructMember><requestId>request-id</requestId></OperationNameResponse>"
         }
       }
     ]


### PR DESCRIPTION
Default timestamp format for EC2 responses is ISO8601 with fractional seconds always set to `.000`.