### PR TITLE
[DMS] Correct success status for test_connection()

### DIFF
--- a/moto/dms/models.py
+++ b/moto/dms/models.py
@@ -896,7 +896,7 @@ class FakeConnection(ManagedState):
         ManagedState.__init__(
             self,
             model_name="dms::connection",
-            transitions=[("testing", "success")],
+            transitions=[("testing", "successful")],
         )
 
         self.replication_instance_arn = replication_instance_arn

--- a/tests/test_dms/test_dms.py
+++ b/tests/test_dms/test_dms.py
@@ -738,7 +738,7 @@ def test_describe_connections():
     connection = response["Connections"][0]
     assert connection["ReplicationInstanceArn"] == replication_instance_arn
     assert connection["EndpointArn"] == endpoint_arn
-    assert connection["Status"] == "success"
+    assert connection["Status"] == "successful"
     assert connection["EndpointIdentifier"] == "test-endpoint"
     assert connection["ReplicationInstanceIdentifier"] == "test-instance"
 

--- a/tests/test_dms/test_dms_connection_state.py
+++ b/tests/test_dms/test_dms_connection_state.py
@@ -77,7 +77,7 @@ def test_describe_connection_with_manual_transition(execution_state_transition):
     connection = response["Connections"][0]
     assert connection["ReplicationInstanceArn"] == replication_instance_arn
     assert connection["EndpointArn"] == endpoint_arn
-    assert connection["Status"] == "success"
+    assert connection["Status"] == "successful"
     assert connection["EndpointIdentifier"] == "test-endpoint"
     assert connection["ReplicationInstanceIdentifier"] == "test-instance"
 
@@ -118,6 +118,6 @@ def test_describe_connection_without_transition():
     connection = response["Connections"][0]
     assert connection["ReplicationInstanceArn"] == replication_instance_arn
     assert connection["EndpointArn"] == endpoint_arn
-    assert connection["Status"] == "success"
+    assert connection["Status"] == "successful"
     assert connection["EndpointIdentifier"] == "test-endpoint"
     assert connection["ReplicationInstanceIdentifier"] == "test-instance"


### PR DESCRIPTION
This is a small correction to my change submitted as part of  https://github.com/getmoto/moto/pull/9447 the DMS API  returns `successful` rather than `success` when a connection test passes