### PR TITLE
SQS: remove `x-amz-crc32` header from responses

### DIFF
--- a/moto/sqs/responses.py
+++ b/moto/sqs/responses.py
@@ -2,7 +2,6 @@ import re
 from typing import Any, Optional
 from urllib.parse import urlparse
 
-from moto.core.common_types import TYPE_RESPONSE
 from moto.core.responses import ActionResult, BaseResponse, EmptyResult
 
 from .constants import (
@@ -57,9 +56,6 @@ class SQSResponse(BaseResponse):
         if visibility_timeout > MAXIMUM_VISIBILITY_TIMEOUT:
             raise ValueError
         return visibility_timeout
-
-    def call_action(self) -> TYPE_RESPONSE:
-        return super().call_action()
 
     def create_queue(self) -> ActionResult:
         request_url = urlparse(self.uri)


### PR DESCRIPTION
Botocore only checks for the `x-amz-crc32` header when dealing with DynamoDB responses and ignores it for any other service, but the .NET SDK will always attempt to validate the checksum as long as the header is present, which is causing problems when Moto includes the header with SQS responses that don't contain any modelled output (reported in #9467).

This header was added to Moto's SQS backend responses quite some time ago as part of #1255, which included support for AWS X-Ray, and provided the following reasoning:

> I added the relevant CRCs and request IDs to the endpoints that the X-Ray SDK lists in a json whitelist file.

The whitelist mentioned [still exists](https://github.com/aws/aws-xray-sdk-python/blob/56a127d926966b12acbc06c8f8860ef65bb06d66/aws_xray_sdk/ext/resources/aws_para_whitelist.json#L155), but as far as I can tell real SQS responses from AWS never contained this header and SQS integration with X-Ray was via the `AWSTraceHeader` (which Moto [partially] supports).  I cannot find any references in any of the current X-Ray documentation or SDK codebase(s) to the `x-amz-crc32` header.

Anyway, all this to say: I don't believe this header should be included in SQS responses (then or now), so this PR removes it entirely.