### PR TITLE
Core: remove obsolete parameter sorting method

### DIFF
--- a/moto/core/responses.py
+++ b/moto/core/responses.py
@@ -42,7 +42,6 @@ from moto.core.utils import (
     get_value,
     gzip_decompress,
     method_names_from_class,
-    params_sort_function,
 )
 from moto.utilities.aws_headers import gen_amzn_requestid_long
 from moto.utilities.utils import get_partition
@@ -731,7 +730,7 @@ class BaseResponse(_TemplateEnvironmentMixin, ActionAuthenticatorMixin):
         if self.automated_parameter_parsing:
             return self.params
         params: dict[str, Any] = {}
-        for k, v in sorted(self.querystring.items(), key=params_sort_function):
+        for k, v in sorted(self.querystring.items()):
             self._parse_param(k, v[0], params)
         return params
 

--- a/moto/core/utils.py
+++ b/moto/core/utils.py
@@ -378,21 +378,6 @@ def extract_region_from_aws_authorization(string: str) -> Optional[str]:
     return region
 
 
-def params_sort_function(item: tuple[str, Any]) -> tuple[str, int, str]:
-    """
-    sort by <string-prefix>.member.<integer>.<string-postfix>:
-    in case there are more than 10 members, the default-string sort would lead to IndexError when parsing the content.
-
-    Note: currently considers only the first occurence of `member`, but there may be cases with nested members
-    """
-    key, _ = item
-
-    match = re.search(r"(.*?member)\.(\d+)(.*)", key)
-    if match:
-        return (match.group(1), int(match.group(2)), match.group(3))
-    return (key, 0, "")
-
-
 def gzip_decompress(body: bytes) -> bytes:
     return decompress(body)
 


### PR DESCRIPTION
History of this method: #6033, #6038, and #7056

Long story short: now that all Query protocol-based services have been integrated with the new request parsing pipeline, this method is no longer needed.  It is also recently reported to be causing problems for non-Query protocol input (#9464).

Supersedes/Closes #9464 