### PR TITLE
Admin: Harden AWS tests

### DIFF
--- a/moto/dynamodb/responses.py
+++ b/moto/dynamodb/responses.py
@@ -726,15 +726,12 @@ class DynamoHandler(BaseResponse):
             )
 
         expression_attribute_names = self.body.get("ExpressionAttributeNames")
+        if projection_expression is None and expression_attribute_names:
+            raise MockValidationException(
+                "ExpressionAttributeNames can only be specified when using expressions"
+            )
         if expression_attribute_names == {}:
-            if projection_expression is None:
-                raise MockValidationException(
-                    "ExpressionAttributeNames can only be specified when using expressions"
-                )
-            else:
-                raise MockValidationException(
-                    "ExpressionAttributeNames must not be empty"
-                )
+            raise MockValidationException("ExpressionAttributeNames must not be empty")
 
         if not all(k in table.attribute_keys for k in key):
             raise ProvidedKeyDoesNotExist

--- a/tests/test_dynamodb/exceptions/test_dynamodb_exceptions.py
+++ b/tests/test_dynamodb/exceptions/test_dynamodb_exceptions.py
@@ -225,9 +225,9 @@ def test_empty_expressionattributenames(table_name=None):
     ddb = boto3.resource("dynamodb", region_name="us-east-1")
     table = ddb.Table(table_name)
     with pytest.raises(ClientError) as exc:
-        # Note: provided key is wrong
-        # Empty ExpressionAttributeName is verified earlier, so that's the error we get
-        table.get_item(Key={"id": "my_id"}, ExpressionAttributeNames={})
+        # Note: provided key is wrong. Expression doesn't exist either.
+        # Whether we can supply ExpressionAttributeName in the first place, that's what we're validating here
+        table.get_item(Key={"id": "my_id"}, ExpressionAttributeNames={"#a": "b"})
     err = exc.value.response["Error"]
     assert err["Code"] == "ValidationException"
     assert (

--- a/tests/test_s3/test_s3_tagging.py
+++ b/tests/test_s3/test_s3_tagging.py
@@ -297,8 +297,8 @@ def test_put_object_tagging(bucket_name=None):
     )
     assert resp["ResponseMetadata"]["HTTPStatusCode"] == 200
 
-    tags_set = s3_client.get_object_tagging(Bucket=bucket_name, Key=key)["TagSet"]
-    assert tags_set == tags_to_set
+    actual_tags = s3_client.get_object_tagging(Bucket=bucket_name, Key=key)["TagSet"]
+    assert all(tag in actual_tags for tag in tags_to_set)
 
 
 @mock_aws


### PR DESCRIPTION
Some of the AWS-validated tests were failing - either because the behaviour has changed, or because the (output of the) tests are non-deterministic. This should fix all of the tests that are known to (occasionally) fail