### PR TITLE
Admin: fix build after Sagemaker major version bump

### DIFF
--- a/.github/workflows/tests_sdk_sagemaker.yml
+++ b/.github/workflows/tests_sdk_sagemaker.yml
@@ -18,7 +18,7 @@ jobs:
         pip install .[sagemaker]
     - name: Install dependencies
       run: |
-        pip install boto3 pytest sagemaker<3
+        pip install boto3 pytest "sagemaker<3"
         # Multiple versions of sagemaker_core failing with the following:
         # E       pydantic_core._pydantic_core.ValidationError: 1 validation error for TrainingJob.create
         # E       session


### PR DESCRIPTION
Just fixing the build for now.  Obviously getting our tests to work with `sagemaker>= 3.0` would take additional effort.