### PR TITLE
S3: create_bucket() no longer throws a MalformedXML-error when parameters are not provided

### DIFF
--- a/moto/s3/responses.py
+++ b/moto/s3/responses.py
@@ -924,8 +924,6 @@ class S3Response(BaseResponse):
                     raise IllegalLocationConstraintException()
                 if location_constraint != self.region:
                     raise IncompatibleLocationConstraintException(location_constraint)
-            if self.body and not location_constraint:
-                raise MalformedXML()
 
             bucket_region = (
                 location_constraint if location_constraint else DEFAULT_REGION_NAME


### PR DESCRIPTION
This was observed in the Terraform tests, where some tests with AWS provider 6.23 are currently failing.

All affected tests have been re-verified against AWS.

Note that the TF tests are still failing - they also require the S3Control: `list_tags_for_resource`-method which isn't implemented yet.

Related LocalStack PR which fixes the same thing: https://github.com/localstack/localstack/pull/13427