### PR TITLE
S3Vectors: Simplify tests by introducing a fixture to create buckets

### DIFF
--- a/moto/s3vectors/exceptions.py
+++ b/moto/s3vectors/exceptions.py
@@ -43,3 +43,10 @@ class VectorBucketAlreadyExists(ServiceException):
 
     def __init__(self) -> None:
         super().__init__("A vector bucket with the specified name already exists")
+
+
+class VectorBucketNotEmpty(ServiceException):
+    code = "ConflictException"
+
+    def __init__(self) -> None:
+        super().__init__("The specified vector bucket is not empty")

--- a/tests/test_s3vectors/__init__.py
+++ b/tests/test_s3vectors/__init__.py
@@ -1,0 +1,74 @@
+from functools import wraps
+from uuid import uuid4
+
+import boto3
+from botocore.exceptions import ClientError
+
+from moto import mock_aws
+from tests import allow_aws_request
+
+
+def s3vectors_aws_verified(
+    create_bucket: bool = True,
+):
+    """
+    Function that is verified to work against AWS.
+    Can be run against AWS at any time by setting:
+      MOTO_TEST_ALLOW_AWS_REQUEST=true
+
+    If this environment variable is not set, the function runs in a `mock_aws` context.
+
+    This decorator will:
+      - Create a S3Vector bucket
+      - Run the test and pass the bucket_name as an argument
+      - Delete the bucket
+    """
+
+    def inner(func):
+        @wraps(func)
+        def pagination_wrapper(**kwargs):
+            bucket_name = str(uuid4())
+            if create_bucket:
+                kwargs["bucket_name"] = bucket_name
+
+            def create_bucket_and_test():
+                client = boto3.client("s3vectors", region_name="us-east-1")
+
+                client.create_vector_bucket(
+                    vectorBucketName=kwargs["bucket_name"],
+                )
+                try:
+                    resp = func(**kwargs)
+                finally:
+                    try:
+                        indexes = client.list_indexes(vectorBucketName=bucket_name)[
+                            "indexes"
+                        ]
+                        for index in indexes:
+                            client.delete_index(
+                                vectorBucketName=bucket_name,
+                                indexName=index["indexName"],
+                            )
+                        client.delete_vector_bucket(vectorBucketName=bucket_name)
+                    except ClientError as e:
+                        # Bucket may have been deleted in the test itself
+                        assert e.response["Error"]["Code"] == "NotFoundException", e
+
+                return resp
+
+            if allow_aws_request():
+                if create_bucket:
+                    print(f"Test {func} will create Vector Bucket {bucket_name}")  # noqa
+                    return create_bucket_and_test()
+                else:
+                    return func(**kwargs)
+            else:
+                with mock_aws():
+                    if create_bucket:
+                        return create_bucket_and_test()
+                    else:
+                        return func(**kwargs)
+
+        return pagination_wrapper
+
+    return inner

--- a/tests/test_s3vectors/test_s3vector_indexes.py
+++ b/tests/test_s3vectors/test_s3vector_indexes.py
@@ -7,184 +7,148 @@ import pytest
 from botocore.exceptions import ClientError
 
 from tests import aws_verified
+from tests.test_s3vectors import s3vectors_aws_verified
 
 # See our Development Tips on writing tests for hints on how to write good tests:
 # http://docs.getmoto.org/en/latest/docs/contributing/development_tips/tests.html
 
 
-@aws_verified
+@s3vectors_aws_verified()
 @pytest.mark.aws_verified
-def test_create_and_get_index_by_name(account_id):
+def test_create_and_get_index_by_name(account_id, bucket_name=None):
     client = boto3.client("s3vectors", region_name="us-east-1")
-    bucket_name = str(uuid4())
-    index_name = str(uuid4())
-    client.create_vector_bucket(vectorBucketName=bucket_name)
 
-    try:
+    index_name = str(uuid4())
+
+    client.create_index(
+        vectorBucketName=bucket_name,
+        indexName=index_name,
+        dataType="float32",
+        dimension=1,
+        distanceMetric="euclidean",
+    )
+
+    get_by_name = client.get_index(
+        vectorBucketName=bucket_name,
+        indexName=index_name,
+    )["index"]
+
+    assert get_by_name["dataType"] == "float32"
+    assert get_by_name["dimension"] == 1
+    assert get_by_name["distanceMetric"] == "euclidean"
+    assert (
+        get_by_name["indexArn"]
+        == f"arn:aws:s3vectors:us-east-1:{account_id}:bucket/{bucket_name}/index/{index_name}"
+    )
+    assert get_by_name["indexName"] == index_name
+    assert get_by_name["vectorBucketName"] == bucket_name
+
+
+@s3vectors_aws_verified()
+@pytest.mark.aws_verified
+def test_create_and_get_index_by_arn(account_id, bucket_name=None):
+    client = boto3.client("s3vectors", region_name="us-east-1")
+    index_name = str(uuid4())
+
+    client.create_index(
+        vectorBucketName=bucket_name,
+        indexName=index_name,
+        dataType="float32",
+        dimension=1,
+        distanceMetric="euclidean",
+    )
+
+    get_by_arn = client.get_index(
+        indexArn=f"arn:aws:s3vectors:us-east-1:{account_id}:bucket/{bucket_name}/index/{index_name}",
+    )["index"]
+
+    assert get_by_arn["indexName"] == index_name
+    assert get_by_arn["vectorBucketName"] == bucket_name
+
+
+@s3vectors_aws_verified()
+@pytest.mark.aws_verified
+def test_create_index_with_unknown_data_type(account_id, bucket_name=None):
+    client = boto3.client("s3vectors", region_name="us-east-1")
+    index_name = str(uuid4())
+
+    with pytest.raises(ClientError) as exc:
+        client.create_index(
+            vectorBucketName=bucket_name,
+            indexName=index_name,
+            dataType="int",
+            dimension=1,
+            distanceMetric="euclidean",
+        )
+    err = exc.value.response["Error"]
+    assert err["Code"] == "ValidationException"
+    assert (
+        err["Message"]
+        == "1 validation error detected. Value at '/dataType' failed to satisfy constraint: Member must satisfy enum value set: [float32]"
+    )
+
+
+@s3vectors_aws_verified()
+@pytest.mark.aws_verified
+def test_create_index_with_unknown_dimension(account_id, bucket_name=None):
+    client = boto3.client("s3vectors", region_name="us-east-1")
+    index_name = str(uuid4())
+
+    with pytest.raises(ClientError) as exc:
+        client.create_index(
+            vectorBucketName=bucket_name,
+            indexName=index_name,
+            dataType="float32",
+            dimension=99999,
+            distanceMetric="euclidean",
+        )
+    err = exc.value.response["Error"]
+    assert err["Code"] == "ValidationException"
+    assert (
+        err["Message"]
+        == "1 validation error detected. Value at '/dimension' failed to satisfy constraint: Member must be between 1 and 4096, inclusive"
+    )
+
+
+@s3vectors_aws_verified()
+@pytest.mark.aws_verified
+def test_create_index_with_unknown_distance_metric(account_id, bucket_name=None):
+    client = boto3.client("s3vectors", region_name="us-east-1")
+    index_name = str(uuid4())
+
+    with pytest.raises(ClientError) as exc:
         client.create_index(
             vectorBucketName=bucket_name,
             indexName=index_name,
             dataType="float32",
             dimension=1,
-            distanceMetric="euclidean",
+            distanceMetric="what",
         )
-
-        get_by_name = client.get_index(
-            vectorBucketName=bucket_name,
-            indexName=index_name,
-        )["index"]
-
-        assert get_by_name["dataType"] == "float32"
-        assert get_by_name["dimension"] == 1
-        assert get_by_name["distanceMetric"] == "euclidean"
-        assert (
-            get_by_name["indexArn"]
-            == f"arn:aws:s3vectors:us-east-1:{account_id}:bucket/{bucket_name}/index/{index_name}"
-        )
-        assert get_by_name["indexName"] == index_name
-        assert get_by_name["vectorBucketName"] == bucket_name
-
-    finally:
-        client.delete_index(vectorBucketName=bucket_name, indexName=index_name)
-        client.delete_vector_bucket(vectorBucketName=bucket_name)
+    err = exc.value.response["Error"]
+    assert err["Code"] == "ValidationException"
+    assert (
+        err["Message"]
+        == "1 validation error detected. Value at '/distanceMetric' failed to satisfy constraint: Member must satisfy enum value set: [euclidean, cosine]"
+    )
 
 
-@aws_verified
+@s3vectors_aws_verified()
 @pytest.mark.aws_verified
-def test_create_and_get_index_by_arn(account_id):
+def test_create_and_get_index_by_name_and_arn(account_id, bucket_name=None):
     client = boto3.client("s3vectors", region_name="us-east-1")
-    bucket_name = str(uuid4())
     index_name = str(uuid4())
-    client.create_vector_bucket(vectorBucketName=bucket_name)
 
-    try:
-        client.create_index(
+    with pytest.raises(ClientError) as exc:
+        client.get_index(
             vectorBucketName=bucket_name,
-            indexName=index_name,
-            dataType="float32",
-            dimension=1,
-            distanceMetric="euclidean",
-        )
-
-        get_by_arn = client.get_index(
             indexArn=f"arn:aws:s3vectors:us-east-1:{account_id}:bucket/{bucket_name}/index/{index_name}",
-        )["index"]
-
-        assert get_by_arn["indexName"] == index_name
-        assert get_by_arn["vectorBucketName"] == bucket_name
-
-    finally:
-        client.delete_index(vectorBucketName=bucket_name, indexName=index_name)
-        client.delete_vector_bucket(vectorBucketName=bucket_name)
-
-
-@aws_verified
-@pytest.mark.aws_verified
-def test_create_index_with_unknown_data_type(account_id):
-    client = boto3.client("s3vectors", region_name="us-east-1")
-    bucket_name = str(uuid4())
-    index_name = str(uuid4())
-    client.create_vector_bucket(vectorBucketName=bucket_name)
-
-    try:
-        with pytest.raises(ClientError) as exc:
-            client.create_index(
-                vectorBucketName=bucket_name,
-                indexName=index_name,
-                dataType="int",
-                dimension=1,
-                distanceMetric="euclidean",
-            )
-        err = exc.value.response["Error"]
-        assert err["Code"] == "ValidationException"
-        assert (
-            err["Message"]
-            == "1 validation error detected. Value at '/dataType' failed to satisfy constraint: Member must satisfy enum value set: [float32]"
         )
-
-    finally:
-        client.delete_vector_bucket(vectorBucketName=bucket_name)
-
-
-@aws_verified
-@pytest.mark.aws_verified
-def test_create_index_with_unknown_dimension(account_id):
-    client = boto3.client("s3vectors", region_name="us-east-1")
-    bucket_name = str(uuid4())
-    index_name = str(uuid4())
-    client.create_vector_bucket(vectorBucketName=bucket_name)
-
-    try:
-        with pytest.raises(ClientError) as exc:
-            client.create_index(
-                vectorBucketName=bucket_name,
-                indexName=index_name,
-                dataType="float32",
-                dimension=99999,
-                distanceMetric="euclidean",
-            )
-        err = exc.value.response["Error"]
-        assert err["Code"] == "ValidationException"
-        assert (
-            err["Message"]
-            == "1 validation error detected. Value at '/dimension' failed to satisfy constraint: Member must be between 1 and 4096, inclusive"
-        )
-
-    finally:
-        client.delete_vector_bucket(vectorBucketName=bucket_name)
-
-
-@aws_verified
-@pytest.mark.aws_verified
-def test_create_index_with_unknown_distance_metric(account_id):
-    client = boto3.client("s3vectors", region_name="us-east-1")
-    bucket_name = str(uuid4())
-    index_name = str(uuid4())
-    client.create_vector_bucket(vectorBucketName=bucket_name)
-
-    try:
-        with pytest.raises(ClientError) as exc:
-            client.create_index(
-                vectorBucketName=bucket_name,
-                indexName=index_name,
-                dataType="float32",
-                dimension=1,
-                distanceMetric="what",
-            )
-        err = exc.value.response["Error"]
-        assert err["Code"] == "ValidationException"
-        assert (
-            err["Message"]
-            == "1 validation error detected. Value at '/distanceMetric' failed to satisfy constraint: Member must satisfy enum value set: [euclidean, cosine]"
-        )
-
-    finally:
-        client.delete_vector_bucket(vectorBucketName=bucket_name)
-
-
-@aws_verified
-@pytest.mark.aws_verified
-def test_create_and_get_index_by_name_and_arn(account_id):
-    client = boto3.client("s3vectors", region_name="us-east-1")
-    bucket_name = str(uuid4())
-    index_name = str(uuid4())
-    client.create_vector_bucket(vectorBucketName=bucket_name)
-
-    try:
-        with pytest.raises(ClientError) as exc:
-            client.get_index(
-                vectorBucketName=bucket_name,
-                indexArn=f"arn:aws:s3vectors:us-east-1:{account_id}:bucket/{bucket_name}/index/{index_name}",
-            )
-        err = exc.value.response["Error"]
-        assert err["Code"] == "ValidationException"
-        assert (
-            err["Message"]
-            == "Must specify either indexArn or both vectorBucketName and indexName"
-        )
-
-    finally:
-        client.delete_vector_bucket(vectorBucketName=bucket_name)
+    err = exc.value.response["Error"]
+    assert err["Code"] == "ValidationException"
+    assert (
+        err["Message"]
+        == "Must specify either indexArn or both vectorBucketName and indexName"
+    )
 
 
 @aws_verified
@@ -225,69 +189,57 @@ def test_get_index_by_unknown_name(account_id):
         client.delete_vector_bucket(vectorBucketName=bucket_name)
 
 
-@aws_verified
+@s3vectors_aws_verified()
 @pytest.mark.aws_verified
-def test_get_index_by_unknown_arn(account_id):
+def test_get_index_by_unknown_arn(account_id, bucket_name=None):
     client = boto3.client("s3vectors", region_name="us-east-1")
-    bucket_name = str(uuid4())
     index_name = str(uuid4())
-    client.create_vector_bucket(vectorBucketName=bucket_name)
 
-    try:
-        with pytest.raises(ClientError) as exc:
-            client.get_index(
-                indexArn=f"arn:aws:s3vectors:us-east-1:{account_id}:bucket/{bucket_name}/index/{index_name}",
-            )
-        err = exc.value.response["Error"]
-        assert err["Code"] == "NotFoundException"
-        assert err["Message"] == "The specified index could not be found"
-
-    finally:
-        client.delete_vector_bucket(vectorBucketName=bucket_name)
+    with pytest.raises(ClientError) as exc:
+        client.get_index(
+            indexArn=f"arn:aws:s3vectors:us-east-1:{account_id}:bucket/{bucket_name}/index/{index_name}",
+        )
+    err = exc.value.response["Error"]
+    assert err["Code"] == "NotFoundException"
+    assert err["Message"] == "The specified index could not be found"
 
 
-@aws_verified
+@s3vectors_aws_verified()
 @pytest.mark.aws_verified
-def test_create_and_list_indexes(account_id):
+def test_create_and_list_indexes(account_id, bucket_name=None):
     client = boto3.client("s3vectors", region_name="us-east-1")
-    bucket_name = str(uuid4())
     bucket_arn = f"arn:aws:s3vectors:us-east-1:{account_id}:bucket/{bucket_name}"
     index_name = str(uuid4())
-    client.create_vector_bucket(vectorBucketName=bucket_name)
 
-    try:
-        client.create_index(
-            vectorBucketName=bucket_name,
-            indexName=index_name,
-            dataType="float32",
-            dimension=1,
-            distanceMetric="euclidean",
-        )
+    client.create_index(
+        vectorBucketName=bucket_name,
+        indexName=index_name,
+        dataType="float32",
+        dimension=1,
+        distanceMetric="euclidean",
+    )
 
-        # List by bucket name
-        indexes = client.list_indexes(vectorBucketName=bucket_name)["indexes"]
-        assert len(indexes) == 1
-        assert indexes[0]["vectorBucketName"] == bucket_name
-        assert indexes[0]["indexName"] == index_name
-        assert (
-            indexes[0]["indexArn"]
-            == f"arn:aws:s3vectors:us-east-1:{account_id}:bucket/{bucket_name}/index/{index_name}"
-        )
+    # List by bucket name
+    indexes = client.list_indexes(vectorBucketName=bucket_name)["indexes"]
+    assert len(indexes) == 1
+    assert indexes[0]["vectorBucketName"] == bucket_name
+    assert indexes[0]["indexName"] == index_name
+    assert (
+        indexes[0]["indexArn"]
+        == f"arn:aws:s3vectors:us-east-1:{account_id}:bucket/{bucket_name}/index/{index_name}"
+    )
 
-        # List by bucket ARN
-        indexes = client.list_indexes(vectorBucketArn=bucket_arn)["indexes"]
-        assert len(indexes) == 1
-        assert indexes[0]["vectorBucketName"] == bucket_name
+    # List by bucket ARN
+    indexes = client.list_indexes(vectorBucketArn=bucket_arn)["indexes"]
+    assert len(indexes) == 1
+    assert indexes[0]["vectorBucketName"] == bucket_name
 
-        # Delete Index
-        client.delete_index(vectorBucketName=bucket_name, indexName=index_name)
+    # Delete Index
+    client.delete_index(vectorBucketName=bucket_name, indexName=index_name)
 
-        # Verify it's been deleted
-        indexes = client.list_indexes(vectorBucketName=bucket_name)["indexes"]
-        assert len(indexes) == 0
-
-    finally:
-        client.delete_vector_bucket(vectorBucketName=bucket_name)
+    # Verify it's been deleted
+    indexes = client.list_indexes(vectorBucketName=bucket_name)["indexes"]
+    assert len(indexes) == 0
 
 
 @aws_verified
@@ -318,3 +270,30 @@ def test_list_indexes_by_name_and_arn(account_id):
         err["Message"]
         == "Must specify either vectorBucketName or vectorBucketArn but not both"
     )
+
+
+@s3vectors_aws_verified()
+@pytest.mark.aws_verified
+def test_delete_bucket_fails_if_index_exists(account_id, bucket_name=None):
+    client = boto3.client("s3vectors", region_name="us-east-1")
+    index_name = str(uuid4())
+
+    client.create_index(
+        vectorBucketName=bucket_name,
+        indexName=index_name,
+        dataType="float32",
+        dimension=1,
+        distanceMetric="euclidean",
+    )
+
+    with pytest.raises(ClientError) as exc:
+        client.delete_vector_bucket(vectorBucketName=bucket_name)
+    err = exc.value.response["Error"]
+    assert err["Code"] == "ConflictException"
+    assert err["Message"] == "The specified vector bucket is not empty"
+
+    # First delete the index
+    client.delete_index(vectorBucketName=bucket_name, indexName=index_name)
+
+    # Now we can delete the bucket
+    client.delete_vector_bucket(vectorBucketName=bucket_name)


### PR DESCRIPTION
Related to #9097 

Having a fixture that automatically creates and deletes a S3 Vector bucket simplifies the tests and reduces the chance of accidentally leaving resources dangling when running these tests against AWS.

Two minor features that were added, to increase parity with AWS:
 - Deleting a bucket now throws an error if any indexes still exist
 - Deleting a bucket that does not exist now throws an error