### PR TITLE
Admin: fix build after dependency updates

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -46,14 +46,16 @@ moto = py.typed
 [options.extras_require]
 all =
     antlr4-python3-runtime
+	aws-sam-translator<=1.103.0
     joserfc>=0.9.0
     jsonpath_ng
     docker>=3.0.0
     graphql-core
     PyYAML>=5.1
-    cfn-lint>=0.40.0
+    cfn-lint>=0.40.0,<=1.41.0
     jsonschema
     openapi-spec-validator>=0.5.0
+	pydantic<=2.12.4
     pyparsing>=3.0.7
     py-partiql-parser==0.6.3
     aws-xray-sdk!=0.96,>=0.93
@@ -61,13 +63,15 @@ all =
     multipart
 proxy =
     antlr4-python3-runtime
+	aws-sam-translator<=1.103.0
     joserfc>=0.9.0
     jsonpath_ng
     docker>=2.5.1
     graphql-core
     PyYAML>=5.1
-    cfn-lint>=0.40.0
+    cfn-lint>=0.40.0,<=1.41.0
     openapi-spec-validator>=0.5.0
+	pydantic<=2.12.4
     pyparsing>=3.0.7
     py-partiql-parser==0.6.3
     aws-xray-sdk!=0.96,>=0.93
@@ -75,13 +79,15 @@ proxy =
     multipart
 server =
     antlr4-python3-runtime
+	aws-sam-translator<=1.103.0
     joserfc>=0.9.0
     jsonpath_ng
     docker>=3.0.0
     graphql-core
     PyYAML>=5.1
-    cfn-lint>=0.40.0
+    cfn-lint>=0.40.0,<=1.41.0
     openapi-spec-validator>=0.5.0
+	pydantic<=2.12.4
     pyparsing>=3.0.7
     py-partiql-parser==0.6.3
     aws-xray-sdk!=0.96,>=0.93
@@ -114,7 +120,7 @@ cloudformation =
     docker>=3.0.0
     graphql-core
     PyYAML>=5.1
-    cfn-lint>=0.40.0
+    cfn-lint>=0.40.0,<=1.41.0
     openapi-spec-validator>=0.5.0
     pyparsing>=3.0.7
     py-partiql-parser==0.6.3
@@ -202,7 +208,7 @@ resourcegroupstaggingapi =
     docker>=3.0.0
     graphql-core
     PyYAML>=5.1
-    cfn-lint>=0.40.0
+    cfn-lint>=0.40.0,<=1.41.0
     openapi-spec-validator>=0.5.0
     pyparsing>=3.0.7
     py-partiql-parser==0.6.3

--- a/tests/test_awslambda/test_lambda.py
+++ b/tests/test_awslambda/test_lambda.py
@@ -810,14 +810,13 @@ def test_delete_function():
         Publish=True,
     )
 
-    success_result = conn.delete_function(FunctionName=function_name)
-    # this is hard to match against, so remove it
-    success_result["ResponseMetadata"].pop("HTTPHeaders", None)
-    # Botocore inserts retry attempts not seen in Python27
-    success_result["ResponseMetadata"].pop("RetryAttempts", None)
-    success_result["ResponseMetadata"].pop("RequestId")
-
-    assert success_result == {"ResponseMetadata": {"HTTPStatusCode": 204}}
+    result = conn.delete_function(FunctionName=function_name)
+    # There are differences in the modelled response between versions of Botocore,
+    # so we check multiple places for the status code and allow for a success range.
+    status_code = result.get(
+        "StatusCode", result.get("ResponseMetadata", {}).get("HTTPStatusCode")
+    )
+    assert 200 <= status_code < 300
 
     func_list = conn.list_functions(FunctionVersion="ALL")["Functions"]
     our_functions = [f for f in func_list if f["FunctionName"] == function_name]


### PR DESCRIPTION
The root cause here seems to be related to this warning:

```
tests/test_cloudformation/test_validate.py::test_json_validate_successful
  /opt/hostedtoolcache/Python/3.14.0/x64/lib/python3.14/site-packages/samtranslator/compat.py:2: UserWarning: Core Pydantic V1 functionality isn't compatible with Python 3.14 or greater.
    from pydantic import v1 as pydantic
```

Moto's tests had been working on Python 3.14, despite this warning, but broke after recent releases of `aws-sam-translator`, `cfn-lint`, and `pydantic` on PyPI.  I ended up having to constrain all of these packages in Moto's requirements in order to get everything to play together nicely.  There is an open issue in the `aws-sam-translator` repo (aws/serverless-application-model/issues/3831) to add support for Python 3.14 / Pydantic V2, but it's not clear when/if it will be addressed.

Aside from all that, Botocore's latest release updated the Lambda model and broke a single one of our tests, which this PR fixes in a backward-compatible way.
