### PR TITLE
EC2: integrate `Launch Templates` backend with core response serializer

### DIFF
--- a/moto/ec2/responses/launch_templates.py
+++ b/moto/ec2/responses/launch_templates.py
@@ -274,13 +274,15 @@ class LaunchTemplates(EC2BaseResponse):
                         "ResourceType": "instance",
                         "Tags": [
                             {
-                                "Key": tag.key,
-                                "Value": tag.value,
+                                "Key": tag["key"],
+                                "Value": tag["value"],
                             }
+                            for tag in instance.get_tags()
                         ],
                     }
-                    for tag in instance.tags
-                ],
+                ]
+                if instance.get_tags()
+                else [],
             }
         }
         return ActionResult(result)


### PR DESCRIPTION
The backend for EC2 Launch Templates was a bit of an oddball in that it contained bespoke XML serialization helpers that aren't used by any of Moto's other EC2 backends.  This was [noted at the time](https://github.com/getmoto/moto/pull/2369#discussion_r315428024) and, ultimately, the author of that PR had the right idea.  This PR replaces the one-off XML serialization code by integrating this backend into Moto's core serialization pipeline.  

Notably, this integration does not touch the model code at all, instead using DTOs in `responses.py` to translate the model objects into dedicated response objects suitable for serialization, which adheres to the general guidelines detailed in #9073:

> When migrating backends to the new request/response flow, there's going to be a trade-off between handling everything in `responses.py` vs. actually "fixing" the model. As a general rule-of-thumb, we should error on the side of a minimal viable changeset. 