### PR TITLE
ELBv2: Support 'health_check_logs.s3.enabled' attribute

### DIFF
--- a/moto/elbv2/models.py
+++ b/moto/elbv2/models.py
@@ -571,6 +571,7 @@ class FakeLoadBalancer(CloudFormationModel):
         "client_keep_alive.seconds",
         "deletion_protection.enabled",
         "dns_record.client_routing_policy",
+        "health_check_logs.s3.enabled",
         "idle_timeout.timeout_seconds",
         "ipv6.deny_all_igw_traffic",
         "load_balancing.cross_zone.enabled",


### PR DESCRIPTION
Terraform assumes that this attribute is supported, so the tests for ELB started failing - this should fix them.

Note that the Python 3.14 tests are still failing because of https://github.com/python/cpython/issues/142214, but I'm hoping we can wait that out until 3.14.2 is released.