### PR TITLE
CI: Run S3 tests in parallel

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,12 +5,12 @@ TEST_NAMES = "*"
 
 ifeq ($(TEST_SERVER_MODE), true)
 	# Exclude parallel tests
-	TEST_EXCLUDE := --ignore tests/test_acm --ignore tests/test_amp --ignore tests/test_awslambda --ignore tests/test_batch --ignore tests/test_dynamodb --ignore tests/test_ec2 --ignore tests/test_sqs
+	TEST_EXCLUDE := --ignore tests/test_acm --ignore tests/test_amp --ignore tests/test_awslambda --ignore tests/test_batch --ignore tests/test_dynamodb --ignore tests/test_ec2 --ignore tests/test_s3/ --ignore tests/test_sqs
 	# Parallel tests will be run separate
-	PARALLEL_TESTS := ./tests/test_acm/ ./tests/test_acmpca/ ./tests/test_amp/ ./tests/test_awslambda ./tests/test_batch ./tests/test_dynamodb ./tests/test_ec2 ./tests/test_sqs
+	PARALLEL_TESTS := ./tests/test_acm/ ./tests/test_acmpca/ ./tests/test_amp/ ./tests/test_awslambda ./tests/test_batch ./tests/test_dynamodb ./tests/test_ec2 ./tests/test_s3/ ./tests/test_sqs
 else
-	TEST_EXCLUDE := --ignore tests/test_batch --ignore tests/test_dynamodb --ignore tests/test_ec2 --ignore tests/test_sqs
-	PARALLEL_TESTS := ./tests/test_batch ./tests/test_dynamodb ./tests/test_ec2 ./tests/test_sqs
+	TEST_EXCLUDE := --ignore tests/test_batch --ignore tests/test_dynamodb --ignore tests/test_ec2 --ignore tests/test_s3/ --ignore tests/test_sqs
+	PARALLEL_TESTS := ./tests/test_batch ./tests/test_dynamodb ./tests/test_ec2 tests/test_s3/ ./tests/test_sqs
 endif
 
 init:

--- a/tests/test_s3/test_s3.py
+++ b/tests/test_s3/test_s3.py
@@ -30,15 +30,19 @@ from . import s3_aws_verified
 
 
 class MyModel:
-    def __init__(self, name, value, metadata=None):
-        self.name = name
+    def __init__(self, bucket_name, key_name, value, metadata=None):
+        self.bucket_name = bucket_name
+        self.name = key_name
         self.value = value
         self.metadata = metadata or {}
 
     def save(self, region=None):
         s3_client = boto3.client("s3", region_name=region or DEFAULT_REGION_NAME)
         s3_client.put_object(
-            Bucket="mybucket", Key=self.name, Body=self.value, Metadata=self.metadata
+            Bucket=self.bucket_name,
+            Key=self.name,
+            Body=self.value,
+            Metadata=self.metadata,
         )
 
 
@@ -63,16 +67,19 @@ def test_keys_are_pickleable():
 )
 def test_my_model_save(region, partition):
     # Create Bucket so that test can run
+    bucket_name = str(uuid.uuid4())
     conn = boto3.resource("s3", region_name=region)
     conn.create_bucket(
-        Bucket="mybucket", CreateBucketConfiguration={"LocationConstraint": region}
+        Bucket=bucket_name, CreateBucketConfiguration={"LocationConstraint": region}
     )
     ####################################
 
-    model_instance = MyModel("steve", "is awesome")
+    model_instance = MyModel(
+        bucket_name=bucket_name, key_name="steve", value="is awesome"
+    )
     model_instance.save(region)
 
-    body = conn.Object("mybucket", "steve").get()["Body"].read().decode()
+    body = conn.Object(bucket_name, "steve").get()["Body"].read().decode()
 
     assert body == "is awesome"
 
@@ -82,15 +89,15 @@ def test_object_metadata():
     """Metadata keys can contain certain special characters like dash and dot"""
     # Create Bucket so that test can run
     conn = boto3.resource("s3", region_name=DEFAULT_REGION_NAME)
-    conn.create_bucket(Bucket="mybucket")
+    bucket = conn.create_bucket(Bucket=str(uuid.uuid4()))
     ####################################
 
     metadata = {"meta": "simple", "my-meta": "dash", "meta.data": "namespaced"}
 
-    model_instance = MyModel("steve", "is awesome", metadata=metadata)
+    model_instance = MyModel(bucket.name, "steve", "is awesome", metadata=metadata)
     model_instance.save()
 
-    meta = conn.Object("mybucket", "steve").get()["Metadata"]
+    meta = conn.Object(bucket.name, "steve").get()["Metadata"]
 
     assert meta == metadata
 
@@ -98,21 +105,19 @@ def test_object_metadata():
 @mock_aws
 def test_resource_get_object_returns_etag():
     conn = boto3.resource("s3", region_name=DEFAULT_REGION_NAME)
-    conn.create_bucket(Bucket="mybucket")
+    bucket = conn.create_bucket(Bucket=str(uuid.uuid4()))
 
-    model_instance = MyModel("steve", "is awesome")
+    model_instance = MyModel(bucket.name, "steve", "is awesome")
     model_instance.save()
 
-    assert conn.Bucket("mybucket").Object("steve").e_tag == (
-        '"d32bda93738f7e03adb22e66c90fbc04"'
-    )
+    assert bucket.Object("steve").e_tag == ('"d32bda93738f7e03adb22e66c90fbc04"')
 
 
 @mock_aws
 def test_key_save_to_missing_bucket():
     s3_resource = boto3.resource("s3")
 
-    key = s3_resource.Object("mybucket", "the-key")
+    key = s3_resource.Object(str(uuid.uuid4()), "the-key")
     with pytest.raises(ClientError) as ex:
         key.put(Body=b"foobar")
     assert ex.value.response["Error"]["Code"] == "NoSuchBucket"
@@ -126,9 +131,10 @@ def test_missing_key_request():
     if not settings.TEST_DECORATOR_MODE:
         raise SkipTest("Only test status code in DecoratorMode")
     s3_client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
-    s3_client.create_bucket(Bucket="foobar")
+    bucket_name = str(uuid.uuid4())
+    s3_client.create_bucket(Bucket=bucket_name)
 
-    response = requests.get("http://foobar.s3.amazonaws.com/the-key")
+    response = requests.get(f"http://{bucket_name}.s3.amazonaws.com/the-key")
     assert response.status_code == 404
 
 
@@ -136,12 +142,12 @@ def test_missing_key_request():
 def test_empty_key():
     s3_resource = boto3.resource("s3", region_name=DEFAULT_REGION_NAME)
     client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
-    s3_resource.create_bucket(Bucket="foobar")
+    bucket = s3_resource.create_bucket(Bucket=str(uuid.uuid4()))
 
-    key = s3_resource.Object("foobar", "the-key")
+    key = bucket.Object("the-key")
     key.put(Body=b"")
 
-    resp = client.get_object(Bucket="foobar", Key="the-key")
+    resp = client.get_object(Bucket=bucket.name, Key="the-key")
     assert resp["ContentLength"] == 0
     assert resp["Body"].read() == b""
 
@@ -150,24 +156,28 @@ def test_empty_key():
 def test_key_name_encoding_in_listing():
     s3_resource = boto3.resource("s3", region_name=DEFAULT_REGION_NAME)
     client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
-    s3_resource.create_bucket(Bucket="foobar")
+    bucket = s3_resource.create_bucket(Bucket=str(uuid.uuid4()))
 
     name = "6T7\x159\x12\r\x08.txt"
 
-    key = s3_resource.Object("foobar", name)
+    key = bucket.Object(name)
     key.put(Body=b"")
 
-    key_received = client.list_objects(Bucket="foobar")["Contents"][0]["Key"]
+    key_received = client.list_objects(Bucket=bucket.name)["Contents"][0]["Key"]
     assert key_received == name
 
-    key_received = client.list_objects_v2(Bucket="foobar")["Contents"][0]["Key"]
+    key_received = client.list_objects_v2(Bucket=bucket.name)["Contents"][0]["Key"]
     assert key_received == name
 
     name = "example/file.text"
-    client.put_object(Bucket="foobar", Key=name, Body=b"")
+    client.put_object(Bucket=bucket.name, Key=name, Body=b"")
 
     key_received = client.list_objects(
-        Bucket="foobar", Prefix="example/", Delimiter="/", MaxKeys=1, EncodingType="url"
+        Bucket=bucket.name,
+        Prefix="example/",
+        Delimiter="/",
+        MaxKeys=1,
+        EncodingType="url",
     )["Contents"][0]["Key"]
     assert key_received == name
 
@@ -176,18 +186,18 @@ def test_key_name_encoding_in_listing():
 def test_empty_key_set_on_existing_key():
     s3_resource = boto3.resource("s3", region_name=DEFAULT_REGION_NAME)
     client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
-    s3_resource.create_bucket(Bucket="foobar")
+    bucket = s3_resource.create_bucket(Bucket=str(uuid.uuid4()))
 
-    key = s3_resource.Object("foobar", "the-key")
+    key = bucket.Object("the-key")
     key.put(Body=b"some content")
 
-    resp = client.get_object(Bucket="foobar", Key="the-key")
+    resp = client.get_object(Bucket=bucket.name, Key="the-key")
     assert resp["ContentLength"] == 12
     assert resp["Body"].read() == b"some content"
 
     key.put(Body=b"")
 
-    resp = client.get_object(Bucket="foobar", Key="the-key")
+    resp = client.get_object(Bucket=bucket.name, Key="the-key")
     assert resp["ContentLength"] == 0
     assert resp["Body"].read() == b""
 
@@ -196,12 +206,12 @@ def test_empty_key_set_on_existing_key():
 def test_large_key_save():
     s3_resource = boto3.resource("s3", region_name=DEFAULT_REGION_NAME)
     client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
-    s3_resource.create_bucket(Bucket="foobar")
+    bucket = s3_resource.create_bucket(Bucket=str(uuid.uuid4()))
 
-    key = s3_resource.Object("foobar", "the-key")
+    key = bucket.Object("the-key")
     key.put(Body=b"foobar" * 100000)
 
-    resp = client.get_object(Bucket="foobar", Key="the-key")
+    resp = client.get_object(Bucket=bucket.name, Key="the-key")
     assert resp["Body"].read() == b"foobar" * 100000
 
 
@@ -209,12 +219,12 @@ def test_large_key_save():
 def test_set_metadata():
     s3_resource = boto3.resource("s3", region_name=DEFAULT_REGION_NAME)
     client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
-    s3_resource.create_bucket(Bucket="foobar")
+    bucket = s3_resource.create_bucket(Bucket=str(uuid.uuid4()))
 
-    key = s3_resource.Object("foobar", "the-key")
+    key = bucket.Object("the-key")
     key.put(Body=b"some value", Metadata={"md": "Metadatastring"})
 
-    resp = client.get_object(Bucket="foobar", Key="the-key")
+    resp = client.get_object(Bucket=bucket.name, Key="the-key")
     assert resp["Metadata"] == {"md": "Metadatastring"}
 
 
@@ -224,15 +234,15 @@ def test_last_modified():
     # See https://github.com/boto/boto/issues/466
     s3_resource = boto3.resource("s3", region_name=DEFAULT_REGION_NAME)
     client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
-    s3_resource.create_bucket(Bucket="foobar")
+    bucket = s3_resource.create_bucket(Bucket=str(uuid.uuid4()))
 
-    key = s3_resource.Object("foobar", "the-key")
+    key = bucket.Object("the-key")
     key.put(Body=b"some value", Metadata={"md": "Metadatastring"})
 
-    resp = client.list_objects_v2(Bucket="foobar")["Contents"]
+    resp = client.list_objects_v2(Bucket=bucket.name)["Contents"]
     assert isinstance(resp[0]["LastModified"], datetime.datetime)
 
-    resp = client.get_object(Bucket="foobar", Key="the-key")
+    resp = client.get_object(Bucket=bucket.name, Key="the-key")
     assert isinstance(resp["LastModified"], datetime.datetime)
     as_header = resp["ResponseMetadata"]["HTTPHeaders"]["last-modified"]
     assert isinstance(as_header, str)
@@ -244,12 +254,7 @@ def test_last_modified():
 def test_missing_bucket():
     client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
     with pytest.raises(ClientError) as ex:
-        client.head_bucket(Bucket="mybucket")
-    assert ex.value.response["Error"]["Code"] == "404"
-    assert ex.value.response["Error"]["Message"] == "Not Found"
-
-    with pytest.raises(ClientError) as ex:
-        client.head_bucket(Bucket="dash-in-name")
+        client.head_bucket(Bucket=str(uuid.uuid4()))
     assert ex.value.response["Error"]["Code"] == "404"
     assert ex.value.response["Error"]["Message"] == "Not Found"
 
@@ -259,7 +264,7 @@ def test_create_existing_bucket():
     """Creating a bucket that already exists should raise an Error."""
     client = boto3.client("s3", region_name="us-west-2")
     kwargs = {
-        "Bucket": "foobar",
+        "Bucket": str(uuid.uuid4()),
         "CreateBucketConfiguration": {"LocationConstraint": "us-west-2"},
     }
     client.create_bucket(**kwargs)
@@ -319,44 +324,46 @@ def test_create_existing_bucket_in_us_east_1():
     bucket exists it Amazon S3 will not do anything).
     """
     client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
-    client.create_bucket(Bucket="foobar")
-    client.create_bucket(Bucket="foobar")
+    bucket_name = str(uuid.uuid4())
+    client.create_bucket(Bucket=bucket_name)
+    client.create_bucket(Bucket=bucket_name)
 
 
 @mock_aws
 def test_bucket_deletion():
     s3_resource = boto3.resource("s3", region_name=DEFAULT_REGION_NAME)
     client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
-    client.create_bucket(Bucket="foobar")
+    bucket_name = str(uuid.uuid4())
+    client.create_bucket(Bucket=bucket_name)
 
-    key = s3_resource.Object("foobar", "the-key")
+    key = s3_resource.Object(bucket_name, "the-key")
     key.put(Body=b"some value")
 
     # Try to delete a bucket that still has keys
     with pytest.raises(ClientError) as ex:
-        client.delete_bucket(Bucket="foobar")
+        client.delete_bucket(Bucket=bucket_name)
     assert ex.value.response["Error"]["Code"] == "BucketNotEmpty"
     assert ex.value.response["Error"]["Message"] == (
         "The bucket you tried to delete is not empty"
     )
 
-    client.delete_object(Bucket="foobar", Key="the-key")
-    client.delete_bucket(Bucket="foobar")
+    client.delete_object(Bucket=bucket_name, Key="the-key")
+    client.delete_bucket(Bucket=bucket_name)
 
     # Delete non-existent bucket
     with pytest.raises(ClientError) as ex:
-        client.delete_bucket(Bucket="foobar")
-    assert ex.value.response["Error"]["Code"] == "NoSuchBucket"
-    assert ex.value.response["Error"]["Message"] == (
-        "The specified bucket does not exist"
-    )
+        client.delete_bucket(Bucket=bucket_name)
+    err = ex.value.response["Error"]
+    assert err["Code"] == "NoSuchBucket"
+    assert err["Message"] == "The specified bucket does not exist"
 
 
 @mock_aws
+@pytest.mark.requires_clean_slate
 def test_get_all_buckets():
     client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
-    client.create_bucket(Bucket="foobar")
-    client.create_bucket(Bucket="foobar2")
+    client.create_bucket(Bucket=str(uuid.uuid4()))
+    client.create_bucket(Bucket=str(uuid.uuid4()))
 
     assert len(client.list_buckets()["Buckets"]) == 2
 
@@ -364,41 +371,42 @@ def test_get_all_buckets():
 @mock_aws
 def test_post_to_bucket():
     if not settings.TEST_DECORATOR_MODE:
-        # ServerMode does not allow unauthorized requests
-        raise SkipTest()
+        raise SkipTest("ServerMode does not allow unauthorized requests")
 
     client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
-    client.create_bucket(Bucket="foobar")
+    bucket_name = str(uuid.uuid4())
+    client.create_bucket(Bucket=bucket_name)
 
     requests.post(
-        "https://foobar.s3.amazonaws.com/", {"key": "the-key", "file": "nothing"}
+        f"https://{bucket_name}.s3.amazonaws.com/",
+        {"key": "the-key", "file": "nothing"},
     )
 
-    resp = client.get_object(Bucket="foobar", Key="the-key")
+    resp = client.get_object(Bucket=bucket_name, Key="the-key")
     assert resp["Body"].read() == b"nothing"
 
 
 @mock_aws
 def test_post_with_metadata_to_bucket():
     if not settings.TEST_DECORATOR_MODE:
-        # ServerMode does not allow unauthorized requests
-        raise SkipTest()
+        raise SkipTest("ServerMode does not allow unauthorized requests")
     client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
-    client.create_bucket(Bucket="foobar")
+    bucket_name = str(uuid.uuid4())
+    client.create_bucket(Bucket=bucket_name)
 
     requests.post(
-        "https://foobar.s3.amazonaws.com/",
+        f"https://{bucket_name}.s3.amazonaws.com/",
         {"key": "the-key", "file": "nothing", "x-amz-meta-test": "metadata"},
     )
 
-    resp = client.get_object(Bucket="foobar", Key="the-key")
+    resp = client.get_object(Bucket=bucket_name, Key="the-key")
     assert resp["Metadata"] == {"test": "metadata"}
 
 
 @mock_aws
 def test_delete_versioned_objects():
     s3_client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
-    bucket = "test"
+    bucket = str(uuid.uuid4())
     key = "test"
 
     s3_client.create_bucket(Bucket=bucket)
@@ -487,11 +495,17 @@ def test_delete_missing_key(bucket_name=None):
 @mock_aws
 def test_delete_empty_keys_list():
     with pytest.raises(ClientError) as err:
-        boto3.client("s3").delete_objects(Bucket="foobar", Delete={"Objects": []})
+        boto3.client("s3").delete_objects(
+            Bucket=str(uuid.uuid4()), Delete={"Objects": []}
+        )
     assert err.value.response["Error"]["Code"] == "MalformedXML"
 
 
-@pytest.mark.parametrize("name", ["firstname.lastname", "with-dash"])
+@pytest.mark.parametrize(
+    "name",
+    [f"firstname.{uuid.uuid4()}", str(uuid.uuid4())],
+    ids=["with.dot", "with-dash"],
+)
 @mock_aws
 def test_bucket_name_with_special_chars(name):
     s3_resource = boto3.resource("s3", region_name=DEFAULT_REGION_NAME)
@@ -514,22 +528,22 @@ def test_key_with_special_characters(key):
         raise SkipTest("Keys starting with a / don't work well in ProxyMode")
     s3_resource = boto3.resource("s3", region_name=DEFAULT_REGION_NAME)
     client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
-    bucket = s3_resource.Bucket("testname")
+    bucket = s3_resource.Bucket(str(uuid.uuid4()))
     bucket.create()
 
-    s3_resource.Object("testname", key).put(Body=b"value")
+    s3_resource.Object(bucket.name, key).put(Body=b"value")
 
     objects = list(bucket.objects.all())
     assert [o.key for o in objects] == [key]
 
-    resp = client.get_object(Bucket="testname", Key=key)
+    resp = client.get_object(Bucket=bucket.name, Key=key)
     assert resp["Body"].read() == b"value"
 
 
 @mock_aws
 def test_bucket_key_listing_order():
     s3_resource = boto3.resource("s3", region_name=DEFAULT_REGION_NAME)
-    bucket_name = "test_bucket"
+    bucket_name = str(uuid.uuid4())
     bucket = s3_resource.Bucket(bucket_name)
     bucket.create()
     prefix = "toplevel/"
@@ -573,7 +587,7 @@ def test_bucket_key_listing_order():
 )
 def test_key_with_reduced_redundancy(region, partition):
     s3_resource = boto3.resource("s3", region_name=region)
-    bucket_name = "test_bucket"
+    bucket_name = str(uuid.uuid4())
     s3_resource.create_bucket(
         Bucket=bucket_name, CreateBucketConfiguration={"LocationConstraint": region}
     )
@@ -592,7 +606,7 @@ def test_key_with_reduced_redundancy(region, partition):
 @mock_aws
 def test_restore_key():
     s3_resource = boto3.resource("s3", region_name=DEFAULT_REGION_NAME)
-    bucket = s3_resource.Bucket("foobar")
+    bucket = s3_resource.Bucket(str(uuid.uuid4()))
     bucket.create()
 
     key = bucket.put_object(Key="the-key", Body=b"somedata", StorageClass="GLACIER")
@@ -628,7 +642,7 @@ def test_restore_key_transition():
     )
 
     s3_resource = boto3.resource("s3", region_name=DEFAULT_REGION_NAME)
-    bucket = s3_resource.Bucket("foobar")
+    bucket = s3_resource.Bucket(str(uuid.uuid4()))
     bucket.create()
 
     key = bucket.put_object(Key="the-key", Body=b"somedata", StorageClass="GLACIER")
@@ -652,11 +666,12 @@ def test_restore_key_transition():
 @mock_aws
 def test_restore_unknown_key():
     client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
-    client.create_bucket(Bucket="mybucket")
+    bucket_name = str(uuid.uuid4())
+    client.create_bucket(Bucket=bucket_name)
 
     with pytest.raises(ClientError) as exc:
         client.restore_object(
-            Bucket="mybucket", Key="unknown", RestoreRequest={"Days": 1}
+            Bucket=bucket_name, Key="unknown", RestoreRequest={"Days": 1}
         )
     err = exc.value.response["Error"]
     assert err["Code"] == "NoSuchKey"
@@ -665,7 +680,7 @@ def test_restore_unknown_key():
 @mock_aws
 def test_cannot_restore_standard_class_object():
     s3_resource = boto3.resource("s3", region_name=DEFAULT_REGION_NAME)
-    bucket = s3_resource.Bucket("foobar")
+    bucket = s3_resource.Bucket(str(uuid.uuid4()))
     bucket.create()
 
     key = bucket.put_object(Key="the-key", Body=b"somedata")
@@ -683,10 +698,11 @@ def test_cannot_restore_standard_class_object():
 @mock_aws
 def test_get_versioning_status():
     s3_resource = boto3.resource("s3", region_name=DEFAULT_REGION_NAME)
-    bucket = s3_resource.Bucket("foobar")
+    bucket_name = str(uuid.uuid4())
+    bucket = s3_resource.Bucket(bucket_name)
     bucket.create()
 
-    version_info = s3_resource.BucketVersioning("foobar")
+    version_info = s3_resource.BucketVersioning(bucket_name)
     assert version_info.status is None
 
     version_info.enable()
@@ -700,7 +716,7 @@ def test_get_versioning_status():
 def test_key_version():
     s3_resource = boto3.resource("s3", region_name=DEFAULT_REGION_NAME)
     client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
-    bucket = s3_resource.Bucket("foobar")
+    bucket = s3_resource.Bucket(str(uuid.uuid4()))
     bucket.create()
     bucket.Versioning().enable()
 
@@ -712,7 +728,7 @@ def test_key_version():
     versions.append(key.version_id)
     assert len(set(versions)) == 2
 
-    key = client.get_object(Bucket="foobar", Key="the-key")
+    key = client.get_object(Bucket=bucket.name, Key="the-key")
     assert key["VersionId"] == versions[-1]
 
 
@@ -720,7 +736,7 @@ def test_key_version():
 def test_list_versions():
     s3_resource = boto3.resource("s3", region_name=DEFAULT_REGION_NAME)
     client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
-    bucket = s3_resource.Bucket("foobar")
+    bucket = s3_resource.Bucket(str(uuid.uuid4()))
     bucket.create()
     bucket.Versioning().enable()
 
@@ -732,29 +748,31 @@ def test_list_versions():
     key_versions.append(key.version_id)
     assert len(key_versions) == 2
 
-    versions = client.list_object_versions(Bucket="foobar")["Versions"]
+    versions = client.list_object_versions(Bucket=bucket.name)["Versions"]
     assert len(versions) == 2
 
     assert versions[0]["Key"] == "the-key"
     assert versions[0]["VersionId"] == key_versions[1]
-    resp = client.get_object(Bucket="foobar", Key="the-key")
+    resp = client.get_object(Bucket=bucket.name, Key="the-key")
     assert resp["Body"].read() == b"Version 2"
     resp = client.get_object(
-        Bucket="foobar", Key="the-key", VersionId=versions[0]["VersionId"]
+        Bucket=bucket.name, Key="the-key", VersionId=versions[0]["VersionId"]
     )
     assert resp["Body"].read() == b"Version 2"
 
     assert versions[1]["Key"] == "the-key"
     assert versions[1]["VersionId"] == key_versions[0]
     resp = client.get_object(
-        Bucket="foobar", Key="the-key", VersionId=versions[1]["VersionId"]
+        Bucket=bucket.name, Key="the-key", VersionId=versions[1]["VersionId"]
     )
     assert resp["Body"].read() == b"Version 1"
 
     bucket.put_object(Key="the2-key", Body=b"Version 1")
 
     assert len(list(bucket.objects.all())) == 2
-    versions = client.list_object_versions(Bucket="foobar", Prefix="the2")["Versions"]
+    versions = client.list_object_versions(Bucket=bucket.name, Prefix="the2")[
+        "Versions"
+    ]
     assert len(versions) == 1
 
 
@@ -762,7 +780,7 @@ def test_list_versions():
 def test_acl_setting():
     s3_resource = boto3.resource("s3", region_name=DEFAULT_REGION_NAME)
     client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
-    bucket = s3_resource.Bucket("foobar")
+    bucket = s3_resource.Bucket(str(uuid.uuid4()))
     bucket.create()
 
     content = b"imafile"
@@ -771,7 +789,7 @@ def test_acl_setting():
         Key=keyname, Body=content, ContentType="text/plain", ACL="public-read"
     )
 
-    grants = client.get_object_acl(Bucket="foobar", Key=keyname)["Grants"]
+    grants = client.get_object_acl(Bucket=bucket.name, Key=keyname)["Grants"]
     assert {
         "Grantee": {
             "Type": "Group",
@@ -785,15 +803,15 @@ def test_acl_setting():
 def test_acl_setting_via_headers():
     s3_resource = boto3.resource("s3", region_name=DEFAULT_REGION_NAME)
     client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
-    bucket = s3_resource.Bucket("foobar")
+    bucket = s3_resource.Bucket(str(uuid.uuid4()))
     bucket.create()
 
     keyname = "test.txt"
 
     bucket.put_object(Key=keyname, Body=b"imafile")
-    client.put_object_acl(ACL="public-read", Bucket="foobar", Key=keyname)
+    client.put_object_acl(ACL="public-read", Bucket=bucket.name, Key=keyname)
 
-    grants = client.get_object_acl(Bucket="foobar", Key=keyname)["Grants"]
+    grants = client.get_object_acl(Bucket=bucket.name, Key=keyname)["Grants"]
     assert {
         "Grantee": {
             "Type": "Group",
@@ -807,14 +825,14 @@ def test_acl_setting_via_headers():
 def test_acl_switching():
     s3_resource = boto3.resource("s3", region_name=DEFAULT_REGION_NAME)
     client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
-    bucket = s3_resource.Bucket("foobar")
+    bucket = s3_resource.Bucket(str(uuid.uuid4()))
     bucket.create()
     keyname = "test.txt"
 
     bucket.put_object(Key=keyname, Body=b"asdf", ACL="public-read")
-    client.put_object_acl(ACL="private", Bucket="foobar", Key=keyname)
+    client.put_object_acl(ACL="private", Bucket=bucket.name, Key=keyname)
 
-    grants = client.get_object_acl(Bucket="foobar", Key=keyname)["Grants"]
+    grants = client.get_object_acl(Bucket=bucket.name, Key=keyname)["Grants"]
     assert {
         "Grantee": {
             "Type": "Group",
@@ -827,25 +845,25 @@ def test_acl_switching():
 @mock_aws
 def test_acl_switching_nonexistent_key():
     s3_client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
-    s3_client.create_bucket(Bucket="mybucket")
+    bucket_name = str(uuid.uuid4())
+    s3_client.create_bucket(Bucket=bucket_name)
 
     with pytest.raises(ClientError) as exc:
-        s3_client.put_object_acl(Bucket="mybucket", Key="nonexistent", ACL="private")
+        s3_client.put_object_acl(Bucket=bucket_name, Key="nonexistent", ACL="private")
 
     assert exc.value.response["Error"]["Code"] == "NoSuchKey"
 
 
 @mock_aws
 def test_streaming_upload_from_file_to_presigned_url():
-    s3_resource = boto3.resource("s3", region_name="us-east-1")
-    bucket = s3_resource.Bucket("test-bucket")
+    client = boto3.client("s3", DEFAULT_REGION_NAME)
+    s3_resource = boto3.resource("s3", region_name=DEFAULT_REGION_NAME)
+    bucket = s3_resource.Bucket(str(uuid.uuid4()))
     bucket.create()
     bucket.put_object(Body=b"ABCD", Key="file.txt")
 
-    params = {"Bucket": "test-bucket", "Key": "file.txt"}
-    presigned_url = boto3.client("s3").generate_presigned_url(
-        "put_object", params, ExpiresIn=900
-    )
+    params = {"Bucket": bucket.name, "Key": "file.txt"}
+    presigned_url = client.generate_presigned_url("put_object", params, ExpiresIn=900)
     with open(__file__, "rb") as fhandle:
         get_kwargs = {"data": fhandle}
         if settings.is_test_proxy_mode():
@@ -857,27 +875,26 @@ def test_streaming_upload_from_file_to_presigned_url():
 @mock_aws
 def test_upload_from_file_to_presigned_url():
     s3_client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
-    s3_client.create_bucket(Bucket="mybucket")
+    bucket_name = str(uuid.uuid4())
+    s3_client.create_bucket(Bucket=bucket_name)
 
-    params = {"Bucket": "mybucket", "Key": "file_upload"}
-    presigned_url = boto3.client("s3").generate_presigned_url(
+    params = {"Bucket": bucket_name, "Key": "file_upload"}
+    presigned_url = s3_client.generate_presigned_url(
         "put_object", params, ExpiresIn=900
     )
 
-    file = open("text.txt", "w", encoding="utf-8")
-    file.write("test")
-    file.close()
-    files = {"upload_file": open("text.txt", "rb")}
+    with open("text.txt", "wb") as file:
+        file.write(b"test")
+        file.flush()
+        files = {"upload_file": open(file.name, "rb")}
 
-    put_kwargs = {"files": files}
-    if settings.is_test_proxy_mode():
-        add_proxy_details(put_kwargs)
-    requests.put(presigned_url, **put_kwargs)
-    resp = s3_client.get_object(Bucket="mybucket", Key="file_upload")
+        put_kwargs = {"files": files}
+        if settings.is_test_proxy_mode():
+            add_proxy_details(put_kwargs)
+        requests.put(presigned_url, **put_kwargs)
+    resp = s3_client.get_object(Bucket=bucket_name, Key="file_upload")
     data = resp["Body"].read()
     assert data == b"test"
-    # cleanup
-    os.remove("text.txt")
 
 
 @mock_aws
@@ -890,7 +907,7 @@ def test_upload_file_with_checksum_algorithm():
         fhandle.write(random_bytes)
     s3_resource = boto3.resource("s3", region_name=DEFAULT_REGION_NAME)
     s3_client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
-    bucket = "mybucket"
+    bucket = str(uuid.uuid4())
     s3_client.create_bucket(Bucket=bucket)
     s3_client.upload_file(
         "rb.tmp", bucket, "my_key.csv", ExtraArgs={"ChecksumAlgorithm": "SHA256"}
@@ -912,7 +929,7 @@ def test_download_file(tmp_path):
     with open(upload_file, mode="wb") as fp:
         fp.write(random_bytes)
     client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
-    bucket_name = "test-bucket"
+    bucket_name = str(uuid.uuid4())
     object_keys = ["key-for-put-object", "key-for-upload-file"]
     client.create_bucket(Bucket=bucket_name)
     # Test both object upload methods.
@@ -929,7 +946,7 @@ def test_download_file(tmp_path):
 @mock_aws
 def test_put_large_with_checksum_algorithm():
     s3_client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
-    bucket = "mybucket"
+    bucket = str(uuid.uuid4())
     s3_client.create_bucket(Bucket=bucket)
     s3_client.put_object(
         Bucket=bucket,
@@ -938,13 +955,13 @@ def test_put_large_with_checksum_algorithm():
         ChecksumAlgorithm="SHA256",
     )
 
-    resp = s3_client.get_object(Bucket="mybucket", Key="the-key")
+    resp = s3_client.get_object(Bucket=bucket, Key="the-key")
     assert resp["Body"].read() == b"test" * 1000000
 
 
 @mock_aws
 def test_put_chunked_with_v4_signature_in_body():
-    bucket_name = "mybucket"
+    bucket_name = str(uuid.uuid4())
     file_name = "file"
     content = "CONTENT"
     content_bytes = bytes(content, encoding="utf8")
@@ -959,14 +976,14 @@ def test_put_chunked_with_v4_signature_in_body():
     s3_client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
     s3_client.create_bucket(Bucket=bucket_name)
 
-    model = MyModel(file_name, content)
+    model = MyModel(bucket_name, file_name, content)
     model.save()
 
     boto_etag = s3_client.get_object(Bucket=bucket_name, Key=file_name)["ETag"]
 
     params = {"Bucket": bucket_name, "Key": file_name}
     # We'll use manipulated presigned PUT, to mimick PUT from SDK
-    presigned_url = boto3.client("s3").generate_presigned_url(
+    presigned_url = s3_client.generate_presigned_url(
         "put_object", params, ExpiresIn=900
     )
     requests.put(
@@ -989,7 +1006,7 @@ def test_put_chunked_with_v4_signature_in_body():
 @mock_aws
 def test_s3_object_in_private_bucket():
     s3_resource = boto3.resource("s3", "us-east-1")
-    bucket = s3_resource.Bucket("test-bucket")
+    bucket = s3_resource.Bucket(str(uuid.uuid4()))
     bucket.create(ACL="private")
     bucket.put_object(ACL="private", Body=b"ABCD", Key="file.txt")
 
@@ -997,12 +1014,12 @@ def test_s3_object_in_private_bucket():
     s3_anonymous.meta.client.meta.events.register("choose-signer.s3.*", disable_signing)
 
     with pytest.raises(ClientError) as exc:
-        s3_anonymous.Object(key="file.txt", bucket_name="test-bucket").get()
+        s3_anonymous.Object(key="file.txt", bucket_name=bucket.name).get()
     assert exc.value.response["Error"]["Code"] == "403"
 
     bucket.put_object(ACL="public-read", Body=b"ABCD", Key="file.txt")
     contents = (
-        s3_anonymous.Object(key="file.txt", bucket_name="test-bucket")
+        s3_anonymous.Object(key="file.txt", bucket_name=bucket.name)
         .get()["Body"]
         .read()
     )
@@ -1012,13 +1029,13 @@ def test_s3_object_in_private_bucket():
 @mock_aws
 def test_unicode_key():
     s3_resource = boto3.resource("s3", region_name=DEFAULT_REGION_NAME)
-    bucket = s3_resource.Bucket("mybucket")
+    bucket = s3_resource.Bucket(str(uuid.uuid4()))
     bucket.create()
 
     key = bucket.put_object(Key="こんにちは.jpg", Body=b"Hello world!")
 
     assert [listed_key.key for listed_key in bucket.objects.all()] == [key.key]
-    fetched_key = s3_resource.Object("mybucket", key.key)
+    fetched_key = s3_resource.Object(bucket.name, key.key)
     assert fetched_key.key == key.key
     assert fetched_key.get()["Body"].read().decode("utf-8") == "Hello world!"
 
@@ -1026,31 +1043,31 @@ def test_unicode_key():
 @mock_aws
 def test_unicode_value():
     s3_resource = boto3.resource("s3", region_name=DEFAULT_REGION_NAME)
-    bucket = s3_resource.Bucket("mybucket")
+    bucket = s3_resource.Bucket(str(uuid.uuid4()))
     bucket.create()
 
     bucket.put_object(Key="some_key", Body="こんにちは.jpg")
 
-    key = s3_resource.Object("mybucket", "some_key")
+    key = bucket.Object("some_key")
     assert key.get()["Body"].read().decode("utf-8") == "こんにちは.jpg"
 
 
 @mock_aws
 def test_setting_content_encoding():
     s3_resource = boto3.resource("s3", region_name=DEFAULT_REGION_NAME)
-    bucket = s3_resource.Bucket("mybucket")
+    bucket = s3_resource.Bucket(str(uuid.uuid4()))
     bucket.create()
 
     bucket.put_object(Body=b"abcdef", ContentEncoding="gzip", Key="keyname")
 
-    key = s3_resource.Object("mybucket", "keyname")
+    key = bucket.Object("keyname")
     assert "gzip" in key.content_encoding
 
 
 @mock_aws
 def test_bucket_location_default():
     cli = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
-    bucket_name = "mybucket"
+    bucket_name = str(uuid.uuid4())
     # No LocationConstraint ==> us-east-1
     cli.create_bucket(Bucket=bucket_name)
     assert cli.get_bucket_location(Bucket=bucket_name)["LocationConstraint"] is None
@@ -1059,7 +1076,7 @@ def test_bucket_location_default():
 @mock_aws
 def test_bucket_location_nondefault():
     cli = boto3.client("s3", region_name="eu-central-1")
-    bucket_name = "mybucket"
+    bucket_name = str(uuid.uuid4())
     # LocationConstraint set for non default regions
     cli.create_bucket(
         Bucket=bucket_name,
@@ -1075,20 +1092,19 @@ def test_bucket_location_nondefault():
 def test_s3_location_should_error_outside_useast1():
     s3_client = boto3.client("s3", region_name="eu-west-1")
 
-    bucket_name = "asdfasdfsdfdsfasda"
+    bucket_name = str(uuid.uuid4())
 
     with pytest.raises(ClientError) as exc:
         s3_client.create_bucket(Bucket=bucket_name)
     assert exc.value.response["Error"]["Message"] == (
-        "The unspecified location constraint is incompatible for the "
-        "region specific endpoint this request was sent to."
+        "The unspecified location constraint is incompatible for the region specific endpoint this request was sent to."
     )
 
 
 @mock_aws
 def test_ranged_get():
     s3_resource = boto3.resource("s3", region_name=DEFAULT_REGION_NAME)
-    bucket = s3_resource.Bucket("mybucket")
+    bucket = s3_resource.Bucket(str(uuid.uuid4()))
     bucket.create()
     rep = b"0123456789"
     key = bucket.put_object(Key="bigkey", Body=rep * 10)
@@ -1175,7 +1191,7 @@ def test_ranged_get():
 def test_policy():
     s3_resource = boto3.resource("s3", region_name=DEFAULT_REGION_NAME)
     client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
-    bucket_name = "mybucket"
+    bucket_name = str(uuid.uuid4())
     bucket = s3_resource.Bucket(bucket_name)
     bucket.create()
 
@@ -1220,7 +1236,7 @@ def test_policy():
 def test_website_configuration_xml():
     s3_resource = boto3.resource("s3", region_name=DEFAULT_REGION_NAME)
     client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
-    bucket_name = "mybucket"
+    bucket_name = str(uuid.uuid4())
     bucket = s3_resource.Bucket(bucket_name)
     bucket.create()
 
@@ -1251,46 +1267,50 @@ def test_website_configuration_xml():
 @mock_aws
 def test_client_get_object_returns_etag():
     s3_client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
-    s3_client.create_bucket(Bucket="mybucket")
-    s3_client.put_object(Bucket="mybucket", Key="steve", Body=b"is awesome")
-    resp = s3_client.get_object(Bucket="mybucket", Key="steve")
+    bucket_name = str(uuid.uuid4())
+    s3_client.create_bucket(Bucket=bucket_name)
+    s3_client.put_object(Bucket=bucket_name, Key="steve", Body=b"is awesome")
+    resp = s3_client.get_object(Bucket=bucket_name, Key="steve")
     assert resp["ETag"] == '"d32bda93738f7e03adb22e66c90fbc04"'
 
 
 @mock_aws
 def test_website_redirect_location():
     s3_client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
-    s3_client.create_bucket(Bucket="mybucket")
+    bucket_name = str(uuid.uuid4())
+    s3_client.create_bucket(Bucket=bucket_name)
 
-    s3_client.put_object(Bucket="mybucket", Key="steve", Body=b"is awesome")
-    resp = s3_client.get_object(Bucket="mybucket", Key="steve")
+    s3_client.put_object(Bucket=bucket_name, Key="steve", Body=b"is awesome")
+    resp = s3_client.get_object(Bucket=bucket_name, Key="steve")
     assert resp.get("WebsiteRedirectLocation") is None
 
     url = "https://github.com/getmoto/moto"
     s3_client.put_object(
-        Bucket="mybucket", Key="steve", Body=b"is awesome", WebsiteRedirectLocation=url
+        Bucket=bucket_name, Key="steve", Body=b"is awesome", WebsiteRedirectLocation=url
     )
-    resp = s3_client.get_object(Bucket="mybucket", Key="steve")
+    resp = s3_client.get_object(Bucket=bucket_name, Key="steve")
     assert resp["WebsiteRedirectLocation"] == url
 
 
 @mock_aws
 def test_delimiter_optional_in_response():
     s3_client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
-    s3_client.create_bucket(Bucket="mybucket")
-    s3_client.put_object(Bucket="mybucket", Key="one", Body=b"1")
-    resp = s3_client.list_objects(Bucket="mybucket", MaxKeys=1)
+    bucket_name = str(uuid.uuid4())
+    s3_client.create_bucket(Bucket=bucket_name)
+    s3_client.put_object(Bucket=bucket_name, Key="one", Body=b"1")
+    resp = s3_client.list_objects(Bucket=bucket_name, MaxKeys=1)
     assert resp.get("Delimiter") is None
-    resp = s3_client.list_objects(Bucket="mybucket", MaxKeys=1, Delimiter="/")
+    resp = s3_client.list_objects(Bucket=bucket_name, MaxKeys=1, Delimiter="/")
     assert resp.get("Delimiter") == "/"
 
 
 @mock_aws
 def test_list_objects_with_pagesize_0():
     s3_client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
-    s3_client.create_bucket(Bucket="mybucket")
-    resp = s3_client.list_objects(Bucket="mybucket", MaxKeys=0)
-    assert resp["Name"] == "mybucket"
+    bucket_name = str(uuid.uuid4())
+    s3_client.create_bucket(Bucket=bucket_name)
+    resp = s3_client.list_objects(Bucket=bucket_name, MaxKeys=0)
+    assert resp["Name"] == bucket_name
     assert resp["MaxKeys"] == 0
     assert resp["IsTruncated"] is False
     assert "Contents" not in resp
@@ -1299,13 +1319,14 @@ def test_list_objects_with_pagesize_0():
 @mock_aws
 def test_list_objects_truncated_response():
     s3_client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
-    s3_client.create_bucket(Bucket="mybucket")
-    s3_client.put_object(Bucket="mybucket", Key="one", Body=b"1")
-    s3_client.put_object(Bucket="mybucket", Key="two", Body=b"22")
-    s3_client.put_object(Bucket="mybucket", Key="three", Body=b"333")
+    bucket_name = str(uuid.uuid4())
+    s3_client.create_bucket(Bucket=bucket_name)
+    s3_client.put_object(Bucket=bucket_name, Key="one", Body=b"1")
+    s3_client.put_object(Bucket=bucket_name, Key="two", Body=b"22")
+    s3_client.put_object(Bucket=bucket_name, Key="three", Body=b"333")
 
     # First list
-    resp = s3_client.list_objects(Bucket="mybucket", MaxKeys=1)
+    resp = s3_client.list_objects(Bucket=bucket_name, MaxKeys=1)
     listed_object = resp["Contents"][0]
 
     assert listed_object["Key"] == "one"
@@ -1318,7 +1339,7 @@ def test_list_objects_truncated_response():
     next_marker = resp["NextMarker"]
 
     # Second list
-    resp = s3_client.list_objects(Bucket="mybucket", MaxKeys=1, Marker=next_marker)
+    resp = s3_client.list_objects(Bucket=bucket_name, MaxKeys=1, Marker=next_marker)
     listed_object = resp["Contents"][0]
 
     assert listed_object["Key"] == "three"
@@ -1331,7 +1352,7 @@ def test_list_objects_truncated_response():
     next_marker = resp["NextMarker"]
 
     # Third list
-    resp = s3_client.list_objects(Bucket="mybucket", MaxKeys=1, Marker=next_marker)
+    resp = s3_client.list_objects(Bucket=bucket_name, MaxKeys=1, Marker=next_marker)
     listed_object = resp["Contents"][0]
 
     assert listed_object["Key"] == "two"
@@ -1345,11 +1366,12 @@ def test_list_objects_truncated_response():
 @mock_aws
 def test_list_keys_xml_escaped():
     s3_client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
-    s3_client.create_bucket(Bucket="mybucket")
+    bucket_name = str(uuid.uuid4())
+    s3_client.create_bucket(Bucket=bucket_name)
     key_name = "Q&A.txt"
-    s3_client.put_object(Bucket="mybucket", Key=key_name, Body=b"is awesome")
+    s3_client.put_object(Bucket=bucket_name, Key=key_name, Body=b"is awesome")
 
-    resp = s3_client.list_objects_v2(Bucket="mybucket", Prefix=key_name)
+    resp = s3_client.list_objects_v2(Bucket=bucket_name, Prefix=key_name)
 
     assert resp["Contents"][0]["Key"] == key_name
     assert resp["KeyCount"] == 1
@@ -1365,16 +1387,17 @@ def test_list_keys_xml_escaped():
 @mock_aws
 def test_list_objects_v2_common_prefix_pagination():
     s3_client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
-    s3_client.create_bucket(Bucket="mybucket")
+    bucket_name = str(uuid.uuid4())
+    s3_client.create_bucket(Bucket=bucket_name)
 
     max_keys = 1
     keys = [f"test/{i}/{i}" for i in range(3)]
     for key in keys:
-        s3_client.put_object(Bucket="mybucket", Key=key, Body=b"v")
+        s3_client.put_object(Bucket=bucket_name, Key=key, Body=b"v")
 
     prefixes = []
     args = {
-        "Bucket": "mybucket",
+        "Bucket": bucket_name,
         "Delimiter": "/",
         "Prefix": "test/",
         "MaxKeys": max_keys,
@@ -1394,39 +1417,38 @@ def test_list_objects_v2_common_prefix_pagination():
 @mock_aws
 def test_list_objects_v2_common_invalid_continuation_token():
     s3_client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
-    s3_client.create_bucket(Bucket="mybucket")
+    bucket_name = str(uuid.uuid4())
+    s3_client.create_bucket(Bucket=bucket_name)
 
     max_keys = 1
     keys = [f"test/{i}/{i}" for i in range(3)]
     for key in keys:
-        s3_client.put_object(Bucket="mybucket", Key=key, Body=b"v")
-
-    args = {
-        "Bucket": "mybucket",
-        "Delimiter": "/",
-        "Prefix": "test/",
-        "MaxKeys": max_keys,
-        "ContinuationToken": "",
-    }
+        s3_client.put_object(Bucket=bucket_name, Key=key, Body=b"v")
 
     with pytest.raises(botocore.exceptions.ClientError) as exc:
-        s3_client.list_objects_v2(**args)
-    assert exc.value.response["Error"]["Code"] == "InvalidArgument"
-    assert exc.value.response["Error"]["Message"] == (
-        "The continuation token provided is incorrect"
-    )
+        s3_client.list_objects_v2(
+            Bucket=bucket_name,
+            Delimiter="/",
+            Prefix="test/",
+            MaxKeys=max_keys,
+            ContinuationToken="",
+        )
+    err = exc.value.response["Error"]
+    assert err["Code"] == "InvalidArgument"
+    assert err["Message"] == "The continuation token provided is incorrect"
 
 
 @mock_aws
 def test_list_objects_v2_truncated_response():
     s3_client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
-    s3_client.create_bucket(Bucket="mybucket")
-    s3_client.put_object(Bucket="mybucket", Key="one", Body=b"1")
-    s3_client.put_object(Bucket="mybucket", Key="two", Body=b"22")
-    s3_client.put_object(Bucket="mybucket", Key="three", Body=b"333")
+    bucket_name = str(uuid.uuid4())
+    s3_client.create_bucket(Bucket=bucket_name)
+    s3_client.put_object(Bucket=bucket_name, Key="one", Body=b"1")
+    s3_client.put_object(Bucket=bucket_name, Key="two", Body=b"22")
+    s3_client.put_object(Bucket=bucket_name, Key="three", Body=b"333")
 
     # First list
-    resp = s3_client.list_objects_v2(Bucket="mybucket", MaxKeys=1)
+    resp = s3_client.list_objects_v2(Bucket=bucket_name, MaxKeys=1)
     listed_object = resp["Contents"][0]
 
     assert listed_object["Key"] == "one"
@@ -1442,7 +1464,7 @@ def test_list_objects_v2_truncated_response():
 
     # Second list
     resp = s3_client.list_objects_v2(
-        Bucket="mybucket", MaxKeys=1, ContinuationToken=next_token
+        Bucket=bucket_name, MaxKeys=1, ContinuationToken=next_token
     )
     listed_object = resp["Contents"][0]
 
@@ -1459,7 +1481,7 @@ def test_list_objects_v2_truncated_response():
 
     # Third list
     resp = s3_client.list_objects_v2(
-        Bucket="mybucket", MaxKeys=1, ContinuationToken=next_token
+        Bucket=bucket_name, MaxKeys=1, ContinuationToken=next_token
     )
     listed_object = resp["Contents"][0]
 
@@ -1477,13 +1499,14 @@ def test_list_objects_v2_truncated_response():
 @mock_aws
 def test_list_objects_v2_truncated_response_start_after():
     s3_client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
-    s3_client.create_bucket(Bucket="mybucket")
-    s3_client.put_object(Bucket="mybucket", Key="one", Body=b"1")
-    s3_client.put_object(Bucket="mybucket", Key="two", Body=b"22")
-    s3_client.put_object(Bucket="mybucket", Key="three", Body=b"333")
+    bucket_name = str(uuid.uuid4())
+    s3_client.create_bucket(Bucket=bucket_name)
+    s3_client.put_object(Bucket=bucket_name, Key="one", Body=b"1")
+    s3_client.put_object(Bucket=bucket_name, Key="two", Body=b"22")
+    s3_client.put_object(Bucket=bucket_name, Key="three", Body=b"333")
 
     # First list
-    resp = s3_client.list_objects_v2(Bucket="mybucket", MaxKeys=1, StartAfter="one")
+    resp = s3_client.list_objects_v2(Bucket=bucket_name, MaxKeys=1, StartAfter="one")
     listed_object = resp["Contents"][0]
 
     assert listed_object["Key"] == "three"
@@ -1500,7 +1523,7 @@ def test_list_objects_v2_truncated_response_start_after():
     # Second list
     # The ContinuationToken must take precedence over StartAfter.
     resp = s3_client.list_objects_v2(
-        Bucket="mybucket", MaxKeys=1, StartAfter="one", ContinuationToken=next_token
+        Bucket=bucket_name, MaxKeys=1, StartAfter="one", ContinuationToken=next_token
     )
     listed_object = resp["Contents"][0]
 
@@ -1519,10 +1542,11 @@ def test_list_objects_v2_truncated_response_start_after():
 @mock_aws
 def test_list_objects_v2_fetch_owner():
     s3_client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
-    s3_client.create_bucket(Bucket="mybucket")
-    s3_client.put_object(Bucket="mybucket", Key="one", Body=b"11")
+    bucket_name = str(uuid.uuid4())
+    s3_client.create_bucket(Bucket=bucket_name)
+    s3_client.put_object(Bucket=bucket_name, Key="one", Body=b"11")
 
-    resp = s3_client.list_objects_v2(Bucket="mybucket", FetchOwner=True)
+    resp = s3_client.list_objects_v2(Bucket=bucket_name, FetchOwner=True)
     owner = resp["Contents"][0]["Owner"]
 
     assert "ID" in owner
@@ -1533,14 +1557,15 @@ def test_list_objects_v2_fetch_owner():
 @mock_aws
 def test_list_objects_v2_truncate_combined_keys_and_folders():
     s3_client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
-    s3_client.create_bucket(Bucket="mybucket")
-    s3_client.put_object(Bucket="mybucket", Key="1/2", Body="")
-    s3_client.put_object(Bucket="mybucket", Key="2", Body="")
-    s3_client.put_object(Bucket="mybucket", Key="3/4", Body="")
-    s3_client.put_object(Bucket="mybucket", Key="4", Body="")
+    bucket_name = str(uuid.uuid4())
+    s3_client.create_bucket(Bucket=bucket_name)
+    s3_client.put_object(Bucket=bucket_name, Key="1/2", Body="")
+    s3_client.put_object(Bucket=bucket_name, Key="2", Body="")
+    s3_client.put_object(Bucket=bucket_name, Key="3/4", Body="")
+    s3_client.put_object(Bucket=bucket_name, Key="4", Body="")
 
     resp = s3_client.list_objects_v2(
-        Bucket="mybucket", Prefix="", MaxKeys=2, Delimiter="/"
+        Bucket=bucket_name, Prefix="", MaxKeys=2, Delimiter="/"
     )
     assert "Delimiter" in resp
     assert resp["IsTruncated"] is True
@@ -1552,7 +1577,7 @@ def test_list_objects_v2_truncate_combined_keys_and_folders():
 
     last_tail = resp["Contents"][-1]["Key"]
     resp = s3_client.list_objects_v2(
-        Bucket="mybucket", MaxKeys=2, Prefix="", Delimiter="/", StartAfter=last_tail
+        Bucket=bucket_name, MaxKeys=2, Prefix="", Delimiter="/", StartAfter=last_tail
     )
     assert resp["KeyCount"] == 2
     assert resp["IsTruncated"] is False
@@ -1568,22 +1593,23 @@ def test_list_objects_v2__more_than_1000():
     if not settings.TEST_DECORATOR_MODE:
         raise SkipTest("Accessing backends directly")
     s3_client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
-    s3_client.create_bucket(Bucket="mybucket")
+    bucket_name = str(uuid.uuid4())
+    s3_client.create_bucket(Bucket=bucket_name)
 
     # Uploading >1000 files using boto3 takes ages, so let's just use the backend directly
     backend = s3_backends[DEFAULT_ACCOUNT_ID]["global"]
     for i in range(1100):
-        backend.put_object(bucket_name="mybucket", key_name=f"{i}", value=b"")
+        backend.put_object(bucket_name=bucket_name, key_name=f"{i}", value=b"")
 
     # Page 1
-    resp = s3_client.list_objects_v2(Bucket="mybucket", Delimiter="/")
+    resp = s3_client.list_objects_v2(Bucket=bucket_name, Delimiter="/")
     assert resp["KeyCount"] == 1000
     assert len(resp["Contents"]) == 1000
     assert resp["IsTruncated"] is True
 
     # Page2
     tail = resp["Contents"][-1]["Key"]
-    resp = s3_client.list_objects_v2(Bucket="mybucket", Delimiter="/", StartAfter=tail)
+    resp = s3_client.list_objects_v2(Bucket=bucket_name, Delimiter="/", StartAfter=tail)
     assert resp["KeyCount"] == 100
     assert len(resp["Contents"]) == 100
     assert resp["IsTruncated"] is False
@@ -1592,12 +1618,13 @@ def test_list_objects_v2__more_than_1000():
 @mock_aws
 def test_list_objects_v2_checksum_algo():
     s3_client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
-    s3_client.create_bucket(Bucket="mybucket")
-    resp = s3_client.put_object(Bucket="mybucket", Key="0", Body="a")
+    bucket_name = str(uuid.uuid4())
+    s3_client.create_bucket(Bucket=bucket_name)
+    resp = s3_client.put_object(Bucket=bucket_name, Key="0", Body="a")
     # Default checksum behavior varies by boto3 version and will not be asserted here.
     assert resp
     resp = s3_client.put_object(
-        Bucket="mybucket", Key="1", Body="a", ChecksumAlgorithm="CRC32"
+        Bucket=bucket_name, Key="1", Body="a", ChecksumAlgorithm="CRC32"
     )
     assert "ChecksumCRC32" in resp
     assert (
@@ -1605,7 +1632,7 @@ def test_list_objects_v2_checksum_algo():
         == "CRC32"
     )
     resp = s3_client.put_object(
-        Bucket="mybucket", Key="2", Body="b", ChecksumAlgorithm="SHA256"
+        Bucket=bucket_name, Key="2", Body="b", ChecksumAlgorithm="SHA256"
     )
     assert "ChecksumSHA256" in resp
     assert (
@@ -1613,23 +1640,10 @@ def test_list_objects_v2_checksum_algo():
         == "SHA256"
     )
 
-    resp = s3_client.list_objects_v2(Bucket="mybucket")["Contents"]
+    resp = s3_client.list_objects_v2(Bucket=bucket_name)["Contents"]
     assert "ChecksumAlgorithm" in resp[0]
     assert resp[1]["ChecksumAlgorithm"] == ["CRC32"]
     assert resp[2]["ChecksumAlgorithm"] == ["SHA256"]
-
-
-@mock_aws
-def test_bucket_create():
-    s3_resource = boto3.resource("s3", region_name=DEFAULT_REGION_NAME)
-    s3_resource.create_bucket(Bucket="blah")
-
-    s3_resource.Object("blah", "hello.txt").put(Body="some text")
-
-    assert (
-        s3_resource.Object("blah", "hello.txt").get()["Body"].read().decode("utf-8")
-        == "some text"
-    )
 
 
 @aws_verified
@@ -1640,7 +1654,7 @@ def test_bucket_create_force_us_east_1():
     )
     with pytest.raises(ClientError) as exc:
         s3_resource.create_bucket(
-            Bucket="blah",
+            Bucket=str(uuid.uuid4()),
             CreateBucketConfiguration={"LocationConstraint": DEFAULT_REGION_NAME},
         )
     assert exc.value.response["Error"]["Code"] == "InvalidLocationConstraint"
@@ -1653,16 +1667,14 @@ def test_bucket_create_force_us_east_1():
 @mock_aws
 def test_bucket_create_eu_central():
     s3_resource = boto3.resource("s3", region_name="eu-central-1")
-    s3_resource.create_bucket(
-        Bucket="blah", CreateBucketConfiguration={"LocationConstraint": "eu-central-1"}
+    bucket = s3_resource.create_bucket(
+        Bucket=str(uuid.uuid4()),
+        CreateBucketConfiguration={"LocationConstraint": "eu-central-1"},
     )
 
-    s3_resource.Object("blah", "hello.txt").put(Body="some text")
+    bucket.Object("hello.txt").put(Body="some text")
 
-    assert (
-        s3_resource.Object("blah", "hello.txt").get()["Body"].read().decode("utf-8")
-        == "some text"
-    )
+    assert bucket.Object("hello.txt").get()["Body"].read() == b"some text"
 
 
 @pytest.mark.aws_verified
@@ -1801,7 +1813,7 @@ def test_get_object(size, bucket_name=None):
 @mock_aws
 def test_s3_content_type():
     s3_resource = boto3.resource("s3", region_name=DEFAULT_REGION_NAME)
-    my_bucket = s3_resource.Bucket("my-cool-bucket")
+    my_bucket = s3_resource.Bucket(str(uuid.uuid4()))
     my_bucket.create()
     s3_path = "test_s3.py"
     s3_resource = boto3.resource("s3", verify=False)
@@ -1817,11 +1829,11 @@ def test_s3_content_type():
 @mock_aws
 def test_get_missing_object_with_part_number():
     s3_resource = boto3.resource("s3", region_name=DEFAULT_REGION_NAME)
-    s3_resource.create_bucket(Bucket="blah")
+    bucket = s3_resource.create_bucket(Bucket=str(uuid.uuid4()))
 
     with pytest.raises(ClientError) as exc:
-        s3_resource.Object("blah", "hello.txt").meta.client.head_object(
-            Bucket="blah", Key="hello.txt", PartNumber=123
+        bucket.meta.client.head_object(
+            Bucket=bucket.name, Key="hello.txt", PartNumber=123
         )
 
     assert exc.value.response["Error"]["Code"] == "404"
@@ -1830,47 +1842,48 @@ def test_get_missing_object_with_part_number():
 @mock_aws
 def test_head_object_with_versioning():
     s3_resource = boto3.resource("s3", region_name=DEFAULT_REGION_NAME)
-    bucket = s3_resource.create_bucket(Bucket="blah")
+    bucket = s3_resource.create_bucket(Bucket=str(uuid.uuid4()))
     bucket.Versioning().enable()
 
     old_content = "some text"
     new_content = "some new text"
-    s3_resource.Object("blah", "hello.txt").put(Body=old_content)
-    s3_resource.Object("blah", "hello.txt").put(Body=new_content)
+    bucket.Object("hello.txt").put(Body=old_content)
+    bucket.Object("hello.txt").put(Body=new_content)
 
-    versions = list(s3_resource.Bucket("blah").object_versions.all())
+    versions = list(bucket.object_versions.all())
     latest = list(filter(lambda item: item.is_latest, versions))[0]
     oldest = list(filter(lambda item: not item.is_latest, versions))[0]
 
-    head_object = s3_resource.Object("blah", "hello.txt").meta.client.head_object(
-        Bucket="blah", Key="hello.txt"
+    head_object = s3_resource.meta.client.head_object(
+        Bucket=bucket.name, Key="hello.txt"
     )
     assert head_object["VersionId"] == latest.id
     assert head_object["ContentLength"] == len(new_content)
 
-    old_head_object = s3_resource.Object("blah", "hello.txt").meta.client.head_object(
-        Bucket="blah", Key="hello.txt", VersionId=oldest.id
+    old_head = s3_resource.meta.client.head_object(
+        Bucket=bucket.name, Key="hello.txt", VersionId=oldest.id
     )
-    assert old_head_object["VersionId"] == oldest.id
-    assert old_head_object["ContentLength"] == len(old_content)
+    assert old_head["VersionId"] == oldest.id
+    assert old_head["ContentLength"] == len(old_content)
 
-    assert old_head_object["VersionId"] != head_object["VersionId"]
+    assert old_head["VersionId"] != head_object["VersionId"]
 
 
 @mock_aws
 def test_deleted_versionings_list():
     client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
+    bucket_name = str(uuid.uuid4())
 
-    client.create_bucket(Bucket="blah")
+    client.create_bucket(Bucket=bucket_name)
     client.put_bucket_versioning(
-        Bucket="blah", VersioningConfiguration={"Status": "Enabled"}
+        Bucket=bucket_name, VersioningConfiguration={"Status": "Enabled"}
     )
 
-    client.put_object(Bucket="blah", Key="test1", Body=b"test1")
-    client.put_object(Bucket="blah", Key="test2", Body=b"test2")
-    client.delete_objects(Bucket="blah", Delete={"Objects": [{"Key": "test1"}]})
+    client.put_object(Bucket=bucket_name, Key="test1", Body=b"test1")
+    client.put_object(Bucket=bucket_name, Key="test2", Body=b"test2")
+    client.delete_objects(Bucket=bucket_name, Delete={"Objects": [{"Key": "test1"}]})
 
-    listed = client.list_objects_v2(Bucket="blah")
+    listed = client.list_objects_v2(Bucket=bucket_name)
     assert len(listed["Contents"]) == 1
 
 
@@ -1908,16 +1921,17 @@ def test_delete_objects_for_specific_version_id(bucket_name=None):
 @mock_aws
 def test_delete_versioned_bucket():
     client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
+    bucket_name = str(uuid.uuid4())
 
-    client.create_bucket(Bucket="blah")
+    client.create_bucket(Bucket=bucket_name)
     client.put_bucket_versioning(
-        Bucket="blah", VersioningConfiguration={"Status": "Enabled"}
+        Bucket=bucket_name, VersioningConfiguration={"Status": "Enabled"}
     )
 
-    resp = client.put_object(Bucket="blah", Key="test1", Body=b"test1")
-    client.delete_object(Bucket="blah", Key="test1", VersionId=resp["VersionId"])
+    resp = client.put_object(Bucket=bucket_name, Key="test1", Body=b"test1")
+    client.delete_object(Bucket=bucket_name, Key="test1", VersionId=resp["VersionId"])
 
-    client.delete_bucket(Bucket="blah")
+    client.delete_bucket(Bucket=bucket_name)
 
 
 @pytest.mark.aws_verified
@@ -2035,7 +2049,7 @@ def test_delete_versioned_bucket_returns_metadata(bucket_name=None):
 @mock_aws
 def test_put_bucket_cors():
     s3_client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
-    bucket_name = "mybucket"
+    bucket_name = str(uuid.uuid4())
     s3_client.create_bucket(Bucket=bucket_name)
 
     resp = s3_client.put_bucket_cors(
@@ -2098,7 +2112,7 @@ def test_put_bucket_cors():
 @mock_aws
 def test_get_bucket_cors():
     s3_client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
-    bucket_name = "mybucket"
+    bucket_name = str(uuid.uuid4())
     s3_client.create_bucket(Bucket=bucket_name)
 
     # Without CORS:
@@ -2181,19 +2195,20 @@ def test_delete_bucket_cors(bucket_name=None):
 )
 def test_put_bucket_notification(region, partition):
     s3_client = boto3.client("s3", region_name=region)
+    bucket_name = str(uuid.uuid4())
     s3_client.create_bucket(
-        Bucket="bucket", CreateBucketConfiguration={"LocationConstraint": region}
+        Bucket=bucket_name, CreateBucketConfiguration={"LocationConstraint": region}
     )
 
     # With no configuration:
-    result = s3_client.get_bucket_notification(Bucket="bucket")
+    result = s3_client.get_bucket_notification(Bucket=bucket_name)
     assert not result.get("TopicConfigurations")
     assert not result.get("QueueConfigurations")
     assert not result.get("LambdaFunctionConfigurations")
 
     # Place proper topic configuration:
     s3_client.put_bucket_notification_configuration(
-        Bucket="bucket",
+        Bucket=bucket_name,
         NotificationConfiguration={
             "TopicConfigurations": [
                 {
@@ -2217,7 +2232,7 @@ def test_put_bucket_notification(region, partition):
     )
 
     # Verify to completion:
-    result = s3_client.get_bucket_notification_configuration(Bucket="bucket")
+    result = s3_client.get_bucket_notification_configuration(Bucket=bucket_name)
     assert len(result["TopicConfigurations"]) == 2
     assert not result.get("QueueConfigurations")
     assert not result.get("LambdaFunctionConfigurations")
@@ -2257,7 +2272,7 @@ def test_put_bucket_notification(region, partition):
 
     # Place proper queue configuration:
     s3_client.put_bucket_notification_configuration(
-        Bucket="bucket",
+        Bucket=bucket_name,
         NotificationConfiguration={
             "QueueConfigurations": [
                 {
@@ -2271,7 +2286,7 @@ def test_put_bucket_notification(region, partition):
             ]
         },
     )
-    result = s3_client.get_bucket_notification_configuration(Bucket="bucket")
+    result = s3_client.get_bucket_notification_configuration(Bucket=bucket_name)
     assert len(result["QueueConfigurations"]) == 1
     assert not result.get("TopicConfigurations")
     assert not result.get("LambdaFunctionConfigurations")
@@ -2294,7 +2309,7 @@ def test_put_bucket_notification(region, partition):
 
     # Place proper Lambda configuration:
     s3_client.put_bucket_notification_configuration(
-        Bucket="bucket",
+        Bucket=bucket_name,
         NotificationConfiguration={
             "LambdaFunctionConfigurations": [
                 {
@@ -2307,7 +2322,7 @@ def test_put_bucket_notification(region, partition):
             ]
         },
     )
-    result = s3_client.get_bucket_notification_configuration(Bucket="bucket")
+    result = s3_client.get_bucket_notification_configuration(Bucket=bucket_name)
     assert len(result["LambdaFunctionConfigurations"]) == 1
     assert not result.get("TopicConfigurations")
     assert not result.get("QueueConfigurations")
@@ -2339,7 +2354,7 @@ def test_put_bucket_notification(region, partition):
 
     # And with all 3 set:
     s3_client.put_bucket_notification_configuration(
-        Bucket="bucket",
+        Bucket=bucket_name,
         NotificationConfiguration={
             "TopicConfigurations": [
                 {
@@ -2361,16 +2376,16 @@ def test_put_bucket_notification(region, partition):
             ],
         },
     )
-    result = s3_client.get_bucket_notification_configuration(Bucket="bucket")
+    result = s3_client.get_bucket_notification_configuration(Bucket=bucket_name)
     assert len(result["LambdaFunctionConfigurations"]) == 1
     assert len(result["TopicConfigurations"]) == 1
     assert len(result["QueueConfigurations"]) == 1
 
     # And clear it out:
     s3_client.put_bucket_notification_configuration(
-        Bucket="bucket", NotificationConfiguration={}
+        Bucket=bucket_name, NotificationConfiguration={}
     )
-    result = s3_client.get_bucket_notification_configuration(Bucket="bucket")
+    result = s3_client.get_bucket_notification_configuration(Bucket=bucket_name)
     assert not result.get("TopicConfigurations")
     assert not result.get("QueueConfigurations")
     assert not result.get("LambdaFunctionConfigurations")
@@ -2379,13 +2394,14 @@ def test_put_bucket_notification(region, partition):
 @mock_aws
 def test_put_bucket_notification_errors():
     s3_client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
-    s3_client.create_bucket(Bucket="bucket")
+    bucket_name = str(uuid.uuid4())
+    s3_client.create_bucket(Bucket=bucket_name)
 
     # With incorrect ARNs:
     for tech in ["Queue", "Topic", "LambdaFunction"]:
         with pytest.raises(ClientError) as err:
             s3_client.put_bucket_notification_configuration(
-                Bucket="bucket",
+                Bucket=bucket_name,
                 NotificationConfiguration={
                     f"{tech}Configurations": [
                         {
@@ -2400,9 +2416,9 @@ def test_put_bucket_notification_errors():
         assert err.value.response["Error"]["Message"] == "The ARN is not well formed"
 
     # Region not the same as the bucket:
-    with pytest.raises(ClientError) as err:
+    with pytest.raises(ClientError) as exc:
         s3_client.put_bucket_notification_configuration(
-            Bucket="bucket",
+            Bucket=bucket_name,
             NotificationConfiguration={
                 "QueueConfigurations": [
                     {
@@ -2413,16 +2429,16 @@ def test_put_bucket_notification_errors():
             },
         )
 
-    assert err.value.response["Error"]["Code"] == "InvalidArgument"
-    assert err.value.response["Error"]["Message"] == (
-        "The notification destination service region is not valid for "
-        "the bucket location constraint"
+    err = exc.value.response["Error"]
+    assert err["Code"] == "InvalidArgument"
+    assert err["Message"] == (
+        "The notification destination service region is not valid for the bucket location constraint"
     )
 
     # Invalid event name:
-    with pytest.raises(ClientError) as err:
+    with pytest.raises(ClientError) as exc:
         s3_client.put_bucket_notification_configuration(
-            Bucket="bucket",
+            Bucket=bucket_name,
             NotificationConfiguration={
                 "QueueConfigurations": [
                     {
@@ -2432,9 +2448,10 @@ def test_put_bucket_notification_errors():
                 ]
             },
         )
-    assert err.value.response["Error"]["Code"] == "InvalidArgument"
+    err = exc.value.response["Error"]
+    assert err["Code"] == "InvalidArgument"
     assert (
-        err.value.response["Error"]["Message"]
+        err["Message"]
         == "The event 'notarealeventname' is not supported for notifications. Supported events are as follows: ['s3:IntelligentTiering', 's3:LifecycleExpiration:*', 's3:LifecycleExpiration:Delete', 's3:LifecycleExpiration:DeleteMarkerCreated', 's3:LifecycleTransition', 's3:ObjectAcl:Put', 's3:ObjectCreated:*', 's3:ObjectCreated:CompleteMultipartUpload', 's3:ObjectCreated:Copy', 's3:ObjectCreated:Post', 's3:ObjectCreated:Put', 's3:ObjectRemoved:*', 's3:ObjectRemoved:Delete', 's3:ObjectRemoved:DeleteMarkerCreated', 's3:ObjectRestore:*', 's3:ObjectRestore:Completed', 's3:ObjectRestore:Delete', 's3:ObjectRestore:Post', 's3:ObjectTagging:*', 's3:ObjectTagging:Delete', 's3:ObjectTagging:Put', 's3:ReducedRedundancyLostObject', 's3:Replication:*', 's3:Replication:OperationFailedReplication', 's3:Replication:OperationMissedThreshold', 's3:Replication:OperationNotTracked', 's3:Replication:OperationReplicatedAfterThreshold']"
     )
 
@@ -2442,7 +2459,7 @@ def test_put_bucket_notification_errors():
 @mock_aws
 def test_delete_markers():
     s3_client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
-    bucket_name = "mybucket"
+    bucket_name = str(uuid.uuid4())
     key = "key-with-versions-and-unicode-ó"
     s3_client.create_bucket(Bucket=bucket_name)
     s3_client.put_bucket_versioning(
@@ -2485,7 +2502,7 @@ def test_delete_markers():
 @mock_aws
 def test_multiple_delete_markers():
     s3_client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
-    bucket_name = "mybucket"
+    bucket_name = str(uuid.uuid4())
     key = "key-with-versions-and-unicode-ó"
     s3_client.create_bucket(Bucket=bucket_name)
     s3_client.put_bucket_versioning(
@@ -2534,19 +2551,20 @@ def test_multiple_delete_markers():
 @mock_aws
 def test_get_stream_gzipped():
     payload = b"this is some stuff here"
+    bucket_name = str(uuid.uuid4())
 
     s3_client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
-    s3_client.create_bucket(Bucket="moto-tests")
+    s3_client.create_bucket(Bucket=bucket_name)
     buffer_ = BytesIO()
     with GzipFile(fileobj=buffer_, mode="w") as fhandle:
         fhandle.write(payload)
     payload_gz = buffer_.getvalue()
 
     s3_client.put_object(
-        Bucket="moto-tests", Key="keyname", Body=payload_gz, ContentEncoding="gzip"
+        Bucket=bucket_name, Key="keyname", Body=payload_gz, ContentEncoding="gzip"
     )
 
-    obj = s3_client.get_object(Bucket="moto-tests", Key="keyname")
+    obj = s3_client.get_object(Bucket=bucket_name, Key="keyname")
     res = zlib.decompress(obj["Body"].read(), 16 + zlib.MAX_WBITS)
     assert res == payload
 
@@ -2589,7 +2607,7 @@ def test_bucket_name_too_short():
 
 @mock_aws
 def test_accelerated_none_when_unspecified():
-    bucket_name = "some_bucket"
+    bucket_name = str(uuid.uuid4())
     s3_client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
     s3_client.create_bucket(Bucket=bucket_name)
     resp = s3_client.get_bucket_accelerate_configuration(Bucket=bucket_name)
@@ -2598,7 +2616,7 @@ def test_accelerated_none_when_unspecified():
 
 @mock_aws
 def test_can_enable_bucket_acceleration():
-    bucket_name = "some_bucket"
+    bucket_name = str(uuid.uuid4())
     s3_client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
     s3_client.create_bucket(Bucket=bucket_name)
     resp = s3_client.put_bucket_accelerate_configuration(
@@ -2612,10 +2630,10 @@ def test_can_enable_bucket_acceleration():
 
 @mock_aws
 def test_can_suspend_bucket_acceleration():
-    bucket_name = "some_bucket"
+    bucket_name = str(uuid.uuid4())
     s3_client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
     s3_client.create_bucket(Bucket=bucket_name)
-    resp = s3_client.put_bucket_accelerate_configuration(
+    s3_client.put_bucket_accelerate_configuration(
         Bucket=bucket_name, AccelerateConfiguration={"Status": "Enabled"}
     )
     resp = s3_client.put_bucket_accelerate_configuration(
@@ -2629,7 +2647,7 @@ def test_can_suspend_bucket_acceleration():
 
 @mock_aws
 def test_suspending_acceleration_on_not_configured_bucket_does_nothing():
-    bucket_name = "some_bucket"
+    bucket_name = str(uuid.uuid4())
     s3_client = boto3.client("s3", DEFAULT_REGION_NAME)
     s3_client.create_bucket(Bucket=bucket_name)
     resp = s3_client.put_bucket_accelerate_configuration(
@@ -2642,7 +2660,7 @@ def test_suspending_acceleration_on_not_configured_bucket_does_nothing():
 
 @mock_aws
 def test_accelerate_configuration_status_validation():
-    bucket_name = "some_bucket"
+    bucket_name = str(uuid.uuid4())
     s3_client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
     s3_client.create_bucket(Bucket=bucket_name)
     with pytest.raises(ClientError) as exc:
@@ -2654,7 +2672,7 @@ def test_accelerate_configuration_status_validation():
 
 @mock_aws
 def test_accelerate_configuration_is_not_supported_when_bucket_name_has_dots():
-    bucket_name = "some.bucket.with.dots"
+    bucket_name = f"some.bucket.with.dots.{uuid.uuid4()}"
     s3_client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
     s3_client.create_bucket(Bucket=bucket_name)
     with pytest.raises(ClientError) as exc:
@@ -2666,7 +2684,7 @@ def test_accelerate_configuration_is_not_supported_when_bucket_name_has_dots():
 
 def store_and_read_back_a_key(key):
     s3_client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
-    bucket_name = "mybucket"
+    bucket_name = str(uuid.uuid4())
     body = b"Some body"
 
     s3_client.create_bucket(Bucket=bucket_name)
@@ -2688,13 +2706,16 @@ def test_root_dir_with_empty_name_works():
     store_and_read_back_a_key("/")
 
 
-@pytest.mark.parametrize("bucket_name", ["mybucket", "my.bucket"])
+@pytest.mark.parametrize("hash_dash", [True, False], ids=["with-dash", "with.dot"])
 @mock_aws
-def test_leading_slashes_not_removed(bucket_name):
+def test_leading_slashes_not_removed(hash_dash):
     """Make sure that leading slashes are not removed internally."""
     if settings.is_test_proxy_mode():
         raise SkipTest("Doesn't quite work right with the Proxy")
     s3_client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
+    bucket_name = (
+        str(uuid.uuid4()) if hash_dash else str(uuid.uuid4()).replace("-", ".")
+    )
     s3_client.create_bucket(Bucket=bucket_name)
 
     uploaded_key = "/key"
@@ -2718,7 +2739,7 @@ def test_leading_slashes_not_removed(bucket_name):
 @mock_aws
 def test_delete_objects_with_url_encoded_key(key):
     s3_client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
-    bucket_name = "mybucket"
+    bucket_name = str(uuid.uuid4())
     body = b"Some body"
 
     s3_client.create_bucket(Bucket=bucket_name)
@@ -2743,7 +2764,7 @@ def test_delete_objects_with_url_encoded_key(key):
 
 @mock_aws
 def test_delete_objects_unknown_key():
-    bucket_name = "test-moto-issue-1581"
+    bucket_name = str(uuid.uuid4())
     client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
     client.create_bucket(Bucket=bucket_name)
     client.put_object(Bucket=bucket_name, Key="file1", Body="body")
@@ -2760,11 +2781,12 @@ def test_delete_objects_unknown_key():
 @mock_aws
 def test_public_access_block():
     client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
-    client.create_bucket(Bucket="mybucket")
+    bucket_name = str(uuid.uuid4())
+    client.create_bucket(Bucket=bucket_name)
 
     # Try to get the public access block (should not exist by default)
     with pytest.raises(ClientError) as exc:
-        client.get_public_access_block(Bucket="mybucket")
+        client.get_public_access_block(Bucket=bucket_name)
 
     assert exc.value.response["Error"]["Code"] == "NoSuchPublicAccessBlockConfiguration"
     assert (
@@ -2786,22 +2808,22 @@ def test_public_access_block():
         test_map[field] = True
 
         client.put_public_access_block(
-            Bucket="mybucket", PublicAccessBlockConfiguration=test_map
+            Bucket=bucket_name, PublicAccessBlockConfiguration=test_map
         )
 
         # Test:
         assert (
             test_map
-            == client.get_public_access_block(Bucket="mybucket")[
+            == client.get_public_access_block(Bucket=bucket_name)[
                 "PublicAccessBlockConfiguration"
             ]
         )
 
     # Assume missing values are default False:
     client.put_public_access_block(
-        Bucket="mybucket", PublicAccessBlockConfiguration={"BlockPublicAcls": True}
+        Bucket=bucket_name, PublicAccessBlockConfiguration={"BlockPublicAcls": True}
     )
-    assert client.get_public_access_block(Bucket="mybucket")[
+    assert client.get_public_access_block(Bucket=bucket_name)[
         "PublicAccessBlockConfiguration"
     ] == {
         "BlockPublicAcls": True,
@@ -2813,20 +2835,18 @@ def test_public_access_block():
     # Test with a blank PublicAccessBlockConfiguration:
     with pytest.raises(ClientError) as exc:
         client.put_public_access_block(
-            Bucket="mybucket", PublicAccessBlockConfiguration={}
+            Bucket=bucket_name, PublicAccessBlockConfiguration={}
         )
 
-    assert exc.value.response["Error"]["Code"] == "InvalidRequest"
-    assert (
-        exc.value.response["Error"]["Message"]
-        == "Must specify at least one configuration."
-    )
+    err = exc.value.response["Error"]
+    assert err["Code"] == "InvalidRequest"
+    assert err["Message"] == "Must specify at least one configuration."
     assert exc.value.response["ResponseMetadata"]["HTTPStatusCode"] == 400
 
     # Test that things work with AWS Config:
     config_client = boto3.client("config", region_name=DEFAULT_REGION_NAME)
     result = config_client.get_resource_config_history(
-        resourceType="AWS::S3::Bucket", resourceId="mybucket"
+        resourceType="AWS::S3::Bucket", resourceId=bucket_name
     )
     pub_block_config = json.loads(
         result["configurationItems"][0]["supplementaryConfiguration"][
@@ -2842,16 +2862,16 @@ def test_public_access_block():
     }
 
     # Delete:
-    client.delete_public_access_block(Bucket="mybucket")
+    client.delete_public_access_block(Bucket=bucket_name)
 
     with pytest.raises(ClientError) as exc:
-        client.get_public_access_block(Bucket="mybucket")
+        client.get_public_access_block(Bucket=bucket_name)
     assert exc.value.response["Error"]["Code"] == "NoSuchPublicAccessBlockConfiguration"
 
 
 @mock_aws
 def test_creating_presigned_post():
-    bucket = "presigned-test"
+    bucket = str(uuid.uuid4())
     s3_client = boto3.client("s3", region_name="us-east-1")
     s3_client.create_bucket(Bucket=bucket)
     success_url = "http://localhost/completed"
@@ -2987,7 +3007,7 @@ def test_presigned_put_url_with_custom_headers():
 
 @mock_aws
 def test_request_partial_content_should_contain_content_length():
-    bucket = "bucket"
+    bucket = str(uuid.uuid4())
     object_key = "key"
     s3_resource = boto3.resource("s3", region_name=DEFAULT_REGION_NAME)
     s3_resource.create_bucket(Bucket=bucket)
@@ -3000,7 +3020,7 @@ def test_request_partial_content_should_contain_content_length():
 
 @mock_aws
 def test_request_partial_content_should_contain_actual_content_length():
-    bucket = "bucket"
+    bucket = str(uuid.uuid4())
     object_key = "key"
     s3_resource = boto3.resource("s3", region_name=DEFAULT_REGION_NAME)
     s3_resource.create_bucket(Bucket=bucket)
@@ -3021,7 +3041,7 @@ def test_request_partial_content_should_contain_actual_content_length():
 
 @mock_aws
 def test_get_unknown_version_should_throw_specific_error():
-    bucket_name = "my_bucket"
+    bucket_name = str(uuid.uuid4())
     object_key = "hello.txt"
     s3_resource = boto3.resource("s3", region_name="us-east-1")
     client = boto3.client("s3", region_name="us-east-1")
@@ -3040,7 +3060,7 @@ def test_get_unknown_version_should_throw_specific_error():
 
 @mock_aws
 def test_request_partial_content_without_specifying_range_should_return_full_object():
-    bucket = "bucket"
+    bucket = str(uuid.uuid4())
     object_key = "key"
     s3_resource = boto3.resource("s3", region_name="us-east-1")
     s3_resource.create_bucket(Bucket=bucket)
@@ -3053,7 +3073,7 @@ def test_request_partial_content_without_specifying_range_should_return_full_obj
 
 @mock_aws
 def test_object_headers():
-    bucket = "my-bucket"
+    bucket = str(uuid.uuid4())
     s3_client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
     s3_client.create_bucket(Bucket=bucket)
 
@@ -3081,11 +3101,11 @@ if settings.TEST_SERVER_MODE:
 
     @mock_aws
     def test_upload_data_without_content_type():
-        bucket = "mybucket"
+        bucket = str(uuid.uuid4())
         s3_client = boto3.client("s3")
         s3_client.create_bucket(Bucket=bucket)
         data_input = b"some data 123 321"
-        req = requests.put("http://localhost:5000/mybucket/test.txt", data=data_input)
+        req = requests.put(f"http://localhost:5000/{bucket}/test.txt", data=data_input)
         assert req.status_code == 200
 
         res = s3_client.get_object(Bucket=bucket, Key="test.txt")
@@ -3098,7 +3118,7 @@ if settings.TEST_SERVER_MODE:
     "prefix", ["file", "file+else", "file&another", "file another"]
 )
 def test_get_object_versions_with_prefix(prefix):
-    bucket_name = "testbucket-3113"
+    bucket_name = str(uuid.uuid4())
     s3_resource = boto3.resource("s3", region_name=DEFAULT_REGION_NAME)
     s3_client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
     s3_client.create_bucket(Bucket=bucket_name)
@@ -3116,7 +3136,7 @@ def test_get_object_versions_with_prefix(prefix):
 
 @mock_aws
 def test_create_bucket_duplicate():
-    bucket_name = "same-bucket-test-1371"
+    bucket_name = str(uuid.uuid4())
     alternate_region = "eu-north-1"
     # Create it in the default region
     default_client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
@@ -3140,7 +3160,7 @@ def test_create_bucket_duplicate():
     assert err["BucketName"] == bucket_name
 
     # Try this again - but creating the bucket in a non-default region in the first place
-    bucket_name = "same-bucket-nondefault-region-test-1371"
+    bucket_name = str(uuid.uuid4())
     diff_client.create_bucket(
         Bucket=bucket_name,
         CreateBucketConfiguration={"LocationConstraint": alternate_region},
@@ -3189,7 +3209,7 @@ def test_create_bucket_duplicate():
 def test_delete_objects_with_empty_keyname():
     client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
     resource = boto3.resource("s3", region_name=DEFAULT_REGION_NAME)
-    bucket_name = "testbucket-4077"
+    bucket_name = str(uuid.uuid4())
     bucket = resource.create_bucket(Bucket=bucket_name)
     key_name = " "
     bucket.put_object(Key=key_name, Body=b"")
@@ -3240,28 +3260,23 @@ def test_delete_objects_percent_encoded(bucket_name=None):
 @mock_aws
 def test_head_object_should_return_default_content_type():
     s3_resource = boto3.resource("s3", region_name="us-east-1")
-    s3_resource.create_bucket(Bucket="testbucket")
-    s3_resource.Bucket("testbucket").upload_fileobj(
-        BytesIO(b"foobar"), Key="testobject"
-    )
+    bucket = s3_resource.create_bucket(Bucket=str(uuid.uuid4()))
+    bucket.upload_fileobj(BytesIO(b"foobar"), Key="testobject")
     s3_client = boto3.client("s3", region_name="us-east-1")
-    resp = s3_client.head_object(Bucket="testbucket", Key="testobject")
+    resp = s3_client.head_object(Bucket=bucket.name, Key="testobject")
 
     assert resp["ContentType"] == "binary/octet-stream"
     assert resp["ResponseMetadata"]["HTTPHeaders"]["content-type"] == (
         "binary/octet-stream"
     )
 
-    assert (
-        s3_resource.Object("testbucket", "testobject").content_type
-        == "binary/octet-stream"
-    )
+    assert bucket.Object("testobject").content_type == "binary/octet-stream"
 
 
 @mock_aws
 def test_request_partial_content_should_contain_all_metadata():
     # github.com/getmoto/moto/issues/4203
-    bucket = "bucket"
+    bucket = str(uuid.uuid4())
     object_key = "key"
     body = "some text"
     query_range = "0-3"
@@ -3282,13 +3297,11 @@ def test_request_partial_content_should_contain_all_metadata():
 @mock_aws
 def test_head_versioned_key_in_not_versioned_bucket():
     client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
-    client.create_bucket(Bucket="simple-bucked")
+    bucket_name = str(uuid.uuid4())
+    client.create_bucket(Bucket=bucket_name)
 
     with pytest.raises(ClientError) as ex:
-        client.head_object(
-            Bucket="simple-bucked", Key="file.txt", VersionId="noVersion"
-        )
-
+        client.head_object(Bucket=bucket_name, Key="file.txt", VersionId="noVersion")
     response = ex.value.response
     assert response["Error"]["Code"] == "400"
 
@@ -3352,7 +3365,7 @@ def test_prefix_encoding():
 @mock_aws
 @pytest.mark.parametrize("algorithm", ["CRC32", "CRC32C", "SHA1", "SHA256"])
 def test_checksum_response(algorithm):
-    bucket_name = "checksum-bucket"
+    bucket_name = str(uuid.uuid4())
     client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
     client.create_bucket(Bucket=bucket_name)
     if (
@@ -3393,8 +3406,8 @@ def enable_versioning(bucket_name, s3_client):
 @mock_aws
 def test_put_and_get_bucket_inventory_configuration():
     client = boto3.client("s3", region_name="us-east-1")
-    bucket = "mybucket"
-    bucket2 = "mybucket2"
+    bucket = str(uuid.uuid4())
+    bucket2 = str(uuid.uuid4())
     id = "my-inventory-config"
     inventory_configuration = {
         "Destination": {
@@ -3445,8 +3458,8 @@ def test_put_and_get_bucket_inventory_configuration():
 @mock_aws
 def test_list_bucket_inventory_configurations():
     client = boto3.client("s3", region_name="us-east-1")
-    bucket = "mybucket"
-    bucket2 = "mybucket2"
+    bucket = str(uuid.uuid4())
+    bucket2 = str(uuid.uuid4())
     id = "my-inventory-config"
 
     client.create_bucket(Bucket=bucket)

--- a/tests/test_s3/test_s3_acl.py
+++ b/tests/test_s3/test_s3_acl.py
@@ -51,14 +51,14 @@ def test_put_object_acl_using_grant(readwrite, type_key, value, has_quotes):
 def test_acl_switching():
     s3_resource = boto3.resource("s3", region_name=DEFAULT_REGION_NAME)
     client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
-    bucket = s3_resource.Bucket("foobar")
+    bucket = s3_resource.Bucket(str(uuid4()))
     bucket.create()
     keyname = "test.txt"
 
     bucket.put_object(Key=keyname, Body=b"asdf", ACL="public-read")
-    client.put_object_acl(ACL="private", Bucket="foobar", Key=keyname)
+    client.put_object_acl(ACL="private", Bucket=bucket.name, Key=keyname)
 
-    grants = client.get_object_acl(Bucket="foobar", Key=keyname)["Grants"]
+    grants = client.get_object_acl(Bucket=bucket.name, Key=keyname)["Grants"]
     assert {
         "Grantee": {
             "Type": "Group",
@@ -71,10 +71,11 @@ def test_acl_switching():
 @mock_aws
 def test_acl_switching_nonexistent_key():
     s3_client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
-    s3_client.create_bucket(Bucket="mybucket")
+    bucket_name = str(uuid4())
+    s3_client.create_bucket(Bucket=bucket_name)
 
     with pytest.raises(ClientError) as exc:
-        s3_client.put_object_acl(Bucket="mybucket", Key="nonexistent", ACL="private")
+        s3_client.put_object_acl(Bucket=bucket_name, Key="nonexistent", ACL="private")
 
     assert exc.value.response["Error"]["Code"] == "NoSuchKey"
 
@@ -82,7 +83,7 @@ def test_acl_switching_nonexistent_key():
 @mock_aws
 def test_s3_object_in_public_bucket():
     s3_resource = boto3.resource("s3", DEFAULT_REGION_NAME)
-    bucket = s3_resource.Bucket("test-bucket")
+    bucket = s3_resource.Bucket(str(uuid4()))
     bucket.create(ACL="public-read")
     bucket.put_object(Body=b"ABCD", Key="file.txt")
 
@@ -90,7 +91,7 @@ def test_s3_object_in_public_bucket():
     s3_anonymous.meta.client.meta.events.register("choose-signer.s3.*", disable_signing)
 
     contents = (
-        s3_anonymous.Object(key="file.txt", bucket_name="test-bucket")
+        s3_anonymous.Object(key="file.txt", bucket_name=bucket.name)
         .get()["Body"]
         .read()
     )
@@ -99,18 +100,18 @@ def test_s3_object_in_public_bucket():
     bucket.put_object(ACL="private", Body=b"ABCD", Key="file.txt")
 
     with pytest.raises(ClientError) as exc:
-        s3_anonymous.Object(key="file.txt", bucket_name="test-bucket").get()
+        s3_anonymous.Object(key="file.txt", bucket_name=bucket.name).get()
     assert exc.value.response["Error"]["Code"] == "403"
 
 
 @mock_aws
 def test_s3_object_in_public_bucket_using_multiple_presigned_urls():
     s3_resource = boto3.resource("s3", DEFAULT_REGION_NAME)
-    bucket = s3_resource.Bucket("test-bucket")
+    bucket = s3_resource.Bucket(str(uuid4()))
     bucket.create(ACL="public-read")
     bucket.put_object(Body=b"ABCD", Key="file.txt")
 
-    params = {"Bucket": "test-bucket", "Key": "file.txt"}
+    params = {"Bucket": bucket.name, "Key": "file.txt"}
     presigned_url = boto3.client("s3").generate_presigned_url(
         "get_object", params, ExpiresIn=900
     )
@@ -125,7 +126,7 @@ def test_s3_object_in_public_bucket_using_multiple_presigned_urls():
 @mock_aws
 def test_s3_object_in_private_bucket():
     s3_resource = boto3.resource("s3", DEFAULT_REGION_NAME)
-    bucket = s3_resource.Bucket("test-bucket")
+    bucket = s3_resource.Bucket(str(uuid4()))
     bucket.create(ACL="private")
     bucket.put_object(ACL="private", Body=b"ABCD", Key="file.txt")
 
@@ -133,12 +134,12 @@ def test_s3_object_in_private_bucket():
     s3_anonymous.meta.client.meta.events.register("choose-signer.s3.*", disable_signing)
 
     with pytest.raises(ClientError) as exc:
-        s3_anonymous.Object(key="file.txt", bucket_name="test-bucket").get()
+        s3_anonymous.Object(key="file.txt", bucket_name=bucket.name).get()
     assert exc.value.response["Error"]["Code"] == "403"
 
     bucket.put_object(ACL="public-read", Body=b"ABCD", Key="file.txt")
     contents = (
-        s3_anonymous.Object(key="file.txt", bucket_name="test-bucket")
+        s3_anonymous.Object(key="file.txt", bucket_name=bucket.name)
         .get()["Body"]
         .read()
     )
@@ -148,10 +149,11 @@ def test_s3_object_in_private_bucket():
 @mock_aws
 def test_put_bucket_acl_body():
     s3_client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
-    s3_client.create_bucket(Bucket="bucket")
-    bucket_owner = s3_client.get_bucket_acl(Bucket="bucket")["Owner"]
+    bucket_name = str(uuid4())
+    s3_client.create_bucket(Bucket=bucket_name)
+    bucket_owner = s3_client.get_bucket_acl(Bucket=bucket_name)["Owner"]
     s3_client.put_bucket_acl(
-        Bucket="bucket",
+        Bucket=bucket_name,
         AccessControlPolicy={
             "Grants": [
                 {
@@ -173,7 +175,7 @@ def test_put_bucket_acl_body():
         },
     )
 
-    result = s3_client.get_bucket_acl(Bucket="bucket")
+    result = s3_client.get_bucket_acl(Bucket=bucket_name)
     assert len(result["Grants"]) == 2
     for grant in result["Grants"]:
         assert (
@@ -184,7 +186,7 @@ def test_put_bucket_acl_body():
 
     # With one:
     s3_client.put_bucket_acl(
-        Bucket="bucket",
+        Bucket=bucket_name,
         AccessControlPolicy={
             "Grants": [
                 {
@@ -198,13 +200,13 @@ def test_put_bucket_acl_body():
             "Owner": bucket_owner,
         },
     )
-    result = s3_client.get_bucket_acl(Bucket="bucket")
+    result = s3_client.get_bucket_acl(Bucket=bucket_name)
     assert len(result["Grants"]) == 1
 
     # With no owner:
     with pytest.raises(ClientError) as err:
         s3_client.put_bucket_acl(
-            Bucket="bucket",
+            Bucket=bucket_name,
             AccessControlPolicy={
                 "Grants": [
                     {
@@ -222,7 +224,7 @@ def test_put_bucket_acl_body():
     # With incorrect permission:
     with pytest.raises(ClientError) as err:
         s3_client.put_bucket_acl(
-            Bucket="bucket",
+            Bucket=bucket_name,
             AccessControlPolicy={
                 "Grants": [
                     {
@@ -240,7 +242,7 @@ def test_put_bucket_acl_body():
 
     # Clear the ACLs:
     result = s3_client.put_bucket_acl(
-        Bucket="bucket", AccessControlPolicy={"Grants": [], "Owner": bucket_owner}
+        Bucket=bucket_name, AccessControlPolicy={"Grants": [], "Owner": bucket_owner}
     )
     assert not result.get("Grants")
 
@@ -249,10 +251,10 @@ def test_put_bucket_acl_body():
 def test_object_acl_with_presigned_post():
     s3_client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
 
-    bucket_name = "imageS3Bucket"
+    bucket_name = str(uuid4())
     object_name = "text.txt"
     fields = {"acl": "public-read"}
-    file = open("text.txt", "w", encoding="utf-8")
+    file = open(object_name, "w", encoding="utf-8")
     file.write("test")
     file.close()
 
@@ -284,7 +286,7 @@ def test_object_acl_with_presigned_post():
 def test_acl_setting():
     s3_resource = boto3.resource("s3", region_name=DEFAULT_REGION_NAME)
     client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
-    bucket = s3_resource.Bucket("foobar")
+    bucket = s3_resource.Bucket(str(uuid4()))
     bucket.create()
 
     content = b"imafile"
@@ -293,7 +295,7 @@ def test_acl_setting():
         Key=keyname, Body=content, ContentType="text/plain", ACL="public-read"
     )
 
-    grants = client.get_object_acl(Bucket="foobar", Key=keyname)["Grants"]
+    grants = client.get_object_acl(Bucket=bucket.name, Key=keyname)["Grants"]
     assert {
         "Grantee": {
             "Type": "Group",
@@ -307,15 +309,15 @@ def test_acl_setting():
 def test_acl_setting_via_headers():
     s3_resource = boto3.resource("s3", region_name=DEFAULT_REGION_NAME)
     client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
-    bucket = s3_resource.Bucket("foobar")
+    bucket = s3_resource.Bucket(str(uuid4()))
     bucket.create()
 
     keyname = "test.txt"
 
     bucket.put_object(Key=keyname, Body=b"imafile")
-    client.put_object_acl(ACL="public-read", Bucket="foobar", Key=keyname)
+    client.put_object_acl(ACL="public-read", Bucket=bucket.name, Key=keyname)
 
-    grants = client.get_object_acl(Bucket="foobar", Key=keyname)["Grants"]
+    grants = client.get_object_acl(Bucket=bucket.name, Key=keyname)["Grants"]
     assert {
         "Grantee": {
             "Type": "Group",
@@ -329,7 +331,7 @@ def test_acl_setting_via_headers():
 def test_raise_exception_for_grant_and_acl():
     client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
     s3_resource = boto3.resource("s3", region_name=DEFAULT_REGION_NAME)
-    bucket_name = "bucketname"
+    bucket_name = str(uuid4())
     client.create_bucket(Bucket=bucket_name)
     bucket = s3_resource.Bucket(bucket_name)
     acl = client.get_bucket_acl(Bucket=bucket_name)

--- a/tests/test_s3/test_s3_cloudformation.py
+++ b/tests/test_s3/test_s3_cloudformation.py
@@ -1,5 +1,6 @@
 import json
 import re
+from uuid import uuid4
 
 import boto3
 
@@ -10,6 +11,7 @@ from moto import mock_aws
 def test_s3_bucket_cloudformation_basic():
     s3_client = boto3.client("s3", region_name="us-east-1")
     cf_client = boto3.client("cloudformation", region_name="us-east-1")
+    stack_name = str(uuid4())
 
     template = {
         "AWSTemplateFormatVersion": "2010-09-09",
@@ -17,8 +19,8 @@ def test_s3_bucket_cloudformation_basic():
         "Outputs": {"Bucket": {"Value": {"Ref": "testInstance"}}},
     }
     template_json = json.dumps(template)
-    cf_client.create_stack(StackName="test_stack", TemplateBody=template_json)
-    stack_description = cf_client.describe_stacks(StackName="test_stack")["Stacks"][0]
+    cf_client.create_stack(StackName=stack_name, TemplateBody=template_json)
+    stack_description = cf_client.describe_stacks(StackName=stack_name)["Stacks"][0]
 
     s3_client.head_bucket(Bucket=stack_description["Outputs"][0]["OutputValue"])
 
@@ -27,8 +29,9 @@ def test_s3_bucket_cloudformation_basic():
 def test_s3_bucket_cloudformation_with_properties():
     s3_client = boto3.client("s3", region_name="us-east-1")
     cf_client = boto3.client("cloudformation", region_name="us-east-1")
+    stack_name = str(uuid4())
 
-    bucket_name = "MyBucket"
+    bucket_name = str(uuid4())
     template = {
         "AWSTemplateFormatVersion": "2010-09-09",
         "Resources": {
@@ -51,8 +54,8 @@ def test_s3_bucket_cloudformation_with_properties():
         "Outputs": {"Bucket": {"Value": {"Ref": "testInstance"}}},
     }
     template_json = json.dumps(template)
-    cf_client.create_stack(StackName="test_stack", TemplateBody=template_json)
-    cf_client.describe_stacks(StackName="test_stack")
+    cf_client.create_stack(StackName=stack_name, TemplateBody=template_json)
+    cf_client.describe_stacks(StackName=stack_name)
     s3_client.head_bucket(Bucket=bucket_name)
 
     encryption = s3_client.get_bucket_encryption(Bucket=bucket_name)
@@ -68,6 +71,7 @@ def test_s3_bucket_cloudformation_with_properties():
 def test_s3_bucket_cloudformation_update_no_interruption():
     s3_client = boto3.client("s3", region_name="us-east-1")
     cf_client = boto3.client("cloudformation", region_name="us-east-1")
+    stack_name = str(uuid4())
 
     template = {
         "AWSTemplateFormatVersion": "2010-09-09",
@@ -75,8 +79,8 @@ def test_s3_bucket_cloudformation_update_no_interruption():
         "Outputs": {"Bucket": {"Value": {"Ref": "testInstance"}}},
     }
     template_json = json.dumps(template)
-    cf_client.create_stack(StackName="test_stack", TemplateBody=template_json)
-    stack_description = cf_client.describe_stacks(StackName="test_stack")["Stacks"][0]
+    cf_client.create_stack(StackName=stack_name, TemplateBody=template_json)
+    stack_description = cf_client.describe_stacks(StackName=stack_name)["Stacks"][0]
     s3_client.head_bucket(Bucket=stack_description["Outputs"][0]["OutputValue"])
 
     template = {
@@ -100,7 +104,7 @@ def test_s3_bucket_cloudformation_update_no_interruption():
         "Outputs": {"Bucket": {"Value": {"Ref": "testInstance"}}},
     }
     template_json = json.dumps(template)
-    cf_client.update_stack(StackName="test_stack", TemplateBody=template_json)
+    cf_client.update_stack(StackName=stack_name, TemplateBody=template_json)
     encryption = s3_client.get_bucket_encryption(
         Bucket=stack_description["Outputs"][0]["OutputValue"]
     )
@@ -116,6 +120,7 @@ def test_s3_bucket_cloudformation_update_no_interruption():
 def test_s3_bucket_cloudformation_update_replacement():
     s3_client = boto3.client("s3", region_name="us-east-1")
     cf_client = boto3.client("cloudformation", region_name="us-east-1")
+    stack_name = str(uuid4())
 
     template = {
         "AWSTemplateFormatVersion": "2010-09-09",
@@ -123,8 +128,8 @@ def test_s3_bucket_cloudformation_update_replacement():
         "Outputs": {"Bucket": {"Value": {"Ref": "testInstance"}}},
     }
     template_json = json.dumps(template)
-    cf_client.create_stack(StackName="test_stack", TemplateBody=template_json)
-    stack_description = cf_client.describe_stacks(StackName="test_stack")["Stacks"][0]
+    cf_client.create_stack(StackName=stack_name, TemplateBody=template_json)
+    stack_description = cf_client.describe_stacks(StackName=stack_name)["Stacks"][0]
     s3_client.head_bucket(Bucket=stack_description["Outputs"][0]["OutputValue"])
 
     template = {
@@ -138,8 +143,8 @@ def test_s3_bucket_cloudformation_update_replacement():
         "Outputs": {"Bucket": {"Value": {"Ref": "testInstance"}}},
     }
     template_json = json.dumps(template)
-    cf_client.update_stack(StackName="test_stack", TemplateBody=template_json)
-    stack_description = cf_client.describe_stacks(StackName="test_stack")["Stacks"][0]
+    cf_client.update_stack(StackName=stack_name, TemplateBody=template_json)
+    stack_description = cf_client.describe_stacks(StackName=stack_name)["Stacks"][0]
     s3_client.head_bucket(Bucket=stack_description["Outputs"][0]["OutputValue"])
 
 
@@ -148,8 +153,8 @@ def test_s3_bucket_cloudformation_outputs():
     region_name = "us-east-1"
     s3_client = boto3.client("s3", region_name=region_name)
     cf_client = boto3.resource("cloudformation", region_name=region_name)
-    stack_name = "test-stack"
-    bucket_name = "test-bucket"
+    stack_name = str(uuid4())
+    bucket_name = str(uuid4())
     template = {
         "AWSTemplateFormatVersion": "2010-09-09",
         "Resources": {

--- a/tests/test_s3/test_s3_copyobject.py
+++ b/tests/test_s3/test_s3_copyobject.py
@@ -26,17 +26,17 @@ from . import s3_aws_verified
 def test_copy_key(key_name):
     s3_resource = boto3.resource("s3", region_name=DEFAULT_REGION_NAME)
     client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
-    s3_resource.create_bucket(Bucket="foobar")
+    bucket = s3_resource.create_bucket(Bucket=str(uuid4()))
 
-    key = s3_resource.Object("foobar", key_name)
+    key = bucket.Object(key_name)
     key.put(Body=b"some value")
 
-    key2 = s3_resource.Object("foobar", "new-key")
-    key2.copy_from(CopySource=f"foobar/{key_name}")
+    key2 = bucket.Object("new-key")
+    key2.copy_from(CopySource=f"{bucket.name}/{key_name}")
 
-    resp = client.get_object(Bucket="foobar", Key=key_name)
+    resp = client.get_object(Bucket=bucket.name, Key=key_name)
     assert resp["Body"].read() == b"some value"
-    resp = client.get_object(Bucket="foobar", Key="new-key")
+    resp = client.get_object(Bucket=bucket.name, Key="new-key")
     assert resp["Body"].read() == b"some value"
 
 
@@ -129,26 +129,28 @@ def test_copy_key_with_args__using_multipart(bucket_name=None):
 def test_copy_key_with_version():
     s3_resource = boto3.resource("s3", region_name=DEFAULT_REGION_NAME)
     client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
-    s3_resource.create_bucket(Bucket="foobar")
+    bucket = s3_resource.create_bucket(Bucket=str(uuid4()))
     client.put_bucket_versioning(
-        Bucket="foobar", VersioningConfiguration={"Status": "Enabled"}
+        Bucket=bucket.name, VersioningConfiguration={"Status": "Enabled"}
     )
 
-    key = s3_resource.Object("foobar", "the-key")
+    key = bucket.Object("the-key")
     key.put(Body=b"some value")
     key.put(Body=b"another value")
 
-    all_versions = client.list_object_versions(Bucket="foobar", Prefix="the-key")[
+    all_versions = client.list_object_versions(Bucket=bucket.name, Prefix="the-key")[
         "Versions"
     ]
     old_version = [v for v in all_versions if not v["IsLatest"]][0]
 
-    key2 = s3_resource.Object("foobar", "new-key")
-    key2.copy_from(CopySource=f"foobar/the-key?versionId={old_version['VersionId']}")
+    key2 = bucket.Object("new-key")
+    key2.copy_from(
+        CopySource=f"{bucket.name}/the-key?versionId={old_version['VersionId']}"
+    )
 
-    resp = client.get_object(Bucket="foobar", Key="the-key")
+    resp = client.get_object(Bucket=bucket.name, Key="the-key")
     assert resp["Body"].read() == b"another value"
-    resp = client.get_object(Bucket="foobar", Key="new-key")
+    resp = client.get_object(Bucket=bucket.name, Key="new-key")
     assert resp["Body"].read() == b"some value"
 
 
@@ -156,7 +158,7 @@ def test_copy_key_with_version():
 def test_copy_object_with_bucketkeyenabled_returns_the_value():
     s3_resource = boto3.resource("s3", region_name=DEFAULT_REGION_NAME)
     client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
-    bucket_name = "test-copy-object-with-bucketkeyenabled"
+    bucket_name = str(uuid4())
     s3_resource.create_bucket(Bucket=bucket_name)
 
     key = s3_resource.Object(bucket_name, "the-key")
@@ -192,16 +194,18 @@ def test_copy_object_with_bucketkeyenabled_returns_the_value():
 def test_copy_key_with_metadata():
     s3_resource = boto3.resource("s3", region_name=DEFAULT_REGION_NAME)
     client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
-    s3_resource.create_bucket(Bucket="foobar")
+    bucket = s3_resource.create_bucket(Bucket=str(uuid4()))
 
-    key = s3_resource.Object("foobar", "the-key")
+    key = bucket.Object("the-key")
     metadata = {"md": "Metadatastring"}
     content_type = "application/json"
     initial = key.put(Body=b"{}", Metadata=metadata, ContentType=content_type)
 
-    client.copy_object(Bucket="foobar", CopySource="foobar/the-key", Key="new-key")
+    client.copy_object(
+        Bucket=bucket.name, CopySource=f"{bucket.name}/the-key", Key="new-key"
+    )
 
-    resp = client.get_object(Bucket="foobar", Key="new-key")
+    resp = client.get_object(Bucket=bucket.name, Key="new-key")
     assert resp["Metadata"] == metadata
     assert resp["ContentType"] == content_type
     assert resp["ETag"] == initial["ETag"]
@@ -211,20 +215,20 @@ def test_copy_key_with_metadata():
 def test_copy_key_replace_metadata():
     s3_resource = boto3.resource("s3", region_name=DEFAULT_REGION_NAME)
     client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
-    s3_resource.create_bucket(Bucket="foobar")
+    bucket = s3_resource.create_bucket(Bucket=str(uuid4()))
 
-    key = s3_resource.Object("foobar", "the-key")
+    key = bucket.Object("the-key")
     initial = key.put(Body=b"some value", Metadata={"md": "Metadatastring"})
 
     client.copy_object(
-        Bucket="foobar",
-        CopySource="foobar/the-key",
+        Bucket=bucket.name,
+        CopySource=f"{bucket.name}/the-key",
         Key="new-key",
         Metadata={"momd": "Mometadatastring"},
         MetadataDirective="REPLACE",
     )
 
-    resp = client.get_object(Bucket="foobar", Key="new-key")
+    resp = client.get_object(Bucket=bucket.name, Key="new-key")
     assert resp["Metadata"] == {"momd": "Mometadatastring"}
     assert resp["ETag"] == initial["ETag"]
 
@@ -279,14 +283,14 @@ def test_copy_key_without_changes_should_not_error(bucket_name=None):
 def test_copy_key_reduced_redundancy():
     s3_resource = boto3.resource("s3", region_name=DEFAULT_REGION_NAME)
     client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
-    bucket = s3_resource.Bucket("test_bucket")
+    bucket = s3_resource.Bucket(str(uuid4()))
     bucket.create()
 
     bucket.put_object(Key="the-key", Body=b"somedata")
 
     client.copy_object(
-        Bucket="test_bucket",
-        CopySource="test_bucket/the-key",
+        Bucket=bucket.name,
+        CopySource=f"{bucket.name}/the-key",
         Key="new-key",
         StorageClass="REDUCED_REDUNDANCY",
     )
@@ -392,17 +396,19 @@ def test_copy_object_with_versioning(bucket_name=None):
 @mock_aws
 def test_copy_object_from_unversioned_to_versioned_bucket():
     client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
+    src = str(uuid4())
+    dest = str(uuid4())
 
-    client.create_bucket(Bucket="src")
-    client.create_bucket(Bucket="dest")
+    client.create_bucket(Bucket=src)
+    client.create_bucket(Bucket=dest)
     client.put_bucket_versioning(
-        Bucket="dest", VersioningConfiguration={"Status": "Enabled"}
+        Bucket=dest, VersioningConfiguration={"Status": "Enabled"}
     )
 
-    client.put_object(Bucket="src", Key="test", Body=b"content")
+    client.put_object(Bucket=src, Key="test", Body=b"content")
 
     obj2_version_new = client.copy_object(
-        CopySource={"Bucket": "src", "Key": "test"}, Bucket="dest", Key="test"
+        CopySource={"Bucket": src, "Key": "test"}, Bucket=dest, Key="test"
     ).get("VersionId")
 
     # VersionId should be present in the response
@@ -412,16 +418,17 @@ def test_copy_object_from_unversioned_to_versioned_bucket():
 @mock_aws
 def test_copy_object_with_replacement_tagging():
     client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
-    client.create_bucket(Bucket="mybucket")
+    bucket_name = str(uuid4())
+    client.create_bucket(Bucket=bucket_name)
     client.put_object(
-        Bucket="mybucket", Key="original", Body=b"test", Tagging="tag=old"
+        Bucket=bucket_name, Key="original", Body=b"test", Tagging="tag=old"
     )
 
     # using system tags will fail
     with pytest.raises(ClientError) as err:
         client.copy_object(
-            CopySource={"Bucket": "mybucket", "Key": "original"},
-            Bucket="mybucket",
+            CopySource={"Bucket": bucket_name, "Key": "original"},
+            Bucket=bucket_name,
             Key="copy1",
             TaggingDirective="REPLACE",
             Tagging="aws:tag=invalid_key",
@@ -431,22 +438,22 @@ def test_copy_object_with_replacement_tagging():
     assert exc.response["Error"]["Code"] == "InvalidTag"
 
     client.copy_object(
-        CopySource={"Bucket": "mybucket", "Key": "original"},
-        Bucket="mybucket",
+        CopySource={"Bucket": bucket_name, "Key": "original"},
+        Bucket=bucket_name,
         Key="copy1",
         TaggingDirective="REPLACE",
         Tagging="tag=new",
     )
     client.copy_object(
-        CopySource={"Bucket": "mybucket", "Key": "original"},
-        Bucket="mybucket",
+        CopySource={"Bucket": bucket_name, "Key": "original"},
+        Bucket=bucket_name,
         Key="copy2",
         TaggingDirective="COPY",
     )
 
-    tags1 = client.get_object_tagging(Bucket="mybucket", Key="copy1")["TagSet"]
+    tags1 = client.get_object_tagging(Bucket=bucket_name, Key="copy1")["TagSet"]
     assert tags1 == [{"Key": "tag", "Value": "new"}]
-    tags2 = client.get_object_tagging(Bucket="mybucket", Key="copy2")["TagSet"]
+    tags2 = client.get_object_tagging(Bucket=bucket_name, Key="copy2")["TagSet"]
     assert tags2 == [{"Key": "tag", "Value": "old"}]
 
 
@@ -456,18 +463,19 @@ def test_copy_object_with_kms_encryption():
     kms_client = boto3.client("kms", region_name=DEFAULT_REGION_NAME)
     kms_key = kms_client.create_key()["KeyMetadata"]["KeyId"]
 
-    client.create_bucket(Bucket="blah")
+    bucket_name = str(uuid4())
+    client.create_bucket(Bucket=bucket_name)
 
-    client.put_object(Bucket="blah", Key="test1", Body=b"test1")
+    client.put_object(Bucket=bucket_name, Key="test1", Body=b"test1")
 
     client.copy_object(
-        CopySource={"Bucket": "blah", "Key": "test1"},
-        Bucket="blah",
+        CopySource={"Bucket": bucket_name, "Key": "test1"},
+        Bucket=bucket_name,
         Key="test2",
         SSEKMSKeyId=kms_key,
         ServerSideEncryption="aws:kms",
     )
-    result = client.head_object(Bucket="blah", Key="test2")
+    result = client.head_object(Bucket=bucket_name, Key="test2")
     assert result["SSEKMSKeyId"] == kms_key
     assert result["ServerSideEncryption"] == "aws:kms"
 
@@ -478,11 +486,11 @@ def test_copy_object_in_place_with_encryption():
     s3_resource = boto3.resource("s3", region_name=DEFAULT_REGION_NAME)
     client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
     kms_key = kms_client.create_key()["KeyMetadata"]["KeyId"]
-    bucket = s3_resource.Bucket("test_bucket")
+    bucket = s3_resource.Bucket(str(uuid4()))
     bucket.create()
     key = "source-key"
     resp = client.put_object(
-        Bucket="test_bucket",
+        Bucket=bucket.name,
         Key=key,
         Body=b"somedata",
         ServerSideEncryption="aws:kms",
@@ -493,8 +501,8 @@ def test_copy_object_in_place_with_encryption():
 
     # assert that you can copy in place with the same Encryption settings
     client.copy_object(
-        Bucket="test_bucket",
-        CopySource=f"test_bucket/{key}",
+        Bucket=bucket.name,
+        CopySource=f"{bucket.name}/{key}",
         Key=key,
         ServerSideEncryption="aws:kms",
         BucketKeyEnabled=True,
@@ -503,8 +511,8 @@ def test_copy_object_in_place_with_encryption():
 
     # assert that the BucketKeyEnabled setting is not kept in the destination key
     resp = client.copy_object(
-        Bucket="test_bucket",
-        CopySource=f"test_bucket/{key}",
+        Bucket=bucket.name,
+        CopySource=f"{bucket.name}/{key}",
         Key=key,
         ServerSideEncryption="aws:kms",
         SSEKMSKeyId=kms_key,
@@ -515,8 +523,8 @@ def test_copy_object_in_place_with_encryption():
     # AWS allows you to not specify any fields as it will use AES256 by
     # default and is different from the source key.
     resp = client.copy_object(
-        Bucket="test_bucket",
-        CopySource=f"test_bucket/{key}",
+        Bucket=bucket.name,
+        CopySource=f"{bucket.name}/{key}",
         Key=key,
     )
     assert resp["ServerSideEncryption"] == "AES256"
@@ -524,8 +532,8 @@ def test_copy_object_in_place_with_encryption():
     # Check that it allows copying in the place with the same
     # ServerSideEncryption setting as the source.
     resp = client.copy_object(
-        Bucket="test_bucket",
-        CopySource=f"test_bucket/{key}",
+        Bucket=bucket.name,
+        CopySource=f"{bucket.name}/{key}",
         Key=key,
         ServerSideEncryption="AES256",
     )
@@ -540,7 +548,7 @@ def test_copy_object_in_place_with_storage_class():
     """
     s3_resource = boto3.resource("s3", region_name=DEFAULT_REGION_NAME)
     client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
-    bucket_name = "test-bucket"
+    bucket_name = str(uuid4())
     bucket = s3_resource.Bucket(bucket_name)
     bucket.create()
     key = "source-key"
@@ -562,14 +570,14 @@ def test_copy_object_in_place_with_storage_class():
 def test_copy_object_does_not_copy_storage_class():
     s3_resource = boto3.resource("s3", region_name=DEFAULT_REGION_NAME)
     client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
-    bucket = s3_resource.Bucket("test_bucket")
+    bucket = s3_resource.Bucket(str(uuid4()))
     bucket.create()
     source_key = "source-key"
     dest_key = "dest-key"
     bucket.put_object(Key=source_key, Body=b"somedata", StorageClass="STANDARD_IA")
     client.copy_object(
-        Bucket="test_bucket",
-        CopySource=f"test_bucket/{source_key}",
+        Bucket=bucket.name,
+        CopySource=f"{bucket.name}/{source_key}",
         Key=dest_key,
     )
 
@@ -583,7 +591,7 @@ def test_copy_object_does_not_copy_storage_class():
 def test_copy_object_does_not_copy_acl():
     s3_resource = boto3.resource("s3", region_name=DEFAULT_REGION_NAME)
     client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
-    bucket_name = "testbucket"
+    bucket_name = str(uuid4())
     bucket = s3_resource.Bucket(bucket_name)
     bucket.create()
     source_key = "source-key"
@@ -648,7 +656,7 @@ def test_copy_object_in_place_with_metadata(bucket_name=None):
 @mock_aws
 def test_copy_objet_legal_hold():
     client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
-    bucket_name = "testbucket"
+    bucket_name = str(uuid4())
     source_key = "source-key"
     dest_key = "dest-key"
     client.create_bucket(Bucket=bucket_name, ObjectLockEnabledForBucket=True)
@@ -681,7 +689,7 @@ def test_copy_objet_legal_hold():
 @mock_aws
 def test_s3_copy_object_lock():
     client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
-    bucket_name = "testbucket"
+    bucket_name = str(uuid4())
     source_key = "source-key"
     dest_key = "dest-key"
     client.create_bucket(Bucket=bucket_name, ObjectLockEnabledForBucket=True)
@@ -724,7 +732,7 @@ def test_s3_copy_object_lock():
 @mock_aws
 def test_copy_object_in_place_website_redirect_location():
     client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
-    bucket_name = "testbucket"
+    bucket_name = str(uuid4())
     key = "source-key"
     client.create_bucket(Bucket=bucket_name)
     # This test will validate that setting WebsiteRedirectLocation
@@ -756,7 +764,7 @@ def test_copy_object_in_place_website_redirect_location():
 def test_copy_object_in_place_with_bucket_encryption():
     # If a bucket has encryption configured, it will allow copy in place per default
     client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
-    bucket_name = "test-bucket"
+    bucket_name = str(uuid4())
     client.create_bucket(Bucket=bucket_name)
     key = "source-key"
 
@@ -867,7 +875,7 @@ def test_copy_key_with_both_sha256_checksum(algorithm):
     client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
     source_key = "source-key"
     dest_key = "dest-key"
-    bucket = "foobar"
+    bucket = str(uuid4())
     body = b"checksum-test"
     client.create_bucket(Bucket=bucket)
 
@@ -906,7 +914,7 @@ def test_copy_object_calculates_checksum(algorithm, checksum):
     client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
     source_key = "source-key"
     dest_key = "dest-key"
-    bucket = "foobar"
+    bucket = str(uuid4())
     body = b"test-checksum"
     client.create_bucket(Bucket=bucket)
 
@@ -934,7 +942,7 @@ def test_copy_object_keeps_checksum():
     client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
     source_key = "source-key"
     dest_key = "dest-key"
-    bucket = "foobar"
+    bucket = str(uuid4())
     body = b"test-checksum"
     expected_checksum = "1YQo81vx2VFUl0q5ccWISq8AkSBQQ0WO80S82TmfdIQ="
     client.create_bucket(Bucket=bucket)

--- a/tests/test_s3/test_s3_lifecycle.py
+++ b/tests/test_s3/test_s3_lifecycle.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from uuid import uuid4
 
 import boto3
 import pytest
@@ -11,7 +12,8 @@ from moto.s3.responses import DEFAULT_REGION_NAME
 @mock_aws
 def test_lifecycle_with_filters():
     client = boto3.client("s3", DEFAULT_REGION_NAME)
-    client.create_bucket(Bucket="bucket")
+    bucket_name = str(uuid4())
+    client.create_bucket(Bucket=bucket_name)
 
     # Create a lifecycle rule with a Filter (no tags):
     lfc = {
@@ -25,9 +27,9 @@ def test_lifecycle_with_filters():
         ]
     }
     client.put_bucket_lifecycle_configuration(
-        Bucket="bucket", LifecycleConfiguration=lfc
+        Bucket=bucket_name, LifecycleConfiguration=lfc
     )
-    result = client.get_bucket_lifecycle_configuration(Bucket="bucket")
+    result = client.get_bucket_lifecycle_configuration(Bucket=bucket_name)
     assert len(result["Rules"]) == 1
     assert result["Rules"][0]["Filter"]["Prefix"] == ""
     assert not result["Rules"][0]["Filter"].get("And")
@@ -47,9 +49,9 @@ def test_lifecycle_with_filters():
         ]
     }
     client.put_bucket_lifecycle_configuration(
-        Bucket="bucket", LifecycleConfiguration=lfc
+        Bucket=bucket_name, LifecycleConfiguration=lfc
     )
-    result = client.get_bucket_lifecycle_configuration(Bucket="bucket")
+    result = client.get_bucket_lifecycle_configuration(Bucket=bucket_name)
     assert len(result["Rules"]) == 1
     with pytest.raises(KeyError):
         assert result["Rules"][0]["Prefix"]
@@ -58,16 +60,16 @@ def test_lifecycle_with_filters():
     lfc["Rules"][0].pop("Filter")
     with pytest.raises(ClientError) as err:
         client.put_bucket_lifecycle_configuration(
-            Bucket="bucket", LifecycleConfiguration=lfc
+            Bucket=bucket_name, LifecycleConfiguration=lfc
         )
     assert err.value.response["Error"]["Code"] == "MalformedXML"
 
     # With a tag:
     lfc["Rules"][0]["Filter"] = {"Tag": {"Key": "mytag", "Value": "mytagvalue"}}
     client.put_bucket_lifecycle_configuration(
-        Bucket="bucket", LifecycleConfiguration=lfc
+        Bucket=bucket_name, LifecycleConfiguration=lfc
     )
-    result = client.get_bucket_lifecycle_configuration(Bucket="bucket")
+    result = client.get_bucket_lifecycle_configuration(Bucket=bucket_name)
     assert len(result["Rules"]) == 1
     with pytest.raises(KeyError):
         assert result["Rules"][0]["Filter"]["Prefix"]
@@ -85,9 +87,9 @@ def test_lifecycle_with_filters():
         }
     }
     client.put_bucket_lifecycle_configuration(
-        Bucket="bucket", LifecycleConfiguration=lfc
+        Bucket=bucket_name, LifecycleConfiguration=lfc
     )
-    result = client.get_bucket_lifecycle_configuration(Bucket="bucket")
+    result = client.get_bucket_lifecycle_configuration(Bucket=bucket_name)
     assert len(result["Rules"]) == 1
     assert not result["Rules"][0]["Filter"].get("Prefix")
     assert result["Rules"][0]["Filter"]["And"]["Prefix"] == "some/prefix"
@@ -106,9 +108,9 @@ def test_lifecycle_with_filters():
         ],
     }
     client.put_bucket_lifecycle_configuration(
-        Bucket="bucket", LifecycleConfiguration=lfc
+        Bucket=bucket_name, LifecycleConfiguration=lfc
     )
-    result = client.get_bucket_lifecycle_configuration(Bucket="bucket")
+    result = client.get_bucket_lifecycle_configuration(Bucket=bucket_name)
     assert len(result["Rules"]) == 1
     assert not result["Rules"][0]["Filter"].get("Prefix")
     assert result["Rules"][0]["Filter"]["And"]["Prefix"] == "some/prefix"
@@ -128,9 +130,9 @@ def test_lifecycle_with_filters():
         ]
     }
     client.put_bucket_lifecycle_configuration(
-        Bucket="bucket", LifecycleConfiguration=lfc
+        Bucket=bucket_name, LifecycleConfiguration=lfc
     )
-    result = client.get_bucket_lifecycle_configuration(Bucket="bucket")
+    result = client.get_bucket_lifecycle_configuration(Bucket=bucket_name)
     assert len(result["Rules"]) == 1
     with pytest.raises(KeyError):
         assert result["Rules"][0]["Filter"]["And"]["Prefix"]
@@ -146,23 +148,23 @@ def test_lifecycle_with_filters():
     lfc["Rules"][0]["Prefix"] = ""
     with pytest.raises(ClientError) as err:
         client.put_bucket_lifecycle_configuration(
-            Bucket="bucket", LifecycleConfiguration=lfc
+            Bucket=bucket_name, LifecycleConfiguration=lfc
         )
     assert err.value.response["Error"]["Code"] == "MalformedXML"
 
     lfc["Rules"][0]["Prefix"] = "some/path"
     with pytest.raises(ClientError) as err:
         client.put_bucket_lifecycle_configuration(
-            Bucket="bucket", LifecycleConfiguration=lfc
+            Bucket=bucket_name, LifecycleConfiguration=lfc
         )
     assert err.value.response["Error"]["Code"] == "MalformedXML"
 
     # No filters -- just a prefix:
     del lfc["Rules"][0]["Filter"]
     client.put_bucket_lifecycle_configuration(
-        Bucket="bucket", LifecycleConfiguration=lfc
+        Bucket=bucket_name, LifecycleConfiguration=lfc
     )
-    result = client.get_bucket_lifecycle_configuration(Bucket="bucket")
+    result = client.get_bucket_lifecycle_configuration(Bucket=bucket_name)
     assert not result["Rules"][0].get("Filter")
     assert result["Rules"][0]["Prefix"] == "some/path"
 
@@ -174,7 +176,7 @@ def test_lifecycle_with_filters():
     }
     with pytest.raises(ClientError) as err:
         client.put_bucket_lifecycle_configuration(
-            Bucket="bucket", LifecycleConfiguration=lfc
+            Bucket=bucket_name, LifecycleConfiguration=lfc
         )
     assert err.value.response["Error"]["Code"] == "MalformedXML"
 
@@ -190,7 +192,7 @@ def test_lifecycle_with_filters():
     }
     with pytest.raises(ClientError) as err:
         client.put_bucket_lifecycle_configuration(
-            Bucket="bucket", LifecycleConfiguration=lfc
+            Bucket=bucket_name, LifecycleConfiguration=lfc
         )
     assert err.value.response["Error"]["Code"] == "MalformedXML"
 
@@ -212,9 +214,9 @@ def test_lifecycle_with_filters():
         ]
     }
     client.put_bucket_lifecycle_configuration(
-        Bucket="bucket", LifecycleConfiguration=lfc
+        Bucket=bucket_name, LifecycleConfiguration=lfc
     )
-    result = client.get_bucket_lifecycle_configuration(Bucket="bucket")["Rules"]
+    result = client.get_bucket_lifecycle_configuration(Bucket=bucket_name)["Rules"]
     assert len(result) == 2
     assert result[0]["ID"] == "wholebucket"
     assert result[1]["ID"] == "Tags"
@@ -223,7 +225,8 @@ def test_lifecycle_with_filters():
 @mock_aws
 def test_lifecycle_with_eodm():
     client = boto3.client("s3", DEFAULT_REGION_NAME)
-    client.create_bucket(Bucket="bucket")
+    bucket_name = str(uuid4())
+    client.create_bucket(Bucket=bucket_name)
 
     lfc = {
         "Rules": [
@@ -236,18 +239,18 @@ def test_lifecycle_with_eodm():
         ]
     }
     client.put_bucket_lifecycle_configuration(
-        Bucket="bucket", LifecycleConfiguration=lfc
+        Bucket=bucket_name, LifecycleConfiguration=lfc
     )
-    result = client.get_bucket_lifecycle_configuration(Bucket="bucket")
+    result = client.get_bucket_lifecycle_configuration(Bucket=bucket_name)
     assert len(result["Rules"]) == 1
     assert result["Rules"][0]["Expiration"]["ExpiredObjectDeleteMarker"]
 
     # Set to False:
     lfc["Rules"][0]["Expiration"]["ExpiredObjectDeleteMarker"] = False
     client.put_bucket_lifecycle_configuration(
-        Bucket="bucket", LifecycleConfiguration=lfc
+        Bucket=bucket_name, LifecycleConfiguration=lfc
     )
-    result = client.get_bucket_lifecycle_configuration(Bucket="bucket")
+    result = client.get_bucket_lifecycle_configuration(Bucket=bucket_name)
     assert len(result["Rules"]) == 1
     assert not result["Rules"][0]["Expiration"]["ExpiredObjectDeleteMarker"]
 
@@ -255,7 +258,7 @@ def test_lifecycle_with_eodm():
     lfc["Rules"][0]["Expiration"]["Days"] = 7
     with pytest.raises(ClientError) as err:
         client.put_bucket_lifecycle_configuration(
-            Bucket="bucket", LifecycleConfiguration=lfc
+            Bucket=bucket_name, LifecycleConfiguration=lfc
         )
     assert err.value.response["Error"]["Code"] == "MalformedXML"
     del lfc["Rules"][0]["Expiration"]["Days"]
@@ -263,7 +266,7 @@ def test_lifecycle_with_eodm():
     lfc["Rules"][0]["Expiration"]["Date"] = datetime(2015, 1, 1)
     with pytest.raises(ClientError) as err:
         client.put_bucket_lifecycle_configuration(
-            Bucket="bucket", LifecycleConfiguration=lfc
+            Bucket=bucket_name, LifecycleConfiguration=lfc
         )
     assert err.value.response["Error"]["Code"] == "MalformedXML"
 
@@ -271,7 +274,8 @@ def test_lifecycle_with_eodm():
 @mock_aws
 def test_lifecycle_with_nve():
     client = boto3.client("s3", DEFAULT_REGION_NAME)
-    client.create_bucket(Bucket="bucket")
+    bucket_name = str(uuid4())
+    client.create_bucket(Bucket=bucket_name)
 
     lfc = {
         "Rules": [
@@ -284,18 +288,18 @@ def test_lifecycle_with_nve():
         ]
     }
     client.put_bucket_lifecycle_configuration(
-        Bucket="bucket", LifecycleConfiguration=lfc
+        Bucket=bucket_name, LifecycleConfiguration=lfc
     )
-    result = client.get_bucket_lifecycle_configuration(Bucket="bucket")
+    result = client.get_bucket_lifecycle_configuration(Bucket=bucket_name)
     assert len(result["Rules"]) == 1
     assert result["Rules"][0]["NoncurrentVersionExpiration"]["NoncurrentDays"] == 30
 
     # Change NoncurrentDays:
     lfc["Rules"][0]["NoncurrentVersionExpiration"]["NoncurrentDays"] = 10
     client.put_bucket_lifecycle_configuration(
-        Bucket="bucket", LifecycleConfiguration=lfc
+        Bucket=bucket_name, LifecycleConfiguration=lfc
     )
-    result = client.get_bucket_lifecycle_configuration(Bucket="bucket")
+    result = client.get_bucket_lifecycle_configuration(Bucket=bucket_name)
     assert len(result["Rules"]) == 1
     assert result["Rules"][0]["NoncurrentVersionExpiration"]["NoncurrentDays"] == 10
 
@@ -305,7 +309,8 @@ def test_lifecycle_with_nve():
 @mock_aws
 def test_lifecycle_with_nvt():
     client = boto3.client("s3", DEFAULT_REGION_NAME)
-    client.create_bucket(Bucket="bucket")
+    bucket_name = str(uuid4())
+    client.create_bucket(Bucket=bucket_name)
 
     lfc = {
         "Rules": [
@@ -320,9 +325,9 @@ def test_lifecycle_with_nvt():
         ]
     }
     client.put_bucket_lifecycle_configuration(
-        Bucket="bucket", LifecycleConfiguration=lfc
+        Bucket=bucket_name, LifecycleConfiguration=lfc
     )
-    result = client.get_bucket_lifecycle_configuration(Bucket="bucket")
+    result = client.get_bucket_lifecycle_configuration(Bucket=bucket_name)
     assert len(result["Rules"]) == 1
     assert result["Rules"][0]["NoncurrentVersionTransitions"][0]["NoncurrentDays"] == 30
     assert (
@@ -333,18 +338,18 @@ def test_lifecycle_with_nvt():
     # Change NoncurrentDays:
     lfc["Rules"][0]["NoncurrentVersionTransitions"][0]["NoncurrentDays"] = 10
     client.put_bucket_lifecycle_configuration(
-        Bucket="bucket", LifecycleConfiguration=lfc
+        Bucket=bucket_name, LifecycleConfiguration=lfc
     )
-    result = client.get_bucket_lifecycle_configuration(Bucket="bucket")
+    result = client.get_bucket_lifecycle_configuration(Bucket=bucket_name)
     assert len(result["Rules"]) == 1
     assert result["Rules"][0]["NoncurrentVersionTransitions"][0]["NoncurrentDays"] == 10
 
     # Change StorageClass:
     lfc["Rules"][0]["NoncurrentVersionTransitions"][0]["StorageClass"] = "GLACIER"
     client.put_bucket_lifecycle_configuration(
-        Bucket="bucket", LifecycleConfiguration=lfc
+        Bucket=bucket_name, LifecycleConfiguration=lfc
     )
-    result = client.get_bucket_lifecycle_configuration(Bucket="bucket")
+    result = client.get_bucket_lifecycle_configuration(Bucket=bucket_name)
     assert len(result["Rules"]) == 1
     assert (
         result["Rules"][0]["NoncurrentVersionTransitions"][0]["StorageClass"]
@@ -355,7 +360,7 @@ def test_lifecycle_with_nvt():
     del lfc["Rules"][0]["NoncurrentVersionTransitions"][0]["NoncurrentDays"]
     with pytest.raises(ClientError) as err:
         client.put_bucket_lifecycle_configuration(
-            Bucket="bucket", LifecycleConfiguration=lfc
+            Bucket=bucket_name, LifecycleConfiguration=lfc
         )
     assert err.value.response["Error"]["Code"] == "MalformedXML"
     lfc["Rules"][0]["NoncurrentVersionTransitions"][0]["NoncurrentDays"] = 30
@@ -363,7 +368,7 @@ def test_lifecycle_with_nvt():
     del lfc["Rules"][0]["NoncurrentVersionTransitions"][0]["StorageClass"]
     with pytest.raises(ClientError) as err:
         client.put_bucket_lifecycle_configuration(
-            Bucket="bucket", LifecycleConfiguration=lfc
+            Bucket=bucket_name, LifecycleConfiguration=lfc
         )
     assert err.value.response["Error"]["Code"] == "MalformedXML"
 
@@ -371,7 +376,8 @@ def test_lifecycle_with_nvt():
 @mock_aws
 def test_lifecycle_with_multiple_nvt():
     client = boto3.client("s3", DEFAULT_REGION_NAME)
-    client.create_bucket(Bucket="bucket")
+    bucket_name = str(uuid4())
+    client.create_bucket(Bucket=bucket_name)
 
     lfc = {
         "Rules": [
@@ -387,9 +393,9 @@ def test_lifecycle_with_multiple_nvt():
         ]
     }
     client.put_bucket_lifecycle_configuration(
-        Bucket="bucket", LifecycleConfiguration=lfc
+        Bucket=bucket_name, LifecycleConfiguration=lfc
     )
-    result = client.get_bucket_lifecycle_configuration(Bucket="bucket")
+    result = client.get_bucket_lifecycle_configuration(Bucket=bucket_name)
     assert len(result["Rules"]) == 1
     assert result["Rules"][0]["NoncurrentVersionTransitions"][0] == {
         "NoncurrentDays": 30,
@@ -404,7 +410,8 @@ def test_lifecycle_with_multiple_nvt():
 @mock_aws
 def test_lifecycle_with_multiple_transitions():
     client = boto3.client("s3", DEFAULT_REGION_NAME)
-    client.create_bucket(Bucket="bucket")
+    bucket_name = str(uuid4())
+    client.create_bucket(Bucket=bucket_name)
 
     lfc = {
         "Rules": [
@@ -420,9 +427,9 @@ def test_lifecycle_with_multiple_transitions():
         ]
     }
     client.put_bucket_lifecycle_configuration(
-        Bucket="bucket", LifecycleConfiguration=lfc
+        Bucket=bucket_name, LifecycleConfiguration=lfc
     )
-    result = client.get_bucket_lifecycle_configuration(Bucket="bucket")
+    result = client.get_bucket_lifecycle_configuration(Bucket=bucket_name)
     assert len(result["Rules"]) == 1
     assert result["Rules"][0]["Transitions"][0] == {
         "Days": 30,
@@ -437,7 +444,8 @@ def test_lifecycle_with_multiple_transitions():
 @mock_aws
 def test_lifecycle_with_aimu():
     client = boto3.client("s3", DEFAULT_REGION_NAME)
-    client.create_bucket(Bucket="bucket")
+    bucket_name = str(uuid4())
+    client.create_bucket(Bucket=bucket_name)
 
     lfc = {
         "Rules": [
@@ -450,9 +458,9 @@ def test_lifecycle_with_aimu():
         ]
     }
     client.put_bucket_lifecycle_configuration(
-        Bucket="bucket", LifecycleConfiguration=lfc
+        Bucket=bucket_name, LifecycleConfiguration=lfc
     )
-    result = client.get_bucket_lifecycle_configuration(Bucket="bucket")
+    result = client.get_bucket_lifecycle_configuration(Bucket=bucket_name)
     assert len(result["Rules"]) == 1
     assert (
         result["Rules"][0]["AbortIncompleteMultipartUpload"]["DaysAfterInitiation"] == 7
@@ -461,9 +469,9 @@ def test_lifecycle_with_aimu():
     # Change DaysAfterInitiation:
     lfc["Rules"][0]["AbortIncompleteMultipartUpload"]["DaysAfterInitiation"] = 30
     client.put_bucket_lifecycle_configuration(
-        Bucket="bucket", LifecycleConfiguration=lfc
+        Bucket=bucket_name, LifecycleConfiguration=lfc
     )
-    result = client.get_bucket_lifecycle_configuration(Bucket="bucket")
+    result = client.get_bucket_lifecycle_configuration(Bucket=bucket_name)
     assert len(result["Rules"]) == 1
     assert (
         result["Rules"][0]["AbortIncompleteMultipartUpload"]["DaysAfterInitiation"]
@@ -477,10 +485,10 @@ def test_lifecycle_with_aimu():
 def test_lifecycle_with_glacier_transition():
     s3_resource = boto3.resource("s3", region_name="us-east-1")
     client = boto3.client("s3", region_name="us-east-1")
-    s3_resource.create_bucket(Bucket="foobar")
+    bucket = s3_resource.create_bucket(Bucket=str(uuid4()))
 
     client.put_bucket_lifecycle_configuration(
-        Bucket="foobar",
+        Bucket=bucket.name,
         LifecycleConfiguration={
             "Rules": [
                 {
@@ -493,7 +501,7 @@ def test_lifecycle_with_glacier_transition():
         },
     )
 
-    response = client.get_bucket_lifecycle_configuration(Bucket="foobar")
+    response = client.get_bucket_lifecycle_configuration(Bucket=bucket.name)
     assert "Rules" in response
     rules = response["Rules"]
     assert len(rules) == 1
@@ -508,13 +516,13 @@ def test_lifecycle_with_glacier_transition():
 def test_lifecycle_multi():
     s3_resource = boto3.resource("s3", region_name="us-east-1")
     client = boto3.client("s3", region_name="us-east-1")
-    s3_resource.create_bucket(Bucket="foobar")
+    bucket = s3_resource.create_bucket(Bucket=str(uuid4()))
 
     date = "2022-10-12T00:00:00.000Z"
     storage_class = "GLACIER"
 
     client.put_bucket_lifecycle_configuration(
-        Bucket="foobar",
+        Bucket=bucket.name,
         LifecycleConfiguration={
             "Rules": [
                 {"ID": "1", "Prefix": "1/", "Status": "Enabled"},
@@ -547,7 +555,7 @@ def test_lifecycle_multi():
     )
 
     # read the lifecycle back
-    rules = client.get_bucket_lifecycle_configuration(Bucket="foobar")["Rules"]
+    rules = client.get_bucket_lifecycle_configuration(Bucket=bucket.name)["Rules"]
 
     for rule in rules:
         if rule["ID"] == "1":
@@ -580,19 +588,19 @@ def test_lifecycle_multi():
 def test_lifecycle_delete():
     s3_resource = boto3.resource("s3", region_name="us-east-1")
     client = boto3.client("s3", region_name="us-east-1")
-    s3_resource.create_bucket(Bucket="foobar")
+    bucket = s3_resource.create_bucket(Bucket=str(uuid4()))
 
     client.put_bucket_lifecycle_configuration(
-        Bucket="foobar",
+        Bucket=bucket.name,
         LifecycleConfiguration={
             "Rules": [{"ID": "myid", "Prefix": "", "Status": "Enabled"}]
         },
     )
 
-    client.delete_bucket_lifecycle(Bucket="foobar")
+    client.delete_bucket_lifecycle(Bucket=bucket.name)
 
     with pytest.raises(ClientError) as ex:
-        client.get_bucket_lifecycle_configuration(Bucket="foobar")
+        client.get_bucket_lifecycle_configuration(Bucket=bucket.name)
     assert ex.value.response["Error"]["Code"] == "NoSuchLifecycleConfiguration"
     assert ex.value.response["Error"]["Message"] == (
         "The lifecycle configuration does not exist"
@@ -603,29 +611,30 @@ def test_lifecycle_delete():
 def test_lifecycle_empty_configuration():
     """Test that empty lifecycle configuration (no rules) works correctly"""
     client = boto3.client("s3", DEFAULT_REGION_NAME)
-    client.create_bucket(Bucket="foobar")
+    bucket_name = str(uuid4())
+    client.create_bucket(Bucket=bucket_name)
 
     # Set lifecycle configuration with rules first
     client.put_bucket_lifecycle_configuration(
-        Bucket="foobar",
+        Bucket=bucket_name,
         LifecycleConfiguration={
             "Rules": [{"ID": "myid", "Prefix": "", "Status": "Enabled"}]
         },
     )
 
     # Verify it exists
-    result = client.get_bucket_lifecycle_configuration(Bucket="foobar")
+    result = client.get_bucket_lifecycle_configuration(Bucket=bucket_name)
     assert len(result["Rules"]) == 1
 
     # Set empty lifecycle configuration (should delete all rules)
     client.put_bucket_lifecycle_configuration(
-        Bucket="foobar",
+        Bucket=bucket_name,
         LifecycleConfiguration={"Rules": []},
     )
 
     # Verify it's deleted
     with pytest.raises(ClientError) as ex:
-        client.get_bucket_lifecycle_configuration(Bucket="foobar")
+        client.get_bucket_lifecycle_configuration(Bucket=bucket_name)
     assert ex.value.response["Error"]["Code"] == "NoSuchLifecycleConfiguration"
     assert ex.value.response["Error"]["Message"] == (
         "The lifecycle configuration does not exist"

--- a/tests/test_s3/test_s3_list_objects.py
+++ b/tests/test_s3/test_s3_list_objects.py
@@ -1,4 +1,5 @@
 from unittest import SkipTest, mock
+from uuid import uuid4
 
 import boto3
 import pytest
@@ -63,7 +64,7 @@ def test_list_object_versions_with_custom_limit():
         raise SkipTest("Can only set env var in DecoratorMode")
     s3_client = boto3.client("s3", region_name="us-east-1")
     s3_resource = boto3.resource("s3", region_name="us-east-1")
-    bucket_name = "foobar"
+    bucket_name = str(uuid4())
     bucket = s3_resource.Bucket(bucket_name)
     bucket.create()
 

--- a/tests/test_s3/test_s3_lock.py
+++ b/tests/test_s3/test_s3_lock.py
@@ -1,5 +1,6 @@
 import datetime
 import time
+from uuid import uuid4
 
 import boto3
 import pytest
@@ -156,7 +157,7 @@ def test_locked_object_governance_mode(bypass_governance_retention, bucket_name=
 
         # We know we couldn't delete the initial version ID
         # Can we delete the DeleteVersion
-        response = s3_client.delete_objects(
+        s3_client.delete_objects(
             Bucket=bucket_name,
             Delete={
                 "Objects": [
@@ -289,7 +290,7 @@ def test_locked_object_compliance_mode(bypass_governance_retention, bucket_name=
 
 @mock_aws
 def test_fail_locked_object():
-    bucket_name = "locked-bucket2"
+    bucket_name = str(uuid4())
     key_name = "file.txt"
     seconds_lock = 2
 
@@ -319,7 +320,7 @@ def test_fail_locked_object():
 def test_put_object_lock():
     s3_client = boto3.client("s3", config=Config(region_name=DEFAULT_REGION_NAME))
 
-    bucket_name = "put-lock-bucket-test"
+    bucket_name = str(uuid4())
     key_name = "file.txt"
     seconds_lock = 1
 
@@ -419,7 +420,7 @@ def test_put_default_lock():
     # do not run this test in aws, it will block the deletion for a whole day
 
     s3_client = boto3.client("s3", config=Config(region_name=DEFAULT_REGION_NAME))
-    bucket_name = "put-default-lock-bucket"
+    bucket_name = str(uuid4())
     key_name = "file.txt"
 
     days = 1
@@ -468,7 +469,7 @@ def test_put_default_lock():
 def test_put_object_legal_hold_with_versions():
     s3_client = boto3.client("s3", config=Config(region_name=DEFAULT_REGION_NAME))
 
-    bucket_name = "put-legal-bucket"
+    bucket_name = str(uuid4())
     key_name = "file.txt"
 
     s3_client.create_bucket(Bucket=bucket_name, ObjectLockEnabledForBucket=True)
@@ -530,7 +531,7 @@ def test_put_object_legal_hold_with_versions():
 def test_put_object_lock_with_versions():
     s3_client = boto3.client("s3", config=Config(region_name=DEFAULT_REGION_NAME))
 
-    bucket_name = "put-lock-bucket-test"
+    bucket_name = str(uuid4())
     key_name = "file.txt"
     seconds_lock = 2
 

--- a/tests/test_s3/test_s3_logging.py
+++ b/tests/test_s3/test_s3_logging.py
@@ -20,9 +20,9 @@ from tests.test_s3 import empty_bucket, s3_aws_verified
 def test_put_bucket_logging():
     s3_client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
     wrong_region_client = boto3.client("s3", region_name="us-west-2")
-    bucket_name = "mybucket"
-    log_bucket = "logbucket"
-    wrong_region_bucket = "wrongregionlogbucket"
+    bucket_name = str(uuid4())
+    log_bucket = str(uuid4())
+    wrong_region_bucket = str(uuid4())
     s3_client.create_bucket(Bucket=bucket_name)
     # Adding the ACL for log-delivery later...
     s3_client.create_bucket(Bucket=log_bucket)
@@ -204,8 +204,8 @@ def test_put_bucket_logging():
 def test_log_file_is_created():
     # Create necessary buckets
     s3_client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
-    bucket_name = "mybucket"
-    log_bucket = "logbucket"
+    bucket_name = str(uuid4())
+    log_bucket = str(uuid4())
     s3_client.create_bucket(Bucket=bucket_name)
     s3_client.create_bucket(Bucket=log_bucket)
 
@@ -261,8 +261,8 @@ def test_log_file_is_created():
 
     # Verify files are created in the target (logging) bucket
     keys = [k["Key"] for k in s3_client.list_objects_v2(Bucket=log_bucket)["Contents"]]
-    assert len([k for k in keys if k.startswith("mybucket/")]) == 3
-    assert len([k for k in keys if not k.startswith("mybucket/")]) == 1
+    assert len([k for k in keys if k.startswith(f"{bucket_name}/")]) == 3
+    assert len([k for k in keys if not k.startswith(f"{bucket_name}/")]) == 1
 
     # Verify (roughly) files have the correct content
     contents = [
@@ -280,8 +280,8 @@ def test_invalid_bucket_logging_when_permissions_are_false():
         raise SkipTest("Can't patch permission logic in ServerMode")
 
     s3_client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
-    bucket_name = "mybucket"
-    log_bucket = "logbucket"
+    bucket_name = str(uuid4())
+    log_bucket = str(uuid4())
     s3_client.create_bucket(Bucket=bucket_name)
     s3_client.create_bucket(Bucket=log_bucket)
     with (
@@ -310,8 +310,8 @@ def test_valid_bucket_logging_when_permissions_are_true():
         raise SkipTest("Can't patch permission logic in ServerMode")
 
     s3_client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
-    bucket_name = "mybucket"
-    log_bucket = "logbucket"
+    bucket_name = str(uuid4())
+    log_bucket = str(uuid4())
     s3_client.create_bucket(Bucket=bucket_name)
     s3_client.create_bucket(Bucket=log_bucket)
     with (

--- a/tests/test_s3/test_s3_metadata.py
+++ b/tests/test_s3/test_s3_metadata.py
@@ -1,3 +1,5 @@
+from uuid import uuid4
+
 import boto3
 
 from moto import mock_aws
@@ -7,13 +9,14 @@ from moto.s3.responses import DEFAULT_REGION_NAME
 @mock_aws
 def test_s3_returns_requestid():
     s3_client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
-    resp = s3_client.create_bucket(Bucket="mybucket")
+    bucket_name = str(uuid4())
+    resp = s3_client.create_bucket(Bucket=bucket_name)
     _check_metadata(resp)
 
-    resp = s3_client.put_object(Bucket="mybucket", Key="steve", Body=b"is awesome")
+    resp = s3_client.put_object(Bucket=bucket_name, Key="steve", Body=b"is awesome")
     _check_metadata(resp)
 
-    resp = s3_client.get_object(Bucket="mybucket", Key="steve")
+    resp = s3_client.get_object(Bucket=bucket_name, Key="steve")
     _check_metadata(resp)
 
 

--- a/tests/test_s3/test_s3_notifications.py
+++ b/tests/test_s3/test_s3_notifications.py
@@ -78,7 +78,7 @@ def test_send_event_bridge_message():
     events_client.put_rule(
         Name=rule_name, EventPattern=json.dumps({"account": [ACCOUNT_ID]})
     )
-    log_group_name = "/test-group"
+    log_group_name = f"/loggroup{str(uuid4())}"
     logs_client.create_log_group(logGroupName=log_group_name)
     mocked_bucket = FakeBucket(str(uuid4()), ACCOUNT_ID, REGION_NAME)
     mocked_key = FakeKey(

--- a/tests/test_s3/test_s3_storageclass.py
+++ b/tests/test_s3/test_s3_storageclass.py
@@ -1,3 +1,5 @@
+from uuid import uuid4
+
 import boto3
 import pytest
 from botocore.exceptions import ClientError
@@ -9,13 +11,13 @@ from moto.s3.responses import DEFAULT_REGION_NAME
 @mock_aws
 def test_s3_storage_class_standard():
     s3_client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
-    s3_client.create_bucket(Bucket="Bucket")
+    bucket_name = str(uuid4())
+    s3_client.create_bucket(Bucket=bucket_name)
 
     # add an object to the bucket with standard storage
+    s3_client.put_object(Bucket=bucket_name, Key="my_key", Body="my_value")
 
-    s3_client.put_object(Bucket="Bucket", Key="my_key", Body="my_value")
-
-    list_of_objects = s3_client.list_objects(Bucket="Bucket")
+    list_of_objects = s3_client.list_objects(Bucket=bucket_name)
 
     assert list_of_objects["Contents"][0]["StorageClass"] == "STANDARD"
 
@@ -23,35 +25,36 @@ def test_s3_storage_class_standard():
 @mock_aws
 def test_s3_storage_class_infrequent_access():
     s3_client = boto3.client("s3", DEFAULT_REGION_NAME)
-    s3_client.create_bucket(Bucket="Bucket")
+    bucket_name = str(uuid4())
+    s3_client.create_bucket(Bucket=bucket_name)
 
     # add an object to the bucket with standard storage
 
     s3_client.put_object(
-        Bucket="Bucket",
+        Bucket=bucket_name,
         Key="my_key_infrequent",
         Body="my_value_infrequent",
         StorageClass="STANDARD_IA",
     )
 
-    objs = s3_client.list_objects(Bucket="Bucket")
-
+    objs = s3_client.list_objects(Bucket=bucket_name)
     assert objs["Contents"][0]["StorageClass"] == "STANDARD_IA"
 
 
 @mock_aws
 def test_s3_storage_class_intelligent_tiering():
     s3_client = boto3.client("s3", DEFAULT_REGION_NAME)
+    bucket_name = str(uuid4())
 
-    s3_client.create_bucket(Bucket="Bucket")
+    s3_client.create_bucket(Bucket=bucket_name)
     s3_client.put_object(
-        Bucket="Bucket",
+        Bucket=bucket_name,
         Key="my_key_infrequent",
         Body="my_value_infrequent",
         StorageClass="INTELLIGENT_TIERING",
     )
 
-    objects = s3_client.list_objects(Bucket="Bucket")
+    objects = s3_client.list_objects(Bucket=bucket_name)
 
     assert objects["Contents"][0]["StorageClass"] == "INTELLIGENT_TIERING"
 
@@ -59,23 +62,25 @@ def test_s3_storage_class_intelligent_tiering():
 @mock_aws
 def test_s3_storage_class_copy():
     s3_client = boto3.client("s3", region_name="us-east-1")
-    s3_client.create_bucket(Bucket="Bucket")
+    bucket_name = str(uuid4())
+    s3_client.create_bucket(Bucket=bucket_name)
     s3_client.put_object(
-        Bucket="Bucket", Key="First_Object", Body="Body", StorageClass="STANDARD"
+        Bucket=bucket_name, Key="First_Object", Body="Body", StorageClass="STANDARD"
     )
 
-    s3_client.create_bucket(Bucket="Bucket2")
+    bucket_name2 = str(uuid4())
+    s3_client.create_bucket(Bucket=bucket_name2)
     # second object is originally of storage class REDUCED_REDUNDANCY
-    s3_client.put_object(Bucket="Bucket2", Key="Second_Object", Body="Body2")
+    s3_client.put_object(Bucket=bucket_name2, Key="Second_Object", Body="Body2")
 
     s3_client.copy_object(
-        CopySource={"Bucket": "Bucket", "Key": "First_Object"},
-        Bucket="Bucket2",
+        CopySource={"Bucket": bucket_name, "Key": "First_Object"},
+        Bucket=bucket_name2,
         Key="Second_Object",
         StorageClass="ONEZONE_IA",
     )
 
-    list_of_copied_objects = s3_client.list_objects(Bucket="Bucket2")
+    list_of_copied_objects = s3_client.list_objects(Bucket=bucket_name2)
 
     # checks that a copied object can be properly copied
     assert list_of_copied_objects["Contents"][0]["StorageClass"] == "ONEZONE_IA"
@@ -84,14 +89,16 @@ def test_s3_storage_class_copy():
 @mock_aws
 def test_s3_invalid_copied_storage_class():
     s3_client = boto3.client("s3", region_name="us-east-1")
-    s3_client.create_bucket(Bucket="Bucket")
+    bucket_name = str(uuid4())
+    s3_client.create_bucket(Bucket=bucket_name)
     s3_client.put_object(
-        Bucket="Bucket", Key="First_Object", Body="Body", StorageClass="STANDARD"
+        Bucket=bucket_name, Key="First_Object", Body="Body", StorageClass="STANDARD"
     )
 
-    s3_client.create_bucket(Bucket="Bucket2")
+    bucket_name2 = str(uuid4())
+    s3_client.create_bucket(Bucket=bucket_name2)
     s3_client.put_object(
-        Bucket="Bucket2",
+        Bucket=bucket_name2,
         Key="Second_Object",
         Body="Body2",
         StorageClass="REDUCED_REDUNDANCY",
@@ -100,45 +107,46 @@ def test_s3_invalid_copied_storage_class():
     # Try to copy an object with an invalid storage class
     with pytest.raises(ClientError) as err:
         s3_client.copy_object(
-            CopySource={"Bucket": "Bucket", "Key": "First_Object"},
-            Bucket="Bucket2",
+            CopySource={"Bucket": bucket_name, "Key": "First_Object"},
+            Bucket=bucket_name2,
             Key="Second_Object",
             StorageClass="STANDARD2",
         )
 
-    err_value = err.value
-    assert err_value.response["Error"]["Code"] == "InvalidStorageClass"
-    assert err_value.response["Error"]["Message"] == (
-        "The storage class you specified is not valid"
-    )
+    err = err.value.response["Error"]
+    assert err["Code"] == "InvalidStorageClass"
+    assert err["Message"] == "The storage class you specified is not valid"
 
 
 @mock_aws
 def test_s3_invalid_storage_class():
     s3_client = boto3.client("s3", DEFAULT_REGION_NAME)
-    s3_client.create_bucket(Bucket="Bucket")
+    bucket_name = str(uuid4())
+    s3_client.create_bucket(Bucket=bucket_name)
 
     # Try to add an object with an invalid storage class
     with pytest.raises(ClientError) as err:
         s3_client.put_object(
-            Bucket="Bucket", Key="First_Object", Body="Body", StorageClass="STANDARDD"
+            Bucket=bucket_name,
+            Key="First_Object",
+            Body="Body",
+            StorageClass="STANDARDD",
         )
 
-    err_value = err.value
-    assert err_value.response["Error"]["Code"] == "InvalidStorageClass"
-    assert err_value.response["Error"]["Message"] == (
-        "The storage class you specified is not valid"
-    )
+    err = err.value.response["Error"]
+    assert err["Code"] == "InvalidStorageClass"
+    assert err["Message"] == "The storage class you specified is not valid"
 
 
 @mock_aws
 def test_s3_default_storage_class():
     s3_client = boto3.client("s3", DEFAULT_REGION_NAME)
-    s3_client.create_bucket(Bucket="Bucket")
+    bucket_name = str(uuid4())
+    s3_client.create_bucket(Bucket=bucket_name)
 
-    s3_client.put_object(Bucket="Bucket", Key="First_Object", Body="Body")
+    s3_client.put_object(Bucket=bucket_name, Key="First_Object", Body="Body")
 
-    list_of_objects = s3_client.list_objects(Bucket="Bucket")
+    list_of_objects = s3_client.list_objects(Bucket=bucket_name)
 
     # tests that the default storage class is still STANDARD
     assert list_of_objects["Contents"][0]["StorageClass"] == "STANDARD"
@@ -147,16 +155,17 @@ def test_s3_default_storage_class():
 @mock_aws
 def test_s3_copy_object_error_for_glacier_storage_class_not_restored():
     s3_client = boto3.client("s3", DEFAULT_REGION_NAME)
-    s3_client.create_bucket(Bucket="Bucket")
+    bucket_name = str(uuid4())
+    s3_client.create_bucket(Bucket=bucket_name)
 
     s3_client.put_object(
-        Bucket="Bucket", Key="First_Object", Body="Body", StorageClass="GLACIER"
+        Bucket=bucket_name, Key="First_Object", Body="Body", StorageClass="GLACIER"
     )
 
     with pytest.raises(ClientError) as exc:
         s3_client.copy_object(
-            CopySource={"Bucket": "Bucket", "Key": "First_Object"},
-            Bucket="Bucket",
+            CopySource={"Bucket": bucket_name, "Key": "First_Object"},
+            Bucket=bucket_name,
             Key="Second_Object",
         )
 
@@ -166,16 +175,17 @@ def test_s3_copy_object_error_for_glacier_storage_class_not_restored():
 @mock_aws
 def test_s3_copy_object_error_for_deep_archive_storage_class_not_restored():
     s3_client = boto3.client("s3", DEFAULT_REGION_NAME)
-    s3_client.create_bucket(Bucket="Bucket")
+    bucket_name = str(uuid4())
+    s3_client.create_bucket(Bucket=bucket_name)
 
     s3_client.put_object(
-        Bucket="Bucket", Key="First_Object", Body="Body", StorageClass="DEEP_ARCHIVE"
+        Bucket=bucket_name, Key="First_Object", Body="Body", StorageClass="DEEP_ARCHIVE"
     )
 
     with pytest.raises(ClientError) as exc:
         s3_client.copy_object(
-            CopySource={"Bucket": "Bucket", "Key": "First_Object"},
-            Bucket="Bucket",
+            CopySource={"Bucket": bucket_name, "Key": "First_Object"},
+            Bucket=bucket_name,
             Key="Second_Object",
         )
 
@@ -185,44 +195,47 @@ def test_s3_copy_object_error_for_deep_archive_storage_class_not_restored():
 @mock_aws
 def test_s3_copy_object_for_glacier_storage_class_restored():
     s3_client = boto3.client("s3", region_name="us-east-1")
-    s3_client.create_bucket(Bucket="Bucket")
+    bucket_name = str(uuid4())
+    s3_client.create_bucket(Bucket=bucket_name)
 
     s3_client.put_object(
-        Bucket="Bucket", Key="First_Object", Body="Body", StorageClass="GLACIER"
+        Bucket=bucket_name, Key="First_Object", Body="Body", StorageClass="GLACIER"
     )
 
-    s3_client.create_bucket(Bucket="Bucket2")
+    bucket_name2 = str(uuid4())
+    s3_client.create_bucket(Bucket=bucket_name2)
     resp = s3_client.restore_object(
-        Bucket="Bucket", Key="First_Object", RestoreRequest={"Days": 123}
+        Bucket=bucket_name, Key="First_Object", RestoreRequest={"Days": 123}
     )
     assert resp["ResponseMetadata"]["HTTPStatusCode"] == 202
 
     s3_client.copy_object(
-        CopySource={"Bucket": "Bucket", "Key": "First_Object"},
-        Bucket="Bucket2",
+        CopySource={"Bucket": bucket_name, "Key": "First_Object"},
+        Bucket=bucket_name2,
         Key="Second_Object",
     )
 
-    list_of_copied_objects = s3_client.list_objects(Bucket="Bucket2")
+    list_of_copied_objects = s3_client.list_objects(Bucket=bucket_name2)
     # checks that copy of restored Glacier object has STANDARD storage class
     assert list_of_copied_objects["Contents"][0]["StorageClass"] == "STANDARD"
     # checks that metadata of copy has no Restore property
     assert not hasattr(
-        s3_client.head_object(Bucket="Bucket2", Key="Second_Object"), "Restore"
+        s3_client.head_object(Bucket=bucket_name2, Key="Second_Object"), "Restore"
     )
 
 
 @mock_aws
 def test_s3_copy_object_for_deep_archive_storage_class_restored():
     s3_client = boto3.client("s3", region_name="us-east-1")
-    s3_client.create_bucket(Bucket="Bucket")
+    bucket_name = str(uuid4())
+    s3_client.create_bucket(Bucket=bucket_name)
 
     s3_client.put_object(
-        Bucket="Bucket", Key="First_Object", Body="Body", StorageClass="DEEP_ARCHIVE"
+        Bucket=bucket_name, Key="First_Object", Body="Body", StorageClass="DEEP_ARCHIVE"
     )
 
     with pytest.raises(ClientError) as exc:
-        s3_client.get_object(Bucket="Bucket", Key="First_Object")
+        s3_client.get_object(Bucket=bucket_name, Key="First_Object")
     err = exc.value.response["Error"]
     assert err["Code"] == "InvalidObjectState"
     assert err["Message"] == (
@@ -230,32 +243,33 @@ def test_s3_copy_object_for_deep_archive_storage_class_restored():
     )
     assert err["StorageClass"] == "DEEP_ARCHIVE"
 
-    s3_client.create_bucket(Bucket="Bucket2")
+    bucket_name2 = str(uuid4())
+    s3_client.create_bucket(Bucket=bucket_name2)
     resp = s3_client.restore_object(
-        Bucket="Bucket", Key="First_Object", RestoreRequest={"Days": 123}
+        Bucket=bucket_name, Key="First_Object", RestoreRequest={"Days": 123}
     )
     assert resp["ResponseMetadata"]["HTTPStatusCode"] == 202
-    s3_client.get_object(Bucket="Bucket", Key="First_Object")
+    s3_client.get_object(Bucket=bucket_name, Key="First_Object")
 
     s3_client.copy_object(
-        CopySource={"Bucket": "Bucket", "Key": "First_Object"},
-        Bucket="Bucket2",
+        CopySource={"Bucket": bucket_name, "Key": "First_Object"},
+        Bucket=bucket_name2,
         Key="Second_Object",
     )
 
-    list_of_copied_objects = s3_client.list_objects(Bucket="Bucket2")
+    list_of_copied_objects = s3_client.list_objects(Bucket=bucket_name2)
     # checks that copy of restored Glacier object has STANDARD storage class
     assert list_of_copied_objects["Contents"][0]["StorageClass"] == "STANDARD"
     # checks that metadata of copy has no Restore property
     assert not hasattr(
-        s3_client.head_object(Bucket="Bucket2", Key="Second_Object"), "Restore"
+        s3_client.head_object(Bucket=bucket_name2, Key="Second_Object"), "Restore"
     )
 
 
 @mock_aws
 def test_s3_get_object_from_glacier():
     s3_client = boto3.client("s3", region_name="us-east-1")
-    bucket_name = "tests3getobjectfromglacier"
+    bucket_name = str(uuid4())
     s3_client.create_bucket(Bucket=bucket_name)
 
     s3_client.put_object(
@@ -280,7 +294,7 @@ def test_s3_get_object_from_glacier():
 @mock_aws
 def test_s3_get_object_from_glacierir():
     s3_client = boto3.client("s3", region_name="us-east-1")
-    bucket_name = "tests3getobjectfromglacierir"
+    bucket_name = str(uuid4())
     s3_client.create_bucket(Bucket=bucket_name)
 
     s3_client.put_object(

--- a/tests/test_s3/test_s3_tagging.py
+++ b/tests/test_s3/test_s3_tagging.py
@@ -1,3 +1,5 @@
+from uuid import uuid4
+
 import boto3
 import pytest
 import requests
@@ -145,7 +147,7 @@ def test_get_bucket_tagging(bucket_name=None):
 @mock_aws
 def test_delete_bucket_tagging():
     s3_client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
-    bucket_name = "mybucket"
+    bucket_name = str(uuid4())
     s3_client.create_bucket(Bucket=bucket_name)
 
     s3_client.put_bucket_tagging(
@@ -304,7 +306,7 @@ def test_put_object_tagging(bucket_name=None):
 @mock_aws
 def test_put_object_tagging_on_earliest_version():
     s3_client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
-    bucket_name = "mybucket"
+    bucket_name = str(uuid4())
     key = "key-with-tags"
     s3_client.create_bucket(Bucket=bucket_name)
     s3_resource = boto3.resource("s3")
@@ -376,7 +378,7 @@ def test_put_object_tagging_on_earliest_version():
 @mock_aws
 def test_put_object_tagging_on_both_version():
     s3_client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
-    bucket_name = "mybucket"
+    bucket_name = str(uuid4())
     key = "key-with-tags"
     s3_client.create_bucket(Bucket=bucket_name)
     s3_resource = boto3.resource("s3")
@@ -461,7 +463,7 @@ def test_put_object_tagging_on_both_version():
 @mock_aws
 def test_put_object_tagging_with_single_tag():
     s3_client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
-    bucket_name = "mybucket"
+    bucket_name = str(uuid4())
     key = "key-with-tags"
     s3_client.create_bucket(Bucket=bucket_name)
 
@@ -479,7 +481,7 @@ def test_put_object_tagging_with_single_tag():
 @mock_aws
 def test_get_object_tagging():
     s3_client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
-    bucket_name = "mybucket"
+    bucket_name = str(uuid4())
     key = "key-with-tags"
     s3_client.create_bucket(Bucket=bucket_name)
 
@@ -510,13 +512,13 @@ def test_objects_tagging_with_same_key_name():
     s3_client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
     key_name = "file.txt"
 
-    bucket1 = "bucket-1"
+    bucket1 = str(uuid4())
     s3_client.create_bucket(Bucket=bucket1)
     tagging = "variable=one"
 
     s3_client.put_object(Bucket=bucket1, Body=b"test", Key=key_name, Tagging=tagging)
 
-    bucket2 = "bucket-2"
+    bucket2 = str(uuid4())
     s3_client.create_bucket(Bucket=bucket2)
     tagging2 = "variable=two"
 
@@ -536,12 +538,13 @@ def test_objects_tagging_with_same_key_name():
 @mock_aws
 def test_generate_url_for_tagged_object():
     s3_client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
-    s3_client.create_bucket(Bucket="my-bucket")
+    bucket_name = str(uuid4())
+    s3_client.create_bucket(Bucket=bucket_name)
     s3_client.put_object(
-        Bucket="my-bucket", Key="test.txt", Body=b"abc", Tagging="MyTag=value"
+        Bucket=bucket_name, Key="test.txt", Body=b"abc", Tagging="MyTag=value"
     )
     url = s3_client.generate_presigned_url(
-        "get_object", Params={"Bucket": "my-bucket", "Key": "test.txt"}
+        "get_object", Params={"Bucket": bucket_name, "Key": "test.txt"}
     )
     kwargs = {}
     if settings.is_test_proxy_mode():


### PR DESCRIPTION
We already run a large chunk of our tests in parallel in the CI - this PR adds S3 to the mix as well, and rewrites all tests to ensure each test uses unique resources names. This significantly speeds up the total test runtime, saving us between 30 secs and 1 minute per Python version.