### PR TITLE
Admin: Remove dateutil invocations, replace with datetime/timezone stdlib

### DIFF
--- a/moto/iot/models.py
+++ b/moto/iot/models.py
@@ -521,7 +521,7 @@ class FakeBillingGroup(CloudFormationModel):
         self.arn = f"arn:{get_partition(self.region_name)}:iot:{self.region_name}:{self.account_id}:billinggroup/{billing_group_name}"
         self.version = 1
         self.things: list[str] = []
-        self.metadata = {"creationDate": datetime.utcnow().isoformat()}
+        self.metadata = {"creationDate": utcnow().isoformat()}
 
     def to_dict(self) -> dict[str, Any]:
         return {

--- a/moto/macie2/models.py
+++ b/moto/macie2/models.py
@@ -1,8 +1,8 @@
-from datetime import datetime
 from typing import Any, Optional
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
+from moto.core.utils import utcnow
 from moto.moto_api._internal import mock_random
 
 from .exceptions import ResourceNotFoundException
@@ -12,7 +12,7 @@ class Invitation(BaseModel):
     def __init__(self, account_id: str, region_name: str, admin_account_id: str):
         self.account_id = account_id
         self.invitation_id = mock_random.get_random_hex()
-        self.invited_at = datetime.utcnow()
+        self.invited_at = utcnow()
         self.relationship_status = "Invited"
         self.arn = f"arn:aws:macie2:{region_name}:{admin_account_id}:invitation/{self.invitation_id}"
 
@@ -35,7 +35,7 @@ class Member(BaseModel):
     ):
         self.account_id = account_id
         self.relationship_status = "Enabled"
-        self.updated_at = datetime.utcnow()
+        self.updated_at = utcnow()
         self.arn = (
             f"arn:aws:macie2:{region_name}:{admin_account_id}:member/{self.account_id}"
         )
@@ -63,11 +63,11 @@ class MacieBackend(BaseBackend):
         self.administrator_account: Optional[Member] = None
         self.organization_admin_account_id: Optional[str] = None
         self.macie_session: Optional[dict[str, Any]] = {
-            "createdAt": datetime.utcnow(),
+            "createdAt": utcnow(),
             "findingPublishingFrequency": "FIFTEEN_MINUTES",
             "serviceRole": f"arn:aws:iam::{account_id}:role/aws-service-role/macie.amazonaws.com/AWSServiceRoleForAmazonMacie",
             "status": "ENABLED",
-            "updatedAt": datetime.utcnow(),
+            "updatedAt": utcnow(),
         }
 
     def create_invitations(self, account_ids: list[str]) -> None:
@@ -168,7 +168,7 @@ class MacieBackend(BaseBackend):
         finding_publishing_frequency: str = "FIFTEEN_MINUTES",
         status: str = "ENABLED",
     ) -> None:
-        now = datetime.utcnow()
+        now = utcnow()
         self.macie_session = {
             "createdAt": now,
             "findingPublishingFrequency": finding_publishing_frequency,

--- a/moto/panorama/models.py
+++ b/moto/panorama/models.py
@@ -1,10 +1,8 @@
 import base64
 import json
 import uuid
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Any, Optional, Union
-
-from dateutil.tz import tzutc
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
@@ -115,8 +113,8 @@ class Device(BaseObject):
             {"Version": "0.2.1"},
         ]
         self.brand: str = "AWS_PANORAMA"  # AWS_PANORAMA | LENOVO
-        self.created_time = datetime.now(tzutc())
-        self.last_updated_time = datetime.now(tzutc())
+        self.created_time = datetime.now(timezone.utc)
+        self.last_updated_time = datetime.now(timezone.utc)
         self.current_networking_status = {
             "Ethernet0Status": {
                 "ConnectionStatus": "CONNECTED",
@@ -128,7 +126,7 @@ class Device(BaseObject):
                 "HwAddress": "8C:0F:6F:60:F4:F1",
                 "IpAddress": "--",
             },
-            "LastUpdatedTime": datetime.now(tzutc()),
+            "LastUpdatedTime": datetime.now(timezone.utc),
             "NtpStatus": {
                 "ConnectionStatus": "CONNECTED",
                 "IpAddress": "91.224.149.41:123",
@@ -139,7 +137,7 @@ class Device(BaseObject):
         self.device_connection_status: str = "ONLINE"  # "ONLINE"|"OFFLINE"|"AWAITING_CREDENTIALS"|"NOT_AVAILABLE"|"ERROR"
         self.latest_device_job = {"JobType": "REBOOT", "Status": "COMPLETED"}
         self.latest_software = "6.2.1"
-        self.lease_expiration_time = datetime.now(tzutc()) + timedelta(days=5)
+        self.lease_expiration_time = datetime.now(timezone.utc) + timedelta(days=5)
         self.serial_number = "GAD81E29013274749"
         self.type: str = "PANORAMA_APPLIANCE"  # "PANORAMA_APPLIANCE_DEVELOPER_KIT", "PANORAMA_APPLIANCE"
 
@@ -249,7 +247,7 @@ class Package(BaseObject):
         self.category = category
         self.description = description
         self.name = name
-        now = datetime.now(tzutc())
+        now = datetime.now(timezone.utc)
         self.created_time = now
         self.last_updated_time = now
         self.package_name = package_name
@@ -294,7 +292,7 @@ class ApplicationInstance(BaseObject):
         self.name = name
         self.runtime_role_arn = runtime_role_arn
         self.tags = tags
-        now = datetime.now(tzutc())
+        now = datetime.now(timezone.utc)
         self.created_time = now
         self.last_updated_time = now
         name = f"{self.name}-{self.created_time}"
@@ -320,7 +318,7 @@ class ApplicationInstance(BaseObject):
     def add_new_runtime_context_states(
         self, desired_state: str, device_reported_status: str
     ) -> None:
-        now = datetime.now(tzutc())
+        now = datetime.now(timezone.utc)
         self.runtime_context_states.append(
             {
                 "DesiredState": desired_state,
@@ -360,7 +358,7 @@ class Node(BaseObject):
         template_type: str,
     ) -> None:
         self.job_id = job_id
-        now = datetime.now(tzutc())
+        now = datetime.now(timezone.utc)
         self.created_time = now
         self.last_updated_time = now
         self.job_tags = job_tags

--- a/moto/redshift/models.py
+++ b/moto/redshift/models.py
@@ -1,11 +1,9 @@
 from __future__ import annotations
 
-import datetime
 from collections import OrderedDict
 from collections.abc import Iterable
+from datetime import datetime, timedelta, timezone
 from typing import Any, Optional
-
-from dateutil.tz import tzutc
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel, CloudFormationModel
@@ -161,8 +159,8 @@ class Cluster(TaggableResourceMixin, CloudFormationModel):
             "LoggingEnabled": "false",  # Lower case is required in response so we use string to simplify
             "BucketName": "",
             "S3KeyPrefix": "",
-            "LastSuccessfulDeliveryTime": datetime.datetime.now(),
-            "LastFailureTime": datetime.datetime.now(),
+            "LastSuccessfulDeliveryTime": datetime.now(),
+            "LastFailureTime": datetime.now(),
             "LastFailureMessage": "",
             "LogDestinationType": "",
             "LogExports": [],
@@ -627,10 +625,7 @@ class RedshiftBackend(BaseBackend):
             raise ClusterAlreadyExistsFaultError()
         cluster = Cluster(self, **cluster_kwargs)
         self.clusters[cluster_identifier] = cluster
-        snapshot_id = (
-            f"rs:{cluster_identifier}-"
-            f"{datetime.datetime.now(tzutc()).strftime('%Y-%m-%d-%H-%M')}"
-        )
+        snapshot_id = f"rs:{cluster_identifier}-{datetime.now(timezone.utc).strftime('%Y-%m-%d-%H-%M')}"
         # Automated snapshots don't copy over the tags
         self.create_cluster_snapshot(
             cluster_identifier,
@@ -1078,9 +1073,7 @@ class RedshiftBackend(BaseBackend):
             raise InvalidParameterValueError(
                 "Token duration must be between 900 and 3600 seconds"
             )
-        expiration = datetime.datetime.now(tzutc()) + datetime.timedelta(
-            0, duration_seconds
-        )
+        expiration = datetime.now(timezone.utc) + timedelta(seconds=duration_seconds)
         if cluster_identifier in self.clusters:
             user_prefix = "IAM:" if auto_create is False else "IAMA:"
             db_user = user_prefix + db_user

--- a/moto/sagemaker/models.py
+++ b/moto/sagemaker/models.py
@@ -5,10 +5,8 @@ import re
 import string
 from collections import defaultdict
 from collections.abc import Iterable
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any, Optional, Union, cast
-
-from dateutil.tz import tzutc
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel, CloudFormationModel
@@ -1074,7 +1072,7 @@ class ModelPackageGroup(BaseObject):
             account_id=account_id,
             region_name=region_name,
         )
-        datetime_now = datetime.now(tzutc())
+        datetime_now = datetime.now(timezone.utc)
         self.model_package_group_name = model_package_group_name
         self.arn = model_package_group_arn
         self.model_package_group_description = model_package_group_description
@@ -1120,7 +1118,7 @@ class FakeModelCard(BaseObject):
         creation_time: Optional[str] = None,
         last_modified_time: Optional[str] = None,
     ) -> None:
-        datetime_now = str(datetime.now(tzutc()))
+        datetime_now = str(datetime.now(timezone.utc))
         self.arn = arn_formatter("model-card", model_card_name, account_id, region_name)
         self.model_card_name = model_card_name
         self.model_card_version = model_card_version
@@ -1269,7 +1267,7 @@ class ModelPackage(BaseObject):
                 else model_package_name.lower()
             ),
         )
-        datetime_now = datetime.now(tzutc())
+        datetime_now = datetime.now(timezone.utc)
         self.model_package_name = model_package_name
         self.model_package_group_name = model_package_group_name
         self.model_package_version = model_package_version
@@ -1368,7 +1366,7 @@ class ModelPackage(BaseObject):
         return response
 
     def modifications_done(self) -> None:
-        self.last_modified_time = datetime.now(tzutc())
+        self.last_modified_time = datetime.now(timezone.utc)
         self.last_modified_by = self.created_by
 
     def set_model_approval_status(self, model_approval_status: Optional[str]) -> None:
@@ -4433,11 +4431,11 @@ class SageMakerModelBackend(BaseBackend):
     ) -> list[ModelPackageGroup]:
         if isinstance(creation_time_before, int):
             creation_time_before_datetime = datetime.fromtimestamp(
-                creation_time_before, tz=tzutc()
+                creation_time_before, tz=timezone.utc
             )
         if isinstance(creation_time_after, int):
             creation_time_after_datetime = datetime.fromtimestamp(
-                creation_time_after, tz=tzutc()
+                creation_time_after, tz=timezone.utc
             )
         model_package_group_summary_list = list(
             filter(
@@ -4497,11 +4495,11 @@ class SageMakerModelBackend(BaseBackend):
     ) -> list[ModelPackage]:
         if isinstance(creation_time_before, int):
             creation_time_before_datetime = datetime.fromtimestamp(
-                creation_time_before, tz=tzutc()
+                creation_time_before, tz=timezone.utc
             )
         if isinstance(creation_time_after, int):
             creation_time_after_datetime = datetime.fromtimestamp(
-                creation_time_after, tz=tzutc()
+                creation_time_after, tz=timezone.utc
             )
         if model_package_group_name is not None:
             model_package_type = "Versioned"
@@ -5604,7 +5602,7 @@ class SageMakerModelBackend(BaseBackend):
         if model_card_name not in self.model_cards:
             raise ResourceNotFound(f"Modelcard {model_card_name} does not exist.")
 
-        datetime_now = str(datetime.now(tzutc()))
+        datetime_now = str(datetime.now(timezone.utc))
 
         first_version = self.model_cards[model_card_name][0]
         creation_time = first_version.creation_time
@@ -5961,9 +5959,9 @@ class FakeTrialComponent(BaseObject):
             metrics_response_object = {
                 "MetricName": metrics_name,
                 "SourceArn": self.arn,
-                "TimeStamp": datetime.fromtimestamp(timestamp_int, tz=tzutc()).strftime(
-                    "%Y-%m-%d %H:%M:%S"
-                ),
+                "TimeStamp": datetime.fromtimestamp(
+                    timestamp_int, tz=timezone.utc
+                ).strftime("%Y-%m-%d %H:%M:%S"),
                 "Max": max(metrics_steps_values),
                 "Min": min(metrics_steps_values),
                 "Last": metrics_steps[max_step]["Value"],

--- a/moto/sagemaker/utils.py
+++ b/moto/sagemaker/utils.py
@@ -1,10 +1,8 @@
 import json
 import typing
 from collections import defaultdict
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any, Optional
-
-from dateutil.tz import tzutc
 
 from moto.s3.models import s3_backends
 from moto.utilities.utils import get_partition
@@ -96,7 +94,7 @@ def filter_model_cards(
         if creation_time_after:
             if isinstance(creation_time_after, int):
                 creation_time_after = datetime.fromtimestamp(
-                    creation_time_after, tz=tzutc()
+                    creation_time_after, tz=timezone.utc
                 )
             filtered_versions = [
                 v
@@ -107,7 +105,7 @@ def filter_model_cards(
         if creation_time_before:
             if isinstance(creation_time_before, int):
                 creation_time_before = datetime.fromtimestamp(
-                    creation_time_before, tz=tzutc()
+                    creation_time_before, tz=timezone.utc
                 )
             filtered_versions = [
                 v

--- a/moto/stepfunctions/models.py
+++ b/moto/stepfunctions/models.py
@@ -1,10 +1,8 @@
 import json
 import re
-from datetime import datetime
+from datetime import datetime, timezone
 from re import Pattern
 from typing import Any, Optional
-
-from dateutil.tz import tzlocal
 
 from moto import settings
 from moto.core.base_backend import BackendDict, BaseBackend
@@ -347,11 +345,12 @@ class Execution:
 
     def get_execution_history(self, roleArn: str) -> list[dict[str, Any]]:
         sf_execution_history_type = settings.get_sf_execution_history_type()
+        tzlocal = datetime.now(timezone.utc).astimezone().tzinfo
         if sf_execution_history_type == "SUCCESS":
             return [
                 {
                     "timestamp": iso_8601_datetime_with_milliseconds(
-                        datetime(2020, 1, 1, 0, 0, 0, tzinfo=tzlocal())
+                        datetime(2020, 1, 1, 0, 0, 0, tzinfo=tzlocal)
                     ),
                     "type": "ExecutionStarted",
                     "id": 1,
@@ -364,7 +363,7 @@ class Execution:
                 },
                 {
                     "timestamp": iso_8601_datetime_with_milliseconds(
-                        datetime(2020, 1, 1, 0, 0, 10, tzinfo=tzlocal())
+                        datetime(2020, 1, 1, 0, 0, 10, tzinfo=tzlocal)
                     ),
                     "type": "PassStateEntered",
                     "id": 2,
@@ -377,7 +376,7 @@ class Execution:
                 },
                 {
                     "timestamp": iso_8601_datetime_with_milliseconds(
-                        datetime(2020, 1, 1, 0, 0, 10, tzinfo=tzlocal())
+                        datetime(2020, 1, 1, 0, 0, 10, tzinfo=tzlocal)
                     ),
                     "type": "PassStateExited",
                     "id": 3,
@@ -390,7 +389,7 @@ class Execution:
                 },
                 {
                     "timestamp": iso_8601_datetime_with_milliseconds(
-                        datetime(2020, 1, 1, 0, 0, 20, tzinfo=tzlocal())
+                        datetime(2020, 1, 1, 0, 0, 20, tzinfo=tzlocal)
                     ),
                     "type": "ExecutionSucceeded",
                     "id": 4,
@@ -405,7 +404,7 @@ class Execution:
             return [
                 {
                     "timestamp": iso_8601_datetime_with_milliseconds(
-                        datetime(2020, 1, 1, 0, 0, 0, tzinfo=tzlocal())
+                        datetime(2020, 1, 1, 0, 0, 0, tzinfo=tzlocal)
                     ),
                     "type": "ExecutionStarted",
                     "id": 1,
@@ -418,7 +417,7 @@ class Execution:
                 },
                 {
                     "timestamp": iso_8601_datetime_with_milliseconds(
-                        datetime(2020, 1, 1, 0, 0, 10, tzinfo=tzlocal())
+                        datetime(2020, 1, 1, 0, 0, 10, tzinfo=tzlocal)
                     ),
                     "type": "FailStateEntered",
                     "id": 2,
@@ -431,7 +430,7 @@ class Execution:
                 },
                 {
                     "timestamp": iso_8601_datetime_with_milliseconds(
-                        datetime(2020, 1, 1, 0, 0, 10, tzinfo=tzlocal())
+                        datetime(2020, 1, 1, 0, 0, 10, tzinfo=tzlocal)
                     ),
                     "type": "ExecutionFailed",
                     "id": 3,

--- a/moto/synthetics/models.py
+++ b/moto/synthetics/models.py
@@ -1,12 +1,11 @@
 """SyntheticsBackend class with methods for supported APIs."""
 
-import datetime
 import uuid
 from typing import Optional
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
-from moto.core.utils import iso_8601_datetime_with_milliseconds
+from moto.core.utils import iso_8601_datetime_with_milliseconds, utcnow
 
 
 class Canary(BaseModel):  # pylint: disable=too-many-instance-attributes,too-few-public-methods
@@ -50,7 +49,7 @@ class Canary(BaseModel):  # pylint: disable=too-many-instance-attributes,too-few
         self.artifact_config = artifact_config
         self.state = "READY"
 
-        now = datetime.datetime.utcnow()
+        now = utcnow()
         self.timeline = {
             "Created": now,
             "LastModified": now,

--- a/tests/test_dsql/test_dsql.py
+++ b/tests/test_dsql/test_dsql.py
@@ -1,10 +1,9 @@
 """Unit tests for dsql-supported APIs."""
 
-from datetime import datetime
+from datetime import datetime, timezone
 
 import boto3
 from botocore.exceptions import ClientError
-from dateutil.tz import tzutc
 from freezegun import freeze_time
 
 from moto import mock_aws, settings
@@ -24,7 +23,9 @@ def test_create_cluster():
     assert resp["deletionProtectionEnabled"] is True
     assert resp["status"] == "CREATING"
     if not settings.TEST_SERVER_MODE:
-        assert resp["creationTime"] == datetime(2024, 12, 22, 12, 34, tzinfo=tzutc())
+        assert resp["creationTime"] == datetime(
+            2024, 12, 22, 12, 34, tzinfo=timezone.utc
+        )
 
 
 @mock_aws
@@ -57,7 +58,7 @@ def test_get_cluster():
     assert get_resp["status"] == "CREATING"
     if not settings.TEST_SERVER_MODE:
         assert get_resp["creationTime"] == datetime(
-            2024, 12, 22, 12, 34, tzinfo=tzutc()
+            2024, 12, 22, 12, 34, tzinfo=timezone.utc
         )
 
 

--- a/tests/test_ecr/test_ecr.py
+++ b/tests/test_ecr/test_ecr.py
@@ -1,11 +1,10 @@
 import json
-from datetime import datetime
+from datetime import datetime, timezone
 from unittest import SkipTest
 
 import boto3
 import pytest
 from botocore.exceptions import ClientError, ParamValidationError
-from dateutil.tz import tzlocal
 from freezegun import freeze_time
 
 from moto import mock_aws, settings
@@ -448,9 +447,10 @@ def test_put_image_with_push_date():
 
     client = boto3.client("ecr", region_name=ECR_REGION)
     _ = client.create_repository(repositoryName="test_repository")
+    tzlocal = datetime.now(timezone.utc).astimezone().tzinfo
 
     with freeze_time("2018-08-28 00:00:00"):
-        image1_date = datetime.now(tzlocal())
+        image1_date = datetime.now(tzlocal)
         _ = client.put_image(
             repositoryName="test_repository",
             imageManifest=json.dumps(_create_image_manifest()),
@@ -458,7 +458,7 @@ def test_put_image_with_push_date():
         )
 
     with freeze_time("2019-05-31 00:00:00"):
-        image2_date = datetime.now(tzlocal())
+        image2_date = datetime.now(tzlocal)
         _ = client.put_image(
             repositoryName="test_repository",
             imageManifest=json.dumps(_create_image_manifest()),
@@ -1015,6 +1015,7 @@ def test_describe_images_by_digest():
 @mock_aws
 def test_get_authorization_token_assume_region():
     client = boto3.client("ecr", region_name=ECR_REGION)
+    tzlocal = datetime.now(timezone.utc).astimezone().tzinfo
     auth_token_response = client.get_authorization_token()
 
     assert "authorizationData" in auth_token_response
@@ -1023,7 +1024,7 @@ def test_get_authorization_token_assume_region():
         {
             "authorizationToken": "QVdTOjEyMzQ1Njc4OTAxMi1hdXRoLXRva2Vu",
             "proxyEndpoint": f"https://{ACCOUNT_ID}.dkr.ecr.us-east-1.amazonaws.com",
-            "expiresAt": datetime(2015, 1, 1, tzinfo=tzlocal()),
+            "expiresAt": datetime(2015, 1, 1, tzinfo=tzlocal),
         }
     ]
 
@@ -1031,6 +1032,7 @@ def test_get_authorization_token_assume_region():
 @mock_aws
 def test_get_authorization_token_explicit_regions():
     client = boto3.client("ecr", region_name=ECR_REGION)
+    tzlocal = datetime.now(timezone.utc).astimezone().tzinfo
     auth_token_response = client.get_authorization_token(
         registryIds=["10987654321", "878787878787"]
     )
@@ -1041,12 +1043,12 @@ def test_get_authorization_token_explicit_regions():
         {
             "authorizationToken": "QVdTOjEwOTg3NjU0MzIxLWF1dGgtdG9rZW4=",
             "proxyEndpoint": "https://10987654321.dkr.ecr.us-east-1.amazonaws.com",
-            "expiresAt": datetime(2015, 1, 1, tzinfo=tzlocal()),
+            "expiresAt": datetime(2015, 1, 1, tzinfo=tzlocal),
         },
         {
             "authorizationToken": "QVdTOjg3ODc4Nzg3ODc4Ny1hdXRoLXRva2Vu",
             "proxyEndpoint": "https://878787878787.dkr.ecr.us-east-1.amazonaws.com",
-            "expiresAt": datetime(2015, 1, 1, tzinfo=tzlocal()),
+            "expiresAt": datetime(2015, 1, 1, tzinfo=tzlocal),
         },
     ]
 

--- a/tests/test_eks/test_eks.py
+++ b/tests/test_eks/test_eks.py
@@ -1,12 +1,11 @@
-import datetime
 from copy import deepcopy
+from datetime import datetime, timezone
 from unittest import SkipTest, mock
 from unittest.mock import PropertyMock
 
 import boto3
 import pytest
 from botocore.exceptions import ClientError
-from dateutil.tz import tzutc
 from freezegun import freeze_time
 
 from moto import mock_aws, settings
@@ -327,7 +326,7 @@ def test_create_cluster_generates_valid_cluster_arn(ClusterBuilder):
 
 @mock_aws
 def test_create_cluster_generates_valid_cluster_created_timestamp(ClusterBuilder):
-    cluster_create_time = datetime.datetime(2013, 11, 27, 1, 42, tzinfo=tzutc())
+    cluster_create_time = datetime(2013, 11, 27, 1, 42, tzinfo=timezone.utc)
     with freeze_time(cluster_create_time):
         _, generated_test_data = ClusterBuilder()
     result_time = generated_test_data.cluster_describe_output[
@@ -607,7 +606,7 @@ def test_create_nodegroup_generates_valid_nodegroup_arn(NodegroupBuilder):
 
 @mock_aws
 def test_create_nodegroup_generates_valid_nodegroup_created_timestamp(NodegroupBuilder):
-    ng_create_time = datetime.datetime(2013, 11, 27, 1, 42, tzinfo=tzutc())
+    ng_create_time = datetime(2013, 11, 27, 1, 42, tzinfo=timezone.utc)
     with freeze_time(ng_create_time):
         _, generated_test_data = NodegroupBuilder()
 
@@ -622,7 +621,7 @@ def test_create_nodegroup_generates_valid_nodegroup_created_timestamp(NodegroupB
 def test_create_nodegroup_generates_valid_nodegroup_modified_timestamp(
     NodegroupBuilder,
 ):
-    ng_mod_time = datetime.datetime(2013, 11, 27, 1, 42, tzinfo=tzutc())
+    ng_mod_time = datetime(2013, 11, 27, 1, 42, tzinfo=timezone.utc)
     with freeze_time(ng_mod_time):
         _, generated_test_data = NodegroupBuilder()
     result_time = generated_test_data.nodegroup_describe_output[
@@ -1057,7 +1056,7 @@ def test_create_fargate_profile_generates_valid_profile_arn(FargateProfileBuilde
 def test_create_fargate_profile_generates_valid_created_timestamp(
     FargateProfileBuilder,
 ):
-    fp_create_time = datetime.datetime(2013, 11, 27, 1, 42, tzinfo=tzutc())
+    fp_create_time = datetime(2013, 11, 27, 1, 42, tzinfo=timezone.utc)
     with freeze_time(fp_create_time):
         _, generated_test_data = FargateProfileBuilder()
     result_time = generated_test_data.fargate_describe_output[

--- a/tests/test_iam/test_iam_access_integration.py
+++ b/tests/test_iam/test_iam_access_integration.py
@@ -1,9 +1,8 @@
 import csv
-import datetime
+from datetime import datetime
 from unittest import SkipTest
 
 import boto3
-from dateutil.parser import parse
 
 from moto import mock_aws, settings
 from moto.iam.models import IAMBackend, iam_backends
@@ -57,7 +56,7 @@ def test_mark_role_as_last_used():
     iam2.create_role(RoleName="name", AssumeRolePolicyDocument="example")
 
     role = iam.get_role(RoleName=role_name)["Role"]
-    assert isinstance(role["RoleLastUsed"]["LastUsedDate"], datetime.datetime)
+    assert isinstance(role["RoleLastUsed"]["LastUsedDate"], datetime)
 
     if not settings.TEST_SERVER_MODE:
         iam: IAMBackend = iam_backends[DEFAULT_ACCOUNT_ID]["global"]
@@ -92,4 +91,5 @@ def test_get_credential_report_content__set_last_used_automatically():
     report_dict = csv.DictReader(report.split("\n"))
     user = next(report_dict)
 
-    assert parse(user["access_key_1_last_used_date"])
+    date_format = "%Y-%m-%dT%H:%M:%S+00:00"
+    assert datetime.strptime(user["access_key_1_last_used_date"], date_format)

--- a/tests/test_iam/test_iam_groups.py
+++ b/tests/test_iam/test_iam_groups.py
@@ -1,11 +1,10 @@
 import json
-from datetime import datetime
+from datetime import datetime, timezone
 from unittest import SkipTest
 
 import boto3
 import pytest
 from botocore.exceptions import ClientError
-from dateutil.tz import tzlocal
 from freezegun import freeze_time
 
 from moto import mock_aws, settings
@@ -114,7 +113,8 @@ def test_add_user_to_unknown_group():
 @mock_aws
 def test_add_user_to_group():
     # Setup
-    frozen_time = datetime(2023, 5, 20, 10, 20, 30, tzinfo=tzlocal())
+    tzlocal = datetime.now(timezone.utc).astimezone().tzinfo
+    frozen_time = datetime(2023, 5, 20, 10, 20, 30, tzinfo=tzlocal)
 
     group = "my-group"
     user = "my-user"

--- a/tests/test_iot/test_iot_cloudformation.py
+++ b/tests/test_iot/test_iot_cloudformation.py
@@ -1,8 +1,7 @@
 import json
-from datetime import datetime
+from datetime import datetime, timezone
 
 import boto3
-from dateutil.tz import tzlocal
 
 from moto import mock_aws
 
@@ -751,7 +750,8 @@ def test_create_job_template_with_simple_cloudformation():
     assert job_template["description"] == "Job template Description"
     assert job_template["document"] == '{"field": "value"}'
     assert job_template["documentSource"] == "a document source link"
-    assert job_template["createdAt"] == datetime(2015, 1, 1, 0, 0, tzinfo=tzlocal())
+    tzlocal = datetime.now(timezone.utc).astimezone().tzinfo
+    assert job_template["createdAt"] == datetime(2015, 1, 1, 0, 0, tzinfo=tzlocal)
     assert job_template["presignedUrlConfig"] == {
         "roleArn": "arn:aws:iam::1:role/service-role/iot_job_role",
         "expiresInSec": 123,

--- a/tests/test_kinesis/test_kinesis.py
+++ b/tests/test_kinesis/test_kinesis.py
@@ -1,10 +1,9 @@
-import datetime
 import time
+from datetime import datetime, timedelta, timezone
 
 import boto3
 import pytest
 from botocore.exceptions import ClientError
-from dateutil.tz import tzlocal
 
 from moto import mock_aws
 from moto.core import DEFAULT_ACCOUNT_ID as ACCOUNT_ID
@@ -489,7 +488,8 @@ def test_get_records_timestamp_filtering():
     conn.put_record(StreamName=stream_name, Data="0", PartitionKey="0")
 
     time.sleep(1.0)
-    timestamp = datetime.datetime.now(tz=tzlocal())
+    tzlocal = datetime.now(timezone.utc).astimezone().tzinfo
+    timestamp = datetime.now(tz=tzlocal)
 
     conn.put_record(StreamName=stream_name, Data="1", PartitionKey="1")
 
@@ -543,7 +543,7 @@ def test_get_records_at_very_new_timestamp():
     for k in keys:
         conn.put_record(StreamName=stream_name, Data=k, PartitionKey=k)
 
-    timestamp = utcnow() + datetime.timedelta(seconds=1)
+    timestamp = utcnow() + timedelta(seconds=1)
 
     # Get a shard iterator
     response = conn.describe_stream(StreamName=stream_name)

--- a/tests/test_kms/test_kms.py
+++ b/tests/test_kms/test_kms.py
@@ -3,7 +3,7 @@ import binascii
 import itertools
 import json
 import os
-from datetime import datetime
+from datetime import datetime, timezone
 from unittest import mock
 
 import boto3
@@ -12,7 +12,6 @@ import pytest
 from botocore.exceptions import ClientError
 from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import ec, rsa
-from dateutil.tz import tzutc
 from freezegun import freeze_time
 
 from moto import mock_aws
@@ -553,7 +552,7 @@ def test_schedule_key_deletion():
             response = client.schedule_key_deletion(KeyId=key_id)
             assert response["KeyId"] == key_id
             assert response["DeletionDate"] == datetime(
-                2015, 1, 31, 12, 0, tzinfo=tzutc()
+                2015, 1, 31, 12, 0, tzinfo=timezone.utc
             )
     else:
         # Can't manipulate time in server mode
@@ -577,7 +576,7 @@ def test_schedule_key_deletion_custom():
             )
             assert response["KeyId"] == key["KeyMetadata"]["KeyId"]
             assert response["DeletionDate"] == datetime(
-                2015, 1, 8, 12, 0, tzinfo=tzutc()
+                2015, 1, 8, 12, 0, tzinfo=timezone.utc
             )
     else:
         # Can't manipulate time in server mode

--- a/tests/test_opensearch/test_opensearch.py
+++ b/tests/test_opensearch/test_opensearch.py
@@ -1,9 +1,8 @@
-from datetime import datetime
+from datetime import datetime, timezone
 
 import boto3
 import pytest
 from botocore.exceptions import ClientError
-from dateutil.tz import tzlocal
 from freezegun import freeze_time
 
 from moto import mock_aws, settings
@@ -127,8 +126,10 @@ def test_describe_domain_config():
     assert ev_status["PendingDeletion"] is False
 
     if not settings.TEST_SERVER_MODE:
-        assert ev_status["CreationDate"] == datetime(2015, 1, 1, 12, tzinfo=tzlocal())
-        assert ev_status["UpdateDate"] == datetime(2015, 1, 1, 12, tzinfo=tzlocal())
+        assert ev_status["CreationDate"] == datetime(
+            2015, 1, 1, 12, tzinfo=timezone.utc
+        )
+        assert ev_status["UpdateDate"] == datetime(2015, 1, 1, 12, tzinfo=timezone.utc)
 
 
 @mock_aws

--- a/tests/test_panorama/test_application_instance.py
+++ b/tests/test_panorama/test_application_instance.py
@@ -1,9 +1,8 @@
-import datetime
+from datetime import datetime, timezone
 from unittest import SkipTest
 from unittest.mock import ANY
 
 import boto3
-from dateutil.tz import tzutc
 from freezegun import freeze_time
 
 from moto import mock_aws, settings
@@ -108,14 +107,14 @@ def test_describe_application_instance() -> None:
         "arn:aws:panorama:eu-west-1:123456789012:application-instance/"
     )
     assert response["Arn"].endswith(response_created["ApplicationInstanceId"])
-    assert isinstance(response["CreatedTime"], datetime.datetime)
+    assert isinstance(response["CreatedTime"], datetime)
     assert (
         response["DefaultRuntimeContextDevice"] == response_device_creation["DeviceId"]
     )
     assert response["DefaultRuntimeContextDeviceName"] == "not-a-device-name"
     assert response["Description"] == "not a description"
     assert response["HealthStatus"] == "RUNNING"
-    assert isinstance(response["LastUpdatedTime"], datetime.datetime)
+    assert isinstance(response["LastUpdatedTime"], datetime)
     assert response["Name"] == given_application_instance_name
     assert response["RuntimeRoleArn"] == given_application_instance_arn
     assert response["Status"] == "DEPLOYMENT_SUCCEEDED"
@@ -155,11 +154,11 @@ def test_create_application_instance_should_set_created_time() -> None:
     )
 
     # Then
-    assert response["CreatedTime"] == datetime.datetime(
-        2020, 1, 1, 12, 0, 0, tzinfo=tzutc()
+    assert response["CreatedTime"] == datetime(
+        2020, 1, 1, 12, 0, 0, tzinfo=timezone.utc
     )
-    assert response["LastUpdatedTime"] == datetime.datetime(
-        2020, 1, 1, 12, 0, 0, tzinfo=tzutc()
+    assert response["LastUpdatedTime"] == datetime(
+        2020, 1, 1, 12, 0, 0, tzinfo=timezone.utc
     )
 
 
@@ -200,7 +199,7 @@ def test_describe_application_instance_details() -> None:
         response["ApplicationInstanceId"] == response_created["ApplicationInstanceId"]
     )
     assert response.get("ApplicationInstanceIdToReplace") is None
-    assert isinstance(response["CreatedTime"], datetime.datetime)
+    assert isinstance(response["CreatedTime"], datetime)
     assert (
         response["DefaultRuntimeContextDevice"] == response_device_creation["DeviceId"]
     )
@@ -275,9 +274,7 @@ def test_list_application_instances() -> None:
     assert response_1["ApplicationInstances"][0]["Arn"].endswith(
         response_created_1["ApplicationInstanceId"]
     )
-    assert isinstance(
-        response_1["ApplicationInstances"][0]["CreatedTime"], datetime.datetime
-    )
+    assert isinstance(response_1["ApplicationInstances"][0]["CreatedTime"], datetime)
     assert (
         response_1["ApplicationInstances"][0]["DefaultRuntimeContextDevice"]
         == response_device_creation["DeviceId"]

--- a/tests/test_panorama/test_panorama_device.py
+++ b/tests/test_panorama/test_panorama_device.py
@@ -1,10 +1,9 @@
-from datetime import datetime
+from datetime import datetime, timezone
 from unittest import SkipTest
 
 import boto3
 import pytest
 from botocore.exceptions import ClientError
-from dateutil.tz import tzutc
 from freezegun import freeze_time
 
 from moto import mock_aws, settings
@@ -105,7 +104,7 @@ def test_describe_device() -> None:
         resp["Arn"] == "arn:aws:panorama:eu-west-1:123456789012:device/test-device-name"
     )
     assert resp["Brand"] == "AWS_PANORAMA"
-    assert resp["CreatedTime"] == datetime(2020, 1, 1, 12, 0, tzinfo=tzutc())
+    assert resp["CreatedTime"] == datetime(2020, 1, 1, 12, 0, tzinfo=timezone.utc)
     assert resp["CurrentNetworkingStatus"] == {
         "Ethernet0Status": {
             "ConnectionStatus": "CONNECTED",
@@ -117,7 +116,7 @@ def test_describe_device() -> None:
             "HwAddress": "8C:0F:6F:60:F4:F1",
             "IpAddress": "--",
         },
-        "LastUpdatedTime": datetime(2020, 1, 1, 12, 0, tzinfo=tzutc()),
+        "LastUpdatedTime": datetime(2020, 1, 1, 12, 0, tzinfo=timezone.utc),
         "NtpStatus": {
             "ConnectionStatus": "CONNECTED",
             "IpAddress": "91.224.149.41:123",
@@ -131,7 +130,9 @@ def test_describe_device() -> None:
     assert resp["DeviceId"] == "device-RsozEWjZpeNe3SXHidX3mg"
     assert resp["LatestDeviceJob"] == {"JobType": "REBOOT", "Status": "COMPLETED"}
     assert resp["LatestSoftware"] == "6.2.1"
-    assert resp["LeaseExpirationTime"] == datetime(2020, 1, 6, 12, 0, tzinfo=tzutc())
+    assert resp["LeaseExpirationTime"] == datetime(
+        2020, 1, 6, 12, 0, tzinfo=timezone.utc
+    )
     assert resp["Name"] == "test-device-name"
     assert resp["ProvisioningStatus"] == "SUCCEEDED"
     assert resp["SerialNumber"] == "GAD81E29013274749"

--- a/tests/test_rds/test_rds.py
+++ b/tests/test_rds/test_rds.py
@@ -1,11 +1,10 @@
-import datetime
 import time
+from datetime import datetime, timedelta, timezone
 from uuid import uuid4
 
 import boto3
 import pytest
 from botocore.exceptions import ClientError
-from dateutil.tz import tzutc
 from freezegun import freeze_time
 
 from moto import mock_aws, settings
@@ -95,7 +94,7 @@ def test_create_database(client):
     assert db_instance["IAMDatabaseAuthenticationEnabled"] is False
     assert "db-" in db_instance["DbiResourceId"]
     assert db_instance["CopyTagsToSnapshot"] is False
-    assert isinstance(db_instance["InstanceCreateTime"], datetime.datetime)
+    assert isinstance(db_instance["InstanceCreateTime"], datetime)
     assert db_instance["VpcSecurityGroups"][0]["VpcSecurityGroupId"] == "sg-123456"
     assert db_instance["DeletionProtection"] is False
     assert db_instance["EnabledCloudwatchLogsExports"] == ["audit", "error"]
@@ -857,7 +856,7 @@ def test_create_db_snapshots(client):
 
     create_db_instance(DBInstanceIdentifier="db-primary-1")
 
-    snapshot_create_time = datetime.datetime(2025, 1, 2, tzinfo=tzutc())
+    snapshot_create_time = datetime(2025, 1, 2, tzinfo=timezone.utc)
     with freeze_time(snapshot_create_time):
         snapshot = client.create_db_snapshot(
             DBInstanceIdentifier="db-primary-1", DBSnapshotIdentifier="g-1"
@@ -942,7 +941,7 @@ def test_copy_db_snapshots(
 ):
     create_db_instance(DBInstanceIdentifier="db-primary-1")
 
-    snapshot_create_time = datetime.datetime(2025, 1, 2, tzinfo=tzutc())
+    snapshot_create_time = datetime(2025, 1, 2, tzinfo=timezone.utc)
     with freeze_time(snapshot_create_time):
         client.create_db_snapshot(
             DBInstanceIdentifier="db-primary-1", DBSnapshotIdentifier="snapshot-1"
@@ -952,7 +951,7 @@ def test_copy_db_snapshots(
         # Delete the original instance, but the copy snapshot operation should still succeed.
         client.delete_db_instance(DBInstanceIdentifier="db-primary-1")
 
-    target_snapshot_create_time = snapshot_create_time + datetime.timedelta(minutes=1)
+    target_snapshot_create_time = snapshot_create_time + timedelta(minutes=1)
     with freeze_time(target_snapshot_create_time):
         target_snapshot = client.copy_db_snapshot(
             SourceDBSnapshotIdentifier=db_snapshot_identifier,
@@ -3046,9 +3045,9 @@ def test_restore_db_instance_to_point_in_time_with_allocated_storage(client):
     allocated_storage = 20
     details_source = create_db_instance(AllocatedStorage=allocated_storage)
     source_identifier = details_source["DBInstanceIdentifier"]
-    restore_time = datetime.datetime.fromtimestamp(
-        time.time() - 600, datetime.timezone.utc
-    ).strftime("%Y-%m-%dT%H:%M:%SZ")
+    restore_time = datetime.fromtimestamp(time.time() - 600, timezone.utc).strftime(
+        "%Y-%m-%dT%H:%M:%SZ"
+    )
     # Default
     restored = client.restore_db_instance_to_point_in_time(
         SourceDBInstanceIdentifier=source_identifier,

--- a/tests/test_redshift/test_redshift.py
+++ b/tests/test_redshift/test_redshift.py
@@ -1,14 +1,14 @@
-import datetime
 import re
 import time
+from datetime import datetime, timedelta
 
 import boto3
 import pytest
 from botocore.exceptions import ClientError
-from dateutil.tz import tzutc
 
 from moto import mock_aws
 from moto.core import DEFAULT_ACCOUNT_ID as ACCOUNT_ID
+from moto.core.utils import utcnow
 
 
 @mock_aws
@@ -27,10 +27,8 @@ def test_create_cluster():
     assert cluster["NodeType"] == "ds2.xlarge"
     assert cluster["ClusterStatus"] == "creating"
     create_time = cluster["ClusterCreateTime"]
-    assert create_time < datetime.datetime.now(create_time.tzinfo)
-    assert create_time > (
-        datetime.datetime.now(create_time.tzinfo) - datetime.timedelta(minutes=1)
-    )
+    assert create_time < datetime.now(create_time.tzinfo)
+    assert create_time > (datetime.now(create_time.tzinfo) - timedelta(minutes=1))
     assert cluster["MasterUsername"] == "user"
     assert cluster["DBName"] == "test"
     assert cluster["AutomatedSnapshotRetentionPeriod"] == 1
@@ -67,10 +65,8 @@ def test_create_cluster_with_enhanced_vpc_routing_enabled():
     )
     assert response["Cluster"]["NodeType"] == "ds2.xlarge"
     create_time = response["Cluster"]["ClusterCreateTime"]
-    assert create_time < datetime.datetime.now(create_time.tzinfo)
-    assert create_time > (
-        datetime.datetime.now(create_time.tzinfo) - datetime.timedelta(minutes=1)
-    )
+    assert create_time < datetime.now(create_time.tzinfo)
+    assert create_time > (datetime.now(create_time.tzinfo) - timedelta(minutes=1))
     assert response["Cluster"]["EnhancedVpcRouting"] is True
 
 
@@ -1904,9 +1900,7 @@ def test_get_cluster_credentials():
         NodeType="ds2.xlarge",
     )
 
-    expected_expiration = time.mktime(
-        (datetime.datetime.now(tzutc()) + datetime.timedelta(0, 900)).timetuple()
-    )
+    expected_expiration = time.mktime((utcnow() + timedelta(seconds=900)).timetuple())
     db_user = "some_user"
     response = client.get_cluster_credentials(
         ClusterIdentifier=cluster_identifier, DbUser=db_user
@@ -1927,9 +1921,7 @@ def test_get_cluster_credentials():
     )
     assert response["DbUser"] == "IAM:some_other_user"
 
-    expected_expiration = time.mktime(
-        (datetime.datetime.now(tzutc()) + datetime.timedelta(0, 3000)).timetuple()
-    )
+    expected_expiration = time.mktime((utcnow() + timedelta(seconds=3000)).timetuple())
     response = client.get_cluster_credentials(
         ClusterIdentifier=cluster_identifier, DbUser=db_user, DurationSeconds=3000
     )

--- a/tests/test_sagemaker/test_sagemaker_model_cards.py
+++ b/tests/test_sagemaker/test_sagemaker_model_cards.py
@@ -1,14 +1,13 @@
 """Unit tests for sagemaker-supported APIs."""
 
 import time
-from datetime import datetime
 
 import boto3
 import pytest
 from botocore.exceptions import ClientError
-from dateutil.tz import tzutc
 
 from moto import mock_aws
+from moto.core.utils import utcnow
 
 # See our Development Tips on writing tests for hints on how to write good tests:
 # http://docs.getmoto.org/en/latest/docs/contributing/development_tips/tests.html
@@ -153,7 +152,7 @@ def test_list_model_cards_advanced():
             Content='{"model_overview": {"model_description": f"my {c} model"}}',
         )
     time.sleep(1)
-    datetime_now = datetime.now(tzutc())
+    datetime_now = utcnow()
     client.create_model_card(
         ModelCardName="my-fourth-model-card",
         ModelCardStatus="Approved",

--- a/tests/test_sagemaker/test_sagemaker_model_package_groups.py
+++ b/tests/test_sagemaker/test_sagemaker_model_package_groups.py
@@ -1,11 +1,10 @@
 import uuid
-from datetime import datetime
+from datetime import datetime, timezone
 from unittest import SkipTest
 
 import boto3
 import pytest
 from botocore.exceptions import ClientError
-from dateutil.tz import tzutc  # type: ignore
 from freezegun import freeze_time
 
 from moto import mock_aws, settings
@@ -191,7 +190,7 @@ def test_describe_model_package_group():
         == "arn:aws:sagemaker:eu-west-1:123456789012:model-package-group/test-model-package-group"
     )
     assert resp["ModelPackageGroupStatus"] == "Completed"
-    assert resp["CreationTime"] == datetime(2020, 1, 1, 0, 0, 0, tzinfo=tzutc())
+    assert resp["CreationTime"] == datetime(2020, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
 
 
 @mock_aws

--- a/tests/test_sagemaker/test_sagemaker_model_packages.py
+++ b/tests/test_sagemaker/test_sagemaker_model_packages.py
@@ -1,10 +1,9 @@
-from datetime import datetime
+from datetime import datetime, timezone
 from unittest import SkipTest, TestCase
 
 import boto3
 import pytest
 from botocore.exceptions import ClientError
-from dateutil.tz import tzutc  # type: ignore
 from freezegun import freeze_time
 
 from moto import mock_aws, settings
@@ -242,7 +241,7 @@ def test_describe_model_package_default():
         resp["ModelPackageArn"]
         == "arn:aws:sagemaker:eu-west-1:123456789012:model-package/test-model-package-group/1"
     )
-    assert resp["CreationTime"] == datetime(2015, 1, 1, 0, 0, 0, tzinfo=tzutc())
+    assert resp["CreationTime"] == datetime(2015, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
     assert (
         resp["CreatedBy"]["UserProfileArn"]
         == "arn:aws:sagemaker:eu-west-1:123456789012:user-profile/fake-domain-id/fake-user-profile-name"
@@ -382,7 +381,9 @@ def test_update_model_package_should_update_last_modified_information():
         )
     resp = client.describe_model_package(ModelPackageName=model_package_arn)
     assert resp.get("LastModifiedTime") is not None
-    assert resp["LastModifiedTime"] == datetime(2020, 1, 1, 12, 0, 0, tzinfo=tzutc())
+    assert resp["LastModifiedTime"] == datetime(
+        2020, 1, 1, 12, 0, 0, tzinfo=timezone.utc
+    )
     assert resp.get("LastModifiedBy") is not None
     assert (
         resp["LastModifiedBy"]["UserProfileArn"]

--- a/tests/test_secretsmanager/test_list_secrets.py
+++ b/tests/test_secretsmanager/test_list_secrets.py
@@ -1,10 +1,9 @@
-from datetime import datetime
+from datetime import datetime, timezone
 from uuid import uuid4
 
 import boto3
 import pytest
 from botocore.exceptions import ClientError
-from dateutil.tz import tzlocal
 
 from moto import mock_aws
 from moto.secretsmanager.list_secrets.filters import split_words
@@ -27,6 +26,7 @@ def test_empty():
 @mock_aws
 def test_list_secrets():
     conn = boto_client()
+    tzlocal = datetime.now(timezone.utc).astimezone().tzinfo
 
     conn.create_secret(Name="test-secret", SecretString="foosecret")
 
@@ -45,10 +45,10 @@ def test_list_secrets():
     assert secrets["SecretList"][1]["Name"] == "test-secret-2"
     assert secrets["SecretList"][1]["Tags"] == [{"Key": "a", "Value": "1"}]
     assert secrets["SecretList"][1]["SecretVersionsToStages"] is not None
-    assert secrets["SecretList"][0]["CreatedDate"] <= datetime.now(tz=tzlocal())
-    assert secrets["SecretList"][1]["CreatedDate"] <= datetime.now(tz=tzlocal())
-    assert secrets["SecretList"][0]["LastChangedDate"] <= datetime.now(tz=tzlocal())
-    assert secrets["SecretList"][1]["LastChangedDate"] <= datetime.now(tz=tzlocal())
+    assert secrets["SecretList"][0]["CreatedDate"] <= datetime.now(tz=tzlocal)
+    assert secrets["SecretList"][1]["CreatedDate"] <= datetime.now(tz=tzlocal)
+    assert secrets["SecretList"][0]["LastChangedDate"] <= datetime.now(tz=tzlocal)
+    assert secrets["SecretList"][1]["LastChangedDate"] <= datetime.now(tz=tzlocal)
 
 
 @mock_aws

--- a/tests/test_stepfunctions/test_stepfunctions.py
+++ b/tests/test_stepfunctions/test_stepfunctions.py
@@ -1,14 +1,13 @@
 import json
 import os
 import re
-from datetime import datetime
+from datetime import datetime, timezone
 from unittest import SkipTest, mock
 from uuid import uuid4
 
 import boto3
 import pytest
 from botocore.exceptions import ClientError, ParamValidationError
-from dateutil.tz import tzutc
 
 from moto import mock_aws
 from moto.core import DEFAULT_ACCOUNT_ID as ACCOUNT_ID
@@ -858,7 +857,7 @@ def test_state_machine_get_execution_history_throws_error_with_unknown_execution
 def test_state_machine_get_execution_history_contains_expected_success_events_when_started():
     expected_events = [
         {
-            "timestamp": datetime(2020, 1, 1, 0, 0, 0, tzinfo=tzutc()),
+            "timestamp": datetime(2020, 1, 1, 0, 0, 0, tzinfo=timezone.utc),
             "type": "ExecutionStarted",
             "id": 1,
             "previousEventId": 0,
@@ -869,7 +868,7 @@ def test_state_machine_get_execution_history_contains_expected_success_events_wh
             },
         },
         {
-            "timestamp": datetime(2020, 1, 1, 0, 0, 10, tzinfo=tzutc()),
+            "timestamp": datetime(2020, 1, 1, 0, 0, 10, tzinfo=timezone.utc),
             "type": "PassStateEntered",
             "id": 2,
             "previousEventId": 0,
@@ -880,7 +879,7 @@ def test_state_machine_get_execution_history_contains_expected_success_events_wh
             },
         },
         {
-            "timestamp": datetime(2020, 1, 1, 0, 0, 10, tzinfo=tzutc()),
+            "timestamp": datetime(2020, 1, 1, 0, 0, 10, tzinfo=timezone.utc),
             "type": "PassStateExited",
             "id": 3,
             "previousEventId": 2,
@@ -891,7 +890,7 @@ def test_state_machine_get_execution_history_contains_expected_success_events_wh
             },
         },
         {
-            "timestamp": datetime(2020, 1, 1, 0, 0, 20, tzinfo=tzutc()),
+            "timestamp": datetime(2020, 1, 1, 0, 0, 20, tzinfo=timezone.utc),
             "type": "ExecutionSucceeded",
             "id": 4,
             "previousEventId": 3,
@@ -953,7 +952,7 @@ def test_state_machine_get_execution_history_contains_expected_failure_events_wh
         raise SkipTest("Cant pass environment variable in server mode")
     expected_events = [
         {
-            "timestamp": datetime(2020, 1, 1, 0, 0, 0, tzinfo=tzutc()),
+            "timestamp": datetime(2020, 1, 1, 0, 0, 0, tzinfo=timezone.utc),
             "type": "ExecutionStarted",
             "id": 1,
             "previousEventId": 0,
@@ -964,7 +963,7 @@ def test_state_machine_get_execution_history_contains_expected_failure_events_wh
             },
         },
         {
-            "timestamp": datetime(2020, 1, 1, 0, 0, 10, tzinfo=tzutc()),
+            "timestamp": datetime(2020, 1, 1, 0, 0, 10, tzinfo=timezone.utc),
             "type": "FailStateEntered",
             "id": 2,
             "previousEventId": 0,
@@ -975,7 +974,7 @@ def test_state_machine_get_execution_history_contains_expected_failure_events_wh
             },
         },
         {
-            "timestamp": datetime(2020, 1, 1, 0, 0, 10, tzinfo=tzutc()),
+            "timestamp": datetime(2020, 1, 1, 0, 0, 10, tzinfo=timezone.utc),
             "type": "ExecutionFailed",
             "id": 3,
             "previousEventId": 2,

--- a/tests/test_swf/responses/test_decision_tasks.py
+++ b/tests/test_swf/responses/test_decision_tasks.py
@@ -1,10 +1,9 @@
 import re
-from datetime import datetime
+from datetime import datetime, timezone
 from time import sleep
 
 import pytest
 from botocore.exceptions import ClientError
-from dateutil.parser import parse as dtparse
 from freezegun import freeze_time
 
 from moto import mock_aws, settings
@@ -519,7 +518,7 @@ def test_respond_decision_task_completed_with_schedule_activity_task():
     assert isinstance(resp["latestActivityTaskTimestamp"], datetime)
     if not settings.TEST_SERVER_MODE:
         ts = resp["latestActivityTaskTimestamp"]
-        assert ts == dtparse("2015-01-01 12:00:00 UTC")
+        assert ts == datetime(2015, 1, 1, 12, 0, 00, tzinfo=timezone.utc)
 
 
 @mock_aws

--- a/tests/test_swf/responses/test_timeouts.py
+++ b/tests/test_swf/responses/test_timeouts.py
@@ -1,7 +1,6 @@
-from datetime import datetime
+from datetime import datetime, timezone
 from unittest import SkipTest
 
-from dateutil.parser import parse as dtparse
 from freezegun import freeze_time
 
 from moto import mock_aws, settings
@@ -47,9 +46,8 @@ def test_activity_task_heartbeat_timeout():
         attrs = resp["events"][-2]["activityTaskTimedOutEventAttributes"]
         assert attrs["timeoutType"] == "HEARTBEAT"
         # checks that event has been emitted at 12:05:00, not 12:05:30
-        assert isinstance(resp["events"][-2]["eventTimestamp"], datetime)
         ts = resp["events"][-2]["eventTimestamp"]
-        assert ts == dtparse("2015-01-01 12:05:00 UTC")
+        assert ts == datetime(2015, 1, 1, 12, 5, 00, tzinfo=timezone.utc)
 
 
 # Decision Task Start to Close timeout
@@ -98,9 +96,8 @@ def test_decision_task_start_to_close_timeout():
             "timeoutType": "START_TO_CLOSE",
         }
         # checks that event has been emitted at 12:05:00, not 12:05:30
-        assert isinstance(resp["events"][-2]["eventTimestamp"], datetime)
         ts = resp["events"][-2]["eventTimestamp"]
-        assert ts == dtparse("2015-01-01 12:05:00 UTC")
+        assert ts == datetime(2015, 1, 1, 12, 5, 00, tzinfo=timezone.utc)
 
 
 # Workflow Execution Start to Close timeout
@@ -137,6 +134,5 @@ def test_workflow_execution_start_to_close_timeout():
         attrs = resp["events"][-1]["workflowExecutionTimedOutEventAttributes"]
         assert attrs == {"childPolicy": "ABANDON", "timeoutType": "START_TO_CLOSE"}
         # checks that event has been emitted at 14:00:00, not 14:00:30
-        assert isinstance(resp["events"][-1]["eventTimestamp"], datetime)
         ts = resp["events"][-1]["eventTimestamp"]
-        assert ts == dtparse("2015-01-01 14:00:00 UTC")
+        assert ts == datetime(2015, 1, 1, 14, 0, 00, tzinfo=timezone.utc)


### PR DESCRIPTION
The `dateutil`-library is not very actively maintained (if not outright abandoned), and we only use it sparingly.

This PR:
 - Removes any usages where we can easily replace with a stdlib call (like `tzutc()` --> `datetime.timezone.utc`)
 - Replace any calls to `datetime.utcnow` to our custom `utcnow` method, just to remove some deprecation-warnings

There are two places where we still use `dateutil`, specifically the `parse` method:
1. Batch, where we parse the timestamp of Docker logs
2. CodeBuild, where we parse a datetime that we created earlier

The first one may be tricky, as the date format in the Docker logs may be configurable. The second one is definitely tricky, as the logic around date handling is really weird, and may need some refactoring at the same time.

But after those two are handled, we should be able to remove the `dateutil` dependency.