### PR TITLE
ResourceGroupsTaggingAPI: WorkspacesWeb: Fail gracefully for unsupported regions

### DIFF
--- a/moto/resourcegroupstaggingapi/models.py
+++ b/moto/resourcegroupstaggingapi/models.py
@@ -209,8 +209,8 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
 
     @property
     def workspacesweb_backends(self) -> Optional[WorkSpacesWebBackend]:
-        # Workspaces service has limited region availability
-        if self.region_name in workspaces_backends[self.account_id].regions:
+        # WorkspacesWeb service has limited region availability
+        if self.region_name in workspacesweb_backends[self.account_id].regions:
             return workspacesweb_backends[self.account_id][self.region_name]
         return None
 

--- a/tests/test_resourcegroupstaggingapi/test_resourcegroupstaggingapi_workspaces.py
+++ b/tests/test_resourcegroupstaggingapi/test_resourcegroupstaggingapi_workspaces.py
@@ -1,0 +1,122 @@
+import boto3
+
+from moto import mock_aws
+from tests.test_ds.test_ds_simple_ad_directory import create_test_directory
+
+
+def create_directory():
+    ec2_client = boto3.client("ec2", region_name="eu-central-1")
+    ds_client = boto3.client("ds", region_name="eu-central-1")
+    directory_id = create_test_directory(ds_client, ec2_client)
+    return directory_id
+
+
+@mock_aws
+def test_get_resources_workspaces():
+    workspaces = boto3.client("workspaces", region_name="eu-central-1")
+
+    # Create two tagged Workspaces
+    directory_id = create_directory()
+    workspaces.register_workspace_directory(DirectoryId=directory_id)
+    workspaces.create_workspaces(
+        Workspaces=[
+            {
+                "DirectoryId": directory_id,
+                "UserName": "Administrator",
+                "BundleId": "wsb-bh8rsxt14",
+                "Tags": [
+                    {"Key": "Test", "Value": "1"},
+                ],
+            },
+            {
+                "DirectoryId": directory_id,
+                "UserName": "Administrator",
+                "BundleId": "wsb-bh8rsxt14",
+                "Tags": [
+                    {"Key": "Test", "Value": "2"},
+                ],
+            },
+        ]
+    )
+
+    rtapi = boto3.client("resourcegroupstaggingapi", region_name="eu-central-1")
+
+    # Basic test
+    resp = rtapi.get_resources(ResourceTypeFilters=["workspaces"])
+    assert len(resp["ResourceTagMappingList"]) == 2
+
+    # Test tag filtering
+    resp = rtapi.get_resources(
+        ResourceTypeFilters=["workspaces"],
+        TagFilters=[{"Key": "Test", "Values": ["1"]}],
+    )
+    assert len(resp["ResourceTagMappingList"]) == 1
+    assert {"Key": "Test", "Value": "1"} in resp["ResourceTagMappingList"][0]["Tags"]
+
+
+@mock_aws
+def test_get_resources_workspace_directories():
+    workspaces = boto3.client("workspaces", region_name="eu-central-1")
+
+    # Create two tagged Workspaces Directories
+    for i in range(1, 3):
+        i_str = str(i)
+        directory_id = create_directory()
+        workspaces.register_workspace_directory(
+            DirectoryId=directory_id,
+            Tags=[{"Key": "Test", "Value": i_str}],
+        )
+
+    rtapi = boto3.client("resourcegroupstaggingapi", region_name="eu-central-1")
+
+    # Basic test
+    resp = rtapi.get_resources(ResourceTypeFilters=["workspaces-directory"])
+    assert len(resp["ResourceTagMappingList"]) == 2
+
+    # Test tag filtering
+    resp = rtapi.get_resources(
+        ResourceTypeFilters=["workspaces-directory"],
+        TagFilters=[{"Key": "Test", "Values": ["1"]}],
+    )
+    assert len(resp["ResourceTagMappingList"]) == 1
+    assert {"Key": "Test", "Value": "1"} in resp["ResourceTagMappingList"][0]["Tags"]
+
+
+@mock_aws
+def test_get_resources_workspace_images():
+    workspaces = boto3.client("workspaces", region_name="eu-central-1")
+
+    # Create two tagged Workspace Images
+    directory_id = create_directory()
+    workspaces.register_workspace_directory(DirectoryId=directory_id)
+    resp = workspaces.create_workspaces(
+        Workspaces=[
+            {
+                "DirectoryId": directory_id,
+                "UserName": "Administrator",
+                "BundleId": "wsb-bh8rsxt14",
+            },
+        ]
+    )
+    workspace_id = resp["PendingRequests"][0]["WorkspaceId"]
+    for i in range(1, 3):
+        i_str = str(i)
+        _ = workspaces.create_workspace_image(
+            Name=f"test-image-{i_str}",
+            Description="Test workspace image",
+            WorkspaceId=workspace_id,
+            Tags=[{"Key": "Test", "Value": i_str}],
+        )
+    rtapi = boto3.client("resourcegroupstaggingapi", region_name="eu-central-1")
+
+    # Basic test
+    resp = rtapi.get_resources(ResourceTypeFilters=["workspaces-image"])
+    assert len(resp["ResourceTagMappingList"]) == 2
+
+    # Test tag filtering
+    resp = rtapi.get_resources(
+        ResourceTypeFilters=["workspaces-image"],
+        TagFilters=[{"Key": "Test", "Values": ["1"]}],
+    )
+    assert len(resp["ResourceTagMappingList"]) == 1
+    assert {"Key": "Test", "Value": "1"} in resp["ResourceTagMappingList"][0]["Tags"]

--- a/tests/test_resourcegroupstaggingapi/test_resourcegroupstaggingapi_workspacesweb.py
+++ b/tests/test_resourcegroupstaggingapi/test_resourcegroupstaggingapi_workspacesweb.py
@@ -1,0 +1,60 @@
+import warnings
+
+import boto3
+
+from moto import mock_aws
+
+
+@mock_aws
+def test_get_resources_workspacesweb():
+    ww_client = boto3.client("workspaces-web", region_name="ap-southeast-1")
+    arn = ww_client.create_portal(
+        additionalEncryptionContext={"Key1": "Encryption", "Key2": "Context"},
+        authenticationType="Standard",
+        clientToken="TestClient",
+        customerManagedKey="abcd1234-5678-90ab-cdef-FAKEKEY",
+        displayName="TestDisplayName",
+        instanceType="TestInstanceType",
+        maxConcurrentSessions=5,
+        tags=[
+            {"Key": "TestKey", "Value": "TestValue"},
+            {"Key": "TestKey2", "Value": "TestValue2"},
+        ],
+    )["portalArn"]
+    rtapi = boto3.client("resourcegroupstaggingapi", region_name="ap-southeast-1")
+    resp = rtapi.get_resources(ResourceTypeFilters=["workspaces-web"])
+    assert len(resp["ResourceTagMappingList"]) == 1
+    assert {"Key": "TestKey", "Value": "TestValue"} in resp["ResourceTagMappingList"][
+        0
+    ]["Tags"]
+    resp = rtapi.get_resources(
+        ResourceTypeFilters=["workspaces-web"],
+        TagFilters=[{"Key": "TestKey3", "Values": ["TestValue3"]}],
+    )
+    assert len(resp["ResourceTagMappingList"]) == 0
+    ww_client.tag_resource(
+        resourceArn=arn, tags=[{"Key": "TestKey3", "Value": "TestValue3"}]
+    )
+    resp = rtapi.get_resources(
+        ResourceTypeFilters=["workspaces-web"],
+        TagFilters=[{"Key": "TestKey3", "Values": ["TestValue3"]}],
+    )
+    assert len(resp["ResourceTagMappingList"]) == 1
+
+
+@mock_aws
+def test_get_resources_workspacesweb_in_unknown_region():
+    session = boto3.Session()
+    all_regions = session.get_available_regions("ec2")
+    supported_regions = session.get_available_regions("workspaces-web")
+    unsupported_regions = [reg for reg in all_regions if reg not in supported_regions]
+    if not unsupported_regions:
+        warnings.warn(
+            "All regions supported - unable to test unsupported region", stacklevel=2
+        )
+        return
+
+    region = unsupported_regions[0]
+    rtapi = boto3.client("resourcegroupstaggingapi", region_name=region)
+    resp = rtapi.get_resources(ResourceTypeFilters=["workspaces-web"])
+    assert len(resp["ResourceTagMappingList"]) == 0


### PR DESCRIPTION
Not all regions are supported for `WorkspacesWeb`, so we should fail gracefully if the user wants to use an unsupported region. (That is: simply not return any resources)

I added one new test to verify this scenario, but most of the diff is just moving the `Workspaces`/`WorkspacesWeb` tests around to a new file.

Fixes #9527 