### PR TITLE
EC2: Verify LaunchTemplates tests against AWS

### DIFF
--- a/moto/ec2/models/launch_templates.py
+++ b/moto/ec2/models/launch_templates.py
@@ -89,7 +89,7 @@ class LaunchTemplate(TaggedEC2Resource, CloudFormationModel):
         return version
 
     def is_default(self, version: LaunchTemplateVersion) -> bool:
-        return self.default_version == version.number  # type: ignore
+        return self.default_version_number == version.number
 
     def get_version(self, num: Any) -> LaunchTemplateVersion:
         if str(num).lower() == "$latest":

--- a/moto/ec2/responses/launch_templates.py
+++ b/moto/ec2/responses/launch_templates.py
@@ -148,7 +148,7 @@ class LaunchTemplates(EC2BaseResponse):
                 {
                     "CreateTime": version.create_time,
                     "CreatedBy": f"arn:{self.partition}:iam::{self.current_account}:root",
-                    "DefaultVersion": True,
+                    "DefaultVersion": template.is_default(version),
                     "LaunchTemplateData": version.data,
                     "LaunchTemplateId": template.id,
                     "LaunchTemplateName": template.name,

--- a/tests/test_ec2/conftest.py
+++ b/tests/test_ec2/conftest.py
@@ -1,0 +1,20 @@
+import boto3
+import pytest
+
+from moto import mock_aws
+from tests import allow_aws_request
+
+
+@pytest.fixture(scope="session")
+def valid_ami():
+    path = "/aws/service/ami-amazon-linux-latest"
+    if allow_aws_request():
+        client = boto3.client("ssm", region_name="us-east-1")
+        param = client.get_parameters_by_path(Path=path, MaxResults=1)["Parameters"][0]
+    else:
+        with mock_aws():
+            client = boto3.client("ssm", region_name="us-east-1")
+            param = client.get_parameters_by_path(Path=path, MaxResults=1)[
+                "Parameters"
+            ][0]
+    yield param["Value"]


### PR DESCRIPTION
I was looking at #9374, and noticed a distinct lack of `aws_verified` tests in this area - that's why started with verifying that our existing tests run against AWS.

While doing that I found a small bug here, where the `DefaultVersion` wasn't correctly set/computed