### PR TITLE
EC2: Improved error handling around Launch Templates

### DIFF
--- a/IMPLEMENTATION_COVERAGE.md
+++ b/IMPLEMENTATION_COVERAGE.md
@@ -3111,7 +3111,7 @@
 - [ ] describe_ipams
 - [ ] describe_ipv6_pools
 - [X] describe_key_pairs
-- [ ] describe_launch_template_versions
+- [X] describe_launch_template_versions
 - [X] describe_launch_templates
 - [ ] describe_local_gateway_route_table_virtual_interface_group_associations
 - [ ] describe_local_gateway_route_table_vpc_associations

--- a/docs/docs/services/ec2.rst
+++ b/docs/docs/services/ec2.rst
@@ -376,7 +376,11 @@ ec2
 - [ ] describe_ipams
 - [ ] describe_ipv6_pools
 - [X] describe_key_pairs
-- [ ] describe_launch_template_versions
+- [X] describe_launch_template_versions
+  
+        The Filters-parameter is not yet implemented
+        
+
 - [X] describe_launch_templates
 - [ ] describe_local_gateway_route_table_virtual_interface_group_associations
 - [ ] describe_local_gateway_route_table_vpc_associations

--- a/moto/ec2/exceptions.py
+++ b/moto/ec2/exceptions.py
@@ -787,8 +787,25 @@ class InvalidLaunchTemplateNameNotFoundWithNameError(EC2ClientError):
     def __init__(self, name: str):
         super().__init__(
             "InvalidLaunchTemplateName.NotFoundException",
-            f"The specified launch template, with template name {name}, does not exist",
+            f"The specified launch template, with template name {name}, does not exist.",
         )
+
+
+class InvalidLaunchTemplateIdNotFound(EC2ClientError):
+    def __init__(self, template_id: str):
+        super().__init__(
+            "InvalidLaunchTemplateId.NotFound",
+            f"The specified launch template, with template ID {template_id}, does not exist.",
+        )
+
+
+class InvalidLaunchTemplateVersionNotFound(EC2ClientError):
+    def __init__(self, version: str, template_id: Optional[str] = None):
+        if template_id:
+            msg = f"Could not find the specified version {version} for the launch template with ID {template_id}."
+        else:
+            msg = f"The launch template version {version} is not found for the specified launch template."
+        super().__init__("InvalidLaunchTemplateId.VersionNotFound", msg)
 
 
 class InvalidParameterDependency(EC2ClientError):

--- a/moto/ec2/models/launch_templates.py
+++ b/moto/ec2/models/launch_templates.py
@@ -5,9 +5,13 @@ from moto.core.common_models import CloudFormationModel
 from moto.core.types import Base64EncodedString
 
 from ..exceptions import (
+    InvalidLaunchTemplateIdNotFound,
     InvalidLaunchTemplateNameAlreadyExistsError,
     InvalidLaunchTemplateNameNotFoundError,
     InvalidLaunchTemplateNameNotFoundWithNameError,
+    InvalidLaunchTemplateVersionNotFound,
+    InvalidParameterValue,
+    MissingParameter,
     MissingParameterError,
 )
 from ..utils import (
@@ -96,7 +100,10 @@ class LaunchTemplate(TaggedEC2Resource, CloudFormationModel):
             return self.versions[-1]
         if str(num).lower() == "$default":
             return self.default_version()
-        return self.versions[int(num) - 1]
+        try:
+            return self.versions[int(num) - 1]
+        except IndexError:
+            raise InvalidLaunchTemplateVersionNotFound(template_id=self.id, version=num)
 
     def default_version(self) -> LaunchTemplateVersion:
         return self.versions[self.default_version_number - 1]
@@ -248,11 +255,17 @@ class LaunchTemplateBackend:
             raise MissingParameterError("launch template ID or launch template name")
         if template_id not in self.launch_templates:
             raise InvalidLaunchTemplateNameNotFoundError()
-        self.launch_templates[template_id].default_version_number = int(default_version)
+        template = self.launch_templates[template_id]
+        if default_version not in [str(v.number) for v in template.versions]:
+            raise InvalidLaunchTemplateVersionNotFound(version=default_version)
+
+        template.default_version_number = int(default_version)
         template = self.launch_templates[template_id]
         return template
 
     def get_launch_template(self, template_id: str) -> LaunchTemplate:
+        if template_id not in self.launch_templates:
+            raise InvalidLaunchTemplateIdNotFound(template_id)
         return self.launch_templates[template_id]
 
     def get_launch_template_by_name(self, name: str) -> LaunchTemplate:
@@ -294,6 +307,58 @@ class LaunchTemplateBackend:
             templates = list(self.launch_templates.values())
 
         return generic_filter(filters, templates)
+
+    def describe_launch_template_versions(
+        self,
+        template_name: str,
+        template_id: str,
+        versions: list[str],
+        min_version: int,
+        max_version: int,
+        max_results: int,
+    ) -> list[tuple[LaunchTemplate, LaunchTemplateVersion]]:
+        """
+        The Filters-parameter is not yet implemented
+        """
+        wrong_param_msg = "To describe the launch template data for all your launch templates, for ‘--versions’ specify ‘$Latest’, ‘$Default’, or both, and omit ‘--launch-template-id’, ‘--launch-template-name’, and version numbers. To describe the launch template data for a specific launch template, specify ‘--launch-template-id’ or ‘--launch-template-name’, and for ‘--versions’ specify one or more of the following values: ‘$Latest’, ‘$Default’, or one or more version numbers."
+        if template_name:
+            template = self.get_launch_template_by_name(template_name)
+        elif template_id:
+            template = self.get_launch_template(template_id)
+        elif not versions:
+            raise MissingParameter(wrong_param_msg)
+        elif versions and ("$Latest" not in versions and "$Default" not in versions):
+            raise InvalidParameterValue(wrong_param_msg)
+        else:
+            template = None
+
+        ret_versions: list[tuple[LaunchTemplate, LaunchTemplateVersion]] = []
+        if versions and template:
+            for v in versions:
+                ret_versions.append((template, template.get_version(v)))
+        elif not template:
+            # Version has to have either $Latest and/or $Default at this point. This was already validated earlier, so here we can just iterate over both
+            for template in self.launch_templates.values():
+                if "$Latest" in versions:
+                    ret_versions.append((template, template.get_version("$Latest")))
+                if "$Default" in versions:
+                    ret_versions.append((template, template.get_version("$Default")))
+        elif min_version:
+            if max_version:
+                vMax = max_version
+            else:
+                vMax = min_version + max_results
+
+            vMin = min_version - 1
+            ret_versions = [(template, ver) for ver in template.versions[vMin:vMax]]
+        elif max_version:
+            vMax = max_version
+            ret_versions = [(template, ver) for ver in template.versions[:vMax]]
+        elif template is not None:
+            ret_versions = [(template, ver) for ver in template.versions]
+
+        ret_versions = ret_versions[:max_results]
+        return ret_versions
 
     def get_launch_template_data(self, instance_id: str) -> Any:
         return self.get_instance(instance_id)  # type: ignore[attr-defined]


### PR DESCRIPTION
Followup to #9543 

 - Moved the logic of `describe_launch_template_versions` to the Model, just to make sure it's picked up by the documentation
 - Improved error handling when calling `describe_launch_template_versions` with invalid parameters (for example, unknown template, no parameters)
 - Improved error handling for `modify_launch_template`

All scenarios are now covered by `aws_parity` tests.