### PR TITLE
EC2: remove invalid NextToken for DescribeInstanceCreditSpecifications

### DIFF
--- a/moto/ec2/responses/instances.py
+++ b/moto/ec2/responses/instances.py
@@ -241,7 +241,6 @@ class InstanceResponse(EC2BaseResponse):
                 {"InstanceId": instance.id, "CpuCredits": "standard"}
                 for instance in instances
             ],
-            "NextToken": "string",
         }
         return ActionResult(result)
 

--- a/other_langs/terraform/ec2/instances.tf
+++ b/other_langs/terraform/ec2/instances.tf
@@ -1,0 +1,22 @@
+data "aws_ssm_parameter" "amazon_linux_2023_x86_64" {
+  name = "/aws/service/ami-amazon-linux-latest/al2023-ami-kernel-default-x86_64"
+}
+
+data "aws_ssm_parameter" "amazon_linux_2023_arm64" {
+  name = "/aws/service/ami-amazon-linux-latest/al2023-ami-kernel-default-arm64"
+}
+
+resource "aws_instance" "example_arm64" {
+  ami = data.aws_ssm_parameter.amazon_linux_2023_arm64.value
+
+  # Use burstable instance type to trigger ec2:DescribeInstanceCreditSpecifications API call
+  instance_type = "t4g.small"
+}
+
+resource "aws_instance" "example_x86" {
+  ami = data.aws_ssm_parameter.amazon_linux_2023_x86_64.value
+
+  # Use burstable instance type to trigger ec2:DescribeInstanceCreditSpecifications API call
+  instance_type = "t2.micro"
+
+}

--- a/other_langs/terraform/ec2/provider.tf
+++ b/other_langs/terraform/ec2/provider.tf
@@ -15,6 +15,7 @@ provider "aws" {
 
   endpoints {
     ec2   = "http://localhost:5000"
+    ssm   = "http://localhost:5000"
   }
 
   access_key = "my-access-key"


### PR DESCRIPTION
This PR removes the invalid NextToken field and includes a Terraform test that was failing before the fix.

The invalid NexToken field was added due to a copy/paste error in #9471.

Closes #9559 