### PR TITLE
Scheduler: implement filtering/pagination for ListSchedules/ListScheduleGroups

### DIFF
--- a/moto/scheduler/responses.py
+++ b/moto/scheduler/responses.py
@@ -91,8 +91,21 @@ class EventBridgeSchedulerResponse(BaseResponse):
     def list_schedules(self) -> str:
         group_names = self.querystring.get("ScheduleGroup")
         state = self._get_param("State")
-        schedules = self.scheduler_backend.list_schedules(group_names, state)
-        return json.dumps({"Schedules": [sch.to_dict(short=True) for sch in schedules]})
+        name_prefix = self._get_param("NamePrefix")
+        next_token = self._get_param("NextToken")
+        max_results = self._get_int_param("MaxResults")
+        schedules, next_token = self.scheduler_backend.list_schedules(
+            group_names,
+            state,
+            name_prefix,
+            max_results=max_results,
+            next_token=next_token,
+        )
+        result = {
+            "Schedules": [sch.to_dict(short=True) for sch in schedules],
+            "NextToken": next_token,
+        }
+        return json.dumps(result)
 
     def create_schedule_group(self) -> str:
         name = self._get_param("Name")
@@ -114,8 +127,17 @@ class EventBridgeSchedulerResponse(BaseResponse):
         return "{}"
 
     def list_schedule_groups(self) -> str:
-        schedule_groups = self.scheduler_backend.list_schedule_groups()
-        return json.dumps({"ScheduleGroups": [sg.to_dict() for sg in schedule_groups]})
+        name_prefix = self._get_param("NamePrefix")
+        next_token = self._get_param("NextToken")
+        max_results = self._get_int_param("MaxResults")
+        schedule_groups, next_token = self.scheduler_backend.list_schedule_groups(
+            name_prefix, max_results=max_results, next_token=next_token
+        )
+        result = {
+            "ScheduleGroups": [sg.to_dict() for sg in schedule_groups],
+            "NextToken": next_token,
+        }
+        return json.dumps(result)
 
     def list_tags_for_resource(self) -> str:
         resource_arn = unquote(self.uri.split("/tags/")[-1])

--- a/tests/test_scheduler/test_schedule_groups.py
+++ b/tests/test_scheduler/test_schedule_groups.py
@@ -58,3 +58,37 @@ def test_get_schedule_groupe_not_found():
     assert err["Message"] == "Schedule group sg does not exist."
     assert err["Code"] == "ResourceNotFoundException"
     assert exc.value.response["ResponseMetadata"]["HTTPStatusCode"] == 404
+
+
+@mock_aws
+def test_list_schedule_groups_with_filters():
+    client = boto3.client("scheduler", region_name="ap-southeast-1")
+
+    # Create test schedule groups
+    groups_to_create = ["blabla-1", "blabla-2", "other-1", "blabla-3", "other-2"]
+
+    for group in groups_to_create:
+        client.create_schedule_group(Name=group)
+
+    # Test NamePrefix filter
+    groups = client.list_schedule_groups(NamePrefix="blabla")["ScheduleGroups"]
+    # +1 for default group
+    assert len(groups) == 3
+    group_names = [g["Name"] for g in groups if g["Name"] != "default"]
+    assert all(name.startswith("blabla") for name in group_names)
+    assert "other-1" not in group_names
+    assert "other-2" not in group_names
+
+    # Test MaxResults filter
+    groups = client.list_schedule_groups(MaxResults=2)["ScheduleGroups"]
+    assert len(groups) == 2
+    assert "NextToken" in client.list_schedule_groups(MaxResults=2)
+
+    # Test both filters together
+    groups = client.list_schedule_groups(NamePrefix="blabla", MaxResults=2)[
+        "ScheduleGroups"
+    ]
+    assert len(groups) == 2
+    filtered_groups = [g for g in groups if g["Name"] != "default"]
+    assert all(g["Name"].startswith("blabla") for g in filtered_groups)
+    assert "NextToken" in client.list_schedule_groups(NamePrefix="blabla", MaxResults=2)


### PR DESCRIPTION
Took the test cases from #8819 and implemented the logic using the Moto paginator utility (as had been requested in the original PR).

Supersedes/Closes #8819 