### PR TITLE
fix(dsql): Return creationTime as Unix timestamp instead of ISO 8601 string

### DIFF
--- a/moto/dsql/models.py
+++ b/moto/dsql/models.py
@@ -5,7 +5,7 @@ from typing import Any, Optional
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
-from moto.core.utils import iso_8601_datetime_with_milliseconds, utcnow
+from moto.core.utils import utcnow
 from moto.moto_api._internal import mock_random
 from moto.moto_api._internal.managed_state_model import ManagedState
 from moto.utilities.utils import get_partition
@@ -21,7 +21,7 @@ class Cluster(BaseModel, ManagedState):
             "identifier": self.identifier,
             "arn": self.arn,
             "status": self.status,
-            "creationTime": iso_8601_datetime_with_milliseconds(self.creation_time),
+            "creationTime": self.creation_time.timestamp(),
             "deletionProtectionEnabled": self.deletion_protection_enabled,
         }
         return {k: v for k, v in dct.items() if v is not None}


### PR DESCRIPTION
The AWS DSQL API returns creationTime as a Unix timestamp (number), not an ISO 8601 string. The Terraform AWS provider expects this format and fails to deserialize the response when it receives a string.

This fix changes the creationTime serialization from:
  `iso_8601_datetime_with_milliseconds(self.creation_time)`
to:
  `self.creation_time.timestamp()`

Fixes compatibility with terraform-provider-aws for aws_dsql_cluster resource.

Also aligned with [boto3 documentation](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/dsql/client/create_cluster.html)

docs show creationTime: `datetime(2015, 1, 1)` as the Python return type, but under the hood:

1. AWS API returns creationTime as Unix timestamp (number)
2. boto3/botocore deserializes it to Python datetime
3. Terraform AWS provider expects the raw JSON to have a number

The fix `self.creation_time.timestamp()` returns a float, which will correctly deserialized to datetime and TF will parse as JSON number