### PR TITLE
Tests: Move 'create_launch_template' functionality into existing @ec2_aws_verified decorator

### DIFF
--- a/tests/test_ec2/__init__.py
+++ b/tests/test_ec2/__init__.py
@@ -1,6 +1,7 @@
 from contextlib import nullcontext
 from functools import wraps
 from time import sleep
+from typing import Optional
 from uuid import uuid4
 
 import boto3
@@ -13,19 +14,39 @@ from tests import allow_aws_request
 pytest.register_assert_rewrite("tests.test_ec2.helpers")
 
 
+MINIMAL_LAUNCH_TEMPLATE_DATA = {
+    "TagSpecifications": [
+        {
+            "ResourceType": "instance",
+            "Tags": [{"Key": "test", "Value": "value"}],
+        }
+    ]
+}
+
+
 def ec2_aws_verified(
     create_vpc: bool = False,
     create_sg: bool = False,
     create_subnet: bool = False,
     create_transit_gateway: bool = False,
     create_customer_gateway: bool = False,
+    create_launch_template: bool = False,
+    launch_template_data: Optional[dict] = None,
+    return_launch_template_details: bool = False,
 ):
     """
-    Function that is verified to work against AWS.
-    Can be run against AWS at any time by setting:
-      MOTO_TEST_ALLOW_AWS_REQUEST=true
+        Function that is vMINIMAL_LAUNCH_TEMPLATE_DATE = {
+        "TagSpecifications": [
+            {
+                "ResourceType": "instance",
+                "Tags": [{"Key": "test", "Value": "value"}],
+            }
+        ]
+    }erified to work against AWS.
+        Can be run against AWS at any time by setting:
+          MOTO_TEST_ALLOW_AWS_REQUEST=true
 
-    If this environment variable is not set, the function runs in a `mock_aws` context.
+        If this environment variable is not set, the function runs in a `mock_aws` context.
 
     """
 
@@ -41,6 +62,9 @@ def ec2_aws_verified(
                     create_subnet=create_subnet,
                     create_transit_gateway=create_transit_gateway,
                     create_customer_gateway=create_customer_gateway,
+                    create_launch_template=create_launch_template,
+                    return_launch_template_details=return_launch_template_details,
+                    launch_template_data=launch_template_data,
                     func=func,
                     kwargs=kwargs,
                 )
@@ -56,13 +80,16 @@ def _invoke_func(
     create_subnet: bool,
     create_transit_gateway: bool,
     create_customer_gateway: bool,
+    create_launch_template: bool,
+    return_launch_template_details: bool,
+    launch_template_data: Optional[dict],
     func,
     kwargs,
 ):
     ec2_client = boto3.client("ec2", "us-east-1")
     kwargs["ec2_client"] = ec2_client
 
-    vpc_id = sg_id = subnet_id = tg_id = cg_id = None
+    vpc_id = sg_id = subnet_id = tg_id = cg_id = lt_name = None
     if create_vpc:
         vpc = ec2_client.create_vpc(
             CidrBlock="10.0.0.0/16",
@@ -101,9 +128,21 @@ def _invoke_func(
         cg_id = customer_gateway["CustomerGateway"]["CustomerGatewayId"]
         kwargs["cg_id"] = cg_id
 
+    if create_launch_template:
+        lt_name = str(uuid4())
+        creation = ec2_client.create_launch_template(
+            LaunchTemplateName=lt_name,
+            LaunchTemplateData=launch_template_data or MINIMAL_LAUNCH_TEMPLATE_DATA,
+        )
+        kwargs["launch_template_name"] = lt_name
+        if return_launch_template_details:
+            kwargs["launch_template_details"] = creation
+
     try:
         func(**kwargs)
     finally:
+        if lt_name:
+            ec2_client.delete_launch_template(LaunchTemplateName=lt_name)
         if cg_id:
             ec2_client.delete_customer_gateway(CustomerGatewayId=cg_id)
         if tg_id:

--- a/tests/test_ec2/test_launch_templates.py
+++ b/tests/test_ec2/test_launch_templates.py
@@ -1,4 +1,3 @@
-from functools import wraps
 from uuid import uuid4
 
 import boto3
@@ -6,85 +5,27 @@ import pytest
 from botocore.client import ClientError
 
 from moto import mock_aws, settings
-from tests import EXAMPLE_AMI_ID, allow_aws_request, aws_verified
+from tests import EXAMPLE_AMI_ID, aws_verified
+from tests.test_ec2 import MINIMAL_LAUNCH_TEMPLATE_DATA, ec2_aws_verified
 
 from .helpers import assert_dryrun_error
 
-MINIMAL_LAUNCH_TEMPLATE_DATE = {
-    "TagSpecifications": [
-        {
-            "ResourceType": "instance",
-            "Tags": [{"Key": "test", "Value": "value"}],
-        }
-    ]
-}
 
-
-def ec2_launch_template_aws_verified(
-    launch_template_data: dict = MINIMAL_LAUNCH_TEMPLATE_DATE,
-    pass_creation_response: bool = False,
-):
-    """
-    Function that is verified to work against AWS.
-    Can be run against AWS at any time by setting:
-      MOTO_TEST_ALLOW_AWS_REQUEST=true
-
-    If this environment variable is not set, the function runs in a `mock_aws` context.
-
-    This decorator will:
-      - Create a launch template
-      - Run the test and pass the name as an argument
-      - Delete the launch template
-    """
-
-    def inner(func):
-        @wraps(func)
-        def pagination_wrapper(**kwargs):
-            template_name = str(uuid4())
-
-            def create_launch_template_and_test():
-                client = boto3.client("ec2", region_name="us-east-1")
-
-                creation = client.create_launch_template(
-                    LaunchTemplateName=template_name,
-                    LaunchTemplateData=launch_template_data,
-                )
-                kwargs["template_name"] = template_name
-                if pass_creation_response:
-                    kwargs["creation"] = creation
-                try:
-                    resp = func(**kwargs)
-                finally:
-                    client.delete_launch_template(LaunchTemplateName=template_name)
-
-                return resp
-
-            if allow_aws_request():
-                return create_launch_template_and_test()
-            else:
-                with mock_aws():
-                    return create_launch_template_and_test()
-
-        return pagination_wrapper
-
-    return inner
-
-
-@ec2_launch_template_aws_verified(pass_creation_response=True)
+@ec2_aws_verified(create_launch_template=True, return_launch_template_details=True)
 @pytest.mark.aws_verified
-def test_launch_template_create(template_name=None, creation=None):
-    cli = boto3.client("ec2", region_name="us-east-1")
-
-    assert "LaunchTemplate" in creation
-    lt = creation["LaunchTemplate"]
-    assert lt["LaunchTemplateName"] == template_name
+def test_launch_template_create(
+    ec2_client=None, launch_template_name=None, launch_template_details=None
+):
+    assert "LaunchTemplate" in launch_template_details
+    lt = launch_template_details["LaunchTemplate"]
+    assert lt["LaunchTemplateName"] == launch_template_name
     assert lt["DefaultVersionNumber"] == 1
     assert lt["LatestVersionNumber"] == 1
 
     with pytest.raises(ClientError) as ex:
-        cli.create_launch_template(
-            LaunchTemplateName=template_name,
-            LaunchTemplateData=MINIMAL_LAUNCH_TEMPLATE_DATE,
+        ec2_client.create_launch_template(
+            LaunchTemplateName=launch_template_name,
+            LaunchTemplateData=MINIMAL_LAUNCH_TEMPLATE_DATA,
         )
 
     assert (
@@ -111,43 +52,43 @@ def test_create_launch_template__dryrun():
     assert_dryrun_error(exc)
 
 
-@ec2_launch_template_aws_verified(pass_creation_response=True)
+@ec2_aws_verified(create_launch_template=True, return_launch_template_details=True)
 @pytest.mark.aws_verified
-def test_describe_launch_template_versions(template_name=None, creation=None):
-    cli = boto3.client("ec2", region_name="us-east-1")
-
+def test_describe_launch_template_versions(
+    ec2_client=None, launch_template_name=None, launch_template_details=None
+):
     # test using name
-    resp = cli.describe_launch_template_versions(
-        LaunchTemplateName=template_name, Versions=["1"]
+    resp = ec2_client.describe_launch_template_versions(
+        LaunchTemplateName=launch_template_name, Versions=["1"]
     )
 
     templ = resp["LaunchTemplateVersions"][0]["LaunchTemplateData"]
-    assert templ == MINIMAL_LAUNCH_TEMPLATE_DATE
+    assert templ == MINIMAL_LAUNCH_TEMPLATE_DATA
 
     # test using id
-    resp = cli.describe_launch_template_versions(
-        LaunchTemplateId=creation["LaunchTemplate"]["LaunchTemplateId"],
+    resp = ec2_client.describe_launch_template_versions(
+        LaunchTemplateId=launch_template_details["LaunchTemplate"]["LaunchTemplateId"],
         Versions=["1"],
     )
 
     templ = resp["LaunchTemplateVersions"][0]["LaunchTemplateData"]
-    assert templ == MINIMAL_LAUNCH_TEMPLATE_DATE
+    assert templ == MINIMAL_LAUNCH_TEMPLATE_DATA
 
     # test using $Latest version
-    resp = cli.describe_launch_template_versions(
-        LaunchTemplateName=template_name, Versions=["$Latest"]
+    resp = ec2_client.describe_launch_template_versions(
+        LaunchTemplateName=launch_template_name, Versions=["$Latest"]
     )
 
     templ = resp["LaunchTemplateVersions"][0]["LaunchTemplateData"]
-    assert templ == MINIMAL_LAUNCH_TEMPLATE_DATE
+    assert templ == MINIMAL_LAUNCH_TEMPLATE_DATA
 
     # test using $Default version
-    resp = cli.describe_launch_template_versions(
-        LaunchTemplateName=template_name, Versions=["$Default"]
+    resp = ec2_client.describe_launch_template_versions(
+        LaunchTemplateName=launch_template_name, Versions=["$Default"]
     )
 
     templ = resp["LaunchTemplateVersions"][0]["LaunchTemplateData"]
-    assert templ == MINIMAL_LAUNCH_TEMPLATE_DATE
+    assert templ == MINIMAL_LAUNCH_TEMPLATE_DATA
 
 
 @mock_aws
@@ -197,14 +138,14 @@ def test_describe_launch_template_versions_with_just_version():
     )
 
 
-@ec2_launch_template_aws_verified(pass_creation_response=True)
+@ec2_aws_verified(create_launch_template=True, return_launch_template_details=True)
 @pytest.mark.aws_verified
-def test_create_launch_template_version(template_name=None, creation=None):
-    cli = boto3.client("ec2", region_name="us-east-1")
-
-    launch_template_id = creation["LaunchTemplate"]["LaunchTemplateId"]
-    version_resp = cli.create_launch_template_version(
-        LaunchTemplateName=template_name,
+def test_create_launch_template_version(
+    ec2_client=None, launch_template_name=None, launch_template_details=None
+):
+    launch_template_id = launch_template_details["LaunchTemplate"]["LaunchTemplateId"]
+    version_resp = ec2_client.create_launch_template_version(
+        LaunchTemplateName=launch_template_name,
         LaunchTemplateData={"ImageId": "ami-def456"},
         VersionDescription="new ami",
     )
@@ -237,14 +178,14 @@ def test_create_launch_template_version__dryrun():
     assert_dryrun_error(exc)
 
 
-@ec2_launch_template_aws_verified(pass_creation_response=True)
+@ec2_aws_verified(create_launch_template=True, return_launch_template_details=True)
 @pytest.mark.aws_verified
-def test_create_launch_template_version_by_id(template_name=None, creation=None):
-    cli = boto3.client("ec2", region_name="us-east-1")
+def test_create_launch_template_version_by_id(
+    ec2_client=None, launch_template_name=None, launch_template_details=None
+):
+    launch_template_id = launch_template_details["LaunchTemplate"]["LaunchTemplateId"]
 
-    launch_template_id = creation["LaunchTemplate"]["LaunchTemplateId"]
-
-    version_resp = cli.create_launch_template_version(
+    version_resp = ec2_client.create_launch_template_version(
         LaunchTemplateId=launch_template_id,
         LaunchTemplateData={"ImageId": "ami-def456"},
         VersionDescription="new ami",
@@ -258,67 +199,65 @@ def test_create_launch_template_version_by_id(template_name=None, creation=None)
     assert version["VersionNumber"] == 2
 
 
-@ec2_launch_template_aws_verified()
+@ec2_aws_verified(create_launch_template=True)
 @pytest.mark.aws_verified
-def test_describe_launch_template_versions_with_multiple_versions(template_name=None):
-    cli = boto3.client("ec2", region_name="us-east-1")
-
-    cli.create_launch_template_version(
-        LaunchTemplateName=template_name,
+def test_describe_launch_template_versions_with_multiple_versions(
+    ec2_client=None, launch_template_name=None
+):
+    ec2_client.create_launch_template_version(
+        LaunchTemplateName=launch_template_name,
         LaunchTemplateData={"ImageId": "ami-def456"},
         VersionDescription="new ami",
     )
 
-    versions = cli.describe_launch_template_versions(LaunchTemplateName=template_name)[
-        "LaunchTemplateVersions"
-    ]
+    versions = ec2_client.describe_launch_template_versions(
+        LaunchTemplateName=launch_template_name
+    )["LaunchTemplateVersions"]
 
     assert len(versions) == 2
     version1 = next(v for v in versions if v["VersionNumber"] == 1)
     version2 = next(v for v in versions if v["VersionNumber"] == 2)
 
     assert version1["LaunchTemplateId"] == version2["LaunchTemplateId"]
-    assert version1["LaunchTemplateName"] == template_name
+    assert version1["LaunchTemplateName"] == launch_template_name
     assert version1["LaunchTemplateName"] == version2["LaunchTemplateName"]
 
-    assert version1["LaunchTemplateData"] == MINIMAL_LAUNCH_TEMPLATE_DATE
+    assert version1["LaunchTemplateData"] == MINIMAL_LAUNCH_TEMPLATE_DATA
     assert version2["LaunchTemplateData"] == {"ImageId": "ami-def456"}
 
     assert version1["DefaultVersion"] is True
     assert version2["DefaultVersion"] is False
 
 
-@ec2_launch_template_aws_verified()
+@ec2_aws_verified(create_launch_template=True)
 @pytest.mark.aws_verified
 def test_describe_launch_template_versions_with_versions_option(
-    valid_ami, template_name=None
+    valid_ami, ec2_client=None, launch_template_name=None
 ):
-    cli = boto3.client("ec2", region_name="us-east-1")
-
-    cli.create_launch_template_version(
-        LaunchTemplateName=template_name,
+    ec2_client.create_launch_template_version(
+        LaunchTemplateName=launch_template_name,
         LaunchTemplateData={"ImageId": "ami-def456"},
         VersionDescription="new ami",
     )
 
-    cli.create_launch_template_version(
-        LaunchTemplateName=template_name,
+    ec2_client.create_launch_template_version(
+        LaunchTemplateName=launch_template_name,
         # AWS will happily accept a fake AMI for the first version
         # But passing in a fake AMI for the second version, it will complain about the format (?)
         LaunchTemplateData={"ImageId": valid_ami},
         VersionDescription="new ami, again",
     )
 
-    versions = cli.describe_launch_template_versions(
-        LaunchTemplateName=template_name, Versions=["3"]
+    versions = ec2_client.describe_launch_template_versions(
+        LaunchTemplateName=launch_template_name, Versions=["3"]
     )["LaunchTemplateVersions"]
     assert len(versions) == 1
     assert versions[0]["LaunchTemplateData"]["ImageId"] == valid_ami
     assert versions[0]["DefaultVersion"] is False
     assert versions[0]["VersionDescription"] == "new ami, again"
 
-    versions = cli.describe_launch_template_versions(
-        LaunchTemplateName=template_name, Versions=["2", "3"]
+    versions = ec2_client.describe_launch_template_versions(
+        LaunchTemplateName=launch_template_name, Versions=["2", "3"]
     )["LaunchTemplateVersions"]
 
     assert len(versions) == 2
@@ -479,17 +418,15 @@ def test_describe_launch_template_versions_with_wrong_id():
     )
 
 
-@ec2_launch_template_aws_verified(pass_creation_response=True)
+@ec2_aws_verified(create_launch_template=True, return_launch_template_details=True)
 @pytest.mark.aws_verified
 def test_describe_launch_template_versions_with_wrong_version(
-    template_name=None, creation=None
+    ec2_client=None, launch_template_name=None, launch_template_details=None
 ):
-    cli = boto3.client("ec2", region_name="us-east-1")
-
-    lt_id = creation["LaunchTemplate"]["LaunchTemplateId"]
+    lt_id = launch_template_details["LaunchTemplate"]["LaunchTemplateId"]
     with pytest.raises(ClientError) as exc:
-        cli.describe_launch_template_versions(
-            LaunchTemplateName=template_name, Versions=["3"]
+        ec2_client.describe_launch_template_versions(
+            LaunchTemplateName=launch_template_name, Versions=["3"]
         )
     err = exc.value.response["Error"]
     assert err["Code"] == "InvalidLaunchTemplateId.VersionNotFound"
@@ -904,28 +841,27 @@ def test_launch_template_describe_with_tags():
     assert lt["Tags"][0] == {"Key": "test1", "Value": "value1"}
 
 
-@ec2_launch_template_aws_verified()
+@ec2_aws_verified(create_launch_template=True)
 @pytest.mark.aws_verified
-def test_modify_launch_template_by_name(template_name=None):
-    cli = boto3.client("ec2", region_name="us-east-1")
-
-    cli.create_launch_template_version(
-        LaunchTemplateName=template_name, LaunchTemplateData={"ImageId": "ami-def456"}
+def test_modify_launch_template_by_name(ec2_client=None, launch_template_name=None):
+    ec2_client.create_launch_template_version(
+        LaunchTemplateName=launch_template_name,
+        LaunchTemplateData={"ImageId": "ami-def456"},
     )
 
-    resp = cli.modify_launch_template(
-        LaunchTemplateName=template_name, DefaultVersion="2"
+    resp = ec2_client.modify_launch_template(
+        LaunchTemplateName=launch_template_name, DefaultVersion="2"
     )
     assert resp["LaunchTemplate"]["DefaultVersionNumber"] == 2
 
-    template = cli.describe_launch_templates(LaunchTemplateNames=[template_name])[
-        "LaunchTemplates"
-    ][0]
+    template = ec2_client.describe_launch_templates(
+        LaunchTemplateNames=[launch_template_name]
+    )["LaunchTemplates"][0]
     assert template["DefaultVersionNumber"] == 2
 
-    versions = cli.describe_launch_template_versions(LaunchTemplateName=template_name)[
-        "LaunchTemplateVersions"
-    ]
+    versions = ec2_client.describe_launch_template_versions(
+        LaunchTemplateName=launch_template_name
+    )["LaunchTemplateVersions"]
 
     version1 = next(v for v in versions if v["VersionNumber"] == 1)
     version2 = next(v for v in versions if v["VersionNumber"] == 2)
@@ -933,29 +869,31 @@ def test_modify_launch_template_by_name(template_name=None):
     assert version2["DefaultVersion"] is True
 
 
-@ec2_launch_template_aws_verified(pass_creation_response=True)
+@ec2_aws_verified(create_launch_template=True, return_launch_template_details=True)
 @pytest.mark.aws_verified
-def test_modify_launch_template_by_id(template_name=None, creation=None):
-    cli = boto3.client("ec2", region_name="us-east-1")
-
-    template_id = creation["LaunchTemplate"]["LaunchTemplateId"]
-    cli.create_launch_template_version(
+def test_modify_launch_template_by_id(
+    ec2_client=None, launch_template_name=None, launch_template_details=None
+):
+    template_id = launch_template_details["LaunchTemplate"]["LaunchTemplateId"]
+    ec2_client.create_launch_template_version(
         LaunchTemplateId=template_id,
         LaunchTemplateData={"ImageId": "ami-def456"},
     )
 
-    resp = cli.modify_launch_template(LaunchTemplateId=template_id, DefaultVersion="2")
+    resp = ec2_client.modify_launch_template(
+        LaunchTemplateId=template_id, DefaultVersion="2"
+    )
 
     assert resp["LaunchTemplate"]["DefaultVersionNumber"] == 2
 
-    template = cli.describe_launch_templates(LaunchTemplateNames=[template_name])[
-        "LaunchTemplates"
-    ][0]
+    template = ec2_client.describe_launch_templates(
+        LaunchTemplateNames=[launch_template_name]
+    )["LaunchTemplates"][0]
     assert template["DefaultVersionNumber"] == 2
 
-    versions = cli.describe_launch_template_versions(LaunchTemplateName=template_name)[
-        "LaunchTemplateVersions"
-    ]
+    versions = ec2_client.describe_launch_template_versions(
+        LaunchTemplateName=launch_template_name
+    )["LaunchTemplateVersions"]
 
     version1 = next(v for v in versions if v["VersionNumber"] == 1)
     version2 = next(v for v in versions if v["VersionNumber"] == 2)
@@ -963,15 +901,15 @@ def test_modify_launch_template_by_id(template_name=None, creation=None):
     assert version2["DefaultVersion"] is True
 
 
-@ec2_launch_template_aws_verified()
+@ec2_aws_verified(create_launch_template=True)
 @pytest.mark.aws_verified
-def test_modify_launch_template_by_name_and_id(template_name=None):
-    cli = boto3.client("ec2", region_name="us-east-1")
-
+def test_modify_launch_template_by_name_and_id(
+    ec2_client=None, launch_template_name=None
+):
     with pytest.raises(ClientError) as exc:
-        cli.modify_launch_template(
+        ec2_client.modify_launch_template(
             LaunchTemplateId="template_n",
-            LaunchTemplateName=template_name,
+            LaunchTemplateName=launch_template_name,
             DefaultVersion="2",
         )
     err = exc.value.response["Error"]
@@ -982,13 +920,15 @@ def test_modify_launch_template_by_name_and_id(template_name=None):
     )
 
 
-@ec2_launch_template_aws_verified()
+@ec2_aws_verified(create_launch_template=True)
 @pytest.mark.aws_verified
-def test_modify_launch_template_with_unknown_version(template_name=None):
-    cli = boto3.client("ec2", region_name="us-east-1")
-
+def test_modify_launch_template_with_unknown_version(
+    ec2_client=None, launch_template_name=None
+):
     with pytest.raises(ClientError) as exc:
-        cli.modify_launch_template(LaunchTemplateName=template_name, DefaultVersion="2")
+        ec2_client.modify_launch_template(
+            LaunchTemplateName=launch_template_name, DefaultVersion="2"
+        )
     err = exc.value.response["Error"]
     assert err["Code"] == "InvalidLaunchTemplateId.VersionNotFound"
     assert (


### PR DESCRIPTION
All the other `aws_verified` functionality (creating VPC's, subnets, etc) is already part of the `ec2_aws_verified` decorator, so it only makes sense to also add the option to create launch templates this way.