### PR TITLE
Autoscaling: Improve parity around LaunchTemplates

### DIFF
--- a/moto/autoscaling/models.py
+++ b/moto/autoscaling/models.py
@@ -151,7 +151,7 @@ class InstanceState:
         lt = {
             "LaunchTemplateId": self.auto_scaling_group.ec2_launch_template.id,
             "LaunchTemplateName": self.auto_scaling_group.ec2_launch_template.name,
-            "Version": self.auto_scaling_group.launch_template_version,
+            "Version": self.auto_scaling_group.ec2_launch_template.default_version_number,
         }
         return lt
 
@@ -589,6 +589,20 @@ class FakeAutoScalingGroup(CloudFormationModel):
         # Will be None if self.launch_template is used instead
         self.launch_config: FakeLaunchConfiguration = None  # type: ignore[assignment]
 
+        # Some defaults, if not set
+        if (
+            self.mixed_instances_policy
+            and "InstancesDistribution" not in self.mixed_instances_policy
+            and "Overrides" not in self.mixed_instances_policy.get("LaunchTemplate", {})
+        ):
+            self.mixed_instances_policy["InstancesDistribution"] = {
+                "OnDemandAllocationStrategy": "prioritized",
+                "OnDemandBaseCapacity": 0,
+                "OnDemandPercentageAboveBaseCapacity": 100,
+                "SpotAllocationStrategy": "lowest-price",
+                "SpotInstancePools": 2,
+            }
+
         self._set_launch_configuration(
             launch_config_name, launch_template, mixed_instances_policy
         )
@@ -763,6 +777,15 @@ class FakeAutoScalingGroup(CloudFormationModel):
                 except (AttributeError, KeyError, TypeError):
                     pass
 
+            try:
+                if (
+                    self.mixed_instances_policy
+                    and "Overrides" not in self.mixed_instances_policy["LaunchTemplate"]
+                ):
+                    self.mixed_instances_policy["LaunchTemplate"]["Overrides"] = []
+            except (AttributeError, KeyError, TypeError):
+                pass
+
     @staticmethod
     def cloudformation_name_type() -> str:
         return "AutoScalingGroupName"
@@ -789,7 +812,7 @@ class FakeAutoScalingGroup(CloudFormationModel):
         target_group_arns = properties.get("TargetGroupARNs", [])
         mixed_instances_policy = properties.get("MixedInstancesPolicy", {})
 
-        backend = autoscaling_backends[account_id][region_name]
+        backend: AutoScalingBackend = autoscaling_backends[account_id][region_name]
         group = backend.create_auto_scaling_group(
             name=resource_name,
             availability_zones=properties.get("AvailabilityZones", []),

--- a/tests/test_autoscaling/__init__.py
+++ b/tests/test_autoscaling/__init__.py
@@ -1,1 +1,78 @@
-# This file is intentionally left blank.
+from contextlib import nullcontext
+from functools import wraps
+from uuid import uuid4
+
+import boto3
+import pytest
+
+from moto import mock_aws
+from tests import allow_aws_request
+
+pytest.register_assert_rewrite("tests.test_ec2.helpers")
+
+
+def autoscaling_aws_verified(
+    create_auto_scaling_group: bool = False,
+    get_group_name: bool = False,
+):
+    def inner(func):
+        @wraps(func)
+        def pagination_wrapper(**kwargs):
+            context = nullcontext() if allow_aws_request() else mock_aws()
+
+            with context:
+                return _invoke_func(
+                    create_auto_scaling_group=create_auto_scaling_group,
+                    get_group_name=get_group_name,
+                    func=func,
+                    kwargs=kwargs,
+                )
+
+        return pagination_wrapper
+
+    return inner
+
+
+def _invoke_func(
+    create_auto_scaling_group: bool,
+    get_group_name: bool,
+    func,
+    kwargs,
+):
+    autoscaling_client = boto3.client("autoscaling", "us-east-1")
+    kwargs["autoscaling_client"] = autoscaling_client
+
+    autoscaling_group_name = None
+    if create_auto_scaling_group:
+        # TODO - actually create one
+        autoscaling_group_name = str(uuid4())
+        kwargs["autoscaling_group_name"] = autoscaling_group_name
+    elif get_group_name:
+        # User will create it - let's still create a name, so we can delete it for them
+        autoscaling_group_name = str(uuid4())
+        kwargs["autoscaling_group_name"] = autoscaling_group_name
+
+    try:
+        func(**kwargs)
+    finally:
+        if autoscaling_group_name:
+            groups = autoscaling_client.describe_auto_scaling_groups(
+                AutoScalingGroupNames=[autoscaling_group_name]
+            )["AutoScalingGroups"]
+
+            if not groups:
+                # group was never created in the first place
+                pass
+            else:
+                group = groups[0]
+                autoscaling_client.delete_auto_scaling_group(
+                    AutoScalingGroupName=autoscaling_group_name,
+                    # Delete underlying instances as well
+                    ForceDelete=True,
+                )
+
+                # Wait until instances are terminated
+                ec2_client = boto3.client("ec2", "us-east-1")
+                waiter = ec2_client.get_waiter("instance_terminated")
+                instances = group["Instances"]
+                waiter.wait(InstanceIds=[inst["InstanceId"] for inst in instances])

--- a/tests/test_autoscaling/test_autoscaling.py
+++ b/tests/test_autoscaling/test_autoscaling.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from time import sleep
 from uuid import uuid4
 
 import boto3
@@ -9,6 +10,9 @@ from moto import mock_aws
 from moto.core import DEFAULT_ACCOUNT_ID as ACCOUNT_ID
 from moto.core.types import Base64EncodedString
 from tests import EXAMPLE_AMI_ID, aws_verified
+from tests.test_autoscaling import autoscaling_aws_verified
+from tests.test_ec2 import ec2_aws_verified
+from tests.test_ec2.conftest import get_valid_ami
 
 from .utils import setup_instance_with_networking, setup_networking
 
@@ -133,18 +137,29 @@ def test_create_autoscaling_group_from_invalid_instance_id():
     assert err["Message"] == f"Instance [{invalid_instance_id}] is invalid."
 
 
-@mock_aws
-def test_create_autoscaling_group_from_template():
-    mocked_networking = setup_networking()
-
-    ec2_client = boto3.client("ec2", region_name="us-east-1")
-    template = ec2_client.create_launch_template(
-        LaunchTemplateName="test_launch_template",
-        LaunchTemplateData={"ImageId": EXAMPLE_AMI_ID, "InstanceType": "t2.micro"},
-    )["LaunchTemplate"]
-    client = boto3.client("autoscaling", region_name="us-east-1")
-    response = client.create_auto_scaling_group(
-        AutoScalingGroupName="test_asg",
+# Create LaunchTemplate first, and delete it last
+# If we first delete the Launch Template and then delete the AutoScalingGroup, AWS will show a notification in the console (even if it's only for a few milliseconds)
+@ec2_aws_verified(
+    create_vpc=True,
+    create_subnet=True,
+    create_launch_template=True,
+    launch_template_data={"ImageId": get_valid_ami(), "InstanceType": "t2.medium"},
+    return_launch_template_details=True,
+)
+@autoscaling_aws_verified(get_group_name=True)
+@pytest.mark.aws_verified
+def test_create_autoscaling_group_from_template(
+    autoscaling_client=None,
+    autoscaling_group_name=None,
+    ec2_client=None,
+    vpc_id=None,
+    subnet_id=None,
+    launch_template_name=None,
+    launch_template_details=None,
+):
+    template = launch_template_details["LaunchTemplate"]
+    response = autoscaling_client.create_auto_scaling_group(
+        AutoScalingGroupName=autoscaling_group_name,
         LaunchTemplate={
             "LaunchTemplateId": template["LaunchTemplateId"],
             "Version": str(template["LatestVersionNumber"]),
@@ -152,7 +167,7 @@ def test_create_autoscaling_group_from_template():
         MinSize=1,
         MaxSize=3,
         DesiredCapacity=2,
-        VPCZoneIdentifier=mocked_networking["subnet1"],
+        VPCZoneIdentifier=subnet_id,
         NewInstancesProtectedFromScaleIn=False,
     )
     assert response["ResponseMetadata"]["HTTPStatusCode"] == 200
@@ -187,22 +202,25 @@ def test_create_auto_scaling_from_template_version__latest():
     assert response["LaunchTemplate"]["Version"] == "$Latest"
 
 
-@mock_aws
-def test_create_auto_scaling_from_template_version__default():
-    ec2_client = boto3.client("ec2", region_name="us-west-1")
-    launch_template_name = "tester"
-    ec2_client.create_launch_template(
-        LaunchTemplateName=launch_template_name,
-        LaunchTemplateData={"ImageId": EXAMPLE_AMI_ID, "InstanceType": "t2.medium"},
-    )
+@ec2_aws_verified(
+    create_launch_template=True,
+    launch_template_data={"ImageId": get_valid_ami(), "InstanceType": "t2.medium"},
+)
+@autoscaling_aws_verified(get_group_name=True)
+@pytest.mark.aws_verified
+def test_create_auto_scaling_from_template_version__default(
+    autoscaling_client=None,
+    autoscaling_group_name=None,
+    ec2_client=None,
+    launch_template_name=None,
+):
     ec2_client.create_launch_template_version(
         LaunchTemplateName=launch_template_name,
-        LaunchTemplateData={"ImageId": EXAMPLE_AMI_ID, "InstanceType": "t3.medium"},
+        LaunchTemplateData={"ImageId": get_valid_ami(), "InstanceType": "t3.medium"},
         VersionDescription="v2",
     )
-    asg_client = boto3.client("autoscaling", region_name="us-west-1")
-    asg_client.create_auto_scaling_group(
-        AutoScalingGroupName="name",
+    autoscaling_client.create_auto_scaling_group(
+        AutoScalingGroupName=autoscaling_group_name,
         DesiredCapacity=1,
         MinSize=1,
         MaxSize=1,
@@ -210,63 +228,63 @@ def test_create_auto_scaling_from_template_version__default():
             "LaunchTemplateName": launch_template_name,
             "Version": "$Default",
         },
-        AvailabilityZones=["us-west-1a"],
+        AvailabilityZones=["us-east-1a"],
     )
 
-    response = asg_client.describe_auto_scaling_groups(AutoScalingGroupNames=["name"])[
-        "AutoScalingGroups"
-    ][0]
-    assert "LaunchTemplate" in response
-    assert response["LaunchTemplate"]["LaunchTemplateName"] == launch_template_name
-    assert response["LaunchTemplate"]["Version"] == "$Default"
+    launch_template = autoscaling_client.describe_auto_scaling_groups(
+        AutoScalingGroupNames=[autoscaling_group_name]
+    )["AutoScalingGroups"][0]["LaunchTemplate"]
+    assert launch_template["LaunchTemplateName"] == launch_template_name
+    assert launch_template["Version"] == "$Default"
 
 
-@mock_aws
-def test_create_auto_scaling_from_template_version__no_version():
-    ec2_client = boto3.client("ec2", region_name="us-west-1")
-    launch_template_name = "tester"
-    ec2_client.create_launch_template(
-        LaunchTemplateName=launch_template_name,
-        LaunchTemplateData={"ImageId": EXAMPLE_AMI_ID, "InstanceType": "t2.medium"},
-    )
-    asg_client = boto3.client("autoscaling", region_name="us-west-1")
-    asg_client.create_auto_scaling_group(
-        AutoScalingGroupName="name",
+@ec2_aws_verified(
+    create_launch_template=True,
+    launch_template_data={"ImageId": get_valid_ami(), "InstanceType": "t2.medium"},
+)
+@autoscaling_aws_verified(get_group_name=True)
+@pytest.mark.aws_verified
+def test_create_auto_scaling_from_template_version__no_version(
+    autoscaling_client=None,
+    autoscaling_group_name=None,
+    ec2_client=None,
+    launch_template_name=None,
+):
+    autoscaling_client.create_auto_scaling_group(
+        AutoScalingGroupName=autoscaling_group_name,
         DesiredCapacity=1,
         MinSize=1,
         MaxSize=1,
         LaunchTemplate={"LaunchTemplateName": launch_template_name},
-        AvailabilityZones=["us-west-1a"],
+        AvailabilityZones=["us-east-1a"],
     )
 
-    response = asg_client.describe_auto_scaling_groups(AutoScalingGroupNames=["name"])[
-        "AutoScalingGroups"
-    ][0]
-    assert "LaunchTemplate" in response
-    # We never specified the version - and AWS will not return anything if we don't
-    assert "Version" not in response["LaunchTemplate"]
+    template = autoscaling_client.describe_auto_scaling_groups(
+        AutoScalingGroupNames=[autoscaling_group_name]
+    )["AutoScalingGroups"][0]["LaunchTemplate"]
+    # We never specified the version - so AWS will not return it
+    assert "Version" not in template
+    assert template["LaunchTemplateName"] == launch_template_name
 
 
-@mock_aws
-def test_create_autoscaling_group_no_template_ref():
-    mocked_networking = setup_networking()
-
-    ec2_client = boto3.client("ec2", region_name="us-east-1")
-    template = ec2_client.create_launch_template(
-        LaunchTemplateName="test_launch_template",
-        LaunchTemplateData={"ImageId": EXAMPLE_AMI_ID, "InstanceType": "t2.micro"},
-    )["LaunchTemplate"]
+@ec2_aws_verified(
+    create_launch_template=True,
+    launch_template_data={"ImageId": get_valid_ami(), "InstanceType": "t2.medium"},
+)
+@pytest.mark.aws_verified
+def test_create_autoscaling_group_no_template_ref(
+    ec2_client=None,
+    launch_template_name=None,
+):
     client = boto3.client("autoscaling", region_name="us-east-1")
-
     with pytest.raises(ClientError) as ex:
         client.create_auto_scaling_group(
-            AutoScalingGroupName="test_asg",
-            LaunchTemplate={"Version": str(template["LatestVersionNumber"])},
+            AutoScalingGroupName=str(uuid4()),
+            LaunchTemplate={"Version": "1"},
             MinSize=0,
-            MaxSize=20,
-            DesiredCapacity=5,
-            VPCZoneIdentifier=mocked_networking["subnet1"],
-            NewInstancesProtectedFromScaleIn=False,
+            MaxSize=3,
+            DesiredCapacity=1,
+            AvailabilityZones=["us-east-1a"],
         )
     err = ex.value.response["Error"]
     assert ex.value.response["ResponseMetadata"]["HTTPStatusCode"] == 400
@@ -372,45 +390,62 @@ def test_create_autoscaling_group_multiple_launch_configurations():
     )
 
 
-@mock_aws
-def test_describe_autoscaling_groups_launch_template():
-    mocked_networking = setup_networking()
-    ec2_client = boto3.client("ec2", region_name="us-east-1")
-    template = ec2_client.create_launch_template(
-        LaunchTemplateName="test_launch_template",
-        LaunchTemplateData={"ImageId": EXAMPLE_AMI_ID, "InstanceType": "t2.micro"},
-    )["LaunchTemplate"]
-    client = boto3.client("autoscaling", region_name="us-east-1")
-    client.create_auto_scaling_group(
-        AutoScalingGroupName="test_asg",
-        LaunchTemplate={"LaunchTemplateName": "test_launch_template", "Version": "1"},
-        MinSize=0,
-        MaxSize=20,
-        DesiredCapacity=5,
-        VPCZoneIdentifier=mocked_networking["subnet1"],
-        NewInstancesProtectedFromScaleIn=True,
+@ec2_aws_verified(
+    create_launch_template=True,
+    return_launch_template_details=True,
+    launch_template_data={"ImageId": get_valid_ami(), "InstanceType": "t2.medium"},
+)
+@autoscaling_aws_verified(get_group_name=True)
+@pytest.mark.aws_verified
+def test_describe_autoscaling_groups_launch_template(
+    autoscaling_client=None,
+    autoscaling_group_name=None,
+    ec2_client=None,
+    launch_template_name=None,
+    launch_template_details=None,
+):
+    template = launch_template_details["LaunchTemplate"]
+    autoscaling_client.create_auto_scaling_group(
+        AutoScalingGroupName=autoscaling_group_name,
+        LaunchTemplate={"LaunchTemplateName": launch_template_name, "Version": "1"},
+        MinSize=1,
+        MaxSize=2,
+        DesiredCapacity=1,
+        AvailabilityZones=["us-east-1a"],
     )
     expected_launch_template = {
         "LaunchTemplateId": template["LaunchTemplateId"],
-        "LaunchTemplateName": "test_launch_template",
+        "LaunchTemplateName": launch_template_name,
         "Version": "1",
     }
 
-    response = client.describe_auto_scaling_groups(AutoScalingGroupNames=["test_asg"])
+    response = autoscaling_client.describe_auto_scaling_groups(
+        AutoScalingGroupNames=[autoscaling_group_name]
+    )
     assert response["ResponseMetadata"]["HTTPStatusCode"] == 200
     group = response["AutoScalingGroups"][0]
-    assert group["AutoScalingGroupName"] == "test_asg"
+    assert group["AutoScalingGroupName"] == autoscaling_group_name
     assert group["LaunchTemplate"] == expected_launch_template
     assert "LaunchConfigurationName" not in group
     assert group["AvailabilityZones"] == ["us-east-1a"]
-    assert group["VPCZoneIdentifier"] == mocked_networking["subnet1"]
-    assert group["NewInstancesProtectedFromScaleIn"] is True
-    for instance in group["Instances"]:
+
+    instances = group["Instances"]
+    count = 0
+    while not instances and count < 10:
+        response = autoscaling_client.describe_auto_scaling_groups(
+            AutoScalingGroupNames=[autoscaling_group_name]
+        )
+        instances = response["AutoScalingGroups"][0]["Instances"]
+        count += 1
+        if instances:
+            break
+        else:
+            sleep(5)
+    for instance in instances:
         assert instance["LaunchTemplate"] == expected_launch_template
         assert "LaunchConfigurationName" not in instance
         assert instance["AvailabilityZone"] == "us-east-1a"
-        assert instance["ProtectedFromScaleIn"] is True
-        assert instance["InstanceType"] == "t2.micro"
+        assert instance["InstanceType"] == "t2.medium"
 
 
 @mock_aws
@@ -1020,81 +1055,127 @@ def test_create_autoscaling_policy_with_predictive_scaling_config():
     }
 
 
-@mock_aws
+@ec2_aws_verified(
+    create_vpc=True,
+    create_subnet=True,
+    create_launch_template=True,
+    return_launch_template_details=True,
+    launch_template_data={"ImageId": get_valid_ami(), "InstanceType": "t2.medium"},
+)
+@autoscaling_aws_verified(get_group_name=True)
+@pytest.mark.aws_verified
 @pytest.mark.parametrize("include_instances_distribution", [True, False])
 def test_create_auto_scaling_group_with_mixed_instances_policy(
     include_instances_distribution,
+    autoscaling_client=None,
+    autoscaling_group_name=None,
+    ec2_client=None,
+    vpc_id=None,
+    subnet_id=None,
+    launch_template_name=None,
+    launch_template_details=None,
 ):
-    mocked_networking = setup_networking(region_name="eu-west-1")
-    client = boto3.client("autoscaling", region_name="eu-west-1")
-    ec2_client = boto3.client("ec2", region_name="eu-west-1")
-    asg_name = "asg_test"
-
-    lt = ec2_client.create_launch_template(
-        LaunchTemplateName="launchie",
-        LaunchTemplateData={"ImageId": EXAMPLE_AMI_ID},
-    )["LaunchTemplate"]
     input_policy = {
         "LaunchTemplate": {
             "LaunchTemplateSpecification": {
-                "LaunchTemplateName": "launchie",
-                "Version": "$DEFAULT",
+                "LaunchTemplateName": launch_template_name,
+                "Version": "$Default",
             }
         }
     }
     if include_instances_distribution:
         input_policy["InstancesDistribution"] = {
-            "OnDemandAllocationStrategy": "string",
+            "OnDemandAllocationStrategy": "lowest-price",
             "OnDemandBaseCapacity": 123,
-            "OnDemandPercentageAboveBaseCapacity": 123,
-            "SpotAllocationStrategy": "string",
-            "SpotInstancePools": 123,
-            "SpotMaxPrice": "string",
+            "OnDemandPercentageAboveBaseCapacity": 50,
+            "SpotAllocationStrategy": "lowest-price",
+            "SpotInstancePools": 1,
+            "SpotMaxPrice": "0.05",
         }
-    client.create_auto_scaling_group(
+    autoscaling_client.create_auto_scaling_group(
         MixedInstancesPolicy=input_policy,
-        AutoScalingGroupName=asg_name,
+        AutoScalingGroupName=autoscaling_group_name,
         MinSize=2,
         MaxSize=2,
-        VPCZoneIdentifier=mocked_networking["subnet1"],
+        VPCZoneIdentifier=subnet_id,
     )
 
     # Assert we can describe MixedInstancesPolicy
-    response = client.describe_auto_scaling_groups(AutoScalingGroupNames=[asg_name])
+    response = autoscaling_client.describe_auto_scaling_groups(
+        AutoScalingGroupNames=[autoscaling_group_name]
+    )
     group = response["AutoScalingGroups"][0]
 
+    lt = launch_template_details["LaunchTemplate"]
     input_policy["LaunchTemplate"]["LaunchTemplateSpecification"][
         "LaunchTemplateId"
     ] = lt["LaunchTemplateId"]
-    assert group["MixedInstancesPolicy"] == input_policy
+    expected_policy = input_policy.copy()
+    expected_policy["LaunchTemplate"]["Overrides"] = []
+    if not include_instances_distribution:
+        # Expect default
+        expected_policy["InstancesDistribution"] = {
+            "OnDemandAllocationStrategy": "prioritized",
+            "OnDemandBaseCapacity": 0,
+            "OnDemandPercentageAboveBaseCapacity": 100,
+            "SpotAllocationStrategy": "lowest-price",
+            "SpotInstancePools": 2,
+        }
+    assert group["MixedInstancesPolicy"] == expected_policy
+
+    # Wait for instances to be ready
+    instances = group["Instances"]
+    count = 0
+    while not instances and count < 10:
+        response = autoscaling_client.describe_auto_scaling_groups(
+            AutoScalingGroupNames=[autoscaling_group_name]
+        )
+        instances = response["AutoScalingGroups"][0]["Instances"]
+        count += 1
+        if instances:
+            break
+        else:
+            sleep(5)
+    waiter = ec2_client.get_waiter("instance_running")
+    waiter.wait(InstanceIds=[inst["InstanceId"] for inst in instances])
 
     # Assert the LaunchTemplate is known for the resulting instances
-    response = client.describe_auto_scaling_instances()
-    assert len(response["AutoScalingInstances"]) == 2
-    for instance in response["AutoScalingInstances"]:
+    instances = autoscaling_client.describe_auto_scaling_instances()[
+        "AutoScalingInstances"
+    ]
+    assert len(instances) == 2
+    for instance in instances:
         assert instance["LaunchTemplate"] == {
             "LaunchTemplateId": lt["LaunchTemplateId"],
-            "LaunchTemplateName": "launchie",
-            "Version": "$DEFAULT",
+            "LaunchTemplateName": launch_template_name,
+            "Version": "1",
         }
 
 
-@mock_aws
-def test_create_auto_scaling_group_with_mixed_instances_policy_overrides():
-    mocked_networking = setup_networking(region_name="eu-west-1")
-    client = boto3.client("autoscaling", region_name="eu-west-1")
-    ec2_client = boto3.client("ec2", region_name="eu-west-1")
-    asg_name = "asg_test"
-
-    lt = ec2_client.create_launch_template(
-        LaunchTemplateName="launchie",
-        LaunchTemplateData={"ImageId": EXAMPLE_AMI_ID},
-    )["LaunchTemplate"]
-    client.create_auto_scaling_group(
+@ec2_aws_verified(
+    create_vpc=True,
+    create_subnet=True,
+    create_launch_template=True,
+    return_launch_template_details=True,
+    launch_template_data={"ImageId": get_valid_ami(), "InstanceType": "t2.medium"},
+)
+@autoscaling_aws_verified(get_group_name=True)
+@pytest.mark.aws_verified
+def test_create_auto_scaling_group_with_mixed_instances_policy_overrides(
+    autoscaling_client=None,
+    autoscaling_group_name=None,
+    ec2_client=None,
+    vpc_id=None,
+    subnet_id=None,
+    launch_template_name=None,
+    launch_template_details=None,
+):
+    lt = launch_template_details["LaunchTemplate"]
+    autoscaling_client.create_auto_scaling_group(
         MixedInstancesPolicy={
             "LaunchTemplate": {
                 "LaunchTemplateSpecification": {
-                    "LaunchTemplateName": "launchie",
+                    "LaunchTemplateName": launch_template_name,
                     "Version": "$DEFAULT",
                 },
                 "Overrides": [
@@ -1105,20 +1186,22 @@ def test_create_auto_scaling_group_with_mixed_instances_policy_overrides():
                 ],
             }
         },
-        AutoScalingGroupName=asg_name,
+        AutoScalingGroupName=autoscaling_group_name,
         MinSize=2,
         MaxSize=2,
-        VPCZoneIdentifier=mocked_networking["subnet1"],
+        VPCZoneIdentifier=subnet_id,
     )
 
     # Assert we can describe MixedInstancesPolicy
-    response = client.describe_auto_scaling_groups(AutoScalingGroupNames=[asg_name])
+    response = autoscaling_client.describe_auto_scaling_groups(
+        AutoScalingGroupNames=[autoscaling_group_name]
+    )
     group = response["AutoScalingGroups"][0]
     assert group["MixedInstancesPolicy"] == {
         "LaunchTemplate": {
             "LaunchTemplateSpecification": {
                 "LaunchTemplateId": lt["LaunchTemplateId"],
-                "LaunchTemplateName": "launchie",
+                "LaunchTemplateName": launch_template_name,
                 "Version": "$DEFAULT",
             },
             "Overrides": [


### PR DESCRIPTION
A ton of Autoscaling tests were rewritten to make sure they behave the same when ran against AWS (and marked with the `aws_parity` to mark them as such.

Related:  #9374 , #9543 
