### PR TITLE
Kinesis: Fix AT_TIMESTAMP shard iterator when timestamp matches first record

### DIFF
--- a/moto/kinesis/models.py
+++ b/moto/kinesis/models.py
@@ -155,7 +155,10 @@ class Shard(BaseModel):
         return 0
 
     def get_sequence_number_at(self, at_timestamp: float) -> int:
-        if not self.records or at_timestamp < list(self.records.values())[0].created_at:
+        if (
+            not self.records
+            or at_timestamp <= list(self.records.values())[0].created_at
+        ):
             return 0
         else:
             # find the last item in the list that was created before

--- a/tests/test_kinesis/test_kinesis.py
+++ b/tests/test_kinesis/test_kinesis.py
@@ -4,6 +4,7 @@ from datetime import datetime, timedelta, timezone
 import boto3
 import pytest
 from botocore.exceptions import ClientError
+from freezegun import freeze_time
 
 from moto import mock_aws
 from moto.core import DEFAULT_ACCOUNT_ID as ACCOUNT_ID
@@ -585,6 +586,33 @@ def test_get_records_from_empty_stream_at_timestamp():
 
     assert len(response["Records"]) == 0
     assert response["MillisBehindLatest"] == 0
+
+
+@freeze_time("2024-01-01 12:00:00")
+@mock_aws
+def test_get_records_at_exact_timestamp():
+    conn = boto3.client("kinesis", region_name="us-west-2")
+    stream_name = "my_stream"
+    conn.create_stream(StreamName=stream_name, ShardCount=1)
+
+    conn.put_record(StreamName=stream_name, Data="0", PartitionKey="0")
+
+    timestamp = datetime(2024, 1, 1, 12, 0, 0)
+
+    response = conn.describe_stream(StreamName=stream_name)
+    shard_id = response["StreamDescription"]["Shards"][0]["ShardId"]
+    response = conn.get_shard_iterator(
+        StreamName=stream_name,
+        ShardId=shard_id,
+        ShardIteratorType="AT_TIMESTAMP",
+        Timestamp=timestamp,
+    )
+    shard_iterator = response["ShardIterator"]
+
+    response = conn.get_records(ShardIterator=shard_iterator)
+
+    assert len(response["Records"]) == 1
+    assert response["Records"][0]["Data"] == b"0"
 
 
 @mock_aws


### PR DESCRIPTION
## Description:

Fixes a bug where `get_shard_iterator` with ShardIteratorType=AT_TIMESTAMP crashes when the provided timestamp exactly matches the first record's `created_at` value.

## Problem

Per the [AWS documentation](https://docs.aws.amazon.com/kinesis/latest/APIReference/API_GetShardIterator.html):

> The time stamp of the data record from which to start reading. Used with shard iterator type AT_TIMESTAMP. A time stamp is the Unix epoch date with precision in milliseconds. For example, 2016-04-04T19:58:46.480-00:00 or 1459799926.480. If a record with this exact time stamp does not exist, the iterator returned is for the next (later) record. If the time stamp is older than the current trim horizon, the iterator returned is for the oldest untrimmed data record (TRIM_HORIZON).

However, when the provided timestamp exactly matches the first record's creation time (when the record's timestamp has 0 microseconds (e.g., created at exactly 1704110400.000000)), the condition `at_timestamp < first_record.created_at` evaluates to `False`, causing the code to search for a record with `created_at < at_timestamp`. 

When there is only one record at that exact timestamp, both conditions will return `False`, making `r = None`, resulting in the following error:-

```
def get_sequence_number_at(self, at_timestamp: float) -> int:
        if (
            not self.records
            or at_timestamp < list(self.records.values())[0].created_at
        ):
            return 0
        else:
            # find the last item in the list that was created before
            # at_timestamp
            r = next(
                (
                    r
                    for r in reversed(self.records.values())
                    if r.created_at < at_timestamp
                ),
                None,
            )
>           return r.sequence_number  # type: ignore
                   ^^^^^^^^^^^^^^^^^
E           AttributeError: 'NoneType' object has no attribute 'sequence_number'
```


## Testing

The condition is simulated in tests by using the `freeze_time` functionality. I was able to verify the failure before the fix.

## Fix

Changed the boundary condition from < to <=