### PR TITLE
[APIGateway] Enhancement to the apply_patch_operations

### DIFF
--- a/moto/apigateway/models.py
+++ b/moto/apigateway/models.py
@@ -1111,6 +1111,7 @@ class RestAPI(CloudFormationModel):
             if self.OPERATION_VALUE in op:
                 value = op[self.OPERATION_VALUE]
             operaton = op[self.OPERATION_OP]
+
             if operaton == self.OPERATION_REPLACE:
                 if to_path(self.PROP_NAME) in path:
                     self.name = value
@@ -1124,6 +1125,9 @@ class RestAPI(CloudFormationModel):
                     self.disableExecuteApiEndpoint = bool(value)
                 if to_path(self.PROP_POLICY) in path:
                     self.policy = value
+                if to_path(self.PROP_ENDPOINT_CONFIGURATION) in path:
+                    self.endpoint_configuration["types"] = [value]
+
             elif operaton == self.OPERATION_ADD:
                 if to_path(self.PROP_BINARY_MEDIA_TYPES) in path:
                     self.binaryMediaTypes.append(value)

--- a/tests/test_apigateway/test_apigateway.py
+++ b/tests/test_apigateway/test_apigateway.py
@@ -57,12 +57,18 @@ def test_update_rest_api():
             "value": '{"Version": "2012-10-17", "Statement": [{"Effect": "Allow", "Principal": "*", "Action": '
             '"execute-api:Invoke", "Resource": ["execute-api:/*"]}]}',
         },
+        {
+            "op": "replace",
+            "path": "/endpointConfiguration/types",
+            "value": "REGIONAL",
+        },
     ]
 
     response = client.update_rest_api(restApiId=api_id, patchOperations=patchOperations)
     response.pop("ResponseMetadata")
     response.pop("createdDate")
     response.pop("binaryMediaTypes")
+
     assert response == {
         "id": api_id,
         "name": "new-name",
@@ -71,7 +77,7 @@ def test_update_rest_api():
         "apiKeySource": "AUTHORIZER",
         "policy": '{"Version": "2012-10-17", "Statement": [{"Effect": "Allow", "Principal": "*", "Action": '
         '"execute-api:Invoke", "Resource": ["execute-api:/*"]}]}',
-        "endpointConfiguration": {"types": ["EDGE"]},
+        "endpointConfiguration": {"types": ["REGIONAL"]},
         "tags": {},
         "disableExecuteApiEndpoint": True,
         "rootResourceId": root_resource_id,


### PR DESCRIPTION
This PR adds the ability for end-users to apply updates to their `endpoint_configuration` via the `update_rest_api` call. Per the [docs](https://docs.aws.amazon.com/apigateway/latest/api/patch-operations.html) the UpdateRestApi only supports the replace operation and the value must be one of the three types.

Currently `update_rest_api` does not allow a user to update their endpointConfigurations.