### PR TITLE
Autoscaling: Improve parity with InstancesDistribution

### DIFF
--- a/moto/autoscaling/models.py
+++ b/moto/autoscaling/models.py
@@ -593,7 +593,6 @@ class FakeAutoScalingGroup(CloudFormationModel):
         if (
             self.mixed_instances_policy
             and "InstancesDistribution" not in self.mixed_instances_policy
-            and "Overrides" not in self.mixed_instances_policy.get("LaunchTemplate", {})
         ):
             self.mixed_instances_policy["InstancesDistribution"] = {
                 "OnDemandAllocationStrategy": "prioritized",

--- a/tests/test_autoscaling/__init__.py
+++ b/tests/test_autoscaling/__init__.py
@@ -74,5 +74,8 @@ def _invoke_func(
                 # Wait until instances are terminated
                 ec2_client = boto3.client("ec2", "us-east-1")
                 waiter = ec2_client.get_waiter("instance_terminated")
-                instances = group["Instances"]
-                waiter.wait(InstanceIds=[inst["InstanceId"] for inst in instances])
+                waiter.wait(
+                    # Delay to get around https://github.com/boto/boto3/issues/176
+                    WaiterConfig={"Delay": 10},
+                    InstanceIds=[inst["InstanceId"] for inst in group["Instances"]],
+                )

--- a/tests/test_autoscaling/test_autoscaling.py
+++ b/tests/test_autoscaling/test_autoscaling.py
@@ -1143,6 +1143,9 @@ def test_create_auto_scaling_group_with_mixed_instances_policy(
     instances = autoscaling_client.describe_auto_scaling_instances()[
         "AutoScalingInstances"
     ]
+    instances = [
+        i for i in instances if i["AutoScalingGroupName"] == autoscaling_group_name
+    ]
     assert len(instances) == 2
     for instance in instances:
         assert instance["LaunchTemplate"] == {
@@ -1176,7 +1179,7 @@ def test_create_auto_scaling_group_with_mixed_instances_policy_overrides(
             "LaunchTemplate": {
                 "LaunchTemplateSpecification": {
                     "LaunchTemplateName": launch_template_name,
-                    "Version": "$DEFAULT",
+                    "Version": "$Default",
                 },
                 "Overrides": [
                     {
@@ -1198,11 +1201,18 @@ def test_create_auto_scaling_group_with_mixed_instances_policy_overrides(
     )
     group = response["AutoScalingGroups"][0]
     assert group["MixedInstancesPolicy"] == {
+        "InstancesDistribution": {
+            "OnDemandAllocationStrategy": "prioritized",
+            "OnDemandBaseCapacity": 0,
+            "OnDemandPercentageAboveBaseCapacity": 100,
+            "SpotAllocationStrategy": "lowest-price",
+            "SpotInstancePools": 2,
+        },
         "LaunchTemplate": {
             "LaunchTemplateSpecification": {
                 "LaunchTemplateId": lt["LaunchTemplateId"],
                 "LaunchTemplateName": launch_template_name,
-                "Version": "$DEFAULT",
+                "Version": "$Default",
             },
             "Overrides": [
                 {
@@ -1210,7 +1220,7 @@ def test_create_auto_scaling_group_with_mixed_instances_policy_overrides(
                     "WeightedCapacity": "50",
                 }
             ],
-        }
+        },
     }
 
 


### PR DESCRIPTION
Followup to #9596 , where I apparently failed to validate all the tests against AWS.

Some improvements:
 - The `InstancesDistribution`-attribute appears to be always present in AWS
 - The `botocore` waiter seems to be bugged when handling 'pending' instances, so we add a delay there to make sure it's out of the `pending` state
 - Tests are run in parallel, so we have to filter the results of `describe_auto_scaling_instances` to only get the instances for this specific test
 - The version `$DEFAULT` is invalid - it is case sensitive, and only `$Default` is allowed