### PR TITLE
Redshift: add support for clusters filtering by tag keys

### DIFF
--- a/moto/redshift/models.py
+++ b/moto/redshift/models.py
@@ -649,12 +649,20 @@ class RedshiftBackend(BaseBackend):
         return self.clusters[cluster_id]
 
     def describe_clusters(
-        self, cluster_identifier: Optional[str] = None
+        self,
+        cluster_identifier: Optional[str] = None,
+        tag_keys: Optional[list[str]] = None,
     ) -> list[Cluster]:
         if cluster_identifier:
             if cluster_identifier in self.clusters:
                 return [self.clusters[cluster_identifier]]
             raise ClusterNotFoundError(cluster_identifier)
+        elif tag_keys:
+            return [
+                cluster
+                for cluster in self.clusters.values()
+                if any(key in [tag["Key"] for tag in cluster.tags] for key in tag_keys)
+            ]
         return list(self.clusters.values())
 
     def modify_cluster(self, **cluster_kwargs: Any) -> Cluster:

--- a/moto/redshift/responses.py
+++ b/moto/redshift/responses.py
@@ -100,7 +100,8 @@ class RedshiftResponse(BaseResponse):
 
     def describe_clusters(self) -> ActionResult:
         cluster_identifier = self._get_param("ClusterIdentifier")
-        clusters = self.redshift_backend.describe_clusters(cluster_identifier)
+        tag_keys = self._get_param("TagKeys")
+        clusters = self.redshift_backend.describe_clusters(cluster_identifier, tag_keys)
 
         return ActionResult({"Clusters": clusters})
 

--- a/tests/test_redshift/test_redshift.py
+++ b/tests/test_redshift/test_redshift.py
@@ -431,6 +431,34 @@ def test_describe_non_existent_cluster():
 
 
 @mock_aws
+def test_describe_clusters_with_tag_keys_filter():
+    client = boto3.client("redshift", region_name="us-east-1")
+
+    client.create_cluster(
+        DBName="test",
+        ClusterIdentifier="test-no-tag",
+        ClusterType="single-node",
+        NodeType="ds2.xlarge",
+        MasterUsername="user",
+        MasterUserPassword="password",
+    )
+    client.create_cluster(
+        DBName="test",
+        ClusterIdentifier="test-tagged",
+        ClusterType="single-node",
+        NodeType="ds2.xlarge",
+        MasterUsername="user",
+        MasterUserPassword="password",
+        Tags=[{"Key": "Test-tag", "Value": "test"}],
+    )
+
+    response = client.describe_clusters(TagKeys=["Test-tag"])
+    assert len(response["Clusters"]) == 1
+    cluster = response["Clusters"][0]
+    assert cluster["ClusterIdentifier"] == "test-tagged"
+
+
+@mock_aws
 def test_modify_cluster_vpc_routing():
     iam_roles_arn = ["arn:aws:iam:::role/my-iam-role"]
     client = boto3.client("redshift", region_name="us-east-1")


### PR DESCRIPTION
This PR adds support for the TagKeys parameter for describe_clusters in Redshift client.