### PR TITLE
EC2: add `GetInstanceUefiData` stub

### DIFF
--- a/moto/ec2/models/instances.py
+++ b/moto/ec2/models/instances.py
@@ -1081,6 +1081,11 @@ class InstanceBackend:
             reservations = filter_reservations(reservations, filters)
         return reservations
 
+    def get_instance_uefi_data(self, instance_id: str) -> bytes:
+        # Just a stub for now, doesn't return any actual data.
+        _ = self.get_instance(instance_id)
+        return b""
+
     def _get_template_from_args(
         self, launch_template_arg: dict[str, Any]
     ) -> LaunchTemplateVersion:

--- a/moto/ec2/responses/instances.py
+++ b/moto/ec2/responses/instances.py
@@ -2,6 +2,7 @@ from copy import deepcopy
 from typing import Any
 
 from moto.core.responses import ActionResult, EmptyResult
+from moto.core.types import Base64EncodedString
 from moto.core.utils import camelcase_to_underscores
 from moto.ec2.exceptions import (
     InvalidParameterCombination,
@@ -282,6 +283,15 @@ class InstanceResponse(EC2BaseResponse):
             metadata_tags=metadata_tags,
         )
         result = {"InstanceId": instance_id, "InstanceMetadataOptions": options}
+        return ActionResult(result)
+
+    def get_instance_uefi_data(self) -> ActionResult:
+        instance_id = self._get_param("InstanceId")
+        uefi_data = self.ec2_backend.get_instance_uefi_data(instance_id)
+        result = {
+            "InstanceId": instance_id,
+            "UefiData": Base64EncodedString.from_encoded_bytes(uefi_data),
+        }
         return ActionResult(result)
 
     def _block_device_mapping_handler(self) -> bool:

--- a/other_langs/terraform/ec2/ami.tf
+++ b/other_langs/terraform/ec2/ami.tf
@@ -1,0 +1,16 @@
+data "aws_ami" "ubuntu" {
+  filter {
+    name   = "name"
+    values = ["ubuntu/images/hvm-ssd/ubuntu-xenial-16.04-amd64-server-20170721"]
+  }
+
+  filter {
+    name   = "state"
+    values = ["available"]
+  }
+
+  most_recent = true
+
+  # Canonical's account ID
+  owners = ["099720109477"]
+}

--- a/tests/test_ec2/test_instances.py
+++ b/tests/test_ec2/test_instances.py
@@ -3095,6 +3095,17 @@ def test_run_instances_default_response():
     assert "VpcId" in instance
 
 
+@mock_aws
+def test_get_instance_uefi_data():
+    client = boto3.client("ec2", region_name="us-east-1")
+    resp = client.run_instances(ImageId=EXAMPLE_AMI_ID, MinCount=1, MaxCount=1)
+    instance_id = resp["Instances"][0]["InstanceId"]
+    resp = client.get_instance_uefi_data(InstanceId=instance_id)
+    assert resp["InstanceId"] == instance_id
+    # Implementation is just a stub at the moment, so just check that value exists.
+    assert "UefiData" in resp
+
+
 def test_block_device_status_conversion():
     """Test EBS block device status conversion."""
     from moto.ec2.models.instances import Instance


### PR DESCRIPTION
Adds a stub implementation for `GetInstanceUefiData` and a Terraform test that had been failing with a `NotImplementedError` prior to this changeset.

Closes #9630 