### PR TITLE
Fix: Duplicate Date Header when Moto running in Server Mode

### DIFF
--- a/moto/core/responses.py
+++ b/moto/core/responses.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import datetime
 import functools
 import json
 import logging
@@ -22,6 +21,7 @@ from xml.dom.minidom import parseString as parseXML
 import boto3
 from jinja2 import DictLoader, Environment, Template
 from werkzeug.exceptions import HTTPException
+from werkzeug.http import http_date
 
 from moto import settings
 from moto.core.authorization import ActionAuthenticatorMixin
@@ -44,6 +44,7 @@ from moto.core.utils import (
     gzip_decompress,
     method_names_from_class,
     set_value,
+    utcnow,
 )
 from moto.utilities.aws_headers import gen_amzn_requestid_long
 from moto.utilities.paginator import paginate
@@ -405,8 +406,9 @@ class BaseResponse(_TemplateEnvironmentMixin, ActionAuthenticatorMixin):
             self.headers["host"] = self.parsed_url.netloc
         self.response_headers = {
             "server": "amazon.com",
-            "date": datetime.datetime.now().strftime("%a, %d %b %Y %H:%M:%S GMT"),
         }
+        if not self.is_werkzeug_request:
+            self.response_headers["date"] = http_date(utcnow())
 
         if self.automated_parameter_parsing:
             self.parse_parameters(request)

--- a/tests/test_core/test_server.py
+++ b/tests/test_core/test_server.py
@@ -64,3 +64,13 @@ def test_request_decompression() -> None:
     resp = test_client.post(headers=headers, data=data)
     assert resp.status_code == 200
     assert "<DescribeDBInstancesResult>" in resp.data.decode("utf-8")
+
+
+def test_date_header_is_not_duplicated(moto_server: str) -> None:
+    client = boto3.client("glue", region_name="us-east-1", endpoint_url=moto_server)
+    resp = client.get_connections()
+    date_header_value = resp["ResponseMetadata"]["HTTPHeaders"]["date"]
+    # RFC 2822 dates should only have 1 comma, e.g. 'Mon, 20 Nov 1995 19:12:08 GMT'
+    # If multiple date headers exist, their values will be concatenated with a comma
+    # and this assertion will fail.
+    assert len(date_header_value.split(",")) == 2


### PR DESCRIPTION
An HTTP `Date` response header was added to Moto in #6329.  Werkzeug, which runs Moto in server mode, automatically adds a `Date` header to all outgoing responses, regardless of whether the header already exists.  There's some debate over whether or not this is a bug (pallets/werkzeug#2500), but this PR resolves the issue by only having Moto add the header if it is not running under Werkzeug.

Closes #9529 