### PR TITLE
SNS: migrate boolean values from string literals to native `bool` type

### DIFF
--- a/moto/core/utils.py
+++ b/moto/core/utils.py
@@ -290,6 +290,19 @@ def tags_from_cloudformation_tags_list(
     return tags
 
 
+def ensure_boolean(val: Any) -> bool:
+    """Ensures a boolean value if a string or boolean is provided
+
+    For strings, the value for True/False is case-insensitive.
+    """
+    if isinstance(val, bool):
+        return val
+    elif isinstance(val, str):
+        return val.lower() == "true"
+    else:
+        return False
+
+
 def remap_nested_keys(root: Any, key_transform: Callable[[str], str]) -> Any:
     """This remap ("recursive map") function is used to traverse and
     transform the dictionary keys of arbitrarily nested structures.

--- a/tests/test_sns/test_publishing.py
+++ b/tests/test_sns/test_publishing.py
@@ -2631,3 +2631,27 @@ def test_publish_with_message_structure_errors():
             err.response["Error"]["Message"]
             == "MessageStructure must be 'json' if provided"
         )
+
+
+@mock_aws
+def test_publish_with_boolean_attributes():
+    sns = boto3.resource("sns", region_name="us-east-1")
+    topic = sns.create_topic(
+        Name="ml.fifo",
+        Attributes={
+            "FifoTopic": str(True),
+            "ContentBasedDeduplication": str(False),
+            "FifoThroughputScope": "Topic",
+        },
+    )
+    message = {
+        "sample_uuid": "hui",
+        "metadata": {"sample_id": "123456"},
+        "key": "178500",
+    }
+    resp = topic.publish(
+        Message=json.dumps(message),
+        MessageDeduplicationId=message["sample_uuid"],
+        MessageGroupId=message["metadata"]["sample_id"],
+    )
+    assert "MessageId" in resp


### PR DESCRIPTION
Storing boolean values as string literals is an anti-pattern.  This PR ensures that the backend model is using proper `bool` types and that `responses.py` has the responsibility of properly translating boolean input/output from strings to the native type and vice versa.

Closes #9637 