### PR TITLE
Prep release 5.1.20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,58 @@
 Moto Changelog
 ==============
 
+5.1.20
+-----
+Docker Digest for 5.1.20: <autopopulateddigest>
+
+    New Methods:
+        * EC2:
+            * create_subnet_cidr_reservation()
+            * delete_subnet_cidr_reservation()
+            * get_instance_uefi_data() (Just a stub, no actual data is returned)
+            * get_subnet_cidr_reservations()
+
+        * IOT:
+            * list_thing_principals_v2()
+
+        * ResourceGroups:
+            * cancel_tag_sync_task()
+            * get_tag_sync_task()
+            * list_tag_sync_tasks()
+            * start_tag_sync_task()
+
+        * Route53Resolver:
+            * get_resolver_dnssec_config()
+            * list_resolver_dnssec_configs()
+            * update_resolver_dnssec_config()
+
+        * S3Control:
+            * create_multi_region_access_point()
+            * delete_multi_region_access_point()
+            * delete_storage_lens_configuration()
+            * describe_multi_region_access_point_operation()
+            * get_multi_region_access_point()
+            * get_multi_region_access_point_policy()
+            * get_multi_region_access_point_policy_status()
+            * list_multi_region_access_points()
+            * put_multi_region_access_point_policy()
+
+        * SecurityHub:
+            * create_members()
+            * get_members()
+            * list_members()
+
+    Miscellaneous:
+        * ACM: import_certificate() now supports all key types, RSA and EC
+        * APIGateway: update_rest_api() now supports `/endpointConfiguration/types`
+        * Autoscaling: update_auto_scaling_group() now supports the MixedInstancesPolicy-parameter
+        * Batch: register_job_definition() now supports the eksProperties-parameter
+        * DMS: create_replication_task() now supports the Tags-parameter
+        * Organizations: list_policies() now support pagination
+        * Organizations now supports Resource Control Policy
+        * Redshift: describe_clusters() now supports the TagKeys-parameter
+        * Logs: put_subscription_filter() now supports other LogGroups
+
 
 5.1.19
 -----

--- a/IMPLEMENTATION_COVERAGE.md
+++ b/IMPLEMENTATION_COVERAGE.md
@@ -2768,7 +2768,7 @@
 
 ## ec2
 <details>
-<summary>28% implemented</summary>
+<summary>29% implemented</summary>
 
 - [ ] accept_address_transfer
 - [ ] accept_capacity_reservation_billing_ownership
@@ -2898,7 +2898,7 @@
 - [ ] create_spot_datafeed_subscription
 - [ ] create_store_image_task
 - [X] create_subnet
-- [ ] create_subnet_cidr_reservation
+- [X] create_subnet_cidr_reservation
 - [X] create_tags
 - [ ] create_traffic_mirror_filter
 - [ ] create_traffic_mirror_filter_rule
@@ -2988,7 +2988,7 @@
 - [X] delete_snapshot
 - [ ] delete_spot_datafeed_subscription
 - [X] delete_subnet
-- [ ] delete_subnet_cidr_reservation
+- [X] delete_subnet_cidr_reservation
 - [X] delete_tags
 - [ ] delete_traffic_mirror_filter
 - [ ] delete_traffic_mirror_filter_rule
@@ -3311,7 +3311,7 @@
 - [ ] get_instance_metadata_defaults
 - [ ] get_instance_tpm_ek_pub
 - [ ] get_instance_types_from_instance_requirements
-- [ ] get_instance_uefi_data
+- [X] get_instance_uefi_data
 - [ ] get_ipam_address_history
 - [ ] get_ipam_discovered_accounts
 - [ ] get_ipam_discovered_public_addresses
@@ -3338,7 +3338,7 @@
 - [ ] get_serial_console_access_status
 - [ ] get_snapshot_block_public_access_state
 - [ ] get_spot_placement_scores
-- [ ] get_subnet_cidr_reservations
+- [X] get_subnet_cidr_reservations
 - [ ] get_transit_gateway_attachment_propagations
 - [ ] get_transit_gateway_metering_policy_entries
 - [ ] get_transit_gateway_multicast_domain_associations
@@ -4415,7 +4415,7 @@
 
 ## glue
 <details>
-<summary>37% implemented</summary>
+<summary>36% implemented</summary>
 
 - [X] batch_create_partition
 - [ ] batch_delete_connection
@@ -4547,6 +4547,7 @@
 - [X] get_job_runs
 - [X] get_jobs
 - [ ] get_mapping
+- [ ] get_materialized_view_refresh_task_run
 - [ ] get_ml_task_run
 - [ ] get_ml_task_runs
 - [ ] get_ml_transform
@@ -4601,6 +4602,7 @@
 - [ ] list_entities
 - [ ] list_integration_resource_properties
 - [X] list_jobs
+- [ ] list_materialized_view_refresh_task_runs
 - [ ] list_ml_transforms
 - [X] list_registries
 - [ ] list_schema_versions
@@ -4634,6 +4636,7 @@
 - [ ] start_export_labels_task_run
 - [ ] start_import_labels_task_run
 - [X] start_job_run
+- [ ] start_materialized_view_refresh_task_run
 - [ ] start_ml_evaluation_task_run
 - [ ] start_ml_labeling_set_generation_task_run
 - [X] start_trigger
@@ -4642,6 +4645,7 @@
 - [ ] stop_column_statistics_task_run_schedule
 - [X] stop_crawler
 - [ ] stop_crawler_schedule
+- [ ] stop_materialized_view_refresh_task_run
 - [X] stop_session
 - [X] stop_trigger
 - [X] stop_workflow_run
@@ -5365,7 +5369,7 @@
 - [X] list_thing_groups
 - [X] list_thing_groups_for_thing
 - [X] list_thing_principals
-- [ ] list_thing_principals_v2
+- [X] list_thing_principals_v2
 - [ ] list_thing_registration_task_reports
 - [ ] list_thing_registration_tasks
 - [X] list_thing_types
@@ -5747,7 +5751,7 @@
 
 ## lakeformation
 <details>
-<summary>33% implemented</summary>
+<summary>32% implemented</summary>
 
 - [X] add_lf_tags_to_resource
 - [ ] assume_decorated_role_with_saml
@@ -5781,6 +5785,7 @@
 - [ ] get_query_statistics
 - [X] get_resource_lf_tags
 - [ ] get_table_objects
+- [ ] get_temporary_data_location_credentials
 - [ ] get_temporary_glue_partition_credentials
 - [ ] get_temporary_glue_table_credentials
 - [ ] get_work_unit_results
@@ -7002,14 +7007,16 @@
 
 ## opensearchserverless
 <details>
-<summary>29% implemented</summary>
+<summary>26% implemented</summary>
 
 - [X] batch_get_collection
+- [ ] batch_get_collection_group
 - [ ] batch_get_effective_lifecycle_policy
 - [ ] batch_get_lifecycle_policy
 - [ ] batch_get_vpc_endpoint
 - [ ] create_access_policy
 - [X] create_collection
+- [ ] create_collection_group
 - [ ] create_index
 - [ ] create_lifecycle_policy
 - [ ] create_security_config
@@ -7017,6 +7024,7 @@
 - [X] create_vpc_endpoint
 - [ ] delete_access_policy
 - [X] delete_collection
+- [ ] delete_collection_group
 - [ ] delete_index
 - [ ] delete_lifecycle_policy
 - [ ] delete_security_config
@@ -7029,6 +7037,7 @@
 - [ ] get_security_config
 - [X] get_security_policy
 - [ ] list_access_policies
+- [ ] list_collection_groups
 - [X] list_collections
 - [ ] list_lifecycle_policies
 - [ ] list_security_configs
@@ -7040,6 +7049,7 @@
 - [ ] update_access_policy
 - [ ] update_account_settings
 - [ ] update_collection
+- [ ] update_collection_group
 - [ ] update_index
 - [ ] update_lifecycle_policy
 - [ ] update_security_config
@@ -8193,25 +8203,25 @@
 
 ## resource-groups
 <details>
-<summary>47% implemented</summary>
+<summary>65% implemented</summary>
 
-- [ ] cancel_tag_sync_task
+- [X] cancel_tag_sync_task
 - [X] create_group
 - [X] delete_group
 - [ ] get_account_settings
 - [X] get_group
 - [X] get_group_configuration
 - [ ] get_group_query
-- [ ] get_tag_sync_task
+- [X] get_tag_sync_task
 - [X] get_tags
 - [ ] group_resources
 - [ ] list_group_resources
 - [ ] list_grouping_statuses
 - [X] list_groups
-- [ ] list_tag_sync_tasks
+- [X] list_tag_sync_tasks
 - [X] put_group_configuration
 - [ ] search_resources
-- [ ] start_tag_sync_task
+- [X] start_tag_sync_task
 - [X] tag
 - [ ] ungroup_resources
 - [X] untag
@@ -8354,7 +8364,7 @@
 
 ## route53resolver
 <details>
-<summary>32% implemented</summary>
+<summary>36% implemented</summary>
 
 - [ ] associate_firewall_rule_group
 - [X] associate_resolver_endpoint_ip_address
@@ -8385,7 +8395,7 @@
 - [ ] get_firewall_rule_group_policy
 - [ ] get_outpost_resolver
 - [ ] get_resolver_config
-- [ ] get_resolver_dnssec_config
+- [X] get_resolver_dnssec_config
 - [X] get_resolver_endpoint
 - [X] get_resolver_query_log_config
 - [ ] get_resolver_query_log_config_association
@@ -8402,7 +8412,7 @@
 - [ ] list_firewall_rules
 - [ ] list_outpost_resolvers
 - [ ] list_resolver_configs
-- [ ] list_resolver_dnssec_configs
+- [X] list_resolver_dnssec_configs
 - [X] list_resolver_endpoint_ip_addresses
 - [X] list_resolver_endpoints
 - [ ] list_resolver_query_log_config_associations
@@ -8421,7 +8431,7 @@
 - [ ] update_firewall_rule_group_association
 - [ ] update_outpost_resolver
 - [ ] update_resolver_config
-- [ ] update_resolver_dnssec_config
+- [X] update_resolver_dnssec_config
 - [X] update_resolver_endpoint
 - [ ] update_resolver_rule
 </details>
@@ -9194,7 +9204,7 @@
 
 ## securityhub
 <details>
-<summary>8% implemented</summary>
+<summary>11% implemented</summary>
 
 - [ ] accept_administrator_invitation
 - [ ] accept_invitation
@@ -9218,7 +9228,7 @@
 - [ ] create_connector_v2
 - [ ] create_finding_aggregator
 - [ ] create_insight
-- [ ] create_members
+- [X] create_members
 - [ ] create_ticket_v2
 - [ ] decline_invitations
 - [ ] delete_action_target
@@ -9266,7 +9276,7 @@
 - [ ] get_insights
 - [ ] get_invitations_count
 - [ ] get_master_account
-- [ ] get_members
+- [X] get_members
 - [ ] get_resources_statistics_v2
 - [ ] get_resources_trends_v2
 - [ ] get_resources_v2
@@ -9281,7 +9291,7 @@
 - [ ] list_enabled_products_for_import
 - [ ] list_finding_aggregators
 - [ ] list_invitations
-- [ ] list_members
+- [X] list_members
 - [ ] list_organization_admin_accounts
 - [ ] list_security_control_definitions
 - [ ] list_standards_control_associations

--- a/docs/docs/services/ec2.rst
+++ b/docs/docs/services/ec2.rst
@@ -148,7 +148,7 @@ ec2
 - [ ] create_spot_datafeed_subscription
 - [ ] create_store_image_task
 - [X] create_subnet
-- [ ] create_subnet_cidr_reservation
+- [X] create_subnet_cidr_reservation
 - [X] create_tags
 - [ ] create_traffic_mirror_filter
 - [ ] create_traffic_mirror_filter_rule
@@ -238,7 +238,7 @@ ec2
 - [X] delete_snapshot
 - [ ] delete_spot_datafeed_subscription
 - [X] delete_subnet
-- [ ] delete_subnet_cidr_reservation
+- [X] delete_subnet_cidr_reservation
 - [X] delete_tags
 - [ ] delete_traffic_mirror_filter
 - [ ] delete_traffic_mirror_filter_rule
@@ -597,7 +597,7 @@ ec2
 - [ ] get_instance_metadata_defaults
 - [ ] get_instance_tpm_ek_pub
 - [ ] get_instance_types_from_instance_requirements
-- [ ] get_instance_uefi_data
+- [X] get_instance_uefi_data
 - [ ] get_ipam_address_history
 - [ ] get_ipam_discovered_accounts
 - [ ] get_ipam_discovered_public_addresses
@@ -624,7 +624,7 @@ ec2
 - [ ] get_serial_console_access_status
 - [ ] get_snapshot_block_public_access_state
 - [ ] get_spot_placement_scores
-- [ ] get_subnet_cidr_reservations
+- [X] get_subnet_cidr_reservations
 - [ ] get_transit_gateway_attachment_propagations
 - [ ] get_transit_gateway_metering_policy_entries
 - [ ] get_transit_gateway_multicast_domain_associations

--- a/docs/docs/services/glue.rst
+++ b/docs/docs/services/glue.rst
@@ -148,6 +148,7 @@ glue
 - [X] get_job_runs
 - [X] get_jobs
 - [ ] get_mapping
+- [ ] get_materialized_view_refresh_task_run
 - [ ] get_ml_task_run
 - [ ] get_ml_task_runs
 - [ ] get_ml_transform
@@ -216,6 +217,7 @@ glue
 - [ ] list_entities
 - [ ] list_integration_resource_properties
 - [X] list_jobs
+- [ ] list_materialized_view_refresh_task_runs
 - [ ] list_ml_transforms
 - [X] list_registries
 - [ ] list_schema_versions
@@ -249,6 +251,7 @@ glue
 - [ ] start_export_labels_task_run
 - [ ] start_import_labels_task_run
 - [X] start_job_run
+- [ ] start_materialized_view_refresh_task_run
 - [ ] start_ml_evaluation_task_run
 - [ ] start_ml_labeling_set_generation_task_run
 - [X] start_trigger
@@ -257,6 +260,7 @@ glue
 - [ ] stop_column_statistics_task_run_schedule
 - [X] stop_crawler
 - [ ] stop_crawler_schedule
+- [ ] stop_materialized_view_refresh_task_run
 - [X] stop_session
 - [X] stop_trigger
 - [X] stop_workflow_run

--- a/docs/docs/services/iot.rst
+++ b/docs/docs/services/iot.rst
@@ -270,7 +270,7 @@ iot
         
 
 - [X] list_thing_principals
-- [ ] list_thing_principals_v2
+- [X] list_thing_principals_v2
 - [ ] list_thing_registration_task_reports
 - [ ] list_thing_registration_tasks
 - [X] list_thing_types

--- a/docs/docs/services/lakeformation.rst
+++ b/docs/docs/services/lakeformation.rst
@@ -46,6 +46,7 @@ lakeformation
 - [ ] get_query_statistics
 - [X] get_resource_lf_tags
 - [ ] get_table_objects
+- [ ] get_temporary_data_location_credentials
 - [ ] get_temporary_glue_partition_credentials
 - [ ] get_temporary_glue_table_credentials
 - [ ] get_work_unit_results

--- a/docs/docs/services/opensearchserverless.rst
+++ b/docs/docs/services/opensearchserverless.rst
@@ -17,11 +17,13 @@ opensearchserverless
 |start-h3| Implemented features for this service |end-h3|
 
 - [X] batch_get_collection
+- [ ] batch_get_collection_group
 - [ ] batch_get_effective_lifecycle_policy
 - [ ] batch_get_lifecycle_policy
 - [ ] batch_get_vpc_endpoint
 - [ ] create_access_policy
 - [X] create_collection
+- [ ] create_collection_group
 - [ ] create_index
 - [ ] create_lifecycle_policy
 - [ ] create_security_config
@@ -29,6 +31,7 @@ opensearchserverless
 - [X] create_vpc_endpoint
 - [ ] delete_access_policy
 - [X] delete_collection
+- [ ] delete_collection_group
 - [ ] delete_index
 - [ ] delete_lifecycle_policy
 - [ ] delete_security_config
@@ -41,6 +44,7 @@ opensearchserverless
 - [ ] get_security_config
 - [X] get_security_policy
 - [ ] list_access_policies
+- [ ] list_collection_groups
 - [X] list_collections
   
         Pagination is not yet implemented
@@ -60,6 +64,7 @@ opensearchserverless
 - [ ] update_access_policy
 - [ ] update_account_settings
 - [ ] update_collection
+- [ ] update_collection_group
 - [ ] update_index
 - [ ] update_lifecycle_policy
 - [ ] update_security_config

--- a/docs/docs/services/resource-groups.rst
+++ b/docs/docs/services/resource-groups.rst
@@ -14,14 +14,14 @@ resource-groups
 
 |start-h3| Implemented features for this service |end-h3|
 
-- [ ] cancel_tag_sync_task
+- [X] cancel_tag_sync_task
 - [X] create_group
 - [X] delete_group
 - [ ] get_account_settings
 - [X] get_group
 - [X] get_group_configuration
 - [ ] get_group_query
-- [ ] get_tag_sync_task
+- [X] get_tag_sync_task
 - [X] get_tags
 - [ ] group_resources
 - [ ] list_group_resources
@@ -31,10 +31,10 @@ resource-groups
         Pagination or the Filters-parameter is not yet implemented
         
 
-- [ ] list_tag_sync_tasks
+- [X] list_tag_sync_tasks
 - [X] put_group_configuration
 - [ ] search_resources
-- [ ] start_tag_sync_task
+- [X] start_tag_sync_task
 - [X] tag
 - [ ] ungroup_resources
 - [X] untag

--- a/docs/docs/services/route53resolver.rst
+++ b/docs/docs/services/route53resolver.rst
@@ -56,7 +56,9 @@ route53resolver
 - [ ] get_firewall_rule_group_policy
 - [ ] get_outpost_resolver
 - [ ] get_resolver_config
-- [ ] get_resolver_dnssec_config
+- [X] get_resolver_dnssec_config
+  Get information about a resolver DNSSEC config.
+
 - [X] get_resolver_endpoint
 - [X] get_resolver_query_log_config
   Get information about a resolver query log config.
@@ -77,7 +79,7 @@ route53resolver
 - [ ] list_firewall_rules
 - [ ] list_outpost_resolvers
 - [ ] list_resolver_configs
-- [ ] list_resolver_dnssec_configs
+- [X] list_resolver_dnssec_configs
 - [X] list_resolver_endpoint_ip_addresses
 - [X] list_resolver_endpoints
 - [ ] list_resolver_query_log_config_associations
@@ -96,7 +98,9 @@ route53resolver
 - [ ] update_firewall_rule_group_association
 - [ ] update_outpost_resolver
 - [ ] update_resolver_config
-- [ ] update_resolver_dnssec_config
+- [X] update_resolver_dnssec_config
+  Update the configuration of the DNSSEC validation.
+
 - [X] update_resolver_endpoint
 - [ ] update_resolver_rule
 

--- a/docs/docs/services/s3control.rst
+++ b/docs/docs/services/s3control.rst
@@ -22,7 +22,7 @@ s3control
 - [ ] create_access_point_for_object_lambda
 - [ ] create_bucket
 - [ ] create_job
-- [ ] create_multi_region_access_point
+- [X] create_multi_region_access_point
 - [ ] create_storage_lens_group
 - [ ] delete_access_grant
 - [ ] delete_access_grants_instance
@@ -39,13 +39,13 @@ s3control
 - [ ] delete_bucket_replication
 - [ ] delete_bucket_tagging
 - [ ] delete_job_tagging
-- [ ] delete_multi_region_access_point
+- [X] delete_multi_region_access_point
 - [X] delete_public_access_block
-- [ ] delete_storage_lens_configuration
+- [X] delete_storage_lens_configuration
 - [ ] delete_storage_lens_configuration_tagging
 - [ ] delete_storage_lens_group
 - [ ] describe_job
-- [ ] describe_multi_region_access_point_operation
+- [X] describe_multi_region_access_point_operation
 - [ ] dissociate_access_grants_identity_center
 - [ ] get_access_grant
 - [ ] get_access_grants_instance
@@ -58,10 +58,6 @@ s3control
 - [X] get_access_point_policy
 - [ ] get_access_point_policy_for_object_lambda
 - [X] get_access_point_policy_status
-  
-        We assume the policy status is always public
-        
-
 - [ ] get_access_point_policy_status_for_object_lambda
 - [ ] get_access_point_scope
 - [ ] get_bucket
@@ -72,9 +68,9 @@ s3control
 - [ ] get_bucket_versioning
 - [ ] get_data_access
 - [ ] get_job_tagging
-- [ ] get_multi_region_access_point
-- [ ] get_multi_region_access_point_policy
-- [ ] get_multi_region_access_point_policy_status
+- [X] get_multi_region_access_point
+- [X] get_multi_region_access_point_policy
+- [X] get_multi_region_access_point_policy_status
 - [ ] get_multi_region_access_point_routes
 - [X] get_public_access_block
 - [X] get_storage_lens_configuration
@@ -88,7 +84,7 @@ s3control
 - [ ] list_access_points_for_object_lambda
 - [ ] list_caller_access_grants
 - [ ] list_jobs
-- [ ] list_multi_region_access_points
+- [X] list_multi_region_access_points
 - [ ] list_regional_buckets
 - [X] list_storage_lens_configurations
 - [ ] list_storage_lens_groups
@@ -104,7 +100,7 @@ s3control
 - [ ] put_bucket_tagging
 - [ ] put_bucket_versioning
 - [ ] put_job_tagging
-- [ ] put_multi_region_access_point_policy
+- [X] put_multi_region_access_point_policy
 - [X] put_public_access_block
 - [X] put_storage_lens_configuration
 - [X] put_storage_lens_configuration_tagging

--- a/docs/docs/services/securityhub.rst
+++ b/docs/docs/services/securityhub.rst
@@ -26,16 +26,6 @@ securityhub
 - [ ] batch_get_security_controls
 - [ ] batch_get_standards_control_associations
 - [X] batch_import_findings
-  
-        Import findings in batch to SecurityHub.
-
-        Args:
-            findings: List of finding dictionaries to import
-
-        Returns:
-            Tuple of (failed_count, success_count, failed_findings)
-        
-
 - [ ] batch_update_automation_rules
 - [ ] batch_update_findings
 - [ ] batch_update_findings_v2
@@ -48,7 +38,7 @@ securityhub
 - [ ] create_connector_v2
 - [ ] create_finding_aggregator
 - [ ] create_insight
-- [ ] create_members
+- [X] create_members
 - [ ] create_ticket_v2
 - [ ] decline_invitations
 - [ ] delete_action_target
@@ -91,7 +81,7 @@ securityhub
 - [ ] get_finding_statistics_v2
 - [X] get_findings
   
-        Returns findings based on optional filters and sort criteria.
+        Filters and SortCriteria is not yet implemented
         
 
 - [ ] get_findings_trends_v2
@@ -100,7 +90,7 @@ securityhub
 - [ ] get_insights
 - [ ] get_invitations_count
 - [ ] get_master_account
-- [ ] get_members
+- [X] get_members
 - [ ] get_resources_statistics_v2
 - [ ] get_resources_trends_v2
 - [ ] get_resources_v2
@@ -115,7 +105,7 @@ securityhub
 - [ ] list_enabled_products_for_import
 - [ ] list_finding_aggregators
 - [ ] list_invitations
-- [ ] list_members
+- [X] list_members
 - [ ] list_organization_admin_accounts
 - [ ] list_security_control_definitions
 - [ ] list_standards_control_associations

--- a/moto/securityhub/models.py
+++ b/moto/securityhub/models.py
@@ -133,10 +133,9 @@ class SecurityHubBackend(BaseBackend):
         filters: Optional[dict[str, Any]] = None,
         sort_criteria: Optional[list[dict[str, str]]] = None,
         max_results: Optional[int] = None,
-        next_token: Optional[str] = None,
     ) -> list[dict[str, str]]:
         """
-        Returns findings based on optional filters and sort criteria.
+        Filters and SortCriteria is not yet implemented
         """
         if max_results is not None:
             try:
@@ -151,25 +150,11 @@ class SecurityHubBackend(BaseBackend):
                     op="GetFindings", msg="MaxResults must be a number greater than 0"
                 )
 
-        findings = self.findings
-
-        # TODO: Apply filters if provided
-        # TODO: Apply sort criteria if provided
-
-        return [f.as_dict() for f in findings]
+        return [f.as_dict() for f in self.findings]
 
     def batch_import_findings(
         self, findings: list[dict[str, Any]]
     ) -> tuple[int, int, list[dict[str, Any]]]:
-        """
-        Import findings in batch to SecurityHub.
-
-        Args:
-            findings: List of finding dictionaries to import
-
-        Returns:
-            Tuple of (failed_count, success_count, failed_findings)
-        """
         failed_count = 0
         success_count = 0
         failed_findings = []
@@ -372,15 +357,6 @@ class SecurityHubBackend(BaseBackend):
     def create_members(
         self, account_details: list[dict[str, str]]
     ) -> list[dict[str, str]]:
-        """
-        Create member accounts for Security Hub.
-
-        Args:
-            account_details: List of dicts with AccountId and optionally Email
-
-        Returns:
-            List of unprocessed accounts
-        """
         unprocessed_accounts: list[dict[str, str]] = []
 
         if not account_details:
@@ -421,15 +397,6 @@ class SecurityHubBackend(BaseBackend):
     def get_members(
         self, account_ids: list[str]
     ) -> tuple[list[dict[str, Any]], list[dict[str, str]]]:
-        """
-        Get member account details by account IDs.
-
-        Args:
-            account_ids: List of account IDs to retrieve
-
-        Returns:
-            Tuple of (members, unprocessed_accounts)
-        """
         members = []
         unprocessed_accounts = []
 
@@ -458,22 +425,8 @@ class SecurityHubBackend(BaseBackend):
 
     @paginate(pagination_model=PAGINATION_MODEL)  # type: ignore[misc]
     def list_members(
-        self,
-        only_associated: Optional[bool] = None,
-        max_results: Optional[int] = None,
-        next_token: Optional[str] = None,
+        self, only_associated: Optional[bool] = None
     ) -> list[dict[str, str]]:
-        """
-        List all member accounts.
-
-        Args:
-            only_associated: If True, only return members with ENABLED status
-            max_results: Maximum number of results to return
-            next_token: Pagination token
-
-        Returns:
-            List of member details
-        """
         if only_associated is None:
             only_associated = True
 

--- a/tests/test_autoscaling/test_autoscaling.py
+++ b/tests/test_autoscaling/test_autoscaling.py
@@ -140,8 +140,6 @@ def test_create_autoscaling_group_from_invalid_instance_id():
 # Create LaunchTemplate first, and delete it last
 # If we first delete the Launch Template and then delete the AutoScalingGroup, AWS will show a notification in the console (even if it's only for a few milliseconds)
 @ec2_aws_verified(
-    create_vpc=True,
-    create_subnet=True,
     create_launch_template=True,
     launch_template_data={"ImageId": get_valid_ami(), "InstanceType": "t2.medium"},
     return_launch_template_details=True,
@@ -153,8 +151,6 @@ def test_create_autoscaling_group_from_template(
     autoscaling_client=None,
     autoscaling_group_name=None,
     ec2_client=None,
-    vpc_id=None,
-    subnet_id=None,
     launch_template_name=None,
     launch_template_details=None,
 ):
@@ -168,7 +164,7 @@ def test_create_autoscaling_group_from_template(
         MinSize=1,
         MaxSize=3,
         DesiredCapacity=2,
-        VPCZoneIdentifier=subnet_id,
+        AvailabilityZones=["us-east-1a"],
         NewInstancesProtectedFromScaleIn=False,
     )
     assert response["ResponseMetadata"]["HTTPStatusCode"] == 200
@@ -1057,8 +1053,6 @@ def test_create_autoscaling_policy_with_predictive_scaling_config():
 
 
 @ec2_aws_verified(
-    create_vpc=True,
-    create_subnet=True,
     create_launch_template=True,
     return_launch_template_details=True,
     launch_template_data={"ImageId": get_valid_ami(), "InstanceType": "t2.medium"},
@@ -1071,8 +1065,6 @@ def test_create_auto_scaling_group_with_mixed_instances_policy(
     autoscaling_client=None,
     autoscaling_group_name=None,
     ec2_client=None,
-    vpc_id=None,
-    subnet_id=None,
     launch_template_name=None,
     launch_template_details=None,
 ):
@@ -1098,7 +1090,7 @@ def test_create_auto_scaling_group_with_mixed_instances_policy(
         AutoScalingGroupName=autoscaling_group_name,
         MinSize=2,
         MaxSize=2,
-        VPCZoneIdentifier=subnet_id,
+        AvailabilityZones=["us-east-1a"],
     )
 
     # Assert we can describe MixedInstancesPolicy
@@ -1157,8 +1149,6 @@ def test_create_auto_scaling_group_with_mixed_instances_policy(
 
 
 @ec2_aws_verified(
-    create_vpc=True,
-    create_subnet=True,
     create_launch_template=True,
     return_launch_template_details=True,
     launch_template_data={"ImageId": get_valid_ami(), "InstanceType": "t2.medium"},
@@ -1169,8 +1159,6 @@ def test_create_auto_scaling_group_with_mixed_instances_policy_overrides(
     autoscaling_client=None,
     autoscaling_group_name=None,
     ec2_client=None,
-    vpc_id=None,
-    subnet_id=None,
     launch_template_name=None,
     launch_template_details=None,
 ):
@@ -1193,7 +1181,7 @@ def test_create_auto_scaling_group_with_mixed_instances_policy_overrides(
         AutoScalingGroupName=autoscaling_group_name,
         MinSize=2,
         MaxSize=2,
-        VPCZoneIdentifier=subnet_id,
+        AvailabilityZones=["us-east-1a"],
     )
 
     # Assert we can describe MixedInstancesPolicy


### PR DESCRIPTION
Removes some of the SecurityHub documentation - this is public facing, so this should only contain information that's relevant for users.

Also simplifies/speeds up the Autoscaling tests. Passing in the `AvailabilityZones`-parameter ensures that we use the default VPC/subnet, so we no longer have to explicitly create/delete a VPC/Subnet.