### PR TITLE
SQS: Fix trailing slash bug

### DIFF
--- a/moto/sqs/urls.py
+++ b/moto/sqs/urls.py
@@ -6,5 +6,5 @@ dispatch = SQSResponse().dispatch
 
 url_paths = {
     "{0}/$": dispatch,
-    r"{0}/(?P<account_id>\d+)/(?P<queue_name>[a-zA-Z0-9\-_\.]+)": dispatch,
+    r"{0}/(?P<account_id>\d+)/(?P<queue_name>[a-zA-Z0-9\-_\.]+)/?": dispatch,
 }


### PR DESCRIPTION
New versions of AWS SDK add a trailing `/` at the end of the queue URL making moto to return a 404 as there is no URL match.