### PR TITLE
AWSLambda: put_function_event_invoke_config() does not require DestinationConfig

### DIFF
--- a/moto/awslambda/models.py
+++ b/moto/awslambda/models.py
@@ -348,8 +348,7 @@ class EventInvokeConfig:
         regex = r"^$|arn:(aws[a-zA-Z0-9-]*):([a-zA-Z0-9\-])+:([a-z]{2}(-gov)?-[a-z]+-\d{1})?:(\d{12})?:(.*)"
         pattern = re.compile(regex)
 
-        if self.config["DestinationConfig"]:
-            destination_config = self.config["DestinationConfig"]
+        if destination_config := self.config.get("DestinationConfig"):
             if (
                 "OnSuccess" in destination_config
                 and "Destination" in destination_config["OnSuccess"]

--- a/other_langs/terraform/awslambda/event_invoke_config.tf
+++ b/other_langs/terraform/awslambda/event_invoke_config.tf
@@ -1,0 +1,5 @@
+resource "aws_lambda_function_event_invoke_config" "test" {
+  function_name                = aws_lambda_function.test_lambda.function_name
+  maximum_retry_attempts       = 2
+  maximum_event_age_in_seconds = 21600
+}

--- a/tests/test_awslambda/test_lambda.py
+++ b/tests/test_awslambda/test_lambda.py
@@ -1933,6 +1933,24 @@ def test_put_event_invoke_config(config):
 
 
 @mock_aws
+def test_put_event_invoke_config_without_config():
+    # Setup
+    client = boto3.client("lambda", _lambda_region)
+    arn_1 = setup_lambda(client, LAMBDA_FUNC_NAME)["FunctionArn"]
+
+    # Execute
+    result = client.put_function_event_invoke_config(
+        FunctionName=LAMBDA_FUNC_NAME, MaximumRetryAttempts=2
+    )
+
+    # Verify
+    assert result["MaximumRetryAttempts"] == 2
+
+    # Clean up for servertests
+    client.delete_function(FunctionName=arn_1)
+
+
+@mock_aws
 @pytest.mark.parametrize(
     "config",
     [


### PR DESCRIPTION
Fixes #9699 

Looks like we didn't have any (positive) tests for this function without sending the `DestinationConfig`, so this flew under the radar. Added a regular Python test + the original TF scenario that showcased the problem.