### PR TITLE
IAM Policies: Support boolean conditions and NULL-resources

### DIFF
--- a/moto/iam/policy_validation.py
+++ b/moto/iam/policy_validation.py
@@ -231,7 +231,7 @@ class BaseIAMPolicyValidator:
             assert isinstance(statement[key], (str, list))
             if isinstance(statement[key], list):
                 for resource in statement[key]:
-                    assert isinstance(resource, str)
+                    assert resource is None or isinstance(resource, str)
 
     @staticmethod
     def _validate_condition_syntax(statement: dict[str, Any]) -> None:  # type: ignore[misc]
@@ -240,7 +240,7 @@ class BaseIAMPolicyValidator:
             for condition_key, condition_value in statement["Condition"].items():
                 assert isinstance(condition_value, dict)
                 for condition_element_value in condition_value.values():
-                    assert isinstance(condition_element_value, (list, str))
+                    assert isinstance(condition_element_value, (bool, list, str))
 
                 if (
                     IAMPolicyDocumentValidator._strip_condition_key(condition_key)
@@ -332,7 +332,9 @@ class BaseIAMPolicyValidator:
                 if isinstance(statement[key], str):
                     self._validate_resource_format(statement[key])
                 else:
-                    for resource in sorted(statement[key], reverse=True):
+                    # Skip validation of None elements
+                    resources = [r for r in statement[key] if r]
+                    for resource in sorted(resources, reverse=True):
                         self._validate_resource_format(resource)
                 if self._resource_error == "":
                     IAMPolicyDocumentValidator._legacy_parse_resource_like(
@@ -456,7 +458,7 @@ class BaseIAMPolicyValidator:
                 assert statement[key].split(":")[2] != ""
         else:  # list
             for resource in statement[key]:
-                if resource != "*":
+                if resource and resource != "*":
                     assert resource.count(":") >= 5 or "::" not in resource
                     assert resource[2] != ""
 

--- a/tests/test_iam/test_iam_policies.py
+++ b/tests/test_iam/test_iam_policies.py
@@ -1336,6 +1336,50 @@ valid_policy_documents = [
         "Version": "2012-10-17",
         "Statement": [
             {
+                "Sid": "BooleanConditionOperations_Strings_And_Booleans",
+                "Action": "kms:CreateGrant",
+                "Condition": {
+                    "Bool": {"kms:GrantIsForAWSResource": True},
+                    "ForAllValues:Bool": {"kms:GrantIsForAWSResource": False},
+                    "ForAnyValue:Bool": {"kms:GrantIsForAWSResource": "True"},
+                },
+                "Effect": "Allow",
+                "Resource": ["arn:aws:kms:*:123456789012:key/*"],
+            }
+        ],
+    },
+    {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Sid": "NullConditionOperator_Strings_And_Booleans",
+                "Action": "kms:CreateGrant",
+                "Condition": {
+                    "Null": {
+                        "kms:EncryptionContextKeys": False,
+                        "kms:GrantOperations": "true",
+                    }
+                },
+                "Effect": "Allow",
+                "Resource": ["arn:aws:kms:*:123456789012:key/*"],
+            }
+        ],
+    },
+    {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Sid": "NullResource",
+                "Action": "kms:CreateGrant",
+                "Effect": "Allow",
+                "Resource": ["arn:aws:kms:*:123456789012:key/*", None],
+            }
+        ],
+    },
+    {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
                 "Sid": "ListAndDescribe",
                 "Effect": "Allow",
                 "Action": [


### PR DESCRIPTION
Testing against an AWS provided template ([direct link](https://s3.amazonaws.com/solutions-reference/instance-scheduler-on-aws/3.0.11/instance-scheduler-on-aws.template)) shows that our policy validation was too strict in two scenarios:
 - Condition values can be boolean values
 - The list of Resources can contain a None-value

See #9701 