### PR TITLE
S3: get_public_access_block() - Return correct 404 body

### DIFF
--- a/moto/s3control/exceptions.py
+++ b/moto/s3control/exceptions.py
@@ -1,6 +1,6 @@
 from typing import Any
 
-from moto.core.exceptions import RESTError
+from moto.core.exceptions import RESTError, ServiceException
 
 ERROR_WITH_ACCESS_POINT_NAME = """{% extends 'wrapped_single_error' %}
 {% block extra %}<AccessPointName>{{ name }}</AccessPointName>{% endblock %}
@@ -97,6 +97,16 @@ class MultiRegionAccessPointOperationNotFound(S3ControlError):
             "The specified async request does not exist",
             **kwargs,
         )
+
+
+class NoSuchPublicAccessBlockConfiguration(ServiceException):
+    # Note that this exception is in the different format then the S3 exception with the same name
+    # This exception should return a nested response `<ErrorResponse><Error>..`
+    # The S3 variant uses a flat `<Error>`-response
+    code = "NoSuchPublicAccessBlockConfiguration"
+
+    def __init__(self) -> None:
+        super().__init__("The public access block configuration was not found")
 
 
 class InvalidRequestException(S3ControlError):

--- a/moto/s3control/models.py
+++ b/moto/s3control/models.py
@@ -9,7 +9,6 @@ from moto.moto_api._internal import mock_random
 from moto.s3 import s3_backends
 from moto.s3.exceptions import (
     InvalidPublicAccessBlockConfiguration,
-    NoSuchPublicAccessBlockConfiguration,
     WrongPublicAccessBlockAccountIdError,
 )
 from moto.s3.models import PublicAccessBlock, S3Backend
@@ -24,6 +23,7 @@ from .exceptions import (
     MultiRegionAccessPointNotFound,
     MultiRegionAccessPointOperationNotFound,
     MultiRegionAccessPointPolicyNotFound,
+    NoSuchPublicAccessBlockConfiguration,
     StorageLensConfigurationNotFound,
 )
 

--- a/other_langs/terraform/s3/public_access_block.tf
+++ b/other_langs/terraform/s3/public_access_block.tf
@@ -1,0 +1,6 @@
+resource "aws_s3_account_public_access_block" "access" {
+  block_public_acls = true
+  block_public_policy = true
+  ignore_public_acls = true
+  restrict_public_buckets = true
+}


### PR DESCRIPTION
Fixes #9706 

When requesting a public access block that didn't exist, Moto used to return a 404 with the following body:
```
<?xml version="1.0" encoding="UTF-8"?>
<Error>
    <Code>NoSuchPublicAccessBlockConfiguration</Code>
    <Message><![CDATA[The public access block configuration was not found]]></Message>
    <RequestID>...</RequestID>
</Error>
```

When trying to delete a public access block, Terraform will first delete it, then make a GET request to the resource to verify that the deletion was successful. But because the error format of the GET request is incorrect, Terraform fails with the following error:

> Error: waiting for S3 Account Public Access Block (123456789012) delete: operation error S3 Control: GetPublicAccessBlock, https response error StatusCode: 404, RequestID: , HostID: , api error UnknownError: UnknownError

When making the same request against AWS, we can see that the root-tag should be `ErrorResponse`:
```
<?xml version="1.0" encoding="UTF-8"?>
<ErrorResponse>
  <Error>
    <Code>NoSuchPublicAccessBlockConfiguration</Code>
    <Message>The public access block configuration was not found</Message>
    <AccountId>193347341732</AccountId>
  </Error>
  <RequestId>1VHQEEBR32DDWTPE</RequestId>
  <HostId>...</HostId>
</ErrorResponse>
```

The fix is for the existing `NoSuchPublicAccessBlockConfiguration`-exception to extend `ServiceException`, as that automatically wraps the response in an `ErrorResponse` tag.