### PR TITLE
S3: fix Terraform error when creating Lifecycle Configuration

### DIFF
--- a/moto/s3/models.py
+++ b/moto/s3/models.py
@@ -14,6 +14,7 @@ import threading
 import urllib.parse
 from bisect import insort
 from collections.abc import Iterator
+from enum import Enum
 from importlib import reload
 from io import BytesIO
 from typing import Any, Optional, Union
@@ -89,6 +90,11 @@ MIN_BUCKET_NAME_LENGTH = 3
 UPLOAD_ID_BYTES = 43
 DEFAULT_TEXT_ENCODING = sys.getdefaultencoding()
 OWNER = "75aa57f09aa0c8caeab4f8c24e99d10f8e7faeebf76c078efc7c6caea54ba06a"
+
+
+class TransitionDefaultMinimumObjectSize(Enum):
+    ALL_STORAGE_CLASSES_128K = "all_storage_classes_128K"
+    VARIES_BY_STORAGE_CLASS = "varies_by_storage_class"
 
 
 class FakeDeleteMarker(BaseModel):

--- a/moto/s3/responses.py
+++ b/moto/s3/responses.py
@@ -68,6 +68,7 @@ from .models import (
     FakeGrantee,
     FakeKey,
     S3Backend,
+    TransitionDefaultMinimumObjectSize,
     get_canned_acl,
     s3_backends,
 )
@@ -1018,7 +1019,10 @@ class S3Response(BaseResponse):
             template = self.response_template(S3_NO_LIFECYCLE)
             return 404, {}, template.render(bucket_name=self.bucket_name)
         template = self.response_template(S3_BUCKET_LIFECYCLE_CONFIGURATION)
-        return template.render(rules=rules)
+        headers = {
+            "x-amz-transition-default-minimum-object-size": TransitionDefaultMinimumObjectSize.ALL_STORAGE_CLASSES_128K.value
+        }
+        return 200, headers, template.render(rules=rules)
 
     def get_bucket_location(self) -> str:
         location: Optional[str] = self.backend.get_bucket_location(self.bucket_name)

--- a/other_langs/terraform/s3/bucket_with_lifecycle_policy.tf
+++ b/other_langs/terraform/s3/bucket_with_lifecycle_policy.tf
@@ -1,0 +1,38 @@
+resource "aws_s3_bucket" "bucket_with_lifecycle_configuration" {
+  bucket = "test-bucket-with-lifecycle-configuration"
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "test_lifecycle_configuration" {
+  bucket = aws_s3_bucket.bucket_with_lifecycle_configuration.id
+  rule {
+    id     = "OptimizeData"
+    status = "Enabled"
+
+    filter {
+      prefix = "test-logs/"
+    }
+
+    transition {
+      days          = 30
+      storage_class = "STANDARD_IA"
+    }
+
+    transition {
+      days          = 90
+      storage_class = "GLACIER_IR"
+    }
+
+    expiration {
+      days = 365
+    }
+
+    noncurrent_version_transition {
+      noncurrent_days = 30
+      storage_class   = "STANDARD_IA"
+    }
+
+    noncurrent_version_expiration {
+      noncurrent_days = 90
+    }
+  }
+}


### PR DESCRIPTION
Terraform expects the `TransitionDefaultMinimumObjectSize` attribute to be returned from the GetBucketLifecycleConfiguration API call.  This PR adds the expected (default) response value, but does not implement setting the value via the PutBucketLifecycleConfiguration API call.

Closes #9708