### PR TITLE
Backup: Implement ReportPlans + Terraform support

### DIFF
--- a/moto/backup/urls.py
+++ b/moto/backup/urls.py
@@ -11,6 +11,7 @@ response = BackupResponse()
 
 
 url_paths = {
+    "{0}/audit/report-plans": response.dispatch,
     "{0}/backup/plans/?$": response.dispatch,
     "{0}/backup/plans/(?P<name>.+)/?$": response.dispatch,
     "{0}/backup-vaults/$": response.dispatch,
@@ -18,4 +19,6 @@ url_paths = {
     "{0}/backup-vaults/(?P<name>[^/]+)/vault-lock$": response.dispatch,
     "{0}/tags/(?P<resource_arn>.+)$": response.dispatch,
     "{0}/untag/(?P<resource_arn>.+)$": response.dispatch,
+    "{0}/audit/report-plans$": BackupResponse.dispatch,
+    "{0}/audit/report-plans/(?P<reportPlanName>[^/]+)$": BackupResponse.dispatch,
 }

--- a/moto/core/responses.py
+++ b/moto/core/responses.py
@@ -112,6 +112,8 @@ def _get_method_urls(service_name: str, region: str) -> dict[str, dict[str, str]
         if service_name == "opensearch" and request_uri.endswith("/tags/"):
             # AWS GO SDK behaves differently from other SDK's, does not send a trailing slash
             request_uri += "?"
+        if service_name == "backup" and request_uri.endswith("/"):
+            request_uri += "?"
         uri_regexp = BaseResponse.uri_to_regexp(request_uri)
         method_urls[_method][uri_regexp] = op_model.name
 

--- a/other_langs/terraform/backup/provider.tf
+++ b/other_langs/terraform/backup/provider.tf
@@ -1,0 +1,15 @@
+provider "aws" {
+  region = "us-east-1"
+
+  access_key                  = "test"
+  secret_key                  = "test"
+  s3_use_path_style           = true
+  skip_credentials_validation = true
+  skip_metadata_api_check     = true
+  skip_requesting_account_id  = true
+
+  endpoints {
+    backup         = "http://localhost:5000"
+    s3             = "http://localhost:5000"
+  }
+}

--- a/other_langs/terraform/backup/resources.tf
+++ b/other_langs/terraform/backup/resources.tf
@@ -1,0 +1,40 @@
+resource "aws_backup_vault" "example" {
+  name        = "example_backup_vault"
+}
+
+resource "aws_backup_plan" "example" {
+  name = "tf_example_backup_plan"
+
+  rule {
+    rule_name         = "tf_example_backup_rule"
+    target_vault_name = aws_backup_vault.example.name
+    schedule          = "cron(0 12 * * ? *)"
+
+    lifecycle {
+      delete_after = 14
+    }
+  }
+
+  advanced_backup_setting {
+    backup_options = {
+      WindowsVSS = "enabled"
+    }
+    resource_type = "EC2"
+  }
+}
+
+resource "aws_backup_report_plan" "test" {
+  name = "test_plan"
+  report_delivery_channel {
+    s3_bucket_name = aws_s3_bucket.simple_bucket.id
+    formats = ["CSV", "JSON"]
+    s3_key_prefix = "test_prefix"
+  }
+  report_setting {
+    report_template = "BACKUP_JOB_REPORT"
+  }
+}
+
+resource "aws_s3_bucket" "simple_bucket" {
+  bucket = "simple-test-bucket"
+}

--- a/tests/test_backup/test_backup.py
+++ b/tests/test_backup/test_backup.py
@@ -260,6 +260,23 @@ def test_create_backup_vault():
     assert "BackupVaultArn" in resp
     assert "CreationDate" in resp
 
+    describe = client.describe_backup_vault(BackupVaultName="backupvault-foobar")
+    assert describe["BackupVaultName"] == "backupvault-foobar"
+    assert describe["BackupVaultArn"] == resp["BackupVaultArn"]
+
+
+@mock_aws
+def test_delete_backup_vault():
+    client = boto3.client("backup", region_name="eu-west-1")
+    client.create_backup_vault(BackupVaultName="backupvault-foobar")
+
+    client.delete_backup_vault(BackupVaultName="backupvault-foobar")
+
+    with pytest.raises(ClientError) as exc:
+        client.describe_backup_vault(BackupVaultName="backupvault-foobar")
+    err = exc.value.response["Error"]
+    assert err["Code"] == "ResourceNotFoundException"
+
 
 @mock_aws
 def test_create_backup_vault_already_exists():

--- a/tests/test_backup/test_backup_report_plans.py
+++ b/tests/test_backup/test_backup_report_plans.py
@@ -1,0 +1,52 @@
+from uuid import uuid4
+
+import boto3
+import pytest
+from botocore.exceptions import ClientError
+
+from moto import mock_aws
+
+
+@mock_aws
+def test_list_report_plans():
+    client = boto3.client("backup", "us-east-1")
+
+    plans = client.list_report_plans()["ReportPlans"]
+    assert plans == []
+
+
+@mock_aws
+def test_create_report_plan():
+    client = boto3.client("backup", "us-east-1")
+
+    plan_name = "RP_" + str(uuid4()).replace("-", "_")
+    create = client.create_report_plan(
+        ReportPlanName=plan_name,
+        ReportDeliveryChannel={"S3BucketName": "mybucket"},
+        ReportSetting={"ReportTemplate": "RESOURCE_COMPLIANCE_REPORT"},
+    )
+    assert create["ReportPlanName"] == plan_name
+
+    get = client.describe_report_plan(ReportPlanName=plan_name)["ReportPlan"]
+
+    assert get["ReportSetting"] == {"ReportTemplate": "RESOURCE_COMPLIANCE_REPORT"}
+    assert get["ReportDeliveryChannel"] == {"S3BucketName": "mybucket"}
+
+
+@mock_aws
+def test_delete_report_plan():
+    client = boto3.client("backup", "us-east-1")
+
+    plan_name = "RP_" + str(uuid4()).replace("-", "_")
+    client.create_report_plan(
+        ReportPlanName=plan_name,
+        ReportDeliveryChannel={"S3BucketName": "mybucket"},
+        ReportSetting={"ReportTemplate": "RESOURCE_COMPLIANCE_REPORT"},
+    )
+
+    client.delete_report_plan(ReportPlanName=plan_name)
+
+    with pytest.raises(ClientError) as exc:
+        client.describe_report_plan(ReportPlanName=plan_name)
+    err = exc.value.response["Error"]
+    assert err["Code"] == "ResourceNotFoundException"


### PR DESCRIPTION
Fixes #9707 

Implements a couple of new methods:
 - describe_backup_vault()
 - delete_backup_vault()
 - create_report_plan()
 - describe_report_plan()
 - list_report_plans()

Plus some necessary changes to make this work against Terraform.