### PR TITLE
Prep release 5.1.21

### DIFF
--- a/.github/workflows/tests_sdk_js.yml
+++ b/.github/workflows/tests_sdk_js.yml
@@ -18,11 +18,7 @@ jobs:
     - uses: actions/setup-node@v6
     - name: Install dependencies
       run: |
-        pwd
-        ls -la
-        cd other_langs/tests_js && npm install
+        cd other_langs/tests_js && npm install && npm list
     - name: Run tests
       run: |
-        pwd
-        ls -la
         cd other_langs/tests_js && npm test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,61 @@
 Moto Changelog
 ==============
 
+5.1.21
+-----
+Docker Digest for 5.1.21: <autopopulateddigest>
+
+    General:
+        * Moto now supports the new AWS partition for the EU sovereign cloud ('eusc-de-east-1')
+
+    New Services:
+        * Account:
+            * delete_alternate_contact()
+            * get_alternate_contact()
+            * put_alternate_contact()
+
+        * Connect:
+            * associate_analytics_data_set()
+            * create_instance()
+            * delete_instance()
+            * describe_instance()
+            * disassociate_analytics_data_set()
+            * list_analytics_data_associations()
+            * list_instances()
+            * list_tags_for_resource()
+            * tag_resource()
+            * untag_resource()
+
+    New Methods:
+        * Backup:
+            * create_report_plan()
+            * delete_backup_vault()
+            * delete_backup_vault_lock_configuration()
+            * describe_backup_vault()
+            * describe_report_plan()
+            * list_report_plans()
+            * put_backup_vault_lock_configuration()
+
+        * EKS:
+            * update_nodegroup_config()
+
+        * Route53Resolver:
+            * get_resolver_query_log_config_association()
+            * list_resolver_query_log_configs()
+            * list_resolver_query_log_config_associations()
+
+        * SecurityHub:
+            * get_master_account()
+
+    Miscellaneous:
+        * DynamoDB now supports multi-attribute composite key support for GSIs
+        * ELBv2: Internal load balancers can now be `dualstack`
+        * IAM: Policy validation now correctly validates Boolean conditions and NULL-resources
+        * Lambda: put_function_event_invoke_config() no longer requires the DestinationConfig-parameter
+        * ResourceGroupsTaggingAPI: tag_resources() and untag_resources() now supports CloudFront resources
+        * SageMaker: describe_domain() now returns the DomainSetting-attribute
+
+
 5.1.20
 -----
 Docker Digest for 5.1.20: _sha256:d2711655244df58411ce0be34236c95736390db17886370d21e12ae2b1e36f79_

--- a/IMPLEMENTATION_COVERAGE.md
+++ b/IMPLEMENTATION_COVERAGE.md
@@ -73,15 +73,17 @@
 
 ## amp
 <details>
-<summary>43% implemented</summary>
+<summary>38% implemented</summary>
 
 - [ ] create_alert_manager_definition
+- [ ] create_anomaly_detector
 - [X] create_logging_configuration
 - [ ] create_query_logging_configuration
 - [X] create_rule_groups_namespace
 - [ ] create_scraper
 - [X] create_workspace
 - [ ] delete_alert_manager_definition
+- [ ] delete_anomaly_detector
 - [X] delete_logging_configuration
 - [ ] delete_query_logging_configuration
 - [ ] delete_resource_policy
@@ -90,6 +92,7 @@
 - [ ] delete_scraper_logging_configuration
 - [X] delete_workspace
 - [ ] describe_alert_manager_definition
+- [ ] describe_anomaly_detector
 - [X] describe_logging_configuration
 - [ ] describe_query_logging_configuration
 - [ ] describe_resource_policy
@@ -99,11 +102,13 @@
 - [X] describe_workspace
 - [ ] describe_workspace_configuration
 - [ ] get_default_scraper_configuration
+- [ ] list_anomaly_detectors
 - [X] list_rule_groups_namespaces
 - [ ] list_scrapers
 - [X] list_tags_for_resource
 - [X] list_workspaces
 - [ ] put_alert_manager_definition
+- [ ] put_anomaly_detector
 - [ ] put_resource_policy
 - [X] put_rule_groups_namespace
 - [X] tag_resource
@@ -257,7 +262,7 @@
 
 ## apigatewayv2
 <details>
-<summary>70% implemented</summary>
+<summary>52% implemented</summary>
 
 - [X] create_api
 - [X] create_api_mapping
@@ -267,6 +272,10 @@
 - [X] create_integration
 - [X] create_integration_response
 - [X] create_model
+- [ ] create_portal
+- [ ] create_portal_product
+- [ ] create_product_page
+- [ ] create_product_rest_endpoint_page
 - [X] create_route
 - [X] create_route_response
 - [ ] create_routing_rule
@@ -282,6 +291,11 @@
 - [X] delete_integration
 - [X] delete_integration_response
 - [X] delete_model
+- [ ] delete_portal
+- [ ] delete_portal_product
+- [ ] delete_portal_product_sharing_policy
+- [ ] delete_product_page
+- [ ] delete_product_rest_endpoint_page
 - [X] delete_route
 - [X] delete_route_request_parameter
 - [X] delete_route_response
@@ -289,6 +303,7 @@
 - [ ] delete_routing_rule
 - [X] delete_stage
 - [X] delete_vpc_link
+- [ ] disable_portal
 - [ ] export_api
 - [X] get_api
 - [X] get_api_mapping
@@ -307,6 +322,11 @@
 - [X] get_model
 - [ ] get_model_template
 - [ ] get_models
+- [ ] get_portal
+- [ ] get_portal_product
+- [ ] get_portal_product_sharing_policy
+- [ ] get_product_page
+- [ ] get_product_rest_endpoint_page
 - [X] get_route
 - [X] get_route_response
 - [ ] get_route_responses
@@ -318,7 +338,14 @@
 - [X] get_vpc_link
 - [X] get_vpc_links
 - [ ] import_api
+- [ ] list_portal_products
+- [ ] list_portals
+- [ ] list_product_pages
+- [ ] list_product_rest_endpoint_pages
 - [ ] list_routing_rules
+- [ ] preview_portal
+- [ ] publish_portal
+- [ ] put_portal_product_sharing_policy
 - [ ] put_routing_rule
 - [X] reimport_api
 - [ ] reset_authorizers_cache
@@ -332,6 +359,10 @@
 - [X] update_integration
 - [X] update_integration_response
 - [X] update_model
+- [ ] update_portal
+- [ ] update_portal_product
+- [ ] update_product_page
+- [ ] update_product_rest_endpoint_page
 - [X] update_route
 - [ ] update_route_response
 - [ ] update_stage
@@ -535,7 +566,7 @@
 
 ## athena
 <details>
-<summary>33% implemented</summary>
+<summary>32% implemented</summary>
 
 - [ ] batch_get_named_query
 - [ ] batch_get_prepared_statement
@@ -568,7 +599,9 @@
 - [X] get_query_execution
 - [X] get_query_results
 - [X] get_query_runtime_statistics
+- [ ] get_resource_dashboard
 - [ ] get_session
+- [ ] get_session_endpoint
 - [ ] get_session_status
 - [ ] get_table_metadata
 - [X] get_work_group
@@ -609,7 +642,7 @@
 
 ## autoscaling
 <details>
-<summary>60% implemented</summary>
+<summary>59% implemented</summary>
 
 - [X] attach_instances
 - [X] attach_load_balancer_target_groups
@@ -661,6 +694,7 @@
 - [X] execute_policy
 - [ ] exit_standby
 - [ ] get_predictive_scaling_forecast
+- [ ] launch_instances
 - [ ] put_lifecycle_hook
 - [ ] put_notification_configuration
 - [X] put_scaling_policy
@@ -680,7 +714,7 @@
 
 ## backup
 <details>
-<summary>9% implemented</summary>
+<summary>15% implemented</summary>
 
 - [ ] associate_backup_vault_mpa_approval_team
 - [ ] cancel_legal_hold
@@ -690,23 +724,25 @@
 - [ ] create_framework
 - [ ] create_legal_hold
 - [ ] create_logically_air_gapped_backup_vault
-- [ ] create_report_plan
+- [X] create_report_plan
 - [ ] create_restore_access_backup_vault
 - [ ] create_restore_testing_plan
 - [ ] create_restore_testing_selection
+- [ ] create_tiering_configuration
 - [X] delete_backup_plan
 - [ ] delete_backup_selection
-- [ ] delete_backup_vault
+- [X] delete_backup_vault
 - [ ] delete_backup_vault_access_policy
-- [ ] delete_backup_vault_lock_configuration
+- [X] delete_backup_vault_lock_configuration
 - [ ] delete_backup_vault_notifications
 - [ ] delete_framework
 - [ ] delete_recovery_point
-- [ ] delete_report_plan
+- [X] delete_report_plan
 - [ ] delete_restore_testing_plan
 - [ ] delete_restore_testing_selection
+- [ ] delete_tiering_configuration
 - [ ] describe_backup_job
-- [ ] describe_backup_vault
+- [X] describe_backup_vault
 - [ ] describe_copy_job
 - [ ] describe_framework
 - [ ] describe_global_settings
@@ -714,8 +750,9 @@
 - [ ] describe_recovery_point
 - [ ] describe_region_settings
 - [ ] describe_report_job
-- [ ] describe_report_plan
+- [X] describe_report_plan
 - [ ] describe_restore_job
+- [ ] describe_scan_job
 - [ ] disassociate_backup_vault_mpa_approval_team
 - [ ] disassociate_recovery_point
 - [ ] disassociate_recovery_point_from_parent
@@ -734,6 +771,7 @@
 - [ ] get_restore_testing_plan
 - [ ] get_restore_testing_selection
 - [ ] get_supported_resource_types
+- [ ] get_tiering_configuration
 - [ ] list_backup_job_summaries
 - [ ] list_backup_jobs
 - [ ] list_backup_plan_templates
@@ -752,16 +790,19 @@
 - [ ] list_recovery_points_by_legal_hold
 - [ ] list_recovery_points_by_resource
 - [ ] list_report_jobs
-- [ ] list_report_plans
+- [X] list_report_plans
 - [ ] list_restore_access_backup_vaults
 - [ ] list_restore_job_summaries
 - [ ] list_restore_jobs
 - [ ] list_restore_jobs_by_protected_resource
 - [ ] list_restore_testing_plans
 - [ ] list_restore_testing_selections
+- [ ] list_scan_job_summaries
+- [ ] list_scan_jobs
 - [X] list_tags
+- [ ] list_tiering_configurations
 - [ ] put_backup_vault_access_policy
-- [ ] put_backup_vault_lock_configuration
+- [X] put_backup_vault_lock_configuration
 - [ ] put_backup_vault_notifications
 - [ ] put_restore_validation_result
 - [ ] revoke_restore_access_backup_vault
@@ -769,6 +810,7 @@
 - [ ] start_copy_job
 - [ ] start_report_job
 - [ ] start_restore_job
+- [ ] start_scan_job
 - [ ] stop_backup_job
 - [X] tag_resource
 - [X] untag_resource
@@ -781,6 +823,7 @@
 - [ ] update_report_plan
 - [ ] update_restore_testing_plan
 - [ ] update_restore_testing_selection
+- [ ] update_tiering_configuration
 </details>
 
 ## batch
@@ -856,6 +899,7 @@
 - [ ] delete_automated_reasoning_policy_test_case
 - [X] delete_custom_model
 - [ ] delete_custom_model_deployment
+- [ ] delete_enforced_guardrail_configuration
 - [ ] delete_foundation_model_agreement
 - [ ] delete_guardrail
 - [ ] delete_imported_model
@@ -896,6 +940,7 @@
 - [ ] list_automated_reasoning_policy_test_results
 - [ ] list_custom_model_deployments
 - [X] list_custom_models
+- [ ] list_enforced_guardrails_configuration
 - [ ] list_evaluation_jobs
 - [ ] list_foundation_model_agreement_offers
 - [ ] list_foundation_models
@@ -910,6 +955,7 @@
 - [ ] list_prompt_routers
 - [ ] list_provisioned_model_throughputs
 - [X] list_tags_for_resource
+- [ ] put_enforced_guardrail_configuration
 - [X] put_model_invocation_logging_configuration
 - [ ] put_use_case_for_model_access
 - [ ] register_marketplace_model_endpoint
@@ -923,6 +969,7 @@
 - [ ] update_automated_reasoning_policy
 - [ ] update_automated_reasoning_policy_annotations
 - [ ] update_automated_reasoning_policy_test_case
+- [ ] update_custom_model_deployment
 - [ ] update_guardrail
 - [ ] update_marketplace_model_endpoint
 - [ ] update_provisioned_model_throughput
@@ -1076,6 +1123,7 @@
 - [ ] list_cost_allocation_tag_backfill_history
 - [ ] list_cost_allocation_tags
 - [ ] list_cost_category_definitions
+- [ ] list_cost_category_resource_associations
 - [ ] list_savings_plans_purchase_recommendation_generation
 - [X] list_tags_for_resource
 - [ ] provide_anomaly_feedback
@@ -1164,7 +1212,7 @@
 
 ## cloudformation
 <details>
-<summary>37% implemented</summary>
+<summary>36% implemented</summary>
 
 - [ ] activate_organizations_access
 - [ ] activate_type
@@ -1188,6 +1236,7 @@
 - [ ] describe_account_limits
 - [X] describe_change_set
 - [ ] describe_change_set_hooks
+- [ ] describe_events
 - [ ] describe_generated_template
 - [ ] describe_organizations_access
 - [ ] describe_publisher
@@ -1211,6 +1260,7 @@
 - [X] execute_change_set
 - [ ] execute_stack_refactor
 - [ ] get_generated_template
+- [ ] get_hook_result
 - [X] get_stack_policy
 - [X] get_template
 - [ ] get_template_summary
@@ -1258,7 +1308,7 @@
 
 ## cloudfront
 <details>
-<summary>17% implemented</summary>
+<summary>14% implemented</summary>
 
 - [ ] associate_alias
 - [ ] associate_distribution_tenant_web_acl
@@ -1267,6 +1317,7 @@
 - [ ] create_anycast_ip_list
 - [ ] create_cache_policy
 - [ ] create_cloud_front_origin_access_identity
+- [ ] create_connection_function
 - [ ] create_connection_group
 - [ ] create_continuous_deployment_policy
 - [X] create_distribution
@@ -1287,10 +1338,12 @@
 - [ ] create_response_headers_policy
 - [ ] create_streaming_distribution
 - [ ] create_streaming_distribution_with_tags
+- [ ] create_trust_store
 - [ ] create_vpc_origin
 - [ ] delete_anycast_ip_list
 - [ ] delete_cache_policy
 - [ ] delete_cloud_front_origin_access_identity
+- [ ] delete_connection_function
 - [ ] delete_connection_group
 - [ ] delete_continuous_deployment_policy
 - [X] delete_distribution
@@ -1305,9 +1358,12 @@
 - [ ] delete_origin_request_policy
 - [X] delete_public_key
 - [ ] delete_realtime_log_config
+- [ ] delete_resource_policy
 - [ ] delete_response_headers_policy
 - [ ] delete_streaming_distribution
+- [ ] delete_trust_store
 - [ ] delete_vpc_origin
+- [ ] describe_connection_function
 - [ ] describe_function
 - [ ] describe_key_value_store
 - [ ] disassociate_distribution_tenant_web_acl
@@ -1317,6 +1373,7 @@
 - [ ] get_cache_policy_config
 - [ ] get_cloud_front_origin_access_identity
 - [ ] get_cloud_front_origin_access_identity_config
+- [ ] get_connection_function
 - [ ] get_connection_group
 - [ ] get_connection_group_by_routing_endpoint
 - [ ] get_continuous_deployment_policy
@@ -1343,15 +1400,18 @@
 - [X] get_public_key
 - [ ] get_public_key_config
 - [ ] get_realtime_log_config
+- [ ] get_resource_policy
 - [ ] get_response_headers_policy
 - [ ] get_response_headers_policy_config
 - [ ] get_streaming_distribution
 - [ ] get_streaming_distribution_config
+- [ ] get_trust_store
 - [ ] get_vpc_origin
 - [ ] list_anycast_ip_lists
 - [ ] list_cache_policies
 - [ ] list_cloud_front_origin_access_identities
 - [ ] list_conflicting_aliases
+- [ ] list_connection_functions
 - [ ] list_connection_groups
 - [ ] list_continuous_deployment_policies
 - [ ] list_distribution_tenants
@@ -1359,11 +1419,14 @@
 - [X] list_distributions
 - [ ] list_distributions_by_anycast_ip_list_id
 - [ ] list_distributions_by_cache_policy_id
+- [ ] list_distributions_by_connection_function
 - [ ] list_distributions_by_connection_mode
 - [ ] list_distributions_by_key_group
 - [ ] list_distributions_by_origin_request_policy_id
+- [ ] list_distributions_by_owned_resource
 - [ ] list_distributions_by_realtime_log_config
 - [ ] list_distributions_by_response_headers_policy_id
+- [ ] list_distributions_by_trust_store
 - [ ] list_distributions_by_vpc_origin_id
 - [ ] list_distributions_by_web_acl_id
 - [ ] list_domain_conflicts
@@ -1381,13 +1444,19 @@
 - [ ] list_response_headers_policies
 - [ ] list_streaming_distributions
 - [X] list_tags_for_resource
+- [ ] list_trust_stores
 - [ ] list_vpc_origins
+- [ ] publish_connection_function
 - [ ] publish_function
+- [ ] put_resource_policy
 - [X] tag_resource
+- [ ] test_connection_function
 - [ ] test_function
 - [X] untag_resource
+- [ ] update_anycast_ip_list
 - [ ] update_cache_policy
 - [ ] update_cloud_front_origin_access_identity
+- [ ] update_connection_function
 - [ ] update_connection_group
 - [ ] update_continuous_deployment_policy
 - [X] update_distribution
@@ -1405,6 +1474,7 @@
 - [ ] update_realtime_log_config
 - [ ] update_response_headers_policy
 - [ ] update_streaming_distribution
+- [ ] update_trust_store
 - [ ] update_vpc_origin
 - [ ] verify_dns_configuration
 </details>
@@ -1435,7 +1505,7 @@
 
 ## cloudtrail
 <details>
-<summary>27% implemented</summary>
+<summary>26% implemented</summary>
 
 - [X] add_tags
 - [ ] cancel_query
@@ -1470,6 +1540,7 @@
 - [ ] list_event_data_stores
 - [ ] list_import_failures
 - [ ] list_imports
+- [ ] list_insights_data
 - [ ] list_insights_metric_data
 - [ ] list_public_keys
 - [ ] list_queries
@@ -2146,7 +2217,7 @@
 
 ## connect
 <details>
-<summary>3% implemented</summary>
+<summary>2% implemented</summary>
 
 - [ ] activate_evaluation_form
 - [X] associate_analytics_data_set
@@ -2154,7 +2225,9 @@
 - [ ] associate_bot
 - [ ] associate_contact_with_user
 - [ ] associate_default_vocabulary
+- [ ] associate_email_address_alias
 - [ ] associate_flow
+- [ ] associate_hours_of_operations
 - [ ] associate_instance_storage_config
 - [ ] associate_lambda_function
 - [ ] associate_lex_bot
@@ -2162,20 +2235,30 @@
 - [ ] associate_queue_quick_connects
 - [ ] associate_routing_profile_queues
 - [ ] associate_security_key
+- [ ] associate_security_profiles
 - [ ] associate_traffic_distribution_group_user
 - [ ] associate_user_proficiencies
+- [ ] associate_workspace
 - [ ] batch_associate_analytics_data_set
+- [ ] batch_create_data_table_value
+- [ ] batch_delete_data_table_value
+- [ ] batch_describe_data_table_value
 - [ ] batch_disassociate_analytics_data_set
 - [ ] batch_get_attached_file_metadata
 - [ ] batch_get_flow_association
 - [ ] batch_put_contact
+- [ ] batch_update_data_table_value
 - [ ] claim_phone_number
 - [ ] complete_attached_file_upload
 - [ ] create_agent_status
 - [ ] create_contact
 - [ ] create_contact_flow
 - [ ] create_contact_flow_module
+- [ ] create_contact_flow_module_alias
+- [ ] create_contact_flow_module_version
 - [ ] create_contact_flow_version
+- [ ] create_data_table
+- [ ] create_data_table_attribute
 - [ ] create_email_address
 - [ ] create_evaluation_form
 - [ ] create_hours_of_operation
@@ -2193,6 +2276,7 @@
 - [ ] create_rule
 - [ ] create_security_profile
 - [ ] create_task_template
+- [ ] create_test_case
 - [ ] create_traffic_distribution_group
 - [ ] create_use_case
 - [ ] create_user
@@ -2200,12 +2284,18 @@
 - [ ] create_view
 - [ ] create_view_version
 - [ ] create_vocabulary
+- [ ] create_workspace
+- [ ] create_workspace_page
 - [ ] deactivate_evaluation_form
 - [ ] delete_attached_file
 - [ ] delete_contact_evaluation
 - [ ] delete_contact_flow
 - [ ] delete_contact_flow_module
+- [ ] delete_contact_flow_module_alias
+- [ ] delete_contact_flow_module_version
 - [ ] delete_contact_flow_version
+- [ ] delete_data_table
+- [ ] delete_data_table_attribute
 - [ ] delete_email_address
 - [ ] delete_evaluation_form
 - [ ] delete_hours_of_operation
@@ -2221,6 +2311,7 @@
 - [ ] delete_rule
 - [ ] delete_security_profile
 - [ ] delete_task_template
+- [ ] delete_test_case
 - [ ] delete_traffic_distribution_group
 - [ ] delete_use_case
 - [ ] delete_user
@@ -2228,12 +2319,18 @@
 - [ ] delete_view
 - [ ] delete_view_version
 - [ ] delete_vocabulary
+- [ ] delete_workspace
+- [ ] delete_workspace_media
+- [ ] delete_workspace_page
 - [ ] describe_agent_status
 - [ ] describe_authentication_profile
 - [ ] describe_contact
 - [ ] describe_contact_evaluation
 - [ ] describe_contact_flow
 - [ ] describe_contact_flow_module
+- [ ] describe_contact_flow_module_alias
+- [ ] describe_data_table
+- [ ] describe_data_table_attribute
 - [ ] describe_email_address
 - [ ] describe_evaluation_form
 - [ ] describe_hours_of_operation
@@ -2249,16 +2346,20 @@
 - [ ] describe_routing_profile
 - [ ] describe_rule
 - [ ] describe_security_profile
+- [ ] describe_test_case
 - [ ] describe_traffic_distribution_group
 - [ ] describe_user
 - [ ] describe_user_hierarchy_group
 - [ ] describe_user_hierarchy_structure
 - [ ] describe_view
 - [ ] describe_vocabulary
+- [ ] describe_workspace
 - [X] disassociate_analytics_data_set
 - [ ] disassociate_approved_origin
 - [ ] disassociate_bot
+- [ ] disassociate_email_address_alias
 - [ ] disassociate_flow
+- [ ] disassociate_hours_of_operations
 - [ ] disassociate_instance_storage_config
 - [ ] disassociate_lambda_function
 - [ ] disassociate_lex_bot
@@ -2266,9 +2367,12 @@
 - [ ] disassociate_queue_quick_connects
 - [ ] disassociate_routing_profile_queues
 - [ ] disassociate_security_key
+- [ ] disassociate_security_profiles
 - [ ] disassociate_traffic_distribution_group_user
 - [ ] disassociate_user_proficiencies
+- [ ] disassociate_workspace
 - [ ] dismiss_user_contact
+- [ ] evaluate_data_table_values
 - [ ] get_attached_file
 - [ ] get_contact_attributes
 - [ ] get_contact_metrics
@@ -2281,8 +2385,10 @@
 - [ ] get_metric_data_v2
 - [ ] get_prompt_file
 - [ ] get_task_template
+- [ ] get_test_case_execution_summary
 - [ ] get_traffic_distribution
 - [ ] import_phone_number
+- [ ] import_workspace_media
 - [ ] list_agent_statuses
 - [X] list_analytics_data_associations
 - [ ] list_analytics_data_lake_data_sets
@@ -2290,12 +2396,20 @@
 - [ ] list_associated_contacts
 - [ ] list_authentication_profiles
 - [ ] list_bots
+- [ ] list_child_hours_of_operations
 - [ ] list_contact_evaluations
+- [ ] list_contact_flow_module_aliases
+- [ ] list_contact_flow_module_versions
 - [ ] list_contact_flow_modules
 - [ ] list_contact_flow_versions
 - [ ] list_contact_flows
 - [ ] list_contact_references
+- [ ] list_data_table_attributes
+- [ ] list_data_table_primary_values
+- [ ] list_data_table_values
+- [ ] list_data_tables
 - [ ] list_default_vocabularies
+- [ ] list_entity_security_profiles
 - [ ] list_evaluation_form_versions
 - [ ] list_evaluation_forms
 - [ ] list_flow_associations
@@ -2321,10 +2435,14 @@
 - [ ] list_rules
 - [ ] list_security_keys
 - [ ] list_security_profile_applications
+- [ ] list_security_profile_flow_modules
 - [ ] list_security_profile_permissions
 - [ ] list_security_profiles
 - [X] list_tags_for_resource
 - [ ] list_task_templates
+- [ ] list_test_case_execution_records
+- [ ] list_test_case_executions
+- [ ] list_test_cases
 - [ ] list_traffic_distribution_group_users
 - [ ] list_traffic_distribution_groups
 - [ ] list_use_cases
@@ -2333,6 +2451,9 @@
 - [ ] list_users
 - [ ] list_view_versions
 - [ ] list_views
+- [ ] list_workspace_media
+- [ ] list_workspace_pages
+- [ ] list_workspaces
 - [ ] monitor_contact
 - [ ] pause_contact
 - [ ] put_user_status
@@ -2342,10 +2463,13 @@
 - [ ] resume_contact_recording
 - [ ] search_agent_statuses
 - [ ] search_available_phone_numbers
+- [ ] search_contact_evaluations
 - [ ] search_contact_flow_modules
 - [ ] search_contact_flows
 - [ ] search_contacts
+- [ ] search_data_tables
 - [ ] search_email_addresses
+- [ ] search_evaluation_forms
 - [ ] search_hours_of_operation_overrides
 - [ ] search_hours_of_operations
 - [ ] search_predefined_attributes
@@ -2355,14 +2479,19 @@
 - [ ] search_resource_tags
 - [ ] search_routing_profiles
 - [ ] search_security_profiles
+- [ ] search_test_cases
 - [ ] search_user_hierarchy_groups
 - [ ] search_users
+- [ ] search_views
 - [ ] search_vocabularies
+- [ ] search_workspace_associations
+- [ ] search_workspaces
 - [ ] send_chat_integration_event
 - [ ] send_outbound_email
 - [ ] start_attached_file_upload
 - [ ] start_chat_contact
 - [ ] start_contact_evaluation
+- [ ] start_contact_media_processing
 - [ ] start_contact_recording
 - [ ] start_contact_streaming
 - [ ] start_email_contact
@@ -2371,10 +2500,13 @@
 - [ ] start_outbound_voice_contact
 - [ ] start_screen_sharing
 - [ ] start_task_contact
+- [ ] start_test_case_execution
 - [ ] start_web_rtc_contact
 - [ ] stop_contact
+- [ ] stop_contact_media_processing
 - [ ] stop_contact_recording
 - [ ] stop_contact_streaming
+- [ ] stop_test_case_execution
 - [ ] submit_contact_evaluation
 - [ ] suspend_contact_recording
 - [ ] tag_contact
@@ -2389,11 +2521,15 @@
 - [ ] update_contact_evaluation
 - [ ] update_contact_flow_content
 - [ ] update_contact_flow_metadata
+- [ ] update_contact_flow_module_alias
 - [ ] update_contact_flow_module_content
 - [ ] update_contact_flow_module_metadata
 - [ ] update_contact_flow_name
 - [ ] update_contact_routing_data
 - [ ] update_contact_schedule
+- [ ] update_data_table_attribute
+- [ ] update_data_table_metadata
+- [ ] update_data_table_primary_values
 - [ ] update_email_address_metadata
 - [ ] update_evaluation_form
 - [ ] update_hours_of_operation
@@ -2422,6 +2558,7 @@
 - [ ] update_rule
 - [ ] update_security_profile
 - [ ] update_task_template
+- [ ] update_test_case
 - [ ] update_traffic_distribution
 - [ ] update_user_hierarchy
 - [ ] update_user_hierarchy_group_name
@@ -2433,6 +2570,10 @@
 - [ ] update_user_security_profiles
 - [ ] update_view_content
 - [ ] update_view_metadata
+- [ ] update_workspace_metadata
+- [ ] update_workspace_page
+- [ ] update_workspace_theme
+- [ ] update_workspace_visibility
 </details>
 
 ## connectcampaigns
@@ -2695,11 +2836,13 @@
 
 ## dms
 <details>
-<summary>15% implemented</summary>
+<summary>14% implemented</summary>
 
 - [ ] add_tags_to_resource
 - [ ] apply_pending_maintenance_action
 - [ ] batch_start_recommendations
+- [ ] cancel_metadata_model_conversion
+- [ ] cancel_metadata_model_creation
 - [ ] cancel_replication_task_assessment_run
 - [ ] create_data_migration
 - [ ] create_data_provider
@@ -2748,8 +2891,11 @@
 - [ ] describe_fleet_advisor_schema_object_summary
 - [ ] describe_fleet_advisor_schemas
 - [ ] describe_instance_profiles
+- [ ] describe_metadata_model
 - [ ] describe_metadata_model_assessments
+- [ ] describe_metadata_model_children
 - [ ] describe_metadata_model_conversions
+- [ ] describe_metadata_model_creations
 - [ ] describe_metadata_model_exports_as_script
 - [ ] describe_metadata_model_exports_to_target
 - [ ] describe_metadata_model_imports
@@ -2772,6 +2918,7 @@
 - [ ] describe_schemas
 - [ ] describe_table_statistics
 - [ ] export_metadata_model_assessment
+- [ ] get_target_selection_rules
 - [ ] import_certificate
 - [X] list_tags_for_resource
 - [ ] modify_conversion_configuration
@@ -2796,6 +2943,7 @@
 - [ ] start_extension_pack_association
 - [ ] start_metadata_model_assessment
 - [ ] start_metadata_model_conversion
+- [ ] start_metadata_model_creation
 - [ ] start_metadata_model_export_as_script
 - [ ] start_metadata_model_export_to_target
 - [ ] start_metadata_model_import
@@ -2899,14 +3047,17 @@
 
 ## dsql
 <details>
-<summary>55% implemented</summary>
+<summary>41% implemented</summary>
 
 - [X] create_cluster
 - [X] delete_cluster
+- [ ] delete_cluster_policy
 - [X] get_cluster
+- [ ] get_cluster_policy
 - [X] get_vpc_endpoint_service_name
 - [ ] list_clusters
 - [X] list_tags_for_resource
+- [ ] put_cluster_policy
 - [ ] tag_resource
 - [ ] untag_resource
 - [ ] update_cluster
@@ -2999,7 +3150,7 @@
 
 ## ec2
 <details>
-<summary>31% implemented</summary>
+<summary>29% implemented</summary>
 
 - [ ] accept_address_transfer
 - [ ] accept_capacity_reservation_billing_ownership
@@ -3086,9 +3237,13 @@
 - [ ] create_instance_event_window
 - [ ] create_instance_export_task
 - [X] create_internet_gateway
+- [ ] create_interruptible_capacity_reservation_allocation
 - [ ] create_ipam
 - [ ] create_ipam_external_resource_verification_token
+- [ ] create_ipam_policy
 - [ ] create_ipam_pool
+- [ ] create_ipam_prefix_list_resolver
+- [ ] create_ipam_prefix_list_resolver_target
 - [ ] create_ipam_resource_discovery
 - [ ] create_ipam_scope
 - [X] create_key_pair
@@ -3134,6 +3289,8 @@
 - [X] create_transit_gateway
 - [ ] create_transit_gateway_connect
 - [ ] create_transit_gateway_connect_peer
+- [ ] create_transit_gateway_metering_policy
+- [ ] create_transit_gateway_metering_policy_entry
 - [ ] create_transit_gateway_multicast_domain
 - [X] create_transit_gateway_peering_attachment
 - [ ] create_transit_gateway_policy_table
@@ -3149,10 +3306,12 @@
 - [X] create_volume
 - [X] create_vpc
 - [ ] create_vpc_block_public_access_exclusion
+- [ ] create_vpc_encryption_control
 - [X] create_vpc_endpoint
 - [ ] create_vpc_endpoint_connection_notification
 - [X] create_vpc_endpoint_service_configuration
 - [X] create_vpc_peering_connection
+- [ ] create_vpn_concentrator
 - [X] create_vpn_connection
 - [ ] create_vpn_connection_route
 - [X] create_vpn_gateway
@@ -3174,7 +3333,10 @@
 - [X] delete_internet_gateway
 - [ ] delete_ipam
 - [ ] delete_ipam_external_resource_verification_token
+- [ ] delete_ipam_policy
 - [ ] delete_ipam_pool
+- [ ] delete_ipam_prefix_list_resolver
+- [ ] delete_ipam_prefix_list_resolver_target
 - [ ] delete_ipam_resource_discovery
 - [ ] delete_ipam_scope
 - [X] delete_key_pair
@@ -3217,6 +3379,8 @@
 - [X] delete_transit_gateway
 - [ ] delete_transit_gateway_connect
 - [ ] delete_transit_gateway_connect_peer
+- [ ] delete_transit_gateway_metering_policy
+- [ ] delete_transit_gateway_metering_policy_entry
 - [ ] delete_transit_gateway_multicast_domain
 - [X] delete_transit_gateway_peering_attachment
 - [ ] delete_transit_gateway_policy_table
@@ -3232,10 +3396,12 @@
 - [X] delete_volume
 - [X] delete_vpc
 - [ ] delete_vpc_block_public_access_exclusion
+- [ ] delete_vpc_encryption_control
 - [ ] delete_vpc_endpoint_connection_notifications
 - [X] delete_vpc_endpoint_service_configurations
 - [X] delete_vpc_endpoints
 - [X] delete_vpc_peering_connection
+- [ ] delete_vpn_concentrator
 - [X] delete_vpn_connection
 - [ ] delete_vpn_connection_route
 - [X] delete_vpn_gateway
@@ -3264,6 +3430,7 @@
 - [ ] describe_capacity_manager_data_exports
 - [ ] describe_capacity_reservation_billing_requests
 - [ ] describe_capacity_reservation_fleets
+- [ ] describe_capacity_reservation_topology
 - [ ] describe_capacity_reservations
 - [X] describe_carrier_gateways
 - [ ] describe_classic_link_instances
@@ -3308,6 +3475,8 @@
 - [ ] describe_instance_event_notification_attributes
 - [ ] describe_instance_event_windows
 - [ ] describe_instance_image_metadata
+- [ ] describe_instance_sql_ha_history_states
+- [ ] describe_instance_sql_ha_states
 - [X] describe_instance_status
 - [ ] describe_instance_topology
 - [X] describe_instance_type_offerings
@@ -3316,7 +3485,10 @@
 - [X] describe_internet_gateways
 - [ ] describe_ipam_byoasn
 - [ ] describe_ipam_external_resource_verification_tokens
+- [ ] describe_ipam_policies
 - [ ] describe_ipam_pools
+- [ ] describe_ipam_prefix_list_resolver_targets
+- [ ] describe_ipam_prefix_list_resolvers
 - [ ] describe_ipam_resource_discoveries
 - [ ] describe_ipam_resource_discovery_associations
 - [ ] describe_ipam_scopes
@@ -3387,6 +3559,7 @@
 - [X] describe_transit_gateway_attachments
 - [ ] describe_transit_gateway_connect_peers
 - [ ] describe_transit_gateway_connects
+- [ ] describe_transit_gateway_metering_policies
 - [ ] describe_transit_gateway_multicast_domains
 - [X] describe_transit_gateway_peering_attachments
 - [ ] describe_transit_gateway_policy_tables
@@ -3409,6 +3582,7 @@
 - [ ] describe_vpc_block_public_access_options
 - [ ] describe_vpc_classic_link
 - [ ] describe_vpc_classic_link_dns_support
+- [ ] describe_vpc_encryption_controls
 - [ ] describe_vpc_endpoint_associations
 - [ ] describe_vpc_endpoint_connection_notifications
 - [ ] describe_vpc_endpoint_connections
@@ -3418,6 +3592,7 @@
 - [X] describe_vpc_endpoints
 - [X] describe_vpc_peering_connections
 - [X] describe_vpcs
+- [ ] describe_vpn_concentrators
 - [X] describe_vpn_connections
 - [X] describe_vpn_gateways
 - [ ] detach_classic_link_vpc
@@ -3437,7 +3612,9 @@
 - [ ] disable_image_block_public_access
 - [ ] disable_image_deprecation
 - [ ] disable_image_deregistration_protection
+- [ ] disable_instance_sql_ha_standby_detections
 - [ ] disable_ipam_organization_admin_account
+- [ ] disable_ipam_policy
 - [ ] disable_route_server_propagation
 - [ ] disable_serial_console_access
 - [ ] disable_snapshot_block_public_access
@@ -3474,7 +3651,9 @@
 - [ ] enable_image_block_public_access
 - [ ] enable_image_deprecation
 - [ ] enable_image_deregistration_protection
+- [ ] enable_instance_sql_ha_standby_detections
 - [ ] enable_ipam_organization_admin_account
+- [ ] enable_ipam_policy
 - [ ] enable_reachability_analyzer_organization_sharing
 - [ ] enable_route_server_propagation
 - [ ] enable_serial_console_access
@@ -3505,9 +3684,11 @@
 - [ ] get_default_credit_specification
 - [ ] get_ebs_default_kms_key_id
 - [X] get_ebs_encryption_by_default
+- [ ] get_enabled_ipam_policy
 - [ ] get_flow_logs_integration_template
 - [ ] get_groups_for_capacity_reservation
 - [ ] get_host_reservation_purchase_preview
+- [ ] get_image_ancestry
 - [ ] get_image_block_public_access_state
 - [ ] get_instance_metadata_defaults
 - [ ] get_instance_tpm_ek_pub
@@ -3517,8 +3698,13 @@
 - [ ] get_ipam_discovered_accounts
 - [ ] get_ipam_discovered_public_addresses
 - [ ] get_ipam_discovered_resource_cidrs
+- [ ] get_ipam_policy_allocation_rules
+- [ ] get_ipam_policy_organization_targets
 - [ ] get_ipam_pool_allocations
 - [ ] get_ipam_pool_cidrs
+- [ ] get_ipam_prefix_list_resolver_rules
+- [ ] get_ipam_prefix_list_resolver_version_entries
+- [ ] get_ipam_prefix_list_resolver_versions
 - [ ] get_ipam_resource_cidrs
 - [X] get_launch_template_data
 - [ ] get_managed_prefix_list_associations
@@ -3536,6 +3722,7 @@
 - [ ] get_spot_placement_scores
 - [X] get_subnet_cidr_reservations
 - [ ] get_transit_gateway_attachment_propagations
+- [ ] get_transit_gateway_metering_policy_entries
 - [ ] get_transit_gateway_multicast_domain_associations
 - [ ] get_transit_gateway_policy_table_associations
 - [ ] get_transit_gateway_policy_table_entries
@@ -3545,6 +3732,7 @@
 - [ ] get_verified_access_endpoint_policy
 - [ ] get_verified_access_endpoint_targets
 - [ ] get_verified_access_group_policy
+- [ ] get_vpc_resources_blocking_encryption_enforcement
 - [ ] get_vpn_connection_device_sample_configuration
 - [ ] get_vpn_connection_device_types
 - [ ] get_vpn_tunnel_replacement_status
@@ -3556,6 +3744,7 @@
 - [ ] import_volume
 - [ ] list_images_in_recycle_bin
 - [ ] list_snapshots_in_recycle_bin
+- [ ] list_volumes_in_recycle_bin
 - [ ] lock_snapshot
 - [ ] modify_address_attribute
 - [ ] modify_availability_zone_group
@@ -3583,7 +3772,10 @@
 - [ ] modify_instance_network_performance_options
 - [ ] modify_instance_placement
 - [ ] modify_ipam
+- [ ] modify_ipam_policy_allocation_rules
 - [ ] modify_ipam_pool
+- [ ] modify_ipam_prefix_list_resolver
+- [ ] modify_ipam_prefix_list_resolver_target
 - [ ] modify_ipam_resource_cidr
 - [ ] modify_ipam_resource_discovery
 - [ ] modify_ipam_scope
@@ -3604,6 +3796,7 @@
 - [ ] modify_traffic_mirror_filter_rule
 - [ ] modify_traffic_mirror_session
 - [X] modify_transit_gateway
+- [ ] modify_transit_gateway_metering_policy
 - [ ] modify_transit_gateway_prefix_list_reference
 - [X] modify_transit_gateway_vpc_attachment
 - [ ] modify_verified_access_endpoint
@@ -3618,6 +3811,7 @@
 - [X] modify_vpc_attribute
 - [ ] modify_vpc_block_public_access_exclusion
 - [ ] modify_vpc_block_public_access_options
+- [ ] modify_vpc_encryption_control
 - [X] modify_vpc_endpoint
 - [ ] modify_vpc_endpoint_connection_notification
 - [X] modify_vpc_endpoint_service_configuration
@@ -3679,6 +3873,7 @@
 - [ ] restore_managed_prefix_list_version
 - [ ] restore_snapshot_from_recycle_bin
 - [ ] restore_snapshot_tier
+- [ ] restore_volume_from_recycle_bin
 - [ ] revoke_client_vpn_ingress
 - [X] revoke_security_group_egress
 - [X] revoke_security_group_ingress
@@ -3702,6 +3897,7 @@
 - [ ] unlock_snapshot
 - [ ] unmonitor_instances
 - [ ] update_capacity_manager_organizations_access
+- [ ] update_interruptible_capacity_reservation_allocation
 - [X] update_security_group_rule_descriptions_egress
 - [X] update_security_group_rule_descriptions_ingress
 - [ ] withdraw_byoip_cidr
@@ -3717,7 +3913,7 @@
 
 ## ecr
 <details>
-<summary>59% implemented</summary>
+<summary>50% implemented</summary>
 
 - [ ] batch_check_layer_availability
 - [X] batch_delete_image
@@ -3733,8 +3929,11 @@
 - [X] delete_repository
 - [ ] delete_repository_creation_template
 - [X] delete_repository_policy
+- [ ] delete_signing_configuration
+- [ ] deregister_pull_time_update_exclusion
 - [ ] describe_image_replication_status
 - [X] describe_image_scan_findings
+- [ ] describe_image_signing_status
 - [X] describe_images
 - [ ] describe_pull_through_cache_rules
 - [X] describe_registry
@@ -3748,8 +3947,11 @@
 - [X] get_registry_policy
 - [X] get_registry_scanning_configuration
 - [X] get_repository_policy
+- [ ] get_signing_configuration
 - [ ] initiate_layer_upload
+- [ ] list_image_referrers
 - [X] list_images
+- [ ] list_pull_time_update_exclusions
 - [X] list_tags_for_resource
 - [ ] put_account_setting
 - [X] put_image
@@ -3759,11 +3961,14 @@
 - [X] put_registry_policy
 - [X] put_registry_scanning_configuration
 - [X] put_replication_configuration
+- [ ] put_signing_configuration
+- [ ] register_pull_time_update_exclusion
 - [X] set_repository_policy
 - [X] start_image_scan
 - [ ] start_lifecycle_policy_preview
 - [X] tag_resource
 - [X] untag_resource
+- [ ] update_image_storage_class
 - [ ] update_pull_through_cache_rule
 - [ ] update_repository_creation_template
 - [ ] upload_layer_part
@@ -3772,16 +3977,18 @@
 
 ## ecs
 <details>
-<summary>75% implemented</summary>
+<summary>70% implemented</summary>
 
 - [X] create_capacity_provider
 - [X] create_cluster
+- [ ] create_express_gateway_service
 - [X] create_service
 - [X] create_task_set
 - [X] delete_account_setting
 - [X] delete_attributes
 - [X] delete_capacity_provider
 - [X] delete_cluster
+- [ ] delete_express_gateway_service
 - [X] delete_service
 - [X] delete_task_definitions
 - [X] delete_task_set
@@ -3790,6 +3997,7 @@
 - [X] describe_capacity_providers
 - [X] describe_clusters
 - [X] describe_container_instances
+- [ ] describe_express_gateway_service
 - [ ] describe_service_deployments
 - [ ] describe_service_revisions
 - [X] describe_services
@@ -3830,6 +4038,7 @@
 - [ ] update_cluster_settings
 - [ ] update_container_agent
 - [X] update_container_instances_state
+- [ ] update_express_gateway_service
 - [X] update_service
 - [X] update_service_primary_task_set
 - [ ] update_task_protection
@@ -3875,13 +4084,14 @@
 
 ## eks
 <details>
-<summary>29% implemented</summary>
+<summary>26% implemented</summary>
 
 - [ ] associate_access_policy
 - [ ] associate_encryption_config
 - [ ] associate_identity_provider_config
 - [ ] create_access_entry
 - [ ] create_addon
+- [ ] create_capability
 - [X] create_cluster
 - [ ] create_eks_anywhere_subscription
 - [X] create_fargate_profile
@@ -3889,6 +4099,7 @@
 - [ ] create_pod_identity_association
 - [ ] delete_access_entry
 - [ ] delete_addon
+- [ ] delete_capability
 - [X] delete_cluster
 - [ ] delete_eks_anywhere_subscription
 - [X] delete_fargate_profile
@@ -3899,6 +4110,7 @@
 - [ ] describe_addon
 - [ ] describe_addon_configuration
 - [ ] describe_addon_versions
+- [ ] describe_capability
 - [X] describe_cluster
 - [ ] describe_cluster_versions
 - [ ] describe_eks_anywhere_subscription
@@ -3915,6 +4127,7 @@
 - [ ] list_access_policies
 - [ ] list_addons
 - [ ] list_associated_access_policies
+- [ ] list_capabilities
 - [X] list_clusters
 - [ ] list_eks_anywhere_subscriptions
 - [X] list_fargate_profiles
@@ -3930,6 +4143,7 @@
 - [X] untag_resource
 - [ ] update_access_entry
 - [ ] update_addon
+- [ ] update_capability
 - [X] update_cluster_config
 - [ ] update_cluster_version
 - [ ] update_eks_anywhere_subscription
@@ -4583,7 +4797,7 @@
 
 ## glue
 <details>
-<summary>37% implemented</summary>
+<summary>36% implemented</summary>
 
 - [X] batch_create_partition
 - [ ] batch_delete_connection
@@ -4644,6 +4858,7 @@
 - [ ] delete_column_statistics_for_table
 - [ ] delete_column_statistics_task_settings
 - [ ] delete_connection
+- [ ] delete_connection_type
 - [X] delete_crawler
 - [ ] delete_custom_entity_type
 - [ ] delete_data_quality_ruleset
@@ -4651,6 +4866,7 @@
 - [X] delete_dev_endpoint
 - [ ] delete_glue_identity_center_configuration
 - [ ] delete_integration
+- [ ] delete_integration_resource_property
 - [ ] delete_integration_table_properties
 - [X] delete_job
 - [ ] delete_ml_transform
@@ -4714,6 +4930,7 @@
 - [X] get_job_runs
 - [X] get_jobs
 - [ ] get_mapping
+- [ ] get_materialized_view_refresh_task_run
 - [ ] get_ml_task_run
 - [ ] get_ml_task_runs
 - [ ] get_ml_transform
@@ -4766,7 +4983,9 @@
 - [ ] list_data_quality_statistics
 - [ ] list_dev_endpoints
 - [ ] list_entities
+- [ ] list_integration_resource_properties
 - [X] list_jobs
+- [ ] list_materialized_view_refresh_task_runs
 - [ ] list_ml_transforms
 - [X] list_registries
 - [ ] list_schema_versions
@@ -4784,6 +5003,7 @@
 - [X] put_schema_version_metadata
 - [X] put_workflow_run_properties
 - [ ] query_schema_version_metadata
+- [ ] register_connection_type
 - [X] register_schema_version
 - [ ] remove_schema_version_metadata
 - [ ] reset_job_bookmark
@@ -4800,6 +5020,7 @@
 - [ ] start_export_labels_task_run
 - [ ] start_import_labels_task_run
 - [X] start_job_run
+- [ ] start_materialized_view_refresh_task_run
 - [ ] start_ml_evaluation_task_run
 - [ ] start_ml_labeling_set_generation_task_run
 - [X] start_trigger
@@ -4808,6 +5029,7 @@
 - [ ] stop_column_statistics_task_run_schedule
 - [X] stop_crawler
 - [ ] stop_crawler_schedule
+- [ ] stop_materialized_view_refresh_task_run
 - [X] stop_session
 - [X] stop_trigger
 - [X] stop_workflow_run
@@ -4944,7 +5166,7 @@
 
 ## guardduty
 <details>
-<summary>14% implemented</summary>
+<summary>13% implemented</summary>
 
 - [ ] accept_administrator_invitation
 - [ ] accept_invitation
@@ -4987,6 +5209,7 @@
 - [ ] get_invitations_count
 - [ ] get_ip_set
 - [ ] get_malware_protection_plan
+- [ ] get_malware_scan
 - [ ] get_malware_scan_settings
 - [ ] get_master_account
 - [ ] get_member_detectors
@@ -5005,6 +5228,7 @@
 - [ ] list_invitations
 - [ ] list_ip_sets
 - [ ] list_malware_protection_plans
+- [ ] list_malware_scans
 - [ ] list_members
 - [X] list_organization_admin_accounts
 - [ ] list_publishing_destinations
@@ -5012,6 +5236,7 @@
 - [ ] list_threat_entity_sets
 - [ ] list_threat_intel_sets
 - [ ] list_trusted_entity_sets
+- [ ] send_object_malware_scan
 - [ ] start_malware_scan
 - [ ] start_monitoring_members
 - [ ] stop_monitoring_members
@@ -5034,17 +5259,20 @@
 
 ## iam
 <details>
-<summary>72% implemented</summary>
+<summary>67% implemented</summary>
 
+- [ ] accept_delegation_request
 - [ ] add_client_id_to_open_id_connect_provider
 - [X] add_role_to_instance_profile
 - [X] add_user_to_group
+- [ ] associate_delegation_request
 - [X] attach_group_policy
 - [X] attach_role_policy
 - [X] attach_user_policy
 - [ ] change_password
 - [X] create_access_key
 - [X] create_account_alias
+- [ ] create_delegation_request
 - [X] create_group
 - [X] create_instance_profile
 - [X] create_login_profile
@@ -5086,9 +5314,11 @@
 - [X] detach_user_policy
 - [ ] disable_organizations_root_credentials_management
 - [ ] disable_organizations_root_sessions
+- [ ] disable_outbound_web_identity_federation
 - [X] enable_mfa_device
 - [ ] enable_organizations_root_credentials_management
 - [ ] enable_organizations_root_sessions
+- [ ] enable_outbound_web_identity_federation
 - [ ] generate_credential_report
 - [ ] generate_organizations_access_report
 - [ ] generate_service_last_accessed_details
@@ -5099,13 +5329,16 @@
 - [ ] get_context_keys_for_custom_policy
 - [ ] get_context_keys_for_principal_policy
 - [X] get_credential_report
+- [ ] get_delegation_request
 - [X] get_group
 - [X] get_group_policy
+- [ ] get_human_readable_summary
 - [X] get_instance_profile
 - [X] get_login_profile
 - [ ] get_mfa_device
 - [X] get_open_id_connect_provider
 - [ ] get_organizations_access_report
+- [ ] get_outbound_web_identity_federation_info
 - [X] get_policy
 - [X] get_policy_version
 - [X] get_role
@@ -5123,6 +5356,7 @@
 - [X] list_attached_group_policies
 - [X] list_attached_role_policies
 - [X] list_attached_user_policies
+- [ ] list_delegation_requests
 - [ ] list_entities_for_policy
 - [X] list_group_policies
 - [X] list_groups
@@ -5158,11 +5392,13 @@
 - [X] put_role_policy
 - [ ] put_user_permissions_boundary
 - [X] put_user_policy
+- [ ] reject_delegation_request
 - [ ] remove_client_id_from_open_id_connect_provider
 - [X] remove_role_from_instance_profile
 - [X] remove_user_from_group
 - [ ] reset_service_specific_credential
 - [ ] resync_mfa_device
+- [ ] send_delegation_token
 - [X] set_default_policy_version
 - [ ] set_security_token_service_preferences
 - [ ] simulate_custom_policy
@@ -5186,6 +5422,7 @@
 - [X] update_access_key
 - [X] update_account_password_policy
 - [X] update_assume_role_policy
+- [ ] update_delegation_request
 - [X] update_group
 - [X] update_login_profile
 - [X] update_open_id_connect_provider_thumbprint
@@ -5643,7 +5880,7 @@
 
 ## kafka
 <details>
-<summary>19% implemented</summary>
+<summary>17% implemented</summary>
 
 - [ ] batch_associate_scram_secret
 - [ ] batch_disassociate_scram_secret
@@ -5664,6 +5901,8 @@
 - [ ] describe_configuration
 - [ ] describe_configuration_revision
 - [ ] describe_replicator
+- [ ] describe_topic
+- [ ] describe_topic_partitions
 - [ ] describe_vpc_connection
 - [ ] get_bootstrap_brokers
 - [ ] get_cluster_policy
@@ -5680,6 +5919,7 @@
 - [ ] list_replicators
 - [ ] list_scram_secrets
 - [X] list_tags_for_resource
+- [ ] list_topics
 - [ ] list_vpc_connections
 - [ ] put_cluster_policy
 - [ ] reboot_broker
@@ -5694,6 +5934,7 @@
 - [ ] update_configuration
 - [ ] update_connectivity
 - [ ] update_monitoring
+- [ ] update_rebalancing
 - [ ] update_replication_info
 - [ ] update_security
 - [ ] update_storage
@@ -5701,7 +5942,7 @@
 
 ## kinesis
 <details>
-<summary>88% implemented</summary>
+<summary>79% implemented</summary>
 
 - [X] add_tags_to_stream
 - [X] create_stream
@@ -5709,6 +5950,7 @@
 - [X] delete_resource_policy
 - [X] delete_stream
 - [X] deregister_stream_consumer
+- [ ] describe_account_settings
 - [X] describe_limits
 - [X] describe_stream
 - [X] describe_stream_consumer
@@ -5736,8 +5978,11 @@
 - [ ] subscribe_to_shard
 - [ ] tag_resource
 - [ ] untag_resource
+- [ ] update_account_settings
+- [ ] update_max_record_size
 - [X] update_shard_count
 - [X] update_stream_mode
+- [ ] update_stream_warm_throughput
 </details>
 
 ## kinesis-video-archived-media
@@ -5793,7 +6038,7 @@
 
 ## kinesisvideo
 <details>
-<summary>16% implemented</summary>
+<summary>15% implemented</summary>
 
 - [ ] create_signaling_channel
 - [X] create_stream
@@ -5807,6 +6052,7 @@
 - [ ] describe_notification_configuration
 - [ ] describe_signaling_channel
 - [X] describe_stream
+- [ ] describe_stream_storage_configuration
 - [X] get_data_endpoint
 - [ ] get_signaling_channel_endpoint
 - [ ] list_edge_agent_configurations
@@ -5825,6 +6071,7 @@
 - [ ] update_notification_configuration
 - [ ] update_signaling_channel
 - [ ] update_stream
+- [ ] update_stream_storage_configuration
 </details>
 
 ## kms
@@ -5888,7 +6135,7 @@
 
 ## lakeformation
 <details>
-<summary>33% implemented</summary>
+<summary>32% implemented</summary>
 
 - [X] add_lf_tags_to_resource
 - [ ] assume_decorated_role_with_saml
@@ -5922,6 +6169,7 @@
 - [ ] get_query_statistics
 - [X] get_resource_lf_tags
 - [ ] get_table_objects
+- [ ] get_temporary_data_location_credentials
 - [ ] get_temporary_glue_partition_credentials
 - [ ] get_temporary_glue_table_credentials
 - [ ] get_work_unit_results
@@ -5954,16 +6202,19 @@
 
 ## lambda
 <details>
-<summary>67% implemented</summary>
+<summary>54% implemented</summary>
 
 - [X] add_layer_version_permission
 - [X] add_permission
+- [ ] checkpoint_durable_execution
 - [X] create_alias
+- [ ] create_capacity_provider
 - [ ] create_code_signing_config
 - [X] create_event_source_mapping
 - [X] create_function
 - [X] create_function_url_config
 - [X] delete_alias
+- [ ] delete_capacity_provider
 - [ ] delete_code_signing_config
 - [X] delete_event_source_mapping
 - [X] delete_function
@@ -5975,7 +6226,11 @@
 - [ ] delete_provisioned_concurrency_config
 - [ ] get_account_settings
 - [X] get_alias
+- [ ] get_capacity_provider
 - [ ] get_code_signing_config
+- [ ] get_durable_execution
+- [ ] get_durable_execution_history
+- [ ] get_durable_execution_state
 - [X] get_event_source_mapping
 - [X] get_function
 - [X] get_function_code_signing_config
@@ -5983,6 +6238,7 @@
 - [ ] get_function_configuration
 - [X] get_function_event_invoke_config
 - [ ] get_function_recursion_config
+- [ ] get_function_scaling_config
 - [X] get_function_url_config
 - [X] get_layer_version
 - [ ] get_layer_version_by_arn
@@ -5994,10 +6250,13 @@
 - [ ] invoke_async
 - [ ] invoke_with_response_stream
 - [X] list_aliases
+- [ ] list_capacity_providers
 - [ ] list_code_signing_configs
+- [ ] list_durable_executions_by_function
 - [X] list_event_source_mappings
 - [X] list_function_event_invoke_configs
 - [ ] list_function_url_configs
+- [ ] list_function_versions_by_capacity_provider
 - [X] list_functions
 - [ ] list_functions_by_code_signing_config
 - [X] list_layer_versions
@@ -6011,13 +6270,19 @@
 - [X] put_function_concurrency
 - [X] put_function_event_invoke_config
 - [ ] put_function_recursion_config
+- [ ] put_function_scaling_config
 - [ ] put_provisioned_concurrency_config
 - [ ] put_runtime_management_config
 - [X] remove_layer_version_permission
 - [X] remove_permission
+- [ ] send_durable_execution_callback_failure
+- [ ] send_durable_execution_callback_heartbeat
+- [ ] send_durable_execution_callback_success
+- [ ] stop_durable_execution
 - [X] tag_resource
 - [X] untag_resource
 - [X] update_alias
+- [ ] update_capacity_provider
 - [ ] update_code_signing_config
 - [X] update_event_source_mapping
 - [X] update_function_code
@@ -6136,15 +6401,19 @@
 
 ## logs
 <details>
-<summary>56% implemented</summary>
+<summary>47% implemented</summary>
 
 - [ ] associate_kms_key
+- [ ] associate_source_to_s3_table_integration
 - [X] cancel_export_task
+- [ ] cancel_import_task
 - [X] create_delivery
 - [X] create_export_task
+- [ ] create_import_task
 - [ ] create_log_anomaly_detector
 - [X] create_log_group
 - [X] create_log_stream
+- [ ] create_scheduled_query
 - [ ] delete_account_policy
 - [ ] delete_data_protection_policy
 - [X] delete_delivery
@@ -6161,6 +6430,7 @@
 - [ ] delete_query_definition
 - [X] delete_resource_policy
 - [X] delete_retention_policy
+- [ ] delete_scheduled_query
 - [X] delete_subscription_filter
 - [ ] delete_transformer
 - [ ] describe_account_policies
@@ -6171,6 +6441,8 @@
 - [X] describe_destinations
 - [X] describe_export_tasks
 - [ ] describe_field_indexes
+- [ ] describe_import_task_batches
+- [ ] describe_import_tasks
 - [ ] describe_index_policies
 - [X] describe_log_groups
 - [X] describe_log_streams
@@ -6180,6 +6452,7 @@
 - [X] describe_resource_policies
 - [X] describe_subscription_filters
 - [ ] disassociate_kms_key
+- [ ] disassociate_source_from_s3_table_integration
 - [X] filter_log_events
 - [ ] get_data_protection_policy
 - [X] get_delivery
@@ -6189,16 +6462,22 @@
 - [ ] get_integration
 - [ ] get_log_anomaly_detector
 - [X] get_log_events
+- [ ] get_log_fields
 - [ ] get_log_group_fields
 - [ ] get_log_object
 - [ ] get_log_record
 - [X] get_query_results
+- [ ] get_scheduled_query
+- [ ] get_scheduled_query_history
 - [ ] get_transformer
+- [ ] list_aggregate_log_group_summaries
 - [ ] list_anomalies
 - [ ] list_integrations
 - [ ] list_log_anomaly_detectors
 - [ ] list_log_groups
 - [ ] list_log_groups_for_query
+- [ ] list_scheduled_queries
+- [ ] list_sources_for_s3_table_integration
 - [X] list_tags_for_resource
 - [X] list_tags_log_group
 - [ ] put_account_policy
@@ -6211,6 +6490,7 @@
 - [ ] put_index_policy
 - [ ] put_integration
 - [X] put_log_events
+- [ ] put_log_group_deletion_protection
 - [X] put_metric_filter
 - [ ] put_query_definition
 - [X] put_resource_policy
@@ -6229,6 +6509,7 @@
 - [ ] update_anomaly
 - [ ] update_delivery_configuration
 - [ ] update_log_anomaly_detector
+- [ ] update_scheduled_query
 </details>
 
 ## macie2
@@ -6353,7 +6634,7 @@
 
 ## mediaconnect
 <details>
-<summary>34% implemented</summary>
+<summary>21% implemented</summary>
 
 - [ ] add_bridge_outputs
 - [ ] add_bridge_sources
@@ -6361,12 +6642,21 @@
 - [X] add_flow_outputs
 - [X] add_flow_sources
 - [X] add_flow_vpc_interfaces
+- [ ] batch_get_router_input
+- [ ] batch_get_router_network_interface
+- [ ] batch_get_router_output
 - [ ] create_bridge
 - [X] create_flow
 - [ ] create_gateway
+- [ ] create_router_input
+- [ ] create_router_network_interface
+- [ ] create_router_output
 - [ ] delete_bridge
 - [X] delete_flow
 - [ ] delete_gateway
+- [ ] delete_router_input
+- [ ] delete_router_network_interface
+- [ ] delete_router_output
 - [ ] deregister_gateway_instance
 - [ ] describe_bridge
 - [X] describe_flow
@@ -6376,6 +6666,11 @@
 - [ ] describe_gateway_instance
 - [ ] describe_offering
 - [ ] describe_reservation
+- [ ] get_router_input
+- [ ] get_router_input_source_metadata
+- [ ] get_router_input_thumbnail
+- [ ] get_router_network_interface
+- [ ] get_router_output
 - [X] grant_flow_entitlements
 - [ ] list_bridges
 - [ ] list_entitlements
@@ -6384,6 +6679,10 @@
 - [ ] list_gateways
 - [ ] list_offerings
 - [ ] list_reservations
+- [ ] list_router_inputs
+- [ ] list_router_network_interfaces
+- [ ] list_router_outputs
+- [ ] list_tags_for_global_resource
 - [X] list_tags_for_resource
 - [ ] purchase_offering
 - [ ] remove_bridge_output
@@ -6392,10 +6691,19 @@
 - [X] remove_flow_output
 - [ ] remove_flow_source
 - [X] remove_flow_vpc_interface
+- [ ] restart_router_input
+- [ ] restart_router_output
 - [X] revoke_flow_entitlement
 - [X] start_flow
+- [ ] start_router_input
+- [ ] start_router_output
 - [X] stop_flow
+- [ ] stop_router_input
+- [ ] stop_router_output
+- [ ] tag_global_resource
 - [X] tag_resource
+- [ ] take_router_input
+- [ ] untag_global_resource
 - [ ] untag_resource
 - [ ] update_bridge
 - [ ] update_bridge_output
@@ -6407,11 +6715,14 @@
 - [X] update_flow_output
 - [X] update_flow_source
 - [ ] update_gateway_instance
+- [ ] update_router_input
+- [ ] update_router_network_interface
+- [ ] update_router_output
 </details>
 
 ## medialive
 <details>
-<summary>10% implemented</summary>
+<summary>9% implemented</summary>
 
 - [ ] accept_input_device_transfer
 - [ ] batch_delete
@@ -6478,10 +6789,12 @@
 - [ ] get_event_bridge_rule_template
 - [ ] get_event_bridge_rule_template_group
 - [ ] get_signal_map
+- [ ] list_alerts
 - [ ] list_channel_placement_groups
 - [X] list_channels
 - [ ] list_cloud_watch_alarm_template_groups
 - [ ] list_cloud_watch_alarm_templates
+- [ ] list_cluster_alerts
 - [ ] list_clusters
 - [ ] list_event_bridge_rule_template_groups
 - [ ] list_event_bridge_rule_templates
@@ -6489,6 +6802,7 @@
 - [ ] list_input_devices
 - [ ] list_input_security_groups
 - [X] list_inputs
+- [ ] list_multiplex_alerts
 - [ ] list_multiplex_programs
 - [ ] list_multiplexes
 - [ ] list_networks
@@ -6803,20 +7117,29 @@
 
 ## network-firewall
 <details>
-<summary>8% implemented</summary>
+<summary>6% implemented</summary>
 
 - [ ] accept_network_firewall_transit_gateway_attachment
 - [ ] associate_availability_zones
 - [ ] associate_firewall_policy
 - [ ] associate_subnets
+- [ ] attach_rule_groups_to_proxy_configuration
 - [X] create_firewall
 - [ ] create_firewall_policy
+- [ ] create_proxy
+- [ ] create_proxy_configuration
+- [ ] create_proxy_rule_group
+- [ ] create_proxy_rules
 - [ ] create_rule_group
 - [ ] create_tls_inspection_configuration
 - [ ] create_vpc_endpoint_association
 - [ ] delete_firewall
 - [ ] delete_firewall_policy
 - [ ] delete_network_firewall_transit_gateway_attachment
+- [ ] delete_proxy
+- [ ] delete_proxy_configuration
+- [ ] delete_proxy_rule_group
+- [ ] delete_proxy_rules
 - [ ] delete_resource_policy
 - [ ] delete_rule_group
 - [ ] delete_tls_inspection_configuration
@@ -6826,12 +7149,17 @@
 - [ ] describe_firewall_policy
 - [ ] describe_flow_operation
 - [X] describe_logging_configuration
+- [ ] describe_proxy
+- [ ] describe_proxy_configuration
+- [ ] describe_proxy_rule
+- [ ] describe_proxy_rule_group
 - [ ] describe_resource_policy
 - [ ] describe_rule_group
 - [ ] describe_rule_group_metadata
 - [ ] describe_rule_group_summary
 - [ ] describe_tls_inspection_configuration
 - [ ] describe_vpc_endpoint_association
+- [ ] detach_rule_groups_from_proxy_configuration
 - [ ] disassociate_availability_zones
 - [ ] disassociate_subnets
 - [ ] get_analysis_report_results
@@ -6840,6 +7168,9 @@
 - [X] list_firewalls
 - [ ] list_flow_operation_results
 - [ ] list_flow_operations
+- [ ] list_proxies
+- [ ] list_proxy_configurations
+- [ ] list_proxy_rule_groups
 - [ ] list_rule_groups
 - [ ] list_tags_for_resource
 - [ ] list_tls_inspection_configurations
@@ -6859,6 +7190,11 @@
 - [ ] update_firewall_policy
 - [ ] update_firewall_policy_change_protection
 - [X] update_logging_configuration
+- [ ] update_proxy
+- [ ] update_proxy_configuration
+- [ ] update_proxy_rule
+- [ ] update_proxy_rule_group_priorities
+- [ ] update_proxy_rule_priorities
 - [ ] update_rule_group
 - [ ] update_subnet_change_protection
 - [ ] update_tls_inspection_configuration
@@ -6866,7 +7202,7 @@
 
 ## networkmanager
 <details>
-<summary>20% implemented</summary>
+<summary>18% implemented</summary>
 
 - [ ] accept_attachment
 - [ ] associate_connect_peer
@@ -6877,6 +7213,7 @@
 - [ ] create_connect_peer
 - [ ] create_connection
 - [X] create_core_network
+- [ ] create_core_network_prefix_list_association
 - [X] create_device
 - [ ] create_direct_connect_gateway_attachment
 - [X] create_global_network
@@ -6891,6 +7228,7 @@
 - [ ] delete_connection
 - [X] delete_core_network
 - [ ] delete_core_network_policy_version
+- [ ] delete_core_network_prefix_list_association
 - [X] delete_device
 - [ ] delete_global_network
 - [X] delete_link
@@ -6931,17 +7269,22 @@
 - [ ] get_transit_gateway_registrations
 - [ ] get_transit_gateway_route_table_attachment
 - [ ] get_vpc_attachment
+- [ ] list_attachment_routing_policy_associations
 - [ ] list_attachments
 - [ ] list_connect_peers
 - [ ] list_core_network_policy_versions
+- [ ] list_core_network_prefix_list_associations
+- [ ] list_core_network_routing_information
 - [X] list_core_networks
 - [ ] list_organization_service_access_status
 - [ ] list_peerings
 - [X] list_tags_for_resource
+- [ ] put_attachment_routing_policy_label
 - [ ] put_core_network_policy
 - [ ] put_resource_policy
 - [ ] register_transit_gateway
 - [ ] reject_attachment
+- [ ] remove_attachment_routing_policy_label
 - [ ] restore_core_network_policy_version
 - [ ] start_organization_service_access_update
 - [ ] start_route_analysis
@@ -6960,7 +7303,7 @@
 
 ## opensearch
 <details>
-<summary>14% implemented</summary>
+<summary>13% implemented</summary>
 
 - [ ] accept_inbound_connection
 - [ ] add_data_source
@@ -6973,6 +7316,7 @@
 - [ ] cancel_service_software_update
 - [ ] create_application
 - [X] create_domain
+- [ ] create_index
 - [ ] create_outbound_connection
 - [ ] create_package
 - [ ] create_vpc_endpoint
@@ -6981,6 +7325,7 @@
 - [ ] delete_direct_query_data_source
 - [X] delete_domain
 - [ ] delete_inbound_connection
+- [ ] delete_index
 - [ ] delete_outbound_connection
 - [ ] delete_package
 - [ ] delete_vpc_endpoint
@@ -7004,8 +7349,10 @@
 - [ ] get_application
 - [X] get_compatible_versions
 - [ ] get_data_source
+- [ ] get_default_application_setting
 - [ ] get_direct_query_data_source
 - [ ] get_domain_maintenance_status
+- [ ] get_index
 - [ ] get_package_version_history
 - [ ] get_upgrade_history
 - [ ] get_upgrade_status
@@ -7024,6 +7371,7 @@
 - [ ] list_vpc_endpoints
 - [ ] list_vpc_endpoints_for_domain
 - [ ] purchase_reserved_instance_offering
+- [ ] put_default_application_setting
 - [ ] reject_inbound_connection
 - [X] remove_tags
 - [ ] revoke_vpc_endpoint_access
@@ -7033,6 +7381,7 @@
 - [ ] update_data_source
 - [ ] update_direct_query_data_source
 - [X] update_domain_config
+- [ ] update_index
 - [ ] update_package
 - [ ] update_package_scope
 - [ ] update_scheduled_action
@@ -7042,14 +7391,16 @@
 
 ## opensearchserverless
 <details>
-<summary>29% implemented</summary>
+<summary>26% implemented</summary>
 
 - [X] batch_get_collection
+- [ ] batch_get_collection_group
 - [ ] batch_get_effective_lifecycle_policy
 - [ ] batch_get_lifecycle_policy
 - [ ] batch_get_vpc_endpoint
 - [ ] create_access_policy
 - [X] create_collection
+- [ ] create_collection_group
 - [ ] create_index
 - [ ] create_lifecycle_policy
 - [ ] create_security_config
@@ -7057,6 +7408,7 @@
 - [X] create_vpc_endpoint
 - [ ] delete_access_policy
 - [X] delete_collection
+- [ ] delete_collection_group
 - [ ] delete_index
 - [ ] delete_lifecycle_policy
 - [ ] delete_security_config
@@ -7069,6 +7421,7 @@
 - [ ] get_security_config
 - [X] get_security_policy
 - [ ] list_access_policies
+- [ ] list_collection_groups
 - [X] list_collections
 - [ ] list_lifecycle_policies
 - [ ] list_security_configs
@@ -7080,6 +7433,7 @@
 - [ ] update_access_policy
 - [ ] update_account_settings
 - [ ] update_collection
+- [ ] update_collection_group
 - [ ] update_index
 - [ ] update_lifecycle_policy
 - [ ] update_security_config
@@ -7089,7 +7443,7 @@
 
 ## organizations
 <details>
-<summary>71% implemented</summary>
+<summary>65% implemented</summary>
 
 - [ ] accept_handshake
 - [X] attach_policy
@@ -7114,6 +7468,7 @@
 - [X] describe_organizational_unit
 - [X] describe_policy
 - [ ] describe_resource_policy
+- [ ] describe_responsibility_transfer
 - [X] detach_policy
 - [X] disable_aws_service_access
 - [X] disable_policy_type
@@ -7121,6 +7476,7 @@
 - [X] enable_aws_service_access
 - [X] enable_policy_type
 - [ ] invite_account_to_organization
+- [ ] invite_organization_to_transfer_responsibility
 - [ ] leave_organization
 - [X] list_accounts
 - [X] list_accounts_for_parent
@@ -7133,7 +7489,9 @@
 - [ ] list_effective_policy_validation_errors
 - [ ] list_handshakes_for_account
 - [ ] list_handshakes_for_organization
+- [ ] list_inbound_responsibility_transfers
 - [X] list_organizational_units_for_parent
+- [ ] list_outbound_responsibility_transfers
 - [X] list_parents
 - [X] list_policies
 - [X] list_policies_for_target
@@ -7145,9 +7503,11 @@
 - [X] register_delegated_administrator
 - [X] remove_account_from_organization
 - [X] tag_resource
+- [ ] terminate_responsibility_transfer
 - [X] untag_resource
 - [X] update_organizational_unit
 - [X] update_policy
+- [ ] update_responsibility_transfer
 </details>
 
 ## osis
@@ -7560,6 +7920,7 @@
 - [ ] describe_quick_sight_q_search_configuration
 - [ ] describe_refresh_schedule
 - [ ] describe_role_custom_permission
+- [ ] describe_self_upgrade_configuration
 - [ ] describe_template
 - [ ] describe_template_alias
 - [ ] describe_template_definition
@@ -7579,6 +7940,7 @@
 - [ ] get_dashboard_embed_url
 - [ ] get_flow_metadata
 - [ ] get_flow_permissions
+- [ ] get_identity_context
 - [ ] get_session_embed_url
 - [ ] list_action_connectors
 - [ ] list_analyses
@@ -7603,6 +7965,7 @@
 - [ ] list_namespaces
 - [ ] list_refresh_schedules
 - [ ] list_role_memberships
+- [ ] list_self_upgrades
 - [X] list_tags_for_resource
 - [ ] list_template_aliases
 - [ ] list_template_versions
@@ -7670,6 +8033,8 @@
 - [ ] update_quick_sight_q_search_configuration
 - [ ] update_refresh_schedule
 - [ ] update_role_custom_permission
+- [ ] update_self_upgrade
+- [ ] update_self_upgrade_configuration
 - [ ] update_spice_capacity_configuration
 - [ ] update_template
 - [ ] update_template_alias
@@ -7687,7 +8052,7 @@
 
 ## ram
 <details>
-<summary>23% implemented</summary>
+<summary>22% implemented</summary>
 
 - [ ] accept_resource_share_invitation
 - [ ] associate_resource_share
@@ -7715,6 +8080,7 @@
 - [ ] list_resource_share_permissions
 - [X] list_resource_types
 - [ ] list_resources
+- [ ] list_source_associations
 - [ ] promote_permission_created_from_policy
 - [ ] promote_resource_share_created_from_policy
 - [ ] reject_resource_share_invitation
@@ -7908,7 +8274,7 @@
 
 ## redshift
 <details>
-<summary>25% implemented</summary>
+<summary>24% implemented</summary>
 
 - [ ] accept_reserved_node_exchange
 - [ ] add_partner
@@ -8010,6 +8376,7 @@
 - [ ] failover_primary_compute
 - [X] get_cluster_credentials
 - [ ] get_cluster_credentials_with_iam
+- [ ] get_identity_center_auth_token
 - [ ] get_reserved_node_exchange_configuration_options
 - [ ] get_reserved_node_exchange_offerings
 - [ ] get_resource_policy
@@ -8028,6 +8395,7 @@
 - [ ] modify_endpoint_access
 - [ ] modify_event_subscription
 - [ ] modify_integration
+- [ ] modify_lakehouse_configuration
 - [ ] modify_redshift_idc_application
 - [ ] modify_scheduled_action
 - [X] modify_snapshot_copy_retention_period
@@ -8249,13 +8617,14 @@
 
 ## resourcegroupstaggingapi
 <details>
-<summary>62% implemented</summary>
+<summary>55% implemented</summary>
 
 - [ ] describe_report_creation
 - [ ] get_compliance_summary
 - [X] get_resources
 - [X] get_tag_keys
 - [X] get_tag_values
+- [ ] list_required_tags
 - [ ] start_report_creation
 - [X] tag_resources
 - [X] untag_resources
@@ -8333,6 +8702,7 @@
 - [ ] test_dns_answer
 - [X] update_health_check
 - [X] update_hosted_zone_comment
+- [ ] update_hosted_zone_features
 - [ ] update_traffic_policy_comment
 - [ ] update_traffic_policy_instance
 </details>
@@ -8453,7 +8823,7 @@
 
 ## s3
 <details>
-<summary>70% implemented</summary>
+<summary>68% implemented</summary>
 
 - [X] abort_multipart_upload
 - [X] complete_multipart_upload
@@ -8482,6 +8852,7 @@
 - [X] delete_object_tagging
 - [X] delete_objects
 - [X] delete_public_access_block
+- [ ] get_bucket_abac
 - [X] get_bucket_accelerate_configuration
 - [X] get_bucket_acl
 - [ ] get_bucket_analytics_configuration
@@ -8528,6 +8899,7 @@
 - [X] list_objects
 - [X] list_objects_v2
 - [X] list_parts
+- [ ] put_bucket_abac
 - [X] put_bucket_accelerate_configuration
 - [X] put_bucket_acl
 - [ ] put_bucket_analytics_configuration
@@ -8560,6 +8932,7 @@
 - [X] select_object_content
 - [ ] update_bucket_metadata_inventory_table_configuration
 - [ ] update_bucket_metadata_journal_table_configuration
+- [ ] update_object_encryption
 - [X] upload_file
 - [X] upload_fileobj
 - [X] upload_part
@@ -8672,7 +9045,7 @@
 
 ## s3tables
 <details>
-<summary>46% implemented</summary>
+<summary>28% implemented</summary>
 
 - [X] create_namespace
 - [X] create_table
@@ -8681,34 +9054,53 @@
 - [X] delete_table
 - [X] delete_table_bucket
 - [ ] delete_table_bucket_encryption
+- [ ] delete_table_bucket_metrics_configuration
 - [ ] delete_table_bucket_policy
+- [ ] delete_table_bucket_replication
 - [ ] delete_table_policy
+- [ ] delete_table_replication
 - [X] get_namespace
 - [X] get_table
 - [X] get_table_bucket
 - [ ] get_table_bucket_encryption
 - [ ] get_table_bucket_maintenance_configuration
+- [ ] get_table_bucket_metrics_configuration
 - [ ] get_table_bucket_policy
+- [ ] get_table_bucket_replication
+- [ ] get_table_bucket_storage_class
 - [ ] get_table_encryption
 - [ ] get_table_maintenance_configuration
 - [ ] get_table_maintenance_job_status
 - [ ] get_table_metadata_location
 - [ ] get_table_policy
+- [ ] get_table_record_expiration_configuration
+- [ ] get_table_record_expiration_job_status
+- [ ] get_table_replication
+- [ ] get_table_replication_status
+- [ ] get_table_storage_class
 - [X] list_namespaces
 - [X] list_table_buckets
 - [X] list_tables
+- [ ] list_tags_for_resource
 - [ ] put_table_bucket_encryption
 - [ ] put_table_bucket_maintenance_configuration
+- [ ] put_table_bucket_metrics_configuration
 - [ ] put_table_bucket_policy
+- [ ] put_table_bucket_replication
+- [ ] put_table_bucket_storage_class
 - [ ] put_table_maintenance_configuration
 - [ ] put_table_policy
+- [ ] put_table_record_expiration_configuration
+- [ ] put_table_replication
 - [X] rename_table
+- [ ] tag_resource
+- [ ] untag_resource
 - [X] update_table_metadata_location
 </details>
 
 ## s3vectors
 <details>
-<summary>93% implemented</summary>
+<summary>78% implemented</summary>
 
 - [X] create_index
 - [X] create_vector_bucket
@@ -8721,16 +9113,19 @@
 - [X] get_vector_bucket_policy
 - [X] get_vectors
 - [X] list_indexes
+- [ ] list_tags_for_resource
 - [X] list_vector_buckets
 - [X] list_vectors
 - [X] put_vector_bucket_policy
 - [X] put_vectors
 - [ ] query_vectors
+- [ ] tag_resource
+- [ ] untag_resource
 </details>
 
 ## sagemaker
 <details>
-<summary>30% implemented</summary>
+<summary>29% implemented</summary>
 
 - [ ] add_association
 - [X] add_tags
@@ -8739,6 +9134,8 @@
 - [ ] batch_add_cluster_nodes
 - [ ] batch_delete_cluster_nodes
 - [ ] batch_describe_model_package
+- [ ] batch_reboot_cluster_nodes
+- [ ] batch_replace_cluster_nodes
 - [ ] create_action
 - [ ] create_algorithm
 - [ ] create_app
@@ -8774,6 +9171,7 @@
 - [ ] create_inference_experiment
 - [ ] create_inference_recommendations_job
 - [ ] create_labeling_job
+- [ ] create_mlflow_app
 - [ ] create_mlflow_tracking_server
 - [X] create_model
 - [X] create_model_bias_job_definition
@@ -8791,6 +9189,7 @@
 - [ ] create_partner_app_presigned_url
 - [X] create_pipeline
 - [ ] create_presigned_domain_url
+- [ ] create_presigned_mlflow_app_url
 - [ ] create_presigned_mlflow_tracking_server_url
 - [ ] create_presigned_notebook_instance_url
 - [X] create_processing_job
@@ -8836,6 +9235,7 @@
 - [ ] delete_image_version
 - [ ] delete_inference_component
 - [ ] delete_inference_experiment
+- [ ] delete_mlflow_app
 - [ ] delete_mlflow_tracking_server
 - [X] delete_model
 - [X] delete_model_bias_job_definition
@@ -8851,10 +9251,12 @@
 - [ ] delete_optimization_job
 - [ ] delete_partner_app
 - [X] delete_pipeline
+- [ ] delete_processing_job
 - [ ] delete_project
 - [ ] delete_space
 - [ ] delete_studio_lifecycle_config
 - [X] delete_tags
+- [ ] delete_training_job
 - [X] delete_trial
 - [X] delete_trial_component
 - [ ] delete_user_profile
@@ -8899,6 +9301,7 @@
 - [ ] describe_inference_recommendations_job
 - [ ] describe_labeling_job
 - [ ] describe_lineage_group
+- [ ] describe_mlflow_app
 - [ ] describe_mlflow_tracking_server
 - [X] describe_model
 - [X] describe_model_bias_job_definition
@@ -8983,6 +9386,7 @@
 - [ ] list_labeling_jobs
 - [ ] list_labeling_jobs_for_workteam
 - [ ] list_lineage_groups
+- [ ] list_mlflow_apps
 - [ ] list_mlflow_tracking_servers
 - [X] list_model_bias_job_definitions
 - [ ] list_model_card_export_jobs
@@ -9082,6 +9486,7 @@
 - [ ] update_inference_component
 - [ ] update_inference_component_runtime_config
 - [ ] update_inference_experiment
+- [ ] update_mlflow_app
 - [ ] update_mlflow_tracking_server
 - [X] update_model_card
 - [X] update_model_package
@@ -9201,7 +9606,6 @@
 - [ ] batch_update_findings
 - [ ] batch_update_findings_v2
 - [ ] batch_update_standards_control_associations
-- [ ] connector_registrations_v2
 - [ ] create_action_target
 - [ ] create_aggregator_v2
 - [ ] create_automation_rule
@@ -9252,6 +9656,7 @@
 - [ ] get_finding_history
 - [ ] get_finding_statistics_v2
 - [X] get_findings
+- [ ] get_findings_trends_v2
 - [ ] get_findings_v2
 - [ ] get_insight_results
 - [ ] get_insights
@@ -9259,6 +9664,7 @@
 - [X] get_master_account
 - [X] get_members
 - [ ] get_resources_statistics_v2
+- [ ] get_resources_trends_v2
 - [ ] get_resources_v2
 - [ ] get_security_control_definition
 - [ ] invite_members
@@ -9276,6 +9682,7 @@
 - [ ] list_security_control_definitions
 - [ ] list_standards_control_associations
 - [ ] list_tags_for_resource
+- [ ] register_connector_v2
 - [ ] start_configuration_policy_association
 - [ ] start_configuration_policy_disassociation
 - [ ] tag_resource
@@ -9296,7 +9703,7 @@
 
 ## service-quotas
 <details>
-<summary>8% implemented</summary>
+<summary>7% implemented</summary>
 
 - [ ] associate_service_quota_template
 - [ ] create_support_case
@@ -9305,6 +9712,7 @@
 - [ ] get_association_for_service_quota_template
 - [ ] get_auto_management_configuration
 - [ ] get_aws_default_service_quota
+- [ ] get_quota_utilization_report
 - [ ] get_requested_service_quota_change
 - [X] get_service_quota
 - [ ] get_service_quota_increase_request_from_template
@@ -9318,6 +9726,7 @@
 - [ ] put_service_quota_increase_request_into_template
 - [ ] request_service_quota_increase
 - [ ] start_auto_management
+- [ ] start_quota_utilization_report
 - [ ] stop_auto_management
 - [ ] tag_resource
 - [ ] untag_resource
@@ -9611,6 +10020,7 @@
 - [ ] get_deliverability_test_report
 - [ ] get_domain_deliverability_campaign
 - [ ] get_domain_statistics_report
+- [ ] get_email_address_insights
 - [X] get_email_identity
 - [X] get_email_identity_policies
 - [ ] get_email_template
@@ -9976,8 +10386,9 @@
 
 ## sso-admin
 <details>
-<summary>33% implemented</summary>
+<summary>31% implemented</summary>
 
+- [ ] add_region
 - [X] attach_customer_managed_policy_reference_to_permission_set
 - [X] attach_managed_policy_to_permission_set
 - [X] create_account_assignment
@@ -10008,6 +10419,7 @@
 - [ ] describe_instance_access_control_attribute_configuration
 - [X] describe_permission_set
 - [ ] describe_permission_set_provisioning_status
+- [ ] describe_region
 - [ ] describe_trusted_token_issuer
 - [X] detach_customer_managed_policy_reference_from_permission_set
 - [X] detach_managed_policy_from_permission_set
@@ -10036,6 +10448,7 @@
 - [ ] list_permission_set_provisioning_status
 - [X] list_permission_sets
 - [X] list_permission_sets_provisioned_to_account
+- [ ] list_regions
 - [ ] list_tags_for_resource
 - [ ] list_trusted_token_issuers
 - [X] provision_permission_set
@@ -10046,6 +10459,7 @@
 - [ ] put_application_session_configuration
 - [X] put_inline_policy_to_permission_set
 - [ ] put_permissions_boundary_to_permission_set
+- [ ] remove_region
 - [ ] tag_resource
 - [ ] untag_resource
 - [ ] update_application
@@ -10100,7 +10514,7 @@
 
 ## sts
 <details>
-<summary>66% implemented</summary>
+<summary>54% implemented</summary>
 
 - [X] assume_role
 - [X] assume_role_with_saml
@@ -10109,8 +10523,10 @@
 - [ ] decode_authorization_message
 - [ ] get_access_key_info
 - [X] get_caller_identity
+- [ ] get_delegated_access_token
 - [X] get_federation_token
 - [X] get_session_token
+- [ ] get_web_identity_token
 </details>
 
 ## support
@@ -10241,7 +10657,7 @@
 
 ## timestream-influxdb
 <details>
-<summary>76% implemented</summary>
+<summary>68% implemented</summary>
 
 - [X] create_db_cluster
 - [X] create_db_instance
@@ -10256,6 +10672,8 @@
 - [ ] list_db_instances_for_cluster
 - [X] list_db_parameter_groups
 - [X] list_tags_for_resource
+- [ ] reboot_db_cluster
+- [ ] reboot_db_instance
 - [X] tag_resource
 - [X] untag_resource
 - [ ] update_db_cluster
@@ -10436,7 +10854,7 @@
 
 ## vpc-lattice
 <details>
-<summary>31% implemented</summary>
+<summary>30% implemented</summary>
 
 - [ ] batch_update_rule
 - [X] create_access_log_subscription
@@ -10452,6 +10870,7 @@
 - [ ] create_target_group
 - [X] delete_access_log_subscription
 - [X] delete_auth_policy
+- [ ] delete_domain_verification
 - [ ] delete_listener
 - [ ] delete_resource_configuration
 - [ ] delete_resource_endpoint_association
@@ -10467,6 +10886,7 @@
 - [ ] deregister_targets
 - [X] get_access_log_subscription
 - [X] get_auth_policy
+- [ ] get_domain_verification
 - [ ] get_listener
 - [ ] get_resource_configuration
 - [ ] get_resource_gateway
@@ -10479,6 +10899,7 @@
 - [ ] get_service_network_vpc_association
 - [ ] get_target_group
 - [X] list_access_log_subscriptions
+- [ ] list_domain_verifications
 - [ ] list_listeners
 - [ ] list_resource_configurations
 - [ ] list_resource_endpoint_associations
@@ -10496,6 +10917,7 @@
 - [X] put_auth_policy
 - [X] put_resource_policy
 - [ ] register_targets
+- [ ] start_domain_verification
 - [X] tag_resource
 - [X] untag_resource
 - [X] update_access_log_subscription
@@ -10751,7 +11173,6 @@
 <details>
 
 - accessanalyzer
-- account
 - aiops
 - amplify
 - amplifybackend
@@ -10765,7 +11186,6 @@
 - applicationcostprofiler
 - apprunner
 - appstream
-- apptest
 - arc-region-switch
 - arc-zonal-shift
 - artifact
@@ -10814,6 +11234,7 @@
 - cognito-sync
 - comprehendmedical
 - compute-optimizer
+- compute-optimizer-automation
 - connect-contact-lens
 - connectcampaignsv2
 - connectcases
@@ -10837,7 +11258,6 @@
 - ds-data
 - ecr-public
 - eks-auth
-- elastictranscoder
 - entityresolution
 - evidently
 - evs
@@ -10871,7 +11291,6 @@
 - iotdeviceadvisor
 - iotevents
 - iotevents-data
-- iotfleethub
 - iotfleetwise
 - iotsecuretunneling
 - iotsitewise
@@ -10899,8 +11318,6 @@
 - lightsail
 - location
 - lookoutequipment
-- lookoutmetrics
-- lookoutvision
 - m2
 - machinelearning
 - mailmanager
@@ -10924,17 +11341,22 @@
 - mpa
 - mturk
 - mwaa
+- mwaa-serverless
 - neptune-graph
 - neptunedata
 - networkflowmonitor
 - networkmonitor
 - notifications
 - notificationscontacts
+- nova-act
 - oam
 - observabilityadmin
 - odb
 - omics
 - outposts
+- partnercentral-account
+- partnercentral-benefits
+- partnercentral-channel
 - partnercentral-selling
 - payment-cryptography
 - payment-cryptography-data
@@ -10952,18 +11374,17 @@
 - qapps
 - qbusiness
 - qconnect
-- qldb
-- qldb-session
 - rbin
 - redshift-serverless
 - repostspace
 - resource-explorer-2
-- robomaker
 - rolesanywhere
 - route53-recovery-cluster
 - route53-recovery-control-config
 - route53-recovery-readiness
+- route53globalresolver
 - route53profiles
+- rtbfabric
 - rum
 - s3outposts
 - sagemaker-a2i-runtime
@@ -10975,6 +11396,7 @@
 - security-ir
 - securitylake
 - serverlessrepo
+- signin
 - simspaceweaver
 - sms-voice
 - snow-device-management
@@ -10999,6 +11421,7 @@
 - waf
 - waf-regional
 - wellarchitected
+- wickr
 - wisdom
 - workdocs
 - workmail

--- a/docs/docs/services/account.rst
+++ b/docs/docs/services/account.rst
@@ -12,8 +12,6 @@
 account
 =======
 
-.. autoclass:: moto.account.models.AccountBackend
-
 |start-h3| Implemented features for this service |end-h3|
 
 - [ ] accept_primary_email_update

--- a/docs/docs/services/backup.rst
+++ b/docs/docs/services/backup.rst
@@ -24,25 +24,29 @@ backup
 - [ ] create_framework
 - [ ] create_legal_hold
 - [ ] create_logically_air_gapped_backup_vault
-- [ ] create_report_plan
+- [X] create_report_plan
+  
+        The parameters ReportPlanTags and IdempotencyToken are not yet supported
+        
+
 - [ ] create_restore_access_backup_vault
 - [ ] create_restore_testing_plan
 - [ ] create_restore_testing_selection
 - [ ] create_tiering_configuration
 - [X] delete_backup_plan
 - [ ] delete_backup_selection
-- [ ] delete_backup_vault
+- [X] delete_backup_vault
 - [ ] delete_backup_vault_access_policy
-- [ ] delete_backup_vault_lock_configuration
+- [X] delete_backup_vault_lock_configuration
 - [ ] delete_backup_vault_notifications
 - [ ] delete_framework
 - [ ] delete_recovery_point
-- [ ] delete_report_plan
+- [X] delete_report_plan
 - [ ] delete_restore_testing_plan
 - [ ] delete_restore_testing_selection
 - [ ] delete_tiering_configuration
 - [ ] describe_backup_job
-- [ ] describe_backup_vault
+- [X] describe_backup_vault
 - [ ] describe_copy_job
 - [ ] describe_framework
 - [ ] describe_global_settings
@@ -50,7 +54,7 @@ backup
 - [ ] describe_recovery_point
 - [ ] describe_region_settings
 - [ ] describe_report_job
-- [ ] describe_report_plan
+- [X] describe_report_plan
 - [ ] describe_restore_job
 - [ ] describe_scan_job
 - [ ] disassociate_backup_vault_mpa_approval_team
@@ -98,7 +102,11 @@ backup
 - [ ] list_recovery_points_by_legal_hold
 - [ ] list_recovery_points_by_resource
 - [ ] list_report_jobs
-- [ ] list_report_plans
+- [X] list_report_plans
+  
+        Pagination is not yet implemented
+        
+
 - [ ] list_restore_access_backup_vaults
 - [ ] list_restore_job_summaries
 - [ ] list_restore_jobs
@@ -114,7 +122,7 @@ backup
 
 - [ ] list_tiering_configurations
 - [ ] put_backup_vault_access_policy
-- [ ] put_backup_vault_lock_configuration
+- [X] put_backup_vault_lock_configuration
 - [ ] put_backup_vault_notifications
 - [ ] put_restore_validation_result
 - [ ] revoke_restore_access_backup_vault

--- a/docs/docs/services/connect.rst
+++ b/docs/docs/services/connect.rst
@@ -20,14 +20,16 @@ connect
 - [X] associate_analytics_data_set
   Associate an analytics data set with a Connect instance.
 
-Enforces one association per (instance_id, data_set_id) pair.
-
+        Enforces one association per (instance_id, data_set_id) pair.
+        
 
 - [ ] associate_approved_origin
 - [ ] associate_bot
 - [ ] associate_contact_with_user
 - [ ] associate_default_vocabulary
+- [ ] associate_email_address_alias
 - [ ] associate_flow
+- [ ] associate_hours_of_operations
 - [ ] associate_instance_storage_config
 - [ ] associate_lambda_function
 - [ ] associate_lex_bot
@@ -35,20 +37,30 @@ Enforces one association per (instance_id, data_set_id) pair.
 - [ ] associate_queue_quick_connects
 - [ ] associate_routing_profile_queues
 - [ ] associate_security_key
+- [ ] associate_security_profiles
 - [ ] associate_traffic_distribution_group_user
 - [ ] associate_user_proficiencies
+- [ ] associate_workspace
 - [ ] batch_associate_analytics_data_set
+- [ ] batch_create_data_table_value
+- [ ] batch_delete_data_table_value
+- [ ] batch_describe_data_table_value
 - [ ] batch_disassociate_analytics_data_set
 - [ ] batch_get_attached_file_metadata
 - [ ] batch_get_flow_association
 - [ ] batch_put_contact
+- [ ] batch_update_data_table_value
 - [ ] claim_phone_number
 - [ ] complete_attached_file_upload
 - [ ] create_agent_status
 - [ ] create_contact
 - [ ] create_contact_flow
 - [ ] create_contact_flow_module
+- [ ] create_contact_flow_module_alias
+- [ ] create_contact_flow_module_version
 - [ ] create_contact_flow_version
+- [ ] create_data_table
+- [ ] create_data_table_attribute
 - [ ] create_email_address
 - [ ] create_evaluation_form
 - [ ] create_hours_of_operation
@@ -68,6 +80,7 @@ Enforces one association per (instance_id, data_set_id) pair.
 - [ ] create_rule
 - [ ] create_security_profile
 - [ ] create_task_template
+- [ ] create_test_case
 - [ ] create_traffic_distribution_group
 - [ ] create_use_case
 - [ ] create_user
@@ -75,12 +88,18 @@ Enforces one association per (instance_id, data_set_id) pair.
 - [ ] create_view
 - [ ] create_view_version
 - [ ] create_vocabulary
+- [ ] create_workspace
+- [ ] create_workspace_page
 - [ ] deactivate_evaluation_form
 - [ ] delete_attached_file
 - [ ] delete_contact_evaluation
 - [ ] delete_contact_flow
 - [ ] delete_contact_flow_module
+- [ ] delete_contact_flow_module_alias
+- [ ] delete_contact_flow_module_version
 - [ ] delete_contact_flow_version
+- [ ] delete_data_table
+- [ ] delete_data_table_attribute
 - [ ] delete_email_address
 - [ ] delete_evaluation_form
 - [ ] delete_hours_of_operation
@@ -96,6 +115,7 @@ Enforces one association per (instance_id, data_set_id) pair.
 - [ ] delete_rule
 - [ ] delete_security_profile
 - [ ] delete_task_template
+- [ ] delete_test_case
 - [ ] delete_traffic_distribution_group
 - [ ] delete_use_case
 - [ ] delete_user
@@ -103,12 +123,18 @@ Enforces one association per (instance_id, data_set_id) pair.
 - [ ] delete_view
 - [ ] delete_view_version
 - [ ] delete_vocabulary
+- [ ] delete_workspace
+- [ ] delete_workspace_media
+- [ ] delete_workspace_page
 - [ ] describe_agent_status
 - [ ] describe_authentication_profile
 - [ ] describe_contact
 - [ ] describe_contact_evaluation
 - [ ] describe_contact_flow
 - [ ] describe_contact_flow_module
+- [ ] describe_contact_flow_module_alias
+- [ ] describe_data_table
+- [ ] describe_data_table_attribute
 - [ ] describe_email_address
 - [ ] describe_evaluation_form
 - [ ] describe_hours_of_operation
@@ -126,18 +152,22 @@ Enforces one association per (instance_id, data_set_id) pair.
 - [ ] describe_routing_profile
 - [ ] describe_rule
 - [ ] describe_security_profile
+- [ ] describe_test_case
 - [ ] describe_traffic_distribution_group
 - [ ] describe_user
 - [ ] describe_user_hierarchy_group
 - [ ] describe_user_hierarchy_structure
 - [ ] describe_view
 - [ ] describe_vocabulary
+- [ ] describe_workspace
 - [X] disassociate_analytics_data_set
   Disassociate an analytics data set from a Connect instance.
 
 - [ ] disassociate_approved_origin
 - [ ] disassociate_bot
+- [ ] disassociate_email_address_alias
 - [ ] disassociate_flow
+- [ ] disassociate_hours_of_operations
 - [ ] disassociate_instance_storage_config
 - [ ] disassociate_lambda_function
 - [ ] disassociate_lex_bot
@@ -145,9 +175,12 @@ Enforces one association per (instance_id, data_set_id) pair.
 - [ ] disassociate_queue_quick_connects
 - [ ] disassociate_routing_profile_queues
 - [ ] disassociate_security_key
+- [ ] disassociate_security_profiles
 - [ ] disassociate_traffic_distribution_group_user
 - [ ] disassociate_user_proficiencies
+- [ ] disassociate_workspace
 - [ ] dismiss_user_contact
+- [ ] evaluate_data_table_values
 - [ ] get_attached_file
 - [ ] get_contact_attributes
 - [ ] get_contact_metrics
@@ -160,8 +193,10 @@ Enforces one association per (instance_id, data_set_id) pair.
 - [ ] get_metric_data_v2
 - [ ] get_prompt_file
 - [ ] get_task_template
+- [ ] get_test_case_execution_summary
 - [ ] get_traffic_distribution
 - [ ] import_phone_number
+- [ ] import_workspace_media
 - [ ] list_agent_statuses
 - [X] list_analytics_data_associations
   List analytics data associations for a Connect instance.
@@ -171,12 +206,20 @@ Enforces one association per (instance_id, data_set_id) pair.
 - [ ] list_associated_contacts
 - [ ] list_authentication_profiles
 - [ ] list_bots
+- [ ] list_child_hours_of_operations
 - [ ] list_contact_evaluations
+- [ ] list_contact_flow_module_aliases
+- [ ] list_contact_flow_module_versions
 - [ ] list_contact_flow_modules
 - [ ] list_contact_flow_versions
 - [ ] list_contact_flows
 - [ ] list_contact_references
+- [ ] list_data_table_attributes
+- [ ] list_data_table_primary_values
+- [ ] list_data_table_values
+- [ ] list_data_tables
 - [ ] list_default_vocabularies
+- [ ] list_entity_security_profiles
 - [ ] list_evaluation_form_versions
 - [ ] list_evaluation_forms
 - [ ] list_flow_associations
@@ -202,10 +245,14 @@ Enforces one association per (instance_id, data_set_id) pair.
 - [ ] list_rules
 - [ ] list_security_keys
 - [ ] list_security_profile_applications
+- [ ] list_security_profile_flow_modules
 - [ ] list_security_profile_permissions
 - [ ] list_security_profiles
-- [ ] list_tags_for_resource
+- [X] list_tags_for_resource
 - [ ] list_task_templates
+- [ ] list_test_case_execution_records
+- [ ] list_test_case_executions
+- [ ] list_test_cases
 - [ ] list_traffic_distribution_group_users
 - [ ] list_traffic_distribution_groups
 - [ ] list_use_cases
@@ -214,6 +261,9 @@ Enforces one association per (instance_id, data_set_id) pair.
 - [ ] list_users
 - [ ] list_view_versions
 - [ ] list_views
+- [ ] list_workspace_media
+- [ ] list_workspace_pages
+- [ ] list_workspaces
 - [ ] monitor_contact
 - [ ] pause_contact
 - [ ] put_user_status
@@ -223,10 +273,13 @@ Enforces one association per (instance_id, data_set_id) pair.
 - [ ] resume_contact_recording
 - [ ] search_agent_statuses
 - [ ] search_available_phone_numbers
+- [ ] search_contact_evaluations
 - [ ] search_contact_flow_modules
 - [ ] search_contact_flows
 - [ ] search_contacts
+- [ ] search_data_tables
 - [ ] search_email_addresses
+- [ ] search_evaluation_forms
 - [ ] search_hours_of_operation_overrides
 - [ ] search_hours_of_operations
 - [ ] search_predefined_attributes
@@ -236,14 +289,19 @@ Enforces one association per (instance_id, data_set_id) pair.
 - [ ] search_resource_tags
 - [ ] search_routing_profiles
 - [ ] search_security_profiles
+- [ ] search_test_cases
 - [ ] search_user_hierarchy_groups
 - [ ] search_users
+- [ ] search_views
 - [ ] search_vocabularies
+- [ ] search_workspace_associations
+- [ ] search_workspaces
 - [ ] send_chat_integration_event
 - [ ] send_outbound_email
 - [ ] start_attached_file_upload
 - [ ] start_chat_contact
 - [ ] start_contact_evaluation
+- [ ] start_contact_media_processing
 - [ ] start_contact_recording
 - [ ] start_contact_streaming
 - [ ] start_email_contact
@@ -252,17 +310,20 @@ Enforces one association per (instance_id, data_set_id) pair.
 - [ ] start_outbound_voice_contact
 - [ ] start_screen_sharing
 - [ ] start_task_contact
+- [ ] start_test_case_execution
 - [ ] start_web_rtc_contact
 - [ ] stop_contact
+- [ ] stop_contact_media_processing
 - [ ] stop_contact_recording
 - [ ] stop_contact_streaming
+- [ ] stop_test_case_execution
 - [ ] submit_contact_evaluation
 - [ ] suspend_contact_recording
 - [ ] tag_contact
-- [ ] tag_resource
+- [X] tag_resource
 - [ ] transfer_contact
 - [ ] untag_contact
-- [ ] untag_resource
+- [X] untag_resource
 - [ ] update_agent_status
 - [ ] update_authentication_profile
 - [ ] update_contact
@@ -270,11 +331,15 @@ Enforces one association per (instance_id, data_set_id) pair.
 - [ ] update_contact_evaluation
 - [ ] update_contact_flow_content
 - [ ] update_contact_flow_metadata
+- [ ] update_contact_flow_module_alias
 - [ ] update_contact_flow_module_content
 - [ ] update_contact_flow_module_metadata
 - [ ] update_contact_flow_name
 - [ ] update_contact_routing_data
 - [ ] update_contact_schedule
+- [ ] update_data_table_attribute
+- [ ] update_data_table_metadata
+- [ ] update_data_table_primary_values
 - [ ] update_email_address_metadata
 - [ ] update_evaluation_form
 - [ ] update_hours_of_operation
@@ -303,6 +368,7 @@ Enforces one association per (instance_id, data_set_id) pair.
 - [ ] update_rule
 - [ ] update_security_profile
 - [ ] update_task_template
+- [ ] update_test_case
 - [ ] update_traffic_distribution
 - [ ] update_user_hierarchy
 - [ ] update_user_hierarchy_group_name
@@ -314,4 +380,8 @@ Enforces one association per (instance_id, data_set_id) pair.
 - [ ] update_user_security_profiles
 - [ ] update_view_content
 - [ ] update_view_metadata
+- [ ] update_workspace_metadata
+- [ ] update_workspace_page
+- [ ] update_workspace_theme
+- [ ] update_workspace_visibility
 

--- a/docs/docs/services/glue.rst
+++ b/docs/docs/services/glue.rst
@@ -77,6 +77,7 @@ glue
 - [ ] delete_column_statistics_for_table
 - [ ] delete_column_statistics_task_settings
 - [ ] delete_connection
+- [ ] delete_connection_type
 - [X] delete_crawler
 - [ ] delete_custom_entity_type
 - [ ] delete_data_quality_ruleset
@@ -235,6 +236,7 @@ glue
 - [X] put_schema_version_metadata
 - [X] put_workflow_run_properties
 - [ ] query_schema_version_metadata
+- [ ] register_connection_type
 - [X] register_schema_version
 - [ ] remove_schema_version_metadata
 - [ ] reset_job_bookmark

--- a/docs/docs/services/ram.rst
+++ b/docs/docs/services/ram.rst
@@ -40,6 +40,7 @@ ram
 - [ ] list_resource_share_permissions
 - [X] list_resource_types
 - [ ] list_resources
+- [ ] list_source_associations
 - [ ] promote_permission_created_from_policy
 - [ ] promote_resource_share_created_from_policy
 - [ ] reject_resource_share_invitation

--- a/docs/docs/services/resourcegroupstaggingapi.rst
+++ b/docs/docs/services/resourcegroupstaggingapi.rst
@@ -23,12 +23,12 @@ resourcegroupstaggingapi
 - [ ] start_report_creation
 - [X] tag_resources
   
-        Only DynamoDB, EFS, Elasticache, Lambda Logs, Quicksight RDS, SageMaker, and SES resources are currently supported
+        Only CloudFront, DynamoDB, EFS, Elasticache, Lambda Logs, Quicksight RDS, SageMaker, and SES resources are currently supported
         
 
 - [X] untag_resources
   
-        Only EFS, Elasticache, Lambda, Quicksight, and SES resources are currently supported
+        Only CloudFront, EFS, Elasticache, Lambda, Quicksight, and SES resources are currently supported
         
 
 

--- a/docs/docs/services/route53resolver.rst
+++ b/docs/docs/services/route53resolver.rst
@@ -63,7 +63,9 @@ route53resolver
 - [X] get_resolver_query_log_config
   Get information about a resolver query log config.
 
-- [ ] get_resolver_query_log_config_association
+- [X] get_resolver_query_log_config_association
+  Get information about a resolver query log config association.
+
 - [ ] get_resolver_query_log_config_policy
 - [X] get_resolver_rule
   Return info for specified resolver rule.
@@ -82,8 +84,8 @@ route53resolver
 - [X] list_resolver_dnssec_configs
 - [X] list_resolver_endpoint_ip_addresses
 - [X] list_resolver_endpoints
-- [ ] list_resolver_query_log_config_associations
-- [ ] list_resolver_query_log_configs
+- [X] list_resolver_query_log_config_associations
+- [X] list_resolver_query_log_configs
 - [X] list_resolver_rule_associations
 - [X] list_resolver_rules
 - [X] list_tags_for_resource

--- a/docs/docs/services/s3.rst
+++ b/docs/docs/services/s3.rst
@@ -190,6 +190,7 @@ s3
 
 - [ ] update_bucket_metadata_inventory_table_configuration
 - [ ] update_bucket_metadata_journal_table_configuration
+- [ ] update_object_encryption
 - [X] upload_file
 - [X] upload_fileobj
 - [X] upload_part

--- a/docs/docs/services/securityhub.rst
+++ b/docs/docs/services/securityhub.rst
@@ -89,7 +89,7 @@ securityhub
 - [ ] get_insight_results
 - [ ] get_insights
 - [ ] get_invitations_count
-- [ ] get_master_account
+- [X] get_master_account
 - [X] get_members
 - [ ] get_resources_statistics_v2
 - [ ] get_resources_trends_v2

--- a/docs/docs/services/sso-admin.rst
+++ b/docs/docs/services/sso-admin.rst
@@ -16,6 +16,7 @@ sso-admin
 
 |start-h3| Implemented features for this service |end-h3|
 
+- [ ] add_region
 - [X] attach_customer_managed_policy_reference_to_permission_set
 - [X] attach_managed_policy_to_permission_set
 - [X] create_account_assignment
@@ -46,6 +47,7 @@ sso-admin
 - [ ] describe_instance_access_control_attribute_configuration
 - [X] describe_permission_set
 - [ ] describe_permission_set_provisioning_status
+- [ ] describe_region
 - [ ] describe_trusted_token_issuer
 - [X] detach_customer_managed_policy_reference_from_permission_set
 - [X] detach_managed_policy_from_permission_set
@@ -82,6 +84,7 @@ sso-admin
         The following parameters are not yet implemented: AccountId, ProvisioningStatus, MaxResults, NextToken
         
 
+- [ ] list_regions
 - [ ] list_tags_for_resource
 - [ ] list_trusted_token_issuers
 - [X] provision_permission_set
@@ -96,6 +99,7 @@ sso-admin
 - [ ] put_application_session_configuration
 - [X] put_inline_policy_to_permission_set
 - [ ] put_permissions_boundary_to_permission_set
+- [ ] remove_region
 - [ ] tag_resource
 - [ ] untag_resource
 - [ ] update_application

--- a/moto/dynamodb/models/table.py
+++ b/moto/dynamodb/models/table.py
@@ -837,9 +837,6 @@ class Table(CloudFormationModel):
             if hash_key_conditions:
                 for attr_name, value in hash_key_conditions:
                     all_hash_conditions[attr_name] = value
-            elif hash_key:
-                # Backward compatibility: use legacy hash_key parameter
-                all_hash_conditions[index_hash_keys[0]["AttributeName"]] = hash_key
 
             # Build a dict of range key equalities (all but last in range_key_conditions)
             range_equality_conditions: dict[str, DynamoType] = {}

--- a/moto/dynamodb/parsing/key_condition_expression.py
+++ b/moto/dynamodb/parsing/key_condition_expression.py
@@ -13,12 +13,6 @@ class EXPRESSION_STAGES(Enum):
     EOF = "EOF"
 
 
-def get_key(schema: list[dict[str, str]], key_type: str) -> Optional[str]:
-    """Get the first key of the specified type (for backward compatibility)."""
-    keys = get_keys(schema, key_type)
-    return keys[0] if keys else None
-
-
 def get_keys(schema: list[dict[str, str]], key_type: str) -> list[str]:
     """Get all keys of the specified type in schema order."""
     return [key["AttributeName"] for key in schema if key["KeyType"] == key_type]

--- a/other_langs/tests_dotnet/s3/UnitTest.cs
+++ b/other_langs/tests_dotnet/s3/UnitTest.cs
@@ -20,7 +20,7 @@ public class UnitTest1
         AmazonS3Client s3Client = new AmazonS3Client(config);
 
         var initial_list = await s3Client.ListBucketsAsync();
-        initial_list.Buckets.Count.Should().Be(0);
+        initial_list.Buckets.Should().BeNull();
 
         var putBucketRequest = new PutBucketRequest
         {

--- a/other_langs/tests_dotnet/s3/s3.csproj
+++ b/other_langs/tests_dotnet/s3/s3.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.S3" Version="3.7.103.34" />
+    <PackageReference Include="AWSSDK.S3" Version="*" />
     <PackageReference Include="FluentAssertions" Version="6.8.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="7.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />

--- a/other_langs/tests_dotnet/sqs/sqs.csproj
+++ b/other_langs/tests_dotnet/sqs/sqs.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.SQS" Version="3.7.200" />
+    <PackageReference Include="AWSSDK.SQS" Version="*" />
     <PackageReference Include="FluentAssertions" Version="6.8.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="7.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />

--- a/other_langs/tests_js/package.json
+++ b/other_langs/tests_js/package.json
@@ -6,7 +6,8 @@
     "@aws-sdk/client-ec2": "^3.749.0",
     "@aws-sdk/client-lambda": "^3.749.0",
     "@aws-sdk/client-rds": "^3.749.0",
-    "@aws-sdk/client-s3": "^3.749.0"
+    "@aws-sdk/client-s3": "^3.749.0",
+    "@aws-sdk/client-sqs": "^3.749.0"
   },
   "type": "module",
   "scripts": {

--- a/other_langs/tests_js/rds.test.js
+++ b/other_langs/tests_js/rds.test.js
@@ -7,7 +7,7 @@ const client = new RDSClient({region: 'us-east-1', endpoint:'http://localhost:50
 const create_command = new CreateDBInstanceCommand(
     {
         DBInstanceClass: "dbic",
-        DBInstanceIdentifier: "dbii",
+        DBInstanceIdentifier: "dbii" + Math.floor(Math.random() * 10000),
         Engine: "mysql",
         DBName: "dbn"
     }

--- a/other_langs/tests_js/sqs.test.js
+++ b/other_langs/tests_js/sqs.test.js
@@ -1,0 +1,28 @@
+import { CreateQueueCommand, GetQueueUrlCommand, SQSClient } from '@aws-sdk/client-sqs'
+
+process.env['AWS_ACCESS_KEY_ID'] = 'test'
+process.env['AWS_SECRET_ACCESS_KEY'] = 'test'
+
+
+const client = new SQSClient({
+  region:'us-east-1',
+  endpoint: 'http://localhost:5000',
+});
+const queueName = "test-queue-" + Math.floor(Math.random() * 10000);
+console.log(queueName);
+console.log("----")
+
+const createQueueCommand = new CreateQueueCommand({
+    QueueName: queueName,
+    Attributes: {
+      DelaySeconds: "60",
+      MessageRetentionPeriod: "86400",
+    },
+});
+
+await client.send(createQueueCommand);
+
+const getUrlCommand = new GetQueueUrlCommand({ QueueName: queueName });
+
+const response = await client.send(getUrlCommand);
+console.log(response);

--- a/tests/test_autoscaling/test_autoscaling.py
+++ b/tests/test_autoscaling/test_autoscaling.py
@@ -144,8 +144,7 @@ def test_create_autoscaling_group_from_invalid_instance_id():
     launch_template_data={"ImageId": get_valid_ami(), "InstanceType": "t2.medium"},
     return_launch_template_details=True,
 )
-# Instances are created in the Subnet - wait until the instances are terminated at the end, otherwise subsequent Subnet deletion fails (because of dangling resources)
-@autoscaling_aws_verified(get_group_name=True, wait_for_instance_termination=True)
+@autoscaling_aws_verified(get_group_name=True)
 @pytest.mark.aws_verified
 def test_create_autoscaling_group_from_template(
     autoscaling_client=None,
@@ -1217,7 +1216,7 @@ def test_create_auto_scaling_group_with_mixed_instances_policy_overrides(
     create_launch_template=True,
     launch_template_data={"ImageId": get_valid_ami(), "InstanceType": "t2.medium"},
 )
-@autoscaling_aws_verified(get_group_name=True, wait_for_instance_termination=False)
+@autoscaling_aws_verified(get_group_name=True)
 @pytest.mark.aws_verified
 def test_update_mixed_instances_policy(
     autoscaling_client=None,


### PR DESCRIPTION
 - Updated documentation showing all new features
 - Improve JS tests to show installed versions
 - Removes some dead code from DynamoDB (see https://github.com/getmoto/moto/pull/9710#issuecomment-3860226791)
 - Upgrades DotNet tests to 9.0
 - Automatically use the latest DotNet dependencies for AWS (just in case that could explain #9711)
 - Add a very simple JS test for SQS (just in case that could explain #9711)
 - Randomizes the RDS tests for JS (makes it a little easier to run them continously locally during development)
 - Removes the `wait_for_instance_termination` in Autoscaling tests. This used to be necessary when we used a dedicated subnet, and we needed to ensure that instances were terminated before trying to delete the subnet. With https://github.com/getmoto/moto/pull/9651 we no longer use a dedicated subnet though, so there's also no point in waiting for the instances to be terminated. This should speed up these tests significantly when running them against AWS.