### PR TITLE
S3: fix missing `Filter` field in `GetBucketLifecycleConfiguration` response

### DIFF
--- a/moto/s3/responses.py
+++ b/moto/s3/responses.py
@@ -2893,6 +2893,8 @@ S3_BUCKET_LIFECYCLE_CONFIGURATION = """<?xml version="1.0" encoding="UTF-8"?>
         {% else %}
             {% if rule.prefix != None %}
             <Prefix>{{ rule.prefix }}</Prefix>
+            {% else %}
+            <Filter/>
             {% endif %}
         {% endif %}
         <Status>{{ rule.status }}</Status>

--- a/other_langs/terraform/s3/minimal_lifecycle_configuration.tf
+++ b/other_langs/terraform/s3/minimal_lifecycle_configuration.tf
@@ -1,0 +1,15 @@
+resource "aws_s3_bucket" "bucket_with_minimal_lifecycle_configuration" {
+  bucket = "test-bucket-with-minimal-lifecycle-configuration"
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "test_minimal_lifecycle_configuration" {
+  bucket = aws_s3_bucket.bucket_with_minimal_lifecycle_configuration.id
+  rule {
+    id     = "MinimalRule"
+    status = "Enabled"
+
+    abort_incomplete_multipart_upload {
+      days_after_initiation = 3
+    }
+  }
+}


### PR DESCRIPTION
`Filter` field is required in the response, even if it is empty.  Adds failing Terraform test case (now passing) from linked issue.

Closes #9729 