### PR TITLE
Pipes: implement `ListTagsForResource` endpoint

### DIFF
--- a/moto/pipes/responses.py
+++ b/moto/pipes/responses.py
@@ -151,6 +151,11 @@ class EventBridgePipesResponse(BaseResponse):
         )
         return EmptyResult()
 
+    def list_tags_for_resource(self) -> ActionResult:
+        resource_arn = unquote(self.uri.split("/tags/")[-1])
+        tags = self.pipes_backend.list_tags_for_resource(resource_arn)
+        return ActionResult({"tags": tags})
+
     def list_pipes(self) -> ActionResult:
         params = json.loads(self.body) if self.body else {}
         if not params and self.querystring:

--- a/tests/test_pipes/test_pipes.py
+++ b/tests/test_pipes/test_pipes.py
@@ -118,6 +118,13 @@ def test_tag_resource():
         "Team": "backend",
     }
 
+    list_tags_resp = client.list_tags_for_resource(resourceArn=create_resp["Arn"])
+    assert list_tags_resp["tags"] == {
+        "Environment": "test",
+        "Project": "moto",
+        "Team": "backend",
+    }
+
 
 @mock_aws
 def test_tag_resource_updates_existing_tags():
@@ -138,6 +145,13 @@ def test_tag_resource_updates_existing_tags():
 
     describe_resp = client.describe_pipe(Name="test-pipe-tag-update")
     assert describe_resp["Tags"] == {
+        "Environment": "prod",
+        "Project": "old-project",
+        "Team": "backend",
+    }
+
+    list_tags_resp = client.list_tags_for_resource(resourceArn=create_resp["Arn"])
+    assert list_tags_resp["tags"] == {
         "Environment": "prod",
         "Project": "old-project",
         "Team": "backend",
@@ -166,6 +180,9 @@ def test_untag_resource():
     describe_resp = client.describe_pipe(Name="test-pipe-untag")
     assert describe_resp["Tags"] == {"Project": "moto"}
 
+    list_tags_resp = client.list_tags_for_resource(resourceArn=create_resp["Arn"])
+    assert list_tags_resp["tags"] == {"Project": "moto"}
+
 
 @mock_aws
 def test_untag_resource_all_tags():
@@ -186,6 +203,9 @@ def test_untag_resource_all_tags():
 
     describe_resp = client.describe_pipe(Name="test-pipe-untag-all")
     assert describe_resp.get("Tags") is None or describe_resp["Tags"] == {}
+
+    list_tags_resp = client.list_tags_for_resource(resourceArn=create_resp["Arn"])
+    assert list_tags_resp["tags"] == {}
 
 
 @mock_aws


### PR DESCRIPTION
This endpoint is needed for the Terraform test mentioned in #9713 to pass.

Note: I removed the TaggingService integration code as it was just duplicating the existing tagging logic (and not actually being used).  Admittedly, I made that choice (and not vice versa) because it was the path of least resistance.