### PR TITLE
CognitoIdp: add `iat` claim to ID and access tokens

### DIFF
--- a/moto/cognitoidp/models.py
+++ b/moto/cognitoidp/models.py
@@ -532,6 +532,7 @@ class CognitoIdpUserPool(BaseModel):
             "sub": self._get_user(username).id,
             "client_id" if token_use == "access" else "aud": client_id,
             "token_use": token_use,
+            "iat": now,
             "auth_time": now,
             "exp": now + expires_in,
             "jti": str(random.uuid4()),

--- a/tests/test_cognitoidp/test_cognitoidp.py
+++ b/tests/test_cognitoidp/test_cognitoidp.py
@@ -3525,6 +3525,8 @@ def test_token_legitimacy():
             f"https://cognito-idp.us-west-2.amazonaws.com/{outputs['user_pool_id']}"
         )
         id_claims = jwt.decode(id_token, json_web_key, ["RS256"]).claims
+        assert "exp" in id_claims
+        assert "iat" in id_claims
         assert id_claims["iss"] == issuer
         assert id_claims["aud"] == client_id
         assert id_claims["token_use"] == "id"
@@ -3532,6 +3534,8 @@ def test_token_legitimacy():
         for k, v in outputs["additional_fields"].items():
             assert id_claims[k] == v
         access_claims = jwt.decode(access_token, json_web_key, ["RS256"]).claims
+        assert "exp" in access_claims
+        assert "iat" in access_claims
         assert access_claims["iss"] == issuer
         assert access_claims["client_id"] == client_id
         assert access_claims["token_use"] == "access"


### PR DESCRIPTION
See #8477

#8581 added the `jti` and `origin_jti` claims but not the `iat` claim.

Not sure about the tests, happy to add a standalone one but added it to `test_token_legitimacy` for now since it is a minor fix.