### PR TITLE
Batch: Use bridge IP address for multinode jobs

### DIFF
--- a/moto/batch/models.py
+++ b/moto/batch/models.py
@@ -955,6 +955,9 @@ class Job(threading.Thread, BaseModel, DockerModel, ManagedState):
                     networks = network_settings["Networks"]
                     if network_name in networks:
                         ip = networks[network_name]["IPAddress"]
+                    elif "bridge" in networks:
+                        # Bridge is the usual network name
+                        ip = networks["bridge"]["IPAddress"]
                     else:
                         ip = network_settings["IPAddress"]
                     env["AWS_BATCH_JOB_MAIN_NODE_PRIVATE_IPV4_ADDRESS"] = ip


### PR DESCRIPTION
The GHA started failing because the `IPAddress` key could not be found in the `Networks`. I'm not sure what has changed - but the more common way to find an `IPAddress` is to use the one from the default network, `bridge`, so that's what I've changed it to.
If users do not use the `bridge` network, then it will default to the old behaviour.