### PR TITLE
CI: allow running a subset of the AWS verified tests

### DIFF
--- a/.github/workflows/tests_real_aws.yml
+++ b/.github/workflows/tests_real_aws.yml
@@ -5,9 +5,8 @@ on:
   workflow_dispatch:
     inputs:
       ref:
-        default: "master"
-        description: "The branch, tag or SHA to checkout, e.g. master or refs/pull/<pr_number>/merge"
-        required: false
+        description: "The branch, tag or SHA to checkout, e.g. refs/pull/<pr_number>/merge"
+        required: true
         type: string
       tests_specifier:
         default: "tests"


### PR DESCRIPTION
Currently, the AWS verified workflow runs once a week.  It can also be run manually as needed, but it only runs against the `master` branch and always runs the entire suite of tests.  When PRs are opened that contain tests marked as `aws_verified`, maintainers don't have an (easy) way to corroborate that claim before merging.  Once merged, it can take up to a week to find out if those tests actually pass against a real AWS backend--and sometimes they don't.

This PR adds input parameters to the `workflow_dispatch` event to allow running specific AWS verified test(s) from a particular git ref.  This change will allow maintainers to run AWS verified tests included in a Pull Request before merging.

Note: I have run this workflow against two existing PRs (#9725 and #9727) that include tests marked as `aws_verified` (see test runs [171](https://github.com/getmoto/moto/actions/runs/22015134144) and [172](https://github.com/getmoto/moto/actions/runs/22015177270)).