### PR TITLE
BedrockAgentCoreControl: add Memory support

### DIFF
--- a/moto/bedrockagentcorecontrol/models.py
+++ b/moto/bedrockagentcorecontrol/models.py
@@ -803,7 +803,6 @@ class BedrockAgentCoreControlBackend(BaseBackend):
         description: Optional[str],
         credential_provider_configurations: Optional[list[dict[str, Any]]],
         metadata_configuration: Optional[dict[str, Any]],
-        tags: Optional[dict[str, str]],
     ) -> GatewayTarget:
         gateway = self._get_gateway(gateway_identifier)
         target = GatewayTarget(
@@ -817,11 +816,6 @@ class BedrockAgentCoreControlBackend(BaseBackend):
             metadata_configuration=metadata_configuration,
         )
         self.gateway_targets[(gateway.gateway_id, target.target_id)] = target
-        if tags:
-            self.tagger.tag_resource(
-                target.gateway_arn,
-                [{"Key": k, "Value": v} for k, v in tags.items()],
-            )
         return target
 
     def get_gateway_target(

--- a/moto/bedrockagentcorecontrol/urls.py
+++ b/moto/bedrockagentcorecontrol/urls.py
@@ -7,14 +7,5 @@ url_bases = [
 ]
 
 url_paths = {
-    "{0}/runtimes/$": BedrockAgentCoreControlResponse.dispatch,
-    "{0}/runtimes/(?P<agentRuntimeId>[^/]+)/$": BedrockAgentCoreControlResponse.dispatch,
-    "{0}/runtimes/(?P<agentRuntimeId>[^/]+)/versions/$": BedrockAgentCoreControlResponse.dispatch,
-    "{0}/runtimes/(?P<agentRuntimeId>[^/]+)/runtime-endpoints/$": BedrockAgentCoreControlResponse.dispatch,
-    "{0}/runtimes/(?P<agentRuntimeId>[^/]+)/runtime-endpoints/(?P<endpointName>[^/]+)/$": BedrockAgentCoreControlResponse.dispatch,
-    "{0}/gateways/$": BedrockAgentCoreControlResponse.dispatch,
-    "{0}/gateways/(?P<gatewayIdentifier>[^/]+)/$": BedrockAgentCoreControlResponse.dispatch,
-    "{0}/gateways/(?P<gatewayIdentifier>[^/]+)/targets/$": BedrockAgentCoreControlResponse.dispatch,
-    "{0}/gateways/(?P<gatewayIdentifier>[^/]+)/targets/(?P<targetId>[^/]+)/$": BedrockAgentCoreControlResponse.dispatch,
-    "{0}/tags/(?P<resourceArn>.+)$": BedrockAgentCoreControlResponse.dispatch,
+    "{0}/.*$": BedrockAgentCoreControlResponse.dispatch,
 }

--- a/tests/test_bedrockagentcorecontrol/test_bedrockagentcorecontrol.py
+++ b/tests/test_bedrockagentcorecontrol/test_bedrockagentcorecontrol.py
@@ -914,38 +914,6 @@ def test_update_gateway_with_optional_fields():
 
 
 @mock_aws
-def test_create_gateway_target_with_optional_fields_and_tags():
-    client = _create_client()
-    gw = client.create_gateway(
-        name="my-gateway",
-        roleArn=GATEWAY_ROLE_ARN,
-        protocolType="MCP",
-        authorizerType="NONE",
-    )
-    gateway_id = gw["gatewayId"]
-
-    metadata_config = {"customMetadataField": "value"}
-    resp = client.create_gateway_target(
-        gatewayIdentifier=gateway_id,
-        name="my-target",
-        targetConfiguration=TARGET_CONFIG,
-        credentialProviderConfigurations=CREDENTIAL_PROVIDER_CONFIGS,
-        description="Tagged target",
-        metadataConfiguration=metadata_config,
-        tags={"env": "prod"},
-    )
-    target_id = resp["targetId"]
-    assert resp["metadataConfiguration"] == metadata_config
-
-    tags = client.list_tags_for_resource(resourceArn=resp["gatewayArn"])["tags"]
-    assert tags == {"env": "prod"}
-
-    targets = client.list_gateway_targets(gatewayIdentifier=gateway_id)["items"]
-    described = [t for t in targets if t["targetId"] == target_id]
-    assert described[0]["description"] == "Tagged target"
-
-
-@mock_aws
 def test_update_gateway_target_with_optional_fields():
     client = _create_client()
     gw = client.create_gateway(

--- a/uv.lock
+++ b/uv.lock
@@ -1,3 +1,0 @@
-version = 1
-revision = 3
-requires-python = ">=3.14"


### PR DESCRIPTION
PR 3 of 3: adds Memory support to `bedrock-agentcore-control`.

Builds on #9775. Memory is a standalone resource with its own strategy management.

**Operations (5):** CreateMemory, GetMemory, UpdateMemory, DeleteMemory, ListMemories

Supports memory strategies (semantic, summary, user-preference, episodic, custom) with add/modify/delete lifecycle.

**Part of a series:**
- [#9774](https://github.com/getmoto/moto/pull/9774) - Initial support with Agent Runtime CRUD (first in series)
- [#9775](https://github.com/getmoto/moto/pull/9775) - Gateway and GatewayTarget support (this PR builds on this)