### PR TITLE
ec2: Add dry run error handling for fleet creation

### DIFF
--- a/moto/ec2/responses/fleets.py
+++ b/moto/ec2/responses/fleets.py
@@ -68,6 +68,8 @@ class Fleets(EC2BaseResponse):
 
         tag_specifications = self._get_param("TagSpecifications", [])
 
+        self.error_on_dryrun()
+
         request = self.ec2_backend.create_fleet(
             on_demand_options=on_demand_options,
             spot_options=spot_options,


### PR DESCRIPTION
When `CreateFleet` operation is called with `DryRun=true`, the fleet object should not be created and stored.

# Changes

* Adds `error_on_dryrun` for `create_fleet`
* Adds `ec2_aws_verified` test for the behavior