### PR TITLE
Core: unquote uri path parameters

### DIFF
--- a/moto/core/responses.py
+++ b/moto/core/responses.py
@@ -15,7 +15,7 @@ from typing import (
     Union,
     cast,
 )
-from urllib.parse import parse_qs, parse_qsl, urlparse
+from urllib.parse import parse_qs, parse_qsl, unquote, urlparse
 from xml.dom.minidom import parseString as parseXML
 
 import boto3
@@ -659,7 +659,8 @@ class BaseResponse(_TemplateEnvironmentMixin, ActionAuthenticatorMixin):
         # try to get path parameter
         if self.uri_match:
             try:
-                return self.uri_match.group(param_name)
+                val = self.uri_match.group(param_name)
+                return unquote(val)
             except IndexError:
                 # do nothing if param is not found
                 pass

--- a/moto/sesv2/responses.py
+++ b/moto/sesv2/responses.py
@@ -2,7 +2,6 @@
 
 import base64
 import json
-from urllib.parse import unquote
 
 from moto.core.responses import BaseResponse
 
@@ -83,7 +82,7 @@ class SESV2Response(BaseResponse):
         return json.dumps({})
 
     def get_contact(self) -> str:
-        email = unquote(self._get_param("EmailAddress"))
+        email = self._get_param("EmailAddress")
         contact_list_name = self._get_param("ContactListName")
         contact = self.sesv2_backend.get_contact(email, contact_list_name)
         return json.dumps(contact.response_object)
@@ -96,7 +95,7 @@ class SESV2Response(BaseResponse):
     def delete_contact(self) -> str:
         email = self._get_param("EmailAddress")
         contact_list_name = self._get_param("ContactListName")
-        self.sesv2_backend.delete_contact(unquote(email), contact_list_name)
+        self.sesv2_backend.delete_contact(email, contact_list_name)
         return json.dumps({})
 
     def create_email_identity(self) -> str:


### PR DESCRIPTION
Automatically decode incoming uri parameters in `core/responses.py` to avoid requiring every backend to manually decode them.  Eliminates manual decoding from the SESV2 backend as a reference example (prioritized as a result of #9771).

