### PR TITLE
ec2: enhance fleet creation with LaunchTemplateAndOverrides in responses

### DIFF
--- a/moto/ec2/responses/fleets.py
+++ b/moto/ec2/responses/fleets.py
@@ -70,7 +70,7 @@ class Fleets(EC2BaseResponse):
 
         self.error_on_dryrun()
 
-        request = self.ec2_backend.create_fleet(
+        fleet = self.ec2_backend.create_fleet(
             on_demand_options=on_demand_options,
             spot_options=spot_options,
             target_capacity_specification=target_capacity_specification,
@@ -83,26 +83,7 @@ class Fleets(EC2BaseResponse):
             valid_until=valid_until,
             tag_specifications=tag_specifications,
         )
-        result = {"FleetId": request.id}
-        if request.fleet_type == "instant":
-            # On Demand and Spot Instances are stored as incompatible types on the backend,
-            # so we have to do some extra work here.
-            # TODO: This should be addressed on the backend.
-            on_demand_instances = [
-                {
-                    "Lifecycle": "on-demand",
-                    "InstanceIds": [instance["instance"].id],
-                    "InstanceType": instance["instance"].instance_type,
-                }
-                for instance in request.on_demand_instances
-            ]
-            spot_requests = [
-                {
-                    "Lifecycle": "spot",
-                    "InstanceIds": [instance.instance.id],
-                    "InstanceType": instance.instance.instance_type,
-                }
-                for instance in request.spot_requests
-            ]
-            result["Instances"] = on_demand_instances + spot_requests
+        result = {"FleetId": fleet.id}
+        if fleet.instances is not None:
+            result["Instances"] = fleet.instances
         return ActionResult(result)


### PR DESCRIPTION
## Motivation 

When creating an EC2 Fleet with `Type=instant`, the response was missing the `LaunchTemplateAndOverrides` field for each instance. This field is present in real AWS responses and contains important information about which launch template and overrides were used to launch each instance.

## Changes

* The `Instances` array in the `create_fleet` response now includes `LaunchTemplateAndOverrides` with:
  * `LaunchTemplateSpecification` - Launch template ID and version used
  * `Overrides` - Any overrides applied (instance type, subnet, AZ, etc.) 
* Version resolution: `$Latest` is now resolved to the actual version number (e.g., "1") in responses, matching AWS
* Template ID normalization: When LaunchTemplateName is used in the request, the response always includes LaunchTemplateId (AWS behavior)