### PR TITLE
SNS: fix handling of custom data type labels 

### DIFF
--- a/moto/sns/responses.py
+++ b/moto/sns/responses.py
@@ -84,7 +84,7 @@ class SNSResponse(BaseResponse):
                 )
 
             data_type_parts = data_type.split(".")
-            if len(data_type_parts) > 2 or data_type_parts[0] not in [
+            if data_type_parts[0] not in [
                 "String",
                 "Binary",
                 "Number",

--- a/tests/test_sns/test_publishing.py
+++ b/tests/test_sns/test_publishing.py
@@ -300,6 +300,41 @@ def test_publish_to_sqs_msg_attr_byte_value():
 
 
 @mock_aws
+def test_publish_to_sqs_with_custom_data_type():
+    conn = boto3.client("sns", region_name="us-east-1")
+    conn.create_topic(Name="some-topic")
+    response = conn.list_topics()
+    topic_arn = response["Topics"][0]["TopicArn"]
+    sqs = boto3.resource("sqs", region_name="us-east-1")
+    queue = sqs.create_queue(QueueName="test-queue")
+    conn.subscribe(
+        TopicArn=topic_arn, Protocol="sqs", Endpoint=queue.attributes["QueueArn"]
+    )
+    queue_raw = sqs.create_queue(QueueName="test-queue-raw")
+    conn.subscribe(
+        TopicArn=topic_arn,
+        Protocol="sqs",
+        Endpoint=queue_raw.attributes["QueueArn"],
+        Attributes={"RawMessageDelivery": "true"},
+    )
+    conn.publish(
+        TopicArn=topic_arn,
+        Message="my message",
+        MessageAttributes={
+            "store": {"DataType": "Number.java.lang.Long", "StringValue": "42"}
+        },
+    )
+    message = json.loads(queue.receive_messages()[0].body)
+    assert message["Message"] == "my message"
+    assert message["MessageAttributes"] == {
+        "store": {
+            "Type": "Number.java.lang.Long",
+            "Value": "42",
+        }
+    }
+
+
+@mock_aws
 def test_publish_to_sqs_msg_attr_number_type():
     sns = boto3.resource("sns", region_name="us-east-1")
     topic = sns.create_topic(Name="test-topic")


### PR DESCRIPTION
Moto was raising an error if a custom data type label contained more than one period (e.g. `Number.custom.type`), but this is not a constraint enforced by AWS.

I tested this against a real AWS backend using `Number.java.lang.Long`.  The message was published successfully and retained the custom label in full when I retrieved it via SQS.

Closes #9792 