### PR TITLE
Modernize Java tests

### DIFF
--- a/other_langs/tests_java/pom.xml
+++ b/other_langs/tests_java/pom.xml
@@ -13,8 +13,6 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.compiler.source>1.9</maven.compiler.source>
-    <maven.compiler.target>1.9</maven.compiler.target>
   </properties>
 
   <dependencyManagement>
@@ -31,9 +29,9 @@
 
   <dependencies>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>4.13.2</version>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <version>6.0.3</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -125,8 +123,7 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <source>9</source>
-          <target>9</target>
+          <release>17</release>
         </configuration>
       </plugin>
     </plugins>

--- a/other_langs/tests_java/src/test/java/moto/tests/CognitoIDPTest.java
+++ b/other_langs/tests_java/src/test/java/moto/tests/CognitoIDPTest.java
@@ -1,9 +1,9 @@
 package moto.tests;
 
 import static moto.tests.DependencyFactory.cognitoIdpClient;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.services.cognitoidentityprovider.CognitoIdentityProviderClient;
 import software.amazon.awssdk.services.cognitoidentityprovider.model.AssociateSoftwareTokenRequest;
 import software.amazon.awssdk.services.cognitoidentityprovider.model.AssociateSoftwareTokenResponse;
@@ -20,10 +20,10 @@ import java.util.List;
 import java.util.Map;
 
 
-public class CognitoIDPTest {
+class CognitoIDPTest {
 
     @Test
-    public void testAssociateSoftwareToken() {
+    void testAssociateSoftwareToken() {
         CognitoIdentityProviderClient client = cognitoIdpClient();
 
         CreateUserPoolRequest up_request = CreateUserPoolRequest.builder()

--- a/other_langs/tests_java/src/test/java/moto/tests/DynamoTest.java
+++ b/other_langs/tests_java/src/test/java/moto/tests/DynamoTest.java
@@ -1,15 +1,15 @@
 package moto.tests;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.services.dynamodb.model.ResourceInUseException;
 
-public class DynamoTest {
+class DynamoTest {
 
     @Test
-    public void testSingleTableExists() {
+    void testSingleTableExists() {
         String tableName = "table" + System.currentTimeMillis();
 
         DynamoLogic logic = new DynamoLogic();
@@ -19,7 +19,7 @@ public class DynamoTest {
     }
 
     @Test
-    public void testTableCannotBeCreatedTwice() {
+    void testTableCannotBeCreatedTwice() {
         String tableName = "table" + System.currentTimeMillis();
         DynamoLogic logic = new DynamoLogic();
         // Going once...

--- a/other_langs/tests_java/src/test/java/moto/tests/S3Test.java
+++ b/other_langs/tests_java/src/test/java/moto/tests/S3Test.java
@@ -1,23 +1,22 @@
 package moto.tests;
 
-import org.junit.Test;
-
+import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.core.ResponseBytes;
 import software.amazon.awssdk.core.sync.ResponseTransformer;
 import software.amazon.awssdk.services.s3.model.*;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Unit test for simple App.
  */
-public class S3Test
+class S3Test
 {
 
     @Test
-    public void put_object_string() {
+    void put_object_string() {
         String bucketName = "bucket" + System.currentTimeMillis();
         String keyName = "mykey";
         S3Client s3Client = DependencyFactory.s3Client();
@@ -50,7 +49,7 @@ public class S3Test
     }
 
     @Test
-    public void create_and_delete_bucket() {
+    void create_and_delete_bucket() {
         String bucketName = "bucket" + System.currentTimeMillis();
         S3Client s3Client = DependencyFactory.s3Client();
 

--- a/other_langs/tests_java/src/test/java/moto/tests/SESTest.java
+++ b/other_langs/tests_java/src/test/java/moto/tests/SESTest.java
@@ -2,11 +2,10 @@ package moto.tests;
 
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.junit.Test;
-import software.amazon.awssdk.services.dynamodb.model.Get;
+import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.services.ses.SesClient;
 import software.amazon.awssdk.services.ses.model.Body;
 import software.amazon.awssdk.services.ses.model.Content;
@@ -17,10 +16,10 @@ import software.amazon.awssdk.services.ses.model.VerifyEmailAddressRequest;
 import software.amazon.awssdk.services.ses.model.GetSendStatisticsResponse;
 import software.amazon.awssdk.services.ses.model.SesException;
 
-public class SESTest {
+class SESTest {
 
     @Test
-    public void testUnverifiedEmail() {
+    void testUnverifiedEmail() {
         SesClient sesClient = DependencyFactory.sesClient();
 
         Message message = Message
@@ -41,12 +40,12 @@ public class SESTest {
             sesClient.sendEmail(request);
 
         } catch (SesException e) {
-            assertEquals(e.awsErrorDetails().errorMessage(), "Email address not verified noreply@thedomain.com");
+            assertEquals("Email address not verified noreply@thedomain.com", e.awsErrorDetails().errorMessage());
         }
     }
 
     @Test
-    public void testGetSendStatistics() {
+    void testGetSendStatistics() {
         SesClient sesClient = DependencyFactory.sesClient();
 
         VerifyEmailAddressRequest verifyEmailAddressRequest = VerifyEmailAddressRequest.builder().emailAddress("noreply@thedomain.com").build();
@@ -73,6 +72,6 @@ public class SESTest {
         GetSendStatisticsResponse statisticsAfter = sesClient.getSendStatistics();
         Long after = statisticsAfter.sendDataPoints().get(0).deliveryAttempts().longValue();
 
-        assertTrue("Delivery attempts should increase", after > prev);
+        assertTrue(after > prev, "Delivery attempts should increase");
     }
 }


### PR DESCRIPTION
Updates JUnit to the current version `6.0.3` (requires `groupId/artifactId` change). The code was adjusted to the new version, also in a few assertions "expected" parameter was swapped with "actual" where it was in a wrong order (could cause misleading error messages).

Also updates Java to LTS version `17` which is a minimum baseline for multiple projects, including JUnit or Spring Boot. Please note that `.github/workflows/tests_sdk_java.yml` already installs Java 17.

This PR is based on minimal reproducible example prepared to issue #9792, except it does not add new tests and new dependencies required for those tests.