### PR TITLE
STS: implement GetAccessKeyInfo operation

### DIFF
--- a/moto/sts/models.py
+++ b/moto/sts/models.py
@@ -183,6 +183,23 @@ class STSBackend(BaseBackend):
         arn = f"arn:{partition}:sts::{self.account_id}:user/moto"
         return user_id, arn, self.account_id
 
+    def get_access_key_info(self, access_key_id: str) -> dict[str, str]:
+        """Return the account ID associated with the given access key.
+
+        In real AWS, this looks up the owning account. In moto, we check
+        IAM users/access keys across known accounts; if nothing matches,
+        we return the current account.
+        """
+        # Try to find the key in IAM backends
+        for account_id in iam_backends:
+            for partition in iam_backends[account_id]:
+                iam_backend = iam_backends[account_id][partition]
+                user = iam_backend.get_user_from_access_key_id(access_key_id)
+                if user:
+                    return {"Account": user.account_id}
+        # Default: return the calling account
+        return {"Account": self.account_id}
+
     def _create_access_key(self, role: str) -> tuple[str, AccessKey]:
         account_id_match = re.search(ARN_PARTITION_REGEX + r":iam::([0-9]+).+", role)
         if account_id_match:

--- a/moto/sts/responses.py
+++ b/moto/sts/responses.py
@@ -151,3 +151,8 @@ class TokenResponse(BaseResponse):
             "Arn": arn,
         }
         return ActionResult(result)
+
+    def get_access_key_info(self) -> ActionResult:
+        access_key_id = self._get_param("AccessKeyId")
+        result = self.backend.get_access_key_info(access_key_id)
+        return ActionResult(result)

--- a/tests/test_sts/test_sts.py
+++ b/tests/test_sts/test_sts.py
@@ -775,3 +775,23 @@ def test_sts_regions(region):
         assert resp["Arn"] == f"arn:aws-cn:sts::{ACCOUNT_ID}:user/moto"
     if region == "us-isob-east-1":
         assert resp["Arn"] == f"arn:aws-iso-b:sts::{ACCOUNT_ID}:user/moto"
+
+
+@mock_aws
+def test_get_access_key_info_default():
+    """GetAccessKeyInfo returns the account ID for the calling account."""
+    client = boto3.client("sts", region_name="us-east-1")
+    resp = client.get_access_key_info(AccessKeyId="AKIAIOSFODNN7EXAMPLE")
+    assert resp["Account"] == str(ACCOUNT_ID)
+
+
+@mock_aws
+def test_get_access_key_info_with_iam_user():
+    """GetAccessKeyInfo returns the correct account for an IAM user's key."""
+    iam = boto3.client("iam", region_name="us-east-1")
+    iam.create_user(UserName="testuser")
+    key = iam.create_access_key(UserName="testuser")["AccessKey"]
+
+    client = boto3.client("sts", region_name="us-east-1")
+    resp = client.get_access_key_info(AccessKeyId=key["AccessKeyId"])
+    assert resp["Account"] == str(ACCOUNT_ID)


### PR DESCRIPTION
Adds `GetAccessKeyInfo` to the STS mock.

Returns the account ID for a given access key by searching IAM backends. Falls back to the calling account if the key is not found.