### PR TITLE
fix(logs): correct CloudWatch query sort direction

### DIFF
--- a/moto/logs/logs_query/query_parser.py
+++ b/moto/logs/logs_query/query_parser.py
@@ -12,9 +12,9 @@ class ParsedQuery:
     def sort_reversed(self) -> bool:
         # Descending is the default
         if self.sort:
-            # sort_reversed is True if we want to sort in ascending order
-            return self.sort[-1][-1] == "asc"
-        return False
+            # sorted(..., reverse=True) gives descending order
+            return self.sort[-1][-1] == "desc"
+        return True
 
 
 def parse_query(query: str) -> ParsedQuery:

--- a/tests/test_logs/test_logs_query/test_query.py
+++ b/tests/test_logs/test_logs_query/test_query.py
@@ -44,7 +44,7 @@ class TestLogsQueries(TestCase):
                 "@logStream": self.stream_1_name,
                 "@log": "test",
             }
-            for event in self.events
+            for event in reversed(self.events)
         ]
 
     def test_simplified_query(self):
@@ -58,5 +58,5 @@ class TestLogsQueries(TestCase):
             event.pop("@ptr")
         assert resp == [
             {"@timestamp": event["timestamp"], "@message": event["message"]}
-            for event in reversed(self.events)
+            for event in self.events
         ]


### PR DESCRIPTION
## Summary
- Fix CloudWatch Logs query sort direction mapping so `sort ... desc` uses descending order and `sort ... asc` uses ascending order.
- Update existing logs query tests to match the documented/default behavior (`desc` by default, `asc` when requested).

## Testing
- `python -m py_compile moto/logs/logs_query/query_parser.py moto/logs/logs_query/__init__.py tests/test_logs/test_logs_query/test_query.py`
- Note: full pytest execution was not run in this environment because test dependencies are unavailable.

## Related
Fixes #9818
