### PR TITLE
fix(events): deduplicate list_rule_names_by_target results

### DIFF
--- a/moto/events/models.py
+++ b/moto/events/models.py
@@ -1348,9 +1348,8 @@ class EventsBackend(BaseBackend):
         matching_rules = []
 
         for _, rule in event_bus.rules.items():
-            for target in rule.targets:
-                if target["Arn"] == target_arn:
-                    matching_rules.append(rule)
+            if any(target["Arn"] == target_arn for target in rule.targets):
+                matching_rules.append(rule)
 
         return matching_rules
 

--- a/tests/test_events/test_events.py
+++ b/tests/test_events/test_events.py
@@ -292,6 +292,27 @@ def test_list_rule_names_by_target():
 
 
 @mock_aws
+def test_list_rule_names_by_target_deduplicates_rule_names_for_same_target_arn():
+    client = boto3.client("events", region_name="us-east-1")
+
+    rule_name = "rule-with-duplicate-target-arn"
+    target_arn = "arn:aws:lambda:us-east-1:123456789012:function:test"
+
+    client.put_rule(Name=rule_name, EventPattern='{"source": ["test-source"]}')
+    client.put_targets(
+        Rule=rule_name,
+        Targets=[
+            {"Id": "target-1", "Arn": target_arn},
+            {"Id": "target-2", "Arn": target_arn},
+        ],
+    )
+
+    response = client.list_rule_names_by_target(TargetArn=target_arn)
+
+    assert response["RuleNames"] == [rule_name]
+
+
+@mock_aws
 def test_list_rule_names_by_target_using_limit():
     test_1_target = TARGETS["test-target-1"]
     client = generate_environment()


### PR DESCRIPTION
## Summary
- ensure `list_rule_names_by_target` returns each matching rule once, even when a rule has multiple targets with the same `TargetArn`
- replace per-target append loop with a per-rule match check so output mirrors AWS behavior
- add regression test covering a single rule configured with duplicate target ARNs

## Testing
- `pytest -q tests/test_events/test_events.py -k "list_rule_names_by_target"` *(fails locally: missing `boto3` dependency in this environment)*
- `python -m py_compile moto/events/models.py tests/test_events/test_events.py`

## Related
Fixes #9761