### PR TITLE
kms: allow generate_mac with HMAC key aliases

### DIFF
--- a/moto/kms/models.py
+++ b/moto/kms/models.py
@@ -834,6 +834,7 @@ class KmsBackend(BaseBackend):
         grant_tokens: list[str],
         dry_run: bool,
     ) -> tuple[str, str, str]:
+        key_id = self.any_id_to_key_id(key_id)
         key = self.keys[key_id]
 
         if (

--- a/tests/test_kms/test_kms_mac.py
+++ b/tests/test_kms/test_kms_mac.py
@@ -41,6 +41,27 @@ def test_generate_mac():
 
 
 @mock_aws
+def test_generate_mac_supports_aliases_for_hmac_keys():
+    # Arrange
+    key_id = create_hmac_key()
+    alias_name = "alias/my-hmac-key"
+    client = boto3.client("kms", region_name="eu-central-1")
+    client.create_alias(AliasName=alias_name, TargetKeyId=key_id)
+
+    # Act
+    resp = client.generate_mac(
+        KeyId=alias_name,
+        MacAlgorithm="HMAC_SHA_512",
+        Message=base64.b64encode(b"Hello World"),
+    )
+
+    # Assert
+    assert "Mac" in resp
+    assert resp["KeyId"] == key_id
+    assert resp["MacAlgorithm"] == "HMAC_SHA_512"
+
+
+@mock_aws
 def test_generate_fails_for_non_existent_key():
     # Arrange
     client = boto3.client("kms", region_name="eu-central-1")


### PR DESCRIPTION
## Summary
- resolve `KeyId` via `any_id_to_key_id()` in `KmsBackend.generate_mac()` so alias names/ARNs work for HMAC keys too
- add regression coverage for generating a MAC using an alias bound to an HMAC key

## Why
`GenerateMac` validated alias key IDs at the response layer, but backend lookup still indexed `self.keys` directly with the alias string and raised `KeyError`.

Fixes #9833

## Validation
- `python -m pytest tests/test_kms/test_kms_mac.py -k "generate_mac_supports_aliases_for_hmac_keys or test_generate_mac"`
- Manual repro script with `mock_aws`: create HMAC key + alias, then `generate_mac` and `verify_mac` using alias