### PR TITLE
SESv2: include default DKIM metadata in create_email_identity response

### DIFF
--- a/moto/ses/models.py
+++ b/moto/ses/models.py
@@ -293,6 +293,8 @@ class EmailIdentity(BaseModel):
         ):
             self.dkim_attributes["SigningEnabled"] = False
             self.dkim_attributes["Status"] = "NOT_STARTED"
+            self.dkim_attributes["NextSigningKeyLength"] = "RSA_1024_BIT"
+            self.dkim_attributes["SigningAttributesOrigin"] = "AWS_SES"
         else:
             self.dkim_attributes["SigningEnabled"] = True
             self.dkim_attributes["Status"] = "SUCCESS"

--- a/tests/test_sesv2/test_sesv2.py
+++ b/tests/test_sesv2/test_sesv2.py
@@ -472,6 +472,11 @@ def test_create_email_identity():
     # Verify
     assert resp["IdentityType"] == "DOMAIN"
     assert resp["VerifiedForSendingStatus"] is False
+    assert "DkimAttributes" in resp
+    assert resp["DkimAttributes"]["Status"] == "NOT_STARTED"
+    assert resp["DkimAttributes"]["SigningEnabled"] is False
+    assert resp["DkimAttributes"]["SigningAttributesOrigin"] == "AWS_SES"
+    assert resp["DkimAttributes"]["NextSigningKeyLength"] == "RSA_1024_BIT"
 
 
 @mock_aws


### PR DESCRIPTION
## Summary
- include default `SigningAttributesOrigin` and `NextSigningKeyLength` in SESv2 DKIM attributes when `create_email_identity` is called without custom DKIM signing attributes
- align the create response with the DKIM metadata expected for issue #9771
- add assertions in `test_create_email_identity` to lock the default DKIM fields in place

## Testing
- `python -m pytest tests/test_sesv2/test_sesv2.py -k test_create_email_identity`

## Related
- Fixes #9771
