### PR TITLE
Fix CloudWatch Logs Insights asc/desc sort direction

### DIFF
--- a/moto/logs/logs_query/query_parser.py
+++ b/moto/logs/logs_query/query_parser.py
@@ -10,10 +10,9 @@ class ParsedQuery:
         self.sort: list[tuple[str, str]] = []
 
     def sort_reversed(self) -> bool:
-        # Descending is the default
         if self.sort:
-            # sort_reversed is True if we want to sort in ascending order
-            return self.sort[-1][-1] == "asc"
+            # Python's sorted(reverse=True) yields descending order.
+            return self.sort[-1][-1] == "desc"
         return False
 
 

--- a/tests/test_logs/test_logs_query/test_query.py
+++ b/tests/test_logs/test_logs_query/test_query.py
@@ -44,7 +44,7 @@ class TestLogsQueries(TestCase):
                 "@logStream": self.stream_1_name,
                 "@log": "test",
             }
-            for event in self.events
+            for event in reversed(self.events)
         ]
 
     def test_simplified_query(self):
@@ -58,5 +58,5 @@ class TestLogsQueries(TestCase):
             event.pop("@ptr")
         assert resp == [
             {"@timestamp": event["timestamp"], "@message": event["message"]}
-            for event in reversed(self.events)
+            for event in self.events
         ]


### PR DESCRIPTION
## Summary
- fix `ParsedQuery.sort_reversed()` so `sort ... desc` maps to `sorted(..., reverse=True)` and `sort ... asc` maps to ascending output
- keep query execution behavior unchanged otherwise and only adjust sort-direction handling
- update logs query tests to assert the corrected ordering for both default (`desc`) and explicit `asc`

## Testing
- `python -m pytest tests/test_logs/test_logs_query/test_query.py`

## Related
- Fixes #9818
