### PR TITLE
KMS alias updates should accept full TargetKeyId ARN

### DIFF
--- a/moto/kms/models.py
+++ b/moto/kms/models.py
@@ -511,14 +511,17 @@ class KmsBackend(BaseBackend):
         return key.aliases[alias_name]
 
     def update_alias(self, target_key_id: str, alias_name: str) -> Alias:
+        raw_key_id = self.get_key_id(target_key_id)
+
         for key in self.keys.values():
-            if alias_name in key.aliases and target_key_id != key.id:
+            if alias_name in key.aliases and raw_key_id != key.id:
                 # Updating the Key that this is an alias of
                 alias = key.aliases.pop(alias_name)
-                self.keys[target_key_id].aliases[alias_name] = alias
+                self.keys[raw_key_id].aliases[alias_name] = alias
                 return alias
+
         # TargetKeyId hasn't changed - nothing to update
-        return self.keys[target_key_id].aliases[alias_name]
+        return self.keys[raw_key_id].aliases[alias_name]
 
     def delete_alias(self, alias_name: str) -> None:
         """Delete the alias."""

--- a/tests/test_kms/test_kms_cloudformation.py
+++ b/tests/test_kms/test_kms_cloudformation.py
@@ -1,4 +1,5 @@
 import json
+from copy import deepcopy
 from uuid import uuid4
 
 import boto3
@@ -27,7 +28,7 @@ def test_alias_create_and_delete():
     kms_key_id1 = kms_client.create_key(Policy="my policy")["KeyMetadata"]["KeyId"]
     kms_key_id2 = kms_client.create_key(Policy="my policy")["KeyMetadata"]["KeyId"]
 
-    template = CF_KMS_ALIAS_TEMPLATE.copy()
+    template = deepcopy(CF_KMS_ALIAS_TEMPLATE)
     template["Resources"]["MyFirstAlias"]["Properties"]["TargetKeyId"] = kms_key_id1
     template["Resources"]["MyFirstAlias"]["Properties"]["AliasName"] = alias_name
 
@@ -58,3 +59,28 @@ def test_alias_create_and_delete():
     # VERIFY
     assert not kms_client.list_aliases(KeyId=kms_key_id1)["Aliases"]
     assert not kms_client.list_aliases(KeyId=kms_key_id2)["Aliases"]
+
+
+@mock_aws
+def test_alias_update_accepts_target_key_arn():
+    cf = boto3.client("cloudformation", region_name="us-east-1")
+    kms_client = boto3.client("kms", region_name="us-east-1")
+
+    alias_name = "alias/my_arn_alias"
+    stack_name = f"Stack{str(uuid4())[0:6]}"
+    key_1 = kms_client.create_key(Policy="my policy")["KeyMetadata"]
+    key_2 = kms_client.create_key(Policy="my policy")["KeyMetadata"]
+
+    template = deepcopy(CF_KMS_ALIAS_TEMPLATE)
+    template["Resources"]["MyFirstAlias"]["Properties"]["AliasName"] = alias_name
+    template["Resources"]["MyFirstAlias"]["Properties"]["TargetKeyId"] = key_1["KeyId"]
+
+    cf.create_stack(StackName=stack_name, TemplateBody=json.dumps(template))
+
+    template["Resources"]["MyFirstAlias"]["Properties"]["TargetKeyId"] = key_2["Arn"]
+    cf.update_stack(StackName=stack_name, TemplateBody=json.dumps(template))
+
+    assert not kms_client.list_aliases(KeyId=key_1["KeyId"])["Aliases"]
+
+    aliases = kms_client.list_aliases(KeyId=key_2["KeyId"])["Aliases"]
+    assert [alias["AliasName"] for alias in aliases] == [alias_name]


### PR DESCRIPTION
## Summary
- normalize `TargetKeyId` in `KmsBackend.update_alias()` so CloudFormation alias updates accept full KMS key ARNs as well as raw key IDs
- keep alias re-assignment logic unchanged while ensuring dictionary lookups use the normalized key id
- add a regression test that creates an alias with a key id, updates the stack with a key ARN, and verifies the alias moves to the new key

## Testing
- `python -m pytest tests/test_kms/test_kms_cloudformation.py -q`

## Related
Fixes #9831
