### PR TITLE
Fix CloudWatch Logs query sort direction

### DIFF
--- a/moto/logs/logs_query/query_parser.py
+++ b/moto/logs/logs_query/query_parser.py
@@ -12,8 +12,9 @@ class ParsedQuery:
     def sort_reversed(self) -> bool:
         # Descending is the default
         if self.sort:
-            # sort_reversed is True if we want to sort in ascending order
-            return self.sort[-1][-1] == "asc"
+            # sorted(..., reverse=True) returns values in descending order.
+            # Keep reverse=True only when query explicitly requests descending.
+            return self.sort[-1][-1] == "desc"
         return False
 
 

--- a/tests/test_logs/test_logs_query/test_query.py
+++ b/tests/test_logs/test_logs_query/test_query.py
@@ -44,7 +44,7 @@ class TestLogsQueries(TestCase):
                 "@logStream": self.stream_1_name,
                 "@log": "test",
             }
-            for event in self.events
+            for event in reversed(self.events)
         ]
 
     def test_simplified_query(self):
@@ -58,5 +58,5 @@ class TestLogsQueries(TestCase):
             event.pop("@ptr")
         assert resp == [
             {"@timestamp": event["timestamp"], "@message": event["message"]}
-            for event in reversed(self.events)
+            for event in self.events
         ]


### PR DESCRIPTION
## Summary
- fix `ParsedQuery.sort_reversed()` so `sorted(..., reverse=...)` is only reversed for `sort ... desc`
- keep default behavior descending when no explicit sort order is given
- update logs query tests so `sort @timestamp desc` expects newest-first and `sort @timestamp asc` expects oldest-first

## Testing
- `python -m pytest tests/test_logs/test_logs_query/test_query.py tests/test_logs/test_logs_query/test_query_parser.py`

## Related
Fixes #9818
