### PR TITLE
Bedrock Runtime: add server mode test coverage

### DIFF
--- a/tests/test_bedrockruntime/test_server.py
+++ b/tests/test_bedrockruntime/test_server.py
@@ -1,0 +1,16 @@
+import moto.server as server
+from moto import mock_aws
+
+
+@mock_aws
+def test_invoke_model():
+    backend = server.create_backend_app("bedrock-runtime")
+    test_client = backend.test_client()
+    headers = {
+        "X-Amzn-Bedrock-PerformanceConfig-Latency": "optimized",
+        "X-Amzn-Bedrock-Service-Tier": "flex",
+    }
+    resp = test_client.post("/model/test-model-id/invoke", headers=headers, json={})
+    assert resp.status_code == 200
+    for header, value in resp.headers.items():
+        assert resp.headers[header] == value

--- a/tests/test_core/test_server.py
+++ b/tests/test_core/test_server.py
@@ -1,4 +1,5 @@
 import gzip
+import json
 from collections.abc import Iterable
 from unittest.mock import Mock, patch
 
@@ -74,3 +75,20 @@ def test_date_header_is_not_duplicated(moto_server: str) -> None:
     # If multiple date headers exist, their values will be concatenated with a comma
     # and this assertion will fail.
     assert len(date_header_value.split(",")) == 2
+
+
+def test_bedrock_service_resolution(moto_server: str) -> None:
+    # Multiple Bedrock services use the same signing name (bedrock),
+    # so this test checks that a bedrock-runtime request is correctly
+    # differentiated in server mode (where there is no host name available).
+    client = boto3.client(
+        "bedrock-runtime", region_name="us-east-1", endpoint_url=moto_server
+    )
+    resp = client.invoke_model(
+        modelId="test-model-id",
+        body=json.dumps({}),
+        performanceConfigLatency="optimized",
+        serviceTier="flex",
+    )
+    assert resp["performanceConfigLatency"] == "optimized"
+    assert resp["serviceTier"] == "flex"


### PR DESCRIPTION
Adds test coverage that should have been included in #9866 