### PR TITLE
S3: Support BucketNamespace parameter for account-regional namespaces

### DIFF
--- a/moto/s3/exceptions.py
+++ b/moto/s3/exceptions.py
@@ -246,6 +246,19 @@ class InvalidLocationConstraintException(S3ClientError):
         )
 
 
+class InvalidNamespaceHeaderException(S3ClientError):
+    code = 400
+
+    def __init__(self, account_id: str, region: str) -> None:
+        super().__init__(
+            "InvalidNamespaceHeader",
+            "The requested bucket name did not include the account-regional namespace suffix, "
+            "but the provided x-amz-bucket-namespace header value is account-regional. "
+            f"Specify -{account_id}-{region}-an as the bucket name suffix to create a bucket "
+            "in your account-regional namespace, or remove the header.",
+        )
+
+
 class MalformedXML(S3ClientError):
     code = 400
 

--- a/moto/s3/models.py
+++ b/moto/s3/models.py
@@ -1062,10 +1062,17 @@ class MultipartDict(dict[str, FakeMultipart]):
 
 
 class FakeBucket(CloudFormationModel):
-    def __init__(self, name: str, account_id: str, region_name: str):
+    def __init__(
+        self,
+        name: str,
+        account_id: str,
+        region_name: str,
+        bucket_namespace: Optional[str] = None,
+    ):
         self.name = name
         self.account_id = account_id
         self.region_name = region_name
+        self.bucket_namespace = bucket_namespace
         self.partition = get_partition(region_name)
         self.keys = _VersionedKeyStore()
         self.multiparts = MultipartDict()
@@ -1894,13 +1901,21 @@ class S3Backend(BaseBackend, CloudWatchMetricProvider):
             )
         return metrics
 
-    def create_bucket(self, bucket_name: str, region_name: str) -> FakeBucket:
+    def create_bucket(
+        self,
+        bucket_name: str,
+        region_name: str,
+        bucket_namespace: Optional[str] = None,
+    ) -> FakeBucket:
         if bucket_name in s3_backends.bucket_accounts.keys():
             raise BucketAlreadyExists(bucket=bucket_name)
         if not MIN_BUCKET_NAME_LENGTH <= len(bucket_name) <= MAX_BUCKET_NAME_LENGTH:
             raise InvalidBucketName()
         new_bucket = FakeBucket(
-            name=bucket_name, account_id=self.account_id, region_name=region_name
+            name=bucket_name,
+            account_id=self.account_id,
+            region_name=region_name,
+            bucket_namespace=bucket_namespace,
         )
 
         self.buckets[bucket_name] = new_bucket

--- a/moto/s3/responses.py
+++ b/moto/s3/responses.py
@@ -39,6 +39,7 @@ from .exceptions import (
     InvalidLocationConstraintException,
     InvalidMaxPartArgument,
     InvalidMaxPartNumberArgument,
+    InvalidNamespaceHeaderException,
     InvalidNotificationARN,
     InvalidObjectState,
     InvalidPartOrder,
@@ -947,8 +948,17 @@ class S3Response(BaseResponse):
             bucket_region = (
                 location_constraint if location_constraint else DEFAULT_REGION_NAME
             )
+            bucket_namespace = request.headers.get("x-amz-bucket-namespace")
+            if bucket_namespace == "account-regional":
+                expected_suffix = f"-{self.get_current_account()}-{bucket_region}-an"
+                if not bucket_name.endswith(expected_suffix):
+                    raise InvalidNamespaceHeaderException(
+                        self.get_current_account(), bucket_region
+                    )
             try:
-                new_bucket = self.backend.create_bucket(bucket_name, bucket_region)
+                new_bucket = self.backend.create_bucket(
+                    bucket_name, bucket_region, bucket_namespace=bucket_namespace
+                )
             except BucketAlreadyExists:
                 new_bucket = self.backend.get_bucket(bucket_name)
                 if new_bucket.account_id == self.get_current_account():
@@ -983,7 +993,10 @@ class S3Response(BaseResponse):
                 new_bucket.ownership_rule = ownership_rule
 
             template = self.response_template(S3_BUCKET_CREATE_RESPONSE)
-            return template.render(bucket=new_bucket)
+            headers: dict[str, str] = {}
+            if new_bucket.bucket_namespace == "account-regional":
+                headers["x-amz-bucket-arn"] = new_bucket.arn
+            return 200, headers, template.render(bucket=new_bucket)
 
     def get_bucket_accelerate_configuration(self) -> str:
         accelerate_configuration = self.backend.get_bucket_accelerate_configuration(
@@ -2850,6 +2863,7 @@ S3_BUCKET_CREATE_RESPONSE = """<CreateBucketResponse xmlns="http://s3.amazonaws.
     <Bucket>{{ bucket.name }}</Bucket>
   </CreateBucketResponse>
 </CreateBucketResponse>"""
+
 
 S3_DELETE_BUCKET_SUCCESS = """<DeleteBucketResponse xmlns="http://s3.amazonaws.com/doc/2006-03-01">
   <DeleteBucketResponse>

--- a/tests/test_s3/test_s3.py
+++ b/tests/test_s3/test_s3.py
@@ -330,6 +330,52 @@ def test_create_existing_bucket_in_us_east_1():
 
 
 @mock_aws
+def test_create_bucket_account_regional_namespace():
+    client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
+    bucket_name = f"my-bucket-{DEFAULT_ACCOUNT_ID}-{DEFAULT_REGION_NAME}-an"
+    response = client.create_bucket(
+        Bucket=bucket_name,
+        BucketNamespace="account-regional",
+    )
+    assert response["ResponseMetadata"]["HTTPStatusCode"] == 200
+    assert response["BucketArn"] == f"arn:aws:s3:::{bucket_name}"
+
+    # Verify bucket exists
+    head = client.head_bucket(Bucket=bucket_name)
+    assert head["ResponseMetadata"]["HTTPStatusCode"] == 200
+
+    client.delete_bucket(Bucket=bucket_name)
+
+
+@mock_aws
+def test_create_bucket_account_regional_namespace_other_region():
+    region = "us-west-2"
+    client = boto3.client("s3", region_name=region)
+    bucket_name = f"my-bucket-{DEFAULT_ACCOUNT_ID}-{region}-an"
+    response = client.create_bucket(
+        Bucket=bucket_name,
+        CreateBucketConfiguration={"LocationConstraint": region},
+        BucketNamespace="account-regional",
+    )
+    assert response["ResponseMetadata"]["HTTPStatusCode"] == 200
+    assert response["BucketArn"] == f"arn:aws:s3:::{bucket_name}"
+
+    client.delete_bucket(Bucket=bucket_name)
+
+
+@mock_aws
+def test_create_bucket_account_regional_namespace_invalid_name():
+    client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
+    with pytest.raises(ClientError) as ex:
+        client.create_bucket(
+            Bucket="my-bucket-wrong-suffix",
+            BucketNamespace="account-regional",
+        )
+    err = ex.value.response["Error"]
+    assert err["Code"] == "InvalidNamespaceHeader"
+
+
+@mock_aws
 def test_bucket_deletion():
     s3_resource = boto3.resource("s3", region_name=DEFAULT_REGION_NAME)
     client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)


### PR DESCRIPTION
Adds support for the `BucketNamespace` parameter in the S3 `CreateBucket` API to enable [account-regional namespaces](https://aws.amazon.com/blogs/aws/introducing-account-regional-namespaces-for-amazon-s3-general-purpose-buckets/).

## Changes

- Parse `x-amz-bucket-namespace` header in `CreateBucket` requests
- Validate that the bucket name includes the required account-regional suffix (`-{accountId}-{region}-an`) when `BucketNamespace` is `account-regional`
- Return `InvalidNamespaceHeader` error when the suffix is missing
- Return `x-amz-bucket-arn` header in the response for account-regional buckets
- Store `bucket_namespace` on `FakeBucket`

## Tests

- `test_create_bucket_account_regional_namespace` — us-east-1
- `test_create_bucket_account_regional_namespace_other_region` — us-west-2
- `test_create_bucket_account_regional_namespace_invalid_name` — error case

closes #9870