### PR TITLE
EC2/DynamoDB: Fix AWS verified tests

### DIFF
--- a/tests/test_dynamodb/test_dynamodb_export_table.py
+++ b/tests/test_dynamodb/test_dynamodb_export_table.py
@@ -11,6 +11,7 @@ from botocore.exceptions import ClientError
 
 from moto import settings
 from moto.dynamodb.models import TableExport
+from tests import allow_aws_request
 from tests.test_s3 import s3_aws_verified
 
 from . import dynamodb_aws_verified
@@ -170,7 +171,7 @@ def test_export_empty_table(table_name=None, bucket_name=None):
 @pytest.mark.aws_verified
 @dynamodb_aws_verified()
 @s3_aws_verified
-def test_export_table(table_name=None, bucket_name=None):
+def test_export_table(account_id, table_name=None, bucket_name=None):
     client = boto3.client("dynamodb", region_name="us-east-1")
     s3 = boto3.client("s3", region_name="us-east-1")
 
@@ -201,12 +202,16 @@ def test_export_table(table_name=None, bucket_name=None):
     )["ExportDescription"]
 
     export_details = wait_for_export(client, export_description)
+
     assert export_details["ExportStatus"] == "COMPLETED"
     assert export_details["ItemCount"] == 3
     assert export_details["ExportFormat"] == "DYNAMODB_JSON"
     assert export_details["TableArn"] == table_arn
     assert export_details["S3Bucket"] == bucket_name
-    assert export_details["S3BucketOwner"] == "123456789012"
+    if not allow_aws_request():
+        # AWS doesn't actually return this, despite the fact that it's mentioned in the documentation
+        # Maybe it's only exported when the owner is different from the requester?
+        assert export_details["S3BucketOwner"] == account_id
     assert export_details["S3Prefix"] == s3_prefix
 
     s3_files = s3.list_objects(Bucket=bucket_name, Prefix=s3_prefix)["Contents"]

--- a/tests/test_ec2/__init__.py
+++ b/tests/test_ec2/__init__.py
@@ -35,18 +35,11 @@ def ec2_aws_verified(
     return_launch_template_details: bool = False,
 ):
     """
-        Function that is vMINIMAL_LAUNCH_TEMPLATE_DATE = {
-        "TagSpecifications": [
-            {
-                "ResourceType": "instance",
-                "Tags": [{"Key": "test", "Value": "value"}],
-            }
-        ]
-    }erified to work against AWS.
-        Can be run against AWS at any time by setting:
-          MOTO_TEST_ALLOW_AWS_REQUEST=true
+    Function that is verified to work against AWS.
+    Can be run against AWS at any time by setting:
+      MOTO_TEST_ALLOW_AWS_REQUEST=true
 
-        If this environment variable is not set, the function runs in a `mock_aws` context.
+    If this environment variable is not set, the function runs in a `mock_aws` context.
 
     """
 

--- a/tests/test_ec2/test_fleets.py
+++ b/tests/test_ec2/test_fleets.py
@@ -22,6 +22,11 @@ def get_subnet_id(conn):
 
 
 def get_launch_template(conn, instance_type="t2.micro", ami_id=EXAMPLE_AMI_ID):
+    # We're going to place some instances in this region
+    # Not all availability zones will support the requested instances types
+    # So here we make sure that we're placing them in the main zone
+    # (Most tests run against `us-east-1`, so availability zone will be `us-east-1a`)
+    azone = conn.meta._client_config.region_name + "a"
     launch_template = conn.create_launch_template(
         LaunchTemplateName="test" + str(uuid4()),
         LaunchTemplateData={
@@ -37,6 +42,9 @@ def get_launch_template(conn, instance_type="t2.micro", ami_id=EXAMPLE_AMI_ID):
                     ],
                 }
             ],
+            "Placement": {
+                "AvailabilityZone": azone,
+            },
         },
     )["LaunchTemplate"]
     launch_template_id = launch_template["LaunchTemplateId"]
@@ -1177,6 +1185,11 @@ def test_create_instant_fleet_with_launch_template_overrides(
             fleet_request["SpotOptions"] = {"AllocationStrategy": "lowest-price"}
 
         fleet_response = ctxt.ec2.create_fleet(**fleet_request)
+
+        if errors := fleet_response.get("Errors"):
+            # Errors only occur occasionally
+            # But when they occur, we want to know about them help us debug the problem
+            print(errors)  # noqa
 
         try:
             assert "FleetId" in fleet_response

--- a/tests/test_ec2/test_launch_templates.py
+++ b/tests/test_ec2/test_launch_templates.py
@@ -5,7 +5,7 @@ import pytest
 from botocore.client import ClientError
 
 from moto import mock_aws, settings
-from tests import EXAMPLE_AMI_ID, aws_verified
+from tests import EXAMPLE_AMI_ID, allow_aws_request, aws_verified
 from tests.test_ec2 import MINIMAL_LAUNCH_TEMPLATE_DATA, ec2_aws_verified
 
 from .helpers import assert_dryrun_error
@@ -125,7 +125,12 @@ def test_describe_launch_template_versions_without_name_or_id():
 def test_describe_launch_template_versions_with_just_version():
     cli = boto3.client("ec2", region_name="us-east-1")
     resp = cli.describe_launch_template_versions(Versions=["$Latest"])
-    assert resp["LaunchTemplateVersions"] == []
+    if not allow_aws_request():
+        # When running this against AWS, we can't really be sure that there are no LaunchTemplates,
+        # as, other tests that create templates will be running at the same time
+        # We can (and do) simply verify that we can execute the operation without errors
+        # Only against Moto can we know for sure that no LaunchTemplates exist
+        assert resp["LaunchTemplateVersions"] == []
 
     # Note that this is only possible when using $Latest/$Default - we can't retrieve versions with just a number
     with pytest.raises(ClientError) as exc:


### PR DESCRIPTION
The `test_create_instant_fleet_with_launch_template_overrides` test was failing against AWS with this error:

> [217](https://github.com/getmoto/moto/actions/runs/23104879978/job/67112354960#step:10:1218)
>               assert len(total_instance_ids) == total_capacity
E               AssertionError: assert 1 == 3
E                +  where 1 = len(['i-00a75cc1ec636ac21'])

The underlying issue is that the `create_fleet(..)` request actually returned an error that the chosen availability zone (`us-east-1e`) did not support the chosen instance type (`t3.nano`.. if memory serves me right).

Fix is to make sure that the instances are always placed in availability zone `a`, as that should support all instance types.

Besides that, we now also print the error - if this happens again, we can at least see what's going wrong.

--------------------
Other tests failed because we can only create 5 VPC's at the same time, and some older VPC's were not deleted correctly.

I'm not sure why they were not cleaned up correctly in the first place - but I have deleted them manually.

--------------------
Note that some tests are still flaky/failing, but at least this should reduce the number of issues.