### PR TITLE
Fix MyPy lint when boto3-stubs is present

### DIFF
--- a/moto/core/models.py
+++ b/moto/core/models.py
@@ -16,9 +16,9 @@ from typing import (
 )
 from unittest.mock import patch
 
-import boto3
-import botocore
 import responses
+from boto3.resources.base import ResourceMeta
+from botocore.client import BaseClient
 from botocore.config import Config
 from botocore.handlers import BUILTIN_HANDLERS
 
@@ -268,7 +268,7 @@ botocore_stubber = BotocoreStubber()
 BUILTIN_HANDLERS.append(("before-send", botocore_stubber))
 
 
-def patch_client(client: botocore.client.BaseClient) -> None:
+def patch_client(client: BaseClient) -> None:
     """
     Explicitly patch a boto3-client
     """
@@ -284,7 +284,7 @@ def patch_client(client: botocore.client.BaseClient) -> None:
     :param client:
     :return:
     """
-    if isinstance(client, botocore.client.BaseClient):
+    if isinstance(client, BaseClient):
         # Check if our event handler was already registered
         try:
             event_emitter = client._ruleset_resolver._event_emitter._emitter  # type: ignore[attr-defined]
@@ -310,9 +310,7 @@ def patch_resource(resource: Any) -> None:
     """
     Explicitly patch a boto3-resource
     """
-    if hasattr(resource, "meta") and isinstance(
-        resource.meta, boto3.resources.factory.ResourceMeta
-    ):
+    if hasattr(resource, "meta") and isinstance(resource.meta, ResourceMeta):
         patch_client(resource.meta.client)
     else:
         raise Exception(f"Argument {resource} should be of type boto3.resource")
@@ -360,7 +358,7 @@ class ServerModeMockAWS(MockAWS):
         from boto3 import client as real_boto3_client
         from boto3 import resource as real_boto3_resource
 
-        def fake_boto3_client(*args: Any, **kwargs: Any) -> botocore.client.BaseClient:
+        def fake_boto3_client(*args: Any, **kwargs: Any) -> BaseClient:
             region = self._get_region(*args, **kwargs)
             if region:
                 if "config" in kwargs:
@@ -426,7 +424,7 @@ class ProxyModeMockAWS(MockAWS):
         from boto3 import client as real_boto3_client
         from boto3 import resource as real_boto3_resource
 
-        def fake_boto3_client(*args: Any, **kwargs: Any) -> botocore.client.BaseClient:
+        def fake_boto3_client(*args: Any, **kwargs: Any) -> BaseClient:
             kwargs["verify"] = False
             proxy_endpoint = (
                 f"http://localhost:{os.environ.get('MOTO_PROXY_PORT', 5005)}"

--- a/moto/core/responses.py
+++ b/moto/core/responses.py
@@ -88,7 +88,7 @@ def _decode_dict(d: dict[Any, Any]) -> dict[str, Any]:
 def _get_method_urls(service_name: str, region: str) -> dict[str, dict[str, str]]:
     method_urls: dict[str, dict[str, str]] = defaultdict(dict)
     service_name = boto3_service_name.get(service_name) or service_name  # type: ignore
-    conn = boto3.client(service_name, region_name=region)
+    conn = boto3.client(service_name, region_name=region)  # type: ignore
     op_names = conn._service_model.operation_names
     for op_name in op_names:
         op_model = conn._service_model.operation_model(op_name)

--- a/moto/dynamodb/models/dynamo_type.py
+++ b/moto/dynamodb/models/dynamo_type.py
@@ -497,7 +497,7 @@ class Item(BaseModel):
             range_key=self.range_key,
             # 'result' is a normal Python dictionary ({'key': 'value'}
             # We need to convert that into DynamoDB dictionary ({'M': {'key': {'S': 'value'}}})
-            attrs=serializer.serialize(result)["M"],
+            attrs=serializer.serialize(result)["M"],  # type: ignore
         )
 
     def is_within_segment(

--- a/moto/ec2/models/availability_zones_and_regions.py
+++ b/moto/ec2/models/availability_zones_and_regions.py
@@ -52,7 +52,7 @@ class RegionsAndZonesBackend:
         "us-west-2",
     ]
 
-    regions = []
+    regions: list[Region] = []
     for region in Session().get_available_regions("ec2"):
         if region in regions_opt_in_not_required:
             regions.append(
@@ -186,9 +186,9 @@ class RegionsAndZonesBackend:
         ],
     }
     # Regularized region->zone mapping for all regions not defined above
-    for region in regions:
-        if region.name not in zones:
-            name = region.name
+    for the_region in regions:
+        if the_region.name not in zones:
+            name = the_region.name
             region_parts = name.split("-")
             shorthand = "usg" if name.startswith("us-gov") else region_parts[0]
             # North and south first - this also handles combinations like northeast -> ne
@@ -196,7 +196,7 @@ class RegionsAndZonesBackend:
                 if cardinal in name:
                     shorthand += cardinal[0]
             shorthand += region_parts[-1]
-            zones[region.name] = [
+            zones[the_region.name] = [
                 Zone(region_name=name, name=f"{name}a", zone_id=f"{shorthand}-az1"),
                 Zone(region_name=name, name=f"{name}b", zone_id=f"{shorthand}-az2"),
                 Zone(region_name=name, name=f"{name}c", zone_id=f"{shorthand}-az3"),

--- a/tests/test_core/test_auth.py
+++ b/tests/test_core/test_auth.py
@@ -20,7 +20,7 @@ boto3_version = sys.modules["botocore"].__version__
 def create_user_with_access_key(user_name: str = "test-user") -> dict[str, str]:
     client = boto3.client("iam", region_name="us-east-1")
     client.create_user(UserName=user_name)
-    return client.create_access_key(UserName=user_name)["AccessKey"]
+    return client.create_access_key(UserName=user_name)["AccessKey"]  # type: ignore
 
 
 @mock_aws
@@ -37,7 +37,7 @@ def create_user_with_access_key_and_inline_policy(  # type: ignore[misc]
         PolicyName=policy_name,
         PolicyDocument=json.dumps(policy_document),
     )
-    return client.create_access_key(UserName=user_name)["AccessKey"]
+    return client.create_access_key(UserName=user_name)["AccessKey"]  # type: ignore
 
 
 @mock_aws
@@ -50,7 +50,7 @@ def create_user_with_access_key_and_attached_policy(  # type: ignore[misc]
         PolicyName=policy_name, PolicyDocument=json.dumps(policy_document)
     )["Policy"]["Arn"]
     client.attach_user_policy(UserName=user_name, PolicyArn=policy_arn)
-    return client.create_access_key(UserName=user_name)["AccessKey"]
+    return client.create_access_key(UserName=user_name)["AccessKey"]  # type: ignore
 
 
 @mock_aws
@@ -73,7 +73,7 @@ def create_user_with_access_key_and_multiple_policies(  # type: ignore[misc]
         PolicyName=inline_policy_name,
         PolicyDocument=json.dumps(inline_policy_document),
     )
-    return client.create_access_key(UserName=user_name)["AccessKey"]
+    return client.create_access_key(UserName=user_name)["AccessKey"]  # type: ignore
 
 
 def create_group_with_attached_policy_and_add_user(
@@ -151,7 +151,7 @@ def create_role_with_attached_policy_and_assume_it(  # type: ignore[misc]
         PolicyName=policy_name, PolicyDocument=json.dumps(policy_document)
     )["Policy"]["Arn"]
     iam_client.attach_role_policy(RoleName=role_name, PolicyArn=policy_arn)
-    return sts_client.assume_role(RoleArn=role_arn, RoleSessionName=session_name)[
+    return sts_client.assume_role(RoleArn=role_arn, RoleSessionName=session_name)[  # type: ignore
         "Credentials"
     ]
 
@@ -174,7 +174,7 @@ def create_role_with_inline_policy_and_assume_it(  # type: ignore[misc]
         PolicyName=policy_name,
         PolicyDocument=json.dumps(policy_document),
     )
-    return sts_client.assume_role(RoleArn=role_arn, RoleSessionName=session_name)[
+    return sts_client.assume_role(RoleArn=role_arn, RoleSessionName=session_name)[  # type: ignore
         "Credentials"
     ]
 
@@ -881,7 +881,8 @@ def test_allow_bucket_access_using_resource_arn(region: str, partition: str) -> 
     )
 
     s3_client.create_bucket(
-        Bucket="my_bucket", CreateBucketConfiguration={"LocationConstraint": region}
+        Bucket="my_bucket",
+        CreateBucketConfiguration={"LocationConstraint": region},  # type: ignore
     )
     with pytest.raises(ClientError):
         s3_client.create_bucket(Bucket="my_bucket2")

--- a/tests/test_core/test_importorder.py
+++ b/tests/test_core/test_importorder.py
@@ -118,7 +118,7 @@ class ImportantBusinessLogic:
         self._s3 = boto3.client("s3", region_name="us-east-1")
 
     def do_important_things(self) -> list[str]:
-        return self._s3.list_buckets()["Buckets"]
+        return self._s3.list_buckets()["Buckets"]  # type: ignore
 
 
 def test_mock_works_when_replacing_client(

--- a/tests/test_iotdata/__init__.py
+++ b/tests/test_iotdata/__init__.py
@@ -46,6 +46,9 @@ def iot_aws_verified() -> "Callable[[Callable[P, T]], Callable[P, T]]":
 def _create_thing_and_execute_test(
     func: "Callable[P, T]", *args: "P.args", **kwargs: "P.kwargs"
 ) -> T:
+    # this is a concession to the type signature of all the iotdata tests
+    # which have (name: str)
+    kwargs.pop("name")
     iot_client = boto3.client("iot", region_name="ap-northeast-1")
     name = str(uuid4())
 

--- a/tests/test_iotdata/test_iotdata.py
+++ b/tests/test_iotdata/test_iotdata.py
@@ -17,9 +17,18 @@ from . import iot_aws_verified
 boto3_version = sys.modules["botocore"].__version__
 
 
+@pytest.fixture(scope="function")
+def name() -> str:
+    """
+    This is a concession to pytest not seeing the wrapper in iot_aws_verified
+    which implicitly passes in a generated name= for the IoT thing it created
+    """
+    return "this is kwargs.pop'ed in __init__.py"
+
+
 @iot_aws_verified()
 @pytest.mark.aws_verified
-def test_basic(name: Optional[str] = None) -> None:
+def test_basic(name: str) -> None:
     client = boto3.client("iot-data", region_name="ap-northeast-1")
 
     raw_payload = b'{"state": {"desired": {"led": "on"}}}'
@@ -51,7 +60,7 @@ def test_basic(name: Optional[str] = None) -> None:
 
 @iot_aws_verified()
 @pytest.mark.aws_verified
-def test_update(name: Optional[str] = None) -> None:
+def test_update(name: str) -> None:
     client = boto3.client("iot-data", region_name="ap-northeast-1")
     raw_payload = b'{"state": {"desired": {"led": "on"}}}'
 
@@ -99,7 +108,7 @@ def test_update(name: Optional[str] = None) -> None:
 
 @iot_aws_verified()
 @pytest.mark.aws_verified
-def test_create_named_shadows(name: Optional[str] = None) -> None:
+def test_create_named_shadows(name: str) -> None:
     if LooseVersion(boto3_version) < LooseVersion("1.29.0"):
         raise SkipTest("Parameter only available in newer versions")
     client = boto3.client("iot-data", region_name="ap-northeast-1")
@@ -165,7 +174,7 @@ def test_publish() -> None:
 
 @iot_aws_verified()
 @pytest.mark.aws_verified
-def test_delete_field_from_device_shadow(name: Optional[str] = None) -> None:
+def test_delete_field_from_device_shadow(name: str) -> None:
     iot = boto3.client("iot-data", region_name="ap-northeast-1")
 
     iot.update_thing_shadow(
@@ -326,7 +335,7 @@ def test_delta_calculation(
     initial_delta: dict[str, dict[str, Optional[bool]]],
     reported: dict[str, dict[str, Optional[bool]]],
     delta_after_report: dict[str, dict[str, Optional[bool]]],
-    name: Optional[str] = None,
+    name: str,
 ) -> None:
     client = boto3.client("iot-data", region_name="ap-northeast-1")
     desired_payload = json.dumps({"state": desired}).encode("utf-8")
@@ -369,7 +378,7 @@ def test_delta_calculation(
 def test_update_desired(
     initial_state: dict[str, str],
     updated_state: dict[str, str],
-    name: Optional[str] = None,
+    name: str,
 ) -> None:
     client = boto3.client("iot-data", region_name="ap-northeast-1")
 
@@ -391,7 +400,7 @@ def test_update_desired(
 
 @iot_aws_verified()
 @pytest.mark.aws_verified
-def test_update_empty_state(name: Optional[str] = None) -> None:
+def test_update_empty_state(name: str) -> None:
     client = boto3.client("iot-data", region_name="ap-northeast-1")
 
     # CREATE


### PR DESCRIPTION
# What?

Fix (or sometimes suppress) type annotation problems that seemingly only show up when one has `boto3-stubs[all]` installed in the venv

# Why?

1. `make lint`
1. `pip install 'boto3-stubs[all]'`
1. `make lint || echo :sad-panda:`

Given what the project is aiming for, it in my opinion invaluable having those type helpers installed, but one cannot do that and also know that `make lint` is behaving as it is going to behave for PRs

Some of the complaint is due to `Mapping[str, str]` versus `dict[str, str]`, some of it is because boto3-stubs actually carries formal type declarations for (e.g.) `CreateAccessKeyResponseTypeDef(TypedDict)`

I did not include the actual dependency because I suspected it was omitted on purpose, but I can do so if was merely an oversight

```diff
diff --git a/requirements-dev.txt b/requirements-dev.txt
index eb1c0c1b3..6cb794832 100644
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -13,6 +13,7 @@ prompt_toolkit

 # type stubs that mypy doesn't install automatically
 botocore-stubs
+boto3-stubs[all]
 types-requests
 types-python-dateutil
 types-PyYAML
```