### PR TITLE
[EC2] Enhance `modify_instance_metadata_options()` endpoint.

### DIFF
--- a/moto/ec2/models/instances.py
+++ b/moto/ec2/models/instances.py
@@ -65,8 +65,9 @@ class MetadataOptions:
         options = options or {}
         self.state = options.get("State", "applied")
         self.http_tokens = options.get("HttpTokens", "optional")
-        self.http_put_response_hop_limit = int(
-            options.get("HttpPutResponseHopLimit", 1)
+        hop_limit = options.get("HttpPutResponseHopLimit")
+        self.http_put_response_hop_limit = (
+            int(hop_limit) if hop_limit is not None else 1
         )
         self.http_endpoint = options.get("HttpEndpoint", "enabled")
         self.http_protocol_ipv6 = options.get("HttpProtocolIpv6", "disabled")

--- a/tests/test_ec2/test_instances.py
+++ b/tests/test_ec2/test_instances.py
@@ -3006,6 +3006,22 @@ def test_modify_instance_metadata_options():
     }
 
 
+def test_metadata_options_hop_limit_none():
+    from moto.ec2.models.instances import MetadataOptions
+
+    # when None is explicitly passed (e.g. from missing input in CloudFormation args or missing keys mapped to None)
+    options = MetadataOptions(options={"HttpPutResponseHopLimit": None})
+    assert options.http_put_response_hop_limit == 1
+
+    # when passing a valid int
+    options = MetadataOptions(options={"HttpPutResponseHopLimit": 5})
+    assert options.http_put_response_hop_limit == 5
+
+    # when the key isn't provided at all
+    options = MetadataOptions(options={})
+    assert options.http_put_response_hop_limit == 1
+
+
 @mock_aws
 def test_run_instances_default_response():
     ec2 = boto3.client("ec2", region_name="us-west-2")


### PR DESCRIPTION
To reviewers and maintainers @bblommers and @bpandola. This PR fixes #9889 a small bug I encountered that throws a type error when calling the [modify_instance_metadata_options()](https://docs.aws.amazon.com/boto3/latest/reference/services/ec2/client/modify_instance_metadata_options.html) endpoint. I had to use bug spray on it.