### PR TITLE
[Dynamo DB] Enhancing Point In Time Recovery Response.

### DIFF
--- a/moto/dynamodb/models/__init__.py
+++ b/moto/dynamodb/models/__init__.py
@@ -739,18 +739,29 @@ class DynamoDBBackend(BaseBackend):
         except ResourceNotFoundException:
             raise TableNotFoundException(table_name)
 
-        if (
-            point_in_time_spec["PointInTimeRecoveryEnabled"]
-            and table.continuous_backups["PointInTimeRecoveryDescription"][
-                "PointInTimeRecoveryStatus"
-            ]
-            == "DISABLED"
-        ):
-            table.continuous_backups["PointInTimeRecoveryDescription"] = {
-                "PointInTimeRecoveryStatus": "ENABLED",
-                "EarliestRestorableDateTime": unix_time(),
-                "LatestRestorableDateTime": unix_time(),
-            }
+        if point_in_time_spec["PointInTimeRecoveryEnabled"]:
+            if (
+                table.continuous_backups["PointInTimeRecoveryDescription"][
+                    "PointInTimeRecoveryStatus"
+                ]
+                == "DISABLED"
+            ):
+                table.continuous_backups["PointInTimeRecoveryDescription"] = {
+                    "PointInTimeRecoveryStatus": "ENABLED",
+                    "EarliestRestorableDateTime": unix_time(),
+                    "LatestRestorableDateTime": unix_time(),
+                }
+            if "RecoveryPeriodInDays" in point_in_time_spec:
+                table.continuous_backups["PointInTimeRecoveryDescription"][
+                    "RecoveryPeriodInDays"
+                ] = point_in_time_spec["RecoveryPeriodInDays"]
+            elif (
+                "RecoveryPeriodInDays"
+                not in table.continuous_backups["PointInTimeRecoveryDescription"]
+            ):
+                table.continuous_backups["PointInTimeRecoveryDescription"][
+                    "RecoveryPeriodInDays"
+                ] = 35
         elif not point_in_time_spec["PointInTimeRecoveryEnabled"]:
             table.continuous_backups["PointInTimeRecoveryDescription"] = {
                 "PointInTimeRecoveryStatus": "DISABLED"

--- a/tests/test_dynamodb/test_dynamodb.py
+++ b/tests/test_dynamodb/test_dynamodb.py
@@ -1794,6 +1794,7 @@ def test_update_continuous_backups():
     latest_datetime = point_in_time["LatestRestorableDateTime"]
     assert isinstance(latest_datetime, datetime)
     assert point_in_time["PointInTimeRecoveryStatus"] == "ENABLED"
+    assert point_in_time["RecoveryPeriodInDays"] == 35
 
     # when
     # a second update should not change anything
@@ -1812,6 +1813,56 @@ def test_update_continuous_backups():
     assert point_in_time["EarliestRestorableDateTime"] == earliest_datetime
     assert point_in_time["LatestRestorableDateTime"] == latest_datetime
     assert point_in_time["PointInTimeRecoveryStatus"] == "ENABLED"
+    assert point_in_time["RecoveryPeriodInDays"] == 35
+
+    # when
+    response = client.update_continuous_backups(
+        TableName=table_name,
+        PointInTimeRecoverySpecification={"PointInTimeRecoveryEnabled": False},
+    )
+
+    # then
+    assert response["ContinuousBackupsDescription"] == {
+        "ContinuousBackupsStatus": "ENABLED",
+        "PointInTimeRecoveryDescription": {"PointInTimeRecoveryStatus": "DISABLED"},
+    }
+
+
+@mock_aws
+def test_update_continuous_backups_with_recovery_period():
+    # given
+    client = boto3.client("dynamodb", region_name="us-east-1")
+    table_name = client.create_table(
+        TableName=f"T{uuid4()}",
+        AttributeDefinitions=[
+            {"AttributeName": "client", "AttributeType": "S"},
+            {"AttributeName": "app", "AttributeType": "S"},
+        ],
+        KeySchema=[
+            {"AttributeName": "client", "KeyType": "HASH"},
+            {"AttributeName": "app", "KeyType": "RANGE"},
+        ],
+        BillingMode="PAY_PER_REQUEST",
+    )["TableDescription"]["TableName"]
+
+    # when
+    response = client.update_continuous_backups(
+        TableName=table_name,
+        PointInTimeRecoverySpecification={
+            "PointInTimeRecoveryEnabled": True,
+            "RecoveryPeriodInDays": 10,
+        },
+    )
+
+    # then
+    assert (
+        response["ContinuousBackupsDescription"]["ContinuousBackupsStatus"] == "ENABLED"
+    )
+    point_in_time = response["ContinuousBackupsDescription"][
+        "PointInTimeRecoveryDescription"
+    ]
+    assert point_in_time["PointInTimeRecoveryStatus"] == "ENABLED"
+    assert point_in_time["RecoveryPeriodInDays"] == 10
 
     # when
     response = client.update_continuous_backups(


### PR DESCRIPTION
To reviewers and maintainers @bblommers and @bpandola. 
This PR fixes #9902 which adds the `RecoveryPeriodInDays` key and its default value to the response of the [update_continuous_backups()](https://docs.aws.amazon.com/boto3/latest/reference/services/dynamodb/client/update_continuous_backups.html) endpoint. A small enhancement. 