### PR TITLE
fix(dynamodb): bytes serialization on ConditionalCheckFailed

### DIFF
--- a/moto/dynamodb/exceptions.py
+++ b/moto/dynamodb/exceptions.py
@@ -1,8 +1,8 @@
-import json
 from typing import Any, Optional
 
 from moto.core.exceptions import JsonRESTError
 from moto.dynamodb.limits import HASH_KEY_MAX_LENGTH, RANGE_KEY_MAX_LENGTH
+from moto.dynamodb.models.utilities import dynamo_json_dump
 
 ERROR_TYPE_PREFIX = "com.amazonaws.dynamodb.v20120810#"
 
@@ -213,7 +213,7 @@ class ConditionalCheckFailed(DynamodbException):
         _msg = msg or "The conditional request failed"
         super().__init__(ConditionalCheckFailed.error_type, _msg)
         if item:
-            self.description = json.dumps(
+            self.description = dynamo_json_dump(
                 {
                     "__type": ConditionalCheckFailed.error_type,
                     # Note the uppercase Message
@@ -223,7 +223,7 @@ class ConditionalCheckFailed(DynamodbException):
                 }
             )
         else:
-            self.description = json.dumps(
+            self.description = dynamo_json_dump(
                 {
                     "__type": ConditionalCheckFailed.error_type,
                     # Note that lowercase 'message'
@@ -252,7 +252,7 @@ class TransactionCanceledException(DynamodbException):
                 r["Item"] = item
             reasons.append(r)
 
-        self.description = json.dumps(
+        self.description = dynamo_json_dump(
             {
                 "__type": TransactionCanceledException.error_type,
                 "CancellationReasons": reasons,

--- a/tests/test_dynamodb/test_dynamodb_condition_expressions.py
+++ b/tests/test_dynamodb/test_dynamodb_condition_expressions.py
@@ -659,3 +659,38 @@ def test_condition_check_failure_exception_is_raised_when_values_are_returned_fo
             "M": {"some_list": {"L": [{"M": {"hello": {"S": "h"}}}]}}
         },
     }
+
+
+@mock_aws
+def test_conditional_check_failed_bytes():
+    dynamodb = boto3.client("dynamodb", region_name="us-east-1")
+    dynamodb.create_table(
+        TableName="test_table_bytes",
+        KeySchema=[{"AttributeName": "pk", "KeyType": "HASH"}],
+        AttributeDefinitions=[{"AttributeName": "pk", "AttributeType": "S"}],
+        BillingMode="PAY_PER_REQUEST",
+    )
+
+    dynamodb.put_item(
+        TableName="test_table_bytes",
+        Item={
+            "pk": {"S": "test"},
+            "my_bytes": {"B": b"somebytes"},
+            "my_bytes_set": {"BS": [b"byte1", b"byte2"]},
+        },
+    )
+
+    with pytest.raises(ClientError) as exc:
+        dynamodb.update_item(
+            TableName="test_table_bytes",
+            Key={"pk": {"S": "test"}},
+            UpdateExpression="SET my_str = :s",
+            ConditionExpression="attribute_not_exists(pk)",
+            ExpressionAttributeValues={":s": {"S": "newstr"}},
+            ReturnValuesOnConditionCheckFailure="ALL_OLD",
+        )
+
+    assert exc.value.response["Error"]["Code"] == "ConditionalCheckFailedException"
+    assert "Item" in exc.value.response
+    assert exc.value.response["Item"]["my_bytes"]["B"] == b"somebytes"
+    assert exc.value.response["Item"]["my_bytes_set"]["BS"] == [b"byte1", b"byte2"]

--- a/tests/test_dynamodb/test_dynamodb_transact.py
+++ b/tests/test_dynamodb/test_dynamodb_transact.py
@@ -682,3 +682,53 @@ def test_transact_using_arns():
         TransactItems=[{"Get": {"Key": {"id": {"S": "foo"}}, "TableName": table_arn}}]
     )["Responses"]
     assert items == [{"Item": {"id": {"S": "foo"}}}]
+
+
+@mock_aws
+def test_transact_canceled_bytes():
+    dynamodb = boto3.client("dynamodb", region_name="us-east-1")
+    dynamodb.create_table(
+        TableName="test_table_transact_bytes",
+        KeySchema=[{"AttributeName": "pk", "KeyType": "HASH"}],
+        AttributeDefinitions=[{"AttributeName": "pk", "AttributeType": "S"}],
+        BillingMode="PAY_PER_REQUEST",
+    )
+
+    dynamodb.put_item(
+        TableName="test_table_transact_bytes",
+        Item={
+            "pk": {"S": "test"},
+            "my_bytes": {"B": b"somebytes"},
+            "my_bytes_set": {"BS": [b"byte1", b"byte2"]},
+        },
+    )
+
+    with pytest.raises(ClientError) as exc:
+        dynamodb.transact_write_items(
+            TransactItems=[
+                {
+                    "Update": {
+                        "TableName": "test_table_transact_bytes",
+                        "Key": {"pk": {"S": "test"}},
+                        "UpdateExpression": "SET my_str = :s",
+                        "ConditionExpression": "attribute_not_exists(pk)",
+                        "ExpressionAttributeValues": {":s": {"S": "newstr"}},
+                        "ReturnValuesOnConditionCheckFailure": "ALL_OLD",
+                    }
+                }
+            ]
+        )
+
+    assert exc.value.response["Error"]["Code"] == "TransactionCanceledException"
+    assert "CancellationReasons" in exc.value.response
+    assert "Item" in exc.value.response["CancellationReasons"][0]
+    assert (
+        exc.value.response["CancellationReasons"][0]["Item"]["my_bytes"]["B"]
+        == b"somebytes"
+    )
+    assert exc.value.response["CancellationReasons"][0]["Item"]["my_bytes_set"][
+        "BS"
+    ] == [
+        b"byte1",
+        b"byte2",
+    ]


### PR DESCRIPTION
## Bug
There's currently a bug on `ConditionalCheckFailed` exceptions where serializing the response can fail due to byte attributes:

File `/moto/moto/dynamodb/models/__init__.py`, line 500, in `update_item`:
```
TypeError: Object of type bytes is not JSON serializable
```

## Fix

Use the DynamoDB specific `dynamo_json_dump` function on the exceptions instead of `json.dumps` to ensure that byte attributes are correctly handled.

- [x] Test cases have been added for both standard and transaction writes.
- [x] All existing cases continue to pass.
- [x] Lint/formatter pass.

## Other

Let me know if there's any other info you need. Thanks for moto! 