### PR TITLE
fix(dynamodb): relax redundant parentheses to align with AWS behavior

### DIFF
--- a/moto/dynamodb/comparisons.py
+++ b/moto/dynamodb/comparisons.py
@@ -913,11 +913,7 @@ class ConditionExpressionParser:
     def _is_redundant_parenthesized_child(
         self, parent_kind: Optional[str], child_kind: str
     ) -> bool:
-        if parent_kind == self.Kind.OR:
-            return child_kind in {self.Kind.OR, self.Kind.AND}
-        if parent_kind == self.Kind.AND:
-            return child_kind == self.Kind.AND
-        return False
+        return child_kind == self.Kind.PARENTHESES
 
     def _assert(self, condition: bool, message: str, nodes: Iterable[Node]) -> None:
         if not condition:

--- a/tests/test_dynamodb/test_dynamodb_condition_expressions.py
+++ b/tests/test_dynamodb/test_dynamodb_condition_expressions.py
@@ -429,7 +429,7 @@ def test_condition_expression_with_reserved_keyword_as_attr_name():
 
 
 @mock_aws
-def test_condition_expression_rejects_redundant_parentheses():
+def test_condition_expression_parentheses_behavior():
     client = boto3.client("dynamodb", region_name="us-east-1")
     table_name = f"T{uuid4()}"
 
@@ -443,25 +443,54 @@ def test_condition_expression_rejects_redundant_parentheses():
         TableName=table_name,
         Item={
             "pk": {"S": "pk"},
-            "a": {"S": "match"},
-            "c": {"S": "match"},
-            "e": {"S": "match"},
+            "a": {"N": "1"},
+            "b": {"N": "2"},
+            "c": {"N": "3"},
+            "e": {"N": "4"},
         },
     )
 
+    # Test Case 1: #a = :b OR (#c = :d AND #e = :f)
+    # AWS DDB allows this. Moto should too.
+    client.update_item(
+        TableName=table_name,
+        Key={"pk": {"S": "pk"}},
+        UpdateExpression="SET z = :z",
+        ConditionExpression="#a = :b OR (#c = :d AND #e = :f)",
+        ExpressionAttributeNames={"#a": "pk", "#c": "pk", "#e": "pk"},
+        ExpressionAttributeValues={
+            ":b": {"S": "pk"},
+            ":d": {"S": "pk"},
+            ":f": {"S": "pk"},
+            ":z": {"S": "updated1"},
+        },
+    )
+
+    # Test Case 2: (attribute_exists (#0)) AND (((#1 <> :0) AND (#1 <> :1)) AND (#2 = :3))
+    # AWS DDB allows this. Moto should too.
+    client.update_item(
+        TableName=table_name,
+        Key={"pk": {"S": "pk"}},
+        UpdateExpression="SET z = :z",
+        ConditionExpression="(attribute_exists (#0)) AND (((#1 <> :0) AND (#1 <> :1)) AND (#2 = :3))",
+        ExpressionAttributeNames={"#0": "pk", "#1": "pk", "#2": "pk"},
+        ExpressionAttributeValues={
+            ":0": {"S": "nope"},
+            ":1": {"S": "nope"},
+            ":3": {"S": "pk"},
+            ":z": {"S": "updated2"},
+        },
+    )
+
+    # Test Case 3: ((((a < b))))
+    # AWS DDB fails this. Moto should too.
     with pytest.raises(ClientError) as exc:
         client.update_item(
             TableName=table_name,
             Key={"pk": {"S": "pk"}},
-            UpdateExpression="SET #z = :z",
-            ConditionExpression="#a = :b OR (#c = :d AND #e = :f)",
-            ExpressionAttributeNames={"#a": "a", "#c": "c", "#e": "e", "#z": "z"},
-            ExpressionAttributeValues={
-                ":b": {"S": "match"},
-                ":d": {"S": "match"},
-                ":f": {"S": "match"},
-                ":z": {"S": "updated"},
-            },
+            UpdateExpression="SET z = :z",
+            ConditionExpression="((((a < b))))",
+            ExpressionAttributeValues={":z": {"S": "updated3"}},
         )
 
     err = exc.value.response["Error"]
@@ -469,6 +498,22 @@ def test_condition_expression_rejects_redundant_parentheses():
     assert (
         err["Message"]
         == "Invalid ConditionExpression: The expression has redundant parentheses;"
+    )
+
+    # Test Case 4: ((#a = :b) OR (#c = :d) AND (#e = :f))
+    # AWS DDB allows this. Moto should too.
+    client.update_item(
+        TableName=table_name,
+        Key={"pk": {"S": "pk"}},
+        UpdateExpression="SET z = :z",
+        ConditionExpression="((#a = :b) OR (#c = :d) AND (#e = :f))",
+        ExpressionAttributeNames={"#a": "pk", "#c": "pk", "#e": "pk"},
+        ExpressionAttributeValues={
+            ":b": {"S": "pk"},
+            ":d": {"S": "pk"},
+            ":f": {"S": "pk"},
+            ":z": {"S": "updated4"},
+        },
     )
 
 


### PR DESCRIPTION
When I was testing out an unrelated fix on `main`, I ran into failures from #9847.

I tested a few different cases against real AWS with the CLI:
 * `#a = :b OR (#c = :d AND #e = :f)` -> allowed! ☑️
 * `(attribute_exists (#0)) AND (((#1 <> :0) AND (#1 <> :1)) AND (#2 = :3))` -> allowed! ☑️
 * `((((a < b))))` -> not allowed 🙅
 * `((#a = :b) OR (#c = :d) AND (#e = :f))` -> allowed! ☑️ 

The first one is from the test cases, which are currently misaligned with real AWS behavior.

The second one is how I came across the issue, it's a real, working query that passes with actual AWS/DynamoDB + 5.1.22 but fails with moto `HEAD`.

The third and failing one is the limitation in AWS, which is that it does not like pointless extra nestings of parens.

The fourth is a nested one that's not just more parentheses to ensure it's not _too_ strict.