### PR TITLE
Fix TransactWriteItems duplicate key detection when key attribute order differs

### DIFF
--- a/moto/dynamodb/models/__init__.py
+++ b/moto/dynamodb/models/__init__.py
@@ -625,7 +625,7 @@ class DynamoDBBackend(BaseBackend):
         target_items: set[tuple[str, str]] = set()
 
         def check_unicity(table_name: str, key: dict[str, Any]) -> None:
-            item = (str(table_name), str(key))
+            item = (str(table_name), str(dict(sorted(key.items()))))
             if item in target_items:
                 raise MultipleTransactionsException()
             target_items.add(item)

--- a/tests/test_dynamodb/exceptions/test_dynamodb_transactions.py
+++ b/tests/test_dynamodb/exceptions/test_dynamodb_transactions.py
@@ -86,6 +86,49 @@ def test_transact_write_items__put_and_delete_on_same_item(table_name=None):
 
 @pytest.mark.aws_verified
 @dynamodb_aws_verified(add_range=True)
+def test_transact_write_items__put_and_delete_with_different_key_order(table_name=None):
+    """Duplicate key detection should work regardless of key attribute order.
+
+    When a Put constructs the key as {pk, sk} but a Delete uses {sk, pk},
+    TransactWriteItems should still detect the duplicate and raise
+    ValidationException. See https://github.com/getmoto/moto/issues/9904.
+    """
+    dynamodb = boto3.client("dynamodb", region_name="us-east-1")
+
+    with pytest.raises(ClientError) as exc:
+        dynamodb.transact_write_items(
+            TransactItems=[
+                {
+                    "Put": {
+                        "TableName": table_name,
+                        "Item": {
+                            "pk": {"S": "pk1"},
+                            "sk": {"S": "sk1"},
+                            "data": {"S": "val"},
+                        },
+                    }
+                },
+                {
+                    "Delete": {
+                        "TableName": table_name,
+                        "Key": {
+                            "sk": {"S": "sk1"},
+                            "pk": {"S": "pk1"},
+                        },
+                    }
+                },
+            ]
+        )
+    err = exc.value.response["Error"]
+    assert err["Code"] == "ValidationException"
+    assert (
+        err["Message"]
+        == "Transaction request cannot include multiple operations on one item"
+    )
+
+
+@pytest.mark.aws_verified
+@dynamodb_aws_verified(add_range=True)
 def test_transact_write_items__update_with_multiple_set_clauses(table_name=None):
     dynamodb = boto3.client("dynamodb", region_name="us-east-1")
 


### PR DESCRIPTION
Closes #9904.

## Summary
- `TransactWriteItems` duplicate key detection (`check_unicity`) uses `str(dict)` for comparison, which is insertion-order-dependent in Python
- When a `Put` constructs the key as `{pk, sk}` but a `Delete` uses `{sk, pk}`, the duplicate is not detected and the transaction silently succeeds
- Real AWS DynamoDB correctly rejects both orderings with `ValidationException`

## Fix
Sort dictionary items before string conversion in `check_unicity` to ensure order-independent comparison:
```python
item = (str(table_name), str(dict(sorted(key.items()))))
```

## Test plan
- [x] Added `test_transact_write_items__put_and_delete_with_different_key_order` that reproduces the exact scenario from the issue (Put with `{pk, sk}` order + Delete with `{sk, pk}` order)
- [x] Test is decorated with `@pytest.mark.aws_verified` and `@dynamodb_aws_verified(add_range=True)` to match the project's test conventions
- [x] All existing transaction tests continue to pass (`test_dynamodb_transactions.py` - 9/9, `test_dynamodb_transact.py` - 18/18)