### PR TITLE
Autoscaling: Add validation to DeleteAutoScalingGroup

### DIFF
--- a/moto/autoscaling/models.py
+++ b/moto/autoscaling/models.py
@@ -1494,6 +1494,11 @@ class AutoScalingBackend(BaseBackend):
         return groups
 
     def delete_auto_scaling_group(self, group_name: str) -> None:
+        if group_name not in self.autoscaling_groups:
+            raise ValidationError(
+                f"AutoScalingGroup name not found - AutoScalingGroup '{group_name}' not found"
+            )
+
         self.set_desired_capacity(group_name, 0)
         self.autoscaling_groups.pop(group_name, None)
 

--- a/tests/test_autoscaling/test_autoscaling_groups.py
+++ b/tests/test_autoscaling/test_autoscaling_groups.py
@@ -1,6 +1,8 @@
 from unittest import TestCase
 
 import boto3
+import pytest
+from botocore.exceptions import ClientError
 
 from moto import mock_aws
 from moto.core import DEFAULT_ACCOUNT_ID as ACCOUNT_ID
@@ -86,6 +88,16 @@ class TestAutoScalingGroup(TestCase):
 
         groups = self.as_client.describe_auto_scaling_groups()["AutoScalingGroups"]
         assert len(groups) == 0
+
+        with pytest.raises(ClientError) as exc:
+            self.as_client.delete_auto_scaling_group(AutoScalingGroupName="invalid")
+        err = exc.value.response["Error"]
+        assert exc.value.response["ResponseMetadata"]["HTTPStatusCode"] == 400
+        assert err["Code"] == "ValidationError"
+        assert (
+            err["Message"]
+            == "AutoScalingGroup name not found - AutoScalingGroup 'invalid' not found"
+        )
 
     def test_describe_autoscaling_groups__instances(self):
         self._create_group(name="test_asg")


### PR DESCRIPTION
This PR adds basic validation to [DeleteAutoScalingGroup](https://docs.aws.amazon.com/autoscaling/ec2/APIReference/API_DeleteAutoScalingGroup.html) for existence of the requested auto-scaling group.