### PR TITLE
Invalid role ARN crashes with AttributeError instead of returning InvalidParameterException

### DIFF
--- a/moto/eks/utils.py
+++ b/moto/eks/utils.py
@@ -10,7 +10,9 @@ def validate_role_arn(arn: str) -> None:
         "arn:(?P<partition>.+):iam::(?P<account_id>[0-9]{12}):role/.+"
     )
     match = valid_role_arn_format.match(arn)
-    valid_partition = match.group("partition") in Session().get_available_partitions()  # type: ignore
+    if not arn or not match:
+        raise InvalidParameterException("Invalid Role Arn: '" + arn + "'")
 
-    if not all({arn, match, valid_partition}):
-        raise InvalidParameterException("Invalid Role Arn: '" + arn + "'")  # type: ignore
+    valid_partition = match.group("partition") in Session().get_available_partitions()
+    if not valid_partition:
+        raise InvalidParameterException("Invalid Role Arn: '" + arn + "'")


### PR DESCRIPTION
## Summary

When `arn` does not match the expected IAM role pattern, `match` is `None`, but the code immediately calls `match.group("partition")`. This raises `AttributeError` and returns a 500-style failure path instead of the intended `InvalidParameterException`. Concrete impact: malformed user input can crash request handling rather than producing a controlled validation error.

## Files changed

- `moto/eks/utils.py` (modified)

## Testing

- Not run in this environment.


Closes #9920