### PR TITLE
Pagination emits next_token at end-of-list, causing extra empty page and potential client loops

### DIFF
--- a/moto/emrcontainers/utils.py
+++ b/moto/emrcontainers/utils.py
@@ -31,9 +31,10 @@ def paginated_list(
 
     sorted_list = sorted(full_list, key=lambda d: d[sort_key])
 
-    values = sorted_list[next_token : next_token + max_results]  # type: ignore
-    if len(values) == max_results:
-        new_next_token = str(next_token + max_results)  # type: ignore
+    end_index = next_token + max_results  # type: ignore
+    values = sorted_list[next_token:end_index]  # type: ignore
+    if end_index < len(sorted_list):
+        new_next_token = str(end_index)
     else:
         new_next_token = None
     return values, new_next_token


### PR DESCRIPTION
## Summary

The function sets `new_next_token` whenever `len(values) == max_results`. If the page ends exactly at the list boundary, it still returns a token even though no further results exist. Clients will fetch an unnecessary empty page, and some token-driven loops may continue incorrectly. This is a pagination boundary bug that produces incorrect API behavior.

## Files changed

- `moto/emrcontainers/utils.py` (modified)

## Testing

- Not run in this environment.


Closes #9922