### PR TITLE
Admin: fix/improve Outdated Dependency Tests

### DIFF
--- a/.github/workflows/test_outdated_versions.yml
+++ b/.github/workflows/test_outdated_versions.yml
@@ -4,6 +4,10 @@ name: "Outdated Dependency Tests"
 
 on:
   pull_request:
+    paths:
+      - ".github/workflows/test_outdated_versions.yml"
+      - "moto/core/**"
+      - "tests/test_core/**"
     types: [ labeled ]
 
 jobs:

--- a/tests/test_core/test_server.py
+++ b/tests/test_core/test_server.py
@@ -81,14 +81,20 @@ def test_bedrock_service_resolution(moto_server: str) -> None:
     # Multiple Bedrock services use the same signing name (bedrock),
     # so this test checks that a bedrock-runtime request is correctly
     # differentiated in server mode (where there is no host name available).
-    client = boto3.client(
-        "bedrock-runtime", region_name="us-east-1", endpoint_url=moto_server
-    )
-    resp = client.invoke_model(
-        modelId="test-model-id",
-        body=json.dumps({}),
-        performanceConfigLatency="optimized",
-        serviceTier="flex",
-    )
-    assert resp["performanceConfigLatency"] == "optimized"
-    assert resp["serviceTier"] == "flex"
+    from botocore.exceptions import UnknownServiceError
+
+    try:
+        client = boto3.client(
+            "bedrock-runtime", region_name="us-east-1", endpoint_url=moto_server
+        )
+    except UnknownServiceError:
+        pytest.skip("Bedrock Runtime not supported in this version of Botocore.")
+    else:
+        resp = client.invoke_model(
+            modelId="test-model-id",
+            body=json.dumps({}),
+            performanceConfigLatency="optimized",
+            serviceTier="flex",
+        )
+        assert resp["performanceConfigLatency"] == "optimized"
+        assert resp["serviceTier"] == "flex"


### PR DESCRIPTION
A recent core test was added that cannot succeed on older versions of Botocore (because the service model does not exist).  This PR skips the test if the service model cannot be found.  It also updates the Outdated Dependency Tests workflow itself to run automatically when "core" updates are detected, instead of relying (solely) on someone remembering to manually label a PR.