### PR TITLE
Admin: update main workflow triggers

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,12 +1,6 @@
 name: TestNDeploy
 
-on:
-  push:
-    paths-ignore:
-      - 'README.md'
-    branches:
-      - master
-  pull_request:
+on: [push, pull_request]
 
 jobs:
   cache:

--- a/.github/workflows/dockertests.yml
+++ b/.github/workflows/dockertests.yml
@@ -1,12 +1,6 @@
 name: DockerTests
 
-on:
-  push:
-    paths-ignore:
-      - 'README.md'
-    branches:
-      - master
-  pull_request:
+on: [push, pull_request]
 
 jobs:
   cache:


### PR DESCRIPTION
I made in a change in #9936 that was intended to prevent double CI runs on branches that both live in the main repo and underlie an open Pull Request.  The idea was to restrict CI runs for pushes to the `master` branch only.  That did solve the problem of double CI runs, but had the unintended consequence of preventing CI from running on branches pushed to forks, which I myself enabled way back in #3622...

This PR puts the workflow triggers back to the way they were.  There should be a way to accomplish both goals, but I'll have to save that for another day.