### PR TITLE
Implement Athena get_database and list_databases APIs, closing #9899

### DIFF
--- a/IMPLEMENTATION_COVERAGE.md
+++ b/IMPLEMENTATION_COVERAGE.md
@@ -566,7 +566,7 @@
 
 ## athena
 <details>
-<summary>35% implemented</summary>
+<summary>38% implemented</summary>
 
 - [ ] batch_get_named_query
 - [ ] batch_get_prepared_statement
@@ -592,7 +592,7 @@
 - [ ] get_capacity_assignment_configuration
 - [X] get_capacity_reservation
 - [X] get_data_catalog
-- [ ] get_database
+- [X] get_database
 - [X] get_named_query
 - [ ] get_notebook_metadata
 - [X] get_prepared_statement
@@ -610,7 +610,7 @@
 - [ ] list_calculation_executions
 - [X] list_capacity_reservations
 - [X] list_data_catalogs
-- [ ] list_databases
+- [X] list_databases
 - [ ] list_engine_versions
 - [ ] list_executors
 - [X] list_named_queries

--- a/moto/athena/exceptions.py
+++ b/moto/athena/exceptions.py
@@ -28,6 +28,13 @@ class InvalidArgumentException(JsonRESTError):
         super().__init__("InvalidArgumentException", message)
 
 
+class MetadataException(JsonRESTError):
+    code = 400
+
+    def __init__(self, message: str):
+        super().__init__("MetadataException", message)
+
+
 class QueryStillRunning(JsonRESTError):
     def __init__(self, current_status: Optional[str]):
         msg = f"Query has not yet finished. Current state: {current_status}"

--- a/moto/athena/models.py
+++ b/moto/athena/models.py
@@ -227,7 +227,13 @@ class AthenaBackend(BaseBackend):
             "limit_key": "max_results",
             "limit_default": 50,
             "unique_attribute": "id",
-        }
+        },
+        "list_databases": {
+            "input_token": "next_token",
+            "limit_key": "max_results",
+            "limit_default": 50,
+            "unique_attribute": "name",
+        },
     }
 
     def __init__(self, region_name: str, account_id: str):
@@ -371,45 +377,13 @@ class AthenaBackend(BaseBackend):
             "Parameters": db.parameters,
         }
 
-    def list_databases(
-        self, catalog_name: str, max_results: Optional[int], next_token: Optional[str]
-    ) -> tuple[list[dict[str, Any]], Optional[str]]:
+    @paginate(pagination_model=PAGINATION_MODEL)
+    def list_databases(self, catalog_name: str) -> list[Database]:
         all_dbs = [
             db for db in self.databases.values() if db.catalog_name == catalog_name
         ]
-        # Sort for stable pagination
         all_dbs.sort(key=lambda d: d.name)
-
-        # Handle pagination
-        start = 0
-        if next_token:
-            for i, db in enumerate(all_dbs):
-                if db.name == next_token:
-                    start = i
-                    break
-
-        if max_results:
-            page = all_dbs[start : start + max_results]
-            new_next_token = (
-                all_dbs[start + max_results].name
-                if start + max_results < len(all_dbs)
-                else None
-            )
-        else:
-            page = all_dbs[start:]
-            new_next_token = None
-
-        return (
-            [
-                {
-                    "Name": db.name,
-                    "Description": db.description,
-                    "Parameters": db.parameters,
-                }
-                for db in page
-            ],
-            new_next_token,
-        )
+        return all_dbs
 
     def _store_predefined_query_results(self, exec_id: str) -> None:
         if exec_id not in self.query_results and self.query_results_queue:

--- a/moto/athena/models.py
+++ b/moto/athena/models.py
@@ -1,8 +1,13 @@
+import re
 import time
 from datetime import datetime
 from typing import Any, Optional
 
-from moto.athena.exceptions import InvalidArgumentException, QueryStillRunning
+from moto.athena.exceptions import (
+    InvalidArgumentException,
+    MetadataException,
+    QueryStillRunning,
+)
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
 from moto.moto_api._internal import mock_random
@@ -169,6 +174,20 @@ class CapacityReservation(TaggableResourceMixin, BaseModel):
         self.tags = tags
 
 
+class Database(BaseModel):
+    def __init__(
+        self,
+        catalog_name: str,
+        database_name: str,
+        description: str = "",
+        parameters: Optional[dict[str, str]] = None,
+    ):
+        self.catalog_name = catalog_name
+        self.name = database_name
+        self.description = description
+        self.parameters = parameters or {}
+
+
 class NamedQuery(BaseModel):
     def __init__(
         self,
@@ -222,6 +241,14 @@ class AthenaBackend(BaseBackend):
         self.query_results_queue: list[QueryResults] = []
         self.prepared_statements: dict[str, PreparedStatement] = {}
         self.tagger = TaggingService()
+        # databases keyed by (catalog_name, database_name)
+        self.databases: dict[tuple[str, str], Database] = {}
+
+        # AWS pre-creates a "default" database under AwsDataCatalog
+        self.databases[("AwsDataCatalog", "default")] = Database(
+            catalog_name="AwsDataCatalog",
+            database_name="default",
+        )
 
         # Initialise with the primary workgroup
         self.create_work_group(
@@ -291,9 +318,98 @@ class AthenaBackend(BaseBackend):
         )
         self.executions[execution.id] = execution
 
+        self._process_ddl(query, context)
         self._store_predefined_query_results(execution.id)
 
         return execution.id
+
+    _CREATE_DB_PATTERN = re.compile(
+        r"^\s*CREATE\s+(?:DATABASE|SCHEMA)\s+(?:IF\s+NOT\s+EXISTS\s+)?`?([^\s`;`]+)`?\s*",
+        re.IGNORECASE,
+    )
+    _DROP_DB_PATTERN = re.compile(
+        r"^\s*DROP\s+(?:DATABASE|SCHEMA)\s+(?:IF\s+EXISTS\s+)?`?([^\s`;`]+)`?\s*",
+        re.IGNORECASE,
+    )
+
+    def _process_ddl(self, query: str, context: Optional[str]) -> None:
+        catalog_name = "AwsDataCatalog"
+        if context and isinstance(context, dict):
+            catalog_name = context.get("Catalog", "AwsDataCatalog")
+
+        match = self._CREATE_DB_PATTERN.match(query)
+        if match:
+            db_name = match.group(1).lower()
+            key = (catalog_name, db_name)
+            if key not in self.databases:
+                self.databases[key] = Database(
+                    catalog_name=catalog_name,
+                    database_name=db_name,
+                )
+            return
+
+        match = self._DROP_DB_PATTERN.match(query)
+        if match:
+            db_name = match.group(1).lower()
+            key = (catalog_name, db_name)
+            self.databases.pop(key, None)
+            return
+
+    def get_database(self, catalog_name: str, database_name: str) -> dict[str, Any]:
+        key = (catalog_name, database_name.lower())
+        if key not in self.databases:
+            raise MetadataException(
+                f"An error occurred (EntityNotFoundException) when calling the "
+                f"GetDatabase operation: Database {database_name} not found. "
+                f"(Service: AmazonDataCatalog; Status Code: 400; "
+                f"Error Code: EntityNotFoundException)"
+            )
+        db = self.databases[key]
+        return {
+            "Name": db.name,
+            "Description": db.description,
+            "Parameters": db.parameters,
+        }
+
+    def list_databases(
+        self, catalog_name: str, max_results: Optional[int], next_token: Optional[str]
+    ) -> tuple[list[dict[str, Any]], Optional[str]]:
+        all_dbs = [
+            db for db in self.databases.values() if db.catalog_name == catalog_name
+        ]
+        # Sort for stable pagination
+        all_dbs.sort(key=lambda d: d.name)
+
+        # Handle pagination
+        start = 0
+        if next_token:
+            for i, db in enumerate(all_dbs):
+                if db.name == next_token:
+                    start = i
+                    break
+
+        if max_results:
+            page = all_dbs[start : start + max_results]
+            new_next_token = (
+                all_dbs[start + max_results].name
+                if start + max_results < len(all_dbs)
+                else None
+            )
+        else:
+            page = all_dbs[start:]
+            new_next_token = None
+
+        return (
+            [
+                {
+                    "Name": db.name,
+                    "Description": db.description,
+                    "Parameters": db.parameters,
+                }
+                for db in page
+            ],
+            new_next_token,
+        )
 
     def _store_predefined_query_results(self, exec_id: str) -> None:
         if exec_id not in self.query_results and self.query_results_queue:

--- a/moto/athena/responses.py
+++ b/moto/athena/responses.py
@@ -1,5 +1,5 @@
 import json
-from typing import Union
+from typing import Any, Union
 
 from moto.core.responses import BaseResponse
 
@@ -215,6 +215,24 @@ class AthenaResponse(BaseResponse):
     def get_data_catalog(self) -> str:
         name = self._get_param("Name")
         return json.dumps({"DataCatalog": self.athena_backend.get_data_catalog(name)})
+
+    def get_database(self) -> str:
+        catalog_name = self._get_param("CatalogName")
+        database_name = self._get_param("DatabaseName")
+        database = self.athena_backend.get_database(catalog_name, database_name)
+        return json.dumps({"Database": database})
+
+    def list_databases(self) -> str:
+        catalog_name = self._get_param("CatalogName")
+        max_results = self._get_param("MaxResults")
+        next_token = self._get_param("NextToken")
+        database_list, new_next_token = self.athena_backend.list_databases(
+            catalog_name, max_results, next_token
+        )
+        result: dict[str, Any] = {"DatabaseList": database_list}
+        if new_next_token:
+            result["NextToken"] = new_next_token
+        return json.dumps(result)
 
     def create_data_catalog(self) -> Union[tuple[str, dict[str, int]], str]:
         name = self._get_param("Name")

--- a/moto/athena/responses.py
+++ b/moto/athena/responses.py
@@ -226,10 +226,19 @@ class AthenaResponse(BaseResponse):
         catalog_name = self._get_param("CatalogName")
         max_results = self._get_param("MaxResults")
         next_token = self._get_param("NextToken")
-        database_list, new_next_token = self.athena_backend.list_databases(
-            catalog_name, max_results, next_token
+        databases, new_next_token = self.athena_backend.list_databases(
+            catalog_name, max_results=max_results, next_token=next_token
         )
-        result: dict[str, Any] = {"DatabaseList": database_list}
+        result: dict[str, Any] = {
+            "DatabaseList": [
+                {
+                    "Name": db.name,
+                    "Description": db.description,
+                    "Parameters": db.parameters,
+                }
+                for db in databases
+            ]
+        }
         if new_next_token:
             result["NextToken"] = new_next_token
         return json.dumps(result)

--- a/other_langs/terraform/athena/database.tf
+++ b/other_langs/terraform/athena/database.tf
@@ -1,0 +1,8 @@
+resource "aws_s3_bucket" "athena_results" {
+  bucket = "athena-query-results"
+}
+
+resource "aws_athena_database" "example" {
+  name   = "example_db"
+  bucket = aws_s3_bucket.athena_results.id
+}

--- a/other_langs/terraform/athena/provider.tf
+++ b/other_langs/terraform/athena/provider.tf
@@ -1,0 +1,25 @@
+terraform {
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
+}
+
+provider "aws" {
+  region                      = "us-east-1"
+  s3_use_path_style           = true
+  skip_credentials_validation = true
+  skip_metadata_api_check     = true
+  skip_requesting_account_id  = true
+
+  endpoints {
+    athena = "http://localhost:5000"
+    glue   = "http://localhost:5000"
+    s3     = "http://localhost:5000"
+    sts    = "http://localhost:5000"
+  }
+
+  access_key = "my-access-key"
+  secret_key = "my-secret-key"
+}

--- a/tests/test_athena/test_athena_database.py
+++ b/tests/test_athena/test_athena_database.py
@@ -1,0 +1,244 @@
+import boto3
+import pytest
+from botocore.exceptions import ClientError
+
+from moto import mock_aws
+
+
+@mock_aws
+def test_get_database_default():
+    """AWS pre-creates a 'default' database under AwsDataCatalog."""
+    client = boto3.client("athena", region_name="us-east-1")
+    result = client.get_database(CatalogName="AwsDataCatalog", DatabaseName="default")
+    db = result["Database"]
+    assert db["Name"] == "default"
+    assert "Description" in db
+    assert "Parameters" in db
+
+
+@mock_aws
+def test_get_database_not_found():
+    """GetDatabase for a nonexistent database should raise MetadataException."""
+    client = boto3.client("athena", region_name="us-east-1")
+    with pytest.raises(ClientError) as exc:
+        client.get_database(CatalogName="AwsDataCatalog", DatabaseName="nonexistent_db")
+    err = exc.value.response["Error"]
+    assert err["Code"] == "MetadataException"
+    assert "nonexistent_db" in err["Message"]
+
+
+@mock_aws
+def test_create_database_via_ddl_and_get():
+    """CREATE DATABASE via start_query_execution should make it available via get_database."""
+    client = boto3.client("athena", region_name="us-east-1")
+    client.start_query_execution(
+        QueryString="CREATE DATABASE my_test_db",
+        ResultConfiguration={"OutputLocation": "s3://bucket/key"},
+    )
+    result = client.get_database(
+        CatalogName="AwsDataCatalog", DatabaseName="my_test_db"
+    )
+    assert result["Database"]["Name"] == "my_test_db"
+
+
+@mock_aws
+def test_create_database_schema_keyword():
+    """CREATE SCHEMA is equivalent to CREATE DATABASE in Athena."""
+    client = boto3.client("athena", region_name="us-east-1")
+    client.start_query_execution(
+        QueryString="CREATE SCHEMA schema_db",
+        ResultConfiguration={"OutputLocation": "s3://bucket/key"},
+    )
+    result = client.get_database(CatalogName="AwsDataCatalog", DatabaseName="schema_db")
+    assert result["Database"]["Name"] == "schema_db"
+
+
+@mock_aws
+def test_create_database_if_not_exists():
+    """CREATE DATABASE IF NOT EXISTS should not error if DB already exists."""
+    client = boto3.client("athena", region_name="us-east-1")
+    config = {"OutputLocation": "s3://bucket/key"}
+    client.start_query_execution(
+        QueryString="CREATE DATABASE my_db", ResultConfiguration=config
+    )
+    # Should not raise
+    client.start_query_execution(
+        QueryString="CREATE DATABASE IF NOT EXISTS my_db",
+        ResultConfiguration=config,
+    )
+    result = client.get_database(CatalogName="AwsDataCatalog", DatabaseName="my_db")
+    assert result["Database"]["Name"] == "my_db"
+
+
+@mock_aws
+def test_drop_database_via_ddl():
+    """DROP DATABASE should remove the database."""
+    client = boto3.client("athena", region_name="us-east-1")
+    config = {"OutputLocation": "s3://bucket/key"}
+    client.start_query_execution(
+        QueryString="CREATE DATABASE drop_me", ResultConfiguration=config
+    )
+    # Verify it exists
+    client.get_database(CatalogName="AwsDataCatalog", DatabaseName="drop_me")
+
+    # Drop it
+    client.start_query_execution(
+        QueryString="DROP DATABASE drop_me", ResultConfiguration=config
+    )
+
+    # Should no longer exist
+    with pytest.raises(ClientError) as exc:
+        client.get_database(CatalogName="AwsDataCatalog", DatabaseName="drop_me")
+    assert exc.value.response["Error"]["Code"] == "MetadataException"
+
+
+@mock_aws
+def test_drop_database_if_exists():
+    """DROP DATABASE IF EXISTS should not error for nonexistent database."""
+    client = boto3.client("athena", region_name="us-east-1")
+    config = {"OutputLocation": "s3://bucket/key"}
+    # Should not raise even though DB doesn't exist
+    client.start_query_execution(
+        QueryString="DROP DATABASE IF EXISTS no_such_db",
+        ResultConfiguration=config,
+    )
+
+
+@mock_aws
+def test_drop_schema_keyword():
+    """DROP SCHEMA is equivalent to DROP DATABASE."""
+    client = boto3.client("athena", region_name="us-east-1")
+    config = {"OutputLocation": "s3://bucket/key"}
+    client.start_query_execution(
+        QueryString="CREATE DATABASE schema_drop_test", ResultConfiguration=config
+    )
+    client.start_query_execution(
+        QueryString="DROP SCHEMA schema_drop_test", ResultConfiguration=config
+    )
+    with pytest.raises(ClientError) as exc:
+        client.get_database(
+            CatalogName="AwsDataCatalog", DatabaseName="schema_drop_test"
+        )
+    assert exc.value.response["Error"]["Code"] == "MetadataException"
+
+
+@mock_aws
+def test_list_databases():
+    """ListDatabases should return all databases for a catalog."""
+    client = boto3.client("athena", region_name="us-east-1")
+    config = {"OutputLocation": "s3://bucket/key"}
+
+    # Create a few databases
+    for name in ["alpha_db", "beta_db", "gamma_db"]:
+        client.start_query_execution(
+            QueryString=f"CREATE DATABASE {name}", ResultConfiguration=config
+        )
+
+    result = client.list_databases(CatalogName="AwsDataCatalog")
+    db_names = [db["Name"] for db in result["DatabaseList"]]
+
+    # Should include default + the 3 we created
+    assert "default" in db_names
+    assert "alpha_db" in db_names
+    assert "beta_db" in db_names
+    assert "gamma_db" in db_names
+
+
+@mock_aws
+def test_list_databases_pagination():
+    """ListDatabases should support MaxResults pagination."""
+    client = boto3.client("athena", region_name="us-east-1")
+    config = {"OutputLocation": "s3://bucket/key"}
+
+    for i in range(5):
+        client.start_query_execution(
+            QueryString=f"CREATE DATABASE pag_db_{i:02d}",
+            ResultConfiguration=config,
+        )
+
+    # First page
+    result = client.list_databases(CatalogName="AwsDataCatalog", MaxResults=3)
+    assert len(result["DatabaseList"]) == 3
+    assert "NextToken" in result
+
+    # Second page
+    result2 = client.list_databases(
+        CatalogName="AwsDataCatalog",
+        MaxResults=3,
+        NextToken=result["NextToken"],
+    )
+    assert len(result2["DatabaseList"]) >= 1
+
+    # All database names should be unique across pages
+    all_names = [db["Name"] for db in result["DatabaseList"]] + [
+        db["Name"] for db in result2["DatabaseList"]
+    ]
+    assert len(all_names) == len(set(all_names))
+
+
+@mock_aws
+def test_list_databases_empty_catalog():
+    """ListDatabases for a catalog with no databases returns empty list."""
+    client = boto3.client("athena", region_name="us-east-1")
+    result = client.list_databases(CatalogName="NonExistentCatalog")
+    assert result["DatabaseList"] == []
+
+
+@mock_aws
+def test_create_database_with_backticks():
+    """Database names with backticks should be handled correctly."""
+    client = boto3.client("athena", region_name="us-east-1")
+    client.start_query_execution(
+        QueryString="CREATE DATABASE `backtick_db`",
+        ResultConfiguration={"OutputLocation": "s3://bucket/key"},
+    )
+    result = client.get_database(
+        CatalogName="AwsDataCatalog", DatabaseName="backtick_db"
+    )
+    assert result["Database"]["Name"] == "backtick_db"
+
+
+@mock_aws
+def test_database_names_are_case_insensitive():
+    """AWS Athena stores database names as lowercase."""
+    client = boto3.client("athena", region_name="us-east-1")
+    client.start_query_execution(
+        QueryString="CREATE DATABASE MyMixedCaseDB",
+        ResultConfiguration={"OutputLocation": "s3://bucket/key"},
+    )
+    # Should be stored as lowercase
+    result = client.get_database(
+        CatalogName="AwsDataCatalog", DatabaseName="mymixedcasedb"
+    )
+    assert result["Database"]["Name"] == "mymixedcasedb"
+
+    # Lookup with different casing should also work
+    result = client.get_database(
+        CatalogName="AwsDataCatalog", DatabaseName="MYMIXEDCASEDB"
+    )
+    assert result["Database"]["Name"] == "mymixedcasedb"
+
+
+@mock_aws
+def test_create_database_with_catalog_context():
+    """Database should be created under the catalog specified in QueryExecutionContext."""
+    client = boto3.client("athena", region_name="us-east-1")
+
+    # First create a custom data catalog
+    client.create_data_catalog(
+        Name="custom_catalog", Type="GLUE", Description="Custom catalog"
+    )
+
+    client.start_query_execution(
+        QueryString="CREATE DATABASE ctx_db",
+        QueryExecutionContext={"Catalog": "custom_catalog"},
+        ResultConfiguration={"OutputLocation": "s3://bucket/key"},
+    )
+
+    result = client.get_database(CatalogName="custom_catalog", DatabaseName="ctx_db")
+    assert result["Database"]["Name"] == "ctx_db"
+
+    # Should NOT be in AwsDataCatalog
+    with pytest.raises(ClientError) as exc:
+        client.get_database(CatalogName="AwsDataCatalog", DatabaseName="ctx_db")
+    assert exc.value.response["Error"]["Code"] == "MetadataException"


### PR DESCRIPTION
Closes #9899
 
 ## Summary
 Implements `get_database` and `list_databases` for the Athena service, matching real AWS behavior.
 
 ## Changes
 - **`moto/athena/exceptions.py`** — Added `MetadataException` (HTTP 400, raised when database not found)
 - **`moto/athena/models.py`** — Added `Database` model, DDL parsing in `start_query_execution` for `CREATE/DROP DATABASE|SCHEMA`, 
`get_database()` and `list_databases()` with pagination
 - **`moto/athena/responses.py`** — Added `get_database` and `list_databases` response handlers
 - **`tests/test_athena/test_athena_database.py`** — 14 tests covering all operations and edge cases
 - **`other_langs/terraform/athena/`** — Terraform example for `aws_athena_database`
 - **`IMPLEMENTATION_COVERAGE.md`** — Marked `get_database` and `list_databases` as implemented (35% → 38%)
 
 ## Behavior
 - Databases created via `CREATE DATABASE` / `CREATE SCHEMA` DDL in `start_query_execution`
 - Database names lowercased (matches AWS/Glue behavior)
 - `default` database pre-populated under `AwsDataCatalog`
 - `IF NOT EXISTS` / `IF EXISTS` supported
 - Catalog context from `QueryExecutionContext.Catalog` respected
 - `MetadataException` raised for nonexistent databases (matches AWS error format)
 
 ## Checklist
 - [x] Feature added
 - [x] Linter passes (`ruff check`, `ruff format`, `mypy`)
 - [x] Tests added (14 new tests)
 - [x] All existing tests pass (59 passed, 1 skipped)