### PR TITLE
WAFV2: support `Arn` parameter in `get_web_acl`

### DIFF
--- a/moto/wafv2/models.py
+++ b/moto/wafv2/models.py
@@ -574,7 +574,15 @@ class WAFV2Backend(BaseBackend):
             raise WAFOptimisticLockException()
         self.wacls.pop(arn)
 
-    def get_web_acl(self, name: str, _id: str) -> FakeWebACL:
+    def get_web_acl(
+        self, arn: Optional[str], name: Optional[str], _id: Optional[str]
+    ) -> FakeWebACL:
+        if arn:
+            wacl = self.wacls.get(arn)
+            if wacl is None:
+                raise WAFNonexistentItemException
+            return wacl
+
         for wacl in self.wacls.values():
             if wacl.name == name and wacl.id == _id:
                 return wacl
@@ -620,7 +628,7 @@ class WAFV2Backend(BaseBackend):
         token_domains: Optional[list[str]],
         association_config: Optional[dict[str, Any]],
     ) -> str:
-        acl = self.get_web_acl(name, _id)
+        acl = self.get_web_acl(None, name, _id)
         if acl.lock_token != lock_token:
             raise WAFOptimisticLockException()
         rule_objs = (

--- a/moto/wafv2/responses.py
+++ b/moto/wafv2/responses.py
@@ -86,7 +86,8 @@ class WAFV2Response(BaseResponse):
             self.region = GLOBAL_REGION
         name = self._get_param("Name")
         _id = self._get_param("Id")
-        web_acl = self.wafv2_backend.get_web_acl(name, _id)
+        arn = self._get_param("ARN")
+        web_acl = self.wafv2_backend.get_web_acl(arn, name, _id)
         response = {"WebACL": web_acl.to_dict(), "LockToken": web_acl.lock_token}
         response_headers = {"Content-Type": "application/json"}
         return 200, response_headers, json.dumps(response)

--- a/tests/test_wafv2/test_wafv2.py
+++ b/tests/test_wafv2/test_wafv2.py
@@ -153,13 +153,36 @@ def test_create_web_acl_with_all_arguments():
 
 
 @mock_aws
-def test_get_web_acl():
+def test_get_web_acl_by_arn():
+    conn = boto3.client("wafv2", region_name="us-east-1")
+    body = CREATE_WEB_ACL_BODY("John", "REGIONAL")
+    web_acl_arn = conn.create_web_acl(**body)["Summary"]["ARN"]
+    wacl = conn.get_web_acl(ARN=web_acl_arn)["WebACL"]
+    assert wacl["Name"] == "John"
+    assert wacl["LabelNamespace"] == f"awswaf:{ACCOUNT_ID}:webacl:John:"
+
+
+@mock_aws
+def test_get_web_acl_by_id_and_name():
     conn = boto3.client("wafv2", region_name="us-east-1")
     body = CREATE_WEB_ACL_BODY("John", "REGIONAL")
     web_acl_id = conn.create_web_acl(**body)["Summary"]["Id"]
     wacl = conn.get_web_acl(Name="John", Scope="REGIONAL", Id=web_acl_id)["WebACL"]
     assert wacl["Name"] == "John"
     assert wacl["Id"] == web_acl_id
+    assert wacl["LabelNamespace"] == f"awswaf:{ACCOUNT_ID}:webacl:John:"
+
+
+@mock_aws
+def test_get_web_acl_by_arn_has_priority():
+    conn = boto3.client("wafv2", region_name="us-east-1")
+    body = CREATE_WEB_ACL_BODY("John", "REGIONAL")
+    web_acl_arn = conn.create_web_acl(**body)["Summary"]["ARN"]
+    wacl = conn.get_web_acl(
+        ARN=web_acl_arn, Name="wrong-name", Scope="REGIONAL", Id="wrong-id"
+    )["WebACL"]
+    assert wacl["Name"] == "John"
+    assert wacl["Id"] != "wrong-id"
     assert wacl["LabelNamespace"] == f"awswaf:{ACCOUNT_ID}:webacl:John:"
 
 

--- a/tests/test_wafv2/test_wafv2.py
+++ b/tests/test_wafv2/test_wafv2.py
@@ -163,6 +163,16 @@ def test_get_web_acl_by_arn():
 
 
 @mock_aws
+def test_get_non_existent_web_acl_by_arn():
+    conn = boto3.client("wafv2", region_name="us-east-1")
+    with pytest.raises(conn.exceptions.WAFNonexistentItemException) as error:
+        conn.get_web_acl(
+            ARN="arn:aws:wafv2:us-east-1:123456789012:regional/webacl/John/id"
+        )["WebACL"]
+    assert error
+
+
+@mock_aws
 def test_get_web_acl_by_id_and_name():
     conn = boto3.client("wafv2", region_name="us-east-1")
     body = CREATE_WEB_ACL_BODY("John", "REGIONAL")


### PR DESCRIPTION
The [`wafv2.get_web_acl`](https://docs.aws.amazon.com/boto3/latest/reference/services/wafv2/client/get_web_acl.html) accepts either an `ARN` or the `(Name, Id, Scope)`. 

This isn't documented (or I couldn't find it), but the ARN takes precedence over the `(Name, Id, Scope)` tuple. Please let me know if there is additional tests needed for this