### PR TITLE
fix: validate KeyId parameter in KMS decrypt

### DIFF
--- a/moto/kms/models.py
+++ b/moto/kms/models.py
@@ -15,6 +15,7 @@ from moto.utilities.tagging_service import TaggingService
 from moto.utilities.utils import get_partition
 
 from .exceptions import (
+    AccessDeniedException,
     InvalidKeyUsageException,
     KMSInvalidMacException,
     ValidationException,
@@ -597,14 +598,24 @@ class KmsBackend(BaseBackend):
         return ciphertext_blob, arn
 
     def decrypt(
-        self, ciphertext_blob: bytes, encryption_context: dict[str, str]
+        self,
+        ciphertext_blob: bytes,
+        encryption_context: dict[str, str],
+        key_id: Optional[str] = None,
     ) -> tuple[bytes, str]:
-        plaintext, key_id = decrypt(
+        plaintext, actual_key_id = decrypt(
             master_keys=self.keys,
             ciphertext_blob=ciphertext_blob,
             encryption_context=encryption_context,
         )
-        arn = self.keys[key_id].arn
+        if key_id is not None:
+            requested_key_id = self.any_id_to_key_id(key_id)
+            if requested_key_id != actual_key_id:
+                raise AccessDeniedException(
+                    "The ciphertext refers to a customer master key that does not exist, "
+                    "does not exist in this region, or you are not allowed to access."
+                )
+        arn = self.keys[actual_key_id].arn
         return plaintext, arn
 
     def re_encrypt(

--- a/moto/kms/responses.py
+++ b/moto/kms/responses.py
@@ -443,9 +443,15 @@ class KmsResponse(BaseResponse):
         """https://docs.aws.amazon.com/kms/latest/APIReference/API_Decrypt.html"""
         ciphertext_blob = self._get_param("CiphertextBlob")
         encryption_context = self._get_param("EncryptionContext", {})
+        key_id = self._get_param("KeyId")
+
+        if key_id:
+            self._validate_key_id(key_id)
 
         plaintext, arn = self.kms_backend.decrypt(
-            ciphertext_blob=ciphertext_blob, encryption_context=encryption_context
+            ciphertext_blob=ciphertext_blob,
+            encryption_context=encryption_context,
+            key_id=key_id,
         )
 
         plaintext_response = base64.b64encode(plaintext).decode("utf-8")

--- a/tests/test_kms/test_kms.py
+++ b/tests/test_kms/test_kms.py
@@ -786,9 +786,7 @@ def test_decrypt_validates_key_id():
     key2_id = key2["KeyMetadata"]["KeyId"]
 
     # Encrypt with key1
-    encrypt_resp = client.encrypt(
-        KeyId=key1_id, Plaintext=b"hello world"
-    )
+    encrypt_resp = client.encrypt(KeyId=key1_id, Plaintext=b"hello world")
 
     # Decrypt with correct key-id should succeed
     decrypt_resp = client.decrypt(
@@ -797,16 +795,12 @@ def test_decrypt_validates_key_id():
     assert decrypt_resp["Plaintext"] == b"hello world"
 
     # Decrypt without key-id should still succeed (key-id is optional)
-    decrypt_resp = client.decrypt(
-        CiphertextBlob=encrypt_resp["CiphertextBlob"]
-    )
+    decrypt_resp = client.decrypt(CiphertextBlob=encrypt_resp["CiphertextBlob"])
     assert decrypt_resp["Plaintext"] == b"hello world"
 
     # Decrypt with wrong key-id should raise AccessDeniedException
     with pytest.raises(ClientError) as exc:
-        client.decrypt(
-            CiphertextBlob=encrypt_resp["CiphertextBlob"], KeyId=key2_id
-        )
+        client.decrypt(CiphertextBlob=encrypt_resp["CiphertextBlob"], KeyId=key2_id)
     assert exc.value.response["Error"]["Code"] == "AccessDeniedException"
 
 

--- a/tests/test_kms/test_kms.py
+++ b/tests/test_kms/test_kms.py
@@ -777,6 +777,39 @@ def test_generate_data_key_decrypt():
     assert resp1["Plaintext"] == resp2["Plaintext"]
 
 
+@mock_aws
+def test_decrypt_validates_key_id():
+    client = boto3.client("kms", region_name="us-east-1")
+    key1 = client.create_key(Description="key-1")
+    key2 = client.create_key(Description="key-2")
+    key1_id = key1["KeyMetadata"]["KeyId"]
+    key2_id = key2["KeyMetadata"]["KeyId"]
+
+    # Encrypt with key1
+    encrypt_resp = client.encrypt(
+        KeyId=key1_id, Plaintext=b"hello world"
+    )
+
+    # Decrypt with correct key-id should succeed
+    decrypt_resp = client.decrypt(
+        CiphertextBlob=encrypt_resp["CiphertextBlob"], KeyId=key1_id
+    )
+    assert decrypt_resp["Plaintext"] == b"hello world"
+
+    # Decrypt without key-id should still succeed (key-id is optional)
+    decrypt_resp = client.decrypt(
+        CiphertextBlob=encrypt_resp["CiphertextBlob"]
+    )
+    assert decrypt_resp["Plaintext"] == b"hello world"
+
+    # Decrypt with wrong key-id should raise AccessDeniedException
+    with pytest.raises(ClientError) as exc:
+        client.decrypt(
+            CiphertextBlob=encrypt_resp["CiphertextBlob"], KeyId=key2_id
+        )
+    assert exc.value.response["Error"]["Code"] == "AccessDeniedException"
+
+
 @pytest.mark.parametrize(
     "kwargs",
     [


### PR DESCRIPTION
Fixes #9907

## Summary

- When `KeyId` is passed to the `Decrypt` API, validate it matches the key embedded in the ciphertext
- Raise `AccessDeniedException` if the provided key does not match, consistent with AWS behavior
- `KeyId` remains optional; omitting it preserves existing behavior

## Changes

- `models.py`: Accept optional `key_id` in `decrypt()`, resolve via `any_id_to_key_id()`, and compare against the actual key
- `responses.py`: Read and validate the `KeyId` parameter before passing to the backend
- `test_kms.py`: Add `test_decrypt_validates_key_id` covering correct key, missing key, and wrong key scenarios