### PR TITLE
Fix #9947: zip2tar preserves Unix file permissions in Lambda

### DIFF
--- a/moto/awslambda/models.py
+++ b/moto/awslambda/models.py
@@ -92,6 +92,7 @@ def zip2tar(zip_bytes: bytes) -> io.BytesIO:
             tarinfo = tarfile.TarInfo(name=zipinfo.filename)
             tarinfo.size = zipinfo.file_size
             tarinfo.mtime = calendar.timegm(zipinfo.date_time) - timeshift
+            tarinfo.mode = (zipinfo.external_attr >> 16) & 0o777
             infile = zipf.open(zipinfo.filename)
             tarf.addfile(tarinfo, infile)
 


### PR DESCRIPTION
## Summary
- Fixes zip2tar not preserving Unix file permissions causing Lambda permission denied
Generated by [OwlMind](https://owlmind.dev)