### PR TITLE
Migrate EMR services to new request parsing/response serialization

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -12,6 +12,7 @@ include moto/ec2/resources/ecs/optimized_amis/*.json
 include moto/elasticache/*/*.json
 include moto/emr/*/*.json
 include moto/emr/resources/*.json
+include moto/emrserverless/*/*.json
 include moto/cognitoidp/resources/*.json
 include moto/dynamodb/parsing/reserved_keywords.txt
 include moto/medialive/*/*.json

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -12,6 +12,7 @@ include moto/ec2/resources/ecs/optimized_amis/*.json
 include moto/elasticache/*/*.json
 include moto/emr/*/*.json
 include moto/emr/resources/*.json
+include moto/emrcontainers/*/*.json
 include moto/emrserverless/*/*.json
 include moto/cognitoidp/resources/*.json
 include moto/dynamodb/parsing/reserved_keywords.txt

--- a/moto/core/loaders.py
+++ b/moto/core/loaders.py
@@ -16,17 +16,29 @@ service model by supplying additional error shapes or default input
 values for use by Moto.
 """
 
+from __future__ import annotations
+
 import os
+from typing import TYPE_CHECKING, Any
 
 from botocore.loaders import Loader as BotocoreLoader
 
 import moto
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
 
 moto_root = os.path.dirname(os.path.abspath(moto.__file__))
 
 
 class Loader(BotocoreLoader):
     BUILTIN_EXTRAS_TYPES = ["moto"]
+
+    def _find_extras(
+        self, service_name: str, type_name: str, api_version: str
+    ) -> Iterator[dict[str, Any]]:
+        moto_service_name = service_name.replace("-", "")
+        yield from super()._find_extras(moto_service_name, type_name, api_version)  # type: ignore[misc]
 
 
 def create_loader() -> Loader:

--- a/moto/emrcontainers/2020-10-01/paginators-1.moto-extras.json
+++ b/moto/emrcontainers/2020-10-01/paginators-1.moto-extras.json
@@ -1,0 +1,13 @@
+{
+  "version": 1.0,
+  "merge": {
+    "pagination": {
+      "ListJobRuns": {
+        "unique_attribute": "id"
+      },
+      "ListVirtualClusters": {
+        "unique_attribute": "id"
+      }
+    }
+  }
+}

--- a/moto/emrcontainers/exceptions.py
+++ b/moto/emrcontainers/exceptions.py
@@ -1,10 +1,11 @@
 """Exceptions raised by the emrcontainers service."""
 
-from moto.core.exceptions import JsonRESTError
+from moto.core.exceptions import ServiceException
 
 
-class ResourceNotFoundException(JsonRESTError):
-    code = 400
+class EMRContainersException(ServiceException):
+    pass
 
-    def __init__(self, resource: str):
-        super().__init__("ResourceNotFoundException", resource)
+
+class ResourceNotFoundException(EMRContainersException):
+    code = "ResourceNotFoundException"

--- a/moto/emrcontainers/models.py
+++ b/moto/emrcontainers/models.py
@@ -1,18 +1,17 @@
 """EMRContainersBackend class with methods for supported APIs."""
 
 import re
-from collections.abc import Iterator
 from datetime import datetime
 from typing import Any, Optional
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
-from moto.core.utils import iso_8601_datetime_without_milliseconds
+from moto.core.utils import utcnow
 from moto.utilities.utils import get_partition
 
 from ..config.exceptions import ValidationException
 from .exceptions import ResourceNotFoundException
-from .utils import paginated_list, random_cluster_id, random_job_id
+from .utils import random_cluster_id, random_job_id
 
 VIRTUAL_CLUSTER_ARN_TEMPLATE = "arn:{partition}:emr-containers:{region}:{account_id}:/virtualclusters/{virtual_cluster_id}"
 
@@ -23,7 +22,7 @@ VIRTUAL_CLUSTER_STATUS = "RUNNING"
 JOB_STATUS = "RUNNING"
 
 
-class FakeCluster(BaseModel):
+class VirtualCluster(BaseModel):
     def __init__(
         self,
         name: str,
@@ -49,35 +48,11 @@ class FakeCluster(BaseModel):
         self.container_provider = container_provider
         self.container_provider_id = container_provider["id"]
         self.namespace = container_provider["info"]["eksInfo"]["namespace"]
-        self.creation_date = iso_8601_datetime_without_milliseconds(
-            datetime.today().replace(hour=0, minute=0, second=0, microsecond=0)
-        )
+        self.created_at = utcnow().replace(hour=0, minute=0, second=0, microsecond=0)
         self.tags = tags
 
-    def __iter__(self) -> Iterator[tuple[str, Any]]:
-        yield "id", self.id
-        yield "name", self.name
-        yield "arn", self.arn
-        yield "state", self.state
-        yield "containerProvider", self.container_provider
-        yield "createdAt", self.creation_date
-        yield "tags", self.tags
 
-    def to_dict(self) -> dict[str, Any]:
-        # Format for summary https://docs.aws.amazon.com/emr-on-eks/latest/APIReference/API_DescribeVirtualCluster.html
-        # (response syntax section)
-        return {
-            "id": self.id,
-            "name": self.name,
-            "arn": self.arn,
-            "state": self.state,
-            "containerProvider": self.container_provider,
-            "createdAt": self.creation_date,
-            "tags": self.tags,
-        }
-
-
-class FakeJob(BaseModel):
+class JobRun(BaseModel):
     def __init__(
         self,
         name: str,
@@ -108,54 +83,12 @@ class FakeJob(BaseModel):
         self.release_label = release_label
         self.job_driver = job_driver
         self.configuration_overrides = configuration_overrides
-        self.created_at = iso_8601_datetime_without_milliseconds(
-            datetime.today().replace(hour=0, minute=0, second=0, microsecond=0)
-        )
+        self.created_at = utcnow().replace(hour=0, minute=0, second=0, microsecond=0)
         self.created_by = None
-        self.finished_at: Optional[str] = None
+        self.finished_at: Optional[datetime] = None
         self.state_details: Optional[str] = None
         self.failure_reason = None
         self.tags = tags
-
-    def __iter__(self) -> Iterator[tuple[str, Any]]:
-        yield "id", self.id
-        yield "name", self.name
-        yield "virtualClusterId", self.virtual_cluster_id
-        yield "arn", self.arn
-        yield "state", self.state
-        yield "clientToken", self.client_token
-        yield "executionRoleArn", self.execution_role_arn
-        yield "releaseLabel", self.release_label
-        yield "configurationOverrides", self.release_label
-        yield "jobDriver", self.job_driver
-        yield "createdAt", self.created_at
-        yield "createdBy", self.created_by
-        yield "finishedAt", self.finished_at
-        yield "stateDetails", self.state_details
-        yield "failureReason", self.failure_reason
-        yield "tags", self.tags
-
-    def to_dict(self) -> dict[str, Any]:
-        # Format for summary https://docs.aws.amazon.com/emr-on-eks/latest/APIReference/API_DescribeJobRun.html
-        # (response syntax section)
-        return {
-            "id": self.id,
-            "name": self.name,
-            "virtualClusterId": self.virtual_cluster_id,
-            "arn": self.arn,
-            "state": self.state,
-            "clientToken": self.client_token,
-            "executionRoleArn": self.execution_role_arn,
-            "releaseLabel": self.release_label,
-            "configurationOverrides": self.configuration_overrides,
-            "jobDriver": self.job_driver,
-            "createdAt": self.created_at,
-            "createdBy": self.created_by,
-            "finishedAt": self.finished_at,
-            "stateDetails": self.state_details,
-            "failureReason": self.failure_reason,
-            "tags": self.tags,
-        }
 
 
 class EMRContainersBackend(BaseBackend):
@@ -163,9 +96,9 @@ class EMRContainersBackend(BaseBackend):
 
     def __init__(self, region_name: str, account_id: str):
         super().__init__(region_name, account_id)
-        self.virtual_clusters: dict[str, FakeCluster] = {}
+        self.virtual_clusters: dict[str, VirtualCluster] = {}
         self.virtual_cluster_count = 0
-        self.jobs: dict[str, FakeJob] = {}
+        self.job_runs: dict[str, JobRun] = {}
         self.job_count = 0
         self.partition = get_partition(region_name)
 
@@ -175,7 +108,7 @@ class EMRContainersBackend(BaseBackend):
         container_provider: dict[str, Any],
         client_token: str,
         tags: Optional[dict[str, str]] = None,
-    ) -> FakeCluster:
+    ) -> VirtualCluster:
         occupied_namespaces = [
             virtual_cluster.namespace
             for virtual_cluster in self.virtual_clusters.values()
@@ -186,7 +119,7 @@ class EMRContainersBackend(BaseBackend):
                 "A virtual cluster already exists in the given namespace"
             )
 
-        virtual_cluster = FakeCluster(
+        virtual_cluster = VirtualCluster(
             name=name,
             container_provider=container_provider,
             client_token=client_token,
@@ -200,71 +133,64 @@ class EMRContainersBackend(BaseBackend):
         self.virtual_cluster_count += 1
         return virtual_cluster
 
-    def delete_virtual_cluster(self, cluster_id: str) -> FakeCluster:
+    def delete_virtual_cluster(self, cluster_id: str) -> VirtualCluster:
         if cluster_id not in self.virtual_clusters:
             raise ValidationException("VirtualCluster does not exist")
 
         self.virtual_clusters[cluster_id].state = "TERMINATED"
         return self.virtual_clusters[cluster_id]
 
-    def describe_virtual_cluster(self, cluster_id: str) -> dict[str, Any]:
+    def describe_virtual_cluster(self, cluster_id: str) -> VirtualCluster:
         if cluster_id not in self.virtual_clusters:
             raise ValidationException(f"Virtual cluster {cluster_id} doesn't exist.")
 
-        return self.virtual_clusters[cluster_id].to_dict()
+        return self.virtual_clusters[cluster_id]
 
     def list_virtual_clusters(
         self,
         container_provider_id: str,
         container_provider_type: str,
-        created_after: str,
-        created_before: str,
+        created_after: datetime,
+        created_before: datetime,
         states: Optional[list[str]],
-        max_results: int,
-        next_token: Optional[str],
-    ) -> tuple[list[dict[str, Any]], Optional[str]]:
-        virtual_clusters = [
-            virtual_cluster.to_dict()
-            for virtual_cluster in self.virtual_clusters.values()
-        ]
+    ) -> list[VirtualCluster]:
+        virtual_clusters = list(self.virtual_clusters.values())
 
         if container_provider_id:
             virtual_clusters = [
                 virtual_cluster
                 for virtual_cluster in virtual_clusters
-                if virtual_cluster["containerProvider"]["id"] == container_provider_id
+                if virtual_cluster.container_provider["id"] == container_provider_id
             ]
 
         if container_provider_type:
             virtual_clusters = [
                 virtual_cluster
                 for virtual_cluster in virtual_clusters
-                if virtual_cluster["containerProvider"]["type"]
-                == container_provider_type
+                if virtual_cluster.container_provider["type"] == container_provider_type
             ]
 
         if created_after:
             virtual_clusters = [
                 virtual_cluster
                 for virtual_cluster in virtual_clusters
-                if virtual_cluster["createdAt"] >= created_after
+                if virtual_cluster.created_at >= created_after
             ]
 
         if created_before:
             virtual_clusters = [
                 virtual_cluster
                 for virtual_cluster in virtual_clusters
-                if virtual_cluster["createdAt"] <= created_before
+                if virtual_cluster.created_at <= created_before
             ]
 
         if states:
             virtual_clusters = [
                 virtual_cluster
                 for virtual_cluster in virtual_clusters
-                if virtual_cluster["state"] in states
+                if virtual_cluster.state in states
             ]
-        sort_key = "name"
-        return paginated_list(virtual_clusters, sort_key, max_results, next_token)
+        return virtual_clusters
 
     def start_job_run(
         self,
@@ -276,7 +202,7 @@ class EMRContainersBackend(BaseBackend):
         job_driver: str,
         configuration_overrides: dict[str, Any],
         tags: dict[str, str],
-    ) -> FakeJob:
+    ) -> JobRun:
         if virtual_cluster_id not in self.virtual_clusters.keys():
             raise ResourceNotFoundException(
                 f"Virtual cluster {virtual_cluster_id} doesn't exist."
@@ -287,7 +213,7 @@ class EMRContainersBackend(BaseBackend):
         ):
             raise ResourceNotFoundException(f"Release {release_label} doesn't exist.")
 
-        job = FakeJob(
+        job_run = JobRun(
             name=name,
             virtual_cluster_id=virtual_cluster_id,
             client_token=client_token,
@@ -301,77 +227,76 @@ class EMRContainersBackend(BaseBackend):
             aws_partition=self.partition,
         )
 
-        self.jobs[job.id] = job
+        self.job_runs[job_run.id] = job_run
         self.job_count += 1
-        return job
+        return job_run
 
-    def cancel_job_run(self, job_id: str, virtual_cluster_id: str) -> FakeJob:
-        if not re.match(r"[a-z,A-Z,0-9]{19}", job_id):
+    def cancel_job_run(self, job_run_id: str, virtual_cluster_id: str) -> JobRun:
+        if not re.match(r"[a-z,A-Z,0-9]{19}", job_run_id):
             raise ValidationException("Invalid job run short id")
 
-        if job_id not in self.jobs.keys():
-            raise ResourceNotFoundException(f"Job run {job_id} doesn't exist.")
+        if job_run_id not in self.job_runs.keys():
+            raise ResourceNotFoundException(f"Job run {job_run_id} doesn't exist.")
 
-        if virtual_cluster_id != self.jobs[job_id].virtual_cluster_id:
-            raise ResourceNotFoundException(f"Job run {job_id} doesn't exist.")
+        if virtual_cluster_id != self.job_runs[job_run_id].virtual_cluster_id:
+            raise ResourceNotFoundException(f"Job run {job_run_id} doesn't exist.")
 
-        if self.jobs[job_id].state in [
+        if self.job_runs[job_run_id].state in [
             "FAILED",
             "CANCELLED",
             "CANCEL_PENDING",
             "COMPLETED",
         ]:
-            raise ValidationException(f"Job run {job_id} is not in a cancellable state")
+            raise ValidationException(
+                f"Job run {job_run_id} is not in a cancellable state"
+            )
 
-        job = self.jobs[job_id]
-        job.state = "CANCELLED"
-        job.finished_at = iso_8601_datetime_without_milliseconds(
-            datetime.today().replace(hour=0, minute=1, second=0, microsecond=0)
+        job_run = self.job_runs[job_run_id]
+        job_run.state = "CANCELLED"
+        job_run.finished_at = utcnow().replace(
+            hour=0, minute=1, second=0, microsecond=0
         )
-        job.state_details = "JobRun CANCELLED successfully."
+        job_run.state_details = "JobRun CANCELLED successfully."
 
-        return job
+        return job_run
 
     def list_job_runs(
         self,
         virtual_cluster_id: str,
-        created_before: str,
-        created_after: str,
+        created_before: datetime,
+        created_after: datetime,
         name: str,
         states: Optional[list[str]],
-        max_results: int,
-        next_token: Optional[str],
-    ) -> tuple[list[dict[str, Any]], Optional[str]]:
-        jobs = [job.to_dict() for job in self.jobs.values()]
+    ) -> list[JobRun]:
+        jobs = list(self.job_runs.values())
 
-        jobs = [job for job in jobs if job["virtualClusterId"] == virtual_cluster_id]
+        jobs = [job for job in jobs if job.virtual_cluster_id == virtual_cluster_id]
 
         if created_after:
-            jobs = [job for job in jobs if job["createdAt"] >= created_after]
+            jobs = [job for job in jobs if job.created_at >= created_after]
 
         if created_before:
-            jobs = [job for job in jobs if job["createdAt"] <= created_before]
+            jobs = [job for job in jobs if job.created_at <= created_before]
 
         if states:
-            jobs = [job for job in jobs if job["state"] in states]
+            jobs = [job for job in jobs if job.state in states]
 
         if name:
-            jobs = [job for job in jobs if job["name"] in name]
+            jobs = [job for job in jobs if job.name in name]
 
-        sort_key = "id"
-        return paginated_list(jobs, sort_key, max_results, next_token)
+        return jobs
 
-    def describe_job_run(self, job_id: str, virtual_cluster_id: str) -> dict[str, Any]:
-        if not re.match(r"[a-z,A-Z,0-9]{19}", job_id):
+    def describe_job_run(self, job_run_id: str, virtual_cluster_id: str) -> JobRun:
+        if not re.match(r"[a-z,A-Z,0-9]{19}", job_run_id):
             raise ValidationException("Invalid job run short id")
 
-        if job_id not in self.jobs.keys():
-            raise ResourceNotFoundException(f"Job run {job_id} doesn't exist.")
+        if job_run_id not in self.job_runs.keys():
+            raise ResourceNotFoundException(f"Job run {job_run_id} doesn't exist.")
 
-        if virtual_cluster_id != self.jobs[job_id].virtual_cluster_id:
-            raise ResourceNotFoundException(f"Job run {job_id} doesn't exist.")
+        if virtual_cluster_id != self.job_runs[job_run_id].virtual_cluster_id:
+            raise ResourceNotFoundException(f"Job run {job_run_id} doesn't exist.")
 
-        return self.jobs[job_id].to_dict()
+        return self.job_runs[job_run_id]
 
 
 emrcontainers_backends = BackendDict(EMRContainersBackend, "emr-containers")

--- a/moto/emrcontainers/responses.py
+++ b/moto/emrcontainers/responses.py
@@ -1,14 +1,9 @@
 """Handles incoming emrcontainers requests, invokes methods, returns responses."""
 
-import json
-
-from moto.core.common_types import TYPE_RESPONSE
-from moto.core.responses import BaseResponse
+from moto.core.responses import ActionResult, BaseResponse, PaginatedResult
 
 from .models import EMRContainersBackend, emrcontainers_backends
 
-DEFAULT_MAX_RESULTS = 100
-DEFAULT_NEXT_TOKEN = ""
 DEFAULT_CONTAINER_PROVIDER_TYPE = "EKS"
 
 
@@ -17,44 +12,47 @@ class EMRContainersResponse(BaseResponse):
 
     def __init__(self) -> None:
         super().__init__(service_name="emr-containers")
+        self.automated_parameter_parsing = True
 
     @property
     def emrcontainers_backend(self) -> EMRContainersBackend:
         """Return backend instance specific for this region."""
         return emrcontainers_backends[self.current_account][self.region]
 
-    def create_virtual_cluster(self) -> TYPE_RESPONSE:
+    def create_virtual_cluster(self) -> ActionResult:
         name = self._get_param("name")
         container_provider = self._get_param("containerProvider")
         client_token = self._get_param("clientToken")
         tags = self._get_param("tags")
-
         virtual_cluster = self.emrcontainers_backend.create_virtual_cluster(
             name=name,
             container_provider=container_provider,
             client_token=client_token,
             tags=tags,
         )
-        return 200, {}, json.dumps(dict(virtual_cluster))
+        result = {
+            "id": virtual_cluster.id,
+            "name": virtual_cluster.name,
+            "arn": virtual_cluster.arn,
+        }
+        return ActionResult(result)
 
-    def delete_virtual_cluster(self) -> TYPE_RESPONSE:
-        cluster_id = self._get_param("virtualClusterId")
-
+    def delete_virtual_cluster(self) -> ActionResult:
+        cluster_id = self._get_param("id")
         virtual_cluster = self.emrcontainers_backend.delete_virtual_cluster(
             cluster_id=cluster_id
         )
-        return 200, {}, json.dumps(dict(virtual_cluster))
+        return ActionResult({"id": virtual_cluster.id})
 
-    def describe_virtual_cluster(self) -> TYPE_RESPONSE:
-        cluster_id = self._get_param("virtualClusterId")
-
+    def describe_virtual_cluster(self) -> ActionResult:
+        cluster_id = self._get_param("id")
         virtual_cluster = self.emrcontainers_backend.describe_virtual_cluster(
             cluster_id=cluster_id
         )
-        response = {"virtualCluster": virtual_cluster}
-        return 200, {}, json.dumps(response)
+        result = {"virtualCluster": virtual_cluster}
+        return ActionResult(result)
 
-    def list_virtual_clusters(self) -> TYPE_RESPONSE:
+    def list_virtual_clusters(self) -> ActionResult:
         container_provider_id = self._get_param("containerProviderId")
         container_provider_type = self._get_param(
             "containerProviderType", DEFAULT_CONTAINER_PROVIDER_TYPE
@@ -62,23 +60,17 @@ class EMRContainersResponse(BaseResponse):
         created_after = self._get_param("createdAfter")
         created_before = self._get_param("createdBefore")
         states = self.querystring.get("states", [])
-        max_results = self._get_int_param("maxResults", DEFAULT_MAX_RESULTS)
-        next_token = self._get_param("nextToken", DEFAULT_NEXT_TOKEN)
-
-        virtual_clusters, next_token = self.emrcontainers_backend.list_virtual_clusters(
+        virtual_clusters = self.emrcontainers_backend.list_virtual_clusters(
             container_provider_id=container_provider_id,
             container_provider_type=container_provider_type,
             created_after=created_after,
             created_before=created_before,
             states=states,
-            max_results=max_results,
-            next_token=next_token,
         )
+        result = {"virtualClusters": virtual_clusters}
+        return PaginatedResult(result)
 
-        response = {"virtualClusters": virtual_clusters, "nextToken": next_token}
-        return 200, {}, json.dumps(response)
-
-    def start_job_run(self) -> TYPE_RESPONSE:
+    def start_job_run(self) -> ActionResult:
         name = self._get_param("name")
         virtual_cluster_id = self._get_param("virtualClusterId")
         client_token = self._get_param("clientToken")
@@ -87,8 +79,7 @@ class EMRContainersResponse(BaseResponse):
         job_driver = self._get_param("jobDriver")
         configuration_overrides = self._get_param("configurationOverrides")
         tags = self._get_param("tags")
-
-        job = self.emrcontainers_backend.start_job_run(
+        job_run = self.emrcontainers_backend.start_job_run(
             name=name,
             virtual_cluster_id=virtual_cluster_id,
             client_token=client_token,
@@ -98,46 +89,47 @@ class EMRContainersResponse(BaseResponse):
             configuration_overrides=configuration_overrides,
             tags=tags,
         )
-        return 200, {}, json.dumps(dict(job))
+        result = {
+            "id": job_run.id,
+            "name": job_run.name,
+            "arn": job_run.arn,
+            "virtualClusterId": job_run.virtual_cluster_id,
+        }
+        return ActionResult(result)
 
-    def cancel_job_run(self) -> TYPE_RESPONSE:
-        job_id = self._get_param("jobRunId")
+    def cancel_job_run(self) -> ActionResult:
+        job_run_id = self._get_param("id")
         virtual_cluster_id = self._get_param("virtualClusterId")
-
-        job = self.emrcontainers_backend.cancel_job_run(
-            job_id=job_id, virtual_cluster_id=virtual_cluster_id
+        job_run = self.emrcontainers_backend.cancel_job_run(
+            job_run_id=job_run_id, virtual_cluster_id=virtual_cluster_id
         )
-        return 200, {}, json.dumps(dict(job))
+        result = {
+            "id": job_run.id,
+            "virtualClusterId": job_run.virtual_cluster_id,
+        }
+        return ActionResult(result)
 
-    def list_job_runs(self) -> TYPE_RESPONSE:
+    def list_job_runs(self) -> ActionResult:
         virtual_cluster_id = self._get_param("virtualClusterId")
         created_before = self._get_param("createdBefore")
         created_after = self._get_param("createdAfter")
         name = self._get_param("name")
         states = self.querystring.get("states", [])
-        max_results = self._get_int_param("maxResults", DEFAULT_MAX_RESULTS)
-        next_token = self._get_param("nextToken", DEFAULT_NEXT_TOKEN)
-
-        job_runs, next_token = self.emrcontainers_backend.list_job_runs(
+        job_runs = self.emrcontainers_backend.list_job_runs(
             virtual_cluster_id=virtual_cluster_id,
             created_before=created_before,
             created_after=created_after,
             name=name,
             states=states,
-            max_results=max_results,
-            next_token=next_token,
         )
+        result = {"jobRuns": job_runs}
+        return PaginatedResult(result)
 
-        response = {"jobRuns": job_runs, "nextToken": next_token}
-        return 200, {}, json.dumps(response)
-
-    def describe_job_run(self) -> TYPE_RESPONSE:
-        job_id = self._get_param("jobRunId")
+    def describe_job_run(self) -> ActionResult:
+        job_run_id = self._get_param("id")
         virtual_cluster_id = self._get_param("virtualClusterId")
-
         job_run = self.emrcontainers_backend.describe_job_run(
-            job_id=job_id, virtual_cluster_id=virtual_cluster_id
+            job_run_id=job_run_id, virtual_cluster_id=virtual_cluster_id
         )
-
-        response = {"jobRun": job_run}
-        return 200, {}, json.dumps(response)
+        result = {"jobRun": job_run}
+        return ActionResult(result)

--- a/moto/emrcontainers/utils.py
+++ b/moto/emrcontainers/utils.py
@@ -1,6 +1,4 @@
-# import json
 import string
-from typing import Any, Optional
 
 from moto.moto_api._internal import mock_random as random
 
@@ -16,24 +14,3 @@ def random_cluster_id() -> str:
 
 def random_job_id() -> str:
     return random_id(size=19)
-
-
-def paginated_list(
-    full_list: list[Any], sort_key: str, max_results: int, next_token: Optional[str]
-) -> tuple[list[Any], Optional[str]]:
-    """
-    Returns a tuple containing a slice of the full list starting at next_token and ending with at most the max_results
-    number of elements, and the new next_token which can be passed back in for the next segment of the full list.
-    """
-    if next_token is None or not next_token:
-        next_token = 0  # type: ignore
-    next_token = int(next_token)  # type: ignore
-
-    sorted_list = sorted(full_list, key=lambda d: d[sort_key])
-
-    values = sorted_list[next_token : next_token + max_results]  # type: ignore
-    if len(values) == max_results:
-        new_next_token = str(next_token + max_results)  # type: ignore
-    else:
-        new_next_token = None
-    return values, new_next_token

--- a/moto/emrserverless/2021-07-13/paginators-1.moto-extras.json
+++ b/moto/emrserverless/2021-07-13/paginators-1.moto-extras.json
@@ -1,0 +1,13 @@
+{
+  "version": 1.0,
+  "merge": {
+    "pagination": {
+      "ListApplications": {
+        "unique_attribute": "id"
+      },
+      "ListJobRuns": {
+        "unique_attribute": "id"
+      }
+    }
+  }
+}

--- a/moto/emrserverless/models.py
+++ b/moto/emrserverless/models.py
@@ -1,15 +1,14 @@
 """EMRServerlessBackend class with methods for supported APIs."""
 
-import inspect
+from __future__ import annotations
+
 import re
-from collections.abc import Iterator
 from datetime import datetime
 from typing import Any, Optional, Union
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
-from moto.core.utils import iso_8601_datetime_without_milliseconds
-from moto.emrcontainers.utils import paginated_list
+from moto.core.utils import utcnow
 from moto.utilities.utils import get_partition
 
 from .exceptions import (
@@ -32,7 +31,7 @@ APPLICATION_STATUS = "STARTED"
 JOB_STATUS = "SUCCESS"
 
 
-class FakeApplication(BaseModel):
+class Application(BaseModel):
     def __init__(
         self,
         name: str,
@@ -46,12 +45,12 @@ class FakeApplication(BaseModel):
         tags: dict[str, str],
         auto_start_configuration: str,
         auto_stop_configuration: str,
-        network_configuration: str,
+        network_configuration: Optional[dict[str, Any]],
     ):
         # Provided parameters
         self.name = name
         self.release_label = release_label
-        self.application_type = application_type.capitalize()
+        self.type = application_type.capitalize()
         self.client_token = client_token
         self.initial_capacity = initial_capacity
         self.maximum_capacity = maximum_capacity
@@ -74,72 +73,11 @@ class FakeApplication(BaseModel):
         )
         self.state = APPLICATION_STATUS
         self.state_details = ""
-        self.created_at = iso_8601_datetime_without_milliseconds(
-            datetime.today().replace(hour=0, minute=0, second=0, microsecond=0)
-        )
+        self.created_at = utcnow().replace(hour=0, minute=0, second=0, microsecond=0)
         self.updated_at = self.created_at
 
-    def __iter__(self) -> Iterator[tuple[str, Any]]:
-        yield "applicationId", self.id
-        yield "name", self.name
-        yield "arn", self.arn
-        yield (
-            "autoStartConfig",
-            self.auto_start_configuration,
-        )
-        yield (
-            "autoStopConfig",
-            self.auto_stop_configuration,
-        )
 
-    def to_dict(self) -> dict[str, Any]:
-        """
-        Dictionary representation of an EMR Serverless Application.
-        When used in `list-applications`, capacity, auto-start/stop configs, and tags are not returned. https://docs.aws.amazon.com/emr-serverless/latest/APIReference/API_ListApplications.html
-        When used in `get-application`, more details are returned. https://docs.aws.amazon.com/emr-serverless/latest/APIReference/API_GetApplication.html#API_GetApplication_ResponseSyntax
-        """
-        caller_methods = inspect.stack()[1].function
-        caller_methods_type = caller_methods.split("_")[0]
-
-        if caller_methods_type in ["get", "update"]:
-            response = {
-                "applicationId": self.id,
-                "name": self.name,
-                "arn": self.arn,
-                "releaseLabel": self.release_label,
-                "type": self.application_type,
-                "state": self.state,
-                "stateDetails": self.state_details,
-                "createdAt": self.created_at,
-                "updatedAt": self.updated_at,
-                "autoStartConfiguration": self.auto_start_configuration,
-                "autoStopConfiguration": self.auto_stop_configuration,
-                "tags": self.tags,
-            }
-        else:
-            response = {
-                "id": self.id,
-                "name": self.name,
-                "arn": self.arn,
-                "releaseLabel": self.release_label,
-                "type": self.application_type,
-                "state": self.state,
-                "stateDetails": self.state_details,
-                "createdAt": self.created_at,
-                "updatedAt": self.updated_at,
-            }
-
-        if self.network_configuration:
-            response.update({"networkConfiguration": self.network_configuration})
-        if self.initial_capacity:
-            response.update({"initialCapacity": self.initial_capacity})
-        if self.maximum_capacity:
-            response.update({"maximumCapacity": self.maximum_capacity})
-
-        return response
-
-
-class FakeJobRun(BaseModel):
+class JobRun(BaseModel):
     def __init__(
         self,
         application_id: str,
@@ -184,10 +122,8 @@ class FakeJobRun(BaseModel):
 
         self.created_by: Optional[str] = None
 
-        self.created_at: str = iso_8601_datetime_without_milliseconds(
-            datetime.today().replace(hour=0, minute=0, second=0, microsecond=0)
-        )
-        self.updated_at: str = self.created_at
+        self.created_at = utcnow().replace(hour=0, minute=0, second=0, microsecond=0)
+        self.updated_at = self.created_at
 
         self.total_execution_duration_seconds: int = 0
         self.billed_resource_utilization: dict[str, float] = {
@@ -198,47 +134,6 @@ class FakeJobRun(BaseModel):
 
         self.tags = tags
 
-    def to_dict(self, caller_methods_type: str) -> dict[str, Any]:
-        # The response structure is different for get/update and list
-        if caller_methods_type in ["get", "update"]:
-            response = {
-                "applicationId": self.application_id,
-                "jobRunId": self.id,
-                "name": self.name,
-                "arn": self.arn,
-                "createdBy": self.created_by,
-                "createdAt": self.created_at,
-                "updatedAt": self.updated_at,
-                "executionRole": self.execution_role_arn,
-                "state": self.state,
-                "stateDetails": self.state_details,
-                "releaseLabel": self.release_label,
-                "configurationOverrides": self.configuration_overrides,
-                "jobDriver": self.job_driver,
-                "tags": self.tags,
-                "networkConfiguration": self.network_configuration,
-                "totalExecutionDurationSeconds": self.total_execution_duration_seconds,
-                "executionTimeoutMinutes": self.execution_timeout_minutes,
-                "billedResourceUtilization": self.billed_resource_utilization,
-            }
-        else:
-            response = {
-                "applicationId": self.application_id,
-                "id": self.id,
-                "name": self.name,
-                "arn": self.arn,
-                "createdBy": self.created_by,
-                "createdAt": self.created_at,
-                "updatedAt": self.updated_at,
-                "executionRole": self.execution_role_arn,
-                "state": self.state,
-                "stateDetails": self.state_details,
-                "releaseLabel": self.release_label,
-                "type": self.application_type,
-            }
-
-        return response
-
 
 class EMRServerlessBackend(BaseBackend):
     """Implementation of EMRServerless APIs."""
@@ -247,9 +142,9 @@ class EMRServerlessBackend(BaseBackend):
         super().__init__(region_name, account_id)
         self.region_name = region_name
         self.partition = get_partition(region_name)
-        self.applications: dict[str, FakeApplication] = {}
+        self.applications: dict[str, Application] = {}
         self.job_runs: dict[
-            str, list[FakeJobRun]
+            str, list[JobRun]
         ] = {}  # {application_id: [job_run1, job_run2]}
 
     def create_application(
@@ -263,8 +158,8 @@ class EMRServerlessBackend(BaseBackend):
         tags: dict[str, str],
         auto_start_configuration: str,
         auto_stop_configuration: str,
-        network_configuration: str,
-    ) -> FakeApplication:
+        network_configuration: Optional[dict[str, Any]],
+    ) -> Application:
         if application_type not in ["HIVE", "SPARK"]:
             raise ValidationException(f"Unsupported engine {application_type}")
 
@@ -273,7 +168,7 @@ class EMRServerlessBackend(BaseBackend):
                 f"Type '{application_type}' is not supported for release label '{release_label}' or release label does not exist"
             )
 
-        application = FakeApplication(
+        application = Application(
             name=name,
             release_label=release_label,
             application_type=application_type,
@@ -301,26 +196,21 @@ class EMRServerlessBackend(BaseBackend):
             )
         self.applications[application_id].state = "TERMINATED"
 
-    def get_application(self, application_id: str) -> dict[str, Any]:
+    def get_application(self, application_id: str) -> Application:
         if application_id not in self.applications.keys():
             raise ResourceNotFoundException(application_id)
 
-        return self.applications[application_id].to_dict()
+        return self.applications[application_id]
 
-    def list_applications(
-        self, next_token: Optional[str], max_results: int, states: Optional[list[str]]
-    ) -> tuple[list[dict[str, Any]], Optional[str]]:
-        applications = [
-            application.to_dict() for application in self.applications.values()
-        ]
+    def list_applications(self, states: Optional[list[str]]) -> list[Application]:
+        applications = list(self.applications.values())
         if states:
             applications = [
                 application
                 for application in applications
-                if application["state"] in states
+                if application.state in states
             ]
-        sort_key = "name"
-        return paginated_list(applications, sort_key, max_results, next_token)
+        return applications
 
     def start_application(self, application_id: str) -> None:
         if application_id not in self.applications.keys():
@@ -339,8 +229,8 @@ class EMRServerlessBackend(BaseBackend):
         maximum_capacity: Optional[str],
         auto_start_configuration: Optional[str],
         auto_stop_configuration: Optional[str],
-        network_configuration: Optional[str],
-    ) -> dict[str, Any]:
+        network_configuration: Optional[dict[str, Any]],
+    ) -> Application:
         if application_id not in self.applications.keys():
             raise ResourceNotFoundException(application_id)
 
@@ -371,13 +261,11 @@ class EMRServerlessBackend(BaseBackend):
                 application_id
             ].network_configuration = network_configuration
 
-        self.applications[
-            application_id
-        ].updated_at = iso_8601_datetime_without_milliseconds(
-            datetime.today().replace(hour=0, minute=0, second=0, microsecond=0)
+        self.applications[application_id].updated_at = utcnow().replace(
+            hour=0, minute=0, second=0, microsecond=0
         )
 
-        return self.applications[application_id].to_dict()
+        return self.applications[application_id]
 
     def start_job_run(
         self,
@@ -389,7 +277,7 @@ class EMRServerlessBackend(BaseBackend):
         tags: Optional[dict[str, str]],
         execution_timeout_minutes: Optional[int],
         name: Optional[str],
-    ) -> FakeJobRun:
+    ) -> JobRun:
         role_account_id = execution_role_arn.split(":")[4]
         if role_account_id != self.account_id:
             raise AccessDeniedException("Cross-account pass role is not allowed.")
@@ -397,24 +285,24 @@ class EMRServerlessBackend(BaseBackend):
         if execution_timeout_minutes and execution_timeout_minutes < 5:
             raise ValidationException("RunTimeout must be at least 5 minutes.")
 
-        application_resp = self.get_application(application_id)
-        job_run = FakeJobRun(
+        application = self.get_application(application_id)
+        job_run = JobRun(
             application_id=application_id,
             client_token=client_token,
             execution_role_arn=execution_role_arn,
             account_id=self.account_id,
             region_name=self.region_name,
-            release_label=application_resp["releaseLabel"],
-            application_type=application_resp["type"],
+            release_label=application.release_label,
+            application_type=application.type,
             job_driver=job_driver,
             configuration_overrides=configuration_overrides,
             tags=tags,
-            network_configuration=application_resp.get("networkConfiguration"),
+            network_configuration=application.network_configuration,
             execution_timeout_minutes=execution_timeout_minutes,
             name=name,
         )
 
-        if application_resp["state"] == "TERMINATED":
+        if application.state == "TERMINATED":
             raise ValidationException(
                 f"Application {application_id} is terminated. Cannot start job run."
             )
@@ -425,7 +313,7 @@ class EMRServerlessBackend(BaseBackend):
 
         return job_run
 
-    def get_job_run(self, application_id: str, job_run_id: str) -> FakeJobRun:
+    def get_job_run(self, application_id: str, job_run_id: str) -> JobRun:
         if application_id not in self.job_runs.keys():
             raise ResourceNotFoundException(application_id, "Application")
         job_run_ids = [job_run.id for job_run in self.job_runs[application_id]]
@@ -438,7 +326,7 @@ class EMRServerlessBackend(BaseBackend):
             if job_run.id == job_run_id
         ]
         assert len(filtered_job_runs) == 1
-        job_run: FakeJobRun = filtered_job_runs[0]
+        job_run: JobRun = filtered_job_runs[0]
 
         return job_run
 
@@ -457,12 +345,10 @@ class EMRServerlessBackend(BaseBackend):
     def list_job_runs(
         self,
         application_id: str,
-        max_results: int,
-        next_token: Optional[str],
-        created_at_after: Optional[str],
-        created_at_before: Optional[str],
+        created_at_after: Optional[datetime],
+        created_at_before: Optional[datetime],
         states: Optional[list[str]],
-    ) -> tuple[list[dict[str, Any]], Optional[str]]:
+    ) -> list[JobRun]:
         if application_id not in self.job_runs.keys():
             raise ResourceNotFoundException(application_id, "Application")
         job_runs = self.job_runs[application_id]
@@ -470,23 +356,16 @@ class EMRServerlessBackend(BaseBackend):
             job_runs = [job_run for job_run in job_runs if job_run.state in states]
         if created_at_after:
             job_runs = [
-                job_run
-                for job_run in job_runs
-                if datetime.strptime(job_run.created_at, "%Y-%m-%dT%H:%M:%SZ")
-                > datetime.strptime(created_at_after, "%Y-%m-%dT%H:%M:%SZ")
+                job_run for job_run in job_runs if job_run.created_at > created_at_after
             ]
         if created_at_before:
             job_runs = [
                 job_run
                 for job_run in job_runs
-                if datetime.strptime(job_run.created_at, "%Y-%m-%dT%H:%M:%SZ")
-                < datetime.strptime(created_at_before, "%Y-%m-%dT%H:%M:%SZ")
+                if job_run.created_at < created_at_before
             ]
 
-        job_run_dicts = [job_run.to_dict("list") for job_run in job_runs]
-
-        sort_key = "createdAt"
-        return paginated_list(job_run_dicts, sort_key, max_results, next_token)
+        return job_runs
 
 
 emrserverless_backends = BackendDict(EMRServerlessBackend, "emr-serverless")

--- a/moto/emrserverless/responses.py
+++ b/moto/emrserverless/responses.py
@@ -1,36 +1,8 @@
 """Handles incoming emrserverless requests, invokes methods, returns responses."""
 
-import json
-
-from moto.core.common_types import TYPE_RESPONSE
-from moto.core.responses import BaseResponse
+from moto.core.responses import ActionResult, BaseResponse, EmptyResult, PaginatedResult
 
 from .models import EMRServerlessBackend, emrserverless_backends
-
-DEFAULT_MAX_RESULTS = 100
-DEFAULT_NEXT_TOKEN = ""
-
-"""
-These are the available methods:
-    can_paginate()
-    cancel_job_run() -> DONE
-    close()
-    create_application() -> DONE
-    delete_application() -> DONE
-    get_application() -> DONE
-    get_job_run() -> DONE
-    get_paginator()
-    get_waiter()
-    list_applications() -> DONE
-    list_job_runs() -> DONE
-    list_tags_for_resource()
-    start_application() -> DONE
-    start_job_run() -> DONE
-    stop_application() -> DONE
-    tag_resource()
-    untag_resource()
-    update_application()
-"""
 
 
 class EMRServerlessResponse(BaseResponse):
@@ -38,13 +10,14 @@ class EMRServerlessResponse(BaseResponse):
 
     def __init__(self) -> None:
         super().__init__("emr-serverless")
+        self.automated_parameter_parsing = True
 
     @property
     def emrserverless_backend(self) -> EMRServerlessBackend:
         """Return backend instance specific for this region."""
         return emrserverless_backends[self.current_account][self.region]
 
-    def create_application(self) -> TYPE_RESPONSE:
+    def create_application(self) -> ActionResult:
         name = self._get_param("name")
         release_label = self._get_param("releaseLabel")
         application_type = self._get_param("type")
@@ -55,7 +28,6 @@ class EMRServerlessResponse(BaseResponse):
         auto_start_configuration = self._get_param("autoStartConfiguration")
         auto_stop_configuration = self._get_param("autoStopConfiguration")
         network_configuration = self._get_param("networkConfiguration")
-
         application = self.emrserverless_backend.create_application(
             name=name,
             release_label=release_label,
@@ -68,56 +40,64 @@ class EMRServerlessResponse(BaseResponse):
             auto_stop_configuration=auto_stop_configuration,
             network_configuration=network_configuration,
         )
-        return 200, {}, json.dumps(dict(application))
+        result = {
+            "applicationId": application.id,
+            "name": application.name,
+            "arn": application.arn,
+        }
+        return ActionResult(result)
 
-    def delete_application(self) -> TYPE_RESPONSE:
+    def delete_application(self) -> ActionResult:
         application_id = self._get_param("applicationId")
-
         self.emrserverless_backend.delete_application(application_id=application_id)
-        return 200, {}, ""
+        return EmptyResult()
 
-    def get_application(self) -> TYPE_RESPONSE:
+    def get_application(self) -> ActionResult:
         application_id = self._get_param("applicationId")
-
         application = self.emrserverless_backend.get_application(
             application_id=application_id
         )
         response = {"application": application}
-        return 200, {}, json.dumps(response)
+        return ActionResult(response)
 
-    def list_applications(self) -> TYPE_RESPONSE:
-        states = self.querystring.get("states", [])
-        max_results = self._get_int_param("maxResults", DEFAULT_MAX_RESULTS)
-        next_token = self._get_param("nextToken", DEFAULT_NEXT_TOKEN)
+    def list_applications(self) -> ActionResult:
+        states = self._get_param("states", [])
+        applications = self.emrserverless_backend.list_applications(states=states)
+        result = {
+            "applications": [
+                {
+                    "id": application.id,
+                    "name": application.name,
+                    "arn": application.arn,
+                    "releaseLabel": application.release_label,
+                    "type": application.type,
+                    "state": application.state,
+                    "stateDetails": application.state_details,
+                    "createdAt": application.created_at,
+                    "updatedAt": application.updated_at,
+                }
+                for application in applications
+            ]
+        }
+        return PaginatedResult(result)
 
-        applications, next_token = self.emrserverless_backend.list_applications(
-            next_token=next_token,
-            max_results=max_results,
-            states=states,
-        )
-        response = {"applications": applications, "nextToken": next_token}
-        return 200, {}, json.dumps(response)
-
-    def start_application(self) -> TYPE_RESPONSE:
+    def start_application(self) -> ActionResult:
         application_id = self._get_param("applicationId")
-
         self.emrserverless_backend.start_application(application_id=application_id)
-        return 200, {}, ""
+        return EmptyResult()
 
-    def stop_application(self) -> TYPE_RESPONSE:
+    def stop_application(self) -> ActionResult:
         application_id = self._get_param("applicationId")
-
         self.emrserverless_backend.stop_application(application_id=application_id)
-        return 200, {}, ""
+        return EmptyResult()
 
-    def update_application(self) -> TYPE_RESPONSE:
+    def update_application(self) -> ActionResult:
         application_id = self._get_param("applicationId")
         initial_capacity = self._get_param("initialCapacity")
         maximum_capacity = self._get_param("maximumCapacity")
         auto_start_configuration = self._get_param("autoStartConfiguration")
         auto_stop_configuration = self._get_param("autoStopConfiguration")
         network_configuration = self._get_param("networkConfiguration")
-
         application = self.emrserverless_backend.update_application(
             application_id=application_id,
             initial_capacity=initial_capacity,
@@ -127,13 +107,10 @@ class EMRServerlessResponse(BaseResponse):
             network_configuration=network_configuration,
         )
         response = {"application": application}
-        return 200, {}, json.dumps(response)
+        return ActionResult(response)
 
-    def start_job_run(self) -> TYPE_RESPONSE:
-        # params = self._get_params()
-        application_id = self._get_param(
-            "applicationId"
-        )  # params["application_id"] #.get()
+    def start_job_run(self) -> ActionResult:
+        application_id = self._get_param("applicationId")
         client_token = self._get_param("clientToken")
         execution_role_arn = self._get_param("executionRoleArn")
         job_driver = self._get_param("jobDriver")
@@ -151,54 +128,59 @@ class EMRServerlessResponse(BaseResponse):
             execution_timeout_minutes=execution_timeout_minutes,
             name=name,
         )
-        return (
-            200,
-            {},
-            json.dumps(
-                {
-                    "applicationId": job_run.application_id,
-                    "jobRunId": job_run.id,
-                    "arn": job_run.arn,
-                }
-            ),
+        return ActionResult(
+            {
+                "applicationId": job_run.application_id,
+                "jobRunId": job_run.id,
+                "arn": job_run.arn,
+            }
         )
 
-    def get_job_run(self) -> TYPE_RESPONSE:
+    def get_job_run(self) -> ActionResult:
         application_id = self._get_param("applicationId")
         job_run_id = self._get_param("jobRunId")
         job_run = self.emrserverless_backend.get_job_run(
             application_id=application_id, job_run_id=job_run_id
         )
-        # TODO: adjust response
-        return 200, {}, json.dumps({"jobRun": job_run.to_dict("get")})
+        return ActionResult({"jobRun": job_run})
 
-    def cancel_job_run(self) -> TYPE_RESPONSE:
+    def cancel_job_run(self) -> ActionResult:
         application_id = self._get_param("applicationId")
         job_run_id = self._get_param("jobRunId")
         application_id, job_run_id = self.emrserverless_backend.cancel_job_run(
             application_id=application_id,
             job_run_id=job_run_id,
         )
+        return ActionResult({"applicationId": application_id, "jobRunId": job_run_id})
 
-        return (
-            200,
-            {},
-            json.dumps({"applicationId": application_id, "jobRunId": job_run_id}),
-        )
-
-    def list_job_runs(self) -> TYPE_RESPONSE:
+    def list_job_runs(self) -> ActionResult:
         application_id = self._get_param("applicationId")
-        next_token = self._get_param("nextToken", DEFAULT_NEXT_TOKEN)
-        max_results = self._get_int_param("maxResults", DEFAULT_MAX_RESULTS)
         created_at_after = self._get_param("createdAtAfter")
         created_at_before = self._get_param("createdAtBefore")
-        states = self.querystring.get("states", [])
-        job_runs, next_token = self.emrserverless_backend.list_job_runs(
+        states = self._get_param("states", [])
+        job_runs = self.emrserverless_backend.list_job_runs(
             application_id=application_id,
-            next_token=next_token,
-            max_results=max_results,
             created_at_after=created_at_after,
             created_at_before=created_at_before,
             states=states,
         )
-        return 200, {}, json.dumps({"jobRuns": job_runs, "nextToken": next_token})
+        result = {
+            "jobRuns": [
+                {
+                    "applicationId": job_run.application_id,
+                    "id": job_run.id,
+                    "name": job_run.name,
+                    "arn": job_run.arn,
+                    "createdBy": job_run.created_by,
+                    "createdAt": job_run.created_at,
+                    "updatedAt": job_run.updated_at,
+                    "executionRole": job_run.execution_role_arn,
+                    "state": job_run.state,
+                    "stateDetails": job_run.state_details,
+                    "releaseLabel": job_run.release_label,
+                    "type": job_run.application_type,
+                }
+                for job_run in job_runs
+            ]
+        }
+        return PaginatedResult(result)

--- a/tests/test_emrcontainers/test_emrcontainers.py
+++ b/tests/test_emrcontainers/test_emrcontainers.py
@@ -1,14 +1,16 @@
 import re
-from datetime import datetime, timedelta, timezone
+from datetime import timedelta
 from unittest import SkipTest
 from unittest.mock import patch
 
 import boto3
 import pytest
 from botocore.exceptions import ClientError
+from dateutil.tz import tzutc
 
 from moto import mock_aws, settings
 from moto.core import DEFAULT_ACCOUNT_ID as ACCOUNT_ID
+from moto.core.utils import utcnow
 
 DEFAULT_REGION = "us-east-1"
 
@@ -177,9 +179,9 @@ class TestDescribeVirtualCluster:
                 "type": "EKS",
             },
             "createdAt": (
-                datetime.today()
+                utcnow()
                 .replace(hour=0, minute=0, second=0, microsecond=0)
-                .replace(tzinfo=timezone.utc)
+                .replace(tzinfo=tzutc())
             ),
             "id": self.virtual_cluster_ids[0],
             "name": "test-emr-virtual-cluster",
@@ -199,7 +201,7 @@ class TestDescribeVirtualCluster:
 
 
 class TestListVirtualClusters:
-    today = datetime.now()
+    today = utcnow()
     yesterday = today - timedelta(days=1)
     tomorrow = today + timedelta(days=1)
 
@@ -252,9 +254,15 @@ class TestListVirtualClusters:
     def test_next_token(self):
         resp = self.client.list_virtual_clusters(maxResults=2)
         assert len(resp["virtualClusters"]) == 2
+        assert "nextToken" in resp
 
         resp = self.client.list_virtual_clusters(nextToken=resp["nextToken"])
         assert len(resp["virtualClusters"]) == 2
+        assert "nextToken" not in resp
+
+        resp = self.client.list_virtual_clusters(maxResults=4)
+        assert len(resp["virtualClusters"]) == 4
+        assert "nextToken" not in resp
 
 
 class TestStartJobRun:
@@ -412,7 +420,7 @@ class TestCancelJobRun:
 
 
 class TestListJobRuns:
-    today = datetime.now()
+    today = utcnow()
     yesterday = today - timedelta(days=1)
     tomorrow = today + timedelta(days=1)
 
@@ -499,15 +507,15 @@ class TestDescribeJobRun:
                 f"/jobruns/{self.job_list[2]}"
             ),
             "createdAt": (
-                datetime.today()
+                utcnow()
                 .replace(hour=0, minute=0, second=0, microsecond=0)
-                .replace(tzinfo=timezone.utc)
+                .replace(tzinfo=tzutc())
             ),
             "executionRoleArn": f"arn:aws:iam::{ACCOUNT_ID}:role/iamrole-emrcontainers",
             "finishedAt": (
-                datetime.today()
+                utcnow()
                 .replace(hour=0, minute=1, second=0, microsecond=0)
-                .replace(tzinfo=timezone.utc)
+                .replace(tzinfo=tzutc())
             ),
             "id": self.job_list[2],
             "jobDriver": {

--- a/tests/test_emrserverless/test_emrserverless.py
+++ b/tests/test_emrserverless/test_emrserverless.py
@@ -2,15 +2,17 @@
 
 import re
 from contextlib import contextmanager
-from datetime import datetime, timezone
+from datetime import datetime
 from unittest.mock import patch
 
 import boto3
 import pytest
 from botocore.exceptions import ClientError
+from dateutil.tz import tzutc
 
 from moto import mock_aws, settings
 from moto.core import DEFAULT_ACCOUNT_ID as ACCOUNT_ID
+from moto.core.utils import utcnow
 from moto.emrserverless import REGION as DEFAULT_REGION
 from moto.emrserverless import RELEASE_LABEL as DEFAULT_RELEASE_LABEL
 
@@ -292,14 +294,14 @@ class TestGetApplication:
             "autoStopConfiguration": {"enabled": True, "idleTimeoutMinutes": 15},
             "tags": {},
             "createdAt": (
-                datetime.today()
+                utcnow()
                 .replace(hour=0, minute=0, second=0, microsecond=0)
-                .replace(tzinfo=timezone.utc)
+                .replace(tzinfo=tzutc())
             ),
             "updatedAt": (
-                datetime.today()
+                utcnow()
                 .replace(hour=0, minute=0, second=0, microsecond=0)
-                .replace(tzinfo=timezone.utc)
+                .replace(tzinfo=tzutc())
             ),
         }
         return {**response, **extra_configuration}
@@ -400,14 +402,14 @@ class TestListApplication:
             "state": "STARTED",
             "stateDetails": "",
             "createdAt": (
-                datetime.today()
+                utcnow()
                 .replace(hour=0, minute=0, second=0, microsecond=0)
-                .replace(tzinfo=timezone.utc)
+                .replace(tzinfo=tzutc())
             ),
             "updatedAt": (
-                datetime.today()
+                utcnow()
                 .replace(hour=0, minute=0, second=0, microsecond=0)
-                .replace(tzinfo=timezone.utc)
+                .replace(tzinfo=tzutc())
             ),
         }
 
@@ -516,14 +518,14 @@ class TestUpdateApplication:
             "autoStopConfiguration": {"enabled": True, "idleTimeoutMinutes": 15},
             "tags": {},
             "createdAt": (
-                datetime.today()
+                utcnow()
                 .replace(hour=0, minute=0, second=0, microsecond=0)
-                .replace(tzinfo=timezone.utc)
+                .replace(tzinfo=tzutc())
             ),
             "updatedAt": (
-                datetime.today()
+                utcnow()
                 .replace(hour=0, minute=0, second=0, microsecond=0)
-                .replace(tzinfo=timezone.utc)
+                .replace(tzinfo=tzutc())
             ),
         }
         return {**response, **extra_configuration}


### PR DESCRIPTION
This PR migrates the EMR Containers and EMR Serverless backends to the new request parsing/response serialization:

- **Response Handling**: Migrated from manual JSON serialization to `ActionResult` helpers
- **Model Class Renames**: `FakeCluster` → `VirtualCluster`, `FakeJob` → `JobRun` (align with AWS naming)
- **Removed Manual Serialization**: Removed `__iter__` and `to_dict()` methods; model now returns objects directly
- **Pagination**: Removed custom `paginated_list` function, now handled by core `PaginatedResult` helper
- **Date/Time Handling**: Replaced string formatted dates in the model with native Python `datetime` objects

Also adds a fix for the core data loader to ensure that Moto "extras" can still be found when Moto's data directory differs from Botocore's (e.g. `emr-containers` → `emrcontainers`).

Closes #9922
Supersedes and Closes #9923 



