### PR TITLE
EKS: fix ARN validation

### DIFF
--- a/moto/eks/utils.py
+++ b/moto/eks/utils.py
@@ -6,11 +6,16 @@ from moto.eks.exceptions import InvalidParameterException
 
 
 def validate_role_arn(arn: str) -> None:
+    valid_partitions = Session().get_available_partitions()
     valid_role_arn_format = re.compile(
         "arn:(?P<partition>.+):iam::(?P<account_id>[0-9]{12}):role/.+"
     )
     match = valid_role_arn_format.match(arn)
-    valid_partition = match.group("partition") in Session().get_available_partitions()  # type: ignore
-
-    if not all({arn, match, valid_partition}):
-        raise InvalidParameterException("Invalid Role Arn: '" + arn + "'")  # type: ignore
+    if not all(
+        [
+            arn,
+            match,
+            match.group("partition") in valid_partitions if match else False,
+        ]
+    ):
+        raise InvalidParameterException(message="Invalid Role Arn: '" + arn + "'")

--- a/tests/test_eks/test_eks.py
+++ b/tests/test_eks/test_eks.py
@@ -1599,3 +1599,13 @@ def test_update_nodegroup_config_nodegroup_not_found(ClusterBuilder):
             labels={"addOrUpdateLabels": {"key": "value"}},
         )
     assert_expected_exception(raised_exception, expected_exception, expected_msg)
+
+
+@mock_aws
+def test_invalid_arn_raises_exception():
+    eks = boto3.client("eks", "us-east-2")
+    with pytest.raises(ClientError, match=r"Invalid.*arn") as exc:
+        eks.create_cluster(
+            name="a", roleArn="arn:invalid:format", resourcesVpcConfig={}
+        )
+    assert exc.value.response["Error"]["Code"] == "InvalidParameterException"


### PR DESCRIPTION
The unhappy path here never had any test coverage and never would have worked as written due to a missing named argument.  This PR fixes the syntax, guards against `match is None`, removes the `# type: ignore` comments, and adds test coverage.

Closes #9920 
Supersedes and Closes #9921 