### PR TITLE
EC2: fix MAC address format

### DIFF
--- a/moto/ec2/utils.py
+++ b/moto/ec2/utils.py
@@ -297,7 +297,7 @@ def generate_dns_from_ip(ip: Any, dns_type: str = "internal") -> str:
 
 
 def random_mac_address() -> str:
-    return f"02:00:00:{random.randint(0, 255)}02x:{random.randint(0, 255)}02x:{random.randint(0, 255)}02x"
+    return f"02:00:00:{random.randint(0, 255):02x}:{random.randint(0, 255):02x}:{random.randint(0, 255):02x}"
 
 
 def randor_ipv4_cidr() -> str:

--- a/tests/test_ec2/test_elastic_network_interfaces.py
+++ b/tests/test_ec2/test_elastic_network_interfaces.py
@@ -38,6 +38,7 @@ def test_elastic_network_interfaces():
     assert eni["RequesterManaged"] is False
     assert eni["PrivateIpAddresses"][0]["PrivateIpAddress"].startswith("10.") is True
     assert "Association" not in eni
+    assert len(eni["MacAddress"]) == 17
 
     with pytest.raises(ClientError) as ex:
         ec2client.delete_network_interface(NetworkInterfaceId=eni_id, DryRun=True)


### PR DESCRIPTION
## Description

Fixes #9977

The `random_mac_address()` function in `moto/ec2/utils.py` had a format string bug where `{random.randint(0, 255)}02x` was missing the colon before `02x` in the format spec.

**Before:**
```
02:00:00:18302x:13202x:9302x
```

**After:**
```
02:00:00:12:34:56
```

The fix adds the missing `:` to make the format specifier `:02x` (zero-padded 2-digit hex), producing valid MAC addresses.

## Changes
- `moto/ec2/utils.py`: Fixed f-string format in `random_mac_address()` function

## Testing
Verified that the generated MAC addresses are valid (6 colon-separated hex pairs, each 2 digits).

Note: I also noticed a typo in a nearby function name `randor_ipv4_cidr` → should be `random_ipv4_cidr`. Happy to fix that in a separate PR if desired.