### PR TITLE
Core: align service names with Botocore

### DIFF
--- a/moto/acmpca/responses.py
+++ b/moto/acmpca/responses.py
@@ -13,7 +13,7 @@ class ACMPCAResponse(BaseResponse):
     """Handler for ACMPCA requests and responses."""
 
     def __init__(self) -> None:
-        super().__init__(service_name="acmpca")
+        super().__init__(service_name="acm-pca")
 
     @property
     def acmpca_backend(self) -> ACMPCABackend:

--- a/moto/ce/responses.py
+++ b/moto/ce/responses.py
@@ -10,6 +10,9 @@ from .models import CostExplorerBackend, ce_backends
 class CostExplorerResponse(BaseResponse):
     """Handler for CostExplorer requests and responses."""
 
+    def __init__(self) -> None:
+        super().__init__(service_name="ce")
+
     @property
     def ce_backend(self) -> CostExplorerBackend:
         """Return backend instance specific for this region."""

--- a/moto/codebuild/responses.py
+++ b/moto/codebuild/responses.py
@@ -97,6 +97,9 @@ def _validate_required_params_id(build_id: str, build_ids: list[str]) -> None:
 
 
 class CodeBuildResponse(BaseResponse):
+    def __init__(self) -> None:
+        super().__init__(service_name="codebuild")
+
     @property
     def codebuild_backend(self) -> CodeBuildBackend:
         return codebuild_backends[self.current_account][self.region]

--- a/moto/ec2instanceconnect/responses.py
+++ b/moto/ec2instanceconnect/responses.py
@@ -5,7 +5,7 @@ from .models import Ec2InstanceConnectBackend, ec2instanceconnect_backends
 
 class Ec2InstanceConnectResponse(BaseResponse):
     def __init__(self) -> None:
-        super().__init__(service_name="ec2-instanceconnect")
+        super().__init__(service_name="ec2-instance-connect")
 
     @property
     def ec2instanceconnect_backend(self) -> Ec2InstanceConnectBackend:

--- a/moto/meteringmarketplace/responses.py
+++ b/moto/meteringmarketplace/responses.py
@@ -6,6 +6,9 @@ from .models import MeteringMarketplaceBackend, meteringmarketplace_backends
 
 
 class MarketplaceMeteringResponse(BaseResponse):
+    def __init__(self) -> None:
+        super().__init__(service_name="meteringmarketplace")
+
     @property
     def backend(self) -> MeteringMarketplaceBackend:
         return meteringmarketplace_backends[self.current_account][self.region]

--- a/moto/networkfirewall/responses.py
+++ b/moto/networkfirewall/responses.py
@@ -11,7 +11,7 @@ class NetworkFirewallResponse(BaseResponse):
     """Handler for NetworkFirewall requests and responses."""
 
     def __init__(self) -> None:
-        super().__init__(service_name="networkfirewall")
+        super().__init__(service_name="network-firewall")
 
     @property
     def networkfirewall_backend(self) -> NetworkFirewallBackend:

--- a/moto/route53domains/responses.py
+++ b/moto/route53domains/responses.py
@@ -8,7 +8,7 @@ from moto.route53domains.validators import Route53Domain, Route53DomainsOperatio
 
 class Route53DomainsResponse(BaseResponse):
     def __init__(self) -> None:
-        super().__init__(service_name="route53-domains")
+        super().__init__(service_name="route53domains")
 
     @property
     def route53domains_backend(self) -> Route53DomainsBackend:

--- a/moto/route53resolver/responses.py
+++ b/moto/route53resolver/responses.py
@@ -14,7 +14,7 @@ class Route53ResolverResponse(BaseResponse):
     """Handler for Route53Resolver requests and responses."""
 
     def __init__(self) -> None:
-        super().__init__(service_name="route53-resolver")
+        super().__init__(service_name="route53resolver")
 
     @property
     def route53resolver_backend(self) -> Route53ResolverBackend:


### PR DESCRIPTION
This is a prerequisite for opting service backends into the new [automated parameter parsing](https://github.com/getmoto/moto/issues/9073).