### PR TITLE
feat(logs): implement start_live_tail

### DIFF
--- a/docs/docs/services/logs.rst
+++ b/docs/docs/services/logs.rst
@@ -146,7 +146,7 @@ logs
 - [X] put_retention_policy
 - [X] put_subscription_filter
 - [ ] put_transformer
-- [ ] start_live_tail
+- [X] start_live_tail
 - [X] start_query
 - [ ] stop_query
 - [X] tag_log_group
@@ -159,4 +159,3 @@ logs
 - [ ] update_delivery_configuration
 - [ ] update_log_anomaly_detector
 - [ ] update_scheduled_query
-

--- a/moto/backend_index.py
+++ b/moto/backend_index.py
@@ -133,6 +133,8 @@ backend_url_patterns = [
     ("lexv2models", re.compile("https?://lex\\.(.+)\\.amazonaws\\.com")),
     ("lexv2models", re.compile("https?://models-v2-lex\\.(.+)\\.amazonaws\\.com")),
     ("logs", re.compile("https?://logs\\.(.+)\\.amazonaws\\.com")),
+    ("logs", re.compile("https?://stream-logs\\.(.+)\\.amazonaws\\.com")),
+    ("logs", re.compile("https?://streaming-logs\\.(.+)\\.amazonaws\\.com")),
     ("macie2", re.compile("https?://macie2\\.(.+)\\.amazonaws\\.com")),
     (
         "managedblockchain",

--- a/moto/logs/models.py
+++ b/moto/logs/models.py
@@ -1161,6 +1161,69 @@ class LogsBackend(BaseBackend):
             log_stream_name, start_time, end_time, limit, next_token, start_from_head
         )
 
+    def start_live_tail(
+        self,
+        log_group_identifiers: list[str],
+        log_stream_names: Optional[list[str]],
+        log_stream_name_prefixes: Optional[list[str]],
+        log_event_filter_pattern: Optional[str],
+    ) -> tuple[dict[str, Any], dict[str, Any]]:
+        if len(log_group_identifiers) > 10:
+            raise InvalidParameterException(
+                msg="1 validation error detected: Value at 'logGroupIdentifiers' failed "
+                "to satisfy constraint: Member must have length less than or equal to 10"
+            )
+        if log_stream_names and log_stream_name_prefixes:
+            raise InvalidParameterException(
+                msg="Only one of logStreamNames or logStreamNamePrefixes can be provided."
+            )
+        if (log_stream_names or log_stream_name_prefixes) and len(log_group_identifiers) != 1:
+            raise InvalidParameterException(
+                msg="logStreamNames and logStreamNamePrefixes can only be used with a single log group."
+            )
+
+        log_groups = [
+            self._find_live_tail_log_group(log_group_identifier)
+            for log_group_identifier in log_group_identifiers
+        ]
+
+        stream_results: list[dict[str, Any]] = []
+        event_filter = EventMessageFilter(log_event_filter_pattern or "")
+        for log_group in log_groups:
+            matching_streams = self._get_live_tail_streams(
+                log_group,
+                log_stream_names=log_stream_names or [],
+                log_stream_name_prefixes=log_stream_name_prefixes or [],
+            )
+            for log_stream in matching_streams:
+                for event in log_stream.events:
+                    if event_filter.matches(event.message):
+                        stream_results.append(
+                            {
+                                "ingestionTime": event.ingestion_time,
+                                "logGroupIdentifier": log_group.arn,
+                                "logStreamName": log_stream.log_stream_name,
+                                "message": event.message,
+                                "timestamp": event.timestamp,
+                            }
+                        )
+
+        stream_results = sorted(stream_results, key=lambda event: event["timestamp"])
+        sampled = len(stream_results) > 500
+        session_update = {
+            "sessionMetadata": {"sampled": sampled},
+            "sessionResults": stream_results[:500],
+        }
+        session_start = {
+            "requestId": str(mock_random.uuid4()),
+            "sessionId": str(mock_random.uuid4()),
+            "logGroupIdentifiers": [log_group.arn for log_group in log_groups],
+            "logStreamNames": log_stream_names or [],
+            "logStreamNamePrefixes": log_stream_name_prefixes or [],
+            "logEventFilterPattern": log_event_filter_pattern or "",
+        }
+        return session_start, session_update
+
     def filter_log_events(
         self,
         log_group_name: str,
@@ -1527,6 +1590,33 @@ class LogsBackend(BaseBackend):
         if not log_group:
             raise ResourceNotFoundException()
         return log_group
+
+    def _find_live_tail_log_group(self, log_group_identifier: str) -> LogGroup:
+        if log_group_identifier in self.groups:
+            return self.groups[log_group_identifier]
+        return self._find_log_group(log_group_id=log_group_identifier)
+
+    @staticmethod
+    def _get_live_tail_streams(
+        log_group: LogGroup,
+        log_stream_names: list[str],
+        log_stream_name_prefixes: list[str],
+    ) -> list[LogStream]:
+        streams = list(log_group.streams.values())
+        if log_stream_names:
+            return [
+                stream for stream in streams if stream.log_stream_name in log_stream_names
+            ]
+        if log_stream_name_prefixes:
+            return [
+                stream
+                for stream in streams
+                if any(
+                    stream.log_stream_name.startswith(prefix)
+                    for prefix in log_stream_name_prefixes
+                )
+            ]
+        return streams
 
     def put_delivery_destination(
         self,

--- a/moto/logs/models.py
+++ b/moto/logs/models.py
@@ -1177,7 +1177,9 @@ class LogsBackend(BaseBackend):
             raise InvalidParameterException(
                 msg="Only one of logStreamNames or logStreamNamePrefixes can be provided."
             )
-        if (log_stream_names or log_stream_name_prefixes) and len(log_group_identifiers) != 1:
+        if (log_stream_names or log_stream_name_prefixes) and len(
+            log_group_identifiers
+        ) != 1:
             raise InvalidParameterException(
                 msg="logStreamNames and logStreamNamePrefixes can only be used with a single log group."
             )
@@ -1605,7 +1607,9 @@ class LogsBackend(BaseBackend):
         streams = list(log_group.streams.values())
         if log_stream_names:
             return [
-                stream for stream in streams if stream.log_stream_name in log_stream_names
+                stream
+                for stream in streams
+                if stream.log_stream_name in log_stream_names
             ]
         if log_stream_name_prefixes:
             return [

--- a/moto/logs/responses.py
+++ b/moto/logs/responses.py
@@ -7,6 +7,7 @@ from moto.core.responses import BaseResponse
 
 from .exceptions import InvalidParameterException
 from .models import LogsBackend, logs_backends
+from .utils import serialize_start_live_tail
 
 # See http://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/Welcome.html
 
@@ -333,6 +334,23 @@ class LogsResponse(BaseResponse):
                 "nextToken": next_token,
                 "searchedLogStreams": searched_streams,
             }
+        )
+
+    def start_live_tail(self) -> tuple[bytes, dict[str, str]]:
+        log_group_identifiers = self._get_param("logGroupIdentifiers")
+        log_stream_names = self._get_param("logStreamNames")
+        log_stream_name_prefixes = self._get_param("logStreamNamePrefixes")
+        log_event_filter_pattern = self._get_param("logEventFilterPattern")
+
+        session_start, session_update = self.logs_backend.start_live_tail(
+            log_group_identifiers=log_group_identifiers,
+            log_stream_names=log_stream_names,
+            log_stream_name_prefixes=log_stream_name_prefixes,
+            log_event_filter_pattern=log_event_filter_pattern,
+        )
+        return (
+            serialize_start_live_tail(session_start, session_update),
+            {"content-type": "application/vnd.amazon.eventstream"},
         )
 
     def put_retention_policy(self) -> str:

--- a/moto/logs/urls.py
+++ b/moto/logs/urls.py
@@ -1,5 +1,9 @@
 from .responses import LogsResponse
 
-url_bases = [r"https?://logs\.(.+)\.amazonaws\.com"]
+url_bases = [
+    r"https?://logs\.(.+)\.amazonaws\.com",
+    r"https?://stream-logs\.(.+)\.amazonaws\.com",
+    r"https?://streaming-logs\.(.+)\.amazonaws\.com",
+]
 
 url_paths = {"{0}/$": LogsResponse.dispatch}

--- a/moto/logs/utils.py
+++ b/moto/logs/utils.py
@@ -1,3 +1,8 @@
+import binascii
+import json
+import struct
+from typing import Any, Optional
+
 PAGINATION_MODEL = {
     "describe_log_groups": {
         "input_token": "next_token",
@@ -57,3 +62,39 @@ class EventMessageFilter:
 
     def matches(self, message: str) -> bool:
         return self.filter_type.matches(message)  # type: ignore
+
+
+def _create_event_stream_header(key: bytes, value: bytes) -> bytes:
+    return struct.pack("b", len(key)) + key + struct.pack("!bh", 7, len(value)) + value
+
+
+def _create_event_stream_message(event_type: bytes, payload: bytes) -> bytes:
+    headers = _create_event_stream_header(b":message-type", b"event")
+    headers += _create_event_stream_header(b":event-type", event_type)
+    headers += _create_event_stream_header(b":content-type", b"application/json")
+
+    headers_length = struct.pack("!I", len(headers))
+    total_length = struct.pack("!I", len(payload) + len(headers) + 16)
+    prelude = total_length + headers_length
+
+    prelude_crc = struct.pack("!I", binascii.crc32(prelude))
+    message_crc = struct.pack(
+        "!I", binascii.crc32(prelude + prelude_crc + headers + payload)
+    )
+
+    return prelude + prelude_crc + headers + payload + message_crc
+
+
+def serialize_start_live_tail(
+    session_start: dict[str, Any], session_update: dict[str, Any]
+) -> bytes:
+    """Serialize a minimal CloudWatch Logs StartLiveTail event stream."""
+    return (
+        _create_event_stream_message(b"initial-response", b"{}")
+        + _create_event_stream_message(
+            b"sessionStart", json.dumps(session_start).encode("utf-8")
+        )
+        + _create_event_stream_message(
+            b"sessionUpdate", json.dumps(session_update).encode("utf-8")
+        )
+    )

--- a/moto/logs/utils.py
+++ b/moto/logs/utils.py
@@ -1,7 +1,7 @@
 import binascii
 import json
 import struct
-from typing import Any, Optional
+from typing import Any
 
 PAGINATION_MODEL = {
     "describe_log_groups": {

--- a/tests/test_logs/test_logs.py
+++ b/tests/test_logs/test_logs.py
@@ -1674,3 +1674,49 @@ def test_delete_delivery_source():
         client.delete_delivery_source(name="foobar")
     err = ex.value.response["Error"]
     assert err["Code"] == "ResourceNotFoundException"
+
+
+@mock_aws
+def test_start_live_tail_returns_session_events():
+    client = boto3.client("logs", TEST_REGION)
+    now = int(unix_time_millis())
+    client.create_log_group(logGroupName="live-tail-group")
+    client.create_log_stream(
+        logGroupName="live-tail-group", logStreamName="application-stream"
+    )
+    client.put_log_events(
+        logGroupName="live-tail-group",
+        logStreamName="application-stream",
+        logEvents=[
+            {"timestamp": now, "message": "info startup complete"},
+            {"timestamp": now + 1, "message": "error unable to connect"},
+        ],
+    )
+
+    log_group = client.describe_log_groups(logGroupNamePrefix="live-tail-group")[
+        "logGroups"
+    ][0]
+    response = client.start_live_tail(
+        logGroupIdentifiers=[log_group["logGroupArn"]],
+        logStreamNames=["application-stream"],
+        logEventFilterPattern="error",
+    )
+
+    event_stream = iter(response["responseStream"])
+    session_start = next(event_stream)
+    session_update = next(event_stream)
+
+    assert session_start["sessionStart"]["logGroupIdentifiers"] == [
+        log_group["logGroupArn"]
+    ]
+    assert session_start["sessionStart"]["logStreamNames"] == ["application-stream"]
+    assert session_update["sessionUpdate"]["sessionMetadata"] == {"sampled": False}
+    assert len(session_update["sessionUpdate"]["sessionResults"]) == 1
+    result = session_update["sessionUpdate"]["sessionResults"][0]
+    assert result["ingestionTime"] > 0
+    assert result["logGroupIdentifier"] == log_group["logGroupArn"]
+    assert result["logStreamName"] == "application-stream"
+    assert result["message"] == "error unable to connect"
+    assert result["timestamp"] == now + 1
+    with pytest.raises(StopIteration):
+        next(event_stream)

--- a/tests/test_logs/test_logs.py
+++ b/tests/test_logs/test_logs.py
@@ -1720,3 +1720,79 @@ def test_start_live_tail_returns_session_events():
     assert result["timestamp"] == now + 1
     with pytest.raises(StopIteration):
         next(event_stream)
+
+
+@mock_aws
+def test_start_live_tail_rejects_more_than_ten_log_groups():
+    client = boto3.client("logs", TEST_REGION)
+    log_group_arns = []
+    for index in range(11):
+        log_group_name = f"live-tail-group-{index}"
+        client.create_log_group(logGroupName=log_group_name)
+        log_group_arns.append(
+            client.describe_log_groups(logGroupNamePrefix=log_group_name)["logGroups"][
+                0
+            ]["logGroupArn"]
+        )
+
+    with pytest.raises(ClientError) as exc:
+        client.start_live_tail(logGroupIdentifiers=log_group_arns)
+
+    error = exc.value.response["Error"]
+    assert error["Code"] == "InvalidParameterException"
+    assert (
+        error["Message"]
+        == "1 validation error detected: Value at 'logGroupIdentifiers' failed to satisfy constraint: Member must have length less than or equal to 10"
+    )
+
+
+@mock_aws
+def test_start_live_tail_rejects_stream_names_and_prefixes_together():
+    client = boto3.client("logs", TEST_REGION)
+    client.create_log_group(logGroupName="live-tail-group")
+    client.create_log_stream(
+        logGroupName="live-tail-group", logStreamName="application-stream"
+    )
+    log_group = client.describe_log_groups(logGroupNamePrefix="live-tail-group")[
+        "logGroups"
+    ][0]
+
+    with pytest.raises(ClientError) as exc:
+        client.start_live_tail(
+            logGroupIdentifiers=[log_group["logGroupArn"]],
+            logStreamNames=["application-stream"],
+            logStreamNamePrefixes=["application"],
+        )
+
+    error = exc.value.response["Error"]
+    assert error["Code"] == "InvalidParameterException"
+    assert (
+        error["Message"]
+        == "Only one of logStreamNames or logStreamNamePrefixes can be provided."
+    )
+
+
+@mock_aws
+def test_start_live_tail_rejects_stream_filters_with_multiple_log_groups():
+    client = boto3.client("logs", TEST_REGION)
+    log_group_arns = []
+    for log_group_name in ("live-tail-group-a", "live-tail-group-b"):
+        client.create_log_group(logGroupName=log_group_name)
+        log_group_arns.append(
+            client.describe_log_groups(logGroupNamePrefix=log_group_name)["logGroups"][
+                0
+            ]["logGroupArn"]
+        )
+
+    with pytest.raises(ClientError) as exc:
+        client.start_live_tail(
+            logGroupIdentifiers=log_group_arns,
+            logStreamNamePrefixes=["application"],
+        )
+
+    error = exc.value.response["Error"]
+    assert error["Code"] == "InvalidParameterException"
+    assert (
+        error["Message"]
+        == "logStreamNames and logStreamNamePrefixes can only be used with a single log group."
+    )


### PR DESCRIPTION
## Description
Implements `start_live_tail` for CloudWatch Logs.

This adds a minimal event-stream response with an initial response frame followed by `sessionStart` and `sessionUpdate` events, wires the Logs backend to the host-prefixed live-tail endpoints, and includes a boto3-facing test covering the happy path.

Fixes #9656

## Validation
- `./.venv/bin/python -m pytest tests/test_logs/test_logs.py -q`