### PR TITLE
[SWF] - Adding SWF Domain tagging support

### DIFF
--- a/moto/resourcegroupstaggingapi/models.py
+++ b/moto/resourcegroupstaggingapi/models.py
@@ -1199,10 +1199,16 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
                 yield {"ResourceARN": state_machine.arn, "Tags": tags}
 
         # SWF
-        if not resource_type_filters or "swf" in resource_type_filters or "swf:domain" in resource_type_filters:
+        if (
+            not resource_type_filters
+            or "swf" in resource_type_filters
+            or "swf:domain" in resource_type_filters
+        ):
             for domain in self.swf_backend.domains:
                 domain_arn = domain.to_short_dict()["arn"]
-                tags = self.swf_backend.tagger.list_tags_for_resource(domain_arn)["Tags"]
+                tags = self.swf_backend.tagger.list_tags_for_resource(domain_arn)[
+                    "Tags"
+                ]
                 if not tags or not tag_filter(tags):
                     continue
                 yield {"ResourceARN": domain_arn, "Tags": tags}

--- a/moto/resourcegroupstaggingapi/models.py
+++ b/moto/resourcegroupstaggingapi/models.py
@@ -58,6 +58,7 @@ from moto.sqs.models import SQSBackend, sqs_backends
 from moto.ssm.models import SimpleSystemManagerBackend, ssm_backends
 from moto.ssm.utils import parameter_arn
 from moto.stepfunctions.models import StepFunctionBackend, stepfunctions_backends
+from moto.swf.models import SWFBackend, swf_backends
 from moto.utilities.tagging_service import TaggingService
 from moto.utilities.utils import get_partition
 from moto.vpclattice.models import VPCLatticeBackend, vpclattice_backends
@@ -251,6 +252,10 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
     @property
     def cloudfront_backend(self) -> CloudFrontBackend:
         return cloudfront_backends[self.account_id][self.partition]
+
+    @property
+    def swf_backend(self) -> SWFBackend:
+        return swf_backends[self.account_id][self.region_name]
 
     @property
     def cloudwatch_backend(self) -> CloudWatchBackend:
@@ -1193,6 +1198,15 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
                     continue
                 yield {"ResourceARN": state_machine.arn, "Tags": tags}
 
+        # SWF
+        if not resource_type_filters or "swf" in resource_type_filters or "swf:domain" in resource_type_filters:
+            for domain in self.swf_backend.domains:
+                domain_arn = domain.to_short_dict()["arn"]
+                tags = self.swf_backend.tagger.list_tags_for_resource(domain_arn)["Tags"]
+                if not tags or not tag_filter(tags):
+                    continue
+                yield {"ResourceARN": domain_arn, "Tags": tags}
+
         # VPC Lattice
         if not resource_type_filters or "vpc-lattice" in resource_type_filters:
             # Service
@@ -1727,7 +1741,7 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
         self, resource_arns: list[str], tags: dict[str, str]
     ) -> dict[str, dict[str, Any]]:
         """
-        Only CloudFront, DynamoDB, EFS, Elasticache, Lambda Logs, Quicksight RDS, SageMaker, and SES resources are currently supported
+        Only CloudFront, DynamoDB, EFS, Elasticache, Lambda, Logs, Quicksight, RDS, SageMaker, SES, and SWF resources are currently supported
         """
         missing_resources = []
         missing_error: dict[str, Any] = {
@@ -1791,6 +1805,10 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
                 self.cloudfront_backend.tag_resource(
                     arn, TaggingService.convert_dict_to_tags_input(tags)
                 )
+            elif arn.startswith(f"arn:{get_partition(self.region_name)}:swf:"):
+                self.swf_backend.tagger.tag_resource(
+                    arn, TaggingService.convert_dict_to_tags_input(tags)
+                )
             else:
                 missing_resources.append(arn)
         return dict.fromkeys(missing_resources, missing_error)
@@ -1799,7 +1817,7 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
         self, resource_arn_list: list[str], tag_keys: list[str]
     ) -> dict[str, dict[str, Any]]:
         """
-        Only CloudFront, EFS, Elasticache, Lambda, Quicksight, and SES resources are currently supported
+        Only CloudFront, EFS, Elasticache, Lambda, Quicksight, SES, and SWF resources are currently supported
         """
         missing_resources = []
         missing_error: dict[str, Any] = {
@@ -1827,6 +1845,8 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
                 self.sesv2_backend.untag_resource(arn, tag_keys)
             elif arn.startswith(f"arn:{get_partition(self.region_name)}:cloudfront:"):
                 self.cloudfront_backend.untag_resource(arn, tag_keys)
+            elif arn.startswith(f"arn:{get_partition(self.region_name)}:swf:"):
+                self.swf_backend.tagger.untag_resource_using_names(arn, tag_keys)
             else:
                 missing_resources.append(arn)
 

--- a/moto/swf/models/__init__.py
+++ b/moto/swf/models/__init__.py
@@ -126,7 +126,6 @@ class SWFBackend(BaseBackend):
         if tags:
             self.tagger.tag_resource(domain.to_short_dict()["arn"], tags)
 
-
     def deprecate_domain(self, name: str) -> None:
         domain = self._get_domain(name)
         if domain.status == "DEPRECATED":

--- a/moto/swf/models/__init__.py
+++ b/moto/swf/models/__init__.py
@@ -2,6 +2,7 @@ from time import sleep
 from typing import Any, Optional
 
 from moto.core.base_backend import BackendDict, BaseBackend
+from moto.utilities.tagging_service import TaggingService
 
 from ..exceptions import (
     SWFDomainAlreadyExistsFault,
@@ -29,6 +30,7 @@ class SWFBackend(BaseBackend):
     def __init__(self, region_name: str, account_id: str):
         super().__init__(region_name, account_id)
         self.domains: list[Domain] = []
+        self.tagger = TaggingService()
 
     def _get_domain(self, name: str, ignore_empty: bool = False) -> Domain:
         matching = [domain for domain in self.domains if domain.name == name]
@@ -109,6 +111,7 @@ class SWFBackend(BaseBackend):
         name: str,
         workflow_execution_retention_period_in_days: int,
         description: Optional[str] = None,
+        tags: Optional[list[dict[str, str]]] = None,
     ) -> None:
         if self._get_domain(name, ignore_empty=True):
             raise SWFDomainAlreadyExistsFault(name)
@@ -120,6 +123,9 @@ class SWFBackend(BaseBackend):
             description=description,
         )
         self.domains.append(domain)
+        if tags:
+            self.tagger.tag_resource(domain.to_short_dict()["arn"], tags)
+
 
     def deprecate_domain(self, name: str) -> None:
         domain = self._get_domain(name)

--- a/moto/swf/responses.py
+++ b/moto/swf/responses.py
@@ -209,10 +209,38 @@ class SWFResponse(BaseResponse):
         name = self._params["name"]
         retention = self._params["workflowExecutionRetentionPeriodInDays"]
         description = self._params.get("description")
+        raw_tags = self._params.get("tags", [])
         self._check_string(retention)
         self._check_string(name)
         self._check_none_or_string(description)
-        self.swf_backend.register_domain(name, retention, description=description)
+        tags = [{"Key": t["key"], "Value": t["value"]} for t in raw_tags]
+        self.swf_backend.register_domain(
+            name, retention, description=description, tags=tags
+        )
+        return ""
+
+    def list_tags_for_resource(self) -> str:
+        resource_arn = self._params["resourceArn"]
+        tags = self.swf_backend.tagger.list_tags_for_resource(resource_arn).get(
+            "Tags", []
+        )
+        return json.dumps(
+            {"tags": [{"key": t["Key"], "value": t["Value"]} for t in tags]}
+        )
+
+    def tag_resource(self) -> str:
+        resource_arn = self._params["resourceArn"]
+        raw_tags = self._params.get("tags", [])
+        self.swf_backend.tagger.tag_resource(
+            resource_arn,
+            [{"Key": t["key"], "Value": t["value"]} for t in raw_tags],
+        )
+        return ""
+
+    def untag_resource(self) -> str:
+        resource_arn = self._params["resourceArn"]
+        tag_keys = self._params.get("tagKeys", [])
+        self.swf_backend.tagger.untag_resource_using_names(resource_arn, tag_keys)
         return ""
 
     def deprecate_domain(self) -> str:

--- a/tests/test_swf/responses/test_tagging.py
+++ b/tests/test_swf/responses/test_tagging.py
@@ -55,7 +55,9 @@ def test_tag_resource():
 @mock_aws
 def test_tag_resource_updates_existing_key():
     client = boto3.client("swf", region_name="us-east-1")
-    arn = _register_and_describe_domain(client, tags=[{"key": "k1", "value": "old"}])["domainInfo"]["arn"]
+    arn = _register_and_describe_domain(client, tags=[{"key": "k1", "value": "old"}])[
+        "domainInfo"
+    ]["arn"]
 
     client.tag_resource(
         resourceArn=arn,
@@ -85,7 +87,9 @@ def test_untag_resource():
 @mock_aws
 def test_untag_resource_nonexistent_key():
     client = boto3.client("swf", region_name="us-east-1")
-    arn = _register_and_describe_domain(client, tags=[{"key": "k1", "value": "v1"}])["domainInfo"]["arn"]
+    arn = _register_and_describe_domain(client, tags=[{"key": "k1", "value": "v1"}])[
+        "domainInfo"
+    ]["arn"]
 
     # Should not raise
     client.untag_resource(resourceArn=arn, tagKeys=["nonexistent"])

--- a/tests/test_swf/responses/test_tagging.py
+++ b/tests/test_swf/responses/test_tagging.py
@@ -1,0 +1,94 @@
+import boto3
+
+from moto import mock_aws
+
+
+def _register_and_describe_domain(client, name="test-domain", tags=None):
+    kwargs = {
+        "name": name,
+        "workflowExecutionRetentionPeriodInDays": "30",
+    }
+    if tags:
+        kwargs["tags"] = tags
+    client.register_domain(**kwargs)
+    return client.describe_domain(name=name)
+
+
+@mock_aws
+def test_register_domain_with_tags():
+    client = boto3.client("swf", region_name="us-east-1")
+    arn = _register_and_describe_domain(
+        client,
+        tags=[{"key": "env", "value": "prod"}, {"key": "team", "value": "platform"}],
+    )["domainInfo"]["arn"]
+
+    tags = client.list_tags_for_resource(resourceArn=arn)["tags"]
+
+    assert {"key": "env", "value": "prod"} in tags
+    assert {"key": "team", "value": "platform"} in tags
+
+
+@mock_aws
+def test_list_tags_for_resource_empty():
+    client = boto3.client("swf", region_name="us-east-1")
+    arn = _register_and_describe_domain(client)["domainInfo"]["arn"]
+
+    tags = client.list_tags_for_resource(resourceArn=arn)["tags"]
+    assert tags == []
+
+
+@mock_aws
+def test_tag_resource():
+    client = boto3.client("swf", region_name="us-east-1")
+    arn = _register_and_describe_domain(client)["domainInfo"]["arn"]
+
+    client.tag_resource(
+        resourceArn=arn,
+        tags=[{"key": "k1", "value": "v1"}, {"key": "k2", "value": "v2"}],
+    )
+
+    tags = client.list_tags_for_resource(resourceArn=arn)["tags"]
+    assert {"key": "k1", "value": "v1"} in tags
+    assert {"key": "k2", "value": "v2"} in tags
+
+
+@mock_aws
+def test_tag_resource_updates_existing_key():
+    client = boto3.client("swf", region_name="us-east-1")
+    arn = _register_and_describe_domain(client, tags=[{"key": "k1", "value": "old"}])["domainInfo"]["arn"]
+
+    client.tag_resource(
+        resourceArn=arn,
+        tags=[{"key": "k1", "value": "new"}],
+    )
+
+    tags = client.list_tags_for_resource(resourceArn=arn)["tags"]
+    assert {"key": "k1", "value": "new"} in tags
+    assert {"key": "k1", "value": "old"} not in tags
+
+
+@mock_aws
+def test_untag_resource():
+    client = boto3.client("swf", region_name="us-east-1")
+    arn = _register_and_describe_domain(
+        client,
+        tags=[{"key": "k1", "value": "v1"}, {"key": "k2", "value": "v2"}],
+    )["domainInfo"]["arn"]
+
+    client.untag_resource(resourceArn=arn, tagKeys=["k1"])
+
+    tags = client.list_tags_for_resource(resourceArn=arn)["tags"]
+    assert {"key": "k1", "value": "v1"} not in tags
+    assert {"key": "k2", "value": "v2"} in tags
+
+
+@mock_aws
+def test_untag_resource_nonexistent_key():
+    client = boto3.client("swf", region_name="us-east-1")
+    arn = _register_and_describe_domain(client, tags=[{"key": "k1", "value": "v1"}])["domainInfo"]["arn"]
+
+    # Should not raise
+    client.untag_resource(resourceArn=arn, tagKeys=["nonexistent"])
+
+    tags = client.list_tags_for_resource(resourceArn=arn)["tags"]
+    assert {"key": "k1", "value": "v1"} in tags

--- a/tests/test_swf/test_swf_integration.py
+++ b/tests/test_swf/test_swf_integration.py
@@ -68,7 +68,7 @@ def test_rgtapi_tag_resources():
 
     domain_arn = _register_and_describe_domain(
         swf, "my-domain", tags=[{"key": "k1", "value": "v1"}]
-    )
+    )["domainInfo"]["arn"]
 
     rtapi.tag_resources(
         ResourceARNList=[domain_arn],
@@ -89,7 +89,7 @@ def test_rgtapi_untag_resources():
         swf,
         "my-domain",
         tags=[{"key": "k1", "value": "v1"}, {"key": "k2", "value": "v2"}],
-    )
+    )["domainInfo"]["arn"]
 
     rtapi.tag_resources(
         ResourceARNList=[domain_arn],

--- a/tests/test_swf/test_swf_integration.py
+++ b/tests/test_swf/test_swf_integration.py
@@ -20,8 +20,12 @@ def test_rgtapi_get_resources():
     swf = boto3.client("swf", region_name="us-east-1")
     rtapi = boto3.client("resourcegroupstaggingapi", region_name="us-east-1")
 
-    a_arn = _register_and_describe_domain(swf, "domain-a", tags=[{"key": "env", "value": "prod"}])["domainInfo"]["arn"]
-    b_arn = _register_and_describe_domain(swf, "domain-b", tags=[{"key": "env", "value": "dev"}])["domainInfo"]["arn"]
+    a_arn = _register_and_describe_domain(
+        swf, "domain-a", tags=[{"key": "env", "value": "prod"}]
+    )["domainInfo"]["arn"]
+    b_arn = _register_and_describe_domain(
+        swf, "domain-b", tags=[{"key": "env", "value": "dev"}]
+    )["domainInfo"]["arn"]
     # domain with no tags should not appear
     c_arn = _register_and_describe_domain(swf, "domain-c")["domainInfo"]["arn"]
 
@@ -39,8 +43,12 @@ def test_rgtapi_get_resources_with_tag_filter():
     swf = boto3.client("swf", region_name="us-east-1")
     rtapi = boto3.client("resourcegroupstaggingapi", region_name="us-east-1")
 
-    _register_and_describe_domain(swf, "domain-prod", tags=[{"key": "env", "value": "prod"}])
-    _register_and_describe_domain(swf, "domain-dev", tags=[{"key": "env", "value": "dev"}])
+    _register_and_describe_domain(
+        swf, "domain-prod", tags=[{"key": "env", "value": "prod"}]
+    )
+    _register_and_describe_domain(
+        swf, "domain-dev", tags=[{"key": "env", "value": "dev"}]
+    )
 
     resp = rtapi.get_resources(
         ResourceTypeFilters=["swf"],
@@ -58,7 +66,9 @@ def test_rgtapi_tag_resources():
     swf = boto3.client("swf", region_name="us-east-1")
     rtapi = boto3.client("resourcegroupstaggingapi", region_name="us-east-1")
 
-    domain_arn = _register_and_describe_domain(swf, "my-domain", tags=[{"key": "k1", "value": "v1"}])
+    domain_arn = _register_and_describe_domain(
+        swf, "my-domain", tags=[{"key": "k1", "value": "v1"}]
+    )
 
     rtapi.tag_resources(
         ResourceARNList=[domain_arn],

--- a/tests/test_swf/test_swf_integration.py
+++ b/tests/test_swf/test_swf_integration.py
@@ -1,0 +1,97 @@
+import boto3
+
+from moto import mock_aws
+
+
+def _register_and_describe_domain(client, name, tags=None):
+    kwargs = {
+        "name": name,
+        "workflowExecutionRetentionPeriodInDays": "30",
+    }
+    if tags:
+        kwargs["tags"] = tags
+    client.register_domain(**kwargs)
+
+    return client.describe_domain(name=name)
+
+
+@mock_aws
+def test_rgtapi_get_resources():
+    swf = boto3.client("swf", region_name="us-east-1")
+    rtapi = boto3.client("resourcegroupstaggingapi", region_name="us-east-1")
+
+    a_arn = _register_and_describe_domain(swf, "domain-a", tags=[{"key": "env", "value": "prod"}])["domainInfo"]["arn"]
+    b_arn = _register_and_describe_domain(swf, "domain-b", tags=[{"key": "env", "value": "dev"}])["domainInfo"]["arn"]
+    # domain with no tags should not appear
+    c_arn = _register_and_describe_domain(swf, "domain-c")["domainInfo"]["arn"]
+
+    resp = rtapi.get_resources(ResourceTypeFilters=["swf"])
+    resources = resp["ResourceTagMappingList"]
+
+    arns = [r["ResourceARN"] for r in resources]
+    assert a_arn in arns
+    assert b_arn in arns
+    assert c_arn not in arns
+
+
+@mock_aws
+def test_rgtapi_get_resources_with_tag_filter():
+    swf = boto3.client("swf", region_name="us-east-1")
+    rtapi = boto3.client("resourcegroupstaggingapi", region_name="us-east-1")
+
+    _register_and_describe_domain(swf, "domain-prod", tags=[{"key": "env", "value": "prod"}])
+    _register_and_describe_domain(swf, "domain-dev", tags=[{"key": "env", "value": "dev"}])
+
+    resp = rtapi.get_resources(
+        ResourceTypeFilters=["swf"],
+        TagFilters=[{"Key": "env", "Values": ["prod"]}],
+    )
+    resources = resp["ResourceTagMappingList"]
+
+    assert len(resources) == 1
+    assert resources[0]["ResourceARN"].endswith("/domain/domain-prod")
+    assert {"Key": "env", "Value": "prod"} in resources[0]["Tags"]
+
+
+@mock_aws
+def test_rgtapi_tag_resources():
+    swf = boto3.client("swf", region_name="us-east-1")
+    rtapi = boto3.client("resourcegroupstaggingapi", region_name="us-east-1")
+
+    domain_arn = _register_and_describe_domain(swf, "my-domain", tags=[{"key": "k1", "value": "v1"}])
+
+    rtapi.tag_resources(
+        ResourceARNList=[domain_arn],
+        Tags={"NewKey": "NewValue"},
+    )
+
+    tags = swf.list_tags_for_resource(resourceArn=domain_arn)["tags"]
+    assert {"key": "k1", "value": "v1"} in tags
+    assert {"key": "NewKey", "value": "NewValue"} in tags
+
+
+@mock_aws
+def test_rgtapi_untag_resources():
+    swf = boto3.client("swf", region_name="us-east-1")
+    rtapi = boto3.client("resourcegroupstaggingapi", region_name="us-east-1")
+
+    domain_arn = _register_and_describe_domain(
+        swf,
+        "my-domain",
+        tags=[{"key": "k1", "value": "v1"}, {"key": "k2", "value": "v2"}],
+    )
+
+    rtapi.tag_resources(
+        ResourceARNList=[domain_arn],
+        Tags={"NewKey": "NewValue"},
+    )
+
+    rtapi.untag_resources(
+        ResourceARNList=[domain_arn],
+        TagKeys=["k1", "k2"],
+    )
+
+    tags = swf.list_tags_for_resource(resourceArn=domain_arn)["tags"]
+    assert {"key": "k1", "value": "v1"} not in tags
+    assert {"key": "k2", "value": "v2"} not in tags
+    assert {"key": "NewKey", "value": "NewValue"} in tags


### PR DESCRIPTION
This PR includes                                                                                                                                                                   

  Adds tagging support for SWF domains, including integration with the Resource Groups Tagging API.                                                                                                       
   
  Changes                                                                                                                                                                                                 
                                                                                                                                                                                                        
  moto/swf/                                                                                                                                                                                               
  - Added a `TaggingService` instance to SWFBackend
  - `register_domain` now accepts an optional tags parameter and applies tags on creation                                                                                                                   
  - Added `list_tags_for_resource`, `tag_resource`, and `untag_resource` response handlers                                                                                                                    
                                                                                                                                                                                                          
  moto/resourcegroupstaggingapi/                                                                                                                                                                          
  - Added swf_backend property                                                                                                                                                                            
  - `get_resources` now yields tagged SWF domains when filtering by swf or swf:domain                                                                                                                       
  - `tag_resources` and `untag_resources` now handle SWF ARNs                                                                                                                                               
                                                                                                                                                                                                          
  Tests                                                                                                                                                                                                   
                                                                                                                                                                                                          
  - tests/test_swf/responses/test_tagging.py — unit tests for SWF-native tagging endpoints                                                                                                                
  - tests/test_swf/test_swf_integration.py — integration tests covering RGTAPI get_resources, tag_resources, and untag_resources with SWF domains