### PR TITLE
Admin: Use requires_clean_slate marker where possible

### DIFF
--- a/tests/test_ec2/test_carrier_gateways.py
+++ b/tests/test_ec2/test_carrier_gateways.py
@@ -1,17 +1,14 @@
-from unittest import SkipTest
-
 import boto3
 import pytest
 from botocore.exceptions import ClientError
 
-from moto import mock_aws, settings
+from moto import mock_aws
 from moto.core import DEFAULT_ACCOUNT_ID as ACCOUNT_ID
 
 
 @mock_aws
+@pytest.mark.requires_clean_slate
 def test_describe_carrier_gateways_none():
-    if settings.TEST_SERVER_MODE:
-        raise SkipTest("ServerMode is not guaranteed to be empty")
     ec2 = boto3.client("ec2", region_name="us-east-1")
     assert ec2.describe_carrier_gateways()["CarrierGateways"] == []
 

--- a/tests/test_ec2/test_instances.py
+++ b/tests/test_ec2/test_instances.py
@@ -1775,9 +1775,8 @@ def test_run_instance_with_block_device_mappings_from_snapshot():
 
 
 @mock_aws
+@pytest.mark.requires_clean_slate
 def test_describe_instance_status_no_instances():
-    if settings.TEST_SERVER_MODE:
-        raise SkipTest("ServerMode is not guaranteed to be empty")
     client = boto3.client("ec2", region_name="us-east-1")
     all_status = client.describe_instance_status()["InstanceStatuses"]
     assert len(all_status) == 0

--- a/tests/test_ec2/test_key_pairs.py
+++ b/tests/test_ec2/test_key_pairs.py
@@ -1,12 +1,11 @@
 from datetime import datetime
-from unittest import SkipTest
 from uuid import uuid4
 
 import boto3
 import pytest
 from botocore.exceptions import ClientError
 
-from moto import mock_aws, settings
+from moto import mock_aws
 
 from .helpers import assert_dryrun_error, check_private_key
 
@@ -92,9 +91,8 @@ moto@github.com"""
 
 
 @mock_aws
+@pytest.mark.requires_clean_slate
 def test_key_pairs_empty():
-    if settings.TEST_SERVER_MODE:
-        raise SkipTest("ServerMode is not guaranteed to be empty")
     client = boto3.client("ec2", "us-west-1")
     assert client.describe_key_pairs()["KeyPairs"] == []
 

--- a/tests/test_ec2/test_nat_gateway.py
+++ b/tests/test_ec2/test_nat_gateway.py
@@ -1,14 +1,12 @@
-from unittest import SkipTest
-
 import boto3
+import pytest
 
-from moto import mock_aws, settings
+from moto import mock_aws
 
 
 @mock_aws
+@pytest.mark.requires_clean_slate
 def test_describe_nat_gateways():
-    if settings.TEST_SERVER_MODE:
-        raise SkipTest("ServerMode is not guaranteed to have no resources")
     conn = boto3.client("ec2", "us-east-1")
 
     response = conn.describe_nat_gateways()

--- a/tests/test_ec2/test_prefix_lists.py
+++ b/tests/test_ec2/test_prefix_lists.py
@@ -1,7 +1,7 @@
 import boto3
 import pytest
 
-from moto import mock_aws, settings
+from moto import mock_aws
 from moto.core import DEFAULT_ACCOUNT_ID as ACCOUNT_ID
 from tests.test_ec2 import ec2_aws_verified
 
@@ -60,13 +60,12 @@ def test_describe_managed_prefix_lists(ec2_client=None):
 
 
 @mock_aws
+@pytest.mark.requires_clean_slate
 def test_describe_managed_prefix_lists_with_prefix():
     ec2 = boto3.client("ec2", region_name="us-west-1")
 
     default_lists = ec2.describe_managed_prefix_lists()["PrefixLists"]
-    if not settings.TEST_SERVER_MODE:
-        # ServerMode is not guaranteed to only have AWS prefix lists
-        assert {pl["OwnerId"] for pl in default_lists} == {"AWS"}
+    assert {pl["OwnerId"] for pl in default_lists} == {"AWS"}
 
     random_list_id = default_lists[0]["PrefixListId"]
 
@@ -74,8 +73,7 @@ def test_describe_managed_prefix_lists_with_prefix():
         "PrefixLists"
     ]
     assert len(lists_by_id) == 1
-    if not settings.TEST_SERVER_MODE:
-        assert lists_by_id[0]["OwnerId"] == "AWS"
+    assert lists_by_id[0]["OwnerId"] == "AWS"
 
 
 @mock_aws

--- a/tests/test_ec2/test_spot_instances.py
+++ b/tests/test_ec2/test_spot_instances.py
@@ -1,12 +1,11 @@
 import datetime
-from unittest import SkipTest
 from uuid import uuid4
 
 import boto3
 import pytest
 from botocore.exceptions import ClientError
 
-from moto import mock_aws, settings
+from moto import mock_aws
 from moto.core.types import Base64EncodedString
 from moto.core.utils import iso_8601_datetime_with_milliseconds
 from tests import EXAMPLE_AMI_ID
@@ -291,11 +290,8 @@ def test_get_all_spot_instance_requests_filtering():
 
 @mock_aws
 @pytest.mark.filterwarnings("ignore")
+@pytest.mark.requires_clean_slate
 def test_request_spot_instances_instance_lifecycle():
-    if settings.TEST_SERVER_MODE:
-        # Currently no easy way to check which instance was created by request_spot_instance
-        # And we can't just pick the first instance in ServerMode and expect it to be the right one
-        raise SkipTest("ServerMode is not guaranteed to be empty")
     client = boto3.client("ec2", region_name="us-east-1")
     client.request_spot_instances(SpotPrice="0.5")
 

--- a/tests/test_ec2/test_subnets.py
+++ b/tests/test_ec2/test_subnets.py
@@ -1,5 +1,4 @@
 import random
-from unittest import SkipTest
 from uuid import uuid4
 
 import boto3
@@ -183,9 +182,8 @@ def test_availability_zone_in_create_subnet():
 
 
 @mock_aws
+@pytest.mark.requires_clean_slate
 def test_default_subnet():
-    if settings.TEST_SERVER_MODE:
-        raise SkipTest("ServerMode will have conflicting CidrBlocks")
     ec2 = boto3.resource("ec2", region_name="us-west-1")
 
     default_vpc = list(ec2.vpcs.all())[0]
@@ -651,11 +649,8 @@ def test_create_subnet_with_tags():
 
 
 @mock_aws
+@pytest.mark.requires_clean_slate
 def test_available_ip_addresses_in_subnet():
-    if settings.TEST_SERVER_MODE:
-        raise SkipTest(
-            "ServerMode is not guaranteed to be empty - other subnets will affect the count"
-        )
     ec2 = boto3.resource("ec2", region_name="us-west-1")
     client = boto3.client("ec2", region_name="us-west-1")
 
@@ -680,11 +675,8 @@ def test_available_ip_addresses_in_subnet():
 
 
 @mock_aws
+@pytest.mark.requires_clean_slate
 def test_available_ip_addresses_in_subnet_with_enis():
-    if settings.TEST_SERVER_MODE:
-        raise SkipTest(
-            "ServerMode is not guaranteed to be empty - other ENI's will affect the count"
-        )
     ec2 = boto3.resource("ec2", region_name="us-west-1")
     client = boto3.client("ec2", region_name="us-west-1")
 

--- a/tests/test_ec2/test_traffic_mirrors.py
+++ b/tests/test_ec2/test_traffic_mirrors.py
@@ -1,10 +1,8 @@
-from unittest import SkipTest
-
 import boto3
 import pytest
 from botocore.exceptions import ClientError
 
-from moto import mock_aws, settings
+from moto import mock_aws
 
 REGION = "us-east-1"
 
@@ -94,9 +92,8 @@ def test_create_traffic_mirror_target_invalid_input():
 
 
 @mock_aws
+@pytest.mark.requires_clean_slate
 def test_describe_traffic_mirror_filters():
-    if settings.TEST_SERVER_MODE:
-        raise SkipTest("ServerMode is not guaranteed to be empty")
     client = boto3.client("ec2", REGION)
     response = client.describe_traffic_mirror_filters()
     assert response["TrafficMirrorFilters"] == []
@@ -142,9 +139,8 @@ def test_describe_traffic_mirror_filters_by_id():
 
 
 @mock_aws
+@pytest.mark.requires_clean_slate
 def test_describe_traffic_mirror_targets():
-    if settings.TEST_SERVER_MODE:
-        raise SkipTest("ServerMode is not guaranteed to be empty")
     client = boto3.client("ec2", REGION)
     response = client.describe_traffic_mirror_targets()
     assert response["TrafficMirrorTargets"] == []

--- a/tests/test_ec2/test_transit_gateway.py
+++ b/tests/test_ec2/test_transit_gateway.py
@@ -1,11 +1,10 @@
 from time import sleep
-from unittest import SkipTest
 
 import boto3
 import pytest
 from botocore.exceptions import ClientError
 
-from moto import mock_aws, settings
+from moto import mock_aws
 from moto.core import DEFAULT_ACCOUNT_ID as ACCOUNT_ID
 from tests.test_ec2 import (
     delete_tg_attachments,
@@ -17,8 +16,6 @@ from tests.test_ec2 import (
 
 @mock_aws
 def test_describe_transit_gateways():
-    if settings.TEST_SERVER_MODE:
-        raise SkipTest("ServerMode is not guaranteed to be empty")
     ec2 = boto3.client("ec2", region_name="us-west-1")
     response = ec2.describe_transit_gateways()
     assert response["TransitGateways"] == []
@@ -190,18 +187,16 @@ def test_modify_transit_gateway():
 
 
 @mock_aws
+@pytest.mark.requires_clean_slate
 def test_describe_transit_gateway_vpc_attachments():
-    if settings.TEST_SERVER_MODE:
-        raise SkipTest("ServerMode is not guaranteed to be empty")
     ec2 = boto3.client("ec2", region_name="us-west-1")
     response = ec2.describe_transit_gateway_vpc_attachments()
     assert response["TransitGatewayVpcAttachments"] == []
 
 
 @mock_aws
+@pytest.mark.requires_clean_slate
 def test_describe_transit_gateway_attachments():
-    if settings.TEST_SERVER_MODE:
-        raise SkipTest("ServerMode is not guaranteed to be empty")
     ec2 = boto3.client("ec2", region_name="us-west-1")
     response = ec2.describe_transit_gateway_attachments()
     assert response["TransitGatewayAttachments"] == []
@@ -341,9 +336,8 @@ def test_create_and_describe_transit_gateway_vpc_attachment(
 
 
 @mock_aws
+@pytest.mark.requires_clean_slate
 def test_describe_transit_gateway_route_tables():
-    if settings.TEST_SERVER_MODE:
-        raise SkipTest("ServerMode is not guaranteed to be empty")
     ec2 = boto3.client("ec2", region_name="us-west-1")
     response = ec2.describe_transit_gateway_route_tables()
     assert response["TransitGatewayRouteTables"] == []

--- a/tests/test_ec2/test_transit_gateway_peering_attachments.py
+++ b/tests/test_ec2/test_transit_gateway_peering_attachments.py
@@ -1,5 +1,5 @@
 import os
-from unittest import SkipTest, mock
+from unittest import mock
 
 import boto3
 import pytest
@@ -10,9 +10,8 @@ from moto.core import DEFAULT_ACCOUNT_ID as ACCOUNT_ID
 
 
 @mock_aws
+@pytest.mark.requires_clean_slate
 def test_describe_transit_gateway_peering_attachment_empty():
-    if settings.TEST_SERVER_MODE:
-        raise SkipTest("ServerMode is not guaranteed to be empty")
     ec2 = boto3.client("ec2", region_name="us-west-1")
 
     all_attachments = ec2.describe_transit_gateway_peering_attachments()[


### PR DESCRIPTION
Rewrites a few tests to use the `requires_clean_slate` marker, instead of simply skipping them.

This will ensure that the tests are executed, but against an empty MotoServer.