### PR TITLE
Admin: Drop Python 3.9 support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ 3.9, "3.10", "3.11", "3.12", "3.13", "3.14" ]
+        python-version: [ "3.10", "3.11", "3.12", "3.13", "3.14" ]
 
     steps:
       - uses: actions/checkout@v6
@@ -42,7 +42,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.9, "3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
     - uses: actions/checkout@v6
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/data-update_config-managed-rules.yml
+++ b/.github/workflows/data-update_config-managed-rules.yml
@@ -26,10 +26,10 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v6
 
-    - name: Set up Python 3.9
+    - name: Set up Python
       uses: actions/setup-python@v6
       with:
-        python-version: 3.9
+        python-version: 3.14
 
     - name: Pull Config managed rules from AWS
       run: |

--- a/.github/workflows/data-update_ec2-instance-offerings.yml
+++ b/.github/workflows/data-update_ec2-instance-offerings.yml
@@ -26,10 +26,10 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v6
 
-    - name: Set up Python 3.9
+    - name: Set up Python
       uses: actions/setup-python@v6
       with:
-        python-version: 3.9
+        python-version: 3.14
 
     - name: Configure AWS
       uses: aws-actions/configure-aws-credentials@v6

--- a/.github/workflows/data-update_ec2-instance-types.yml
+++ b/.github/workflows/data-update_ec2-instance-types.yml
@@ -26,10 +26,10 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v6
 
-    - name: Set up Python 3.9
+    - name: Set up Python
       uses: actions/setup-python@v6
       with:
-        python-version: 3.9
+        python-version: 3.14
 
     - name: Configure AWS
       uses: aws-actions/configure-aws-credentials@v6

--- a/.github/workflows/data-update_emr_instance_types.yml
+++ b/.github/workflows/data-update_emr_instance_types.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v6
 
-    - name: Set up Python 3.11
+    - name: Set up Python
       uses: actions/setup-python@v6
       with:
         python-version: 3.11

--- a/.github/workflows/data-update_iam-managed-policies.yml
+++ b/.github/workflows/data-update_iam-managed-policies.yml
@@ -26,10 +26,10 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v6
 
-    - name: Set up Python 3.9
+    - name: Set up Python
       uses: actions/setup-python@v6
       with:
-        python-version: 3.9
+        python-version: 3.14
 
     - name: Configure AWS
       uses: aws-actions/configure-aws-credentials@v6

--- a/.github/workflows/data-update_ssm-default-amis.yml
+++ b/.github/workflows/data-update_ssm-default-amis.yml
@@ -26,10 +26,10 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v6
 
-    - name: Set up Python 3.9
+    - name: Set up Python
       uses: actions/setup-python@v6
       with:
-        python-version: 3.9
+        python-version: 3.14
 
     - name: Configure AWS
       uses: aws-actions/configure-aws-credentials@v6

--- a/.github/workflows/data-update_ssm-default-parameters.yml
+++ b/.github/workflows/data-update_ssm-default-parameters.yml
@@ -26,10 +26,10 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v6
 
-    - name: Set up Python 3.9
+    - name: Set up Python
       uses: actions/setup-python@v6
       with:
-        python-version: 3.9
+        python-version: 3.14
 
     - name: Configure AWS
       uses: aws-actions/configure-aws-credentials@v6

--- a/.github/workflows/data-update_ssm-optimized-amis.yml
+++ b/.github/workflows/data-update_ssm-optimized-amis.yml
@@ -26,10 +26,10 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v6
 
-    - name: Set up Python 3.9
+    - name: Set up Python
       uses: actions/setup-python@v6
       with:
-        python-version: 3.9
+        python-version: 3.14
 
     - name: Configure AWS
       uses: aws-actions/configure-aws-credentials@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
     - uses: actions/checkout@v6
       with:
         fetch-depth: 0
-    - name: Set up Python 3.12
+    - name: Set up Python
       uses: actions/setup-python@v6
       with:
         python-version: 3.12

--- a/.github/workflows/test_outdated_versions.yml
+++ b/.github/workflows/test_outdated_versions.yml
@@ -50,7 +50,7 @@ jobs:
     - name: Start MotoServer
       run: |
         python -m build
-        docker run --rm -t --name motoserver -e TEST_SERVER_MODE=true -e AWS_SECRET_ACCESS_KEY=server_secret -e AWS_ACCESS_KEY_ID=server_key -v `pwd`:/moto -p 5000:5000 -v /var/run/docker.sock:/var/run/docker.sock python:3.9-slim /moto/scripts/ci_moto_server.sh &
+        docker run --rm -t --name motoserver -e TEST_SERVER_MODE=true -e AWS_SECRET_ACCESS_KEY=server_secret -e AWS_ACCESS_KEY_ID=server_key -v `pwd`:/moto -p 5000:5000 -v /var/run/docker.sock:/var/run/docker.sock python:3.10-slim /moto/scripts/ci_moto_server.sh &
         python scripts/ci_wait_for_server.py
     - name: Test ServerMode/Coverage
       env:

--- a/.github/workflows/tests_cdk.yml
+++ b/.github/workflows/tests_cdk.yml
@@ -67,7 +67,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v6
-    - name: Set up Python 3.12
+    - name: Set up Python
       uses: actions/setup-python@v6
       with:
         python-version: "3.12"

--- a/.github/workflows/tests_cli.yml
+++ b/.github/workflows/tests_cli.yml
@@ -9,7 +9,7 @@ jobs:
     - uses: actions/checkout@v6
       with:
         fetch-depth: 0
-    - name: Set up Python 3.12
+    - name: Set up Python
       uses: actions/setup-python@v6
       with:
         python-version: "3.12"

--- a/.github/workflows/tests_decoratormode.yml
+++ b/.github/workflows/tests_decoratormode.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.9, "3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
     - uses: actions/checkout@v6

--- a/.github/workflows/tests_sdk_cpp.yml
+++ b/.github/workflows/tests_sdk_cpp.yml
@@ -9,7 +9,7 @@ jobs:
     - uses: actions/checkout@v6
       with:
         fetch-depth: 0
-    - name: Set up Python 3.12
+    - name: Set up Python
       uses: actions/setup-python@v6
       with:
         python-version: "3.12"

--- a/.github/workflows/tests_sdk_dotnet.yml
+++ b/.github/workflows/tests_sdk_dotnet.yml
@@ -9,7 +9,7 @@ jobs:
     - uses: actions/checkout@v6
       with:
         fetch-depth: 0
-    - name: Set up Python 3.12
+    - name: Set up Python
       uses: actions/setup-python@v6
       with:
         python-version: "3.12"

--- a/.github/workflows/tests_sdk_java.yml
+++ b/.github/workflows/tests_sdk_java.yml
@@ -9,7 +9,7 @@ jobs:
     - uses: actions/checkout@v6
       with:
         fetch-depth: 0
-    - name: Set up Python 3.12
+    - name: Set up Python
       uses: actions/setup-python@v6
       with:
         python-version: "3.12"

--- a/.github/workflows/tests_sdk_js.yml
+++ b/.github/workflows/tests_sdk_js.yml
@@ -9,7 +9,7 @@ jobs:
     - uses: actions/checkout@v6
       with:
         fetch-depth: 0
-    - name: Set up Python 3.11
+    - name: Set up Python
       uses: actions/setup-python@v6
       with:
         python-version: "3.11"

--- a/.github/workflows/tests_sdk_ruby.yml
+++ b/.github/workflows/tests_sdk_ruby.yml
@@ -16,7 +16,7 @@ jobs:
         uses: ruby/setup-ruby@3ff19f5e2baf30647122352b96108b1fbe250c64
         with:
           ruby-version: ${{ matrix.ruby-version }}
-      - name: Set up Python 3.12
+      - name: Set up Python
         uses: actions/setup-python@v6
         with:
           python-version: "3.12"

--- a/.github/workflows/tests_sdk_sagemaker.yml
+++ b/.github/workflows/tests_sdk_sagemaker.yml
@@ -9,7 +9,7 @@ jobs:
     - uses: actions/checkout@v6
       with:
         fetch-depth: 0
-    - name: Set up Python 3.12
+    - name: Set up Python
       uses: actions/setup-python@v6
       with:
         python-version: "3.12"

--- a/.github/workflows/tests_servermode.yml
+++ b/.github/workflows/tests_servermode.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.9, "3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
     - uses: actions/checkout@v6

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,7 +11,6 @@ license = Apache-2.0
 test_suite = tests
 classifiers =
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
@@ -25,7 +24,7 @@ project_urls =
     Changelog = https://github.com/getmoto/moto/blob/master/CHANGELOG.md
 
 [options]
-python_requires = >=3.9
+python_requires = >=3.10
 install_requires =
     boto3>=1.9.201
     botocore>=1.20.88,!=1.35.45,!=1.35.46

--- a/tests/test_secretsmanager/test_rotate_simple_lambda.py
+++ b/tests/test_secretsmanager/test_rotate_simple_lambda.py
@@ -76,7 +76,7 @@ def create_mock_rotator_lambda():
     client = boto3.client("lambda", region_name="us-east-1")
     return client.create_function(
         FunctionName="mock-rotator",
-        Runtime="python3.9",
+        Runtime="python3.14",
         Role=get_mock_role_arn(),
         Handler="lambda_function.lambda_handler",
         Code={"ZipFile": mock_lambda_zip()},

--- a/tests/test_utilities/test_docker_utilities.py
+++ b/tests/test_utilities/test_docker_utilities.py
@@ -7,7 +7,7 @@ from moto.utilities.docker_utilities import parse_image_ref
     "image_name,expected",
     [
         ("python", ("docker.io/library/python", "latest")),
-        ("python:3.9", ("docker.io/library/python", "3.9")),
+        ("python:3.14", ("docker.io/library/python", "3.14")),
         ("docker.io/python", ("docker.io/library/python", "latest")),
         ("localhost/foobar", ("localhost/foobar", "latest")),
         ("lambci/lambda:python2.7", ("docker.io/lambci/lambda", "python2.7")),


### PR DESCRIPTION
EOL was 31 Oct 2025, almost 6 months ago.