### PR TITLE
Admin: Set Ruff's target version to 3.10

### DIFF
--- a/moto/backends.py
+++ b/moto/backends.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, Optional, Union, overload
 import moto
 
 if TYPE_CHECKING:
-    from typing_extensions import Literal
+    from typing import Literal
 
     from moto.acm.models import AWSCertificateManagerBackend
     from moto.acmpca.models import ACMPCABackend

--- a/moto/ec2/utils.py
+++ b/moto/ec2/utils.py
@@ -5,7 +5,7 @@ import ipaddress
 import re
 from collections.abc import Callable
 from datetime import datetime
-from typing import TYPE_CHECKING, Any, Optional, TypedDict, TypeVar, Union
+from typing import TYPE_CHECKING, Any, Optional, TypeAlias, TypedDict, TypeVar, Union
 
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import serialization
@@ -24,8 +24,6 @@ from moto.moto_api._internal import mock_random as random
 from moto.utilities.utils import md5_hash
 
 if TYPE_CHECKING:
-    from typing_extensions import TypeAlias
-
     HashType: TypeAlias = hashlib._Hash
 
 EC2_RESOURCE_TO_PREFIX = {

--- a/moto/events/models.py
+++ b/moto/events/models.py
@@ -1062,7 +1062,9 @@ class EventPattern:
                 if not isinstance(val, (int, float)):
                     return False
                 as_function = {"<": lt, "<=": le, "=": eq, ">=": ge, ">": gt}
-                operators_and_values = zip(filter_value[::2], filter_value[1::2])
+                operators_and_values = zip(
+                    filter_value[::2], filter_value[1::2], strict=False
+                )
                 numeric_matches = [
                     as_function[operator](val, value)
                     for operator, value in operators_and_values

--- a/moto/glue/utils.py
+++ b/moto/glue/utils.py
@@ -333,7 +333,7 @@ class _Ident(_Expr):
         raise InvalidInputException("GetPartitions", "Invalid partition expression!")
 
     def _eval(self, part_keys: list[dict[str, str]], part_input: dict[str, Any]) -> Any:
-        for key, value in zip(part_keys, part_input["Values"]):
+        for key, value in zip(part_keys, part_input["Values"], strict=False):
             if self.ident == key["Name"]:
                 return _cast(key["Type"], value)
 

--- a/moto/kinesis/models.py
+++ b/moto/kinesis/models.py
@@ -364,7 +364,9 @@ class Stream(CloudFormationModel):
                 [s for s in self.shards.values() if s.is_open],
                 key=lambda x: x.starting_hash,
             )
-            adjacent_shards = zip(list(shard_list[0:-1:2]), list(shard_list[1::2]))
+            adjacent_shards = zip(
+                list(shard_list[0:-1:2]), list(shard_list[1::2]), strict=False
+            )
 
             for shard, adjacent in adjacent_shards:
                 self.merge_shards(shard.shard_id, adjacent.shard_id)

--- a/moto/sns/utils.py
+++ b/moto/sns/utils.py
@@ -411,7 +411,9 @@ class FilterPolicyMatcher:
                     if attributes_based_check:
                         if dict_body.get(field, {}).get("Type", "") == "Number":
                             checks = value
-                            numeric_ranges = zip(checks[0::2], checks[1::2])
+                            numeric_ranges = zip(
+                                checks[0::2], checks[1::2], strict=False
+                            )
                             if _numeric_match(
                                 numeric_ranges, float(dict_body[field]["Value"])
                             ):
@@ -421,7 +423,7 @@ class FilterPolicyMatcher:
                             return False
 
                         checks = value
-                        numeric_ranges = zip(checks[0::2], checks[1::2])
+                        numeric_ranges = zip(checks[0::2], checks[1::2], strict=False)
                         if _numeric_match(numeric_ranges, dict_body[field]):
                             return True
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ markers = [
 ]
 
 [tool.ruff]
-target-version = "py39"  # Same as python_requires in setup.cfg
+target-version = "py310"  # Same as python_requires in setup.cfg
 
 [tool.ruff.lint]
 ignore = [

--- a/tests/test_emr/test_emr_boto3.py
+++ b/tests/test_emr/test_emr_boto3.py
@@ -833,11 +833,11 @@ def test_bootstrap_actions():
     cluster_id = client.run_job_flow(**args)["JobFlowId"]
 
     cl = client.describe_job_flows(JobFlowIds=[cluster_id])["JobFlows"][0]
-    for x, y in zip(cl["BootstrapActions"], bootstrap_actions):
+    for x, y in zip(cl["BootstrapActions"], bootstrap_actions, strict=True):
         assert x["BootstrapActionConfig"] == y
 
     resp = client.list_bootstrap_actions(ClusterId=cluster_id)
-    for x, y in zip(resp["BootstrapActions"], bootstrap_actions):
+    for x, y in zip(resp["BootstrapActions"], bootstrap_actions, strict=True):
         assert x["Name"] == y["Name"]
         if "Args" in y["ScriptBootstrapAction"]:
             assert x["Args"] == y["ScriptBootstrapAction"]["Args"]
@@ -1040,7 +1040,7 @@ def test_steps():
 
     jf = client.describe_job_flows(JobFlowIds=[cluster_id])["JobFlows"][0]
     assert len(jf["Steps"]) == 2
-    for idx, (x, y) in enumerate(zip(jf["Steps"], input_steps)):
+    for idx, (x, y) in enumerate(zip(jf["Steps"], input_steps, strict=True)):
         assert "CreationDateTime" in x["ExecutionStatusDetail"]
         # assert 'EndDateTime' in x['ExecutionStatusDetail']
         # assert 'LastStateChangeReason' in x['ExecutionStatusDetail']

--- a/tests/test_iot/test_iot_topic_rules.py
+++ b/tests/test_iot/test_iot_topic_rules.py
@@ -56,7 +56,7 @@ def test_topic_rule_list():
 
     res = client.list_topic_rules()
     assert len(res["rules"]) == 2
-    for rule, rule_name in zip(res["rules"], [name, f"{name}2"]):
+    for rule, rule_name in zip(res["rules"], [name, f"{name}2"], strict=True):
         assert rule["ruleName"] == rule_name
         assert rule["createdAt"] is not None
         assert rule["ruleArn"] is not None

--- a/tests/test_logs/test_logs_filter_log_events.py
+++ b/tests/test_logs/test_logs_filter_log_events.py
@@ -42,7 +42,7 @@ class TestLogFilterParameters(TestLogFilter):
             interleaved=True,
         )
         events = res["events"]
-        for original_message, resulting_event in zip(messages, events):
+        for original_message, resulting_event in zip(messages, events, strict=True):
             assert resulting_event["eventId"] == str(resulting_event["eventId"])
             assert resulting_event["timestamp"] == original_message["timestamp"]
             assert resulting_event["message"] == original_message["message"]
@@ -108,7 +108,7 @@ class TestLogFilterParameters(TestLogFilter):
         assert len(events) == 25
         assert "nextToken" not in res
 
-        for original_message, resulting_event in zip(messages, events):
+        for original_message, resulting_event in zip(messages, events, strict=True):
             assert resulting_event["eventId"] == str(resulting_event["eventId"])
             assert resulting_event["timestamp"] == original_message["timestamp"]
             assert resulting_event["message"] == original_message["message"]


### PR DESCRIPTION
Followup to #9989  - now that we've dropped Python 3.9, we should also tell `ruff` to use Python 3.10 as the minimal version.